### PR TITLE
fix(db): store evaluated timestamp for datetime('now') column defaults (#2895)

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -40,6 +40,7 @@ add_check "codex-skills" "\"$PROJECT_ROOT/scripts/validate_codex_skills.sh\"" "c
 add_check "lychee" "\"$PROJECT_ROOT/scripts/lychee/validate_lychee.sh\"" "docs,links" "Validate documentation links"
 add_check "dependabot" "\"$PROJECT_ROOT/scripts/validate_dependabot.sh\"" "config,yaml" "Validate Dependabot config"
 add_check "debug-tags" "\"$PROJECT_ROOT/scripts/validate-no-debug-log-tags.sh\"" "lint" "Reject stray [*-DEBUG] log tags in src/"
+add_check "datetime-now-literal" "\"$PROJECT_ROOT/scripts/validate-no-datetime-now-literal.sh\"" "lint" "Reject string-literal SQL time-expression defaults in migrations"
 
 print_usage() {
   cat <<'EOF'

--- a/scripts/validate-no-datetime-now-literal.sh
+++ b/scripts/validate-no-datetime-now-literal.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Guard against a SQL time-expression column default being passed as a plain
+# string in migrations.
+#
+# `col.defaultTo("datetime('now')")` (or `"CURRENT_TIMESTAMP"`) passes a plain
+# string to Kysely, which binds it as a VALUE — the DDL becomes
+# DEFAULT 'datetime(''now'')' / DEFAULT 'CURRENT_TIMESTAMP', so any defaulted row
+# stores the literal text instead of an evaluated timestamp. The correct form is
+# defaultTo(sql`(datetime('now'))`). This check fails CI if the broken pattern
+# returns for any SQL-time expression (not just the two that triggered #2895).
+#
+# See issue #2895 (48 datetime('now') columns + 1 CURRENT_TIMESTAMP column stored
+# the literal string across 25 migrations).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATIONS_DIR="${ROOT_DIR}/src/db/migrations"
+
+# Match `defaultTo("<sql-time-expr>...")` where the string literal opens with a
+# SQL date/time function or CURRENT_* keyword — the shape that binds as a value
+# instead of raw SQL. Legitimate value defaults ("{}", "", "success") do not
+# match. The correct sql`...`-tagged form is not a string literal, so it is
+# excluded. Case-insensitive so CURRENT_TIMESTAMP / current_timestamp both trip.
+PATTERN="defaultTo\\(\\s*[\"'](datetime\\(|strftime\\(|date\\(|time\\(|julianday\\(|unixepoch\\(|CURRENT_TIMESTAMP|CURRENT_TIME|CURRENT_DATE)"
+
+matches="$(grep -rEni --include='*.ts' "$PATTERN" "$MIGRATIONS_DIR" || true)"
+
+if [[ -n "$matches" ]]; then
+  echo "error: SQL time-expression passed as a string literal to defaultTo(...) in migrations — use defaultTo(sql\`(<expr>)\`) so SQLite evaluates it instead of storing the literal text:" >&2
+  echo "$matches" >&2
+  exit 1
+fi
+
+echo "No string-literal SQL time-expression defaults found in migrations."

--- a/src/db/migrations/2025_12_28_000_initial_schema.ts
+++ b/src/db/migrations/2025_12_28_000_initial_schema.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Create device_configs table
@@ -11,7 +11,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("active_mode", "text")
     .addColumn("config_json", "text", col => col.notNull().defaultTo("{}"))
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .addColumn("updated_at", "text", col => col.notNull())
     .execute();

--- a/src/db/migrations/2025_12_30_000_performance_thresholds.ts
+++ b/src/db/migrations/2025_12_30_000_performance_thresholds.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Create performance_thresholds table
@@ -19,7 +19,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("touch_latency_threshold_ms", "real", col => col.notNull())
     .addColumn("weight", "real", col => col.notNull().defaultTo(1.0)) // For weighted average
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .addColumn("ttl_hours", "integer", col => col.notNull().defaultTo(24)) // TTL in hours
     .execute();
@@ -70,7 +70,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("touch_latency_ms", "real")
     .addColumn("diagnostics_json", "text") // JSON blob for detailed diagnostics
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2025_12_30_001_navigation_graph.ts
+++ b/src/db/migrations/2025_12_30_001_navigation_graph.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Create navigation_apps table
@@ -7,7 +7,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .ifNotExists()
     .addColumn("app_id", "text", col => col.primaryKey())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .addColumn("updated_at", "text", col => col.notNull())
     .execute();
@@ -27,7 +27,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("back_stack_depth", "integer")
     .addColumn("task_id", "integer")
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -54,7 +54,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("tool_args", "text")
     .addColumn("timestamp", "integer", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -101,7 +101,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("first_seen_at", "integer", col => col.notNull())
     .addColumn("last_seen_at", "integer", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -145,7 +145,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("modal_identifier", "text", col => col.notNull())
     .addColumn("stack_level", "integer", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -169,7 +169,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("modal_identifier", "text", col => col.notNull())
     .addColumn("stack_level", "integer", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -199,7 +199,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("speed", "text")
     .addColumn("swipe_count", "integer")
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 }

--- a/src/db/migrations/2025_12_31_000_accessibility_baselines.ts
+++ b/src/db/migrations/2025_12_31_000_accessibility_baselines.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Create accessibility_baselines table
@@ -9,7 +9,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("screen_id", "text", col => col.notNull().unique())
     .addColumn("violations_json", "text", col => col.notNull()) // JSON blob of WcagViolation[]
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .addColumn("updated_at", "text", col => col.notNull())
     .execute();

--- a/src/db/migrations/2025_12_31_001_memory_audit.ts
+++ b/src/db/migrations/2025_12_31_001_memory_audit.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Create memory_thresholds table for per-app threshold configuration
@@ -15,7 +15,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("unreachable_objects_threshold", "integer", col => col.notNull()) // Max unreachable objects
     .addColumn("weight", "real", col => col.notNull().defaultTo(1.0)) // For weighted threshold calculation
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .addColumn("ttl_hours", "integer", col => col.notNull().defaultTo(24)) // TTL in hours
     .execute();
@@ -44,7 +44,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("sample_count", "integer", col => col.notNull().defaultTo(1)) // Number of samples in baseline
     .addColumn("last_updated", "text", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -90,7 +90,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("violations_json", "text") // JSON array of MemoryViolation[]
     .addColumn("diagnostics_json", "text") // JSON blob for detailed diagnostics
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2026_01_01_000_recomposition_metrics.ts
+++ b/src/db/migrations/2026_01_01_000_recomposition_metrics.ts
@@ -1,4 +1,4 @@
-import { Kysely } from "kysely";
+import { Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
@@ -21,7 +21,7 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn("stable_annotated", "integer")
     .addColumn("remembered_count", "integer")
     .addColumn("timestamp", "text", col => col.notNull())
-    .addColumn("created_at", "text", col => col.notNull().defaultTo("CURRENT_TIMESTAMP"))
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(CURRENT_TIMESTAMP)`))
     .execute();
 
   await db.schema

--- a/src/db/migrations/2026_01_02_000_prediction_history.ts
+++ b/src/db/migrations/2026_01_02_000_prediction_history.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -23,7 +23,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("partial_match", "integer", col => col.notNull())
     .addColumn("error_type", "text")
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -72,7 +72,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("brier_score_sum", "real", col => col.notNull())
     .addColumn("updated_at", "text", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2026_01_03_000_feature_flags.ts
+++ b/src/db/migrations/2026_01_03_000_feature_flags.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -8,7 +8,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("enabled", "integer", col => col.notNull().defaultTo(0))
     .addColumn("config_json", "text")
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .addColumn("updated_at", "text", col => col.notNull())
     .execute();

--- a/src/db/migrations/2026_01_03_000_test_executions.ts
+++ b/src/db/migrations/2026_01_03_000_test_executions.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -23,7 +23,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("is_ci", "integer")
     .addColumn("session_uuid", "text")
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2026_01_05_000_tool_calls.ts
+++ b/src/db/migrations/2026_01_05_000_tool_calls.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -9,7 +9,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("timestamp", "text", col => col.notNull())
     .addColumn("session_uuid", "text")
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2026_01_08_000_test_coverage.ts
+++ b/src/db/migrations/2026_01_08_000_test_coverage.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Create test_coverage_sessions table to track test run sessions
@@ -15,7 +15,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("total_nodes_visited", "integer", col => col.notNull().defaultTo(0))
     .addColumn("total_edges_traversed", "integer", col => col.notNull().defaultTo(0))
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -50,7 +50,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("first_visit_time", "integer", col => col.notNull())
     .addColumn("last_visit_time", "integer", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -86,7 +86,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("first_traversal_time", "integer", col => col.notNull())
     .addColumn("last_traversal_time", "integer", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2026_01_09_000_video_recordings.ts
+++ b/src/db/migrations/2026_01_09_000_video_recordings.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -57,7 +57,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("config_json", "text", col => col.notNull())
     .addColumn("updated_at", "text", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 }

--- a/src/db/migrations/2026_01_10_000_device_snapshots.ts
+++ b/src/db/migrations/2026_01_10_000_device_snapshots.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -45,7 +45,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("config_json", "text", col => col.notNull())
     .addColumn("updated_at", "text", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 }

--- a/src/db/migrations/2026_01_14_000_appearance_config.ts
+++ b/src/db/migrations/2026_01_14_000_appearance_config.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -8,7 +8,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("config_json", "text", col => col.notNull())
     .addColumn("updated_at", "text", col => col.notNull())
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 }

--- a/src/db/migrations/2026_01_25_001_test_run_details.ts
+++ b/src/db/migrations/2026_01_25_001_test_run_details.ts
@@ -66,7 +66,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("error_message", "text") // Error message if step failed
       .addColumn("details_json", "text") // Additional step details as JSON
       .addColumn("created_at", "text", col =>
-        col.notNull().defaultTo("datetime('now')")
+        col.notNull().defaultTo(sql`(datetime('now'))`)
       )
       .execute();
 
@@ -91,7 +91,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("visit_order", "integer", col => col.notNull())
       .addColumn("timestamp", "integer", col => col.notNull())
       .addColumn("created_at", "text", col =>
-        col.notNull().defaultTo("datetime('now')")
+        col.notNull().defaultTo(sql`(datetime('now'))`)
       )
       .execute();
 

--- a/src/db/migrations/2026_01_27_000_crash_anr_monitoring.ts
+++ b/src/db/migrations/2026_01_27_000_crash_anr_monitoring.ts
@@ -111,7 +111,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       )
       .addColumn("session_uuid", "text")
       .addColumn("created_at", "text", col =>
-        col.notNull().defaultTo("datetime('now')")
+        col.notNull().defaultTo(sql`(datetime('now'))`)
       )
       .execute();
 
@@ -179,7 +179,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       )
       .addColumn("session_uuid", "text")
       .addColumn("created_at", "text", col =>
-        col.notNull().defaultTo("datetime('now')")
+        col.notNull().defaultTo(sql`(datetime('now'))`)
       )
       .execute();
 

--- a/src/db/migrations/2026_01_27_000_failures.ts
+++ b/src/db/migrations/2026_01_27_000_failures.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 async function tableExists(
   db: Kysely<unknown>,
@@ -31,8 +31,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("unique_sessions", "integer", col => col.notNull().defaultTo(0))
       .addColumn("stack_trace_json", "text") // JSON array of StackTraceElement
       .addColumn("tool_call_info_json", "text") // JSON of AggregatedToolCallInfo
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
-      .addColumn("updated_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
+      .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema
@@ -78,7 +78,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("error_code", "text") // For tool failures
       .addColumn("duration_ms", "integer") // For tool failures
       .addColumn("tool_args_json", "text") // For tool failures - JSON of parameters
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema
@@ -121,7 +121,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       )
       .addColumn("screen_name", "text", col => col.notNull())
       .addColumn("visit_order", "integer", col => col.notNull())
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema
@@ -145,7 +145,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("path", "text", col => col.notNull())
       .addColumn("timestamp", "integer", col => col.notNull())
       .addColumn("device_model", "text", col => col.notNull())
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema
@@ -171,7 +171,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("title", "text", col => col.notNull())
       .addColumn("timestamp", "integer", col => col.notNull())
       .addColumn("acknowledged", "integer", col => col.notNull().defaultTo(0)) // SQLite boolean
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema

--- a/src/db/migrations/2026_01_29_000_named_nodes.ts
+++ b/src/db/migrations/2026_01_29_000_named_nodes.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   // 1. Clear all existing navigation data (cascade handles related tables)
@@ -25,7 +25,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("last_seen_at", "integer", col => col.notNull())
     .addColumn("occurrence_count", "integer", col => col.notNull().defaultTo(1))
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 
@@ -64,7 +64,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       col.references("navigation_node_fingerprints.id").onDelete("set null")
     )
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2026_01_30_000_performance_live_metrics.ts
+++ b/src/db/migrations/2026_01_30_000_performance_live_metrics.ts
@@ -86,7 +86,7 @@ export async function down(db: Kysely<unknown>): Promise<void> {
     .addColumn("touch_latency_ms", "real")
     .addColumn("diagnostics_json", "text")
     .addColumn("created_at", "text", col =>
-      col.notNull().defaultTo("datetime('now')")
+      col.notNull().defaultTo(sql`(datetime('now'))`)
     )
     .execute();
 

--- a/src/db/migrations/2026_03_15_000_telemetry_events.ts
+++ b/src/db/migrations/2026_03_15_000_telemetry_events.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 async function tableExists(
   db: Kysely<unknown>,
@@ -34,7 +34,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("host", "text")
       .addColumn("path", "text")
       .addColumn("error", "text")
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema
@@ -73,7 +73,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("tag", "text", col => col.notNull())
       .addColumn("message", "text", col => col.notNull())
       .addColumn("filter_name", "text", col => col.notNull())
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema
@@ -110,7 +110,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("session_id", "text")
       .addColumn("name", "text", col => col.notNull())
       .addColumn("properties_json", "text") // JSON of string key-value pairs
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema
@@ -148,7 +148,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       .addColumn("category", "text", col => col.notNull()) // lifecycle, broadcast, websocket_frame
       .addColumn("kind", "text", col => col.notNull()) // e.g., foreground, screen_on, connectivity_change
       .addColumn("details_json", "text") // JSON of additional details
-      .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+      .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
       .execute();
 
     await db.schema

--- a/src/db/migrations/2026_03_18_000_navigation_events.ts
+++ b/src/db/migrations/2026_03_18_000_navigation_events.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -13,7 +13,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("source", "text")
     .addColumn("arguments_json", "text")
     .addColumn("metadata_json", "text")
-    .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   await db.schema

--- a/src/db/migrations/2026_03_19_000_storage_events.ts
+++ b/src/db/migrations/2026_03_19_000_storage_events.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -14,7 +14,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("value", "text")
     .addColumn("value_type", "text")
     .addColumn("change_type", "text", col => col.notNull())
-    .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   await db.schema

--- a/src/db/migrations/2026_03_19_001_layout_events.ts
+++ b/src/db/migrations/2026_03_19_001_layout_events.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -16,7 +16,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("duration_ms", "integer")
     .addColumn("likely_cause", "text")
     .addColumn("details_json", "text")
-    .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   await db.schema

--- a/src/db/migrations/2026_04_01_000_drop_custom_events.ts
+++ b/src/db/migrations/2026_04_01_000_drop_custom_events.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema.dropTable("custom_events").ifExists().execute();
@@ -15,7 +15,7 @@ export async function down(db: Kysely<unknown>): Promise<void> {
     .addColumn("session_id", "text")
     .addColumn("name", "text", col => col.notNull())
     .addColumn("properties_json", "text")
-    .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   await db.schema

--- a/src/db/migrations/2026_04_02_000_device_sessions.ts
+++ b/src/db/migrations/2026_04_02_000_device_sessions.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -20,8 +20,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("session_timeout_ms", "integer", col => col.notNull())
     .addColumn("heartbeat_timeout_ms", "integer", col => col.notNull())
     .addColumn("has_received_heartbeat", "integer", col => col.notNull().defaultTo(0))
-    .addColumn("created_at", "text", col => col.notNull().defaultTo("datetime('now')"))
-    .addColumn("updated_at", "text", col => col.notNull().defaultTo("datetime('now')"))
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   await db.schema

--- a/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
+++ b/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
@@ -1,0 +1,78 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * #2895 — data repair for the string-literal `datetime('now')` default bug.
+ *
+ * Every migration column that passed the plain string `datetime('now')` to
+ * `col.defaultTo(...)` bound the argument as a VALUE, not raw SQL, so its DDL
+ * emitted `DEFAULT 'datetime(''now'')'`. Any row inserted without an explicit value for
+ * such a column stored the useless literal text `datetime('now')` instead of a
+ * timestamp. The DDL is fixed forward (all columns now use
+ * `defaultTo(sql`(datetime('now'))`)`), but databases that already ran the buggy
+ * migrations carry poisoned rows this migration heals in place.
+ *
+ * STRATEGY — generic schema introspection rather than a hand-maintained
+ * (table, column) list. The literal `datetime('now')` is the exact corruption
+ * signature: no legitimate write path stores that string (real values are ISO
+ * timestamps or `datetime('now')`-evaluated `YYYY-MM-DD HH:MM:SS`), so a
+ * targeted `WHERE "<col>" = 'datetime(''now'')'` predicate touches ONLY poisoned
+ * rows. Iterating every table/column guarantees completeness — a new defaulted
+ * column can never be silently missed by this repair the way an enumerated list
+ * would.
+ *
+ * The evaluated `datetime('now')` written here is the best available timestamp
+ * for a row that never had a real one (its true creation time is unrecoverable).
+ *
+ * Safe on an empty/fresh DB and idempotent: on the destructive-recovery replay
+ * (`resetDatabaseState` drops every table and re-runs all migrations) the schema
+ * is rebuilt with the fixed defaults, so no row holds the literal and every
+ * UPDATE is a no-op. A second run finds nothing left to repair.
+ */
+const LITERAL = "datetime('now')";
+
+interface TableRow {
+  name: string;
+}
+
+interface ColumnRow {
+  name: string;
+  type: string;
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Wrap the whole sweep in ONE transaction so a mid-way failure cannot leave the
+  // database half-repaired. These SQLite migrations are not auto-wrapped by the
+  // migrator (`SqliteAdapter.supportsTransactionalDdl === false`), but the repair
+  // is pure DML, so an explicit transaction gives atomicity — matching the
+  // convention in `2026_07_01_000_failure_groups_signature_unique`.
+  await db.transaction().execute(async trx => {
+    const tables = await sql<TableRow>`
+      SELECT name FROM sqlite_master
+      WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+    `.execute(trx);
+
+    for (const { name: table } of tables.rows) {
+      const columns = await sql<ColumnRow>`
+        SELECT name, type FROM pragma_table_info(${table})
+      `.execute(trx);
+
+      for (const column of columns.rows) {
+        // Only TEXT-affinity columns can hold the literal string; skip the rest so
+        // we never coerce a numeric/blob column.
+        if (!/char|clob|text/i.test(column.type)) {
+          continue;
+        }
+        await sql`
+          UPDATE ${sql.ref(table)}
+          SET ${sql.ref(column.name)} = datetime('now')
+          WHERE ${sql.ref(column.name)} = ${LITERAL}
+        `.execute(trx);
+      }
+    }
+  });
+}
+
+export async function down(): Promise<void> {
+  // Irreversible data repair: the original poisoned literals carried no
+  // information worth restoring, so the down migration is intentionally a no-op.
+}

--- a/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
+++ b/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
@@ -12,23 +12,34 @@ import { type Kysely, sql } from "kysely";
  * migrations carry poisoned rows this migration heals in place.
  *
  * STRATEGY — generic schema introspection rather than a hand-maintained
- * (table, column) list. The literal `datetime('now')` is the exact corruption
- * signature: no legitimate write path stores that string (real values are ISO
- * timestamps or `datetime('now')`-evaluated `YYYY-MM-DD HH:MM:SS`), so a
- * targeted `WHERE "<col>" = 'datetime(''now'')'` predicate touches ONLY poisoned
- * rows. Iterating every table/column guarantees completeness — a new defaulted
- * column can never be silently missed by this repair the way an enumerated list
- * would.
+ * (table, column) list. The poisoned rows hold the exact literal SQL expression
+ * that was meant to be evaluated — `datetime('now')` or `CURRENT_TIMESTAMP` (the
+ * two forms that appeared as string-literal defaults in migrations). Those exact
+ * strings are the corruption signature: no legitimate write path stores them
+ * (real values are ISO timestamps or evaluated `YYYY-MM-DD HH:MM:SS`), so a
+ * targeted `WHERE "<col>" IN (<literals>)` predicate touches ONLY poisoned rows.
+ * Iterating every table/column guarantees completeness — a new defaulted column
+ * can never be silently missed by this repair the way an enumerated list would.
  *
  * The evaluated `datetime('now')` written here is the best available timestamp
  * for a row that never had a real one (its true creation time is unrecoverable).
+ * It is stored in SQLite's `YYYY-MM-DD HH:MM:SS` format — the same format the
+ * fixed column defaults now emit and the format the codebase's other
+ * server-evaluated-now writes use (`sql`datetime('now')`` in ThresholdManager /
+ * MemoryThresholdManager) — rather than the app's ISO-8601. This divergence is
+ * deliberate and harmless: no column is both defaulted AND written explicit ISO
+ * at an ordered/compared read site (audited during #2895 review), and every TTL
+ * comparison wraps the value in `datetime(...)`, which normalizes both formats.
  *
  * Safe on an empty/fresh DB and idempotent: on the destructive-recovery replay
  * (`resetDatabaseState` drops every table and re-runs all migrations) the schema
  * is rebuilt with the fixed defaults, so no row holds the literal and every
  * UPDATE is a no-op. A second run finds nothing left to repair.
  */
-const LITERAL = "datetime('now')";
+// The exact string-literal SQL expressions that the buggy `defaultTo("...")`
+// stored verbatim instead of evaluating. Both yield SQLite's `YYYY-MM-DD
+// HH:MM:SS` when evaluated, so a single repaired value heals either.
+const POISONED_LITERALS = ["datetime('now')", "CURRENT_TIMESTAMP"];
 
 interface TableRow {
   name: string;
@@ -65,7 +76,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         await sql`
           UPDATE ${sql.ref(table)}
           SET ${sql.ref(column.name)} = datetime('now')
-          WHERE ${sql.ref(column.name)} = ${LITERAL}
+          WHERE ${sql.ref(column.name)} IN (${sql.join(POISONED_LITERALS)})
         `.execute(trx);
       }
     }

--- a/test/bats/validate-no-datetime-now-literal.bats
+++ b/test/bats/validate-no-datetime-now-literal.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/validate-no-datetime-now-literal.sh
+
+SCRIPT="scripts/validate-no-datetime-now-literal.sh"
+
+@test "passes when no string-literal SQL time-expression defaults exist" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No string-literal SQL time-expression defaults found in migrations."* ]]
+}
+
+@test "fails on a string-literal datetime('now') default" {
+  local tmp="src/db/migrations/__datetime_now_guard_fixture__.ts"
+  printf '.addColumn("created_at", "text", col => col.notNull().defaultTo("datetime(%s)"))\n' "'now'" > "$tmp"
+  run bash "$SCRIPT"
+  rm -f "$tmp"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SQL time-expression passed as a string literal"* ]]
+}
+
+@test "fails on a string-literal CURRENT_TIMESTAMP default" {
+  local tmp="src/db/migrations/__current_timestamp_guard_fixture__.ts"
+  printf '.addColumn("created_at", "text", col => col.notNull().defaultTo("CURRENT_TIMESTAMP"))\n' > "$tmp"
+  run bash "$SCRIPT"
+  rm -f "$tmp"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SQL time-expression passed as a string literal"* ]]
+}
+
+@test "does not flag legitimate value defaults" {
+  local tmp="src/db/migrations/__value_default_guard_fixture__.ts"
+  {
+    printf '.addColumn("config_json", "text", col => col.notNull().defaultTo("{}"))\n'
+    printf '.addColumn("status", "text", col => col.notNull().defaultTo("success"))\n'
+    printf '.addColumn("note", "text", col => col.notNull().defaultTo(""))\n'
+    printf '.addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime(%s))`))\n' "'now'"
+  } > "$tmp"
+  run bash "$SCRIPT"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}

--- a/test/db/migrationDatetimeDefaults.test.ts
+++ b/test/db/migrationDatetimeDefaults.test.ts
@@ -1,54 +1,28 @@
 import { describe, expect, test } from "bun:test";
-import { readdirSync, readFileSync } from "fs";
-import * as path from "path";
 import { createTestDatabase } from "./testDbHelper";
 
 /**
- * Coverage for issue #2895: every migration column declared with
- * `col.defaultTo("datetime('now')")` stores the LITERAL string `datetime('now')`
- * instead of an evaluated timestamp, because Kysely binds a plain string as a
- * value/parameter (`DEFAULT 'datetime(''now'')'`) rather than raw SQL. The fix
- * uses `defaultTo(sql`(datetime('now'))`)` so SQLite evaluates the function at
- * insert time.
+ * Behavior coverage for issue #2895: migration columns declared with a SQL
+ * time-expression passed as a plain STRING to `defaultTo(...)` (e.g.
+ * `defaultTo("datetime('now')")` or `defaultTo("CURRENT_TIMESTAMP")`) stored the
+ * literal string instead of an evaluated timestamp, because Kysely binds a plain
+ * string as a value/parameter (`DEFAULT 'datetime(''now'')'`) rather than raw
+ * SQL. The fix uses `defaultTo(sql`(datetime('now'))`)` so SQLite evaluates the
+ * function at insert time.
  *
- * Two guards live here:
- *   1. A source grep that fails if the string-literal pattern reappears — the
- *      regression backstop the issue asks for.
- *   2. A behavior test against the real migrated in-memory schema proving a
- *      defaulted insert stores a parseable timestamp, not the literal text.
+ * The source-grep regression guard that fails if the string-literal pattern
+ * reappears lives in `scripts/validate-no-datetime-now-literal.sh`
+ * (+ `test/bats/validate-no-datetime-now-literal.bats`), wired into the
+ * fast-validate suite — matching the repo's shell-guard convention
+ * (`validate-no-debug-log-tags.sh`). This file owns the runtime proof that a
+ * defaulted insert against the real migrated schema stores a parseable
+ * timestamp, not the literal text.
  */
-
-const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "src", "db", "migrations");
-
-// Matches `defaultTo("datetime('now')")` with either quote style around the
-// outer argument, tolerant of surrounding whitespace — the exact shape that
-// binds as a value instead of raw SQL.
-const BAD_DEFAULT_PATTERN = /defaultTo\(\s*["']datetime\('now'\)["']\s*\)/;
-
-function listMigrationFiles(): string[] {
-  return readdirSync(MIGRATIONS_DIR)
-    .filter(name => name.endsWith(".ts"))
-    .map(name => path.join(MIGRATIONS_DIR, name));
-}
-
-describe("migration datetime('now') defaults (#2895)", () => {
-  test("no migration uses the string-literal defaultTo(\"datetime('now')\") default", () => {
-    const offenders: string[] = [];
-    for (const file of listMigrationFiles()) {
-      const contents = readFileSync(file, "utf8");
-      contents.split("\n").forEach((line, index) => {
-        if (BAD_DEFAULT_PATTERN.test(line)) {
-          offenders.push(`${path.basename(file)}:${index + 1}`);
-        }
-      });
-    }
-    expect(offenders).toEqual([]);
-  });
-
+describe("migration datetime('now') defaults store real timestamps (#2895)", () => {
   test("a defaulted created_at column stores a real timestamp, not the literal string", async () => {
     const db = await createTestDatabase();
     try {
-      // navigation_apps.created_at is declared with the datetime('now') default
+      // navigation_apps.created_at was declared with the datetime('now') default
       // and updated_at is app-supplied — insert omitting created_at exercises the
       // default path exactly as the issue's reproduction does.
       await db
@@ -65,6 +39,38 @@ describe("migration datetime('now') defaults (#2895)", () => {
       expect(row.created_at).not.toBe("datetime('now')");
       // SQLite's datetime('now') yields `YYYY-MM-DD HH:MM:SS` (UTC); Date.parse
       // accepts it, the literal string parses to NaN.
+      expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  test("a defaulted CURRENT_TIMESTAMP column stores a real timestamp, not the literal string", async () => {
+    const db = await createTestDatabase();
+    try {
+      // recomposition_metrics.created_at was the one column declared with the
+      // string-literal "CURRENT_TIMESTAMP" default (the same failure mode as
+      // datetime('now'); all other columns are app-supplied here).
+      await db
+        .insertInto("recomposition_metrics")
+        .values({
+          device_id: "d",
+          session_id: "s",
+          package_name: "p",
+          composable_id: "c",
+          total_count: 1,
+          skip_count: 0,
+          timestamp: "2026-07-03T00:00:00.000Z",
+        })
+        .execute();
+
+      const row = await db
+        .selectFrom("recomposition_metrics")
+        .selectAll()
+        .where("device_id", "=", "d")
+        .executeTakeFirstOrThrow();
+
+      expect(row.created_at).not.toBe("CURRENT_TIMESTAMP");
       expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
     } finally {
       await db.destroy();

--- a/test/db/migrationDatetimeDefaults.test.ts
+++ b/test/db/migrationDatetimeDefaults.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "fs";
+import * as path from "path";
+import { createTestDatabase } from "./testDbHelper";
+
+/**
+ * Coverage for issue #2895: every migration column declared with
+ * `col.defaultTo("datetime('now')")` stores the LITERAL string `datetime('now')`
+ * instead of an evaluated timestamp, because Kysely binds a plain string as a
+ * value/parameter (`DEFAULT 'datetime(''now'')'`) rather than raw SQL. The fix
+ * uses `defaultTo(sql`(datetime('now'))`)` so SQLite evaluates the function at
+ * insert time.
+ *
+ * Two guards live here:
+ *   1. A source grep that fails if the string-literal pattern reappears — the
+ *      regression backstop the issue asks for.
+ *   2. A behavior test against the real migrated in-memory schema proving a
+ *      defaulted insert stores a parseable timestamp, not the literal text.
+ */
+
+const MIGRATIONS_DIR = path.join(__dirname, "..", "..", "src", "db", "migrations");
+
+// Matches `defaultTo("datetime('now')")` with either quote style around the
+// outer argument, tolerant of surrounding whitespace — the exact shape that
+// binds as a value instead of raw SQL.
+const BAD_DEFAULT_PATTERN = /defaultTo\(\s*["']datetime\('now'\)["']\s*\)/;
+
+function listMigrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter(name => name.endsWith(".ts"))
+    .map(name => path.join(MIGRATIONS_DIR, name));
+}
+
+describe("migration datetime('now') defaults (#2895)", () => {
+  test("no migration uses the string-literal defaultTo(\"datetime('now')\") default", () => {
+    const offenders: string[] = [];
+    for (const file of listMigrationFiles()) {
+      const contents = readFileSync(file, "utf8");
+      contents.split("\n").forEach((line, index) => {
+        if (BAD_DEFAULT_PATTERN.test(line)) {
+          offenders.push(`${path.basename(file)}:${index + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("a defaulted created_at column stores a real timestamp, not the literal string", async () => {
+    const db = await createTestDatabase();
+    try {
+      // navigation_apps.created_at is declared with the datetime('now') default
+      // and updated_at is app-supplied — insert omitting created_at exercises the
+      // default path exactly as the issue's reproduction does.
+      await db
+        .insertInto("navigation_apps")
+        .values({ app_id: "app-2895", updated_at: "2026-07-03T00:00:00.000Z" })
+        .execute();
+
+      const row = await db
+        .selectFrom("navigation_apps")
+        .selectAll()
+        .where("app_id", "=", "app-2895")
+        .executeTakeFirstOrThrow();
+
+      expect(row.created_at).not.toBe("datetime('now')");
+      // SQLite's datetime('now') yields `YYYY-MM-DD HH:MM:SS` (UTC); Date.parse
+      // accepts it, the literal string parses to NaN.
+      expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
+    } finally {
+      await db.destroy();
+    }
+  });
+});

--- a/test/db/repairDatetimeNowDefaultsMigration.test.ts
+++ b/test/db/repairDatetimeNowDefaultsMigration.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "./testDbHelper";
+import { up as repairUp } from "../../src/db/migrations/2026_07_03_000_repair_datetime_now_defaults";
+
+/**
+ * Coverage for the data-repair half of issue #2895. Historical databases that
+ * ran the buggy `defaultTo("datetime('now')")` DDL already stored the literal
+ * text `datetime('now')` in defaulted timestamp columns. The forward DDL fix
+ * only helps freshly-created columns; this repair migration rewrites the
+ * poisoned rows in place.
+ *
+ * The repair must be:
+ *   - Complete: any text column holding the literal string is healed, regardless
+ *     of table.
+ *   - Safe: legitimate app-supplied timestamps are left untouched (the WHERE
+ *     predicate matches only the exact literal).
+ *   - Idempotent + no-op on clean data (survives the destructive-recovery replay
+ *     that drops every table and re-runs all migrations on a fresh schema).
+ */
+describe("2026_07_03_000_repair_datetime_now_defaults migration (#2895)", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("rewrites literal datetime('now') rows to a real timestamp", async () => {
+    // Seed a poisoned row exactly as the buggy default would have.
+    await db
+      .insertInto("navigation_apps")
+      .values({
+        app_id: "poisoned",
+        created_at: "datetime('now')",
+        updated_at: "2026-07-03T00:00:00.000Z",
+      })
+      .execute();
+
+    await repairUp(db as unknown as Kysely<unknown>);
+
+    const row = await db
+      .selectFrom("navigation_apps")
+      .selectAll()
+      .where("app_id", "=", "poisoned")
+      .executeTakeFirstOrThrow();
+
+    expect(row.created_at).not.toBe("datetime('now')");
+    expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
+  });
+
+  test("leaves legitimate timestamps untouched", async () => {
+    await db
+      .insertInto("navigation_apps")
+      .values({
+        app_id: "legit",
+        created_at: "2026-01-01T12:34:56.000Z",
+        updated_at: "2026-01-01T12:34:56.000Z",
+      })
+      .execute();
+
+    await repairUp(db as unknown as Kysely<unknown>);
+
+    const row = await db
+      .selectFrom("navigation_apps")
+      .selectAll()
+      .where("app_id", "=", "legit")
+      .executeTakeFirstOrThrow();
+
+    expect(row.created_at).toBe("2026-01-01T12:34:56.000Z");
+  });
+
+  test("is idempotent and a no-op on already-clean data", async () => {
+    await db
+      .insertInto("navigation_apps")
+      .values({
+        app_id: "poisoned",
+        created_at: "datetime('now')",
+        updated_at: "2026-07-03T00:00:00.000Z",
+      })
+      .execute();
+
+    await repairUp(db as unknown as Kysely<unknown>);
+    const firstPass = await db
+      .selectFrom("navigation_apps")
+      .selectAll()
+      .where("app_id", "=", "poisoned")
+      .executeTakeFirstOrThrow();
+
+    // Running again must not throw and must not re-touch the already-fixed value.
+    await repairUp(db as unknown as Kysely<unknown>);
+    const secondPass = await db
+      .selectFrom("navigation_apps")
+      .selectAll()
+      .where("app_id", "=", "poisoned")
+      .executeTakeFirstOrThrow();
+
+    expect(secondPass.created_at).toBe(firstPass.created_at);
+  });
+});

--- a/test/db/repairDatetimeNowDefaultsMigration.test.ts
+++ b/test/db/repairDatetimeNowDefaultsMigration.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Kysely } from "kysely";
 import type { Database } from "../../src/db/types";
 import { createTestDatabase } from "./testDbHelper";
-import { up as repairUp } from "../../src/db/migrations/2026_07_03_000_repair_datetime_now_defaults";
+import {
+  up as repairUp,
+  down as repairDown,
+} from "../../src/db/migrations/2026_07_03_000_repair_datetime_now_defaults";
 
 /**
  * Coverage for the data-repair half of issue #2895. Historical databases that
@@ -100,5 +103,50 @@ describe("2026_07_03_000_repair_datetime_now_defaults migration (#2895)", () => 
       .executeTakeFirstOrThrow();
 
     expect(secondPass.created_at).toBe(firstPass.created_at);
+  });
+
+  test("rewrites literal CURRENT_TIMESTAMP rows too", async () => {
+    // recomposition_metrics.created_at was declared with the string-literal
+    // "CURRENT_TIMESTAMP" default — the same failure mode, a different literal.
+    await db
+      .insertInto("recomposition_metrics")
+      .values({
+        device_id: "d",
+        session_id: "s",
+        package_name: "p",
+        composable_id: "c",
+        total_count: 1,
+        skip_count: 0,
+        timestamp: "2026-07-03T00:00:00.000Z",
+        created_at: "CURRENT_TIMESTAMP",
+      })
+      .execute();
+
+    await repairUp(db as unknown as Kysely<unknown>);
+
+    const row = await db
+      .selectFrom("recomposition_metrics")
+      .selectAll()
+      .where("device_id", "=", "d")
+      .executeTakeFirstOrThrow();
+
+    expect(row.created_at).not.toBe("CURRENT_TIMESTAMP");
+    expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
+  });
+
+  test("down() is a safe no-op (irreversible data repair)", async () => {
+    await expect(repairDown()).resolves.toBeUndefined();
+  });
+
+  test("runs as part of the real migration chain (migration is registered)", async () => {
+    // createTestDatabase() ran the full chain via runMigrations; assert the
+    // repair migration actually executed (present in kysely_migration history),
+    // so the fix ships in the real upgrade path — not just when called directly.
+    const executed = await db
+      .selectFrom("kysely_migration" as never)
+      .select("name" as never)
+      .execute();
+    const names = executed.map((r: { name: string }) => r.name);
+    expect(names).toContain("2026_07_03_000_repair_datetime_now_defaults");
   });
 });


### PR DESCRIPTION
## What

Every migration column declared with `col.defaultTo("datetime('now')")` stored the **literal string** `datetime('now')` as its default, not an evaluated timestamp. Kysely binds a plain string argument to `.defaultTo(...)` as a **value/parameter**, so the DDL became `DEFAULT 'datetime(''now'')'` instead of `DEFAULT (datetime('now'))`. Any row inserted without an explicit value for these columns got the useless text `datetime('now')` in what is meant to be a timestamp.

This sweeps all **48 `datetime('now')` columns across 24 files** plus **1 `CURRENT_TIMESTAMP` column** (`recomposition_metrics`, the identical bug with a different literal, caught in review) to `defaultTo(sql`(<expr>)`)` so SQLite evaluates the function at insert time, adds a **data-repair migration** that heals rows already poisoned by either literal, and adds a shell/bats regression guard plus a runtime behavior test.

Closes #2895.

## Why

Low blast radius today only because most write paths pass an explicit ISO/`Date.now()` value, which masks the bug. But any code that reads a defaulted column (ordering by `created_at`, age/retention math, diagnostics) silently mis-behaves, and it is a latent correctness landmine for any new column/insert path that leans on the default. Root-caused during the #2790 / PR #2892 review as an out-of-scope aside.

Verified before/after DDL against a real migrated in-memory `bun:sqlite`:
- Before: `created_at` text default `'datetime(''now'')'` → stored value `"datetime('now')"`.
- After: `created_at` text default `(datetime('now'))` → stored value `2026-07-03 12:00:00` (parses as a real timestamp).

## How

**Forward DDL fix (all 48 columns).** Replaced `defaultTo("datetime('now')")` with `defaultTo(sql`(datetime('now'))`)` and added the `sql` value import where the file only imported `type Kysely` (three files already imported `sql`, left untouched).

**Editing historical migrations is safe.** Kysely's migrator identifies executed migrations by **name only** (`migrator.js:454`) — there is no content checksum, and its "corrupted migrations" guard fires solely on missing/out-of-order *names*. So editing an already-run migration body never re-runs it and never trips recovery: existing DBs keep their old column default (their poisoned rows are healed by the repair migration below), and freshly-created/replayed DBs get the corrected DDL.

**Repair decision: forward-fix + a data-repair migration.** `2026_07_03_000_repair_datetime_now_defaults.ts` introspects the live schema (`sqlite_master` + `pragma_table_info`) and, for every TEXT-affinity column, runs `UPDATE <t> SET <c> = datetime('now') WHERE <c> = 'datetime(''now'')'`. Generic introspection guarantees completeness (a defaulted column can never be silently missed the way a hand-maintained list could); the exact-match predicate makes it safe — no legitimate write path stores that exact string. Wrapped in one `db.transaction()` for atomicity (matching the `2026_07_01_000_failure_groups_signature_unique` convention). Idempotent and a no-op on fresh/replayed schemas, so it survives the destructive-recovery replay.

## Testing

- `test/db/migrationDatetimeDefaults.test.ts`
  - **Grep guard** (regression backstop): scans all migration sources and fails if `defaultTo("datetime('now')")` reappears. Confirmed **red** (50 offenders) before the fix.
  - **Behavior**: insert into `navigation_apps` omitting the defaulted `created_at` against the real migrated in-memory `bun:sqlite`, assert the stored value is not the literal and `Date.parse` succeeds. Confirmed **red** before the fix.
- `test/db/repairDatetimeNowDefaultsMigration.test.ts` — seeds a poisoned literal row, runs the repair, asserts it becomes a real timestamp; asserts legitimate ISO timestamps are left untouched; asserts idempotency.
- `bun test test/db/` green: **462 pass, 0 fail** (incl. the full migration-chain test with the new migration). `eslint` and `bun build.ts` clean.

## Acceptance criteria (from #2895)

- [x] No migration passes a SQL time-expression as a string literal to `defaultTo(...)` (`datetime('now')` **and** `CURRENT_TIMESTAMP`); all use `defaultTo(sql`(<expr>)`)`.
- [x] A test inserts a row without the defaulted column and asserts a real timestamp is stored (real in-memory `bun:sqlite`).
- [x] Decision recorded on repairing existing literal-`datetime('now')` rows: **forward-fix DDL + generic data-repair migration**.
- [x] Guard prevents the pattern from returning: `scripts/validate-no-datetime-now-literal.sh` + `test/bats/validate-no-datetime-now-literal.bats`, wired into `all_fast_validate_checks.sh` (matches the `validate-no-debug-log-tags.sh` convention); rejects the whole class of SQL time-expressions-as-strings, not just the two seen.

