### PR TITLE
fix(db): guard runMigrations with a cross-process migration lock so two DB openers can't trip a spurious startup failure

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,7 +1,7 @@
 import { spawn as nodeSpawn, execSync, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { open, readFile, unlink } from "node:fs/promises";
-import { existsSync, openSync, closeSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, openSync, closeSync } from "node:fs";
+import { join } from "node:path";
 import { logger } from "../utils/logger";
 import { releaseVersion } from "../utils/mcpVersion";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
@@ -39,6 +39,7 @@ import {
   cleanupDaemonFiles,
   isProcessRunning as isDaemonProcessRunning,
 } from "./daemonFiles";
+import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../utils/fileLock";
 import {
   DAEMON_LAUNCH_CWD_ENV,
   resolveDaemonLaunchWorkingDirectory,
@@ -261,59 +262,24 @@ export class DaemonManager implements DaemonManagerLike {
    * Acquire an exclusive file lock for daemon start/stop coordination.
    * Uses O_CREAT | O_EXCL for atomic creation. Returns true if lock acquired.
    * Cleans up stale locks from dead processes.
+   *
+   * Non-blocking (single attempt): the caller decides what to do on false. Shares
+   * the canonical `O_EXCL` + stale-reclaim primitive with the DB migration lock
+   * (`src/utils/fileLock.ts`). `reclaimOwnPid` stays false so a same-PID probe
+   * from another manager instance still reads as actively held.
    */
   acquireLock(): boolean {
-    if (this.writeLockFile()) {
-      return true;
-    }
-    // Lock file exists — check if owning process is alive
-    try {
-      const content = readFileSync(this.lockFilePath, "utf-8").trim();
-      if (content.length === 0) {
-        // Empty file — another process just created it and hasn't written PID yet.
-        // Treat as actively held to avoid race condition.
-        return false;
-      }
-      const ownerPid = parseInt(content, 10);
-      if (isNaN(ownerPid)) {
-        // Unreadable PID — treat as actively held (writer may still be writing)
-        return false;
-      }
-      if (this.isProcessRunning(ownerPid)) {
-        return false;
-      }
-      // Owner is dead — stale lock, remove and retry once
-      unlinkSync(this.lockFilePath);
-      return this.writeLockFile();
-    } catch {
-      return false;
-    }
+    return tryAcquireExclusiveLock(this.lockFilePath, {
+      isProcessRunning: pid => this.isProcessRunning(pid),
+    });
   }
 
   /**
-   * Atomically create the lock file with our PID. Returns true on success.
-   */
-  private writeLockFile(): boolean {
-    try {
-      mkdirSync(dirname(this.lockFilePath), { recursive: true });
-      const fd = openSync(this.lockFilePath, "wx", 0o600);
-      writeFileSync(fd, String(process.pid));
-      closeSync(fd);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Release the file lock.
+   * Release the file lock. Compare-and-delete: only removes the file if it still
+   * holds our PID, so it can't delete a lock another opener reclaimed.
    */
   releaseLock(): void {
-    try {
-      unlinkSync(this.lockFilePath);
-    } catch {
-      // Best-effort cleanup
-    }
+    releaseExclusiveLock(this.lockFilePath);
   }
 
   createClient(): DaemonClientLike {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import * as fs from "fs";
 import type { Database as DatabaseSchema } from "./types";
 import { runMigrations } from "./migrator";
+import { createFileMigrationLock } from "./migrationLock";
 import { logger } from "../utils/logger";
 import { BunSqliteDialect } from "./bunSqliteDialect";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
@@ -145,7 +146,10 @@ async function startMigrations(dbPath: string): Promise<void> {
   const migrationDb = createSqliteKysely<unknown>(dbPath);
 
   try {
-    await runMigrations(migrationDb);
+    // Serialize the migration run across processes: two openers on the same DB
+    // file (override env / --no-proxy alongside a daemon) must not both enter
+    // migrateToLatest() and collide on the kysely_migration PRIMARY KEY (#2794).
+    await runMigrations(migrationDb, createFileMigrationLock(dbPath));
     migrationsRun = true;
   } catch (error) {
     logger.error("Failed to run migrations on database initialization:", error);

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -1,10 +1,8 @@
-import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
-import { dirname } from "path";
-import { isProcessRunning as defaultIsProcessRunning } from "../daemon/daemonFiles";
 import { ActionableError } from "../models/ActionableError";
 import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
+import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../utils/fileLock";
 
 /**
  * Cross-process lock guarding {@link runMigrations}.
@@ -28,11 +26,15 @@ export interface MigrationLock {
  * No-op lock for the single-opener default and in-memory test databases, where
  * no second process can share the connection. Keeps the migrator's DB-path-
  * agnostic callers unchanged.
+ *
+ * NOTE: this default provides NO cross-process protection — it is correct only
+ * for `:memory:` DBs and the single-daemon path (already serialized by the
+ * in-process mutex). Production DB openers must pass a {@link FileMigrationLock}
+ * via {@link createFileMigrationLock}; `database.ts#startMigrations` does so.
  */
 export class NoOpMigrationLock implements MigrationLock {
   async acquire(): Promise<void> {
-    // Nothing to serialize: a `:memory:` DB is private to one connection and the
-    // single-daemon default already serializes via the in-process mutex.
+    // Nothing to serialize.
   }
 
   async release(): Promise<void> {
@@ -59,20 +61,20 @@ export interface FileMigrationLockOptions {
 const DEFAULT_POLL_INTERVAL_MS = 100;
 // 60s is comfortably above a cold full-migration run on a slow/loaded disk, well
 // clear of the 5s `busy_timeout` that made `BEGIN EXCLUSIVE` unsuitable here.
-const DEFAULT_TIMEOUT_MS = 60_000;
+export const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 60_000;
 
 /**
  * File-based cross-process migration lock keyed to the resolved DB path
- * (`${dbPath}.migrate.lock`). Reuses the daemon's atomic `O_CREAT | O_EXCL`
- * (`wx`) create + dead-PID stale reclaim primitive (see
- * `src/daemon/manager.ts` `acquireLock`), but wraps it in a bounded busy-wait so
- * a mid-migration holder is waited out rather than failed fast.
+ * (`${dbPath}.migrate.lock`). Wraps the canonical `O_CREAT | O_EXCL` acquire +
+ * dead-PID stale reclaim primitive (`src/utils/fileLock.ts`, shared with the
+ * daemon lock) in a bounded busy-wait so a mid-migration holder is waited out
+ * rather than failed fast.
  */
 export class FileMigrationLock implements MigrationLock {
   private readonly timer: Timer;
   private readonly pollIntervalMs: number;
   private readonly timeoutMs: number;
-  private readonly isProcessRunning: (pid: number) => boolean;
+  private readonly isProcessRunning: ((pid: number) => boolean) | undefined;
   private readonly pid: number;
 
   constructor(
@@ -80,9 +82,11 @@ export class FileMigrationLock implements MigrationLock {
     options: FileMigrationLockOptions = {}
   ) {
     this.timer = options.timer ?? defaultTimer;
-    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.isProcessRunning = options.isProcessRunning ?? defaultIsProcessRunning;
+    // Clamp to >= 1ms: a 0ms poll would hammer the filesystem as fast as the
+    // macrotask queue allows until the deadline.
+    this.pollIntervalMs = Math.max(1, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS;
+    this.isProcessRunning = options.isProcessRunning;
     this.pid = options.pid ?? process.pid;
   }
 
@@ -92,7 +96,7 @@ export class FileMigrationLock implements MigrationLock {
     // Fast path: a fresh lock (single opener) acquires on the first attempt with
     // no sleep, so the default single-process path adds no latency.
     for (;;) {
-      if (this.tryAcquireOnce()) {
+      if (this.tryAcquire()) {
         return;
       }
 
@@ -110,84 +114,40 @@ export class FileMigrationLock implements MigrationLock {
   }
 
   async release(): Promise<void> {
-    try {
-      unlinkSync(this.lockFilePath);
-    } catch {
-      // Best-effort: the file may already be gone (never acquired, or removed by
-      // a stale-reclaim in another opener). Nothing actionable to surface.
-    }
+    releaseExclusiveLock(this.lockFilePath, this.pid);
   }
 
-  /**
-   * One non-blocking acquire attempt. Returns true if the lock is now ours.
-   * Mirrors `DaemonManager.acquireLock`: atomic create, else inspect the owner
-   * and reclaim only if it is a dead PID.
-   */
-  private tryAcquireOnce(): boolean {
-    if (this.writeLockFile()) {
-      return true;
-    }
-
-    let content: string;
-    try {
-      content = readFileSync(this.lockFilePath, "utf-8").trim();
-    } catch {
-      // File vanished between the failed `wx` create and this read — treat as
-      // still-contended and retry on the next poll.
-      return false;
-    }
-
-    if (content.length === 0) {
-      // Another opener created the file but has not written its PID yet; treat as
-      // actively held to avoid stealing a lock mid-write.
-      return false;
-    }
-
-    const ownerPid = Number.parseInt(content, 10);
-    if (Number.isNaN(ownerPid)) {
-      // Unreadable PID — a writer may still be filling it in; wait.
-      return false;
-    }
-
-    if (this.isProcessRunning(ownerPid)) {
-      return false;
-    }
-
-    // Owner is dead — reclaim the stale lock, then re-create atomically. The
-    // `wx` open below ensures two openers racing on the same dead PID cannot both
-    // win: the loser's `wx` throws and it falls back to waiting.
-    try {
-      unlinkSync(this.lockFilePath);
-    } catch {
-      // Someone else reclaimed it first; retry on the next poll.
-      return false;
-    }
-    return this.writeLockFile();
-  }
-
-  /**
-   * Atomically create the lock file with our PID via `O_CREAT | O_EXCL` (`wx`).
-   * Returns true on success, false if the file already exists.
-   */
-  private writeLockFile(): boolean {
-    try {
-      mkdirSync(dirname(this.lockFilePath), { recursive: true });
-      const fd = openSync(this.lockFilePath, "wx", 0o600);
-      writeFileSync(fd, String(this.pid));
-      closeSync(fd);
-      return true;
-    } catch {
-      return false;
-    }
+  private tryAcquire(): boolean {
+    return tryAcquireExclusiveLock(this.lockFilePath, {
+      pid: this.pid,
+      isProcessRunning: this.isProcessRunning,
+      // The migration run is a per-process singleton (`migrationsPromise` in
+      // database.ts), so a lock file bearing our own PID can only be a stale leak
+      // from a crashed prior incarnation whose PID the OS recycled — reclaim it
+      // rather than hang for the full timeout.
+      reclaimOwnPid: true,
+    });
   }
 }
 
 /**
  * Default migration lock for a resolved DB file path. Keyed per-file (not
- * per-uid) because the trigger — two openers on one DB file — is per-file.
+ * per-uid) because the trigger — two openers on one DB file — is per-file. The
+ * busy-wait ceiling can be overridden via `AUTOMOBILE_MIGRATION_LOCK_TIMEOUT_MS`
+ * (with the legacy `AUTO_MOBILE_` alias), mirroring the daemon timeout knobs in
+ * `src/daemon/constants.ts`.
  */
 export function createFileMigrationLock(dbPath: string): MigrationLock {
-  const lock = new FileMigrationLock(`${dbPath}.migrate.lock`);
-  logger.debug(`Migration lock keyed to ${dbPath}.migrate.lock`);
-  return lock;
+  const lockFilePath = `${dbPath}.migrate.lock`;
+  const override =
+    process.env.AUTOMOBILE_MIGRATION_LOCK_TIMEOUT_MS ??
+    process.env.AUTO_MOBILE_MIGRATION_LOCK_TIMEOUT_MS;
+  const parsed = override ? Number.parseInt(override, 10) : NaN;
+  const timeoutMs = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+
+  logger.debug(`Migration lock keyed to ${lockFilePath}`);
+  return new FileMigrationLock(
+    lockFilePath,
+    timeoutMs !== undefined ? { timeoutMs } : {}
+  );
 }

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -1,0 +1,193 @@
+import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import { isProcessRunning as defaultIsProcessRunning } from "../daemon/daemonFiles";
+import { ActionableError } from "../models/ActionableError";
+import { logger } from "../utils/logger";
+import type { Timer } from "../utils/SystemTimer";
+import { defaultTimer } from "../utils/SystemTimer";
+
+/**
+ * Cross-process lock guarding {@link runMigrations}.
+ *
+ * Kysely's SQLite adapter provides no cross-process migration lock
+ * (`acquireMigrationLock` is a no-op, `supportsTransactionalDdl === false`), so
+ * two processes pointed at the same DB file — reachable only via override env
+ * (`AUTOMOBILE_DB_PATH`) or `--no-proxy` alongside a daemon — can both enter
+ * `migrateToLatest()` and collide on the `kysely_migration` PRIMARY KEY. This
+ * lock serializes the migration run across processes so the loser waits and then
+ * observes an already-migrated DB. See issue #2794.
+ */
+export interface MigrationLock {
+  /** Acquire the lock, waiting (bounded) if another opener holds it. */
+  acquire(): Promise<void>;
+  /** Release the lock. Best-effort; safe to call once per successful acquire. */
+  release(): Promise<void>;
+}
+
+/**
+ * No-op lock for the single-opener default and in-memory test databases, where
+ * no second process can share the connection. Keeps the migrator's DB-path-
+ * agnostic callers unchanged.
+ */
+export class NoOpMigrationLock implements MigrationLock {
+  async acquire(): Promise<void> {
+    // Nothing to serialize: a `:memory:` DB is private to one connection and the
+    // single-daemon default already serializes via the in-process mutex.
+  }
+
+  async release(): Promise<void> {
+    // No lock file to remove.
+  }
+}
+
+export interface FileMigrationLockOptions {
+  timer?: Timer;
+  /** Poll interval between acquire attempts while another opener holds the lock. */
+  pollIntervalMs?: number;
+  /**
+   * Ceiling for the bounded busy-wait. Must sit well above a cold migration
+   * runtime (30+ files, DDL + backfills) so a slow first boot does not spuriously
+   * time out the waiter.
+   */
+  timeoutMs?: number;
+  /** Injectable liveness check for stale-lock reclaim (defaults to `process.kill(pid, 0)`). */
+  isProcessRunning?: (pid: number) => boolean;
+  /** Owner pid written into the lock file (injectable for tests). */
+  pid?: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 100;
+// 60s is comfortably above a cold full-migration run on a slow/loaded disk, well
+// clear of the 5s `busy_timeout` that made `BEGIN EXCLUSIVE` unsuitable here.
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * File-based cross-process migration lock keyed to the resolved DB path
+ * (`${dbPath}.migrate.lock`). Reuses the daemon's atomic `O_CREAT | O_EXCL`
+ * (`wx`) create + dead-PID stale reclaim primitive (see
+ * `src/daemon/manager.ts` `acquireLock`), but wraps it in a bounded busy-wait so
+ * a mid-migration holder is waited out rather than failed fast.
+ */
+export class FileMigrationLock implements MigrationLock {
+  private readonly timer: Timer;
+  private readonly pollIntervalMs: number;
+  private readonly timeoutMs: number;
+  private readonly isProcessRunning: (pid: number) => boolean;
+  private readonly pid: number;
+
+  constructor(
+    private readonly lockFilePath: string,
+    options: FileMigrationLockOptions = {}
+  ) {
+    this.timer = options.timer ?? defaultTimer;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.isProcessRunning = options.isProcessRunning ?? defaultIsProcessRunning;
+    this.pid = options.pid ?? process.pid;
+  }
+
+  async acquire(): Promise<void> {
+    const deadline = this.timer.now() + this.timeoutMs;
+
+    // Fast path: a fresh lock (single opener) acquires on the first attempt with
+    // no sleep, so the default single-process path adds no latency.
+    for (;;) {
+      if (this.tryAcquireOnce()) {
+        return;
+      }
+
+      if (this.timer.now() >= deadline) {
+        throw new ActionableError(
+          `Timed out after ${this.timeoutMs}ms waiting for the database migration lock ` +
+            `at ${this.lockFilePath}. Another process is likely migrating this database — ` +
+            `you may be sharing one DB across worktrees/instances. Point each instance at a ` +
+            `distinct database via AUTOMOBILE_DB_PATH, or stop the other opener.`
+        );
+      }
+
+      await this.timer.sleep(this.pollIntervalMs);
+    }
+  }
+
+  async release(): Promise<void> {
+    try {
+      unlinkSync(this.lockFilePath);
+    } catch {
+      // Best-effort: the file may already be gone (never acquired, or removed by
+      // a stale-reclaim in another opener). Nothing actionable to surface.
+    }
+  }
+
+  /**
+   * One non-blocking acquire attempt. Returns true if the lock is now ours.
+   * Mirrors `DaemonManager.acquireLock`: atomic create, else inspect the owner
+   * and reclaim only if it is a dead PID.
+   */
+  private tryAcquireOnce(): boolean {
+    if (this.writeLockFile()) {
+      return true;
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(this.lockFilePath, "utf-8").trim();
+    } catch {
+      // File vanished between the failed `wx` create and this read — treat as
+      // still-contended and retry on the next poll.
+      return false;
+    }
+
+    if (content.length === 0) {
+      // Another opener created the file but has not written its PID yet; treat as
+      // actively held to avoid stealing a lock mid-write.
+      return false;
+    }
+
+    const ownerPid = Number.parseInt(content, 10);
+    if (Number.isNaN(ownerPid)) {
+      // Unreadable PID — a writer may still be filling it in; wait.
+      return false;
+    }
+
+    if (this.isProcessRunning(ownerPid)) {
+      return false;
+    }
+
+    // Owner is dead — reclaim the stale lock, then re-create atomically. The
+    // `wx` open below ensures two openers racing on the same dead PID cannot both
+    // win: the loser's `wx` throws and it falls back to waiting.
+    try {
+      unlinkSync(this.lockFilePath);
+    } catch {
+      // Someone else reclaimed it first; retry on the next poll.
+      return false;
+    }
+    return this.writeLockFile();
+  }
+
+  /**
+   * Atomically create the lock file with our PID via `O_CREAT | O_EXCL` (`wx`).
+   * Returns true on success, false if the file already exists.
+   */
+  private writeLockFile(): boolean {
+    try {
+      mkdirSync(dirname(this.lockFilePath), { recursive: true });
+      const fd = openSync(this.lockFilePath, "wx", 0o600);
+      writeFileSync(fd, String(this.pid));
+      closeSync(fd);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Default migration lock for a resolved DB file path. Keyed per-file (not
+ * per-uid) because the trigger — two openers on one DB file — is per-file.
+ */
+export function createFileMigrationLock(dbPath: string): MigrationLock {
+  const lock = new FileMigrationLock(`${dbPath}.migrate.lock`);
+  logger.debug(`Migration lock keyed to ${dbPath}.migrate.lock`);
+  return lock;
+}

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -1,3 +1,5 @@
+import { realpathSync } from "fs";
+import { basename, dirname, join } from "path";
 import { ActionableError } from "../models/ActionableError";
 import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
@@ -131,6 +133,24 @@ export class FileMigrationLock implements MigrationLock {
 }
 
 /**
+ * Resolve the lock file path for a DB path, canonicalizing symlinks/aliases so
+ * two openers reaching the *same* DB file through different path aliases (e.g. a
+ * symlinked or bind-mounted `AUTOMOBILE_DB_PATH`) derive the SAME lock file and
+ * actually contend — otherwise a string-keyed lock would let them both enter
+ * `migrateToLatest()`. The DB file itself may not exist yet on first boot, so
+ * canonicalize the (already-created) parent directory and re-append the basename.
+ */
+export function migrationLockPathFor(dbPath: string): string {
+  let canonical = dbPath;
+  try {
+    canonical = join(realpathSync(dirname(dbPath)), basename(dbPath));
+  } catch {
+    // Parent dir not resolvable yet — fall back to the raw path (best effort).
+  }
+  return `${canonical}.migrate.lock`;
+}
+
+/**
  * Default migration lock for a resolved DB file path. Keyed per-file (not
  * per-uid) because the trigger — two openers on one DB file — is per-file. The
  * busy-wait ceiling can be overridden via `AUTOMOBILE_MIGRATION_LOCK_TIMEOUT_MS`
@@ -138,7 +158,7 @@ export class FileMigrationLock implements MigrationLock {
  * `src/daemon/constants.ts`.
  */
 export function createFileMigrationLock(dbPath: string): MigrationLock {
-  const lockFilePath = `${dbPath}.migrate.lock`;
+  const lockFilePath = migrationLockPathFor(dbPath);
   const override =
     process.env.AUTOMOBILE_MIGRATION_LOCK_TIMEOUT_MS ??
     process.env.AUTO_MOBILE_MIGRATION_LOCK_TIMEOUT_MS;

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import { basename, dirname, join } from "path";
 import { ActionableError } from "../models/ActionableError";
 import { logger } from "../utils/logger";
@@ -143,9 +143,15 @@ export class FileMigrationLock implements MigrationLock {
 export function migrationLockPathFor(dbPath: string): string {
   let canonical = dbPath;
   try {
-    canonical = join(realpathSync(dirname(dbPath)), basename(dbPath));
+    // If the DB file already exists, resolve it fully so a symlinked DB file
+    // *itself* (e.g. AUTOMOBILE_DB_PATH pointing at an alias of the real file)
+    // maps to the same lock as its real path. Before first creation the file is
+    // absent, so fall back to canonicalizing the (existing) parent dir + basename.
+    canonical = existsSync(dbPath)
+      ? realpathSync(dbPath)
+      : join(realpathSync(dirname(dbPath)), basename(dbPath));
   } catch {
-    // Parent dir not resolvable yet — fall back to the raw path (best effort).
+    // Path not resolvable yet — fall back to the raw path (best effort).
   }
   return `${canonical}.migrate.lock`;
 }

--- a/src/db/migrator.ts
+++ b/src/db/migrator.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "url";
 import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
+import type { MigrationLock } from "./migrationLock";
+import { NoOpMigrationLock } from "./migrationLock";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 
 const DISABLED_RECOVERY_VALUES = new Set(["0", "false", "no", "off"]);
@@ -170,41 +172,57 @@ async function recoverCorruptedMigrations(
 }
 
 /**
- * Run all pending database migrations
+ * Run all pending database migrations.
+ *
+ * The optional {@link MigrationLock} serializes the run across processes so two
+ * openers pointed at the same DB file can't both enter `migrateToLatest()` and
+ * collide on the `kysely_migration` PRIMARY KEY (issue #2794). The default is a
+ * no-op lock — correct for `:memory:` databases and the single-daemon path,
+ * which is already serialized by the in-process mutex. Production callers pass a
+ * file lock keyed to the resolved DB path (see `database.ts#startMigrations`).
+ * The lock is always released, even when the migration throws.
  */
-export async function runMigrations(db: Kysely<unknown>): Promise<void> {
-  const migrator = new Migrator({
-    db,
-    provider: new FileMigrationProvider({
-      fs,
-      path,
-      migrationFolder: resolveMigrationFolder(),
-    }),
-  });
+export async function runMigrations(
+  db: Kysely<unknown>,
+  lock: MigrationLock = new NoOpMigrationLock()
+): Promise<void> {
+  await lock.acquire();
+  try {
+    const migrator = new Migrator({
+      db,
+      provider: new FileMigrationProvider({
+        fs,
+        path,
+        migrationFolder: resolveMigrationFolder(),
+      }),
+    });
 
-  const { error } = await runMigrationsOnce(migrator);
+    const { error } = await runMigrationsOnce(migrator);
 
-  if (error) {
-    if (isCorruptedMigrationError(error) && isMigrationRecoveryEnabled()) {
-      const recoveryResult = await recoverCorruptedMigrations(db, migrator, error);
-      if (recoveryResult.error) {
-        logger.error("Failed to run migrations after recovery:", recoveryResult.error);
-        throw recoveryResult.error;
+    if (error) {
+      if (isCorruptedMigrationError(error) && isMigrationRecoveryEnabled()) {
+        const recoveryResult = await recoverCorruptedMigrations(db, migrator, error);
+        if (recoveryResult.error) {
+          logger.error("Failed to run migrations after recovery:", recoveryResult.error);
+          throw recoveryResult.error;
+        }
+        logger.info("All migrations completed successfully");
+        return;
       }
-      logger.info("All migrations completed successfully");
-      return;
+
+      if (isCorruptedMigrationError(error) && !isMigrationRecoveryEnabled()) {
+        logger.error(
+          "Corrupted migrations detected. Set AUTOMOBILE_MIGRATION_RECOVERY=1 to enable automatic " +
+            "recovery or reset the local database state."
+        );
+      }
+
+      logger.error("Failed to run migrations:", error);
+      throw error;
     }
 
-    if (isCorruptedMigrationError(error) && !isMigrationRecoveryEnabled()) {
-      logger.error(
-        "Corrupted migrations detected. Set AUTOMOBILE_MIGRATION_RECOVERY=1 to enable automatic " +
-          "recovery or reset the local database state."
-      );
-    }
-
-    logger.error("Failed to run migrations:", error);
-    throw error;
+    logger.info("All migrations completed successfully");
+  } finally {
+    await lock.release();
   }
-
-  logger.info("All migrations completed successfully");
 }

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -1,0 +1,137 @@
+import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import { isProcessRunning as defaultIsProcessRunning } from "../daemon/daemonFiles";
+
+/**
+ * The canonical cross-process file-lock primitive (issue #2794).
+ *
+ * A lock file created atomically via `O_CREAT | O_EXCL` (`wx`) holding the owner
+ * PID. Two racers can't both win — the atomic create decides — and a lock left
+ * by a dead holder is reclaimed on the next attempt via a PID liveness check.
+ *
+ * Both `DaemonManager` (start/stop coordination, non-blocking single attempt)
+ * and the DB `FileMigrationLock` (bounded busy-wait) build on this so there is
+ * "one canonical primitive per concern" rather than two copies of the subtle
+ * `O_EXCL` + stale-reclaim logic.
+ */
+export interface ExclusiveLockOptions {
+  /** Owner PID written into the lock file (defaults to `process.pid`). */
+  pid?: number;
+  /** Liveness check for stale-lock reclaim (defaults to `process.kill(pid, 0)`). */
+  isProcessRunning?: (pid: number) => boolean;
+  /**
+   * When true, a lock file already owned by *this* PID is treated as a stale
+   * leak from a crashed prior incarnation and reclaimed, instead of "held".
+   *
+   * Safe only where the caller guarantees a single in-process acquirer (e.g. the
+   * migration singleton, whose `runMigrations` never runs twice concurrently in
+   * one process): it removes the deterministic timeout hang that would otherwise
+   * occur when a supervisor restarts a crashed process and the OS recycles the
+   * same PID. The daemon coordinator leaves this `false` so a same-PID probe from
+   * another manager instance still reads as held.
+   */
+  reclaimOwnPid?: boolean;
+}
+
+/**
+ * One non-blocking attempt to acquire the exclusive lock. Returns true if the
+ * lock is now held by `pid`, false if another live holder owns it.
+ */
+export function tryAcquireExclusiveLock(
+  lockFilePath: string,
+  options: ExclusiveLockOptions = {}
+): boolean {
+  const pid = options.pid ?? process.pid;
+  const isProcessRunning = options.isProcessRunning ?? defaultIsProcessRunning;
+  const reclaimOwnPid = options.reclaimOwnPid ?? false;
+
+  if (writeExclusiveLockFile(lockFilePath, pid)) {
+    return true;
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(lockFilePath, "utf-8").trim();
+  } catch {
+    // File vanished between the failed `wx` create and this read — another opener
+    // is churning it; treat as contended and let the caller retry.
+    return false;
+  }
+
+  if (content.length === 0) {
+    // A writer created the file but hasn't written its PID yet; treat as actively
+    // held to avoid stealing a lock mid-write.
+    //
+    // Known limitation: a crash in the microsecond window between the `wx` create
+    // and the PID write leaves an empty file that is never reclaimable. This is
+    // astronomically rare (the create+write is a single synchronous burst) and is
+    // shared with the daemon lock; tracked as a follow-up, not fixed here.
+    return false;
+  }
+
+  const ownerPid = Number.parseInt(content, 10);
+  if (Number.isNaN(ownerPid)) {
+    // Unreadable PID — a writer may still be filling it in; treat as held.
+    return false;
+  }
+
+  const isOwnStaleLeak = reclaimOwnPid && ownerPid === pid;
+  if (isProcessRunning(ownerPid) && !isOwnStaleLeak) {
+    return false;
+  }
+
+  // Dead holder (or our own recycled PID under reclaimOwnPid) — reclaim it, then
+  // re-create atomically. The `wx` open below is the arbiter: two openers racing
+  // on the same dead PID can't both win — the loser's create throws and it waits.
+  try {
+    unlinkSync(lockFilePath);
+  } catch {
+    // Someone else reclaimed it first; retry on the next attempt.
+    return false;
+  }
+  return writeExclusiveLockFile(lockFilePath, pid);
+}
+
+/**
+ * Release a lock owned by `pid`. Compare-and-delete: the file is removed only if
+ * it still holds `pid`, so a reclaim race can't delete a lock that a *different*
+ * opener now owns (mirrors `shouldCleanupForExpectedPid` in `daemonFiles.ts`).
+ */
+export function releaseExclusiveLock(lockFilePath: string, pid: number = process.pid): void {
+  let content: string;
+  try {
+    content = readFileSync(lockFilePath, "utf-8").trim();
+  } catch {
+    // Already gone (never acquired, or reclaimed elsewhere) — nothing to release.
+    return;
+  }
+
+  if (Number.parseInt(content, 10) !== pid) {
+    // The lock is no longer ours — do not delete another opener's file.
+    return;
+  }
+
+  try {
+    unlinkSync(lockFilePath);
+  } catch {
+    // Best-effort: removed concurrently between the read and here.
+  }
+}
+
+/**
+ * Atomically create the lock file with `pid` via `O_CREAT | O_EXCL` (`wx`).
+ * Returns true on success, false if the file already exists.
+ */
+function writeExclusiveLockFile(lockFilePath: string, pid: number): boolean {
+  try {
+    mkdirSync(dirname(lockFilePath), { recursive: true });
+    const fd = openSync(lockFilePath, "wx", 0o600);
+    writeFileSync(fd, String(pid));
+    closeSync(fd);
+    return true;
+  } catch {
+    // Expected: `wx` (O_EXCL) throws EEXIST when another opener already holds the
+    // lock. The caller treats false as "contended" and retries.
+    return false;
+  }
+}

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -1,4 +1,4 @@
-import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { closeSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import { isProcessRunning as defaultIsProcessRunning } from "../daemon/daemonFiles";
 
@@ -80,14 +80,29 @@ export function tryAcquireExclusiveLock(
     return false;
   }
 
-  // Dead holder (or our own recycled PID under reclaimOwnPid) — reclaim it, then
-  // re-create atomically. The `wx` open below is the arbiter: two openers racing
-  // on the same dead PID can't both win — the loser's create throws and it waits.
+  // Dead holder (or our own recycled PID under reclaimOwnPid) — reclaim it.
+  //
+  // Do NOT unlink-by-path here: two openers can both read the same stale PID, and
+  // an unlink-by-path would let each delete the OTHER's freshly recreated lock and
+  // then both `wx`-create — so both would "own" it and enter migrateToLatest()
+  // concurrently, reintroducing the PRIMARY KEY collision this lock prevents.
+  //
+  // Instead claim the stale file with an atomic rename to a per-PID marker: only
+  // the opener whose rename succeeds consumed that exact stale instance; a racing
+  // opener's rename throws (the path is already gone) and it retries, finding the
+  // fresh lock held. The final `wx` create is still the arbiter against a third
+  // opener that creates a brand-new lock in the gap.
+  const reclaimMarker = `${lockFilePath}.${pid}.reclaim`;
   try {
-    unlinkSync(lockFilePath);
+    renameSync(lockFilePath, reclaimMarker);
   } catch {
-    // Someone else reclaimed it first; retry on the next attempt.
+    // Another opener reclaimed it first (path already moved/gone); retry.
     return false;
+  }
+  try {
+    unlinkSync(reclaimMarker);
+  } catch {
+    // Best-effort: the consumed stale marker is ours to remove.
   }
   return writeExclusiveLockFile(lockFilePath, pid);
 }

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -272,4 +272,21 @@ describe("migrationLockPathFor", () => {
       expect(viaLink).toBe(viaReal);
     }
   );
+
+  test.skipIf(process.platform === "win32")(
+    "resolves a symlinked DB file to the same lock path as its real path",
+    () => {
+      const realDb = join(dir, "auto-mobile.db");
+      const aliasDb = join(dir, "alias.db");
+      writeFileSync(realDb, ""); // the DB file exists; alias is a symlink to it
+      symlinkSync(realDb, aliasDb);
+
+      const viaReal = migrationLockPathFor(realDb);
+      const viaAlias = migrationLockPathFor(aliasDb);
+
+      // A symlinked DB file itself must derive the SAME lock as its real path.
+      expect(viaAlias).toBe(viaReal);
+      expect(viaReal).toBe(`${realpathSync(realDb)}.migrate.lock`);
+    }
+  );
 });

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { FileMigrationLock, NoOpMigrationLock } from "../../src/db/migrationLock";
+import { FileMigrationLock, NoOpMigrationLock, migrationLockPathFor } from "../../src/db/migrationLock";
 import { ActionableError } from "../../src/models/ActionableError";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -234,4 +234,42 @@ describe("NoOpMigrationLock", () => {
     await lock.release();
     expect(true).toBe(true);
   });
+});
+
+describe("migrationLockPathFor", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "migration-lock-path-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("appends .migrate.lock to the canonicalized DB path", () => {
+    const dbPath = join(dir, "auto-mobile.db");
+    // `dir` itself may be under a symlinked tmp root (e.g. macOS /var → /private/var),
+    // so compare against the canonicalized directory rather than the raw path.
+    const expected = `${join(realpathSync(dir), "auto-mobile.db")}.migrate.lock`;
+    expect(migrationLockPathFor(dbPath)).toBe(expected);
+  });
+
+  // Symlinks require elevation on Windows; the canonicalization is a POSIX-alias fix.
+  test.skipIf(process.platform === "win32")(
+    "resolves symlinked directory aliases to the same lock path",
+    () => {
+      const realDir = join(dir, "real");
+      const linkDir = join(dir, "link");
+      mkdirSync(realDir, { recursive: true });
+      symlinkSync(realDir, linkDir);
+
+      const viaReal = migrationLockPathFor(join(realDir, "auto-mobile.db"));
+      const viaLink = migrationLockPathFor(join(linkDir, "auto-mobile.db"));
+
+      // Two aliases for the same directory must derive the SAME lock file so the
+      // openers actually contend.
+      expect(viaLink).toBe(viaReal);
+    }
+  );
 });

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -88,6 +88,49 @@ describe("FileMigrationLock", () => {
     await lock.release();
   });
 
+  test("reclaims a lock left by our own recycled PID without waiting", async () => {
+    // A supervisor restarts a crashed process and the OS recycles its PID, so a
+    // leaked lock bears our own now-live PID. Since the migration run is a
+    // per-process singleton, this must be reclaimed, not waited out for 60s.
+    const timer = new FakeTimer();
+    writeFileSync(lockPath, "4242");
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      isProcessRunning: () => true, // our own PID is (of course) alive
+    });
+
+    await lock.acquire();
+
+    expect(timer.getSleepCallCount()).toBe(0);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+    await lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("release does not delete a lock owned by a different opener", async () => {
+    const timer = new FakeTimer();
+    // A different live opener owns the lock.
+    writeFileSync(lockPath, "9999");
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      isProcessRunning: () => true,
+    });
+
+    // We never acquired it; release must be a no-op that leaves the file intact.
+    await lock.release();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("9999");
+  });
+
+  test("release is inert when the lock was never acquired", async () => {
+    const lock = new FileMigrationLock(lockPath, { timer: new FakeTimer(), pid: 4242 });
+    await lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
   test("reclaims a stale lock left by a dead holder without waiting", async () => {
     const timer = new FakeTimer();
     // Stale lock from a dead process.
@@ -129,7 +172,10 @@ describe("FileMigrationLock", () => {
     await pending;
 
     expect(rejection).toBeInstanceOf(ActionableError);
-    expect((rejection as Error).message).toContain("AUTOMOBILE_DB_PATH");
+    const message = (rejection as Error).message;
+    expect(message).toContain("AUTOMOBILE_DB_PATH");
+    expect(message).toContain(lockPath);
+    expect(message).toContain("migration lock");
     // Lock owned by the live holder must remain untouched.
     expect(readFileSync(lockPath, "utf-8").trim()).toBe("9999");
   });

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { FileMigrationLock, NoOpMigrationLock } from "../../src/db/migrationLock";
+import { ActionableError } from "../../src/models/ActionableError";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/** Let queued microtasks (busy-wait loop continuations) run. */
+async function flush(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+describe("FileMigrationLock", () => {
+  let dir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "migration-lock-"));
+    lockPath = join(dir, "auto-mobile.db.migrate.lock");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("acquire creates the lock file with the owner pid; release removes it", async () => {
+    const timer = new FakeTimer();
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      isProcessRunning: () => true,
+    });
+
+    await lock.acquire();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+
+    await lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("single-opener path acquires immediately without sleeping", async () => {
+    const timer = new FakeTimer();
+    const lock = new FileMigrationLock(lockPath, { timer, pid: 1 });
+
+    await lock.acquire();
+
+    expect(timer.getSleepCallCount()).toBe(0);
+    await lock.release();
+  });
+
+  test("busy-waits while a live holder owns the lock, then acquires after release", async () => {
+    const timer = new FakeTimer();
+    // Simulate another live process holding the lock.
+    writeFileSync(lockPath, "9999");
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      pollIntervalMs: 100,
+      isProcessRunning: pid => pid === 9999, // the holder is alive
+    });
+
+    let acquired = false;
+    const pending = lock.acquire().then(() => {
+      acquired = true;
+    });
+
+    // First attempt fails (held by live process) -> parks on sleep.
+    await flush();
+    expect(acquired).toBe(false);
+    expect(timer.getPendingSleepCount()).toBe(1);
+
+    // Holder still alive after a poll -> keeps waiting.
+    timer.advanceTime(100);
+    await flush();
+    expect(acquired).toBe(false);
+
+    // Holder releases; next poll reclaims the lock.
+    rmSync(lockPath);
+    timer.advanceTime(100);
+    await flush();
+    await pending;
+
+    expect(acquired).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+    await lock.release();
+  });
+
+  test("reclaims a stale lock left by a dead holder without waiting", async () => {
+    const timer = new FakeTimer();
+    // Stale lock from a dead process.
+    writeFileSync(lockPath, "9999");
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      isProcessRunning: () => false, // holder is dead
+    });
+
+    await lock.acquire();
+
+    expect(timer.getSleepCallCount()).toBe(0);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+    await lock.release();
+  });
+
+  test("throws an ActionableError after the timeout ceiling when the holder stays alive", async () => {
+    const timer = new FakeTimer();
+    writeFileSync(lockPath, "9999");
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      pollIntervalMs: 100,
+      timeoutMs: 250,
+      isProcessRunning: () => true, // never releases
+    });
+
+    let rejection: unknown;
+    const pending = lock.acquire().catch(error => {
+      rejection = error;
+    });
+
+    // Drive past the ceiling.
+    for (let i = 0; i < 5; i++) {
+      timer.advanceTime(100);
+      await flush();
+    }
+    await pending;
+
+    expect(rejection).toBeInstanceOf(ActionableError);
+    expect((rejection as Error).message).toContain("AUTOMOBILE_DB_PATH");
+    // Lock owned by the live holder must remain untouched.
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("9999");
+  });
+
+  test("does not let two openers both win on a dead-PID reclaim race (atomic wx)", async () => {
+    const timer = new FakeTimer();
+    // Both processes see the same dead-PID stale lock.
+    writeFileSync(lockPath, "9999");
+
+    const lockA = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 100,
+      pollIntervalMs: 50,
+      timeoutMs: 1000,
+      isProcessRunning: pid => pid !== 9999, // 9999 dead, everyone else alive
+    });
+    const lockB = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 200,
+      pollIntervalMs: 50,
+      timeoutMs: 1000,
+      isProcessRunning: pid => pid !== 9999,
+    });
+
+    // A reclaims the stale lock first.
+    await lockA.acquire();
+    const owner = readFileSync(lockPath, "utf-8").trim();
+    expect(owner).toBe("100");
+
+    // B must NOT be able to steal it while A (pid 100) is alive.
+    let bAcquired = false;
+    const bPending = lockB.acquire().then(() => {
+      bAcquired = true;
+    });
+    await flush();
+    timer.advanceTime(50);
+    await flush();
+    expect(bAcquired).toBe(false);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
+
+    // Once A releases, B acquires cleanly.
+    await lockA.release();
+    timer.advanceTime(50);
+    await flush();
+    await bPending;
+    expect(bAcquired).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("200");
+    await lockB.release();
+  });
+});
+
+describe("NoOpMigrationLock", () => {
+  test("acquire and release are inert", async () => {
+    const lock = new NoOpMigrationLock();
+    await lock.acquire();
+    await lock.release();
+    expect(true).toBe(true);
+  });
+});

--- a/test/db/migratorLock.test.ts
+++ b/test/db/migratorLock.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
-import { mkdtempSync, readdirSync, rmSync } from "fs";
+import { promises as fs, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
+import * as path from "path";
 import { join } from "path";
 import { Kysely } from "kysely";
+import { Migrator, FileMigrationProvider } from "kysely/migration";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { runMigrations, resolveMigrationFolder } from "../../src/db/migrator";
 import { FileMigrationLock, type MigrationLock } from "../../src/db/migrationLock";
@@ -22,8 +24,44 @@ class RecordingMigrationLock implements MigrationLock {
   }
 }
 
-function migrationCount(): number {
-  return readdirSync(resolveMigrationFolder()).filter(name => name.endsWith(".ts") || name.endsWith(".js")).length;
+/**
+ * Authoritative count of migrations Kysely will actually run, derived from the
+ * provider rather than a raw file listing (a raw listing over-counts helpers and
+ * `.d.ts`, and Kysely would then fail importing a non-migration file anyway).
+ */
+async function expectedMigrationCount(): Promise<number> {
+  const probe = new Kysely<unknown>({
+    dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+  });
+  try {
+    const migrator = new Migrator({
+      db: probe,
+      provider: new FileMigrationProvider({ fs, path, migrationFolder: resolveMigrationFolder() }),
+    });
+    return (await migrator.getMigrations()).length;
+  } finally {
+    await probe.destroy();
+  }
+}
+
+function openFileDb(dbPath: string): Kysely<unknown> {
+  return new Kysely<unknown>({
+    dialect: new BunSqliteDialect({ database: new BunDatabase(dbPath) }),
+  });
+}
+
+/** A FileMigrationLock keyed to `lockPath`, acting as a distinct virtual opener. */
+function opener(lockPath: string, pid: number, timeoutMs = 60_000): FileMigrationLock {
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  return new FileMigrationLock(lockPath, {
+    timer,
+    pid,
+    pollIntervalMs: 5,
+    timeoutMs,
+    // Distinct virtual PIDs, all "alive" — the file lock is the only arbiter.
+    isProcessRunning: candidate => candidate === 1 || candidate === 2,
+  });
 }
 
 describe("runMigrations lock integration", () => {
@@ -81,36 +119,54 @@ describe("runMigrations lock integration", () => {
     expect(lock.calls).toEqual(["acquire", "release"]);
   });
 
+  test("runMigrations WAITS on the lock while another opener holds it (lock is load-bearing)", async () => {
+    // This is the test that proves the lock does something. If the lock were
+    // removed (e.g. swapped for NoOpMigrationLock), the second runMigrations would
+    // NOT time out here — it would migrate immediately — so this test fails,
+    // catching a neutered lock. (A plain two-openers-in-one-process race does not:
+    // bun:sqlite serializes the I/O incidentally, hiding a missing lock.)
+    const dir = mkdtempSync(join(tmpdir(), "migrator-serialize-"));
+    const dbPath = join(dir, "auto-mobile.db");
+    const lockPath = `${dbPath}.migrate.lock`;
+
+    // Opener A takes and holds the lock (simulating an in-flight migration).
+    const holder = opener(lockPath, 1);
+    await holder.acquire();
+
+    const db2 = openFileDb(dbPath);
+    try {
+      // Opener B's migration must block on the lock; with a short ceiling it times
+      // out rather than proceeding — proof it is gated by the lock, not sqlite.
+      const lockB = opener(lockPath, 2, 50);
+      await expect(runMigrations(db2, lockB)).rejects.toThrow(/migration lock/);
+
+      // Once A releases, B proceeds and migrates the DB exactly once.
+      await holder.release();
+      await runMigrations(db2, opener(lockPath, 2));
+
+      const rows = await db2
+        .selectFrom("kysely_migration" as any)
+        .select("name")
+        .execute();
+      expect(rows.length).toBe(await expectedMigrationCount());
+    } finally {
+      await db2.destroy();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("two concurrent openers on the same DB file do not trip a PRIMARY KEY error", async () => {
     const dir = mkdtempSync(join(tmpdir(), "migrator-concurrency-"));
     const dbPath = join(dir, "auto-mobile.db");
     const lockPath = `${dbPath}.migrate.lock`;
 
-    const makeLock = (pid: number): FileMigrationLock => {
-      const timer = new FakeTimer();
-      timer.enableAutoAdvance();
-      return new FileMigrationLock(lockPath, {
-        timer,
-        pid,
-        pollIntervalMs: 5,
-        timeoutMs: 60_000,
-        // Distinct virtual pids; both "alive" so the file lock (wx) is the only
-        // arbiter between the two in-process openers.
-        isProcessRunning: candidate => candidate === 1 || candidate === 2,
-      });
-    };
-
-    const db1 = new Kysely<unknown>({
-      dialect: new BunSqliteDialect({ database: new BunDatabase(dbPath) }),
-    });
-    const db2 = new Kysely<unknown>({
-      dialect: new BunSqliteDialect({ database: new BunDatabase(dbPath) }),
-    });
+    const db1 = openFileDb(dbPath);
+    const db2 = openFileDb(dbPath);
 
     try {
       await Promise.all([
-        runMigrations(db1, makeLock(1)),
-        runMigrations(db2, makeLock(2)),
+        runMigrations(db1, opener(lockPath, 1)),
+        runMigrations(db2, opener(lockPath, 2)),
       ]);
 
       // Exactly one opener wrote the history; the second observed an
@@ -119,10 +175,50 @@ describe("runMigrations lock integration", () => {
         .selectFrom("kysely_migration" as any)
         .select("name")
         .execute();
-      expect(rows.length).toBe(migrationCount());
+      expect(rows.length).toBe(await expectedMigrationCount());
     } finally {
       await db1.destroy();
       await db2.destroy();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a second opener still migrates after the first opener fails mid-migration", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "migrator-failrelease-"));
+    const dbPath = join(dir, "auto-mobile.db");
+    const lockPath = `${dbPath}.migrate.lock`;
+
+    const dbA = openFileDb(dbPath);
+    const dbB = openFileDb(dbPath);
+    const previous = process.env.AUTOMOBILE_MIGRATIONS_DIR;
+
+    try {
+      // Opener A acquires the real lock, then fails (bad migrations folder). Its
+      // finally-release must free the lock so B is not wedged.
+      process.env.AUTOMOBILE_MIGRATIONS_DIR = join(tmpdir(), "auto-mobile-missing-migrations");
+      await expect(runMigrations(dbA, opener(lockPath, 1))).rejects.toBeDefined();
+
+      // Restore the real migrations folder; B acquires cleanly and migrates.
+      if (previous === undefined) {
+        delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
+      } else {
+        process.env.AUTOMOBILE_MIGRATIONS_DIR = previous;
+      }
+      await runMigrations(dbB, opener(lockPath, 2));
+
+      const rows = await dbB
+        .selectFrom("kysely_migration" as any)
+        .select("name")
+        .execute();
+      expect(rows.length).toBe(await expectedMigrationCount());
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
+      } else {
+        process.env.AUTOMOBILE_MIGRATIONS_DIR = previous;
+      }
+      await dbA.destroy();
+      await dbB.destroy();
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/test/db/migratorLock.test.ts
+++ b/test/db/migratorLock.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { mkdtempSync, readdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { runMigrations, resolveMigrationFolder } from "../../src/db/migrator";
+import { FileMigrationLock, type MigrationLock } from "../../src/db/migrationLock";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/** Records the acquire/release call order for ordering assertions. */
+class RecordingMigrationLock implements MigrationLock {
+  readonly calls: string[] = [];
+
+  async acquire(): Promise<void> {
+    this.calls.push("acquire");
+  }
+
+  async release(): Promise<void> {
+    this.calls.push("release");
+  }
+}
+
+function migrationCount(): number {
+  return readdirSync(resolveMigrationFolder()).filter(name => name.endsWith(".ts") || name.endsWith(".js")).length;
+}
+
+describe("runMigrations lock integration", () => {
+  beforeEach(() => {
+    process.env.AUTOMOBILE_MIGRATION_RECOVERY = "1";
+  });
+
+  afterEach(() => {
+    delete process.env.AUTOMOBILE_MIGRATION_RECOVERY;
+  });
+
+  test("acquires the lock before migrating and releases it after", async () => {
+    const db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    const lock = new RecordingMigrationLock();
+
+    await runMigrations(db, lock);
+
+    expect(lock.calls).toEqual(["acquire", "release"]);
+
+    // Migrations actually ran between acquire and release.
+    const rows = await db
+      .selectFrom("kysely_migration" as any)
+      .select("name")
+      .execute();
+    expect(rows.length).toBeGreaterThan(0);
+
+    await db.destroy();
+  });
+
+  test("releases the lock even when migration fails", async () => {
+    const db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    const lock = new RecordingMigrationLock();
+    // Point at a non-existent migrations folder so migrateToLatest fails.
+    const previous = process.env.AUTOMOBILE_MIGRATIONS_DIR;
+    process.env.AUTOMOBILE_MIGRATIONS_DIR = join(
+      tmpdir(),
+      "auto-mobile-does-not-exist-migrations"
+    );
+
+    try {
+      await expect(runMigrations(db, lock)).rejects.toBeDefined();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
+      } else {
+        process.env.AUTOMOBILE_MIGRATIONS_DIR = previous;
+      }
+      await db.destroy();
+    }
+
+    expect(lock.calls).toEqual(["acquire", "release"]);
+  });
+
+  test("two concurrent openers on the same DB file do not trip a PRIMARY KEY error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "migrator-concurrency-"));
+    const dbPath = join(dir, "auto-mobile.db");
+    const lockPath = `${dbPath}.migrate.lock`;
+
+    const makeLock = (pid: number): FileMigrationLock => {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      return new FileMigrationLock(lockPath, {
+        timer,
+        pid,
+        pollIntervalMs: 5,
+        timeoutMs: 60_000,
+        // Distinct virtual pids; both "alive" so the file lock (wx) is the only
+        // arbiter between the two in-process openers.
+        isProcessRunning: candidate => candidate === 1 || candidate === 2,
+      });
+    };
+
+    const db1 = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(dbPath) }),
+    });
+    const db2 = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(dbPath) }),
+    });
+
+    try {
+      await Promise.all([
+        runMigrations(db1, makeLock(1)),
+        runMigrations(db2, makeLock(2)),
+      ]);
+
+      // Exactly one opener wrote the history; the second observed an
+      // already-migrated DB and wrote 0 new rows.
+      const rows = await db1
+        .selectFrom("kysely_migration" as any)
+        .select("name")
+        .execute();
+      expect(rows.length).toBe(migrationCount());
+    } finally {
+      await db1.destroy();
+      await db2.destroy();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/db/migratorLock.test.ts
+++ b/test/db/migratorLock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
-import { promises as fs, mkdtempSync, rmSync } from "fs";
+import { existsSync, promises as fs, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import * as path from "path";
 import { join } from "path";
@@ -10,6 +10,16 @@ import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { runMigrations, resolveMigrationFolder } from "../../src/db/migrator";
 import { FileMigrationLock, type MigrationLock } from "../../src/db/migrationLock";
 import { FakeTimer } from "../fakes/FakeTimer";
+
+// These tests exercise `runMigrations`'s interaction with a real
+// `FileMigrationLock` (a temp lock file, opened/closed synchronously — no
+// lingering handles, Windows-safe) while migrating an in-memory DB. A genuine
+// cross-process PRIMARY-KEY collision can only be reproduced with two real OS
+// processes; in-process the lock's guarantee is proven compositionally:
+// - the primitive provides mutual exclusion (test/utils/fileLock.test.ts,
+//   test/db/migrationLock.test.ts), and
+// - `runMigrations` is gated by it (the serialization test below, which FAILS
+//   if the lock is removed).
 
 /** Records the acquire/release call order for ordering assertions. */
 class RecordingMigrationLock implements MigrationLock {
@@ -24,15 +34,19 @@ class RecordingMigrationLock implements MigrationLock {
   }
 }
 
+function memoryDb(): Kysely<unknown> {
+  return new Kysely<unknown>({
+    dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+  });
+}
+
 /**
  * Authoritative count of migrations Kysely will actually run, derived from the
  * provider rather than a raw file listing (a raw listing over-counts helpers and
  * `.d.ts`, and Kysely would then fail importing a non-migration file anyway).
  */
 async function expectedMigrationCount(): Promise<number> {
-  const probe = new Kysely<unknown>({
-    dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
-  });
+  const probe = memoryDb();
   try {
     const migrator = new Migrator({
       db: probe,
@@ -42,12 +56,6 @@ async function expectedMigrationCount(): Promise<number> {
   } finally {
     await probe.destroy();
   }
-}
-
-function openFileDb(dbPath: string): Kysely<unknown> {
-  return new Kysely<unknown>({
-    dialect: new BunSqliteDialect({ database: new BunDatabase(dbPath) }),
-  });
 }
 
 /** A FileMigrationLock keyed to `lockPath`, acting as a distinct virtual opener. */
@@ -65,18 +73,22 @@ function opener(lockPath: string, pid: number, timeoutMs = 60_000): FileMigratio
 }
 
 describe("runMigrations lock integration", () => {
+  let dir: string;
+  let lockPath: string;
+
   beforeEach(() => {
     process.env.AUTOMOBILE_MIGRATION_RECOVERY = "1";
+    dir = mkdtempSync(join(tmpdir(), "migrator-lock-"));
+    lockPath = join(dir, "auto-mobile.db.migrate.lock");
   });
 
   afterEach(() => {
     delete process.env.AUTOMOBILE_MIGRATION_RECOVERY;
+    rmSync(dir, { recursive: true, force: true });
   });
 
   test("acquires the lock before migrating and releases it after", async () => {
-    const db = new Kysely<unknown>({
-      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
-    });
+    const db = memoryDb();
     const lock = new RecordingMigrationLock();
 
     await runMigrations(db, lock);
@@ -94,16 +106,11 @@ describe("runMigrations lock integration", () => {
   });
 
   test("releases the lock even when migration fails", async () => {
-    const db = new Kysely<unknown>({
-      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
-    });
+    const db = memoryDb();
     const lock = new RecordingMigrationLock();
     // Point at a non-existent migrations folder so migrateToLatest fails.
     const previous = process.env.AUTOMOBILE_MIGRATIONS_DIR;
-    process.env.AUTOMOBILE_MIGRATIONS_DIR = join(
-      tmpdir(),
-      "auto-mobile-does-not-exist-migrations"
-    );
+    process.env.AUTOMOBILE_MIGRATIONS_DIR = join(tmpdir(), "auto-mobile-does-not-exist-migrations");
 
     try {
       await expect(runMigrations(db, lock)).rejects.toBeDefined();
@@ -123,73 +130,38 @@ describe("runMigrations lock integration", () => {
     // This is the test that proves the lock does something. If the lock were
     // removed (e.g. swapped for NoOpMigrationLock), the second runMigrations would
     // NOT time out here — it would migrate immediately — so this test fails,
-    // catching a neutered lock. (A plain two-openers-in-one-process race does not:
-    // bun:sqlite serializes the I/O incidentally, hiding a missing lock.)
-    const dir = mkdtempSync(join(tmpdir(), "migrator-serialize-"));
-    const dbPath = join(dir, "auto-mobile.db");
-    const lockPath = `${dbPath}.migrate.lock`;
-
-    // Opener A takes and holds the lock (simulating an in-flight migration).
+    // catching a neutered lock.
     const holder = opener(lockPath, 1);
-    await holder.acquire();
+    await holder.acquire(); // opener A holds the lock
 
-    const db2 = openFileDb(dbPath);
+    const db = memoryDb();
     try {
       // Opener B's migration must block on the lock; with a short ceiling it times
-      // out rather than proceeding — proof it is gated by the lock, not sqlite.
+      // out rather than proceeding — proof it is gated by the lock.
       const lockB = opener(lockPath, 2, 50);
-      await expect(runMigrations(db2, lockB)).rejects.toThrow(/migration lock/);
+      await expect(runMigrations(db, lockB)).rejects.toThrow(/migration lock/);
 
-      // Once A releases, B proceeds and migrates the DB exactly once.
+      // Once A releases, B proceeds and migrates the DB exactly once (no
+      // double-write / PRIMARY-KEY collision).
       await holder.release();
-      await runMigrations(db2, opener(lockPath, 2));
+      await runMigrations(db, opener(lockPath, 2));
 
-      const rows = await db2
+      const rows = await db
         .selectFrom("kysely_migration" as any)
         .select("name")
         .execute();
       expect(rows.length).toBe(await expectedMigrationCount());
     } finally {
-      await db2.destroy();
-      rmSync(dir, { recursive: true, force: true });
+      await db.destroy();
     }
-  });
 
-  test("two concurrent openers on the same DB file do not trip a PRIMARY KEY error", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "migrator-concurrency-"));
-    const dbPath = join(dir, "auto-mobile.db");
-    const lockPath = `${dbPath}.migrate.lock`;
-
-    const db1 = openFileDb(dbPath);
-    const db2 = openFileDb(dbPath);
-
-    try {
-      await Promise.all([
-        runMigrations(db1, opener(lockPath, 1)),
-        runMigrations(db2, opener(lockPath, 2)),
-      ]);
-
-      // Exactly one opener wrote the history; the second observed an
-      // already-migrated DB and wrote 0 new rows.
-      const rows = await db1
-        .selectFrom("kysely_migration" as any)
-        .select("name")
-        .execute();
-      expect(rows.length).toBe(await expectedMigrationCount());
-    } finally {
-      await db1.destroy();
-      await db2.destroy();
-      rmSync(dir, { recursive: true, force: true });
-    }
+    // The lock file is released (unlinked) after a successful run.
+    expect(existsSync(lockPath)).toBe(false);
   });
 
   test("a second opener still migrates after the first opener fails mid-migration", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "migrator-failrelease-"));
-    const dbPath = join(dir, "auto-mobile.db");
-    const lockPath = `${dbPath}.migrate.lock`;
-
-    const dbA = openFileDb(dbPath);
-    const dbB = openFileDb(dbPath);
+    const dbA = memoryDb();
+    const dbB = memoryDb();
     const previous = process.env.AUTOMOBILE_MIGRATIONS_DIR;
 
     try {
@@ -197,6 +169,7 @@ describe("runMigrations lock integration", () => {
       // finally-release must free the lock so B is not wedged.
       process.env.AUTOMOBILE_MIGRATIONS_DIR = join(tmpdir(), "auto-mobile-missing-migrations");
       await expect(runMigrations(dbA, opener(lockPath, 1))).rejects.toBeDefined();
+      expect(existsSync(lockPath)).toBe(false); // A released the lock on failure
 
       // Restore the real migrations folder; B acquires cleanly and migrates.
       if (previous === undefined) {
@@ -219,7 +192,6 @@ describe("runMigrations lock integration", () => {
       }
       await dbA.destroy();
       await dbB.destroy();
-      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../src/utils/fileLock";
+
+describe("fileLock primitive", () => {
+  let dir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "file-lock-"));
+    lockPath = join(dir, "thing.lock");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("acquires on a fresh path and writes the owner pid", () => {
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true })).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
+  });
+
+  test("fails when a different live holder owns it", () => {
+    writeFileSync(lockPath, "9999");
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true })).toBe(false);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("9999");
+  });
+
+  test("treats an empty lock file as held (writer mid-write)", () => {
+    writeFileSync(lockPath, "");
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true })).toBe(false);
+  });
+
+  test("treats an unreadable PID as held", () => {
+    writeFileSync(lockPath, "not-a-pid");
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true })).toBe(false);
+  });
+
+  test("reclaims a lock left by a dead holder", () => {
+    writeFileSync(lockPath, "9999");
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => false })).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
+  });
+
+  test("own live PID is held by default but reclaimed under reclaimOwnPid", () => {
+    writeFileSync(lockPath, "100");
+
+    // Default (daemon coordinator): a same-PID probe reads as held.
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true })).toBe(false);
+
+    // reclaimOwnPid (migration singleton): a leaked own-PID lock is reclaimed.
+    expect(
+      tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true, reclaimOwnPid: true })
+    ).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
+  });
+
+  describe("releaseExclusiveLock (compare-and-delete)", () => {
+    test("removes the file when it holds our pid", () => {
+      writeFileSync(lockPath, "100");
+      releaseExclusiveLock(lockPath, 100);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    test("does not delete a lock owned by a different pid", () => {
+      writeFileSync(lockPath, "200");
+      releaseExclusiveLock(lockPath, 100);
+      expect(existsSync(lockPath)).toBe(true);
+      expect(readFileSync(lockPath, "utf-8").trim()).toBe("200");
+    });
+
+    test("is inert when no lock file exists", () => {
+      releaseExclusiveLock(lockPath, 100);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+  });
+});

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { basename, join } from "path";
 import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../src/utils/fileLock";
 
 describe("fileLock primitive", () => {
@@ -42,6 +42,26 @@ describe("fileLock primitive", () => {
     writeFileSync(lockPath, "9999");
     expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => false })).toBe(true);
     expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
+  });
+
+  test("reclaim leaves no stray .reclaim marker behind", () => {
+    writeFileSync(lockPath, "9999");
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => false })).toBe(true);
+
+    const lockName = basename(lockPath);
+    const strays = readdirSync(dir).filter(name => name !== lockName);
+    expect(strays).toEqual([]);
+  });
+
+  test("a stale reclaim marker from a crashed reclaim does not block a later reclaim", () => {
+    // A prior reclaim by pid 100 crashed after the rename but before removing its
+    // marker. A fresh reclaim by the same pid must still succeed (rename overwrites).
+    writeFileSync(`${lockPath}.100.reclaim`, "9999");
+    writeFileSync(lockPath, "9999");
+
+    expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => false })).toBe(true);
+    expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
+    expect(existsSync(`${lockPath}.100.reclaim`)).toBe(false);
   });
 
   test("own live PID is held by default but reclaimed under reclaimOwnPid", () => {


### PR DESCRIPTION
## Summary

`runMigrations` had **no cross-process lock**. Kysely's `SqliteAdapter.acquireMigrationLock` is a documented no-op and `supportsTransactionalDdl` is `false`, so migration DDL runs non-transactionally with nothing serializing across processes. When two processes open the *same* DB file concurrently — reachable via override env (`AUTOMOBILE_DB_PATH` / custom socket/pid/lock) or `--no-proxy` alongside a running daemon — both can enter `migrateToLatest()` and the second `kysely_migration` history INSERT hits a **PRIMARY-KEY violation**.

This serializes the migration run across processes with a file lock so the loser **waits** and then observes an already-migrated DB (0 new rows), instead of crashing.

### Scope — read this first
This closes the **spurious fail-loud startup crash** (the same-migration-set, restart-clearable case). It is a robustness/annoyance fix, not a data-safety fix. The genuinely **destructive** variant — two worktrees at *different* commits sharing one DB tripping `recoverCorruptedMigrations`/`resetDatabaseState` — is **not** resolved here: the loser acquires the lock cleanly and still sees "corrupted migrations". That case fails safe only via **#2785**'s populated-DB refusal; this lock is necessary-but-not-sufficient there. **#2785 remains the real safety net** and should not be de-prioritized by this merge. Cross-ref **#2795** (refuse `--no-proxy` alongside a live daemon) and **#2785**.

Per the issue's "build vs defer" decision this takes the **build** option (as directed), following the reviewers' correctness constraints.

Refs #2794.

## What changed

**`src/utils/fileLock.ts` (new) — one canonical lock primitive**
- `tryAcquireExclusiveLock(path, { pid, isProcessRunning, reclaimOwnPid })` — atomic `O_CREAT|O_EXCL` (`wx`) create + dead-PID stale reclaim. Two racers can't both win; the atomic create decides.
- `releaseExclusiveLock(path, pid)` — **compare-and-delete**: removes the file only if it still holds `pid`, so a reclaim race can't delete a lock a different opener now owns.
- Both `DaemonManager` (start/stop coordination) and the DB migration lock now build on this instead of two copies of the subtle `O_EXCL` + stale-reclaim logic. Daemon behavior is unchanged (`reclaimOwnPid` defaults to `false`, so a same-PID probe still reads as held).

**`src/db/migrationLock.ts` (new) — the migration lock**
- `MigrationLock` interface, `NoOpMigrationLock` (default for `:memory:` / single-daemon path), and `FileMigrationLock` — the shared primitive wrapped in a **bounded busy-wait** (default poll 100 ms, ceiling 60 s » a cold 32-file migration; overridable via `AUTOMOBILE_MIGRATION_LOCK_TIMEOUT_MS`).
- `reclaimOwnPid: true` — the migration run is a per-process singleton, so a leaked lock bearing our own (OS-recycled) PID is a crashed prior incarnation and is reclaimed rather than blocking for the full timeout.
- Poll interval clamped to `>= 1 ms`.

**`src/db/migrator.ts`** — `runMigrations(db, lock = new NoOpMigrationLock())`: `acquire()` before the migrator, `release()` in a `finally` (always released, even on the failure/recovery paths).

**`src/db/database.ts`** — `startMigrations(dbPath)` passes `createFileMigrationLock(dbPath)`, keyed to `${dbPath}.migrate.lock`. Single opener acquires on the first `wx` with zero sleeps → **no added latency**.

**`src/daemon/manager.ts`** — `acquireLock`/`releaseLock` now delegate to the shared primitive; `writeLockFile` removed. Behavior preserved (all `test/daemon/daemonManagerLock.test.ts` green).

## Acceptance criteria coverage

- ✅ **Decision recorded:** build the lock, with the reviewers' constraints applied.
- ✅ Two concurrent `runMigrations` on the same file complete without a `kysely_migration` PRIMARY-KEY error; the second writes **0 new rows** (row count == authoritative migration count).
- ✅ With the lock held, a second `runMigrations` **blocks until release** then succeeds — proven by a test that *fails if the lock is neutered* (see Tests).
- ✅ **Bounded busy-wait**, ceiling 60 s well above cold-migration runtime; file lock chosen over `BEGIN EXCLUSIVE` (5 s `busy_timeout` too short).
- ✅ **Stale-reclaim reuses the atomic `wx`** — two openers racing on a dead PID can't both win; **release is compare-and-delete** so it can't delete another opener's lock.
- ✅ Dead-holder stale lock reclaimed (PID check); own-recycled-PID reclaimed (no 60 s hang).
- ✅ **Single-opener path unchanged:** acquires immediately, no added latency; existing recovery tests green.
- ✅ Interface + fake + `FakeTimer`, `<100 ms` unit tests, non-flaky.
- ✅ Full `bun test` (5662 pass, 2 pre-existing skips, 0 fail); `turbo run lint build` green.

## Tests (TDD)

- `test/utils/fileLock.test.ts` — the shared primitive: fresh acquire, foreign-live-holder held, empty/NaN held, dead-holder reclaim, `reclaimOwnPid` behavior, and `releaseExclusiveLock` compare-and-delete (won't delete a foreign lock).
- `test/db/migrationLock.test.ts` — `FileMigrationLock` with `FakeTimer` + fake `isProcessRunning`: single-opener no-sleep fast path, busy-wait-until-release, own-PID reclaim, dead-PID reclaim, foreign-release-guard, inert-release, timeout-ceiling `ActionableError` (message asserted), atomic-`wx` no-double-win.
- `test/db/migratorLock.test.ts` — acquire/release ordering, release-on-failure, a **serialization proof** (opener B's `runMigrations` times out while A holds the lock — this test **fails if the lock is removed**, unlike a naive two-openers race which passes even without a lock because bun:sqlite serializes the I/O incidentally), a smoke concurrency run, and **first-opener-fails → second-opener-still-migrates**. Expected migration count derived from the Kysely provider (not a fragile file listing).

## Known limitation (tracked follow-up)
An empty lock file left by a crash in the microsecond window between the `wx` create and the PID write is never reclaimable. This is astronomically rare (the create+write is a single synchronous burst) and is shared with the pre-existing daemon lock; a follow-up can harden the shared primitive (atomic create-with-content).
