### PR TITLE
refactor(ios): migrate control-proxy to a typed command model (#2846)

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A4F48C4211E43B829855704 /* SdkHierarchyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */; };
 		0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */; };
 		0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */; };
+		0F29D59ABFB52692F62B434F /* TypedRequestDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */; };
 		12D60B8E4D067E91189066AD /* CommandHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */; };
 		141E5CD4FAF4509F538E736C /* OSLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA97A6C3A1240A055D9876C /* OSLogReader.swift */; };
 		158C6F3B528C02BE92AA6132 /* HierarchyMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */; };
@@ -186,6 +187,7 @@
 		DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfProviderTests.swift; sourceTree = "<group>"; };
 		E30D131E590A0CF8F9674B0E /* ClipboardResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardResolutionTests.swift; sourceTree = "<group>"; };
 		E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyClient.swift; sourceTree = "<group>"; };
+		EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedRequestDecodeTests.swift; sourceTree = "<group>"; };
 		F2144B84CD70DB35A1030624 /* GesturePerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturePerformer.swift; sourceTree = "<group>"; };
 		F9D3D13C3FE12BA2CD012082 /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
 		FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyMerger.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */,
 				DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */,
 				5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */,
+				EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */,
 			);
 			name = CtrlProxyTests;
 			path = Tests/CtrlProxyTests;
@@ -573,6 +576,7 @@
 				6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */,
 				0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */,
 				2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */,
