### PR TITLE
feat(server): finalizeToolResponse chokepoint + lastHierarchy cache repair (#2758)

### DIFF
--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -1,0 +1,115 @@
+import type { ObserveResult } from "../models/ObserveResult";
+import { sanitizeObserveResult, type SanitizeObserveConfig } from "../features/observe/output/ObserveResultOutput";
+import { serverConfig } from "../utils/ServerConfig";
+import { stringifyToolResponse } from "../utils/toolUtils";
+
+/**
+ * Context needed to finalize a tool response at the serialization chokepoint.
+ * `name` selects where the `ObserveResult` lives (top-level for `observe`, else
+ * `.observation`); `sessionUuid` is accepted for symmetry with the call site and
+ * future per-session gating, though the current sanitize config is global.
+ */
+export interface FinalizeToolResponseContext {
+  name: string;
+  sessionUuid?: string;
+}
+
+/**
+ * Single post-handler serialization hook (issue #2758). Handlers pre-serialize
+ * via `createStructuredToolResponse` into an MCP envelope
+ * `{ content: [{ type: "text", text }], structuredContent }`. This runs once at
+ * `toolRegistry.ts` return and shrinks the one `ObserveResult` the payload may
+ * carry, rewriting BOTH representations so the wire text and `structuredContent`
+ * never disagree.
+ *
+ * Output-only: `sanitizeObserveResult` deep-clones, so the handler's in-memory
+ * result (and anything already cached from it, e.g. `lastHierarchy`) is
+ * untouched. Non-envelope, image, non-JSON-text, and non-observe payloads pass
+ * through unchanged — a safe no-op.
+ */
+export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseContext): T {
+  if (!response || typeof response !== "object") {
+    return response;
+  }
+
+  const envelope = response as {
+    content?: Array<{ type?: string; text?: string }>;
+    structuredContent?: unknown;
+  };
+
+  // Prefer structuredContent; fall back to the serialized text part when a tool
+  // returned text only. Anything else (image parts, non-JSON text) is left alone.
+  const hasStructured =
+    envelope.structuredContent !== undefined &&
+    envelope.structuredContent !== null &&
+    typeof envelope.structuredContent === "object";
+
+  const textPart =
+    Array.isArray(envelope.content) &&
+    envelope.content[0]?.type === "text" &&
+    typeof envelope.content[0].text === "string"
+      ? envelope.content[0]
+      : undefined;
+
+  let payload: Record<string, unknown> | undefined;
+  if (hasStructured) {
+    payload = envelope.structuredContent as Record<string, unknown>;
+  } else if (textPart) {
+    try {
+      const parsed = JSON.parse(textPart.text as string);
+      if (parsed && typeof parsed === "object") {
+        payload = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Not JSON — nothing to sanitize, leave the response as-is.
+      return response;
+    }
+  }
+
+  if (!payload) {
+    return response;
+  }
+
+  const cfg: SanitizeObserveConfig = {
+    dropElements: serverConfig.isObserveResultDropElementsEnabled(),
+  };
+
+  // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
+  let sanitizedPayload: Record<string, unknown> | undefined;
+  if (ctx.name === "observe" && isObserveResult(payload)) {
+    sanitizedPayload = sanitizeObserveResult(payload as unknown as ObserveResult, cfg) as unknown as Record<string, unknown>;
+  } else if (isObserveResult(payload.observation)) {
+    sanitizedPayload = {
+      ...payload,
+      observation: sanitizeObserveResult(payload.observation as ObserveResult, cfg),
+    };
+  }
+
+  if (!sanitizedPayload) {
+    return response;
+  }
+
+  // Rewrite both representations from the same object so they cannot diverge.
+  if (hasStructured) {
+    envelope.structuredContent = sanitizedPayload;
+  }
+  if (textPart) {
+    textPart.text = stringifyToolResponse(sanitizedPayload);
+  }
+
+  return response;
+}
+
+/**
+ * A value is treated as an `ObserveResult` for sanitization purposes when it is
+ * an object carrying a `viewHierarchy`. This is intentionally lax: sanitize is a
+ * safe no-op on a result with no hierarchy/elements/perf, but requiring the
+ * marker field avoids cloning arbitrary success payloads for nothing.
+ */
+function isObserveResult(value: unknown): value is ObserveResult {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "viewHierarchy" in (value as Record<string, unknown>)
+  );
+}

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -24,6 +24,7 @@ import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { getMcpRecorder } from "./mcpRecordingManager";
 import { formatToolResultLog } from "./toolResultLog";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
