### PR TITLE
fix(ios): de-flake RemindersAddPlanTests with a deterministic add-reminder plan (#2811)

### DIFF
--- a/docs/design-docs/mcp/test-plan-validation.md
+++ b/docs/design-docs/mcp/test-plan-validation.md
@@ -126,7 +126,39 @@ name: my-test-plan          # Required: unique plan identifier
 steps:                      # Required: at least one step
   - tool: observe           # Required: tool name
     label: Wait for app     # Optional: human-readable description
+    optional: true          # Optional: best-effort step (see below)
 ```
+
+### Optional (best-effort) steps
+
+A step marked `optional: true` becomes **best-effort**: if its tool fails —
+returns `success: false`, an `observe` `waitFor` times out, or the handler
+throws — the executor logs the failure, records the step as `skipped`, and
+**continues** instead of aborting the plan. An abort/cancellation is never
+swallowed as a skip.
+
+Use this to guard against intermittent UI that may or may not be present, so a
+plan doesn't fail on the runs where it is absent. For example, dismissing a
+system dialog that only appears sometimes:
+
+```yaml
+steps:
+  # If the "Not Now" alert isn't up on this run, both steps skip and the plan
+  # continues instead of failing.
+  - tool: observe
+    waitFor:
+      text: "Not Now"
+      timeout: 5000
+    optional: true
+    label: Wait for the alert (if shown)
+  - tool: tapOn
+    text: "Not Now"
+    optional: true
+    label: Dismiss the alert (if shown)
+```
+
+`optional` is a step-level field, not a tool parameter — it is never forwarded
+to the tool.
 
 ### Complete Example
 

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
@@ -60,6 +60,16 @@ final class RemindersAddPlanTests: RemindersIntegrationBase {
             ?? "add-reminder.yaml"
     }
 
+    // #2811: this exercises the system Reminders app, whose exact control labels and layout timing
+    // vary across iOS versions. `add-reminder.yaml`'s waitFor guards remove the common races and its
+    // optional "Not Now" step dismisses the intermittent iCloud alert, but a single retry still
+    // absorbs the residual "fails once, passes on a plain re-run" flake this issue documents. An
+    // explicit AUTOMOBILE_TEST_RETRY_COUNT always wins; a genuine break still fails on every attempt.
+    override var retryCount: Int {
+        let base = super.retryCount
+        return base > 0 ? base : 1
+    }
+
     func testAddReminderPlan() throws {
         PerfTimer.log("testAddReminderPlan START - planPath: \(planPath)")
         let result = try executePlan()

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
@@ -67,8 +67,14 @@ final class RemindersAddPlanTests: RemindersIntegrationBase {
     // explicit AUTOMOBILE_TEST_RETRY_COUNT always wins; a genuine break still fails on every attempt.
     // The retry is tracked for removal once the guards are proven sufficient — see issue #2855.
     override var retryCount: Int {
-        let base = super.retryCount
-        return base > 0 ? base : 1
+        // Honor an explicit override — including 0 to disable retries — and default to 1 only when
+        // no override is set. (super.retryCount can't distinguish an explicit 0 from the unset
+        // default, so read the env directly.)
+        let environment = AutoMobileEnvironment()
+        if let explicit = environment.intValue(["AUTOMOBILE_TEST_RETRY_COUNT", "RETRY_COUNT"]) {
+            return explicit
+        }
+        return 1
     }
 
     func testAddReminderPlan() throws {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
@@ -65,6 +65,7 @@ final class RemindersAddPlanTests: RemindersIntegrationBase {
     // optional "Not Now" step dismisses the intermittent iCloud alert, but a single retry still
     // absorbs the residual "fails once, passes on a plain re-run" flake this issue documents. An
     // explicit AUTOMOBILE_TEST_RETRY_COUNT always wins; a genuine break still fails on every attempt.
+    // The retry is tracked for removal once the guards are proven sufficient — see issue #2855.
     override var retryCount: Int {
         let base = super.retryCount
         return base > 0 ? base : 1

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -1,0 +1,239 @@
+import XCTest
+@testable import XCTestRunner
+
+/// Structural (no-simulator) guards for the bundled `add-reminder.yaml` plan.
+///
+/// `RemindersAddPlanTests.testAddReminderPlan` was flaky because plan step 5 was a bare
+/// `tapOn text: "Done"` fired immediately after `inputText`; on a slow simulator the "Done"
+/// control isn't present yet and the tap fails with "Element not found" (issue #2811). These tests
+/// encode the determinism invariant — the save tap must be guarded by a preceding `observe`
+/// `waitFor` on the same control — so the plan can't silently regress back to a racy bare tap.
+///
+/// They parse the real bundled resource (not a fixture) and need no booted simulator or daemon,
+/// so they run in the plain `swift test` macOS suite.
+final class RemindersPlanContentTests: XCTestCase {
+    private func loadAddReminderPlan() throws -> String {
+        return try DefaultPlanLoader().loadPlan(at: "add-reminder.yaml", bundle: Bundle.module)
+    }
+
+    /// The save tap must be immediately preceded by an `observe`/`waitFor` guard on "Done", so the
+    /// executor polls for the control (and its `awaitTimeout` path fails fast on genuine absence)
+    /// instead of racing a bare tap.
+    func testAddReminderPlanWaitsForDoneBeforeTappingIt() throws {
+        let steps = PlanStepSequence.parse(try loadAddReminderPlan())
+
+        guard let saveTapIndex = steps.firstIndex(where: { $0.tool == "tapOn" && $0.mentionsDone }) else {
+            XCTFail("Plan is missing the tapOn \"Done\" save step")
+            return
+        }
+
+        XCTAssertGreaterThan(
+            saveTapIndex,
+            0,
+            "The tapOn \"Done\" step cannot be the first step; it must follow a wait guard"
+        )
+
+        let guardStep = steps[saveTapIndex - 1]
+        XCTAssertEqual(
+            guardStep.tool,
+            "observe",
+            "The step before tapOn \"Done\" must be an observe guard, was \(guardStep.tool)"
+        )
+        XCTAssertTrue(
+            guardStep.hasWaitFor,
+            "The observe step guarding the \"Done\" tap must use waitFor"
+        )
+        XCTAssertTrue(
+            guardStep.mentionsDone,
+            "The waitFor guard before the \"Done\" tap must target \"Done\""
+        )
+    }
+
+    /// The guard must be bounded so a genuinely-absent control fails fast instead of hanging for the
+    /// whole plan timeout.
+    func testDoneWaitGuardHasBoundedTimeout() throws {
+        let steps = PlanStepSequence.parse(try loadAddReminderPlan())
+
+        guard let saveTapIndex = steps.firstIndex(where: { $0.tool == "tapOn" && $0.mentionsDone }),
+              saveTapIndex > 0
+        else {
+            XCTFail("Plan is missing a guarded tapOn \"Done\" step")
+            return
+        }
+
+        let guardStep = steps[saveTapIndex - 1]
+        guard let timeout = guardStep.waitForTimeoutMs else {
+            XCTFail("The waitFor guard before the \"Done\" tap must declare a timeout")
+            return
+        }
+        XCTAssertGreaterThan(timeout, 0, "waitFor timeout must be positive")
+        XCTAssertLessThanOrEqual(
+            timeout,
+            30000,
+            "waitFor timeout should stay bounded so genuine failures don't hang the plan"
+        )
+    }
+
+    /// The add-flow test retry-wraps itself (#2811) so the residual cross-iOS-version flake doesn't
+    /// red-flag otherwise-green PRs, while a genuine break still fails on every attempt.
+    func testAddReminderPlanDefaultsToOneRetry() {
+        // An explicit env override legitimately wins, so only assert the default when unset.
+        let env = ProcessInfo.processInfo.environment
+        if env["AUTOMOBILE_TEST_RETRY_COUNT"] != nil || env["RETRY_COUNT"] != nil {
+            return
+        }
+        XCTAssertEqual(RemindersAddPlanTests().retryCount, 1)
+    }
+
+    /// The intermittent "Enable iCloud Syncing?" alert must be dismissed best-effort before the
+    /// create step, and the create tap must itself be guarded by a wait. The dismissal has to be
+    /// `optional` so runs where the alert never appears don't fail.
+    func testDismissesICloudAlertBestEffortBeforeCreating() throws {
+        let steps = PlanStepSequence.parse(try loadAddReminderPlan())
+
+        guard let createTapIndex = steps.firstIndex(where: {
+            $0.tool == "tapOn" && $0.mentions("New Reminder")
+        }) else {
+            XCTFail("Plan is missing the tapOn \"New Reminder\" step")
+            return
+        }
+
+        // A best-effort dismissal of the "Not Now" alert button precedes the create tap.
+        let dismissIndex = steps.firstIndex { $0.tool == "tapOn" && $0.mentions("Not Now") }
+        guard let dismissIndex = dismissIndex else {
+            XCTFail("Plan must dismiss the iCloud alert via a tapOn \"Not Now\" step")
+            return
+        }
+        XCTAssertLessThan(dismissIndex, createTapIndex, "The alert dismissal must precede creating a reminder")
+        XCTAssertTrue(
+            steps[dismissIndex].isOptional,
+            "The \"Not Now\" dismissal must be optional so alert-absent runs don't fail"
+        )
+
+        // Any waitFor guarding the (intermittent) alert must also be optional for the same reason.
+        for index in 0..<dismissIndex where steps[index].tool == "observe" && steps[index].mentions("Not Now") {
+            XCTAssertTrue(
+                steps[index].isOptional,
+                "A waitFor guarding the intermittent alert must be optional"
+            )
+        }
+
+        // The create tap is guarded by a preceding observe waitFor on the same control.
+        XCTAssertGreaterThan(createTapIndex, 0)
+        let createGuard = steps[createTapIndex - 1]
+        XCTAssertEqual(createGuard.tool, "observe", "The tapOn \"New Reminder\" must follow an observe guard")
+        XCTAssertTrue(createGuard.hasWaitFor && createGuard.mentions("New Reminder"))
+    }
+
+    /// Regression guard: the determinism fix must not break the surrounding flow — the plan still
+    /// launches Reminders first, terminates it last, and keeps the create/type steps in order.
+    func testAddReminderPlanKeepsValidIosFlow() throws {
+        let content = try loadAddReminderPlan()
+        let steps = PlanStepSequence.parse(content)
+
+        XCTAssertTrue(
+            content.contains("platform: ios"),
+            "Plan must still declare the ios platform"
+        )
+        XCTAssertEqual(steps.first?.tool, "launchApp", "Plan must launch Reminders first")
+        XCTAssertEqual(steps.last?.tool, "terminateApp", "Plan must terminate Reminders last")
+
+        let toolOrder = steps.map { $0.tool }
+        let createIndex = steps.firstIndex { $0.tool == "tapOn" && $0.mentions("New Reminder") }
+        let typeIndex = toolOrder.firstIndex(of: "inputText")
+        let saveIndex = steps.firstIndex { $0.tool == "tapOn" && $0.mentionsDone }
+
+        XCTAssertNotNil(createIndex, "Plan must still focus a new reminder")
+        XCTAssertNotNil(typeIndex, "Plan must still type the reminder title")
+        XCTAssertNotNil(saveIndex, "Plan must still save via the \"Done\" control")
+        if let createIndex = createIndex, let typeIndex = typeIndex, let saveIndex = saveIndex {
+            XCTAssertLessThan(createIndex, typeIndex, "Reminder must be focused before typing")
+            XCTAssertLessThan(typeIndex, saveIndex, "Title must be typed before saving")
+        }
+    }
+}
+
+/// A single parsed plan step: its tool and a flattened view of its property block, enough to assert
+/// ordering and the wait-before-tap invariant without pulling in a YAML dependency.
+private struct PlanStep {
+    let tool: String
+    let bodyLines: [String]
+
+    var body: String { bodyLines.joined(separator: "\n") }
+
+    var hasWaitFor: Bool {
+        bodyLines.contains { $0.trimmingCharacters(in: .whitespaces).hasPrefix("waitFor:") }
+    }
+
+    /// True when the step declares `optional: true` (best-effort; failure does not abort the plan).
+    var isOptional: Bool {
+        bodyLines.contains { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("optional:") else {
+                return false
+            }
+            return trimmed.dropFirst("optional:".count).trimmingCharacters(in: .whitespaces) == "true"
+        }
+    }
+
+    var mentionsDone: Bool { mentions("Done") }
+
+    func mentions(_ needle: String) -> Bool {
+        body.contains("\"\(needle)\"") || body.contains(needle)
+    }
+
+    /// The `timeout:` value declared anywhere in the step body (the waitFor block), in milliseconds.
+    var waitForTimeoutMs: Int? {
+        for line in bodyLines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("timeout:") else {
+                continue
+            }
+            let value = trimmed.dropFirst("timeout:".count).trimmingCharacters(in: .whitespaces)
+            if let parsed = Int(value) {
+                return parsed
+            }
+        }
+        return nil
+    }
+}
+
+/// Minimal ordered-step extractor for a single-device plan YAML. Each step begins at a
+/// `- tool: <name>` list item; following more-indented lines are its property block.
+private enum PlanStepSequence {
+    static func parse(_ yaml: String) -> [PlanStep] {
+        var steps: [PlanStep] = []
+        var currentTool: String?
+        var currentBody: [String] = []
+
+        func flush() {
+            if let tool = currentTool {
+                steps.append(PlanStep(tool: tool, bodyLines: currentBody))
+            }
+            currentTool = nil
+            currentBody = []
+        }
+
+        for rawLine in yaml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            if let tool = toolName(fromListItem: trimmed) {
+                flush()
+                currentTool = tool
+                currentBody = [rawLine]
+            } else if currentTool != nil {
+                currentBody.append(rawLine)
+            }
+        }
+        flush()
+        return steps
+    }
+
+    /// Returns the tool name for a `- tool: <name>` list item line, or nil for any other line.
+    private static func toolName(fromListItem trimmed: String) -> String? {
+        guard trimmed.hasPrefix("- tool:") else {
+            return nil
+        }
+        let value = trimmed.dropFirst("- tool:".count).trimmingCharacters(in: .whitespaces)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -216,6 +216,11 @@ private enum PlanStepSequence {
 
         for rawLine in yaml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
             let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            // Skip full-line comments so a comment block preceding a step isn't misattributed to the
+            // previous step's body (which would make `mentions(...)` match on comment text).
+            if trimmed.hasPrefix("#") {
+                continue
+            }
             if let tool = toolName(fromListItem: trimmed) {
                 flush()
                 currentTool = tool

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -85,6 +85,22 @@ final class RemindersPlanContentTests: XCTestCase {
         XCTAssertEqual(RemindersAddPlanTests().retryCount, 1)
     }
 
+    /// An explicit retry override wins — including 0 to disable retries for CI/local repro runs.
+    func testExplicitZeroRetryOverrideIsHonored() {
+        let key = "AUTOMOBILE_TEST_RETRY_COUNT"
+        let original = ProcessInfo.processInfo.environment[key]
+        setenv(key, "0", 1)
+        defer {
+            if let original = original {
+                setenv(key, original, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        XCTAssertEqual(RemindersAddPlanTests().retryCount, 0)
+    }
+
     /// The intermittent "Enable iCloud Syncing?" alert must be dismissed best-effort before the
     /// create step, and the create tap must itself be guarded by a wait. The dismissal has to be
     /// `optional` so runs where the alert never appears don't fail.

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
@@ -13,6 +13,33 @@ steps:
       timeout: 20000
     label: Wait for Reminders UI
 
+  # Reminders intermittently shows an "Enable iCloud Syncing?" alert on launch that covers the
+  # list and blocks the create/save controls. It appears on some simulators (fresh state, no iCloud
+  # account) and not others, which is the flaky-test root cause (issue #2811): when present the
+  # later taps fail, when absent the plan sails through. Dismiss it best-effort — both the wait and
+  # the tap are optional, so a run where the alert never appears skips them and continues instead of
+  # failing.
+  - tool: observe
+    waitFor:
+      text: "Not Now"
+      timeout: 5000
+    optional: true
+    label: Wait for the iCloud syncing alert (if shown)
+
+  - tool: tapOn
+    text: "Not Now"
+    action: "tap"
+    optional: true
+    label: Dismiss the iCloud syncing alert (if shown)
+
+  # Wait for the create control to render before tapping it, so the tap doesn't race the shade/list
+  # layout on a slow simulator.
+  - tool: observe
+    waitFor:
+      text: "New Reminder"
+      timeout: 10000
+    label: Wait for New Reminder control
+
   - tool: tapOn
     text: "New Reminder"
     action: "tap"
@@ -21,6 +48,15 @@ steps:
   - tool: inputText
     text: "AutoMobile XCTest demo"
     label: Type reminder title
+
+  # Wait for the "Done" save control to render before tapping it. Without this guard the tap races
+  # the keyboard/nav-bar layout and fails with "Element not found with provided text 'Done'"
+  # (issue #2811). observe waitFor polls until it appears and fails fast via awaitTimeout otherwise.
+  - tool: observe
+    waitFor:
+      text: "Done"
+      timeout: 10000
+    label: Wait for Done control
 
   - tool: tapOn
     text: "Done"

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
@@ -8,9 +8,14 @@ description: Create a basic reminder in the iOS Reminders app (English UI assume
 # the "New Reminder" control, which would break this plan.
 platform: ios
 steps:
+  # coldBoot force-terminates + relaunches so a retry (the test retries once, #2811/#2855) starts
+  # from the Reminders home rather than a partial edit screen left by a failed attempt. A warm iOS
+  # launch would resume that stale screen and then time out waiting for "New Reminder". coldBoot
+  # (unlike clearAppData) keeps the app data, so it avoids the empty-home issue noted above.
   - tool: launchApp
     appId: com.apple.reminders
-    label: Launch Reminders
+    coldBoot: true
+    label: Launch Reminders (cold, for clean retry state)
 
   - tool: observe
     waitFor:

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
@@ -1,6 +1,11 @@
 ---
 name: add-reminder
 description: Create a basic reminder in the iOS Reminders app (English UI assumed)
+# NOTE: the system Reminders UI varies by iOS version — the "New Reminder" and "Done" control
+# labels below are pinned to the CI simulator's iOS (English). On some iOS versions the save
+# control is labelled "Add" instead of "Done". Cross-version tolerance is tracked in issue #2855.
+# Deliberately does NOT clearAppData: on newer iOS a cleared Reminders launches to a home without
+# the "New Reminder" control, which would break this plan.
 platform: ios
 steps:
   - tool: launchApp

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -178,6 +178,10 @@
           "type": "string",
           "description": "Human-readable description of what this step does"
         },
+        "optional": {
+          "type": "boolean",
+          "description": "Best-effort step: if the tool fails (returns success:false, an observe waitFor times out, or throws), the executor logs it, records the step as skipped, and continues instead of aborting the plan. Use for steps that guard against intermittent UI (e.g. dismissing a dialog that may or may not be present)."
+        },
         "description": {
           "type": "string",
           "description": "DEPRECATED: Use 'label' instead (legacy field)"

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -6,6 +6,13 @@ export interface PlanStep {
   tool: string;
   params: Record<string, any>;
   label?: string;
+  /**
+   * Best-effort step: if the tool fails (returns success:false, an observe waitFor times out, or
+   * throws), the executor logs it, records the step as skipped, and continues instead of aborting
+   * the plan. Use for steps that guard against intermittent UI (e.g. dismissing a dialog that may
+   * or may not be present).
+   */
+  optional?: boolean;
 }
 
 export interface PlanDeviceDefinition {

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -1,5 +1,6 @@
 import {
   Plan,
+  PlanStep,
   PlanExecutionResult,
   DeviceExecutionResult,
   AbortStrategy,
@@ -164,6 +165,32 @@ export class DefaultPlanExecutor implements PlanExecutor {
     if (payload.tapDebug !== undefined && payload.tapDebug !== null) {
       details.tapDebug = payload.tapDebug;
     }
+  }
+
+  /**
+   * Record a failed `optional: true` step as skipped so the sequential executor can continue
+   * without aborting the plan. Returns nothing; the caller continues its loop.
+   */
+  private recordSkippedOptionalStep(
+    debugSteps: ExecutePlanStepDebugInfo[],
+    stepNumber: number,
+    step: PlanStep,
+    durationMs: number,
+    error: string,
+  ): void {
+    logger.warn(
+      `[PLAN_STEP_${stepNumber}] optional step ${step.tool} failed; skipping and continuing: ${error}`
+    );
+    debugSteps.push({
+      step: `Execute step ${stepNumber}: ${step.tool}`,
+      status: "skipped",
+      durationMs,
+      details: {
+        params: step.params,
+        error,
+        optional: true,
+      },
+    });
   }
 
   private static readonly FAILURE_OBSERVATION_TIMEOUT_MS = 3000;
@@ -446,6 +473,10 @@ export class DefaultPlanExecutor implements PlanExecutor {
           // Check if the response indicates failure
           if (toolResult && typeof toolResult === "object" && "success" in toolResult && toolResult.success === false) {
             const errorMsg = toolResult.error || "Unknown error";
+            if (step.optional) {
+              this.recordSkippedOptionalStep(debugSteps, i + 1, step, this.timer.now() - stepStartTime, String(errorMsg));
+              continue;
+            }
             logger.error(`[PLAN_STEP_${i + 1}] FAILED: ${step.tool} - ${errorMsg}`);
             const failureObservation = await this.buildFailureObservationContext(
               step.tool,
@@ -487,6 +518,10 @@ export class DefaultPlanExecutor implements PlanExecutor {
 
           if (observeTimedOut) {
             const errorMsg = `observe waitFor timed out after ${observeTimedOut.awaitDuration ?? "unknown"}ms`;
+            if (step.optional) {
+              this.recordSkippedOptionalStep(debugSteps, i + 1, step, this.timer.now() - stepStartTime, errorMsg);
+              continue;
+            }
             logger.error(`[PLAN_STEP_${i + 1}] FAILED: ${step.tool} - ${errorMsg}`);
             debugSteps.push({
               step: `Execute step ${i + 1}: ${step.tool}`,
@@ -541,6 +576,12 @@ export class DefaultPlanExecutor implements PlanExecutor {
           executedSteps++;
           logger.info(`[PLAN_STEP_${i + 1}] Successfully completed. Total executed: ${executedSteps}/${plan.steps.length}`);
         } catch (error) {
+          // An abort must never be swallowed as an optional skip; let it fall through to the normal
+          // failure path (and, for non-optional steps, preserve existing behavior).
+          if (step.optional && !signal?.aborted) {
+            this.recordSkippedOptionalStep(debugSteps, i + 1, step, this.timer.now() - stepStartTime, `${error}`);
+            continue;
+          }
           logger.error(`[PLAN_STEP_${i + 1}] EXCEPTION in ${step.tool}: ${error}`);
           const failureObservation = await this.buildFailureObservationContext(
             step.tool,
@@ -921,6 +962,12 @@ export class DefaultPlanExecutor implements PlanExecutor {
             checkResult.success === false
           ) {
             const errorMsg = "error" in checkResult ? String(checkResult.error) : "Tool execution failed";
+            if (step.optional) {
+              logger.warn(
+                `[PARALLEL_EXEC][${device}] optional step ${step.tool} failed; skipping and continuing: ${errorMsg}`
+              );
+              continue;
+            }
             logger.error(`[PARALLEL_EXEC][${device}] Tool failed: ${errorMsg}`);
 
             const failureObservation = await this.buildFailureObservationContext(
@@ -949,6 +996,12 @@ export class DefaultPlanExecutor implements PlanExecutor {
             step.tool === "observe" ? this.observeWaitForTimedOut(response) : null;
           if (observeTimedOutParallel) {
             const errorMsg = `observe waitFor timed out after ${observeTimedOutParallel.awaitDuration ?? "unknown"}ms`;
+            if (step.optional) {
+              logger.warn(
+                `[PARALLEL_EXEC][${device}] optional step ${step.tool} timed out; skipping and continuing: ${errorMsg}`
+              );
+              continue;
+            }
             logger.error(`[PARALLEL_EXEC][${device}] Tool failed: ${errorMsg}`);
             return {
               success: false,
@@ -969,6 +1022,13 @@ export class DefaultPlanExecutor implements PlanExecutor {
           );
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
+          // An abort must never be swallowed as an optional skip.
+          if (step.optional && !signal?.aborted) {
+            logger.warn(
+              `[PARALLEL_EXEC][${device}] optional step ${step.tool} threw; skipping and continuing: ${errorMessage}`
+            );
+            continue;
+          }
           logger.error(`[PARALLEL_EXEC][${device}] Step execution error: ${errorMessage}`);
 
           const failureObservation = await this.buildFailureObservationContext(

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -15,6 +15,7 @@ import {
   type PlanExecutionOptions,
 } from "../../models/ExecutePlanResult";
 import { throwIfAborted } from "../toolUtils";
+import { ZodError } from "zod";
 import { PlanPartitioner, TrackedStep } from "./PlanPartitioner";
 import { DaemonState } from "../../daemon/daemonState";
 import { Timer, defaultTimer } from "../SystemTimer";
@@ -576,9 +577,11 @@ export class DefaultPlanExecutor implements PlanExecutor {
           executedSteps++;
           logger.info(`[PLAN_STEP_${i + 1}] Successfully completed. Total executed: ${executedSteps}/${plan.steps.length}`);
         } catch (error) {
-          // An abort must never be swallowed as an optional skip; let it fall through to the normal
-          // failure path (and, for non-optional steps, preserve existing behavior).
-          if (step.optional && !signal?.aborted) {
+          // `optional` skips runtime UI/tool failures, NOT plan-authoring errors: a schema
+          // validation throw (ZodError from tool.schema.parse) stays fatal so a typo in an optional
+          // step surfaces instead of silently becoming a no-op. An abort must also never be swallowed
+          // as a skip.
+          if (step.optional && !signal?.aborted && !(error instanceof ZodError)) {
             this.recordSkippedOptionalStep(debugSteps, i + 1, step, this.timer.now() - stepStartTime, `${error}`);
             continue;
           }
@@ -1025,8 +1028,8 @@ export class DefaultPlanExecutor implements PlanExecutor {
           );
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          // An abort must never be swallowed as an optional skip.
-          if (step.optional && !signal?.aborted) {
+          // Skip runtime failures only — a schema validation throw (ZodError) or an abort stays fatal.
+          if (step.optional && !signal?.aborted && !(error instanceof ZodError)) {
             logger.warn(
               `[PARALLEL_EXEC][${device}] optional step ${step.tool} threw; skipping and continuing: ${errorMessage}`
             );

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -963,6 +963,9 @@ export class DefaultPlanExecutor implements PlanExecutor {
           ) {
             const errorMsg = "error" in checkResult ? String(checkResult.error) : "Tool execution failed";
             if (step.optional) {
+              // Parallel tracks do not emit the unified debug-step array (see the captureObserveSteps
+              // warning in executeParallel), so — consistently with that design — a skipped optional
+              // step is logged rather than recorded as a debug step.
               logger.warn(
                 `[PARALLEL_EXEC][${device}] optional step ${step.tool} failed; skipping and continuing: ${errorMsg}`
               );

--- a/src/utils/plan/PlanMigrator.ts
+++ b/src/utils/plan/PlanMigrator.ts
@@ -184,7 +184,10 @@ const migrateStepFields = (
   const paramsFromStep = isRecord(step.params) ? { ...step.params } : {};
   const inlineParams: Record<string, any> = {};
   for (const [key, value] of Object.entries(step)) {
-    if (["tool", "command", "label", "params"].includes(key)) {
+    // Keep step-level keys (not tool params) at the step level. `optional` must survive migration —
+    // importPlanFromYaml runs migratePlan() before PlanNormalizer, so moving it into params here
+    // would strip the flag before the executor sees it, making a best-effort step mandatory (#2853).
+    if (["tool", "command", "label", "params", "optional"].includes(key)) {
       continue;
     }
     inlineParams[key] = value;

--- a/src/utils/plan/PlanNormalizer.ts
+++ b/src/utils/plan/PlanNormalizer.ts
@@ -28,7 +28,13 @@ export class PlanNormalizer {
 
     const inlineParams: Record<string, any> = {};
     Object.keys(step).forEach(key => {
-      if (key !== "tool" && key !== "command" && key !== "label" && key !== "params") {
+      if (
+        key !== "tool" &&
+        key !== "command" &&
+        key !== "label" &&
+        key !== "params" &&
+        key !== "optional"
+      ) {
         inlineParams[key] = step[key];
       }
     });
@@ -46,6 +52,10 @@ export class PlanNormalizer {
 
     if (typeof step.label === "string") {
       normalizedStep.label = step.label;
+    }
+
+    if (step.optional === true) {
+      normalizedStep.optional = true;
     }
 
     logger.info(`Normalized step ${index}:`, JSON.stringify(normalizedStep, null, 2));

--- a/test/plan/planExecutorOptionalStep.test.ts
+++ b/test/plan/planExecutorOptionalStep.test.ts
@@ -68,6 +68,21 @@ describe("PlanExecutor — optional steps", () => {
       mock(async () => createStructuredToolResponse({ success: true }))
     );
     markDevice("optionalStepOk");
+
+    // A tool whose schema requires a field, so bad params throw a ZodError at parse time.
+    const strictSchema = z.object({
+      requiredField: z.string(),
+      platform: z.string().optional(),
+      deviceId: z.string().optional(),
+      sessionUuid: z.string().optional(),
+    });
+    ToolRegistry.register(
+      "optionalStepStrict",
+      "requires a field",
+      strictSchema,
+      mock(async () => createStructuredToolResponse({ success: true }))
+    );
+    markDevice("optionalStepStrict");
   });
 
   afterEach(() => {
@@ -121,6 +136,23 @@ describe("PlanExecutor — optional steps", () => {
 
     expect(result.success).toBe(true);
     expect(result.executedSteps).toBe(1);
+  });
+
+  test("a malformed optional step (schema validation error) stays fatal", async () => {
+    const plan: Plan = {
+      name: "optional-invalid-params",
+      steps: [
+        // Missing requiredField -> tool.schema.parse throws a ZodError before the handler runs.
+        { tool: "optionalStepStrict", params: {}, optional: true },
+        { tool: "optionalStepOk", params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "ios", "sim-1");
+
+    // Plan-authoring errors must not be silently skipped, even for optional steps.
+    expect(result.success).toBe(false);
+    expect(result.failedStep?.tool).toBe("optionalStepStrict");
   });
 
   test("still aborts the plan when a NON-optional step fails", async () => {

--- a/test/plan/planExecutorOptionalStep.test.ts
+++ b/test/plan/planExecutorOptionalStep.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
+import { Plan } from "../../src/models/Plan";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerObserveTools } from "../../src/server/observeTools";
+import { z } from "zod";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+
+/**
+ * Optional (best-effort) plan steps. A step marked `optional: true` whose tool fails must NOT abort
+ * the plan — the executor logs it, records it as skipped, and continues. This is the primitive that
+ * lets a plan dismiss an intermittent dialog (e.g. the Reminders "Enable iCloud Syncing?" alert,
+ * issue #2811) without breaking the runs where that dialog is absent.
+ */
+describe("PlanExecutor — optional steps", () => {
+  let planExecutor: DefaultPlanExecutor;
+
+  beforeEach(() => {
+    planExecutor = new DefaultPlanExecutor();
+    const deviceSchema = z.object({
+      platform: z.string().optional(),
+      deviceId: z.string().optional(),
+      sessionUuid: z.string().optional(),
+      waitFor: z.any().optional(),
+    });
+
+    const markDevice = (name: string) => {
+      (ToolRegistry.getTool(name) as { requiresDevice: boolean }).requiresDevice = true;
+    };
+
+    ToolRegistry.register(
+      "optionalStepFail",
+      "always fails",
+      deviceSchema,
+      mock(async () => createStructuredToolResponse({ success: false, error: "element not found" }))
+    );
+    markDevice("optionalStepFail");
+
+    ToolRegistry.register(
+      "optionalStepThrow",
+      "always throws",
+      deviceSchema,
+      mock(async () => {
+        throw new Error("boom");
+      })
+    );
+    markDevice("optionalStepThrow");
+
+    // The awaitTimeout skip path only applies to the real `observe` tool, so override it here.
+    ToolRegistry.register(
+      "observe",
+      "observe timeout",
+      deviceSchema,
+      mock(async () =>
+        createStructuredToolResponse({
+          updatedAt: 0,
+          awaitTimeout: true,
+          awaitDuration: 5000,
+        })
+      )
+    );
+    markDevice("observe");
+
+    ToolRegistry.register(
+      "optionalStepOk",
+      "succeeds",
+      deviceSchema,
+      mock(async () => createStructuredToolResponse({ success: true }))
+    );
+    markDevice("optionalStepOk");
+  });
+
+  afterEach(() => {
+    registerObserveTools();
+  });
+
+  test("continues past a failed optional step and still succeeds", async () => {
+    const plan: Plan = {
+      name: "optional-fail-then-ok",
+      steps: [
+        { tool: "optionalStepFail", params: {}, optional: true },
+        { tool: "optionalStepOk", params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "ios", "sim-1");
+
+    expect(result.success).toBe(true);
+    expect(result.failedStep).toBeUndefined();
+    // Only the mandatory step counts as executed; the optional one is skipped.
+    expect(result.executedSteps).toBe(1);
+    const statuses = result.debug?.steps.map(s => s.status);
+    expect(statuses).toEqual(["skipped", "completed"]);
+  });
+
+  test("skips an optional step whose handler throws and continues", async () => {
+    const plan: Plan = {
+      name: "optional-throw-then-ok",
+      steps: [
+        { tool: "optionalStepThrow", params: {}, optional: true },
+        { tool: "optionalStepOk", params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "ios", "sim-1");
+
+    expect(result.success).toBe(true);
+    expect(result.executedSteps).toBe(1);
+  });
+
+  test("skips an optional observe awaitTimeout and continues", async () => {
+    const plan: Plan = {
+      name: "optional-observe-timeout",
+      steps: [
+        { tool: "observe", params: { waitFor: { text: "x", timeout: 1 } }, optional: true },
+        { tool: "optionalStepOk", params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "ios", "sim-1");
+
+    expect(result.success).toBe(true);
+    expect(result.executedSteps).toBe(1);
+  });
+
+  test("still aborts the plan when a NON-optional step fails", async () => {
+    const plan: Plan = {
+      name: "mandatory-fail",
+      steps: [
+        { tool: "optionalStepFail", params: {} },
+        { tool: "optionalStepOk", params: {} },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "ios", "sim-1");
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep?.tool).toBe("optionalStepFail");
+  });
+});

--- a/test/utils/plan/PlanNormalizer.test.ts
+++ b/test/utils/plan/PlanNormalizer.test.ts
@@ -26,4 +26,21 @@ describe("PlanNormalizer", () => {
     expect(normalized.params).toEqual({ text: "params", device: "B" });
     expect(normalized.label).toBe("Tap button");
   });
+
+  test("promotes optional flag to the step, not into tool params", () => {
+    const normalized = PlanNormalizer.normalizeStep(
+      { tool: "tapOn", text: "Not Now", optional: true },
+      0
+    );
+
+    expect(normalized.optional).toBe(true);
+    // `optional` is a step-level concern; it must not leak into the tool schema (tapOn is strict).
+    expect(normalized.params).toEqual({ text: "Not Now" });
+  });
+
+  test("omits optional when not set to true", () => {
+    const normalized = PlanNormalizer.normalizeStep({ tool: "observe" }, 0);
+
+    expect(normalized.optional).toBeUndefined();
+  });
 });

--- a/test/utils/plan/PlanSerializer.test.ts
+++ b/test/utils/plan/PlanSerializer.test.ts
@@ -250,5 +250,28 @@ describe("YamlPlanSerializer", () => {
 
       expect(() => serializer.importPlanFromYaml(yamlContent)).toThrow();
     });
+
+    test("preserves step-level optional flag through migration + normalization (#2853)", () => {
+      // Regression: importPlanFromYaml runs migratePlan() before PlanNormalizer. `optional` must
+      // stay at the step level and NOT be swept into tool params, or a best-effort step becomes
+      // mandatory and the executor never skips it.
+      const yamlContent = yaml.dump({
+        name: "Optional Plan",
+        steps: [
+          { tool: "tapOn", text: "Not Now", optional: true },
+          { tool: "observe", params: { waitFor: { text: "x" } }, optional: true },
+          { tool: "terminateApp", appId: "com.example.app" },
+        ],
+      });
+
+      const plan = serializer.importPlanFromYaml(yamlContent);
+
+      expect(plan.steps[0].optional).toBe(true);
+      expect(plan.steps[1].optional).toBe(true);
+      expect(plan.steps[2].optional).toBeUndefined();
+      // The flag must not leak into tool params (strict tool schemas would reject it).
+      expect(plan.steps[0].params.optional).toBeUndefined();
+      expect(plan.steps[1].params.optional).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2811. `RemindersAddPlanTests.testAddReminderPlan` was flaky because the add-reminder plan raced the system Reminders UI. Live investigation on booted simulators (**iOS 18.6 and iOS 26.2**) surfaced two root causes:

1. **Bare `tapOn` at fixed steps.** Steps tapped "New Reminder" and "Done" without waiting for the control to render — the documented step-5 "Done" race (`Element not found with provided text 'Done'`).
2. **An intermittent "Enable iCloud Syncing?" alert** (`Not Now` / `Go to Settings`) that covers the list on launch and blocks the create/save taps. It shows on some simulator states and not others — exactly why the test **"failed once, passed on a plain re-run"**.

## Changes

**1. Deterministic plan — `ios/.../Resources/Plans/add-reminder.yaml`**
- `observe waitFor` guards before the "New Reminder" and "Done" taps (mirrors the existing "wait for Reminders" step and the Android `set-alarm` plan), so a tap polls until its control appears and fails fast via `awaitTimeout` if it genuinely never does.
- Best-effort dismissal of the iCloud alert (`observe waitFor "Not Now"` + `tapOn "Not Now"`, both `optional`), so alert-present runs dismiss it and alert-absent runs skip it instead of failing.

**2. New plan primitive — `optional: true` steps (`src/`)**
- `PlanStep.optional` (`Plan.ts`); `PlanNormalizer` promotes it to the step (and keeps it out of the strict tool schemas).
- `PlanExecutor` (sequential **and** parallel): a failed `optional` step — `success:false`, an `observe` `waitFor` timeout, or a thrown handler — is logged, recorded as `skipped`, and execution continues instead of aborting. An abort is **never** swallowed as a skip (`!signal?.aborted`).

**3. Retry-wrap — `RemindersIntegrationTests.swift`**
- `RemindersAddPlanTests` defaults to one retry (the issue's sanctioned "retry-wrap" option) to absorb the residual cross-iOS-version flake. An explicit `AUTOMOBILE_TEST_RETRY_COUNT` still wins; a genuine break still fails on every attempt.

## Tests (TDD — red first, no simulator required)

- **TS:** `test/plan/planExecutorOptionalStep.test.ts` — a failed optional step is skipped-and-continued across all three failure modes, and a non-optional failure still aborts; `PlanNormalizer.test.ts` — `optional` promotes to the step, never into params.
- **Swift:** `RemindersPlanContentTests` — parses the bundled plan and asserts it waits before each tap, dismisses the alert best-effort (and the dismissal is `optional`), keeps a valid iOS launch→create→type→save→terminate flow, bounds the wait timeout, and that the add-flow test defaults to one retry.

## Validation

- `swift test -Xswiftc -warnings-as-errors` (XCTestRunner unit suite) green.
- `bun test test/plan test/utils/plan` — 204 pass; recorder + server plan suites green.
- `bunx turbo run build lint` green; `scripts/all_fast_validate_checks.sh` — 10/10 pass.
- Live-normalized the bundled plan end-to-end (`js-yaml` → `PlanNormalizer`) to confirm `optional` flows through and never leaks into tool params.

## Known caveat / reviewer note

The system Reminders UI genuinely varies by iOS version (on iOS 18.6 the commit control is labeled **"Add"**, not "Done", and its home lacks the toolbar "New Reminder"). The mandatory `waitFor` guards target the labels CI's iOS 26 runner renders (per the issue's evidence that CI reaches the "Done" step); the retry covers the residual. The full end-to-end plan only runs against a version-matched daemon in the **XCTestRunner Simulator Tests** CI job — locally the shared daemon runs main `dist/`, which predates the `optional` primitive.

Refs #2749, #2744.

---

## Multi-agent review — findings addressed

Ran three independent review perspectives (iOS UI-automation, TS executor/systems, architecture direction). Changes made in response:

- **`optional` was untyped in the plan schema** (only allowed via `additionalProperties: true`, so a typo silently disabled the skip). Now typed as a boolean `planStep` property in `schemas/test-plan.schema.json` and documented in `docs/design-docs/mcp/test-plan-validation.md`.
- **Parser comment-attribution nit** in `RemindersPlanContentTests` — now strips full-line comments so a preceding comment block can't be misattributed to a step.
- **Parallel-path optional skip** logs rather than records a debug step — added a comment noting this is consistent with the existing design that parallel tracks don't emit a unified debug-step array.
- **Retry not masking real breaks** — confirmed: a deterministic break still fails both attempts; only the "fails once, passes on re-run" flake is absorbed. Tracked for removal in #2855.

### Investigated and deliberately not changed (with evidence)

- **Cross-iOS-version label divergence** (the top risk from two reviewers): verified live that iOS 18.6 labels the commit control **"Add"** (not "Done"), that `clearAppData` on iOS 26.2 yields a home **without** "New Reminder", and that a created reminder's title is **not observable** after saving (the accounts-home shows list summaries only). So a version-tolerant "tap Done or Add, then verify" plan has no cheap reliable verification and `clearAppData` is unsafe on newer iOS. The plan is therefore pinned to CI's iOS reality (per #2811, CI's iOS 26 image uses "Done"), documented in the plan header, with cross-version tolerance tracked in **#2855**. The **XCTestRunner Simulator Tests** CI job is the authoritative check that "Done"/"New Reminder" are correct on the CI image.
- **`addUIInterruptionMonitor`** for global system-alert dismissal was considered as a more reusable alternative to the per-plan optional "Not Now" step; it's tracked in #2855 (AutoMobile drives gestures via its own daemon rather than native XCUIElement taps, so the monitor may not fire — needs evaluation).
- **`launch-reminders-app.yaml` / `RemindersLaunchPlanTests`** are intentionally out of scope (the launch plan never taps a control the alert can cover).