### PR TITLE
fix(talkback): FocusNavigationExecutor.navigateToElement throws ReferenceError on zero-swipe path

### DIFF
--- a/src/features/talkback/FocusNavigationExecutor.ts
+++ b/src/features/talkback/FocusNavigationExecutor.ts
@@ -159,7 +159,7 @@ export class FocusNavigationExecutor {
 
     if (remainingSwipes === 0) {
       const initialVerification = await this.verifyNavigationState(
-        accessibilityService,
+        driver,
         targetSelector
       );
       if (initialVerification.reachedTarget) {

--- a/test/features/talkback/FocusNavigationExecutor.test.ts
+++ b/test/features/talkback/FocusNavigationExecutor.test.ts
@@ -151,4 +151,116 @@ describe("FocusNavigationExecutor", () => {
     expect(result).toBe(true);
     expect(driver.getSwipeCount()).toBe(4);
   });
+
+  test("returns true without swiping when target is already focused (zero-swipe path)", async () => {
+    const timer = new FakeTimer();
+    const driver = new FakeFocusNavigationDriver();
+    const elements = [
+      makeElement("a", 0),
+      makeElement("b", 1),
+      makeElement("c", 2)
+    ];
+    // Focus is already on the target element "c" (index 2).
+    driver.setElements(elements, 2);
+
+    const targetSelector: FocusElementSelector = { resourceId: "c" };
+    const path: FocusNavigationPath = {
+      currentFocusIndex: 2,
+      targetFocusIndex: 2,
+      swipeCount: 0,
+      direction: "forward",
+      intermediateCheckpoints: []
+    };
+
+    const driverFactory: FocusNavigationDriverFactory = {
+      createDriver: () => driver
+    };
+    const executor = new FocusNavigationExecutor({ timer, driverFactory });
+
+    const result = await executor.navigateToElement("device-1", targetSelector, path, {
+      verificationInterval: 1,
+      swipeDelay: 0
+    });
+
+    expect(result).toBe(true);
+    expect(driver.getSwipeCount()).toBe(0);
+  });
+
+  test("recalculates and navigates when zero-swipe path but target is not yet focused", async () => {
+    const timer = new FakeTimer();
+    const driver = new FakeFocusNavigationDriver();
+    const elements = [
+      makeElement("a", 0),
+      makeElement("b", 1),
+      makeElement("c", 2)
+    ];
+    // Focus is on "a" (index 0) but the caller supplied a stale zero-swipe path.
+    driver.setElements(elements, 0);
+
+    const targetSelector: FocusElementSelector = { resourceId: "c" };
+    const path: FocusNavigationPath = {
+      currentFocusIndex: 0,
+      targetFocusIndex: 2,
+      swipeCount: 0,
+      direction: "forward",
+      intermediateCheckpoints: []
+    };
+
+    const driverFactory: FocusNavigationDriverFactory = {
+      createDriver: () => driver
+    };
+    const executor = new FocusNavigationExecutor({ timer, driverFactory });
+
+    const resultPromise = executor.navigateToElement("device-1", targetSelector, path, {
+      verificationInterval: 1,
+      swipeDelay: 0
+    });
+
+    for (let i = 0; i < 10; i++) {
+      timer.advanceTime(100);
+      await new Promise(r => setImmediate(r));
+    }
+
+    const result = await resultPromise;
+
+    expect(result).toBe(true);
+    expect(driver.getSwipeCount()).toBe(2);
+  });
+
+  test("throws an actionable error (not a ReferenceError) when zero-swipe path but target is not found", async () => {
+    const timer = new FakeTimer();
+    const driver = new FakeFocusNavigationDriver();
+    const elements = [
+      makeElement("a", 0),
+      makeElement("b", 1)
+    ];
+    driver.setElements(elements, 0);
+
+    const targetSelector: FocusElementSelector = { resourceId: "does-not-exist" };
+    const path: FocusNavigationPath = {
+      currentFocusIndex: 0,
+      targetFocusIndex: 0,
+      swipeCount: 0,
+      direction: "forward",
+      intermediateCheckpoints: []
+    };
+
+    const driverFactory: FocusNavigationDriverFactory = {
+      createDriver: () => driver
+    };
+    const executor = new FocusNavigationExecutor({ timer, driverFactory });
+
+    let thrownError: Error | null = null;
+    await executor.navigateToElement("device-1", targetSelector, path, {
+      verificationInterval: 1,
+      swipeDelay: 0
+    }).catch(e => {
+      thrownError = e as Error;
+    });
+
+    expect(thrownError).not.toBeNull();
+    expect(thrownError).not.toBeInstanceOf(ReferenceError);
+    expect(thrownError!.message).toContain("Target not found");
+    expect(driver.getSwipeCount()).toBe(0);
+  });
 });


### PR DESCRIPTION
## What

Fixes a runtime `ReferenceError` in TalkBack focus navigation. `FocusNavigationExecutor.navigateToElement` referenced an out-of-scope variable `accessibilityService` in its `remainingSwipes === 0` branch ([`FocusNavigationExecutor.ts:162`](src/features/talkback/FocusNavigationExecutor.ts#L162)). The one-line fix passes the in-scope `driver` instead, matching every other `verifyNavigationState` call site (`:219`, `:275`).

## Why

- The in-scope local is `driver`, created at `:148` (`const driver = this.driverFactory.createDriver(device)`).
- `accessibilityService` only exists as a private field of `DefaultFocusNavigationDriver` (`:53`) and as a local inside the driver factory (`:92`) — neither is visible in `navigateToElement`.
- `verifyNavigationState` is typed `(driver: FocusNavigationDriver, ...)`, so `tsc` flags it: `FocusNavigationExecutor.ts(162,9): error TS2304: Cannot find name 'accessibilityService'`.

### Why it shipped

The build (`bun build.ts`) transpiles without type-checking, so `tsc` errors don't fail the build. (CI type-checking gap tracked in [#2766](https://github.com/kaeawc/auto-mobile/issues/2766).)

### Reachability

Reachable whenever the target element is **already focused**: `TalkBackTapStrategy.ts:127-156` computes `swipeCount = Math.abs(targetIndex - boundedCurrentIndex)` (i.e. `0` when target == current focus) and passes that path into `navigateToElement`, which enters the `remainingSwipes === 0` branch and throws. The defect has existed since the file's original commit (`909626fb`) — never exercised, never caught.

## Testing

TDD: the three new tests were written first and confirmed to fail with the exact `ReferenceError` from the issue, then the fix turned them green. They cover all three sub-branches of the zero-swipe block:

- **target already focused** → returns `true` without swiping (the regression test the issue asked for).
- **stale zero-swipe path, target not yet focused** → recalculates the path and navigates (2 swipes) to `true`.
- **target not found** → throws an `ActionableError` (explicitly asserted `not.toBeInstanceOf(ReferenceError)`, message contains "Target not found").

All use the existing `FakeFocusNavigationDriver` + `FakeTimer` + injected `driverFactory` (Interface + Fake convention), no real device/network, sub-ms each.

- `turbo run lint build test` — green (5641 pass / 2 skip / 0 fail).
- `tsc --noEmit` — the TS2304 for this file is resolved.

Closes #2765