+import { finalizeToolResponse } from "./finalizeToolResponse";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -432,12 +433,18 @@ class ToolRegistryClass {
               platform: platform === "android" || platform === "ios" ? platform : undefined
             });
 
-            // Cache observation data for certain tools to reduce API calls
-            if (name === "observe" && response?.viewHierarchy) {
-              await updateSessionCache(context, "lastHierarchy", response.viewHierarchy);
+            // Cache observation data for certain tools to reduce API calls.
+            // Handlers pre-serialize into an MCP envelope, so the ObserveResult
+            // lives under `structuredContent`, not on `response` directly (the
+            // former read of `response.viewHierarchy` was always undefined, so
+            // `lastHierarchy` never populated — the #2761 diff baseline needs it).
+            // Runs before finalizeToolResponse, so the cache keeps the full,
+            // untrimmed hierarchy while the wire copy is sanitized.
+            if (name === "observe" && response?.structuredContent?.viewHierarchy) {
+              await updateSessionCache(context, "lastHierarchy", response.structuredContent.viewHierarchy);
             }
-            if (name === "observe" && response?.screenshot) {
-              await updateSessionCache(context, "lastScreenshot", response.screenshot);
+            if (name === "observe" && response?.structuredContent?.screenshot) {
+              await updateSessionCache(context, "lastScreenshot", response.structuredContent.screenshot);
             }
 
             // Update last action timestamp for interaction tools
@@ -446,7 +453,7 @@ class ToolRegistryClass {
             }
           }
 
-          return response;
+          return finalizeToolResponse(response, { name, sessionUuid });
         } catch (error) {
           if (error instanceof ActionableError) {
             throw error;

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { finalizeToolResponse } from "../../src/server/finalizeToolResponse";
+import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import type { ObserveResult } from "../../src/models/ObserveResult";
+
+/**
+ * Build a minimal ObserveResult whose hierarchy carries trimmable attributes:
+ * an empty-string field, a default-false boolean, and a `view-id` that
+ * duplicates `resource-id`. sanitizeObserveResult should drop all three.
+ */
+function makeObserveResult(): ObserveResult {
+  return {
+    updatedAt: 123,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    viewHierarchy: {
+      hierarchy: {
+        node: {
+          "resource-id": "com.example:id/root",
+          "view-id": "com.example:id/root", // duplicate → dropped
+          "text": "", // empty → dropped
+          "clickable": "false", // default-false boolean → dropped
+          "content-desc": "keep-me",
+          "node": [
+            {
+              "resource-id": "com.example:id/child",
+              "text": "Hello",
+              "focusable": "false", // dropped
+            } as any,
+          ],
+        } as any,
+      },
+    },
+    elements: {
+      clickable: [{ text: "btn" } as any],
+      scrollable: [],
+      text: [],
+      media: [],
+    },
+  } as ObserveResult;
+}
+
+describe("finalizeToolResponse", () => {
+  let originalDropElements: boolean;
+
+  beforeEach(() => {
+    originalDropElements = serverConfig.isObserveResultDropElementsEnabled();
+    serverConfig.setObserveResultDropElementsEnabled(false);
+  });
+
+  afterEach(() => {
+    serverConfig.setObserveResultDropElementsEnabled(originalDropElements);
+  });
+
+  test("EC1: observe response is sanitized in both structuredContent and text", () => {
+    const obs = makeObserveResult();
+    const response = createStructuredToolResponse(obs);
+
+    const finalized = finalizeToolResponse(response, { name: "observe", sessionUuid: "s1" });
+
+    const rootSc = (finalized.structuredContent as ObserveResult).viewHierarchy!.hierarchy.node as any;
+    // Trimmed: duplicate view-id, empty text, default-false clickable all gone.
+    expect(rootSc["view-id"]).toBeUndefined();
+    expect(rootSc.text).toBeUndefined();
+    expect(rootSc.clickable).toBeUndefined();
+    // Preserved: content-desc and resource-id.
+    expect(rootSc["content-desc"]).toBe("keep-me");
+    expect(rootSc["resource-id"]).toBe("com.example:id/root");
+    // Child trimmed too.
+    expect(rootSc.node[0].focusable).toBeUndefined();
+    expect(rootSc.node[0].text).toBe("Hello");
+
+    // EC7: text mirrors the sanitized structuredContent exactly.
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    const rootText = JSON.parse(finalized.content[0].text).viewHierarchy.hierarchy.node;
+    expect(rootText["view-id"]).toBeUndefined();
+  });
+
+  test("EC2: action response has its .observation sanitized in both text and structuredContent", () => {
+    const obs = makeObserveResult();
+    const actionPayload = { success: true, observation: obs };
+    const response = createStructuredToolResponse(actionPayload);
+
+    const finalized = finalizeToolResponse(response, { name: "tapOn", sessionUuid: "s1" });
+
+    const obsSc = (finalized.structuredContent as any).observation as ObserveResult;
+    const rootSc = obsSc.viewHierarchy!.hierarchy.node as any;
+    expect(rootSc["view-id"]).toBeUndefined();
+    expect(rootSc.clickable).toBeUndefined();
+    expect((finalized.structuredContent as any).success).toBe(true);
+
+    const parsed = JSON.parse(finalized.content[0].text);
+    expect(parsed.observation.viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+  });
+
+  test("EC4: elements are dropped only when the gate is enabled", () => {
+    serverConfig.setObserveResultDropElementsEnabled(false);
+    const keep = finalizeToolResponse(createStructuredToolResponse(makeObserveResult()), { name: "observe" });
+    expect((keep.structuredContent as ObserveResult).elements).toBeDefined();
+
+    serverConfig.setObserveResultDropElementsEnabled(true);
+    const drop = finalizeToolResponse(createStructuredToolResponse(makeObserveResult()), { name: "observe" });
+    expect((drop.structuredContent as ObserveResult).elements).toBeUndefined();
+    expect(JSON.parse(drop.content[0].text).elements).toBeUndefined();
+  });
+
+  test("EC6: the caller's in-memory ObserveResult is never mutated", () => {
+    const obs = makeObserveResult();
+    const response = createStructuredToolResponse(obs);
+    // The handler's own result object is the structuredContent reference.
+    finalizeToolResponse(response, { name: "observe" });
+
+    // Original object still carries the redundant fields — sanitize is output-only.
+    const originalRoot = obs.viewHierarchy!.hierarchy.node as any;
+    expect(originalRoot["view-id"]).toBe("com.example:id/root");
+    expect(originalRoot.clickable).toBe("false");
+    expect(obs.elements).toBeDefined();
+  });
+
+  test("EC5: non-observe/non-observation responses pass through unchanged", () => {
+    const payload = { success: true, message: "done" };
+    const response = createStructuredToolResponse(payload);
+    const finalized = finalizeToolResponse(response, { name: "pressButton" });
+    expect(finalized.structuredContent).toEqual(payload);
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(payload));
+  });
+
+  test("EC5: image responses (no text part) pass through unchanged", () => {
+    const imageResponse: any = {
+      content: [{ type: "image", data: "base64==", mimeType: "image/png" }],
+    };
+    const finalized = finalizeToolResponse(imageResponse, { name: "observe" });
+    expect(finalized).toBe(imageResponse);
+    expect(finalized.content[0].type).toBe("image");
+  });
+
+  test("EC5: non-JSON text-only responses pass through unchanged", () => {
+    const textResponse: any = { content: [{ type: "text", text: "not json at all" }] };
+    const finalized = finalizeToolResponse(textResponse, { name: "observe" });
+    expect(finalized.content[0].text).toBe("not json at all");
+  });
+
+  test("EC5: null / primitive responses are returned as-is", () => {
+    expect(finalizeToolResponse(null, { name: "observe" })).toBeNull();
+    expect(finalizeToolResponse(undefined, { name: "observe" })).toBeUndefined();
+    expect(finalizeToolResponse("plain", { name: "observe" })).toBe("plain");
+  });
+
+  test("EC5: observe payload without a viewHierarchy is a safe no-op", () => {
+    const payload: any = { updatedAt: 1, screenSize: { width: 1, height: 1 }, systemInsets: {} };
+    const response = createStructuredToolResponse(payload);
+    const finalized = finalizeToolResponse(response, { name: "observe" });
+    expect(finalized.structuredContent).toEqual(payload);
+  });
+
+  test("falls back to content text when structuredContent is absent", () => {
+    const obs = makeObserveResult();
+    const textOnly: any = { content: [{ type: "text", text: JSON.stringify(obs) }] };
+    const finalized = finalizeToolResponse(textOnly, { name: "observe" });
+    const root = JSON.parse(finalized.content[0].text).viewHierarchy.hierarchy.node;
+    expect(root["view-id"]).toBeUndefined();
+    expect(root.clickable).toBeUndefined();
+  });
+});

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { finalizeToolResponse } from "../../src/server/finalizeToolResponse";
 import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
+import { GFXINFO_DUMP_MARKER } from "../../src/features/observe/output/ObserveResultOutput";
 import type { ObserveResult } from "../../src/models/ObserveResult";
 
 /**
@@ -153,6 +154,57 @@ describe("finalizeToolResponse", () => {
     const response = createStructuredToolResponse(payload);
     const finalized = finalizeToolResponse(response, { name: "observe" });
     expect(finalized.structuredContent).toEqual(payload);
+  });
+
+  test("strips the performance-audit raw dumps and truncates diagnostics at the GFXINFO marker", () => {
+    const obs = makeObserveResult();
+    (obs as any).performanceAudit = {
+      metrics: { gfxinfoRaw: "HUGE RAW DUMP", cpuStatsRaw: "CPU RAW", p99: 16 },
+      diagnostics: `summary line\n${GFXINFO_DUMP_MARKER}\nmegabytes of raw frame data`,
+    };
+    const finalized = finalizeToolResponse(createStructuredToolResponse(obs), { name: "observe" });
+
+    const audit = (finalized.structuredContent as any).performanceAudit;
+    expect(audit.metrics.gfxinfoRaw).toBeNull();
+    expect(audit.metrics.cpuStatsRaw).toBeNull();
+    expect(audit.metrics.p99).toBe(16); // computed metric preserved
+    expect(audit.diagnostics).toBe("summary line");
+    // Original in-memory audit is untouched (output-only).
+    expect((obs as any).performanceAudit.metrics.gfxinfoRaw).toBe("HUGE RAW DUMP");
+  });
+
+  test("preserves the observe-only awaitedElement extras spread into the payload", () => {
+    const obs = makeObserveResult();
+    const withExtras = { ...obs, awaitedElement: { text: "Found" }, awaitDuration: 250, awaitTimeout: false };
+    const finalized = finalizeToolResponse(createStructuredToolResponse(withExtras), { name: "observe" });
+
+    const sc = finalized.structuredContent as any;
+    expect(sc.awaitedElement).toEqual({ text: "Found" });
+    expect(sc.awaitDuration).toBe(250);
+    // Hierarchy still trimmed alongside the preserved extras.
+    expect(sc.viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+  });
+
+  test("drops elements on an action's nested .observation when the gate is enabled", () => {
+    serverConfig.setObserveResultDropElementsEnabled(true);
+    const response = createStructuredToolResponse({ success: true, observation: makeObserveResult() });
+    const finalized = finalizeToolResponse(response, { name: "tapOn" });
+    expect((finalized.structuredContent as any).observation.elements).toBeUndefined();
+    expect(JSON.parse(finalized.content[0].text).observation.elements).toBeUndefined();
+  });
+
+  test("trims an array-shaped root node (both roots)", () => {
+    const obs = makeObserveResult();
+    obs.viewHierarchy!.hierarchy.node = [
+      { "resource-id": "a", "view-id": "a", "clickable": "false" } as any,
+      { "resource-id": "b", "view-id": "b", "focusable": "false" } as any,
+    ] as any;
+    const finalized = finalizeToolResponse(createStructuredToolResponse(obs), { name: "observe" });
+    const roots = (finalized.structuredContent as any).viewHierarchy.hierarchy.node;
+    expect(roots[0]["view-id"]).toBeUndefined();
+    expect(roots[0].clickable).toBeUndefined();
+    expect(roots[1]["view-id"]).toBeUndefined();
+    expect(roots[1].focusable).toBeUndefined();
   });
 
   test("falls back to content text when structuredContent is absent", () => {

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { BootedDevice } from "../../src/models";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { KEEP_SCREEN_AWAKE_STATE_KEY } from "../../src/utils/KeepScreenAwakeManager";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import type { ObserveResult } from "../../src/models/ObserveResult";
+
+/**
+ * Integration coverage for issue #2758: the `lastHierarchy` session-cache write
+ * must read the ObserveResult out of the MCP envelope's `structuredContent`
+ * (previously it read `response.viewHierarchy`, which never existed on the
+ * envelope, so the cache was silently never populated — the #2761 diff baseline
+ * depends on it). Also verifies the `finalizeToolResponse` chokepoint sanitizes
+ * the observe response while the cache keeps the full untrimmed hierarchy.
+ */
+describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
+  const androidA: BootedDevice = { name: "Pixel A", deviceId: "emulator-5554", platform: "android" };
+
+  let fakeDeviceSessionManager: FakeDeviceSessionManager;
+  let originalDeviceSessionManager: unknown;
+  let daemonSessionManager: SessionManager | undefined;
+  let originalDropElements: boolean;
+
+  function makeObserveResult(): ObserveResult {
+    return {
+      updatedAt: 42,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          node: {
+            "resource-id": "com.example:id/root",
+            "view-id": "com.example:id/root", // redundant duplicate
+            "clickable": "false", // default-false boolean
+            "content-desc": "root",
+          } as any,
+        },
+      },
+    } as ObserveResult;
+  }
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+    originalDropElements = serverConfig.isObserveResultDropElementsEnabled();
+    serverConfig.setObserveResultDropElementsEnabled(false);
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
+    daemonSessionManager?.stopCleanupTimer();
+    serverConfig.setObserveResultDropElementsEnabled(originalDropElements);
+    delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
+  });
+
+  test("populates lastHierarchy from structuredContent and sanitizes the returned response", async () => {
+    fakeDeviceSessionManager.setConnectedDevices([androidA]);
+
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA]);
+    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([androidA]);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    const sessionId = await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1");
+
+    // Pre-seed keep-awake state so createToolExecutionContext skips real device I/O.
+    const session = daemonSessionManager.getSession(sessionId)!;
+    daemonSessionManager.updateSessionCache(sessionId, {
+      ...session.cacheData,
+      customData: {
+        ...(session.cacheData.customData ?? {}),
+        [KEEP_SCREEN_AWAKE_STATE_KEY]: { applied: false, skipReason: "test" },
+      },
+    });
+
+    const observeResult = makeObserveResult();
+    ToolRegistry.registerDeviceAware(
+      "observe",
+      "observe",
+      z.object({
+        platform: z.enum(["ios", "android"]).optional(),
+        deviceId: z.string().optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      async () => createStructuredToolResponse(observeResult)
+    );
+    const tool = ToolRegistry.getTool("observe")!;
+
+    const response = await tool.handler({
+      platform: "android",
+      __mcpSessionId: "mcp-session-1",
+    });
+
+    // Cache is populated (was dormant before the fix) with the FULL hierarchy.
+    const cached = daemonSessionManager.getSession(sessionId)!.cacheData.customData?.lastHierarchy as any;
+    expect(cached).toBeDefined();
+    expect(cached.hierarchy.node["view-id"]).toBe("com.example:id/root");
+    expect(cached.hierarchy.node.clickable).toBe("false");
+
+    // Returned wire response is sanitized at the chokepoint.
+    const returnedRoot = (response.structuredContent as ObserveResult).viewHierarchy!.hierarchy.node as any;
+    expect(returnedRoot["view-id"]).toBeUndefined();
+    expect(returnedRoot.clickable).toBeUndefined();
+    expect(returnedRoot["content-desc"]).toBe("root");
+  });
+});

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -9,7 +9,7 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { KEEP_SCREEN_AWAKE_STATE_KEY } from "../../src/utils/KeepScreenAwakeManager";
-import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
 
