### PR TITLE
feat(observe): sanitizeObserveResult output transform (#2757)

### DIFF
--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -10,6 +10,14 @@ import type { ViewHierarchyNode } from "../../../models/ViewHierarchyResult";
  * `ObserveResult`. Internal consumers (`BaseVisualChange`,
  * `summarizeFailureObservation`, action selection, predictions) read the
  * original object and must be unaffected, so this is a pure function.
+ *
+ * Distinct concern from `ViewHierarchy.cleanNodeProperties`: that is an
+ * allow-list normalizer applied during capture (it *drops* any attribute not
+ * on its list, e.g. `className`). This is a lossless deny-list shrink of the
+ * already-materialized output tree — it only removes redundant/default fields
+ * and must preserve everything else the result carries. The two share the
+ * empty-string / default-boolean / `enabled`-default-true rules on purpose so
+ * their trimmed output agrees; they are not interchangeable.
  */
 
 /** Marker that separates the human-readable perf summary from the raw dump. */
@@ -21,6 +29,10 @@ export const GFXINFO_DUMP_MARKER = "--- GFXINFO DUMP ---";
  * `"false"` / `false` value is lossless for decision-making. Restricting the
  * drop to this known set (rather than any falsy value) avoids nuking a legit
  * text field that happens to hold the string `"false"`.
+ *
+ * `enabled` is deliberately absent: its default is *true*, so it is handled
+ * separately (dropped when true, kept when `"false"`) — the same rule the
+ * repo's canonical node cleaner uses (`ViewHierarchy.cleanNodeProperties`).
  */
 const DEFAULT_FALSE_BOOLEAN_ATTRS: ReadonlySet<string> = new Set([
   "clickable",
@@ -36,8 +48,10 @@ const DEFAULT_FALSE_BOOLEAN_ATTRS: ReadonlySet<string> = new Set([
 
 export interface SanitizeObserveConfig {
   /**
-   * Gate for elements-drop (`--observe-result-drop-elements`). When true the
-   * flattened `elements` block is omitted from the output copy.
+   * Gate for elements-drop. Maps to the `observeResultDropElements` output-
+   * reduction flag (`--observe-result-drop-elements`); the wiring layer (#2758)
+   * supplies it from `ServerConfig.isObserveResultDropElementsEnabled()`. When
+   * true the flattened `elements` block is omitted from the output copy.
    */
   dropElements: boolean;
   /**
@@ -134,6 +148,13 @@ function trimHierarchyNodes(node: ViewHierarchyNode | undefined): void {
   for (const [key, value] of Object.entries(attrs)) {
     // Omit empty-string fields.
     if (value === "") {
+      delete attrs[key];
+      continue;
+    }
+    // Omit `enabled` when true: it defaults to true, so absence reads as
+    // enabled by convention. A disabled control keeps its explicit
+    // `enabled: "false"`. Mirrors ViewHierarchy.cleanNodeProperties.
+    if (key === "enabled" && (value === true || value === "true")) {
       delete attrs[key];
       continue;
     }

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -1,0 +1,149 @@
+import type { ObserveResult } from "../../../models/ObserveResult";
+import type { ViewHierarchyNode } from "../../../models/ViewHierarchyResult";
+
+/**
+ * Output-only shrinking of a single `ObserveResult` for serialization
+ * (issue #2757). Part of the MCP output-context reduction effort.
+ *
+ * Guiding principle — OUTPUT-ONLY: every transform here operates on a deep
+ * copy destined for the wire and never touches the caller's in-memory
+ * `ObserveResult`. Internal consumers (`BaseVisualChange`,
+ * `summarizeFailureObservation`, action selection, predictions) read the
+ * original object and must be unaffected, so this is a pure function.
+ */
+
+/** Marker that separates the human-readable perf summary from the raw dump. */
+export const GFXINFO_DUMP_MARKER = "--- GFXINFO DUMP ---";
+
+/**
+ * View-hierarchy boolean attributes whose default is `false`. When absent, a
+ * consumer reads them as `false` by convention, so omitting an explicit
+ * `"false"` / `false` value is lossless for decision-making. Restricting the
+ * drop to this known set (rather than any falsy value) avoids nuking a legit
+ * text field that happens to hold the string `"false"`.
+ */
+const DEFAULT_FALSE_BOOLEAN_ATTRS: ReadonlySet<string> = new Set([
+  "clickable",
+  "long-clickable",
+  "focusable",
+  "focused",
+  "scrollable",
+  "checkable",
+  "checked",
+  "selected",
+  "password",
+]);
+
+export interface SanitizeObserveConfig {
+  /**
+   * Gate for elements-drop (`--observe-result-drop-elements`). When true the
+   * flattened `elements` block is omitted from the output copy.
+   */
+  dropElements: boolean;
+  /**
+   * Per-node trim toggle. Default on (issue: "default on"); pass `false` to
+   * emit the untrimmed hierarchy.
+   */
+  trimNodes?: boolean;
+}
+
+/**
+ * Return an output-only copy of `obs` shrunk for serialization. Applies, in
+ * order: perf-audit strip (always), per-node trim (default on), and
+ * elements-drop (gated by `cfg.dropElements`). The input is never mutated.
+ */
+export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveConfig): ObserveResult {
+  // Deep-clone boundary: mutate only the copy that goes to the wire. The
+  // JSON round-trip matches the repo's hierarchy-cloning convention
+  // (ViewHierarchy.ts) and the wire's own JSON semantics (undefined/functions
+  // dropped), so it can never throw on a value structuredClone would reject.
+  const out = JSON.parse(JSON.stringify(obs)) as ObserveResult;
+
+  stripPerformanceAudit(out);
+
+  if (cfg.trimNodes !== false) {
+    for (const root of toNodeArray(out.viewHierarchy?.hierarchy?.node)) {
+      trimHierarchyNodes(root);
+    }
+  }
+
+  if (cfg.dropElements) {
+    delete out.elements;
+  }
+
+  return out;
+}
+
+/**
+ * Null the heavy raw dumps and truncate diagnostics to the summary lines above
+ * the GFXINFO dump. Computed metrics (`p50–p99`, `jankCount`,
+ * `cpuUsagePercent`, `threadCount`, `touchLatencyMs`, `anrDetected`) and
+ * `violations[]` are left intact. No-op when no audit is present.
+ */
+function stripPerformanceAudit(out: ObserveResult): void {
+  const audit = out.performanceAudit;
+  if (!audit) {
+    return;
+  }
+
+  if (audit.metrics) {
+    audit.metrics.gfxinfoRaw = null;
+    audit.metrics.cpuStatsRaw = null;
+  }
+
+  if (typeof audit.diagnostics === "string") {
+    const markerIndex = audit.diagnostics.indexOf(GFXINFO_DUMP_MARKER);
+    if (markerIndex !== -1) {
+      audit.diagnostics = audit.diagnostics.slice(0, markerIndex).trimEnd();
+    }
+  }
+}
+
+/**
+ * Normalize a hierarchy `node` slot to an array. The `node` field is typed as a
+ * single `ViewHierarchyNode` at the `Hierarchy` root but a `ViewHierarchyNode[]`
+ * on child nodes, and real captures put an array in both places — this collapses
+ * that runtime shape variance into one traversal path.
+ */
+function toNodeArray(
+  node: ViewHierarchyNode | ViewHierarchyNode[] | undefined
+): ViewHierarchyNode[] {
+  if (!node) {
+    return [];
+  }
+  return Array.isArray(node) ? node : [node];
+}
+
+/**
+ * Recursively trim each node in-place (on the already-cloned tree): drop
+ * `view-id` when it duplicates `resource-id`, omit default-false booleans, and
+ * omit empty-string fields. Lossless for decision-making.
+ */
+function trimHierarchyNodes(node: ViewHierarchyNode | undefined): void {
+  if (!node) {
+    return;
+  }
+
+  const attrs = node as unknown as Record<string, unknown>;
+
+  // Drop view-id when it is identical to resource-id (redundant duplicate).
+  if (attrs["view-id"] !== undefined && attrs["view-id"] === attrs["resource-id"]) {
+    delete attrs["view-id"];
+  }
+
+  for (const [key, value] of Object.entries(attrs)) {
+    // Omit empty-string fields.
+    if (value === "") {
+      delete attrs[key];
+      continue;
+    }
+    // Omit default-false booleans (string "false" or boolean false).
+    if ((value === "false" || value === false) && DEFAULT_FALSE_BOOLEAN_ATTRS.has(key)) {
+      delete attrs[key];
+    }
+  }
+
+  for (const child of toNodeArray(node.node)) {
+    trimHierarchyNodes(child);
+  }
+}

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -216,13 +216,74 @@ describe("sanitizeObserveResult", () => {
       expect(node["resource-id"]).toBe("id/keep");
     });
 
-    test("measurably shrinks the payload from node trim", () => {
+    test("drops enabled when true but preserves enabled=false (default-true convention)", () => {
+      const makeObs = (enabled: string): ObserveResult => ({
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: {
+          hierarchy: {
+            node: {
+              "enabled": enabled,
+              "resource-id": "id/keep",
+              "node": [],
+              "$": {},
+            } as any,
+          },
+        },
+      });
+
+      const enabledTrue = sanitizeObserveResult(makeObs("true"), DROP_NONE);
+      const enabledFalse = sanitizeObserveResult(makeObs("false"), DROP_NONE);
+      const trueNode = enabledTrue.viewHierarchy!.hierarchy!.node as unknown as Record<string, unknown>;
+      const falseNode = enabledFalse.viewHierarchy!.hierarchy!.node as unknown as Record<string, unknown>;
+
+      // enabled defaults to true → absence is lossless; a disabled control is high-signal.
+      expect(trueNode).not.toHaveProperty("enabled");
+      expect(falseNode.enabled).toBe("false");
+    });
+
+    test("measurably shrinks the payload from node trim (view-id dedup, real fixture)", () => {
       const { observe } = loadAndroidHomeObserve();
       // Isolate node-trim: strip perf first so the delta is attributable to trim.
       const perfStripped = sanitizeObserveResult(observe, DROP_NONE);
       // Re-run with trim disabled to get a trim-off baseline of the same output.
       const trimOff = sanitizeObserveResult(observe, { dropElements: false, trimNodes: false });
       expect(measureValue(perfStripped).bytes).toBeLessThan(measureValue(trimOff).bytes);
+    });
+
+    test("measurably shrinks a hierarchy carrying false booleans, empty strings, and enabled=true", () => {
+      // The committed fixture is already boolean/empty-string-clean (the extractor
+      // only emits meaningful attrs), so this synthetic tree exercises the
+      // boolean/empty-string/enabled drop paths against a real byte measurement.
+      const node = (id: number): Record<string, unknown> => ({
+        "view-id": `v-${id}`,
+        "resource-id": `r-${id}`,
+        "className": "android.widget.TextView",
+        "clickable": "false",
+        "long-clickable": "false",
+        "scrollable": "false",
+        "checkable": "false",
+        "checked": "false",
+        "selected": "false",
+        "focused": "false",
+        "enabled": "true",
+        "text": "",
+        "content-desc": `desc ${id}`,
+        "node": [],
+      });
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: {
+          hierarchy: { node: Array.from({ length: 20 }, (_, i) => node(i)) as any },
+        },
+      };
+
+      const trimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: true });
+      const untrimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: false });
+      expect(measureValue(trimmed).bytes).toBeLessThan(measureValue(untrimmed).bytes);
     });
 
     test("does not touch rawViewHierarchy (raw stays raw)", () => {
@@ -286,6 +347,16 @@ describe("sanitizeObserveResult", () => {
       const before = measureValue(observe).bytes;
       const after = measureValue(out).bytes;
       // Perf strip (~17k) + elements drop + node trim take a large bite.
+      expect(after).toBeLessThan(before * 0.7);
+    });
+
+    test("also reduces the token count — the metric the MCP output cap enforces", () => {
+      // Tokens (not bytes) are what the tool-output cap is measured in, so the
+      // reduction must hold on tokens as well. See observeFixture.ts / #2755.
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, DROP_ELEMENTS);
+      const before = measureValue(observe).tokens;
+      const after = measureValue(out).tokens;
       expect(after).toBeLessThan(before * 0.7);
     });
   });

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult } from "../../../../src/models/ObserveResult";
+import type { ViewHierarchyNode } from "../../../../src/models/ViewHierarchyResult";
+import {
+  sanitizeObserveResult,
+  GFXINFO_DUMP_MARKER,
+} from "../../../../src/features/observe/output/ObserveResultOutput";
+import {
+  loadAndroidHomeObserve,
+  measureValue,
+} from "../../../fixtures/observe/observeFixture";
+
+/**
+ * Unit tests for `sanitizeObserveResult` — the output-only transform for issue
+ * #2757. Every reduction is measured against the frozen #2755 baseline fixture
+ * (`android-home.json`) with the production formatter (`measureValue` ->
+ * `stringifyToolResponse`), so a "does this actually shrink the wire payload?"
+ * assertion is trustworthy rather than a compact-JSON undercount.
+ *
+ * The overarching contract: the function is PURE and OUTPUT-ONLY. It returns a
+ * copy destined for the wire and never mutates the caller's in-memory
+ * `ObserveResult` (internal consumers must be unaffected).
+ */
+
+/** Normalize a `node` slot (single or array, as real captures vary) to array. */
+function toNodeArray(
+  node: ViewHierarchyNode | ViewHierarchyNode[] | undefined
+): ViewHierarchyNode[] {
+  if (!node) {
+    return [];
+  }
+  return Array.isArray(node) ? node : [node];
+}
+
+/** Deep structural walk collecting every hierarchy node (root + descendants). */
+function collectNodes(node: ViewHierarchyNode | undefined): ViewHierarchyNode[] {
+  if (!node) {
+    return [];
+  }
+  const out: ViewHierarchyNode[] = [node];
+  for (const child of toNodeArray(node.node)) {
+    out.push(...collectNodes(child));
+  }
+  return out;
+}
+
+/** All hierarchy nodes reachable from an observe result's viewHierarchy. */
+function allHierarchyNodes(obs: ObserveResult): ViewHierarchyNode[] {
+  return toNodeArray(obs.viewHierarchy?.hierarchy?.node).flatMap(collectNodes);
+}
+
+const DROP_NONE = { dropElements: false } as const;
+const DROP_ELEMENTS = { dropElements: true } as const;
+
+describe("sanitizeObserveResult", () => {
+  describe("purity / output-only contract", () => {
+    test("does not mutate the input ObserveResult (deep-clone boundary)", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const before = JSON.stringify(observe);
+
+      sanitizeObserveResult(observe, DROP_ELEMENTS);
+
+      expect(JSON.stringify(observe)).toBe(before);
+    });
+
+    test("returns a distinct object, not the same reference", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      expect(out).not.toBe(observe);
+      expect(out.viewHierarchy).not.toBe(observe.viewHierarchy);
+    });
+
+    test("completes well under the 100ms unit-test budget", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const start = performance.now();
+      sanitizeObserveResult(observe, DROP_ELEMENTS);
+      expect(performance.now() - start).toBeLessThan(100);
+    });
+  });
+
+  describe("perf-audit strip (always)", () => {
+    test("nulls gfxinfoRaw and cpuStatsRaw", () => {
+      const { observe } = loadAndroidHomeObserve();
+      // Precondition: the baseline carries the heavy raw dumps.
+      expect(observe.performanceAudit?.metrics.gfxinfoRaw?.length).toBeGreaterThan(0);
+      expect(observe.performanceAudit?.metrics.cpuStatsRaw?.length).toBeGreaterThan(0);
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.performanceAudit?.metrics.gfxinfoRaw).toBeNull();
+      expect(out.performanceAudit?.metrics.cpuStatsRaw).toBeNull();
+    });
+
+    test("truncates diagnostics to the summary above the GFXINFO DUMP marker", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const original = observe.performanceAudit!.diagnostics!;
+      expect(original).toContain(GFXINFO_DUMP_MARKER);
+      const expectedSummary = original.slice(0, original.indexOf(GFXINFO_DUMP_MARKER)).trimEnd();
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      const diagnostics = out.performanceAudit!.diagnostics!;
+
+      expect(diagnostics).not.toContain(GFXINFO_DUMP_MARKER);
+      expect(diagnostics).toBe(expectedSummary);
+      // The high-signal summary lines survive.
+      expect(diagnostics).toContain("Performance issues detected:");
+      expect(diagnostics).toContain("Top contributors:");
+    });
+
+    test("preserves computed metrics and violations", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      const m = out.performanceAudit!.metrics;
+      const om = observe.performanceAudit!.metrics;
+      expect(m.p50Ms).toBe(om.p50Ms);
+      expect(m.p90Ms).toBe(om.p90Ms);
+      expect(m.p95Ms).toBe(om.p95Ms);
+      expect(m.p99Ms).toBe(om.p99Ms);
+      expect(m.jankCount).toBe(om.jankCount);
+      expect(m.cpuUsagePercent).toBe(om.cpuUsagePercent);
+      expect(m.threadCount).toBe(om.threadCount);
+      expect(m.touchLatencyMs).toBe(om.touchLatencyMs);
+      expect(m.anrDetected).toBe(om.anrDetected);
+      expect(out.performanceAudit!.violations).toEqual(observe.performanceAudit!.violations);
+    });
+
+    test("measurably shrinks the payload from the perf strip alone", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      // The raw dumps + inlined GFXINFO dominate the perf section (~17k bytes).
+      expect(measureValue(out).bytes).toBeLessThan(measureValue(observe).bytes - 10_000);
+    });
+
+    test("is a no-op when performanceAudit is absent", () => {
+      const { observe } = loadAndroidHomeObserve();
+      delete observe.performanceAudit;
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      expect(out.performanceAudit).toBeUndefined();
+    });
+  });
+
+  describe("per-node trim (default on)", () => {
+    test("drops view-id when it equals resource-id", () => {
+      const { observe } = loadAndroidHomeObserve();
+      // Precondition: the baseline has nodes where view-id === resource-id.
+      const dupBefore = allHierarchyNodes(observe).filter(
+        n => n["view-id"] !== undefined && n["view-id"] === (n as Record<string, unknown>)["resource-id"]
+      );
+      expect(dupBefore.length).toBeGreaterThan(0);
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      for (const n of allHierarchyNodes(out)) {
+        const rec = n as Record<string, unknown>;
+        if (rec["resource-id"] !== undefined && n["view-id"] !== undefined) {
+          expect(n["view-id"]).not.toBe(rec["resource-id"]);
+        }
+      }
+    });
+
+    test("keeps view-id when it differs from resource-id", () => {
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: {
+          hierarchy: {
+            node: {
+              "view-id": "distinct-uuid",
+              "node": [],
+              "$": {},
+            } as any,
+          },
+        },
+      };
+      (obs.viewHierarchy!.hierarchy!.node as unknown as Record<string, unknown>)["resource-id"] =
+        "android:id/content";
+
+      const out = sanitizeObserveResult(obs, DROP_NONE);
+      expect(out.viewHierarchy!.hierarchy!.node!["view-id"]).toBe("distinct-uuid");
+    });
+
+    test("omits default-false booleans and empty-string fields (synthetic)", () => {
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: {
+          hierarchy: {
+            node: {
+              "clickable": "false",
+              "long-clickable": false,
+              "focusable": "true",
+              "text": "",
+              "content-desc": "Keep me",
+              "resource-id": "id/keep",
+              "node": [],
+              "$": {},
+            } as any,
+          },
+        },
+      };
+
+      const out = sanitizeObserveResult(obs, DROP_NONE);
+      const node = out.viewHierarchy!.hierarchy!.node as unknown as Record<string, unknown>;
+
+      // Default-false booleans (string or boolean form) are dropped.
+      expect(node).not.toHaveProperty("clickable");
+      expect(node).not.toHaveProperty("long-clickable");
+      // Empty-string fields are dropped.
+      expect(node).not.toHaveProperty("text");
+      // Meaningful values survive.
+      expect(node.focusable).toBe("true");
+      expect(node["content-desc"]).toBe("Keep me");
+      expect(node["resource-id"]).toBe("id/keep");
+    });
+
+    test("measurably shrinks the payload from node trim", () => {
+      const { observe } = loadAndroidHomeObserve();
+      // Isolate node-trim: strip perf first so the delta is attributable to trim.
+      const perfStripped = sanitizeObserveResult(observe, DROP_NONE);
+      // Re-run with trim disabled to get a trim-off baseline of the same output.
+      const trimOff = sanitizeObserveResult(observe, { dropElements: false, trimNodes: false });
+      expect(measureValue(perfStripped).bytes).toBeLessThan(measureValue(trimOff).bytes);
+    });
+
+    test("does not touch rawViewHierarchy (raw stays raw)", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.rawViewHierarchy = {
+        hierarchy: {
+          node: {
+            "view-id": "android:id/content",
+            "resource-id": "android:id/content",
+            "clickable": "false",
+            "text": "",
+            "node": [],
+            "$": {},
+          },
+        } as any,
+      };
+      const rawBefore = JSON.stringify(observe.rawViewHierarchy);
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(JSON.stringify(out.rawViewHierarchy)).toBe(rawBefore);
+    });
+
+    test("can be disabled via trimNodes:false", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, { dropElements: false, trimNodes: false });
+      const dup = allHierarchyNodes(out).filter(
+        n => n["view-id"] !== undefined && n["view-id"] === (n as Record<string, unknown>)["resource-id"]
+      );
+      expect(dup.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("elements-drop (gated)", () => {
+    test("omits the elements block when dropElements is true", () => {
+      const { observe } = loadAndroidHomeObserve();
+      expect(observe.elements).toBeDefined();
+
+      const out = sanitizeObserveResult(observe, DROP_ELEMENTS);
+      expect(out.elements).toBeUndefined();
+    });
+
+    test("keeps the elements block when dropElements is false", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      expect(out.elements).toBeDefined();
+    });
+
+    test("measurably shrinks the payload when elements are dropped", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const kept = sanitizeObserveResult(observe, DROP_NONE);
+      const dropped = sanitizeObserveResult(observe, DROP_ELEMENTS);
+      expect(measureValue(dropped).bytes).toBeLessThan(measureValue(kept).bytes);
+    });
+  });
+
+  describe("combined reduction", () => {
+    test("all three steps together substantially shrink the baseline", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, DROP_ELEMENTS);
+      const before = measureValue(observe).bytes;
+      const after = measureValue(out).bytes;
+      // Perf strip (~17k) + elements drop + node trim take a large bite.
+      expect(after).toBeLessThan(before * 0.7);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `sanitizeObserveResult(obs, cfg)` — a **pure, output-only** transform (new `src/features/observe/output/ObserveResultOutput.ts`) that shrinks a single `ObserveResult` for serialization. It applies, in order:

1. **Perf-audit strip** (always, when `performanceAudit` is populated): nulls `metrics.gfxinfoRaw` and `metrics.cpuStatsRaw`, and truncates `diagnostics` to the summary lines above `--- GFXINFO DUMP ---`. Computed metrics (`p50–p99`, `jankCount`, `cpuUsagePercent`, `threadCount`, `touchLatencyMs`, `anrDetected`) and `violations[]` are preserved.
2. **Per-node trim** (default on) over `viewHierarchy.hierarchy`: drops `view-id` when it equals `resource-id`, omits default-false booleans, and omits empty-string fields. **Never touches `rawViewHierarchy`** (raw stays raw).
3. **Elements-drop** (gated by `cfg.dropElements`, i.e. `--observe-result-drop-elements`): omits the flattened `elements` block.

Closes #2757.

## Why

Part of the MCP output-context reduction effort (milestone: Output Size Reduction). An observe result exceeds the MCP tool-output token cap; the heaviest offenders are the perf-audit raw dumps (~17k bytes, gfxinfo inlined twice), the duplicated `elements` tree, and redundant per-node fields. This transform removes that waste **on a copy destined for the wire only** — the in-memory `ObserveResult` is left untouched so internal consumers (`BaseVisualChange`, `summarizeFailureObservation`, action selection, predictions) are unaffected.

Dependencies #2755 (measurement fixture) and #2756 (config plumbing) have already landed.

## How

- **Deep-clone boundary:** clones via `JSON.parse(JSON.stringify(obs))` — matching the repo's existing hierarchy-cloning convention (`ViewHierarchy.ts`) and the wire's own JSON semantics, so it can never throw on a value `structuredClone` would reject.
- **Hierarchy shape variance:** real captures put an **array** in `hierarchy.node` (typed as a single node) as well as on child `node[]`; a `toNodeArray` normalizer collapses both into one traversal path.
- **Default-false booleans:** restricted to a known attribute set (`clickable`, `long-clickable`, `focusable`, `focused`, `scrollable`, `checkable`, `checked`, `selected`, `password`) so a legit text field holding `"false"` is never dropped. `enabled` (default *true*) is intentionally excluded to stay lossless.
- `cfg.trimNodes` defaults on; pass `false` to emit the untrimmed hierarchy.

## Scope note (deliberately not wired in yet)

Per the issue, this PR delivers **only** the pure function + unit tests. Wiring it into the tool-output boundary is the downstream issue **#2758** (`finalizeToolResponse` hook), and the compact/TOON encoding is **#2760** — both intentionally out of scope here to avoid overlapping those PRs.

## Testing

- New `test/features/observe/output/ObserveResultOutput.test.ts` (18 tests, all < 100ms), measured against the frozen #2755 baseline fixture with the production formatter (`stringifyToolResponse`):
  - **Purity:** input `ObserveResult` deep-equal before/after; distinct output reference.
  - **Perf-strip:** raws nulled, diagnostics truncated at the marker, computed metrics + `violations` preserved, ≥10k byte reduction, no-op when audit absent.
  - **Node-trim:** no node has `view-id === resource-id`; synthetic default-false booleans + empty strings dropped; meaningful values survive; `rawViewHierarchy` byte-for-byte unchanged; measurable byte reduction; `trimNodes:false` disables it.
  - **Elements-drop:** gated both ways; measurable byte reduction when on.
  - **Combined:** all three steps shrink the baseline to < 70% of original bytes.
- `bun run lint` clean, `bun run build` OK on the new files.
- Note: one pre-existing unrelated failure (`AndroidCtrlProxyClient > getLatestHierarchy > should preserve SDK screen names…`) reproduces on clean `main` without this change — not introduced here.

## Follow-up (out of scope)

- Wire `sanitizeObserveResult` into the observe/action output path under #2758.
