### PR TITLE
test(db): harden Windows file-DB close/reopen tests against EBUSY livelock (#2916)

### DIFF
--- a/test/db/databaseIncompleteExtraction.test.ts
+++ b/test/db/databaseIncompleteExtraction.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import { isIncompleteExtractionError } from "../../src/db/migrationDependencyIntegrity";
+import { removeTempDbDir } from "./tempDbDir";
 
 /**
  * Issue #2833: the incomplete-extraction mapping is scoped to KNOWN migration
@@ -34,31 +35,13 @@ describe("startup migration failure does not mislabel a genuine bad import", () 
     restore("AUTOMOBILE_DB_PATH", originalDbPath);
     restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
     if (tempDir) {
-      await removeTempDirWithRetry(tempDir);
+      await removeTempDbDir(tempDir);
       tempDir = undefined;
     }
   });
 
   async function importFreshDatabaseModule() {
     return import(`../../src/db/database.ts?incomplete-extraction-test=${Date.now()}-${Math.random()}`);
-  }
-
-  // Windows holds the sqlite file until the handle is fully released; retry the
-  // removal past a transient EBUSY/EPERM rather than failing the test on cleanup.
-  async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await rm(dir, { recursive: true, force: true });
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
-          throw error;
-        }
-        await defaultTimer.sleep(50);
-      }
-    }
-    await rm(dir, { recursive: true, force: true });
   }
 
   test("an unknown missing package surfaces the generic error, not incomplete-extraction", async () => {

--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
-import { defaultTimer } from "../../src/utils/SystemTimer";
+import { removeTempDbDir } from "./tempDbDir";
 
 /**
  * Regression test for the module-load-time-vs-runtime path hazard.
@@ -39,23 +39,6 @@ describe("database path lazy resolution", () => {
   async function importFreshDatabaseModule() {
     // Fresh module instance so its lazy cache is not shared with other tests.
     return import(`../../src/db/database.ts?lazy-db-path-test=${Date.now()}-${Math.random()}`);
-  }
-
-  async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await rm(dir, { recursive: true, force: true });
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
-          throw error;
-        }
-        await defaultTimer.sleep(50);
-      }
-    }
-
-    await rm(dir, { recursive: true, force: true });
   }
 
   test("resolves relative AUTOMOBILE_DB_DIR against the launch cwd set AFTER import", async () => {
@@ -112,7 +95,7 @@ describe("database path lazy resolution", () => {
       expect(rows).toEqual([]);
     } finally {
       await databaseModule.closeDatabase();
-      await removeTempDirWithRetry(dbDir);
+      await removeTempDbDir(dbDir);
     }
   });
 
@@ -140,7 +123,7 @@ describe("database path lazy resolution", () => {
       );
     } finally {
       await databaseModule.closeDatabase();
-      await removeTempDirWithRetry(dbDir);
+      await removeTempDbDir(dbDir);
     }
   });
 });

--- a/test/db/databaseMigrationFailure.test.ts
+++ b/test/db/databaseMigrationFailure.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { removeTempDbDir } from "./tempDbDir";
 
 /**
  * Verifies the cached-error migration contract that issue #2784 depends on and
@@ -33,7 +34,7 @@ describe("database startup migration failure contract", () => {
   afterEach(async () => {
     restore("AUTOMOBILE_DB_PATH", originalDbPath);
     if (tempDir) {
-      await rm(tempDir, { recursive: true, force: true });
+      await removeTempDbDir(tempDir);
       tempDir = undefined;
     }
   });

--- a/test/db/databaseReset.test.ts
+++ b/test/db/databaseReset.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
-import { defaultTimer } from "../../src/utils/SystemTimer";
+import { removeTempDbDir } from "./tempDbDir";
 
 /**
  * Regression tests for issue #2796.
@@ -23,6 +23,13 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
  * than reading internals directly.
  */
 describe("closeDatabase resets migration + path globals (issue #2796)", () => {
+  // Tests that genuinely open a real file-backed DB (migration/query paths use a
+  // separate connection from the app connection, so they need a shared on-disk
+  // file — `:memory:` gives each connection its own empty DB). Give them a
+  // generous timeout so slow Windows disk I/O plus bounded best-effort cleanup
+  // can never trip the default per-test timeout (issue #2916).
+  const FILE_BACKED_TEST_TIMEOUT_MS = 30000;
+
   const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
   const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
   const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
@@ -46,7 +53,7 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
     restore("AUTO_MOBILE_MIGRATIONS_DIR", originalLegacyMigrationsDir);
     for (const dir of tempDirs.splice(0)) {
-      await removeTempDirWithRetry(dir);
+      await removeTempDbDir(dir);
     }
   });
 
@@ -59,22 +66,6 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     const dir = await mkdtemp(path.join(tmpdir(), prefix));
     tempDirs.push(dir);
     return dir;
-  }
-
-  async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await rm(dir, { recursive: true, force: true });
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
-          throw error;
-        }
-        await defaultTimer.sleep(50);
-      }
-    }
-    await rm(dir, { recursive: true, force: true });
   }
 
   function queryToolCalls(db: any) {
@@ -113,17 +104,23 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     expect(await queryToolCalls(secondDb)).toEqual([]);
 
     await databaseModule.closeDatabase();
-  });
+  }, FILE_BACKED_TEST_TIMEOUT_MS);
 
   test("reopen after close re-resolves the DB path under a changed env (resolvedDbPath reset)", async () => {
+    // This assertion is on the pure path-resolution cache (`resolvedDbPath`),
+    // which `resolveDatabasePathFromEnvironment()` computes as a string without
+    // touching the filesystem. Drive it through `getDatabasePath()` alone and
+    // never open a real `auto-mobile.db`, so it carries no dependency on Windows
+    // file-handle release (issue #2916). `closeDatabase()` resets the path cache
+    // unconditionally — even with no open connection — so the reset is still
+    // exercised here.
     const firstDir = await makeTempDbDir("auto-mobile-reset-path-first-");
     process.env.AUTOMOBILE_DB_DIR = firstDir;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
     const databaseModule = await importFreshDatabaseModule();
 
-    // Resolve + open once so resolvedDbPath is cached.
-    databaseModule.getDatabase();
+    // Resolve once so resolvedDbPath is cached (no DB file opened).
     expect(databaseModule.getDatabasePath()).toBe(path.join(firstDir, "auto-mobile.db"));
 
     await databaseModule.closeDatabase();
@@ -167,5 +164,5 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     expect(databaseModule.getMigrationsError()).toBeNull();
 
     await databaseModule.closeDatabase();
-  });
+  }, FILE_BACKED_TEST_TIMEOUT_MS);
 });

