### PR TITLE
Add Codex discovery for AutoMobile review skill

### DIFF
--- a/.agents/skills/auto-mobile-code-review/SKILL.md
+++ b/.agents/skills/auto-mobile-code-review/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: auto-mobile-code-review
+description: "Use this workflow skill to review an AutoMobile change (a PR number or the current branch diff) the way this repo demands: ground every finding in file:line, reproduce before asserting, separate real bugs from daemon-session/environment artifacts, prefer reusing existing repo helpers and conventions over new code, and catch the regression or false-negative a fix can introduce."
+---
+
+# AutoMobile Code Review
+
+Read and follow the canonical AutoMobile code review skill at
+`../../../skills/auto-mobile-code-review/SKILL.md`.
+
+Treat that file as the source of truth for the workflow. This wrapper only
+exposes the shared repo skill through Codex's `.agents/skills` discovery path.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -552,7 +552,7 @@ jobs:
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \
-            --only yaml,xml,shellcheck,mkdocs-nav,ktfmt,claude-plugin \
+            --only yaml,xml,shellcheck,mkdocs-nav,ktfmt,claude-plugin,codex-skills \
             --max-parallel 4
 
       - name: "Run BATS Tests (Ubuntu)"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -199,7 +199,7 @@ See individual script directories for specialized validation:
 - `xml/` - XML validation and formatting
 
 Root-level validation scripts:
-- `validate_codex_skills.sh` - Validate `skills/*/SKILL.md` metadata and `AGENTS.md` inventory consistency
+- `validate_codex_skills.sh` - Validate `skills/*/SKILL.md` metadata, optional `agents/openai.yaml` metadata, `.agents/skills` Codex discovery wrappers, and `AGENTS.md` inventory consistency
 - `validate_dependabot.sh` - Validate Dependabot config YAML
 - `validate_mkdocs_nav.sh` - Validate MkDocs nav configuration
 

--- a/scripts/validate_codex_skills.sh
+++ b/scripts/validate_codex_skills.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 SKILLS_DIR="${PROJECT_ROOT}/skills"
+AGENTS_SKILLS_DIR="${PROJECT_ROOT}/.agents/skills"
 AGENTS_FILE="${PROJECT_ROOT}/AGENTS.md"
 
 if [[ ! -d "${SKILLS_DIR}" ]]; then
@@ -25,6 +26,11 @@ trim() {
   printf '%s' "$value"
 }
 
