### PR TITLE
perf(db): drop now-redundant single-column device indexes on telemetry event tables (#2893)

### DIFF
--- a/src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts
+++ b/src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts
@@ -1,0 +1,64 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Drop the now-redundant single-column `idx_<table>_device` indexes on the six
+ * telemetry event tables (#2893, follow-up to #2788 / PR #2890).
+ *
+ * PR #2890 added composite `(device_id, timestamp)` indexes
+ * (`idx_<table>_device_timestamp`) but was deliberately kept additive-only per
+ * #2788's scope ("do not modify the existing single-column indexes"). This
+ * migration completes the optimization it deferred.
+ *
+ * A composite `(device_id, timestamp)` index serves every access path a
+ * standalone `(device_id)` index can, via SQLite's left-prefix rule:
+ *   - `WHERE device_id=?` — equality on the composite's leading column.
+ *   - `WHERE device_id=? ORDER BY timestamp DESC` — filter + order from one index.
+ *   - `COUNT(*) WHERE device_id=?` — covering scan of the composite.
+ * There is no `ANALYZE`/`sqlite_stat1` in `src/db/`, so the planner chooses
+ * structurally and deterministically; the standalone device index is dead weight
+ * maintained on every insert for no read benefit. At the retention cap with a
+ * high insert rate this is pure write amplification.
+ *
+ * Left intact (different query shapes — out of scope):
+ *   - The standalone `timestamp` index: the retention cutoff query
+ *     (`ORDER BY timestamp DESC LIMIT 1 OFFSET <cap>`, no device filter) uses it
+ *     as a covering scan, and the composite CANNOT substitute because `device_id`
+ *     leads the composite.
+ *   - The category/content indexes (`idx_network_events_host`,
+ *     `idx_log_events_tag`, `idx_os_events_category`).
+ *
+ * Forward-only, replay-safe (`.ifExists()` / `.ifNotExists()`) so the migration
+ * survives #2785's destructive-recovery replay (drop-all then replay every
+ * migration on an empty DB) in unusual orders. Sorts after
+ * `2026_07_02_000_event_composite_indexes.ts`, so the composite that subsumes
+ * each device index is guaranteed present when its device index is dropped.
+ */
+const TABLES = [
+  "network_events",
+  "log_events",
+  "os_events",
+  "navigation_events",
+  "storage_events",
+  "layout_events",
+] as const;
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  for (const table of TABLES) {
+    // .ifExists() so replay on a DB that never had the standalone device index
+    // (or a partial recovery order) does not throw.
+    await db.schema.dropIndex(`idx_${table}_device`).ifExists().execute();
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  for (const table of TABLES) {
+    // Recreate the single-column device index exactly as the base migrations
+    // defined it. .ifNotExists() so a down after a partial-up is idempotent.
+    await db.schema
+      .createIndex(`idx_${table}_device`)
+      .ifNotExists()
+      .on(table)
+      .column("device_id")
+      .execute();
+  }
+}

--- a/test/db/dropRedundantDeviceIndexes.test.ts
+++ b/test/db/dropRedundantDeviceIndexes.test.ts
@@ -173,6 +173,23 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
     }
   });
 
