### PR TITLE
fix(ios): make XCTestRunner iOS observe/CtrlProxy reliable in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1274,6 +1274,18 @@ jobs:
           cd ios/XCTestRunner
           swift test --filter RemindersLaunchPlanTests 2>&1
 
+      # Daemon-internal logs (CtrlProxy attach/teardown, observe timing) are the
+      # only way to diagnose iOS observe failures — the swift-test stdout doesn't
+      # include them. Upload always so we can see why observe timed out.
+      - name: "Upload AutoMobile daemon logs"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: automobile-daemon-logs-xctestrunner
+          path: ~/.auto-mobile/logs/
+          if-no-files-found: ignore
+          retention-days: 7
+
   ios-spm-root-package-build:
     name: "Build Root SPM Package"
     runs-on: macos-26

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1174,11 +1174,13 @@ jobs:
     # break it while the pure-Swift build jobs skip on src-only changes.
     if: needs.detect-changes.outputs.ios_integration_should_run == 'true'
     timeout-minutes: 45
-    # CI's XCUITest cold-start routinely exceeds the default CtrlProxy health-poll
-    # budget; give the daemon a generous window (240 × 500ms = 120s) so it doesn't
-    # give up (and then kill+respawn) a runner that is still coming up (#2834).
+    # CI's XCUITest cold-start routinely exceeds the defaults; give the daemon a
+    # generous health-poll window (240 × 500ms = 120s) so it doesn't give up (and
+    # then kill+respawn) a runner still coming up, and let an `observe` request wait
+    # (150s > 120s) for that cold start instead of aborting at the 30s default (#2834).
     env:
       AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS: "240"
+      AUTOMOBILE_OBSERVE_MCP_TIMEOUT_MS: "150000"
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -277,6 +277,9 @@ jobs:
               - 'schemas/**'
               - 'ios/**'
               - 'scripts/ios/**'
+              # The XCTestRunner job runs these readiness scripts directly, so
+              # changes to them must exercise the job (they were skipped before).
+              - 'scripts/ci/**'
               - 'package.json'
               - 'bun.lock'
 
@@ -1274,15 +1277,18 @@ jobs:
           cd ios/XCTestRunner
           swift test --filter RemindersLaunchPlanTests 2>&1
 
-      # Daemon-internal logs (CtrlProxy attach/teardown, observe timing) are the
-      # only way to diagnose iOS observe failures — the swift-test stdout doesn't
-      # include them. Upload always so we can see why observe timed out.
+      # Daemon-internal logs (CtrlProxy startup/health/observe timing) are the only
+      # way to diagnose iOS observe failures — the swift-test stdout doesn't include
+      # them. Upload on failure only (they aren't needed on green runs, and this
+      # avoids publishing env/path details from passing runs). `include-hidden-files`
+      # is required because the logs live under the dot-dir ~/.auto-mobile.
       - name: "Upload AutoMobile daemon logs"
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: automobile-daemon-logs-xctestrunner
           path: ~/.auto-mobile/logs/
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1237,6 +1237,9 @@ jobs:
       # so the test's first `observe` doesn't pay that cost inside its short
       # waitFor window and time out (#2730 follow-up).
       - name: "Warm up iOS CtrlProxy"
+        # Worst case ≈ 3 × (observe floor 150s + delay); bound the step so a
+        # pathological hang points here instead of at the 45-min job cap.
+        timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
       - name: "Run Reminders integration tests (Xcode 26.2)"
@@ -1274,6 +1277,7 @@ jobs:
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       - name: "Warm up iOS CtrlProxy (Xcode 26.3)"
+        timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
       - name: "Run Reminders integration tests (Xcode 26.3)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1174,6 +1174,11 @@ jobs:
     # break it while the pure-Swift build jobs skip on src-only changes.
     if: needs.detect-changes.outputs.ios_integration_should_run == 'true'
     timeout-minutes: 45
+    # CI's XCUITest cold-start routinely exceeds the default CtrlProxy health-poll
+    # budget; give the daemon a generous window (240 × 500ms = 120s) so it doesn't
+    # give up (and then kill+respawn) a runner that is still coming up (#2834).
+    env:
+      AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS: "240"
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -41,16 +41,31 @@ export const DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS = 90_000;
 export const OPEN_LINK_MCP_TIMEOUT_ENV_VAR = "AUTOMOBILE_OPEN_LINK_MCP_TIMEOUT_MS";
 export const LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR = "AUTO_MOBILE_OPEN_LINK_MCP_TIMEOUT_MS";
 
-function resolveOpenLinkMcpTimeoutFloorMs(): number {
-  const raw = process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] ??
-    process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+/**
+ * Floor for `observe` — on iOS the first observe after a device becomes active
+ * lazily launches the CtrlProxy XCUITest runner and waits for its health endpoint,
+ * a cold start that routinely exceeds the default 30s window on a loaded CI machine
+ * (#2834). Aborting at 30s fails an observe whose runner is still coming up — and,
+ * worse, the retry then reclaims the port and kills the still-starting runner. Give
+ * observe the same generous floor as `launchApp` (which shares this dependency), and
+ * make it env-overridable so CI — where the health-poll budget is extended — can
+ * raise it in lockstep without a code change.
+ */
+export const DEFAULT_OBSERVE_MCP_TIMEOUT_MS = 90_000;
+export const OBSERVE_MCP_TIMEOUT_ENV_VAR = "AUTOMOBILE_OBSERVE_MCP_TIMEOUT_MS";
+export const LEGACY_OBSERVE_MCP_TIMEOUT_ENV_VAR = "AUTO_MOBILE_OBSERVE_MCP_TIMEOUT_MS";
+
+function resolveEnvTimeoutFloorMs(
+  primaryEnvVar: string,
+  legacyEnvVar: string,
+  fallbackMs: number
+): number {
+  const raw = process.env[primaryEnvVar] ?? process.env[legacyEnvVar];
   if (!raw) {
-    return DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS;
+    return fallbackMs;
   }
   const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0
-    ? parsed
-    : DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
 }
 
 function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undefined {
@@ -62,7 +77,17 @@ function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undef
     case "launchApp":
       return MIN_LAUNCH_APP_MCP_TIMEOUT_MS;
     case "openLink":
-      return resolveOpenLinkMcpTimeoutFloorMs();
+      return resolveEnvTimeoutFloorMs(
+        OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
+        LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
+        DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS
+      );
+    case "observe":
+      return resolveEnvTimeoutFloorMs(
+        OBSERVE_MCP_TIMEOUT_ENV_VAR,
+        LEGACY_OBSERVE_MCP_TIMEOUT_ENV_VAR,
+        DEFAULT_OBSERVE_MCP_TIMEOUT_MS
+      );
     default:
       return undefined;
   }

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -560,6 +560,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       // failure is transient (e.g. service just restarted by hot-reload). Skip the
       // full setup/download cycle — just reset attempts and retry the connection.
       const alreadyRunning = await manager.isRunning();
+      // Diagnostic: the decisive state for why a reused session's observe fails.
+      // alreadyRunning=false ⇒ the runner is gone since a prior session ⇒ a slow
+      // cold setup happens inside the caller's bounded waitFor. alreadyRunning=true
+      // ⇒ the runner lives and only the WebSocket needs re-opening (fast). (#2825)
+      logger.info(
+        `[IOSCtrlProxyClient] auto-setup decision: alreadyRunning(health)=${alreadyRunning}, ` +
+        `port=${this.port}, hadOpenWs=${!!this.ws}, device=${this.device.deviceId}`
+      );
       if (alreadyRunning) {
         logger.info(`[IOSCtrlProxyClient] Service is running but WebSocket failed — transient issue, retrying connection`);
         this.syncPortFromManager(manager);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -733,7 +733,21 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `[IOSCtrlProxy] Deferred-to CtrlProxy runner (PID ${hungPid}) never became ` +
             `healthy within ${timeoutSeconds}s; terminating it so the next start spawns a fresh runner`
           );
