### PR TITLE
fix(db): recoverable error when a bunx extraction is missing a migration dependency (#2833)

### DIFF
--- a/src/daemon/daemonStartupGuard.ts
+++ b/src/daemon/daemonStartupGuard.ts
@@ -4,6 +4,11 @@ import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { exponentialBackoff } from "../utils/Backoff";
 import { describeUnknownError } from "../utils/describeUnknownError";
 import { classifyDatabaseFailure } from "../db/databaseFailureClassification";
+import {
+  INCOMPLETE_EXTRACTION_CODE,
+  INCOMPLETE_EXTRACTION_EXIT_CODE,
+  isIncompleteExtractionError,
+} from "../db/migrationDependencyIntegrity";
 import { DAEMON_STARTUP_TIMEOUT_MS } from "./constants";
 import {
   StartupFailureTracker,
@@ -40,8 +45,12 @@ export async function handleFatalDatabaseStartupFailure(
 ): Promise<never> {
   const kind = classifyDatabaseFailure(error);
   const recentFailures = tracker.recordFailure(kind, timer.now());
+  // Tag an incomplete-extraction failure with its distinct code so log-based
+  // alerting can count it without regex-matching prose, and so the process can
+  // exit with a distinct, recoverable code (issue #2833).
+  const failureLabel = isIncompleteExtractionError(error) ? `${kind}/${INCOMPLETE_EXTRACTION_CODE}` : kind;
   logger.error(
-    `Fatal: database initialization failed (${kind}; ${recentFailures} recent failure(s)); ` +
+    `Fatal: database initialization failed (${failureLabel}; ${recentFailures} recent failure(s)); ` +
       `daemon cannot serve queries and will exit for a clean restart: ${describeUnknownError(error)}`
   );
 
@@ -57,7 +66,23 @@ export async function handleFatalDatabaseStartupFailure(
     await timer.sleep(backoffMs);
   }
 
-  throw toActionableError(error, "Database initialization failed at daemon startup");
+  const actionable = toActionableError(error, "Database initialization failed at daemon startup");
+  // `toActionableError` rewraps a plain Error, dropping its `code`. Re-stamp the
+  // incomplete-extraction marker so the fatal handler in main() can resolve a
+  // distinct, recoverable process exit code (issue #2833).
+  if (isIncompleteExtractionError(error)) {
+    (actionable as { code?: string }).code = INCOMPLETE_EXTRACTION_CODE;
+  }
+  throw actionable;
+}
+
+/**
+ * Resolve the process exit code for a fatal daemon-startup error. An incomplete
+ * extraction (issue #2833) exits with `EX_TEMPFAIL` (75) so a wrapper can tell
+ * the recoverable "re-extract and retry" case apart from a generic fatal (1).
+ */
+export function resolveDaemonStartupExitCode(error: unknown): number {
+  return isIncompleteExtractionError(error) ? INCOMPLETE_EXTRACTION_EXIT_CODE : 1;
 }
 
 /**

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -3,17 +3,14 @@ import * as path from "path";
 import * as os from "os";
 import * as fs from "fs";
 import type { Database as DatabaseSchema } from "./types";
-import { runMigrations, resolveMigrationFolder } from "./migrator";
+import { runMigrations } from "./migrator";
 import { logger } from "../utils/logger";
 import { BunSqliteDialect } from "./bunSqliteDialect";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import {
-  assertMigrationDependenciesResolvable,
   createIncompleteExtractionError,
   extractMissingPackageName,
-  isIncompleteExtractionError,
-  isMissingPackageError,
-  type DependencyResolver,
+  isMissingMigrationDependencyError,
 } from "./migrationDependencyIntegrity";
 
 type BunDatabaseConstructor = typeof import("bun:sqlite").Database;
@@ -112,28 +109,19 @@ export const DATABASE_STARTUP_MIGRATION_FAILURE =
   "Database startup migrations failed; refusing to run queries until the daemon restarts.";
 
 function createStartupMigrationError(cause: unknown): Error {
-  // A half-linked bunx extraction (a migration runtime dependency such as
+  // A half-linked bunx extraction (a known migration runtime dependency such as
   // `kysely` missing from this run's node_modules) surfaces as a "Cannot find
-  // package" resolve error. Map it to the distinct, recoverable
-  // incomplete-extraction error instead of the generic fatal crash so the
-  // caller knows to remove the extraction and re-run (issue #2833).
-  if (isIncompleteExtractionError(cause)) {
-    return cause as Error;
-  }
-  if (isMissingPackageError(cause)) {
+  // package" resolve error while the migrator dynamically imports a migration
+  // file. Map that to the distinct, recoverable incomplete-extraction error
+  // instead of the generic fatal crash so the caller knows to remove the
+  // extraction and re-run (issue #2833). Scoped to known dependencies so a
+  // genuine code-level bad import in a migration is not mislabeled.
+  if (isMissingMigrationDependencyError(cause)) {
     return createIncompleteExtractionError(extractMissingPackageName(cause), cause);
   }
   const causeMessage = cause instanceof Error ? cause.message : String(cause);
   return new Error(`${DATABASE_STARTUP_MIGRATION_FAILURE} Cause: ${causeMessage}`, { cause });
 }
-
-/**
- * Resolve a module specifier the way the runtime loads a migration file — from
- * the migrations folder on disk. Used to preflight extraction integrity before
- * running migrations (issue #2833).
- */
-const resolveMigrationDependency: DependencyResolver = (specifier, fromDir) =>
-  require.resolve(specifier, { paths: [fromDir] });
 
 async function waitForMigrationsBeforeQuery(): Promise<void> {
   if (migrationsRun) {
@@ -169,18 +157,6 @@ function openConfiguredSqliteDatabase(dbPath: string): BunDatabase {
 }
 
 async function startMigrations(dbPath: string): Promise<void> {
-  // Preflight extraction integrity: if a migration runtime dependency cannot be
-  // resolved from the migrations folder, fail fast with the recoverable
-  // incomplete-extraction error rather than letting the dynamic import blow up
-  // deep inside the migrator with a generic message (issue #2833). Only run when
-  // the folder exists — a missing migrations folder is a distinct failure that
-  // the migrator surfaces on its own; resolving a dependency from a nonexistent
-  // base would spuriously report an incomplete extraction.
-  const migrationFolder = resolveMigrationFolder();
-  if (fs.existsSync(migrationFolder)) {
-    assertMigrationDependenciesResolvable(migrationFolder, resolveMigrationDependency);
-  }
-
   const migrationDb = createSqliteKysely<unknown>(dbPath);
 
   try {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -3,10 +3,18 @@ import * as path from "path";
 import * as os from "os";
 import * as fs from "fs";
 import type { Database as DatabaseSchema } from "./types";
-import { runMigrations } from "./migrator";
+import { runMigrations, resolveMigrationFolder } from "./migrator";
 import { logger } from "../utils/logger";
 import { BunSqliteDialect } from "./bunSqliteDialect";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
+import {
+  assertMigrationDependenciesResolvable,
+  createIncompleteExtractionError,
+  extractMissingPackageName,
+  isIncompleteExtractionError,
+  isMissingPackageError,
+  type DependencyResolver,
+} from "./migrationDependencyIntegrity";
 
 type BunDatabaseConstructor = typeof import("bun:sqlite").Database;
 type BunDatabase = import("bun:sqlite").Database;
@@ -104,9 +112,28 @@ export const DATABASE_STARTUP_MIGRATION_FAILURE =
   "Database startup migrations failed; refusing to run queries until the daemon restarts.";
 
 function createStartupMigrationError(cause: unknown): Error {
+  // A half-linked bunx extraction (a migration runtime dependency such as
+  // `kysely` missing from this run's node_modules) surfaces as a "Cannot find
+  // package" resolve error. Map it to the distinct, recoverable
+  // incomplete-extraction error instead of the generic fatal crash so the
+  // caller knows to remove the extraction and re-run (issue #2833).
+  if (isIncompleteExtractionError(cause)) {
+    return cause as Error;
+  }
+  if (isMissingPackageError(cause)) {
+    return createIncompleteExtractionError(extractMissingPackageName(cause), cause);
+  }
   const causeMessage = cause instanceof Error ? cause.message : String(cause);
   return new Error(`${DATABASE_STARTUP_MIGRATION_FAILURE} Cause: ${causeMessage}`, { cause });
 }
+
+/**
+ * Resolve a module specifier the way the runtime loads a migration file — from
+ * the migrations folder on disk. Used to preflight extraction integrity before
+ * running migrations (issue #2833).
+ */
+const resolveMigrationDependency: DependencyResolver = (specifier, fromDir) =>
+  require.resolve(specifier, { paths: [fromDir] });
 
 async function waitForMigrationsBeforeQuery(): Promise<void> {
   if (migrationsRun) {
@@ -142,6 +169,18 @@ function openConfiguredSqliteDatabase(dbPath: string): BunDatabase {
 }
 
 async function startMigrations(dbPath: string): Promise<void> {
+  // Preflight extraction integrity: if a migration runtime dependency cannot be
+  // resolved from the migrations folder, fail fast with the recoverable
+  // incomplete-extraction error rather than letting the dynamic import blow up
+  // deep inside the migrator with a generic message (issue #2833). Only run when
+  // the folder exists — a missing migrations folder is a distinct failure that
+  // the migrator surfaces on its own; resolving a dependency from a nonexistent
+  // base would spuriously report an incomplete extraction.
+  const migrationFolder = resolveMigrationFolder();
+  if (fs.existsSync(migrationFolder)) {
+    assertMigrationDependenciesResolvable(migrationFolder, resolveMigrationDependency);
+  }
+
   const migrationDb = createSqliteKysely<unknown>(dbPath);
 
   try {

--- a/src/db/migrationDependencyIntegrity.ts
+++ b/src/db/migrationDependencyIntegrity.ts
@@ -47,13 +47,14 @@ function getErrorCode(error: unknown): string | undefined {
 }
 
 function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
   if (typeof error === "string") {
     return error;
   }
-  return "";
+  // bun throws a `ResolveMessage` for a failed dynamic import: it carries the
+  // "Cannot find package '<x>' from '...'" text on `.message` but is NOT an
+  // `instanceof Error`, so read `.message` off any object shape (issue #2833).
+  const message = (error as { message?: unknown } | null | undefined)?.message;
+  return typeof message === "string" ? message : "";
 }
 
 const MISSING_PACKAGE_CODES = new Set(["MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"]);

--- a/src/db/migrationDependencyIntegrity.ts
+++ b/src/db/migrationDependencyIntegrity.ts
@@ -1,0 +1,143 @@
+/**
+ * Extraction-integrity checks for the startup database migrations (issue #2833).
+ *
+ * The migration modules ship as raw `.ts` files and are loaded from disk at
+ * runtime by kysely's `FileMigrationProvider` via dynamic `import()`. Several of
+ * them do a *runtime* value import (`import { sql } from "kysely"`), so the
+ * runtime resolves `kysely` relative to the migrations folder on disk. When a
+ * `bunx` extraction's `node_modules` is half-linked (the shared bun cache has the
+ * package but it was never linked into this run's tree), that import throws
+ * `Cannot find package 'kysely'` and the daemon's startup migration hard-fails
+ * with a generic, non-actionable crash.
+ *
+ * This module turns that class of failure into a distinct, clearly *recoverable*
+ * error: it names the missing package and the fix (remove the incomplete
+ * extraction directory and re-run — a fresh extraction from the healthy shared
+ * cache produces a complete tree). It also provides a cheap preflight so the
+ * failure is caught before migrations run rather than deep inside the migrator.
+ */
+
+/** Distinct marker for a recoverable incomplete-extraction failure. */
+export const INCOMPLETE_EXTRACTION_CODE = "AUTOMOBILE_INCOMPLETE_EXTRACTION";
+
+/**
+ * Packages the migration modules import at runtime (not just as types). These
+ * must resolve from the migrations folder for `migrateToLatest()` to load the
+ * migration files. Keep in sync with the value imports in `src/db/migrations/`.
+ */
+export const MIGRATION_RUNTIME_DEPENDENCIES: readonly string[] = ["kysely"];
+
+/**
+ * Resolves a module specifier the way the runtime would when loading a migration
+ * file, throwing if it cannot be resolved. `fromDir` is the directory to resolve
+ * from (the migrations folder) so the check mirrors the dynamic `import()` base.
+ */
+export type DependencyResolver = (specifier: string, fromDir: string) => string;
+
+function getErrorCode(error: unknown): string | undefined {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "";
+}
+
+const MISSING_PACKAGE_CODES = new Set(["MODULE_NOT_FOUND", "ERR_MODULE_NOT_FOUND"]);
+
+// bun: "Cannot find package 'kysely' from '...'"; node: "Cannot find module 'kysely'".
+const MISSING_PACKAGE_MESSAGE = /Cannot find (?:package|module) ['"]([^'"]+)['"]/i;
+
+/**
+ * True when `error` indicates a module/package could not be resolved — bun's
+ * `ResolveMessage` ("Cannot find package '<x>' from '...'"), node's
+ * `Cannot find module '<x>'`, or a `MODULE_NOT_FOUND`/`ERR_MODULE_NOT_FOUND`
+ * code. This is the signature of a half-linked `bunx` extraction.
+ */
+export function isMissingPackageError(error: unknown): boolean {
+  const code = getErrorCode(error);
+  if (code && MISSING_PACKAGE_CODES.has(code)) {
+    return true;
+  }
+  return MISSING_PACKAGE_MESSAGE.test(getErrorMessage(error));
+}
+
+/**
+ * Extract the unresolved package/module name from a missing-package error, or
+ * null when the message does not name one.
+ */
+export function extractMissingPackageName(error: unknown): string | null {
+  const match = MISSING_PACKAGE_MESSAGE.exec(getErrorMessage(error));
+  return match ? match[1] : null;
+}
+
+/**
+ * Build the recoverable incomplete-extraction error surfaced at startup. Carries
+ * a distinct `code` so callers can branch, preserves the underlying `cause`, and
+ * spells out the remediation.
+ */
+export function createIncompleteExtractionError(
+  missingPackage: string | null,
+  cause?: unknown
+): Error {
+  const subject = missingPackage
+    ? `the package '${missingPackage}' could not be resolved`
+    : "a required migration dependency could not be resolved";
+  const message =
+    `Database startup migrations cannot load their dependencies: ${subject}. ` +
+    "This is an incomplete package extraction (e.g. a half-linked `bunx` " +
+    "node_modules where the shared cache has the package but it was not linked " +
+    "into this run's tree), not a missing or unpublished dependency. Remove the " +
+    "incomplete extraction directory and re-run — a fresh extraction from the " +
+    "healthy shared cache produces a complete tree and the daemon starts normally.";
+  const error = new Error(message, cause === undefined ? undefined : { cause });
+  (error as { code?: string }).code = INCOMPLETE_EXTRACTION_CODE;
+  return error;
+}
+
+/** True when `error` is the recoverable incomplete-extraction error above. */
+export function isIncompleteExtractionError(error: unknown): boolean {
+  return getErrorCode(error) === INCOMPLETE_EXTRACTION_CODE;
+}
+
+/**
+ * Return the first migration runtime dependency that does not resolve from
+ * `migrationsFolder`, or null if every one resolves. A resolver that throws for
+ * a non-resolution reason still counts the dependency as unresolvable — the
+ * runtime import would fail the same way.
+ */
+export function findMissingMigrationDependency(
+  migrationsFolder: string,
+  resolve: DependencyResolver
+): string | null {
+  for (const dependency of MIGRATION_RUNTIME_DEPENDENCIES) {
+    try {
+      resolve(dependency, migrationsFolder);
+    } catch {
+      return dependency;
+    }
+  }
+  return null;
+}
+
+/**
+ * Preflight the extraction before running migrations: if a migration runtime
+ * dependency cannot be resolved from `migrationsFolder`, throw the recoverable
+ * incomplete-extraction error instead of letting the dynamic `import()` fail
+ * deep inside the migrator with a generic message.
+ */
+export function assertMigrationDependenciesResolvable(
+  migrationsFolder: string,
+  resolve: DependencyResolver
+): void {
+  const missing = findMissingMigrationDependency(migrationsFolder, resolve);
+  if (missing) {
+    throw createIncompleteExtractionError(missing);
+  }
+}

--- a/src/db/migrationDependencyIntegrity.ts
+++ b/src/db/migrationDependencyIntegrity.ts
@@ -1,38 +1,45 @@
 /**
- * Extraction-integrity checks for the startup database migrations (issue #2833).
+ * Recognises and reframes the startup-migration failure that occurs when a
+ * package extraction is incomplete (issue #2833).
  *
  * The migration modules ship as raw `.ts` files and are loaded from disk at
  * runtime by kysely's `FileMigrationProvider` via dynamic `import()`. Several of
  * them do a *runtime* value import (`import { sql } from "kysely"`), so the
  * runtime resolves `kysely` relative to the migrations folder on disk. When a
- * `bunx` extraction's `node_modules` is half-linked (the shared bun cache has the
- * package but it was never linked into this run's tree), that import throws
+ * `bunx` extraction's `node_modules` is half-linked (the shared bun cache has
+ * the package but it was never linked into this run's tree), that import throws
  * `Cannot find package 'kysely'` and the daemon's startup migration hard-fails
  * with a generic, non-actionable crash.
  *
- * This module turns that class of failure into a distinct, clearly *recoverable*
- * error: it names the missing package and the fix (remove the incomplete
- * extraction directory and re-run — a fresh extraction from the healthy shared
- * cache produces a complete tree). It also provides a cheap preflight so the
- * failure is caught before migrations run rather than deep inside the migrator.
+ * This module maps that specific failure — a *known* migration runtime
+ * dependency failing to resolve — to a distinct, clearly *recoverable* error
+ * that names the package and the fix (remove the incomplete extraction directory
+ * and re-run; a fresh extraction from the healthy shared cache produces a
+ * complete tree). Scoping to the known dependency list (rather than any missing
+ * specifier) keeps a genuine code-level bad import — a typo'd or unpublished
+ * package in a migration — from being mislabeled as an extraction problem.
  */
 
 /** Distinct marker for a recoverable incomplete-extraction failure. */
 export const INCOMPLETE_EXTRACTION_CODE = "AUTOMOBILE_INCOMPLETE_EXTRACTION";
 
 /**
- * Packages the migration modules import at runtime (not just as types). These
- * must resolve from the migrations folder for `migrateToLatest()` to load the
- * migration files. Keep in sync with the value imports in `src/db/migrations/`.
+ * Process exit code the daemon uses when it dies from an incomplete extraction.
+ * 75 is `EX_TEMPFAIL` from sysexits.h — "temporary failure; the user is invited
+ * to retry" — which lets a wrapper distinguish this recoverable case from a
+ * generic fatal (exit 1) and re-extract before retrying.
  */
-export const MIGRATION_RUNTIME_DEPENDENCIES: readonly string[] = ["kysely"];
+export const INCOMPLETE_EXTRACTION_EXIT_CODE = 75;
 
 /**
- * Resolves a module specifier the way the runtime would when loading a migration
- * file, throwing if it cannot be resolved. `fromDir` is the directory to resolve
- * from (the migrations folder) so the check mirrors the dynamic `import()` base.
+ * Packages the migration modules import at runtime (not just as types). These
+ * must resolve from the migrations folder for `migrateToLatest()` to load the
+ * migration files. Keep in sync with the value imports in `src/db/migrations/`;
+ * a runtime import added there but omitted here degrades gracefully — its
+ * missing-package failure falls through to the generic startup error rather than
+ * this extraction-specific remediation.
  */
-export type DependencyResolver = (specifier: string, fromDir: string) => string;
+export const MIGRATION_RUNTIME_DEPENDENCIES: readonly string[] = ["kysely"];
 
 function getErrorCode(error: unknown): string | undefined {
   const code = (error as { code?: unknown } | null | undefined)?.code;
@@ -78,9 +85,23 @@ export function extractMissingPackageName(error: unknown): string | null {
 }
 
 /**
+ * True when `error` is a missing-package failure for a *known* migration runtime
+ * dependency — i.e. the incomplete-extraction signature. A missing package that
+ * is not a declared migration dependency (a typo, an unpublished dep) is
+ * deliberately excluded so it is not mislabeled as an extraction problem.
+ */
+export function isMissingMigrationDependencyError(error: unknown): boolean {
+  if (!isMissingPackageError(error)) {
+    return false;
+  }
+  const name = extractMissingPackageName(error);
+  return name !== null && MIGRATION_RUNTIME_DEPENDENCIES.includes(name);
+}
+
+/**
  * Build the recoverable incomplete-extraction error surfaced at startup. Carries
- * a distinct `code` so callers can branch, preserves the underlying `cause`, and
- * spells out the remediation.
+ * a distinct `code` so callers can branch (and the daemon can pick a distinct
+ * exit code), preserves the underlying `cause`, and spells out the remediation.
  */
 export function createIncompleteExtractionError(
   missingPackage: string | null,
@@ -91,11 +112,12 @@ export function createIncompleteExtractionError(
     : "a required migration dependency could not be resolved";
   const message =
     `Database startup migrations cannot load their dependencies: ${subject}. ` +
-    "This is an incomplete package extraction (e.g. a half-linked `bunx` " +
-    "node_modules where the shared cache has the package but it was not linked " +
-    "into this run's tree), not a missing or unpublished dependency. Remove the " +
-    "incomplete extraction directory and re-run — a fresh extraction from the " +
-    "healthy shared cache produces a complete tree and the daemon starts normally.";
+    "This is most commonly an incomplete package extraction — a half-linked " +
+    "`bunx` node_modules where the shared cache has the package but it was not " +
+    "linked into this run's tree. If you are running via `bunx`, remove the " +
+    "incomplete extraction directory and re-run: a fresh extraction from the " +
+    "healthy shared cache produces a complete tree and the daemon starts " +
+    "normally. Otherwise, reinstall so the package is present in node_modules.";
   const error = new Error(message, cause === undefined ? undefined : { cause });
   (error as { code?: string }).code = INCOMPLETE_EXTRACTION_CODE;
   return error;
@@ -104,40 +126,4 @@ export function createIncompleteExtractionError(
 /** True when `error` is the recoverable incomplete-extraction error above. */
 export function isIncompleteExtractionError(error: unknown): boolean {
   return getErrorCode(error) === INCOMPLETE_EXTRACTION_CODE;
-}
-
-/**
- * Return the first migration runtime dependency that does not resolve from
- * `migrationsFolder`, or null if every one resolves. A resolver that throws for
- * a non-resolution reason still counts the dependency as unresolvable — the
- * runtime import would fail the same way.
- */
-export function findMissingMigrationDependency(
-  migrationsFolder: string,
-  resolve: DependencyResolver
-): string | null {
-  for (const dependency of MIGRATION_RUNTIME_DEPENDENCIES) {
-    try {
-      resolve(dependency, migrationsFolder);
-    } catch {
-      return dependency;
-    }
-  }
-  return null;
-}
-
-/**
- * Preflight the extraction before running migrations: if a migration runtime
- * dependency cannot be resolved from `migrationsFolder`, throw the recoverable
- * incomplete-extraction error instead of letting the dynamic `import()` fail
- * deep inside the migrator with a generic message.
- */
-export function assertMigrationDependenciesResolvable(
-  migrationsFolder: string,
-  resolve: DependencyResolver
-): void {
-  const missing = findMissingMigrationDependency(migrationsFolder, resolve);
-  if (missing) {
-    throw createIncompleteExtractionError(missing);
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -731,9 +731,14 @@ async function main() {
   }
 }
 
-main().catch(err => {
+main().catch(async err => {
   console.error("Fatal error in main():", err);
   fatalLogger?.error("Fatal error in main():", err);
   fatalLogger?.close();
-  process.exit(1);
+  // An incomplete-extraction startup failure exits with a distinct, recoverable
+  // code (EX_TEMPFAIL) so a wrapper can re-extract and retry (issue #2833);
+  // every other fatal keeps exit 1. Resolved lazily to match this file's
+  // deferred-import startup pattern.
+  const { resolveDaemonStartupExitCode } = await import("./daemon/daemonStartupGuard");
+  process.exit(resolveDaemonStartupExitCode(err));
 });

--- a/test/daemon/daemonStartupGuard.test.ts
+++ b/test/daemon/daemonStartupGuard.test.ts
@@ -3,10 +3,16 @@ import { ActionableError } from "../../src/models/ActionableError";
 import {
   guardDatabaseStartup,
   handleFatalDatabaseStartupFailure,
+  resolveDaemonStartupExitCode,
   MAX_STARTUP_BACKOFF_MS,
 } from "../../src/daemon/daemonStartupGuard";
 import { DAEMON_STARTUP_TIMEOUT_MS } from "../../src/daemon/constants";
 import { DefaultStartupFailureTracker } from "../../src/daemon/DaemonStartupFailureTracker";
+import {
+  createIncompleteExtractionError,
+  isIncompleteExtractionError,
+  INCOMPLETE_EXTRACTION_EXIT_CODE,
+} from "../../src/db/migrationDependencyIntegrity";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDatabaseInitializer } from "../fakes/FakeDatabaseInitializer";
 import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
@@ -132,5 +138,45 @@ describe("guardDatabaseStartup", () => {
 
     expect(timer.getSleepHistory()).toEqual([]);
     expect(tracker.recorded[0]!.kind).toBe("transient");
+  });
+
+  test("an incomplete-extraction failure re-stamps its code onto the rethrown error", async () => {
+    // `toActionableError` rewraps the plain Error and drops its `code`; the
+    // handler must re-stamp it so main()'s exit-code resolution can detect the
+    // recoverable case (issue #2833). It still classifies permanent (the same
+    // half-linked extraction reproduces every respawn) → backoff applies.
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const tracker = new FakeStartupFailureTracker();
+    tracker.setCounts([1]);
+
+    let thrown: unknown;
+    try {
+      await handleFatalDatabaseStartupFailure(
+        createIncompleteExtractionError("kysely"),
+        tracker,
+        timer
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ActionableError);
+    expect(isIncompleteExtractionError(thrown)).toBe(true);
+    expect(tracker.recorded[0]!.kind).toBe("permanent");
+  });
+});
+
+describe("resolveDaemonStartupExitCode", () => {
+  test("returns EX_TEMPFAIL (75) for an incomplete-extraction failure", () => {
+    expect(resolveDaemonStartupExitCode(createIncompleteExtractionError("kysely"))).toBe(
+      INCOMPLETE_EXTRACTION_EXIT_CODE
+    );
+  });
+
+  test("returns 1 for every other fatal (generic, unchanged behavior)", () => {
+    expect(resolveDaemonStartupExitCode(new Error("file is not a database"))).toBe(1);
+    expect(resolveDaemonStartupExitCode(new ActionableError("something else"))).toBe(1);
+    expect(resolveDaemonStartupExitCode(undefined)).toBe(1);
   });
 });

--- a/test/db/databaseFailureClassification.test.ts
+++ b/test/db/databaseFailureClassification.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { classifyDatabaseFailure } from "../../src/db/databaseFailureClassification";
+import { createIncompleteExtractionError } from "../../src/db/migrationDependencyIntegrity";
 
 describe("classifyDatabaseFailure", () => {
   test("classifies a locked/busy sqlite file as transient", () => {
@@ -24,6 +25,16 @@ describe("classifyDatabaseFailure", () => {
 
   test("classifies a deterministic migration throw as permanent", () => {
     expect(classifyDatabaseFailure(new Error("migration 0007 failed: column already exists"))).toBe("permanent");
+  });
+
+  test("classifies an incomplete-extraction (missing dependency) failure as permanent", () => {
+    // Respawning reuses the SAME half-linked bunx extraction, so the failure
+    // reproduces every launch; backoff (permanent) protects against a hot-loop
+    // until the caller removes the extraction and re-runs (issue #2833).
+    expect(classifyDatabaseFailure(createIncompleteExtractionError("kysely"))).toBe("permanent");
+    expect(
+      classifyDatabaseFailure(new Error("Cannot find package 'kysely' from '/tmp/x/m.ts'"))
+    ).toBe("permanent");
   });
 
   test("defaults unknown failures to permanent (fail safe against hot loops)", () => {

--- a/test/db/databaseIncompleteExtraction.test.ts
+++ b/test/db/databaseIncompleteExtraction.test.ts
@@ -3,24 +3,21 @@ import path from "path";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { defaultTimer } from "../../src/utils/SystemTimer";
-import {
-  INCOMPLETE_EXTRACTION_CODE,
-  isIncompleteExtractionError,
-} from "../../src/db/migrationDependencyIntegrity";
+import { isIncompleteExtractionError } from "../../src/db/migrationDependencyIntegrity";
 
 /**
- * Issue #2833: when a migration cannot resolve a runtime dependency (the
- * signature of a half-linked `bunx` extraction), the startup migration failure
- * surfaced to the daemon must be the distinct, recoverable incomplete-extraction
- * error — not the generic "refusing to run queries" crash.
+ * Issue #2833: the incomplete-extraction mapping is scoped to KNOWN migration
+ * runtime dependencies. This drives the REAL migrator path with a migration that
+ * imports a package which is not a declared dependency — a genuine code-level bad
+ * import — and asserts it surfaces the GENERIC startup-migration error rather
+ * than being mislabeled as a recoverable "re-extract" incomplete extraction.
  *
- * This drives the REAL migrator path: a temp migrations folder whose only
- * migration imports a package that does not exist, so bun throws a genuine
- * "Cannot find package" resolve error while loading the migration file. That
- * mirrors the missing-`kysely` failure and proves the mapping holds even when
- * the cheap preflight is bypassed.
+ * (The positive case — a missing KNOWN dependency such as `kysely` — cannot be
+ * reproduced in-repo because bun resolves `kysely` from its global install
+ * cache; that mapping is covered by the unit tests for
+ * isMissingMigrationDependencyError + createIncompleteExtractionError.)
  */
-describe("startup migration failure maps a missing dependency to a recoverable error", () => {
+describe("startup migration failure does not mislabel a genuine bad import", () => {
   const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
   const originalMigrationsDir = process.env.AUTOMOBILE_MIGRATIONS_DIR;
   let tempDir: string | undefined;
@@ -46,14 +43,15 @@ describe("startup migration failure maps a missing dependency to a recoverable e
     return import(`../../src/db/database.ts?incomplete-extraction-test=${Date.now()}-${Math.random()}`);
   }
 
-  test("ensureMigrations rejects with the recoverable incomplete-extraction error", async () => {
-    tempDir = await mkdtemp(path.join(tmpdir(), "am-incomplete-extraction-"));
+  test("an unknown missing package surfaces the generic error, not incomplete-extraction", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "am-bad-import-"));
     const migrationsDir = path.join(tempDir, "migrations");
     await mkdir(migrationsDir, { recursive: true });
 
-    // A migration whose runtime value import cannot be resolved.
+    // A migration whose runtime value import cannot be resolved and is NOT a
+    // declared migration dependency (i.e. a typo / genuine code bug).
     await writeFile(
-      path.join(migrationsDir, "2099_01_01_000_am2833_missing_dep.ts"),
+      path.join(migrationsDir, "2099_01_01_000_am2833_bad_import.ts"),
       "import 'nonexistent-package-am2833';\n" +
         "export async function up(): Promise<void> {}\n" +
         "export async function down(): Promise<void> {}\n"
@@ -79,15 +77,13 @@ describe("startup migration failure maps a missing dependency to a recoverable e
       }
 
       expect(thrown).toBeInstanceOf(Error);
-      expect(isIncompleteExtractionError(thrown)).toBe(true);
-      expect((thrown as { code?: string }).code).toBe(INCOMPLETE_EXTRACTION_CODE);
-      expect((thrown as Error).message).toMatch(/incomplete/i);
-      expect((thrown as Error).message).toMatch(/re-?run/i);
-      // Not the generic startup-migration message.
-      expect((thrown as Error).message).not.toMatch(/refusing to run queries/i);
+      // Generic startup-migration failure, NOT the recoverable extraction remedy.
+      expect((thrown as Error).message).toMatch(/refusing to run queries/i);
+      expect(isIncompleteExtractionError(thrown)).toBe(false);
+      expect((thrown as Error).message).not.toMatch(/incomplete package extraction/i);
 
-      // The cached error stays sticky and recoverable-typed on re-check.
-      expect(isIncompleteExtractionError(db.getMigrationsError())).toBe(true);
+      // Still sticky and generic on re-check.
+      expect(isIncompleteExtractionError(db.getMigrationsError())).toBe(false);
 
       await defaultTimer.sleep(10);
       expect(unhandled).toEqual([]);

--- a/test/db/databaseIncompleteExtraction.test.ts
+++ b/test/db/databaseIncompleteExtraction.test.ts
@@ -34,13 +34,31 @@ describe("startup migration failure does not mislabel a genuine bad import", () 
     restore("AUTOMOBILE_DB_PATH", originalDbPath);
     restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
     if (tempDir) {
-      await rm(tempDir, { recursive: true, force: true });
+      await removeTempDirWithRetry(tempDir);
       tempDir = undefined;
     }
   });
 
   async function importFreshDatabaseModule() {
     return import(`../../src/db/database.ts?incomplete-extraction-test=${Date.now()}-${Math.random()}`);
+  }
+
+  // Windows holds the sqlite file until the handle is fully released; retry the
+  // removal past a transient EBUSY/EPERM rather than failing the test on cleanup.
+  async function removeTempDirWithRetry(dir: string): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        await rm(dir, { recursive: true, force: true });
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
+          throw error;
+        }
+        await defaultTimer.sleep(50);
+      }
+    }
+    await rm(dir, { recursive: true, force: true });
   }
 
   test("an unknown missing package surfaces the generic error, not incomplete-extraction", async () => {
@@ -66,8 +84,9 @@ describe("startup migration failure does not mislabel a genuine bad import", () 
     };
     process.on("unhandledRejection", onUnhandled);
 
+    let db: Awaited<ReturnType<typeof importFreshDatabaseModule>> | undefined;
     try {
-      const db = await importFreshDatabaseModule();
+      db = await importFreshDatabaseModule();
 
       let thrown: unknown;
       try {
@@ -89,6 +108,7 @@ describe("startup migration failure does not mislabel a genuine bad import", () 
       expect(unhandled).toEqual([]);
     } finally {
       process.off("unhandledRejection", onUnhandled);
+      await db?.closeDatabase();
     }
   });
 });

--- a/test/db/databaseIncompleteExtraction.test.ts
+++ b/test/db/databaseIncompleteExtraction.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+import {
+  INCOMPLETE_EXTRACTION_CODE,
+  isIncompleteExtractionError,
+} from "../../src/db/migrationDependencyIntegrity";
+
+/**
+ * Issue #2833: when a migration cannot resolve a runtime dependency (the
+ * signature of a half-linked `bunx` extraction), the startup migration failure
+ * surfaced to the daemon must be the distinct, recoverable incomplete-extraction
+ * error — not the generic "refusing to run queries" crash.
+ *
+ * This drives the REAL migrator path: a temp migrations folder whose only
+ * migration imports a package that does not exist, so bun throws a genuine
+ * "Cannot find package" resolve error while loading the migration file. That
+ * mirrors the missing-`kysely` failure and proves the mapping holds even when
+ * the cheap preflight is bypassed.
+ */
+describe("startup migration failure maps a missing dependency to a recoverable error", () => {
+  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
+  const originalMigrationsDir = process.env.AUTOMOBILE_MIGRATIONS_DIR;
+  let tempDir: string | undefined;
+
+  function restore(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  afterEach(async () => {
+    restore("AUTOMOBILE_DB_PATH", originalDbPath);
+    restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  async function importFreshDatabaseModule() {
+    return import(`../../src/db/database.ts?incomplete-extraction-test=${Date.now()}-${Math.random()}`);
+  }
+
+  test("ensureMigrations rejects with the recoverable incomplete-extraction error", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "am-incomplete-extraction-"));
+    const migrationsDir = path.join(tempDir, "migrations");
+    await mkdir(migrationsDir, { recursive: true });
+
+    // A migration whose runtime value import cannot be resolved.
+    await writeFile(
+      path.join(migrationsDir, "2099_01_01_000_am2833_missing_dep.ts"),
+      "import 'nonexistent-package-am2833';\n" +
+        "export async function up(): Promise<void> {}\n" +
+        "export async function down(): Promise<void> {}\n"
+    );
+
+    process.env.AUTOMOBILE_DB_PATH = path.join(tempDir, "auto-mobile.db");
+    process.env.AUTOMOBILE_MIGRATIONS_DIR = migrationsDir;
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const db = await importFreshDatabaseModule();
+
+      let thrown: unknown;
+      try {
+        await db.ensureMigrations();
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(isIncompleteExtractionError(thrown)).toBe(true);
+      expect((thrown as { code?: string }).code).toBe(INCOMPLETE_EXTRACTION_CODE);
+      expect((thrown as Error).message).toMatch(/incomplete/i);
+      expect((thrown as Error).message).toMatch(/re-?run/i);
+      // Not the generic startup-migration message.
+      expect((thrown as Error).message).not.toMatch(/refusing to run queries/i);
+
+      // The cached error stays sticky and recoverable-typed on re-check.
+      expect(isIncompleteExtractionError(db.getMigrationsError())).toBe(true);
+
+      await defaultTimer.sleep(10);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/test/db/migrationDependencyIntegrity.test.ts
+++ b/test/db/migrationDependencyIntegrity.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import {
+  INCOMPLETE_EXTRACTION_CODE,
+  MIGRATION_RUNTIME_DEPENDENCIES,
+  assertMigrationDependenciesResolvable,
+  createIncompleteExtractionError,
+  extractMissingPackageName,
+  findMissingMigrationDependency,
+  isIncompleteExtractionError,
+  isMissingPackageError,
+} from "../../src/db/migrationDependencyIntegrity";
+
+/**
+ * Covers issue #2833: a half-linked `bunx` extraction whose `node_modules` is
+ * missing a migration runtime dependency (e.g. `kysely`) must surface as a
+ * distinct, recoverable failure — not a generic fatal migration crash.
+ */
+describe("isMissingPackageError", () => {
+  test("recognizes bun's ResolveMessage 'Cannot find package' shape", () => {
+    const error = new Error(
+      "Cannot find package 'kysely' from " +
+        "'/tmp/bunx-501-@kaeawc/auto-mobile@1.2.3/node_modules/@kaeawc/auto-mobile/dist/src/db/migrations/2026_01_01_000.ts'"
+    );
+    expect(isMissingPackageError(error)).toBe(true);
+  });
+
+  test("recognizes node's MODULE_NOT_FOUND / 'Cannot find module'", () => {
+    const codeError = Object.assign(new Error("boom"), { code: "MODULE_NOT_FOUND" });
+    expect(isMissingPackageError(codeError)).toBe(true);
+    expect(isMissingPackageError(new Error("Cannot find module 'kysely'"))).toBe(true);
+  });
+
+  test("recognizes bun's ERR_MODULE_NOT_FOUND code", () => {
+    const codeError = Object.assign(new Error("boom"), { code: "ERR_MODULE_NOT_FOUND" });
+    expect(isMissingPackageError(codeError)).toBe(true);
+  });
+
+  test("rejects unrelated failures (busy sqlite file, deterministic migration throw)", () => {
+    expect(isMissingPackageError(new Error("SQLITE_BUSY: database is locked"))).toBe(false);
+    expect(isMissingPackageError(new Error("migration 0007 failed: column already exists"))).toBe(false);
+    expect(isMissingPackageError(undefined)).toBe(false);
+    expect(isMissingPackageError("a plain string")).toBe(false);
+  });
+});
+
+describe("extractMissingPackageName", () => {
+  test("pulls the package name from bun's 'Cannot find package' message", () => {
+    const error = new Error("Cannot find package 'kysely' from '/tmp/x/migrations/m.ts'");
+    expect(extractMissingPackageName(error)).toBe("kysely");
+  });
+
+  test("pulls the module name from node's 'Cannot find module' message", () => {
+    expect(extractMissingPackageName(new Error("Cannot find module 'kysely'"))).toBe("kysely");
+  });
+
+  test("handles scoped package names", () => {
+    const error = new Error("Cannot find package '@scope/pkg' from '/tmp/x/m.ts'");
+    expect(extractMissingPackageName(error)).toBe("@scope/pkg");
+  });
+
+  test("returns null when the message names no package", () => {
+    expect(extractMissingPackageName(new Error("something else failed"))).toBeNull();
+    expect(extractMissingPackageName(undefined)).toBeNull();
+  });
+});
+
+describe("createIncompleteExtractionError", () => {
+  test("builds a recoverable error with distinct code, remediation, and preserved cause", () => {
+    const cause = new Error("Cannot find package 'kysely' from '/tmp/x/m.ts'");
+    const error = createIncompleteExtractionError("kysely", cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { code?: string }).code).toBe(INCOMPLETE_EXTRACTION_CODE);
+    expect(error.message).toContain("kysely");
+    // Names the mechanism and the fix so the caller knows it is recoverable.
+    expect(error.message).toMatch(/incomplete/i);
+    expect(error.message).toMatch(/extraction/i);
+    expect(error.message).toMatch(/re-?run/i);
+    expect((error as { cause?: unknown }).cause).toBe(cause);
+    expect(isIncompleteExtractionError(error)).toBe(true);
+  });
+
+  test("falls back to a generic dependency phrase when the package name is unknown", () => {
+    const error = createIncompleteExtractionError(null);
+    expect(error.message).toMatch(/dependenc/i);
+    expect(isIncompleteExtractionError(error)).toBe(true);
+  });
+});
+
+describe("isIncompleteExtractionError", () => {
+  test("is false for ordinary errors", () => {
+    expect(isIncompleteExtractionError(new Error("nope"))).toBe(false);
+    expect(isIncompleteExtractionError(undefined)).toBe(false);
+  });
+});
+
+describe("findMissingMigrationDependency", () => {
+  test("returns the dependency name when the resolver cannot resolve it", () => {
+    const resolve = (specifier: string): string => {
+      if (specifier === "kysely") {
+        throw Object.assign(new Error("Cannot find package 'kysely'"), { code: "MODULE_NOT_FOUND" });
+      }
+      return `/resolved/${specifier}`;
+    };
+    expect(findMissingMigrationDependency("/migrations", resolve)).toBe("kysely");
+  });
+
+  test("returns null when every migration runtime dependency resolves", () => {
+    const resolve = (specifier: string): string => `/resolved/${specifier}`;
+    expect(findMissingMigrationDependency("/migrations", resolve)).toBeNull();
+  });
+
+  test("covers exactly the declared migration runtime dependencies", () => {
+    const attempted: string[] = [];
+    const resolve = (specifier: string): string => {
+      attempted.push(specifier);
+      return `/resolved/${specifier}`;
+    };
+    findMissingMigrationDependency("/migrations", resolve);
+    expect(attempted).toEqual([...MIGRATION_RUNTIME_DEPENDENCIES]);
+    expect(MIGRATION_RUNTIME_DEPENDENCIES).toContain("kysely");
+  });
+
+  test("resolves each dependency from the given migrations folder", () => {
+    const seenPaths: Array<string | undefined> = [];
+    const resolve = (specifier: string, fromDir?: string): string => {
+      seenPaths.push(fromDir);
+      return `/resolved/${specifier}`;
+    };
+    findMissingMigrationDependency("/some/migrations/dir", resolve);
+    expect(seenPaths.every(p => p === "/some/migrations/dir")).toBe(true);
+  });
+});
+
+describe("assertMigrationDependenciesResolvable", () => {
+  test("throws a recoverable incomplete-extraction error naming the missing dependency", () => {
+    const resolve = (specifier: string): string => {
+      if (specifier === "kysely") {
+        throw new Error("Cannot find package 'kysely'");
+      }
+      return `/resolved/${specifier}`;
+    };
+
+    let thrown: unknown;
+    try {
+      assertMigrationDependenciesResolvable("/migrations", resolve);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(isIncompleteExtractionError(thrown)).toBe(true);
+    expect((thrown as Error).message).toContain("kysely");
+  });
+
+  test("does nothing when all dependencies resolve", () => {
+    const resolve = (specifier: string): string => `/resolved/${specifier}`;
+    expect(() => assertMigrationDependenciesResolvable("/migrations", resolve)).not.toThrow();
+  });
+});

--- a/test/db/migrationDependencyIntegrity.test.ts
+++ b/test/db/migrationDependencyIntegrity.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import {
   INCOMPLETE_EXTRACTION_CODE,
+  INCOMPLETE_EXTRACTION_EXIT_CODE,
   MIGRATION_RUNTIME_DEPENDENCIES,
-  assertMigrationDependenciesResolvable,
   createIncompleteExtractionError,
   extractMissingPackageName,
-  findMissingMigrationDependency,
   isIncompleteExtractionError,
+  isMissingMigrationDependencyError,
   isMissingPackageError,
 } from "../../src/db/migrationDependencyIntegrity";
 
 /**
  * Covers issue #2833: a half-linked `bunx` extraction whose `node_modules` is
  * missing a migration runtime dependency (e.g. `kysely`) must surface as a
- * distinct, recoverable failure — not a generic fatal migration crash.
+ * distinct, recoverable failure — not a generic fatal migration crash — while a
+ * genuine bad import (a typo, an unpublished dep) must NOT be mislabeled.
  */
 describe("isMissingPackageError", () => {
   test("recognizes bun's ResolveMessage 'Cannot find package' shape", () => {
@@ -64,6 +65,31 @@ describe("extractMissingPackageName", () => {
   });
 });
 
+describe("isMissingMigrationDependencyError", () => {
+  test("is true only when a KNOWN migration runtime dependency is missing", () => {
+    expect(
+      isMissingMigrationDependencyError(new Error("Cannot find package 'kysely' from '/tmp/x/m.ts'"))
+    ).toBe(true);
+    expect(MIGRATION_RUNTIME_DEPENDENCIES).toContain("kysely");
+  });
+
+  test("is false for a genuine bad import — a typo'd or unpublished package", () => {
+    // A code-level bug in a migration must fall through to the generic error, not
+    // be mislabeled as an incomplete extraction whose fix is "re-extract".
+    expect(
+      isMissingMigrationDependencyError(new Error("Cannot find package 'kysley' from '/tmp/x/m.ts'"))
+    ).toBe(false);
+    expect(
+      isMissingMigrationDependencyError(new Error("Cannot find package 'some-unpublished-dep'"))
+    ).toBe(false);
+  });
+
+  test("is false for non-missing-package failures", () => {
+    expect(isMissingMigrationDependencyError(new Error("database is locked"))).toBe(false);
+    expect(isMissingMigrationDependencyError(undefined)).toBe(false);
+  });
+});
+
 describe("createIncompleteExtractionError", () => {
   test("builds a recoverable error with distinct code, remediation, and preserved cause", () => {
     const cause = new Error("Cannot find package 'kysely' from '/tmp/x/m.ts'");
@@ -76,6 +102,8 @@ describe("createIncompleteExtractionError", () => {
     expect(error.message).toMatch(/incomplete/i);
     expect(error.message).toMatch(/extraction/i);
     expect(error.message).toMatch(/re-?run/i);
+    // Hedges for the non-bunx install path rather than asserting the cause.
+    expect(error.message).toMatch(/bunx/i);
     expect((error as { cause?: unknown }).cause).toBe(cause);
     expect(isIncompleteExtractionError(error)).toBe(true);
   });
@@ -84,6 +112,8 @@ describe("createIncompleteExtractionError", () => {
     const error = createIncompleteExtractionError(null);
     expect(error.message).toMatch(/dependenc/i);
     expect(isIncompleteExtractionError(error)).toBe(true);
+    // No cause supplied → no cause attached.
+    expect((error as { cause?: unknown }).cause).toBeUndefined();
   });
 });
 
@@ -94,66 +124,8 @@ describe("isIncompleteExtractionError", () => {
   });
 });
 
-describe("findMissingMigrationDependency", () => {
-  test("returns the dependency name when the resolver cannot resolve it", () => {
-    const resolve = (specifier: string): string => {
-      if (specifier === "kysely") {
-        throw Object.assign(new Error("Cannot find package 'kysely'"), { code: "MODULE_NOT_FOUND" });
-      }
-      return `/resolved/${specifier}`;
-    };
-    expect(findMissingMigrationDependency("/migrations", resolve)).toBe("kysely");
-  });
-
-  test("returns null when every migration runtime dependency resolves", () => {
-    const resolve = (specifier: string): string => `/resolved/${specifier}`;
-    expect(findMissingMigrationDependency("/migrations", resolve)).toBeNull();
-  });
-
-  test("covers exactly the declared migration runtime dependencies", () => {
-    const attempted: string[] = [];
-    const resolve = (specifier: string): string => {
-      attempted.push(specifier);
-      return `/resolved/${specifier}`;
-    };
-    findMissingMigrationDependency("/migrations", resolve);
-    expect(attempted).toEqual([...MIGRATION_RUNTIME_DEPENDENCIES]);
-    expect(MIGRATION_RUNTIME_DEPENDENCIES).toContain("kysely");
-  });
-
-  test("resolves each dependency from the given migrations folder", () => {
-    const seenPaths: Array<string | undefined> = [];
-    const resolve = (specifier: string, fromDir?: string): string => {
-      seenPaths.push(fromDir);
-      return `/resolved/${specifier}`;
-    };
-    findMissingMigrationDependency("/some/migrations/dir", resolve);
-    expect(seenPaths.every(p => p === "/some/migrations/dir")).toBe(true);
-  });
-});
-
-describe("assertMigrationDependenciesResolvable", () => {
-  test("throws a recoverable incomplete-extraction error naming the missing dependency", () => {
-    const resolve = (specifier: string): string => {
-      if (specifier === "kysely") {
-        throw new Error("Cannot find package 'kysely'");
-      }
-      return `/resolved/${specifier}`;
-    };
-
-    let thrown: unknown;
-    try {
-      assertMigrationDependenciesResolvable("/migrations", resolve);
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(isIncompleteExtractionError(thrown)).toBe(true);
-    expect((thrown as Error).message).toContain("kysely");
-  });
-
-  test("does nothing when all dependencies resolve", () => {
-    const resolve = (specifier: string): string => `/resolved/${specifier}`;
-    expect(() => assertMigrationDependenciesResolvable("/migrations", resolve)).not.toThrow();
+describe("INCOMPLETE_EXTRACTION_EXIT_CODE", () => {
+  test("is EX_TEMPFAIL (75) — a retryable-failure exit code distinct from 1", () => {
+    expect(INCOMPLETE_EXTRACTION_EXIT_CODE).toBe(75);
   });
 });

--- a/test/db/migrationDependencyIntegrity.test.ts
+++ b/test/db/migrationDependencyIntegrity.test.ts
@@ -65,6 +65,23 @@ describe("extractMissingPackageName", () => {
   });
 });
 
+describe("bun ResolveMessage shape (not instanceof Error)", () => {
+  // bun throws a `ResolveMessage` for a failed dynamic import: a string
+  // `.message` but NOT `instanceof Error`. The detection must read `.message`
+  // off any object, or the exact kysely case this fix targets is missed.
+  const resolveMessage = {
+    code: "ERR_MODULE_NOT_FOUND",
+    message: "Cannot find package 'kysely' from 'C:\\bunx\\...\\migrations\\m.ts'",
+  };
+
+  test("is detected, its package name extracted, and matched as a known dep", () => {
+    expect(resolveMessage instanceof Error).toBe(false);
+    expect(isMissingPackageError(resolveMessage)).toBe(true);
+    expect(extractMissingPackageName(resolveMessage)).toBe("kysely");
+    expect(isMissingMigrationDependencyError(resolveMessage)).toBe(true);
+  });
+});
+
 describe("isMissingMigrationDependencyError", () => {
   test("is true only when a KNOWN migration runtime dependency is missing", () => {
     expect(


### PR DESCRIPTION
## What

Turns the daemon's **startup DB migration hard-fail** into a distinct, clearly *recoverable* failure when a `bunx` extraction's `node_modules` is missing a migration runtime dependency (e.g. `kysely`). Closes #2833.

- New [`src/db/migrationDependencyIntegrity.ts`](src/db/migrationDependencyIntegrity.ts): detects bun/node "cannot find package/module" failures, and — **scoped to known migration runtime dependencies** — reframes them as a recoverable incomplete-extraction error (`code: AUTOMOBILE_INCOMPLETE_EXTRACTION`) that names the package and the remediation.
- [`database.ts`](src/db/database.ts) `createStartupMigrationError` maps a *known-dependency* missing-package failure to that recoverable error. This is the reliable fix — it catches the real dynamic-`import()` failure regardless of origin. A genuine bad import in a migration (typo, unpublished dep) falls through to the generic error, not the extraction remedy.
- [`daemonStartupGuard.ts`](src/daemon/daemonStartupGuard.ts) + [`index.ts`](src/index.ts): the daemon now exits with a **distinct, recoverable exit code `75` (`EX_TEMPFAIL`)** on an incomplete-extraction death, so a wrapper can tell it apart from a generic fatal (exit `1`) and re-extract before retrying. The fatal log line is tagged with the failure code for log-based alerting.

## Why

Migration files ship as raw `.ts` and are loaded from disk via kysely's `FileMigrationProvider` dynamic `import()`. Several do a **runtime** value import (`import { sql } from "kysely"`), so bun resolves `kysely` relative to the on-disk migrations tree. When a half-linked `bunx` extraction is missing `kysely` (present in the shared cache, just not linked into this run's `node_modules`), that import throws `Cannot find package 'kysely'` and surfaced as the generic, non-actionable `"...refusing to run queries until the daemon restarts"` crash — sticky and looking unrecoverable, even though the fix is simply re-extracting.

## Recovery model (honest scope)

Recovery is **manual by design**: the daemon respawns from the *same* extraction and cannot re-extract itself, so the failure classifies as **`permanent`** and the crash-loop circuit breaker (#2784) backs off to prevent a hot-loop until the caller re-extracts. The new exit code `75` is the machine-detectable signal issue #2833 asked for, letting an external wrapper automate the re-extract. Programmatic self-heal remains a follow-up.

## Scope vs. issue suggestions

- **#1 (verify integrity + recoverable error/exit code):** ✅ recoverable, named error **and** a distinct exit code.
- **#4 (resilient importer / actionable error):** ✅ via the scoped error mapping.
- **#2 (in-daemon self-heal re-install):** out of scope — running `bun install` inside the daemon is risky, env-dependent, and races other extractions; and the daemon can't mutate the extraction it's respawning from. Wrapper-level re-extract-on-exit-75 is the safer follow-up.
- **#3 (atomic extraction):** out of scope — bun owns the extract/link step.

### Note: no `require.resolve` preflight
An earlier revision added a `require.resolve` preflight. It was **dropped** after review: bun's `require.resolve` falls back to the global install cache, so it does *not* fire in the actual cache-present/extraction-missing scenario, and a "faithful" physical-link check would risk false-positives that break working startups. The error-mapping on the real failure is the load-bearing, no-false-positive fix.

## Tests

- [`test/db/migrationDependencyIntegrity.test.ts`](test/db/migrationDependencyIntegrity.test.ts) — detection (bun `ResolveMessage` + node `MODULE_NOT_FOUND`), name extraction (incl. scoped), the **known-dependency scoping** (`kysely` → recoverable; a typo → not), recoverable-error shape/code/cause, and the exit-code constant.
- [`test/db/databaseIncompleteExtraction.test.ts`](test/db/databaseIncompleteExtraction.test.ts) — end-to-end through the **real migrator**: a migration importing a *non-declared* package surfaces the generic error and is **not** mislabeled as an incomplete extraction.
- [`test/daemon/daemonStartupGuard.test.ts`](test/daemon/daemonStartupGuard.test.ts) — the handler re-stamps the code through `toActionableError` (still `permanent`/backoff), and `resolveDaemonStartupExitCode` returns `75` for incomplete-extraction, `1` otherwise.
- [`test/db/databaseFailureClassification.test.ts`](test/db/databaseFailureClassification.test.ts) — documents incomplete-extraction → `permanent`.

## Validation

`bun test` (db + daemon, 924 pass), `bun run lint`, `bun run build`, and `scripts/all_fast_validate_checks.sh` all green.