+is_quoted() {
+  local value="$1"
+  [[ "$value" == \"*\" || "$value" == \'*\' ]]
+}
+
 skill_files=()
 while IFS= read -r file; do
   skill_files+=("$file")
@@ -39,6 +45,7 @@ echo "Validating ${#skill_files[@]} Codex skill file(s)..."
 
 skill_paths=()
 skill_names=()
+skills_with_openai_metadata=()
 
 for file in "${skill_files[@]}"; do
   rel_path="${file#"${PROJECT_ROOT}/"}"
@@ -74,6 +81,11 @@ for file in "${skill_files[@]}"; do
     errors=1
   fi
 
+  if [[ "$description_line" == *": "* ]] && ! is_quoted "$description_line"; then
+    echo "[ERROR] ${rel_path}: frontmatter description containing ': ' must be quoted" >&2
+    errors=1
+  fi
+
   if [[ -n "$skill_name" && "$skill_name" != "$dir_name" ]]; then
     echo "[ERROR] ${rel_path}: frontmatter name '${skill_name}' does not match directory '${dir_name}'" >&2
     errors=1
@@ -87,6 +99,134 @@ for file in "${skill_files[@]}"; do
   skill_paths+=("$rel_path")
   if [[ -n "$skill_name" ]]; then
     skill_names+=("$skill_name")
+  fi
+
+  openai_yaml="$(dirname "$file")/agents/openai.yaml"
+  if [[ -f "$openai_yaml" ]]; then
+    openai_rel_path="${openai_yaml#"${PROJECT_ROOT}/"}"
+    display_name="$(sed -n 's/^[[:space:]]*display_name:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
+    short_description="$(sed -n 's/^[[:space:]]*short_description:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
+    default_prompt="$(sed -n 's/^[[:space:]]*default_prompt:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
+
+    if ! grep -Eq '^interface:[[:space:]]*$' "$openai_yaml"; then
+      echo "[ERROR] ${openai_rel_path}: missing top-level interface block" >&2
+      errors=1
+    fi
+
+    if [[ -z "$display_name" ]]; then
+      echo "[ERROR] ${openai_rel_path}: missing quoted interface.display_name" >&2
+      errors=1
+    fi
+
+    if [[ -z "$short_description" ]]; then
+      echo "[ERROR] ${openai_rel_path}: missing quoted interface.short_description" >&2
+      errors=1
+    fi
+
+    if [[ -z "$default_prompt" ]]; then
+      echo "[ERROR] ${openai_rel_path}: missing quoted interface.default_prompt" >&2
+      errors=1
+    elif [[ "$default_prompt" != *"\$${skill_name}"* ]]; then
+      echo "[ERROR] ${openai_rel_path}: default_prompt must mention \$${skill_name}" >&2
+      errors=1
+    fi
+
+    if [[ -n "$skill_name" ]]; then
+      skills_with_openai_metadata+=("$skill_name")
+    fi
+  fi
+done
+
+if [[ -d "${AGENTS_SKILLS_DIR}" ]]; then
+  agents_skill_files=()
+  while IFS= read -r entry; do
+    rel_path="${entry#"${PROJECT_ROOT}/"}"
+    wrapper_file="${entry}/SKILL.md"
+
+    if [[ -L "$entry" ]]; then
+      echo "[ERROR] ${rel_path}: .agents skill wrapper directories must not be symlinks" >&2
+      errors=1
+      continue
+    fi
+
+    if [[ ! -d "$entry" ]]; then
+      echo "[ERROR] ${rel_path}: .agents skill wrapper must be a directory" >&2
+      errors=1
+      continue
+    fi
+
+    if [[ -L "$wrapper_file" ]]; then
+      echo "[ERROR] ${wrapper_file#"${PROJECT_ROOT}/"}: .agents skill wrapper files must not be symlinks" >&2
+      errors=1
+      continue
+    fi
+
+    if [[ ! -f "$wrapper_file" ]]; then
+      echo "[ERROR] ${wrapper_file#"${PROJECT_ROOT}/"}: missing .agents skill wrapper file" >&2
+      errors=1
+      continue
+    fi
+
+    agents_skill_files+=("$wrapper_file")
+  done < <(find "${AGENTS_SKILLS_DIR}" -mindepth 1 -maxdepth 1 | sort)
+
+  for file in "${agents_skill_files[@]}"; do
+    rel_path="${file#"${PROJECT_ROOT}/"}"
+    dir_name="$(basename "$(dirname "$file")")"
+
+    canonical_path="skills/${dir_name}/SKILL.md"
+    if [[ ! -f "${PROJECT_ROOT}/${canonical_path}" ]]; then
+      echo "[ERROR] ${rel_path}: no canonical skill found at ${canonical_path}" >&2
+      errors=1
+    fi
+
+    first_line="$(sed -n '1p' "$file")"
+    if [[ "$first_line" != "---" ]]; then
+      echo "[ERROR] ${rel_path}: missing opening YAML frontmatter delimiter" >&2
+      errors=1
+      continue
+    fi
+
+    second_delim_line="$(awk 'NR > 1 && $0 == "---" { print NR; exit }' "$file")"
+    if [[ -z "$second_delim_line" ]]; then
+      echo "[ERROR] ${rel_path}: missing closing YAML frontmatter delimiter" >&2
+      errors=1
+      continue
+    fi
+
+    frontmatter="$(sed -n "2,$((second_delim_line - 1))p" "$file")"
+    name_line="$(printf '%s\n' "$frontmatter" | sed -n 's/^name:[[:space:]]*//p' | head -n 1)"
+    description_line="$(printf '%s\n' "$frontmatter" | sed -n 's/^description:[[:space:]]*//p' | head -n 1)"
+    wrapper_name="$(trim "$name_line")"
+    wrapper_description="$(trim "$description_line")"
+
+    if [[ "$wrapper_name" != "$dir_name" ]]; then
+      echo "[ERROR] ${rel_path}: frontmatter name '${wrapper_name}' does not match directory '${dir_name}'" >&2
+      errors=1
+    fi
+
+    if [[ -z "$wrapper_description" ]]; then
+      echo "[ERROR] ${rel_path}: missing frontmatter description" >&2
+      errors=1
+    fi
+
+    if [[ "$description_line" == *": "* ]] && ! is_quoted "$description_line"; then
+      echo "[ERROR] ${rel_path}: frontmatter description containing ': ' must be quoted" >&2
+      errors=1
+    fi
+
+    if ! grep -Fq "../../../${canonical_path}" "$file"; then
+      echo "[ERROR] ${rel_path}: wrapper must reference ../../../${canonical_path}" >&2
+      errors=1
+    fi
+  done
+fi
+
+for skill_name in "${skills_with_openai_metadata[@]}"; do
+  wrapper_path="${AGENTS_SKILLS_DIR}/${skill_name}/SKILL.md"
+  if [[ ! -f "$wrapper_path" ]]; then
+    echo "[ERROR] .agents/skills: missing Codex discovery wrapper for ${skill_name}" >&2
+    errors=1
   fi
 done
 

--- a/skills/auto-mobile-code-review/agents/openai.yaml
+++ b/skills/auto-mobile-code-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AutoMobile Code Review"
+  short_description: "Verified AutoMobile PR and diff review"
+  default_prompt: "Use $auto-mobile-code-review to review the current branch diff or a specific AutoMobile PR with verified, file:line findings."

--- a/skills/check-ci/SKILL.md
+++ b/skills/check-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-ci
-description: Use this workflow skill for PR CI triage: inspect failing or pending checks, mergeability, and related review feedback, then reproduce likely failures locally and summarize next steps.
+description: "Use this workflow skill for PR CI triage: inspect failing or pending checks, mergeability, and related review feedback, then reproduce likely failures locally and summarize next steps."
 ---
 
 # Check CI

--- a/skills/push-pr/SKILL.md
+++ b/skills/push-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: push-pr
-description: Use this workflow skill to publish the current branch: validate local changes, commit, push, create or update one PR, and optionally enable automerge.
+description: "Use this workflow skill to publish the current branch: validate local changes, commit, push, create or update one PR, and optionally enable automerge."
 ---
 
 # Push PR

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: Use this workflow skill for running tests only: choose the narrowest relevant test command first and keep test runs fast and actionable; prefer validate when the user wants broader non-test checks too.
+description: "Use this workflow skill for running tests only: choose the narrowest relevant test command first and keep test runs fast and actionable; prefer validate when the user wants broader non-test checks too."
 ---
 
 # Run Tests


### PR DESCRIPTION
## Summary

- expose the existing AutoMobile code review workflow to Codex via `.agents/skills/auto-mobile-code-review`
- add Codex UI metadata for `$auto-mobile-code-review` while keeping `skills/auto-mobile-code-review/SKILL.md` as the canonical workflow
- extend Codex skill validation to cover `agents/openai.yaml`, `.agents/skills` wrappers, and YAML-unsafe frontmatter descriptions
- run the `codex-skills` check in PR fast validation

## Review follow-up addressed

- Replaced the original `.agents/skills` symlink with a real wrapper skill so Codex discovery does not depend on symlink support.
- Added validation for the new Codex metadata/discovery surface.
- Quoted existing skill descriptions that the stricter validation exposed as invalid YAML frontmatter.

## Validation

- `for d in skills/* .agents/skills/*; do [ -d "$d" ] || continue; python3 /Users/jason/.codex/skills/.system/skill-creator/scripts/quick_validate.py "$d" || exit 1; done`
- `bash scripts/validate_codex_skills.sh`
- `shellcheck scripts/validate_codex_skills.sh`
- `bash scripts/all_fast_validate_checks.sh --only codex-skills,shellcheck --max-parallel 2`
- `bash scripts/all_fast_validate_checks.sh --only yaml,xml,shellcheck,mkdocs-nav,claude-plugin,codex-skills --max-parallel 4`
- `git diff --check`