--- a/test/db/databaseReset.test.ts
+++ b/test/db/databaseReset.test.ts
@@ -25,9 +25,12 @@ import { removeTempDbDir } from "./tempDbDir";
 describe("closeDatabase resets migration + path globals (issue #2796)", () => {
   // Tests that genuinely open a real file-backed DB (migration/query paths use a
   // separate connection from the app connection, so they need a shared on-disk
-  // file — `:memory:` gives each connection its own empty DB). Give them a
-  // generous timeout so slow Windows disk I/O plus bounded best-effort cleanup
-  // can never trip the default per-test timeout (issue #2916).
+  // file — `:memory:` gives each connection its own empty DB). This timeout only
+  // covers the test BODY (migrations + queries on slow Windows disk I/O); it does
+  // NOT govern the `afterEach` hook, which uses bun's default hook timeout
+  // independently. The cleanup stall from issue #2916 is bounded separately by
+  // `removeTempDbDir` (best-effort, ~200ms/dir), keeping afterEach well under the
+  // hook timeout.
   const FILE_BACKED_TEST_TIMEOUT_MS = 30000;
 
   const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
-import { defaultTimer } from "../../src/utils/SystemTimer";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
+import { removeTempDbDir } from "./tempDbDir";
 
 /**
  * Regression tests for issue #2896 (follow-up to #2796).
@@ -28,6 +28,12 @@ import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarr
  * `beforeEach`/`afterEach` isolates these tests from the rest of the suite.
  */
 describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)", () => {
+  // Opens a real file-backed DB (needs a shared on-disk file across the
+  // migration and app connections); give it a generous timeout so slow Windows
+  // disk I/O plus bounded best-effort temp-dir cleanup can never trip the
+  // default per-test timeout (issue #2916).
+  const FILE_BACKED_TEST_TIMEOUT_MS = 30000;
+
   const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
   const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
   const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
@@ -54,7 +60,7 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     restore("AUTOMOBILE_DB_DIR", originalDbDir);
     restore("AUTOMOBILE_DB_PATH", originalDbPath);
     for (const dir of tempDirs.splice(0)) {
-      await removeTempDirWithRetry(dir);
+      await removeTempDbDir(dir);
     }
   });
 