+  test("storage previous-value lookup (device_id + extra equality predicates) still uses the composite", async () => {
+    // storageEventRepository.ts:33-42 is the only device query with equality
+    // predicates beyond timestamp: WHERE device_id=? AND file_name=? AND key=?
+    // ORDER BY timestamp DESC LIMIT 1. The composite's device_id left-prefix
+    // must still serve it (the extra columns are not indexed either way).
+    await dropUp(db);
+
+    const plan = queryPlan(
+      bunDb,
+      `SELECT value FROM storage_events
+       WHERE device_id = 'dev-1' AND file_name = 'prefs.xml' AND key = 'theme'
+       ORDER BY timestamp DESC LIMIT 1`
+    ).join("\n");
+    expect(plan).toMatch(/SEARCH .*USING INDEX idx_storage_events_device_timestamp/);
+    expect(plan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+  });
+
   test("retention cutoff (ORDER BY timestamp DESC, no device filter) still uses the timestamp index", async () => {
     await dropUp(db);
 

--- a/test/db/dropRedundantDeviceIndexes.test.ts
+++ b/test/db/dropRedundantDeviceIndexes.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { runMigrations } from "../../src/db/migrator";
+import { up as telemetryUp } from "../../src/db/migrations/2026_03_15_000_telemetry_events";
+import { up as navigationUp } from "../../src/db/migrations/2026_03_18_000_navigation_events";
+import { up as storageUp } from "../../src/db/migrations/2026_03_19_000_storage_events";
+import { up as layoutUp } from "../../src/db/migrations/2026_03_19_001_layout_events";
+import { up as compositeUp } from "../../src/db/migrations/2026_07_02_000_event_composite_indexes";
+import {
+  up as dropUp,
+  down as dropDown,
+} from "../../src/db/migrations/2026_07_03_000_drop_redundant_device_indexes";
+
+/**
+ * Migration coverage for #2893 (follow-up to #2788 / PR #2890). PR #2890 added
+ * composite `(device_id, timestamp)` indexes but was deliberately additive-only,
+ * leaving the now-redundant standalone `idx_<table>_device` indexes in place.
+ *
+ * A composite `(device_id, timestamp)` index serves every `device_id=?` access
+ * path the standalone `(device_id)` index can, via the left-prefix rule. This
+ * migration drops the six redundant single-column device indexes to cut
+ * per-insert write amplification.
+ *
+ * The tests assert the whole point is real: the six device indexes are gone, the
+ * planner still serves every `device_id=?` shape (equality, ordered, COUNT) from
+ * the composite with no filesort, the standalone `timestamp` and category indexes
+ * are left intact, and the migration is reversible / idempotent / replay-safe.
+ */
+const TABLES = [
+  "network_events",
+  "log_events",
+  "os_events",
+  "navigation_events",
+  "storage_events",
+  "layout_events",
+] as const;
+
+/** Category/content indexes that must survive the drop (different query shapes). */
+const CATEGORY_INDEX: Partial<Record<(typeof TABLES)[number], string>> = {
+  network_events: "idx_network_events_host",
+  log_events: "idx_log_events_tag",
+  os_events: "idx_os_events_category",
+};
+
+/**
+ * Build the six event tables via their original migrations, then add the
+ * composite indexes (#2790's precedent). The drop migration only makes sense
+ * once the composite that subsumes the device index exists.
+ */
+async function buildEventSchema(db: Kysely<unknown>): Promise<void> {
+  await telemetryUp(db); // network_events, log_events, os_events (+ custom_events)
+  await navigationUp(db); // navigation_events
+  await storageUp(db); // storage_events
+  await layoutUp(db); // layout_events
+  await compositeUp(db); // idx_<table>_device_timestamp on all six
+}
+
+async function indexExists(db: Kysely<unknown>, name: string): Promise<boolean> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'index' AND name = ${name}
+  `.execute(db);
+  return result.rows.length > 0;
+}
+
+/** Ordered column names participating in an index (PRAGMA index_info). */
+async function indexColumns(db: Kysely<unknown>, name: string): Promise<string[]> {
+  const result = await sql<{ seqno: number; name: string }>`
+    SELECT seqno, name FROM pragma_index_info(${name}) ORDER BY seqno
+  `.execute(db);
+  return result.rows.map(r => r.name);
+}
+
+/** All index names attached to a table (PRAGMA index_list). */
+async function indexList(db: Kysely<unknown>, table: string): Promise<string[]> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM pragma_index_list(${table})
+  `.execute(db);
+  return result.rows.map(r => r.name);
+}
+
+/** EXPLAIN QUERY PLAN detail lines for an arbitrary statement (raw bun:sqlite handle). */
+function queryPlan(bunDb: BunDatabase, sqlText: string): string[] {
+  const rows = bunDb.query(`EXPLAIN QUERY PLAN ${sqlText}`).all() as Array<{ detail: string }>;
+  return rows.map(r => r.detail);
+}
+
+describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
+  let bunDb: BunDatabase;
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    bunDb = new BunDatabase(":memory:");
+    db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    await buildEventSchema(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("up drops the six redundant idx_<table>_device indexes", async () => {
+    // Precondition: the device indexes exist before the drop.
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device`)).toBe(true);
+    }
+
+    await dropUp(db);
+
+    // sqlite_master no longer lists any of the six device indexes.
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device`)).toBe(false);
+    }
+  });
+
+  test("up leaves the composite, timestamp, and category indexes intact", async () => {
+    await dropUp(db);
+
+    for (const table of TABLES) {
+      const list = await indexList(db, table);
+      // Composite survives — it is what subsumes the dropped device index.
+      expect(list).toContain(`idx_${table}_device_timestamp`);
+      // Standalone timestamp index survives — retention cutoff covering scan.
+      expect(list).toContain(`idx_${table}_timestamp`);
+      // The redundant device index is gone.
+      expect(list).not.toContain(`idx_${table}_device`);
+      // Category/content index survives where the table has one.
+      const category = CATEGORY_INDEX[table];
+      if (category) {
+        expect(list).toContain(category);
+      }
+    }
+  });
+
+  test("device_id=? ORDER BY timestamp DESC LIMIT n still uses the composite, no filesort", async () => {
+    await dropUp(db);
+
+    for (const table of TABLES) {
+      const plan = queryPlan(
+        bunDb,
+        `SELECT * FROM ${table} WHERE device_id = 'dev-1' ORDER BY timestamp DESC LIMIT 100`
+      ).join("\n");
+      const composite = `idx_${table}_device_timestamp`;
+      expect(plan).toMatch(new RegExp(`SEARCH .*USING INDEX ${composite}`));
+      // The device index is gone; the composite left-prefix serves the filter,
+      // and its ordering removes the sort.
+      expect(plan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    }
+  });
+
+  test("bare device_id=? (no ORDER BY) still uses the composite left-prefix", async () => {
+    await dropUp(db);
+
+    for (const table of TABLES) {
+      const plan = queryPlan(
+        bunDb,
+        `SELECT * FROM ${table} WHERE device_id = 'dev-1'`
+      ).join("\n");
+      expect(plan).toMatch(new RegExp(`SEARCH .*USING INDEX idx_${table}_device_timestamp`));
+    }
+  });
+
+  test("COUNT(*) WHERE device_id=? is served by the composite (covering scan)", async () => {
+    await dropUp(db);
+
+    for (const table of TABLES) {
+      const plan = queryPlan(
+        bunDb,
+        `SELECT COUNT(*) FROM ${table} WHERE device_id = 'dev-1'`
+      ).join("\n");
+      expect(plan).toContain(`idx_${table}_device_timestamp`);
+    }
+  });
+
+  test("retention cutoff (ORDER BY timestamp DESC, no device filter) still uses the timestamp index", async () => {
+    await dropUp(db);
+
+    for (const table of TABLES) {
+      const plan = queryPlan(
+        bunDb,
+        `SELECT timestamp FROM ${table} ORDER BY timestamp DESC LIMIT 1 OFFSET 10000`
+      ).join("\n");
+      // The composite cannot substitute (device_id leads it); the standalone
+      // timestamp index provides the covering scan with no filesort.
+      expect(plan).toContain(`idx_${table}_timestamp`);
+      expect(plan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    }
+  });
+
+  test("device_id=? query results are unchanged after the drop", async () => {
+    await sql`INSERT INTO network_events (device_id, timestamp, url, method, status_code, duration_ms)
+      VALUES ('dev-1', 300, 'https://a', 'GET', 200, 1),
+             ('dev-1', 100, 'https://b', 'GET', 200, 1),
+             ('dev-1', 200, 'https://c', 'GET', 200, 1),
+             ('dev-2', 250, 'https://d', 'GET', 200, 1)`.execute(db);
+
+    const read = async (): Promise<Array<{ url: string; timestamp: number }>> => {
+      const result = await sql<{ url: string; timestamp: number }>`
+        SELECT url, timestamp FROM network_events
+        WHERE device_id = 'dev-1' ORDER BY timestamp DESC LIMIT 100
+      `.execute(db);
+      return result.rows;
+    };
+
+    const before = await read();
+    await dropUp(db);
+    const after = await read();
+
+    expect(after).toEqual(before);
+    expect(after.map(r => r.timestamp)).toEqual([300, 200, 100]);
+  });
+
+  test("up is idempotent (safe to re-run, as destructive-recovery replay would)", async () => {
+    await dropUp(db);
+    await expect(dropUp(db)).resolves.toBeUndefined();
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device`)).toBe(false);
+    }
+  });
+
+  test("down recreates the six single-column device indexes", async () => {
+    await dropUp(db);
+    await dropDown(db);
+    for (const table of TABLES) {
+      const name = `idx_${table}_device`;
+      expect(await indexExists(db, name)).toBe(true);
+      expect(await indexColumns(db, name)).toEqual(["device_id"]);
+    }
+  });
+
+  test("down is idempotent — a partial-up followed by down does not throw", async () => {
+    // Never dropped: down() must recreate cleanly even though indexes already exist.
+    await expect(dropDown(db)).resolves.toBeUndefined();
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device`)).toBe(true);
+    }
+    // And after a full up, a double down is still safe.
+    await dropUp(db);
+    await dropDown(db);
+    await expect(dropDown(db)).resolves.toBeUndefined();
+  });
+});
+
+describe("2026_07_03_000_drop_redundant_device_indexes migration — full replay", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    // Full forward replay of every migration on a fresh DB (the #2785
+    // destructive-recovery path). Proves the migration is discovered/wired and
+    // runs cleanly in filename order after the composite indexes exist.
+    await runMigrations(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("the six device indexes are gone after a fresh full migration chain", async () => {
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device`)).toBe(false);
+    }
+  });
+
+  test("the composite and timestamp indexes survive the full chain", async () => {
+    for (const table of TABLES) {
+      expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(true);
+      expect(await indexExists(db, `idx_${table}_timestamp`)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #2788 / PR #2890, which added composite `(device_id, timestamp)` indexes (`idx_<table>_device_timestamp`) to the six telemetry event tables but was deliberately kept **additive-only** per #2788's scope ("do not modify the existing single-column indexes"). This PR completes the optimization it deferred: it drops the six now-redundant standalone `idx_<table>_device` indexes to cut per-insert write amplification.

New forward-only migration `2026_07_03_000_drop_redundant_device_indexes.ts` (sorts after `2026_07_02_000_event_composite_indexes.ts`) drops the six device indexes in `up()` and recreates them in `down()`.

Closes #2893.

## Why

A composite `(device_id, timestamp)` index serves every access path a standalone `(device_id)` index can, via SQLite's left-prefix rule — so each of the six tables was carrying **4 indexes where 3 suffice** (`timestamp`, the category column, the redundant `device_id`, and the composite). At the retention cap with a high insert rate, the redundant `device_id` B-tree was maintained on every insert for no read benefit.

There is no `ANALYZE`/`sqlite_stat1` in `src/db/`, so the planner chooses structurally and deterministically — the composite is picked for `device_id=?` access whether or not the standalone index exists.

## How

Dropped indexes (one per table), confirmed against each source migration:

- `idx_network_events_device`, `idx_log_events_device`, `idx_os_events_device` (`2026_03_15_000_telemetry_events.ts`)
- `idx_navigation_events_device` (`2026_03_18_000_navigation_events.ts`)
- `idx_storage_events_device` (`2026_03_19_000_storage_events.ts`)
- `idx_layout_events_device` (`2026_03_19_001_layout_events.ts`)

`up()` uses `.dropIndex(...).ifExists()`; `down()` recreates each with `.createIndex(...).ifNotExists().column("device_id")` — byte-identical to the base migrations — so the migration is idempotent, reversible, and replay-safe under #2785's destructive-recovery path.

**Deliberately left intact** (different query shapes, explicitly out of scope):
- The standalone **`timestamp`** indexes — the retention cutoff (`ORDER BY timestamp DESC LIMIT 1 OFFSET <cap>`, no device filter) uses them as a covering scan, and the composite **cannot** substitute because `device_id` leads it.
- The category/content indexes (`idx_network_events_host`, `idx_log_events_tag`, `idx_os_events_category`).

## Testing

New `test/db/dropRedundantDeviceIndexes.test.ts` (12 tests, all <100ms) — confirmed **red before the migration existed** (module-not-found), green after:

- All six `idx_<table>_device` indexes dropped by `up()`; absent from `sqlite_master`.
- `PRAGMA index_list` per table shows composite + timestamp + category (where applicable), device index gone.
- `EXPLAIN QUERY PLAN` after the drop, for all six tables: `WHERE device_id=? ORDER BY timestamp DESC LIMIT n`, bare `WHERE device_id=?`, and `COUNT(*) WHERE device_id=?` all use `idx_<table>_device_timestamp` with **no** `USE TEMP B-TREE FOR ORDER BY`.
- Retention cutoff query still uses the standalone `idx_<table>_timestamp` (composite cannot substitute).
- `device_id=?` query results byte-identical before/after; `up`/`down` idempotent; full `runMigrations` replay leaves device indexes gone and composite/timestamp intact.

Independently reproduced the planner behavior with stock `sqlite3` (not just bun:sqlite) to confirm it isn't a dialect quirk.

- `bunx turbo run lint build test` green: **5869 pass, 0 fail** (452 files).
- `scripts/all_fast_validate_checks.sh`: 10/10 passed.

## Acceptance / evaluation criteria (from #2893)

- [x] New migration drops the six redundant `idx_<table>_device` indexes; `down()` recreates them (`.ifExists()`/`.ifNotExists()`, replay-safe).
- [x] `EXPLAIN QUERY PLAN` for `WHERE device_id=? ORDER BY timestamp DESC LIMIT n`, bare `WHERE device_id=?`, and `COUNT(*) WHERE device_id=?` still use `idx_<table>_device_timestamp` with no temp B-tree — asserted for all six tables.
- [x] The standalone `timestamp` indexes left intact (retention cutoff still uses them as a covering scan).
- [x] `sqlite_master` no longer lists the six `idx_<table>_device` indexes; `PRAGMA index_list` shows composite + timestamp + category per table.
- [x] Existing event-repo tests + `bun test` + `turbo run lint build test` green.
