### PR TITLE
chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -323,4 +323,4 @@ export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (
 // iOS downloads are ever wired (resolveChecksum(<pinned>, "ios")), move this to a
 // per-entry ReleaseChecksumEntry.runnerSha256 or the check would compare the
 // newest runner sha against an older IPA and reject a valid bundle.
-export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "";
+export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982";


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `  apkSha256: string;` | `cb32a19076dafae3b246b99d3b1e59b4eb658e8c4c5bb111e4c744380e7f582a` | ✅ Yes |
| **IPA** | `  ipaSha256: string;` | `b3412749359761df6feb0d8370bee29194e706ab7cde2964311026aecf5e8655` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow