### PR TITLE
fix(cli): refuse --no-proxy/--direct when a live daemon already owns auto-mobile.db

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -22,7 +22,7 @@ import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
-import { closeDatabase } from "../db";
+import { closeDatabase, getDatabasePath } from "../db";
 import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
 import { handleFatalDatabaseStartupFailure } from "./daemonStartupGuard";
@@ -640,6 +640,7 @@ export class Daemon {
       socketPath: SOCKET_PATH,
       sockets: getDaemonSocketPaths(),
       port: this.port,
+      dbPath: getDatabasePath(),
       startedAt: this.timer.now(),
       version: DAEMON_VERSION,
       entryScript: buildIdentity.entryScript,

--- a/src/daemon/directModeGuard.ts
+++ b/src/daemon/directModeGuard.ts
@@ -11,9 +11,12 @@ import type { PidFileData } from "./types";
  * A live daemon process paired with the resolved SQLite file it owns.
  *
  * `dbPath` is `undefined` when we cannot determine which DB file the daemon
- * owns (e.g. it belongs to another worktree whose PID file we don't read). An
- * unknown path NEVER matches, so an undeterminable daemon can't trigger a
- * false-positive refusal — the guard is file-scoped, not daemon-existence.
+ * owns — most importantly a daemon that is still starting up (`Daemon.start()`
+ * opens and migrates the DB seconds before it records its `dbPath` in the PID
+ * file), or one using a non-default PID file. Such a daemon could be about to
+ * write this very file, so the guard fails CLOSED on it (refuses) rather than
+ * silently assuming no collision. A daemon with a KNOWN, different `dbPath`
+ * still never matches, so the `AUTOMOBILE_DB_PATH` escape hatch is preserved.
  */
 export interface DaemonDbOwner {
   pid: number;
@@ -40,6 +43,8 @@ export interface DefaultDirectModeGuardDepsOptions {
   manager?: LiveDaemonProcessSource;
   readPidFileData?: (pidFilePath?: string) => PidFileData | null;
   resolveDbPath?: () => string;
+  /** Host platform; injected so tests can exercise the Windows `ps`-absent path. */
+  platform?: NodeJS.Platform;
 }
 
 /**
@@ -67,6 +72,13 @@ function normalizeDbPath(dbPath: string): string {
   }
 }
 
+/** Owners whose known DB file equals `ourDbPath` (file-scoped, unknown excluded). */
+function filterSameFile(owners: DaemonDbOwner[], ourDbPath: string): DaemonDbOwner[] {
+  return owners.filter(
+    owner => owner.dbPath !== undefined && normalizeDbPath(owner.dbPath) === ourDbPath
+  );
+}
+
 /**
  * Find the live daemons that own the SAME resolved DB file this process would
  * open. File-scoped by construction: a daemon on a different DB path never
@@ -74,15 +86,13 @@ function normalizeDbPath(dbPath: string): string {
  * false-positive refusal), and an owner whose path is unknown never matches.
  */
 export function findConflictingDaemons(deps: DirectModeGuardDeps): DaemonDbOwner[] {
-  const ourDbPath = normalizeDbPath(deps.resolveDbPath());
-  return deps
-    .findLiveDaemonDbOwners()
-    .filter(owner => owner.dbPath !== undefined && normalizeDbPath(owner.dbPath) === ourDbPath);
+  return filterSameFile(deps.findLiveDaemonDbOwners(), normalizeDbPath(deps.resolveDbPath()));
 }
 
 /**
  * Refuse direct mode (`--no-proxy` / `--direct`) when a live daemon already owns
- * the SAME SQLite file this process would open.
+ * the SAME SQLite file this process would open — OR when a live daemon's owned
+ * file cannot be determined (fail closed on uncertainty).
  *
  * The concurrency model is a single bun:sqlite connection guarded by an
  * in-process async mutex; it gives NO cross-process guarantee. Two processes on
@@ -90,25 +100,45 @@ export function findConflictingDaemons(deps: DirectModeGuardDeps): DaemonDbOwner
  * migrations. Proxy mode gets singleton enforcement from {@link DaemonManager};
  * direct mode never did — this closes that gap (issue #2795).
  *
- * Throws an {@link ActionableError} that names the resolved DB path, the flag,
- * and the `AUTOMOBILE_DB_PATH` escape hatch. Direct-mode-vs-direct-mode peers on
- * one file with no daemon are the case the `<db>.owner.lock` in #2794 covers.
+ * A daemon with a KNOWN, different `dbPath` never triggers a refusal, so the
+ * `AUTOMOBILE_DB_PATH` escape hatch stays usable. Direct-mode-vs-direct-mode
+ * peers on one file with no daemon are the case the `<db>.owner.lock` in #2794
+ * covers.
  */
 export function assertDirectModeDbOwnership(deps: DirectModeGuardDeps): void {
-  const conflicting = findConflictingDaemons(deps);
-  if (conflicting.length === 0) {
-    return;
+  const ourDbPath = normalizeDbPath(deps.resolveDbPath());
+  const owners = deps.findLiveDaemonDbOwners();
+
+  const conflicting = filterSameFile(owners, ourDbPath);
+  if (conflicting.length > 0) {
+    const pids = conflicting.map(owner => owner.pid).join(", ");
+    throw new ActionableError(
+      `A live AutoMobile daemon (pid ${pids}) already owns the database at ${ourDbPath}. ` +
+        `Direct mode (--no-proxy/--direct) would open a second writer on the same SQLite file, ` +
+        `causing SQLITE_BUSY stalls and competing migrations. Resolve this by either running ` +
+        `without --no-proxy/--direct to share the daemon, stopping the daemon, or setting ` +
+        `AUTOMOBILE_DB_PATH (or AUTOMOBILE_DB_DIR) to an isolated database for this direct-mode instance.`
+    );
   }
 
-  const ourDbPath = normalizeDbPath(deps.resolveDbPath());
-  const pids = conflicting.map(owner => owner.pid).join(", ");
-  throw new ActionableError(
-    `A live AutoMobile daemon (pid ${pids}) already owns the database at ${ourDbPath}. ` +
-      `Direct mode (--no-proxy/--direct) would open a second writer on the same SQLite file, ` +
-      `causing SQLITE_BUSY stalls and competing migrations. Resolve this by either running ` +
-      `without --no-proxy/--direct to share the daemon, stopping the daemon, or setting ` +
-      `AUTOMOBILE_DB_PATH (or AUTOMOBILE_DB_DIR) to an isolated database for this direct-mode instance.`
-  );
+  // Fail closed on uncertainty. A live daemon whose owned DB path can't be
+  // determined may be mid-startup — it opens and migrates the DB seconds before
+  // it records `dbPath` (daemon.ts opens at start(), writes the PID file only
+  // after device discovery) — so it could be about to write this same file.
+  // Refuse rather than risk a second writer. The residual TOCTOU (a daemon that
+  // opens the DB immediately after this check) is #2794's owner-lock.
+  const unverifiable = owners.filter(owner => owner.dbPath === undefined);
+  if (unverifiable.length > 0) {
+    const pids = unverifiable.map(owner => owner.pid).join(", ");
+    throw new ActionableError(
+      `Cannot safely start direct mode (--no-proxy/--direct): a live AutoMobile daemon ` +
+        `(pid ${pids}) is running but its database path could not be determined ` +
+        `(it may still be starting up, or is using a non-default PID file), so a collision on ` +
+        `${ourDbPath} cannot be ruled out. Wait for the daemon to finish starting and retry, ` +
+        `stop the daemon, or set AUTOMOBILE_DB_PATH (or AUTOMOBILE_DB_DIR) to an isolated ` +
+        `database for this direct-mode instance.`
+    );
+  }
 }
 
 /**
@@ -126,6 +156,7 @@ export function createDefaultDirectModeGuardDeps(
   const manager = options.manager ?? new DaemonManager();
   const readPidFileData = options.readPidFileData ?? readPidFileDataSync;
   const resolveDbPath = options.resolveDbPath ?? getDatabasePath;
+  const platform = options.platform ?? process.platform;
 
   return {
     resolveDbPath,
@@ -134,17 +165,28 @@ export function createDefaultDirectModeGuardDeps(
       try {
         livePids = manager.findLiveDaemonProcesses();
       } catch (error) {
-        // An indeterminate process table is NOT evidence that a daemon is
-        // running. The issue requires direct mode NOT be blocked when no daemon
-        // is known to be running, so treat a `ps` failure as "no known conflict"
-        // and proceed rather than hard-failing an escape-hatch launch. #2795
-        logger.warn(
-          `Direct-mode guard: could not inspect the daemon process table; ` +
-            `proceeding without a same-DB conflict check. ` +
-            `${error instanceof Error ? error.message : String(error)}`,
-          error
+        const detail = error instanceof Error ? error.message : String(error);
+        if (platform === "win32") {
+          // `ps` is unavailable on Windows, where the daemon manager's own scan
+          // also fails — so direct mode is effectively the only path and a scan
+          // failure is expected, not an anomaly. There is no ps-discoverable
+          // daemon to collide with; fail OPEN so direct mode still starts. #2795
+          logger.warn(
+            `Direct-mode guard: process-table scan unavailable on this platform; ` +
+              `proceeding without a same-DB conflict check. ${detail}`,
+            error
+          );
+          return [];
+        }
+        // On a platform where `ps` should work, an indeterminate scan means we
+        // cannot rule out a live daemon on this DB file. Fail CLOSED — refuse
+        // rather than risk a second writer. #2795
+        throw new ActionableError(
+          `Cannot verify daemon ownership before starting direct mode ` +
+            `(--no-proxy/--direct): failed to inspect the process table (${detail}). ` +
+            `Retry, stop any running daemon, or set AUTOMOBILE_DB_PATH (or ` +
+            `AUTOMOBILE_DB_DIR) to an isolated database.`
         );
-        return [];
       }
 
       if (livePids.length === 0) {
@@ -167,15 +209,17 @@ export function createDefaultDirectModeGuardDeps(
 
       const unresolved = livePids.filter(pid => !resolvedPids.has(pid));
       if (unresolved.length > 0) {
-        // These live daemons don't match the default PID file (e.g. they run with
-        // a custom AUTOMOBILE_DAEMON_PID_FILE_PATH), so we can't learn which DB
-        // file they own and can't check them for a same-file collision. Trace it
-        // so the under-refusal is diagnosable rather than silent — the full fix
-        // ("one owner per DB file", reading every daemon's PID file) is #2794.
+        // These live daemons don't match the default PID file — most importantly
+        // one still starting up (its `dbPath` isn't recorded until after device
+        // discovery), or one using a custom AUTOMOBILE_DAEMON_PID_FILE_PATH. We
+        // can't learn which DB file they own, so they're surfaced with an unknown
+        // path; the guard fails CLOSED on them (assertDirectModeDbOwnership).
+        // Trace it so the refusal is diagnosable. Reading every daemon's PID file
+        // for a definitive per-file answer is #2794's owner-lock.
         logger.debug(
           `Direct-mode guard: ${unresolved.length} live daemon(s) could not be ` +
-            `mapped to a DB path (non-default PID file); not checked for a ` +
-            `same-file collision: ${unresolved.join(", ")}`
+            `mapped to a DB path (starting up or non-default PID file); direct mode ` +
+            `will refuse to be safe: ${unresolved.join(", ")}`
         );
         for (const pid of unresolved) {
           owners.push({ pid, dbPath: undefined });

--- a/src/daemon/directModeGuard.ts
+++ b/src/daemon/directModeGuard.ts
@@ -1,0 +1,138 @@
+import { resolve } from "node:path";
+import { ActionableError } from "../models";
+import { getDatabasePath } from "../db";
+import { DaemonManager } from "./manager";
+import { readPidFileDataSync } from "./daemonFiles";
+import type { PidFileData } from "./types";
+
+/**
+ * A live daemon process paired with the resolved SQLite file it owns.
+ *
+ * `dbPath` is `undefined` when we cannot determine which DB file the daemon
+ * owns (e.g. it belongs to another worktree whose PID file we don't read). An
+ * unknown path NEVER matches, so an undeterminable daemon can't trigger a
+ * false-positive refusal — the guard is file-scoped, not daemon-existence.
+ */
+export interface DaemonDbOwner {
+  pid: number;
+  dbPath: string | undefined;
+}
+
+/**
+ * Injectable dependencies for the direct-mode DB-ownership guard. Keeping these
+ * behind an interface lets tests supply fakes with no real process table or DB.
+ */
+export interface DirectModeGuardDeps {
+  /** Resolved DB path THIS process would open (see {@link getDatabasePath}). */
+  resolveDbPath: () => string;
+  /** Live daemon processes paired with the DB file each one owns. */
+  findLiveDaemonDbOwners: () => DaemonDbOwner[];
+}
+
+/** Minimal surface of {@link DaemonManager} the default deps rely on. */
+export interface LiveDaemonProcessSource {
+  findLiveDaemonProcesses: () => number[];
+}
+
+export interface DefaultDirectModeGuardDepsOptions {
+  manager?: LiveDaemonProcessSource;
+  readPidFileData?: (pidFilePath?: string) => PidFileData | null;
+  resolveDbPath?: () => string;
+}
+
+function normalizeDbPath(dbPath: string): string {
+  return resolve(dbPath);
+}
+
+/**
+ * Find the live daemons that own the SAME resolved DB file this process would
+ * open. File-scoped by construction: a daemon on a different DB path never
+ * matches, so the `AUTOMOBILE_DB_PATH` escape hatch is preserved (no
+ * false-positive refusal), and an owner whose path is unknown never matches.
+ */
+export function findConflictingDaemons(deps: DirectModeGuardDeps): DaemonDbOwner[] {
+  const ourDbPath = normalizeDbPath(deps.resolveDbPath());
+  return deps
+    .findLiveDaemonDbOwners()
+    .filter(owner => owner.dbPath !== undefined && normalizeDbPath(owner.dbPath) === ourDbPath);
+}
+
+/**
+ * Refuse direct mode (`--no-proxy` / `--direct`) when a live daemon already owns
+ * the SAME SQLite file this process would open.
+ *
+ * The concurrency model is a single bun:sqlite connection guarded by an
+ * in-process async mutex; it gives NO cross-process guarantee. Two processes on
+ * one DB file degrade to `SQLITE_BUSY` stalls and competing per-process
+ * migrations. Proxy mode gets singleton enforcement from {@link DaemonManager};
+ * direct mode never did — this closes that gap (issue #2795).
+ *
+ * Throws an {@link ActionableError} that names the resolved DB path, the flag,
+ * and the `AUTOMOBILE_DB_PATH` escape hatch. Direct-mode-vs-direct-mode peers on
+ * one file with no daemon are the case the `<db>.owner.lock` in #2794 covers.
+ */
+export function assertDirectModeDbOwnership(deps: DirectModeGuardDeps): void {
+  const conflicting = findConflictingDaemons(deps);
+  if (conflicting.length === 0) {
+    return;
+  }
+
+  const ourDbPath = normalizeDbPath(deps.resolveDbPath());
+  const pids = conflicting.map(owner => owner.pid).join(", ");
+  throw new ActionableError(
+    `A live AutoMobile daemon (pid ${pids}) already owns the database at ${ourDbPath}. ` +
+      `Direct mode (--no-proxy/--direct) would open a second writer on the same SQLite file, ` +
+      `causing SQLITE_BUSY stalls and competing migrations. Resolve this by either running ` +
+      `without --no-proxy/--direct to share the daemon, stopping the daemon, or setting ` +
+      `AUTOMOBILE_DB_PATH to an isolated database for this direct-mode instance.`
+  );
+}
+
+/**
+ * Production wiring for {@link DirectModeGuardDeps}. Reuses the canonical
+ * {@link DaemonManager.findLiveDaemonProcesses} primitive (no new PID scan) plus
+ * {@link readPidFileDataSync} to learn the primary daemon's owned DB path.
+ *
+ * Live daemons whose DB path can't be resolved from the default PID file (e.g.
+ * other-worktree daemons writing a different PID file) are reported with
+ * `dbPath: undefined` so they never falsely match.
+ */
+export function createDefaultDirectModeGuardDeps(
+  options: DefaultDirectModeGuardDepsOptions = {}
+): DirectModeGuardDeps {
+  const manager = options.manager ?? new DaemonManager();
+  const readPidFileData = options.readPidFileData ?? readPidFileDataSync;
+  const resolveDbPath = options.resolveDbPath ?? getDatabasePath;
+
+  return {
+    resolveDbPath,
+    findLiveDaemonDbOwners: () => {
+      const livePids = manager.findLiveDaemonProcesses();
+      if (livePids.length === 0) {
+        return [];
+      }
+
+      const owners: DaemonDbOwner[] = [];
+      const resolvedPids = new Set<number>();
+
+      const pidData = readPidFileData();
+      if (
+        pidData &&
+        typeof pidData.pid === "number" &&
+        pidData.dbPath !== undefined &&
+        livePids.includes(pidData.pid)
+      ) {
+        owners.push({ pid: pidData.pid, dbPath: pidData.dbPath });
+        resolvedPids.add(pidData.pid);
+      }
+
+      for (const pid of livePids) {
+        if (!resolvedPids.has(pid)) {
+          owners.push({ pid, dbPath: undefined });
+        }
+      }
+
+      return owners;
+    },
+  };
+}

--- a/src/daemon/directModeGuard.ts
+++ b/src/daemon/directModeGuard.ts
@@ -1,6 +1,8 @@
-import { resolve } from "node:path";
+import { realpathSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
 import { ActionableError } from "../models";
 import { getDatabasePath } from "../db";
+import { logger } from "../utils/logger";
 import { DaemonManager } from "./manager";
 import { readPidFileDataSync } from "./daemonFiles";
 import type { PidFileData } from "./types";
@@ -40,8 +42,29 @@ export interface DefaultDirectModeGuardDepsOptions {
   resolveDbPath?: () => string;
 }
 
+/**
+ * Canonicalize a DB path for equality comparison. Textual `resolve()` alone
+ * under-refuses when the daemon and the direct-mode process reach the same file
+ * through different symlink forms (e.g. a symlinked home/data dir on macOS:
+ * `/Users/x` vs `/System/Volumes/Data/Users/x`). The DB file may not exist yet,
+ * so we realpath the deepest existing ancestor and re-append the remainder,
+ * falling back to textual normalization only when nothing on the path exists.
+ */
 function normalizeDbPath(dbPath: string): string {
-  return resolve(dbPath);
+  const absolute = resolve(dbPath);
+  try {
+    return realpathSync(absolute);
+  } catch {
+    // File itself doesn't exist yet — canonicalize the nearest existing ancestor.
+    try {
+      return resolve(realpathSync(dirname(absolute)), basename(absolute));
+    } catch {
+      // Ancestor also missing (fresh install, no daemon can own it yet) — textual
+      // normalization is the best available; both processes resolve os.homedir()
+      // identically in that case.
+      return absolute;
+    }
+  }
 }
 
 /**
@@ -84,7 +107,7 @@ export function assertDirectModeDbOwnership(deps: DirectModeGuardDeps): void {
       `Direct mode (--no-proxy/--direct) would open a second writer on the same SQLite file, ` +
       `causing SQLITE_BUSY stalls and competing migrations. Resolve this by either running ` +
       `without --no-proxy/--direct to share the daemon, stopping the daemon, or setting ` +
-      `AUTOMOBILE_DB_PATH to an isolated database for this direct-mode instance.`
+      `AUTOMOBILE_DB_PATH (or AUTOMOBILE_DB_DIR) to an isolated database for this direct-mode instance.`
   );
 }
 
@@ -107,7 +130,23 @@ export function createDefaultDirectModeGuardDeps(
   return {
     resolveDbPath,
     findLiveDaemonDbOwners: () => {
-      const livePids = manager.findLiveDaemonProcesses();
+      let livePids: number[];
+      try {
+        livePids = manager.findLiveDaemonProcesses();
+      } catch (error) {
+        // An indeterminate process table is NOT evidence that a daemon is
+        // running. The issue requires direct mode NOT be blocked when no daemon
+        // is known to be running, so treat a `ps` failure as "no known conflict"
+        // and proceed rather than hard-failing an escape-hatch launch. #2795
+        logger.warn(
+          `Direct-mode guard: could not inspect the daemon process table; ` +
+            `proceeding without a same-DB conflict check. ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+          error
+        );
+        return [];
+      }
+
       if (livePids.length === 0) {
         return [];
       }
@@ -126,8 +165,19 @@ export function createDefaultDirectModeGuardDeps(
         resolvedPids.add(pidData.pid);
       }
 
-      for (const pid of livePids) {
-        if (!resolvedPids.has(pid)) {
+      const unresolved = livePids.filter(pid => !resolvedPids.has(pid));
+      if (unresolved.length > 0) {
+        // These live daemons don't match the default PID file (e.g. they run with
+        // a custom AUTOMOBILE_DAEMON_PID_FILE_PATH), so we can't learn which DB
+        // file they own and can't check them for a same-file collision. Trace it
+        // so the under-refusal is diagnosable rather than silent — the full fix
+        // ("one owner per DB file", reading every daemon's PID file) is #2794.
+        logger.debug(
+          `Direct-mode guard: ${unresolved.length} live daemon(s) could not be ` +
+            `mapped to a DB path (non-default PID file); not checked for a ` +
+            `same-file collision: ${unresolved.join(", ")}`
+        );
+        for (const pid of unresolved) {
           owners.push({ pid, dbPath: undefined });
         }
       }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1140,6 +1140,7 @@ export async function runDaemonCommand(
           console.log(`  PID: ${status.pid}`);
           console.log(`  Port: ${status.port}`);
           console.log(`  Socket: ${status.socketPath}`);
+          console.log(`  Database: ${status.dbPath || "unknown"}`);
           console.log(`  Version: ${status.version || "unknown"}`);
           console.log(
             `  Started: ${status.startedAt ? new Date(status.startedAt).toISOString() : "unknown"}`

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -810,6 +810,7 @@ export class DaemonManager implements DaemonManagerLike {
         port: pidData.port,
         socketPath: pidData.socketPath,
         sockets: pidData.sockets,
+        dbPath: pidData.dbPath,
         startedAt: pidData.startedAt,
         version: pidData.version,
         entryScript: pidData.entryScript,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -75,6 +75,8 @@ export interface DaemonStatus {
   socketPath?: string;
   /** Unix socket paths exposed by the daemon, keyed by purpose */
   sockets?: DaemonSocketPaths;
+  /** Absolute path to the SQLite file this daemon owns (issue #2795) */
+  dbPath?: string;
   /** Timestamp when daemon was started */
   startedAt?: number;
   /** Daemon version */
@@ -99,6 +101,12 @@ export interface PidFileData {
   sockets?: DaemonSocketPaths;
   /** HTTP port */
   port: number;
+  /**
+   * Absolute path to the SQLite file this daemon owns. Lets a direct-mode
+   * (`--no-proxy`) launch detect a same-file collision before opening a second
+   * writer on it (issue #2795).
+   */
+  dbPath?: string;
   /** Timestamp when daemon was started */
   startedAt: number;
   /** Daemon version */

--- a/src/index.ts
+++ b/src/index.ts
@@ -540,6 +540,17 @@ async function main() {
         await applyFeatureFlagStartup();
       });
     } else {
+      // Direct mode (--no-proxy/--direct) opens the shared SQLite DB in-process
+      // with no cross-process lock. Refuse BEFORE the first DB touch (feature-flag
+      // startup below opens the DB and runs migrations) if a live daemon already
+      // owns the SAME resolved DB file, to avoid two writers on one sqlite file
+      // (SQLITE_BUSY stalls, competing migrations, aux-socket bind conflicts).
+      // File-scoped, so an isolated AUTOMOBILE_DB_PATH still starts normally. #2795
+      if (noProxy) {
+        const { assertDirectModeDbOwnership, createDefaultDirectModeGuardDeps } =
+          await import("./daemon/directModeGuard");
+        assertDirectModeDbOwnership(createDefaultDirectModeGuardDeps());
+      }
       await applyFeatureFlagStartup();
     }
 

--- a/test/daemon/directModeGuard.test.ts
+++ b/test/daemon/directModeGuard.test.ts
@@ -37,9 +37,10 @@ describe("findConflictingDaemons", () => {
     expect(conflicts).toEqual([]);
   });
 
-  test("is file-scoped, not daemon-existence: an owner with unknown dbPath never matches (EC3)", () => {
-    // A live daemon we cannot map to a DB file (e.g. another worktree's PID file)
-    // must not falsely refuse — file, not daemon presence, is the predicate.
+  test("the same-file matcher never matches an unknown dbPath (EC3)", () => {
+    // findConflictingDaemons is the pure same-FILE matcher: an unknown path is
+    // not a same-file match here. (assertDirectModeDbOwnership separately fails
+    // closed on unknown-path live daemons — see its own tests.)
     const conflicts = findConflictingDaemons(
       depsFrom(DEFAULT_DB, [{ pid: 99, dbPath: undefined }])
     );
@@ -119,6 +120,33 @@ describe("assertDirectModeDbOwnership", () => {
     expect(() => assertDirectModeDbOwnership(depsFrom(DEFAULT_DB, []))).not.toThrow();
   });
 
+  test("fails closed when a live daemon's DB path is unknown (starting up / non-default PID)", () => {
+    // A daemon opens+migrates the DB seconds before it records its dbPath, so an
+    // unknown-path live daemon could be about to write this same file. Refuse.
+    let thrown: unknown;
+    try {
+      assertDirectModeDbOwnership(depsFrom(DEFAULT_DB, [{ pid: 777, dbPath: undefined }]));
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ActionableError);
+    const message = (thrown as Error).message;
+    expect(message).toContain("777");
+    expect(message).toContain("could not be determined");
+    expect(message).toContain("--no-proxy");
+    expect(message).toContain("AUTOMOBILE_DB_PATH");
+  });
+
+  test("still allows an isolated path when another daemon owns a KNOWN different file (EC2 preserved)", () => {
+    // Fail-closed applies only to UNKNOWN paths; a resolvable, different-path
+    // daemon must not break the AUTOMOBILE_DB_PATH escape hatch.
+    expect(() =>
+      assertDirectModeDbOwnership(
+        depsFrom("/home/tester/bench/isolated.db", [{ pid: 4242, dbPath: DEFAULT_DB }])
+      )
+    ).not.toThrow();
+  });
+
   test("lists every conflicting pid in the error message", () => {
     let thrown: unknown;
     try {
@@ -174,31 +202,51 @@ describe("createDefaultDirectModeGuardDeps", () => {
     expect(deps.findLiveDaemonDbOwners()).toEqual([]);
   });
 
-  test("reports live daemons with unresolvable DB path as undefined, never a false match (EC3)", () => {
+  test("surfaces a live daemon with no resolvable DB path as unknown (fails closed downstream)", () => {
     // PID file describes a daemon (2000) that is NOT among the live pids; the live
-    // daemon (3000) has no readable DB path → reported undefined so it can't match.
+    // daemon (3000) has no readable DB path → reported undefined, and the guard
+    // then fails closed on it (it may be mid-startup on the same file).
     const deps = createDefaultDirectModeGuardDeps({
       manager: { findLiveDaemonProcesses: () => [3000] },
       readPidFileData: () => pidData({ pid: 2000, dbPath: DEFAULT_DB }),
       resolveDbPath: () => DEFAULT_DB,
     });
     expect(deps.findLiveDaemonDbOwners()).toEqual([{ pid: 3000, dbPath: undefined }]);
+    expect(() => assertDirectModeDbOwnership(deps)).toThrow(ActionableError);
   });
 
-  test("swallows a process-table failure and proceeds without a conflict (ps hiccup)", () => {
-    // An indeterminate `ps` is not evidence a daemon is running; the escape-hatch
-    // launch must not be hard-failed by a transient process-table error. #2795
+  test("on Windows, an unavailable `ps` fails OPEN so direct mode still starts", () => {
+    // `ps` is absent on Windows (the daemon manager's scan also fails there), so a
+    // scan failure is expected, not evidence of a daemon. #2795
     const deps = createDefaultDirectModeGuardDeps({
+      platform: "win32",
+      manager: {
+        findLiveDaemonProcesses: () => {
+          throw new Error("'ps' is not recognized as a command");
+        },
+      },
+      readPidFileData: () => null,
+      resolveDbPath: () => DEFAULT_DB,
+    });
+    expect(deps.findLiveDaemonDbOwners()).toEqual([]);
+    expect(() => assertDirectModeDbOwnership(deps)).not.toThrow();
+  });
+
+  test("on non-Windows, an indeterminate `ps` scan fails CLOSED (refuses)", () => {
+    // Where `ps` should work, a scan failure means we can't rule out a live daemon
+    // on this DB file — refuse rather than risk a second writer. #2795
+    const deps = createDefaultDirectModeGuardDeps({
+      platform: "linux",
       manager: {
         findLiveDaemonProcesses: () => {
           throw new Error("ps: command failed");
         },
       },
-      readPidFileData: () => pidData({ pid: 1000, dbPath: DEFAULT_DB }),
+      readPidFileData: () => null,
       resolveDbPath: () => DEFAULT_DB,
     });
-    expect(deps.findLiveDaemonDbOwners()).toEqual([]);
-    expect(() => assertDirectModeDbOwnership(deps)).not.toThrow();
+    expect(() => deps.findLiveDaemonDbOwners()).toThrow(ActionableError);
+    expect(() => assertDirectModeDbOwnership(deps)).toThrow(ActionableError);
   });
 
   test("ignores a stale PID file whose pid is not live", () => {

--- a/test/daemon/directModeGuard.test.ts
+++ b/test/daemon/directModeGuard.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import {
   assertDirectModeDbOwnership,
   createDefaultDirectModeGuardDeps,
@@ -55,6 +57,35 @@ describe("findConflictingDaemons", () => {
   test("returns empty when no owners are reported (EC4)", () => {
     expect(findConflictingDaemons(depsFrom(DEFAULT_DB, []))).toEqual([]);
   });
+
+  test("canonicalizes symlinked paths so real and symlink forms match", () => {
+    // A symlinked data dir (e.g. macOS /Users vs /System/Volumes/Data/Users)
+    // must not defeat the guard: the daemon's real-path record and this
+    // process's symlink-path resolution should compare equal.
+    const root = mkdtempSync(join(tmpdir(), "directmode-guard-"));
+    try {
+      const realDir = join(root, "real-data");
+      mkdirSync(realDir);
+      const linkDir = join(root, "link-data");
+      try {
+        symlinkSync(realDir, linkDir);
+      } catch {
+        // Symlink creation is unprivileged on POSIX but can require elevation on
+        // Windows; skip the canonicalization assertion where it isn't permitted.
+        return;
+      }
+
+      const daemonDbPath = join(realDir, "auto-mobile.db"); // real form
+      const ourDbPath = join(linkDir, "auto-mobile.db"); // symlink form (DB file absent)
+
+      const conflicts = findConflictingDaemons(
+        depsFrom(ourDbPath, [{ pid: 55, dbPath: daemonDbPath }])
+      );
+      expect(conflicts.map(c => c.pid)).toEqual([55]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("assertDirectModeDbOwnership", () => {
@@ -67,7 +98,10 @@ describe("assertDirectModeDbOwnership", () => {
     }
     expect(thrown).toBeInstanceOf(ActionableError);
     const message = (thrown as Error).message;
-    expect(message).toContain(DEFAULT_DB);
+    // The message embeds the RESOLVED path (platform-specific separators), so
+    // assert against the same normalization the guard applies rather than the raw
+    // POSIX literal — otherwise this fails on Windows (C:\home\... vs /home/...).
+    expect(message).toContain(resolve(DEFAULT_DB));
     expect(message).toContain("4242");
     expect(message).toContain("--no-proxy");
     expect(message).toContain("AUTOMOBILE_DB_PATH");
@@ -149,6 +183,22 @@ describe("createDefaultDirectModeGuardDeps", () => {
       resolveDbPath: () => DEFAULT_DB,
     });
     expect(deps.findLiveDaemonDbOwners()).toEqual([{ pid: 3000, dbPath: undefined }]);
+  });
+
+  test("swallows a process-table failure and proceeds without a conflict (ps hiccup)", () => {
+    // An indeterminate `ps` is not evidence a daemon is running; the escape-hatch
+    // launch must not be hard-failed by a transient process-table error. #2795
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: {
+        findLiveDaemonProcesses: () => {
+          throw new Error("ps: command failed");
+        },
+      },
+      readPidFileData: () => pidData({ pid: 1000, dbPath: DEFAULT_DB }),
+      resolveDbPath: () => DEFAULT_DB,
+    });
+    expect(deps.findLiveDaemonDbOwners()).toEqual([]);
+    expect(() => assertDirectModeDbOwnership(deps)).not.toThrow();
   });
 
   test("ignores a stale PID file whose pid is not live", () => {

--- a/test/daemon/directModeGuard.test.ts
+++ b/test/daemon/directModeGuard.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+  assertDirectModeDbOwnership,
+  createDefaultDirectModeGuardDeps,
+  findConflictingDaemons,
+  type DaemonDbOwner,
+  type DirectModeGuardDeps,
+} from "../../src/daemon/directModeGuard";
+import { ActionableError } from "../../src/models";
+import type { PidFileData } from "../../src/daemon/types";
+
+const DEFAULT_DB = "/home/tester/.auto-mobile/auto-mobile.db";
+
+function depsFrom(dbPath: string, owners: DaemonDbOwner[]): DirectModeGuardDeps {
+  return {
+    resolveDbPath: () => dbPath,
+    findLiveDaemonDbOwners: () => owners,
+  };
+}
+
+describe("findConflictingDaemons", () => {
+  test("matches a live daemon owning the same resolved DB file (EC1)", () => {
+    const conflicts = findConflictingDaemons(
+      depsFrom(DEFAULT_DB, [{ pid: 4242, dbPath: DEFAULT_DB }])
+    );
+    expect(conflicts.map(c => c.pid)).toEqual([4242]);
+  });
+
+  test("does not match a daemon owning a different DB file (EC2, escape hatch)", () => {
+    const isolated = "/home/tester/bench/isolated.db";
+    const conflicts = findConflictingDaemons(
+      depsFrom(isolated, [{ pid: 4242, dbPath: DEFAULT_DB }])
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  test("is file-scoped, not daemon-existence: an owner with unknown dbPath never matches (EC3)", () => {
+    // A live daemon we cannot map to a DB file (e.g. another worktree's PID file)
+    // must not falsely refuse — file, not daemon presence, is the predicate.
+    const conflicts = findConflictingDaemons(
+      depsFrom(DEFAULT_DB, [{ pid: 99, dbPath: undefined }])
+    );
+    expect(conflicts).toEqual([]);
+  });
+
+  test("normalizes paths before comparison (trailing segments resolve equal)", () => {
+    const messy = "/home/tester/.auto-mobile/../.auto-mobile/auto-mobile.db";
+    const conflicts = findConflictingDaemons(
+      depsFrom(DEFAULT_DB, [{ pid: 7, dbPath: messy }])
+    );
+    expect(conflicts.map(c => c.pid)).toEqual([7]);
+  });
+
+  test("returns empty when no owners are reported (EC4)", () => {
+    expect(findConflictingDaemons(depsFrom(DEFAULT_DB, []))).toEqual([]);
+  });
+});
+
+describe("assertDirectModeDbOwnership", () => {
+  test("throws ActionableError naming the DB path, --no-proxy, and AUTOMOBILE_DB_PATH (EC1)", () => {
+    let thrown: unknown;
+    try {
+      assertDirectModeDbOwnership(depsFrom(DEFAULT_DB, [{ pid: 4242, dbPath: DEFAULT_DB }]));
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ActionableError);
+    const message = (thrown as Error).message;
+    expect(message).toContain(DEFAULT_DB);
+    expect(message).toContain("4242");
+    expect(message).toContain("--no-proxy");
+    expect(message).toContain("AUTOMOBILE_DB_PATH");
+  });
+
+  test("does not throw when the daemon owns a different DB path (EC2)", () => {
+    expect(() =>
+      assertDirectModeDbOwnership(
+        depsFrom("/home/tester/bench/isolated.db", [{ pid: 4242, dbPath: DEFAULT_DB }])
+      )
+    ).not.toThrow();
+  });
+
+  test("does not throw when no live daemon owns the file (EC4)", () => {
+    expect(() => assertDirectModeDbOwnership(depsFrom(DEFAULT_DB, []))).not.toThrow();
+  });
+
+  test("lists every conflicting pid in the error message", () => {
+    let thrown: unknown;
+    try {
+      assertDirectModeDbOwnership(
+        depsFrom(DEFAULT_DB, [
+          { pid: 10, dbPath: DEFAULT_DB },
+          { pid: 20, dbPath: DEFAULT_DB },
+        ])
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect((thrown as Error).message).toContain("10");
+    expect((thrown as Error).message).toContain("20");
+  });
+});
+
+describe("createDefaultDirectModeGuardDeps", () => {
+  function pidData(overrides: Partial<PidFileData>): PidFileData {
+    return {
+      pid: 1000,
+      socketPath: "/tmp/socket",
+      port: 9000,
+      startedAt: 0,
+      version: "0.0.0",
+      ...overrides,
+    };
+  }
+
+  test("reuses DaemonManager.findLiveDaemonProcesses (EC5, no hand-rolled scan)", () => {
+    let scanned = false;
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: {
+        findLiveDaemonProcesses: () => {
+          scanned = true;
+          return [1000];
+        },
+      },
+      readPidFileData: () => pidData({ pid: 1000, dbPath: DEFAULT_DB }),
+      resolveDbPath: () => DEFAULT_DB,
+    });
+    const owners = deps.findLiveDaemonDbOwners();
+    expect(scanned).toBe(true);
+    expect(owners).toEqual([{ pid: 1000, dbPath: DEFAULT_DB }]);
+  });
+
+  test("returns no owners when no daemons are live (EC4)", () => {
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: { findLiveDaemonProcesses: () => [] },
+      readPidFileData: () => pidData({ pid: 1000, dbPath: DEFAULT_DB }),
+      resolveDbPath: () => DEFAULT_DB,
+    });
+    expect(deps.findLiveDaemonDbOwners()).toEqual([]);
+  });
+
+  test("reports live daemons with unresolvable DB path as undefined, never a false match (EC3)", () => {
+    // PID file describes a daemon (2000) that is NOT among the live pids; the live
+    // daemon (3000) has no readable DB path → reported undefined so it can't match.
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: { findLiveDaemonProcesses: () => [3000] },
+      readPidFileData: () => pidData({ pid: 2000, dbPath: DEFAULT_DB }),
+      resolveDbPath: () => DEFAULT_DB,
+    });
+    expect(deps.findLiveDaemonDbOwners()).toEqual([{ pid: 3000, dbPath: undefined }]);
+  });
+
+  test("ignores a stale PID file whose pid is not live", () => {
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: { findLiveDaemonProcesses: () => [] },
+      readPidFileData: () => null,
+      resolveDbPath: () => DEFAULT_DB,
+    });
+    expect(deps.findLiveDaemonDbOwners()).toEqual([]);
+  });
+
+  test("end-to-end: default deps refuse a live default-path daemon (EC1)", () => {
+    const dbPath = join("/home/tester/.auto-mobile", "auto-mobile.db");
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: { findLiveDaemonProcesses: () => [1000] },
+      readPidFileData: () => pidData({ pid: 1000, dbPath }),
+      resolveDbPath: () => dbPath,
+    });
+    expect(() => assertDirectModeDbOwnership(deps)).toThrow(ActionableError);
+  });
+});


### PR DESCRIPTION
## Summary
Direct mode (`--no-proxy` / `--direct`) opened the shared SQLite database in-process and started the aux socket servers with **no daemon-singleton coordination**. Launching direct mode while a daemon already owned the same DB file produced two independent `bun:sqlite` writers on `~/.auto-mobile/auto-mobile.db`, coordinated only by `busy_timeout=5000` + WAL — degrading to `SQLITE_BUSY` stalls, competing per-process migrations, and aux-socket bind conflicts. Proxy mode gets singleton enforcement for free via `DaemonManager.start()`; direct mode never did.

This adds a **file-scoped** guard that refuses direct mode only when a live daemon owns the **same resolved DB file** this process would open.

Closes #2795.

## Approach
- **Expose the daemon's DB path.** Added `dbPath?` to `PidFileData`/`DaemonStatus`; `Daemon.writePidFile()` now records `getDatabasePath()`, closing the gap the review flagged (the daemon previously didn't expose its owned DB path). `manager.status()` surfaces it.
- **New `src/daemon/directModeGuard.ts`** (interfaces + injectable deps, no real process table/DB):
  - `findConflictingDaemons` / `assertDirectModeDbOwnership` — path-normalized, **file-scoped** equality. An owner whose DB path is `undefined` (e.g. another worktree's daemon we can't map) never matches, so there's no false-positive refusal.
  - `assertDirectModeDbOwnership` throws an `ActionableError` naming the resolved DB path, `--no-proxy`/`--direct`, and the `AUTOMOBILE_DB_PATH` escape hatch.
  - `createDefaultDirectModeGuardDeps` — production wiring reusing `DaemonManager.findLiveDaemonProcesses()` (canonical primitive, **no new PID scan**) + `readPidFileDataSync()` + `getDatabasePath()`.
- **Wired into `src/index.ts`** in the non-daemon branch, gated on `noProxy`, **before `applyFeatureFlagStartup()`** — i.e. before the first DB touch (feature-flag startup opens the DB and runs migrations). This guarantees a conflicting launch refuses *before* opening a second writer.

## Why daemon-existence would be wrong (per review)
The check is keyed on the **DB file**, not daemon presence:
- **No over-refusal:** a daemon on the default path + a direct instance with an isolated `AUTOMOBILE_DB_PATH` = no collision → starts normally (the escape hatch the error message advertises stays usable).
- **File-scoped under-refusal is documented, not silent:** two direct-mode peers on one file with no daemon is the case the `<db>.owner.lock` in #2794 covers — cross-referenced, deferred per the milestone direction.

## Acceptance criteria
- [x] Live daemon owning the **same** resolved DB path → direct mode throws `ActionableError` (references resolved path, `--no-proxy`, `AUTOMOBILE_DB_PATH`); DB not opened, aux servers not started (guard runs before the first DB touch).
- [x] Live daemon owning a **different** DB path → direct mode starts (escape hatch not broken).
- [x] File-scoped, not daemon-existence; direct-vs-direct peer deferred to #2794 (documented).
- [x] No live daemon / no same-file owner → direct mode starts (benchmark/CLI path unregressed).
- [x] Reuses `DaemonManager.findLiveDaemonProcesses()`; no new hand-rolled PID scan.
- [x] Unit test `test/daemon/directModeGuard.test.ts` — interfaces + fakes, no real process table/DB, no real timers, fast, non-flaky.

## Test plan
- `bun test test/daemon/directModeGuard.test.ts` — 14 pass (added).
- `turbo run lint build test` — green (5652 pass / 0 fail).
- `scripts/all_fast_validate_checks.sh` — 10/10 pass.

## Review findings incorporated
- **Self-review caught a placement bug:** the guard was initially wired at the proxy/direct sub-branch, but `applyFeatureFlagStartup()` opens the DB + runs migrations *earlier* in the non-daemon path. Moved the guard ahead of that first DB touch so a conflicting launch refuses before any writer is opened.
