### PR TITLE
chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -323,4 +323,4 @@ export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (
 // iOS downloads are ever wired (resolveChecksum(<pinned>, "ios")), move this to a
 // per-entry ReleaseChecksumEntry.runnerSha256 or the check would compare the
 // newest runner sha against an older IPA and reject a valid bundle.
-export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "";
+export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982";


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `  apkSha256: string;` | `0a325c9712558564b86dbb8dc248f990b0c59666e48db41ab5b9d3a0c51de52a` | ✅ Yes |
| **IPA** | `  ipaSha256: string;` | `d2bf0f0569e35988471cd21f3cf57cbcd8fb05db79a36fbb01c927f0a2bd6853` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow