### PR TITLE
docs(ios): document pinchOn/dragAndDrop/shake iOS parity in tools.md (#2482)

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -8,11 +8,13 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 
 #### Interactions
 
-- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match). <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
-- 👉 `swipeOn` handles directional swipes and scrolling within container bounds. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
-- ↔️ `dragAndDrop` for element-to-element moves. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
-- 🔍 `pinchOn` for zoom in/out gestures. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
-- 📳 `shake` for accelerometer simulation. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd> <kbd>📱 Simulator Only</kbd> *(iOS: XCTest exposes no shake API for physical devices, so `shake` returns an actionable error there.)*
+- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match).
+- 👉 `swipeOn` handles directional swipes and scrolling within container bounds.
+- ↔️ `dragAndDrop` for element-to-element moves.
+- 🔍 `pinchOn` for zoom in/out gestures.
+- 📳 `shake` for accelerometer simulation.
+
+All Interactions tools — including `pinchOn`, which routes coordinate-based pinch/zoom through the runner's synthesized two-finger events — run on **Android** (physical devices and emulators) and **iOS** via the XCUITest CtrlProxy runner. iOS support is currently <kbd>📱 Simulator Only</kbd> (see the [iOS overview](../plat/ios/index.md)). `shake` is the one exception with no physical-iOS path even once physical support lands, because XCTest exposes no shake API for real devices — it returns an actionable error there.
 
 #### App Management
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -12,7 +12,7 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 - 👉 `swipeOn` handles directional swipes and scrolling within container bounds. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
 - ↔️ `dragAndDrop` for element-to-element moves. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
 - 🔍 `pinchOn` for zoom in/out gestures. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
-- 📳 `shake` for accelerometer simulation. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
+- 📳 `shake` for accelerometer simulation. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd> <kbd>📱 Simulator Only</kbd> *(iOS: XCTest exposes no shake API for physical devices, so `shake` returns an actionable error there.)*
 
 #### App Management
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -8,11 +8,11 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 
 #### Interactions
 
-- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match).
-- 👉 `swipeOn` handles directional swipes and scrolling within container bounds.
-- ↔️ `dragAndDrop` for element-to-element moves.
-- 🔍 `pinchOn` for zoom in/out gestures.
-- 📳 `shake` for accelerometer simulation.
+- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match). <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
+- 👉 `swipeOn` handles directional swipes and scrolling within container bounds. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
+- ↔️ `dragAndDrop` for element-to-element moves. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
+- 🔍 `pinchOn` for zoom in/out gestures. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
+- 📳 `shake` for accelerometer simulation. <kbd>🤖 Android</kbd> <kbd>🍎 iOS</kbd>
 
 #### App Management
 


### PR DESCRIPTION
## Summary

Working issue #2482 (`feat(ios): pinchOn — coordinate-based pinch/zoom via XCUITest CtrlProxy runner`) surfaced that the **runtime work is already complete on `main`** — PR #2653 removed the `PinchOn.ts` iOS hard-reject, routed iOS through `IOSCtrlProxyClient.requestPinch`, and implemented the Swift runner via the private `XCPointerEventPath` / `XCSynthesizedEventRecord` event-path synthesis (`ObjCExceptionCatcher_synthesizePinch`), honoring `centerX/centerY`, `distanceStart/End`, `rotationDegrees`, and `duration`. TS + Swift tests exist and pass.

The **one unmet evaluation criterion** from #2482 was documentation parity:

> - [ ] Parity documented: `pinchOn` listed as supported on iOS in docs/tool reference; remove "not supported on iOS" notes.

This PR closes that gap.

## Change

`docs/design-docs/mcp/tools.md` — add one note under the **Interactions** section stating that all interaction tools (`tapOn`, `swipeOn`, `dragAndDrop`, `pinchOn`, `shake`) run on Android and iOS via the XCUITest CtrlProxy runner, with the accurate `📱 Simulator Only` iOS caveat (linking the [iOS overview](../plat/ios/index.md)) and `shake`'s permanent lack of a physical-iOS path.

An earlier revision of this PR used per-tool `<kbd>` badges; review feedback (see the review comment below) showed that badging 5 of ~40 tools re-asserted the cross-platform default and a bare `🍎 iOS` chip overstated support (the iOS runner is documented `📱 Simulator Only`). The section note is accurate, consistent with the Status Glossary vocabulary, and avoids the asymmetry.

## Review

Ran `/auto-mobile-code-review` plus three independent perspective audits (iOS/XCTest internals, cross-platform parity/regression, docs accuracy). Outcome:

- **No shipped bug or regression** in the pinch path. Result-shape parity with Android confirmed; error propagation is structured (`success:false`, never a throw); Android path unaffected; the `#2234`-class `getInstance` arg bug did **not** recur (the shipped code correctly passes `adbFactory` to Android and a port to iOS — notably the issue's *proposed* snippet would have been a bug).
- Docs-accuracy feedback drove the badges→note change above.

Deferred follow-ups filed as issues (not blockers for this docs PR):
- Runner robustness: `RequestPinch` (and sibling gesture requests) decode coordinates as `Int` with `roundCoordinates:false`, so a direct caller passing fractional values would hit an opaque Swift decode failure. Shipped `PinchOn` rounds upstream, so nothing is broken today.
- iOS pinch durability: no public `pinch(withScale:velocity:)` fallback if the private XCTest symbols change on a future iOS (the issue recommended one).
- Rotation semantics: the start axis is horizontal while the end axis is rotated (combined pinch+rotate); worth documenting/reconsidering the shared Android/iOS convention.

## Testing

- `bash scripts/validate_mkdocs_nav.sh` — ✓ all docs linked, no orphans
- `bun test test/features/action/PinchOn.test.ts` — ✓ 6 pass (regression check on the already-shipped iOS path)

## Notes

Docs-only change. No `.github/pull_request_template.md` exists in the repo; this body follows the repo's Summary/Testing convention. Recommend **closing #2482** as completed once this merges (runtime landed in #2653).
