### PR TITLE
test(utils): de-flake ProcessExecutor exec tests via injected exec seam (#2914)

### DIFF
--- a/src/utils/ProcessExecutor.ts
+++ b/src/utils/ProcessExecutor.ts
@@ -15,7 +15,7 @@ export interface ProcessExecutor {
   spawn(command: string, args: string[], options?: SpawnOptions): ChildProcess;
 }
 
-type ExecAsync = (
+export type ExecAsync = (
   command: string,
   options?: {
     timeout?: number;
@@ -59,9 +59,18 @@ const createExecResult = (stdout: string | Buffer, stderr: string | Buffer): Exe
 };
 
 export class DefaultProcessExecutor implements ProcessExecutor {
+  private execAsync: ExecAsync;
+
+  // The exec seam is injectable so tests can exercise the ExecResult helpers and
+  // error-context formatting against a fake instead of spawning a real subprocess,
+  // which stalls past the timeout on contended CI runners (#2914).
+  constructor(execAsyncFn: ExecAsync = execAsync) {
+    this.execAsync = execAsyncFn;
+  }
+
   async exec(command: string, options: ProcessExecOptions = {}): Promise<ExecResult> {
     try {
-      const { stdout, stderr } = await execAsync(command, {
+      const { stdout, stderr } = await this.execAsync(command, {
         timeout: options.timeoutMs,
         maxBuffer: options.maxBuffer,
         cwd: options.cwd

--- a/test/contracts/CommandExecutorContract.ts
+++ b/test/contracts/CommandExecutorContract.ts
@@ -2,15 +2,20 @@ import { describe, expect, test } from "bun:test";
 import type { HostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 import type { ProcessExecutor } from "../../src/utils/ProcessExecutor";
 
+// Real-implementation contract factories spawn a subprocess; forking under CI load
+// can stall for seconds, so those cases opt into a generous timeout via timeoutMs.
+// Fake-backed factories resolve instantly and leave it undefined (bun's fast default).
 export interface ProcessExecutorContractFactory {
   make(): ProcessExecutor;
   command: string;
+  timeoutMs?: number;
 }
 
 export interface HostCommandExecutorContractFactory {
   make(): HostCommandExecutor;
   file: string;
   args: string[];
+  timeoutMs?: number;
 }
 
 export const runProcessExecutorContract = (
@@ -26,7 +31,7 @@ export const runProcessExecutorContract = (
       expect(result.toString().trim()).toBe("contract-output");
       expect(result.trim()).toBe("contract-output");
       expect(result.includes("output")).toBe(true);
-    });
+    }, factory.timeoutMs);
   });
 };
 
@@ -43,6 +48,6 @@ export const runHostCommandExecutorContract = (
       expect(result.toString().trim()).toBe("contract-output");
       expect(result.trim()).toBe("contract-output");
       expect(result.includes("output")).toBe(true);
-    });
+    }, factory.timeoutMs);
   });
 };

--- a/test/contracts/runAll.test.ts
+++ b/test/contracts/runAll.test.ts
@@ -65,9 +65,14 @@ runFileDownloaderContract("FakeFileDownloader", payload => {
   return downloader;
 });
 