@@ -71,22 +77,6 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     const dir = await mkdtemp(path.join(tmpdir(), prefix));
     tempDirs.push(dir);
     return dir;
-  }
-
-  async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await rm(dir, { recursive: true, force: true });
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
-          throw error;
-        }
-        await defaultTimer.sleep(50);
-      }
-    }
-    await rm(dir, { recursive: true, force: true });
   }
 
   test("a tracked best-effort write after drain -> close -> reopen is NOT skipped", async () => {
@@ -129,7 +119,7 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     expect(result).toBe("written");
 
     await databaseModule.closeDatabase();
-  });
+  }, FILE_BACKED_TEST_TIMEOUT_MS);
 
   test("closeDatabase clears a drain latch even with no open connection", async () => {
     const dir = await makeTempDbDir("auto-mobile-barrier-reset-noconn-");

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -29,9 +29,11 @@ import { removeTempDbDir } from "./tempDbDir";
  */
 describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)", () => {
   // Opens a real file-backed DB (needs a shared on-disk file across the
-  // migration and app connections); give it a generous timeout so slow Windows
-  // disk I/O plus bounded best-effort temp-dir cleanup can never trip the
-  // default per-test timeout (issue #2916).
+  // migration and app connections). This timeout only covers the test BODY
+  // (migrations + queries on slow Windows disk I/O); it does NOT govern the
+  // `afterEach` hook, which uses bun's default hook timeout independently. The
+  // cleanup stall from issue #2916 is bounded separately by `removeTempDbDir`
+  // (best-effort, ~200ms/dir).
   const FILE_BACKED_TEST_TIMEOUT_MS = 30000;
 
   const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];

--- a/test/db/tempDbDir.test.ts
+++ b/test/db/tempDbDir.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import path from "path";
+import { existsSync } from "node:fs";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { removeTempDbDir } from "./tempDbDir";
 
@@ -106,6 +110,31 @@ describe("removeTempDbDir (issue #2916)", () => {
       expect(gaveUp).toBe(true);
     }
   );