-          await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, hungPid);
+          if (this.useHostControl()) {
+            // The runner PID belongs to the macOS HOST, not this (Docker) container —
+            // a local kill would miss it (or signal an unrelated same-PID container
+            // process). Stop it through host control, matching stop() (#2834 review).
+            try {
+              await this.hostControl.stop({ deviceId: this.device.deviceId, pid: hungPid });
+            } catch (error) {
+              logger.warn(
+                `[IOSCtrlProxy] Host control stop of hung runner ${hungPid} failed: ` +
+                `${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+          } else {
+            await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, hungPid);
+          }
         } else {
           logger.warn(
             `[IOSCtrlProxy] Tracked runner PID ${hungPid} is no longer our CtrlProxy runner ` +

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -720,9 +720,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       //
       // Re-verify ownership right before the kill: the multi-minute health poll above is
       // a window in which our runner could exit and its PID be recycled to a foreign
-      // process. isOwnRunnerProcessAlive re-runs getProcessInfo + isOwnedCtrlProxyRunner
-      // Process on the tracked PID, so a recycled/foreign PID is no longer identified as
-      // ours and we skip the kill, only un-tracking (#2834 review — MINOR-1).
+      // process. Locally, isOwnRunnerProcessAlive re-runs getProcessInfo +
+      // isOwnedCtrlProxyRunnerProcess on the tracked PID, so a recycled/foreign PID is
+      // no longer identified as ours and we skip the kill, only un-tracking. Under host
+      // control the re-verify is PID-strict via `status.data.pid === tracked` — the
+      // host-control daemon resolves status/stop by deviceId BEFORE pid, so without the
+      // PID compare a NEWER runner for this device would alias as "ours" and the stop
+      // below could kill it (#2834 review). Residual accepted risk: the status→stop
+      // race (runner replaced between the two calls) — the daemon is the sole per-device
+      // orchestrator, so within one daemon that window is effectively empty; daemon-side
+      // pid-match enforcement is tracked as a follow-up.
       const hungPid = this.xcTestProcessId;
       const stillOurs = await this.isOwnRunnerProcessAlive();
       // Suppress the exit-handler auto-restart across the kill + child-exit event only.
@@ -746,7 +753,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
               );
             }
           } else {
-            await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, hungPid);
+            // Tree kill, not single-PID: the tracked PID is the shell wrapper, and
+            // signaling only it would orphan the xcodebuild child, which keeps the
+            // hung in-sim runner alive to be re-adopted or contend the port on the
+            // next start (#2834 review).
+            await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, hungPid);
           }
         } else {
           logger.warn(
@@ -757,10 +768,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         this.stopProcessMonitoring();
         this.xcTestProcessId = null;
         this.xcTestProcess = null;
+        // Host-control mode has no local child-exit event to clear these as a side
+        // effect (handleProcessExit), so clear explicitly for both modes — otherwise
+        // cachedRunning/cachedAvailability can serve a stale positive to the next
+        // setup() for up to STATUS_CACHE_TTL (#2834 review).
+        this.clearCaches();
       } finally {
         // Do NOT leave isStopping latched across the throw below (#2834 review — MINOR-2):
         // a caller that does not retry start() would otherwise wedge the manager in
         // "stopping", disabling handleProcessExit()/scheduleAutoRestart() self-heal.
+        // A late child-exit after this reset is ignored by the untracked-exit guard on
+        // the spawn handlers (xcTestProcess was nulled above).
         this.isStopping = false;
       }
     }
@@ -1178,9 +1196,20 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // this process by reading its env via `ps eww` (see findExternalXcodebuildCtrlProxyProcess
     // / isDaemonManagedSimulatorXcodebuildProcess).
     // Routed through the injected processExecutor so tests can observe/control the process.
-    const child = this.processExecutor.spawn(command, [], { shell: true, env: { ...process.env, ...runnerEnv }, stdio: ["ignore", "pipe", "pipe"] });
+    // detached:true makes the shell a process-group leader so terminateProcessTree can
+    // signal the whole group (`kill -- -pid`): under shell:true the tracked PID is the
+    // /bin/sh wrapper, and TERM to the shell alone does NOT propagate to the xcodebuild
+    // child (#2834 review) — group signaling reaches both. stdio pipes and the exit
+    // handler are unaffected by detachment.
+    const child = this.processExecutor.spawn(command, [], { shell: true, detached: true, env: { ...process.env, ...runnerEnv }, stdio: ["ignore", "pipe", "pipe"] });
 
     child.on("error", error => {
+      // Ignore events from a process we no longer track (e.g. hung-recovery already
+      // tore it down and cleared tracking) so a late error can't double-run cleanup
+      // or schedule an auto-restart of a deliberately-removed runner (#2834 review).
+      if (this.xcTestProcess !== child) {
+        return;
+      }
       logger.warn(`[IOSCtrlProxy] xcodebuild test error: ${error.message}`);
       this.handleProcessExit();
     });
@@ -1188,6 +1217,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     child.on("exit", (code, signal) => {
       if (code !== 0 || signal) {
         logger.warn(`[IOSCtrlProxy] xcodebuild test exited: code=${code}, signal=${signal}`);
+      }
+      // Same untracked-exit guard as the error handler: after hung-recovery (or stop())
+      // has already cleaned up and untracked this child, its late exit event must not
+      // re-enter handleProcessExit and race an auto-restart against the caller.
+      if (this.xcTestProcess !== child) {
+        return;
       }
       this.handleProcessExit();
     });
@@ -1408,7 +1443,13 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           deviceId: this.device.deviceId,
           pid: this.xcTestProcessId
         });
-        return status.success && (status.data?.running ?? false);
+        // PID-strict: the host-control daemon resolves status by deviceId BEFORE pid,
+        // so running=true alone is not proof the TRACKED pid is alive — a newer runner
+        // for the same device aliases it, and treating it as "ours" would make us wait
+        // on (and eventually stop) that newer runner (#2834 review).
+        return status.success &&
+          (status.data?.running ?? false) &&
+          status.data?.pid === this.xcTestProcessId;
       } catch {
         return false;
       }
@@ -1466,7 +1507,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           deviceId: this.device.deviceId,
           pid: this.xcTestProcessId
         });
-        return status.success && (status.data?.running ?? false);
+        // PID-strict for the same reason as isOwnRunnerProcessAlive: deviceId-first
+        // resolution in the host-control daemon means running=true may describe a
+        // NEWER runner, not the tracked one. On mismatch we return false and the
+        // host-control start path re-adopts the device's current runner via
+        // status({deviceId}) — the correct adoption point (#2834 review).
+        return status.success &&
+          (status.data?.running ?? false) &&
+          status.data?.pid === this.xcTestProcessId;
       } catch {
         return false;
       }
@@ -1827,6 +1875,36 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   private static isDirectCtrlProxyRunnerCommand(command: string): boolean {
     return command.includes("CtrlProxyUITests-Runner");
+  }
+
+  /**
+   * Terminate a runner process TREE rooted at `pid` (TERM → wait → KILL), signaling the
+   * process group first and falling back to the single PID. Under `spawn(..., {shell:
+   * true, detached: true})` the tracked PID is a /bin/sh group leader whose xcodebuild
+   * child does NOT die when only the shell is signaled (#2834 review) — the group signal
+   * (`kill -- -pid`) reaches both. The single-PID fallback covers processes that predate
+   * detachment (not group leaders) or whose group is already gone. Scoped to this tree —
+   * deliberately NOT a machine-wide pkill sweep, which would hit other devices' runners.
+   */
+  private static async terminateProcessTree(
+    processExecutor: ProcessExecutor,
+    timer: Timer,
+    pid: number
+  ): Promise<void> {
+    try {
+      await processExecutor.exec(`kill -TERM -- -${pid} 2>/dev/null || kill -TERM ${pid} 2>/dev/null`);
+    } catch {
+      // Process/group may have already exited.
+    }
+
+    if (!await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid)) {
+      try {
+        await processExecutor.exec(`kill -KILL -- -${pid} 2>/dev/null || kill -KILL ${pid} 2>/dev/null`);
+      } catch {
+        // Process/group may have exited between liveness check and kill.
+      }
+      await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid);
+    }
   }
 
   private static async terminateProcess(

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -233,6 +233,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private targetBundleId: string | null = null;
 
   public static readonly DEFAULT_PORT = 8765;
+  /** Health-poll attempts (× 500ms) awaiting the runner. 60 = 30s; env-overridable. */
+  private static readonly DEFAULT_HEALTH_POLL_MAX_ATTEMPTS = 60;
   public static readonly BUNDLE_ID = "dev.jasonpearson.automobile.ctrlproxy";
   public static readonly APP_BUNDLE_ID = "dev.jasonpearson.automobile.ctrlproxy";
   /** Bundle ID used before the rename to CtrlProxy — uninstalled opportunistically on device setup */
@@ -601,30 +603,44 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       // Check for externally-managed xcodebuild processes (e.g. hot-reload script)
       // before spawning our own to avoid conflicting xcodebuild instances.
       if (this.isSimulator()) {
-        perf.startOperation("externalProcessCheck");
-        const externalProcess = await this.findExternalCtrlProxyProcess();
-        const defaultPortIsHealthyForDevice = externalProcess === null &&
-          !this.useHostControl() &&
-          this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
-          await this.checkHealthEndpointOnPortForDevice(
-            IOSCtrlProxyManager.DEFAULT_PORT,
-            this.device.deviceId
-          );
-        perf.endOperation("externalProcessCheck");
-        if (externalProcess || defaultPortIsHealthyForDevice) {
-          const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
+        // A runner WE already spawned may still be mid-startup: on a loaded CI
+        // machine XCUITest can take well past the health-poll budget to answer, so
+        // an earlier setup() gave up and this call is a retry while the same runner
+        // is still coming up. Its PID is alive but its health endpoint isn't yet.
+        // Reclaiming the port here would SIGTERM that starting runner and restart
+        // the ~30-60s clock — a livelock under repeated setup calls (#2834). Skip
+        // the port-reclaim + respawn and just wait (below) for it to become healthy.
+        if (await this.isOwnRunnerProcessAlive()) {
           logger.info(
-            `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
+            `[IOSCtrlProxy] Own CtrlProxy runner (PID ${this.xcTestProcessId}) is still starting; ` +
+            `waiting for its health endpoint instead of respawning`
           );
-          if (externalPort !== this.servicePort) {
-            this.adoptServicePort(externalPort);
-          }
-          // Fall through to health polling below instead of spawning
         } else {
-          await this.ensureServicePortReadyForLaunch();
-          perf.startOperation("spawnRunner");
-          await this.startOnSimulator();
-          perf.endOperation("spawnRunner");
+          perf.startOperation("externalProcessCheck");
+          const externalProcess = await this.findExternalCtrlProxyProcess();
+          const defaultPortIsHealthyForDevice = externalProcess === null &&
+            !this.useHostControl() &&
+            this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
+            await this.checkHealthEndpointOnPortForDevice(
+              IOSCtrlProxyManager.DEFAULT_PORT,
+              this.device.deviceId
+            );
+          perf.endOperation("externalProcessCheck");
+          if (externalProcess || defaultPortIsHealthyForDevice) {
+            const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
+            logger.info(
+              `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
+            );
+            if (externalPort !== this.servicePort) {
+              this.adoptServicePort(externalPort);
+            }
+            // Fall through to health polling below instead of spawning
+          } else {
+            await this.ensureServicePortReadyForLaunch();
+            perf.startOperation("spawnRunner");
+            await this.startOnSimulator();
+            perf.endOperation("spawnRunner");
+          }
         }
       } else {
         perf.startOperation("spawnRunner");
@@ -633,10 +649,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
     }
 
-    // Wait for HTTP health endpoint to be ready
-    // XCUITest can take 10+ seconds to fully initialize after xcodebuild starts
-    const maxAttempts = 30;
+    // Wait for HTTP health endpoint to be ready. XCUITest can take well over 15s to
+    // fully initialize after xcodebuild starts on a loaded CI machine, so the budget
+    // is env-configurable (AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS) and defaults
+    // generous — too short a budget declares failure while the runner is still
+    // coming up, which then triggers a kill+respawn livelock (#2834).
     const delayMs = 500;
+    const maxAttempts = IOSCtrlProxyManager.resolveHealthPollMaxAttempts();
+    const timeoutSeconds = Math.round((maxAttempts * delayMs) / 1000);
 
     perf.startOperation("healthPolling");
     for (let i = 0; i < maxAttempts; i++) {
@@ -667,12 +687,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const heldProcesses = await this.findListeningProcessesOnPort(this.servicePort);
     if (heldProcesses.length > 0) {
       throw new Error(
-        `CtrlProxy failed to start within timeout (15s); port ${this.servicePort} ` +
+        `CtrlProxy failed to start within timeout (${timeoutSeconds}s); port ${this.servicePort} ` +
         `still held by ${this.formatListeningProcesses(heldProcesses)}`
       );
     }
 
-    throw new Error("CtrlProxy failed to start within timeout (15s)");
+    throw new Error(`CtrlProxy failed to start within timeout (${timeoutSeconds}s)`);
   }
 
   /**
@@ -1291,6 +1311,46 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * a stale xcTestProcessId that has been PID-reused by a different process does
    * not produce a false "alive" result and cause setup() to silently skip restart.
    */
+  /**
+   * Whether the runner process WE spawned is alive at the OS level, regardless of
+   * whether its health endpoint is up yet. Unlike {@link isCtrlProxyProcessAlive}
+   * this does NOT require a health response, so a runner still initializing counts
+   * as alive — used to avoid killing+respawning our own still-starting runner (#2834).
+   */
+  private async isOwnRunnerProcessAlive(): Promise<boolean> {
+    if (!this.xcTestProcessId) {
+      return false;
+    }
+    if (this.useHostControl()) {
+      try {
+        const status = await this.hostControl.status({
+          deviceId: this.device.deviceId,
+          pid: this.xcTestProcessId
+        });
+        return status.success && (status.data?.running ?? false);
+      } catch {
+        return false;
+      }
+    }
+    return this.isProcessRunning(this.xcTestProcessId);
+  }
+
+  /**
+   * Resolve the health-poll attempt budget. Env-overridable so CI (where XCUITest
+   * cold-start routinely exceeds the default) can extend it without a code change.
+   */
+  private static resolveHealthPollMaxAttempts(): number {
+    const raw = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS
+      ?? process.env.AUTO_MOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+    if (raw !== undefined) {
+      const parsed = Number.parseInt(raw, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+    return IOSCtrlProxyManager.DEFAULT_HEALTH_POLL_MAX_ATTEMPTS;
+  }
+
   private async isCtrlProxyProcessAlive(): Promise<boolean> {
     if (!this.xcTestProcessId) {
       return false;

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -558,6 +558,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const isAlive = await this.isCtrlProxyProcessAlive();
     perf.endOperation("processAliveCheck");
     let restartedAliveProcess = false;
+    // True when we deferred to an already-starting own runner instead of respawning;
+    // drives hung-runner recovery after the health wait below (#2834 review).
+    let waitedForStartingRunner = false;
     if (isAlive) {
       logger.info("[IOSCtrlProxy] CtrlProxy process is alive, skipping start");
       // On physical devices the iproxy tunnel may have been stopped independently
@@ -615,6 +618,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `[IOSCtrlProxy] Own CtrlProxy runner (PID ${this.xcTestProcessId}) is still starting; ` +
             `waiting for its health endpoint instead of respawning`
           );
+          waitedForStartingRunner = true;
         } else {
           perf.startOperation("externalProcessCheck");
           const externalProcess = await this.findExternalCtrlProxyProcess();
@@ -683,6 +687,27 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       await this.timer.sleep(delayMs);
     }
     perf.endOperation("healthPolling");
+
+    if (waitedForStartingRunner && this.xcTestProcessId !== null) {
+      // We deferred to an already-starting runner but it never became healthy within
+      // the budget — it is hung. Merely un-tracking it is NOT enough: the process stays
+      // alive and its environment carries AUTOMOBILE_DEVICE_ID, so on the next start()
+      // findExternalCtrlProxyProcess() would re-adopt it ("external CtrlProxy detected,
+      // skipping spawn") and we would defer to the hung runner forever, never respawning
+      // (#2834 review — restore stale-runner cleanup after the health wait). Terminate it
+      // outright so the next start() spawns a fresh runner. Set isStopping first so the
+      // process exit handler does not schedule an auto-restart of the hung runner.
+      logger.warn(
+        `[IOSCtrlProxy] Deferred-to CtrlProxy runner (PID ${this.xcTestProcessId}) never became ` +
+        `healthy within ${timeoutSeconds}s; terminating it so the next start spawns a fresh runner`
+      );
+      const hungPid = this.xcTestProcessId;
+      this.isStopping = true;
+      await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, hungPid);
+      this.stopProcessMonitoring();
+      this.xcTestProcessId = null;
+      this.xcTestProcess = null;
+    }
 
     const heldProcesses = await this.findListeningProcessesOnPort(this.servicePort);
     if (heldProcesses.length > 0) {
@@ -1332,7 +1357,21 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         return false;
       }
     }
-    return this.isProcessRunning(this.xcTestProcessId);
+    if (!await this.isProcessRunning(this.xcTestProcessId)) {
+      return false;
+    }
+    // Guard against PID reuse (#2834 review): a bare `kill -0` only proves *some*
+    // process holds this PID. Confirm it is genuinely our xcodebuild-launched runner
+    // for THIS device before treating it as "still starting" — otherwise a recycled
+    // PID (our runner exited, its PID reassigned to an unrelated process) would make
+    // us defer to a health endpoint that never comes.
+    const info = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, this.xcTestProcessId);
+    if (!info) {
+      return false;
+    }
+    const identityText = `${info.command} ${info.environment ?? ""}`;
+    return info.command.includes("xcodebuild") &&
+      IOSCtrlProxyManager.hasDeviceIdentity(identityText, this.device.deviceId);
   }
 
   /**

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -606,49 +606,50 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       // Check for externally-managed xcodebuild processes (e.g. hot-reload script)
       // before spawning our own to avoid conflicting xcodebuild instances.
       if (this.isSimulator()) {
-        // Adopt an already-running runner BEFORE deciding to wait on or respawn the
-        // tracked one: an externally-managed runner, or ours that bound CtrlProxy's
-        // default port instead of our reallocated port (#2731). Doing this first is
-        // essential — otherwise, if our runner is healthy on the default port while we
-        // allocated a different one, the wait-branch below would poll the wrong port and
-        // eventually terminate a HEALTHY runner as "hung" instead of adopting it
-        // (#2834 review).
-        perf.startOperation("externalProcessCheck");
-        const externalProcess = await this.findExternalCtrlProxyProcess();
-        const defaultPortIsHealthyForDevice = externalProcess === null &&
-          !this.useHostControl() &&
-          this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
-          await this.checkHealthEndpointOnPortForDevice(
-            IOSCtrlProxyManager.DEFAULT_PORT,
-            this.device.deviceId
-          );
-        perf.endOperation("externalProcessCheck");
-        if (externalProcess || defaultPortIsHealthyForDevice) {
-          const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
-          logger.info(
-            `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
-          );
-          if (externalPort !== this.servicePort) {
-            this.adoptServicePort(externalPort);
-          }
-          // Fall through to health polling below instead of spawning
-        } else if (await this.isOwnRunnerProcessAlive()) {
-          // A runner WE already spawned is still mid-startup: on a loaded CI machine
-          // XCUITest can take well past the health-poll budget to answer, so an earlier
-          // setup() gave up and this call is a retry while the same runner is still
-          // coming up. Its PID is alive but its health endpoint isn't yet. Reclaiming
-          // the port here would SIGTERM that starting runner and restart the clock — a
-          // livelock under repeated setup calls (#2834). Wait for it instead.
+        // Decide about OUR OWN tracked runner first. A runner WE already spawned may
+        // still be mid-startup: on a loaded CI machine XCUITest can take well past the
+        // health-poll budget to answer, so an earlier setup() gave up and this call is a
+        // retry while the same runner is still coming up. Its PID is alive but its health
+        // endpoint isn't yet. Reclaiming the port here would SIGTERM that starting runner
+        // and restart the clock — a livelock under repeated setup calls (#2834). Wait for
+        // it instead. Checking this BEFORE the external-process probe is important: that
+        // probe discovers our own child xcodebuild (whose PID differs from the tracked
+        // shell PID under shell:true) and would otherwise mis-classify it as "external"
+        // (#2834 review). A runner that actually came up healthy on the default port
+        // instead of our reallocated port (#2731) is handled by the health-wait recovery
+        // below, which re-checks the default port and adopts it rather than terminating.
+        if (await this.isOwnRunnerProcessAlive()) {
           logger.info(
             `[IOSCtrlProxy] Own CtrlProxy runner (PID ${this.xcTestProcessId}) is still starting; ` +
             `waiting for its health endpoint instead of respawning`
           );
           waitedForStartingRunner = true;
         } else {
-          await this.ensureServicePortReadyForLaunch();
-          perf.startOperation("spawnRunner");
-          await this.startOnSimulator();
-          perf.endOperation("spawnRunner");
+          perf.startOperation("externalProcessCheck");
+          const externalProcess = await this.findExternalCtrlProxyProcess();
+          const defaultPortIsHealthyForDevice = externalProcess === null &&
+            !this.useHostControl() &&
+            this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
+            await this.checkHealthEndpointOnPortForDevice(
+              IOSCtrlProxyManager.DEFAULT_PORT,
+              this.device.deviceId
+            );
+          perf.endOperation("externalProcessCheck");
+          if (externalProcess || defaultPortIsHealthyForDevice) {
+            const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
+            logger.info(
+              `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
+            );
+            if (externalPort !== this.servicePort) {
+              this.adoptServicePort(externalPort);
+            }
+            // Fall through to health polling below instead of spawning
+          } else {
+            await this.ensureServicePortReadyForLaunch();
+            perf.startOperation("spawnRunner");
+            await this.startOnSimulator();
+            perf.endOperation("spawnRunner");
+          }
         }
       } else {
         perf.startOperation("spawnRunner");

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -606,45 +606,49 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       // Check for externally-managed xcodebuild processes (e.g. hot-reload script)
       // before spawning our own to avoid conflicting xcodebuild instances.
       if (this.isSimulator()) {
-        // A runner WE already spawned may still be mid-startup: on a loaded CI
-        // machine XCUITest can take well past the health-poll budget to answer, so
-        // an earlier setup() gave up and this call is a retry while the same runner
-        // is still coming up. Its PID is alive but its health endpoint isn't yet.
-        // Reclaiming the port here would SIGTERM that starting runner and restart
-        // the ~30-60s clock — a livelock under repeated setup calls (#2834). Skip
-        // the port-reclaim + respawn and just wait (below) for it to become healthy.
-        if (await this.isOwnRunnerProcessAlive()) {
+        // Adopt an already-running runner BEFORE deciding to wait on or respawn the
+        // tracked one: an externally-managed runner, or ours that bound CtrlProxy's
+        // default port instead of our reallocated port (#2731). Doing this first is
+        // essential — otherwise, if our runner is healthy on the default port while we
+        // allocated a different one, the wait-branch below would poll the wrong port and
+        // eventually terminate a HEALTHY runner as "hung" instead of adopting it
+        // (#2834 review).
+        perf.startOperation("externalProcessCheck");
+        const externalProcess = await this.findExternalCtrlProxyProcess();
+        const defaultPortIsHealthyForDevice = externalProcess === null &&
+          !this.useHostControl() &&
+          this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
+          await this.checkHealthEndpointOnPortForDevice(
+            IOSCtrlProxyManager.DEFAULT_PORT,
+            this.device.deviceId
+          );
+        perf.endOperation("externalProcessCheck");
+        if (externalProcess || defaultPortIsHealthyForDevice) {
+          const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
+          logger.info(
+            `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
+          );
+          if (externalPort !== this.servicePort) {
+            this.adoptServicePort(externalPort);
+          }
+          // Fall through to health polling below instead of spawning
+        } else if (await this.isOwnRunnerProcessAlive()) {
+          // A runner WE already spawned is still mid-startup: on a loaded CI machine
+          // XCUITest can take well past the health-poll budget to answer, so an earlier
+          // setup() gave up and this call is a retry while the same runner is still
+          // coming up. Its PID is alive but its health endpoint isn't yet. Reclaiming
+          // the port here would SIGTERM that starting runner and restart the clock — a
+          // livelock under repeated setup calls (#2834). Wait for it instead.
           logger.info(
             `[IOSCtrlProxy] Own CtrlProxy runner (PID ${this.xcTestProcessId}) is still starting; ` +
             `waiting for its health endpoint instead of respawning`
           );
           waitedForStartingRunner = true;
         } else {
-          perf.startOperation("externalProcessCheck");
-          const externalProcess = await this.findExternalCtrlProxyProcess();
-          const defaultPortIsHealthyForDevice = externalProcess === null &&
-            !this.useHostControl() &&
-            this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
-            await this.checkHealthEndpointOnPortForDevice(
-              IOSCtrlProxyManager.DEFAULT_PORT,
-              this.device.deviceId
-            );
-          perf.endOperation("externalProcessCheck");
-          if (externalProcess || defaultPortIsHealthyForDevice) {
-            const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
-            logger.info(
-              `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
-            );
-            if (externalPort !== this.servicePort) {
-              this.adoptServicePort(externalPort);
-            }
-            // Fall through to health polling below instead of spawning
-          } else {
-            await this.ensureServicePortReadyForLaunch();
-            perf.startOperation("spawnRunner");
-            await this.startOnSimulator();
-            perf.endOperation("spawnRunner");
-          }
+          await this.ensureServicePortReadyForLaunch();
+          perf.startOperation("spawnRunner");
+          await this.startOnSimulator();
+          perf.endOperation("spawnRunner");
         }
       } else {
         perf.startOperation("spawnRunner");
@@ -689,24 +693,61 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     perf.endOperation("healthPolling");
 
     if (waitedForStartingRunner && this.xcTestProcessId !== null) {
-      // We deferred to an already-starting runner but it never became healthy within
-      // the budget — it is hung. Merely un-tracking it is NOT enough: the process stays
-      // alive and its environment carries AUTOMOBILE_DEVICE_ID, so on the next start()
-      // findExternalCtrlProxyProcess() would re-adopt it ("external CtrlProxy detected,
-      // skipping spawn") and we would defer to the hung runner forever, never respawning
-      // (#2834 review — restore stale-runner cleanup after the health wait). Terminate it
-      // outright so the next start() spawns a fresh runner. Set isStopping first so the
-      // process exit handler does not schedule an auto-restart of the hung runner.
-      logger.warn(
-        `[IOSCtrlProxy] Deferred-to CtrlProxy runner (PID ${this.xcTestProcessId}) never became ` +
-        `healthy within ${timeoutSeconds}s; terminating it so the next start spawns a fresh runner`
-      );
+      // Before giving up, adopt the runner if it actually came up healthy on CtrlProxy's
+      // default port (env-injection fallback #2731) rather than our reallocated port —
+      // the health poll above only checks servicePort, so a runner that bound the default
+      // port would look "hung" here. Adopt it instead of killing a healthy runner
+      // (#2834 review).
+      if (this.servicePort !== IOSCtrlProxyManager.DEFAULT_PORT &&
+        await this.checkHealthEndpointOnPortForDevice(IOSCtrlProxyManager.DEFAULT_PORT, this.device.deviceId)) {
+        logger.info(
+          `[IOSCtrlProxy] Deferred-to runner is healthy on default port ${IOSCtrlProxyManager.DEFAULT_PORT}; ` +
+          `adopting it instead of terminating`
+        );
+        this.adoptServicePort(IOSCtrlProxyManager.DEFAULT_PORT);
+        this.clearCaches();
+        // Mirror the normal success path's WebSocket-init settle (#2834 review — MINOR-3).
+        await this.timer.sleep(500);
+        return;
+      }
+      // Otherwise it is genuinely hung. Merely un-tracking it is NOT enough: the process
+      // stays alive and its environment carries AUTOMOBILE_DEVICE_ID, so on the next
+      // start() findExternalCtrlProxyProcess() would re-adopt it ("external CtrlProxy
+      // detected, skipping spawn") and we would defer to the hung runner forever, never
+      // respawning (#2834 review — restore stale-runner cleanup after the health wait).
+      // Terminate it outright so the next start() spawns a fresh runner.
+      //
+      // Re-verify ownership right before the kill: the multi-minute health poll above is
+      // a window in which our runner could exit and its PID be recycled to a foreign
+      // process. isOwnRunnerProcessAlive re-runs getProcessInfo + isOwnedCtrlProxyRunner
+      // Process on the tracked PID, so a recycled/foreign PID is no longer identified as
+      // ours and we skip the kill, only un-tracking (#2834 review — MINOR-1).
       const hungPid = this.xcTestProcessId;
+      const stillOurs = await this.isOwnRunnerProcessAlive();
+      // Suppress the exit-handler auto-restart across the kill + child-exit event only.
       this.isStopping = true;
-      await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, hungPid);
-      this.stopProcessMonitoring();
-      this.xcTestProcessId = null;
-      this.xcTestProcess = null;
+      try {
+        if (stillOurs) {
+          logger.warn(
+            `[IOSCtrlProxy] Deferred-to CtrlProxy runner (PID ${hungPid}) never became ` +
+            `healthy within ${timeoutSeconds}s; terminating it so the next start spawns a fresh runner`
+          );
+          await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, hungPid);
+        } else {
+          logger.warn(
+            `[IOSCtrlProxy] Tracked runner PID ${hungPid} is no longer our CtrlProxy runner ` +
+            `(exited/PID-reused); un-tracking without terminating`
+          );
+        }
+        this.stopProcessMonitoring();
+        this.xcTestProcessId = null;
+        this.xcTestProcess = null;
+      } finally {
+        // Do NOT leave isStopping latched across the throw below (#2834 review — MINOR-2):
+        // a caller that does not retry start() would otherwise wedge the manager in
+        // "stopping", disabling handleProcessExit()/scheduleAutoRestart() self-heal.
+        this.isStopping = false;
+      }
     }
 
     const heldProcesses = await this.findListeningProcessesOnPort(this.servicePort);
@@ -1369,9 +1410,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (!info) {
       return false;
     }
-    const identityText = `${info.command} ${info.environment ?? ""}`;
-    return info.command.includes("xcodebuild") &&
-      IOSCtrlProxyManager.hasDeviceIdentity(identityText, this.device.deviceId);
+    // Require CtrlProxy-specific identity, not merely any xcodebuild for this device
+    // (#2834 review): a user's own `xcodebuild … -destination id=<deviceId>` on the same
+    // simulator must NOT be mistaken for our runner, or we would wait on it and later
+    // terminate it as "hung", killing an unrelated process. Our launch carries CtrlProxy
+    // markers ("-only-testing:CtrlProxyUITests…", the automobile-runner xctestrun), so the
+    // canonical isOwnedCtrlProxyRunnerProcess predicate (also used by the port-reclaim
+    // path) distinguishes it.
+    return this.isOwnedCtrlProxyRunnerProcess({
+      pid: this.xcTestProcessId,
+      port: this.servicePort,
+      command: info.command,
+      environment: info.environment,
+    });
   }
 
   /**

--- a/test/daemon/clientRequestTimeout.test.ts
+++ b/test/daemon/clientRequestTimeout.test.ts
@@ -49,7 +49,9 @@ describe("DaemonClient per-request timeout", () => {
   test("regular tool uses DEFAULT_MCP_REQUEST_TIMEOUT_MS", async () => {
     const client = createConnectedClient(fakeTimer);
 
-    const promise = client.callTool("observe", {});
+    // tapOn has no per-tool floor, so it uses the standard default (unlike observe,
+    // launchApp, etc. which carry generous CtrlProxy cold-start floors — #2834).
+    const promise = client.callTool("tapOn", {});
     fakeTimer.advanceTime(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
 
     try {
@@ -58,7 +60,7 @@ describe("DaemonClient per-request timeout", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(McpTimeoutError);
       const timeoutErr = err as McpTimeoutError;
-      expect(timeoutErr.toolName).toBe("observe");
+      expect(timeoutErr.toolName).toBe("tapOn");
       expect(timeoutErr.timeoutMs).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
       expect(timeoutErr.origin).toBe("DaemonClient.sendRequest");
     } finally {

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -1,43 +1,50 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+  DEFAULT_OBSERVE_MCP_TIMEOUT_MS,
   DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS,
+  LEGACY_OBSERVE_MCP_TIMEOUT_ENV_VAR,
   LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
   MIN_START_DEVICE_MCP_TIMEOUT_MS,
+  OBSERVE_MCP_TIMEOUT_ENV_VAR,
   OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   resolveMcpRequestTimeoutMs
 } from "../../src/daemon/mcpRequestTimeout";
 import type { DaemonRequest } from "../../src/daemon/types";
 
 describe("resolveMcpRequestTimeoutMs", () => {
-  const originalOpenLinkTimeout = process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
-  const originalLegacyOpenLinkTimeout = process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+  const timeoutEnvVars = [
+    OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
+    LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
+    OBSERVE_MCP_TIMEOUT_ENV_VAR,
+    LEGACY_OBSERVE_MCP_TIMEOUT_ENV_VAR,
+  ];
+  const originalEnv = new Map(timeoutEnvVars.map(name => [name, process.env[name]]));
 
   beforeEach(() => {
-    delete process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
-    delete process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
+    for (const name of timeoutEnvVars) {
+      delete process.env[name];
+    }
   });
 
   afterEach(() => {
-    if (originalOpenLinkTimeout === undefined) {
-      delete process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
-    } else {
-      process.env[OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = originalOpenLinkTimeout;
-    }
-    if (originalLegacyOpenLinkTimeout === undefined) {
-      delete process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR];
-    } else {
-      process.env[LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR] = originalLegacyOpenLinkTimeout;
+    for (const name of timeoutEnvVars) {
+      const original = originalEnv.get(name);
+      if (original === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = original;
+      }
     }
   });
 
-  test("uses default for non-executePlan tools/call", () => {
+  test("uses default for a tool without a floor", () => {
     const request: DaemonRequest = {
       id: "1",
       type: "mcp_request",
       method: "tools/call",
-      params: { name: "observe", arguments: {} }
+      params: { name: "tapOn", arguments: {} }
     };
     expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
   });
@@ -79,7 +86,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
       id: "1",
       type: "mcp_request",
       method: "tools/call",
-      params: { name: "observe", arguments: {} },
+      params: { name: "tapOn", arguments: {} },
       timeoutMs: NaN
     };
     expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
@@ -101,7 +108,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
       id: "1",
       type: "mcp_request",
       method: "tools/call",
-      params: { name: "observe", arguments: {} },
+      params: { name: "tapOn", arguments: {} },
       timeoutMs: -1
     };
     expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
@@ -112,10 +119,58 @@ describe("resolveMcpRequestTimeoutMs", () => {
       id: "1",
       type: "mcp_request",
       method: "tools/call",
-      params: { name: "observe", arguments: {} },
+      params: { name: "tapOn", arguments: {} },
       timeoutMs: 0
     };
     expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+
+  test("default observe floor is higher than the standard request timeout", () => {
+    expect(DEFAULT_OBSERVE_MCP_TIMEOUT_MS).toBe(90_000);
+    expect(DEFAULT_OBSERVE_MCP_TIMEOUT_MS).toBeGreaterThan(DEFAULT_MCP_REQUEST_TIMEOUT_MS);
+  });
+
+  test("applies default observe floor when client omits timeoutMs", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_OBSERVE_MCP_TIMEOUT_MS);
+  });
+
+  test("raises short observe timeouts to the floor (the CI cold-start case)", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} },
+      timeoutMs: 30_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(DEFAULT_OBSERVE_MCP_TIMEOUT_MS);
+  });
+
+  test("preserves observe timeouts above the floor", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} },
+      timeoutMs: 150_000
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(150_000);
+  });
+
+  test("applies configured observe floor from environment", () => {
+    process.env[OBSERVE_MCP_TIMEOUT_ENV_VAR] = "150000";
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "observe", arguments: {} }
+    };
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(150_000);
   });
 
   test("applies startDevice floor when client omits timeoutMs", () => {

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -702,8 +702,10 @@ describe("UnixSocketServer MCP forward serialization", () => {
       return fake;
     };
 
-    // First request: blocks in callTool until we release it
-    const first = sendToolsCallWithArgs(socketPath, "observe", { deviceId: "device-1" });
+    // First request: blocks in callTool until we release it. Uses tapOn (no per-tool
+    // timeout floor) so the second request's short 500ms timeout is honored verbatim
+    // rather than raised to observe's CtrlProxy cold-start floor (#2834).
+    const first = sendToolsCallWithArgs(socketPath, "tapOn", { deviceId: "device-1" });
 
     // Yield to the real event loop so the first request enters callTool
     for (let i = 0; i < 10; i++) {
@@ -715,7 +717,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       id: randomUUID(),
       type: "mcp_request",
       method: "tools/call",
-      params: { name: "observe", arguments: { deviceId: "device-1" } },
+      params: { name: "tapOn", arguments: { deviceId: "device-1" } },
       timeoutMs: 500,
     });
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -789,15 +789,19 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(0);
     });
 
-    // Builds a fake ownable runner process (our xcodebuild for this device) so
-    // isOwnRunnerProcessAlive()'s PID-reuse guard treats it as genuinely ours.
+    // Builds a fake ownable runner process modelled on the REAL launch command
+    // (see startOnSimulator): xcodebuild with the CtrlProxy UI test target and this
+    // device's identity, so isOwnRunnerProcessAlive()'s CtrlProxy-ownership guard
+    // treats it as genuinely ours.
     function ownRunnerProcess(pid: number): FakeListeningProcess {
       return {
         pid,
         port: 8765,
         command: `xcodebuild test-without-building ` +
-          `-xctestrun /tmp/automobile-runner-${testDevice.deviceId}.xctestrun ` +
-          `-destination id=${testDevice.deviceId}`,
+          `-xctestrun /tmp/automobile-ctrl-proxy/automobile-runner-${testDevice.deviceId}.xctestrun ` +
+          `-destination "platform=iOS Simulator,id=${testDevice.deviceId}" ` +
+          `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
         alive: true,
       };
     }
@@ -848,6 +852,45 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(true);
       expect(runnerProcs[0].alive).toBe(false);
       expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
+      // The auto-restart suppression latch is not left set across the throw (MINOR-2).
+      expect((manager as unknown as { isStopping: boolean }).isStopping).toBe(false);
+    });
+
+    test("start() does NOT terminate the tracked PID if it was recycled during the wait (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+
+      // PID 12345 stays alive throughout, and health never answers.
+      fakeExecutor.setCommandHandler("kill -0", () => createExecResult("", ""));
+      fakeExecutor.setCommandHandler("ps eww", () => createExecResult("some-process", ""));
+      fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
+      // `ps -p … -o args=` reports our CtrlProxy runner at the initial wait decision, but
+      // a foreign process by the pre-terminate re-verify (the tracked PID was recycled
+      // during the long health poll). Registered first so it wins the "ps -p" match.
+      let psArgsCalls = 0;
+      fakeExecutor.setCommandHandler("ps -p", () => {
+        psArgsCalls++;
+        const command = psArgsCalls <= 1
+          ? `1 xcodebuild test-without-building ` +
+            `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService ` +
+            `-destination "platform=iOS Simulator,id=${testDevice.deviceId}"`
+          : "1 /usr/sbin/some-unrelated-daemon --serve";
+        return createExecResult(command, "");
+      });
+
+      await withHealthBudget("1", async () => {
+        fakeTimer.enableAutoAdvance();
+        await expect(manager.start()).rejects.toThrow(/failed to start within timeout/);
+      });
+
+      // The re-verify sees a foreign command, so the recycled PID is NOT killed — we only
+      // un-track it (MINOR-1). isStopping is not left latched (MINOR-2).
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(false);
+      expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
+      expect((manager as unknown as { isStopping: boolean }).isStopping).toBe(false);
+      expect(psArgsCalls).toBeGreaterThanOrEqual(2); // wait-decision + pre-kill re-verify
     });
 
     test("start() reuses an own runner that becomes healthy during the wait (#2834)", async function() {
@@ -901,16 +944,40 @@ describe("IOSCtrlProxyManager", function() {
       expect(await callIsOwnRunnerProcessAlive(manager)).toBe(false);
     });
 
-    test("isOwnRunnerProcessAlive rejects a live xcodebuild runner for a DIFFERENT device (#2834)", async function() {
+    test("isOwnRunnerProcessAlive rejects a CtrlProxy runner for a DIFFERENT device (#2834)", async function() {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice, fakeTimer, undefined, fakeExecutor
       );
       (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
-      // An xcodebuild runner, but for a sibling simulator (different device id).
+      // A genuine CtrlProxy runner, but for a sibling simulator (different device id).
       installListeningProcessFakes(fakeExecutor, [{
         pid: 12345,
         port: 8765,
-        command: "xcodebuild test-without-building -xctestrun /tmp/automobile-runner-OTHER.xctestrun -destination id=OTHER-DEVICE-UUID",
+        command: "xcodebuild test-without-building " +
+          "-xctestrun /tmp/automobile-ctrl-proxy/automobile-runner-OTHER.xctestrun " +
+          "-destination \"platform=iOS Simulator,id=OTHER-DEVICE-UUID\" " +
+          "-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService",
+        environment: "CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=OTHER-DEVICE-UUID",
+        alive: true,
+      }]);
+
+      expect(await callIsOwnRunnerProcessAlive(manager)).toBe(false);
+    });
+
+    test("isOwnRunnerProcessAlive rejects a user's own xcodebuild on the same simulator (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      // The tracked PID was reused by the user's OWN app test run, which targets the
+      // same simulator (xcodebuild + our device id) but is NOT a CtrlProxy runner. It
+      // must not be mistaken for our runner — otherwise we would wait on it and later
+      // terminate it as "hung", killing the user's process (#2834 review, thread 2).
+      installListeningProcessFakes(fakeExecutor, [{
+        pid: 12345,
+        port: 8999,
+        command: `xcodebuild test -project MyApp.xcodeproj ` +
+          `-destination "platform=iOS Simulator,id=${testDevice.deviceId}"`,
         alive: true,
       }]);
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -789,7 +789,34 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(0);
     });
 
-    test("start() waits for an own still-starting runner instead of killing+respawning it (#2834)", async function() {
+    // Builds a fake ownable runner process (our xcodebuild for this device) so
+    // isOwnRunnerProcessAlive()'s PID-reuse guard treats it as genuinely ours.
+    function ownRunnerProcess(pid: number): FakeListeningProcess {
+      return {
+        pid,
+        port: 8765,
+        command: `xcodebuild test-without-building ` +
+          `-xctestrun /tmp/automobile-runner-${testDevice.deviceId}.xctestrun ` +
+          `-destination id=${testDevice.deviceId}`,
+        alive: true,
+      };
+    }
+
+    async function withHealthBudget(attempts: string, fn: () => Promise<void>): Promise<void> {
+      const prev = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+      process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = attempts;
+      try {
+        await fn();
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+        } else {
+          process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = prev;
+        }
+      }
+    }
+
+    test("start() waits for an own runner then terminates it if it never becomes healthy (#2834)", async function() {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice, // simulator UUID
         fakeTimer,
@@ -800,40 +827,118 @@ describe("IOSCtrlProxyManager", function() {
       // A runner we spawned in an earlier setup() whose health endpoint is not up
       // yet (XCUITest still cold-starting on a loaded CI machine). Its PID is alive.
       (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
-      // Health endpoint does NOT respond → isRunning()/isCtrlProxyProcessAlive() are false.
+      // Health endpoint never responds within this test's tiny budget → the runner
+      // is hung, exercising the recovery path below.
       fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
-      // The still-starting runner is alive and holding the service port.
-      const runnerProcs: FakeListeningProcess[] = [{
-        pid: 12345,
-        port: 8765,
-        command: `xcodebuild test-without-building ` +
-          `-xctestrun /tmp/automobile-runner-${testDevice.deviceId}.xctestrun ` +
-          `-destination id=${testDevice.deviceId}`,
-        alive: true,
-      }];
+      const runnerProcs = [ownRunnerProcess(12345)];
       installListeningProcessFakes(fakeExecutor, runnerProcs);
 
-      // Tiny health budget so the (expected) timeout is fast; the point of the test
-      // is what happens to the runner, not the wait.
-      const prev = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
-      process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = "1";
-      fakeTimer.enableAutoAdvance();
-      try {
+      await withHealthBudget("1", async () => {
+        fakeTimer.enableAutoAdvance();
         await expect(manager.start()).rejects.toThrow(/failed to start within timeout/);
-      } finally {
-        if (prev === undefined) {
-          delete process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
-        } else {
-          process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = prev;
-        }
-      }
+      });
 
-      // The fix: our own still-starting runner is NOT terminated to reclaim the port
-      // (that SIGTERM mid-startup is the livelock), and no competing runner is spawned.
-      expect(runnerProcs[0].alive).toBe(true);
-      expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(false);
+      // While it was still starting we did NOT respawn a competing runner (the original
+      // livelock was: reclaim the port + respawn mid-startup).
       expect(fakeExecutor.wasCommandExecuted("simctl")).toBe(false);
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(0);
+      // Thread-3 recovery: because it never became healthy we TERMINATE the hung runner
+      // (rather than leave it alive to be re-adopted by findExternalCtrlProxyProcess on
+      // the next start), and clear our tracking so the next start spawns fresh.
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(true);
+      expect(runnerProcs[0].alive).toBe(false);
+      expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
+    });
+
+    test("start() reuses an own runner that becomes healthy during the wait (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      const runnerProcs = [ownRunnerProcess(12345)];
+      installListeningProcessFakes(fakeExecutor, runnerProcs);
+
+      // Health is down for the initial liveness/running checks (still starting) then
+      // comes up once the health poll begins.
+      let curlCalls = 0;
+      fakeExecutor.setCommandHandler("curl -s", () => {
+        curlCalls++;
+        return createExecResult(curlCalls > 2 ? "ok" : "", "");
+      });
+
+      await withHealthBudget("30", async () => {
+        fakeTimer.enableAutoAdvance();
+        await manager.start(); // resolves — runner became healthy, no throw
+      });
+
+      // Reused the starting runner: never respawned, never killed, tracking retained.
+      expect(fakeExecutor.getSpawnedProcesses().length).toBe(0);
+      expect(fakeExecutor.wasCommandExecuted("simctl")).toBe(false);
+      expect(runnerProcs[0].alive).toBe(true);
+      expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBe(12345);
+    });
+
+    // Directly exercise the PID-reuse guard added in review (thread 2). Testing the
+    // predicate rather than a full start() keeps it precise and avoids spawning a
+    // runner (whose background monitor would leak into later tests under autoAdvance).
+    const callIsOwnRunnerProcessAlive = (m: IOSCtrlProxyManager): Promise<boolean> =>
+      (m as unknown as { isOwnRunnerProcessAlive(): Promise<boolean> }).isOwnRunnerProcessAlive();
+
+    test("isOwnRunnerProcessAlive rejects a reused PID that is not our runner (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      // The tracked PID is alive but has been reused by an UNRELATED process
+      // (not xcodebuild, no device identity).
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [{
+        pid: 12345,
+        port: 9999,
+        command: "/usr/sbin/some-unrelated-daemon --serve",
+        alive: true,
+      }]);
+
+      expect(await callIsOwnRunnerProcessAlive(manager)).toBe(false);
+    });
+
+    test("isOwnRunnerProcessAlive rejects a live xcodebuild runner for a DIFFERENT device (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      // An xcodebuild runner, but for a sibling simulator (different device id).
+      installListeningProcessFakes(fakeExecutor, [{
+        pid: 12345,
+        port: 8765,
+        command: "xcodebuild test-without-building -xctestrun /tmp/automobile-runner-OTHER.xctestrun -destination id=OTHER-DEVICE-UUID",
+        alive: true,
+      }]);
+
+      expect(await callIsOwnRunnerProcessAlive(manager)).toBe(false);
+    });
+
+    test("isOwnRunnerProcessAlive accepts our live xcodebuild runner for this device (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(12345)]);
+
+      expect(await callIsOwnRunnerProcessAlive(manager)).toBe(true);
+    });
+
+    test("isOwnRunnerProcessAlive returns false when the tracked PID is dead (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      // No living process with this PID (installListeningProcessFakes' kill -0 throws).
+      installListeningProcessFakes(fakeExecutor, [{
+        ...ownRunnerProcess(12345),
+        alive: false,
+      }]);
+
+      expect(await callIsOwnRunnerProcessAlive(manager)).toBe(false);
     });
 
     test("health-poll budget is env-configurable with a generous default (#2834)", function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -893,6 +893,55 @@ describe("IOSCtrlProxyManager", function() {
       expect(psArgsCalls).toBeGreaterThanOrEqual(2); // wait-decision + pre-kill re-verify
     });
 
+    test("start() stops a hung host-control runner via host control, not a local kill (#2834)", async function() {
+      const { runner, stops } = createHostControlRunner();
+      // Model the race that reaches the wait-branch under host control: the top-level
+      // liveness check sees the runner as not-running, but by the wait-branch check it
+      // reports running — and then it never becomes healthy.
+      let statusCalls = 0;
+      const racingRunner = {
+        ...runner,
+        status: async (params: { deviceId?: string; pid?: number; port?: number }) => {
+          statusCalls++;
+          return {
+            success: true,
+            data: { running: statusCalls > 1, pid: params.pid, port: params.port },
+          };
+        },
+      };
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, // simulator UUID → isSimulator() true, but running via host control
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+        undefined,
+        undefined,
+        racingRunner as unknown as Parameters<typeof IOSCtrlProxyManager.createForTestingWithDeps>[6]
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+
+      // Host-control health checks go through fetch; never healthy.
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        throw new Error("health unreachable");
+      }) as unknown as typeof fetch;
+      try {
+        await withHealthBudget("1", async () => {
+          fakeTimer.enableAutoAdvance();
+          await expect(manager.start()).rejects.toThrow(/failed to start within timeout/);
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      // The hung runner's PID lives on the macOS HOST — a local kill would miss it (or
+      // hit an unrelated same-PID container process). It must be stopped via host control.
+      expect(stops).toContainEqual({ deviceId: testDevice.deviceId, pid: 12345 });
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(false);
+      expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
+      expect((manager as unknown as { isStopping: boolean }).isStopping).toBe(false);
+    });
+
     test("start() reuses an own runner that becomes healthy during the wait (#2834)", async function() {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice, fakeTimer, undefined, fakeExecutor

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -789,6 +789,75 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(0);
     });
 
+    test("start() waits for an own still-starting runner instead of killing+respawning it (#2834)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, // simulator UUID
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      // A runner we spawned in an earlier setup() whose health endpoint is not up
+      // yet (XCUITest still cold-starting on a loaded CI machine). Its PID is alive.
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      // Health endpoint does NOT respond → isRunning()/isCtrlProxyProcessAlive() are false.
+      fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
+      // The still-starting runner is alive and holding the service port.
+      const runnerProcs: FakeListeningProcess[] = [{
+        pid: 12345,
+        port: 8765,
+        command: `xcodebuild test-without-building ` +
+          `-xctestrun /tmp/automobile-runner-${testDevice.deviceId}.xctestrun ` +
+          `-destination id=${testDevice.deviceId}`,
+        alive: true,
+      }];
+      installListeningProcessFakes(fakeExecutor, runnerProcs);
+
+      // Tiny health budget so the (expected) timeout is fast; the point of the test
+      // is what happens to the runner, not the wait.
+      const prev = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+      process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = "1";
+      fakeTimer.enableAutoAdvance();
+      try {
+        await expect(manager.start()).rejects.toThrow(/failed to start within timeout/);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+        } else {
+          process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = prev;
+        }
+      }
+
+      // The fix: our own still-starting runner is NOT terminated to reclaim the port
+      // (that SIGTERM mid-startup is the livelock), and no competing runner is spawned.
+      expect(runnerProcs[0].alive).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("simctl")).toBe(false);
+      expect(fakeExecutor.getSpawnedProcesses().length).toBe(0);
+    });
+
+    test("health-poll budget is env-configurable with a generous default (#2834)", function() {
+      const resolve = (): number =>
+        (IOSCtrlProxyManager as unknown as { resolveHealthPollMaxAttempts(): number })
+          .resolveHealthPollMaxAttempts();
+      const prev = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+      try {
+        process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = "240";
+        expect(resolve()).toBe(240);
+        // Invalid values fall back to the default (which is well above the old 30 = 15s).
+        process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = "nonsense";
+        expect(resolve()).toBeGreaterThan(30);
+        delete process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+        expect(resolve()).toBeGreaterThan(30);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+        } else {
+          process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = prev;
+        }
+      }
+    });
+
     test("start() re-establishes iproxy tunnel when CtrlProxy is alive but tunnel is gone (physical device)", async function() {
       fakeExecutor.setCommandResponse("idevice_id -l", createExecResult(`${physicalDevice.deviceId}\n`, ""));
       // Health endpoint responds → confirms the tracked PID really is CtrlProxy

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -850,6 +850,9 @@ describe("IOSCtrlProxyManager", function() {
       // (rather than leave it alive to be re-adopted by findExternalCtrlProxyProcess on
       // the next start), and clear our tracking so the next start spawns fresh.
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(true);
+      // The kill targets the process GROUP (tracked PID is the shell wrapper; a
+      // single-PID TERM would orphan the xcodebuild child — #2834 review round 5).
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -12345")).toBe(true);
       expect(runnerProcs[0].alive).toBe(false);
       expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
       // The auto-restart suppression latch is not left set across the throw (MINOR-2).
@@ -940,6 +943,56 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(false);
       expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
       expect((manager as unknown as { isStopping: boolean }).isStopping).toBe(false);
+    });
+
+    test("host-control status reporting a DIFFERENT pid is not ours; untrack without stopping (#2834)", async function() {
+      const { runner, stops } = createHostControlRunner();
+      // The host-control daemon resolves status by deviceId BEFORE pid, so a NEWER
+      // runner for the same device answers running=true with ITS pid. The tracked
+      // (stale) pid must not alias as ours — stopping would kill the newer runner.
+      let statusCalls = 0;
+      const aliasingRunner = {
+        ...runner,
+        status: async () => {
+          statusCalls++;
+          // First call (top-level liveness) not running; afterwards a NEWER runner
+          // (pid 99999) answers for the device — never the tracked pid 12345.
+          return {
+            success: true,
+            data: { running: statusCalls > 1, pid: 99999, port: 8765 },
+          };
+        },
+      };
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor,
+        undefined,
+        undefined,
+        aliasingRunner as unknown as Parameters<typeof IOSCtrlProxyManager.createForTestingWithDeps>[6]
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        throw new Error("health unreachable");
+      }) as unknown as typeof fetch;
+      try {
+        await withHealthBudget("1", async () => {
+          fakeTimer.enableAutoAdvance();
+          // PID-strict ownership rejects the aliased status, so the wait-branch never
+          // fires; the flow proceeds to the host-control start path instead.
+          await expect(manager.start()).rejects.toThrow();
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      // The newer runner (99999) must never be stopped on the stale pid's behalf.
+      expect(stops).not.toContainEqual({ deviceId: testDevice.deviceId, pid: 12345 });
+      expect(stops.length).toBe(0);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 12345")).toBe(false);
     });
 
     test("start() reuses an own runner that becomes healthy during the wait (#2834)", async function() {


### PR DESCRIPTION
## Summary
Follow-up to #2825. Fixing the daemon-startup gate (#2825) un-masked a pre-existing failure: the Reminders XCTest plan's `observe waitFor {text:"Reminders"}` times out in CI. That test **never actually ran in CI before** (it always skipped on the daemon-not-found gate), so this iOS `observe`/CtrlProxy path has never been exercised in CI.

## Investigation so far (from #2825 CI runs + local repro)
- The added CtrlProxy warm-up step **does** launch CtrlProxy (`observe` returns a hierarchy) — but after ~3 attempts / ~2.5 min (CtrlProxy setup in CI is slow and flaky).
- Despite that, the Reminders test's `observe` still times out (~46s): CtrlProxy is up during warm-up but **gone/unreachable by test time** (~1.5 min later, after the warm-up's CLI session was idle-released).
- **Locally, reuse works**: warm-up `observe` → `executePlan` reused the running CtrlProxy and passed 3/3 (the same run also finalized a valid MP4, re-confirming the #2825 video-stop fix on a real sim). The difference is the short gap — locally the warm-up session isn't released before the plan runs.
- `IOSCtrlProxyManager` is a per-device singleton that is **not** stopped on session release; on a new session `start()` may skip relaunch when the old PID is still alive — so the new session can attach to an alive-but-unreachable runner. This is a *hypothesis*; the local pass contradicts the simplest version of it, so I want ground truth before committing to a fix.

## This PR (diagnostic only)
Uploads the daemon's internal logs (`~/.auto-mobile/logs/`) from the XCTestRunner job as an artifact. The swift-test stdout doesn't include daemon internals (CtrlProxy attach/teardown, WebSocket reconnect, port allocation, observe timing), which are the only way to tell **which** link breaks across the released-session → new-session boundary.

Once this run's logs pinpoint the cause, I'll push the precise fix (e.g. reconnect-on-reuse, keep-alive, or port reconciliation) in this same PR. No behavior change yet — deliberately avoiding a speculative fix that could make things worse (e.g. stop-on-release or per-session runners would force the test to cold-start CtrlProxy inside its bounded waitFor and still time out).

Refs #2825
