### PR TITLE
fix(ios): widen CtrlProxy gesture request coordinate fields to Double (#2909)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -347,7 +347,7 @@ public class CommandHandler: CommandHandling {
 
     private func handleTapCoordinates(_ request: RequestTapCoordinates, startTime: Date) throws -> WebSocketResponse {
         let duration = request.duration ?? 0
-        try gesturePerformer.tap(x: Double(request.x), y: Double(request.y), duration: TimeInterval(duration) / 1000.0)
+        try gesturePerformer.tap(x: request.x, y: request.y, duration: TimeInterval(duration) / 1000.0)
 
         return WebSocketResponse.success(
             type: ResponseType.tapCoordinatesResult.rawValue,
@@ -359,8 +359,8 @@ public class CommandHandler: CommandHandling {
     private func handleSwipe(_ request: RequestSwipe, startTime: Date) throws -> WebSocketResponse {
         let duration = request.duration ?? 300
         try gesturePerformer.swipe(
-            startX: Double(request.x1), startY: Double(request.y1),
-            endX: Double(request.x2), endY: Double(request.y2),
+            startX: request.x1, startY: request.y1,
+            endX: request.x2, endY: request.y2,
             duration: TimeInterval(duration) / 1000.0
         )
 
@@ -384,10 +384,10 @@ public class CommandHandler: CommandHandling {
         let fingerSpacing = request.offset ?? 25
 
         try gesturePerformer.multiFingerSwipe(
-            startX: Double(request.x1),
-            startY: Double(request.y1),
-            endX: Double(request.x2),
-            endY: Double(request.y2),
+            startX: request.x1,
+            startY: request.y1,
+            endX: request.x2,
+            endY: request.y2,
             fingerCount: fingerCount,
             fingerSpacing: fingerSpacing,
             duration: TimeInterval(duration) / 1000.0
@@ -406,8 +406,8 @@ public class CommandHandler: CommandHandling {
         let holdDuration = request.holdDurationMs ?? 100
 
         try gesturePerformer.drag(
-            startX: Double(request.x1), startY: Double(request.y1),
-            endX: Double(request.x2), endY: Double(request.y2),
+            startX: request.x1, startY: request.y1,
+            endX: request.x2, endY: request.y2,
             pressDuration: TimeInterval(pressDuration) / 1000.0,
             dragDuration: TimeInterval(dragDuration) / 1000.0,
             holdDuration: TimeInterval(holdDuration) / 1000.0
@@ -422,10 +422,10 @@ public class CommandHandler: CommandHandling {
 
     private func handlePinch(_ request: RequestPinch, startTime: Date) throws -> WebSocketResponse {
         try gesturePerformer.pinch(
-            centerX: Double(request.centerX),
-            centerY: Double(request.centerY),
-            distanceStart: Double(request.distanceStart),
-            distanceEnd: Double(request.distanceEnd),
+            centerX: request.centerX,
+            centerY: request.centerY,
+            distanceStart: request.distanceStart,
+            distanceEnd: request.distanceEnd,
             rotationDegrees: Double(request.rotationDegrees ?? 0),
             duration: TimeInterval(request.duration ?? 300) / 1000.0
         )

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -36,28 +36,37 @@ public struct RequestHierarchy: Decodable {
 
 // MARK: Gestures
 
+// Coordinate fields are `Double`, not `Int`: the iOS TS wire path runs with
+// `roundCoordinates: false` (see `CtrlProxyGestures.ts`), so a direct or future
+// caller can legitimately send sub-pixel coordinates or computed distances. An
+// `Int` field would reject those with an opaque `Decodable` failure (issue
+// #2909). `Double` decodes both integer and fractional JSON numbers, so the
+// existing rounded-input path is unaffected. The gesture engine
+// (`GesturePerformer`) already operates in `Double`; only durations, finger
+// counts, and rotation stay in their original numeric types below.
+
 public struct RequestTapCoordinates: Decodable {
     public var requestId: String?
-    public var x: Int
-    public var y: Int
+    public var x: Double
+    public var y: Double
     public var duration: Int?
 }
 
 public struct RequestSwipe: Decodable {
     public var requestId: String?
-    public var x1: Int
-    public var y1: Int
-    public var x2: Int
-    public var y2: Int
+    public var x1: Double
+    public var y1: Double
+    public var x2: Double
+    public var y2: Double
     public var duration: Int?
 }
 
 public struct RequestMultiFingerSwipe: Decodable {
     public var requestId: String?
-    public var x1: Int
-    public var y1: Int
-    public var x2: Int
-    public var y2: Int
+    public var x1: Double
+    public var y1: Double
+    public var x2: Double
+    public var y2: Double
     public var fingerCount: Int?
     public var duration: Int?
     public var offset: Double?
@@ -65,10 +74,10 @@ public struct RequestMultiFingerSwipe: Decodable {
 
 public struct RequestDrag: Decodable {
     public var requestId: String?
-    public var x1: Int
-    public var y1: Int
-    public var x2: Int
-    public var y2: Int
+    public var x1: Double
+    public var y1: Double
+    public var x2: Double
+    public var y2: Double
     public var pressDurationMs: Int?
     public var dragDurationMs: Int?
     public var holdDurationMs: Int?
@@ -77,10 +86,10 @@ public struct RequestDrag: Decodable {
 
 public struct RequestPinch: Decodable {
     public var requestId: String?
-    public var centerX: Int
-    public var centerY: Int
-    public var distanceStart: Int
-    public var distanceEnd: Int
+    public var centerX: Double
+    public var centerY: Double
+    public var distanceStart: Double
+    public var distanceEnd: Double
     public var rotationDegrees: Float?
     public var duration: Int?
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -236,6 +236,75 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         XCTAssertEqual(history.first?.rotationDegrees, 15)
     }
 
+    // MARK: - Fractional coordinates (issue #2909)
+
+    /// The iOS TS wire path sets `roundCoordinates: false`, so a direct/future
+    /// caller can send sub-pixel coordinates. The runner must decode fractional
+    /// gesture coordinates instead of throwing an opaque `Int` decode error, and
+    /// must preserve the fraction end-to-end (not truncate it).
+    func testTapCoordinatesDecodeAcceptsFractionalCoordinates() {
+        let response = dispatch(
+            #"{"type":"request_tap_coordinates","requestId":"tap-frac","x":100.5,"y":200.25,"duration":50}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "tap_coordinates_result")
+        let history = fakeGesturePerformer.getTapHistory()
+        XCTAssertEqual(history.first?.x ?? .nan, 100.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.y ?? .nan, 200.25, accuracy: 0.0001)
+    }
+
+    func testSwipeDecodeAcceptsFractionalCoordinates() {
+        let response = dispatch(
+            #"{"type":"request_swipe","requestId":"sw-frac","x1":10.5,"y1":20.5,"x2":30.25,"y2":40.75,"duration":250}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "swipe_result")
+        let history = fakeGesturePerformer.getSwipeHistory()
+        XCTAssertEqual(history.first?.startX ?? .nan, 10.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.endY ?? .nan, 40.75, accuracy: 0.0001)
+    }
+
+    func testMultiFingerSwipeDecodeAcceptsFractionalCoordinates() {
+        let response = dispatch(
+            #"""
+            {"type":"request_multi_finger_swipe","requestId":"mfs-frac","x1":10.5,"y1":20.5,"x2":30.25,"y2":40.75,"fingerCount":3,"offset":31.5}
+            """#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "multi_finger_swipe_result")
+        let history = fakeGesturePerformer.getMultiFingerSwipeHistory()
+        XCTAssertEqual(history.first?.startX ?? .nan, 10.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.endY ?? .nan, 40.75, accuracy: 0.0001)
+    }
+
+    func testDragDecodeAcceptsFractionalCoordinates() {
+        let response = dispatch(
+            #"""
+            {"type":"request_drag","requestId":"drag-frac","x1":10.5,"y1":20.5,"x2":30.25,"y2":40.75,"dragDurationMs":250}
+            """#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "drag_result")
+        let history = fakeGesturePerformer.getDragHistory()
+        XCTAssertEqual(history.first?.startX ?? .nan, 10.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.endY ?? .nan, 40.75, accuracy: 0.0001)
+    }
+
+    func testPinchDecodeAcceptsFractionalCoordinates() {
+        let response = dispatch(
+            #"""
+            {"type":"request_pinch","requestId":"pinch-frac","centerX":100.5,"centerY":200.25,"distanceStart":40.5,"distanceEnd":120.75,"rotationDegrees":15,"duration":700}
+            """#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "pinch_result")
+        let history = fakeGesturePerformer.getPinchHistory()
+        XCTAssertEqual(history.first?.centerX ?? .nan, 100.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.centerY ?? .nan, 200.25, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.distanceStart ?? .nan, 40.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.distanceEnd ?? .nan, 120.75, accuracy: 0.0001)
+    }
+
     // MARK: - Text input
 
     func testSetTextDecodeDispatchTypesText() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -290,6 +290,24 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         XCTAssertEqual(history.first?.endY ?? .nan, 40.75, accuracy: 0.0001)
     }
 
+    /// Negative fractional coordinates are a legitimate computed input (e.g. an
+    /// off-screen anchor or a delta relative to an origin). Asserts the exact
+    /// values survive at the payload-decode boundary — not merely that decode
+    /// did not throw — so a future accidental re-narrowing to `Int` (which would
+    /// truncate the fraction and reject nothing) is caught.
+    func testGestureCoordinatesDecodeNegativeFractionalAtBoundary() throws {
+        let request = try decodeWebSocketRequest(
+            #"{"type":"request_swipe","requestId":"neg-1","x1":-5.5,"y1":0.25,"x2":30.75,"y2":-40.5}"#
+        )
+        guard case let .swipe(payload) = request else {
+            return XCTFail("Expected .swipe, got \(request)")
+        }
+        XCTAssertEqual(payload.x1, -5.5, accuracy: 0.0001)
+        XCTAssertEqual(payload.y1, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(payload.x2, 30.75, accuracy: 0.0001)
+        XCTAssertEqual(payload.y2, -40.5, accuracy: 0.0001)
+    }
+
     func testPinchDecodeAcceptsFractionalCoordinates() {
         let response = dispatch(
             #"""


### PR DESCRIPTION
## What

Widen the iOS CtrlProxy runner's gesture **request** coordinate fields from `Int` to `Double` so fractional coordinates decode and execute cleanly instead of throwing an opaque Swift `Decodable` error.

Affected request models in `ios/control-proxy/Sources/CtrlProxy/Models.swift`:
- `RequestTapCoordinates.x/y`
- `RequestSwipe.x1/y1/x2/y2`
- `RequestMultiFingerSwipe.x1/y1/x2/y2`
- `RequestDrag.x1/y1/x2/y2`
- `RequestPinch.centerX/centerY/distanceStart/distanceEnd`

Closes #2909.

## Why

The iOS TS wire path runs with `roundCoordinates: false` (`src/features/observe/ios/CtrlProxyGestures.ts:15`), so `SharedGestureDelegate.coord()` is a passthrough — fractional values are **not** rounded before hitting the wire. The runner's `Int` decode fields meant the only thing keeping fractions off the wire was the explicit rounding in `PinchOn.ts` (`:135-136`, `:450-451`). Any direct or future caller passing sub-pixel centers / computed distances would hit `DecodingError` (*"Number 100.5 is not representable in Swift"*) rather than a pinch.

A fractional coordinate is a legitimate input, and the runner should be robust to any client — not silently dependent on every caller rounding first. This implements the issue's **preferred option 1** (widen in the runner).

## How

- `Models.swift` — the five gesture request structs now type coordinate fields as `Double`. `Double` decodes both integer and fractional JSON numbers, so integer payloads decode identically; `RequestType` / the `connected` handshake `supportedCommands` are untouched, and the fields stay non-optional so required-field decode rejection (`keyNotFound`) is preserved. Durations, `fingerCount`, `offset`, and `rotationDegrees` (already `Float?`) keep their original types — they are not coordinates.
- `CommandHandler.swift` — dropped the now-redundant `Double(request.x)` wrappers on the coordinate arguments; the gesture engine (`GesturePerformer`) and `FakeGesturePerformer` already operate in `Double`, so nothing downstream changed.

`ElementBounds` (runner **output**) and `HighlightBounds` (a separate feature) remain `Int` — deliberately out of scope; only gesture-request **inputs** are widened.

## Testing

Added fractional-coordinate decode+dispatch tests to `TypedRequestDecodeTests.swift` for tap, swipe, multi-finger swipe, drag, and pinch. Each sends sub-pixel values (e.g. `centerX:100.5`, `distanceEnd:120.75`) and asserts the fraction is preserved end-to-end to the fake performer (`accuracy: 0.0001`) — not truncated. These reproduce the bug first (red: *"Number 100.5 is not representable in Swift"*) and pass after the widening.

Verified locally:
- `swift test -Xswiftc -warnings-as-errors` in `ios/control-proxy` — **295 tests pass, 0 failures** (5 new).
- `swiftformat --lint` clean on all touched files; `swiftlint` clean (the two pre-existing `ok` identifier warnings in `SetNetworkMockRulesResponse` are on `main` too, unrelated to this change).

## Acceptance criteria (#2909)
- [x] A `request_pinch` (and siblings tap/swipe/drag/multi-finger) with fractional coordinates decodes and executes without a decode error.
- [x] Swift decode test covering a fractional coordinate payload.
- [x] No behavioral change to the existing rounded-input path (integer JSON decodes identically; TS `PinchOn` rounding untouched; existing integer tests green).

## Follow-up note

This fix lives in the iOS runner source. It only reaches deployed sessions once the pinned iOS runner release + checksum registry (`src/constants/release.ts`) is re-cut. There is **no interim regression**: the shipped TS path still rounds today, so nothing that works now breaks — this purely removes a latent robustness gap for direct/future callers.