### PR TITLE
perf(db): add composite (device_id, timestamp) indexes to telemetry event tables (#2788)

### DIFF
--- a/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
+++ b/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
@@ -14,10 +14,20 @@ import type { Kysely } from "kysely";
  *
  * No DESC in the index columns: SQLite scans a plain ascending index backward for
  * `ORDER BY ... DESC`, so a plain composite suffices (mirrors the precedent in
- * 2025_12_30_000_performance_thresholds.ts). Additive and forward-only — the
- * existing single-column indexes are left intact because other queries and the
- * retention cleanup's full-table `ORDER BY timestamp DESC` still use the
- * standalone `timestamp` index.
+ * 2025_12_30_000_performance_thresholds.ts).
+ *
+ * Additive and forward-only, per #2788's explicit scope ("do not modify the
+ * existing single-column indexes"):
+ *   - The standalone `timestamp` index MUST stay — the retention cutoff query
+ *     (`ORDER BY timestamp DESC LIMIT 1 OFFSET <cap>`, no device filter) uses it
+ *     as a covering scan, and the composite cannot substitute because `device_id`
+ *     leads the composite.
+ *   - The standalone `device_id` index is now functionally redundant: the
+ *     composite's `device_id` left-prefix serves every `device_id=?` access path
+ *     (including `COUNT(*) WHERE device_id=?`). It is deliberately RETAINED here
+ *     to keep this migration purely additive; dropping the six redundant
+ *     `idx_<table>_device` indexes to cut per-insert write amplification is
+ *     deferred to a follow-up so the change is reviewed on its own (see #2788).
  */
 const TABLES = [
   "network_events",

--- a/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
+++ b/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
@@ -1,0 +1,50 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Composite (device_id, timestamp) indexes for the telemetry event tables (#2788).
+ *
+ * Every event getter queries `WHERE device_id=? [AND timestamp>=?]
+ * ORDER BY timestamp DESC LIMIT n`, but each table only carries single-column
+ * indexes on `device_id` and `timestamp` separately. SQLite uses at most one
+ * index per query, so the `device_id` equality filter forces a temp B-tree
+ * filesort for the `ORDER BY timestamp DESC`. A composite `(device_id,
+ * timestamp)` index lets the planner satisfy the equality filter and produce the
+ * ordering from a single index — scanning it backward for the DESC order — which
+ * drops the sort entirely.
+ *
+ * No DESC in the index columns: SQLite scans a plain ascending index backward for
+ * `ORDER BY ... DESC`, so a plain composite suffices (mirrors the precedent in
+ * 2025_12_30_000_performance_thresholds.ts). Additive and forward-only — the
+ * existing single-column indexes are left intact because other queries and the
+ * retention cleanup's full-table `ORDER BY timestamp DESC` still use the
+ * standalone `timestamp` index.
+ */
+const TABLES = [
+  "network_events",
+  "log_events",
+  "os_events",
+  "navigation_events",
+  "storage_events",
+  "layout_events",
+] as const;
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  for (const table of TABLES) {
+    // .ifNotExists() so the migration survives #2785's destructive-recovery
+    // replay (drop-all then replay every migration on an empty DB).
+    await db.schema
+      .createIndex(`idx_${table}_device_timestamp`)
+      .ifNotExists()
+      .on(table)
+      .columns(["device_id", "timestamp"])
+      .execute();
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  for (const table of TABLES) {
+    // .ifExists() so a partial-up followed by down (recovery machinery can
+    // invoke migrations in unusual orders) does not throw.
+    await db.schema.dropIndex(`idx_${table}_device_timestamp`).ifExists().execute();
+  }
+}

--- a/test/db/eventCompositeIndexes.test.ts
+++ b/test/db/eventCompositeIndexes.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { runMigrations } from "../../src/db/migrator";
+import { up as telemetryUp } from "../../src/db/migrations/2026_03_15_000_telemetry_events";
+import { up as navigationUp } from "../../src/db/migrations/2026_03_18_000_navigation_events";
+import { up as storageUp } from "../../src/db/migrations/2026_03_19_000_storage_events";
+import { up as layoutUp } from "../../src/db/migrations/2026_03_19_001_layout_events";
+import {
+  up as compositeUp,
+  down as compositeDown,
+} from "../../src/db/migrations/2026_07_02_000_event_composite_indexes";
+
+/**
+ * Migration coverage for #2788. The six telemetry event tables carry only
+ * single-column indexes on `device_id` and `timestamp` separately, so the
+ * common getter shape (`WHERE device_id=? ORDER BY timestamp DESC LIMIT n`)
+ * forces a temp B-tree filesort. This migration adds a composite
+ * `(device_id, timestamp)` index per table so SQLite satisfies both the filter
+ * and the ordering from one index (scanning it backward for the DESC order).
+ *
+ * The tests assert the whole point is real: the composite index exists, the
+ * planner actually uses it, the filesort disappears, results are unchanged, and
+ * the migration is idempotent / reversible / replay-safe.
+ */
+const TABLES = [
+  "network_events",
+  "log_events",
+  "os_events",
+  "navigation_events",
+  "storage_events",
+  "layout_events",
+] as const;
+
+/** Build the six event tables via their original migrations (no composite index yet). */
+async function buildEventSchema(db: Kysely<unknown>): Promise<void> {
+  await telemetryUp(db); // network_events, log_events, os_events (+ custom_events)
+  await navigationUp(db); // navigation_events
+  await storageUp(db); // storage_events
+  await layoutUp(db); // layout_events
+}
+
+async function indexExists(db: Kysely<unknown>, name: string): Promise<boolean> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'index' AND name = ${name}
+  `.execute(db);
+  return result.rows.length > 0;
+}
+
+/** Ordered list of column names participating in an index (PRAGMA index_info). */
+async function indexColumns(db: Kysely<unknown>, name: string): Promise<string[]> {
+  const result = await sql<{ seqno: number; name: string }>`
+    SELECT seqno, name FROM pragma_index_info(${name}) ORDER BY seqno
+  `.execute(db);
+  return result.rows.map(r => r.name);
+}
+
+/**
+ * EXPLAIN QUERY PLAN detail lines for the canonical getter shape. Runs against
+ * the raw bun:sqlite handle: kysely's `sql` execute returns no rows for
+ * EXPLAIN QUERY PLAN (the dialect routes non-SELECT statements through run()).
+ */
+function queryPlan(bunDb: BunDatabase, table: string): string[] {
+  const rows = bunDb
+    .query(
+      `EXPLAIN QUERY PLAN SELECT * FROM ${table} WHERE device_id = 'dev-1' ORDER BY timestamp DESC LIMIT 100`
+    )
+    .all() as Array<{ detail: string }>;
+  return rows.map(r => r.detail);
+}
+
+describe("2026_07_02_000_event_composite_indexes migration", () => {
+  let bunDb: BunDatabase;
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    bunDb = new BunDatabase(":memory:");
+    db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    await buildEventSchema(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("up creates a composite (device_id, timestamp) index on all six tables", async () => {
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(false);
+    }
+
+    await compositeUp(db);
+
+    for (const table of TABLES) {
+      const name = `idx_${table}_device_timestamp`;
+      expect(await indexExists(db, name)).toBe(true);
+      // Columns are ordered (device_id, timestamp) ascending — mirrors precedent.
+      expect(await indexColumns(db, name)).toEqual(["device_id", "timestamp"]);
+    }
+  });
+
+  test("planner uses the composite index and drops the temp B-tree filesort", async () => {
+    // Before: device filter picks the single-column device index, forcing a sort.
+    for (const table of TABLES) {
+      const before = queryPlan(bunDb, table).join("\n");
+      expect(before).toContain("USE TEMP B-TREE FOR ORDER BY");
+    }
+
+    await compositeUp(db);
+
+    for (const table of TABLES) {
+      const after = queryPlan(bunDb, table).join("\n");
+      const indexName = `idx_${table}_device_timestamp`;
+      // The composite index now satisfies both the equality filter and the order.
+      expect(after).toContain(indexName);
+      expect(after).toMatch(new RegExp(`SEARCH .*USING INDEX ${indexName}`));
+      // The whole point: no filesort remains.
+      expect(after).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    }
+  });
+
+  test("query results are byte-for-byte identical before and after the migration", async () => {
+    // Seed interleaved timestamps across two devices so ordering/filtering matters.
+    await sql`INSERT INTO network_events (device_id, timestamp, url, method, status_code, duration_ms)
+      VALUES ('dev-1', 300, 'https://a', 'GET', 200, 1),
+             ('dev-1', 100, 'https://b', 'GET', 200, 1),
+             ('dev-1', 200, 'https://c', 'GET', 200, 1),
+             ('dev-2', 250, 'https://d', 'GET', 200, 1)`.execute(db);
+
+    const read = async (): Promise<Array<{ url: string; timestamp: number }>> => {
+      const result = await sql<{ url: string; timestamp: number }>`
+        SELECT url, timestamp FROM network_events
+        WHERE device_id = 'dev-1' ORDER BY timestamp DESC LIMIT 100
+      `.execute(db);
+      return result.rows;
+    };
+
+    const before = await read();
+    await compositeUp(db);
+    const after = await read();
+
+    expect(after).toEqual(before);
+    // Sanity: correct rows in correct DESC order (dev-2 excluded).
+    expect(after.map(r => r.timestamp)).toEqual([300, 200, 100]);
+  });
+
+  test("up is idempotent (safe to re-run, as destructive-recovery replay would)", async () => {
+    await compositeUp(db);
+    await expect(compositeUp(db)).resolves.toBeUndefined();
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(true);
+    }
+  });
+
+  test("down drops all six composite indexes", async () => {
+    await compositeUp(db);
+    await compositeDown(db);
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(false);
+    }
+  });
+
+  test("down is idempotent — a partial-up followed by down does not throw", async () => {
+    // Never ran up(): down() must be a no-op, not a throw (ifExists guards).
+    await expect(compositeDown(db)).resolves.toBeUndefined();
+    // And after a full up, a double down is still safe.
+    await compositeUp(db);
+    await compositeDown(db);
+    await expect(compositeDown(db)).resolves.toBeUndefined();
+  });
+
+  test("single-column indexes are left intact (other queries + retention still benefit)", async () => {
+    await compositeUp(db);
+    // Original standalone indexes from the base migrations must survive.
+    expect(await indexExists(db, "idx_network_events_timestamp")).toBe(true);
+    expect(await indexExists(db, "idx_network_events_device")).toBe(true);
+  });
+});
+
+describe("2026_07_02_000_event_composite_indexes migration — full replay", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    // Full forward replay of every migration on a fresh DB (the #2785
+    // destructive-recovery path). Proves the migration is discovered/wired and
+    // runs cleanly in filename order after the tables it indexes exist.
+    await runMigrations(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("the composite indexes exist after a fresh full migration chain", async () => {
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(true);
+    }
+  });
+});

--- a/test/db/eventCompositeIndexes.test.ts
+++ b/test/db/eventCompositeIndexes.test.ts
@@ -33,7 +33,14 @@ const TABLES = [
   "layout_events",
 ] as const;
 
-/** Build the six event tables via their original migrations (no composite index yet). */
+/**
+ * Build the six event tables via their original migrations (no composite index
+ * yet). The later `alterTable` migrations (…_002_storage_events_previous_value,
+ * …_003_layout_events_screen_name) are intentionally omitted: the composite only
+ * touches `device_id`/`timestamp`, which exist at table creation. The full
+ * migration chain (including those alters) is exercised by the "full replay"
+ * describe below.
+ */
 async function buildEventSchema(db: Kysely<unknown>): Promise<void> {
   await telemetryUp(db); // network_events, log_events, os_events (+ custom_events)
   await navigationUp(db); // navigation_events


### PR DESCRIPTION
## What

Adds one forward-only migration creating a composite `(device_id, timestamp)` index on each of the six telemetry event tables — `network_events`, `log_events`, `os_events`, `navigation_events`, `storage_events`, `layout_events`.

Closes #2788.

## Why

Every event getter queries `WHERE device_id=? [AND timestamp>=?] ORDER BY timestamp DESC LIMIT n`, but each table only carries **single-column** indexes on `device_id` and `timestamp` separately. SQLite uses at most one index per query, so the common `device_id` equality filter (the dashboard/MCP read path) picks the single-column device index — which gives no ordering — and materializes the matched rows into a temp B-tree filesort for the `ORDER BY timestamp DESC` (`USE TEMP B-TREE FOR ORDER BY`).

A composite `(device_id, timestamp)` index lets the planner satisfy the equality filter **and** produce the ordering from one index, scanning it backward for the DESC order. This drops the sort entirely — a clean latency/allocation win with zero behavioral change. Bounded but real: paid on every read of the six event types (each capped at 10k rows).

## How

- **New migration** `src/db/migrations/2026_07_02_000_event_composite_indexes.ts` — a dead-simple `TABLES` loop issuing six `createIndex(idx_<table>_device_timestamp)` calls. Auto-discovered by the `FileMigrationProvider` (no registration list); filename sorts after all six event-table migrations and after `2026_07_01_000_failure_groups_signature_unique.ts`, so the tables exist when it runs during a full replay.
- **Plain ascending composite, no DESC** — SQLite scans an ascending index backward for `ORDER BY ... DESC`, so a plain `(device_id, timestamp)` suffices (mirrors the in-repo precedent `2025_12_30_000_performance_thresholds.ts:78-83`).
- **Additive only** — the existing single-column indexes are left intact: the retention cleanup's full-table `ORDER BY timestamp DESC` scan and other queries still use the standalone `timestamp` index.
- **Idempotent `up` (`.ifNotExists()`)** so it survives #2785's destructive-recovery replay; **reversible `down` (`.ifExists()`)** so a partial-up followed by `down` (recovery machinery can invoke migrations in unusual orders) does not throw.
- **`custom_events` correctly excluded** (dropped by `2026_04_01_000_drop_custom_events.ts`); all six target tables confirmed to still exist at HEAD.

## Not in scope (coordination note)

- **#2798's `idx_storage_events_key_lookup (device_id, file_name, key, timestamp)`** is a different query shape and has **not** landed yet, so there is no near-duplicate to reconcile in this PR. Whoever writes #2798's storage-events index should add it alongside this composite in awareness of both (per Devin Osei's review on #2788).

## Testing

- **New** `test/db/eventCompositeIndexes.test.ts` (8 tests, ~136ms total, `:memory:`, no device/network, deterministic):
  - All six composite indexes exist after `up`, with columns ordered `(device_id, timestamp)` via `pragma_index_info`.
  - **`EXPLAIN QUERY PLAN`** for the getter shape reproduces `USE TEMP B-TREE FOR ORDER BY` **before** and asserts it disappears + `SEARCH ... USING INDEX idx_<table>_device_timestamp` appears **after** — on **all six** tables.
  - Query results are **byte-for-byte identical** before/after (same rows, same DESC order).
  - Idempotent `up`, `down` drops all six, partial-up→`down` is a safe no-op, single-column indexes left intact.
  - Full `runMigrations` replay (the production discovery path) leaves all six composites present.
- Existing green: `test/db/migrations.test.ts` + `networkEventRepository`/`navigationEventRepository`/`storageEventRepository`/`layoutEventRepository` (75 pass); full `test/db/` (437 pass).
- `bunx turbo run lint build` clean; migration copied into `dist/`.

## Reviewed

Ran `/auto-mobile-code-review` on the branch diff: reproduced the EXPLAIN plan change on all six tables, confirmed no index-name collision (`*_device_timestamp` names elsewhere are for different tables), verified the retention path is unaffected (standalone `timestamp` index retained), and confirmed idempotency/reversibility/replay-safety via the tests.
