### PR TITLE
fix(db): cold-start dbWriteBarrier drain latch on closeDatabase (#2896)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -14,6 +14,7 @@ import {
   extractMissingPackageName,
   isMissingMigrationDependencyError,
 } from "./migrationDependencyIntegrity";
+import { resetDbWriteBarrier } from "./dbWriteBarrier";
 
 type BunDatabaseConstructor = typeof import("bun:sqlite").Database;
 type BunDatabase = import("bun:sqlite").Database;
@@ -302,6 +303,17 @@ export async function closeDatabase(): Promise<void> {
   migrationsPromise = null;
   migrationsError = null;
   resolvedDbPath = null;
+
+  // Cold-start the write barrier too (issue #2896, follow-up to #2796). Its
+  // draining flag latches for the process lifetime, so shutdown's
+  // `getDbWriteBarrier().drain(...)` before this close (issue #2792 ordering)
+  // would otherwise leave the shared barrier permanently draining. Any future
+  // in-process reopen (config reload / DB path switch / restart-without-exit)
+  // would then silently skip every tracked best-effort write against the
+  // reopened DB. Resetting here makes the "reopen behaves like a cold start"
+  // contract fully true instead of carrying a barrier-shaped exception. Inert
+  // in the daemon, where the only caller is shutdown-then-`process.exit`.
+  resetDbWriteBarrier();
 }
 
 /**

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -310,9 +310,13 @@ export async function closeDatabase(): Promise<void> {
   // would otherwise leave the shared barrier permanently draining. Any future
   // in-process reopen (config reload / DB path switch / restart-without-exit)
   // would then silently skip every tracked best-effort write against the
-  // reopened DB. Resetting here makes the "reopen behaves like a cold start"
-  // contract fully true instead of carrying a barrier-shaped exception. Inert
-  // in the daemon, where the only caller is shutdown-then-`process.exit`.
+  // reopened DB. Resetting here extends the "reopen behaves like a cold start"
+  // contract to the write barrier for consumers that resolve
+  // `getDbWriteBarrier()` at use-time; construction-captured consumers keep
+  // their pinned barrier and remain the documented reopen exception (#2912).
+  // Inert in the daemon, where the only caller is
+  // shutdown-then-`process.exit`. If the migration/path resets above are ever
+  // consolidated into a single reset(), this must move with them.
   resetDbWriteBarrier();
 }
 

--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -27,9 +27,12 @@ export interface DbWriteBarrier {
 
   /**
    * Flip the draining flag so subsequent {@link track} calls short-circuit.
-   * The flag latches for the process lifetime: production exits after shutdown,
-   * and a same-process restart (tests) starts from a fresh barrier via
-   * {@link resetDbWriteBarrier} or an injected instance.
+   * The flag latches for the instance's lifetime; a fresh cold start comes from
+   * a new barrier. `closeDatabase()` clears the shared barrier via
+   * {@link resetDbWriteBarrier} on every DB close, so a same-process reopen —
+   * whether a real shutdown drain-then-reopen or a test restart — always sees a
+   * fresh, non-draining barrier (issue #2896). Injected instances are reset by
+   * their owner.
    */
   beginDrain(): void;
 
@@ -123,7 +126,13 @@ export function getDbWriteBarrier(): DbWriteBarrier {
   return sharedBarrier;
 }
 
-/** Reset the shared barrier (testing only). */
+/**
+ * Discard the shared barrier so the next {@link getDbWriteBarrier} lazily
+ * creates a fresh, non-draining one. Called by `closeDatabase()` so a
+ * same-process DB reopen cold-starts the barrier (issue #2896) — its draining
+ * flag would otherwise latch for the process lifetime after a shutdown drain —
+ * and by tests for isolation.
+ */
 export function resetDbWriteBarrier(): void {
   sharedBarrier = null;
 }

