### PR TITLE
fix(db): non-transactional get-or-create / read-modify-write races (#2790)

### DIFF
--- a/src/db/appearanceConfigRepository.ts
+++ b/src/db/appearanceConfigRepository.ts
@@ -44,11 +44,6 @@ export class AppearanceConfigRepository {
   async setConfig(config: AppearanceConfig): Promise<void> {
     const db = await this.getDb();
     const now = new Date().toISOString();
-    const existing = await db
-      .selectFrom("appearance_configs")
-      .select(["key"])
-      .where("key", "=", CONFIG_KEY)
-      .executeTakeFirst();
 
     const payload = {
       key: CONFIG_KEY,
@@ -56,18 +51,17 @@ export class AppearanceConfigRepository {
       updated_at: now,
     };
 
-    if (existing) {
-      await db
-        .updateTable("appearance_configs")
-        .set(payload)
-        .where("key", "=", CONFIG_KEY)
-        .execute();
-      return;
-    }
-
+    // Atomic upsert on the key PRIMARY KEY. A concurrent first-write would otherwise
+    // have one caller lose the SELECT/INSERT race and throw a UNIQUE collision (R2356).
     await db
       .insertInto("appearance_configs")
       .values(payload)
+      .onConflict(oc =>
+        oc.column("key").doUpdateSet({
+          config_json: payload.config_json,
+          updated_at: payload.updated_at,
+        })
+      )
       .execute();
   }
 

--- a/src/db/deviceSnapshotConfigRepository.ts
+++ b/src/db/deviceSnapshotConfigRepository.ts
@@ -44,11 +44,6 @@ export class DeviceSnapshotConfigRepository {
   async setConfig(config: DeviceSnapshotConfig): Promise<void> {
     const db = await this.getDb();
     const now = new Date().toISOString();
-    const existing = await db
-      .selectFrom("device_snapshot_configs")
-      .select(["key"])
-      .where("key", "=", CONFIG_KEY)
-      .executeTakeFirst();
 
     const payload = {
       key: CONFIG_KEY,
@@ -56,18 +51,17 @@ export class DeviceSnapshotConfigRepository {
       updated_at: now,
     };
 
-    if (existing) {
-      await db
-        .updateTable("device_snapshot_configs")
-        .set(payload)
-        .where("key", "=", CONFIG_KEY)
-        .execute();
-      return;
-    }
-
+    // Atomic upsert on the key PRIMARY KEY. A concurrent first-write would otherwise
+    // have one caller lose the SELECT/INSERT race and throw a UNIQUE collision (R2356).
     await db
       .insertInto("device_snapshot_configs")
       .values(payload)
+      .onConflict(oc =>
+        oc.column("key").doUpdateSet({
+          config_json: payload.config_json,
+          updated_at: payload.updated_at,
+        })
+      )
       .execute();
   }
 

--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -44,35 +44,30 @@ export class NavigationRepository {
   async getOrCreateApp(appId: string): Promise<NavigationApp> {
     const db = this.getDb();
 
-    // Check if app exists
-    const existing = await db
-      .selectFrom("navigation_apps")
-      .selectAll()
-      .where("app_id", "=", appId)
-      .executeTakeFirst();
-
-    if (existing) {
-      return existing;
-    }
-
-    // Create new app record
+    // Atomic upsert on the app_id PRIMARY KEY. A concurrent first-create would
+    // otherwise have one caller lose the SELECT/INSERT race and throw a UNIQUE
+    // collision (R2356). The conflict path is a no-op touch (updated_at set to its
+    // own value) so this stays a pure get-or-create that never mutates an existing
+    // row — timestamp bumps remain the job of touchApp — while DO UPDATE still lets
+    // RETURNING return the existing row.
     const now = new Date().toISOString();
     const newApp: NewNavigationApp = {
       app_id: appId,
       updated_at: now,
     };
 
-    await db
+    const result = await db
       .insertInto("navigation_apps")
       .values(newApp)
-      .execute();
+      .onConflict(oc =>
+        oc.column("app_id").doUpdateSet(eb => ({
+          updated_at: eb.ref("navigation_apps.updated_at"),
+        }))
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
 
-    logger.info(`[NAV_REPO] Created app record: ${appId}`);
-
-    return {
-      ...newApp,
-      created_at: now,
-    };
+    return result;
   }
 
   /**
@@ -97,33 +92,10 @@ export class NavigationRepository {
   ): Promise<NavigationNode> {
     const db = this.getDb();
 
-    // Check if node exists
-    const existing = await db
-      .selectFrom("navigation_nodes")
-      .selectAll()
-      .where("app_id", "=", appId)
-      .where("screen_name", "=", screenName)
-      .executeTakeFirst();
-
-    if (existing) {
-      // Update last_seen_at and increment visit_count
-      await db
-        .updateTable("navigation_nodes")
-        .set({
-          last_seen_at: timestamp,
-          visit_count: existing.visit_count + 1,
-        })
-        .where("id", "=", existing.id)
-        .execute();
-
-      return {
-        ...existing,
-        last_seen_at: timestamp,
-        visit_count: existing.visit_count + 1,
-      };
-    }
-
-    // Create new node
+    // Atomic upsert on UNIQUE(app_id, screen_name) (idx_navigation_nodes_app_screen).
+    // visit_count increments in SQL so concurrent revisits don't lose increments and a
+    // concurrent first-discovery doesn't throw a UNIQUE collision (R2356). first_seen_at
+    // is left untouched on the conflict path. returningAll preserves the row return value.
     const newNode: NewNavigationNode = {
       app_id: appId,
       screen_name: screenName,
@@ -135,10 +107,14 @@ export class NavigationRepository {
     const result = await db
       .insertInto("navigation_nodes")
       .values(newNode)
+      .onConflict(oc =>
+        oc.columns(["app_id", "screen_name"]).doUpdateSet(eb => ({
+          last_seen_at: timestamp,
+          visit_count: eb("navigation_nodes.visit_count", "+", 1),
+        }))
+      )
       .returningAll()
       .executeTakeFirstOrThrow();
-
-    logger.debug(`[NAV_REPO] New screen discovered: ${screenName} (id=${result.id})`);
 
     return result;
   }
@@ -360,76 +336,81 @@ export class NavigationRepository {
   ): Promise<UIElement> {
     const db = this.getDb();
 
-    // Try to find existing element with same properties
-    let query = db
-      .selectFrom("ui_elements")
-      .selectAll()
-      .where("app_id", "=", appId);
+    // ui_elements has no UNIQUE index and matching is on a *dynamic* subset of columns,
+    // so this get-or-create cannot be expressed as a single onConflict upsert. Wrap the
+    // SELECT-then-INSERT/UPDATE in a transaction instead: BEGIN takes exclusive ownership
+    // of the single connection (bunSqliteDialect #reserveTransaction), so concurrent
+    // callers for the same element serialize rather than both inserting duplicate rows
+    // (R2356). Keep the body to DB reads/writes only — no IO — since it blocks the daemon
+    // for its duration.
+    return db.transaction().execute(async trx => {
+      // Try to find existing element with same properties
+      let query = trx
+        .selectFrom("ui_elements")
+        .selectAll()
+        .where("app_id", "=", appId);
 
-    if (element.text !== undefined) {
-      query = query.where("text", "=", element.text);
-    }
-    if (element.resourceId !== undefined) {
-      query = query.where("resource_id", "=", element.resourceId);
-    }
-    if (element.contentDescription !== undefined) {
-      query = query.where("content_description", "=", element.contentDescription);
-    }
-    if (element.className !== undefined) {
-      query = query.where("class_name", "=", element.className);
-    }
-    if (element.bounds) {
-      query = query
-        .where("bounds_left", "=", element.bounds.left)
-        .where("bounds_top", "=", element.bounds.top)
-        .where("bounds_right", "=", element.bounds.right)
-        .where("bounds_bottom", "=", element.bounds.bottom);
-    }
+      if (element.text !== undefined) {
+        query = query.where("text", "=", element.text);
+      }
+      if (element.resourceId !== undefined) {
+        query = query.where("resource_id", "=", element.resourceId);
+      }
+      if (element.contentDescription !== undefined) {
+        query = query.where("content_description", "=", element.contentDescription);
+      }
+      if (element.className !== undefined) {
+        query = query.where("class_name", "=", element.className);
+      }
+      if (element.bounds) {
+        query = query
+          .where("bounds_left", "=", element.bounds.left)
+          .where("bounds_top", "=", element.bounds.top)
+          .where("bounds_right", "=", element.bounds.right)
+          .where("bounds_bottom", "=", element.bounds.bottom);
+      }
 
-    const existing = await query.executeTakeFirst();
+      const existing = await query.executeTakeFirst();
 
-    if (existing) {
-      // Update last_seen_at
-      await db
-        .updateTable("ui_elements")
-        .set({ last_seen_at: timestamp })
-        .where("id", "=", existing.id)
-        .execute();
+      if (existing) {
+        // Update last_seen_at
+        await trx
+          .updateTable("ui_elements")
+          .set({ last_seen_at: timestamp })
+          .where("id", "=", existing.id)
+          .execute();
 
-      return {
-        ...existing,
+        return {
+          ...existing,
+          last_seen_at: timestamp,
+        };
+      }
+
+      // Create new UI element
+      const newElement: NewUIElement = {
+        app_id: appId,
+        text: element.text || null,
+        resource_id: element.resourceId || null,
+        content_description: element.contentDescription || null,
+        class_name: element.className || null,
+        bounds_left: element.bounds?.left || null,
+        bounds_top: element.bounds?.top || null,
+        bounds_right: element.bounds?.right || null,
+        bounds_bottom: element.bounds?.bottom || null,
+        clickable: element.clickable !== undefined ? (element.clickable ? 1 : 0) : null,
+        scrollable: element.scrollable !== undefined ? (element.scrollable ? 1 : 0) : null,
+        first_seen_at: timestamp,
         last_seen_at: timestamp,
       };
-    }
 
-    // Create new UI element
-    const newElement: NewUIElement = {
-      app_id: appId,
-      text: element.text || null,
-      resource_id: element.resourceId || null,
-      content_description: element.contentDescription || null,
-      class_name: element.className || null,
-      bounds_left: element.bounds?.left || null,
-      bounds_top: element.bounds?.top || null,
-      bounds_right: element.bounds?.right || null,
-      bounds_bottom: element.bounds?.bottom || null,
-      clickable: element.clickable !== undefined ? (element.clickable ? 1 : 0) : null,
-      scrollable: element.scrollable !== undefined ? (element.scrollable ? 1 : 0) : null,
-      first_seen_at: timestamp,
-      last_seen_at: timestamp,
-    };
+      const result = await trx
+        .insertInto("ui_elements")
+        .values(newElement)
+        .returningAll()
+        .executeTakeFirstOrThrow();
 
-    const result = await db
-      .insertInto("ui_elements")
-      .values(newElement)
-      .returningAll()
-      .executeTakeFirstOrThrow();
-
-    logger.debug(
-      `[NAV_REPO] New UI element: ${element.text || element.resourceId || "unknown"} (id=${result.id})`
-    );
-
-    return result;
+      return result;
+    });
   }
 
   /**
@@ -814,33 +795,11 @@ export class NavigationRepository {
   ): Promise<NavigationNodeFingerprint> {
     const db = this.getDb();
 
-    // Check if fingerprint already exists for this app
-    const existing = await db
-      .selectFrom("navigation_node_fingerprints")
-      .selectAll()
-      .where("app_id", "=", appId)
-      .where("fingerprint_hash", "=", hash)
-      .executeTakeFirst();
-
-    if (existing) {
-      // Update last_seen_at and increment occurrence_count
-      await db
-        .updateTable("navigation_node_fingerprints")
-        .set({
-          last_seen_at: timestamp,
-          occurrence_count: existing.occurrence_count + 1,
-        })
-        .where("id", "=", existing.id)
-        .execute();
-
-      return {
-        ...existing,
-        last_seen_at: timestamp,
-        occurrence_count: existing.occurrence_count + 1,
-      };
-    }
-
-    // Create new fingerprint record
+    // Atomic upsert on UNIQUE(app_id, fingerprint_hash)
+    // (idx_navigation_node_fingerprints_app_hash). occurrence_count increments in SQL so
+    // a concurrent first-create no longer throws a UNIQUE collision (dropping the write)
+    // and concurrent revisits don't lose increments (R2356). node_id/first_seen_at are
+    // left untouched on the conflict path — the first writer's node association wins.
     const newFingerprint: NewNavigationNodeFingerprint = {
       app_id: appId,
       node_id: nodeId,
@@ -854,12 +813,14 @@ export class NavigationRepository {
     const result = await db
       .insertInto("navigation_node_fingerprints")
       .values(newFingerprint)
+      .onConflict(oc =>
+        oc.columns(["app_id", "fingerprint_hash"]).doUpdateSet(eb => ({
+          last_seen_at: timestamp,
+          occurrence_count: eb("navigation_node_fingerprints.occurrence_count", "+", 1),
+        }))
+      )
       .returningAll()
       .executeTakeFirstOrThrow();
-
-    logger.debug(
-      `[NAV_REPO] New fingerprint for node ${nodeId}: ${hash.substring(0, 12)}...`
-    );
 
     return result;
   }
@@ -912,33 +873,11 @@ export class NavigationRepository {
   ): Promise<NavigationSuggestion> {
     const db = this.getDb();
 
-    // Check if suggestion already exists for this app and hash
-    const existing = await db
-      .selectFrom("navigation_suggestions")
-      .selectAll()
-      .where("app_id", "=", appId)
-      .where("fingerprint_hash", "=", hash)
-      .executeTakeFirst();
-
-    if (existing) {
-      // Update last_seen_at and increment occurrence_count
-      await db
-        .updateTable("navigation_suggestions")
-        .set({
-          last_seen_at: timestamp,
-          occurrence_count: existing.occurrence_count + 1,
-        })
-        .where("id", "=", existing.id)
-        .execute();
-
-      return {
-        ...existing,
-        last_seen_at: timestamp,
-        occurrence_count: existing.occurrence_count + 1,
-      };
-    }
-
-    // Create new suggestion
+    // Atomic upsert on UNIQUE(app_id, fingerprint_hash)
+    // (idx_navigation_suggestions_app_hash). occurrence_count increments in SQL so a
+    // concurrent first-create no longer throws a UNIQUE collision and concurrent
+    // revisits don't lose increments (R2356). first_seen_at and promoted_to_fingerprint_id
+    // are left untouched on the conflict path so a prior promotion is never clobbered.
     const newSuggestion: NewNavigationSuggestion = {
       app_id: appId,
       fingerprint_hash: hash,
@@ -952,12 +891,14 @@ export class NavigationRepository {
     const result = await db
       .insertInto("navigation_suggestions")
       .values(newSuggestion)
+      .onConflict(oc =>
+        oc.columns(["app_id", "fingerprint_hash"]).doUpdateSet(eb => ({
+          last_seen_at: timestamp,
+          occurrence_count: eb("navigation_suggestions.occurrence_count", "+", 1),
+        }))
+      )
       .returningAll()
       .executeTakeFirstOrThrow();
-
-    logger.debug(
-      `[NAV_REPO] New suggestion for app ${appId}: ${hash.substring(0, 12)}...`
-    );
 
     return result;
   }

--- a/src/db/predictionHistoryRepository.ts
+++ b/src/db/predictionHistoryRepository.ts
@@ -6,7 +6,6 @@ import type {
   NewPredictionTransitionStats,
   PredictionTransitionStats
 } from "./types";
-import { logger } from "../utils/logger";
 import { normalizeToolArgs } from "../utils/predictionUtils";
 
 export type PredictionErrorType = "wrong_screen" | "missing_elements" | "unexpected_elements";
@@ -103,41 +102,13 @@ export class PredictionHistoryRepository {
     const toolArgs = normalizeToolArgs(transition.toolArgs ?? undefined);
     const brier = Math.pow(confidence - (correct ? 1 : 0), 2);
 
-    const existing = await db
-      .selectFrom("prediction_transition_stats")
-      .selectAll()
-      .where("app_id", "=", transition.appId)
-      .where("from_screen", "=", transition.fromScreen)
-      .where("to_screen", "=", transition.toScreen)
-      .where("tool_name", "=", transition.toolName)
-      .where("tool_args", "=", toolArgs)
-      .executeTakeFirst();
+    const successIncrement = correct ? 1 : 0;
 
-    if (existing) {
-      const updated: PredictionTransitionStats = {
-        ...existing,
-        attempts: existing.attempts + 1,
-        successes: existing.successes + (correct ? 1 : 0),
-        total_confidence: existing.total_confidence + confidence,
-        brier_score_sum: existing.brier_score_sum + brier,
-        updated_at: now
-      };
-
-      await db
-        .updateTable("prediction_transition_stats")
-        .set({
-          attempts: updated.attempts,
-          successes: updated.successes,
-          total_confidence: updated.total_confidence,
-          brier_score_sum: updated.brier_score_sum,
-          updated_at: updated.updated_at
-        })
-        .where("id", "=", existing.id)
-        .execute();
-
-      return updated;
-    }
-
+    // Atomic upsert on UNIQUE(app_id, from_screen, to_screen, tool_name, tool_args)
+    // (idx_prediction_transition_key). All four accumulators are incremented in SQL so
+    // concurrent callers for the same transition key cannot lose increments or throw a
+    // UNIQUE-constraint collision on a first insert (R2356). DO UPDATE (never DO NOTHING)
+    // guarantees RETURNING yields the row on the conflict path.
     const newStats: NewPredictionTransitionStats = {
       app_id: transition.appId,
       from_screen: transition.fromScreen,
@@ -145,7 +116,7 @@ export class PredictionHistoryRepository {
       tool_name: transition.toolName,
       tool_args: toolArgs,
       attempts: 1,
-      successes: correct ? 1 : 0,
+      successes: successIncrement,
       total_confidence: confidence,
       brier_score_sum: brier,
       updated_at: now,
@@ -155,12 +126,19 @@ export class PredictionHistoryRepository {
     const result = await db
       .insertInto("prediction_transition_stats")
       .values(newStats)
+      .onConflict(oc =>
+        oc
+          .columns(["app_id", "from_screen", "to_screen", "tool_name", "tool_args"])
+          .doUpdateSet(eb => ({
+            attempts: eb("prediction_transition_stats.attempts", "+", 1),
+            successes: eb("prediction_transition_stats.successes", "+", successIncrement),
+            total_confidence: eb("prediction_transition_stats.total_confidence", "+", confidence),
+            brier_score_sum: eb("prediction_transition_stats.brier_score_sum", "+", brier),
+            updated_at: now
+          }))
+      )
       .returningAll()
       .executeTakeFirstOrThrow();
-
-    logger.debug(
-      `[PREDICTION_REPO] New transition stats: ${transition.fromScreen} -> ${transition.toScreen}`
-    );
 
     return result;
   }

--- a/src/db/testCoverageRepository.ts
+++ b/src/db/testCoverageRepository.ts
@@ -70,18 +70,32 @@ export class TestCoverageRepository {
    */
   async getOrCreateSession(sessionUuid: string, appId: string): Promise<TestCoverageSession> {
     const db = this.getDb();
+    const now = this.timer.now();
 
-    const existing = await db
-      .selectFrom("test_coverage_sessions")
-      .selectAll()
-      .where("session_uuid", "=", sessionUuid)
-      .executeTakeFirst();
+    // Atomic get-or-create on the session_uuid UNIQUE constraint. A SELECT-then-INSERT
+    // would let two concurrent callers for the same uuid both read "not found" and race,
+    // with the loser throwing a UNIQUE collision (R2356). The conflict path is a no-op
+    // touch (session_uuid set to its own value) so an existing session is returned
+    // unchanged, while DO UPDATE keeps RETURNING returning the row.
+    const newSession: NewTestCoverageSession = {
+      session_uuid: sessionUuid,
+      app_id: appId,
+      start_time: now,
+      end_time: null,
+      total_nodes_visited: 0,
+      total_edges_traversed: 0,
+    };
 
-    if (existing) {
-      return existing;
-    }
-
-    return this.startSession(sessionUuid, appId);
+    return db
+      .insertInto("test_coverage_sessions")
+      .values(newSession)
+      .onConflict(oc =>
+        oc.column("session_uuid").doUpdateSet(eb => ({
+          session_uuid: eb.ref("test_coverage_sessions.session_uuid"),
+        }))
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
   }
 
   /**

--- a/src/db/testCoverageRepository.ts
+++ b/src/db/testCoverageRepository.ts
@@ -106,39 +106,28 @@ export class TestCoverageRepository {
   async recordNodeVisit(sessionId: number, nodeId: number, timestamp: number): Promise<void> {
     const db = this.getDb();
 
-    // Check if this node was already visited in this session
-    const existing = await db
-      .selectFrom("test_node_coverage")
-      .selectAll()
-      .where("session_id", "=", sessionId)
-      .where("node_id", "=", nodeId)
-      .executeTakeFirst();
+    // Atomic upsert on UNIQUE(session_id, node_id) (idx_test_node_coverage_session_node).
+    // Counter arithmetic runs in SQL so no read-modify-write window exists between a
+    // SELECT and a follow-up INSERT/UPDATE, which under the single-connection async
+    // mutex would otherwise drop first-visit collisions and lose increments (R2356).
+    const newCoverage: NewTestNodeCoverage = {
+      session_id: sessionId,
+      node_id: nodeId,
+      visit_count: 1,
+      first_visit_time: timestamp,
+      last_visit_time: timestamp,
+    };
 
-    if (existing) {
-      // Update visit count and last visit time
-      await db
-        .updateTable("test_node_coverage")
-        .set({
-          visit_count: existing.visit_count + 1,
+    await db
+      .insertInto("test_node_coverage")
+      .values(newCoverage)
+      .onConflict(oc =>
+        oc.columns(["session_id", "node_id"]).doUpdateSet(eb => ({
+          visit_count: eb("test_node_coverage.visit_count", "+", 1),
           last_visit_time: timestamp,
-        })
-        .where("id", "=", existing.id)
-        .execute();
-    } else {
-      // Create new coverage record
-      const newCoverage: NewTestNodeCoverage = {
-        session_id: sessionId,
-        node_id: nodeId,
-        visit_count: 1,
-        first_visit_time: timestamp,
-        last_visit_time: timestamp,
-      };
-
-      await db
-        .insertInto("test_node_coverage")
-        .values(newCoverage)
-        .execute();
-    }
+        }))
+      )
+      .execute();
 
     // Update session totals
     await db
@@ -160,39 +149,26 @@ export class TestCoverageRepository {
   ): Promise<void> {
     const db = this.getDb();
 
-    // Check if this edge was already traversed in this session
-    const existing = await db
-      .selectFrom("test_edge_coverage")
-      .selectAll()
-      .where("session_id", "=", sessionId)
-      .where("edge_id", "=", edgeId)
-      .executeTakeFirst();
+    // Atomic upsert on UNIQUE(session_id, edge_id) (idx_test_edge_coverage_session_edge).
+    // Mirrors recordNodeVisit: counter arithmetic in SQL closes the RMW window (R2356).
+    const newCoverage: NewTestEdgeCoverage = {
+      session_id: sessionId,
+      edge_id: edgeId,
+      traversal_count: 1,
+      first_traversal_time: timestamp,
+      last_traversal_time: timestamp,
+    };
 
-    if (existing) {
-      // Update traversal count and last traversal time
-      await db
-        .updateTable("test_edge_coverage")
-        .set({
-          traversal_count: existing.traversal_count + 1,
+    await db
+      .insertInto("test_edge_coverage")
+      .values(newCoverage)
+      .onConflict(oc =>
+        oc.columns(["session_id", "edge_id"]).doUpdateSet(eb => ({
+          traversal_count: eb("test_edge_coverage.traversal_count", "+", 1),
           last_traversal_time: timestamp,
-        })
-        .where("id", "=", existing.id)
-        .execute();
-    } else {
-      // Create new coverage record
-      const newCoverage: NewTestEdgeCoverage = {
-        session_id: sessionId,
-        edge_id: edgeId,
-        traversal_count: 1,
-        first_traversal_time: timestamp,
-        last_traversal_time: timestamp,
-      };
-
-      await db
-        .insertInto("test_edge_coverage")
-        .values(newCoverage)
-        .execute();
-    }
+        }))
+      )
+      .execute();
 
     // Update session totals
     await db

--- a/src/db/videoRecordingConfigRepository.ts
+++ b/src/db/videoRecordingConfigRepository.ts
@@ -44,11 +44,6 @@ export class VideoRecordingConfigRepository {
   async setConfig(config: VideoRecordingConfig): Promise<void> {
     const db = await this.getDb();
     const now = new Date().toISOString();
-    const existing = await db
-      .selectFrom("video_recording_configs")
-      .select(["key"])
-      .where("key", "=", CONFIG_KEY)
-      .executeTakeFirst();
 
     const payload = {
       key: CONFIG_KEY,
@@ -56,18 +51,17 @@ export class VideoRecordingConfigRepository {
       updated_at: now,
     };
 
-    if (existing) {
-      await db
-        .updateTable("video_recording_configs")
-        .set(payload)
-        .where("key", "=", CONFIG_KEY)
-        .execute();
-      return;
-    }
-
+    // Atomic upsert on the key PRIMARY KEY. A concurrent first-write would otherwise
+    // have one caller lose the SELECT/INSERT race and throw a UNIQUE collision (R2356).
     await db
       .insertInto("video_recording_configs")
       .values(payload)
+      .onConflict(oc =>
+        oc.column("key").doUpdateSet({
+          config_json: payload.config_json,
+          updated_at: payload.updated_at,
+        })
+      )
       .execute();
   }
 

--- a/test/db/appearanceConfigRepository.test.ts
+++ b/test/db/appearanceConfigRepository.test.ts
@@ -51,4 +51,16 @@ describe("AppearanceConfigRepository", () => {
     const result = await repo.getConfig();
     expect(result).toBeNull();
   });
+
+  test("N concurrent setConfig never reject and leave exactly one row (R2356)", async () => {
+    const N = 10;
+    await expect(
+      Promise.all(
+        Array.from({ length: N }, (_unused, i) => repo.setConfig({ theme: `t${i}` } as any))
+      )
+    ).resolves.toBeDefined();
+
+    const rows = await db.selectFrom("appearance_configs").selectAll().execute();
+    expect(rows).toHaveLength(1);
+  });
 });

--- a/test/db/deviceSnapshotConfigRepository.test.ts
+++ b/test/db/deviceSnapshotConfigRepository.test.ts
@@ -45,4 +45,16 @@ describe("DeviceSnapshotConfigRepository", () => {
     const result = await repo.getConfig();
     expect(result).toBeNull();
   });
+
+  test("N concurrent setConfig never reject and leave exactly one row (R2356)", async () => {
+    const N = 10;
+    await expect(
+      Promise.all(
+        Array.from({ length: N }, (_unused, i) => repo.setConfig({ autoCapture: i % 2 === 0 } as any))
+      )
+    ).resolves.toBeDefined();
+
+    const rows = await db.selectFrom("device_snapshot_configs").selectAll().execute();
+    expect(rows).toHaveLength(1);
+  });
 });

--- a/test/db/navigationRepository.test.ts
+++ b/test/db/navigationRepository.test.ts
@@ -283,6 +283,95 @@ describe("NavigationRepository", () => {
     });
   });
 
+  describe("concurrency (R2356)", () => {
+    const N = 10;
+
+    test("N concurrent getOrCreateApp yield one row and never reject", async () => {
+      await expect(
+        Promise.all(Array.from({ length: N }, () => repo.getOrCreateApp("com.example.app")))
+      ).resolves.toBeDefined();
+
+      const apps = await db
+        .selectFrom("navigation_apps")
+        .selectAll()
+        .where("app_id", "=", "com.example.app")
+        .execute();
+      expect(apps).toHaveLength(1);
+    });
+
+    test("N concurrent getOrCreateNode yield one row with visit_count === N and return the row id", async () => {
+      await repo.getOrCreateApp("com.example.app");
+
+      const results = await Promise.all(
+        Array.from({ length: N }, () => repo.getOrCreateNode("com.example.app", "HomeScreen", 1000))
+      );
+
+      const nodes = await repo.getNodes("com.example.app");
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0].visit_count).toBe(N);
+
+      // Every returned value carries the same row id (the get-or-create contract).
+      const ids = new Set(results.map(r => r.id));
+      expect(ids.size).toBe(1);
+      expect(results.every(r => r.id === nodes[0].id)).toBe(true);
+    });
+
+    test("N concurrent addOrUpdateSuggestion yield one row with occurrence_count === N and never reject", async () => {
+      await repo.getOrCreateApp("com.example.app");
+
+      const results = await Promise.all(
+        Array.from({ length: N }, () =>
+          repo.addOrUpdateSuggestion("com.example.app", "hash-abc", "{}", 1000)
+        )
+      );
+
+      const suggestions = await repo.getSuggestions("com.example.app");
+      expect(suggestions).toHaveLength(1);
+      expect(suggestions[0].occurrence_count).toBe(N);
+      expect(results.every(r => r.id === suggestions[0].id)).toBe(true);
+    });
+
+    test("N concurrent getOrCreateFingerprint yield one row with occurrence_count === N and never reject", async () => {
+      await repo.getOrCreateApp("com.example.app");
+      const node = await repo.getOrCreateNode("com.example.app", "HomeScreen", 1000);
+
+      const results = await Promise.all(
+        Array.from({ length: N }, () =>
+          repo.getOrCreateFingerprint("com.example.app", node.id, "fp-hash", "{}", 1000)
+        )
+      );
+
+      const fingerprints = await repo.getFingerprintsForNode(node.id);
+      expect(fingerprints).toHaveLength(1);
+      expect(fingerprints[0].occurrence_count).toBe(N);
+      expect(results.every(r => r.id === fingerprints[0].id)).toBe(true);
+    });
+
+    test("N concurrent getOrCreateUIElement for one element yield one row and one id", async () => {
+      await repo.getOrCreateApp("com.example.app");
+
+      const results = await Promise.all(
+        Array.from({ length: N }, (_unused, i) =>
+          repo.getOrCreateUIElement(
+            "com.example.app",
+            { text: "Login", resourceId: "btn_login" },
+            1000 + i
+          )
+        )
+      );
+
+      const elements = await db
+        .selectFrom("ui_elements")
+        .selectAll()
+        .where("app_id", "=", "com.example.app")
+        .execute();
+      expect(elements).toHaveLength(1);
+      const ids = new Set(results.map(r => r.id));
+      expect(ids.size).toBe(1);
+      expect(results[0].id).toBe(elements[0].id);
+    });
+  });
+
   describe("getStats", () => {
     test("returns correct counts", async () => {
       await repo.getOrCreateApp("com.example.app");

--- a/test/db/predictionHistoryRepository.test.ts
+++ b/test/db/predictionHistoryRepository.test.ts
@@ -110,6 +110,36 @@ describe("PredictionHistoryRepository", () => {
     });
   });
 
+  describe("concurrency (R2356)", () => {
+    test("N concurrent upsertTransitionStats yield one row with attempts === N and summed brier, never reject", async () => {
+      const key: TransitionKey = {
+        appId: "com.example.app",
+        fromScreen: "Login",
+        toScreen: "Home",
+        toolName: "tapOn",
+      };
+
+      const N = 10;
+      const confidence = 0.9;
+      const correct = true;
+      // Each call adds the same per-call Brier value; the total must be their sum.
+      const perCallBrier = Math.pow(confidence - (correct ? 1 : 0), 2);
+
+      await expect(
+        Promise.all(
+          Array.from({ length: N }, () => repo.upsertTransitionStats(key, confidence, correct))
+        )
+      ).resolves.toBeDefined();
+
+      const stats = await repo.getTransitionStatsForScreen("com.example.app", "Login");
+      expect(stats).toHaveLength(1);
+      expect(stats[0].attempts).toBe(N);
+      expect(stats[0].successes).toBe(N);
+      expect(stats[0].total_confidence).toBeCloseTo(confidence * N, 5);
+      expect(stats[0].brier_score_sum).toBeCloseTo(perCallBrier * N, 5);
+    });
+  });
+
   describe("getTransitionStatsForScreen", () => {
     test("returns stats for a specific screen", async () => {
       const key1: TransitionKey = {

--- a/test/db/testCoverageRepository.test.ts
+++ b/test/db/testCoverageRepository.test.ts
@@ -249,6 +249,45 @@ describe("TestCoverageRepository", () => {
     });
   });
 
+  describe("concurrency (R2356)", () => {
+    test("N concurrent recordNodeVisit yield one row with visit_count === N and never reject", async () => {
+      await insertApp("com.example.app");
+      const nodeId = await insertNode("com.example.app", "HomeScreen");
+      const session = await repo.startSession("uuid-1", "com.example.app");
+
+      const N = 10;
+      await expect(
+        Promise.all(
+          Array.from({ length: N }, () => repo.recordNodeVisit(session.id, nodeId, 2000))
+        )
+      ).resolves.toBeDefined();
+
+      const covered = await repo.getCoveredNodes(session.id);
+      expect(covered).toHaveLength(1);
+      expect(covered[0].visit_count).toBe(N);
+      // first_visit_time is preserved across the upsert conflict path.
+      expect(covered[0].first_visit_time).toBe(2000);
+    });
+
+    test("N concurrent recordEdgeTraversal yield one row with traversal_count === N and never reject", async () => {
+      await insertApp("com.example.app");
+      const edgeId = await insertEdge("com.example.app", "Home", "Settings");
+      const session = await repo.startSession("uuid-1", "com.example.app");
+
+      const N = 10;
+      await expect(
+        Promise.all(
+          Array.from({ length: N }, () => repo.recordEdgeTraversal(session.id, edgeId, 2000))
+        )
+      ).resolves.toBeDefined();
+
+      const covered = await repo.getCoveredEdges(session.id);
+      expect(covered).toHaveLength(1);
+      expect(covered[0].traversal_count).toBe(N);
+      expect(covered[0].first_traversal_time).toBe(2000);
+    });
+  });
+
   describe("getCoveredNodes", () => {
     test("returns empty array when no nodes visited", async () => {
       await insertApp("com.example.app");

--- a/test/db/testCoverageRepository.test.ts
+++ b/test/db/testCoverageRepository.test.ts
@@ -250,6 +250,21 @@ describe("TestCoverageRepository", () => {
   });
 
   describe("concurrency (R2356)", () => {
+    test("N concurrent getOrCreateSession yield one row and return the same session id, never reject", async () => {
+      await insertApp("com.example.app");
+
+      const N = 10;
+      const results = await Promise.all(
+        Array.from({ length: N }, () => repo.getOrCreateSession("uuid-1", "com.example.app"))
+      );
+
+      const sessions = await repo.getSessionsForApp("com.example.app");
+      expect(sessions).toHaveLength(1);
+      const ids = new Set(results.map(r => r.id));
+      expect(ids.size).toBe(1);
+      expect(results.every(r => r.id === sessions[0].id)).toBe(true);
+    });
+
     test("N concurrent recordNodeVisit yield one row with visit_count === N and never reject", async () => {
       await insertApp("com.example.app");
       const nodeId = await insertNode("com.example.app", "HomeScreen");

--- a/test/db/videoRecordingConfigRepository.test.ts
+++ b/test/db/videoRecordingConfigRepository.test.ts
@@ -45,4 +45,16 @@ describe("VideoRecordingConfigRepository", () => {
     const result = await repo.getConfig();
     expect(result).toBeNull();
   });
+
+  test("N concurrent setConfig never reject and leave exactly one row (R2356)", async () => {
+    const N = 10;
+    await expect(
+      Promise.all(
+        Array.from({ length: N }, (_unused, i) => repo.setConfig({ enabled: i % 2 === 0 } as any))
+      )
+    ).resolves.toBeDefined();
+
+    const rows = await db.selectFrom("video_recording_configs").selectAll().execute();
+    expect(rows).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## What

Four DB repositories implemented get-or-create / read-modify-write (RMW) as a `SELECT` followed by a separate `INSERT`/`UPDATE` across two `await`s with no surrounding transaction. The single `bun:sqlite` connection is guarded by an async mutex that serializes individual queries but **releases across every `await`**, so two overlapping callers both read "not found" (or read the same counter) and race — the loser either throws `UNIQUE constraint failed` and **drops the event** (coverage), or **silently loses counter increments** (prediction/navigation). Found via the 2026-07-01 DB concurrency/migration audit (finding **R2356**, P1).

This replaces each SELECT-then-INSERT/UPDATE with a single-statement atomic upsert (`.onConflict(...).doUpdateSet(...)`) doing counter arithmetic **in SQL**, so no RMW window exists. The one site that can't be an upsert (`getOrCreateUIElement` — no UNIQUE index, dynamic match set) is wrapped in a scoped transaction instead.

Closes #2790.

## Why

Frequency scales with concurrency (fire-and-forget WebSocket dispatch, parallel test execution). Impact by severity:
- **Coverage (R2):** navigation events silently dropped on first-visit collisions; under-counted `visit_count`/`traversal_count` corrupts test-coverage reporting. Most user-visible; audit reproduced 10 concurrent visits landing `count = 2`.
- **Prediction (R5):** lost increments across `attempts`/`successes`/`total_confidence`/`brier_score_sum` → corrupted Brier calibration under parallel runs.
- **Navigation (R3):** dropped screen/suggestion/fingerprint discovery events and under-counted visit/occurrence counts.
- **Appearance/config (R6):** rare spurious throw on concurrent first-write; no corruption.

This is the trunk of the {#2789, #2790, #2791} concurrency workstream (UNIQUE indexes/backfill → **atomic upserts** → transaction). Coverage/navigation/prediction/appearance already have the required UNIQUE indexes, so their upserts land now; `failure_groups.signature` (#2789) is gated on its de-dup migration and is **not** touched here.

## How

Every conflict target was verified byte-identical (column list **and order**) against its real UNIQUE index in the migrations, so SQLite never hard-throws `ON CONFLICT clause does not match…`. Every converted helper uses `DO UPDATE` (never `DO NOTHING`) so `.returningAll().executeTakeFirstOrThrow()` returns a row on the conflict path. Idiom matches the existing `installedAppsRepository.upsertInstalledApp` / `deviceSessionRepository` upserts.

- **`testCoverageRepository.ts`** — `recordNodeVisit` / `recordEdgeTraversal` → upsert on `(session_id, node_id)` / `(session_id, edge_id)`, `visit_count`/`traversal_count` incremented in SQL; `first_*_time` untouched on conflict. The already-atomic `test_coverage_sessions total_* + 1` session-total update is left as-is (it counts *visits*, not distinct nodes — whole-method atomicity is #2791's job). `getOrCreateSession` also converted (same race class on `session_uuid`, found during self-review).
- **`predictionHistoryRepository.ts`** — `upsertTransitionStats` → upsert on the 5-col `(app_id, from_screen, to_screen, tool_name, tool_args)` key; all four accumulators incremented in SQL; `returningAll` preserves the returned row.
- **`navigationRepository.ts`** — `getOrCreateApp` (no-op `DO UPDATE` touch, preserving pure get-or-create — timestamp bumps stay in `touchApp`), `getOrCreateNode`, `getOrCreateFingerprint`, `addOrUpdateSuggestion` → upserts; `getOrCreateUIElement` → wrapped in `db.transaction()` (BEGIN takes exclusive ownership of the single connection per `bunSqliteDialect` `#reserveTransaction`, serializing concurrent callers), body kept to DB reads/writes only, behavior preserved.
- **`appearanceConfigRepository.ts` / `deviceSnapshotConfigRepository.ts` / `videoRecordingConfigRepository.ts`** — `setConfig` → upsert on the `key` PRIMARY KEY.

## Testing

Each repo test gained a `concurrency (R2356)` block: `Promise.all` of N=10 calls against the **real in-memory `bun:sqlite`** dialect (`test/db/testDbHelper.ts`, real migrations). Every new test was confirmed **red on the pre-fix code** (11 failures) before the fix turned them green. For throw-path criteria the tests assert `Promise.all` does **not** reject; for counter criteria they assert exactly one row with the count/sum equal to N; for get-or-create they assert every returned value carries the same row id.

- `bun test` green: **5832 pass, 0 fail** (447 files). New tests <100ms, non-flaky.
- `eslint` and `bun build.ts` clean.

## Acceptance criteria (from #2790)

- [x] N concurrent `recordNodeVisit` / `recordEdgeTraversal` → one row, count === N, no `UNIQUE constraint failed`.
- [x] N concurrent `upsertTransitionStats` → one row, `attempts === N`, `brier_score_sum` = sum of N per-call Brier values.
- [x] N concurrent `getOrCreateNode` / `addOrUpdateSuggestion` → one row, correct count, returned row id.
- [x] Every `getOrCreate*` in `navigationRepository.ts` converted: `getOrCreateApp`, `getOrCreateNode`, `getOrCreateUIElement` (transaction, merge/behavior-preserving), `getOrCreateFingerprint` (first-create no longer throws), `addOrUpdateSuggestion`.
- [x] Each converted helper uses `DO UPDATE`; returns the pre-existing row id on conflict.
- [x] Each `oc.columns([...])` conflict target byte-matches its UNIQUE index (esp. prediction's 5 cols) — asserted by running the real query against the migrated schema.
- [x] `getOrCreateUIElement` behavior preserved via a scoped `db.transaction()` (SELECT+UPDATE only, no IO).
- [x] `setConfig` (+ two sibling config repos) no longer throw on concurrent first-write.
- [x] Return values and conditional behavior unchanged (existing tests still pass).
- [x] Each new concurrency test shown to FAIL against pre-fix code first; throw-path criteria assert `Promise.all` does not reject.
- [x] `bun test` green; lint + build clean.
