### PR TITLE
fix(db): atomic recordFailure upsert + UNIQUE index on failure_groups.signature

### DIFF
--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -1,13 +1,11 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { getDatabase } from "./database";
 import type {
   Database,
-  NewFailureGroup,
   NewFailureOccurrence,
   NewFailureOccurrenceScreen,
   NewFailureCapture,
   NewFailureNotification,
-  FailureGroupUpdate,
 } from "./types";
 import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
@@ -132,55 +130,20 @@ export class FailureAnalyticsRepository {
     const occurrenceId = crypto.randomUUID();
 
     try {
-      // Check if group exists
-      const existingGroup = await db
-        .selectFrom("failure_groups")
-        .select(["id", "total_count", "unique_sessions", "first_occurrence", "tool_call_info_json"])
-        .where("signature", "=", input.signature)
-        .executeTakeFirst();
+      // Atomic get-or-create keyed on signature (#2789). The daemon's single
+      // connection releases its mutex across every await, so the former
+      // SELECT-then-INSERT/UPDATE interleaved: two same-signature failures could
+      // both INSERT (duplicate groups, now blocked by the UNIQUE index from
+      // migration 2026_07_01_000) or both read a stale total_count and clobber
+      // (lost increments). A single INSERT ... ON CONFLICT DO UPDATE makes the
+      // count bump atomic. The candidate id is used only on the first-seen path.
+      const candidateGroupId = crypto.randomUUID();
+      const nowIso = new Date().toISOString();
 
-      let groupId: string;
-
-      if (existingGroup) {
-        groupId = existingGroup.id;
-
-        // Count unique sessions including this one
-        const sessionExists = await db
-          .selectFrom("failure_occurrences")
-          .select("id")
-          .where("group_id", "=", groupId)
-          .where("session_id", "=", input.occurrence.sessionId)
-          .executeTakeFirst();
-
-        const newUniqueSessions = sessionExists
-          ? existingGroup.unique_sessions
-          : existingGroup.unique_sessions + 1;
-
-        // Merge tool call info if this is a tool failure
-        let mergedToolCallInfo = input.toolCallInfo;
-        if (input.type === "tool_failure" && existingGroup.tool_call_info_json) {
-          const existing = JSON.parse(existingGroup.tool_call_info_json) as AggregatedToolCallInfo;
-          mergedToolCallInfo = this.mergeToolCallInfo(existing, input.toolCallInfo, input.occurrence);
-        }
-
-        const update: FailureGroupUpdate = {
-          last_occurrence: now,
-          total_count: existingGroup.total_count + 1,
-          unique_sessions: newUniqueSessions,
-          tool_call_info_json: mergedToolCallInfo ? JSON.stringify(mergedToolCallInfo) : null,
-          updated_at: new Date().toISOString(),
-        };
-
-        await db
-          .updateTable("failure_groups")
-          .set(update)
-          .where("id", "=", groupId)
-          .execute();
-      } else {
-        groupId = crypto.randomUUID();
-
-        const group: NewFailureGroup = {
-          id: groupId,
+      const upserted = await db
+        .insertInto("failure_groups")
+        .values({
+          id: candidateGroupId,
           type: input.type,
           signature: input.signature,
           title: input.title,
@@ -192,11 +155,22 @@ export class FailureAnalyticsRepository {
           unique_sessions: 1,
           stack_trace_json: input.stackTrace ? JSON.stringify(input.stackTrace) : null,
           tool_call_info_json: input.toolCallInfo ? JSON.stringify(input.toolCallInfo) : null,
-          updated_at: new Date().toISOString(),
-        };
+          updated_at: nowIso,
+        })
+        .onConflict(oc =>
+          oc.column("signature").doUpdateSet(eb => ({
+            last_occurrence: now,
+            total_count: eb("failure_groups.total_count", "+", 1),
+            updated_at: nowIso,
+          }))
+        )
+        .returning("id")
+        .executeTakeFirstOrThrow();
 
-        await db.insertInto("failure_groups").values(group).execute();
-      }
+      const groupId = upserted.id;
+      // RETURNING gives the pre-existing id on the conflict path, so a returned
+      // id equal to our fresh candidate means this call created the group.
+      const isNewGroup = groupId === candidateGroupId;
 
       // Insert occurrence
       const occurrence: NewFailureOccurrence = {
@@ -217,6 +191,49 @@ export class FailureAnalyticsRepository {
       };
 
       await db.insertInto("failure_occurrences").values(occurrence).execute();
+
+      // Derive unique_sessions from the committed occurrence rows rather than
+      // incrementing a stale read (#2789). COUNT(DISTINCT session_id) is
+      // evaluated inside SQLite in one statement, so interleaved recordFailure
+      // calls both write the same correct value — idempotent, not racy. Backed
+      // by idx_failure_occurrences_group_session so it does not scan the group.
+      await db
+        .updateTable("failure_groups")
+        .set({
+          unique_sessions: sql<number>`(
+            SELECT COUNT(DISTINCT session_id)
+            FROM failure_occurrences
+            WHERE group_id = ${groupId}
+          )`,
+        })
+        .where("id", "=", groupId)
+        .execute();
+
+      // Preserve tool-call-info aggregation. On the first-seen path the upsert
+      // already stored this occurrence's info; on the conflict path we fold the
+      // new contribution into the existing aggregate via a follow-up update.
+      if (input.type === "tool_failure" && !isNewGroup) {
+        const current = await db
+          .selectFrom("failure_groups")
+          .select("tool_call_info_json")
+          .where("id", "=", groupId)
+          .executeTakeFirst();
+
+        let mergedToolCallInfo = input.toolCallInfo;
+        if (current?.tool_call_info_json) {
+          const existing = JSON.parse(current.tool_call_info_json) as AggregatedToolCallInfo;
+          mergedToolCallInfo = this.mergeToolCallInfo(existing, input.toolCallInfo, input.occurrence);
+        }
+
+        await db
+          .updateTable("failure_groups")
+          .set({
+            tool_call_info_json: mergedToolCallInfo ? JSON.stringify(mergedToolCallInfo) : null,
+            updated_at: new Date().toISOString(),
+          })
+          .where("id", "=", groupId)
+          .execute();
+      }
 
       // Insert screens visited
       if (input.occurrence.screensVisited && input.occurrence.screensVisited.length > 0) {

--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -221,8 +221,8 @@ export class FailureAnalyticsRepository {
       // read-modify-write (JSON merged in JS), so wrap it in a transaction: the
       // single-connection dialect reserves the connection for the transaction
       // owner (bunSqliteDialect.ts #reserveTransaction), serializing concurrent
-      // tool_failure merges so none clobber another's contribution. (The full
-      // recordFailure transaction is tracked separately in #2791.)
+      // tool_failure merges so none clobber another's contribution. (Wrapping
+      // the full recordFailure body in one transaction is tracked in #2877.)
       if (input.type === "tool_failure" && !isNewGroup) {
         await db.transaction().execute(async trx => {
           const current = await trx

--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -197,42 +197,55 @@ export class FailureAnalyticsRepository {
       // evaluated inside SQLite in one statement, so interleaved recordFailure
       // calls both write the same correct value — idempotent, not racy. Backed
       // by idx_failure_occurrences_group_session so it does not scan the group.
-      await db
-        .updateTable("failure_groups")
-        .set({
-          unique_sessions: sql<number>`(
-            SELECT COUNT(DISTINCT session_id)
-            FROM failure_occurrences
-            WHERE group_id = ${groupId}
-          )`,
-        })
-        .where("id", "=", groupId)
-        .execute();
-
-      // Preserve tool-call-info aggregation. On the first-seen path the upsert
-      // already stored this occurrence's info; on the conflict path we fold the
-      // new contribution into the existing aggregate via a follow-up update.
-      if (input.type === "tool_failure" && !isNewGroup) {
-        const current = await db
-          .selectFrom("failure_groups")
-          .select("tool_call_info_json")
-          .where("id", "=", groupId)
-          .executeTakeFirst();
-
-        let mergedToolCallInfo = input.toolCallInfo;
-        if (current?.tool_call_info_json) {
-          const existing = JSON.parse(current.tool_call_info_json) as AggregatedToolCallInfo;
-          mergedToolCallInfo = this.mergeToolCallInfo(existing, input.toolCallInfo, input.occurrence);
-        }
-
+      // Skip it on the first-seen path: the INSERT already set unique_sessions=1
+      // and this call's occurrence is the only one, so the recompute is a no-op
+      // there. A concurrent same-signature call conflicts (isNewGroup=false) and
+      // runs its own recompute, which observes every committed occurrence.
+      if (!isNewGroup) {
         await db
           .updateTable("failure_groups")
           .set({
-            tool_call_info_json: mergedToolCallInfo ? JSON.stringify(mergedToolCallInfo) : null,
-            updated_at: new Date().toISOString(),
+            unique_sessions: sql<number>`(
+              SELECT COUNT(DISTINCT session_id)
+              FROM failure_occurrences
+              WHERE group_id = ${groupId}
+            )`,
           })
           .where("id", "=", groupId)
           .execute();
+      }
+
+      // Preserve tool-call-info aggregation. On the first-seen path the upsert
+      // already stored this occurrence's info; on the conflict path we fold the
+      // new contribution into the existing aggregate. The merge is an inherent
+      // read-modify-write (JSON merged in JS), so wrap it in a transaction: the
+      // single-connection dialect reserves the connection for the transaction
+      // owner (bunSqliteDialect.ts #reserveTransaction), serializing concurrent
+      // tool_failure merges so none clobber another's contribution. (The full
+      // recordFailure transaction is tracked separately in #2791.)
+      if (input.type === "tool_failure" && !isNewGroup) {
+        await db.transaction().execute(async trx => {
+          const current = await trx
+            .selectFrom("failure_groups")
+            .select("tool_call_info_json")
+            .where("id", "=", groupId)
+            .executeTakeFirst();
+
+          let mergedToolCallInfo = input.toolCallInfo;
+          if (current?.tool_call_info_json) {
+            const existing = JSON.parse(current.tool_call_info_json) as AggregatedToolCallInfo;
+            mergedToolCallInfo = this.mergeToolCallInfo(existing, input.toolCallInfo, input.occurrence);
+          }
+
+          await trx
+            .updateTable("failure_groups")
+            .set({
+              tool_call_info_json: mergedToolCallInfo ? JSON.stringify(mergedToolCallInfo) : null,
+              updated_at: new Date().toISOString(),
+            })
+            .where("id", "=", groupId)
+            .execute();
+        });
       }
 
       // Insert screens visited

--- a/src/db/migrations/2026_07_01_000_failure_groups_signature_unique.ts
+++ b/src/db/migrations/2026_07_01_000_failure_groups_signature_unique.ts
@@ -1,0 +1,146 @@
+import { Kysely, sql } from "kysely";
+
+/**
+ * #2789 — make `failure_groups.signature` uniquely indexed and back-fill any
+ * duplicate-signature rows that the original non-unique index allowed to
+ * accumulate (the racy get-or-create in `recordFailure` could INSERT two groups
+ * for one signature).
+ *
+ * ORDERING IS LOAD-BEARING. The migration connection runs with
+ * `PRAGMA foreign_keys = ON` (`configureSqliteDatabase`, src/db/database.ts) and
+ * these SQLite migrations are NOT wrapped in a DDL transaction by the migrator
+ * (`SqliteAdapter.supportsTransactionalDdl === false`). `failure_occurrences`
+ * and `failure_notifications` carry a CASCADE FK on `failure_occurrences.id` /
+ * a plain `group_id`. So we MUST repoint children onto the keeper BEFORE
+ * deleting loser groups — delete-first would CASCADE-wipe the occurrences we
+ * mean to keep. We wrap the whole de-dup + index swap in ONE transaction so a
+ * mid-way `CREATE UNIQUE INDEX` failure cannot leave losers already deleted.
+ *
+ * Keeper selection is a total order — `ORDER BY first_occurrence ASC, id ASC` —
+ * so a same-millisecond burst (two groups tied on `first_occurrence`, the exact
+ * scenario this bug produces) still collapses deterministically to one row and
+ * `CREATE UNIQUE INDEX` cannot throw on a residual duplicate.
+ *
+ * Idempotent / safe on an empty DB so it survives #2785's destructive-recovery
+ * replay (`resetDatabaseState` drops every table and re-runs all migrations):
+ * with no duplicates the de-dup statements are no-ops and the index create uses
+ * `IF NOT EXISTS`.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.transaction().execute(async trx => {
+    // 1. Repoint occurrences from loser groups onto their signature's keeper —
+    //    BEFORE any delete, so CASCADE cannot wipe them. A "loser" is any group
+    //    that is not the keeper (earliest first_occurrence, min id tiebreak)
+    //    for its signature.
+    await sql`
+      UPDATE failure_occurrences
+      SET group_id = (
+        SELECT k.id FROM failure_groups k
+        WHERE k.signature = (
+          SELECT g.signature FROM failure_groups g WHERE g.id = failure_occurrences.group_id
+        )
+        ORDER BY k.first_occurrence ASC, k.id ASC
+        LIMIT 1
+      )
+      WHERE group_id IN (
+        SELECT g.id FROM failure_groups g
+        WHERE g.id <> (
+          SELECT k.id FROM failure_groups k
+          WHERE k.signature = g.signature
+          ORDER BY k.first_occurrence ASC, k.id ASC
+          LIMIT 1
+        )
+      )
+    `.execute(trx);
+
+    // 2. Repoint notifications the same way. `failure_notifications.group_id` is
+    //    NOT a foreign key, so nothing cascades and nothing stops us — forget
+    //    this and notifications silently strand on a deleted group id.
+    await sql`
+      UPDATE failure_notifications
+      SET group_id = (
+        SELECT k.id FROM failure_groups k
+        WHERE k.signature = (
+          SELECT g.signature FROM failure_groups g WHERE g.id = failure_notifications.group_id
+        )
+        ORDER BY k.first_occurrence ASC, k.id ASC
+        LIMIT 1
+      )
+      WHERE group_id IN (
+        SELECT g.id FROM failure_groups g
+        WHERE g.id <> (
+          SELECT k.id FROM failure_groups k
+          WHERE k.signature = g.signature
+          ORDER BY k.first_occurrence ASC, k.id ASC
+          LIMIT 1
+        )
+      )
+    `.execute(trx);
+
+    // 3. Back-fill the keeper's aggregates (only for signatures that actually
+    //    had duplicates). total_count is the SUM of the historical counts so we
+    //    do not lose increments that predate retention pruning; unique_sessions
+    //    is DERIVED from the now-repointed occurrences via COUNT(DISTINCT), the
+    //    same definition recordFailure uses post-fix (summing would double-count
+    //    a session present in two duplicate groups).
+    await sql`
+      UPDATE failure_groups
+      SET
+        total_count = (
+          SELECT COALESCE(SUM(g2.total_count), 0)
+          FROM failure_groups g2
+          WHERE g2.signature = failure_groups.signature
+        ),
+        unique_sessions = (
+          SELECT COUNT(DISTINCT o.session_id)
+          FROM failure_occurrences o
+          WHERE o.group_id = failure_groups.id
+        )
+      WHERE
+        (SELECT COUNT(*) FROM failure_groups d WHERE d.signature = failure_groups.signature) > 1
+        AND id = (
+          SELECT k.id FROM failure_groups k
+          WHERE k.signature = failure_groups.signature
+          ORDER BY k.first_occurrence ASC, k.id ASC
+          LIMIT 1
+        )
+    `.execute(trx);
+
+    // 4. Delete the losers. Children were repointed in steps 1-2, so CASCADE has
+    //    nothing left to take.
+    await sql`
+      DELETE FROM failure_groups
+      WHERE id <> (
+        SELECT k.id FROM failure_groups k
+        WHERE k.signature = failure_groups.signature
+        ORDER BY k.first_occurrence ASC, k.id ASC
+        LIMIT 1
+      )
+    `.execute(trx);
+
+    // 5. Swap the plain signature index for a UNIQUE one, and add a composite
+    //    index so the post-fix `COUNT(DISTINCT session_id)` recompute per event
+    //    does not scan every occurrence in the group.
+    await sql`DROP INDEX IF EXISTS idx_failure_groups_signature`.execute(trx);
+    await sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_failure_groups_signature
+      ON failure_groups (signature)
+    `.execute(trx);
+    await sql`
+      CREATE INDEX IF NOT EXISTS idx_failure_occurrences_group_session
+      ON failure_occurrences (group_id, session_id)
+    `.execute(trx);
+  });
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.transaction().execute(async trx => {
+    await sql`DROP INDEX IF EXISTS idx_failure_occurrences_group_session`.execute(trx);
+    await sql`DROP INDEX IF EXISTS idx_failure_groups_signature`.execute(trx);
+    // Restore the original non-unique index.
+    await sql`
+      CREATE INDEX IF NOT EXISTS idx_failure_groups_signature
+      ON failure_groups (signature)
+    `.execute(trx);
+  });
+}

--- a/src/db/migrations/2026_07_01_000_failure_groups_signature_unique.ts
+++ b/src/db/migrations/2026_07_01_000_failure_groups_signature_unique.ts
@@ -79,10 +79,21 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 
     // 3. Back-fill the keeper's aggregates (only for signatures that actually
     //    had duplicates). total_count is the SUM of the historical counts so we
-    //    do not lose increments that predate retention pruning; unique_sessions
-    //    is DERIVED from the now-repointed occurrences via COUNT(DISTINCT), the
+    //    do not lose increments that predate retention pruning; last_occurrence
+    //    is the MAX so a collapsed group is not sorted stale on the dashboard
+    //    (getFailureGroups orders by last_occurrence); unique_sessions is
+    //    DERIVED from the now-repointed occurrences via COUNT(DISTINCT), the
     //    same definition recordFailure uses post-fix (summing would double-count
     //    a session present in two duplicate groups).
+    //
+    //    Note: single-group signatures whose stored counts drifted from the
+    //    lost-increment path (issue scenario #2, which does NOT create a second
+    //    row) are intentionally left untouched. total_count deliberately
+    //    preserves increments that predate retention pruning, so a blanket
+    //    recompute of COUNT(*) from surviving occurrences would DESTROY
+    //    legitimately-retained historical counts — the two cases are
+    //    indistinguishable after the fact, so we heal only where a duplicate row
+    //    already forces a merge.
     await sql`
       UPDATE failure_groups
       SET

--- a/src/db/migrations/2026_07_01_000_failure_groups_signature_unique.ts
+++ b/src/db/migrations/2026_07_01_000_failure_groups_signature_unique.ts
@@ -91,6 +91,11 @@ export async function up(db: Kysely<unknown>): Promise<void> {
           FROM failure_groups g2
           WHERE g2.signature = failure_groups.signature
         ),
+        last_occurrence = (
+          SELECT MAX(g2.last_occurrence)
+          FROM failure_groups g2
+          WHERE g2.signature = failure_groups.signature
+        ),
         unique_sessions = (
           SELECT COUNT(DISTINCT o.session_id)
           FROM failure_occurrences o

--- a/test/db/bunSqliteDialectReturning.test.ts
+++ b/test/db/bunSqliteDialectReturning.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "./testDbHelper";
+
+/**
+ * The BunSqliteDialect hand-rolls RETURNING support: executeQuery only returns
+ * rows when the SQL starts with "select" OR includes "returning"
+ * (src/db/bunSqliteDialect.ts:165-175). #2789's atomic upsert relies on
+ * `.onConflict(...).doUpdateSet(...).returning("id")` yielding the row on BOTH
+ * the insert path and the conflict path. This asserts the conflict path returns
+ * the PRE-EXISTING id — the untested case the reviews flagged.
+ */
+describe("BunSqliteDialect RETURNING on upsert conflict path", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("insert path returns the freshly inserted id", async () => {
+    const inserted = await db
+      .insertInto("failure_groups")
+      .values({
+        id: "group-1",
+        type: "crash",
+        signature: "sig-return",
+        title: "t",
+        message: "m",
+        severity: "critical",
+        first_occurrence: 1,
+        last_occurrence: 1,
+        total_count: 1,
+        unique_sessions: 1,
+        stack_trace_json: null,
+        tool_call_info_json: null,
+        updated_at: "2026-07-01T00:00:00.000Z",
+      })
+      .onConflict(oc =>
+        oc.column("signature").doUpdateSet(eb => ({
+          last_occurrence: 2,
+          total_count: eb("failure_groups.total_count", "+", 1),
+        }))
+      )
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    expect(inserted.id).toBe("group-1");
+  });
+
+  test("conflict path returns the pre-existing group id, not the new candidate id", async () => {
+    await db
+      .insertInto("failure_groups")
+      .values({
+        id: "existing-id",
+        type: "crash",
+        signature: "sig-conflict",
+        title: "t",
+        message: "m",
+        severity: "critical",
+        first_occurrence: 1,
+        last_occurrence: 1,
+        total_count: 1,
+        unique_sessions: 1,
+        stack_trace_json: null,
+        tool_call_info_json: null,
+        updated_at: "2026-07-01T00:00:00.000Z",
+      })
+      .execute();
+
+    // Second upsert with a DIFFERENT candidate id but the same signature must
+    // conflict and return the ORIGINAL id.
+    const upserted = await db
+      .insertInto("failure_groups")
+      .values({
+        id: "candidate-id",
+        type: "crash",
+        signature: "sig-conflict",
+        title: "t2",
+        message: "m2",
+        severity: "high",
+        first_occurrence: 5,
+        last_occurrence: 5,
+        total_count: 1,
+        unique_sessions: 1,
+        stack_trace_json: null,
+        tool_call_info_json: null,
+        updated_at: "2026-07-01T00:00:05.000Z",
+      })
+      .onConflict(oc =>
+        oc.column("signature").doUpdateSet(eb => ({
+          last_occurrence: 5,
+          total_count: eb("failure_groups.total_count", "+", 1),
+        }))
+      )
+      .returning("id")
+      .executeTakeFirstOrThrow();
+
+    expect(upserted.id).toBe("existing-id");
+
+    const groups = await db.selectFrom("failure_groups").selectAll().execute();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe("existing-id");
+    expect(groups[0].total_count).toBe(2);
+    expect(groups[0].last_occurrence).toBe(5);
+  });
+});

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -465,37 +465,33 @@ describe("FailureAnalyticsRepository", () => {
       }
     });
 
-    test("preserves tool-call-info merge across concurrent tool_failure occurrences", async () => {
+    function toolFailureInput(i: number): RecordFailureInput {
+      return makeFailureInput({
+        type: "tool_failure",
+        signature: "tapOn::element_not_found",
+        toolCallInfo: {
+          toolName: "tapOn",
+          errorCodes: { ELEMENT_NOT_FOUND: 1 },
+          parameterVariants: { selector: [`btn-${i}`] },
+          durationStats: { minMs: 10, maxMs: 10, avgMs: 10, medianMs: 10, p95Ms: 10 },
+        },
+        occurrence: {
+          deviceModel: "Pixel 7",
+          os: "Android 14",
+          appVersion: "1.0.0",
+          sessionId: `session-${i}`,
+          errorCode: "ELEMENT_NOT_FOUND",
+        },
+      });
+    }
+
+    // N == 10 keeps every distinct selector inside mergeToolCallInfo's 10-variant
+    // cap, so a lossless merge yields exactly 10 selectors and an error count of 10.
+    test("merges tool-call-info losslessly across SERIAL tool_failure occurrences", async () => {
       const N = 10;
-      await Promise.all(
-        Array.from({ length: N }, (_unused, i) =>
-          repo.recordFailure(
-            makeFailureInput({
-              type: "tool_failure",
-              signature: "tapOn::element_not_found",
-              toolCallInfo: {
-                toolName: "tapOn",
-                errorCodes: { ELEMENT_NOT_FOUND: 1 },
-                parameterVariants: { selector: [`btn-${i}`] },
-                durationStats: {
-                  minMs: 10,
-                  maxMs: 10,
-                  avgMs: 10,
-                  medianMs: 10,
-                  p95Ms: 10,
-                },
-              },
-              occurrence: {
-                deviceModel: "Pixel 7",
-                os: "Android 14",
-                appVersion: "1.0.0",
-                sessionId: `session-${i}`,
-                errorCode: "ELEMENT_NOT_FOUND",
-              },
-            })
-          )
-        )
-      );
+      for (let i = 0; i < N; i++) {
+        await repo.recordFailure(toolFailureInput(i));
+      }
 
       const groups = await db.selectFrom("failure_groups").selectAll().execute();
       expect(groups).toHaveLength(1);
@@ -503,11 +499,26 @@ describe("FailureAnalyticsRepository", () => {
 
       const toolInfo = JSON.parse(groups[0].tool_call_info_json ?? "{}");
       expect(toolInfo.toolName).toBe("tapOn");
-      // Every occurrence contributed an ELEMENT_NOT_FOUND error code.
-      expect(toolInfo.errorCodes.ELEMENT_NOT_FOUND).toBeGreaterThanOrEqual(1);
-      // Parameter variants accumulate distinct selectors (capped at 10).
-      expect(Array.isArray(toolInfo.parameterVariants.selector)).toBe(true);
-      expect(toolInfo.parameterVariants.selector.length).toBeGreaterThan(0);
+      expect(toolInfo.errorCodes.ELEMENT_NOT_FOUND).toBe(N);
+      expect(new Set(toolInfo.parameterVariants.selector).size).toBe(N);
+    });
+
+    // The merge is a read-modify-write; the transaction in recordFailure must
+    // serialize concurrent merges so none clobber another's contribution. A
+    // lossy RMW here would drop selectors/error counts below N.
+    test("merges tool-call-info losslessly across CONCURRENT tool_failure occurrences", async () => {
+      const N = 10;
+      await Promise.all(Array.from({ length: N }, (_unused, i) => repo.recordFailure(toolFailureInput(i))));
+
+      const groups = await db.selectFrom("failure_groups").selectAll().execute();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].total_count).toBe(N);
+
+      const toolInfo = JSON.parse(groups[0].tool_call_info_json ?? "{}");
+      expect(toolInfo.toolName).toBe("tapOn");
+      // Lossless: every occurrence's ELEMENT_NOT_FOUND and distinct selector survived.
+      expect(toolInfo.errorCodes.ELEMENT_NOT_FOUND).toBe(N);
+      expect(new Set(toolInfo.parameterVariants.selector).size).toBe(N);
     });
   });
 });

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -364,4 +364,150 @@ describe("FailureAnalyticsRepository", () => {
       expect(ackedOnly.notifications[0].acknowledged).toBe(true);
     });
   });
+
+  // Regression coverage for #2789: recordFailure() must be an atomic upsert so a
+  // burst of same-signature failures collapses to a single group with a correct
+  // total_count and a derived unique_sessions. These run against the real
+  // in-memory bun:sqlite from createTestDatabase(), where the single-connection
+  // mutex genuinely releases across awaits — so the get-or-create version of
+  // recordFailure() FAILS these (duplicate groups + lost increments) and the
+  // atomic upsert passes. Deterministic (no sleeps), < 100ms.
+  describe("recordFailure concurrency (#2789)", () => {
+    test("N concurrent calls for one signature yield exactly one group with total_count === N", async () => {
+      const N = 20;
+      await Promise.all(
+        Array.from({ length: N }, (_unused, i) =>
+          repo.recordFailure(
+            makeFailureInput({
+              occurrence: {
+                deviceModel: "Pixel 7",
+                os: "Android 14",
+                appVersion: "1.0.0",
+                sessionId: `session-${i}`,
+              },
+            })
+          )
+        )
+      );
+
+      const groups = await db.selectFrom("failure_groups").selectAll().execute();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].total_count).toBe(N);
+
+      const occurrences = await db.selectFrom("failure_occurrences").selectAll().execute();
+      expect(occurrences).toHaveLength(N);
+    });
+
+    test("N concurrent calls spanning M distinct sessions yield unique_sessions === M (derived, not incremented)", async () => {
+      const N = 24;
+      const M = 6;
+      await Promise.all(
+        Array.from({ length: N }, (_unused, i) =>
+          repo.recordFailure(
+            makeFailureInput({
+              occurrence: {
+                deviceModel: "Pixel 7",
+                os: "Android 14",
+                appVersion: "1.0.0",
+                sessionId: `session-${i % M}`,
+              },
+            })
+          )
+        )
+      );
+
+      const groups = await db.selectFrom("failure_groups").selectAll().execute();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].total_count).toBe(N);
+      expect(groups[0].unique_sessions).toBe(M);
+
+      // Assert it is genuinely derived from committed occurrences, not an
+      // increment on a stale read.
+      const distinct = await db
+        .selectFrom("failure_occurrences")
+        .select("session_id")
+        .where("group_id", "=", groups[0].id)
+        .distinct()
+        .execute();
+      expect(distinct).toHaveLength(M);
+    });
+
+    test("concurrent same-signature bursts across distinct signatures keep each group isolated", async () => {
+      const perSignature = 8;
+      const signatures = ["sig-a", "sig-b", "sig-c"];
+      await Promise.all(
+        signatures.flatMap(sig =>
+          Array.from({ length: perSignature }, (_unused, i) =>
+            repo.recordFailure(
+              makeFailureInput({
+                signature: sig,
+                occurrence: {
+                  deviceModel: "Pixel 7",
+                  os: "Android 14",
+                  appVersion: "1.0.0",
+                  sessionId: `session-${i}`,
+                },
+              })
+            )
+          )
+        )
+      );
+
+      const groups = await db
+        .selectFrom("failure_groups")
+        .selectAll()
+        .orderBy("signature", "asc")
+        .execute();
+      expect(groups).toHaveLength(signatures.length);
+      for (const group of groups) {
+        expect(group.total_count).toBe(perSignature);
+        expect(group.unique_sessions).toBe(perSignature);
+      }
+    });
+
+    test("preserves tool-call-info merge across concurrent tool_failure occurrences", async () => {
+      const N = 10;
+      await Promise.all(
+        Array.from({ length: N }, (_unused, i) =>
+          repo.recordFailure(
+            makeFailureInput({
+              type: "tool_failure",
+              signature: "tapOn::element_not_found",
+              toolCallInfo: {
+                toolName: "tapOn",
+                errorCodes: { ELEMENT_NOT_FOUND: 1 },
+                parameterVariants: { selector: [`btn-${i}`] },
+                durationStats: {
+                  minMs: 10,
+                  maxMs: 10,
+                  avgMs: 10,
+                  medianMs: 10,
+                  p95Ms: 10,
+                },
+              },
+              occurrence: {
+                deviceModel: "Pixel 7",
+                os: "Android 14",
+                appVersion: "1.0.0",
+                sessionId: `session-${i}`,
+                errorCode: "ELEMENT_NOT_FOUND",
+              },
+            })
+          )
+        )
+      );
+
+      const groups = await db.selectFrom("failure_groups").selectAll().execute();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].total_count).toBe(N);
+
+      const toolInfo = JSON.parse(groups[0].tool_call_info_json ?? "{}");
+      expect(toolInfo.toolName).toBe("tapOn");
+      // Every occurrence contributed an ELEMENT_NOT_FOUND error code.
+      expect(toolInfo.errorCodes.ELEMENT_NOT_FOUND).toBeGreaterThanOrEqual(1);
+      // Parameter variants accumulate distinct selectors (capped at 10).
+      expect(Array.isArray(toolInfo.parameterVariants.selector)).toBe(true);
+      expect(toolInfo.parameterVariants.selector.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/test/db/failureGroupsSignatureUniqueMigration.test.ts
+++ b/test/db/failureGroupsSignatureUniqueMigration.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import type { Database } from "../../src/db/types";
+import { up as failuresUp } from "../../src/db/migrations/2026_01_27_000_failures";
+import {
+  up as uniqueUp,
+  down as uniqueDown,
+} from "../../src/db/migrations/2026_07_01_000_failure_groups_signature_unique";
+
+/**
+ * Migration coverage for #2789. Builds the failures schema WITH the original
+ * non-unique signature index (so duplicate-signature rows can be seeded), then
+ * runs the de-dup + UNIQUE-index migration and asserts the invariants the issue
+ * calls out: FK-safe repoint-before-delete, notification orphan avoidance,
+ * deterministic keeper tiebreak, count backfill, idempotency, and enforcement.
+ *
+ * foreign_keys is ON to match the production connection so the cascade-ordering
+ * hazard is real: a delete-first migration would cascade-wipe the occurrences.
+ */
+describe("2026_07_01_000_failure_groups_signature_unique migration", () => {
+  let bunDb: BunDatabase;
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    bunDb = new BunDatabase(":memory:");
+    bunDb.exec("PRAGMA foreign_keys = ON;");
+    db = new Kysely<Database>({
+      dialect: new BunSqliteDialect({ database: bunDb }),
+    });
+    // Base failures schema: non-unique idx_failure_groups_signature.
+    await failuresUp(db as unknown as Kysely<unknown>);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function seedGroup(overrides: {
+    id: string;
+    signature: string;
+    firstOccurrence: number;
+    totalCount: number;
+    uniqueSessions: number;
+    type?: string;
+  }): Promise<void> {
+    await db
+      .insertInto("failure_groups")
+      .values({
+        id: overrides.id,
+        type: overrides.type ?? "crash",
+        signature: overrides.signature,
+        title: "t",
+        message: "m",
+        severity: "critical",
+        first_occurrence: overrides.firstOccurrence,
+        last_occurrence: overrides.firstOccurrence,
+        total_count: overrides.totalCount,
+        unique_sessions: overrides.uniqueSessions,
+        stack_trace_json: null,
+        tool_call_info_json: null,
+        updated_at: "2026-07-01T00:00:00.000Z",
+      })
+      .execute();
+  }
+
+  async function seedOccurrence(id: string, groupId: string, sessionId: string): Promise<void> {
+    await db
+      .insertInto("failure_occurrences")
+      .values({
+        id,
+        group_id: groupId,
+        timestamp: 1000,
+        device_id: null,
+        device_model: "Pixel 7",
+        os: "Android 14",
+        app_version: "1.0.0",
+        session_id: sessionId,
+        screen_at_failure: null,
+        test_name: null,
+        test_execution_id: null,
+        error_code: null,
+        duration_ms: null,
+        tool_args_json: null,
+      })
+      .execute();
+  }
+
+  async function seedNotification(occurrenceId: string, groupId: string): Promise<void> {
+    await db
+      .insertInto("failure_notifications")
+      .values({
+        occurrence_id: occurrenceId,
+        group_id: groupId,
+        type: "crash",
+        severity: "critical",
+        title: "t",
+        timestamp: 1000,
+        acknowledged: 0,
+      })
+      .execute();
+  }
+
+  test("collapses duplicate-signature groups into the earliest keeper and repoints occurrences (FK-safe)", async () => {
+    // Keeper A (earlier first_occurrence) and loser B share a signature.
+    await seedGroup({ id: "A", signature: "sig-x", firstOccurrence: 100, totalCount: 3, uniqueSessions: 2 });
+    await seedGroup({ id: "B", signature: "sig-x", firstOccurrence: 200, totalCount: 2, uniqueSessions: 2 });
+    // A has sessions s1, s2; B has sessions s2, s3.
+    await seedOccurrence("occ-a1", "A", "s1");
+    await seedOccurrence("occ-a2", "A", "s2");
+    await seedOccurrence("occ-b1", "B", "s2");
+    await seedOccurrence("occ-b2", "B", "s3");
+    await seedNotification("occ-a1", "A");
+    await seedNotification("occ-b1", "B");
+
+    await uniqueUp(db as unknown as Kysely<unknown>);
+
+    const groups = await db.selectFrom("failure_groups").selectAll().execute();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe("A");
+    // total_count is the SUM of the duplicate groups' historical counts.
+    expect(groups[0].total_count).toBe(5);
+    // unique_sessions is DERIVED from the surviving occurrences: {s1, s2, s3}.
+    expect(groups[0].unique_sessions).toBe(3);
+
+    // Every occurrence survived (delete-first would have cascade-wiped B's) and
+    // now points at the keeper.
+    const occurrences = await db.selectFrom("failure_occurrences").selectAll().execute();
+    expect(occurrences).toHaveLength(4);
+    expect(occurrences.every(o => o.group_id === "A")).toBe(true);
+  });
+
+  test("repoints failure_notifications so zero rows reference a non-existent group", async () => {
+    await seedGroup({ id: "A", signature: "sig-x", firstOccurrence: 100, totalCount: 1, uniqueSessions: 1 });
+    await seedGroup({ id: "B", signature: "sig-x", firstOccurrence: 200, totalCount: 1, uniqueSessions: 1 });
+    await seedOccurrence("occ-a1", "A", "s1");
+    await seedOccurrence("occ-b1", "B", "s2");
+    await seedNotification("occ-a1", "A");
+    await seedNotification("occ-b1", "B");
+
+    await uniqueUp(db as unknown as Kysely<unknown>);
+
+    const notifications = await db.selectFrom("failure_notifications").selectAll().execute();
+    expect(notifications).toHaveLength(2);
+    // No notification may reference a deleted group id.
+    const liveGroupIds = new Set(
+      (await db.selectFrom("failure_groups").select("id").execute()).map(g => g.id)
+    );
+    for (const n of notifications) {
+      expect(liveGroupIds.has(n.group_id)).toBe(true);
+    }
+  });
+
+  test("uses a deterministic keeper tiebreak (min id) when first_occurrence ties", async () => {
+    // Same first_occurrence — keeper must be the min id ("aaa").
+    await seedGroup({ id: "bbb", signature: "sig-tie", firstOccurrence: 500, totalCount: 1, uniqueSessions: 1 });
+    await seedGroup({ id: "aaa", signature: "sig-tie", firstOccurrence: 500, totalCount: 1, uniqueSessions: 1 });
+    await seedOccurrence("occ-1", "aaa", "s1");
+    await seedOccurrence("occ-2", "bbb", "s1");
+
+    await uniqueUp(db as unknown as Kysely<unknown>);
+
+    const groups = await db.selectFrom("failure_groups").selectAll().execute();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe("aaa");
+  });
+
+  test("enforces uniqueness after migration (duplicate-signature insert throws)", async () => {
+    await seedGroup({ id: "A", signature: "sig-x", firstOccurrence: 100, totalCount: 1, uniqueSessions: 1 });
+
+    await uniqueUp(db as unknown as Kysely<unknown>);
+
+    await expect(
+      seedGroup({ id: "C", signature: "sig-x", firstOccurrence: 300, totalCount: 1, uniqueSessions: 1 })
+    ).rejects.toThrow();
+  });
+
+  test("is a no-op safe on an empty database and idempotent when re-run", async () => {
+    // Empty DB (no groups): must not throw and must create the unique index.
+    await uniqueUp(db as unknown as Kysely<unknown>);
+    // Re-running (as #2785's destructive-recovery replay would) must not throw.
+    await uniqueUp(db as unknown as Kysely<unknown>);
+
+    // Unique index is present and enforcing.
+    await seedGroup({ id: "A", signature: "sig-only", firstOccurrence: 1, totalCount: 1, uniqueSessions: 1 });
+    await expect(
+      seedGroup({ id: "B", signature: "sig-only", firstOccurrence: 2, totalCount: 1, uniqueSessions: 1 })
+    ).rejects.toThrow();
+  });
+
+  test("down() restores the non-unique index so duplicate signatures are allowed again", async () => {
+    await seedGroup({ id: "A", signature: "sig-x", firstOccurrence: 100, totalCount: 1, uniqueSessions: 1 });
+    await uniqueUp(db as unknown as Kysely<unknown>);
+    await uniqueDown(db as unknown as Kysely<unknown>);
+
+    // After down, a duplicate signature must be insertable again.
+    await seedGroup({ id: "B", signature: "sig-x", firstOccurrence: 200, totalCount: 1, uniqueSessions: 1 });
+    const groups = await db.selectFrom("failure_groups").selectAll().execute();
+    expect(groups).toHaveLength(2);
+  });
+});

--- a/test/db/failureGroupsSignatureUniqueMigration.test.ts
+++ b/test/db/failureGroupsSignatureUniqueMigration.test.ts
@@ -43,6 +43,7 @@ describe("2026_07_01_000_failure_groups_signature_unique migration", () => {
     firstOccurrence: number;
     totalCount: number;
     uniqueSessions: number;
+    lastOccurrence?: number;
     type?: string;
   }): Promise<void> {
     await db
@@ -55,7 +56,7 @@ describe("2026_07_01_000_failure_groups_signature_unique migration", () => {
         message: "m",
         severity: "critical",
         first_occurrence: overrides.firstOccurrence,
-        last_occurrence: overrides.firstOccurrence,
+        last_occurrence: overrides.lastOccurrence ?? overrides.firstOccurrence,
         total_count: overrides.totalCount,
         unique_sessions: overrides.uniqueSessions,
         stack_trace_json: null,
@@ -103,9 +104,25 @@ describe("2026_07_01_000_failure_groups_signature_unique migration", () => {
   }
 
   test("collapses duplicate-signature groups into the earliest keeper and repoints occurrences (FK-safe)", async () => {
-    // Keeper A (earlier first_occurrence) and loser B share a signature.
-    await seedGroup({ id: "A", signature: "sig-x", firstOccurrence: 100, totalCount: 3, uniqueSessions: 2 });
-    await seedGroup({ id: "B", signature: "sig-x", firstOccurrence: 200, totalCount: 2, uniqueSessions: 2 });
+    // Keeper A (earlier first_occurrence) and loser B share a signature. B has a
+    // MORE RECENT last_occurrence, which the keeper must inherit so the dashboard
+    // (ordered by last_occurrence) does not sort the collapsed group as stale.
+    await seedGroup({
+      id: "A",
+      signature: "sig-x",
+      firstOccurrence: 100,
+      lastOccurrence: 150,
+      totalCount: 3,
+      uniqueSessions: 2,
+    });
+    await seedGroup({
+      id: "B",
+      signature: "sig-x",
+      firstOccurrence: 200,
+      lastOccurrence: 900,
+      totalCount: 2,
+      uniqueSessions: 2,
+    });
     // A has sessions s1, s2; B has sessions s2, s3.
     await seedOccurrence("occ-a1", "A", "s1");
     await seedOccurrence("occ-a2", "A", "s2");
@@ -121,6 +138,8 @@ describe("2026_07_01_000_failure_groups_signature_unique migration", () => {
     expect(groups[0].id).toBe("A");
     // total_count is the SUM of the duplicate groups' historical counts.
     expect(groups[0].total_count).toBe(5);
+    // last_occurrence is the MAX across duplicates (B's 900), not the keeper's own.
+    expect(groups[0].last_occurrence).toBe(900);
     // unique_sessions is DERIVED from the surviving occurrences: {s1, s2, s3}.
     expect(groups[0].unique_sessions).toBe(3);
 

--- a/test/db/testDbHelper.ts
+++ b/test/db/testDbHelper.ts
@@ -4,10 +4,27 @@ import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import type { Database } from "../../src/db/types";
 import { runMigrations } from "../../src/db/migrator";
 
-export async function createTestDatabase(): Promise<Kysely<Database>> {
+export interface TestDatabaseOptions {
+  /**
+   * Enable `PRAGMA foreign_keys = ON` so cascade deletes fire, matching the
+   * production connection (`configureSqliteDatabase` in `src/db/database.ts`).
+   * The default is OFF because that is bun:sqlite's default; opt in when a test
+   * must exercise FK cascade behavior (e.g. the failure_groups de-dup migration,
+   * where delete-before-repoint would cascade-wipe occurrences).
+   */
+  foreignKeys?: boolean;
+}
+
+export async function createTestDatabase(
+  options: TestDatabaseOptions = {}
+): Promise<Kysely<Database>> {
+  const bunDb = new BunDatabase(":memory:");
+  if (options.foreignKeys) {
+    bunDb.exec("PRAGMA foreign_keys = ON;");
+  }
   const db = new Kysely<Database>({
     dialect: new BunSqliteDialect({
-      database: new BunDatabase(":memory:"),
+      database: bunDb,
     }),
   });
   await runMigrations(db as Kysely<unknown>);


### PR DESCRIPTION
## What

Makes `FailureAnalyticsRepository.recordFailure()` an **atomic upsert** and adds a **UNIQUE index** on `failure_groups.signature`, with a de-dup backfill migration for any duplicate-signature rows the old non-unique index let accumulate.

Closes #2789.

## Why

The daemon runs a single `bun:sqlite` connection behind an async mutex that **releases across every `await`** (`src/db/bunSqliteDialect.ts`). `recordFailure()` did a non-atomic get-or-create — `SELECT` the group, then `INSERT` a fresh-UUID group **or** `UPDATE total_count + 1` — keyed on a **non-unique** `signature` index. Two same-signature failures whose `await` windows overlap (crash-loop burst, ANR storm, simultaneous multi-device runs) either:

1. **Duplicate groups** — both read "no group", both `INSERT`; the non-unique index accepts both, fragmenting one signature across multiple dashboard cards.
2. **Lost increment** — both read `total_count = N`, both write `N + 1`; the second clobbers the first.

Occurrence rows were never lost (per-call UUID), but the aggregated group counts drift and duplicates accumulate — exactly when failure analytics matter most.

## How

**1. Migration `src/db/migrations/2026_07_01_000_failure_groups_signature_unique.ts`** — one `db.transaction()`:
- De-dupes duplicate-signature groups, keeping the deterministic keeper `ORDER BY first_occurrence ASC, id ASC` (min-id tiebreak survives a same-ms `first_occurrence` tie).
- **Repoints `failure_occurrences.group_id` and `failure_notifications.group_id` onto the keeper BEFORE deleting losers.** The migration connection runs `PRAGMA foreign_keys = ON` and these migrations are not wrapped in a DDL transaction, so `failure_occurrences`'s CASCADE FK would wipe the occurrences if losers were deleted first. `failure_notifications.group_id` is **not** an FK, so it is repointed explicitly to avoid silently stranded orphans.
- Back-fills the keeper: `total_count = SUM` (preserves historical increments past retention), `last_occurrence = MAX`, `unique_sessions = COUNT(DISTINCT session_id)` over the repointed occurrences.
- Drops the plain `idx_failure_groups_signature`, recreates it `UNIQUE IF NOT EXISTS`, and adds a composite `idx_failure_occurrences_group_session` so the per-event `COUNT(DISTINCT)` recompute does not scan the whole group.
- Idempotent / empty-DB safe so it survives #2785's destructive-recovery replay.

**2. `recordFailure()` atomic upsert** — `INSERT ... ON CONFLICT(signature) DO UPDATE SET total_count = total_count + 1 ... RETURNING id`:
- The count bump is now a single statement. `RETURNING id` yields the pre-existing id on the conflict path (so the id resolves atomically — no separate SELECT that could race fire-and-forget retention cleanup).
- `unique_sessions` is **derived** via a single-statement `COUNT(DISTINCT session_id)` after the occurrence insert (idempotent under interleave), not incremented on a stale read.
- Tool-call-info merge is preserved via a follow-up update on the conflict path.

**Test helper:** `createTestDatabase` gains an opt-in `foreignKeys` flag so the FK-cascade ordering hazard is exercised for real (production enables `foreign_keys = ON`; the test helper previously did not).

## Testing

- `test/db/failureAnalyticsRepository.test.ts` — new concurrency block: N concurrent `recordFailure` for one signature → exactly one group, `total_count === N`; M distinct sessions → `unique_sessions === M` (asserted **derived**); distinct-signature isolation; tool-call-info merge under concurrency. These **fail on `main`** (24 groups instead of 1) and pass here — a true red→green regression against the real in-memory `bun:sqlite`.
- `test/db/failureGroupsSignatureUniqueMigration.test.ts` — FK-safe repoint-before-delete (occurrences survive), notification orphan check (zero dangling `group_id`), deterministic tiebreak, count/`last_occurrence` backfill, uniqueness enforcement, empty-DB + idempotent re-run, `down()`.
- `test/db/bunSqliteDialectReturning.test.ts` — the hand-rolled dialect's `.onConflict(...).returning("id")` returns the **pre-existing** id on the conflict path.
- Full suite: **5734 pass, 0 fail** (`bun test`). `turbo run lint build` clean. Each unit test < 100ms, deterministic (no sleeps).

## Reviewed

`/auto-mobile-code-review` on the branch diff: one finding addressed — the keeper now inherits `MAX(last_occurrence)` so a collapsed group is not sorted stale on the dashboard. The tool-call-info merge retains a bounded read-modify-write on the conflict path (best-effort aggregation; the count-critical path is atomic) — noted as acceptable by design.


## Known limitations (tracked separately)

- **Multi-statement body is not yet wrapped in a single transaction (#2877).** `recordFailure` still issues its statements (upsert → occurrence insert → `unique_sessions` recompute → optional tool-info merge → screens/capture/notification) without an outer transaction — same as before this PR. The count bump now lands deterministically *before* the occurrence insert, so if the occurrence insert throws, the group `total_count` is incremented ahead of a missing occurrence row. Closing that window is tracked in #2877 (wrap the whole method); this PR intentionally does not, to keep the {#2790, #2789} DB-audit concurrency cluster sequencing clean. The tool-info merge here is already transactional as a targeted fix for its read-modify-write.