+
+  test("removes a real temp dir (and its contents) through the default rm/timer", async () => {
+    // Exercises the un-injected happy path: the default `fsRm(..., recursive,
+    // force)` closure and the default timer. macOS/Linux release handles
+    // immediately, so this resolves on the first attempt.
+    const dir = await mkdtemp(path.join(tmpdir(), "auto-mobile-tempdbdir-real-"));
+    await writeFile(path.join(dir, "auto-mobile.db"), "not-a-real-db");
+    expect(existsSync(dir)).toBe(true);
+
+    await removeTempDbDir(dir);
+
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("the default onGiveUp runs without throwing when a lock never clears", async () => {
+    // Drives the default onGiveUp (logger.warn) branch — omit `onGiveUp` but keep
+    // `rm` failing. Must still resolve, never reject.
+    const rm = async () => {
+      throw ebusy();
+    };
+
+    await expect(
+      removeTempDbDir("/tmp/auto-mobile-locked", { rm, maxAttempts: 2, delayMs: 1 })
+    ).resolves.toBeUndefined();
+  });
 
   test("rethrows an unexpected (non-lock) error code without retrying", async () => {
     const timer = new FakeTimer();

--- a/test/db/tempDbDir.test.ts
+++ b/test/db/tempDbDir.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { removeTempDbDir } from "./tempDbDir";
+
+/**
+ * Unit tests for the shared bounded temp-dir cleanup helper (issue #2916).
+ *
+ * The real hazard the helper guards against — bun:sqlite holding a Windows
+ * file handle past `destroy()` so `rm` throws EBUSY — cannot be reproduced on
+ * macOS/Linux. So instead of a real DB we inject a fake `rm` and a `FakeTimer`
+ * and prove the two properties that keep the Windows CI job from stalling:
+ *   1. a persistent lock makes the helper GIVE UP (never throws) within a
+ *      strictly bounded sleep budget, and
+ *   2. it retries transient locks a bounded number of times before giving up.
+ * These run with no real filesystem or wall-clock, so they stay <100ms.
+ */
+describe("removeTempDbDir (issue #2916)", () => {
+  function ebusy(code = "EBUSY"): NodeJS.ErrnoException {
+    const error = new Error(`${code}: resource busy`) as NodeJS.ErrnoException;
+    error.code = code;
+    return error;
+  }
+
+  test("removes the dir on the first attempt and never sleeps when rm succeeds", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const calls: string[] = [];
+    const rm = async (dir: string) => {
+      calls.push(dir);
+    };
+
+    await removeTempDbDir("/tmp/auto-mobile-x", { rm, timer });
+
+    expect(calls).toEqual(["/tmp/auto-mobile-x"]);
+    expect(timer.getSleepCallCount()).toBe(0);
+  });
+
+  test("retries a transient EBUSY, then succeeds", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    let attempts = 0;
+    const rm = async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw ebusy();
+      }
+    };
+
+    await removeTempDbDir("/tmp/auto-mobile-x", { rm, timer, maxAttempts: 5, delayMs: 50 });
+
+    expect(attempts).toBe(3);
+    // One sleep between each of the two failed attempts and the retry.
+    expect(timer.getSleepHistory()).toEqual([50, 50]);
+  });
+
+  test("gives up WITHOUT throwing after a persistent lock, within a bounded sleep budget", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    let attempts = 0;
+    const rm = async () => {
+      attempts += 1;
+      throw ebusy();
+    };
+    const gaveUp: Array<{ dir: string; error: unknown }> = [];
+
+    // Must resolve, not reject — a rejected afterEach cleanup would fail the test.
+    await removeTempDbDir("/tmp/auto-mobile-locked", {
+      rm,
+      timer,
+      maxAttempts: 5,
+      delayMs: 50,
+      onGiveUp: (dir, error) => gaveUp.push({ dir, error }),
+    });
+
+    expect(attempts).toBe(5);
+    // At most (maxAttempts - 1) sleeps, and the total is strictly bounded so the
+    // helper can never approach the CI test timeout on a Windows livelock.
+    const history = timer.getSleepHistory();
+    expect(history.length).toBe(4);
+    expect(history.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(200);
+    expect(gaveUp.length).toBe(1);
+    expect(gaveUp[0].dir).toBe("/tmp/auto-mobile-locked");
+    expect((gaveUp[0].error as NodeJS.ErrnoException).code).toBe("EBUSY");
+  });
+
+  test.each(["EPERM", "ENOTEMPTY"])(
+    "treats %s as a transient Windows lock and gives up gracefully",
+    async code => {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const rm = async () => {
+        throw ebusy(code);
+      };
+      let gaveUp = false;
+
+      await removeTempDbDir("/tmp/auto-mobile-x", {
+        rm,
+        timer,
+        maxAttempts: 3,
+        delayMs: 10,
+        onGiveUp: () => {
+          gaveUp = true;
+        },
+      });
+
+      expect(gaveUp).toBe(true);
+    }
+  );
+
+  test("rethrows an unexpected (non-lock) error code without retrying", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    let attempts = 0;
+    const rm = async () => {
+      attempts += 1;
+      throw ebusy("EACCES");
+    };
+
+    await expect(
+      removeTempDbDir("/tmp/auto-mobile-x", { rm, timer, maxAttempts: 5, delayMs: 50 })
+    ).rejects.toThrow("EACCES");
+    expect(attempts).toBe(1);
+    expect(timer.getSleepCallCount()).toBe(0);
+  });
+});

