### PR TITLE
test(db): add CI drift guard for telemetry event tables' index inventory (#2908)

### DIFF
--- a/test/db/telemetryEventIndexInventory.test.ts
+++ b/test/db/telemetryEventIndexInventory.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely, sql } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
@@ -21,122 +21,165 @@ import { runMigrations } from "../../src/db/migrator";
  * `dropRedundantDeviceIndexes.test.ts` proves that *one migration* is correct.
  * It does NOT stop a *future* migration from silently re-adding an
  * `idx_<table>_device` index (re-introducing the exact write amplification
- * #2893 removed) or dropping the `timestamp` index the retention cutoff scan
- * depends on. This test is that standing guard: it replays the whole migration
- * chain and pins the canonical per-table index inventory, so any future
- * migration that perturbs it must consciously update the canonical set below.
+ * #2893 removed), dropping the `timestamp` index the retention cutoff scan
+ * depends on, or — subtler — recreating a same-named index over the WRONG
+ * columns (e.g. reordering the composite to `(timestamp, device_id)`, which
+ * breaks the `device_id=?` left-prefix path that is the whole rationale). This
+ * test is that standing guard: it replays the whole migration chain and pins
+ * the canonical per-table index inventory *including each index's column
+ * composition*, so any future migration that perturbs it must consciously
+ * update the canonical set below.
  */
-
-/** The six telemetry event tables whose index inventory this guard pins. */
-const TABLES = [
-  "network_events",
-  "log_events",
-  "os_events",
-  "navigation_events",
-  "storage_events",
-  "layout_events",
-] as const;
 
 /**
  * Canonical explicit-index inventory per table after a full `runMigrations`
- * replay (post-#2904). Every entry is a `CREATE INDEX` (PRAGMA index_list
- * origin `c`); the auto-created PK/rowid index is intentionally excluded.
+ * replay (post-#2904): index name → ordered column list. Every entry is a
+ * `CREATE INDEX` (PRAGMA index_list origin `c`); the auto-created PK/rowid
+ * index is intentionally excluded.
  *
  * Invariants this set encodes:
- *   - `idx_<table>_timestamp`          — retention cutoff covering scan, MUST stay.
- *   - `idx_<table>_device_timestamp`   — composite; serves every `device_id=?` path.
+ *   - `idx_<table>_timestamp` → `[timestamp]`         — retention cutoff covering scan, MUST stay.
+ *   - `idx_<table>_device_timestamp` → `[device_id, timestamp]`
+ *                                                     — composite; the column ORDER is load-bearing:
+ *                                                       `device_id` must be the left prefix or the
+ *                                                       `device_id=?` access paths regress.
  *   - category/content index where the table has one.
  *   - NO standalone `idx_<table>_device` — dropped in #2904, must not return.
+ *
+ * The keys of this map are also the authoritative list of the six telemetry
+ * event tables; the guard asserts the live `%_events` table set equals these
+ * keys, so a future 7th event table can't be silently outside the guard.
  */
-const CANONICAL_INDEXES: Record<(typeof TABLES)[number], string[]> = {
-  network_events: [
-    "idx_network_events_timestamp",
-    "idx_network_events_host",
-    "idx_network_events_device_timestamp",
-  ],
-  log_events: [
-    "idx_log_events_timestamp",
-    "idx_log_events_tag",
-    "idx_log_events_device_timestamp",
-  ],
-  os_events: [
-    "idx_os_events_timestamp",
-    "idx_os_events_category",
-    "idx_os_events_device_timestamp",
-  ],
-  navigation_events: [
-    "idx_navigation_events_timestamp",
-    "idx_navigation_events_device_timestamp",
-  ],
-  storage_events: [
-    "idx_storage_events_timestamp",
-    "idx_storage_events_device_timestamp",
-  ],
-  layout_events: [
-    "idx_layout_events_timestamp",
-    "idx_layout_events_device_timestamp",
-  ],
+const CANONICAL_INDEXES: Record<string, Record<string, string[]>> = {
+  network_events: {
+    idx_network_events_timestamp: ["timestamp"],
+    idx_network_events_host: ["host"],
+    idx_network_events_device_timestamp: ["device_id", "timestamp"],
+  },
+  log_events: {
+    idx_log_events_timestamp: ["timestamp"],
+    idx_log_events_tag: ["tag"],
+    idx_log_events_device_timestamp: ["device_id", "timestamp"],
+  },
+  os_events: {
+    idx_os_events_timestamp: ["timestamp"],
+    idx_os_events_category: ["category"],
+    idx_os_events_device_timestamp: ["device_id", "timestamp"],
+  },
+  navigation_events: {
+    idx_navigation_events_timestamp: ["timestamp"],
+    idx_navigation_events_device_timestamp: ["device_id", "timestamp"],
+  },
+  storage_events: {
+    idx_storage_events_timestamp: ["timestamp"],
+    idx_storage_events_device_timestamp: ["device_id", "timestamp"],
+  },
+  layout_events: {
+    idx_layout_events_timestamp: ["timestamp"],
+    idx_layout_events_device_timestamp: ["device_id", "timestamp"],
+  },
 };
 
+const TABLES = Object.keys(CANONICAL_INDEXES);
+
 /**
- * Names of the explicitly-created (`CREATE INDEX`) indexes attached to a table,
- * ignoring the auto-created PK/rowid index (origin `pk`) and any auto UNIQUE
- * index (origin `u`) — the guard pins the deliberate `idx_*` inventory only.
+ * Explicit-index inventory of a table: name → ordered columns, ignoring the
+ * auto-created PK/rowid index (origin `pk`) and any auto UNIQUE-constraint
+ * index (origin `u`). The guard pins the deliberate `idx_*` inventory only.
+ *
+ * `pragma_index_list` on a NON-existent table returns `[]` rather than raising,
+ * so a vanished/renamed table would otherwise make every per-table assertion
+ * pass vacuously — the `tables present in the schema` test below closes that
+ * hole by pinning the live table set independently.
  */
-async function explicitIndexNames(db: Kysely<unknown>, table: string): Promise<string[]> {
-  const result = await sql<{ name: string; origin: string }>`
+async function explicitIndexInventory(
+  db: Kysely<unknown>,
+  table: string
+): Promise<Record<string, string[]>> {
+  const indexes = await sql<{ name: string; origin: string }>`
     SELECT name, origin FROM pragma_index_list(${table})
   `.execute(db);
-  return result.rows.filter(r => r.origin === "c").map(r => r.name);
+
+  const inventory: Record<string, string[]> = {};
+  for (const index of indexes.rows) {
+    if (index.origin !== "c") {
+      continue;
+    }
+    const columns = await sql<{ name: string }>`
+      SELECT name FROM pragma_index_info(${index.name}) ORDER BY seqno
+    `.execute(db);
+    inventory[index.name] = columns.rows.map(c => c.name);
+  }
+  return inventory;
+}
+
+/** All tables whose name ends in `_events` in the live schema (drift-detects a new event table). */
+async function liveEventTables(db: Kysely<unknown>): Promise<string[]> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table' AND name LIKE '%\\_events' ESCAPE '\\'
+    ORDER BY name
+  `.execute(db);
+  return result.rows.map(r => r.name);
 }
 
 describe("telemetry event tables index inventory drift guard (#2908)", () => {
   let db: Kysely<unknown>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     // Full forward replay of every on-disk migration against a fresh :memory:
     // DB — the same path the #2785 destructive-recovery rebuild takes. No
     // provider override: this asserts the *shipped* migration chain, so a new
-    // migration file is exercised here the moment it lands.
+    // migration file is exercised the moment it lands. A single shared DB is
+    // safe here because every test below is strictly read-only.
     db = new Kysely<unknown>({
       dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
     });
     await runMigrations(db);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await db.destroy();
   });
 
-  test("each event table has exactly its canonical explicit-index inventory", async () => {
+  test("the live schema has exactly the six canonical event tables (no new table escapes the guard)", async () => {
+    const actual = (await liveEventTables(db)).sort();
+    const expected = [...TABLES].sort();
+    // A newly-added `%_events` table (e.g. a future `custom_events` revival with
+    // its own device index) forces a conscious edit to CANONICAL_INDEXES here,
+    // rather than silently sailing past a hardcoded table list.
+    expect(actual).toEqual(expected);
+  });
+
+  test("each event table has exactly its canonical explicit-index inventory (names AND columns)", async () => {
     for (const table of TABLES) {
-      const actual = (await explicitIndexNames(db, table)).sort();
-      const expected = [...CANONICAL_INDEXES[table]].sort();
-      // Set equality catches BOTH drift directions in one assertion: an added
-      // index (e.g. a re-introduced idx_<table>_device) and a removed one
-      // (e.g. a dropped timestamp/composite index).
-      expect(actual).toEqual(expected);
+      const actual = await explicitIndexInventory(db, table);
+      // Deep equality on name → columns catches every drift direction in one
+      // assertion: an added index (a re-introduced idx_<table>_device), a
+      // removed index (a dropped timestamp/composite), AND a same-named index
+      // recreated over the wrong columns or wrong order.
+      expect(actual).toEqual(CANONICAL_INDEXES[table]);
     }
   });
 
   test("no standalone idx_<table>_device index reappears (the #2893 regression)", async () => {
     for (const table of TABLES) {
-      const names = await explicitIndexNames(db, table);
+      const names = Object.keys(await explicitIndexInventory(db, table));
       expect(names).not.toContain(`idx_${table}_device`);
     }
   });
 
-  test("the retention-cutoff timestamp index survives for every table", async () => {
+  test("the retention-cutoff timestamp index survives, covering [timestamp], for every table", async () => {
     for (const table of TABLES) {
-      const names = await explicitIndexNames(db, table);
-      expect(names).toContain(`idx_${table}_timestamp`);
+      const inventory = await explicitIndexInventory(db, table);
+      expect(inventory[`idx_${table}_timestamp`]).toEqual(["timestamp"]);
     }
   });
 
-  test("the device_id composite index survives for every table", async () => {
+  test("the device_id composite survives with device_id as the load-bearing left prefix", async () => {
     for (const table of TABLES) {
-      const names = await explicitIndexNames(db, table);
-      expect(names).toContain(`idx_${table}_device_timestamp`);
+      const inventory = await explicitIndexInventory(db, table);
+      expect(inventory[`idx_${table}_device_timestamp`]).toEqual(["device_id", "timestamp"]);
     }
   });
 });

--- a/test/db/telemetryEventIndexInventory.test.ts
+++ b/test/db/telemetryEventIndexInventory.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { runMigrations } from "../../src/db/migrator";
+
+/**
+ * Standing drift guard for the telemetry event tables' index inventory
+ * (issue #2908, follow-up to #2893 / PR #2904).
+ *
+ * Provenance of the intended shape:
+ *   - #2788 scoped the composite-index work as additive-only.
+ *   - PR #2890 (`2026_07_02_000_event_composite_indexes.ts`) added the
+ *     `(device_id, timestamp)` composite indexes on all six event tables.
+ *   - #2893 / PR #2904 (`2026_07_03_000_drop_redundant_device_indexes.ts`)
+ *     dropped the now-redundant standalone `idx_<table>_device` indexes — a
+ *     composite `(device_id, timestamp)` serves every `device_id=?` access path
+ *     via the left-prefix rule, so the single-column device index was pure
+ *     per-insert write amplification.
+ *
+ * `dropRedundantDeviceIndexes.test.ts` proves that *one migration* is correct.
+ * It does NOT stop a *future* migration from silently re-adding an
+ * `idx_<table>_device` index (re-introducing the exact write amplification
+ * #2893 removed) or dropping the `timestamp` index the retention cutoff scan
+ * depends on. This test is that standing guard: it replays the whole migration
+ * chain and pins the canonical per-table index inventory, so any future
+ * migration that perturbs it must consciously update the canonical set below.
+ */
+
+/** The six telemetry event tables whose index inventory this guard pins. */
+const TABLES = [
+  "network_events",
+  "log_events",
+  "os_events",
+  "navigation_events",
+  "storage_events",
+  "layout_events",
+] as const;
+
+/**
+ * Canonical explicit-index inventory per table after a full `runMigrations`
+ * replay (post-#2904). Every entry is a `CREATE INDEX` (PRAGMA index_list
+ * origin `c`); the auto-created PK/rowid index is intentionally excluded.
+ *
+ * Invariants this set encodes:
+ *   - `idx_<table>_timestamp`          — retention cutoff covering scan, MUST stay.
+ *   - `idx_<table>_device_timestamp`   — composite; serves every `device_id=?` path.
+ *   - category/content index where the table has one.
+ *   - NO standalone `idx_<table>_device` — dropped in #2904, must not return.
+ */
+const CANONICAL_INDEXES: Record<(typeof TABLES)[number], string[]> = {
+  network_events: [
+    "idx_network_events_timestamp",
+    "idx_network_events_host",
+    "idx_network_events_device_timestamp",
+  ],
+  log_events: [
+    "idx_log_events_timestamp",
+    "idx_log_events_tag",
+    "idx_log_events_device_timestamp",
+  ],
+  os_events: [
+    "idx_os_events_timestamp",
+    "idx_os_events_category",
+    "idx_os_events_device_timestamp",
+  ],
+  navigation_events: [
+    "idx_navigation_events_timestamp",
+    "idx_navigation_events_device_timestamp",
+  ],
+  storage_events: [
+    "idx_storage_events_timestamp",
+    "idx_storage_events_device_timestamp",
+  ],
+  layout_events: [
+    "idx_layout_events_timestamp",
+    "idx_layout_events_device_timestamp",
+  ],
+};
+
+/**
+ * Names of the explicitly-created (`CREATE INDEX`) indexes attached to a table,
+ * ignoring the auto-created PK/rowid index (origin `pk`) and any auto UNIQUE
+ * index (origin `u`) — the guard pins the deliberate `idx_*` inventory only.
+ */
+async function explicitIndexNames(db: Kysely<unknown>, table: string): Promise<string[]> {
+  const result = await sql<{ name: string; origin: string }>`
+    SELECT name, origin FROM pragma_index_list(${table})
+  `.execute(db);
+  return result.rows.filter(r => r.origin === "c").map(r => r.name);
+}
+
+describe("telemetry event tables index inventory drift guard (#2908)", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    // Full forward replay of every on-disk migration against a fresh :memory:
+    // DB — the same path the #2785 destructive-recovery rebuild takes. No
+    // provider override: this asserts the *shipped* migration chain, so a new
+    // migration file is exercised here the moment it lands.
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    await runMigrations(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("each event table has exactly its canonical explicit-index inventory", async () => {
+    for (const table of TABLES) {
+      const actual = (await explicitIndexNames(db, table)).sort();
+      const expected = [...CANONICAL_INDEXES[table]].sort();
+      // Set equality catches BOTH drift directions in one assertion: an added
+      // index (e.g. a re-introduced idx_<table>_device) and a removed one
+      // (e.g. a dropped timestamp/composite index).
+      expect(actual).toEqual(expected);
+    }
+  });
+
+  test("no standalone idx_<table>_device index reappears (the #2893 regression)", async () => {
+    for (const table of TABLES) {
+      const names = await explicitIndexNames(db, table);
+      expect(names).not.toContain(`idx_${table}_device`);
+    }
+  });
+
+  test("the retention-cutoff timestamp index survives for every table", async () => {
+    for (const table of TABLES) {
+      const names = await explicitIndexNames(db, table);
+      expect(names).toContain(`idx_${table}_timestamp`);
+    }
+  });
+
+  test("the device_id composite index survives for every table", async () => {
+    for (const table of TABLES) {
+      const names = await explicitIndexNames(db, table);
+      expect(names).toContain(`idx_${table}_device_timestamp`);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a standing **drift guard** for the telemetry event tables' index inventory — the CI check requested in #2908 (follow-up surfaced during the multi-persona review of #2904 / issue #2893).

New test: `test/db/telemetryEventIndexInventory.test.ts`. It replays the **full** on-disk migration chain against a fresh `:memory:` DB and pins the canonical per-table explicit-index inventory — **name and column composition** — for the six event tables (`network_events`, `log_events`, `os_events`, `navigation_events`, `storage_events`, `layout_events`).

Closes #2908.

## Why

#2890 added the `(device_id, timestamp)` composite indexes (additive-only per #2788); #2904 dropped the now-redundant standalone `idx_<table>_device` indexes (a composite serves every `device_id=?` path via the left-prefix rule, so the single-column index was pure per-insert write amplification).

`dropRedundantDeviceIndexes.test.ts` proves that **one migration** is correct, but nothing stops a **future** migration from silently:
- re-adding an `idx_<table>_device` index (re-introducing the exact write amplification #2893 removed),
- dropping a `timestamp` index the retention-cutoff scan depends on, or
- recreating a same-named index over the **wrong columns/order** (e.g. reordering the composite to `(timestamp, device_id)`, which breaks the `device_id=?` left-prefix path that is the whole rationale).

Both reviewers on #2904 (DBA + test-quality personas) flagged the absence of this standing whole-inventory guard as the one non-blocking gap. This PR is that guard, filed and reviewed independently as #2893/#2904 intended.

## How

- `beforeAll` builds the schema once via `runMigrations(db)` with **no provider override**, so it asserts the *shipped* chain — a new migration is exercised the moment it lands. A single shared DB is safe because every test is strictly read-only.
- Canonical inventory is a single source-of-truth `Record<table, Record<indexName, columns[]>>`. Each table is asserted with **deep equality** against it, catching all drift directions at once (added, removed, or repointed/reordered index). Its keys are also the authoritative table list.
- **Derives** the live `%_events` table set from `sqlite_master` and asserts it equals the canonical keys — so a future 7th event table can't silently escape the guard (`pragma_index_list` on a missing table returns `[]`, which would otherwise make per-table assertions pass vacuously).
- Inventory is read from `PRAGMA index_list` filtered to `origin = 'c'` (explicit `CREATE INDEX`), ignoring the auto-created PK/rowid index exactly as the issue asks; columns come from `pragma_index_info`.
- Rationale linking #2788 → #2890 → #2893/#2904 documented in the file header.

## Testing

- `bun test test/db/telemetryEventIndexInventory.test.ts` → **5 pass, 0 fail** (~180ms, one shared full-replay, `:memory:`, no device/network, non-flaky).
- **Red proof** (each reverted after): re-adding `idx_network_events_device` → fails; reordering the composite to `(timestamp, device_id)` → fails the column-composition + left-prefix tests; adding a 7th `%_events` table → fails the live-table-set test.
- `bun test test/db/` → **483 pass, 0 fail** (no regressions). `eslint` clean.

## Evaluation criteria (#2908)
- [x] Builds full schema via `runMigrations` and asserts `PRAGMA index_list` per table equals the canonical set, ignoring the auto-created PK/rowid index.
- [x] Fails loudly if a standalone `idx_<table>_device` reappears or a `timestamp`/composite index is removed (proven with probe migrations).
- [x] Runs <100ms/test against `:memory:`, non-flaky, no real device/network.
- [x] Documented rationale linking #2788 → #2890 → #2893/#2904.