@@ -47,6 +47,34 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     } as ObserveResult;
   }
 
+  /**
+   * Stand up a daemon-backed session locked to `androidA` and pre-seed keep-awake
+   * state so `createToolExecutionContext` performs no real device I/O. Returns the
+   * resolved autolock sessionId whose cache the tool call will populate.
+   */
+  async function setupAutolockedSession(): Promise<string> {
+    fakeDeviceSessionManager.setConnectedDevices([androidA]);
+
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA]);
+    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([androidA]);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    const sessionId = (await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1"))!;
+
+    const session = daemonSessionManager.getSession(sessionId)!;
+    daemonSessionManager.updateSessionCache(sessionId, {
+      ...session.cacheData,
+      customData: {
+        ...(session.cacheData.customData ?? {}),
+        [KEEP_SCREEN_AWAKE_STATE_KEY]: { applied: false, skipReason: "test" },
+      },
+    });
+    return sessionId;
+  }
+
   beforeEach(() => {
     ToolRegistry.clearTools();
     fakeDeviceSessionManager = new FakeDeviceSessionManager();
@@ -67,37 +95,21 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
   });
 
-  test("populates lastHierarchy from structuredContent and sanitizes the returned response", async () => {
-    fakeDeviceSessionManager.setConnectedDevices([androidA]);
+  const toolSchema = z.object({
+    platform: z.enum(["ios", "android"]).optional(),
+    deviceId: z.string().optional(),
+    sessionUuid: z.string().optional(),
+  });
 
-    const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
-    const fakeDeviceUtils = new FakeDeviceUtils();
-    fakeDeviceUtils.setBootedDevices("android", [androidA]);
-    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
-    await pool.initializeWithDevices([androidA]);
-    DaemonState.getInstance().initialize(daemonSessionManager, pool);
-    const sessionId = await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1");
-
-    // Pre-seed keep-awake state so createToolExecutionContext skips real device I/O.
-    const session = daemonSessionManager.getSession(sessionId)!;
-    daemonSessionManager.updateSessionCache(sessionId, {
-      ...session.cacheData,
-      customData: {
-        ...(session.cacheData.customData ?? {}),
-        [KEEP_SCREEN_AWAKE_STATE_KEY]: { applied: false, skipReason: "test" },
-      },
-    });
+  test("populates lastHierarchy + lastScreenshot from structuredContent and sanitizes the returned response", async () => {
+    const sessionId = await setupAutolockedSession();
 
     const observeResult = makeObserveResult();
+    (observeResult as any).screenshot = "base64-screenshot-data";
     ToolRegistry.registerDeviceAware(
       "observe",
       "observe",
-      z.object({
-        platform: z.enum(["ios", "android"]).optional(),
-        deviceId: z.string().optional(),
-        sessionUuid: z.string().optional(),
-      }),
+      toolSchema,
       async () => createStructuredToolResponse(observeResult)
     );
     const tool = ToolRegistry.getTool("observe")!;
@@ -107,16 +119,51 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
       __mcpSessionId: "mcp-session-1",
     });
 
-    // Cache is populated (was dormant before the fix) with the FULL hierarchy.
-    const cached = daemonSessionManager.getSession(sessionId)!.cacheData.customData?.lastHierarchy as any;
-    expect(cached).toBeDefined();
-    expect(cached.hierarchy.node["view-id"]).toBe("com.example:id/root");
-    expect(cached.hierarchy.node.clickable).toBe("false");
+    // Caches are populated (were dormant before the fix) with the FULL hierarchy.
+    const cache = daemonSessionManager!.getSession(sessionId)!.cacheData.customData!;
+    const cachedHierarchy = cache.lastHierarchy as any;
+    expect(cachedHierarchy).toBeDefined();
+    expect(cachedHierarchy.hierarchy.node["view-id"]).toBe("com.example:id/root");
+    expect(cachedHierarchy.hierarchy.node.clickable).toBe("false");
+    // Screenshot cache repair (symmetric structuredContent read).
+    expect(cache.lastScreenshot).toBe("base64-screenshot-data");
 
     // Returned wire response is sanitized at the chokepoint.
     const returnedRoot = (response.structuredContent as ObserveResult).viewHierarchy!.hierarchy.node as any;
     expect(returnedRoot["view-id"]).toBeUndefined();
     expect(returnedRoot.clickable).toBeUndefined();
     expect(returnedRoot["content-desc"]).toBe("root");
+  });
+
+  test("sanitizes a tapOn action response's .observation end-to-end through the chokepoint", async () => {
+    await setupAutolockedSession();
+
+    const observation = makeObserveResult();
+    ToolRegistry.registerDeviceAware(
+      "tapOn",
+      "tapOn",
+      toolSchema,
+      async () => createStructuredToolResponse({
+        success: true,
+        message: "Tapped on element",
+        observation,
+      })
+    );
+    const tool = ToolRegistry.getTool("tapOn")!;
+
+    const response = await tool.handler({
+      platform: "android",
+      __mcpSessionId: "mcp-session-1",
+    });
+
+    // Action's nested observation is sanitized in BOTH representations.
+    const scRoot = (response.structuredContent as any).observation.viewHierarchy.hierarchy.node;
+    expect(scRoot["view-id"]).toBeUndefined();
+    expect(scRoot.clickable).toBeUndefined();
+    expect((response.structuredContent as any).success).toBe(true);
+
+    const parsed = JSON.parse(response.content[0].text);
+    expect(parsed.observation.viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+    expect(response.content[0].text).toBe(stringifyToolResponse(response.structuredContent));
   });
 });


