### PR TITLE
chore(db): harden bunSqliteDialect — nested-txn guard, preserve SqliteError cause, word-boundary RETURNING

### DIFF
--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -197,11 +197,14 @@ export class BunSqliteConnectionState {
         typeof value === "bigint" ? value.toString() : value
       );
       // Preserve the original SqliteError (code/stack) via `cause` so future
-      // BUSY/constraint-aware retries and describeUnknownError can reach it.
-      // ActionableError drops `cause`, so use a plain Error here. Keep the
-      // original error text inline too: callers (e.g. the startup-migration
-      // gate) match on that message, and the inline `${error}` is BigInt-safe
-      // (unlike JSON.stringify) because it goes through toString().
+      // BUSY/constraint-aware retries and describeUnknownError (which recurses
+      // into `.cause`) can reach it. ActionableError drops `cause`, so use a
+      // plain Error here. Keep the original error text inline too: the
+      // `#beforeQuery` migration gate above runs inside this try, so its
+      // "startup migrations failed" throw is caught and rewrapped here — and
+      // databaseLazyPath.test.ts asserts that text via `.message`. The inline
+      // `${error}` is BigInt-safe (unlike JSON.stringify) since it goes
+      // through toString().
       throw new Error(`Query failed: ${error}\nSQL: ${sql}\nParameters: ${params}`, {
         cause: error,
       });

--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -13,6 +13,7 @@ import {
   TransactionSettings,
 } from "kysely";
 import { CompiledQuery } from "kysely";