+// Real subprocess: a contended CI runner can stall the fork/exec, so allow a
+// generous timeout (matching the ProcessExecutor smoke test) instead of bun's default (#2914).
+const REAL_SUBPROCESS_CONTRACT_TIMEOUT_MS = 30_000;
+
 runProcessExecutorContract("DefaultProcessExecutor", {
   make: () => new DefaultProcessExecutor(),
-  command: "echo contract-output"
+  command: "echo contract-output",
+  timeoutMs: REAL_SUBPROCESS_CONTRACT_TIMEOUT_MS
 });
 runProcessExecutorContract("FakeProcessExecutor", {
   make: () => {
@@ -87,7 +92,8 @@ runProcessExecutorContract("FakeProcessExecutor", {
 runHostCommandExecutorContract("DefaultHostCommandExecutor", {
   make: () => new DefaultHostCommandExecutor(),
   file: process.execPath,
-  args: ["-e", "process.stdout.write('contract-output')"]
+  args: ["-e", "process.stdout.write('contract-output')"],
+  timeoutMs: REAL_SUBPROCESS_CONTRACT_TIMEOUT_MS
 });
 runHostCommandExecutorContract("FakeHostCommandExecutor", {
   make: () => {

--- a/test/utils/ProcessExecutor.test.ts
+++ b/test/utils/ProcessExecutor.test.ts
@@ -1,20 +1,52 @@
 import { describe, expect, test } from "bun:test";
-import process from "process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { DefaultProcessExecutor, shellCommandForPlatform } from "../../src/utils/ProcessExecutor";
+import {
+  DefaultProcessExecutor,
+  shellCommandForPlatform,
+  type ExecAsync,
+} from "../../src/utils/ProcessExecutor";
 import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 
-// Real subprocess spawns; shared CI runners can take seconds to fork/exec under load.
-const SUBPROCESS_TEST_TIMEOUT_MS = 30_000;
-const STDERR_FAILURE_COMMAND = process.platform === "win32"
-  ? "echo SQLITE_BUSY: database is locked 1>&2 & exit /b 7"
-  : "printf '%s\\n' 'SQLITE_BUSY: database is locked' >&2; exit 7";
+// The bulk of these assertions inject a fake exec seam so they never spawn a real
+// subprocess — real forks stall past a 30s timeout on contended CI runners (#2914).
+// A single retry-tolerant smoke test (bottom of the file) still exercises a real spawn.
+const FAST_TEST_TIMEOUT_MS = 100;
+// Real subprocess smoke test only; forking under CI load can take seconds.
+const SMOKE_TEST_TIMEOUT_MS = 30_000;
 
-describe("DefaultProcessExecutor", function() {
-  const executor = new DefaultProcessExecutor();
+/** Build a fake ExecAsync that resolves with the given stdout/stderr. */
+function fakeExecOk(stdout: string, stderr = ""): ExecAsync {
+  return async () => ({ stdout, stderr });
+}
 
-  test("exec selects the platform shell argv", function() {
+/** Build a fake ExecAsync that rejects with a Node-style exec error. */
+function fakeExecError(overrides: {
+  message?: string;
+  code?: number | string;
+  stderr?: string;
+  signal?: NodeJS.Signals;
+}): ExecAsync {
+  return async () => {
+    const error = new Error(overrides.message ?? "Command failed") as NodeJS.ErrnoException & {
+      stderr?: string;
+      signal?: NodeJS.Signals;
+    };
+    if (overrides.code !== undefined) {
+      (error as unknown as { code: number | string }).code = overrides.code;
+    }
+    if (overrides.stderr !== undefined) {
+      error.stderr = overrides.stderr;
+    }
+    if (overrides.signal !== undefined) {
+      error.signal = overrides.signal;
+    }
+    throw error;
+  };
+}
+
+describe("shellCommandForPlatform", function() {
+  test("selects the platform shell argv", function() {
     expect(shellCommandForPlatform("echo hello", "win32")).toEqual({
       file: "cmd.exe",
       args: ["/d", "/s", "/c", "echo hello"],
@@ -24,66 +56,99 @@ describe("DefaultProcessExecutor", function() {
       args: ["-c", "echo hello"],
     });
   });
+});
 
+describe("DefaultProcessExecutor (injected exec seam)", function() {
   test("exec captures stdout", async function() {
+    const executor = new DefaultProcessExecutor(fakeExecOk("hello\n"));
     const result = await executor.exec("echo hello");
     expect(result.stdout.trim()).toBe("hello");
     expect(result.stderr).toBe("");
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("exec ExecResult helpers work", async function() {
+    const executor = new DefaultProcessExecutor(fakeExecOk("world\n"));
     const result = await executor.exec("echo world");
     expect(result.trim()).toBe("world");
     expect(result.toString()).toContain("world");
     expect(result.includes("world")).toBe(true);
     expect(result.includes("nope")).toBe(false);
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
+
+  test("exec surfaces Buffer stdout/stderr as strings", async function() {
+    const executor = new DefaultProcessExecutor(async () => ({
+      stdout: Buffer.from("buffered-out"),
+      stderr: Buffer.from("buffered-err"),
+    }));
+    const result = await executor.exec("cmd");
+    expect(result.stdout).toBe("buffered-out");
+    expect(result.stderr).toBe("buffered-err");
+    expect(result.trim()).toBe("buffered-out");
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("exec rejects on non-zero exit", async function() {
+    const executor = new DefaultProcessExecutor(fakeExecError({ code: 1 }));
     await expect(executor.exec("false")).rejects.toThrow();
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("exec failure includes stderr and exit code context", async function() {
-    await expect(executor.exec(STDERR_FAILURE_COMMAND)).rejects.toThrow(
+    const executor = new DefaultProcessExecutor(fakeExecError({
+      message: "Command failed",
+      code: 7,
+      stderr: "SQLITE_BUSY: database is locked",
+    }));
+    await expect(executor.exec("busy-command")).rejects.toThrow(
       /exit code: 7[\s\S]*stderr:[\s\S]*SQLITE_BUSY: database is locked/
     );
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("exec bad cwd preserves raw spawn error", async function() {
-    const missingCwd = join(tmpdir(), `auto-mobile-missing-cwd-${Date.now()}`);
+    const missingCwd = join(tmpdir(), "auto-mobile-missing-cwd-fake");
+    const executor = new DefaultProcessExecutor(fakeExecError({
+      message: "spawn /bin/sh ENOENT",
+      code: "ENOENT",
+    }));
     await expect(executor.exec("echo ok", { cwd: missingCwd })).rejects.toThrow(
-      /cwd: .*auto-mobile-missing-cwd-[\s\S]*error code: ENOENT[\s\S]*raw error: .*spawn/
+      /cwd: .*auto-mobile-missing-cwd-fake[\s\S]*error code: ENOENT[\s\S]*raw error: .*spawn/
     );
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
-  test("spawn returns a ChildProcess", function() {
-    const child = executor.spawn("echo", ["hi"]);
-    expect(child).toBeDefined();
-    expect(typeof child.pid).toBe("number");
-    child.kill();
-  });
+  test("exec passes options through to the exec seam", async function() {
+    let seen: unknown;
+    const executor = new DefaultProcessExecutor(async (_command, options) => {
+      seen = options;
+      return { stdout: "", stderr: "" };
+    });
+    await executor.exec("echo hi", { timeoutMs: 1234, maxBuffer: 42, cwd: "/tmp" });
+    expect(seen).toEqual({ timeout: 1234, maxBuffer: 42, cwd: "/tmp" });
+  }, FAST_TEST_TIMEOUT_MS);
 });
 
-describe("DefaultHostCommandExecutor", function() {
-  const executor = new DefaultHostCommandExecutor();
-
+describe("DefaultHostCommandExecutor (injected exec seam)", function() {
   test("executeCommand captures stdout", async function() {
+    const executor = new DefaultHostCommandExecutor(async () => ({ stdout: "hello\n", stderr: "" }));
     const result = await executor.executeCommand("echo", ["hello"]);
     expect(result.stdout.trim()).toBe("hello");
     expect(result.stderr).toBe("");
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("executeCommand ExecResult helpers work", async function() {
+    const executor = new DefaultHostCommandExecutor(async () => ({ stdout: "world\n", stderr: "" }));
     const result = await executor.executeCommand("echo", ["world"]);
     expect(result.trim()).toBe("world");
     expect(result.toString()).toContain("world");
     expect(result.includes("world")).toBe(true);
     expect(result.includes("nope")).toBe(false);
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("executeCommand rejects on non-zero exit", async function() {
+    const executor = new DefaultHostCommandExecutor(async () => {
+      const error = new Error("Command failed");
+      (error as unknown as { code: number }).code = 1;
+      throw error;
+    });
     await expect(executor.executeCommand("false")).rejects.toThrow();
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("executeCommand failure includes stderr and exit code context", async function() {
     const failingExecutor = new DefaultHostCommandExecutor(async () => {
@@ -95,7 +160,7 @@ describe("DefaultHostCommandExecutor", function() {
     await expect(failingExecutor.executeCommand("tool", ["arg"])).rejects.toThrow(
       /exit code: 9[\s\S]*stderr:[\s\S]*fork ENOENT detail/
     );
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("executeCommand bounds raw error text before appending stderr", async function() {
     const failingExecutor = new DefaultHostCommandExecutor(async () => {
@@ -113,22 +178,61 @@ describe("DefaultHostCommandExecutor", function() {
       expect(message).toContain("RAW_TAIL");
       expect(message).toContain("stderr detail");
     }
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
   test("executeCommand bad cwd preserves raw spawn error", async function() {
-    const missingCwd = join(tmpdir(), `auto-mobile-missing-host-cwd-${Date.now()}`);
+    const missingCwd = join(tmpdir(), "auto-mobile-missing-host-cwd-fake");
     const failingExecutor = new DefaultHostCommandExecutor(async () => {
       const error = new Error("spawn /bin/sh ENOENT");
       (error as NodeJS.ErrnoException).code = "ENOENT";
       throw error;
     });
     await expect(failingExecutor.executeCommand("echo", ["ok"], { cwd: missingCwd })).rejects.toThrow(
-      /cwd: .*auto-mobile-missing-host-cwd-[\s\S]*error code: ENOENT[\s\S]*raw error: .*spawn/
+      /cwd: .*auto-mobile-missing-host-cwd-fake[\s\S]*error code: ENOENT[\s\S]*raw error: .*spawn/
     );
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
 
-  test("executeCommand passes multiple args", async function() {
-    const result = await executor.executeCommand(process.execPath, ["-e", "console.log('foo bar')"]);
+  test("executeCommand passes multiple args to the exec seam", async function() {
+    let seenArgs: string[] | undefined;
+    const executor = new DefaultHostCommandExecutor(async (_file, args) => {
+      seenArgs = args;
+      return { stdout: "foo bar", stderr: "" };
+    });
+    const result = await executor.executeCommand("node", ["-e", "console.log('foo bar')"]);
+    expect(seenArgs).toEqual(["-e", "console.log('foo bar')"]);
     expect(result.stdout.trim()).toBe("foo bar");
-  }, SUBPROCESS_TEST_TIMEOUT_MS);
+  }, FAST_TEST_TIMEOUT_MS);
+});
+
+/**
+ * Retry a real-subprocess assertion a few times so a single stalled fork/exec on a
+ * contended CI runner does not fail the job (#2914). Each attempt is bounded; on the
+ * final attempt the error propagates so a genuine regression still fails loudly.
+ */
+async function withSubprocessRetry(fn: () => Promise<void>, attempts = 3): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      await fn();
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+describe("DefaultProcessExecutor real-subprocess smoke test", function() {
+  test("round-trips a real echo through exec and spawn", async function() {
+    const executor = new DefaultProcessExecutor();
+    await withSubprocessRetry(async () => {
+      const result = await executor.exec("echo hello", { timeoutMs: 8_000 });
+      expect(result.stdout.trim()).toBe("hello");
+
+      const child = executor.spawn("echo", ["hi"]);
+      expect(child).toBeDefined();
+      expect(typeof child.pid).toBe("number");
+      child.kill();
+    });
+  }, SMOKE_TEST_TIMEOUT_MS);
 });

--- a/test/utils/ProcessExecutor.test.ts
+++ b/test/utils/ProcessExecutor.test.ts
@@ -226,7 +226,9 @@ describe("DefaultProcessExecutor real-subprocess smoke test", function() {
   test("round-trips a real echo through exec and spawn", async function() {
     const executor = new DefaultProcessExecutor();
     await withSubprocessRetry(async () => {
-      const result = await executor.exec("echo hello", { timeoutMs: 8_000 });
+      // Keep each attempt well under SMOKE_TEST_TIMEOUT_MS so 3 retries plus the
+      // synchronous spawn assertion stay comfortably inside the 30s test budget (#2914).
+      const result = await executor.exec("echo hello", { timeoutMs: 4_000 });
       expect(result.stdout.trim()).toBe("hello");
 
       const child = executor.spawn("echo", ["hi"]);


### PR DESCRIPTION
## What

`DefaultProcessExecutor > exec captures stdout` (and its exec-family siblings in `test/utils/ProcessExecutor.test.ts`) spawned a **real** subprocess via `execFile`. On contended CI macOS runners the fork/exec or stdout pipe stalls past the 30s timeout, so the test intermittently times out and blocks *unrelated* PRs' merges (surfaced landing #2903 / issue #2897). It passes locally in ~57ms.

This adds an **injectable exec seam** to `DefaultProcessExecutor` (mirroring the one `DefaultHostCommandExecutor` already has) so the exec-family assertions run against a fake instead of a real spawn, and collapses the real-subprocess coverage to a **single retry-tolerant smoke test**.

Closes #2914.

## Why

Per CLAUDE.md: *"Always use interfaces & fakes ... keep tests extremely fast and non-flaky. Unit tests should pass in 100ms or less."* The flake was structural, not a logic failure: `DefaultProcessExecutor.exec` used a module-level `execAsync` const with **no seam**, so every one of its assertions (stdout capture, ExecResult helpers, non-zero-exit rejection, stderr/exit-code context, bad-cwd ENOENT) forked a real process. `DefaultHostCommandExecutor` already took an injectable `execAsyncFn` and only its happy-path cases still spawned.

The faked tests still exercise the **real** production formatting code — `createExecResult` and `wrapCommandError` — only the subprocess I/O boundary is faked (the same fake-error-shape convention `DefaultHostCommandExecutor`'s failure tests already use). So error-context coverage is genuine, not narrowed.

## How

- **`src/utils/ProcessExecutor.ts`**: exported the `ExecAsync` type and added a constructor `DefaultProcessExecutor(execAsyncFn: ExecAsync = execAsync)`; `exec()` now calls `this.execAsync`. The default arg keeps every production caller (`VoiceOverToggle`, `SystemConfigurationManager`, `createPlatformClient`, `IOSCtrlProxyManager`) behavior-identical.
- **`test/utils/ProcessExecutor.test.ts`**: exec-family assertions for both executors now inject a fake `ExecAsync` — stdout capture, helper methods, Buffer→string coercion, non-zero-exit rejection, stderr+exit-code context, bad-cwd raw-spawn-error preservation, and options pass-through — each bounded to a **100ms** timeout so a regression to real spawning fails loudly. One `withSubprocessRetry`-wrapped smoke test still round-trips a real `echo` through `exec` + `spawn` under a generous, clearly-labeled 30s budget; it retries transient stalls but re-throws on the final attempt so a genuine break still fails.

## Sibling audit

Audited every `test/utils/` file that touches process execution. Only `ProcessExecutor.test.ts` spawned real subprocesses; `AccessibilityDetector`, `CtrlProxyManager`, `DeepLinkManagerIos`, and the emulator/simctl tests already drive injected fakes. No other exposure to fix.

## Testing

- `bun test test/utils/ProcessExecutor.test.ts` → **16 pass, 0 fail [36ms]** (whole file, including the smoke test).
- Consumer suites unchanged: `VoiceOverToggle`, `SystemConfigurationManager`, `PlatformClient`, `InstallApp` → **158 pass, 0 fail**.
- `eslint` on both changed files: 0 problems. `bun build.ts`: OK.

## Acceptance criteria (#2914)
- [x] The `exec`-family assertions run against an interface + fake (no real spawn) and complete <100ms (enforced per-test).
- [x] At most a single, retry-tolerant real-subprocess smoke test remains.
- [x] Sibling real-subprocess tests in `test/utils/` audited (none other exposed).
- [ ] Ten consecutive CI runs of `Node TypeScript Build and Test (macos-latest)` show no `ProcessExecutor` timeout — to be observed post-merge (only one real spawn remains, retry-tolerant).