--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -28,11 +28,17 @@ export interface DbWriteBarrier {
   /**
    * Flip the draining flag so subsequent {@link track} calls short-circuit.
    * The flag latches for the instance's lifetime; a fresh cold start comes from
-   * a new barrier. `closeDatabase()` clears the shared barrier via
+   * a new barrier. `closeDatabase()` clears the *shared* barrier via
    * {@link resetDbWriteBarrier} on every DB close, so a same-process reopen —
-   * whether a real shutdown drain-then-reopen or a test restart — always sees a
-   * fresh, non-draining barrier (issue #2896). Injected instances are reset by
-   * their owner.
+   * whether a real shutdown drain-then-reopen or a test restart — resolves a
+   * fresh, non-draining barrier from {@link getDbWriteBarrier} (issue #2896).
+   *
+   * This only covers consumers that resolve `getDbWriteBarrier()` at use-time.
+   * Consumers that capture a barrier once at construction (TelemetryRecorder,
+   * FailureAnalyticsRepository, SessionManager — all injected) keep their
+   * pinned instance across the null-swap, so a future in-process reopen path
+   * MUST reconstruct them (or the barrier lifecycle must move to in-place
+   * reset). Inert today: no in-process reopen path exists — see #2912.
    */
   beginDrain(): void;
 
@@ -132,6 +138,12 @@ export function getDbWriteBarrier(): DbWriteBarrier {
  * same-process DB reopen cold-starts the barrier (issue #2896) — its draining
  * flag would otherwise latch for the process lifetime after a shutdown drain —
  * and by tests for isolation.
+ *
+ * Identity swap, not in-place reset: callers holding a captured reference keep
+ * the old instance (see {@link beginDrain}). That is intentional for today's
+ * only caller — the daemon closes then exits, so leaving captured barriers
+ * draining keeps a late best-effort write safely short-circuited instead of
+ * hitting the just-destroyed connection.
  */
 export function resetDbWriteBarrier(): void {
   sharedBarrier = null;

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
+
+/**
+ * Regression tests for issue #2896 (follow-up to #2796).
+ *
+ * #2796 made `closeDatabase()` reset the migration/path module globals so a
+ * same-process reopen behaves like a cold start. The one shutdown-state global
+ * it deliberately left untouched was the {@link getDbWriteBarrier} drain latch:
+ * once `beginDrain()`/`drain()` flips it, it stays draining for the process
+ * lifetime and every tracked best-effort write short-circuits
+ * (`dbWriteBarrier.ts` `track()`).
+ *
+ * The daemon quiesces in-flight writes by calling `getDbWriteBarrier().drain()`
+ * BEFORE `closeDatabase()` (issue #2792 ordering). If any future path reopens
+ * the DB in the same process after that drain (config reload, DB path switch,
+ * restart-without-exit) without also cold-starting the barrier, the reopened DB
+ * would silently skip every tracked best-effort write. `closeDatabase()` now
+ * clears the barrier via `resetDbWriteBarrier()` so the cold-start contract is
+ * fully true.
+ *
+ * The shared barrier is a process-global singleton; `resetDbWriteBarrier()` in
+ * `beforeEach`/`afterEach` isolates these tests from the rest of the suite.
+ */
+describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)", () => {
+  const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+  const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
+  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
+
+  const tempDirs: string[] = [];
+
+  function restore(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  beforeEach(() => {
+    // Start every test from a fresh, non-draining shared barrier so a latched
+    // barrier leaked by another test cannot mask the reset under test.
+    resetDbWriteBarrier();
+  });
+
+  afterEach(async () => {
+    resetDbWriteBarrier();
+    restore(DAEMON_LAUNCH_CWD_ENV, originalLaunchCwd);
+    restore("AUTOMOBILE_DB_DIR", originalDbDir);
+    restore("AUTOMOBILE_DB_PATH", originalDbPath);
+    for (const dir of tempDirs.splice(0)) {
+      await removeTempDirWithRetry(dir);
+    }
+  });
+
+  // Fresh `database.ts` instance per test so its lazy migration globals are not
+  // shared with other tests. The fresh module still imports the same shared
+  // `dbWriteBarrier` singleton this test reads (relative imports resolve without
+  // the cache-busting query string), so `closeDatabase()` and
+  // `getDbWriteBarrier()` operate on one barrier instance.
+  async function importFreshDatabaseModule() {
+    return import(`../../src/db/database.ts?barrier-reset-test=${Date.now()}-${Math.random()}`);
+  }
+
+  async function makeTempDbDir(prefix: string): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function removeTempDirWithRetry(dir: string): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        await rm(dir, { recursive: true, force: true });
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
+          throw error;
+        }
+        await defaultTimer.sleep(50);
+      }
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  test("a tracked best-effort write after drain -> close -> reopen is NOT skipped", async () => {
+    const firstDir = await makeTempDbDir("auto-mobile-barrier-reset-first-");
+    process.env.AUTOMOBILE_DB_DIR = firstDir;
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+
+    const databaseModule = await importFreshDatabaseModule();
+
+    // Cold start on the first DB.
+    databaseModule.getDatabase();
+
+    // Model the daemon shutdown ordering: drain in-flight best-effort writes,
+    // then close the connection (issue #2792).
+    const shutdownBarrier = getDbWriteBarrier();
+    expect(await shutdownBarrier.drain(1000)).toBe(true);
+    expect(shutdownBarrier.isDraining()).toBe(true);
+
+    await databaseModule.closeDatabase();
+
+    // Reopen in the same process against a brand-new DB dir (config reload / DB
+    // path switch / restart-without-exit).
+    const secondDir = await makeTempDbDir("auto-mobile-barrier-reset-second-");
+    process.env.AUTOMOBILE_DB_DIR = secondDir;
+    databaseModule.getDatabase();
+
+    // The barrier must have cold-started: a distinct, non-draining instance.
+    const reopenedBarrier = getDbWriteBarrier();
+    expect(reopenedBarrier).not.toBe(shutdownBarrier);
+    expect(reopenedBarrier.isDraining()).toBe(false);
+
+    // The core contract: a tracked best-effort write actually runs against the
+    // reopened DB instead of being silently skipped by a latched barrier.
+    let ran = false;
+    const result = await reopenedBarrier.track(async () => {
+      ran = true;
+      return "written";
+    });
+    expect(ran).toBe(true);
+    expect(result).toBe("written");
+
+    await databaseModule.closeDatabase();
+  });
+
+  test("closeDatabase clears a drain latch even with no open connection", async () => {
+    const dir = await makeTempDbDir("auto-mobile-barrier-reset-noconn-");
+    process.env.AUTOMOBILE_DB_DIR = dir;
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+
+    const databaseModule = await importFreshDatabaseModule();
+
+    // Latch the barrier without ever opening the DB, then close. The reset is
+    // unconditional (mirrors the migration-global reset), so the latch clears
+    // even on a partially-initialized shutdown.
+    const latched = getDbWriteBarrier();
+    latched.beginDrain();
+    expect(latched.isDraining()).toBe(true);
+
+    await databaseModule.closeDatabase();
+
+    const fresh = getDbWriteBarrier();
+    expect(fresh).not.toBe(latched);
+    expect(fresh.isDraining()).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #2889 (issue #2796). `closeDatabase()` resets the migration/path
module globals (`migrationsRun` / `migrationsPromise` / `migrationsError` /
`resolvedDbPath`) so a **same-process reopen behaves like a cold start** — but
it deliberately left one shutdown-state global untouched: the `dbWriteBarrier`
drain latch.

`dbWriteBarrier`'s draining flag latches for the process lifetime. Daemon
shutdown calls `getDbWriteBarrier().drain(...)` (`daemon.ts:1278`) to quiesce
in-flight best-effort writes **before** `closeDatabase()` (`daemon.ts:1285`,
issue #2792 ordering). If any future path reopens the DB **in the same process**
after that drain (config reload, DB path switch, restart-without-exit) without
also cold-starting the barrier, the shared barrier stays permanently draining
and every tracked best-effort write is silently skipped
(`dbWriteBarrier.ts` `track()`) against the reopened DB.

`closeDatabase()` now clears the shared barrier via `resetDbWriteBarrier()`,
extending the "reopen behaves like a cold start" contract from #2796 to the
write barrier for consumers that resolve `getDbWriteBarrier()` at use-time.
Construction-captured consumers keep their pinned barrier and remain a
documented reopen exception (tracked in #2912).

Closes #2896.

## Why

**No production impact today**, latent hardening only (issue is P3):

- The sole `closeDatabase()` caller is `daemon.ts:1285`, terminal daemon
  shutdown-then-`process.exit` (`logger.close()` immediately follows). There is
  no in-process reopen path, so the latch is never observed post-drain in a
  reopened process.
- It becomes a real, silent bug the moment any feature reopens the DB in-process
  after a drain.

**Ownership decision** (the issue asked to pick one): rather than documenting an
exception that every future reopen path must remember, the DB-lifecycle reset
now **owns** clearing the write barrier. This matches the existing #2796 pattern
where `closeDatabase()` already resets every other shutdown-state global as a
set. No import cycle is introduced — `dbWriteBarrier.ts` imports only
`SystemTimer`/`logger`, neither of which imports `database.ts`.

**Daemon shutdown is unaffected.** `stop()` tears down every writer — all socket
servers, the health/heartbeat/device timers, and HTTP sessions — *before*
`drain()`/`closeDatabase()`, so no live writer exists in the tiny window between
the reset and `process.exit`. The extra reset is inert there.

## How

`src/db/database.ts` — `closeDatabase()` calls `resetDbWriteBarrier()` after the
existing migration/path global resets, so the barrier cold-starts alongside them:

```ts
migrationsRun = false;
migrationsPromise = null;
migrationsError = null;
resolvedDbPath = null;
resetDbWriteBarrier();
```

`src/db/dbWriteBarrier.ts` — updated the `beginDrain()` and `resetDbWriteBarrier()`
doc comments to reflect that `closeDatabase()` now clears the shared barrier on
every DB close, so a same-process reopen always sees a fresh, non-draining
barrier.

## Testing

- **`test/db/dbWriteBarrierResetOnClose.test.ts`** (new, TDD — written red first,
  then made green) covering the issue's acceptance criteria:
  - `drain() → closeDatabase() → reopen → tracked best-effort write is NOT
    skipped` — models the daemon shutdown ordering, then asserts the reopened
    barrier is a **distinct, non-draining** instance and a tracked write actually
    runs (returns its value) instead of short-circuiting.
  - `closeDatabase() clears a drain latch even with no open connection` — the
    reset is unconditional, mirroring the migration-global reset, so a
    partially-initialized shutdown still cold-starts the barrier.
- Follows repo conventions (fresh `database.ts` import per case for global
  isolation, temp dirs, `defaultTimer` for retry, `resetDbWriteBarrier()` in
  `beforeEach`/`afterEach` for suite isolation).
- Full `test/db/` suite: **454 pass, 0 fail**. `test/daemon/`: **578 pass, 0
  fail**. `turbo run lint build` clean.

## Follow-up (filed: #2912)

The injected-barrier consumers — `TelemetryRecorder` (singleton), `SessionManager`
(`daemon.ts:141`), `FailureAnalyticsRepository` (module-level `const`) — capture
`getDbWriteBarrier()` at construction. A future in-process reopen path must
reconstruct them (or they'd hold the stale, drained barrier). Moot today (no
reopen path exists); flagged in the `beginDrain()` doc comment and tracked in
#2912 (which also captures a self-limiting, already-swallowed closed-DB write
window in the daemon shutdown-exit path surfaced by the review).