+import { ActionableError } from "../models/ActionableError";
 
 /**
  * Kysely dialect for Bun's built-in SQLite.
@@ -100,7 +101,7 @@ class BunSqliteDriver implements Driver {
   }
 }
 
-class BunSqliteConnectionState {
+export class BunSqliteConnectionState {
   readonly #databaseSource: BunDatabase | (() => BunDatabase);
   readonly #beforeQuery?: () => Promise<void>;
   #db: BunDatabase | null = null;
@@ -164,7 +165,10 @@ class BunSqliteConnectionState {
       // Check if this is a SELECT query or query with RETURNING clause
       const sqlLower = sql.trim().toLowerCase();
       const isSelect = sqlLower.startsWith("select");
-      const hasReturning = sqlLower.includes("returning");
+      // Word boundary (not a bare substring) so an identifier like
+      // `returning_items` isn't misclassified as a RETURNING clause. `_` is a
+      // word char, so `\breturning\b` correctly rejects `returning_items`.
+      const hasReturning = /\breturning\b/.test(sqlLower);
 
       if (isSelect || hasReturning) {
         // For SELECT queries or queries with RETURNING, return all rows
@@ -186,9 +190,21 @@ class BunSqliteConnectionState {
         };
       }
     } catch (error) {
-      throw new Error(
-        `Query failed: ${error}\nSQL: ${sql}\nParameters: ${JSON.stringify(parameters)}`
+      // BigInt-safe: Kysely can bind BigInt params, and a bare
+      // JSON.stringify(parameters) throws on BigInt — which would mask the real
+      // SqliteError with a TypeError from the error reporter itself.
+      const params = JSON.stringify(parameters, (_key, value) =>
+        typeof value === "bigint" ? value.toString() : value
       );
+      // Preserve the original SqliteError (code/stack) via `cause` so future
+      // BUSY/constraint-aware retries and describeUnknownError can reach it.
+      // ActionableError drops `cause`, so use a plain Error here. Keep the
+      // original error text inline too: callers (e.g. the startup-migration
+      // gate) match on that message, and the inline `${error}` is BigInt-safe
+      // (unlike JSON.stringify) because it goes through toString().
+      throw new Error(`Query failed: ${error}\nSQL: ${sql}\nParameters: ${params}`, {
+        cause: error,
+      });
     } finally {
       this.#activeQueries -= 1;
       this.#notifyWaiters();
@@ -214,6 +230,15 @@ class BunSqliteConnectionState {
   }
 
   async #reserveTransaction(owner: symbol): Promise<void> {
+    // A nested beginTransaction on a lease that already holds the transaction
+    // lock would busy-loop forever here (the owner waiting for itself to
+    // release), deadlocking the daemon's only DB connection. Mirror
+    // #enterQuery's `=== owner` carve-out by failing fast with a clear error
+    // instead. The caller (beginTransaction) still decrements
+    // #pendingTransactions and wakes waiters in its finally, so no counter leak.
+    if (this.#transactionOwner === owner) {
+      throw new ActionableError("Nested transactions are not supported by BunSqliteDialect");
+    }
     while (this.#transactionOwner !== null || this.#activeQueries > 0) {
       await this.#waitForStateChange();
     }

--- a/test/db/bunSqliteDialect.test.ts
+++ b/test/db/bunSqliteDialect.test.ts
@@ -116,6 +116,23 @@ describe("BunSqliteConnectionState — C4 nested-transaction guard", () => {
     // A distinct lease must still be able to open a transaction.
     await expect(withTimeout(state.beginTransaction(owner2), 1000)).resolves.toBeUndefined();
   });
+
+  test("the same lease can reopen a transaction after commit (guard only blocks re-entry)", async () => {
+    const db = new FakeDatabase();
+    const state = makeState(db);
+    const owner = Symbol("lease");
+
+    // commit clears #transactionOwner, so a fresh begin on the SAME owner is
+    // NOT a nested re-entry and must be allowed (the guard is scoped to an
+    // already-held lock, not to owner identity).
+    await withTimeout(state.beginTransaction(owner), 1000);
+    await withTimeout(state.commitTransaction(owner), 1000);
+    await expect(withTimeout(state.beginTransaction(owner), 1000)).resolves.toBeUndefined();
+
+    // Same for rollback.
+    await withTimeout(state.rollbackTransaction(owner), 1000);
+    await expect(withTimeout(state.beginTransaction(owner), 1000)).resolves.toBeUndefined();
+  });
 });
 
 describe("BunSqliteConnectionState — C5 error wrapping", () => {

--- a/test/db/bunSqliteDialect.test.ts
+++ b/test/db/bunSqliteDialect.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import { CompiledQuery, Kysely } from "kysely";
+import { BunSqliteConnectionState, BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { ActionableError } from "../../src/models/ActionableError";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+
+/**
+ * Fake bun:sqlite Database that records whether `.all` or `.run` was used for
+ * the last prepared statement and lets a test inject a throwing statement. This
+ * keeps the dialect tests off a real DB / wall-clock so they stay <100ms and
+ * non-flaky (per CLAUDE.md).
+ */
+interface FakeRunResult {
+  changes: number | bigint;
+  lastInsertRowid: number | bigint;
+}
+
+class FakeStatement {
+  constructor(
+    private readonly db: FakeDatabase,
+    private readonly sql: string
+  ) {}
+
+  all(...params: unknown[]): unknown[] {
+    this.db.record("all", this.sql, params);
+    if (this.db.throwOn) {
+      throw this.db.throwOn;
+    }
+    return this.db.rows;
+  }
+
+  run(...params: unknown[]): FakeRunResult {
+    this.db.record("run", this.sql, params);
+    if (this.db.throwOn) {
+      throw this.db.throwOn;
+    }
+    return { changes: 0, lastInsertRowid: 0 };
+  }
+}
+
+class FakeDatabase {
+  readonly calls: Array<{ method: "all" | "run"; sql: string; params: unknown[] }> = [];
+  rows: unknown[] = [];
+  throwOn?: unknown;
+
+  prepare(sql: string): FakeStatement {
+    return new FakeStatement(this, sql);
+  }
+
+  record(method: "all" | "run", sql: string, params: unknown[]): void {
+    this.calls.push({ method, sql, params });
+  }
+
+  close(): void {
+    // no-op
+  }
+
+  get last(): { method: "all" | "run"; sql: string; params: unknown[] } | undefined {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+function makeState(db: FakeDatabase): BunSqliteConnectionState {
+  return new BunSqliteConnectionState(db as unknown as never);
+}
+
+function rawQuery(sql: string, parameters: unknown[] = []): CompiledQuery {
+  return { sql, parameters } as unknown as CompiledQuery;
+}
+
+/**
+ * Reject rather than hang the whole suite if a fix regresses the nested-txn
+ * guard back into a busy-loop (per the issue's acceptance criteria).
+ */
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let handle: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    handle = defaultTimer.setTimeout(
+      () => reject(new Error(`TIMEOUT: call hung after ${ms}ms`)),
+      ms
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (handle) {
+      defaultTimer.clearTimeout(handle);
+    }
+  }
+}
+
+describe("BunSqliteConnectionState — C4 nested-transaction guard", () => {
+  test("a second beginTransaction on the same owner rejects with ActionableError instead of hanging", async () => {
+    const db = new FakeDatabase();
+    const state = makeState(db);
+    const owner = Symbol("lease");
+
+    await withTimeout(state.beginTransaction(owner), 1000);
+
+    // Second begin on the SAME owner previously busy-looped forever in
+    // #reserveTransaction (owner waiting for itself to release).
+    await expect(withTimeout(state.beginTransaction(owner), 1000)).rejects.toBeInstanceOf(
+      ActionableError
+    );
+  });
+
+  test("the guard does not break a fresh transaction from a different owner", async () => {
+    const db = new FakeDatabase();
+    const state = makeState(db);
+    const owner1 = Symbol("lease-1");
+    const owner2 = Symbol("lease-2");
+
+    await withTimeout(state.beginTransaction(owner1), 1000);
+    await withTimeout(state.commitTransaction(owner1), 1000);
+
+    // A distinct lease must still be able to open a transaction.
+    await expect(withTimeout(state.beginTransaction(owner2), 1000)).resolves.toBeUndefined();
+  });
+});
+
+describe("BunSqliteConnectionState — C5 error wrapping", () => {
+  test("preserves the original SqliteError as cause (by identity) with its code", async () => {
+    const db = new FakeDatabase();
+    const original = Object.assign(new Error("constraint failed"), {
+      code: "SQLITE_CONSTRAINT",
+    });
+    db.throwOn = original;
+    const state = makeState(db);
+    const owner = Symbol("lease");
+
+    let caught: unknown;
+    try {
+      await state.executeQuery(rawQuery("insert into foo (id) values (?)", [1]), owner);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    // Identity, not a stringified copy — describeUnknownError and any future
+    // BUSY/constraint-retry path depend on reaching the real error object.
+    expect((caught as Error).cause).toBe(original);
+    expect(((caught as Error).cause as { code?: string }).code).toBe("SQLITE_CONSTRAINT");
+  });
+
+  test("does not throw a TypeError from JSON.stringify when a parameter is a BigInt", async () => {
+    const db = new FakeDatabase();
+    const original = new Error("boom");
+    db.throwOn = original;
+    const state = makeState(db);
+    const owner = Symbol("lease");
+
+    let caught: unknown;
+    try {
+      await state.executeQuery(rawQuery("insert into foo (n) values (?)", [123n]), owner);
+    } catch (error) {
+      caught = error;
+    }
+
+    // The reporter itself must not throw while serializing BigInt params.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).not.toContain("serialize a BigInt");
+    expect((caught as Error).cause).toBe(original);
+    // BigInt should be rendered as its string form in the diagnostic message.
+    expect((caught as Error).message).toContain("123");
+  });
+});
+
+describe("BunSqliteConnectionState — C6 word-boundary RETURNING detection", () => {
+  test("an identifier containing 'returning' is NOT treated as a RETURNING clause", async () => {
+    const db = new FakeDatabase();
+    const state = makeState(db);
+    const owner = Symbol("lease");
+
+    // Only occurrence of 'returning' is the table name — must take the run() branch.
+    await state.executeQuery(rawQuery("insert into returning_items (name) values (?)", ["x"]), owner);
+
+    expect(db.last?.method).toBe("run");
+  });
+
+  test("a real compiled Kysely .returning() query IS treated as row-returning", async () => {
+    const db = new FakeDatabase();
+    const kysely = new Kysely<{ foo: { id: number; name: string } }>({
+      dialect: new BunSqliteDialect({ database: db as unknown as never }),
+    });
+
+    const compiled = kysely
+      .insertInto("foo")
+      .values({ id: 1, name: "x" })
+      .returning("id")
+      .compile();
+
+    // Sanity: the compiled SQL is the real, lowercased-friendly RETURNING output.
+    expect(compiled.sql.toLowerCase()).toContain(" returning ");
+
+    const state = makeState(db);
+    const owner = Symbol("lease");
+    await state.executeQuery(compiled, owner);
+
+    expect(db.last?.method).toBe("all");
+  });
+});


### PR DESCRIPTION
## What

Harden the single-connection Bun SQLite Kysely dialect (`src/db/bunSqliteDialect.ts`) against three latent, defensive gaps found in the 2026-07-01 DB concurrency/migration audit (finding C456, P2). None are reachable through today's Kysely 0.29 usage, but all sit in the code path that **every** daemon DB query flows through.

- **C4 — nested-txn deadlock guard.** `#reserveTransaction` now throws an `ActionableError` when the same lease re-enters `beginTransaction` (`#transactionOwner === owner`) instead of busy-looping forever and deadlocking the daemon's only DB connection.
- **C5 — preserve `SqliteError` + BigInt-safe params.** The `executeQuery` error wrapper now attaches the original error via `{ cause }` (code/stack reachable) and serializes parameters with a BigInt-safe replacer so the reporter can't mask the real failure with a `TypeError`.
- **C6 — word-boundary `RETURNING` detection.** `sqlLower.includes("returning")` → `/\breturning\b/.test(sqlLower)`, so an identifier like `returning_items` isn't misclassified as a row-returning statement.

Closes #2793.

## Why

All three are latent landmines, verified against source (and by the two review passes recorded on the issue):

- **C4** is unreachable today (Kysely 0.29 `Transaction.transaction()` throws before dispatching a nested `beginTransaction`), but if ever reached it is a full, unrecoverable hang of the daemon's single SQLite connection. A guard converts that into a clear thrown error. The throw lands in `#reserveTransaction`; the caller's `finally` still decrements `#pendingTransactions` and wakes waiters, so there is no counter leak.
- **C5** — `new Error("Query failed: " + error ...)` flattened the original into a string, discarding `SqliteError.code`/stack/cause that any future BUSY/constraint-aware retry needs. Worse, `JSON.stringify(parameters)` **throws** on a BigInt param (Kysely binds BigInt for `bigint` columns), so a failing query with a BigInt param would throw a `TypeError` *inside the catch*, masking the real SQLite error. `describeUnknownError` already recurses into `.cause`, so `{ cause }` is a net diagnostic win today, not just latent.
- **C6** is a consistency fix (the `startsWith("select")` above it is already anchored). No current identifier contains `returning`, so it's not reachable now — but a future `is_returning_user` column would trip it.

## How

All within `src/db/bunSqliteDialect.ts`:

- `#reserveTransaction(owner)`: early `throw new ActionableError("Nested transactions are not supported by BunSqliteDialect")` when `#transactionOwner === owner`.
- `executeQuery` catch: BigInt-safe `JSON.stringify(parameters, replacer)` + `throw new Error(msg, { cause: error })`. Kept the inline `${error}` text (a plain `${error}` toString is BigInt-safe) so the startup-migration gate's `.message` match still surfaces to callers. Plain `Error` because `ActionableError`/`toActionableError` drop `cause`.
- `hasReturning = /\breturning\b/.test(sqlLower)`.
- Exported `BunSqliteConnectionState` for direct unit testing.

## Testing

New `test/db/bunSqliteDialect.test.ts` — fake `bun:sqlite` `Database` (fake `prepare`/`all`/`run`), no real DB or wall-clock, all <100ms:

- **C4:** a second `beginTransaction` on the same owner rejects with `ActionableError` (wrapped in a `Promise.race` timeout guard so a regressed fix rejects the test rather than hanging the suite); a distinct owner can still open a fresh transaction after commit.
- **C5:** `err.cause` **is** the original error object *by identity* and `err.cause.code` is populated; a BigInt parameter does **not** produce a `TypeError` and renders as its string form.
- **C6:** `insert into returning_items ...` takes the `run()` branch; a real compiled Kysely `.returning()` query takes the `all()` branch.

Full validation green: `turbo run lint build test` — **5728 pass, 0 fail** (440 files); lint and build clean. Existing `test/db/*` (387 tests) unchanged, including the startup-migration-gate message assertion.

## Acceptance criteria (from #2793)

- [x] Re-entrant `beginTransaction(owner)` throws `ActionableError` rather than hanging (timeout-guarded test).
- [x] BigInt-param failure surfaces the underlying error via `err.cause` (identity, `.code` populated); no `TypeError` from serialization.
- [x] `hasReturning` false for an identifier-only occurrence, true for a real compiled Kysely `.returning()` query.
- [x] New `test/db/bunSqliteDialect.test.ts` uses fakes, runs <100ms, non-flaky.
- [x] `turbo run lint build test` green; all existing DB tests' branch selection / `numAffectedRows` / `insertId` unchanged.