--- a/test/db/tempDbDir.ts
+++ b/test/db/tempDbDir.ts
@@ -1,6 +1,7 @@
 import { rm as fsRm } from "node:fs/promises";
 import type { Timer } from "../../src/utils/SystemTimer";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { logger } from "../../src/utils/logger";
 
 /**
  * Shared bounded, best-effort temp-dir cleanup for file-backed DB tests (issue
@@ -23,6 +24,16 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
  * `rm`/`timer` are injectable so the retry/give-up behavior is unit-tested with
  * a fake filesystem and {@link FakeTimer} (no real handle livelock exists off
  * Windows to reproduce).
+ *
+ * Why not eliminate the file entirely? The migration-dependent close/reopen
+ * tests need the app connection to see a schema migrated on a SEPARATE
+ * connection (`startMigrations` in `src/db/database.ts` opens and destroys its
+ * own Kysely), so a plain `:memory:` DB — private per connection — cannot work.
+ * `file::memory:?cache=shared` would give one shared in-memory DB with no handle
+ * to leak, but bun:sqlite URI-filename support plus the real file-based
+ * migration lock (`createFileMigrationLock(dbPath)`) make it higher-risk than a
+ * real temp file with bounded cleanup. The issue (#2916) explicitly sanctioned
+ * this bounded-retry approach.
  */
 export interface RemoveTempDbDirOptions {
   /** Removal primitive. Defaults to `rm(dir, { recursive: true, force: true })`. */
@@ -35,7 +46,7 @@ export interface RemoveTempDbDirOptions {
   delayMs?: number;
   /**
    * Invoked once if every attempt loses to a persistent lock. Defaults to a
-   * single `console.warn` so a leaked dir is visible in CI logs; the unit test
+   * single `logger.warn` so a leaked dir is visible in CI logs; the unit test
    * injects a spy instead.
    */
   onGiveUp?: (dir: string, error: unknown) => void;
@@ -53,8 +64,9 @@ function defaultOnGiveUp(dir: string, error: unknown): void {
   const code = (error as NodeJS.ErrnoException | undefined)?.code ?? "unknown";
   // Log-and-continue: the dir is a throwaway temp dir the OS will sweep; a
   // Windows handle livelock is the expected reason and is safe to swallow.
-  console.warn(
-    `removeTempDbDir: gave up removing ${dir} after ${code}; leaving it for OS temp cleanup (issue #2916)`
+  logger.warn(
+    `removeTempDbDir: gave up removing ${dir} after ${code}; leaving it for OS temp cleanup (issue #2916)`,
+    error
   );
 }
 

--- a/test/db/tempDbDir.ts
+++ b/test/db/tempDbDir.ts
@@ -1,0 +1,89 @@
+import { rm as fsRm } from "node:fs/promises";
+import type { Timer } from "../../src/utils/SystemTimer";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+
+/**
+ * Shared bounded, best-effort temp-dir cleanup for file-backed DB tests (issue
+ * #2916).
+ *
+ * On `windows-latest` CI, bun:sqlite can hold the `.db`/`-wal`/`-shm` file
+ * handles past `Kysely.destroy()`, so removing the enclosing `mkdtemp` dir
+ * throws `EBUSY`/`EPERM`/`ENOTEMPTY`. The previous per-file helpers retried
+ * 100×50ms = 5s PER DIR; a close/reopen test with two temp dirs therefore
+ * stalled ~10s in `afterEach` and blew the test timeout — a different file-DB
+ * test flaked each run.
+ *
+ * This helper caps the wait: it retries a small, bounded number of times and
+ * then GIVES UP, leaving the temp dir for the OS temp sweeper rather than
+ * blocking. Each test uses a fresh unique `mkdtemp` dir, so a leaked dir never
+ * contends with another test; correctness never depends on the removal
+ * succeeding. macOS/Linux release handles immediately, so the first `rm` wins
+ * and the retry path is Windows-only.
+ *
+ * `rm`/`timer` are injectable so the retry/give-up behavior is unit-tested with
+ * a fake filesystem and {@link FakeTimer} (no real handle livelock exists off
+ * Windows to reproduce).
+ */
+export interface RemoveTempDbDirOptions {
+  /** Removal primitive. Defaults to `rm(dir, { recursive: true, force: true })`. */
+  rm?: (dir: string) => Promise<void>;
+  /** Backoff sleeper. Defaults to the real system timer. */
+  timer?: Pick<Timer, "sleep">;
+  /** Total attempts before giving up. Bounded so cleanup can never stall CI. */
+  maxAttempts?: number;
+  /** Delay between attempts, in ms. */
+  delayMs?: number;
+  /**
+   * Invoked once if every attempt loses to a persistent lock. Defaults to a
+   * single `console.warn` so a leaked dir is visible in CI logs; the unit test
+   * injects a spy instead.
+   */
+  onGiveUp?: (dir: string, error: unknown) => void;
+}
+
+// Windows raises these while a bun:sqlite handle outlives destroy(); they are
+// the only codes we treat as a transient lock and retry. Anything else is a
+// real failure and rethrown.
+const TRANSIENT_LOCK_CODES = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_DELAY_MS = 50;
+
+function defaultOnGiveUp(dir: string, error: unknown): void {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code ?? "unknown";
+  // Log-and-continue: the dir is a throwaway temp dir the OS will sweep; a
+  // Windows handle livelock is the expected reason and is safe to swallow.
+  console.warn(
+    `removeTempDbDir: gave up removing ${dir} after ${code}; leaving it for OS temp cleanup (issue #2916)`
+  );
+}
+
+export async function removeTempDbDir(
+  dir: string,
+  options: RemoveTempDbDirOptions = {}
+): Promise<void> {
+  const rm = options.rm ?? (target => fsRm(target, { recursive: true, force: true }));
+  const timer = options.timer ?? defaultTimer;
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
+  const onGiveUp = options.onGiveUp ?? defaultOnGiveUp;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      await rm(dir);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!code || !TRANSIENT_LOCK_CODES.has(code)) {
+        throw error;
+      }
+      lastError = error;
+      if (attempt < maxAttempts - 1) {
+        await timer.sleep(delayMs);
+      }
+    }
+  }
+
+  onGiveUp(dir, lastError);
+}


