### PR TITLE
fix(db): default updated_at to datetime('now') to match created_at (#2913)

### DIFF
--- a/src/db/migrations/2025_12_28_000_initial_schema.ts
+++ b/src/db/migrations/2025_12_28_000_initial_schema.ts
@@ -13,7 +13,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   // Create index on device_id for fast lookups

--- a/src/db/migrations/2025_12_30_001_navigation_graph.ts
+++ b/src/db/migrations/2025_12_30_001_navigation_graph.ts
@@ -9,7 +9,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   // Create navigation_nodes table

--- a/src/db/migrations/2025_12_31_000_accessibility_baselines.ts
+++ b/src/db/migrations/2025_12_31_000_accessibility_baselines.ts
@@ -11,7 +11,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 
   // Create index on screen_id for fast lookups

--- a/src/db/migrations/2026_01_02_000_prediction_history.ts
+++ b/src/db/migrations/2026_01_02_000_prediction_history.ts
@@ -70,7 +70,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("successes", "integer", col => col.notNull())
     .addColumn("total_confidence", "real", col => col.notNull())
     .addColumn("brier_score_sum", "real", col => col.notNull())
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )

--- a/src/db/migrations/2026_01_03_000_feature_flags.ts
+++ b/src/db/migrations/2026_01_03_000_feature_flags.ts
@@ -10,7 +10,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();
 }
 

--- a/src/db/migrations/2026_01_09_000_video_recordings.ts
+++ b/src/db/migrations/2026_01_09_000_video_recordings.ts
@@ -55,7 +55,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .ifNotExists()
     .addColumn("key", "text", col => col.primaryKey())
     .addColumn("config_json", "text", col => col.notNull())
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )

--- a/src/db/migrations/2026_01_10_000_device_snapshots.ts
+++ b/src/db/migrations/2026_01_10_000_device_snapshots.ts
@@ -43,7 +43,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .ifNotExists()
     .addColumn("key", "text", col => col.primaryKey())
     .addColumn("config_json", "text", col => col.notNull())
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )

--- a/src/db/migrations/2026_01_14_000_appearance_config.ts
+++ b/src/db/migrations/2026_01_14_000_appearance_config.ts
@@ -6,7 +6,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .ifNotExists()
     .addColumn("key", "text", col => col.primaryKey())
     .addColumn("config_json", "text", col => col.notNull())
