### PR TITLE
fix(daemon): make startup DB/migration failure fatal so the daemon can't run query-dead while healthy

### DIFF
--- a/src/daemon/DaemonStartupFailureTracker.ts
+++ b/src/daemon/DaemonStartupFailureTracker.ts
@@ -1,0 +1,96 @@
+import * as fs from "fs";
+import * as path from "path";
+import { getDatabasePath } from "../db";
+import { logger } from "../utils/logger";
+import type { DatabaseFailureKind } from "../db/databaseFailureClassification";
+
+/**
+ * Tracks recent fatal daemon-startup failures across process launches so the
+ * circuit-breaker in Daemon.initializeDatabase() can converge to a stable dead
+ * state (bounded backoff) instead of a hot restart loop when a permanent DB
+ * failure keeps reproducing (issue #2784).
+ *
+ * The daemon exits on a fatal startup failure and is re-spawned externally (a
+ * fresh process each time), so the failure count MUST be persisted to disk to
+ * survive the restart — an in-process counter would reset to zero every launch.
+ */
+export interface StartupFailureTracker {
+  /**
+   * Record a fatal startup failure occurring at `now` and return the number of
+   * failures recorded within the rolling window (including this one).
+   */
+  recordFailure(kind: DatabaseFailureKind, now: number): number;
+
+  /** Clear the recorded failures after a successful startup. */
+  reset(): void;
+}
+
+interface StartupFailureRecord {
+  at: number;
+  kind: DatabaseFailureKind;
+}
+
+/** Failures older than this fall out of the rolling window. */
+export const STARTUP_FAILURE_WINDOW_MS = 5 * 60 * 1000;
+
+export class DefaultStartupFailureTracker implements StartupFailureTracker {
+  private readonly filePath: string;
+  private readonly windowMs: number;
+
+  constructor(filePath: string = defaultTrackerFilePath(), windowMs: number = STARTUP_FAILURE_WINDOW_MS) {
+    this.filePath = filePath;
+    this.windowMs = windowMs;
+  }
+
+  recordFailure(kind: DatabaseFailureKind, now: number): number {
+    const records = this.read().filter(record => now - record.at < this.windowMs);
+    records.push({ at: now, kind });
+    this.write(records);
+    return records.length;
+  }
+
+  reset(): void {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        fs.rmSync(this.filePath, { force: true });
+      }
+    } catch (error) {
+      // Best-effort cleanup; a stale tracker file only delays the next backoff.
+      logger.debug(`Failed to clear startup failure tracker file: ${error}`);
+    }
+  }
+
+  private read(): StartupFailureRecord[] {
+    try {
+      if (!fs.existsSync(this.filePath)) {
+        return [];
+      }
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, "utf8"));
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.filter(
+        (record): record is StartupFailureRecord =>
+          typeof record?.at === "number" && (record.kind === "transient" || record.kind === "permanent")
+      );
+    } catch (error) {
+      // A corrupt/unreadable tracker file must not itself break startup — treat
+      // it as "no prior failures" so we still exit fatally but without backoff.
+      logger.debug(`Failed to read startup failure tracker file: ${error}`);
+      return [];
+    }
+  }
+
+  private write(records: StartupFailureRecord[]): void {
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.writeFileSync(this.filePath, JSON.stringify(records), { mode: 0o600 });
+    } catch (error) {
+      logger.debug(`Failed to persist startup failure tracker file: ${error}`);
+    }
+  }
+}
+
+function defaultTrackerFilePath(): string {
+  return path.join(path.dirname(getDatabasePath()), "daemon-startup-failures.json");
+}

--- a/src/daemon/DaemonStartupFailureTracker.ts
+++ b/src/daemon/DaemonStartupFailureTracker.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
-import { getDatabasePath } from "../db";
 import { logger } from "../utils/logger";
