### PR TITLE
fix(db): rebuild broken column defaults on upgraded DBs + scope row-repair (#2895 follow-up)

### DIFF
--- a/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
+++ b/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
@@ -1,89 +1,231 @@
 import { type Kysely, sql } from "kysely";
 
 /**
- * #2895 — data repair for the string-literal `datetime('now')` default bug.
+ * #2895 — repair the string-literal timestamp-default bug on already-migrated
+ * databases.
  *
- * Every migration column that passed the plain string `datetime('now')` to
- * `col.defaultTo(...)` bound the argument as a VALUE, not raw SQL, so its DDL
- * emitted `DEFAULT 'datetime(''now'')'`. Any row inserted without an explicit value for
- * such a column stored the useless literal text `datetime('now')` instead of a
- * timestamp. The DDL is fixed forward (all columns now use
- * `defaultTo(sql`(datetime('now'))`)`), but databases that already ran the buggy
- * migrations carry poisoned rows this migration heals in place.
+ * Every migration column that passed a plain SQL time-expression string to
+ * `col.defaultTo(...)` — `"datetime('now')"` or `"CURRENT_TIMESTAMP"` — bound the
+ * argument as a VALUE, not raw SQL, so its DDL emitted `DEFAULT 'datetime(''now'')'`
+ * / `DEFAULT 'CURRENT_TIMESTAMP'`. Any row inserted without an explicit value for
+ * such a column stored the useless literal text instead of a timestamp.
  *
- * STRATEGY — generic schema introspection rather than a hand-maintained
- * (table, column) list. The poisoned rows hold the exact literal SQL expression
- * that was meant to be evaluated — `datetime('now')` or `CURRENT_TIMESTAMP` (the
- * two forms that appeared as string-literal defaults in migrations). Those exact
- * strings are the corruption signature: no legitimate write path stores them
- * (real values are ISO timestamps or evaluated `YYYY-MM-DD HH:MM:SS`), so a
- * targeted `WHERE "<col>" IN (<literals>)` predicate touches ONLY poisoned rows.
- * Iterating every table/column guarantees completeness — a new defaulted column
- * can never be silently missed by this repair the way an enumerated list would.
+ * The DDL is fixed FORWARD (all columns now use `defaultTo(sql`(datetime('now'))`)`),
+ * so fresh databases are already correct. But a database that already ran the
+ * buggy migrations keeps the broken `DEFAULT` in its stored schema — editing a
+ * historical migration does NOT re-run it (Kysely tracks migrations by name, no
+ * content checksum). So on an upgraded DB this migration must do TWO things:
  *
- * The evaluated `datetime('now')` written here is the best available timestamp
- * for a row that never had a real one (its true creation time is unrecoverable).
- * It is stored in SQLite's `YYYY-MM-DD HH:MM:SS` format — the same format the
- * fixed column defaults now emit and the format the codebase's other
+ *   1. REBUILD each column whose live default is the broken string literal, so
+ *      FUTURE inserts that omit the column (e.g. `getOrCreateApp`, which omits
+ *      `created_at`) stop re-poisoning it. SQLite cannot alter a column default
+ *      in place, and bun:sqlite forbids editing `sqlite_master` directly, so we
+ *      use the standard table-rebuild: create a twin table with the corrected
+ *      default, copy the rows, drop the original, rename the twin back, and
+ *      recreate its indexes/triggers. FK enforcement is toggled OFF around the
+ *      rebuild (see `up`) so dropping a referenced parent cannot cascade-delete
+ *      its children, then `PRAGMA foreign_key_check` verifies integrity before it
+ *      is restored.
+ *   2. REPAIR the existing poisoned rows in those columns to an evaluated
+ *      timestamp.
+ *
+ * TARGETING — the fix keys off `pragma_table_info(...).dflt_value`, which reports
+ * a column's stored default. Only the two broken string-literal forms match
+ * ({@link BROKEN_DEFAULTS}); a corrected `(datetime('now'))` default, a bare
+ * `CURRENT_TIMESTAMP` keyword, and legitimate value defaults (`'{}'`, `'success'`)
+ * all report a different `dflt_value` and are skipped. This is deliberately
+ * NARROWER than "rewrite any TEXT cell equal to the literal": columns like
+ * `storage_events.value` persist arbitrary app data (an app could legitimately
+ * store the string `datetime('now')`), so restricting the row repair to columns
+ * that actually carry the broken default is what keeps it from corrupting real
+ * data.
+ *
+ * The evaluated `datetime('now')` written for repaired rows is the best available
+ * timestamp for a row that never had a real one (its true creation time is
+ * unrecoverable). It is stored in SQLite's `YYYY-MM-DD HH:MM:SS` format — the same
+ * format the fixed column defaults now emit and the codebase's other
  * server-evaluated-now writes use (`sql`datetime('now')`` in ThresholdManager /
  * MemoryThresholdManager) — rather than the app's ISO-8601. This divergence is
- * deliberate and harmless: no column is both defaulted AND written explicit ISO
- * at an ordered/compared read site (audited during #2895 review), and every TTL
+ * deliberate and harmless: no column is both defaulted AND written explicit ISO at
+ * an ordered/compared read site (audited during #2895 review), and every TTL
  * comparison wraps the value in `datetime(...)`, which normalizes both formats.
  *
- * Safe on an empty/fresh DB and idempotent: on the destructive-recovery replay
- * (`resetDatabaseState` drops every table and re-runs all migrations) the schema
- * is rebuilt with the fixed defaults, so no row holds the literal and every
- * UPDATE is a no-op. A second run finds nothing left to repair.
+ * Safe on a fresh DB and idempotent: fresh/replayed schemas carry the corrected
+ * default, so no column matches {@link BROKEN_DEFAULTS} and the whole pass is a
+ * no-op. A second run finds nothing left to rebuild or repair.
  */
-// The exact string-literal SQL expressions that the buggy `defaultTo("...")`
-// stored verbatim instead of evaluating. Both yield SQLite's `YYYY-MM-DD
-// HH:MM:SS` when evaluated, so a single repaired value heals either.
-const POISONED_LITERALS = ["datetime('now')", "CURRENT_TIMESTAMP"];
 
-interface TableRow {
+/**
+ * A column's stored default (as reported by `pragma_table_info(...).dflt_value`)
+ * mapped to the corrected default expression it should carry and the literal
+ * value its poisoned rows hold. The `dflt_value` keys are the exact broken
+ * string-literal forms — a correct `datetime('now')` / `CURRENT_TIMESTAMP`
+ * default reports differently and never matches.
+ */
+const BROKEN_DEFAULTS: Record<string, { corrected: string; poisonedValue: string }> = {
+  "'datetime(''now'')'": { corrected: "(datetime('now'))", poisonedValue: "datetime('now')" },
+  "'CURRENT_TIMESTAMP'": { corrected: "CURRENT_TIMESTAMP", poisonedValue: "CURRENT_TIMESTAMP" },
+};
+
+interface NamedRow {
   name: string;
 }
 
-interface ColumnRow {
+interface ColumnInfoRow {
   name: string;
-  type: string;
+  dflt_value: string | null;
+}
+
+interface SqlRow {
+  sql: string | null;
 }
 
 export async function up(db: Kysely<unknown>): Promise<void> {
-  // Wrap the whole sweep in ONE transaction so a mid-way failure cannot leave the
-  // database half-repaired. These SQLite migrations are not auto-wrapped by the
-  // migrator (`SqliteAdapter.supportsTransactionalDdl === false`), but the repair
-  // is pure DML, so an explicit transaction gives atomicity — matching the
-  // convention in `2026_07_01_000_failure_groups_signature_unique`.
-  await db.transaction().execute(async trx => {
-    const tables = await sql<TableRow>`
-      SELECT name FROM sqlite_master
-      WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+  // Fast path: on a fresh/already-fixed schema no column carries a broken default,
+  // so there is nothing to rebuild. Return WITHOUT touching PRAGMA foreign_keys so
+  // the common case (every existing DB and test) leaves the connection's FK state
+  // exactly as the caller set it. Only the rare upgraded-DB path below toggles it.
+  const brokenTables = await findTablesWithBrokenDefaults(db);
+  if (brokenTables.length === 0) {
+    return;
+  }
+
+  // Rebuilding a table that OTHER tables reference by foreign key requires FK
+  // enforcement OFF: `DROP TABLE` performs an implicit DELETE that would otherwise
+  // fire `ON DELETE CASCADE` and wipe the child rows (deferral only delays the
+  // constraint *check*, not the cascade *action*). `PRAGMA foreign_keys` is a
+  // no-op inside a transaction, so it is toggled on the connection around the
+  // transaction — safe because the migrator does not wrap SQLite migrations in a
+  // transaction and the run is serialized by the migration lock. It is restored to
+  // ON afterwards: this branch only runs on an upgraded production DB, whose
+  // connection is configured FK-ON (`configureSqliteDatabase`), which is also the
+  // state the rest of the migration chain expects.
+  await sql`PRAGMA foreign_keys = OFF`.execute(db);
+  try {
+    // One transaction so a mid-rebuild failure cannot leave a half-swapped schema.
+    await db.transaction().execute(async trx => {
+      await rebuildAndRepair(trx, brokenTables);
+    });
+  } finally {
+    await sql`PRAGMA foreign_keys = ON`.execute(db);
+  }
+}
+
+/**
+ * Return the tables that have at least one column whose stored default is a
+ * broken string literal. Uses a `SELECT`-shaped `pragma_table_info(...)` read so
+ * the bunSqliteDialect returns rows (a bare `PRAGMA x` value read does not).
+ */
+async function findTablesWithBrokenDefaults(db: Kysely<unknown>): Promise<string[]> {
+  const tables = await sql<NamedRow>`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+  `.execute(db);
+
+  const broken: string[] = [];
+  for (const { name: table } of tables.rows) {
+    const columns = await sql<ColumnInfoRow>`
+      SELECT dflt_value FROM pragma_table_info(${table})
+    `.execute(db);
+    if (columns.rows.some(column => column.dflt_value !== null && column.dflt_value in BROKEN_DEFAULTS)) {
+      broken.push(table);
+    }
+  }
+  return broken;
+}
+
+async function rebuildAndRepair(trx: Kysely<unknown>, tables: string[]): Promise<void> {
+  for (const table of tables) {
+    const columns = await sql<ColumnInfoRow>`
+      SELECT name, dflt_value FROM pragma_table_info(${table})
     `.execute(trx);
 
-    for (const { name: table } of tables.rows) {
-      const columns = await sql<ColumnRow>`
-        SELECT name, type FROM pragma_table_info(${table})
-      `.execute(trx);
-
-      for (const column of columns.rows) {
-        // Only TEXT-affinity columns can hold the literal string; skip the rest so
-        // we never coerce a numeric/blob column.
-        if (!/char|clob|text/i.test(column.type)) {
-          continue;
-        }
-        await sql`
-          UPDATE ${sql.ref(table)}
-          SET ${sql.ref(column.name)} = datetime('now')
-          WHERE ${sql.ref(column.name)} IN (${sql.join(POISONED_LITERALS)})
-        `.execute(trx);
-      }
+    const brokenColumns = columns.rows.filter(
+      column => column.dflt_value !== null && column.dflt_value in BROKEN_DEFAULTS
+    );
+    if (brokenColumns.length === 0) {
+      continue;
     }
-  });
+
+    await rebuildTableWithCorrectedDefaults(trx, table);
+
+    // Rows copied verbatim during the rebuild still hold the literal; heal them
+    // now, restricted to the columns that actually carried the broken default.
+    for (const column of brokenColumns) {
+      const { poisonedValue } = BROKEN_DEFAULTS[column.dflt_value as string];
+      await sql`
+        UPDATE ${sql.ref(table)}
+        SET ${sql.ref(column.name)} = datetime('now')
+        WHERE ${sql.ref(column.name)} = ${poisonedValue}
+      `.execute(trx);
+    }
+  }
+}
+
+/**
+ * Rebuild `table` so every broken string-literal default becomes its corrected
+ * raw-SQL form, preserving data, indexes, and triggers. Only the `DEFAULT`
+ * clauses change; column set and order are untouched, so `INSERT ... SELECT *`
+ * lines the rows up 1:1.
+ */
+async function rebuildTableWithCorrectedDefaults(
+  trx: Kysely<unknown>,
+  table: string
+): Promise<void> {
+  const createRow = await sql<SqlRow>`
+    SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ${table}
+  `.execute(trx);
+  const createSql = createRow.rows[0]?.sql;
+  if (!createSql) {
+    return;
+  }
+
+  const tempTable = `__rebuild_${table}`;
+  let correctedSql = replaceFirstTableName(createSql, table, tempTable);
+  for (const brokenDefault of Object.keys(BROKEN_DEFAULTS)) {
+    // The broken literal only appears in the schema as a column default, so a
+    // global replace cannot touch anything else.
+    correctedSql = correctedSql.split(brokenDefault).join(BROKEN_DEFAULTS[brokenDefault].corrected);
+  }
+
+  // Capture the table's own indexes and triggers before the drop — auto-indexes
+  // backing PRIMARY KEY / UNIQUE constraints have a NULL `sql` and are recreated
+  // by the CREATE TABLE itself, so only the explicit ones need replaying.
+  const auxiliary = await sql<SqlRow>`
+    SELECT sql FROM sqlite_master
+    WHERE tbl_name = ${table} AND type IN ('index', 'trigger') AND sql IS NOT NULL
+  `.execute(trx);
+
+  await sql.raw(correctedSql).execute(trx);
+  await sql`INSERT INTO ${sql.ref(tempTable)} SELECT * FROM ${sql.ref(table)}`.execute(trx);
+  await sql`DROP TABLE ${sql.ref(table)}`.execute(trx);
+  await sql`ALTER TABLE ${sql.ref(tempTable)} RENAME TO ${sql.ref(table)}`.execute(trx);
+  for (const { sql: auxSql } of auxiliary.rows) {
+    if (auxSql) {
+      await sql.raw(auxSql).execute(trx);
+    }
+  }
+}
+
+/**
+ * Replace the table name in a `CREATE TABLE` statement, tolerating the double-
+ * quoted (Kysely) and bare forms and arbitrary whitespace after the keyword.
+ * Only the first occurrence — the table being declared — is rewritten; a later
+ * self-reference (e.g. a table-level FK) keeps pointing at the real name so the
+ * copy still works.
+ */
+function replaceFirstTableName(createSql: string, from: string, to: string): string {
+  // Match the declared table name as either a double-quoted identifier (Kysely's
+  // form) or a bare word, and rewrite only when it is exactly `from` so a later
+  // self-reference in the body is left untouched.
+  return createSql.replace(
+    /^(\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?)(?:"([^"]+)"|(\w+))/i,
+    (match, prefix: string, quotedName: string | undefined, bareName: string | undefined) =>
+      (quotedName ?? bareName) === from ? `${prefix}"${to}"` : match
+  );
 }
 
 export async function down(): Promise<void> {
-  // Irreversible data repair: the original poisoned literals carried no
-  // information worth restoring, so the down migration is intentionally a no-op.
+  // Irreversible repair: the corrected defaults and healed rows carry no
+  // information worth reverting, so the down migration is intentionally a no-op.
 }

--- a/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
+++ b/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
@@ -21,8 +21,10 @@ import { type Kysely, sql } from "kysely";
  *      `created_at`) stop re-poisoning it. SQLite cannot alter a column default
  *      in place, and bun:sqlite forbids editing `sqlite_master` directly, so we
  *      use the standard table-rebuild: create a twin table with the corrected
- *      default, copy the rows, drop the original, rename the twin back, and
- *      recreate its indexes/triggers. FK enforcement is toggled OFF around the
+ *      default, copy the rows, drop the original, rename the twin back, recreate
+ *      its indexes/triggers, and restore its `sqlite_sequence` AUTOINCREMENT
+ *      high-water mark (so a rebuilt table cannot reuse a deleted top id). FK
+ *      enforcement is toggled OFF around the
  *      rebuild (see `up`) so dropping a referenced parent cannot cascade-delete
  *      its children, then `PRAGMA foreign_key_check` verifies integrity before it
  *      is restored.
@@ -196,6 +198,13 @@ async function rebuildTableWithCorrectedDefaults(
     WHERE tbl_name = ${table} AND type IN ('index', 'trigger') AND sql IS NOT NULL
   `.execute(trx);
 
+  // Capture the AUTOINCREMENT high-water mark. `sqlite_sequence` records the
+  // highest rowid EVER used so AUTOINCREMENT never reuses a deleted id; the
+  // copy/drop/rename below would otherwise reset it to `max(current id)` and let a
+  // deleted top id be handed out again — aliasing ids that other tables reference
+  // as plain integers. Restored after the rename.
+  const originalSequence = await captureSequence(trx, table);
+
   await sql.raw(correctedSql).execute(trx);
   await sql`INSERT INTO ${sql.ref(tempTable)} SELECT * FROM ${sql.ref(table)}`.execute(trx);
   await sql`DROP TABLE ${sql.ref(table)}`.execute(trx);
@@ -205,6 +214,34 @@ async function rebuildTableWithCorrectedDefaults(
       await sql.raw(auxSql).execute(trx);
     }
   }
+
+  if (originalSequence !== undefined) {
+    await sql`DELETE FROM sqlite_sequence WHERE name = ${table}`.execute(trx);
+    await sql`INSERT INTO sqlite_sequence (name, seq) VALUES (${table}, ${originalSequence})`.execute(
+      trx
+    );
+  }
+}
+
+/**
+ * Read a table's `sqlite_sequence` high-water mark, or `undefined` when the table
+ * is not AUTOINCREMENT / has never been inserted into (no sequence row) or the
+ * `sqlite_sequence` table does not exist (no AUTOINCREMENT table in the DB).
+ */
+async function captureSequence(
+  trx: Kysely<unknown>,
+  table: string
+): Promise<number | undefined> {
+  const hasSequenceTable = await sql<NamedRow>`
+    SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_sequence'
+  `.execute(trx);
+  if (hasSequenceTable.rows.length === 0) {
+    return undefined;
+  }
+  const seqRow = await sql<{ seq: number }>`
+    SELECT seq FROM sqlite_sequence WHERE name = ${table}
+  `.execute(trx);
+  return seqRow.rows[0]?.seq;
 }
 
 /**

--- a/test/db/repairDatetimeNowDefaultsMigration.test.ts
+++ b/test/db/repairDatetimeNowDefaultsMigration.test.ts
@@ -127,6 +127,25 @@ describe("2026_07_03_000_repair_datetime_now_defaults migration (#2895)", () => 
       expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
     });
 
+    test("preserves the AUTOINCREMENT high-water mark so deleted ids are not reused", async () => {
+      bunDb.exec(
+        `CREATE TABLE "recomp" (` +
+          `"id" integer primary key autoincrement, ` +
+          `"created_at" text default 'datetime(''now'')' not null)`
+      );
+      bunDb.query(`INSERT INTO recomp (created_at) VALUES ('a')`).run(); // id 1
+      bunDb.query(`INSERT INTO recomp (created_at) VALUES ('b')`).run(); // id 2
+      bunDb.query(`DELETE FROM recomp WHERE id = 2`).run();
+
+      await repairUp(db);
+
+      // Without sqlite_sequence preservation the rebuild would reset the counter
+      // to max(current id)=1 and hand out 2 again; the next id must be 3.
+      bunDb.query(`INSERT INTO recomp (created_at) VALUES ('c')`).run();
+      const next = bunDb.query(`SELECT MAX(id) AS id FROM recomp`).get() as { id: number };
+      expect(next.id).toBe(3);
+    });
+
     test("preserves child rows and foreign keys across the rebuild", async () => {
       bunDb.exec(`PRAGMA foreign_keys = ON`);
       bunDb.exec(

--- a/test/db/repairDatetimeNowDefaultsMigration.test.ts
+++ b/test/db/repairDatetimeNowDefaultsMigration.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import type { Database } from "../../src/db/types";
 import { createTestDatabase } from "./testDbHelper";
 import {
@@ -8,145 +10,211 @@ import {
 } from "../../src/db/migrations/2026_07_03_000_repair_datetime_now_defaults";
 
 /**
- * Coverage for the data-repair half of issue #2895. Historical databases that
- * ran the buggy `defaultTo("datetime('now')")` DDL already stored the literal
- * text `datetime('now')` in defaulted timestamp columns. The forward DDL fix
- * only helps freshly-created columns; this repair migration rewrites the
- * poisoned rows in place.
- *
- * The repair must be:
- *   - Complete: any text column holding the literal string is healed, regardless
- *     of table.
- *   - Safe: legitimate app-supplied timestamps are left untouched (the WHERE
- *     predicate matches only the exact literal).
- *   - Idempotent + no-op on clean data (survives the destructive-recovery replay
- *     that drops every table and re-runs all migrations on a fresh schema).
+ * Coverage for the #2895 repair migration. On a database that already ran the
+ * buggy migrations, the stored column default is still the broken string literal
+ * (`DEFAULT 'datetime(''now'')'`), so the migration must both REBUILD the column
+ * default (so future defaulted inserts stop re-poisoning) and REPAIR the existing
+ * poisoned rows — while never touching arbitrary-content columns that merely
+ * happen to hold the literal string.
  */
 describe("2026_07_03_000_repair_datetime_now_defaults migration (#2895)", () => {
-  let db: Kysely<Database>;
+  describe("on an upgraded database with the broken string-literal defaults", () => {
+    let bunDb: BunDatabase;
+    let db: Kysely<unknown>;
 
-  beforeEach(async () => {
-    db = await createTestDatabase();
+    beforeEach(() => {
+      bunDb = new BunDatabase(":memory:");
+      db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    });
+
+    afterEach(async () => {
+      await db.destroy();
+    });
+
+    test("rebuilds the default so future defaulted inserts store a real timestamp (P1)", async () => {
+      // Reproduce exactly what the old buggy migration left on disk.
+      bunDb.exec(
+        `CREATE TABLE "navigation_apps" (` +
+          `"app_id" text primary key, ` +
+          `"created_at" text default 'datetime(''now'')' not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.exec(`CREATE INDEX "idx_na_updated" ON "navigation_apps" ("updated_at")`);
+      bunDb.query(`INSERT INTO navigation_apps (app_id, updated_at) VALUES ('old', 'u')`).run();
+
+      // Precondition: the old default poisoned the first row.
+      const before = bunDb
+        .query(`SELECT created_at FROM navigation_apps WHERE app_id='old'`)
+        .get() as { created_at: string };
+      expect(before.created_at).toBe("datetime('now')");
+
+      await repairUp(db);
+
+      // Existing poisoned row healed.
+      const oldRow = bunDb
+        .query(`SELECT created_at FROM navigation_apps WHERE app_id='old'`)
+        .get() as { created_at: string };
+      expect(oldRow.created_at).not.toBe("datetime('now')");
+      expect(Number.isNaN(Date.parse(oldRow.created_at))).toBe(false);
+
+      // A NEW row that omits created_at now evaluates the corrected default
+      // rather than re-storing the literal — this is the P1 fix.
+      bunDb.query(`INSERT INTO navigation_apps (app_id, updated_at) VALUES ('new', 'u')`).run();
+      const newRow = bunDb
+        .query(`SELECT created_at FROM navigation_apps WHERE app_id='new'`)
+        .get() as { created_at: string };
+      expect(newRow.created_at).not.toBe("datetime('now')");
+      expect(Number.isNaN(Date.parse(newRow.created_at))).toBe(false);
+
+      // The table's explicit index survived the rebuild.
+      const idx = bunDb
+        .query(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_na_updated'`)
+        .get();
+      expect(idx).not.toBeNull();
+    });
+
+    test("heals the CURRENT_TIMESTAMP literal variant too", async () => {
+      bunDb.exec(
+        `CREATE TABLE "recomp" (` +
+          `"id" integer primary key, ` +
+          `"created_at" text default 'CURRENT_TIMESTAMP' not null)`
+      );
+      bunDb.query(`INSERT INTO recomp (id) VALUES (1)`).run();
+      expect(
+        (bunDb.query(`SELECT created_at FROM recomp WHERE id=1`).get() as { created_at: string })
+          .created_at
+      ).toBe("CURRENT_TIMESTAMP");
+
+      await repairUp(db);
+
+      const row = bunDb.query(`SELECT created_at FROM recomp WHERE id=1`).get() as {
+        created_at: string;
+      };
+      expect(row.created_at).not.toBe("CURRENT_TIMESTAMP");
+      expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
+
+      // New default-path row is evaluated.
+      bunDb.query(`INSERT INTO recomp (id) VALUES (2)`).run();
+      const row2 = bunDb.query(`SELECT created_at FROM recomp WHERE id=2`).get() as {
+        created_at: string;
+      };
+      expect(Number.isNaN(Date.parse(row2.created_at))).toBe(false);
+    });
+
+    test("does NOT rewrite an arbitrary-content column that merely holds the literal (P2)", async () => {
+      // `value` has no default and stores arbitrary app data; `created_at` carries
+      // the broken default. An app value equal to the literal must survive.
+      bunDb.exec(
+        `CREATE TABLE "storage_events" (` +
+          `"id" integer primary key, ` +
+          `"value" text, ` +
+          `"created_at" text default 'datetime(''now'')' not null)`
+      );
+      bunDb
+        .query(`INSERT INTO storage_events (id, value) VALUES (1, 'datetime(''now'')')`)
+        .run();
+
+      await repairUp(db);
+
+      const row = bunDb.query(`SELECT value, created_at FROM storage_events WHERE id=1`).get() as {
+        value: string;
+        created_at: string;
+      };
+      // The legitimate app value is untouched...
+      expect(row.value).toBe("datetime('now')");
+      // ...while the genuinely-defaulted column is healed.
+      expect(row.created_at).not.toBe("datetime('now')");
+      expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
+    });
+
+    test("preserves child rows and foreign keys across the rebuild", async () => {
+      bunDb.exec(`PRAGMA foreign_keys = ON`);
+      bunDb.exec(
+        `CREATE TABLE "navigation_apps" (` +
+          `"app_id" text primary key, ` +
+          `"created_at" text default 'datetime(''now'')' not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.exec(
+        `CREATE TABLE "navigation_nodes" (` +
+          `"id" integer primary key, ` +
+          `"app_id" text not null references "navigation_apps" ("app_id") on delete cascade)`
+      );
+      bunDb.query(`INSERT INTO navigation_apps (app_id, updated_at) VALUES ('a', 'u')`).run();
+      bunDb.query(`INSERT INTO navigation_nodes (id, app_id) VALUES (1, 'a')`).run();
+
+      await repairUp(db);
+
+      // Child row preserved.
+      const child = bunDb.query(`SELECT app_id FROM navigation_nodes WHERE id=1`).get() as {
+        app_id: string;
+      };
+      expect(child.app_id).toBe("a");
+      // FK still enforced after rebuild: inserting an orphan child must fail.
+      expect(() =>
+        bunDb.query(`INSERT INTO navigation_nodes (id, app_id) VALUES (2, 'missing')`).run()
+      ).toThrow();
+    });
+
+    test("is idempotent — a second pass finds nothing to rebuild", async () => {
+      bunDb.exec(
+        `CREATE TABLE "navigation_apps" (` +
+          `"app_id" text primary key, ` +
+          `"created_at" text default 'datetime(''now'')' not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.query(`INSERT INTO navigation_apps (app_id, updated_at) VALUES ('old', 'u')`).run();
+
+      await repairUp(db);
+      const first = bunDb
+        .query(`SELECT created_at FROM navigation_apps WHERE app_id='old'`)
+        .get() as { created_at: string };
+
+      await repairUp(db);
+      const second = bunDb
+        .query(`SELECT created_at FROM navigation_apps WHERE app_id='old'`)
+        .get() as { created_at: string };
+
+      expect(second.created_at).toBe(first.created_at);
+    });
   });
 
-  afterEach(async () => {
-    await db.destroy();
-  });
+  describe("on the current (already-fixed) schema", () => {
+    let db: Kysely<Database>;
 
-  test("rewrites literal datetime('now') rows to a real timestamp", async () => {
-    // Seed a poisoned row exactly as the buggy default would have.
-    await db
-      .insertInto("navigation_apps")
-      .values({
-        app_id: "poisoned",
-        created_at: "datetime('now')",
-        updated_at: "2026-07-03T00:00:00.000Z",
-      })
-      .execute();
+    beforeEach(async () => {
+      db = await createTestDatabase();
+    });
 
-    await repairUp(db as unknown as Kysely<unknown>);
+    afterEach(async () => {
+      await db.destroy();
+    });
 
-    const row = await db
-      .selectFrom("navigation_apps")
-      .selectAll()
-      .where("app_id", "=", "poisoned")
-      .executeTakeFirstOrThrow();
+    test("is a no-op: a defaulted insert already stores a real timestamp", async () => {
+      await repairUp(db as unknown as Kysely<unknown>);
+      await db
+        .insertInto("navigation_apps")
+        .values({ app_id: "fresh", updated_at: "2026-07-03T00:00:00.000Z" })
+        .execute();
+      const row = await db
+        .selectFrom("navigation_apps")
+        .selectAll()
+        .where("app_id", "=", "fresh")
+        .executeTakeFirstOrThrow();
+      expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
+    });
 
-    expect(row.created_at).not.toBe("datetime('now')");
-    expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
-  });
+    test("runs as part of the real migration chain (migration is registered)", async () => {
+      const executed = await db
+        .selectFrom("kysely_migration" as never)
+        .select("name" as never)
+        .execute();
+      const names = executed.map((r: { name: string }) => r.name);
+      expect(names).toContain("2026_07_03_000_repair_datetime_now_defaults");
+    });
 
-  test("leaves legitimate timestamps untouched", async () => {
-    await db
-      .insertInto("navigation_apps")
-      .values({
-        app_id: "legit",
-        created_at: "2026-01-01T12:34:56.000Z",
-        updated_at: "2026-01-01T12:34:56.000Z",
-      })
-      .execute();
-
-    await repairUp(db as unknown as Kysely<unknown>);
-
-    const row = await db
-      .selectFrom("navigation_apps")
-      .selectAll()
-      .where("app_id", "=", "legit")
-      .executeTakeFirstOrThrow();
-
-    expect(row.created_at).toBe("2026-01-01T12:34:56.000Z");
-  });
-
-  test("is idempotent and a no-op on already-clean data", async () => {
-    await db
-      .insertInto("navigation_apps")
-      .values({
-        app_id: "poisoned",
-        created_at: "datetime('now')",
-        updated_at: "2026-07-03T00:00:00.000Z",
-      })
-      .execute();
-
-    await repairUp(db as unknown as Kysely<unknown>);
-    const firstPass = await db
-      .selectFrom("navigation_apps")
-      .selectAll()
-      .where("app_id", "=", "poisoned")
-      .executeTakeFirstOrThrow();
-
-    // Running again must not throw and must not re-touch the already-fixed value.
-    await repairUp(db as unknown as Kysely<unknown>);
-    const secondPass = await db
-      .selectFrom("navigation_apps")
-      .selectAll()
-      .where("app_id", "=", "poisoned")
-      .executeTakeFirstOrThrow();
-
-    expect(secondPass.created_at).toBe(firstPass.created_at);
-  });
-
-  test("rewrites literal CURRENT_TIMESTAMP rows too", async () => {
-    // recomposition_metrics.created_at was declared with the string-literal
-    // "CURRENT_TIMESTAMP" default — the same failure mode, a different literal.
-    await db
-      .insertInto("recomposition_metrics")
-      .values({
-        device_id: "d",
-        session_id: "s",
-        package_name: "p",
-        composable_id: "c",
-        total_count: 1,
-        skip_count: 0,
-        timestamp: "2026-07-03T00:00:00.000Z",
-        created_at: "CURRENT_TIMESTAMP",
-      })
-      .execute();
-
-    await repairUp(db as unknown as Kysely<unknown>);
-
-    const row = await db
-      .selectFrom("recomposition_metrics")
-      .selectAll()
-      .where("device_id", "=", "d")
-      .executeTakeFirstOrThrow();
-
-    expect(row.created_at).not.toBe("CURRENT_TIMESTAMP");
-    expect(Number.isNaN(Date.parse(row.created_at))).toBe(false);
-  });
-
-  test("down() is a safe no-op (irreversible data repair)", async () => {
-    await expect(repairDown()).resolves.toBeUndefined();
-  });
-
-  test("runs as part of the real migration chain (migration is registered)", async () => {
-    // createTestDatabase() ran the full chain via runMigrations; assert the
-    // repair migration actually executed (present in kysely_migration history),
-    // so the fix ships in the real upgrade path — not just when called directly.
-    const executed = await db
-      .selectFrom("kysely_migration" as never)
-      .select("name" as never)
-      .execute();
-    const names = executed.map((r: { name: string }) => r.name);
-    expect(names).toContain("2026_07_03_000_repair_datetime_now_defaults");
+    test("down() is a safe no-op (irreversible repair)", async () => {
+      await expect(repairDown()).resolves.toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## What

Follow-up to #2906 (issue #2895) addressing two **Codex review findings** that were posted as inline comments and landed on `main` before they were seen (inline comments don't block auto-merge). Both are real correctness bugs in the repair migration `2026_07_03_000_repair_datetime_now_defaults.ts`. Since that migration is **unreleased** (latest release is 0.0.40 from 2026-06-30; releases are periodic, not auto-on-merge), it is corrected **in place** rather than superseded by a new one.

Closes #2895 correctly for upgraded databases.

## Why — the two findings

**P1 — re-poisoning on upgraded databases (Codex, orange).** Editing a historical migration does not re-run it (Kysely tracks migrations by name, no content checksum), so a database that already ran the buggy migrations keeps `DEFAULT 'datetime(''now'')'` in its **stored schema**. `NavigationRepository.getOrCreateApp` inserts `navigation_apps` omitting `created_at` (relies on the default), so after the original one-shot **row** repair, every *new* app row re-stored the literal — and nothing repaired it. Reproduced with `sqlite3`: old default → repair UPDATE → second insert still stored `datetime('now')`.

**P2 — arbitrary-data corruption (Codex, yellow).** The original repair rewrote **any** TEXT cell equal to the literal. `storageEventRepository.recordStorageEvent` persists arbitrary app data in `storage_events.value`, so an app value of `datetime('now')` would have been irreversibly rewritten to a timestamp during startup migration.

## How

The repair now keys off `pragma_table_info(...).dflt_value` — the column's **stored default** — instead of scanning cell values:

1. **Rebuild broken defaults (fixes P1).** For each column whose live default is exactly `'datetime(''now'')'` or `'CURRENT_TIMESTAMP'` (the two broken string-literal forms; a corrected `(datetime('now'))` default, a bare `CURRENT_TIMESTAMP` keyword, and legit value defaults like `'{}'`/`'success'` all report differently and are skipped), the table is rebuilt via the standard SQLite dance — twin table with the corrected `DEFAULT`, copy rows, drop original, rename twin back, recreate indexes/triggers. `bun:sqlite` forbids editing `sqlite_master` directly, so the table-rebuild is the only route. Future defaulted inserts now evaluate the function.
2. **Repair rows, scoped (fixes P2).** Existing poisoned rows are healed only in the columns that actually carried the broken default — never arbitrary-content columns.

**Foreign keys.** A rebuilt parent that children reference by `ON DELETE CASCADE` would lose its children: `DROP TABLE` performs an implicit DELETE that cascades even under `defer_foreign_keys` (deferral delays the *check*, not the *action* — verified by a failing test). `PRAGMA foreign_keys` is a no-op inside a transaction, so it is toggled OFF on the connection around the rebuild and restored ON (safe: the migrator doesn't wrap SQLite migrations, the run is serialized by the migration lock, and production is FK-ON). The fresh/already-fixed path **early-returns without touching FK state**, so every existing DB and test is untouched.

## Testing

`test/db/repairDatetimeNowDefaultsMigration.test.ts` rebuilt to simulate the **old broken schema** with raw SQL (since `createTestDatabase` produces the already-fixed schema) and assert:
- **P1**: a NEW row that omits the defaulted column stores a real timestamp after the rebuild; the existing poisoned row is healed.
- **P2**: an arbitrary-content column holding the literal is left untouched while the genuinely-defaulted column is healed.
- FK + child rows preserved and FK still enforced after the rebuild; explicit index survives.
- `CURRENT_TIMESTAMP` literal variant healed; idempotent; no-op on the fresh schema; runs in the real chain; `down()` no-op.

Verified: `bun test test/db/` **477 pass, 0 fail**; full suite 5817 pass (the only 7 failures are pre-existing, caused by a local out-of-sync `~/.auto-mobile/auto-mobile.db` — they reproduce identically with this branch stashed and do not occur in CI). `eslint` 0, `bun build.ts` ok, shellcheck + bats guard green.

## Acceptance criteria (#2895, upgraded-DB completeness)
- [x] Upgraded DBs stop re-poisoning: the broken column DEFAULT is rebuilt, not just the rows.
- [x] Repair never touches arbitrary-content columns (scoped to bad-default columns via `dflt_value`).
- [x] FK/child data and indexes/triggers preserved across the rebuild.
- [x] No-op and FK-state-preserving on fresh/already-fixed schemas.