-    .addColumn("updated_at", "text", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
     .addColumn("created_at", "text", col =>
       col.notNull().defaultTo(sql`(datetime('now'))`)
     )

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -13,7 +13,7 @@ export interface DeviceConfigTable {
   active_mode: string | null;
   config_json: string; // JSON blob for flexible config storage
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Installed apps cache table
@@ -78,7 +78,7 @@ export interface PerformanceAuditResultsTable {
 export interface NavigationAppsTable {
   app_id: string;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 export interface NavigationNodesTable {
@@ -212,7 +212,7 @@ export interface PredictionTransitionStatsTable {
   successes: number;
   total_confidence: number;
   brier_score_sum: number;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
@@ -283,7 +283,7 @@ interface AccessibilityBaselinesTable {
   screen_id: string;
   violations_json: string; // JSON blob of WcagViolation[]
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Memory audit tables
@@ -468,7 +468,7 @@ export interface DeviceSessionsTable {
   heartbeat_timeout_ms: number;
   has_received_heartbeat: number;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Feature flags table
@@ -477,7 +477,7 @@ export interface FeatureFlagsTable {
   enabled: number; // SQLite boolean (0/1)
   config_json: string | null;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Device snapshot tables
@@ -498,7 +498,7 @@ export interface DeviceSnapshotsTable {
 export interface DeviceSnapshotConfigsTable {
   key: string;
   config_json: string;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
@@ -526,14 +526,14 @@ export interface VideoRecordingsTable {
 export interface VideoRecordingConfigsTable {
   key: string;
   config_json: string;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
 export interface AppearanceConfigsTable {
   key: string;
   config_json: string;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
@@ -775,7 +775,7 @@ interface FailureGroupsTable {
   stack_trace_json: string | null;
   tool_call_info_json: string | null;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 interface FailureOccurrencesTable {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -13,7 +13,7 @@ export interface DeviceConfigTable {
   active_mode: string | null;
   config_json: string; // JSON blob for flexible config storage
   created_at: Generated<string>;
-  updated_at: Generated<string>;
+  updated_at: string;
 }
 
 // Installed apps cache table
@@ -78,7 +78,7 @@ export interface PerformanceAuditResultsTable {
 export interface NavigationAppsTable {
   app_id: string;
   created_at: Generated<string>;
-  updated_at: Generated<string>;
+  updated_at: string;
 }
 
 export interface NavigationNodesTable {
@@ -212,7 +212,7 @@ export interface PredictionTransitionStatsTable {
   successes: number;
   total_confidence: number;
   brier_score_sum: number;
-  updated_at: Generated<string>;
+  updated_at: string;
   created_at: Generated<string>;
 }
 
@@ -283,7 +283,7 @@ interface AccessibilityBaselinesTable {
   screen_id: string;
   violations_json: string; // JSON blob of WcagViolation[]
   created_at: Generated<string>;
-  updated_at: Generated<string>;
+  updated_at: string;
 }
 
 // Memory audit tables
@@ -468,7 +468,7 @@ export interface DeviceSessionsTable {
   heartbeat_timeout_ms: number;
   has_received_heartbeat: number;
   created_at: Generated<string>;
-  updated_at: Generated<string>;
+  updated_at: string;
 }
 
 // Feature flags table
@@ -477,7 +477,7 @@ export interface FeatureFlagsTable {
   enabled: number; // SQLite boolean (0/1)
   config_json: string | null;
   created_at: Generated<string>;
-  updated_at: Generated<string>;
+  updated_at: string;
 }
 
 // Device snapshot tables
@@ -498,7 +498,7 @@ export interface DeviceSnapshotsTable {
 export interface DeviceSnapshotConfigsTable {
   key: string;
   config_json: string;
-  updated_at: Generated<string>;
+  updated_at: string;
   created_at: Generated<string>;
 }
 
@@ -526,14 +526,14 @@ export interface VideoRecordingsTable {
 export interface VideoRecordingConfigsTable {
   key: string;
   config_json: string;
-  updated_at: Generated<string>;
+  updated_at: string;
   created_at: Generated<string>;
 }
 
 export interface AppearanceConfigsTable {
   key: string;
   config_json: string;
-  updated_at: Generated<string>;
+  updated_at: string;
   created_at: Generated<string>;
 }
 
@@ -775,7 +775,7 @@ interface FailureGroupsTable {
   stack_trace_json: string | null;
   tool_call_info_json: string | null;
   created_at: Generated<string>;
-  updated_at: Generated<string>;
+  updated_at: string;
 }
 
 interface FailureOccurrencesTable {

--- a/test/db/updatedAtColumnDefaults.test.ts
+++ b/test/db/updatedAtColumnDefaults.test.ts
@@ -82,8 +82,12 @@ describe("updated_at columns default to a real timestamp (#2913)", () => {
     });
 
     test(`${table}: updated_at carries the same evaluated default as its created_at sibling`, async () => {
+      // Inline the table name as a literal (`sql.lit`) rather than a bound
+      // parameter: a parameterized `pragma_table_info(?)` read was observed to
+      // intermittently return a null `dflt_value` under parallel-file load
+      // (a bun:sqlite quirk), which would flake this assertion in CI.
       const columns = await sql<{ name: string; dflt_value: string | null }>`
-        SELECT name, dflt_value FROM pragma_table_info(${table as string})
+        SELECT name, dflt_value FROM pragma_table_info(${sql.lit(table as string)})
       `.execute(db);
       const updatedAt = columns.rows.find(c => c.name === "updated_at");
       const createdAt = columns.rows.find(c => c.name === "created_at");

--- a/test/db/updatedAtColumnDefaults.test.ts
+++ b/test/db/updatedAtColumnDefaults.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { sql, type Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "./testDbHelper";
+
+/**
+ * Behavior coverage for issue #2913: eight tables gave `created_at` a
+ * server-evaluated `(datetime('now'))` default but declared their sibling
+ * `updated_at` as `.notNull()` with NO default, forcing every writer to supply
+ * it. Two newer tables (`failure_groups`, `device_sessions`) already default
+ * `updated_at` the same way `created_at` is defaulted, so the fix reconciles the
+ * older eight to that established convention (option (a) in the issue).
+ *
+ * Each row below inserts ONLY the columns that are required with no default,
+ * deliberately OMITTING `updated_at`, so the default path is exercised exactly
+ * the way a future defaulted writer would hit it. Before the fix these inserts
+ * throw a NOT NULL constraint failure; after it they store a real timestamp.
+ *
+ * The source-grep guard that rejects the buggy string-literal form
+ * (`defaultTo("datetime('now')")`, the #2895 class) lives in
+ * `scripts/validate-no-datetime-now-literal.sh`; this file owns the runtime
+ * proof that the defaulted `updated_at` insert stores a parseable timestamp and
+ * that the stored DDL default is the raw expression, not the literal text.
+ */
+
+// The eight tables reconciled by #2913, each with the minimal set of
+// required-no-default columns needed to insert a row while omitting updated_at.
+const TABLES: ReadonlyArray<{ table: keyof Database; values: Record<string, unknown> }> = [
+  { table: "device_configs", values: { device_id: "d-2913", platform: "android" } },
+  { table: "navigation_apps", values: { app_id: "app-2913" } },
+  {
+    table: "prediction_transition_stats",
+    values: {
+      app_id: "app-2913",
+      from_screen: "a",
+      to_screen: "b",
+      tool_name: "tapOn",
+      attempts: 1,
+      successes: 1,
+      total_confidence: 0.5,
+      brier_score_sum: 0.25,
+    },
+  },
+  {
+    table: "accessibility_baselines",
+    values: { screen_id: "screen-2913", violations_json: "[]" },
+  },
+  { table: "feature_flags", values: { key: "flag-2913" } },
+  { table: "device_snapshot_configs", values: { key: "dsc-2913", config_json: "{}" } },
+  { table: "video_recording_configs", values: { key: "vrc-2913", config_json: "{}" } },
+  { table: "appearance_configs", values: { key: "ac-2913", config_json: "{}" } },
+];
+
+describe("updated_at columns default to a real timestamp (#2913)", () => {
+  let db: Kysely<Database>;
+
+  beforeAll(async () => {
+    db = await createTestDatabase();
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  for (const { table, values } of TABLES) {
+    test(`${table}: a defaulted updated_at stores a real timestamp, not the literal or a NOT NULL failure`, async () => {
+      await db
+        .insertInto(table as never)
+        .values(values as never)
+        .execute();
+
+      const rows = await sql<{ updated_at: string }>`
+        SELECT updated_at FROM ${sql.ref(table as string)} LIMIT 1
+      `.execute(db);
+      const updatedAt = rows.rows[0]?.updated_at;
+
+      // Not the #2895-class literal text...
+      expect(updatedAt).not.toBe("datetime('now')");
+      // ...and a real, parseable timestamp (SQLite's `YYYY-MM-DD HH:MM:SS`).
+      expect(updatedAt).toBeTruthy();
+      expect(Number.isNaN(Date.parse(updatedAt as string))).toBe(false);
+    });
+
+    test(`${table}: updated_at carries the same evaluated default as its created_at sibling`, async () => {
+      const columns = await sql<{ name: string; dflt_value: string | null }>`
+        SELECT name, dflt_value FROM pragma_table_info(${table as string})
+      `.execute(db);
+      const updatedAt = columns.rows.find(c => c.name === "updated_at");
+      const createdAt = columns.rows.find(c => c.name === "created_at");
+
+      expect(updatedAt).toBeDefined();
+      // The reconciliation guarantee of #2913: the sibling timestamp columns now
+      // share one default. `pragma_table_info.dflt_value` strips the outer parens
+      // of `sql`(datetime('now'))``, reporting the evaluated expression.
+      expect(updatedAt?.dflt_value).toBe("datetime('now')");
+      // Not the #2895-class value literal `'datetime(''now'')'` (quoted string).
+      expect(updatedAt?.dflt_value).not.toBe("'datetime(''now'')'");
+      // Symmetric with created_at — the asymmetry the issue set out to remove.
+      expect(updatedAt?.dflt_value).toBe(createdAt?.dflt_value);
+    });
+  }
+});

--- a/test/db/updatedAtColumnDefaults.test.ts
+++ b/test/db/updatedAtColumnDefaults.test.ts
@@ -9,12 +9,24 @@ import { createTestDatabase } from "./testDbHelper";
  * `updated_at` as `.notNull()` with NO default, forcing every writer to supply
  * it. Two newer tables (`failure_groups`, `device_sessions`) already default
  * `updated_at` the same way `created_at` is defaulted, so the fix reconciles the
- * older eight to that established convention (option (a) in the issue).
+ * older eight schema declarations to that established convention (option (a)).
  *
  * Each row below inserts ONLY the columns that are required with no default,
- * deliberately OMITTING `updated_at`, so the default path is exercised exactly
- * the way a future defaulted writer would hit it. Before the fix these inserts
- * throw a NOT NULL constraint failure; after it they store a real timestamp.
+ * deliberately OMITTING `updated_at`, so the SQL-level default path is exercised
+ * exactly the way a future defaulted writer would hit it. Before the fix these
+ * inserts throw a NOT NULL constraint failure; after it they store a real
+ * timestamp.
+ *
+ * NOTE the insert casts (`as never`): the `updated_at` TypeScript type is
+ * INTENTIONALLY left required (`string`, not `Generated<string>`) even though
+ * the fresh schema now carries a default. An upgraded database — one that
+ * already ran the historical migration — keeps the old no-default column, since
+ * editing a migration body does not re-run it (Kysely tracks migrations by name).
+ * Advertising the column as omittable in TypeScript would let a writer pass local
+ * validation yet fail `NOT NULL` for upgraded users. The type may be relaxed once
+ * a repair migration rebuilds these columns' defaults on upgraded DBs (unlike
+ * `created_at`, whose default #2915 already repaired everywhere). The cast lets
+ * this test exercise the SQL default directly, which is what the fix delivers.
  *
  * The source-grep guard that rejects the buggy string-literal form
  * (`defaultTo("datetime('now')")`, the #2895 class) lives in


### PR DESCRIPTION
## What

Reconciles the eight tables flagged in #2913 whose `created_at` column carries a
server-evaluated `(datetime('now'))` default while their sibling `updated_at` was
declared `.notNull()` with **no default**, forcing every writer to supply it.

Each `updated_at` migration declaration now uses
`col.notNull().defaultTo(sql`(datetime('now'))`)` — the same expression its
`created_at` sibling uses, and the same form two newer tables (`failure_groups`,
`device_sessions`) already adopted. This is **option (a)** from the issue.

Affected columns (all `updated_at`):

- `device_configs` — `2025_12_28_000_initial_schema.ts`
- `navigation_apps` — `2025_12_30_001_navigation_graph.ts`
- `accessibility_baselines` — `2025_12_31_000_accessibility_baselines.ts`
- `prediction_transition_stats` — `2026_01_02_000_prediction_history.ts`
- `feature_flags` — `2026_01_03_000_feature_flags.ts`
- `video_recording_configs` — `2026_01_09_000_video_recordings.ts`
- `device_snapshot_configs` — `2026_01_10_000_device_snapshots.ts`
- `appearance_configs` — `2026_01_14_000_appearance_config.ts`

The change is **migration-DDL only** — no TypeScript type change (see below).

## Why

Option (a) over (b) (documenting the asymmetry as intentional) because the codebase
already treats a defaulted `updated_at` as normal: `failure_groups`
(`2026_01_27_000_failures.ts:35`) and `device_sessions`
(`2026_04_02_000_device_sessions.ts:24`) both declare
`updated_at ... .defaultTo(sql`(datetime('now'))`)`. The eight older tables simply
predate that convention. Documenting the split as intentional would contradict
existing code.

Not a bug today — every current writer passes `updated_at` explicitly (verified in
`navigationRepository`, `appearanceConfigRepository`, `FeatureFlagRepository`, etc.),
so there is no missing-value failure. This removes the latent trap: a future insert
path that leans on the default (the way `created_at` already does) would otherwise
fail the `NOT NULL` constraint on these eight tables only.

Editing historical migrations is safe: Kysely identifies executed migrations by name
only (no content checksum, verified in #2906), so an already-migrated DB never
re-runs them. Existing rows already hold explicit `updated_at` values, so **no data
repair is needed** — consistent with the issue.

Format: kept `datetime('now')` (SQLite `YYYY-MM-DD HH:MM:SS`) to match the
`created_at` sibling and the codebase's other server-evaluated-now writes.

## Why the TypeScript type stays required (`string`, not `Generated<string>`)

An earlier revision of this PR also relaxed `updated_at` to `Generated<string>` in
`src/db/types.ts` for consistency with `created_at`. That was reverted
([Codex P2](https://github.com/kaeawc/auto-mobile/pull/2922#discussion_r3521011927)):
because editing a historical migration does not re-run it, an **already-upgraded**
database keeps the old no-default column (reproduced: a defaulted insert there still
throws `NOT NULL`). Advertising the column as omittable in TypeScript would let a
writer pass local/fresh-schema validation yet fail for upgraded users.

So the fix is migration-DDL only. The type now honestly encodes reality:
`created_at` is `Generated` because #2915 rebuilt its default on upgraded DBs too
(safe to omit everywhere); `updated_at` stays **required** because its default lands
only on fresh DBs — until an equivalent repair migration is added (filed as
follow-up). This resolves the schema asymmetry the issue describes with **zero**
migration risk.

## How

`src/db/migrations/*` — 8 one-line edits changing `col.notNull()` to
`col.notNull().defaultTo(sql`(datetime('now'))`)` (every file already imported `sql`).

`test/db/updatedAtColumnDefaults.test.ts` (new) — for each of the 8 reconciled
tables, proves against the real migrated in-memory schema that:

1. an insert **omitting** `updated_at` succeeds and stores a parseable timestamp
   (before this change it threw `NOT NULL constraint failed`), and
2. `updated_at`'s stored default equals its `created_at` sibling's — the symmetry the
   issue set out to restore — and is the evaluated `datetime('now')`, not the
   #2895-class value literal `'datetime(''now'')'`.

The insert casts through `as never` to exercise the SQL default directly, since the
TS type remains required by design.

## Verification

- `bun test test/db/updatedAtColumnDefaults.test.ts` → 16 pass (stable across repeated / parallel-file runs)
- `bun test` (full suite) → 5904 pass, 0 fail
- `bunx turbo run lint build` → clean
- `tsc --noEmit` → 0 errors
- `scripts/validate-no-datetime-now-literal.sh` + bats → pass (no string-literal form reintroduced)

## Follow-up (deferred)

Upgraded-DB parity: a table-rebuild repair migration (as #2915 did for the broken
`created_at` defaults) would let `updated_at` be safely typed `Generated` and omitted
everywhere. Deferred because no writer omits `updated_at` today, so the rebuild would
be disproportionate risk for a column nothing defaults on. A follow-up issue tracks it,
including the `BaselineManager` retention trap (it compares `updated_at < cutoffIso`,
so a defaulted `datetime('now')` value would need format-normalization there first).

Closes #2913