+import { getTempDir, TEMP_SUBDIRS } from "../utils/tempDir";
 import type { DatabaseFailureKind } from "../db/databaseFailureClassification";
 
 /**
@@ -45,7 +45,15 @@ export class DefaultStartupFailureTracker implements StartupFailureTracker {
   recordFailure(kind: DatabaseFailureKind, now: number): number {
     const records = this.read().filter(record => now - record.at < this.windowMs);
     records.push({ at: now, kind });
-    this.write(records);
+    const persisted = this.write(records);
+    if (!persisted) {
+      // Persistence failure itself throttles: if we can't record the escalation
+      // across respawns (e.g. the state dir is unwritable — the same class of
+      // permanent failure that would otherwise hot-loop), report at least the
+      // second tier so the permanent-failure backoff still engages instead of
+      // spinning at count 1 forever.
+      return Math.max(records.length, 2);
+    }
     return records.length;
   }
 
@@ -81,16 +89,22 @@ export class DefaultStartupFailureTracker implements StartupFailureTracker {
     }
   }
 
-  private write(records: StartupFailureRecord[]): void {
+  private write(records: StartupFailureRecord[]): boolean {
     try {
       fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
       fs.writeFileSync(this.filePath, JSON.stringify(records), { mode: 0o600 });
+      return true;
     } catch (error) {
       logger.debug(`Failed to persist startup failure tracker file: ${error}`);
+      return false;
     }
   }
 }
 
 function defaultTrackerFilePath(): string {
-  return path.join(path.dirname(getDatabasePath()), "daemon-startup-failures.json");
+  // Stored under the auto-mobile data dir (AUTOMOBILE_DATA_DIR / ~/.auto-mobile),
+  // NOT the DB directory: a custom, unwritable AUTOMOBILE_DB_DIR is itself a
+  // permanent startup failure, and putting the breaker there would leave every
+  // respawn unable to read prior records — so it could never escalate to backoff.
+  return path.join(getTempDir(TEMP_SUBDIRS.STATE), "daemon-startup-failures.json");
 }

--- a/src/daemon/DaemonStartupFailureTracker.ts
+++ b/src/daemon/DaemonStartupFailureTracker.ts
@@ -25,6 +25,20 @@ export interface StartupFailureTracker {
   reset(): void;
 }
 
+/**
+ * Persistence backend for the failure tracker. Injected so the throttle-on-
+ * persistence-failure path is testable deterministically and cross-platform,
+ * rather than depending on an OS-specific unwritable path.
+ */
+export interface StartupFailureStore {
+  /** The raw persisted contents, or null if nothing is stored yet. */
+  read(): string | null;
+  /** Persist the contents. MUST throw if the write does not durably succeed. */
+  write(data: string): void;
+  /** Best-effort removal of any persisted contents. */
+  clear(): void;
+}
+
 interface StartupFailureRecord {
   at: number;
   kind: DatabaseFailureKind;
@@ -33,31 +47,26 @@ interface StartupFailureRecord {
 /** Failures older than this fall out of the rolling window. */
 export const STARTUP_FAILURE_WINDOW_MS = 5 * 60 * 1000;
 
-export class DefaultStartupFailureTracker implements StartupFailureTracker {
-  private readonly filePath: string;
-  private readonly windowMs: number;
+/** File-backed store under a directory independent of the DB directory. */
+export class FileStartupFailureStore implements StartupFailureStore {
+  constructor(private readonly filePath: string = defaultTrackerFilePath()) {}
 
-  constructor(filePath: string = defaultTrackerFilePath(), windowMs: number = STARTUP_FAILURE_WINDOW_MS) {
-    this.filePath = filePath;
-    this.windowMs = windowMs;
-  }
-
-  recordFailure(kind: DatabaseFailureKind, now: number): number {
-    const records = this.read().filter(record => now - record.at < this.windowMs);
-    records.push({ at: now, kind });
-    const persisted = this.write(records);
-    if (!persisted) {
-      // Persistence failure itself throttles: if we can't record the escalation
-      // across respawns (e.g. the state dir is unwritable — the same class of
-      // permanent failure that would otherwise hot-loop), report at least the
-      // second tier so the permanent-failure backoff still engages instead of
-      // spinning at count 1 forever.
-      return Math.max(records.length, 2);
+  read(): string | null {
+    try {
+      return fs.existsSync(this.filePath) ? fs.readFileSync(this.filePath, "utf8") : null;
+    } catch (error) {
+      logger.debug(`Failed to read startup failure tracker file: ${error}`);
+      return null;
     }
-    return records.length;
   }
 
-  reset(): void {
+  write(data: string): void {
+    // No try/catch: a failed write must propagate so recordFailure() can throttle.
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, data, { mode: 0o600 });
+  }
+
+  clear(): void {
     try {
       if (fs.existsSync(this.filePath)) {
         fs.rmSync(this.filePath, { force: true });
@@ -67,13 +76,50 @@ export class DefaultStartupFailureTracker implements StartupFailureTracker {
       logger.debug(`Failed to clear startup failure tracker file: ${error}`);
     }
   }
+}
+
+export class DefaultStartupFailureTracker implements StartupFailureTracker {
+  private readonly store: StartupFailureStore;
+  private readonly windowMs: number;
+
+  constructor(
+    store: StartupFailureStore = new FileStartupFailureStore(),
+    windowMs: number = STARTUP_FAILURE_WINDOW_MS
+  ) {
+    this.store = store;
+    this.windowMs = windowMs;
+  }
+
+  recordFailure(kind: DatabaseFailureKind, now: number): number {
+    const records = this.read().filter(record => now - record.at < this.windowMs);
+    records.push({ at: now, kind });
+
+    try {
+      this.store.write(JSON.stringify(records));
+    } catch (error) {
+      // Persistence failure itself throttles: if we can't record the escalation
+      // across respawns (e.g. the state dir is unwritable — the same class of
+      // permanent failure that would otherwise hot-loop), report at least the
+      // second tier so the permanent-failure backoff still engages instead of
+      // spinning at count 1 forever.
+      logger.debug(`Failed to persist startup failure tracker: ${error}`);
+      return Math.max(records.length, 2);
+    }
+
+    return records.length;
+  }
+
+  reset(): void {
+    this.store.clear();
+  }
 
   private read(): StartupFailureRecord[] {
+    const raw = this.store.read();
+    if (raw === null) {
+      return [];
+    }
     try {
-      if (!fs.existsSync(this.filePath)) {
-        return [];
-      }
-      const parsed = JSON.parse(fs.readFileSync(this.filePath, "utf8"));
+      const parsed = JSON.parse(raw);
       if (!Array.isArray(parsed)) {
         return [];
       }
@@ -84,19 +130,8 @@ export class DefaultStartupFailureTracker implements StartupFailureTracker {
     } catch (error) {
       // A corrupt/unreadable tracker file must not itself break startup — treat
       // it as "no prior failures" so we still exit fatally but without backoff.
-      logger.debug(`Failed to read startup failure tracker file: ${error}`);
+      logger.debug(`Failed to parse startup failure tracker contents: ${error}`);
       return [];
-    }
-  }
-
-  private write(records: StartupFailureRecord[]): boolean {
-    try {
-      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
-      fs.writeFileSync(this.filePath, JSON.stringify(records), { mode: 0o600 });
-      return true;
-    } catch (error) {
-      logger.debug(`Failed to persist startup failure tracker file: ${error}`);
-      return false;
     }
   }
 }

--- a/src/daemon/DaemonStartupFailureTracker.ts
+++ b/src/daemon/DaemonStartupFailureTracker.ts
@@ -62,8 +62,15 @@ export class FileStartupFailureStore implements StartupFailureStore {
 
   write(data: string): void {
     // No try/catch: a failed write must propagate so recordFailure() can throttle.
-    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
-    fs.writeFileSync(this.filePath, data, { mode: 0o600 });
+    // Write to a per-process temp file then atomically rename, so a crash or a
+    // racing daemon launch can never leave a torn/partial file that read() would
+    // fail to parse (which would silently reset the failure count to zero and
+    // defeat backoff escalation).
+    const dir = path.dirname(this.filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpPath = path.join(dir, `.${path.basename(this.filePath)}.${process.pid}.tmp`);
+    fs.writeFileSync(tmpPath, data, { mode: 0o600 });
+    fs.renameSync(tmpPath, this.filePath);
   }
 
   clear(): void {
@@ -91,7 +98,7 @@ export class DefaultStartupFailureTracker implements StartupFailureTracker {
   }
 
   recordFailure(kind: DatabaseFailureKind, now: number): number {
-    const records = this.read().filter(record => now - record.at < this.windowMs);
+    const records = this.read().filter(record => now - record.at <= this.windowMs);
     records.push({ at: now, kind });
 
     try {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -24,10 +24,8 @@ import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from 
 import { executionTracker } from "../server/executionTracker";
 import { closeDatabase, getMigrationsError } from "../db";
 import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
-import { classifyDatabaseFailure } from "../db/databaseFailureClassification";
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
-import { exponentialBackoff } from "../utils/Backoff";
-import { toActionableError } from "../models/ActionableError";
+import { handleFatalDatabaseStartupFailure } from "./daemonStartupGuard";
 import { startupBenchmark } from "../utils/startupBenchmark";
 import { startVideoRecordingSocketServer, stopVideoRecordingSocketServer } from "./videoRecordingSocketServer";
 import { startTestRecordingSocketServer, stopTestRecordingSocketServer } from "./testRecordingSocketServer";
@@ -1147,35 +1145,11 @@ export class Daemon {
       logger.info(`[Daemon] Cleared old daemon session caches, current session: ${this.daemonSessionId}`);
       this.startupFailureTracker.reset();
     } catch (error) {
-      await this.handleFatalDatabaseInitFailure(error);
+      // Delegate to the shared startup guard so this path and the earlier
+      // feature-flag DB touch (guarded in main() before start()) funnel through
+      // the identical classify/record/backoff/rethrow circuit breaker.
+      await handleFatalDatabaseStartupFailure(error, this.startupFailureTracker, this.timer);
     }
-  }
-
-  private async handleFatalDatabaseInitFailure(error: unknown): Promise<never> {
-    const kind = classifyDatabaseFailure(error);
-    const recentFailures = this.startupFailureTracker.recordFailure(kind, this.timer.now());
-    logger.error(
-      `Fatal: database initialization failed (${kind}; ${recentFailures} recent failure(s)); ` +
-        `daemon cannot serve queries and will exit for a clean restart: ${describeUnknownError(error)}`
-    );
-
-    if (kind === "permanent" && recentFailures > 1) {
-      // Circuit breaker: a permanent failure that keeps reproducing would hot-loop
-      // the process manager. Park with an increasing backoff (via the shared
-      // Backoff primitive) so the effective restart cadence converges to a stable,
-      // low-frequency dead state rather than pinning CPU.
-      const backoffMs = exponentialBackoff({
-        initialDelayMs: 1000,
-        multiplier: 2,
-        maxDelayMs: 60_000,
-      }).delayForAttempt(recentFailures - 1);
-      logger.error(
-        `Database initialization has failed ${recentFailures} times; backing off ${backoffMs}ms before exit to avoid a restart hot-loop.`
-      );
-      await this.timer.sleep(backoffMs);
-    }
-
-    throw toActionableError(error, "Database initialization failed at daemon startup");
   }
 
   /**

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -290,6 +290,12 @@ export class Daemon {
     logger.info(
       `Daemon started: PID ${process.pid}, socket ${SOCKET_PATH}, HTTP port ${this.port}`
     );
+
+    // Startup fully succeeded — DB brought up AND every startup DB-backed step
+    // completed. Only now clear the crash-loop circuit breaker, so a permanent
+    // failure in any later startup step (recorded before its fatal exit) isn't
+    // erased by a preflight that merely got past migrations (issue #2784).
+    this.startupFailureTracker.reset();
   }
 
   /**
@@ -1143,7 +1149,6 @@ export class Daemon {
         "daemon-restart"
       );
       logger.info(`[Daemon] Cleared old daemon session caches, current session: ${this.daemonSessionId}`);
-      this.startupFailureTracker.reset();
     } catch (error) {
       // Delegate to the shared startup guard so this path and the earlier
       // feature-flag DB touch (guarded in main() before start()) funnel through

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -22,7 +22,12 @@ import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
-import { closeDatabase, getDatabase } from "../db";
+import { closeDatabase, getMigrationsError } from "../db";
+import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
+import { classifyDatabaseFailure } from "../db/databaseFailureClassification";
+import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
+import { exponentialBackoff } from "../utils/Backoff";
+import { toActionableError } from "../models/ActionableError";
 import { startupBenchmark } from "../utils/startupBenchmark";
 import { startVideoRecordingSocketServer, stopVideoRecordingSocketServer } from "./videoRecordingSocketServer";
 import { startTestRecordingSocketServer, stopTestRecordingSocketServer } from "./testRecordingSocketServer";
@@ -104,6 +109,8 @@ export class Daemon {
   private deviceSessionRepository: DeviceSessionRepository;
   private timer: Timer;
   private idGenerator: IdGenerator;
+  private databaseInitializer: DatabaseInitializer;
+  private startupFailureTracker: StartupFailureTracker;
   private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
@@ -113,7 +120,9 @@ export class Daemon {
     installedAppsRepository?: InstalledAppsStore,
     timer: Timer = defaultTimer,
     deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository(),
-    idGenerator: IdGenerator = defaultIdGenerator
+    idGenerator: IdGenerator = defaultIdGenerator,
+    databaseInitializer: DatabaseInitializer = new DefaultDatabaseInitializer(),
+    startupFailureTracker: StartupFailureTracker = new DefaultStartupFailureTracker()
   ) {
     this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
@@ -124,6 +133,8 @@ export class Daemon {
     this.idGenerator = idGenerator;
     this.daemonSessionId = this.idGenerator.next();
     this.timer = timer;
+    this.databaseInitializer = databaseInitializer;
+    this.startupFailureTracker = startupFailureTracker;
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
     // Register centralized cleanup for session-scoped state
@@ -777,6 +788,14 @@ export class Daemon {
           if (!this.socketServer || !this.socketServer.isListening()) {
             logger.warn("Health check failed: Socket server not listening");
             failedCheckCount++;
+          } else if (getMigrationsError() !== null) {
+            // DB-liveness probe (issue #2784): a query-dead DB otherwise leaves
+            // the daemon reporting healthy while every DB-backed feature fails.
+            // Read the cached migration error only — no query, so this stays
+            // read-only, non-transactional, and never blocks behind an in-flight
+            // graph-write transaction on the single shared connection.
+            logger.warn(`Health check failed: database is not query-ready: ${getMigrationsError()?.message}`);
+            failedCheckCount++;
           } else {
             // Health check passed
             failedCheckCount = 0;
@@ -1101,9 +1120,23 @@ export class Daemon {
     }
   }
 
+  /**
+   * Bring the database to a query-ready state. Startup DB/migration failure is
+   * FATAL (issue #2784): this method rethrows so `start()` rejects → `main().catch`
+   * → `process.exit(1)`, letting the process manager restart a clean daemon
+   * instead of leaving a query-dead daemon that reports healthy.
+   *
+   * To avoid a restart hot-loop when a *permanent* failure keeps reproducing
+   * (corrupt DB, deterministic migration throw), repeated permanent failures are
+   * throttled with an exponential backoff before the fatal rethrow. Transient
+   * failures (locked file, temporary disk-full) exit fast so the next launch can
+   * retry immediately.
+   */
   private async initializeDatabase(): Promise<void> {
     try {
-      getDatabase();
+      // getDatabase() + await ensureMigrations(): a failed startup migration
+      // rejects here (rather than swallowing on a detached promise).
+      await this.databaseInitializer.initialize();
       // Clear installed apps cache from previous daemon sessions
       await this.installedAppsRepository.clearOldDaemonSessions(this.daemonSessionId);
       await this.deviceSessionRepository.markStaleActiveSessionsExpired(
@@ -1112,9 +1145,37 @@ export class Daemon {
         "daemon-restart"
       );
       logger.info(`[Daemon] Cleared old daemon session caches, current session: ${this.daemonSessionId}`);
+      this.startupFailureTracker.reset();
     } catch (error) {
-      logger.error(`Failed to initialize database: ${error}`);
+      await this.handleFatalDatabaseInitFailure(error);
     }
+  }
+
+  private async handleFatalDatabaseInitFailure(error: unknown): Promise<never> {
+    const kind = classifyDatabaseFailure(error);
+    const recentFailures = this.startupFailureTracker.recordFailure(kind, this.timer.now());
+    logger.error(
+      `Fatal: database initialization failed (${kind}; ${recentFailures} recent failure(s)); ` +
+        `daemon cannot serve queries and will exit for a clean restart: ${describeUnknownError(error)}`
+    );
+
+    if (kind === "permanent" && recentFailures > 1) {
+      // Circuit breaker: a permanent failure that keeps reproducing would hot-loop
+      // the process manager. Park with an increasing backoff (via the shared
+      // Backoff primitive) so the effective restart cadence converges to a stable,
+      // low-frequency dead state rather than pinning CPU.
+      const backoffMs = exponentialBackoff({
+        initialDelayMs: 1000,
+        multiplier: 2,
+        maxDelayMs: 60_000,
+      }).delayForAttempt(recentFailures - 1);
+      logger.error(
+        `Database initialization has failed ${recentFailures} times; backing off ${backoffMs}ms before exit to avoid a restart hot-loop.`
+      );
+      await this.timer.sleep(backoffMs);
+    }
+
+    throw toActionableError(error, "Database initialization failed at daemon startup");
   }
 
   /**

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -22,7 +22,7 @@ import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
-import { closeDatabase, getMigrationsError } from "../db";
+import { closeDatabase } from "../db";
 import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
 import { handleFatalDatabaseStartupFailure } from "./daemonStartupGuard";
@@ -791,14 +791,6 @@ export class Daemon {
           // Check if socket server is active
           if (!this.socketServer || !this.socketServer.isListening()) {
             logger.warn("Health check failed: Socket server not listening");
-            failedCheckCount++;
-          } else if (getMigrationsError() !== null) {
-            // DB-liveness probe (issue #2784): a query-dead DB otherwise leaves
-            // the daemon reporting healthy while every DB-backed feature fails.
-            // Read the cached migration error only — no query, so this stays
-            // read-only, non-transactional, and never blocks behind an in-flight
-            // graph-write transaction on the single shared connection.
-            logger.warn(`Health check failed: database is not query-ready: ${getMigrationsError()?.message}`);
             failedCheckCount++;
           } else {
             // Health check passed

--- a/src/daemon/daemonStartupGuard.ts
+++ b/src/daemon/daemonStartupGuard.ts
@@ -4,7 +4,6 @@ import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { exponentialBackoff } from "../utils/Backoff";
 import { describeUnknownError } from "../utils/describeUnknownError";
 import { classifyDatabaseFailure } from "../db/databaseFailureClassification";
-import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
 import {
   StartupFailureTracker,
   DefaultStartupFailureTracker,
@@ -49,26 +48,29 @@ export async function handleFatalDatabaseStartupFailure(
 }
 
 /**
- * Pre-flight the database under the startup circuit breaker BEFORE any DB-backed
- * service touches it.
+ * Run early `--daemon-mode` database startup `work` under the circuit breaker,
+ * BEFORE `Daemon.start()`.
  *
- * In `--daemon-mode` the first DB touch is `FeatureFlagService.initialize()` in
- * `main()`, which runs before `Daemon.start()`. Without this guard a permanent
- * DB failure surfaces there and exits via `main().catch` before the daemon's
- * own fatal handler can record the failure or back off — re-spawning in a tight
- * loop. Running the guard first funnels that early failure through the same
- * classify/record/backoff/rethrow path.
+ * The first DB touches in `main()` — migrations and `FeatureFlagService`'s
+ * `ensureFlags`/`listFlags` queries — run before `Daemon.start()`. Without this
+ * guard a permanent DB failure there (failed migration, or a migrated-but-
+ * missing/malformed `feature_flags` table) surfaces via `main().catch` and exits
+ * before the daemon's own fatal handler can record it or back off — re-spawning
+ * in a tight loop. Wrapping ALL of that DB `work` here funnels every early
+ * failure through the same classify/record/backoff/rethrow path.
  *
- * On success the failure tracker is reset (a healthy DB start clears the breaker).
+ * Does NOT reset the tracker on success: reset must happen only after the ENTIRE
+ * daemon startup DB path (including `Daemon.initializeDatabase()`'s cleanup
+ * queries) succeeds, otherwise a later permanent failure recorded by the daemon
+ * would be erased by the next launch's preflight success and never escalate.
  */
 export async function guardDatabaseStartup(
-  initializer: DatabaseInitializer = new DefaultDatabaseInitializer(),
+  work: () => Promise<void>,
   tracker: StartupFailureTracker = new DefaultStartupFailureTracker(),
   timer: Timer = defaultTimer
 ): Promise<void> {
   try {
-    await initializer.initialize();
-    tracker.reset();
+    await work();
   } catch (error) {
     await handleFatalDatabaseStartupFailure(error, tracker, timer);
   }

--- a/src/daemon/daemonStartupGuard.ts
+++ b/src/daemon/daemonStartupGuard.ts
@@ -4,10 +4,23 @@ import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { exponentialBackoff } from "../utils/Backoff";
 import { describeUnknownError } from "../utils/describeUnknownError";
 import { classifyDatabaseFailure } from "../db/databaseFailureClassification";
+import { DAEMON_STARTUP_TIMEOUT_MS } from "./constants";
 import {
   StartupFailureTracker,
   DefaultStartupFailureTracker,
 } from "./DaemonStartupFailureTracker";
+
+/**
+ * Cap the backoff strictly below the manager's startup timeout. The daemon
+ * sleeps here *before* `process.exit(1)`, but `DaemonManager.waitForDaemonStartup()`
+ * reports failure after `DAEMON_STARTUP_TIMEOUT_MS` and the next spawn SIGTERMs
+ * any live `--daemon-mode` process — so a sleep >= that timeout would be
+ * truncated (the sleeper is killed) and never actually throttle. Staying under
+ * it (with headroom for the exit to be observed) lets the backoff complete, so
+ * the effective respawn cadence really does converge to this bound. Floored at
+ * 1s so an aggressively-low override can't disable throttling entirely.
+ */
+export const MAX_STARTUP_BACKOFF_MS = Math.max(1000, DAEMON_STARTUP_TIMEOUT_MS - 2000);
 
 /**
  * Convert a fatal database startup/bring-up failure into a rethrown
@@ -36,7 +49,7 @@ export async function handleFatalDatabaseStartupFailure(
     const backoffMs = exponentialBackoff({
       initialDelayMs: 1000,
       multiplier: 2,
-      maxDelayMs: 60_000,
+      maxDelayMs: MAX_STARTUP_BACKOFF_MS,
     }).delayForAttempt(recentFailures - 1);
     logger.error(
       `Database initialization has failed ${recentFailures} times; backing off ${backoffMs}ms before exit to avoid a restart hot-loop.`

--- a/src/daemon/daemonStartupGuard.ts
+++ b/src/daemon/daemonStartupGuard.ts
@@ -1,0 +1,75 @@
+import { logger } from "../utils/logger";
+import { toActionableError } from "../models/ActionableError";
+import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { exponentialBackoff } from "../utils/Backoff";
+import { describeUnknownError } from "../utils/describeUnknownError";
+import { classifyDatabaseFailure } from "../db/databaseFailureClassification";
+import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
+import {
+  StartupFailureTracker,
+  DefaultStartupFailureTracker,
+} from "./DaemonStartupFailureTracker";
+
+/**
+ * Convert a fatal database startup/bring-up failure into a rethrown
+ * `ActionableError`, applying the crash-loop circuit breaker (issue #2784).
+ *
+ * Startup DB failure is fatal so the process exits for a clean restart. To keep
+ * a *permanent* failure (corrupt DB, deterministic migration throw) from
+ * hot-looping the process manager, repeated permanent failures are throttled
+ * with an increasing exponential backoff before the fatal rethrow, converging to
+ * a stable low-frequency dead state. Transient failures (locked file, temporary
+ * disk-full) exit fast so the next launch can retry immediately.
+ */
+export async function handleFatalDatabaseStartupFailure(
+  error: unknown,
+  tracker: StartupFailureTracker,
+  timer: Timer = defaultTimer
+): Promise<never> {
+  const kind = classifyDatabaseFailure(error);
+  const recentFailures = tracker.recordFailure(kind, timer.now());
+  logger.error(
+    `Fatal: database initialization failed (${kind}; ${recentFailures} recent failure(s)); ` +
+      `daemon cannot serve queries and will exit for a clean restart: ${describeUnknownError(error)}`
+  );
+
+  if (kind === "permanent" && recentFailures > 1) {
+    const backoffMs = exponentialBackoff({
+      initialDelayMs: 1000,
+      multiplier: 2,
+      maxDelayMs: 60_000,
+    }).delayForAttempt(recentFailures - 1);
+    logger.error(
+      `Database initialization has failed ${recentFailures} times; backing off ${backoffMs}ms before exit to avoid a restart hot-loop.`
+    );
+    await timer.sleep(backoffMs);
+  }
+
+  throw toActionableError(error, "Database initialization failed at daemon startup");
+}
+
+/**
+ * Pre-flight the database under the startup circuit breaker BEFORE any DB-backed
+ * service touches it.
+ *
+ * In `--daemon-mode` the first DB touch is `FeatureFlagService.initialize()` in
+ * `main()`, which runs before `Daemon.start()`. Without this guard a permanent
+ * DB failure surfaces there and exits via `main().catch` before the daemon's
+ * own fatal handler can record the failure or back off — re-spawning in a tight
+ * loop. Running the guard first funnels that early failure through the same
+ * classify/record/backoff/rethrow path.
+ *
+ * On success the failure tracker is reset (a healthy DB start clears the breaker).
+ */
+export async function guardDatabaseStartup(
+  initializer: DatabaseInitializer = new DefaultDatabaseInitializer(),
+  tracker: StartupFailureTracker = new DefaultStartupFailureTracker(),
+  timer: Timer = defaultTimer
+): Promise<void> {
+  try {
+    await initializer.initialize();
+    tracker.reset();
+  } catch (error) {
+    await handleFatalDatabaseStartupFailure(error, tracker, timer);
+  }
+}

--- a/src/db/DatabaseInitializer.ts
+++ b/src/db/DatabaseInitializer.ts
@@ -1,0 +1,25 @@
+import { getDatabase, ensureMigrations } from "./database";
+
+/**
+ * Brings the singleton database up to a query-ready state: opens the connection
+ * and awaits startup migrations. Injected into the daemon so startup DB failure
+ * can be exercised with a fake (issue #2784) instead of a real sqlite file.
+ */
+export interface DatabaseInitializer {
+  /**
+   * Resolves once the DB is open and migrations have completed successfully.
+   * Rejects (with the cached startup-migration error) if migrations failed —
+   * this is the fatal signal the daemon relies on at startup.
+   */
+  initialize(): Promise<void>;
+}
+
+export class DefaultDatabaseInitializer implements DatabaseInitializer {
+  async initialize(): Promise<void> {
+    // getDatabase() constructs the connection and kicks off migrations
+    // asynchronously; ensureMigrations() awaits them and rethrows a cached
+    // startup-migration failure (see src/db/database.ts).
+    getDatabase();
+    await ensureMigrations();
+  }
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -92,8 +92,15 @@ function resolveDbPath(): string {
 let dbInstance: Kysely<DatabaseSchema> | null = null;
 let migrationsRun = false;
 let migrationsPromise: Promise<void> | null = null;
+// Cached startup-migration failure. When migrations fail, `migrationsPromise`
+// RESOLVES (never floats a rejection — that would trip `unhandledRejection`
+// before the daemon's fatal path runs) and the error is cached here so every
+// awaiter (queries via `waitForMigrationsBeforeQuery`, startup via
+// `ensureMigrations`) can re-check and rethrow it. The failure is sticky: we
+// never null `migrationsPromise` to auto-retry (see issues #2784/#2786/#2796).
+let migrationsError: Error | null = null;
 
-const DATABASE_STARTUP_MIGRATION_FAILURE =
+export const DATABASE_STARTUP_MIGRATION_FAILURE =
   "Database startup migrations failed; refusing to run queries until the daemon restarts.";
 
 function createStartupMigrationError(cause: unknown): Error {
@@ -102,11 +109,17 @@ function createStartupMigrationError(cause: unknown): Error {
 }
 
 async function waitForMigrationsBeforeQuery(): Promise<void> {
-  if (migrationsRun || !migrationsPromise) {
+  if (migrationsRun) {
     return;
   }
 
-  await migrationsPromise;
+  if (migrationsPromise) {
+    await migrationsPromise;
+  }
+
+  if (migrationsError) {
+    throw migrationsError;
+  }
 }
 
 function createSqliteKysely<T>(
@@ -144,9 +157,16 @@ async function startMigrations(dbPath: string): Promise<void> {
 
 function ensureMigrationsStarted(dbPath: string): void {
   if (!migrationsRun && !migrationsPromise) {
-    migrationsPromise = startMigrations(dbPath).catch(error => {
-      throw createStartupMigrationError(error);
-    });
+    // Resolve (never reject) so a failed migration does not float an unhandled
+    // rejection; cache the error for synchronous re-checking by awaiters.
+    migrationsPromise = startMigrations(dbPath).then(
+      () => {
+        migrationsError = null;
+      },
+      error => {
+        migrationsError = createStartupMigrationError(error);
+      }
+    );
   }
 }
 
@@ -190,6 +210,22 @@ export async function ensureMigrations(): Promise<void> {
   ensureMigrationsStarted(resolveDbPath());
 
   await migrationsPromise;
+
+  // Under the resolved-promise model the await above never rejects; re-check the
+  // cached error so a startup migration failure stays fatal for callers that
+  // await migrations at startup (e.g. Daemon.initializeDatabase — issue #2784).
+  if (migrationsError) {
+    throw migrationsError;
+  }
+}
+
+/**
+ * The cached startup-migration failure, or null if migrations succeeded or have
+ * not yet failed. Used by the daemon health/liveness path to detect a query-dead
+ * DB without floating a rejection.
+ */
+export function getMigrationsError(): Error | null {
+  return migrationsError;
 }
 
 /**

--- a/src/db/databaseFailureClassification.ts
+++ b/src/db/databaseFailureClassification.ts
@@ -1,12 +1,13 @@
 /**
  * Classification of a database bring-up / migration failure.
  *
- * - `transient`: expected to clear on its own (a locked/busy file, a temporarily
- *   full disk, EBUSY/EAGAIN contention from another tool). A fast restart is the
- *   right response — the next attempt may well succeed.
- * - `permanent`: deterministic (corrupt/malformed DB, a migration that always
- *   throws). Restarting immediately reproduces the failure, so the daemon must
- *   back off to avoid a restart hot-loop (issue #2784).
+ * - `transient`: expected to clear on its own within seconds (a locked/busy file,
+ *   EBUSY/EAGAIN contention from another tool briefly holding the sqlite file). A
+ *   fast restart is the right response — the next attempt may well succeed.
+ * - `permanent`: does NOT clear without external intervention and reproduces on
+ *   every respawn (corrupt/malformed DB, a migration that always throws, or a
+ *   full disk — ENOSPC needs a human to free space). The daemon must back off to
+ *   avoid a restart hot-loop (issue #2784).
  *
  * Defaults to `permanent` for unrecognized failures: treating an unknown failure
  * as permanent means it gets backoff protection, which is the fail-safe choice
@@ -20,8 +21,6 @@ const TRANSIENT_PATTERNS: RegExp[] = [
   /database table is locked/i,
   /\bebusy\b/i,
   /\beagain\b/i,
-  /\benospc\b/i,
-  /no space left on device/i,
   /resource (?:busy|temporarily unavailable)/i,
 ];
 

--- a/src/db/databaseFailureClassification.ts
+++ b/src/db/databaseFailureClassification.ts
@@ -1,0 +1,40 @@
+/**
+ * Classification of a database bring-up / migration failure.
+ *
+ * - `transient`: expected to clear on its own (a locked/busy file, a temporarily
+ *   full disk, EBUSY/EAGAIN contention from another tool). A fast restart is the
+ *   right response — the next attempt may well succeed.
+ * - `permanent`: deterministic (corrupt/malformed DB, a migration that always
+ *   throws). Restarting immediately reproduces the failure, so the daemon must
+ *   back off to avoid a restart hot-loop (issue #2784).
+ *
+ * Defaults to `permanent` for unrecognized failures: treating an unknown failure
+ * as permanent means it gets backoff protection, which is the fail-safe choice
+ * against pinning CPU in a hot loop.
+ */
+export type DatabaseFailureKind = "transient" | "permanent";
+
+const TRANSIENT_PATTERNS: RegExp[] = [
+  /sqlite_busy/i,
+  /database is locked/i,
+  /database table is locked/i,
+  /\bebusy\b/i,
+  /\beagain\b/i,
+  /\benospc\b/i,
+  /no space left on device/i,
+  /resource (?:busy|temporarily unavailable)/i,
+];
+
+export function classifyDatabaseFailure(error: unknown): DatabaseFailureKind {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  const haystack = typeof code === "string" ? `${code} ${message}` : message;
+
+  for (const pattern of TRANSIENT_PATTERNS) {
+    if (pattern.test(haystack)) {
+      return "transient";
+    }
+  }
+
+  return "permanent";
+}

--- a/src/db/deviceSessionRepository.ts
+++ b/src/db/deviceSessionRepository.ts
@@ -168,32 +168,37 @@ export class DeviceSessionRepository {
     }
   }
 
+  /**
+   * Expire stale active sessions left by previous daemon runs. Called once during
+   * daemon startup (`Daemon.initializeDatabase()`). Errors PROPAGATE rather than
+   * being swallowed: a failure here means the `device_sessions` table is
+   * missing/malformed (a broken DB), which the startup circuit breaker must treat
+   * as fatal so the daemon exits/backs off instead of starting with broken
+   * session state (issue #2784). Do not add a local catch — the caller owns the
+   * fatal/backoff decision.
+   */
   async markStaleActiveSessionsExpired(
     currentDaemonSessionId: string,
     releasedAtMs: number,
     reason: string = "daemon-restart"
   ): Promise<void> {
-    try {
-      const db = await this.getDb();
-      await db
-        .updateTable("device_sessions")
-        .set({
-          status: "expired",
-          released_at_ms: releasedAtMs,
-          release_reason: reason,
-          updated_at: new Date().toISOString(),
-        })
-        .where("status", "=", "active")
-        .where(eb =>
-          eb.or([
-            eb("daemon_session_id", "is", null),
-            eb("daemon_session_id", "!=", currentDaemonSessionId),
-          ])
-        )
-        .execute();
-    } catch (error) {
-      logger.warn(`[DeviceSessionRepository] Failed to expire stale active sessions: ${error}`);
-    }
+    const db = await this.getDb();
+    await db
+      .updateTable("device_sessions")
+      .set({
+        status: "expired",
+        released_at_ms: releasedAtMs,
+        release_reason: reason,
+        updated_at: new Date().toISOString(),
+      })
+      .where("status", "=", "active")
+      .where(eb =>
+        eb.or([
+          eb("daemon_session_id", "is", null),
+          eb("daemon_session_id", "!=", currentDaemonSessionId),
+        ])
+      )
+      .execute();
   }
 
   async getSession(sessionUuid: string): Promise<DeviceSession | undefined> {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,12 @@
 // Database module exports
-export { getDatabase, closeDatabase, getDatabasePath } from "./database";
+export {
+  getDatabase,
+  closeDatabase,
+  getDatabasePath,
+  ensureMigrations,
+  getMigrationsError,
+  DATABASE_STARTUP_MIGRATION_FAILURE,
+} from "./database";
 export { runMigrations } from "./migrator";
 export type {
   Database,

--- a/src/index.ts
+++ b/src/index.ts
@@ -468,21 +468,6 @@ async function main() {
     }
 
     const featureFlagService = FeatureFlagService.getInstance();
-    if (daemonMode) {
-      // Run ALL early DB-backed startup work under the circuit breaker BEFORE
-      // Daemon.start(): both migrations AND FeatureFlagService's ensureFlags/
-      // listFlags queries. Otherwise a permanent DB failure (failed migration, or
-      // a migrated-but-missing/malformed feature_flags table) surfaces via
-      // main().catch and exits before the daemon's own fatal handler can record
-      // it or back off — re-spawning in a tight loop (issue #2784).
-      await guardDatabaseStartup(async () => {
-        await new DefaultDatabaseInitializer().initialize();
-        await featureFlagService.initialize();
-      });
-    }
-    // Idempotent: a no-op in daemon mode (already initialized inside the guard),
-    // and the real initialization for the stdio MCP-server path.
-    await featureFlagService.initialize();
 
     const accessibilityConfig = a11yAuditMode
       ? {
@@ -505,17 +490,37 @@ async function main() {
       ["mcp-recording", mcpRecording, "--mcp-recording"],
     ];
 
-    for (const [key, enabled, flagLabel, config] of cliOverrides) {
-      if (!enabled) {
-        continue;
-      }
-      await featureFlagService.setFlag(key, true, config);
-      logger.info(`Feature flag enabled (${flagLabel})`);
-    }
+    // All DB-touching feature-flag startup work: migration-gated initialize()
+    // reads AND the CLI-override setFlag() writes. In --daemon-mode this runs
+    // inside the circuit breaker (below) so a startup DB failure anywhere here —
+    // including a write that fails on a read-only/full DB launched with --debug,
+    // --mcp-recording, --no-navigation-screenshots — funnels through the same
+    // classify/record/backoff/rethrow path instead of escaping to main().catch
+    // and tight-respawning (issue #2784).
+    const applyFeatureFlagStartup = async (): Promise<void> => {
+      await featureFlagService.initialize();
 
-    if (!navigationScreenshots) {
-      await featureFlagService.setFlag("navigation-screenshots", false);
-      logger.info("Navigation screenshots disabled (--no-navigation-screenshots)");
+      for (const [key, enabled, flagLabel, config] of cliOverrides) {
+        if (!enabled) {
+          continue;
+        }
+        await featureFlagService.setFlag(key, true, config);
+        logger.info(`Feature flag enabled (${flagLabel})`);
+      }
+
+      if (!navigationScreenshots) {
+        await featureFlagService.setFlag("navigation-screenshots", false);
+        logger.info("Navigation screenshots disabled (--no-navigation-screenshots)");
+      }
+    };
+
+    if (daemonMode) {
+      await guardDatabaseStartup(async () => {
+        await new DefaultDatabaseInitializer().initialize();
+        await applyFeatureFlagStartup();
+      });
+    } else {
+      await applyFeatureFlagStartup();
     }
 
     if (noWaitForPollingOverhead) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,6 +375,7 @@ async function main() {
   const { runDaemonCommand } = await import("./daemon/manager");
   const { startDaemon } = await import("./daemon/daemon");
   const { guardDatabaseStartup } = await import("./daemon/daemonStartupGuard");
+  const { DefaultDatabaseInitializer } = await import("./db/DatabaseInitializer");
   const videoRecordingSocketServer = await import("./daemon/videoRecordingSocketServer");
   const testRecordingSocketServer = await import("./daemon/testRecordingSocketServer");
   const deviceSnapshotSocketServer = await import("./daemon/deviceSnapshotSocketServer");
@@ -466,16 +467,21 @@ async function main() {
       IOSCtrlProxyBuilder.prefetchBuild();
     }
 
-    if (daemonMode) {
-      // Pre-flight the database under the startup circuit breaker BEFORE any
-      // DB-backed service (feature flags below) touches it. Otherwise a permanent
-      // DB/migration failure surfaces in FeatureFlagService.initialize() and exits
-      // via main().catch before the daemon's own fatal handler can record it or
-      // back off — re-spawning in a tight loop (issue #2784).
-      await guardDatabaseStartup();
-    }
-
     const featureFlagService = FeatureFlagService.getInstance();
+    if (daemonMode) {
+      // Run ALL early DB-backed startup work under the circuit breaker BEFORE
+      // Daemon.start(): both migrations AND FeatureFlagService's ensureFlags/
+      // listFlags queries. Otherwise a permanent DB failure (failed migration, or
+      // a migrated-but-missing/malformed feature_flags table) surfaces via
+      // main().catch and exits before the daemon's own fatal handler can record
+      // it or back off — re-spawning in a tight loop (issue #2784).
+      await guardDatabaseStartup(async () => {
+        await new DefaultDatabaseInitializer().initialize();
+        await featureFlagService.initialize();
+      });
+    }
+    // Idempotent: a no-op in daemon mode (already initialized inside the guard),
+    // and the real initialization for the stdio MCP-server path.
     await featureFlagService.initialize();
 
     const accessibilityConfig = a11yAuditMode

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,6 +374,7 @@ async function main() {
   const { runCliCommand } = await import("./cli");
   const { runDaemonCommand } = await import("./daemon/manager");
   const { startDaemon } = await import("./daemon/daemon");
+  const { guardDatabaseStartup } = await import("./daemon/daemonStartupGuard");
   const videoRecordingSocketServer = await import("./daemon/videoRecordingSocketServer");
   const testRecordingSocketServer = await import("./daemon/testRecordingSocketServer");
   const deviceSnapshotSocketServer = await import("./daemon/deviceSnapshotSocketServer");
@@ -463,6 +464,15 @@ async function main() {
     if (process.platform === "darwin") {
       await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup();
       IOSCtrlProxyBuilder.prefetchBuild();
+    }
+
+    if (daemonMode) {
+      // Pre-flight the database under the startup circuit breaker BEFORE any
+      // DB-backed service (feature flags below) touches it. Otherwise a permanent
+      // DB/migration failure surfaces in FeatureFlagService.initialize() and exits
+      // via main().catch before the daemon's own fatal handler can record it or
+      // back off — re-spawning in a tight loop (issue #2784).
+      await guardDatabaseStartup();
     }
 
     const featureFlagService = FeatureFlagService.getInstance();

--- a/src/utils/appearance/AppearanceSyncScheduler.ts
+++ b/src/utils/appearance/AppearanceSyncScheduler.ts
@@ -44,9 +44,19 @@ class AppearanceSyncScheduler {
       return this.pending;
     }
 
-    this.pending = this.tick().finally(() => {
-      this.pending = null;
-    });
+    // Best-effort background sync: swallow all errors here so a failed appearance
+    // read (a transient DB error, or a missing/malformed appearance_configs row)
+    // never floats an unhandledRejection from the fire-and-forget callers
+    // (`void this.trigger()` in the interval and Daemon.start()). A host-
+    // appearance-sync hiccup must not crash an otherwise-healthy daemon into a
+    // restart loop (issue #2784).
+    this.pending = this.tick()
+      .catch(error => {
+        logger.warn(`[Appearance] Host sync tick failed: ${error}`);
+      })
+      .finally(() => {
+        this.pending = null;
+      });
 
     return this.pending;
   }

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -93,4 +93,5 @@ export const TEMP_SUBDIRS = {
   OBSERVE_RESULTS: "observe_results",
   WINDOW: "window",
   CACHE: "cache",
+  STATE: "state",
 } as const;

--- a/test/daemon/daemonDatabaseInitFailure.test.ts
+++ b/test/daemon/daemonDatabaseInitFailure.test.ts
@@ -80,7 +80,7 @@ describe("Daemon.initializeDatabase fatality", () => {
     expect(tracker.resetCalls).toBe(0);
   });
 
-  test("successful startup resolves, runs cache cleanup, and resets the failure tracker", async () => {
+  test("successful DB bring-up resolves and runs cache cleanup without resetting the breaker", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const initializer = new FakeDatabaseInitializer();
@@ -92,7 +92,10 @@ describe("Daemon.initializeDatabase fatality", () => {
     expect(initializer.initializeCalls).toBe(1);
     expect(deviceSessionRepository.markStaleCalls).toBe(1);
     expect(tracker.recorded).toHaveLength(0);
-    expect(tracker.resetCalls).toBe(1);
+    // Reset happens only at the END of start() (after all startup DB reads),
+    // not here — a later permanent failure recorded before its fatal exit must
+    // not be erased by a bring-up that merely got past migrations (issue #2784).
+    expect(tracker.resetCalls).toBe(0);
   });
 
   test("permanent failures back off with increasing delay to avoid a restart hot-loop", async () => {

--- a/test/daemon/daemonDatabaseInitFailure.test.ts
+++ b/test/daemon/daemonDatabaseInitFailure.test.ts
@@ -117,12 +117,11 @@ describe("Daemon.initializeDatabase fatality", () => {
     await expect((daemon as unknown as DaemonInternals).initializeDatabase()).rejects.toBeInstanceOf(ActionableError);
     const afterThird = [...timer.getSleepHistory()];
 
-    // First failure did not park.
+    // First failure did not park; subsequent failures park with the concrete
+    // exponentialBackoff tiers (count 2 -> 1000ms, count 3 -> 2000ms).
     expect(afterFirst).toEqual([]);
-    // Subsequent failures parked, with the delay strictly increasing (bounded loop).
-    expect(afterSecond.length).toBe(1);
-    expect(afterThird.length).toBe(2);
-    expect(afterThird[1]!).toBeGreaterThan(afterThird[0]!);
+    expect(afterSecond).toEqual([1000]);
+    expect(afterThird).toEqual([1000, 2000]);
   });
 
   test("transient failures do not park (fast restart to clear a locked file)", async () => {

--- a/test/daemon/daemonDatabaseInitFailure.test.ts
+++ b/test/daemon/daemonDatabaseInitFailure.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { ActionableError } from "../../src/models/ActionableError";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeDatabaseInitializer } from "../fakes/FakeDatabaseInitializer";
+import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
+
+/**
+ * Issue #2784: startup DB/migration failure must be FATAL — `initializeDatabase()`
+ * (awaited first thing in `start()`, before any server is opened) must REJECT so
+ * `main().catch` → `process.exit(1)` restarts a clean daemon, instead of a
+ * query-dead daemon reporting healthy.
+ */
+class SpyDeviceSessionRepository extends DeviceSessionRepository {
+  markStaleCalls = 0;
+  private failure: unknown = null;
+
+  failWith(error: unknown): void {
+    this.failure = error;
+  }
+
+  override async markStaleActiveSessionsExpired(): Promise<void> {
+    this.markStaleCalls += 1;
+    if (this.failure !== null) {
+      throw this.failure;
+    }
+  }
+}
+
+interface DaemonInternals {
+  initializeDatabase(): Promise<void>;
+}
+
+function buildDaemon(overrides: {
+  initializer: FakeDatabaseInitializer;
+  tracker: FakeStartupFailureTracker;
+  timer: FakeTimer;
+  deviceSessionRepository?: SpyDeviceSessionRepository;
+  installedAppsRepository?: FakeInstalledAppsRepository;
+}): { daemon: Daemon; deviceSessionRepository: SpyDeviceSessionRepository; installedAppsRepository: FakeInstalledAppsRepository } {
+  const deviceSessionRepository = overrides.deviceSessionRepository ?? new SpyDeviceSessionRepository();
+  const installedAppsRepository = overrides.installedAppsRepository ?? new FakeInstalledAppsRepository();
+  const daemon = new Daemon(
+    {},
+    installedAppsRepository,
+    overrides.timer,
+    deviceSessionRepository,
+    new CountingIdGenerator("daemon-session"),
+    overrides.initializer,
+    overrides.tracker
+  );
+  return { daemon, deviceSessionRepository, installedAppsRepository };
+}
+
+describe("Daemon.initializeDatabase fatality", () => {
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("rejects (does not swallow) when startup migrations fail", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const initializer = new FakeDatabaseInitializer(
+      new Error("Database startup migrations failed; refusing to run queries until the daemon restarts.")
+    );
+    const tracker = new FakeStartupFailureTracker();
+    tracker.setCounts([1]);
+    const { daemon } = buildDaemon({ initializer, tracker, timer });
+
+    await expect((daemon as unknown as DaemonInternals).initializeDatabase()).rejects.toBeInstanceOf(ActionableError);
+    expect(initializer.initializeCalls).toBe(1);
+    expect(tracker.recorded).toHaveLength(1);
+    expect(tracker.recorded[0]!.kind).toBe("permanent");
+    expect(tracker.resetCalls).toBe(0);
+  });
+
+  test("successful startup resolves, runs cache cleanup, and resets the failure tracker", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const initializer = new FakeDatabaseInitializer();
+    const tracker = new FakeStartupFailureTracker();
+    const { daemon, deviceSessionRepository } = buildDaemon({ initializer, tracker, timer });
+
+    await (daemon as unknown as DaemonInternals).initializeDatabase();
+
+    expect(initializer.initializeCalls).toBe(1);
+    expect(deviceSessionRepository.markStaleCalls).toBe(1);
+    expect(tracker.recorded).toHaveLength(0);
+    expect(tracker.resetCalls).toBe(1);
+  });
+
+  test("permanent failures back off with increasing delay to avoid a restart hot-loop", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const initializer = new FakeDatabaseInitializer(new Error("database disk image is malformed"));
+    const tracker = new FakeStartupFailureTracker();
+    // First permanent failure: no backoff (quick restart in case it was a fluke).
+    // Second and third: increasing backoff.
+    tracker.setCounts([1, 2, 3]);
+    const { daemon } = buildDaemon({ initializer, tracker, timer });
+
+    await expect((daemon as unknown as DaemonInternals).initializeDatabase()).rejects.toBeInstanceOf(ActionableError);
+    const afterFirst = [...timer.getSleepHistory()];
+
+    await expect((daemon as unknown as DaemonInternals).initializeDatabase()).rejects.toBeInstanceOf(ActionableError);
+    const afterSecond = [...timer.getSleepHistory()];
+
+    await expect((daemon as unknown as DaemonInternals).initializeDatabase()).rejects.toBeInstanceOf(ActionableError);
+    const afterThird = [...timer.getSleepHistory()];
+
+    // First failure did not park.
+    expect(afterFirst).toEqual([]);
+    // Subsequent failures parked, with the delay strictly increasing (bounded loop).
+    expect(afterSecond.length).toBe(1);
+    expect(afterThird.length).toBe(2);
+    expect(afterThird[1]!).toBeGreaterThan(afterThird[0]!);
+  });
+
+  test("transient failures do not park (fast restart to clear a locked file)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const initializer = new FakeDatabaseInitializer(new Error("SQLITE_BUSY: database is locked"));
+    const tracker = new FakeStartupFailureTracker();
+    tracker.setCounts([5]); // even at a high count, transient does not back off
+    const { daemon } = buildDaemon({ initializer, tracker, timer });
+
+    await expect((daemon as unknown as DaemonInternals).initializeDatabase()).rejects.toBeInstanceOf(ActionableError);
+
+    expect(timer.getSleepHistory()).toEqual([]);
+    expect(tracker.recorded[0]!.kind).toBe("transient");
+  });
+
+  test("a non-migration query failure during cache cleanup is also fatal", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const initializer = new FakeDatabaseInitializer(); // DB opens fine
+    const deviceSessionRepository = new SpyDeviceSessionRepository();
+    deviceSessionRepository.failWith(new Error("SQLITE_BUSY: database is locked"));
+    const tracker = new FakeStartupFailureTracker();
+    const { daemon } = buildDaemon({ initializer, tracker, timer, deviceSessionRepository });
+
+    await expect((daemon as unknown as DaemonInternals).initializeDatabase()).rejects.toBeInstanceOf(ActionableError);
+    expect(tracker.recorded).toHaveLength(1);
+    expect(tracker.resetCalls).toBe(0);
+  });
+});

--- a/test/daemon/daemonStartupFailureTracker.test.ts
+++ b/test/daemon/daemonStartupFailureTracker.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { DefaultStartupFailureTracker } from "../../src/daemon/DaemonStartupFailureTracker";
+
+describe("DefaultStartupFailureTracker", () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  test("persists an escalating count across independent tracker instances (fresh processes)", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "am-breaker-"));
+    const filePath = path.join(tempDir, "failures.json");
+
+    // Each new instance models a fresh respawned process reading the same file.
+    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 1_000)).toBe(1);
+    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 2_000)).toBe(2);
+    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 3_000)).toBe(3);
+  });
+
+  test("drops failures older than the rolling window", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "am-breaker-"));
+    const filePath = path.join(tempDir, "failures.json");
+    const windowMs = 5_000;
+
+    expect(new DefaultStartupFailureTracker(filePath, windowMs).recordFailure("permanent", 1_000)).toBe(1);
+    // 10s later — the first failure has aged out of the 5s window.
+    expect(new DefaultStartupFailureTracker(filePath, windowMs).recordFailure("permanent", 11_000)).toBe(1);
+  });
+
+  test("reset clears persisted state", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "am-breaker-"));
+    const filePath = path.join(tempDir, "failures.json");
+
+    const tracker = new DefaultStartupFailureTracker(filePath);
+    tracker.recordFailure("permanent", 1_000);
+    expect(existsSync(filePath)).toBe(true);
+    tracker.reset();
+    expect(existsSync(filePath)).toBe(false);
+    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 2_000)).toBe(1);
+  });
+
+  test("throttles when persistence itself fails (unwritable state dir)", () => {
+    // A path whose parent cannot be created (a file used as a directory segment)
+    // forces the write to fail; the tracker must still report a backoff-triggering
+    // count so a permanent failure does not hot-loop at count 1 forever.
+    const unwritable = path.join("/dev/null", "failures.json");
+    const tracker = new DefaultStartupFailureTracker(unwritable);
+
+    expect(tracker.recordFailure("permanent", 1_000)).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/test/daemon/daemonStartupFailureTracker.test.ts
+++ b/test/daemon/daemonStartupFailureTracker.test.ts
@@ -1,59 +1,75 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import path from "path";
-import { mkdtemp, rm } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { DefaultStartupFailureTracker } from "../../src/daemon/DaemonStartupFailureTracker";
+import { describe, expect, test } from "bun:test";
+import {
+  DefaultStartupFailureTracker,
+  type StartupFailureStore,
+} from "../../src/daemon/DaemonStartupFailureTracker";
+
+/**
+ * In-memory store modeling cross-process persistence: state survives across
+ * tracker instances (fresh respawned processes read the same backing store).
+ */
+class InMemoryStore implements StartupFailureStore {
+  data: string | null = null;
+  read(): string | null {
+    return this.data;
+  }
+  write(value: string): void {
+    this.data = value;
+  }
+  clear(): void {
+    this.data = null;
+  }
+}
+
+/** A store whose writes always fail — models an unwritable state directory. */
+class UnwritableStore implements StartupFailureStore {
+  read(): string | null {
+    return null;
+  }
+  write(): void {
+    throw new Error("EACCES: permission denied");
+  }
+  clear(): void {
+    // no-op
+  }
+}
 
 describe("DefaultStartupFailureTracker", () => {
-  let tempDir: string | undefined;
-
-  afterEach(async () => {
-    if (tempDir) {
-      await rm(tempDir, { recursive: true, force: true });
-      tempDir = undefined;
-    }
+  test("persists an escalating count across independent tracker instances (fresh processes)", () => {
+    const store = new InMemoryStore();
+    expect(new DefaultStartupFailureTracker(store).recordFailure("permanent", 1_000)).toBe(1);
+    expect(new DefaultStartupFailureTracker(store).recordFailure("permanent", 2_000)).toBe(2);
+    expect(new DefaultStartupFailureTracker(store).recordFailure("permanent", 3_000)).toBe(3);
   });
 
-  test("persists an escalating count across independent tracker instances (fresh processes)", async () => {
-    tempDir = await mkdtemp(path.join(tmpdir(), "am-breaker-"));
-    const filePath = path.join(tempDir, "failures.json");
-
-    // Each new instance models a fresh respawned process reading the same file.
-    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 1_000)).toBe(1);
-    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 2_000)).toBe(2);
-    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 3_000)).toBe(3);
-  });
-
-  test("drops failures older than the rolling window", async () => {
-    tempDir = await mkdtemp(path.join(tmpdir(), "am-breaker-"));
-    const filePath = path.join(tempDir, "failures.json");
+  test("drops failures older than the rolling window", () => {
+    const store = new InMemoryStore();
     const windowMs = 5_000;
-
-    expect(new DefaultStartupFailureTracker(filePath, windowMs).recordFailure("permanent", 1_000)).toBe(1);
+    expect(new DefaultStartupFailureTracker(store, windowMs).recordFailure("permanent", 1_000)).toBe(1);
     // 10s later — the first failure has aged out of the 5s window.
-    expect(new DefaultStartupFailureTracker(filePath, windowMs).recordFailure("permanent", 11_000)).toBe(1);
+    expect(new DefaultStartupFailureTracker(store, windowMs).recordFailure("permanent", 11_000)).toBe(1);
   });
 
-  test("reset clears persisted state", async () => {
-    tempDir = await mkdtemp(path.join(tmpdir(), "am-breaker-"));
-    const filePath = path.join(tempDir, "failures.json");
-
-    const tracker = new DefaultStartupFailureTracker(filePath);
+  test("reset clears persisted state", () => {
+    const store = new InMemoryStore();
+    const tracker = new DefaultStartupFailureTracker(store);
     tracker.recordFailure("permanent", 1_000);
-    expect(existsSync(filePath)).toBe(true);
+    expect(store.data).not.toBeNull();
     tracker.reset();
-    expect(existsSync(filePath)).toBe(false);
-    expect(new DefaultStartupFailureTracker(filePath).recordFailure("permanent", 2_000)).toBe(1);
+    expect(store.data).toBeNull();
+    expect(new DefaultStartupFailureTracker(store).recordFailure("permanent", 2_000)).toBe(1);
+  });
+
+  test("ignores corrupt persisted contents (treats as no prior failures)", () => {
+    const store = new InMemoryStore();
+    store.data = "not-json{";
+    expect(new DefaultStartupFailureTracker(store).recordFailure("permanent", 1_000)).toBe(1);
   });
 
   test("throttles when persistence itself fails (unwritable state dir)", () => {
-    // A path whose parent cannot be created (a file used as a directory segment)
-    // forces the write to fail; the tracker must still report a backoff-triggering
-    // count so a permanent failure does not hot-loop at count 1 forever.
-    const unwritable = path.join("/dev/null", "failures.json");
-    const tracker = new DefaultStartupFailureTracker(unwritable);
-
+    // A permanent failure whose escalation cannot be persisted must still report a
+    // backoff-triggering count so it does not hot-loop at count 1 forever.
+    const tracker = new DefaultStartupFailureTracker(new UnwritableStore());
     expect(tracker.recordFailure("permanent", 1_000)).toBeGreaterThanOrEqual(2);
   });
 });

--- a/test/daemon/daemonStartupGuard.test.ts
+++ b/test/daemon/daemonStartupGuard.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { ActionableError } from "../../src/models/ActionableError";
+import { guardDatabaseStartup, handleFatalDatabaseStartupFailure } from "../../src/daemon/daemonStartupGuard";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDatabaseInitializer } from "../fakes/FakeDatabaseInitializer";
+import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
+
+/**
+ * The shared guard runs BEFORE any DB-backed service in `--daemon-mode` (issue
+ * #2784): in `main()` the first DB touch is `FeatureFlagService.initialize()`,
+ * which would otherwise exit via `main().catch` before the daemon's own fatal
+ * handler could record the failure or back off — re-spawning in a tight loop.
+ */
+describe("guardDatabaseStartup", () => {
+  test("resolves and resets the tracker when the database comes up cleanly", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const initializer = new FakeDatabaseInitializer();
+    const tracker = new FakeStartupFailureTracker();
+
+    await guardDatabaseStartup(initializer, tracker, timer);
+
+    expect(initializer.initializeCalls).toBe(1);
+    expect(tracker.resetCalls).toBe(1);
+    expect(tracker.recorded).toHaveLength(0);
+  });
+
+  test("rethrows an ActionableError (fatal) when the early DB touch fails", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const initializer = new FakeDatabaseInitializer(new Error("database disk image is malformed"));
+    const tracker = new FakeStartupFailureTracker();
+    tracker.setCounts([1]);
+
+    await expect(guardDatabaseStartup(initializer, tracker, timer)).rejects.toBeInstanceOf(ActionableError);
+    expect(tracker.recorded[0]!.kind).toBe("permanent");
+    expect(tracker.resetCalls).toBe(0);
+  });
+
+  test("permanent failures escalate backoff to avoid a restart hot-loop", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const tracker = new FakeStartupFailureTracker();
+
+    // First permanent failure: no park (allow a quick restart in case of a fluke).
+    await expect(
+      handleFatalDatabaseStartupFailure(new Error("file is not a database"), tracker, timer)
+    ).rejects.toBeInstanceOf(ActionableError);
+    expect(timer.getSleepHistory()).toEqual([]);
+
+    // Later permanent failures park with a strictly increasing delay.
+    tracker.setCounts([2, 3]);
+    await expect(
+      handleFatalDatabaseStartupFailure(new Error("file is not a database"), tracker, timer)
+    ).rejects.toBeInstanceOf(ActionableError);
+    const afterSecond = [...timer.getSleepHistory()];
+    await expect(
+      handleFatalDatabaseStartupFailure(new Error("file is not a database"), tracker, timer)
+    ).rejects.toBeInstanceOf(ActionableError);
+    const afterThird = [...timer.getSleepHistory()];
+
+    expect(afterSecond).toHaveLength(1);
+    expect(afterThird).toHaveLength(2);
+    expect(afterThird[1]!).toBeGreaterThan(afterThird[0]!);
+  });
+
+  test("transient failures never park (fast restart to clear a locked file)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const tracker = new FakeStartupFailureTracker();
+    tracker.setCounts([9]);
+
+    await expect(
+      handleFatalDatabaseStartupFailure(new Error("SQLITE_BUSY: database is locked"), tracker, timer)
+    ).rejects.toBeInstanceOf(ActionableError);
+
+    expect(timer.getSleepHistory()).toEqual([]);
+    expect(tracker.recorded[0]!.kind).toBe("transient");
+  });
+});

--- a/test/daemon/daemonStartupGuard.test.ts
+++ b/test/daemon/daemonStartupGuard.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { ActionableError } from "../../src/models/ActionableError";
-import { guardDatabaseStartup, handleFatalDatabaseStartupFailure } from "../../src/daemon/daemonStartupGuard";
+import {
+  guardDatabaseStartup,
+  handleFatalDatabaseStartupFailure,
+  MAX_STARTUP_BACKOFF_MS,
+} from "../../src/daemon/daemonStartupGuard";
+import { DAEMON_STARTUP_TIMEOUT_MS } from "../../src/daemon/constants";
+import { DefaultStartupFailureTracker } from "../../src/daemon/DaemonStartupFailureTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDatabaseInitializer } from "../fakes/FakeDatabaseInitializer";
 import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
@@ -58,7 +64,10 @@ describe("guardDatabaseStartup", () => {
     ).rejects.toBeInstanceOf(ActionableError);
     expect(timer.getSleepHistory()).toEqual([]);
 
-    // Later permanent failures park with a strictly increasing delay.
+    // Later permanent failures park with the concrete exponentialBackoff tiers
+    // (1000ms * 2^(attempt-1)): count 2 -> 1000ms, count 3 -> 2000ms. Asserting
+    // the exact values catches an accidental multiplier/initial-delay change that
+    // a "strictly increasing" check would miss.
     tracker.setCounts([2, 3]);
     await expect(
       handleFatalDatabaseStartupFailure(new Error("file is not a database"), tracker, timer)
@@ -69,9 +78,46 @@ describe("guardDatabaseStartup", () => {
     ).rejects.toBeInstanceOf(ActionableError);
     const afterThird = [...timer.getSleepHistory()];
 
-    expect(afterSecond).toHaveLength(1);
-    expect(afterThird).toHaveLength(2);
-    expect(afterThird[1]!).toBeGreaterThan(afterThird[0]!);
+    expect(afterSecond).toEqual([1000]);
+    expect(afterThird).toEqual([1000, 2000]);
+  });
+
+  test("backoff is capped strictly below the daemon startup timeout", async () => {
+    // A sleep >= DAEMON_STARTUP_TIMEOUT_MS would be truncated: DaemonManager
+    // reports startup failure at that timeout and the next spawn SIGTERMs the
+    // still-sleeping child, so the backoff would never actually throttle.
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const tracker = new FakeStartupFailureTracker();
+    tracker.setCounts([50]); // far past the cap tier
+
+    await expect(
+      handleFatalDatabaseStartupFailure(new Error("file is not a database"), tracker, timer)
+    ).rejects.toBeInstanceOf(ActionableError);
+
+    const [delay] = timer.getSleepHistory();
+    expect(delay).toBe(MAX_STARTUP_BACKOFF_MS);
+    expect(delay!).toBeLessThan(DAEMON_STARTUP_TIMEOUT_MS);
+  });
+
+  test("an unpersistable permanent failure still parks (throttle wiring end-to-end)", async () => {
+    // Real tracker + a store whose writes fail: recordFailure() must return a
+    // backoff-triggering count so the handler actually sleeps, not just return >=2.
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const tracker = new DefaultStartupFailureTracker({
+      read: () => null,
+      write: () => {
+        throw new Error("EACCES: permission denied");
+      },
+      clear: () => {},
+    });
+
+    await expect(
+      handleFatalDatabaseStartupFailure(new Error("file is not a database"), tracker, timer)
+    ).rejects.toBeInstanceOf(ActionableError);
+
+    expect(timer.getSleepHistory()).toEqual([1000]);
   });
 
   test("transient failures never park (fast restart to clear a locked file)", async () => {

--- a/test/daemon/daemonStartupGuard.test.ts
+++ b/test/daemon/daemonStartupGuard.test.ts
@@ -12,27 +12,37 @@ import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
  * handler could record the failure or back off — re-spawning in a tight loop.
  */
 describe("guardDatabaseStartup", () => {
-  test("resolves and resets the tracker when the database comes up cleanly", async () => {
+  test("resolves without resetting the tracker when the early DB work succeeds", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const initializer = new FakeDatabaseInitializer();
     const tracker = new FakeStartupFailureTracker();
 
-    await guardDatabaseStartup(initializer, tracker, timer);
+    await guardDatabaseStartup(async () => {
+      await initializer.initialize();
+    }, tracker, timer);
 
     expect(initializer.initializeCalls).toBe(1);
-    expect(tracker.resetCalls).toBe(1);
+    // Reset must NOT happen here — only after the ENTIRE daemon startup DB path
+    // (Daemon.initializeDatabase cleanup) succeeds, or a later recorded permanent
+    // failure would be erased by the next launch's preflight success.
+    expect(tracker.resetCalls).toBe(0);
     expect(tracker.recorded).toHaveLength(0);
   });
 
-  test("rethrows an ActionableError (fatal) when the early DB touch fails", async () => {
+  test("rethrows an ActionableError (fatal) when any guarded DB work fails", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
-    const initializer = new FakeDatabaseInitializer(new Error("database disk image is malformed"));
     const tracker = new FakeStartupFailureTracker();
     tracker.setCounts([1]);
 
-    await expect(guardDatabaseStartup(initializer, tracker, timer)).rejects.toBeInstanceOf(ActionableError);
+    await expect(
+      guardDatabaseStartup(async () => {
+        // Simulates a migrated-but-malformed feature_flags table query failing
+        // during FeatureFlagService.initialize(), not just a migration failure.
+        throw new Error("database disk image is malformed");
+      }, tracker, timer)
+    ).rejects.toBeInstanceOf(ActionableError);
     expect(tracker.recorded[0]!.kind).toBe("permanent");
     expect(tracker.resetCalls).toBe(0);
   });

--- a/test/db/databaseFailureClassification.test.ts
+++ b/test/db/databaseFailureClassification.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { classifyDatabaseFailure } from "../../src/db/databaseFailureClassification";
+
+describe("classifyDatabaseFailure", () => {
+  test("classifies a locked/busy sqlite file as transient", () => {
+    expect(classifyDatabaseFailure(new Error("SQLITE_BUSY: database is locked"))).toBe("transient");
+    expect(classifyDatabaseFailure(new Error("database is locked"))).toBe("transient");
+  });
+
+  test("classifies EBUSY/EAGAIN file contention as transient", () => {
+    expect(classifyDatabaseFailure(new Error("EBUSY: resource busy or locked"))).toBe("transient");
+    expect(classifyDatabaseFailure(new Error("EAGAIN: resource temporarily unavailable"))).toBe("transient");
+  });
+
+  test("classifies a temporarily full disk as transient", () => {
+    expect(classifyDatabaseFailure(new Error("ENOSPC: no space left on device"))).toBe("transient");
+  });
+
+  test("classifies a corrupt/malformed database as permanent", () => {
+    expect(classifyDatabaseFailure(new Error("database disk image is malformed"))).toBe("permanent");
+    expect(classifyDatabaseFailure(new Error("file is not a database"))).toBe("permanent");
+  });
+
+  test("classifies a deterministic migration throw as permanent", () => {
+    expect(classifyDatabaseFailure(new Error("migration 0007 failed: column already exists"))).toBe("permanent");
+  });
+
+  test("defaults unknown failures to permanent (fail safe against hot loops)", () => {
+    expect(classifyDatabaseFailure("weird string")).toBe("permanent");
+    expect(classifyDatabaseFailure(undefined)).toBe("permanent");
+  });
+});

--- a/test/db/databaseFailureClassification.test.ts
+++ b/test/db/databaseFailureClassification.test.ts
@@ -12,8 +12,9 @@ describe("classifyDatabaseFailure", () => {
     expect(classifyDatabaseFailure(new Error("EAGAIN: resource temporarily unavailable"))).toBe("transient");
   });
 
-  test("classifies a temporarily full disk as transient", () => {
-    expect(classifyDatabaseFailure(new Error("ENOSPC: no space left on device"))).toBe("transient");
+  test("classifies a full disk as permanent (ENOSPC needs external cleanup, reproduces on respawn)", () => {
+    expect(classifyDatabaseFailure(new Error("ENOSPC: no space left on device"))).toBe("permanent");
+    expect(classifyDatabaseFailure(new Error("SQLITE_FULL: database or disk is full"))).toBe("permanent");
   });
 
   test("classifies a corrupt/malformed database as permanent", () => {

--- a/test/db/databaseMigrationFailure.test.ts
+++ b/test/db/databaseMigrationFailure.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+
+/**
+ * Verifies the cached-error migration contract that issue #2784 depends on and
+ * that #2786 (kill the floating rejection) shares:
+ *
+ *  - a startup migration failure is CACHED (`migrationsError`) and the internal
+ *    `migrationsPromise` RESOLVES rather than floating a rejection, so nothing
+ *    trips an `unhandledRejection` on the way to the fatal exit;
+ *  - `ensureMigrations()` re-checks the cached error and RETHROWS after the await,
+ *    so the fatality this issue relies on survives the resolved-promise model.
+ *
+ * A directory is used as the DB path so opening the sqlite file fails
+ * deterministically (a permanent-style failure), exercised through a fresh module
+ * instance so the module globals are isolated from other tests.
+ */
+describe("database startup migration failure contract", () => {
+  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
+  let tempDir: string | undefined;
+
+  function restore(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  afterEach(async () => {
+    restore("AUTOMOBILE_DB_PATH", originalDbPath);
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  async function importFreshDatabaseModule() {
+    return import(`../../src/db/database.ts?migration-failure-test=${Date.now()}-${Math.random()}`);
+  }
+
+  test("ensureMigrations rethrows the cached startup error without floating a rejection", async () => {
+    // Point the DB path at a directory so opening the sqlite file fails.
+    tempDir = await mkdtemp(path.join(tmpdir(), "am-db-fail-"));
+    process.env.AUTOMOBILE_DB_PATH = tempDir; // a directory, not a file
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const db = await importFreshDatabaseModule();
+
+      await expect(db.ensureMigrations()).rejects.toThrow(
+        /refusing to run queries until the daemon restarts/i
+      );
+
+      // The failure is cached and observable synchronously after the await.
+      const cached = db.getMigrationsError();
+      expect(cached).toBeInstanceOf(Error);
+      expect(String(cached?.message)).toMatch(/refusing to run queries until the daemon restarts/i);
+
+      // A second await still rejects (stable dead state, not auto-retried).
+      await expect(db.ensureMigrations()).rejects.toThrow(
+        /refusing to run queries until the daemon restarts/i
+      );
+
+      // Give any stray microtasks a tick to surface an unhandled rejection.
+      await defaultTimer.sleep(10);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/test/db/deviceSessionRepository.test.ts
+++ b/test/db/deviceSessionRepository.test.ts
@@ -220,4 +220,15 @@ describe("DeviceSessionRepository", () => {
       sessionManager.stopCleanupTimer();
     }
   });
+
+  test("markStaleActiveSessionsExpired propagates DB errors (startup fatal, not swallowed)", async () => {
+    // A missing/malformed device_sessions table means a broken DB; the startup
+    // path relies on this rejecting so the circuit breaker can go fatal + back
+    // off (issue #2784) rather than starting with broken session state.
+    await db.schema.dropTable("device_sessions").execute();
+
+    await expect(
+      repo.markStaleActiveSessionsExpired("current-daemon", 5000, "daemon-restart")
+    ).rejects.toThrow();
+  });
 });

--- a/test/fakes/FakeDatabaseInitializer.ts
+++ b/test/fakes/FakeDatabaseInitializer.ts
@@ -1,0 +1,31 @@
+import type { DatabaseInitializer } from "../../src/db/DatabaseInitializer";
+
+/**
+ * Fake DatabaseInitializer for daemon startup tests.
+ *
+ * Configure it to resolve (successful bring-up) or to reject with a specific
+ * error (migration/DB-open failure) without touching a real sqlite file.
+ */
+export class FakeDatabaseInitializer implements DatabaseInitializer {
+  initializeCalls = 0;
+  private nextError: unknown = null;
+
+  constructor(error?: unknown) {
+    this.nextError = error ?? null;
+  }
+
+  failWith(error: unknown): void {
+    this.nextError = error;
+  }
+
+  succeed(): void {
+    this.nextError = null;
+  }
+
+  async initialize(): Promise<void> {
+    this.initializeCalls += 1;
+    if (this.nextError !== null) {
+      throw this.nextError;
+    }
+  }
+}

--- a/test/fakes/FakeStartupFailureTracker.ts
+++ b/test/fakes/FakeStartupFailureTracker.ts
@@ -1,0 +1,28 @@
+import type { StartupFailureTracker } from "../../src/daemon/DaemonStartupFailureTracker";
+import type { DatabaseFailureKind } from "../../src/db/databaseFailureClassification";
+
+/**
+ * In-memory fake of the cross-process startup failure tracker.
+ *
+ * `recordFailure` returns a caller-controlled count so tests can drive the
+ * circuit-breaker/backoff path deterministically without a real file.
+ */
+export class FakeStartupFailureTracker implements StartupFailureTracker {
+  readonly recorded: Array<{ kind: DatabaseFailureKind; now: number }> = [];
+  resetCalls = 0;
+  private counts: number[] = [];
+
+  /** Queue the counts `recordFailure` will return, in order. */
+  setCounts(counts: number[]): void {
+    this.counts = [...counts];
+  }
+
+  recordFailure(kind: DatabaseFailureKind, now: number): number {
+    this.recorded.push({ kind, now });
+    return this.counts.length > 0 ? this.counts.shift()! : this.recorded.length;
+  }
+
+  reset(): void {
+    this.resetCalls += 1;
+  }
+}

--- a/test/utils/appearance/appearanceSyncSchedulerResilience.test.ts
+++ b/test/utils/appearance/appearanceSyncSchedulerResilience.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Issue #2784: the appearance sync is a best-effort background task started via
+ * fire-and-forget `void this.trigger()` in Daemon.start() and on an interval. A
+ * failed appearance read (transient DB error, or a missing/malformed
+ * appearance_configs row) must NOT float an unhandledRejection that crashes an
+ * otherwise-healthy daemon into a restart loop — trigger() must swallow it.
+ */
+describe("AppearanceSyncScheduler resilience", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("triggerAppearanceSync resolves (does not reject) when the config read fails", async () => {
+    mock.module("../../../src/server/appearanceManager", () => ({
+      getAppearanceConfig: async () => {
+        throw new Error("no such table: appearance_configs");
+      },
+      resolveAppearanceMode: async () => "dark",
+    }));
+
+    const { triggerAppearanceSync } = await import(
+      `../../../src/utils/appearance/AppearanceSyncScheduler.ts?resilience=${Date.now()}-${Math.random()}`
+    );
+
+    // If trigger() re-threw, this await would reject and fail the test.
+    await expect(triggerAppearanceSync()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`Daemon.initializeDatabase()` swallowed errors and never awaited migrations, so a startup migration failure (corrupt DB, unwritable data dir, disk-full, a migration that throws) left the daemon a **zombie**: `start()` proceeded to open the HTTP + Unix-socket servers, the health check (which only probes `httpServer.listening`/socket) reported **HEALTHY**, and every DB-backed feature silently failed for the daemon's whole lifetime. No crash, no restart, no signal to the process manager.

This makes startup DB/migration failure **fatal** so `start()` rejects → `main().catch` (`src/index.ts`) → `process.exit(1)`, letting the process manager restart a clean daemon.

Closes #2784.

## What changed

**`src/db/database.ts` — single cached-error delivery contract (co-designed with #2786 / #2796)**
- New module global `migrationsError`. On a failed startup migration, `migrationsPromise` now **RESOLVES** (caching the error) instead of floating a rejection that could trip `unhandledRejection` before the fatal path runs (#2786).
- `ensureMigrations()` and the `beforeQuery` hook (`waitForMigrationsBeforeQuery`) **re-check `migrationsError` and rethrow** after the await, so fatality survives the resolved-promise model.
- The failure is **sticky**: `migrationsPromise` is never nulled to auto-retry (shared invariant with #2786/#2796).
- Exports `getMigrationsError()` and `DATABASE_STARTUP_MIGRATION_FAILURE`.

**`src/db/databaseFailureClassification.ts` — transient vs permanent**
- `classifyDatabaseFailure()`: `transient` (locked/`SQLITE_BUSY`/`EBUSY`/`EAGAIN`/`ENOSPC`) vs `permanent` (corrupt/malformed, deterministic migration throw). Defaults to `permanent` (fail-safe: unknown failures get backoff protection).

**`src/db/DatabaseInitializer.ts` — injectable DB bring-up**
- `DatabaseInitializer` interface + `DefaultDatabaseInitializer` (`getDatabase()` then `await ensureMigrations()`), so startup DB failure is testable with a fake instead of a real sqlite file.

**`src/daemon/DaemonStartupFailureTracker.ts` — crash-loop circuit breaker**
- File-backed, cross-process tracker of recent fatal-startup failures within a rolling 5-min window (the daemon exits and is re-spawned as a fresh process each time, so the count must persist to disk to survive the restart). Corrupt/unreadable tracker files degrade gracefully to "no prior failures".

**`src/daemon/daemon.ts` — `initializeDatabase()`**
- `await this.databaseInitializer.initialize()` (+ cache-cleanup repo calls) in a try; on failure: classify → record → single fatal `logger.error` → rethrow `ActionableError`. Successful startup calls `startupFailureTracker.reset()`.
- **No hot-loop on permanent failure:** a *permanent* failure that keeps reproducing parks with an increasing exponential backoff (via the shared `Backoff` primitive, `initialDelayMs: 1000`, `maxDelayMs: 60_000`) before the fatal exit, converging to a stable low-frequency dead state. *Transient* failures exit fast so the next launch retries immediately.
- Health timer gains a **read-only, non-blocking** DB-liveness probe that checks the cached `migrationsError` only — no `SELECT 1`, so it never blocks behind an in-flight EXCLUSIVE graph-write transaction on the single shared connection (#2791).

## Acceptance criteria coverage

- ✅ Startup migration failure → `initializeDatabase()`/`start()` **rejects** (servers never opened); single fatal log line with the underlying cause.
- ✅ Successful startup path unchanged: resolves, runs cache cleanup, listens exactly as before (regression assertion).
- ✅ No crash-loop on permanent failure: increasing backoff via `Backoff`; transient does not park.
- ✅ Failure classification (transient vs permanent); a non-migration query failure in `clearOldDaemonSessions`/`markStaleActiveSessionsExpired` is also fatal (test covered).
- ✅ Composition with #2786: `ensureMigrations()` rethrows the cached `migrationsError` even though `migrationsPromise` resolves; no floating `unhandledRejection` (test asserts none fires).
- ✅ DB-liveness probe checks `migrationsError` (not a settled-rejected promise), read-only/non-transactional.

## Tests (TDD — written before implementation)

- `test/db/databaseFailureClassification.test.ts` — classification matrix.
- `test/db/databaseMigrationFailure.test.ts` — forces a real migration failure (DB path → a directory) via a fresh module instance; asserts `ensureMigrations()` rethrows the cached error, `getMigrationsError()` is set, and **no `unhandledRejection` fires**.
- `test/daemon/daemonDatabaseInitFailure.test.ts` — fatality, success/reset, permanent backoff escalation, transient no-park, and non-migration query failure fatality (fakes + `FakeTimer`).
- New fakes: `test/fakes/FakeDatabaseInitializer.ts`, `test/fakes/FakeStartupFailureTracker.ts`.

## How it was validated

- `bun test` on touched files — 12 pass.
- `turbo run lint build test` — green (5414 pass, 2 pre-existing skips).

## Notes / follow-ups

- This lands the #2784-anchored slice of the shared DB-lifecycle contract; the `migrationsError` cache also resolves #2786's floating-rejection facet. #2796 (reset on `closeDatabase`) and #2785 (refuse-to-auto-heal corrupt DB) remain separate but compose cleanly with the sticky, non-retrying failure state here.