### PR DESCRIPTION
## What

Harden the file-backed SQLite **close/reopen** tests against the `windows-latest`
`EBUSY`/livelock flake tracked in #2916. Test-only change — no production code
touched.

Closes #2916.

## Why

`bun:sqlite` can hold the `.db`/`-wal`/`-shm` file handles past
`Kysely.destroy()` on Windows, so removing the enclosing `mkdtemp` dir throws
`EBUSY`/`EPERM`/`ENOTEMPTY`. Several `test/db` files each duplicated a cleanup
helper that retried **100 × 50 ms = 5 s per dir**. A close/reopen test that
creates two temp dirs therefore stalled ~10 s in `afterEach`, blowing the
per-test timeout — matching the observed `10688 ms` / `5282 ms` failures. Each
run flaked a *different* file-DB test, and re-running the job turned it green
with no code change, forcing manual "re-run failed jobs" to land unrelated PRs.
`ubuntu`/`macos` release handles immediately, so the retry path never triggers
there and local `bun test` can't catch it.

## How

1. **Shared bounded, best-effort cleanup helper** — `test/db/tempDbDir.ts`
   (`removeTempDbDir`). Retries a small **bounded** number of times (default
   5 × 50 ms) on the transient Windows lock codes, then **gives up**, leaving the
   throwaway temp dir for the OS temp sweeper instead of blocking. Unexpected
   error codes are rethrown. `rm`/`timer` are injectable so the retry/give-up
   behavior is unit-tested with a fake filesystem + `FakeTimer` — the real handle
   livelock has no off-Windows reproduction. Each test uses a fresh unique
   `mkdtemp` dir, so a leaked dir never contends with another test and
   correctness never depends on removal succeeding.
2. **Adopted the helper** across the flaky files, deleting the duplicated 5 s
   retry loops: `databaseReset`, `dbWriteBarrierResetOnClose`, `databaseLazyPath`,
   `databaseIncompleteExtraction`, and the previously un-retried
   `databaseMigrationFailure`.
3. **`databaseReset` path-reset test opens no real DB.** The "resolvedDbPath
   reset" assertion is on the pure string path cache (`resolveDatabasePathFrom­Environment`
   never touches the filesystem), so it now drives `getDatabasePath()` alone and
   opens no `auto-mobile.db` — removing its file-handle dependency entirely.
   `closeDatabase()` resets the path cache unconditionally (even with no open
   connection), so the reset is still exercised; the full close-with-open-connection
   path stays covered by the `migrationsRun` test.
4. **Generous timeouts** (30 s) on the genuinely file-backed close/reopen tests
   (they need a shared on-disk file across the migration and app connections —
   `:memory:` gives each connection its own empty DB) as belt-and-suspenders
   against slow Windows disk I/O.

Every behavioral assertion is preserved: migrations re-run on reopen, path
re-resolved under a changed env, `migrationsError` cleared on close, and the
`dbWriteBarrier` drain-latch cold start.

## Testing

New `test/db/tempDbDir.test.ts` (fake `rm` + `FakeTimer`, no real fs/clock,
31 ms) proves the two properties that keep CI from stalling: a persistent lock
**gives up without throwing within a strictly bounded sleep budget**, and
transient locks retry a bounded number of times before succeeding/giving up;
plus first-try success without sleeping and rethrow of unexpected codes.

- `bun test test/db/` — **484 pass, 0 fail** (7.0 s).
- The six affected files run in **369 ms**.
- `eslint` on changed files: 0 problems. `bun build.ts`: ok.

The `windows-latest` acceptance criterion (green across N runs) can only be
confirmed in CI, since the handle livelock has no off-Windows reproduction.

## Acceptance criteria (#2916)
- [x] No file-backed SQLite close/reopen test relies on prompt Windows
      file-handle release / real-file cleanup timing (bounded best-effort
      cleanup; path-reset test opens no file).
- [x] The original behavior each test proves is still asserted (global reset on
      close, migrations re-run on reopen, drain-latch cold start).
- [ ] `windows-latest` green across N consecutive runs with no code change —
      verify in CI post-merge.
