### PR TITLE
fix(ios): honestly report DND unsupported on iOS 18+ simulators (#2545)

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -286,13 +286,15 @@ per-package resilience of iOS app-data restore.
 
 ## Do Not Disturb (setDeviceState)
 
-<kbd>✅ Implemented</kbd> <kbd>📱 Simulator Only</kbd>
+<kbd>✅ Implemented</kbd> <kbd>📱 Simulator (iOS ≤17) Only</kbd>
 
 The `setDeviceState` / `getDeviceState` MCP tools control Do Not Disturb. On iOS,
 DND is **simulator-only and binary** (on/off) — this is a hard platform
-limitation, not a missing wiring detail.
+limitation, not a missing wiring detail. **On iOS 18+ simulators it is not
+available at all** (see below): DND moved to the private `donotdisturbd` Focus
+daemon, so both read and write report `capability: "unsupported"`.
 
-### How it works
+### How it works (iOS ≤17 simulators)
 
 1. **Binary toggle** — the only lever the simulator exposes is the
    `com.apple.donotdisturb.enabled` Darwin notification, driven via
@@ -307,21 +309,33 @@ limitation, not a missing wiring detail.
    - `notifyutil -p com.apple.donotdisturb.enabled` posts it so observers react.
 2. **Honest capability reporting** — every result carries a machine-readable
    `capability` field so callers can branch instead of string-matching warnings:
-   - `binary` — simulator: on/off only.
-   - `unsupported` — physical device: DND cannot be set at all.
+   - `binary` — iOS ≤17 simulator: on/off only.
+   - `unsupported` — physical device, or **iOS 18+ simulator**: DND cannot be
+     read or set at all.
    - (`full` is reserved for Android, where all four `zen_mode` tiers are
      distinct, persisted, and verified.)
 3. **No silent downgrade** — a `priority` or `alarms` request applies plain DND
    and reports it honestly: `requestedMode: "priority"|"alarms"`,
    `appliedMode: "none"`, a structured `warning`, and `verified: false` (so
    `success` is `false`). The tool never claims a tier it cannot deliver.
-4. **Best effort** — results are `bestEffort: true`. `notifyutil` values are
-   registration-scoped, so the setter verifies inside the registered invocation.
-   A later standalone `-g` read may not reflect a prior `-s`; the readback is
-   advisory, not authoritative.
+4. **Best effort** — results are `bestEffort: true`. The setter verifies inside
+   the registered invocation; the readback is advisory, not authoritative.
 
 ### Limitations
 
+- **iOS 18+ simulators: unsupported.** iOS 18 moved Do Not Disturb / Focus to the
+  private **`donotdisturbd`** daemon (a Core Data store + Focus-assertion model).
+  That daemon owns the legacy `com.apple.donotdisturb.enabled` notification and
+  immediately resets it to its authoritative value — verified empirically, a
+  `notifyutil -s` write reads back `0` from a fresh process even sub-second later
+  (an unmanaged notify key set the same way persists). So the legacy key neither
+  reflects nor controls the real Focus state: writes cannot verify and reads are a
+  confident falsehood. The simulator's iOS major version is detected (from device
+  metadata or `simctl list devices <udid> --json`) and, on 18+, both
+  `getDeviceState` and `setDeviceState` return `capability: "unsupported"` with a
+  precise error rather than trusting the dead key. Apple exposes no public API to
+  read or set Focus/DND. Use an iOS 17 or earlier simulator, or set it manually /
+  via a Shortcuts automation.
 - **Simulator only.** Physical iOS devices return `supported: false`,
   `capability: "unsupported"`, and a specific error: iOS exposes **no public
   API** to enable/disable Focus or Do Not Disturb (only the read-only Focus

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -11,6 +11,10 @@ import {
   iosNotifyutilRegisteredSetCommand,
   parseNotifyutilState
 } from "../../utils/ios-cmdline-tools/notifyutil";
+import {
+  iosMajorVersionFromSimctlListDevices,
+  parseIosMajorVersion
+} from "../../utils/ios-cmdline-tools/iosVersion";
 
 export type DoNotDisturbMode = "off" | "none" | "priority" | "alarms";
 
@@ -82,6 +86,26 @@ const IOS_PHYSICAL_DND_UNSUPPORTED_ERROR =
   "Do Not Disturb cannot be set on a physical iOS device: iOS exposes no public API to "
   + "enable/disable Focus or Do Not Disturb (only the read-only Focus Filter API). "
   + "Use an iOS Simulator for DND automation, or trigger DND manually / via a Shortcuts automation on device.";
+
+/** iOS major version at/after which the legacy binary-DND notification is dead. */
+const IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR = 17;
+
+/**
+ * iOS 18 moved Do Not Disturb / Focus to the `com.apple.donotdisturbd` daemon
+ * (Core Data store + a Focus-assertion model). The legacy
+ * `com.apple.donotdisturb.enabled` Darwin notification is no longer authoritative:
+ * its state is not persisted past the setting process (notify(3): a key's state
+ * only exists while a registration is held) and `donotdisturbd` does not consume
+ * it, so a posted toggle can never verify. Apple ships no public API to set
+ * Focus/DND, so on iOS 18+ simulators the write path honestly reports unsupported
+ * rather than posting a notification that has no effect.
+ */
+const IOS18_SIM_DND_UNSUPPORTED_ERROR =
+  "Do Not Disturb cannot be reliably set on an iOS 18+ simulator: iOS 18 moved Do Not Disturb to "
+  + "the donotdisturbd Focus daemon, and the legacy com.apple.donotdisturb.enabled notification is "
+  + "non-authoritative — its state is not persisted and donotdisturbd does not consume it, so the "
+  + "toggle cannot be verified. iOS exposes no public API to set Focus / Do Not Disturb. Use an "
+  + "iOS 17 or earlier simulator for binary DND automation, or set it manually / via a Shortcuts automation.";
 
 function parseAndroidZenMode(raw: string): DoNotDisturbState {
   const value = raw.trim();
@@ -341,6 +365,30 @@ export class DeviceState {
     }
   }
 
+  /**
+   * Resolve the simulator's major iOS version. Prefers the version already on the
+   * `BootedDevice` (populated by the daemon device pool); falls back to a live
+   * `simctl list devices <udid> --json` probe. Returns `null` when the version
+   * cannot be determined, so callers treat it as "unknown".
+   */
+  private async resolveSimulatorIosMajorVersion(simctl: IosSimulatorClient): Promise<number | null> {
+    const fromDevice = parseIosMajorVersion(this.device.iosVersion ?? this.device.osVersion);
+    if (fromDevice !== null) {
+      return fromDevice;
+    }
+    try {
+      const result = await simctl.executeCommand(`list devices ${this.device.deviceId} --json`);
+      return iosMajorVersionFromSimctlListDevices(result.stdout ?? "", this.device.deviceId);
+    } catch (error) {
+      logger.warn(
+        `[DeviceState] could not resolve iOS version for ${this.device.deviceId}: `
+        + `${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+      return null;
+    }
+  }
+
   private async setIosDoNotDisturb(input: SetDeviceStateInput["doNotDisturb"]): Promise<DoNotDisturbState> {
     const requestedMode = modeForInput(input);
 
@@ -355,7 +403,26 @@ export class DeviceState {
       };
     }
 
-    // Simulator: the only lever is the binary `com.apple.donotdisturb.enabled`
+    const simctl = this.simctl ?? new SimCtlClient(this.device);
+
+    // iOS 18+ simulators: the legacy binary-DND notification is dead (DND moved to
+    // donotdisturbd, which does not consume it, and the notify state does not
+    // persist past the setting process — so a posted toggle can never verify).
+    // Report unsupported and issue no misleading notifyutil write, mirroring the
+    // physical-device early return. iOS <18 (and unknown) keep the legacy
+    // best-effort path below.
+    const iosMajor = await this.resolveSimulatorIosMajorVersion(simctl);
+    if (iosMajor !== null && iosMajor > IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR) {
+      return {
+        supported: false,
+        capability: "unsupported",
+        requestedMode,
+        verified: false,
+        error: IOS18_SIM_DND_UNSUPPORTED_ERROR,
+      };
+    }
+
+    // Simulator (iOS <18): the only lever is the binary `com.apple.donotdisturb.enabled`
     // Darwin notification. `notifyutil -s` is a no-op unless the key has a
     // registration, so set/read/post must happen in one registered invocation.
     // There is no per-mode (priority/alarms) Darwin notification analogous to
@@ -367,7 +434,6 @@ export class DeviceState {
     const downgraded = requestedMode === "priority" || requestedMode === "alarms";
 
     try {
-      const simctl = this.simctl ?? new SimCtlClient(this.device);
       const value = requestedEnabled ? "1" : "0";
       const writeResult = await simctl.executeCommand(
         iosNotifyutilRegisteredSetCommand(this.device.deviceId, IOS_DND_NOTIFICATION, value),

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -92,20 +92,23 @@ const IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR = 17;
 
 /**
  * iOS 18 moved Do Not Disturb / Focus to the `com.apple.donotdisturbd` daemon
- * (Core Data store + a Focus-assertion model). The legacy
- * `com.apple.donotdisturb.enabled` Darwin notification is no longer authoritative:
- * its state is not persisted past the setting process (notify(3): a key's state
- * only exists while a registration is held) and `donotdisturbd` does not consume
- * it, so a posted toggle can never verify. Apple ships no public API to set
- * Focus/DND, so on iOS 18+ simulators the write path honestly reports unsupported
- * rather than posting a notification that has no effect.
+ * (private Core Data store + a Focus-assertion model). That daemon now owns the
+ * legacy `com.apple.donotdisturb.enabled` Darwin notification and immediately
+ * resets it to its authoritative value: empirically, a value posted via
+ * `notifyutil -s` is read back as `0` from a fresh process even sub-second later,
+ * while an unmanaged notify key (e.g. BiometricKit's) set the same way persists.
+ * So the legacy key neither reflects nor controls the real Focus state — a write
+ * cannot verify and a read is a confident falsehood (always `0`). Apple ships no
+ * public API to read or set Focus/DND, so on iOS 18+ simulators both the read and
+ * write paths honestly report unsupported instead of trusting the dead key.
  */
 const IOS18_SIM_DND_UNSUPPORTED_ERROR =
-  "Do Not Disturb cannot be reliably set on an iOS 18+ simulator: iOS 18 moved Do Not Disturb to "
-  + "the donotdisturbd Focus daemon, and the legacy com.apple.donotdisturb.enabled notification is "
-  + "non-authoritative — its state is not persisted and donotdisturbd does not consume it, so the "
-  + "toggle cannot be verified. iOS exposes no public API to set Focus / Do Not Disturb. Use an "
-  + "iOS 17 or earlier simulator for binary DND automation, or set it manually / via a Shortcuts automation.";
+  "Do Not Disturb cannot be reliably read or set on an iOS 18+ simulator: iOS 18 moved Do Not "
+  + "Disturb to the donotdisturbd Focus daemon, which owns the state in a private store and resets "
+  + "the legacy com.apple.donotdisturb.enabled notification — so that notification neither reflects "
+  + "nor controls the real Focus state. iOS exposes no public API to read or set Focus / Do Not "
+  + "Disturb. Use an iOS 17 or earlier simulator for binary DND automation, or set it manually / via "
+  + "a Shortcuts automation.";
 
 function parseAndroidZenMode(raw: string): DoNotDisturbState {
   const value = raw.trim();
@@ -348,8 +351,22 @@ export class DeviceState {
       };
     }
 
+    const simctl = this.simctl ?? new SimCtlClient(this.device);
+
+    // iOS 18+ simulators: the legacy key is owned/reset by donotdisturbd, so
+    // `notifyutil -g` always reads `0` regardless of the real Focus state. Report
+    // unsupported rather than a confident falsehood — symmetric with the write
+    // path. iOS <18 (and unknown) keep the legacy best-effort read below.
+    const iosMajor = await this.resolveSimulatorIosMajorVersion(simctl);
+    if (iosMajor !== null && iosMajor > IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR) {
+      return {
+        supported: false,
+        capability: "unsupported",
+        error: IOS18_SIM_DND_UNSUPPORTED_ERROR,
+      };
+    }
+
     try {
-      const simctl = this.simctl ?? new SimCtlClient(this.device);
       const result = await simctl.executeCommand(
         iosNotifyutilGetCommand(this.device.deviceId, IOS_DND_NOTIFICATION)
       );
@@ -369,7 +386,9 @@ export class DeviceState {
    * Resolve the simulator's major iOS version. Prefers the version already on the
    * `BootedDevice` (populated by the daemon device pool); falls back to a live
    * `simctl list devices <udid> --json` probe. Returns `null` when the version
-   * cannot be determined, so callers treat it as "unknown".
+   * cannot be determined, so callers treat it as "unknown". Non-iOS runtimes
+   * (visionOS/tvOS/watchOS simulators) also resolve to `null` and fall through to
+   * the harmless legacy path — they are not real DND targets.
    */
   private async resolveSimulatorIosMajorVersion(simctl: IosSimulatorClient): Promise<number | null> {
     const fromDevice = parseIosMajorVersion(this.device.iosVersion ?? this.device.osVersion);
@@ -406,11 +425,11 @@ export class DeviceState {
     const simctl = this.simctl ?? new SimCtlClient(this.device);
 
     // iOS 18+ simulators: the legacy binary-DND notification is dead (DND moved to
-    // donotdisturbd, which does not consume it, and the notify state does not
-    // persist past the setting process — so a posted toggle can never verify).
-    // Report unsupported and issue no misleading notifyutil write, mirroring the
-    // physical-device early return. iOS <18 (and unknown) keep the legacy
-    // best-effort path below.
+    // donotdisturbd, which owns the key and immediately resets it to its
+    // authoritative value — so a posted toggle is overwritten and can never
+    // verify). Report unsupported and issue no misleading notifyutil write,
+    // mirroring the physical-device early return. iOS <18 (and unknown) keep the
+    // legacy best-effort path below.
     const iosMajor = await this.resolveSimulatorIosMajorVersion(simctl);
     if (iosMajor !== null && iosMajor > IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR) {
       return {

--- a/src/utils/ios-cmdline-tools/iosVersion.ts
+++ b/src/utils/ios-cmdline-tools/iosVersion.ts
@@ -1,0 +1,44 @@
+import { logger } from "../logger";
+
+/**
+ * Parse the major iOS version integer from a version string such as `"18.6"`,
+ * `"17.5.1"`, or a bare `"18"`. Returns `null` when the input is missing or
+ * carries no leading numeric component, so callers can treat the version as
+ * "unknown" rather than guessing.
+ */
+export function parseIosMajorVersion(version: string | undefined | null): number | null {
+  if (!version) {
+    return null;
+  }
+  const match = version.trim().match(/^(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Resolve the major iOS version for a booted simulator `udid` from the JSON
+ * emitted by `simctl list devices <udid> --json`. The payload groups devices by
+ * runtime identifier (e.g. `com.apple.CoreSimulator.SimRuntime.iOS-18-6`), so we
+ * find the runtime whose device list contains the udid and read the version from
+ * that identifier. Returns `null` when the udid is absent, the runtime carries no
+ * iOS version token, or the JSON is malformed.
+ */
+export function iosMajorVersionFromSimctlListDevices(json: string, udid: string): number | null {
+  let parsed: { devices?: Record<string, Array<{ udid?: string }>> };
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    // Malformed/empty simctl output is a best-effort probe failure: the caller
+    // treats an unresolved version as "unknown" and falls back accordingly.
+    logger.debug(`iosMajorVersionFromSimctlListDevices: could not parse simctl JSON: ${error}`);
+    return null;
+  }
+
+  const devices = parsed.devices ?? {};
+  for (const [runtimeId, deviceList] of Object.entries(devices)) {
+    if (Array.isArray(deviceList) && deviceList.some(device => device?.udid === udid)) {
+      const match = runtimeId.match(/iOS[-_](\d+)/i);
+      return match ? parseInt(match[1], 10) : null;
+    }
+  }
+  return null;
+}

--- a/src/utils/ios-cmdline-tools/iosVersion.ts
+++ b/src/utils/ios-cmdline-tools/iosVersion.ts
@@ -23,7 +23,7 @@ export function parseIosMajorVersion(version: string | undefined | null): number
  * iOS version token, or the JSON is malformed.
  */
 export function iosMajorVersionFromSimctlListDevices(json: string, udid: string): number | null {
-  let parsed: { devices?: Record<string, Array<{ udid?: string }>> };
+  let parsed: unknown;
   try {
     parsed = JSON.parse(json);
   } catch (error) {
@@ -33,11 +33,22 @@ export function iosMajorVersionFromSimctlListDevices(json: string, udid: string)
     return null;
   }
 
-  const devices = parsed.devices ?? {};
+  // `JSON.parse` accepts scalars ("null", "42", '"x"') that are not usable device
+  // maps; guard the shape before indexing so a valid-but-wrong payload yields the
+  // documented "unknown" (null) rather than a TypeError.
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  const devices = (parsed as { devices?: Record<string, Array<{ udid?: string }>> }).devices ?? {};
   for (const [runtimeId, deviceList] of Object.entries(devices)) {
     if (Array.isArray(deviceList) && deviceList.some(device => device?.udid === udid)) {
       const match = runtimeId.match(/iOS[-_](\d+)/i);
-      return match ? parseInt(match[1], 10) : null;
+      // Keep scanning: a udid should appear under exactly one runtime, but if an
+      // earlier-iterated runtime id carries no iOS version token, later runtimes
+      // may still resolve it rather than short-circuiting to null.
+      if (match) {
+        return parseInt(match[1], 10);
+      }
     }
   }
   return null;

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -10,10 +10,21 @@ const androidDevice: BootedDevice = {
   deviceId: "emulator-5554",
 };
 
+// iOS < 18 simulator: the legacy notifyutil binary-DND path still applies.
 const iosSimulator: BootedDevice = {
   name: "iPhone 16",
   platform: "ios",
   deviceId: "12345678-1234-1234-1234-123456789ABC",
+  iosVersion: "17.5",
+};
+
+// iOS 18+ simulator: DND moved to donotdisturbd, so the write path must honestly
+// report unsupported instead of posting a non-authoritative legacy notification.
+const ios18Simulator: BootedDevice = {
+  name: "iPhone 16 Pro",
+  platform: "ios",
+  deviceId: "7B3A3792-DB53-4654-BA94-27A1D305C3B7",
+  iosVersion: "18.6",
 };
 
 describe("DeviceState", () => {
@@ -55,7 +66,7 @@ describe("DeviceState", () => {
     ]);
   });
 
-  test("sets iOS simulator Do Not Disturb on with notifyutil best-effort commands", async () => {
+  test("sets iOS <18 simulator Do Not Disturb on with notifyutil best-effort commands", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandResult(
       "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
@@ -87,7 +98,7 @@ describe("DeviceState", () => {
     ]);
   });
 
-  test("sets iOS simulator Do Not Disturb off with notifyutil best-effort commands", async () => {
+  test("sets iOS <18 simulator Do Not Disturb off with notifyutil best-effort commands", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandResult(
       "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
@@ -231,6 +242,130 @@ describe("DeviceState", () => {
     });
     expect(result.doNotDisturb?.error).toContain("simctl spawn failed");
     expect(result.error).toContain("simctl spawn failed");
+  });
+
+  test("reports iOS 18+ simulator DND enable as unsupported without issuing a notifyutil write", async () => {
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(ios18Simulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: true },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      requestedMode: "none",
+      verified: false,
+    });
+    // Honest, actionable reason: DND moved to donotdisturbd; no public setter.
+    expect(result.doNotDisturb?.error).toContain("donotdisturbd");
+    expect(result.doNotDisturb?.error).toContain("iOS 18");
+    expect(result.doNotDisturb?.error).toContain("no public API");
+    expect(result.error).toContain("donotdisturbd");
+    // Critically: no misleading notifyutil command was ever posted.
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
+  });
+
+  test("reports iOS 18+ simulator DND disable as unsupported without issuing a notifyutil write", async () => {
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(ios18Simulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: false },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      requestedMode: "off",
+      verified: false,
+    });
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
+  });
+
+  test("reports iOS 18+ simulator priority/alarms DND as unsupported", async () => {
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(ios18Simulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { mode: "priority" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      requestedMode: "priority",
+      verified: false,
+    });
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
+  });
+
+  test("resolves iOS 18+ live via `simctl list devices` when the device omits iosVersion", async () => {
+    const bareSimulator: BootedDevice = {
+      name: "iPhone 16 Pro",
+      platform: "ios",
+      deviceId: "7B3A3792-DB53-4654-BA94-27A1D305C3B7",
+    };
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      "list devices 7B3A3792-DB53-4654-BA94-27A1D305C3B7 --json",
+      JSON.stringify({
+        devices: {
+          "com.apple.CoreSimulator.SimRuntime.iOS-18-6": [
+            { udid: "7B3A3792-DB53-4654-BA94-27A1D305C3B7", name: "iPhone 16 Pro", state: "Booted" },
+          ],
+        },
+      })
+    );
+
+    const deviceState = new DeviceState(bareSimulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: true },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb?.capability).toBe("unsupported");
+    // The version was resolved via the list query; still no notifyutil write.
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
+    expect(commands).toContain("list devices 7B3A3792-DB53-4654-BA94-27A1D305C3B7 --json");
+  });
+
+  test("falls back to the legacy notifyutil path when the iOS version cannot be resolved", async () => {
+    const bareSimulator: BootedDevice = {
+      name: "iPhone",
+      platform: "ios",
+      deviceId: "AAAAAAAA-1111-2222-3333-444444444444",
+    };
+    const simctl = new FakeSimCtlClient();
+    // No iosVersion on the device and the list query returns nothing usable →
+    // unknown version → attempt the legacy path rather than over-refusing.
+    simctl.setCommandResult(
+      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 1\n"
+    );
+
+    const deviceState = new DeviceState(bareSimulator, { simctl });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: true },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: true,
+      capability: "binary",
+      enabled: true,
+      verified: true,
+    });
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(true);
   });
 
   test("reports physical iOS as unsupported with a precise no-public-API error", async () => {

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -46,6 +46,43 @@ describe("DeviceState", () => {
     });
   });
 
+  test("reads iOS <18 simulator Do Not Disturb from the legacy notifyutil key", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 1\n"
+    );
+
+    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const result = await deviceState.getState();
+
+    expect(result.success).toBe(true);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: true,
+      capability: "binary",
+      enabled: true,
+      bestEffort: true,
+    });
+  });
+
+  test("reports iOS 18+ simulator Do Not Disturb read as unsupported (dead legacy key)", async () => {
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(ios18Simulator, { simctl });
+    const result = await deviceState.getState();
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+    });
+    expect(result.doNotDisturb?.error).toContain("donotdisturbd");
+    expect(result.error).toContain("donotdisturbd");
+    // No misleading `notifyutil -g` read is issued once we know the key is dead.
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
+  });
+
   test("sets Android Do Not Disturb with cmd notification and verifies readback", async () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();
@@ -304,6 +341,44 @@ describe("DeviceState", () => {
       verified: false,
     });
     const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
+  });
+
+  test("treats iOS 26 simulators as unsupported (> last legacy-supported major)", async () => {
+    const ios26Simulator: BootedDevice = {
+      name: "iPhone 17 Pro",
+      platform: "ios",
+      deviceId: "34C35F33-224C-4E74-B8C0-668FF03E49F5",
+      iosVersion: "26.2",
+    };
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(ios26Simulator, { simctl });
+    const result = await deviceState.setState({ doNotDisturb: { enabled: true } });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb?.capability).toBe("unsupported");
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
+  });
+
+  test("resolves the iOS major version from `osVersion` when `iosVersion` is absent", async () => {
+    const osVersionOnlySimulator: BootedDevice = {
+      name: "iPhone 16 Pro",
+      platform: "ios",
+      deviceId: "7B3A3792-DB53-4654-BA94-27A1D305C3B7",
+      osVersion: "18.0",
+    };
+    const simctl = new FakeSimCtlClient();
+
+    const deviceState = new DeviceState(osVersionOnlySimulator, { simctl });
+    const result = await deviceState.setState({ doNotDisturb: { enabled: true } });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb?.capability).toBe("unsupported");
+    // Resolved from the device field → no live `simctl list devices` probe needed.
+    const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
+    expect(commands.some(c => c.includes("list devices"))).toBe(false);
     expect(commands.some(c => c.includes("notifyutil"))).toBe(false);
   });
 

--- a/test/utils/ios-cmdline-tools/iosVersion.test.ts
+++ b/test/utils/ios-cmdline-tools/iosVersion.test.ts
@@ -58,10 +58,31 @@ describe("iosMajorVersionFromSimctlListDevices", () => {
     expect(iosMajorVersionFromSimctlListDevices("", udid)).toBeNull();
   });
 
+  test("returns null for valid JSON scalars (never throws)", () => {
+    // `JSON.parse` accepts these; the function must still honor its null contract.
+    expect(iosMajorVersionFromSimctlListDevices("null", udid)).toBeNull();
+    expect(iosMajorVersionFromSimctlListDevices("42", udid)).toBeNull();
+    expect(iosMajorVersionFromSimctlListDevices("\"hi\"", udid)).toBeNull();
+    expect(iosMajorVersionFromSimctlListDevices("[]", udid)).toBeNull();
+    expect(iosMajorVersionFromSimctlListDevices("{\"devices\":null}", udid)).toBeNull();
+  });
+
   test("returns null when the runtime id has no iOS version token", () => {
     const weird = JSON.stringify({
       devices: { "com.apple.CoreSimulator.SimRuntime.watchOS-11-0": [{ udid }] },
     });
     expect(iosMajorVersionFromSimctlListDevices(weird, udid)).toBeNull();
+  });
+
+  test("keeps scanning past a non-iOS runtime that also lists the udid", () => {
+    // A tokenless runtime iterated first must not short-circuit the resolution of
+    // a later iOS runtime that lists the same udid.
+    const multi = JSON.stringify({
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.watchOS-11-0": [{ udid }],
+        "com.apple.CoreSimulator.SimRuntime.iOS-18-6": [{ udid }],
+      },
+    });
+    expect(iosMajorVersionFromSimctlListDevices(multi, udid)).toBe(18);
   });
 });

--- a/test/utils/ios-cmdline-tools/iosVersion.test.ts
+++ b/test/utils/ios-cmdline-tools/iosVersion.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseIosMajorVersion,
+  iosMajorVersionFromSimctlListDevices,
+} from "../../../src/utils/ios-cmdline-tools/iosVersion";
+
+describe("parseIosMajorVersion", () => {
+  test("parses dotted versions", () => {
+    expect(parseIosMajorVersion("18.6")).toBe(18);
+    expect(parseIosMajorVersion("17.5.1")).toBe(17);
+    expect(parseIosMajorVersion("26.2")).toBe(26);
+  });
+
+  test("parses a bare major version", () => {
+    expect(parseIosMajorVersion("18")).toBe(18);
+  });
+
+  test("tolerates surrounding whitespace", () => {
+    expect(parseIosMajorVersion("  18.6 \n")).toBe(18);
+  });
+
+  test("returns null for missing or unparseable input", () => {
+    expect(parseIosMajorVersion(undefined)).toBeNull();
+    expect(parseIosMajorVersion(null)).toBeNull();
+    expect(parseIosMajorVersion("")).toBeNull();
+    expect(parseIosMajorVersion("unknown")).toBeNull();
+  });
+});
+
+describe("iosMajorVersionFromSimctlListDevices", () => {
+  const udid = "7B3A3792-DB53-4654-BA94-27A1D305C3B7";
+
+  const listJson = JSON.stringify({
+    devices: {
+      "com.apple.CoreSimulator.SimRuntime.iOS-18-6": [
+        { udid, name: "iPhone 16 Pro", state: "Booted" },
+      ],
+      "com.apple.CoreSimulator.SimRuntime.iOS-17-5": [
+        { udid: "OTHER-UDID", name: "iPhone 15", state: "Shutdown" },
+      ],
+    },
+  });
+
+  test("resolves the major version for the runtime containing the udid", () => {
+    expect(iosMajorVersionFromSimctlListDevices(listJson, udid)).toBe(18);
+  });
+
+  test("resolves an iOS 17 device", () => {
+    expect(iosMajorVersionFromSimctlListDevices(listJson, "OTHER-UDID")).toBe(17);
+  });
+
+  test("returns null when the udid is not present", () => {
+    expect(iosMajorVersionFromSimctlListDevices(listJson, "MISSING")).toBeNull();
+  });
+
+  test("returns null for malformed JSON", () => {
+    expect(iosMajorVersionFromSimctlListDevices("not json", udid)).toBeNull();
+    expect(iosMajorVersionFromSimctlListDevices("", udid)).toBeNull();
+  });
+
+  test("returns null when the runtime id has no iOS version token", () => {
+    const weird = JSON.stringify({
+      devices: { "com.apple.CoreSimulator.SimRuntime.watchOS-11-0": [{ udid }] },
+    });
+    expect(iosMajorVersionFromSimctlListDevices(weird, udid)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

On an iOS **18+** simulator, both `setDeviceState` and `getDeviceState` Do Not Disturb now return an honest **`capability: "unsupported"`** result with a precise reason and issue **no** notifyutil command, instead of posting/reading a `donotdisturbd`-owned key that has no effect and reporting a misleading result.

iOS ≤17 simulators keep the existing legacy `notifyutil` best-effort path unchanged. Physical iOS devices keep their existing unsupported early-return.

Closes #2545.

## Why

Reverse-engineered on a real iOS 18.6 simulator (`xcrun simctl`, iPhone 16 Pro):

1. **`donotdisturbd` owns and resets the legacy key.** `notifyutil -s com.apple.donotdisturb.enabled 1 -p` then a fresh-process `-g` reads back `0` **immediately** — the daemon pins the key to its authoritative value. (Control: an *unmanaged* notify key, `com.apple.BiometricKit.enrollmentChanged`, set the exact same way persists at `1` for 8s+, proving notify(3) state itself persists cross-process — the DND revert is daemon reclamation, not registration lifetime.) The same-invocation `-g` in the old combined command sometimes read `1` before the daemon reclaimed, which is exactly the flaky `verified` #2545 saw.
2. **The key is non-authoritative on iOS 18.** DND / Focus moved to the **`com.apple.donotdisturbd`** daemon (private Core Data store + Focus-assertion model). The legacy `com.apple.donotdisturb.enabled` notification neither reflects nor controls real Focus state, and Apple exposes **no public setter or reader**.

So the binary toggle cannot verify — and a read is a confident falsehood (always `0`) — on iOS 18+ through any public/stable mechanism. In keeping with the honest-contract reporting from #2508, the fix reports this precisely rather than posting/reading a dead key.

## How

- New util [`src/utils/ios-cmdline-tools/iosVersion.ts`](src/utils/ios-cmdline-tools/iosVersion.ts): `parseIosMajorVersion` and `iosMajorVersionFromSimctlListDevices` (shape-guarded — a valid JSON scalar yields `null`, never throws).
- [`DeviceState`](src/features/utility/DeviceState.ts): `resolveSimulatorIosMajorVersion` (prefers `BootedDevice.iosVersion`/`osVersion`, falls back to a live `simctl list devices <udid> --json` probe) gates **both** `setIosDoNotDisturb` and `getIosDoNotDisturb`. On iOS major > 17 they return `IOS18_SIM_DND_UNSUPPORTED_ERROR` with no notifyutil command.

## Not broadened (verified)

`BiometricAuth.ts` uses the same `notifyutil -1 -s -g -p` pattern for Touch ID enrollment. Verified on the iOS 18.6 sim that its key **persists** (no daemon reclaims it), so biometrics are **not** affected — intentionally left out of scope.

## Follow-up (out of scope here)

Behavior-based detection (write → independent-process readback) could make the version gate a fast-path hint rather than the sole signal, and would be more future-proof if Apple ever restores a lever. Deferred; the version gate is correct for all shipping runtimes today.

## Testing

- `test/utils/ios-cmdline-tools/iosVersion.test.ts` — version-helper units incl. JSON-scalar/`null`-literal (no-throw) and multi-runtime resolution.
- `test/features/utility/DeviceState.test.ts` — iOS 18+ read **and** write unsupported (asserting **no** notifyutil command), iOS 17 legacy read/write, iOS 26 end-to-end unsupported, `osVersion`-only fallback, live `simctl list` resolution, unknown-version → legacy fallback.
- Full suite: **5658 pass, 0 fail** (`bun test`). `bun run lint` clean, `bun run build` OK. Each unit test < 100ms.
- **Verified end-to-end on a real iOS 18.6 simulator** (incl. the live-version fallback with no `iosVersion` on the device).

## Reviewed

Three independent review passes (iOS-platform / regression / product perspectives), all findings addressed in the second commit: corrected the mechanism claim, gated the read path, hardened the version parser, and updated `docs/design-docs/plat/ios/simctl.md`.