### PR TITLE
fix(server): swipeOn scroll-position update reads found off structuredContent (#2897)

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -159,7 +159,13 @@ export class DefaultUIStateSetup implements UIStateSetup {
       // Execute swipeOn with lookFor
       const result = await swipeOnTool.handler(swipeOnArgs);
 
-      if (result?.success && result?.found) {
+      // `swipeOn` pre-serializes into an MCP envelope via createStructuredToolResponse,
+      // which hoists only `success`/`error` to the top level — `found` lives under
+      // `structuredContent`. Reading `result?.found` off the envelope was always
+      // undefined, so this success branch was dead and setup always logged the
+      // "could not find" warning even on a successful scroll (issue #2897; same class
+      // as the toolRegistry scroll-position and #2758 lastHierarchy fixes).
+      if (result?.structuredContent?.success && result?.structuredContent?.found) {
         logger.info(`[UI_STATE_SETUP] Successfully scrolled to target element`);
         return `swipeOn(lookFor: ${JSON.stringify(scrollPosition.targetElement)})`;
       } else {

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -413,8 +413,13 @@ class ToolRegistryClass {
             getMcpRecorder()?.record(name, args);
           }
 
-          // After swipeOn executes with lookFor, update the tool call with scroll position
-          if (name === "swipeOn" && args.lookFor && response?.success && response?.found) {
+          // After swipeOn executes with lookFor, update the tool call with scroll position.
+          // Handlers pre-serialize into an MCP envelope, so `found` lives under
+          // `structuredContent` — `createStructuredToolResponse` only hoists
+          // `success`/`error` to the envelope top level. The former `response?.found`
+          // read was always undefined, so this block was dead and scroll-position
+          // tracking never fired (issue #2897; same class as the #2758 lastHierarchy fix).
+          if (name === "swipeOn" && args.lookFor && response?.structuredContent?.success && response?.structuredContent?.found) {
             const scrollPosition = UIStateExtractor.createScrollPosition(args);
             if (scrollPosition) {
               const scrollNavManager = sessionUuid

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { DefaultUIStateSetup, type ObserveScreenLike } from "../../../src/features/navigation/DefaultUIStateSetup";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import type { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import type { BootedDevice } from "../../../src/models";
 import type { ObserveResult } from "../../../src/models/ObserveResult";
 import type { NavigationEdge } from "../../../src/features/navigation/NavigationGraphManager";
+import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { createStructuredToolResponse } from "../../../src/utils/toolUtils";
+import type { ScrollPosition } from "../../../src/utils/interfaces/NavigationGraph";
 
 const device: BootedDevice = {
   deviceId: "test-device",
@@ -67,5 +70,56 @@ describe("DefaultUIStateSetup", () => {
 
     expect(actions).toEqual([]);
     expect(calls).toBe(0);
+  });
+
+  // Regression for issue #2897 (sibling of the toolRegistry scroll-position fix):
+  // `swipeOn`'s handler returns an MCP envelope from createStructuredToolResponse,
+  // which hoists only `success`/`error` to the top level — `found` lives under
+  // `structuredContent`. setupScrollPosition read `result?.found` off the envelope,
+  // so it was always undefined: the success branch was dead and setup returned null
+  // (logging "could not find") even when the scroll succeeded.
+  describe("setupScrollPosition envelope read (#2897)", () => {
+    afterEach(() => {
+      ToolRegistry.clearTools();
+    });
+
+    const scrollPosition: ScrollPosition = {
+      targetElement: { text: "Target", resourceId: "com.example:id/target" },
+      direction: "up",
+    };
+
+    function registerSwipeOn(found: boolean): void {
+      ToolRegistry.register(
+        "swipeOn",
+        "swipeOn",
+        {},
+        async () => createStructuredToolResponse({
+          success: true,
+          found,
+          message: found ? "Swiped up and found element" : "Swiped up",
+          observation: {},
+          scrollIterations: 1,
+        })
+      );
+    }
+
+    test("returns the swipeOn marker action when the element is found (found lives in structuredContent)", async () => {
+      registerSwipeOn(true);
+      const setup = makeSetup();
+
+      const action = await setup.setupScrollPosition(scrollPosition, "android");
+
+      expect(action).not.toBeNull();
+      expect(action).toContain("swipeOn(lookFor:");
+    });
+
+    test("returns null when the element is not found", async () => {
+      registerSwipeOn(false);
+      const setup = makeSetup();
+
+      const action = await setup.setupScrollPosition(scrollPosition, "android");
+
+      expect(action).toBeNull();
+    });
   });
 });

--- a/test/server/toolRegistry.scrollPositionUpdate.test.ts
+++ b/test/server/toolRegistry.scrollPositionUpdate.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { BootedDevice } from "../../src/models";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { KEEP_SCREEN_AWAKE_STATE_KEY } from "../../src/utils/KeepScreenAwakeManager";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import type { ScrollPosition } from "../../src/utils/interfaces/NavigationGraph";
+
+/**
+ * Integration coverage for issue #2897: the swipeOn scroll-position update block
+ * in `toolRegistry` must read `success`/`found` out of the MCP envelope's
+ * `structuredContent`. `createStructuredToolResponse` only hoists `success`/`error`
+ * to the envelope top level — `found` lives under `structuredContent`, so the prior
+ * `response?.found` read was always `undefined` and `updateScrollPosition` never ran
+ * after a `swipeOn` with `lookFor`. Same envelope-vs-structuredContent bug class as
+ * #2758 / PR #2891.
+ */
+describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
+  const androidA: BootedDevice = { name: "Pixel A", deviceId: "emulator-5554", platform: "android" };
+
+  let fakeDeviceSessionManager: FakeDeviceSessionManager;
+  let originalDeviceSessionManager: unknown;
+  let daemonSessionManager: SessionManager | undefined;
+  let originalDropElements: boolean;
+  let spiedSessionIds: string[];
+
+  /**
+   * Stand up a daemon-backed session locked to `androidA` and pre-seed keep-awake
+   * state so `createToolExecutionContext` performs no real device I/O. Returns the
+   * resolved autolock sessionId whose NavigationGraphManager the tool call targets.
+   */
+  async function setupAutolockedSession(): Promise<string> {
+    fakeDeviceSessionManager.setConnectedDevices([androidA]);
+
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA]);
+    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([androidA]);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    const sessionId = (await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1"))!;
+
+    const session = daemonSessionManager.getSession(sessionId)!;
+    daemonSessionManager.updateSessionCache(sessionId, {
+      ...session.cacheData,
+      customData: {
+        ...(session.cacheData.customData ?? {}),
+        [KEEP_SCREEN_AWAKE_STATE_KEY]: { applied: false, skipReason: "test" },
+      },
+    });
+    return sessionId;
+  }
+
+  /**
+   * Spy on the session-scoped NavigationGraphManager's updateScrollPosition,
+   * capturing every ScrollPosition it is called with. Getting the instance here
+   * eagerly guarantees the tool handler resolves the same instance later.
+   */
+  function spyScrollPosition(sessionId: string): ScrollPosition[] {
+    spiedSessionIds.push(sessionId);
+    const manager = NavigationGraphManager.getInstanceForSession(sessionId);
+    const captured: ScrollPosition[] = [];
+    (manager as any).updateScrollPosition = (scrollPosition: ScrollPosition) => {
+      captured.push(scrollPosition);
+    };
+    return captured;
+  }
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+    originalDropElements = serverConfig.isObserveResultDropElementsEnabled();
+    serverConfig.setObserveResultDropElementsEnabled(false);
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    spiedSessionIds = [];
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
+    daemonSessionManager?.stopCleanupTimer();
+    serverConfig.setObserveResultDropElementsEnabled(originalDropElements);
+    for (const sessionId of spiedSessionIds) {
+      NavigationGraphManager.releaseSession(sessionId);
+    }
+    delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
+  });
+
+  const swipeSchema = z.object({
+    platform: z.enum(["ios", "android"]).optional(),
+    deviceId: z.string().optional(),
+    sessionUuid: z.string().optional(),
+    direction: z.enum(["up", "down", "left", "right"]).optional(),
+    lookFor: z.any().optional(),
+    container: z.any().optional(),
+    speed: z.number().optional(),
+  });
+
+  function registerSwipeOn(found: boolean): void {
+    ToolRegistry.registerDeviceAware(
+      "swipeOn",
+      "swipeOn",
+      swipeSchema,
+      async () => createStructuredToolResponse({
+        success: true,
+        found,
+        message: found ? "Swiped up and found element after 1 swipe(s)" : "Swiped up",
+        observation: {},
+        scrollIterations: 1,
+      })
+    );
+  }
+
+  test("invokes updateScrollPosition when swipeOn with lookFor reports found=true", async () => {
+    const sessionId = await setupAutolockedSession();
+    const captured = spyScrollPosition(sessionId);
+    registerSwipeOn(true);
+    const tool = ToolRegistry.getTool("swipeOn")!;
+
+    await tool.handler({
+      platform: "android",
+      direction: "up",
+      lookFor: { text: "Target", elementId: "com.example:id/target" },
+      __mcpSessionId: "mcp-session-1",
+    });
+
+    expect(captured.length).toBe(1);
+    expect(captured[0].direction).toBe("up");
+    expect(captured[0].targetElement.text).toBe("Target");
+    expect(captured[0].targetElement.resourceId).toBe("com.example:id/target");
+  });
+
+  test("does NOT invoke updateScrollPosition when found=false", async () => {
+    const sessionId = await setupAutolockedSession();
+    const captured = spyScrollPosition(sessionId);
+    registerSwipeOn(false);
+    const tool = ToolRegistry.getTool("swipeOn")!;
+
+    await tool.handler({
+      platform: "android",
+      direction: "up",
+      lookFor: { text: "Target" },
+      __mcpSessionId: "mcp-session-1",
+    });
+
+    expect(captured.length).toBe(0);
+  });
+
+  test("does NOT invoke updateScrollPosition when lookFor is absent", async () => {
+    const sessionId = await setupAutolockedSession();
+    const captured = spyScrollPosition(sessionId);
+    registerSwipeOn(true);
+    const tool = ToolRegistry.getTool("swipeOn")!;
+
+    await tool.handler({
+      platform: "android",
+      direction: "up",
+      __mcpSessionId: "mcp-session-1",
+    });
+
+    expect(captured.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Fix the dead swipeOn scroll-position update block in `toolRegistry`, plus an identical sibling dead-read in `DefaultUIStateSetup` surfaced by adversarial review.

Both read `found` off the **MCP envelope**, but handlers pre-serialize via `createStructuredToolResponse`, which hoists only `success`/`error` to the envelope top level — `found` lives under `structuredContent`. So `response?.found` was always `undefined`:

1. **`src/server/toolRegistry.ts`** — the swipeOn scroll-position block never ran, so `NavigationGraphManager.updateScrollPosition` was never called after a `swipeOn` with `lookFor`. Scroll-position tracking in the navigation graph silently did nothing.
2. **`src/features/navigation/DefaultUIStateSetup.ts`** — `setupScrollPosition` executes swipeOn via the registry handler and read `result?.found` off the envelope. The success branch was dead: setup always logged "could not find target element" and returned `null` even on a successful scroll, dropping the swipeOn setup action from replay.

This is the follow-up explicitly deferred from #2758 / PR #2891 (which fixed the sibling `lastHierarchy` bug of the same class).

Closes #2897.

## Why

`swipeOn`'s real result (`ScrollUntilVisible.ts:160-164` / `344-348`) carries `success: true, found: true`, which `swipeOnHandler` spreads into `createStructuredToolResponse({ message, observation, ...result })`. `createStructuredToolResponse` (`src/utils/toolUtils.ts:98-122`) copies the payload to `structuredContent` and hoists only `success`/`error` to the top level — so `found` exists **only** under `structuredContent`. Reading it off the envelope was a guaranteed `undefined`, making the branch unreachable. (In `lookFor` mode a not-found scroll throws `ActionableError`, so the guard's real purpose is gating the found path — which was never reachable.)

## How

- **`src/server/toolRegistry.ts`** — read both `success` and `found` from `response.structuredContent`, matching the #2758 `lastHierarchy` repair. Comment added explaining the envelope-vs-`structuredContent` hazard. The block runs before `finalizeToolResponse`, so `structuredContent` is intact when read.
- **`src/features/navigation/DefaultUIStateSetup.ts`** — same repair for `result?.structuredContent?.success && result?.structuredContent?.found`, with the same explanatory comment.

## Testing

- `test/server/toolRegistry.scrollPositionUpdate.test.ts` (new) — integration coverage mirroring `toolRegistry.lastHierarchyCache.test.ts` (real `SessionManager`/`DevicePool`/`DaemonState` autolock recipe, `FakeTimer`/`FakeDeviceUtils`, no device I/O): `found: true` + `lookFor` → `updateScrollPosition` **is** invoked with a matching `ScrollPosition`; `found: false` → **not** invoked; `lookFor` absent → **not** invoked.
- `test/features/navigation/DefaultUIStateSetup.test.ts` (extended) — `setupScrollPosition` returns the `swipeOn(lookFor: …)` marker action on `found: true`, `null` on `found: false`.
- Both TDD-verified red→green (each new positive test fails against the pre-fix envelope read, passes after).
- Full navigation + server suites: **988 pass, 0 fail**. `turbo run lint build` clean.

## Reviewed

Ran `/auto-mobile-code-review` plus three adversarial subagent passes (correctness skeptic, test-quality auditor, architecture/scope). Correctness and test-quality passes found no defects. The architecture pass surfaced the `DefaultUIStateSetup` sibling (now fixed here) and recommended a systemic follow-up: a typed `getStructuredField` accessor / typed envelope so this whole bug class is caught at the type checker rather than per-site — filed as a follow-up issue.
