### PR TITLE
fix(android): make unsubscribe_storage actually unsubscribe (resolve subscriptionId)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -64,8 +64,8 @@ import kotlinx.serialization.json.Json
  * @param actions the device actions to dispatch to (the [CtrlProxy] service in production, a fake
  *   in tests).
  * @param log diagnostic sink for the few requests with no wired action (an ahead-of-need request
- *   type, or a storage message the device can't resolve). Defaults to a no-op so tests stay
- *   Android-free; production wires it to `Log`.
+ *   type, or a malformed storage message the device can't resolve). Defaults to a no-op so tests
+ *   stay Android-free; production wires it to `Log`.
  */
 class CtrlProxyMessageHandler(
     private val actions: CtrlProxyActions,
@@ -194,12 +194,26 @@ class CtrlProxyMessageHandler(
       is UnsubscribeStorage -> {
         val packageName = request.packageName
         val fileName = request.fileName
-        if (packageName != null && fileName != null) {
-          actions.unsubscribeStorage(request.requestId, packageName, fileName)
-        } else {
-          // Pre-existing behavior: the TS client sends only `subscriptionId`, so the device cannot
-          // resolve packageName/fileName and the unsubscribe is a no-op. Tracked as a follow-up.
-          log("unsubscribe_storage received subscriptionId=${request.subscriptionId} without packageName/fileName; ignoring")
+        val subscriptionId = request.subscriptionId
+        when {
+          packageName != null && fileName != null ->
+              actions.unsubscribeStorage(request.requestId, packageName, fileName)
+          // Real TS traffic sends only `subscriptionId`, formatted as "packageName:fileName" by
+          // StorageSubscriptionManager.subscribe(). Package names never contain ':', so split on the
+          // FIRST ':' to recover packageName/fileName (a file name could theoretically contain ':').
+          subscriptionId != null -> {
+            val separator = subscriptionId.indexOf(':')
+            if (separator > 0 && separator < subscriptionId.length - 1) {
+              actions.unsubscribeStorage(
+                  request.requestId,
+                  subscriptionId.substring(0, separator),
+                  subscriptionId.substring(separator + 1),
+              )
+            } else {
+              log("unsubscribe_storage received malformed subscriptionId=$subscriptionId; ignoring")
+            }
+          }
+          else -> log("unsubscribe_storage received without subscriptionId or packageName/fileName; ignoring")
         }
       }
       is GetPreference ->

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -352,14 +352,38 @@ class CtrlProxyMessageHandlerTest {
   }
 
   @Test
-  fun `unsubscribe_storage with only subscriptionId is a no-op matching the TS wire`() = runTest {
+  fun `unsubscribe_storage with only subscriptionId resolves packageName and fileName`() = runTest {
+    // Real TS traffic sends only the subscriptionId ("packageName:fileName"). The handler must split
+    // it and dispatch the unsubscribe so the device actually tears down the subscription.
     dispatch(
         """{"type":"unsubscribe_storage","requestId":"unsub1","subscriptionId":"com.example:settings.xml"}"""
     )
-    assertTrue("no action should fire without packageName/fileName", calls.isEmpty())
+    assertEquals(
+        "unsubscribeStorage" to listOf<Any?>("unsub1", "com.example", "settings.xml"),
+        lastCall,
+    )
+    assertTrue("no diagnostic log expected for a resolvable subscriptionId", logs.isEmpty())
+  }
+
+  @Test
+  fun `unsubscribe_storage splits subscriptionId on the first colon only`() = runTest {
+    // subscriptionId = "packageName:fileName"; a file name may itself contain ':', so only the first
+    // ':' delimits packageName from fileName.
+    dispatch(
+        """{"type":"unsubscribe_storage","requestId":"unsub3","subscriptionId":"com.example:weird:name.xml"}"""
+    )
+    assertEquals(
+        "unsubscribeStorage" to listOf<Any?>("unsub3", "com.example", "weird:name.xml"),
+        lastCall,
+    )
+  }
+
+  @Test
+  fun `unsubscribe_storage with a malformed subscriptionId is a logged no-op`() = runTest {
+    dispatch("""{"type":"unsubscribe_storage","requestId":"unsub4","subscriptionId":"nocolon"}""")
+    assertTrue("no action should fire for an unsplittable subscriptionId", calls.isEmpty())
     assertEquals(1, logs.size)
-    assertTrue(logs[0], logs[0].contains("unsubscribe_storage"))
-    assertTrue(logs[0], logs[0].contains("subscriptionId=com.example:settings.xml"))
+    assertTrue(logs[0], logs[0].contains("malformed subscriptionId=nocolon"))
   }
 
   @Test
@@ -509,7 +533,7 @@ class CtrlProxyMessageHandlerTest {
   @Test
   fun `handleMessage returns null for every command (fire-and-forget)`() = runTest {
     // A spread across categories, including the branches that do extra work: shape conversion,
-    // rule re-encoding, the ahead-of-need type, recording, and the storage no-op.
+    // rule re-encoding, the ahead-of-need type, recording, and the subscriptionId-only unsubscribe.
     val messages =
         listOf(
             """{"type":"request_screenshot","requestId":"s1"}""",

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -310,9 +310,9 @@ data class SubscribeStorage(
 data class UnsubscribeStorage(
   override val requestId: String? = null,
   // The TS client sends only `subscriptionId` (formatted as "packageName:fileName"); packageName
-  // and fileName are kept nullable so the real wire message decodes without throwing. The device
-  // handler needs packageName/fileName, so when only subscriptionId is present the request is a
-  // no-op (matching the pre-migration behavior). See CtrlProxyMessageHandler for details.
+  // and fileName are kept nullable so the real wire message decodes without throwing. When only
+  // subscriptionId is present, CtrlProxyMessageHandler splits it on the first ':' to recover
+  // packageName/fileName before dispatching the unsubscribe. See CtrlProxyMessageHandler for details.
   val subscriptionId: String? = null,
   val packageName: String? = null,
   val fileName: String? = null,


### PR DESCRIPTION
## Problem

`unsubscribe_storage` never actually unsubscribed. This is a pre-existing latent bug that predates and was deliberately preserved by the typed-handler migration in #2771.

- The TS client (`src/features/observe/android/CtrlProxyStorage.ts`) sends `unsubscribe_storage` with only `{ type, requestId, subscriptionId }` — never `packageName`/`fileName`. The `subscriptionId` is formatted `"packageName:fileName"` (created device-side in `StorageSubscriptionManager.subscribe()`).
- The device dispatch (`CtrlProxyMessageHandler`, `is UnsubscribeStorage ->`) required both `packageName` and `fileName`; when absent (always, for real traffic) it logged and no-oped.
- Result: the device **never** unsubscribed, and the TS `resultPromise` only resolved via **timeout** — every `unsubscribeStorage` call hung until `timeoutMs`.

## Fix

Device-side (Option 1 — smaller, self-contained, keeps the wire stable): in the `UnsubscribeStorage` dispatch, when `packageName`/`fileName` are absent but `subscriptionId` is present, split it on the **first** `:` into `packageName`/`fileName` and dispatch the unsubscribe. Package names never contain `:`; a file name theoretically could, so only the first `:` delimits (matching `subscriptionId = "$packageName:$fileName"`). A genuinely malformed id (no usable split) stays a logged no-op.

- Updated the now-stale no-op / tracked-follow-up comments in `CtrlProxyMessageHandler.kt` and `WebSocketRequest.kt`.

## Tests

`CtrlProxyMessageHandlerTest`:
- subscriptionId-only message resolves `packageName`/`fileName` and invokes the action (proves unsubscribe actually fires)
- first-`:`-only split (`com.example:weird:name.xml` → `com.example` / `weird:name.xml`)
- malformed subscriptionId (no colon) is a logged no-op

Run with JDK 21 (default JDK 26 breaks Robolectric):

```
JAVA_HOME=.../azul-21.0.9/Contents/Home android/gradlew -p android :control-proxy:test :protocol:test
```

`BUILD SUCCESSFUL` — `CtrlProxyMessageHandlerTest`: 55 tests, 0 failures.