### PR DESCRIPTION
## What

Wire `sanitizeObserveResult` (#2757) in at the single serialization chokepoint and repair the dormant `lastHierarchy` session-cache write.

Handlers pre-serialize via `createStructuredToolResponse(result)` into an MCP envelope `{ content: [{ type: "text", text }], structuredContent }`. This adds a `finalizeToolResponse(response, { name, sessionUuid })` hook at the one post-handler return (`src/server/toolRegistry.ts`) that shrinks the single `ObserveResult` a payload may carry and rewrites **both** representations so the wire text and `structuredContent` never disagree.

It also fixes a latent bug: the `lastHierarchy` cache write read `response.viewHierarchy`, but `response` is the envelope, so the read was always `undefined` and the cache was **never populated**. The #2761 diff baseline depends on it.

Closes #2758.

## Why

An `ObserveResult` (~25k tokens, with `elements` duplicating the tree) rides on both the top-level `observe` result and every action result's `.observation`. Sanitizing once at the chokepoint — where the tool `name` and `sessionUuid` are in scope — is the minimal, single-owner place to shrink the wire output without touching any of the internal consumers that read the in-memory result.

## How

- **`src/server/finalizeToolResponse.ts`** (new):
  - Extract payload — prefer `structuredContent`, else guarded `JSON.parse(content[0].text)`.
  - Locate the `ObserveResult` — the payload itself for `observe`, else `payload.observation` (gated on a `viewHierarchy` marker so arbitrary success payloads aren't cloned for nothing).
  - Apply `sanitizeObserveResult` with `cfg.dropElements` from `serverConfig.isObserveResultDropElementsEnabled()` (`trimNodes` default on). Sanitize deep-clones, so it is **output-only** — the handler's in-memory result and anything already cached from it are untouched.
  - Rewrite **both** `structuredContent` and `content[0].text` (via `stringifyToolResponse`) from the same object.
  - Safe no-op for non-envelope, image, non-JSON-text, and non-observe payloads.
- **`toolRegistry.ts`** — call `finalizeToolResponse(response, { name, sessionUuid })` at the return chokepoint; repair the cache read to `response.structuredContent.viewHierarchy` (and the parallel screenshot read). The cache write runs **before** finalize, so it keeps the full, untrimmed hierarchy the diff baseline needs while the wire copy is sanitized.

## Not in scope (deferred, see follow-up)

- **`toolRegistry.ts:417` `response?.found`** — the swipeOn scroll-position update reads `response?.found`, but `createStructuredToolResponse` only hoists `success`/`error` to the envelope, so `found` is always `undefined` and the block is dead. Same envelope-vs-`structuredContent` class as the `lastHierarchy` bug fixed here, but outside this issue's scope. Filed as a follow-up.

## Testing

- `test/server/finalizeToolResponse.test.ts` — unit coverage (interface-free pure fn): observe + action `.observation` sanitized in **both** `structuredContent` and text; text/structuredContent stay byte-identical; elements-drop honors the config gate; caller's in-memory result never mutated; pass-through for non-observe / image / non-JSON-text / null / primitive / hierarchy-less payloads; structuredContent-absent text fallback.
- `test/server/toolRegistry.lastHierarchyCache.test.ts` — integration (real `SessionManager`/`DevicePool`/`DaemonState` autolock recipe, `FakeTimer`/`FakeDeviceUtils`, no device I/O): `lastHierarchy` is actually populated after an `observe` and holds the **full** hierarchy, while the returned wire response is sanitized at the chokepoint.
- Full server suite: **701 pass, 0 fail**. `turbo run lint build` clean.

## Reviewed

Ran `/auto-mobile-code-review` on the branch diff: verified sanitize is output-only (cache keeps the untrimmed tree), the text/structuredContent rewrite can't diverge, and every pass-through path is a no-op. Flagged the `response?.found` latent bug as a follow-up (above).