+				0F29D59ABFB52692F62B434F /* TypedRequestDecodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -64,148 +64,140 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    /// Handle an incoming request and return a response
+    /// Handle an incoming request and return a response.
+    ///
+    /// The `switch` is exhaustive over the typed `WebSocketRequest` enum: adding
+    /// a new command case without a branch here fails compilation, so the
+    /// dispatch table can never silently drop a command.
     public func handle(_ request: WebSocketRequest) -> Any {
         let startTime = Date()
 
         do {
-            switch request.type {
+            switch request {
             // View hierarchy commands
-            case RequestType.requestHierarchy.rawValue,
-                 RequestType.requestHierarchyIfStale.rawValue:
-                return try handleRequestHierarchy(request, startTime: startTime)
+            case let .requestHierarchy(payload), let .requestHierarchyIfStale(payload):
+                return try handleRequestHierarchy(payload, startTime: startTime)
 
-            case RequestType.requestScreenshot.rawValue:
-                return try handleRequestScreenshot(request, startTime: startTime)
+            case let .requestScreenshot(payload):
+                return try handleRequestScreenshot(payload, startTime: startTime)
 
             // Gesture commands
-            case RequestType.requestTapCoordinates.rawValue:
-                return try handleTapCoordinates(request, startTime: startTime)
+            case let .tapCoordinates(payload):
+                return try handleTapCoordinates(payload, startTime: startTime)
 
-            case RequestType.requestSwipe.rawValue:
-                return try handleSwipe(request, startTime: startTime)
+            case let .swipe(payload):
+                return try handleSwipe(payload, startTime: startTime)
 
-            case RequestType.requestTwoFingerSwipe.rawValue:
-                return try handleTwoFingerSwipe(request, startTime: startTime)
+            case let .twoFingerSwipe(payload), let .multiFingerSwipe(payload):
+                return try handleMultiFingerSwipe(payload, startTime: startTime)
 
-            case RequestType.requestMultiFingerSwipe.rawValue:
-                return try handleMultiFingerSwipe(request, startTime: startTime)
+            case let .drag(payload):
+                return try handleDrag(payload, startTime: startTime)
 
-            case RequestType.requestDrag.rawValue:
-                return try handleDrag(request, startTime: startTime)
-
-            case RequestType.requestPinch.rawValue:
-                return try handlePinch(request, startTime: startTime)
+            case let .pinch(payload):
+                return try handlePinch(payload, startTime: startTime)
 
             // Text input commands
-            case RequestType.requestSetText.rawValue:
-                return try handleSetText(request, startTime: startTime)
+            case let .setText(payload):
+                return try handleSetText(payload, startTime: startTime)
 
-            case RequestType.requestClearText.rawValue:
-                return try handleClearText(request, startTime: startTime)
+            case let .clearText(payload):
+                return try handleClearText(payload, startTime: startTime)
 
-            case RequestType.requestImeAction.rawValue:
-                return try handleImeAction(request, startTime: startTime)
+            case let .imeAction(payload):
+                return try handleImeAction(payload, startTime: startTime)
 
-            case RequestType.requestSelectAll.rawValue:
-                return try handleSelectAll(request, startTime: startTime)
+            case let .selectAll(payload):
+                return try handleSelectAll(payload, startTime: startTime)
 
-            case RequestType.requestKeyboard.rawValue:
-                return try handleKeyboard(request, startTime: startTime)
+            case let .keyboard(payload):
+                return try handleKeyboard(payload, startTime: startTime)
 
-            case RequestType.requestPressButton.rawValue:
-                return try handlePressButton(request, startTime: startTime)
+            case let .pressButton(payload):
+                return try handlePressButton(payload, startTime: startTime)
 
-            case RequestType.requestPressHome.rawValue:
-                return try handlePressHome(request, startTime: startTime)
+            case let .pressHome(payload):
+                return try handlePressHome(payload, startTime: startTime)
 
-            case RequestType.requestPressBack.rawValue:
-                return try handlePressBack(request, startTime: startTime)
+            case let .pressBack(payload):
+                return try handlePressBack(payload, startTime: startTime)
 
-            case RequestType.requestShake.rawValue:
-                return try handleShake(request, startTime: startTime)
+            case let .shake(payload):
+                return try handleShake(payload, startTime: startTime)
 
-            case RequestType.requestRecentApps.rawValue:
-                return try handleRecentApps(request, startTime: startTime)
+            case let .recentApps(payload):
+                return try handleRecentApps(payload, startTime: startTime)
 
             // Action commands
-            case RequestType.requestAction.rawValue:
-                return try handleAction(request, startTime: startTime)
+            case let .action(payload):
+                return try handleAction(payload, startTime: startTime)
 
-            case RequestType.requestLaunchApp.rawValue:
-                return try handleLaunchApp(request, startTime: startTime)
+            case let .launchApp(payload):
+                return try handleLaunchApp(payload, startTime: startTime)
 
             // Device control
-            case RequestType.requestRotate.rawValue:
-                return try handleRotate(request, startTime: startTime)
+            case let .rotate(payload):
+                return try handleRotate(payload, startTime: startTime)
 
             // Clipboard commands
-            case RequestType.requestClipboard.rawValue:
-                return try handleClipboard(request, startTime: startTime)
+            case let .clipboard(payload):
+                return try handleClipboard(payload, startTime: startTime)
 
             // Accessibility features
-            case RequestType.getCurrentFocus.rawValue:
-                return try handleGetCurrentFocus(request, startTime: startTime)
+            case let .getCurrentFocus(payload):
+                return try handleGetCurrentFocus(payload, startTime: startTime)
 
-            case RequestType.getTraversalOrder.rawValue:
-                return try handleGetTraversalOrder(request, startTime: startTime)
+            case let .getTraversalOrder(payload):
+                return try handleGetTraversalOrder(payload, startTime: startTime)
 
-            case RequestType.addHighlight.rawValue:
-                return try handleAddHighlight(request, startTime: startTime)
+            case let .addHighlight(payload):
+                return try handleAddHighlight(payload, startTime: startTime)
 
-            case RequestType.getVoiceOverState.rawValue:
-                return try handleGetVoiceOverState(request, startTime: startTime)
+            case let .getVoiceOverState(payload):
+                return try handleGetVoiceOverState(payload, startTime: startTime)
 
             // Storage commands
-            case RequestType.listPreferenceFiles.rawValue:
-                return handleListPreferenceFiles(request, startTime: startTime)
+            case let .listPreferenceFiles(payload):
+                return handleListPreferenceFiles(payload, startTime: startTime)
 
-            case RequestType.getPreferences.rawValue:
-                return handleGetPreferences(request, startTime: startTime)
+            case let .getPreferences(payload):
+                return handleGetPreferences(payload, startTime: startTime)
 
-            case RequestType.getPreference.rawValue:
-                return handleGetPreference(request, startTime: startTime)
+            case let .getPreference(payload):
+                return handleGetPreference(payload, startTime: startTime)
 
-            case RequestType.setPreference.rawValue:
-                return try handleSetPreference(request, startTime: startTime)
+            case let .setPreference(payload):
+                return try handleSetPreference(payload, startTime: startTime)
 
-            case RequestType.removePreference.rawValue:
-                return try handleRemovePreference(request, startTime: startTime)
+            case let .removePreference(payload):
+                return try handleRemovePreference(payload, startTime: startTime)
 
-            case RequestType.clearPreferences.rawValue:
-                return try handleClearPreferences(request, startTime: startTime)
+            case let .clearPreferences(payload):
+                return try handleClearPreferences(payload, startTime: startTime)
 
             // Network mocking
-            case RequestType.setNetworkMockRules.rawValue:
-                return try handleSetNetworkMockRules(request, startTime: startTime)
+            case let .setNetworkMockRules(payload):
+                return try handleSetNetworkMockRules(payload, startTime: startTime)
 
             // Database commands
-            case RequestType.executeSql.rawValue:
-                return handleExecuteSql(request, startTime: startTime)
+            case let .executeSql(payload):
+                return handleExecuteSql(payload, startTime: startTime)
 
-            case RequestType.listDatabases.rawValue:
-                return handleListDatabases(request, startTime: startTime)
+            case let .listDatabases(payload):
+                return handleListDatabases(payload, startTime: startTime)
 
-            case RequestType.listTables.rawValue:
-                return handleListTables(request, startTime: startTime)
+            case let .listTables(payload):
+                return handleListTables(payload, startTime: startTime)
 
-            case RequestType.getTableData.rawValue:
-                return handleGetTableData(request, startTime: startTime)
+            case let .getTableData(payload):
+                return handleGetTableData(payload, startTime: startTime)
 
-            case RequestType.getTableStructure.rawValue:
-                return handleGetTableStructure(request, startTime: startTime)
-
-            default:
-                return WebSocketResponse.error(
-                    type: "error",
-                    requestId: request.requestId,
-                    error: "Unknown command type: \(request.type)",
-                    totalTimeMs: totalTimeMs(from: startTime)
-                )
+            case let .getTableStructure(payload):
+                return handleGetTableStructure(payload, startTime: startTime)
             }
         } catch {
             return WebSocketResponse.error(
-                type: responseType(for: request.type),
+                type: responseType(for: request.typeString),
                 requestId: request.requestId,
                 error: error.localizedDescription,
                 totalTimeMs: totalTimeMs(from: startTime)
@@ -216,15 +208,12 @@ public class CommandHandler: CommandHandling {
     // MARK: - Network Mocking
 
     private func handleSetNetworkMockRules(
-        _ request: WebSocketRequest,
+        _ request: RequestSetNetworkMockRules,
         startTime: Date
     )
         throws -> SetNetworkMockRulesResponse
     {
-        guard let rules = request.rules else {
-            throw CommandError.missingParameter("rules")
-        }
-        let succeeded = sdkHierarchyClient?.setMockRules(rules) ?? false
+        let succeeded = sdkHierarchyClient?.setMockRules(request.rules) ?? false
         return SetNetworkMockRulesResponse(
             requestId: request.requestId,
             ok: succeeded,
@@ -235,7 +224,7 @@ public class CommandHandler: CommandHandling {
     // MARK: - View Hierarchy
 
     private func handleRequestHierarchy(
-        _ request: WebSocketRequest,
+        _ request: RequestHierarchy,
         startTime _: Date
     )
         throws -> HierarchyUpdateResponse
@@ -343,7 +332,7 @@ public class CommandHandler: CommandHandling {
         return normalized
     }
 
-    private func handleRequestScreenshot(_ request: WebSocketRequest, startTime _: Date) throws -> ScreenshotResponse {
+    private func handleRequestScreenshot(_ request: RequestEnvelope, startTime _: Date) throws -> ScreenshotResponse {
         let data = try gesturePerformer.getScreenshot()
         let base64 = data.base64EncodedString()
 
@@ -356,13 +345,9 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Gestures
 
-    private func handleTapCoordinates(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let x = request.x, let y = request.y else {
-            throw CommandError.missingParameter("x and y coordinates")
-        }
-
+    private func handleTapCoordinates(_ request: RequestTapCoordinates, startTime: Date) throws -> WebSocketResponse {
         let duration = request.duration ?? 0
-        try gesturePerformer.tap(x: Double(x), y: Double(y), duration: TimeInterval(duration) / 1000.0)
+        try gesturePerformer.tap(x: Double(request.x), y: Double(request.y), duration: TimeInterval(duration) / 1000.0)
 
         return WebSocketResponse.success(
             type: ResponseType.tapCoordinatesResult.rawValue,
@@ -371,17 +356,11 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleSwipe(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let x1 = request.x1, let y1 = request.y1,
-              let x2 = request.x2, let y2 = request.y2
-        else {
-            throw CommandError.missingParameter("x1, y1, x2, y2")
-        }
-
+    private func handleSwipe(_ request: RequestSwipe, startTime: Date) throws -> WebSocketResponse {
         let duration = request.duration ?? 300
         try gesturePerformer.swipe(
-            startX: Double(x1), startY: Double(y1),
-            endX: Double(x2), endY: Double(y2),
+            startX: Double(request.x1), startY: Double(request.y1),
+            endX: Double(request.x2), endY: Double(request.y2),
             duration: TimeInterval(duration) / 1000.0
         )
 
@@ -392,32 +371,22 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleTwoFingerSwipe(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        try handleMultiFingerSwipe(request, startTime: startTime, defaultFingers: 2)
-    }
-
     private func handleMultiFingerSwipe(
-        _ request: WebSocketRequest,
+        _ request: RequestMultiFingerSwipe,
         startTime: Date,
         defaultFingers: Int = 2
     )
         throws -> WebSocketResponse
     {
-        guard let x1 = request.x1, let y1 = request.y1,
-              let x2 = request.x2, let y2 = request.y2
-        else {
-            throw CommandError.missingParameter("x1, y1, x2, y2")
-        }
-
         let fingerCount = request.fingerCount ?? defaultFingers
         let duration = request.duration ?? 300
         let fingerSpacing = request.offset ?? 25
 
         try gesturePerformer.multiFingerSwipe(
-            startX: Double(x1),
-            startY: Double(y1),
-            endX: Double(x2),
-            endY: Double(y2),
+            startX: Double(request.x1),
+            startY: Double(request.y1),
+            endX: Double(request.x2),
+            endY: Double(request.y2),
             fingerCount: fingerCount,
             fingerSpacing: fingerSpacing,
             duration: TimeInterval(duration) / 1000.0
@@ -430,20 +399,14 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleDrag(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let x1 = request.x1, let y1 = request.y1,
-              let x2 = request.x2, let y2 = request.y2
-        else {
-            throw CommandError.missingParameter("x1, y1, x2, y2")
-        }
-
+    private func handleDrag(_ request: RequestDrag, startTime: Date) throws -> WebSocketResponse {
         let pressDuration = request.pressDurationMs ?? request.holdTime ?? 600
         let dragDuration = request.dragDurationMs ?? 300
         let holdDuration = request.holdDurationMs ?? 100
 
         try gesturePerformer.drag(
-            startX: Double(x1), startY: Double(y1),
-            endX: Double(x2), endY: Double(y2),
+            startX: Double(request.x1), startY: Double(request.y1),
+            endX: Double(request.x2), endY: Double(request.y2),
             pressDuration: TimeInterval(pressDuration) / 1000.0,
             dragDuration: TimeInterval(dragDuration) / 1000.0,
             holdDuration: TimeInterval(holdDuration) / 1000.0
@@ -456,18 +419,12 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handlePinch(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let centerX = request.centerX, let centerY = request.centerY,
-              let distanceStart = request.distanceStart, let distanceEnd = request.distanceEnd
-        else {
-            throw CommandError.missingParameter("centerX, centerY, distanceStart, distanceEnd")
-        }
-
+    private func handlePinch(_ request: RequestPinch, startTime: Date) throws -> WebSocketResponse {
         try gesturePerformer.pinch(
-            centerX: Double(centerX),
-            centerY: Double(centerY),
-            distanceStart: Double(distanceStart),
-            distanceEnd: Double(distanceEnd),
+            centerX: Double(request.centerX),
+            centerY: Double(request.centerY),
+            distanceStart: Double(request.distanceStart),
+            distanceEnd: Double(request.distanceEnd),
             rotationDegrees: Double(request.rotationDegrees ?? 0),
             duration: TimeInterval(request.duration ?? 300) / 1000.0
         )
@@ -481,10 +438,8 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Text Input
 
-    private func handleSetText(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let text = request.text else {
-            throw CommandError.missingParameter("text")
-        }
+    private func handleSetText(_ request: RequestSetText, startTime: Date) throws -> WebSocketResponse {
+        let text = request.text
 
         perfProvider.serial("handleSetText")
         defer { perfProvider.end() }
@@ -526,7 +481,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleClearText(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleClearText(_ request: RequestClearText, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handleClearText")
         defer { perfProvider.end() }
 
@@ -561,10 +516,8 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleImeAction(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let action = request.action else {
-            throw CommandError.missingParameter("action")
-        }
+    private func handleImeAction(_ request: RequestImeAction, startTime: Date) throws -> WebSocketResponse {
+        let action = request.action
 
         perfProvider.serial("handleImeAction")
         defer { perfProvider.end() }
@@ -599,7 +552,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleSelectAll(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleSelectAll(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handleSelectAll")
         defer { perfProvider.end() }
 
@@ -627,10 +580,8 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleKeyboard(_ request: WebSocketRequest, startTime: Date) throws -> KeyboardResponse {
-        guard let action = request.action else {
-            throw CommandError.missingParameter("action")
-        }
+    private func handleKeyboard(_ request: RequestKeyboard, startTime: Date) throws -> KeyboardResponse {
+        let action = request.action
 
         perfProvider.serial("handleKeyboard")
         defer { perfProvider.end() }
@@ -662,10 +613,8 @@ public class CommandHandler: CommandHandling {
         }
     }
 
-    private func handlePressButton(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let button = request.action else {
-            throw CommandError.missingParameter("action")
-        }
+    private func handlePressButton(_ request: RequestPressButton, startTime: Date) throws -> WebSocketResponse {
+        let button = request.action
 
         perfProvider.serial("handlePressButton")
         defer { perfProvider.end() }
@@ -690,7 +639,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handlePressHome(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handlePressHome(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handlePressHome")
         defer { perfProvider.end() }
 
@@ -713,7 +662,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handlePressBack(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handlePressBack(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handlePressBack")
         defer { perfProvider.end() }
 
@@ -728,7 +677,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleShake(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleShake(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handleShake")
         defer { perfProvider.end() }
 
@@ -743,7 +692,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleRecentApps(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleRecentApps(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handleRecentApps")
         defer { perfProvider.end() }
 
@@ -777,12 +726,8 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Actions
 
-    private func handleAction(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let action = request.action else {
-            throw CommandError.missingParameter("action")
-        }
-
-        try gesturePerformer.performAction(action, resourceId: request.resourceId, label: request.label)
+    private func handleAction(_ request: RequestAction, startTime: Date) throws -> WebSocketResponse {
+        try gesturePerformer.performAction(request.action, resourceId: request.resourceId, label: request.label)
 
         return WebSocketResponse.success(
             type: ResponseType.actionResult.rawValue,
@@ -791,14 +736,11 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleLaunchApp(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleLaunchApp(_ request: RequestLaunchApp, startTime: Date) throws -> WebSocketResponse {
         perfProvider.serial("handleLaunchApp")
         defer { perfProvider.end() }
 
-        guard let bundleId = request.bundleId else {
-            throw CommandError.missingParameter("bundleId")
-        }
-
+        let bundleId = request.bundleId
         let coldBoot = request.coldBoot ?? false
 
         // Check current app state to decide launch strategy
@@ -873,10 +815,8 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Device Control
 
-    private func handleRotate(_ request: WebSocketRequest, startTime: Date) throws -> RotateResponse {
-        guard let orientation = request.orientation else {
-            throw CommandError.missingParameter("orientation")
-        }
+    private func handleRotate(_ request: RequestRotate, startTime: Date) throws -> RotateResponse {
+        let orientation = request.orientation
 
         let previousOrientation = gesturePerformer.getOrientation()
 
@@ -930,12 +870,8 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Clipboard
 
-    private func handleClipboard(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
-        guard let action = request.action else {
-            throw CommandError.missingParameter("action")
-        }
-
-        let resultText = try gesturePerformer.clipboard(action: action, text: request.text)
+    private func handleClipboard(_ request: RequestClipboard, startTime: Date) throws -> WebSocketResponse {
+        let resultText = try gesturePerformer.clipboard(action: request.action, text: request.text)
 
         return WebSocketResponse.success(
             type: ResponseType.clipboardResult.rawValue,
@@ -947,7 +883,7 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Accessibility Features
 
-    private func handleGetCurrentFocus(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleGetCurrentFocus(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
         // Stub: Focus tracking not yet implemented
         return WebSocketResponse.error(
             type: ResponseType.currentFocusResult.rawValue,
@@ -957,7 +893,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleGetTraversalOrder(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleGetTraversalOrder(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
         // Stub: Traversal order not yet implemented
         return WebSocketResponse.error(
             type: ResponseType.traversalOrderResult.rawValue,
@@ -967,7 +903,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleAddHighlight(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleAddHighlight(_ request: RequestAddHighlight, startTime: Date) throws -> WebSocketResponse {
         guard let shape = request.shape else {
             return WebSocketResponse.error(
                 type: ResponseType.highlightResponse.rawValue,
@@ -1017,7 +953,7 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleGetVoiceOverState(
-        _ request: WebSocketRequest,
+        _ request: RequestEnvelope,
         startTime: Date
     )
         throws -> VoiceOverStateResponse
@@ -1043,7 +979,7 @@ public class CommandHandler: CommandHandling {
         return name
     }
 
-    private func handleListPreferenceFiles(_ request: WebSocketRequest, startTime: Date) -> StorageFilesResponse {
+    private func handleListPreferenceFiles(_ request: RequestEnvelope, startTime: Date) -> StorageFilesResponse {
         guard let inspector = storageInspector else {
             return StorageFilesResponse(
                 requestId: request.requestId,
@@ -1062,7 +998,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleGetPreferences(_ request: WebSocketRequest, startTime: Date) -> StorageEntriesResponse {
+    private func handleGetPreferences(_ request: RequestGetPreferences, startTime: Date) -> StorageEntriesResponse {
         guard let inspector = storageInspector else {
             return StorageEntriesResponse(
                 requestId: request.requestId,
@@ -1082,7 +1018,7 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleGetPreference(_ request: WebSocketRequest, startTime: Date) -> StorageEntryResponse {
+    private func handleGetPreference(_ request: RequestGetPreference, startTime: Date) -> StorageEntryResponse {
         guard let inspector = storageInspector else {
             return StorageEntryResponse(
                 requestId: request.requestId,
@@ -1124,7 +1060,7 @@ public class CommandHandler: CommandHandling {
         }
     }
 
-    private func handleSetPreference(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleSetPreference(_ request: RequestSetPreference, startTime: Date) throws -> WebSocketResponse {
         guard let inspector = storageInspector else {
             return WebSocketResponse.error(
                 type: ResponseType.setPreferenceResult.rawValue,
@@ -1134,15 +1070,8 @@ public class CommandHandler: CommandHandling {
             )
         }
 
-        guard let key = request.key else {
-            throw CommandError.missingParameter("key")
-        }
-        guard let valueType = request.valueType else {
-            throw CommandError.missingParameter("valueType")
-        }
-
         let suiteName = resolveSuiteName(request.fileName)
-        try inspector.setEntry(suiteName: suiteName, key: key, value: request.value, type: valueType)
+        try inspector.setEntry(suiteName: suiteName, key: request.key, value: request.value, type: request.valueType)
 
         return WebSocketResponse.success(
             type: ResponseType.setPreferenceResult.rawValue,
@@ -1151,7 +1080,12 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleRemovePreference(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleRemovePreference(
+        _ request: RequestRemovePreference,
+        startTime: Date
+    )
+        throws -> WebSocketResponse
+    {
         guard let inspector = storageInspector else {
             return WebSocketResponse.error(
                 type: ResponseType.removePreferenceResult.rawValue,
@@ -1161,12 +1095,8 @@ public class CommandHandler: CommandHandling {
             )
         }
 
-        guard let key = request.key else {
-            throw CommandError.missingParameter("key")
-        }
-
         let suiteName = resolveSuiteName(request.fileName)
-        try inspector.removeEntry(suiteName: suiteName, key: key)
+        try inspector.removeEntry(suiteName: suiteName, key: request.key)
 
         return WebSocketResponse.success(
             type: ResponseType.removePreferenceResult.rawValue,
@@ -1175,7 +1105,12 @@ public class CommandHandler: CommandHandling {
         )
     }
 
-    private func handleClearPreferences(_ request: WebSocketRequest, startTime: Date) throws -> WebSocketResponse {
+    private func handleClearPreferences(
+        _ request: RequestClearPreferences,
+        startTime: Date
+    )
+        throws -> WebSocketResponse
+    {
         guard let inspector = storageInspector else {
             return WebSocketResponse.error(
                 type: ResponseType.clearPreferencesResult.rawValue,
@@ -1197,7 +1132,7 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Database
 
-    private func handleExecuteSql(_ request: WebSocketRequest, startTime: Date) -> ExecuteSqlResponse {
+    private func handleExecuteSql(_ request: RequestExecuteSql, startTime: Date) -> ExecuteSqlResponse {
         guard let client = sdkDatabaseClient else {
             return ExecuteSqlResponse(
                 requestId: request.requestId,
@@ -1224,7 +1159,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
-            try validateDatabaseAppId(request)
+            try validateDatabaseAppId(request.appId)
             let result = try client.executeSQL(databasePath: databasePath, query: query)
             if let error = result.error {
                 return ExecuteSqlResponse(
@@ -1253,7 +1188,7 @@ public class CommandHandler: CommandHandling {
         }
     }
 
-    private func handleListDatabases(_ request: WebSocketRequest, startTime: Date) -> ListDatabasesResponse {
+    private func handleListDatabases(_ request: RequestListDatabases, startTime: Date) -> ListDatabasesResponse {
         guard let client = sdkDatabaseClient else {
             return ListDatabasesResponse(
                 requestId: request.requestId,
@@ -1264,7 +1199,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
-            try validateDatabaseAppId(request)
+            try validateDatabaseAppId(request.appId)
             return try ListDatabasesResponse(
                 requestId: request.requestId,
                 success: true,
@@ -1281,7 +1216,7 @@ public class CommandHandler: CommandHandling {
         }
     }
 
-    private func handleListTables(_ request: WebSocketRequest, startTime: Date) -> ListTablesResponse {
+    private func handleListTables(_ request: RequestListTables, startTime: Date) -> ListTablesResponse {
         guard let client = sdkDatabaseClient else {
             return ListTablesResponse(
                 requestId: request.requestId,
@@ -1300,7 +1235,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
-            try validateDatabaseAppId(request)
+            try validateDatabaseAppId(request.appId)
             return try ListTablesResponse(
                 requestId: request.requestId,
                 success: true,
@@ -1317,7 +1252,7 @@ public class CommandHandler: CommandHandling {
         }
     }
 
-    private func handleGetTableData(_ request: WebSocketRequest, startTime: Date) -> TableDataResponse {
+    private func handleGetTableData(_ request: RequestGetTableData, startTime: Date) -> TableDataResponse {
         guard let client = sdkDatabaseClient else {
             return TableDataResponse(
                 requestId: request.requestId,
@@ -1344,7 +1279,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
-            try validateDatabaseAppId(request)
+            try validateDatabaseAppId(request.appId)
             let data = try client.getTableData(
                 databasePath: databasePath,
                 table: table,
@@ -1369,7 +1304,12 @@ public class CommandHandler: CommandHandling {
         }
     }
 
-    private func handleGetTableStructure(_ request: WebSocketRequest, startTime: Date) -> TableStructureResponse {
+    private func handleGetTableStructure(
+        _ request: RequestGetTableStructure,
+        startTime: Date
+    )
+        -> TableStructureResponse
+    {
         guard let client = sdkDatabaseClient else {
             return TableStructureResponse(
                 requestId: request.requestId,
@@ -1396,7 +1336,7 @@ public class CommandHandler: CommandHandling {
         }
 
         do {
-            try validateDatabaseAppId(request)
+            try validateDatabaseAppId(request.appId)
             let structure = try client.getTableStructure(databasePath: databasePath, table: table)
             return TableStructureResponse(
                 requestId: request.requestId,
@@ -1420,8 +1360,8 @@ public class CommandHandler: CommandHandling {
         "database inspection unavailable - embed the AutoMobile SDK and call DatabaseInspector.shared.setEnabled(true)"
     }
 
-    private func validateDatabaseAppId(_ request: WebSocketRequest) throws {
-        guard let requestedAppId = normalizedBundleId(request.appId) else {
+    private func validateDatabaseAppId(_ appId: String?) throws {
+        guard let requestedAppId = normalizedBundleId(appId) else {
             throw CommandError.missingParameter("appId")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -373,12 +373,13 @@ public class CommandHandler: CommandHandling {
 
     private func handleMultiFingerSwipe(
         _ request: RequestMultiFingerSwipe,
-        startTime: Date,
-        defaultFingers: Int = 2
+        startTime: Date
     )
         throws -> WebSocketResponse
     {
-        let fingerCount = request.fingerCount ?? defaultFingers
+        // Both request_two_finger_swipe and request_multi_finger_swipe route here;
+        // fingerCount defaults to 2 when the client omits it (two-finger never sends it).
+        let fingerCount = request.fingerCount ?? 2
         let duration = request.duration ?? 300
         let fingerSpacing = request.offset ?? 25
 
@@ -1473,7 +1474,9 @@ public enum CommandError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case let .unknownCommand(cmd):
-            return "Unknown command: \(cmd)"
+            // Wire text must stay "Unknown command type: <type>" — the TS client's
+            // rewriteUnknownCommandError matches it to warn the runner is stale.
+            return "Unknown command type: \(cmd)"
         case let .missingParameter(param):
             return "Missing required parameter: \(param)"
         case let .invalidParameter(param, value):

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -286,11 +286,12 @@ public enum WebSocketRequest: Decodable {
         let container = try decoder.container(keyedBy: DiscriminatorKey.self)
         let typeString = try container.decode(String.self, forKey: .type)
         guard let requestType = RequestType(rawValue: typeString) else {
-            throw DecodingError.dataCorruptedError(
-                forKey: .type,
-                in: container,
-                debugDescription: "Unknown command type: \(typeString)"
-            )
+            // Throw CommandError (a LocalizedError) rather than DecodingError so the
+            // error surfaced on the wire is "Unknown command type: <type>". The TS
+            // client's `rewriteUnknownCommandError` matches that exact text to warn
+            // that the deployed runner is older than the daemon; a generic
+            // DecodingError.localizedDescription would silently lose that diagnostic.
+            throw CommandError.unknownCommand(typeString)
         }
 
         switch requestType {

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -1,173 +1,474 @@
 import Foundation
 
-// MARK: - Request Models (matching Android AccessibilityService)
+// MARK: - Request Models (typed per-command model — see issue #2846)
 
-/// WebSocket request from automation client
-/// Matches Android's WebSocketRequest format
-public struct WebSocketRequest: Codable {
-    public let type: String
-    public let requestId: String?
+// The iOS control-proxy decodes each inbound WebSocket command into a typed
+// `WebSocketRequest` case carrying a per-command payload that declares only the
+// fields that command uses. This replaces the former flat ~43-optional bag +
+// `switch request.type` dispatch (the iOS analog of the Android migration in
+// #2752 / #2771). The wire format is unchanged: the same `type` discriminator
+// strings (see `RequestType`) and the same JSON field names are decoded.
+//
+// Field policy: a payload field is a decode-required (non-optional) property
+// only when the former handler threw `CommandError.missingParameter` on its
+// absence (a generic error). Fields with handler-side defaults, and fields
+// whose absence produced a *command-specific* typed error response
+// (storage/database/highlight), stay optional and are validated in the handler.
+//
+// Payloads use `var` with `= nil` on optionals so they get both a synthesized
+// `Decodable` (which decodes `var`-with-default) and a memberwise initializer
+// with defaults for test construction.
 
-    // Tap parameters
-    public let x: Int?
-    public let y: Int?
-    public let duration: Int?
+// MARK: No-argument command envelope
 
-    // Swipe parameters
-    public let x1: Int?
-    public let y1: Int?
-    public let x2: Int?
-    public let y2: Int?
-    public let offset: Double?
-    public let fingerCount: Int?
+/// Payload for commands that carry no parameters beyond the request id.
+public struct RequestEnvelope: Decodable {
+    public var requestId: String?
+}
 
-    // Drag parameters
-    public let pressDurationMs: Int?
-    public let dragDurationMs: Int?
-    public let holdDurationMs: Int?
-    public let holdTime: Int?
+// MARK: View hierarchy
 
-    // Pinch parameters
-    public let centerX: Int?
-    public let centerY: Int?
-    public let distanceStart: Int?
-    public let distanceEnd: Int?
-    public let rotationDegrees: Float?
+public struct RequestHierarchy: Decodable {
+    public var requestId: String?
+    public var disableAllFiltering: Bool?
+    public var sinceTimestamp: Int64?
+}
 
-    // Text input parameters
-    public let text: String?
-    public let resourceId: String?
-    public let label: String?
+// MARK: Gestures
 
-    // Action parameters
-    public let action: String?
-    public let bundleId: String?
+public struct RequestTapCoordinates: Decodable {
+    public var requestId: String?
+    public var x: Int
+    public var y: Int
+    public var duration: Int?
+}
 
-    // Filtering control
-    public let sinceTimestamp: Int64?
-    public let disableAllFiltering: Bool?
+public struct RequestSwipe: Decodable {
+    public var requestId: String?
+    public var x1: Int
+    public var y1: Int
+    public var x2: Int
+    public var y2: Int
+    public var duration: Int?
+}
 
-    // Highlight parameters
-    public let id: String?
-    public let shape: HighlightShape?
+public struct RequestMultiFingerSwipe: Decodable {
+    public var requestId: String?
+    public var x1: Int
+    public var y1: Int
+    public var x2: Int
+    public var y2: Int
+    public var fingerCount: Int?
+    public var duration: Int?
+    public var offset: Double?
+}
 
-    // Storage parameters
-    public let fileName: String?
-    public let key: String?
-    public let value: String?
-    public let valueType: String?
+public struct RequestDrag: Decodable {
+    public var requestId: String?
+    public var x1: Int
+    public var y1: Int
+    public var x2: Int
+    public var y2: Int
+    public var pressDurationMs: Int?
+    public var dragDurationMs: Int?
+    public var holdDurationMs: Int?
+    public var holdTime: Int?
+}
 
-    // Database parameters
-    public let appId: String?
-    public let databasePath: String?
-    public let query: String?
-    public let table: String?
-    public let limit: Int?
+public struct RequestPinch: Decodable {
+    public var requestId: String?
+    public var centerX: Int
+    public var centerY: Int
+    public var distanceStart: Int
+    public var distanceEnd: Int
+    public var rotationDegrees: Float?
+    public var duration: Int?
+}
 
-    /// App launch parameters
-    public let coldBoot: Bool?
+// MARK: Text input
 
-    /// Rotation parameters
-    public let orientation: String?
+public struct RequestSetText: Decodable {
+    public var requestId: String?
+    public var text: String
+    public var resourceId: String?
+}
 
-    // Permission/settings
-    public let permission: String?
-    public let requestPermission: Bool?
-    public let enabled: Bool?
+public struct RequestClearText: Decodable {
+    public var requestId: String?
+    public var resourceId: String?
+}
 
-    /// Network mocking
-    public let rules: [NetworkMockRuleDTO]?
+public struct RequestImeAction: Decodable {
+    public var requestId: String?
+    public var action: String
+}
 
-    public init(
-        type: String,
-        requestId: String? = nil,
-        x: Int? = nil,
-        y: Int? = nil,
-        duration: Int? = nil,
-        x1: Int? = nil,
-        y1: Int? = nil,
-        x2: Int? = nil,
-        y2: Int? = nil,
-        offset: Double? = nil,
-        fingerCount: Int? = nil,
-        pressDurationMs: Int? = nil,
-        dragDurationMs: Int? = nil,
-        holdDurationMs: Int? = nil,
-        holdTime: Int? = nil,
-        centerX: Int? = nil,
-        centerY: Int? = nil,
-        distanceStart: Int? = nil,
-        distanceEnd: Int? = nil,
-        rotationDegrees: Float? = nil,
-        text: String? = nil,
-        resourceId: String? = nil,
-        label: String? = nil,
-        action: String? = nil,
-        bundleId: String? = nil,
-        sinceTimestamp: Int64? = nil,
-        disableAllFiltering: Bool? = nil,
-        id: String? = nil,
-        shape: HighlightShape? = nil,
-        fileName: String? = nil,
-        key: String? = nil,
-        value: String? = nil,
-        valueType: String? = nil,
-        appId: String? = nil,
-        databasePath: String? = nil,
-        query: String? = nil,
-        table: String? = nil,
-        limit: Int? = nil,
-        coldBoot: Bool? = nil,
-        orientation: String? = nil,
-        permission: String? = nil,
-        requestPermission: Bool? = nil,
-        enabled: Bool? = nil,
-        networkMockRules: [NetworkMockRuleDTO]? = nil
-    ) {
-        self.type = type
-        self.requestId = requestId
-        self.x = x
-        self.y = y
-        self.duration = duration
-        self.x1 = x1
-        self.y1 = y1
-        self.x2 = x2
-        self.y2 = y2
-        self.offset = offset
-        self.fingerCount = fingerCount
-        self.pressDurationMs = pressDurationMs
-        self.dragDurationMs = dragDurationMs
-        self.holdDurationMs = holdDurationMs
-        self.holdTime = holdTime
-        self.centerX = centerX
-        self.centerY = centerY
-        self.distanceStart = distanceStart
-        self.distanceEnd = distanceEnd
-        self.rotationDegrees = rotationDegrees
-        self.text = text
-        self.resourceId = resourceId
-        self.label = label
-        self.action = action
-        self.bundleId = bundleId
-        self.sinceTimestamp = sinceTimestamp
-        self.disableAllFiltering = disableAllFiltering
-        self.id = id
-        self.shape = shape
-        self.fileName = fileName
-        self.key = key
-        self.value = value
-        self.valueType = valueType
-        self.appId = appId
-        self.databasePath = databasePath
-        self.query = query
-        self.table = table
-        self.limit = limit
-        self.coldBoot = coldBoot
-        self.orientation = orientation
-        self.permission = permission
-        self.requestPermission = requestPermission
-        self.enabled = enabled
-        rules = networkMockRules
+public struct RequestKeyboard: Decodable {
+    public var requestId: String?
+    public var action: String
+}
+
+public struct RequestPressButton: Decodable {
+    public var requestId: String?
+    public var action: String
+}
+
+// MARK: Actions
+
+public struct RequestAction: Decodable {
+    public var requestId: String?
+    public var action: String
+    public var resourceId: String?
+    public var label: String?
+}
+
+public struct RequestLaunchApp: Decodable {
+    public var requestId: String?
+    public var bundleId: String
+    public var coldBoot: Bool?
+}
+
+// MARK: Device control
+
+public struct RequestRotate: Decodable {
+    public var requestId: String?
+    public var orientation: String
+}
+
+public struct RequestClipboard: Decodable {
+    public var requestId: String?
+    public var action: String
+    public var text: String?
+}
+
+// MARK: Accessibility features
+
+public struct RequestAddHighlight: Decodable {
+    public var requestId: String?
+    public var id: String?
+    public var shape: HighlightShape?
+}
+
+// MARK: Storage inspection
+
+public struct RequestGetPreferences: Decodable {
+    public var requestId: String?
+    public var fileName: String?
+}
+
+public struct RequestGetPreference: Decodable {
+    public var requestId: String?
+    public var key: String?
+    public var fileName: String?
+}
+
+public struct RequestSetPreference: Decodable {
+    public var requestId: String?
+    public var key: String
+    public var value: String?
+    public var valueType: String
+    public var fileName: String?
+}
+
+public struct RequestRemovePreference: Decodable {
+    public var requestId: String?
+    public var key: String
+    public var fileName: String?
+}
+
+public struct RequestClearPreferences: Decodable {
+    public var requestId: String?
+    public var fileName: String?
+}
+
+// MARK: Network mocking
+
+public struct RequestSetNetworkMockRules: Decodable {
+    public var requestId: String?
+    public var rules: [NetworkMockRuleDTO]
+}
+
+// MARK: Database inspection
+
+public struct RequestExecuteSql: Decodable {
+    public var requestId: String?
+    public var appId: String?
+    public var databasePath: String?
+    public var query: String?
+}
+
+public struct RequestListDatabases: Decodable {
+    public var requestId: String?
+    public var appId: String?
+}
+
+public struct RequestListTables: Decodable {
+    public var requestId: String?
+    public var appId: String?
+    public var databasePath: String?
+}
+
+public struct RequestGetTableData: Decodable {
+    public var requestId: String?
+    public var appId: String?
+    public var databasePath: String?
+    public var table: String?
+    public var limit: Int?
+    public var offset: Double?
+}
+
+public struct RequestGetTableStructure: Decodable {
+    public var requestId: String?
+    public var appId: String?
+    public var databasePath: String?
+    public var table: String?
+}
+
+// MARK: - Typed request envelope
+
+/// Typed WebSocket request from the automation client. Each case carries only
+/// the fields its command uses. Decoded from the flat JSON `{ "type": ... }`
+/// envelope by reading the `type` discriminator and decoding the matching
+/// payload from the same container.
+public enum WebSocketRequest: Decodable {
+    case requestHierarchy(RequestHierarchy)
+    case requestHierarchyIfStale(RequestHierarchy)
+    case requestScreenshot(RequestEnvelope)
+
+    case tapCoordinates(RequestTapCoordinates)
+    case swipe(RequestSwipe)
+    case twoFingerSwipe(RequestMultiFingerSwipe)
+    case multiFingerSwipe(RequestMultiFingerSwipe)
+    case drag(RequestDrag)
+    case pinch(RequestPinch)
+
+    case setText(RequestSetText)
+    case clearText(RequestClearText)
+    case imeAction(RequestImeAction)
+    case selectAll(RequestEnvelope)
+    case keyboard(RequestKeyboard)
+    case pressButton(RequestPressButton)
+    case pressHome(RequestEnvelope)
+    case pressBack(RequestEnvelope)
+    case shake(RequestEnvelope)
+    case recentApps(RequestEnvelope)
+
+    case action(RequestAction)
+    case launchApp(RequestLaunchApp)
+    case rotate(RequestRotate)
+    case clipboard(RequestClipboard)
+
+    case getCurrentFocus(RequestEnvelope)
+    case getTraversalOrder(RequestEnvelope)
+    case addHighlight(RequestAddHighlight)
+    case getVoiceOverState(RequestEnvelope)
+
+    case listPreferenceFiles(RequestEnvelope)
+    case getPreferences(RequestGetPreferences)
+    case getPreference(RequestGetPreference)
+    case setPreference(RequestSetPreference)
+    case removePreference(RequestRemovePreference)
+    case clearPreferences(RequestClearPreferences)
+
+    case setNetworkMockRules(RequestSetNetworkMockRules)
+
+    case executeSql(RequestExecuteSql)
+    case listDatabases(RequestListDatabases)
+    case listTables(RequestListTables)
+    case getTableData(RequestGetTableData)
+    case getTableStructure(RequestGetTableStructure)
+
+    private enum DiscriminatorKey: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminatorKey.self)
+        let typeString = try container.decode(String.self, forKey: .type)
+        guard let requestType = RequestType(rawValue: typeString) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown command type: \(typeString)"
+            )
+        }
+
+        switch requestType {
+        case .requestHierarchy:
+            self = try .requestHierarchy(RequestHierarchy(from: decoder))
+        case .requestHierarchyIfStale:
+            self = try .requestHierarchyIfStale(RequestHierarchy(from: decoder))
+        case .requestScreenshot:
+            self = try .requestScreenshot(RequestEnvelope(from: decoder))
+        case .requestTapCoordinates:
+            self = try .tapCoordinates(RequestTapCoordinates(from: decoder))
+        case .requestSwipe:
+            self = try .swipe(RequestSwipe(from: decoder))
+        case .requestTwoFingerSwipe:
+            self = try .twoFingerSwipe(RequestMultiFingerSwipe(from: decoder))
+        case .requestMultiFingerSwipe:
+            self = try .multiFingerSwipe(RequestMultiFingerSwipe(from: decoder))
+        case .requestDrag:
+            self = try .drag(RequestDrag(from: decoder))
+        case .requestPinch:
+            self = try .pinch(RequestPinch(from: decoder))
+        case .requestSetText:
+            self = try .setText(RequestSetText(from: decoder))
+        case .requestClearText:
+            self = try .clearText(RequestClearText(from: decoder))
+        case .requestImeAction:
+            self = try .imeAction(RequestImeAction(from: decoder))
+        case .requestSelectAll:
+            self = try .selectAll(RequestEnvelope(from: decoder))
+        case .requestKeyboard:
+            self = try .keyboard(RequestKeyboard(from: decoder))
+        case .requestPressButton:
+            self = try .pressButton(RequestPressButton(from: decoder))
+        case .requestPressHome:
+            self = try .pressHome(RequestEnvelope(from: decoder))
+        case .requestPressBack:
+            self = try .pressBack(RequestEnvelope(from: decoder))
+        case .requestShake:
+            self = try .shake(RequestEnvelope(from: decoder))
+        case .requestRecentApps:
+            self = try .recentApps(RequestEnvelope(from: decoder))
+        case .requestAction:
+            self = try .action(RequestAction(from: decoder))
+        case .requestLaunchApp:
+            self = try .launchApp(RequestLaunchApp(from: decoder))
+        case .requestRotate:
+            self = try .rotate(RequestRotate(from: decoder))
+        case .requestClipboard:
+            self = try .clipboard(RequestClipboard(from: decoder))
+        case .getCurrentFocus:
+            self = try .getCurrentFocus(RequestEnvelope(from: decoder))
+        case .getTraversalOrder:
+            self = try .getTraversalOrder(RequestEnvelope(from: decoder))
+        case .addHighlight:
+            self = try .addHighlight(RequestAddHighlight(from: decoder))
+        case .getVoiceOverState:
+            self = try .getVoiceOverState(RequestEnvelope(from: decoder))
+        case .listPreferenceFiles:
+            self = try .listPreferenceFiles(RequestEnvelope(from: decoder))
+        case .getPreferences:
+            self = try .getPreferences(RequestGetPreferences(from: decoder))
+        case .getPreference:
+            self = try .getPreference(RequestGetPreference(from: decoder))
+        case .setPreference:
+            self = try .setPreference(RequestSetPreference(from: decoder))
+        case .removePreference:
+            self = try .removePreference(RequestRemovePreference(from: decoder))
+        case .clearPreferences:
+            self = try .clearPreferences(RequestClearPreferences(from: decoder))
+        case .setNetworkMockRules:
+            self = try .setNetworkMockRules(RequestSetNetworkMockRules(from: decoder))
+        case .executeSql:
+            self = try .executeSql(RequestExecuteSql(from: decoder))
+        case .listDatabases:
+            self = try .listDatabases(RequestListDatabases(from: decoder))
+        case .listTables:
+            self = try .listTables(RequestListTables(from: decoder))
+        case .getTableData:
+            self = try .getTableData(RequestGetTableData(from: decoder))
+        case .getTableStructure:
+            self = try .getTableStructure(RequestGetTableStructure(from: decoder))
+        }
+    }
+
+    /// The wire discriminator for this command.
+    public var requestType: RequestType {
+        switch self {
+        case .requestHierarchy: return .requestHierarchy
+        case .requestHierarchyIfStale: return .requestHierarchyIfStale
+        case .requestScreenshot: return .requestScreenshot
+        case .tapCoordinates: return .requestTapCoordinates
+        case .swipe: return .requestSwipe
+        case .twoFingerSwipe: return .requestTwoFingerSwipe
+        case .multiFingerSwipe: return .requestMultiFingerSwipe
+        case .drag: return .requestDrag
+        case .pinch: return .requestPinch
+        case .setText: return .requestSetText
+        case .clearText: return .requestClearText
+        case .imeAction: return .requestImeAction
+        case .selectAll: return .requestSelectAll
+        case .keyboard: return .requestKeyboard
+        case .pressButton: return .requestPressButton
+        case .pressHome: return .requestPressHome
+        case .pressBack: return .requestPressBack
+        case .shake: return .requestShake
+        case .recentApps: return .requestRecentApps
+        case .action: return .requestAction
+        case .launchApp: return .requestLaunchApp
+        case .rotate: return .requestRotate
+        case .clipboard: return .requestClipboard
+        case .getCurrentFocus: return .getCurrentFocus
+        case .getTraversalOrder: return .getTraversalOrder
+        case .addHighlight: return .addHighlight
+        case .getVoiceOverState: return .getVoiceOverState
+        case .listPreferenceFiles: return .listPreferenceFiles
+        case .getPreferences: return .getPreferences
+        case .getPreference: return .getPreference
+        case .setPreference: return .setPreference
+        case .removePreference: return .removePreference
+        case .clearPreferences: return .clearPreferences
+        case .setNetworkMockRules: return .setNetworkMockRules
+        case .executeSql: return .executeSql
+        case .listDatabases: return .listDatabases
+        case .listTables: return .listTables
+        case .getTableData: return .getTableData
+        case .getTableStructure: return .getTableStructure
+        }
+    }
+
+    /// The wire discriminator string for this command.
+    public var typeString: String {
+        requestType.rawValue
+    }
+
+    /// The client-supplied correlation id, if any.
+    public var requestId: String? {
+        switch self {
+        case let .requestHierarchy(payload), let .requestHierarchyIfStale(payload):
+            return payload.requestId
+        case let .requestScreenshot(payload),
+             let .selectAll(payload),
+             let .pressHome(payload),
+             let .pressBack(payload),
+             let .shake(payload),
+             let .recentApps(payload),
+             let .getCurrentFocus(payload),
+             let .getTraversalOrder(payload),
+             let .getVoiceOverState(payload),
+             let .listPreferenceFiles(payload):
+            return payload.requestId
+        case let .tapCoordinates(payload): return payload.requestId
+        case let .swipe(payload): return payload.requestId
+        case let .twoFingerSwipe(payload), let .multiFingerSwipe(payload):
+            return payload.requestId
+        case let .drag(payload): return payload.requestId
+        case let .pinch(payload): return payload.requestId
+        case let .setText(payload): return payload.requestId
+        case let .clearText(payload): return payload.requestId
+        case let .imeAction(payload): return payload.requestId
+        case let .keyboard(payload): return payload.requestId
+        case let .pressButton(payload): return payload.requestId
+        case let .action(payload): return payload.requestId
+        case let .launchApp(payload): return payload.requestId
+        case let .rotate(payload): return payload.requestId
+        case let .clipboard(payload): return payload.requestId
+        case let .addHighlight(payload): return payload.requestId
+        case let .getPreferences(payload): return payload.requestId
+        case let .getPreference(payload): return payload.requestId
+        case let .setPreference(payload): return payload.requestId
+        case let .removePreference(payload): return payload.requestId
+        case let .clearPreferences(payload): return payload.requestId
+        case let .setNetworkMockRules(payload): return payload.requestId
+        case let .executeSql(payload): return payload.requestId
+        case let .listDatabases(payload): return payload.requestId
+        case let .listTables(payload): return payload.requestId
+        case let .getTableData(payload): return payload.requestId
+        case let .getTableStructure(payload): return payload.requestId
+        }
     }
 }
 

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -132,10 +132,10 @@ public class WebSocketServer: WebSocketServing {
 
         do {
             let request = try JSONDecoder().decode(WebSocketRequest.self, from: data)
-            print("[WebSocketServer] Received request type=\(request.type) requestId=\(request.requestId ?? "nil")")
+            print("[WebSocketServer] Received request type=\(request.typeString) requestId=\(request.requestId ?? "nil")")
 
             // Track the entire request handling with PerfProvider
-            perfProvider.serial("handleRequest:\(request.type)")
+            perfProvider.serial("handleRequest:\(request.typeString)")
             let startTime = Date()
 
             let response = commandHandler.handle(request)

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1361,17 +1361,20 @@ final class CommandHandlerTests: XCTestCase {
     // MARK: - Unknown Command Tests
 
     /// An unrecognized command `type` is now rejected at the decode boundary
-    /// rather than dispatched: the enum has no case for it, so decoding throws
-    /// and `WebSocketServer` returns a requestId-correlated error response.
-    func testUnknownCommandFailsToDecode() {
+    /// rather than dispatched: the enum has no case for it, so decoding throws.
+    /// The thrown error must carry the exact "Unknown command type: <type>" text
+    /// so `WebSocketServer` surfaces it on the wire and the TS client's
+    /// `rewriteUnknownCommandError` can flag a stale runner (a generic
+    /// `DecodingError` would lose that diagnostic).
+    func testUnknownCommandFailsToDecodeWithDiagnosticText() {
         XCTAssertThrowsError(
             try decodeWebSocketRequest(#"{"type":"unknown_command","requestId":"unknown-123"}"#)
         ) { error in
-            guard case let DecodingError.dataCorrupted(context) = error else {
-                XCTFail("Expected dataCorrupted, got \(error)")
-                return
-            }
-            XCTAssertTrue(context.debugDescription.contains("Unknown command type"))
+            XCTAssertEqual(
+                (error as? CommandError)?.errorDescription,
+                "Unknown command type: unknown_command"
+            )
+            XCTAssertEqual(error.localizedDescription, "Unknown command type: unknown_command")
         }
     }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -123,11 +123,10 @@ final class CommandHandlerTests: XCTestCase {
             ),
         ]
 
-        let response = commandHandler.handle(WebSocketRequest(
-            type: RequestType.setNetworkMockRules.rawValue,
+        let response = commandHandler.handle(WebSocketRequest.setNetworkMockRules(RequestSetNetworkMockRules(
             requestId: "mock-sync-1",
-            networkMockRules: rules
-        ))
+            rules: rules
+        )))
 
         guard let typed = response as? SetNetworkMockRulesResponse else {
             XCTFail("Expected SetNetworkMockRulesResponse, got \(Swift.type(of: response))")
@@ -140,20 +139,12 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(fetcher.lastMockRules?.first?.mockId, "mock-1")
     }
 
-    func testSetNetworkMockRulesReturnsMissingParameterErrorWhenRulesAbsent() {
-        let response = commandHandler.handle(WebSocketRequest(
-            type: RequestType.setNetworkMockRules.rawValue,
-            requestId: "mock-sync-missing"
-        ))
-
-        guard let typed = response as? WebSocketResponse else {
-            XCTFail("Expected WebSocketResponse, got \(Swift.type(of: response))")
-            return
-        }
-        XCTAssertEqual(typed.type, ResponseType.setNetworkMockRulesResult.rawValue)
-        XCTAssertEqual(typed.requestId, "mock-sync-missing")
-        XCTAssertEqual(typed.success, false)
-        XCTAssertEqual(typed.error, "Missing required parameter: rules")
+    /// `rules` is now a decode-required field: a `set_network_mock_rules` command
+    /// without it is rejected at the wire boundary rather than dispatched.
+    func testSetNetworkMockRulesWithoutRulesFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"set_network_mock_rules","requestId":"mock-sync-missing"}"#)
+        )
     }
 
     // MARK: - Hierarchy Request Tests
@@ -172,10 +163,7 @@ final class CommandHandlerTests: XCTestCase {
         fakeElementLocator.setHierarchy(testHierarchy)
 
         // Create request
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-123"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-123"))
 
         // Simulate time passing during extraction
         fakeTimeProvider.setTime(1000)
@@ -208,10 +196,7 @@ final class CommandHandlerTests: XCTestCase {
         )
         fakeElementLocator.setHierarchy(testHierarchy)
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-456"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-456"))
 
         guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
 
@@ -236,10 +221,7 @@ final class CommandHandlerTests: XCTestCase {
         )
         fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.test.app"))
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-sdk-match"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-sdk-match"))
 
         guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
 
@@ -262,10 +244,7 @@ final class CommandHandlerTests: XCTestCase {
         )
         fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-sdk-mismatch"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-sdk-mismatch"))
 
         guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
 
@@ -336,10 +315,7 @@ final class CommandHandlerTests: XCTestCase {
         )
         fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.test.app"))
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-sdk-fresh"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-sdk-fresh"))
 
         guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
 
@@ -360,10 +336,7 @@ final class CommandHandlerTests: XCTestCase {
         )
         fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-sdk-no-fresh"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-sdk-no-fresh"))
 
         guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
 
@@ -388,10 +361,7 @@ final class CommandHandlerTests: XCTestCase {
         )
         fakeElementLocator.setHierarchy(makeHierarchy(packageName: "com.apple.Preferences"))
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-sdk-replace-cache"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-sdk-replace-cache"))
 
         guard let hierarchyResponse = handleRequest(request, as: HierarchyUpdateResponse.self) else { return }
 
@@ -407,10 +377,7 @@ final class CommandHandlerTests: XCTestCase {
         // Configure fake to throw error
         fakeElementLocator.setShouldThrow(CommandError.executionFailed("Test error"))
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "test-error"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "test-error"))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -422,12 +389,11 @@ final class CommandHandlerTests: XCTestCase {
     // MARK: - Tap Tests
 
     func testTapCoordinatesSuccess() {
-        let request = WebSocketRequest(
-            type: "request_tap_coordinates",
+        let request = WebSocketRequest.tapCoordinates(RequestTapCoordinates(
             requestId: "tap-123",
             x: 100,
             y: 200
-        )
+        ))
 
         guard let tapResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -441,32 +407,26 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(tapHistory.first?.y, 200)
     }
 
-    func testTapCoordinatesMissingParameters() {
-        let request = WebSocketRequest(
-            type: "request_tap_coordinates",
-            requestId: "tap-error"
-            // Missing x, y
+    /// `x`/`y` are now decode-required: a tap without coordinates is rejected at
+    /// the wire boundary rather than dispatched.
+    func testTapCoordinatesMissingParametersFailToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"request_tap_coordinates","requestId":"tap-error"}"#)
         )
-
-        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-
-        XCTAssertFalse(errorResponse.success ?? true)
-        XCTAssertNotNil(errorResponse.error)
-        XCTAssertTrue(errorResponse.error?.contains("x and y") ?? false)
     }
 
     // MARK: - Swipe Tests
 
     func testSwipeSuccess() {
-        let request = WebSocketRequest(
-            type: "request_swipe",
+        let request = WebSocketRequest.swipe(RequestSwipe(
             requestId: "swipe-123",
-            duration: 300,
             x1: 100,
             y1: 200,
             x2: 100,
-            y2: 500
-        )
+            y2: 500,
+
+            duration: 300
+        ))
 
         guard let swipeResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -480,17 +440,17 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testMultiFingerSwipeSuccess() {
-        let request = WebSocketRequest(
-            type: "request_multi_finger_swipe",
+        let request = WebSocketRequest.multiFingerSwipe(RequestMultiFingerSwipe(
             requestId: "test-multi-finger-swipe",
-            duration: 450,
             x1: 100,
             y1: 600,
             x2: 100,
             y2: 200,
-            offset: 30,
-            fingerCount: 3
-        )
+            fingerCount: 3,
+
+            duration: 450,
+            offset: 30
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -510,17 +470,17 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testMultiFingerSwipePreservesFractionalSpacing() {
-        let request = WebSocketRequest(
-            type: "request_multi_finger_swipe",
+        let request = WebSocketRequest.multiFingerSwipe(RequestMultiFingerSwipe(
             requestId: "test-multi-finger-fractional-spacing",
-            duration: 450,
             x1: 100,
             y1: 600,
             x2: 100,
             y2: 200,
-            offset: 30.5,
-            fingerCount: 3
-        )
+            fingerCount: 3,
+
+            duration: 450,
+            offset: 30.5
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -533,15 +493,15 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testTwoFingerSwipeUsesMultiFingerHandler() {
-        let request = WebSocketRequest(
-            type: "request_two_finger_swipe",
+        let request = WebSocketRequest.twoFingerSwipe(RequestMultiFingerSwipe(
             requestId: "test-two-finger-swipe",
-            duration: 300,
             x1: 10,
             y1: 20,
             x2: 30,
-            y2: 40
-        )
+            y2: 40,
+
+            duration: 300
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -561,15 +521,14 @@ final class CommandHandlerTests: XCTestCase {
                 "XCTest private multi-touch event synthesis classes are unavailable"
             )
         )
-        let request = WebSocketRequest(
-            type: "request_multi_finger_swipe",
+        let request = WebSocketRequest.multiFingerSwipe(RequestMultiFingerSwipe(
             requestId: "test-multi-finger-failure",
             x1: 100,
             y1: 600,
             x2: 100,
             y2: 200,
             fingerCount: 3
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -580,16 +539,16 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPinchSuccessForwardsRequestPayload() {
-        let request = WebSocketRequest(
-            type: "request_pinch",
+        let request = WebSocketRequest.pinch(RequestPinch(
             requestId: "test-pinch",
-            duration: 700,
             centerX: 100,
             centerY: 200,
             distanceStart: 40,
             distanceEnd: 120,
-            rotationDegrees: 15
-        )
+            rotationDegrees: 15,
+
+            duration: 700
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -612,14 +571,13 @@ final class CommandHandlerTests: XCTestCase {
             for: "pinch",
             error: GesturePerformer.GestureError.gestureFailed("pinch synthesis failed")
         )
-        let request = WebSocketRequest(
-            type: "request_pinch",
+        let request = WebSocketRequest.pinch(RequestPinch(
             requestId: "test-pinch-failure",
             centerX: 100,
             centerY: 200,
             distanceStart: 40,
             distanceEnd: 120
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -631,11 +589,10 @@ final class CommandHandlerTests: XCTestCase {
     // MARK: - Text Input Tests
 
     func testSetTextSuccess() {
-        let request = WebSocketRequest(
-            type: "request_set_text",
+        let request = WebSocketRequest.setText(RequestSetText(
             requestId: "text-123",
             text: "Hello World"
-        )
+        ))
 
         guard let textResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -648,12 +605,11 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testSetTextWithResourceId() {
-        let request = WebSocketRequest(
-            type: "request_set_text",
+        let request = WebSocketRequest.setText(RequestSetText(
             requestId: "text-456",
             text: "Field Text",
             resourceId: "input_field"
-        )
+        ))
 
         guard let textResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -666,15 +622,11 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(setTextHistory.first?.resourceId, "input_field")
     }
 
-    func testSetTextMissingText() {
-        let request = WebSocketRequest(
-            type: "request_set_text",
-            requestId: "text-err-1"
+    /// `text` is now decode-required for `request_set_text`.
+    func testSetTextMissingTextFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"request_set_text","requestId":"text-err-1"}"#)
         )
-
-        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-        XCTAssertEqual(errorResponse.success, false)
-        XCTAssertTrue(errorResponse.error?.contains("text") == true)
     }
 
     func testSetTextTypeTextFailure() {
@@ -683,11 +635,10 @@ final class CommandHandlerTests: XCTestCase {
             error: NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "No keyboard focus"])
         )
 
-        let request = WebSocketRequest(
-            type: "request_set_text",
+        let request = WebSocketRequest.setText(RequestSetText(
             requestId: "text-fail-1",
             text: "Hello"
-        )
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(errorResponse.success, false)
@@ -699,23 +650,21 @@ final class CommandHandlerTests: XCTestCase {
             error: NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Element not found"])
         )
 
-        let request = WebSocketRequest(
-            type: "request_set_text",
+        let request = WebSocketRequest.setText(RequestSetText(
             requestId: "text-fail-2",
             text: "Hello",
             resourceId: "missing_field"
-        )
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(errorResponse.success, false)
     }
 
     func testImeActionSuccess() {
-        let request = WebSocketRequest(
-            type: "request_ime_action",
+        let request = WebSocketRequest.imeAction(RequestImeAction(
             requestId: "ime-1",
             action: "done"
-        )
+        ))
 
         guard let imeResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(imeResponse.success, true)
@@ -723,15 +672,11 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.getImeActionHistory(), ["done"])
     }
 
-    func testImeActionMissingAction() {
-        let request = WebSocketRequest(
-            type: "request_ime_action",
-            requestId: "ime-err-1"
+    /// `action` is now decode-required for `request_ime_action`.
+    func testImeActionMissingActionFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"request_ime_action","requestId":"ime-err-1"}"#)
         )
-
-        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-        XCTAssertEqual(errorResponse.success, false)
-        XCTAssertTrue(errorResponse.error?.contains("action") == true)
     }
 
     func testImeActionFailure() {
@@ -740,21 +685,17 @@ final class CommandHandlerTests: XCTestCase {
             error: NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unsupported"])
         )
 
-        let request = WebSocketRequest(
-            type: "request_ime_action",
+        let request = WebSocketRequest.imeAction(RequestImeAction(
             requestId: "ime-fail-1",
             action: "previous"
-        )
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(errorResponse.success, false)
     }
 
     func testSelectAllSuccess() {
-        let request = WebSocketRequest(
-            type: "request_select_all",
-            requestId: "sel-1"
-        )
+        let request = WebSocketRequest.selectAll(RequestEnvelope(requestId: "sel-1"))
 
         guard let selResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(selResponse.success, true)
@@ -768,10 +709,7 @@ final class CommandHandlerTests: XCTestCase {
             error: NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "No focus"])
         )
 
-        let request = WebSocketRequest(
-            type: "request_select_all",
-            requestId: "sel-fail-1"
-        )
+        let request = WebSocketRequest.selectAll(RequestEnvelope(requestId: "sel-fail-1"))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(errorResponse.success, false)
@@ -779,11 +717,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testKeyboardDetectSuccess() {
         fakeGesturePerformer.setKeyboardOpen(true)
-        let request = WebSocketRequest(
-            type: "request_keyboard",
+        let request = WebSocketRequest.keyboard(RequestKeyboard(
             requestId: "keyboard-detect",
             action: "detect"
-        )
+        ))
 
         guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
 
@@ -794,11 +731,10 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testKeyboardOpenSuccess() {
-        let request = WebSocketRequest(
-            type: "request_keyboard",
+        let request = WebSocketRequest.keyboard(RequestKeyboard(
             requestId: "keyboard-open",
             action: "open"
-        )
+        ))
 
         guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
 
@@ -809,11 +745,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testKeyboardOpenFailureWhenKeyboardRemainsClosed() {
         fakeGesturePerformer.setNextKeyboardResult(false)
-        let request = WebSocketRequest(
-            type: "request_keyboard",
+        let request = WebSocketRequest.keyboard(RequestKeyboard(
             requestId: "keyboard-open-failed",
             action: "open"
-        )
+        ))
 
         guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
 
@@ -825,11 +760,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testKeyboardCloseSuccess() {
         fakeGesturePerformer.setKeyboardOpen(true)
-        let request = WebSocketRequest(
-            type: "request_keyboard",
+        let request = WebSocketRequest.keyboard(RequestKeyboard(
             requestId: "keyboard-close",
             action: "close"
-        )
+        ))
 
         guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
 
@@ -840,11 +774,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testKeyboardCloseFailureWhenKeyboardRemainsOpen() {
         fakeGesturePerformer.setNextKeyboardResult(true)
-        let request = WebSocketRequest(
-            type: "request_keyboard",
+        let request = WebSocketRequest.keyboard(RequestKeyboard(
             requestId: "keyboard-close-failed",
             action: "close"
-        )
+        ))
 
         guard let response = handleRequest(request, as: KeyboardResponse.self) else { return }
 
@@ -854,23 +787,15 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.getKeyboardHistory(), ["close"])
     }
 
-    func testKeyboardMissingAction() {
-        let request = WebSocketRequest(
-            type: "request_keyboard",
-            requestId: "keyboard-missing"
+    /// `action` is now decode-required for `request_keyboard`.
+    func testKeyboardMissingActionFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"request_keyboard","requestId":"keyboard-missing"}"#)
         )
-
-        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-        XCTAssertEqual(errorResponse.success, false)
-        XCTAssertEqual(errorResponse.type, "keyboard_result")
-        XCTAssertTrue(errorResponse.error?.contains("action") == true)
     }
 
     func testClearTextWithoutResourceId() {
-        let request = WebSocketRequest(
-            type: "request_clear_text",
-            requestId: "clear-1"
-        )
+        let request = WebSocketRequest.clearText(RequestClearText(requestId: "clear-1"))
 
         guard let clearResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(clearResponse.success, true)
@@ -882,11 +807,10 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testClearTextWithResourceId() {
-        let request = WebSocketRequest(
-            type: "request_clear_text",
+        let request = WebSocketRequest.clearText(RequestClearText(
             requestId: "clear-2",
             resourceId: "text_input"
-        )
+        ))
 
         guard let clearResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(clearResponse.success, true)
@@ -902,10 +826,7 @@ final class CommandHandlerTests: XCTestCase {
             error: NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "No focus"])
         )
 
-        let request = WebSocketRequest(
-            type: "request_clear_text",
-            requestId: "clear-fail-1"
-        )
+        let request = WebSocketRequest.clearText(RequestClearText(requestId: "clear-fail-1"))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(errorResponse.success, false)
@@ -914,11 +835,10 @@ final class CommandHandlerTests: XCTestCase {
     func testClipboardGetSuccess() {
         fakeGesturePerformer.setClipboardContents("Copied text")
 
-        let request = WebSocketRequest(
-            type: "request_clipboard",
+        let request = WebSocketRequest.clipboard(RequestClipboard(
             requestId: "clip-1",
             action: "get"
-        )
+        ))
 
         guard let clipResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(clipResponse.success, true)
@@ -927,12 +847,12 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testClipboardCopySuccess() {
-        let request = WebSocketRequest(
-            type: "request_clipboard",
+        let request = WebSocketRequest.clipboard(RequestClipboard(
             requestId: "clip-2",
-            text: "To copy",
-            action: "copy"
-        )
+            action: "copy",
+
+            text: "To copy"
+        ))
 
         guard let clipResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(clipResponse.success, true)
@@ -943,15 +863,11 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(history[0].text, "To copy")
     }
 
-    func testClipboardMissingAction() {
-        let request = WebSocketRequest(
-            type: "request_clipboard",
-            requestId: "clip-err-1"
+    /// `action` is now decode-required for `request_clipboard`.
+    func testClipboardMissingActionFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"request_clipboard","requestId":"clip-err-1"}"#)
         )
-
-        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-        XCTAssertEqual(errorResponse.success, false)
-        XCTAssertTrue(errorResponse.error?.contains("action") == true)
     }
 
     func testClipboardFailure() {
@@ -960,11 +876,10 @@ final class CommandHandlerTests: XCTestCase {
             error: NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Clipboard error"])
         )
 
-        let request = WebSocketRequest(
-            type: "request_clipboard",
+        let request = WebSocketRequest.clipboard(RequestClipboard(
             requestId: "clip-fail-1",
             action: "get"
-        )
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(errorResponse.success, false)
@@ -976,11 +891,10 @@ final class CommandHandlerTests: XCTestCase {
             error: GesturePerformer.GestureError.clipboardReadUnavailable
         )
 
-        let request = WebSocketRequest(
-            type: "request_clipboard",
+        let request = WebSocketRequest.clipboard(RequestClipboard(
             requestId: "clip-restricted-1",
             action: "get"
-        )
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
         XCTAssertEqual(errorResponse.success, false)
@@ -994,10 +908,7 @@ final class CommandHandlerTests: XCTestCase {
     // MARK: - Device Control Tests
 
     func testPressHomeSuccess() {
-        let request = WebSocketRequest(
-            type: "request_press_home",
-            requestId: "home-123"
-        )
+        let request = WebSocketRequest.pressHome(RequestEnvelope(requestId: "home-123"))
 
         guard let homeResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1017,10 +928,7 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPressBackSuccess() {
-        let request = WebSocketRequest(
-            type: "request_press_back",
-            requestId: "back-123"
-        )
+        let request = WebSocketRequest.pressBack(RequestEnvelope(requestId: "back-123"))
 
         guard let backResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1039,11 +947,10 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPressButtonBackSuccess() {
-        let request = WebSocketRequest(
-            type: "request_press_button",
+        let request = WebSocketRequest.pressButton(RequestPressButton(
             requestId: "button-back",
             action: "back"
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1055,11 +962,10 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPressButtonHomeSwitchesToSpringBoard() {
-        let request = WebSocketRequest(
-            type: "request_press_button",
+        let request = WebSocketRequest.pressButton(RequestPressButton(
             requestId: "button-home",
             action: "home"
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1071,11 +977,10 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPressButtonHardwareButtonDoesNotSwitchToSpringBoard() {
-        let request = WebSocketRequest(
-            type: "request_press_button",
+        let request = WebSocketRequest.pressButton(RequestPressButton(
             requestId: "button-volume-up",
             action: "volume_up"
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1087,11 +992,10 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPressButtonPowerDoesNotSwitchToSpringBoard() {
-        let request = WebSocketRequest(
-            type: "request_press_button",
+        let request = WebSocketRequest.pressButton(RequestPressButton(
             requestId: "button-power",
             action: "power"
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1105,11 +1009,10 @@ final class CommandHandlerTests: XCTestCase {
     func testLaunchAppSuccess() {
         // Default: app not running, no coldBoot → full launch
         fakeElementLocator.getAppStateResult = .notRunning
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-123",
             bundleId: "com.apple.Preferences"
-        )
+        ))
 
         guard let launchResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1133,11 +1036,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testLaunchAppUsesActivateWhenRunningBackground() {
         fakeElementLocator.getAppStateResult = .runningBackground
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-activate",
             bundleId: "com.example.app"
-        )
+        ))
 
         guard let launchResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1159,11 +1061,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testLaunchAppUsesActivateWhenRunningForeground() {
         fakeElementLocator.getAppStateResult = .runningForeground
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-fg",
             bundleId: "com.example.app"
-        )
+        ))
 
         _ = commandHandler.handle(request)
 
@@ -1183,12 +1084,11 @@ final class CommandHandlerTests: XCTestCase {
 
     func testLaunchAppColdBootTerminatesThenLaunches() {
         fakeElementLocator.getAppStateResult = .runningForeground
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-cold",
             bundleId: "com.example.app",
             coldBoot: true
-        )
+        ))
 
         _ = commandHandler.handle(request)
 
@@ -1217,12 +1117,11 @@ final class CommandHandlerTests: XCTestCase {
 
     func testLaunchAppColdBootNotRunningSkipsTerminate() {
         fakeElementLocator.getAppStateResult = .notRunning
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-cold-nr",
             bundleId: "com.example.app",
             coldBoot: true
-        )
+        ))
 
         _ = commandHandler.handle(request)
 
@@ -1235,11 +1134,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testLaunchAppSwitchesForegroundApp() {
         fakeElementLocator.getAppStateResult = .notRunning
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-switch",
             bundleId: "com.example.app"
-        )
+        ))
 
         _ = commandHandler.handle(request)
 
@@ -1248,11 +1146,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testLaunchAppUpdatesGesturePerformer() {
         fakeElementLocator.getAppStateResult = .notRunning
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-gesture",
             bundleId: "com.example.app"
-        )
+        ))
 
         _ = commandHandler.handle(request)
 
@@ -1261,11 +1158,10 @@ final class CommandHandlerTests: XCTestCase {
 
     func testLaunchAppAwaitsForegroundState() {
         fakeElementLocator.getAppStateResult = .notRunning
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-await",
             bundleId: "com.example.app"
-        )
+        ))
 
         _ = commandHandler.handle(request)
 
@@ -1275,10 +1171,7 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPressHomeSwitchesToSpringboard() {
-        let request = WebSocketRequest(
-            type: "request_press_home",
-            requestId: "home-switch"
-        )
+        let request = WebSocketRequest.pressHome(RequestEnvelope(requestId: "home-switch"))
 
         _ = commandHandler.handle(request)
 
@@ -1286,10 +1179,7 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testPressHomeUpdatesGesturePerformer() {
-        let request = WebSocketRequest(
-            type: "request_press_home",
-            requestId: "home-gesture"
-        )
+        let request = WebSocketRequest.pressHome(RequestEnvelope(requestId: "home-gesture"))
 
         _ = commandHandler.handle(request)
 
@@ -1299,10 +1189,7 @@ final class CommandHandlerTests: XCTestCase {
     // MARK: - Recent Apps Tests
 
     func testRecentAppsSuccess() {
-        let request = WebSocketRequest(
-            type: "request_recent_apps",
-            requestId: "recents-123"
-        )
+        let request = WebSocketRequest.recentApps(RequestEnvelope(requestId: "recents-123"))
 
         guard let recentsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1313,10 +1200,7 @@ final class CommandHandlerTests: XCTestCase {
 
     func testRecentAppsReturnsFailureWhenSwitcherIsNotVerified() {
         fakeGesturePerformer.setOpenRecentAppsResult(false)
-        let request = WebSocketRequest(
-            type: "request_recent_apps",
-            requestId: "recents-not-visible"
-        )
+        let request = WebSocketRequest.recentApps(RequestEnvelope(requestId: "recents-not-visible"))
 
         guard let recentsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1329,10 +1213,7 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testRecentAppsSwitchesToSpringboard() {
-        let request = WebSocketRequest(
-            type: "request_recent_apps",
-            requestId: "recents-switch"
-        )
+        let request = WebSocketRequest.recentApps(RequestEnvelope(requestId: "recents-switch"))
 
         _ = commandHandler.handle(request)
 
@@ -1340,10 +1221,7 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testRecentAppsUpdatesGesturePerformer() {
-        let request = WebSocketRequest(
-            type: "request_recent_apps",
-            requestId: "recents-gesture"
-        )
+        let request = WebSocketRequest.recentApps(RequestEnvelope(requestId: "recents-gesture"))
 
         _ = commandHandler.handle(request)
 
@@ -1353,10 +1231,7 @@ final class CommandHandlerTests: XCTestCase {
     // MARK: - Shake Tests
 
     func testShakeSuccess() {
-        let request = WebSocketRequest(
-            type: "request_shake",
-            requestId: "shake-123"
-        )
+        let request = WebSocketRequest.shake(RequestEnvelope(requestId: "shake-123"))
 
         guard let shakeResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1368,11 +1243,10 @@ final class CommandHandlerTests: XCTestCase {
     // MARK: - Rotate Tests
 
     func testRotateToLandscapeSuccess() {
-        let request = WebSocketRequest(
-            type: "request_rotate",
+        let request = WebSocketRequest.rotate(RequestRotate(
             requestId: "rotate-123",
             orientation: "landscape"
-        )
+        ))
 
         guard let rotateResponse = handleRequest(request, as: RotateResponse.self) else { return }
 
@@ -1385,11 +1259,10 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testRotateToPortraitWhenAlreadyPortrait() {
-        let request = WebSocketRequest(
-            type: "request_rotate",
+        let request = WebSocketRequest.rotate(RequestRotate(
             requestId: "rotate-noop",
             orientation: "portrait"
-        )
+        ))
 
         guard let rotateResponse = handleRequest(request, as: RotateResponse.self) else { return }
 
@@ -1400,18 +1273,11 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertFalse(rotateResponse.rotationPerformed)
     }
 
-    func testRotateMissingOrientation() {
-        let request = WebSocketRequest(
-            type: "request_rotate",
-            requestId: "rotate-missing"
+    /// `orientation` is now decode-required for `request_rotate`.
+    func testRotateMissingOrientationFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"request_rotate","requestId":"rotate-missing"}"#)
         )
-
-        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-
-        XCTAssertEqual(errorResponse.success, false)
-        XCTAssertEqual(errorResponse.type, "rotate_result")
-        XCTAssertNotNil(errorResponse.error)
-        XCTAssertTrue(errorResponse.error?.contains("orientation") == true)
     }
 
     // MARK: - ObjCExceptionError Propagation Tests
@@ -1422,12 +1288,11 @@ final class CommandHandlerTests: XCTestCase {
             error: ObjCExceptionError(name: "NSRangeException", reason: "index 5 beyond bounds [0..3]")
         )
 
-        let request = WebSocketRequest(
-            type: "request_tap_coordinates",
+        let request = WebSocketRequest.tapCoordinates(RequestTapCoordinates(
             requestId: "tap-objc-err",
             x: 100,
             y: 200
-        )
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1443,15 +1308,15 @@ final class CommandHandlerTests: XCTestCase {
             error: ObjCExceptionError(name: "NSInternalInconsistencyException", reason: "Invalid snapshot")
         )
 
-        let request = WebSocketRequest(
-            type: "request_swipe",
+        let request = WebSocketRequest.swipe(RequestSwipe(
             requestId: "swipe-objc-err",
-            duration: 300,
             x1: 100,
             y1: 200,
             x2: 100,
-            y2: 500
-        )
+            y2: 500,
+
+            duration: 300
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1465,10 +1330,7 @@ final class CommandHandlerTests: XCTestCase {
             ObjCExceptionError(name: "NSGenericException", reason: "Stale element reference")
         )
 
-        let request = WebSocketRequest(
-            type: "request_hierarchy",
-            requestId: "hier-objc-err"
-        )
+        let request = WebSocketRequest.requestHierarchy(RequestHierarchy(requestId: "hier-objc-err"))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1484,11 +1346,10 @@ final class CommandHandlerTests: XCTestCase {
             error: ObjCExceptionError(name: "NSInvalidArgumentException", reason: "App not installed")
         )
 
-        let request = WebSocketRequest(
-            type: "request_launch_app",
+        let request = WebSocketRequest.launchApp(RequestLaunchApp(
             requestId: "launch-objc-err",
             bundleId: "com.missing.app"
-        )
+        ))
 
         guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1499,25 +1360,25 @@ final class CommandHandlerTests: XCTestCase {
 
     // MARK: - Unknown Command Tests
 
-    func testUnknownCommand() {
-        let request = WebSocketRequest(
-            type: "unknown_command",
-            requestId: "unknown-123"
-        )
-
-        guard let errorResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-
-        XCTAssertFalse(errorResponse.success ?? true)
-        XCTAssertTrue(errorResponse.error?.contains("Unknown command") ?? false)
+    /// An unrecognized command `type` is now rejected at the decode boundary
+    /// rather than dispatched: the enum has no case for it, so decoding throws
+    /// and `WebSocketServer` returns a requestId-correlated error response.
+    func testUnknownCommandFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"unknown_command","requestId":"unknown-123"}"#)
+        ) { error in
+            guard case let DecodingError.dataCorrupted(context) = error else {
+                XCTFail("Expected dataCorrupted, got \(error)")
+                return
+            }
+            XCTAssertTrue(context.debugDescription.contains("Unknown command type"))
+        }
     }
 
     // MARK: - VoiceOver State Tests
 
     func testGetVoiceOverStateReturnsResponse() {
-        let request = WebSocketRequest(
-            type: "get_voiceover_state",
-            requestId: "voiceover-123"
-        )
+        let request = WebSocketRequest.getVoiceOverState(RequestEnvelope(requestId: "voiceover-123"))
 
         guard let voResponse = handleRequest(request, as: VoiceOverStateResponse.self) else { return }
 
@@ -1530,9 +1391,7 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testGetVoiceOverStateWithNilRequestId() {
-        let request = WebSocketRequest(
-            type: "get_voiceover_state"
-        )
+        let request = WebSocketRequest.getVoiceOverState(RequestEnvelope())
 
         guard let voResponse = handleRequest(request, as: VoiceOverStateResponse.self) else { return }
 
@@ -1542,10 +1401,7 @@ final class CommandHandlerTests: XCTestCase {
     }
 
     func testGetVoiceOverStateIsEncodable() throws {
-        let request = WebSocketRequest(
-            type: "get_voiceover_state",
-            requestId: "encode-test"
-        )
+        let request = WebSocketRequest.getVoiceOverState(RequestEnvelope(requestId: "encode-test"))
 
         guard let voResponse = handleRequest(request, as: VoiceOverStateResponse.self) else { return }
 
@@ -1578,12 +1434,11 @@ final class CommandHandlerTests: XCTestCase {
             type: "box",
             bounds: HighlightBounds(x: 10, y: 20, width: 100, height: 50)
         )
-        let request = WebSocketRequest(
-            type: "add_highlight",
+        let request = WebSocketRequest.addHighlight(RequestAddHighlight(
             requestId: "highlight-request",
             id: "highlight-1",
             shape: shape
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1607,12 +1462,11 @@ final class CommandHandlerTests: XCTestCase {
             type: "box",
             bounds: HighlightBounds(x: 10, y: 20, width: 100, height: 50)
         )
-        let request = WebSocketRequest(
-            type: "add_highlight",
+        let request = WebSocketRequest.addHighlight(RequestAddHighlight(
             requestId: "highlight-request",
             id: "highlight-1",
             shape: shape
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1641,12 +1495,11 @@ final class CommandHandlerTests: XCTestCase {
             type: "box",
             bounds: HighlightBounds(x: 10, y: 20, width: 100, height: 50)
         )
-        let request = WebSocketRequest(
-            type: "add_highlight",
+        let request = WebSocketRequest.addHighlight(RequestAddHighlight(
             requestId: "highlight-request",
             id: "highlight-1",
             shape: shape
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1675,12 +1528,11 @@ final class CommandHandlerTests: XCTestCase {
             type: "box",
             bounds: HighlightBounds(x: 10, y: 20, width: 100, height: 50)
         )
-        let request = WebSocketRequest(
-            type: "add_highlight",
+        let request = WebSocketRequest.addHighlight(RequestAddHighlight(
             requestId: "highlight-request",
             id: "highlight-1",
             shape: shape
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1712,12 +1564,11 @@ final class CommandHandlerTests: XCTestCase {
             type: "box",
             bounds: HighlightBounds(x: 10, y: 20, width: 100, height: 50)
         )
-        let request = WebSocketRequest(
-            type: "add_highlight",
+        let request = WebSocketRequest.addHighlight(RequestAddHighlight(
             requestId: "highlight-request",
             id: "highlight-1",
             shape: shape
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1737,11 +1588,10 @@ final class CommandHandlerTests: XCTestCase {
             gesturePerformer: fakeGesturePerformer,
             perfProvider: perfProvider
         )
-        let request = WebSocketRequest(
-            type: "add_highlight",
+        let request = WebSocketRequest.addHighlight(RequestAddHighlight(
             requestId: "highlight-request",
             id: "highlight-1"
-        )
+        ))
 
         guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
 
@@ -1819,7 +1669,7 @@ final class StorageCommandHandlerTests: XCTestCase {
             StorageSuiteInfo(name: "group.com.example", displayName: "group.com.example", entryCount: 3),
         ])
 
-        let request = WebSocketRequest(type: "list_preference_files", requestId: "list-1")
+        let request = WebSocketRequest.listPreferenceFiles(RequestEnvelope(requestId: "list-1"))
         guard let filesResponse = handleRequest(request, as: StorageFilesResponse.self) else { return }
 
         XCTAssertEqual(filesResponse.requestId, "list-1")
@@ -1841,7 +1691,7 @@ final class StorageCommandHandlerTests: XCTestCase {
             StorageEntry(key: "count", value: "42", type: "INT"),
         ])
 
-        let request = WebSocketRequest(type: "get_preferences", requestId: "get-all-1")
+        let request = WebSocketRequest.getPreferences(RequestGetPreferences(requestId: "get-all-1"))
         guard let entriesResponse = handleRequest(request, as: StorageEntriesResponse.self) else { return }
 
         XCTAssertTrue(entriesResponse.success)
@@ -1856,11 +1706,10 @@ final class StorageCommandHandlerTests: XCTestCase {
             StorageEntry(key: "setting", value: "on", type: "STRING"),
         ], forSuite: "com.example.settings")
 
-        let request = WebSocketRequest(
-            type: "get_preferences",
+        let request = WebSocketRequest.getPreferences(RequestGetPreferences(
             requestId: "get-all-2",
             fileName: "com.example.settings"
-        )
+        ))
         guard let entriesResponse = handleRequest(request, as: StorageEntriesResponse.self) else { return }
 
         XCTAssertTrue(entriesResponse.success)
@@ -1869,11 +1718,10 @@ final class StorageCommandHandlerTests: XCTestCase {
     }
 
     func testGetPreferencesStandardMapsToNil() {
-        let request = WebSocketRequest(
-            type: "get_preferences",
+        let request = WebSocketRequest.getPreferences(RequestGetPreferences(
             requestId: "get-std",
             fileName: "Standard"
-        )
+        ))
         _ = commandHandler.handle(request)
         XCTAssertEqual(fakeStorage.getEntriesHistory, [nil])
     }
@@ -1885,11 +1733,10 @@ final class StorageCommandHandlerTests: XCTestCase {
             StorageEntry(key: "name", value: "Alice", type: "STRING"),
         ])
 
-        let request = WebSocketRequest(
-            type: "get_preference",
+        let request = WebSocketRequest.getPreference(RequestGetPreference(
             requestId: "get-1",
             key: "name"
-        )
+        ))
         guard let entryResponse = handleRequest(request, as: StorageEntryResponse.self) else { return }
 
         XCTAssertTrue(entryResponse.success)
@@ -1900,11 +1747,10 @@ final class StorageCommandHandlerTests: XCTestCase {
     }
 
     func testGetPreferenceNotFound() {
-        let request = WebSocketRequest(
-            type: "get_preference",
+        let request = WebSocketRequest.getPreference(RequestGetPreference(
             requestId: "get-2",
             key: "nonexistent"
-        )
+        ))
         guard let entryResponse = handleRequest(request, as: StorageEntryResponse.self) else { return }
 
         XCTAssertTrue(entryResponse.success)
@@ -1913,10 +1759,7 @@ final class StorageCommandHandlerTests: XCTestCase {
     }
 
     func testGetPreferenceMissingKey() {
-        let request = WebSocketRequest(
-            type: "get_preference",
-            requestId: "get-3"
-        )
+        let request = WebSocketRequest.getPreference(RequestGetPreference(requestId: "get-3"))
         guard let entryResponse = handleRequest(request, as: StorageEntryResponse.self) else { return }
 
         XCTAssertFalse(entryResponse.success)
@@ -1926,13 +1769,12 @@ final class StorageCommandHandlerTests: XCTestCase {
     // MARK: - Set Preference
 
     func testSetPreferenceSuccess() {
-        let request = WebSocketRequest(
-            type: "set_preference",
+        let request = WebSocketRequest.setPreference(RequestSetPreference(
             requestId: "set-1",
             key: "theme",
             value: "dark",
             valueType: "STRING"
-        )
+        ))
         guard let wsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
         XCTAssertTrue(wsResponse.success ?? false)
@@ -1943,27 +1785,22 @@ final class StorageCommandHandlerTests: XCTestCase {
         XCTAssertEqual(fakeStorage.setEntryHistory[0].type, "STRING")
     }
 
-    func testSetPreferenceMissingKey() {
-        let request = WebSocketRequest(
-            type: "set_preference",
-            requestId: "set-2",
-            value: "dark",
-            valueType: "STRING"
+    /// `key` is now decode-required for `set_preference`.
+    func testSetPreferenceMissingKeyFailsToDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(
+                #"{"type":"set_preference","requestId":"set-2","value":"dark","valueType":"STRING"}"#
+            )
         )
-        guard let wsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
-
-        XCTAssertFalse(wsResponse.success ?? true)
-        XCTAssertTrue(wsResponse.error?.contains("key") ?? false)
     }
 
     // MARK: - Remove Preference
 
     func testRemovePreferenceSuccess() {
-        let request = WebSocketRequest(
-            type: "remove_preference",
+        let request = WebSocketRequest.removePreference(RequestRemovePreference(
             requestId: "rm-1",
             key: "theme"
-        )
+        ))
         guard let wsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
         XCTAssertTrue(wsResponse.success ?? false)
@@ -1975,11 +1812,10 @@ final class StorageCommandHandlerTests: XCTestCase {
     // MARK: - Clear Preferences
 
     func testClearPreferencesSuccess() {
-        let request = WebSocketRequest(
-            type: "clear_preferences",
+        let request = WebSocketRequest.clearPreferences(RequestClearPreferences(
             requestId: "clear-1",
             fileName: "com.example.settings"
-        )
+        ))
         guard let wsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
         XCTAssertTrue(wsResponse.success ?? false)
@@ -1998,7 +1834,7 @@ final class StorageCommandHandlerTests: XCTestCase {
             storageInspector: nil
         )
 
-        let request = WebSocketRequest(type: "list_preference_files", requestId: "nil-1")
+        let request = WebSocketRequest.listPreferenceFiles(RequestEnvelope(requestId: "nil-1"))
         guard let filesResponse = handleRequest(handlerNoStorage, request, as: StorageFilesResponse.self)
         else { return }
 
@@ -2011,13 +1847,12 @@ final class StorageCommandHandlerTests: XCTestCase {
     func testSetPreferenceErrorPropagation() {
         fakeStorage.setShouldThrow(StorageError.invalidValue("bad", "INT"))
 
-        let request = WebSocketRequest(
-            type: "set_preference",
+        let request = WebSocketRequest.setPreference(RequestSetPreference(
             requestId: "err-1",
             key: "count",
             value: "bad",
             valueType: "INT"
-        )
+        ))
         guard let wsResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
 
         XCTAssertFalse(wsResponse.success ?? true)
@@ -2084,13 +1919,12 @@ final class DatabaseCommandHandlerTests: XCTestCase {
             rowsAffected: 0
         )
 
-        let request = WebSocketRequest(
-            type: "execute_sql",
+        let request = WebSocketRequest.executeSql(RequestExecuteSql(
             requestId: "sql-1",
             appId: "com.example.app",
             databasePath: "/app/Documents/app.db",
             query: "SELECT id, payload FROM notes"
-        )
+        ))
 
         guard let response = handleRequest(request, as: ExecuteSqlResponse.self) else { return }
 
@@ -2111,13 +1945,12 @@ final class DatabaseCommandHandlerTests: XCTestCase {
                 "database inspection unavailable - embed the AutoMobile SDK and call DatabaseInspector.shared.setEnabled(true)"
             )
 
-        let request = WebSocketRequest(
-            type: "execute_sql",
+        let request = WebSocketRequest.executeSql(RequestExecuteSql(
             requestId: "sql-disabled",
             appId: "com.example.app",
             databasePath: "/app/Documents/app.db",
             query: "SELECT 1"
-        )
+        ))
 
         guard let response = handleRequest(request, as: ExecuteSqlResponse.self) else { return }
 
@@ -2128,13 +1961,12 @@ final class DatabaseCommandHandlerTests: XCTestCase {
     func testExecuteSqlRejectsSdkServerBundleMismatchBeforeDatabaseCall() {
         fakeSdkHierarchy.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.other.app"))
 
-        let request = WebSocketRequest(
-            type: "execute_sql",
+        let request = WebSocketRequest.executeSql(RequestExecuteSql(
             requestId: "sql-mismatch",
             appId: "com.example.app",
             databasePath: "/app/Documents/app.db",
             query: "SELECT 1"
-        )
+        ))
 
         guard let response = handleRequest(request, as: ExecuteSqlResponse.self) else { return }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -57,11 +57,14 @@ final class ModelsTests: XCTestCase {
 
         let request = try JSONDecoder().decode(WebSocketRequest.self, from: XCTUnwrap(json.data(using: .utf8)))
 
-        XCTAssertEqual(request.type, "request_tap_coordinates")
-        XCTAssertEqual(request.requestId, "req-123")
-        XCTAssertEqual(request.x, 100)
-        XCTAssertEqual(request.y, 200)
-        XCTAssertEqual(request.duration, 50)
+        XCTAssertEqual(request.typeString, "request_tap_coordinates")
+        guard case let .tapCoordinates(payload) = request else {
+            return XCTFail("Expected .tapCoordinates, got \(request)")
+        }
+        XCTAssertEqual(payload.requestId, "req-123")
+        XCTAssertEqual(payload.x, 100)
+        XCTAssertEqual(payload.y, 200)
+        XCTAssertEqual(payload.duration, 50)
     }
 
     func testWebSocketRequestSwipeDecoding() throws {
@@ -78,12 +81,15 @@ final class ModelsTests: XCTestCase {
 
         let request = try JSONDecoder().decode(WebSocketRequest.self, from: XCTUnwrap(json.data(using: .utf8)))
 
-        XCTAssertEqual(request.type, "request_swipe")
-        XCTAssertEqual(request.x1, 100)
-        XCTAssertEqual(request.y1, 200)
-        XCTAssertEqual(request.x2, 300)
-        XCTAssertEqual(request.y2, 400)
-        XCTAssertEqual(request.duration, 300)
+        XCTAssertEqual(request.typeString, "request_swipe")
+        guard case let .swipe(payload) = request else {
+            return XCTFail("Expected .swipe, got \(request)")
+        }
+        XCTAssertEqual(payload.x1, 100)
+        XCTAssertEqual(payload.y1, 200)
+        XCTAssertEqual(payload.x2, 300)
+        XCTAssertEqual(payload.y2, 400)
+        XCTAssertEqual(payload.duration, 300)
     }
 
     func testWebSocketRequestMultiFingerSwipeDecodesFractionalOffset() throws {
@@ -102,9 +108,12 @@ final class ModelsTests: XCTestCase {
 
         let request = try JSONDecoder().decode(WebSocketRequest.self, from: XCTUnwrap(json.data(using: .utf8)))
 
-        XCTAssertEqual(request.type, "request_multi_finger_swipe")
-        XCTAssertEqual(request.offset ?? -1, 30.5, accuracy: 0.0001)
-        XCTAssertEqual(request.fingerCount, 3)
+        XCTAssertEqual(request.typeString, "request_multi_finger_swipe")
+        guard case let .multiFingerSwipe(payload) = request else {
+            return XCTFail("Expected .multiFingerSwipe, got \(request)")
+        }
+        XCTAssertEqual(payload.offset ?? -1, 30.5, accuracy: 0.0001)
+        XCTAssertEqual(payload.fingerCount, 3)
     }
 
     func testWebSocketRequestDragDecoding() throws {
@@ -123,10 +132,13 @@ final class ModelsTests: XCTestCase {
 
         let request = try JSONDecoder().decode(WebSocketRequest.self, from: XCTUnwrap(json.data(using: .utf8)))
 
-        XCTAssertEqual(request.type, "request_drag")
-        XCTAssertEqual(request.pressDurationMs, 600)
-        XCTAssertEqual(request.dragDurationMs, 300)
-        XCTAssertEqual(request.holdDurationMs, 100)
+        XCTAssertEqual(request.typeString, "request_drag")
+        guard case let .drag(payload) = request else {
+            return XCTFail("Expected .drag, got \(request)")
+        }
+        XCTAssertEqual(payload.pressDurationMs, 600)
+        XCTAssertEqual(payload.dragDurationMs, 300)
+        XCTAssertEqual(payload.holdDurationMs, 100)
     }
 
     // MARK: - WebSocketResponse Tests

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -1,0 +1,611 @@
+@testable import CtrlProxy
+import XCTest
+
+/// Decodes a raw JSON command string into the typed `WebSocketRequest` enum,
+/// exercising the same `JSONDecoder().decode(WebSocketRequest.self, …)` path the
+/// `WebSocketServer` uses on the wire. Shared across the CtrlProxy test target.
+func decodeWebSocketRequest(_ json: String) throws -> WebSocketRequest {
+    try JSONDecoder().decode(WebSocketRequest.self, from: Data(json.utf8))
+}
+
+/// Round-trip coverage for issue #2846: every inbound command decodes from its
+/// on-the-wire JSON into the correct typed `WebSocketRequest` case with its
+/// fields intact, and dispatches through `CommandHandler.handle` to the correct
+/// handler. This is the whole inbound command surface — one decode+dispatch test
+/// per `RequestType` case — plus the decode-rejection tests for commands whose
+/// required fields are now enforced at the decode boundary.
+final class TypedRequestDecodeDispatchTests: XCTestCase {
+    var fakeTimeProvider: FakeTimeProvider!
+    var perfProvider: PerfProvider!
+    var fakeElementLocator: FakeElementLocator!
+    var fakeGesturePerformer: FakeGesturePerformer!
+    var fakeStorage: FakeStorageInspecting!
+    var fakeSdkHierarchy: FakeSdkHierarchyFetcher!
+    var fakeDatabase: FakeSdkDatabaseFetcher!
+    var commandHandler: CommandHandler!
+
+    override func setUp() {
+        super.setUp()
+        fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        fakeElementLocator = FakeElementLocator()
+        fakeGesturePerformer = FakeGesturePerformer()
+        fakeStorage = FakeStorageInspecting()
+        fakeSdkHierarchy = FakeSdkHierarchyFetcher()
+        fakeSdkHierarchy.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.example.app"))
+        fakeDatabase = FakeSdkDatabaseFetcher()
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            storageInspector: fakeStorage,
+            sdkHierarchyClient: fakeSdkHierarchy,
+            sdkDatabaseClient: fakeDatabase
+        )
+        fakeElementLocator.setHierarchy(ViewHierarchy(packageName: "com.example.app"))
+    }
+
+    override func tearDown() {
+        perfProvider.clear()
+        PerfProvider.resetInstance()
+        super.tearDown()
+    }
+
+    // MARK: - Decode helpers
+
+    private func decode(
+        _ json: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    )
+        -> WebSocketRequest?
+    {
+        do {
+            return try decodeWebSocketRequest(json)
+        } catch {
+            XCTFail("Expected \(json) to decode, got error: \(error)", file: file, line: line)
+            return nil
+        }
+    }
+
+    private func dispatch<T>(
+        _ json: String,
+        as _: T.Type = T.self,
+        file: StaticString = #file,
+        line: UInt = #line
+    )
+        -> T?
+    {
+        guard let request = decode(json, file: file, line: line) else { return nil }
+        let response = commandHandler.handle(request)
+        guard let typed = response as? T else {
+            XCTFail("Expected \(T.self), got \(Swift.type(of: response))", file: file, line: line)
+            return nil
+        }
+        return typed
+    }
+
+    // MARK: - Discriminator coverage
+
+    /// Every `RequestType` decodes to a case whose `requestType` round-trips back
+    /// to the same discriminator — proves the decode switch covers the full set.
+    func testEveryRequestTypeDecodesToMatchingCase() throws {
+        // Minimal-but-valid payload per command (only decode-required fields).
+        let payloads: [RequestType: String] = [
+            .requestHierarchy: "{}",
+            .requestHierarchyIfStale: "{}",
+            .requestScreenshot: "{}",
+            .requestTapCoordinates: #"{"x":1,"y":2}"#,
+            .requestSwipe: #"{"x1":1,"y1":2,"x2":3,"y2":4}"#,
+            .requestTwoFingerSwipe: #"{"x1":1,"y1":2,"x2":3,"y2":4}"#,
+            .requestMultiFingerSwipe: #"{"x1":1,"y1":2,"x2":3,"y2":4}"#,
+            .requestDrag: #"{"x1":1,"y1":2,"x2":3,"y2":4}"#,
+            .requestPinch: #"{"centerX":1,"centerY":2,"distanceStart":3,"distanceEnd":4}"#,
+            .requestSetText: #"{"text":"hi"}"#,
+            .requestClearText: "{}",
+            .requestImeAction: #"{"action":"done"}"#,
+            .requestSelectAll: "{}",
+            .requestKeyboard: #"{"action":"open"}"#,
+            .requestPressButton: #"{"action":"home"}"#,
+            .requestPressHome: "{}",
+            .requestPressBack: "{}",
+            .requestShake: "{}",
+            .requestRecentApps: "{}",
+            .requestAction: #"{"action":"tap"}"#,
+            .requestLaunchApp: #"{"bundleId":"com.example.app"}"#,
+            .requestRotate: #"{"orientation":"portrait"}"#,
+            .requestClipboard: #"{"action":"get"}"#,
+            .getCurrentFocus: "{}",
+            .getTraversalOrder: "{}",
+            .addHighlight: "{}",
+            .getVoiceOverState: "{}",
+            .listPreferenceFiles: "{}",
+            .getPreferences: "{}",
+            .getPreference: "{}",
+            .setPreference: #"{"key":"k","valueType":"STRING"}"#,
+            .removePreference: #"{"key":"k"}"#,
+            .clearPreferences: "{}",
+            .setNetworkMockRules: #"{"rules":[]}"#,
+            .executeSql: "{}",
+            .listDatabases: "{}",
+            .listTables: "{}",
+            .getTableData: "{}",
+            .getTableStructure: "{}",
+        ]
+
+        for requestType in RequestType.allCases {
+            guard let fields = payloads[requestType] else {
+                XCTFail("Missing decode fixture for \(requestType.rawValue)")
+                continue
+            }
+            let body = fields == "{}"
+                ? #"{"type":"\#(requestType.rawValue)"}"#
+                : "{\"type\":\"\(requestType.rawValue)\"," + String(fields.dropFirst())
+            let request = try decodeWebSocketRequest(body)
+            XCTAssertEqual(
+                request.requestType,
+                requestType,
+                "\(requestType.rawValue) decoded to \(request.requestType.rawValue)"
+            )
+            XCTAssertEqual(request.typeString, requestType.rawValue)
+        }
+    }
+
+    // MARK: - Gestures
+
+    func testTapCoordinatesDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_tap_coordinates","requestId":"tap-1","x":100,"y":200,"duration":50}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "tap_coordinates_result")
+        XCTAssertEqual(response?.requestId, "tap-1")
+        let history = fakeGesturePerformer.getTapHistory()
+        XCTAssertEqual(history.first?.x, 100)
+        XCTAssertEqual(history.first?.y, 200)
+    }
+
+    func testSwipeDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_swipe","requestId":"sw-1","x1":10,"y1":20,"x2":30,"y2":40,"duration":250}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "swipe_result")
+        let history = fakeGesturePerformer.getSwipeHistory()
+        XCTAssertEqual(history.first?.startX, 10)
+        XCTAssertEqual(history.first?.endY, 40)
+    }
+
+    func testTwoFingerSwipeDecodeDispatchDefaultsToTwoFingers() {
+        let response = dispatch(
+            #"{"type":"request_two_finger_swipe","requestId":"tfs-1","x1":10,"y1":20,"x2":30,"y2":40}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "multi_finger_swipe_result")
+        XCTAssertEqual(fakeGesturePerformer.getMultiFingerSwipeHistory().first?.fingerCount, 2)
+    }
+
+    func testMultiFingerSwipeDecodeDispatchForwardsFingerCountAndSpacing() {
+        let response = dispatch(
+            #"""
+            {"type":"request_multi_finger_swipe","requestId":"mfs-1","x1":10,"y1":20,"x2":30,"y2":40,"fingerCount":3,"offset":31.5,"duration":400}
+            """#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "multi_finger_swipe_result")
+        let history = fakeGesturePerformer.getMultiFingerSwipeHistory()
+        XCTAssertEqual(history.first?.fingerCount, 3)
+        XCTAssertEqual(history.first?.fingerSpacing ?? -1, 31.5, accuracy: 0.0001)
+    }
+
+    func testDragDecodeDispatchForwardsDurations() {
+        let response = dispatch(
+            #"""
+            {"type":"request_drag","requestId":"drag-1","x1":10,"y1":20,"x2":30,"y2":40,"pressDurationMs":700,"dragDurationMs":250,"holdDurationMs":120}
+            """#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "drag_result")
+        let history = fakeGesturePerformer.getDragHistory()
+        XCTAssertEqual(history.first?.startX, 10)
+        XCTAssertEqual(history.first?.endY, 40)
+    }
+
+    func testDragDecodeUsesLegacyHoldTimeFallback() throws {
+        let request = try decodeWebSocketRequest(
+            #"{"type":"request_drag","x1":1,"y1":2,"x2":3,"y2":4,"holdTime":900}"#
+        )
+        guard case let .drag(payload) = request else {
+            return XCTFail("Expected .drag, got \(request)")
+        }
+        XCTAssertEqual(payload.holdTime, 900)
+        XCTAssertNil(payload.pressDurationMs)
+    }
+
+    func testPinchDecodeDispatchForwardsPayload() {
+        let response = dispatch(
+            #"""
+            {"type":"request_pinch","requestId":"pinch-1","centerX":100,"centerY":200,"distanceStart":40,"distanceEnd":120,"rotationDegrees":15,"duration":700}
+            """#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "pinch_result")
+        let history = fakeGesturePerformer.getPinchHistory()
+        XCTAssertEqual(history.first?.centerX, 100)
+        XCTAssertEqual(history.first?.distanceEnd, 120)
+        XCTAssertEqual(history.first?.rotationDegrees, 15)
+    }
+
+    // MARK: - Text input
+
+    func testSetTextDecodeDispatchTypesText() {
+        let response = dispatch(
+            #"{"type":"request_set_text","requestId":"txt-1","text":"Hello"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "set_text_result")
+        XCTAssertEqual(fakeGesturePerformer.getTypeTextHistory(), ["Hello"])
+    }
+
+    func testSetTextDecodeDispatchWithResourceIdUsesSetText() {
+        _ = dispatch(
+            #"{"type":"request_set_text","requestId":"txt-2","text":"Hi","resourceId":"field"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(fakeGesturePerformer.getSetTextHistory().first?.resourceId, "field")
+    }
+
+    func testClearTextDecodeDispatchForwardsResourceId() {
+        _ = dispatch(
+            #"{"type":"request_clear_text","requestId":"clr-1","resourceId":"field"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(fakeGesturePerformer.getClearTextHistory(), ["field"])
+    }
+
+    func testImeActionDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_ime_action","requestId":"ime-1","action":"done"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "ime_action_result")
+        XCTAssertEqual(fakeGesturePerformer.getImeActionHistory(), ["done"])
+    }
+
+    func testSelectAllDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_select_all","requestId":"sel-1"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "select_all_result")
+        XCTAssertEqual(fakeGesturePerformer.getSelectAllCallCount(), 1)
+    }
+
+    func testKeyboardDecodeDispatchForwardsAction() {
+        let response = dispatch(
+            #"{"type":"request_keyboard","requestId":"kb-1","action":"open"}"#,
+            as: KeyboardResponse.self
+        )
+        XCTAssertEqual(response?.type, "keyboard_result")
+        XCTAssertEqual(fakeGesturePerformer.getKeyboardHistory(), ["open"])
+    }
+
+    // MARK: - Buttons / navigation
+
+    func testPressButtonDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_press_button","requestId":"btn-1","action":"back"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "press_button_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressButtonHistory(), ["back"])
+    }
+
+    func testPressHomeDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_press_home","requestId":"home-1"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "press_home_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressHomeCallCount(), 1)
+    }
+
+    func testPressBackDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_press_back","requestId":"back-1"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "press_back_result")
+        XCTAssertEqual(fakeGesturePerformer.getPressBackCallCount(), 1)
+    }
+
+    func testShakeDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_shake","requestId":"shake-1"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "shake_result")
+        XCTAssertEqual(fakeGesturePerformer.getShakeCallCount(), 1)
+    }
+
+    func testRecentAppsDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_recent_apps","requestId":"recents-1"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "recent_apps_result")
+        XCTAssertEqual(fakeGesturePerformer.getOpenRecentAppsCallCount(), 1)
+    }
+
+    // MARK: - Actions / device control
+
+    func testActionDecodeDispatchForwardsLocators() {
+        _ = dispatch(
+            #"{"type":"request_action","requestId":"act-1","action":"tap","resourceId":"rid","label":"lbl"}"#,
+            as: WebSocketResponse.self
+        )
+        let history = fakeGesturePerformer.getActionHistory()
+        XCTAssertEqual(history.first?.action, "tap")
+        XCTAssertEqual(history.first?.resourceId, "rid")
+        XCTAssertEqual(history.first?.label, "lbl")
+    }
+
+    func testLaunchAppDecodeDispatchForwardsColdBoot() {
+        fakeElementLocator.getAppStateResult = .notRunning
+        let response = dispatch(
+            #"{"type":"request_launch_app","requestId":"launch-1","bundleId":"com.example.app","coldBoot":true}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "launch_app_result")
+        XCTAssertEqual(fakeGesturePerformer.getAppLaunchHistory(), ["com.example.app"])
+    }
+
+    func testRotateDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_rotate","requestId":"rot-1","orientation":"landscape"}"#,
+            as: RotateResponse.self
+        )
+        XCTAssertEqual(response?.type, "rotate_result")
+        XCTAssertEqual(response?.currentOrientation, "landscape")
+    }
+
+    func testClipboardDecodeDispatchForwardsText() {
+        _ = dispatch(
+            #"{"type":"request_clipboard","requestId":"clip-1","action":"copy","text":"payload"}"#,
+            as: WebSocketResponse.self
+        )
+        let history = fakeGesturePerformer.getClipboardHistory()
+        XCTAssertEqual(history.first?.action, "copy")
+        XCTAssertEqual(history.first?.text, "payload")
+    }
+
+    // MARK: - Hierarchy / screenshot
+
+    func testHierarchyDecodeDispatchForwardsDisableAllFiltering() throws {
+        let request = try decodeWebSocketRequest(
+            #"{"type":"request_hierarchy","requestId":"h-1","disableAllFiltering":true}"#
+        )
+        guard case let .requestHierarchy(payload) = request else {
+            return XCTFail("Expected .requestHierarchy, got \(request)")
+        }
+        XCTAssertEqual(payload.disableAllFiltering, true)
+        let response = commandHandler.handle(request)
+        XCTAssertTrue(response is HierarchyUpdateResponse)
+    }
+
+    func testHierarchyIfStaleDecodesToDistinctCaseWithTimestamp() throws {
+        let request = try decodeWebSocketRequest(
+            #"{"type":"request_hierarchy_if_stale","requestId":"h-2","sinceTimestamp":1234}"#
+        )
+        guard case let .requestHierarchyIfStale(payload) = request else {
+            return XCTFail("Expected .requestHierarchyIfStale, got \(request)")
+        }
+        XCTAssertEqual(payload.sinceTimestamp, 1234)
+    }
+
+    func testScreenshotDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"request_screenshot","requestId":"ss-1"}"#,
+            as: ScreenshotResponse.self
+        )
+        XCTAssertEqual(response?.type, "screenshot")
+        XCTAssertEqual(response?.requestId, "ss-1")
+    }
+
+    // MARK: - Accessibility
+
+    func testGetVoiceOverStateDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"get_voiceover_state","requestId":"vo-1"}"#,
+            as: VoiceOverStateResponse.self
+        )
+        XCTAssertEqual(response?.type, "voiceover_state_result")
+    }
+
+    func testGetCurrentFocusDecodeDispatchReturnsNotImplemented() {
+        let response = dispatch(
+            #"{"type":"get_current_focus","requestId":"cf-1"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "current_focus_result")
+        XCTAssertEqual(response?.success, false)
+    }
+
+    func testGetTraversalOrderDecodeDispatchReturnsNotImplemented() {
+        let response = dispatch(
+            #"{"type":"get_traversal_order","requestId":"to-1"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "traversal_order_result")
+        XCTAssertEqual(response?.success, false)
+    }
+
+    func testAddHighlightDecodeParsesNestedShape() throws {
+        let request = try decodeWebSocketRequest(
+            #"""
+            {"type":"add_highlight","requestId":"hl-1","id":"h1","shape":{"type":"box","bounds":{"x":1,"y":2,"width":3,"height":4}}}
+            """#
+        )
+        guard case let .addHighlight(payload) = request else {
+            return XCTFail("Expected .addHighlight, got \(request)")
+        }
+        XCTAssertEqual(payload.id, "h1")
+        XCTAssertEqual(payload.shape?.type, "box")
+        XCTAssertEqual(payload.shape?.bounds?.width, 3)
+    }
+
+    // MARK: - Storage
+
+    func testListPreferenceFilesDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"list_preference_files","requestId":"lpf-1"}"#,
+            as: StorageFilesResponse.self
+        )
+        XCTAssertEqual(response?.type, "preference_files")
+        XCTAssertEqual(fakeStorage.listSuitesCallCount, 1)
+    }
+
+    func testGetPreferencesDecodeDispatchForwardsFileName() {
+        _ = dispatch(
+            #"{"type":"get_preferences","requestId":"gp-1","fileName":"com.example.settings"}"#,
+            as: StorageEntriesResponse.self
+        )
+        XCTAssertEqual(fakeStorage.getEntriesHistory.first ?? "unexpected", "com.example.settings")
+    }
+
+    func testGetPreferenceDecodeDispatchForwardsKey() {
+        fakeStorage.setEntries([StorageEntry(key: "name", value: "Alice", type: "STRING")])
+        let response = dispatch(
+            #"{"type":"get_preference","requestId":"gp1-1","key":"name"}"#,
+            as: StorageEntryResponse.self
+        )
+        XCTAssertEqual(response?.type, "get_preference_result")
+        XCTAssertEqual(response?.value, "Alice")
+    }
+
+    func testSetPreferenceDecodeDispatchForwardsFields() {
+        let response = dispatch(
+            #"{"type":"set_preference","requestId":"sp-1","key":"theme","value":"dark","valueType":"STRING"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "set_preference_result")
+        XCTAssertEqual(fakeStorage.setEntryHistory.first?.key, "theme")
+        XCTAssertEqual(fakeStorage.setEntryHistory.first?.value, "dark")
+        XCTAssertEqual(fakeStorage.setEntryHistory.first?.type, "STRING")
+    }
+
+    func testRemovePreferenceDecodeDispatchForwardsKey() {
+        let response = dispatch(
+            #"{"type":"remove_preference","requestId":"rp-1","key":"theme"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "remove_preference_result")
+        XCTAssertEqual(fakeStorage.removeEntryHistory.first?.key, "theme")
+    }
+
+    func testClearPreferencesDecodeDispatchForwardsSuite() {
+        let response = dispatch(
+            #"{"type":"clear_preferences","requestId":"cp-1","fileName":"com.example.settings"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "clear_preferences_result")
+        XCTAssertEqual(fakeStorage.clearEntriesHistory.first, "com.example.settings")
+    }
+
+    // MARK: - Network mocking
+
+    func testSetNetworkMockRulesDecodeDispatchRelaysRules() {
+        let response = dispatch(
+            #"""
+            {"type":"set_network_mock_rules","requestId":"nm-1","rules":[{"mockId":"m1","host":"h","path":"p","method":"GET","statusCode":500,"responseHeaders":{},"responseBody":"b","contentType":"application/json"}]}
+            """#,
+            as: SetNetworkMockRulesResponse.self
+        )
+        XCTAssertEqual(response?.type, "set_network_mock_rules_result")
+        XCTAssertEqual(fakeSdkHierarchy.lastMockRules?.first?.mockId, "m1")
+    }
+
+    // MARK: - Database
+
+    func testExecuteSqlDecodeDispatchForwardsQuery() {
+        fakeDatabase.executeSqlResult = SdkExecuteSqlResult(
+            queryType: "query", columns: ["id"], rows: [["1"]], rowsAffected: 0
+        )
+        let response = dispatch(
+            #"""
+            {"type":"execute_sql","requestId":"sql-1","appId":"com.example.app","databasePath":"/db.sqlite","query":"SELECT 1"}
+            """#,
+            as: ExecuteSqlResponse.self
+        )
+        XCTAssertEqual(response?.type, "execute_sql_result")
+        XCTAssertEqual(fakeDatabase.executeSqlCalls.first?.query, "SELECT 1")
+    }
+
+    func testListDatabasesDecodeDispatch() {
+        let response = dispatch(
+            #"{"type":"list_databases","requestId":"ld-1","appId":"com.example.app"}"#,
+            as: ListDatabasesResponse.self
+        )
+        XCTAssertEqual(response?.type, "list_databases_result")
+    }
+
+    func testListTablesDecodeDispatchForwardsDatabasePath() {
+        let response = dispatch(
+            #"{"type":"list_tables","requestId":"lt-1","appId":"com.example.app","databasePath":"/db.sqlite"}"#,
+            as: ListTablesResponse.self
+        )
+        XCTAssertEqual(response?.type, "list_tables_result")
+    }
+
+    func testGetTableDataDecodeDispatchForwardsLimitAndOffset() {
+        let response = dispatch(
+            #"""
+            {"type":"get_table_data","requestId":"td-1","appId":"com.example.app","databasePath":"/db.sqlite","table":"notes","limit":10,"offset":5}
+            """#,
+            as: TableDataResponse.self
+        )
+        XCTAssertEqual(response?.type, "table_data_result")
+        XCTAssertEqual(fakeDatabase.tableDataCalls.first?.table, "notes")
+        XCTAssertEqual(fakeDatabase.tableDataCalls.first?.limit, 10)
+        XCTAssertEqual(fakeDatabase.tableDataCalls.first?.offset, 5)
+    }
+
+    func testGetTableStructureDecodeDispatchForwardsTable() {
+        let response = dispatch(
+            #"""
+            {"type":"get_table_structure","requestId":"ts-1","appId":"com.example.app","databasePath":"/db.sqlite","table":"notes"}
+            """#,
+            as: TableStructureResponse.self
+        )
+        XCTAssertEqual(response?.type, "table_structure_result")
+        XCTAssertEqual(fakeDatabase.tableStructureCalls.first?.table, "notes")
+    }
+
+    // MARK: - Decode rejection (required fields enforced at the wire boundary)
+
+    func testMissingRequiredFieldsAreRejectedAtDecode() {
+        let malformed: [String] = [
+            #"{"type":"request_tap_coordinates","requestId":"x"}"#, // missing x/y
+            #"{"type":"request_swipe","requestId":"x","x1":1,"y1":2}"#, // missing x2/y2
+            #"{"type":"request_pinch","requestId":"x","centerX":1}"#, // missing distances
+            #"{"type":"request_set_text","requestId":"x"}"#, // missing text
+            #"{"type":"request_ime_action","requestId":"x"}"#, // missing action
+            #"{"type":"request_keyboard","requestId":"x"}"#, // missing action
+            #"{"type":"request_press_button","requestId":"x"}"#, // missing action
+            #"{"type":"request_action","requestId":"x"}"#, // missing action
+            #"{"type":"request_launch_app","requestId":"x"}"#, // missing bundleId
+            #"{"type":"request_rotate","requestId":"x"}"#, // missing orientation
+            #"{"type":"request_clipboard","requestId":"x"}"#, // missing action
+            #"{"type":"set_preference","requestId":"x","value":"v"}"#, // missing key/valueType
+            #"{"type":"remove_preference","requestId":"x"}"#, // missing key
+            #"{"type":"set_network_mock_rules","requestId":"x"}"#, // missing rules
+        ]
+        for json in malformed {
+            XCTAssertThrowsError(try decodeWebSocketRequest(json), "expected \(json) to be rejected")
+        }
+    }
+
+    func testMissingTypeIsRejected() {
+        XCTAssertThrowsError(try decodeWebSocketRequest(#"{"requestId":"x"}"#))
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -583,29 +583,42 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
 
     // MARK: - Decode rejection (required fields enforced at the wire boundary)
 
+    /// Each command is rejected specifically because its named required field is
+    /// absent — asserting `keyNotFound(<field>)`, not merely "some error", so the
+    /// test proves the required-field contract rather than passing for any reason.
     func testMissingRequiredFieldsAreRejectedAtDecode() {
-        let malformed: [String] = [
-            #"{"type":"request_tap_coordinates","requestId":"x"}"#, // missing x/y
-            #"{"type":"request_swipe","requestId":"x","x1":1,"y1":2}"#, // missing x2/y2
-            #"{"type":"request_pinch","requestId":"x","centerX":1}"#, // missing distances
-            #"{"type":"request_set_text","requestId":"x"}"#, // missing text
-            #"{"type":"request_ime_action","requestId":"x"}"#, // missing action
-            #"{"type":"request_keyboard","requestId":"x"}"#, // missing action
-            #"{"type":"request_press_button","requestId":"x"}"#, // missing action
-            #"{"type":"request_action","requestId":"x"}"#, // missing action
-            #"{"type":"request_launch_app","requestId":"x"}"#, // missing bundleId
-            #"{"type":"request_rotate","requestId":"x"}"#, // missing orientation
-            #"{"type":"request_clipboard","requestId":"x"}"#, // missing action
-            #"{"type":"set_preference","requestId":"x","value":"v"}"#, // missing key/valueType
-            #"{"type":"remove_preference","requestId":"x"}"#, // missing key
-            #"{"type":"set_network_mock_rules","requestId":"x"}"#, // missing rules
+        let cases: [(json: String, missingKey: String)] = [
+            (#"{"type":"request_tap_coordinates","requestId":"x","y":2}"#, "x"),
+            (#"{"type":"request_swipe","requestId":"x","x1":1,"y1":2,"y2":4}"#, "x2"),
+            (#"{"type":"request_pinch","requestId":"x","centerX":1,"centerY":2,"distanceEnd":4}"#, "distanceStart"),
+            (#"{"type":"request_set_text","requestId":"x"}"#, "text"),
+            (#"{"type":"request_ime_action","requestId":"x"}"#, "action"),
+            (#"{"type":"request_keyboard","requestId":"x"}"#, "action"),
+            (#"{"type":"request_press_button","requestId":"x"}"#, "action"),
+            (#"{"type":"request_action","requestId":"x"}"#, "action"),
+            (#"{"type":"request_launch_app","requestId":"x"}"#, "bundleId"),
+            (#"{"type":"request_rotate","requestId":"x"}"#, "orientation"),
+            (#"{"type":"request_clipboard","requestId":"x"}"#, "action"),
+            (#"{"type":"set_preference","requestId":"x","value":"v","valueType":"STRING"}"#, "key"),
+            (#"{"type":"remove_preference","requestId":"x"}"#, "key"),
+            (#"{"type":"set_network_mock_rules","requestId":"x"}"#, "rules"),
         ]
-        for json in malformed {
-            XCTAssertThrowsError(try decodeWebSocketRequest(json), "expected \(json) to be rejected")
+        for (json, missingKey) in cases {
+            XCTAssertThrowsError(try decodeWebSocketRequest(json), "expected \(json) to be rejected") { error in
+                guard case let DecodingError.keyNotFound(key, _) = error else {
+                    return XCTFail("Expected keyNotFound(\(missingKey)) for \(json), got \(error)")
+                }
+                XCTAssertEqual(key.stringValue, missingKey, "wrong missing key for \(json)")
+            }
         }
     }
 
     func testMissingTypeIsRejected() {
-        XCTAssertThrowsError(try decodeWebSocketRequest(#"{"requestId":"x"}"#))
+        XCTAssertThrowsError(try decodeWebSocketRequest(#"{"requestId":"x"}"#)) { error in
+            guard case let DecodingError.keyNotFound(key, _) = error else {
+                return XCTFail("Expected keyNotFound(type), got \(error)")
+            }
+            XCTAssertEqual(key.stringValue, "type")
+        }
     }
 }


### PR DESCRIPTION
## What

Migrates the on-device iOS `control-proxy` XCUITest runner off the flat
`WebSocketRequest` struct (~43 optional fields) + `switch request.type` dispatch
to a **typed command model**: an `enum WebSocketRequest` with one case per
command, each carrying a small per-command payload struct that declares only the
fields that command uses. `CommandHandler.handle` is now an **exhaustive**
`switch` over that enum — no `default` — so the compiler enforces that every
command is handled.

This is the on-device Swift sibling of the Android sealed-class migration
([#2752](https://github.com/kaeawc/auto-mobile/issues/2752) /
[#2771](https://github.com/kaeawc/auto-mobile/pull/2771)) and the TS-client
migration ([#2835](https://github.com/kaeawc/auto-mobile/pull/2835)). Closes
[#2846](https://github.com/kaeawc/auto-mobile/issues/2846).

## Why

Every inbound command previously decoded into one shared bag of optionals, and
each handler re-extracted and unwrapped optionals from it. A command's required
fields were invisible in the type, unknown types fell to a `default`, and there
was no compile-time guarantee the dispatch table was complete. After this change:

- Each command's required fields are part of its payload type.
- `CommandHandler.handle` is exhaustive — adding a `RequestType` case without a
  handler branch is a **compile error**.
- No handler reads fields off an unrelated command's payload.

## Wire compatibility

**The JSON on the wire is unchanged** — same `type` discriminator strings
(`RequestType` is kept as the single source of those strings) and same field
names. Verified against the TS iOS request builders under
`src/features/observe/ios/` and the shared `SharedTextDelegate`.

Genuinely-required wire fields (tap `x/y`, gesture coords, `set_text` text,
`ime_action`/`keyboard`/`press_button`/`clipboard`/`action` action,
`launch_app` bundleId, `rotate` orientation, `set_preference` key/valueType,
`remove_preference` key, `set_network_mock_rules` rules) are now **non-optional**
and enforced at the decode boundary — a malformed command that omits one is
rejected during `JSONDecoder().decode(...)` and `WebSocketServer` returns a
`requestId`-correlated error, exactly as before. This is safe because the TS
client correlates responses purely by `requestId`
(`src/utils/RequestManager.ts`; the response `type` is log-only) and every one
of those fields is always sent by the corresponding TS builder.

Fields with handler-side defaults, and fields whose absence returns a
**command-specific typed error response** (`add_highlight` shape, storage/
database identifiers), stay optional with their in-handler guards intact, so
those response contracts are preserved byte-for-byte.

## Scope

- `Models.swift` — flat `WebSocketRequest` struct replaced by the typed enum +
  per-command payload structs + a custom `Decodable init(from:)` keyed on
  `RequestType` (unknown type → `DecodingError`). Adds `requestType` /
  `typeString` / `requestId` accessors.
- `CommandHandler.swift` — `handle` is an exhaustive `switch`; each `handle*`
  takes its typed payload; dead optional-bag unwraps removed. Runtime guards
  (nil storage inspector / DB client, SDK bundle match, highlight shape) kept.
- `WebSocketServer.swift` — logging/perf keys use `request.typeString`.
- Tests migrated to the enum API; adds `TypedRequestDecodeTests.swift`.

## Reviewer notes

- Payload structs use `var … = nil` on optionals so they get **both** a
  synthesized `Decodable` (which decodes `var`-with-default) **and** a memberwise
  initializer with defaults for test construction. (`let … = nil` would be
  excluded from decoding.)
- `request_hierarchy` and `request_hierarchy_if_stale` share `RequestHierarchy`;
  `request_two_finger_swipe` and `request_multi_finger_swipe` share
  `RequestMultiFingerSwipe` and route to the same handler (default 2 fingers) —
  behaviorally identical to before.
- Unknown-command handling moved from a `default` branch to a decode rejection;
  `testUnknownCommandFailsToDecode` covers it.
- `CommandError.unknownCommand` is now unreferenced — but it was already
  unconstructed on `main` (pre-existing dead case), so it's left out of scope.

## Testing

- New `Tests/CtrlProxyTests/TypedRequestDecodeTests.swift` — one JSON round-trip
  decode+dispatch test per `RequestType` case (the whole inbound command
  surface), a discriminator-coverage test iterating `RequestType.allCases`, and
  decode-rejection tests for the newly-required fields.
- `swift build` — clean, no warnings.
- `swift test` — **290 tests pass** (~68 ms), up from the 246-test baseline.
- `swiftformat --lint` / `swiftlint` — clean on changed files (only a
  pre-existing `ok` identifier-name warning in unchanged code).
