### PR TITLE
fix(android): complete storage subscription lifecycle + dedupe subscriptionId parsing

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
+import dev.jasonpearson.automobile.ctrlproxy.storage.StorageSubscription
 import dev.jasonpearson.automobile.protocol.AddHighlight
 import dev.jasonpearson.automobile.protocol.ClearPreferences
 import dev.jasonpearson.automobile.protocol.GetCurrentFocus
@@ -198,17 +199,13 @@ class CtrlProxyMessageHandler(
         when {
           packageName != null && fileName != null ->
               actions.unsubscribeStorage(request.requestId, packageName, fileName)
-          // Real TS traffic sends only `subscriptionId`, formatted as "packageName:fileName" by
-          // StorageSubscriptionManager.subscribe(). Package names never contain ':', so split on the
-          // FIRST ':' to recover packageName/fileName (a file name could theoretically contain ':').
+          // Real TS traffic sends only `subscriptionId` (formatted "packageName:fileName" by
+          // StorageSubscriptionManager.subscribe()). StorageSubscription.parseId is the single
+          // canonical inverse of that format — see its doc for the first-colon rationale.
           subscriptionId != null -> {
-            val separator = subscriptionId.indexOf(':')
-            if (separator > 0 && separator < subscriptionId.length - 1) {
-              actions.unsubscribeStorage(
-                  request.requestId,
-                  subscriptionId.substring(0, separator),
-                  subscriptionId.substring(separator + 1),
-              )
+            val parts = StorageSubscription.parseId(subscriptionId)
+            if (parts != null) {
+              actions.unsubscribeStorage(request.requestId, parts.first, parts.second)
             } else {
               log("unsubscribe_storage received malformed subscriptionId=$subscriptionId; ignoring")
             }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageModels.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageModels.kt
@@ -8,7 +8,26 @@ data class StorageSubscription(
     val packageName: String,
     val fileName: String,
     val subscriptionId: String = "$packageName:$fileName",
-)
+) {
+  companion object {
+    /**
+     * Inverts the [subscriptionId] format back into its `(packageName, fileName)` parts. This is the
+     * single canonical parse for the `"$packageName:$fileName"` format built above — both the
+     * inbound `unsubscribe_storage` dispatch (which receives only a subscriptionId from the TS
+     * client) and [StorageSubscriptionManager.destroy] resolve ids through here, so the format lives
+     * in one place.
+     *
+     * Package names never contain `:`, so the FIRST `:` delimits packageName from fileName (a file
+     * name could theoretically contain `:`). Returns null when [subscriptionId] has no `:` or an
+     * empty package/file segment — i.e. it could not have been produced by a real subscription.
+     */
+    fun parseId(subscriptionId: String): Pair<String, String>? {
+      val separator = subscriptionId.indexOf(':')
+      if (separator <= 0 || separator >= subscriptionId.length - 1) return null
+      return subscriptionId.substring(0, separator) to subscriptionId.substring(separator + 1)
+    }
+  }
+}
 
 /** Information about a SharedPreferences file. */
 @Serializable

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
@@ -464,11 +464,11 @@ class StorageSubscriptionManager(
 
   /** Cleans up all subscriptions and observers. Call when the service is destroyed. */
   fun destroy() {
-    // Unsubscribe from all
+    // Unsubscribe from all. Resolve ids through the same canonical parse the inbound
+    // unsubscribe_storage dispatch uses, so the "packageName:fileName" format has one inverse.
     subscriptions.keys.toList().forEach { subscriptionId ->
-      val parts = subscriptionId.split(":", limit = 2)
-      if (parts.size == 2) {
-        unsubscribe(parts[0], parts[1])
+      StorageSubscription.parseId(subscriptionId)?.let { (packageName, fileName) ->
+        unsubscribe(packageName, fileName)
       }
     }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -387,6 +387,38 @@ class CtrlProxyMessageHandlerTest {
   }
 
   @Test
+  fun `unsubscribe_storage rejects an empty package or file segment as malformed`() = runTest {
+    // A real subscription can never have an empty package or file, so these are unsplittable.
+    dispatch("""{"type":"unsubscribe_storage","requestId":"unsub5","subscriptionId":":settings.xml"}""")
+    dispatch("""{"type":"unsubscribe_storage","requestId":"unsub6","subscriptionId":"com.example:"}""")
+    assertTrue("no action should fire for an empty-segment subscriptionId", calls.isEmpty())
+    assertEquals(2, logs.size)
+    assertTrue(logs[0], logs[0].contains("malformed subscriptionId=:settings.xml"))
+    assertTrue(logs[1], logs[1].contains("malformed subscriptionId=com.example:"))
+  }
+
+  @Test
+  fun `unsubscribe_storage prefers explicit packageName and fileName over subscriptionId`() =
+      runTest {
+        // If a client ever sends both, the explicit fields are authoritative over the parsed id.
+        dispatch(
+            """{"type":"unsubscribe_storage","requestId":"unsub7","subscriptionId":"other.pkg:other.xml","packageName":"com.example","fileName":"settings.xml"}"""
+        )
+        assertEquals(
+            "unsubscribeStorage" to listOf<Any?>("unsub7", "com.example", "settings.xml"),
+            lastCall,
+        )
+      }
+
+  @Test
+  fun `unsubscribe_storage without any identifier is a logged no-op`() = runTest {
+    dispatch("""{"type":"unsubscribe_storage","requestId":"unsub8"}""")
+    assertTrue("no action should fire without any identifier", calls.isEmpty())
+    assertEquals(1, logs.size)
+    assertTrue(logs[0], logs[0].contains("without subscriptionId or packageName/fileName"))
+  }
+
+  @Test
   fun `unsubscribe_storage with packageName and fileName invokes the action`() = runTest {
     dispatch(
         """{"type":"unsubscribe_storage","requestId":"unsub2","packageName":"com.example","fileName":"settings.xml"}"""

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionTest.kt
@@ -1,0 +1,56 @@
+package dev.jasonpearson.automobile.ctrlproxy.storage
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [StorageSubscription.parseId], the single canonical inverse of the
+ * `"$packageName:$fileName"` subscriptionId format. Pure JVM — no Android, no Robolectric.
+ *
+ * This helper is shared by the inbound `unsubscribe_storage` dispatch and
+ * [StorageSubscriptionManager.destroy], so pinning its behavior here guarantees both sites agree.
+ */
+class StorageSubscriptionTest {
+
+  @Test
+  fun `parseId inverts the format subscribe builds`() {
+    // subscribe() sets subscriptionId = "$packageName:$fileName" by default.
+    val subscription = StorageSubscription("com.example", "settings.xml")
+    assertEquals("com.example:settings.xml", subscription.subscriptionId)
+    assertEquals(
+        "com.example" to "settings.xml",
+        StorageSubscription.parseId(subscription.subscriptionId),
+    )
+  }
+
+  @Test
+  fun `parseId splits on the first colon only`() {
+    // A file name may itself contain ':'; only the first ':' delimits packageName from fileName.
+    assertEquals(
+        "com.example" to "weird:name.xml",
+        StorageSubscription.parseId("com.example:weird:name.xml"),
+    )
+  }
+
+  @Test
+  fun `parseId returns null when there is no colon`() {
+    assertNull(StorageSubscription.parseId("nocolon"))
+  }
+
+  @Test
+  fun `parseId returns null for an empty package segment`() {
+    assertNull(StorageSubscription.parseId(":settings.xml"))
+  }
+
+  @Test
+  fun `parseId returns null for an empty file segment`() {
+    assertNull(StorageSubscription.parseId("com.example:"))
+  }
+
+  @Test
+  fun `parseId returns null for a lone colon and empty string`() {
+    assertNull(StorageSubscription.parseId(":"))
+    assertNull(StorageSubscription.parseId(""))
+  }
+}

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -375,7 +375,10 @@ interface WsSubscribeStorageResultMessage extends WsMessageBase {
   type: "subscribe_storage_result";
   requestId: string;
   success?: boolean;
-  subscription?: StorageSubscription;
+  // The device sends the subscription as flat fields, not a nested `subscription` object.
+  packageName?: string;
+  fileName?: string;
+  subscriptionId?: string;
   totalTimeMs?: number;
 }
 
@@ -2222,8 +2225,19 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       }
 
       if (message.type === "subscribe_storage_result" && message.requestId) {
+        // Android sends flat packageName/fileName/subscriptionId fields, not a nested `subscription`
+        // object (like preference_files/preferences above). Rebuild the subscription from them so
+        // the awaiting subscribeStorage() promise gets a usable StorageSubscription.
+        const subscription =
+          message.success && message.subscriptionId
+            ? {
+              packageName: message.packageName ?? "",
+              fileName: message.fileName ?? "",
+              subscriptionId: message.subscriptionId
+            }
+            : undefined;
         this.requestManager.resolve(message.requestId, {
-          success: message.success ?? false, subscription: message.subscription,
+          success: message.success ?? false, subscription,
           totalTimeMs: message.totalTimeMs ?? 0, error: message.error
         });
       }

--- a/test/features/observe/android/CtrlProxyStorage.test.ts
+++ b/test/features/observe/android/CtrlProxyStorage.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
+import { NavigationGraphManager } from "../../../../src/features/navigation/NavigationGraphManager";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
+import { BootedDevice } from "../../../../src/models";
+import { FakeWebSocket, WebSocketState } from "../../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+/**
+ * End-to-end WebSocket round-trip tests for the storage subscribe/unsubscribe lifecycle on the
+ * Android CtrlProxy client. These pin the wire contract between the device (which emits flat
+ * packageName/fileName/subscriptionId fields) and the TS client (which awaits a resolved promise),
+ * so a timeout-only resolution or a dropped field is caught here.
+ */
+describe("CtrlProxyStorage (Android)", function() {
+  let fakeAdb: FakeAdbExecutor;
+  let testDevice: BootedDevice;
+  let fakeTimer: FakeTimer;
+  const serverPort: number = 8765;
+
+  beforeEach(function() {
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setCommandResponse("forward", { stdout: `${serverPort}`, stderr: "" });
+    fakeAdb.setScreenState(true);
+
+    testDevice = {
+      deviceId: "test-device-storage",
+      platform: "android",
+      isEmulator: true,
+      name: "Test Device"
+    };
+
+    AndroidCtrlProxyManager.resetInstances();
+    AndroidCtrlProxyClient.resetInstances();
+    AndroidCtrlProxyManager.getInstance(testDevice, new FakeAdbClientFactory()).clearAvailabilityCache();
+  });
+
+  afterEach(function() {
+    NavigationGraphManager.getInstance();
+  });
+
+  class CapturingWebSocket extends FakeWebSocket {
+    sentMessages: string[] = [];
+    send(data: any): void {
+      this.sentMessages.push(data.toString());
+      super.send(data);
+    }
+  }
+
+  const createCapturingFactory = (timer?: FakeTimer): {
+    factory: (url: string) => CapturingWebSocket;
+    getSocket: () => CapturingWebSocket | null;
+  } => {
+    let socket: CapturingWebSocket | null = null;
+    return {
+      factory: (url: string) => {
+        socket = new CapturingWebSocket(url, "none", 0, timer);
+        return socket;
+      },
+      getSocket: () => socket
+    };
+  };
+
+  const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
+    if (!socket || socket.readyState === WebSocketState.OPEN) {return;}
+    await new Promise<void>(resolve => socket.once("open", () => resolve()));
+  };
+
+  const waitForSocket = async (getSocket: () => CapturingWebSocket | null): Promise<CapturingWebSocket | null> => {
+    for (let i = 0; i < 5; i++) {
+      const s = getSocket();
+      if (s) {return s;}
+      await new Promise(r => setImmediate(r));
+    }
+    return getSocket();
+  };
+
+  const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount = 1): Promise<void> => {
+    if (!socket) {return;}
+    for (let i = 0; i < 10; i++) {
+      if (socket.sentMessages.length >= minCount) {return;}
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  const findSentMessage = (socket: CapturingWebSocket, type: string): any => {
+    for (let i = socket.sentMessages.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(socket.sentMessages[i]);
+        if (parsed.type === type) {return parsed;}
+      } catch {
+        // skip non-JSON control frames
+      }
+    }
+    throw new Error(`No message of type ${type} in: ${socket.sentMessages.join(", ")}`);
+  };
+
+  describe("subscribeStorage", function() {
+    test("resolves with a subscription rebuilt from the device's flat result fields", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.subscribeStorage("com.example", "settings.xml");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "subscribe_storage");
+        expect(sent.packageName).toBe("com.example");
+        expect(sent.fileName).toBe("settings.xml");
+
+        // The device emits flat fields (no nested `subscription` object).
+        socket!.simulateMessage(JSON.stringify({
+          type: "subscribe_storage_result",
+          requestId: sent.requestId,
+          success: true,
+          packageName: "com.example",
+          fileName: "settings.xml",
+          subscriptionId: "com.example:settings.xml",
+          totalTimeMs: 5,
+        }));
+
+        const subscription = await resultPromise;
+        expect(subscription.subscriptionId).toBe("com.example:settings.xml");
+        expect(subscription.packageName).toBe("com.example");
+        expect(subscription.fileName).toBe("settings.xml");
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects when the device reports failure", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.subscribeStorage("com.example", "settings.xml");
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket!, "subscribe_storage");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "subscribe_storage_result",
+          requestId: sent.requestId,
+          success: false,
+          packageName: "com.example",
+          fileName: "settings.xml",
+          error: "SDK not installed",
+        }));
+
+        await expect(resultPromise).rejects.toThrow("SDK not installed");
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  describe("unsubscribeStorage", function() {
+    test("sends the subscriptionId and resolves on the device's result", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.unsubscribeStorage("com.example:settings.xml");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "unsubscribe_storage");
+        expect(sent.subscriptionId).toBe("com.example:settings.xml");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "unsubscribe_storage_result",
+          requestId: sent.requestId,
+          success: true,
+          packageName: "com.example",
+          fileName: "settings.xml",
+          totalTimeMs: 3,
+        }));
+
+        // Resolves (does not hang until timeout) — this is the bug the device-side fix repairs.
+        await expect(resultPromise).resolves.toBeUndefined();
+      } finally {
+        await client.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #2830 (merged). A three-perspective review of the storage subscribe/unsubscribe round trip surfaced findings beyond the merged unsubscribe fix; this PR addresses them.

## Finding A — consistency (the code #2830 touched)
The `"packageName:fileName"` subscriptionId format was parsed by **two divergent idioms**:
- the `unsubscribe_storage` dispatch used `indexOf` + a guard that **rejects** empty segments;
- `StorageSubscriptionManager.destroy()` used `split(":", limit=2)` that **accepts** them.

Same format, two behaviors — a latent drift. Introduced a single canonical inverse, `StorageSubscription.parseId()`, next to where the id is built, and routed **both** the dispatch and `destroy()` through it. One format, one parse.

## Finding B — pre-existing bug that blocked the whole feature
The device broadcasts `subscribe_storage_result` with **flat** `packageName`/`fileName`/`subscriptionId` fields ([CtrlProxy.kt:5768-5773](https://github.com/kaeawc/auto-mobile/blob/main/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt)), but `AndroidCtrlProxyClient` read a nested `message.subscription` object that is **never sent**. So `subscribeStorage()` always hit `if (!result.subscription) throw` and no `subscriptionId` could ever be obtained — making unsubscribe unreachable via the intended subscribe→unsubscribe flow. Now the subscription is rebuilt from the flat fields, matching the sibling `preference_files`/`preferences` handlers.

## Finding C — considered, intentionally not changed
`StorageSubscriptionManager.unsubscribe()` returns `false` for an untracked subscription, which surfaces as a thrown "Failed to unsubscribe" on the TS side. This is a **documented, tested contract** (`unsubscribe returns false when not subscribed`) with **no production callers**, and only "regresses" from the always-timeout bug #2830 fixed. Throwing on an untracked unsubscribe is defensible, so it's left as-is rather than expanding contract surface here.

## Tests
- **`StorageSubscriptionTest`** (pure JVM): `parseId` for normal / first-colon-only / no-colon / empty-package / empty-file / lone-colon / empty-string.
- **`CtrlProxyMessageHandlerTest`**: added empty-segment rejection, explicit-fields-over-subscriptionId precedence, and no-identifier no-op.
- **`CtrlProxyStorage.test.ts`** (Android, new): subscribe rebuilds the subscription from flat fields (regression for B), subscribe rejects on device failure, and unsubscribe round-trips to resolution (no timeout).

Local: `bun test` (storage/observe suites) green; `:control-proxy:test` + `:protocol:test` green under JDK 21; `turbo run lint build` clean.