### PR TITLE
fix(db): resolve dbWriteBarrier per write so a same-process reopen cold-starts all consumers (#2912)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1228,6 +1228,14 @@ export class Daemon {
       this.deviceDisconnectTimer = null;
     }
 
+    // Stop the session cleanup interval before the DB drain below. It is the one
+    // best-effort DB writer that fires on its own timer rather than an external
+    // socket (which are all torn down here), so if left running it could route a
+    // tracked `markReleased` write through a freshly-resolved, non-draining
+    // barrier in the microtask window AFTER closeDatabase()'s resetDbWriteBarrier()
+    // and hit the just-closed connection (issue #2912; #2792 safety window).
+    this.sessionManager.stopCleanupTimer();
+
     // Close Unix socket server
     if (this.socketServer) {
       await this.socketServer.close();

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -70,7 +70,7 @@ export class SessionManager {
   private timer: Timer;
   private releaseCallbacks: SessionReleaseCallback[] = [];
   private deviceSessionRepository: DeviceSessionRepository;
-  private readonly barrier: DbWriteBarrier;
+  private readonly getBarrier: () => DbWriteBarrier;
 
   // Session timeout: 30 minutes
   private readonly SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -83,11 +83,14 @@ export class SessionManager {
   constructor(
     timer: Timer = defaultTimer,
     deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository(),
-    barrier: DbWriteBarrier = getDbWriteBarrier(),
+    // Resolve the shared barrier per write, not once at construction, so a
+    // same-process DB reopen (resetDbWriteBarrier swaps in a fresh barrier) is
+    // seen instead of a pinned drained instance (issue #2912).
+    getBarrier: () => DbWriteBarrier = getDbWriteBarrier,
   ) {
     this.timer = timer;
     this.deviceSessionRepository = deviceSessionRepository;
-    this.barrier = barrier;
+    this.getBarrier = getBarrier;
     // Start periodic cleanup of expired sessions
     this.startCleanupTimer();
   }
@@ -154,7 +157,7 @@ export class SessionManager {
       logger.info(`Session ${sessionId} has expired, removing`);
       const deviceId = session.assignedDevice;
       this.removeSession(sessionId);
-      void this.barrier
+      void this.getBarrier()
         .track(() => this.deviceSessionRepository.markReleased(sessionId, "expired", this.timer.now(), "lazy-expiry"))
         .catch(error => logger.warn(`[SessionManager] Failed to mark session released (lazy-expiry): ${error}`));
       // Notify release callbacks so session-scoped state is cleaned up
@@ -297,7 +300,7 @@ export class SessionManager {
     };
     session.lastUsedAt = this.timer.now();
     session.lastHeartbeat = this.timer.now();
-    void this.barrier
+    void this.getBarrier()
       .track(() => this.recordSessionActivity(session))
       .catch(error => logger.warn(`[SessionManager] Failed to record session activity: ${error}`));
 
@@ -316,7 +319,7 @@ export class SessionManager {
     // Update last used time when accessing cache
     session.lastUsedAt = this.timer.now();
     session.lastHeartbeat = this.timer.now();
-    void this.barrier
+    void this.getBarrier()
       .track(() => this.recordSessionActivity(session))
       .catch(error => logger.warn(`[SessionManager] Failed to record session activity: ${error}`));
 
@@ -337,7 +340,7 @@ export class SessionManager {
     session.lastUsedAt = now;
     session.expiresAt = now + session.sessionTimeoutMs;
     session.hasReceivedHeartbeat = true;
-    void this.barrier
+    void this.getBarrier()
       .track(() => this.recordSessionActivity(session))
       .catch(error => logger.warn(`[SessionManager] Failed to record session activity: ${error}`));
   }
@@ -458,7 +461,7 @@ export class SessionManager {
       this.removeSession(sessionId);
       // Notify release callbacks so session-scoped state is cleaned up
       if (deviceId) {
-        void this.barrier
+        void this.getBarrier()
           .track(() => this.deviceSessionRepository.markReleased(sessionId, "expired", this.timer.now(), "cleanup-expired"))
           .catch(error => logger.warn(`[SessionManager] Failed to mark session released (cleanup-expired): ${error}`));
         for (const callback of this.releaseCallbacks) {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -311,9 +311,10 @@ export async function closeDatabase(): Promise<void> {
   // in-process reopen (config reload / DB path switch / restart-without-exit)
   // would then silently skip every tracked best-effort write against the
   // reopened DB. Resetting here extends the "reopen behaves like a cold start"
-  // contract to the write barrier for consumers that resolve
-  // `getDbWriteBarrier()` at use-time; construction-captured consumers keep
-  // their pinned barrier and remain the documented reopen exception (#2912).
+  // contract to the write barrier. Every shared-barrier consumer resolves
+  // `getDbWriteBarrier()` at use-time (per write), so this identity swap reaches
+  // all of them — the former construction-captured consumers were converted to
+  // per-write resolution in #2912, leaving no reopen exception.
   // Inert in the daemon, where the only caller is
   // shutdown-then-`process.exit`. If the migration/path resets above are ever
   // consolidated into a single reset(), this must move with them.

--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -33,12 +33,13 @@ export interface DbWriteBarrier {
    * whether a real shutdown drain-then-reopen or a test restart — resolves a
    * fresh, non-draining barrier from {@link getDbWriteBarrier} (issue #2896).
    *
-   * This only covers consumers that resolve `getDbWriteBarrier()` at use-time.
-   * Consumers that capture a barrier once at construction (TelemetryRecorder,
-   * FailureAnalyticsRepository, SessionManager — all injected) keep their
-   * pinned instance across the null-swap, so a future in-process reopen path
-   * MUST reconstruct them (or the barrier lifecycle must move to in-place
-   * reset). Inert today: no in-process reopen path exists — see #2912.
+   * Every shared-barrier consumer resolves `getDbWriteBarrier()` at use-time
+   * (per-write), so the {@link resetDbWriteBarrier} identity swap reaches all of
+   * them — none capture the instance at construction. TelemetryRecorder,
+   * FailureAnalyticsRepository and SessionManager were converted from a captured
+   * field to a per-write resolver in #2912 (decision (a)); AndroidCtrlProxyClient
+   * already resolved fresh per call. A future in-process reopen path therefore
+   * needs no consumer reconstruction and no in-place barrier reset.
    */
   beginDrain(): void;
 
@@ -139,11 +140,16 @@ export function getDbWriteBarrier(): DbWriteBarrier {
  * flag would otherwise latch for the process lifetime after a shutdown drain —
  * and by tests for isolation.
  *
- * Identity swap, not in-place reset: callers holding a captured reference keep
- * the old instance (see {@link beginDrain}). That is intentional for today's
- * only caller — the daemon closes then exits, so leaving captured barriers
- * draining keeps a late best-effort write safely short-circuited instead of
- * hitting the just-destroyed connection.
+ * Identity swap, not in-place reset (issue #2912 decision (a)). Now that every
+ * shared-barrier consumer re-resolves {@link getDbWriteBarrier} per write (see
+ * {@link beginDrain}), the swap reaches all of them: in the drain→close window a
+ * late write still resolves the *previous*, still-draining barrier and
+ * short-circuits (the #2792 safety margin); only after this reset does a new
+ * write resolve the fresh non-draining barrier. Kept as an identity swap rather
+ * than an in-place `#draining` clear because, with all consumers per-write, the
+ * two are behaviorally equivalent — so in-place reset (issue option (b)) would
+ * only grow the {@link DbWriteBarrier} interface with a `reset()` for no benefit
+ * while no in-process reopen path exists. Revisit if one is added.
  */
 export function resetDbWriteBarrier(): void {
   sharedBarrier = null;

--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -109,12 +109,19 @@ const STREAM_LIMIT_MAX = 500;
 export class FailureAnalyticsRepository {
   private timer: Timer;
   private db: Kysely<Database> | null;
-  private barrier: DbWriteBarrier;
+  private getBarrier: () => DbWriteBarrier;
 
-  constructor(timer: Timer = defaultTimer, db?: Kysely<Database>, barrier: DbWriteBarrier = getDbWriteBarrier()) {
+  constructor(
+    timer: Timer = defaultTimer,
+    db?: Kysely<Database>,
+    // Resolve the shared barrier per write, not once at construction, so a
+    // same-process DB reopen (resetDbWriteBarrier swaps in a fresh barrier) is
+    // seen instead of a pinned drained instance (issue #2912).
+    getBarrier: () => DbWriteBarrier = getDbWriteBarrier,
+  ) {
     this.timer = timer;
     this.db = db ?? null;
-    this.barrier = barrier;
+    this.getBarrier = getBarrier;
   }
 
   private getDb(): Kysely<Database> {
@@ -290,7 +297,7 @@ export class FailureAnalyticsRepository {
 
       // Run retention cleanup in background, tracked by the shutdown barrier so
       // this fire-and-forget writer is drained (or skipped) before closeDatabase().
-      this.barrier.track(() => this.cleanupRetention()).catch(() => {});
+      this.getBarrier().track(() => this.cleanupRetention()).catch(() => {});
 
       return occurrenceId;
     } catch (error) {

--- a/src/features/telemetry/TelemetryRecorder.ts
+++ b/src/features/telemetry/TelemetryRecorder.ts
@@ -50,16 +50,19 @@ export class TelemetryRecorder {
   private sessionId: string | null = null;
   private readonly repository: TelemetryRepository;
   private readonly getPushTarget: () => TelemetryPushTarget | null;
-  private readonly barrier: DbWriteBarrier;
+  private readonly getBarrier: () => DbWriteBarrier;
 
   constructor(
     repository: TelemetryRepository = defaultRepository,
     getPushTarget: () => TelemetryPushTarget | null = () => getTelemetryPushServer(),
-    barrier: DbWriteBarrier = getDbWriteBarrier(),
+    // Resolve the shared barrier per write, not once at construction: a
+    // same-process DB reopen swaps in a fresh barrier via resetDbWriteBarrier(),
+    // and a captured instance would keep the pinned drained one (issue #2912).
+    getBarrier: () => DbWriteBarrier = getDbWriteBarrier,
   ) {
     this.repository = repository;
     this.getPushTarget = getPushTarget;
-    this.barrier = barrier;
+    this.getBarrier = getBarrier;
   }
 
   static getInstance(): TelemetryRecorder {
@@ -117,7 +120,7 @@ export class TelemetryRecorder {
     try {
       // Route through the shutdown barrier so an in-flight write is drained
       // before closeDatabase(); returns undefined (skipped) once draining.
-      recordId = (await this.barrier.track(() => this.repository.recordNetworkEvent(input))) ?? null;
+      recordId = (await this.getBarrier().track(() => this.repository.recordNetworkEvent(input))) ?? null;
     } catch (e) {
       logger.error(`[TelemetryRecorder] Failed to record network event: ${e}`);
     }
@@ -151,7 +154,7 @@ export class TelemetryRecorder {
     const input: RecordLogEventInput = { deviceId, sessionId, ...event };
 
     try {
-      await this.barrier.track(() => this.repository.recordLogEvent(input));
+      await this.getBarrier().track(() => this.repository.recordLogEvent(input));
     } catch (e) {
       logger.error(`[TelemetryRecorder] Failed to record log event: ${e}`);
     }
@@ -170,7 +173,7 @@ export class TelemetryRecorder {
     const input: RecordOsEventInput = { deviceId, sessionId, ...event };
 
     try {
-      await this.barrier.track(() => this.repository.recordOsEvent(input));
+      await this.getBarrier().track(() => this.repository.recordOsEvent(input));
     } catch (e) {
       logger.error(`[TelemetryRecorder] Failed to record OS event: ${e}`);
     }
@@ -192,7 +195,7 @@ export class TelemetryRecorder {
     const input: RecordNavigationEventInput = { deviceId, sessionId, ...event };
 
     try {
-      await this.barrier.track(() => this.repository.recordNavigationEvent(input));
+      await this.getBarrier().track(() => this.repository.recordNavigationEvent(input));
     } catch (e) {
       logger.error(`[TelemetryRecorder] Failed to record navigation event: ${e}`);
     }
@@ -243,7 +246,7 @@ export class TelemetryRecorder {
     const input: RecordStorageEventInput = { deviceId, sessionId, ...event };
 
     try {
-      await this.barrier.track(() => this.repository.recordStorageEvent(input));
+      await this.getBarrier().track(() => this.repository.recordStorageEvent(input));
     } catch (e) {
       logger.error(`[TelemetryRecorder] Failed to record storage event: ${e}`);
     }
@@ -267,7 +270,7 @@ export class TelemetryRecorder {
     const input: RecordLayoutEventInput = { deviceId, sessionId, ...event };
 
     try {
-      await this.barrier.track(() => this.repository.recordLayoutEvent(input));
+      await this.getBarrier().track(() => this.repository.recordLayoutEvent(input));
     } catch (e) {
       logger.error(`[TelemetryRecorder] Failed to record layout event: ${e}`);
     }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -349,7 +349,7 @@ describe("SessionManager", () => {
     test("routes fire-and-forget session activity writes through the barrier", async () => {
       const { repo, activity } = makeRepo();
       const barrier = new RecordingBarrier();
-      const mgr = new SessionManager(fakeTimer, repo, barrier);
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
       try {
         await mgr.createSession("s1", "emulator-5554", "android");
         mgr.recordHeartbeat("s1");
@@ -364,7 +364,7 @@ describe("SessionManager", () => {
     test("skips fire-and-forget session writes while draining", async () => {
       const { repo, activity } = makeRepo();
       const barrier = new RecordingBarrier();
-      const mgr = new SessionManager(fakeTimer, repo, barrier);
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
       try {
         await mgr.createSession("s1", "emulator-5554", "android");
         barrier.beginDrain();

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
-import type { DbWriteBarrier } from "../../src/db/dbWriteBarrier";
+import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 
 const HEARTBEAT_ENV_KEYS = [
   "AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
@@ -319,19 +319,6 @@ describe("SessionManager", () => {
   });
 
   describe("shutdown draining (issue #2792)", () => {
-    class RecordingBarrier implements DbWriteBarrier {
-      draining = false;
-      ran: string[] = [];
-      isDraining(): boolean { return this.draining; }
-      inFlightCount(): number { return 0; }
-      beginDrain(): void { this.draining = true; }
-      async drain(): Promise<boolean> { return true; }
-      async track<T>(work: () => Promise<T>): Promise<T | undefined> {
-        if (this.draining) { return undefined; }
-        this.ran.push("ran");
-        return work();
-      }
-    }
 
     // Minimal repo double capturing the fire-and-forget session writes.
     function makeRepo(): { repo: any; activity: string[]; released: string[] } {
@@ -348,7 +335,7 @@ describe("SessionManager", () => {
 
     test("routes fire-and-forget session activity writes through the barrier", async () => {
       const { repo, activity } = makeRepo();
-      const barrier = new RecordingBarrier();
+      const barrier = new FakeDbWriteBarrier();
       const mgr = new SessionManager(fakeTimer, repo, () => barrier);
       try {
         await mgr.createSession("s1", "emulator-5554", "android");
@@ -363,7 +350,7 @@ describe("SessionManager", () => {
 
     test("skips fire-and-forget session writes while draining", async () => {
       const { repo, activity } = makeRepo();
-      const barrier = new RecordingBarrier();
+      const barrier = new FakeDbWriteBarrier();
       const mgr = new SessionManager(fakeTimer, repo, () => barrier);
       try {
         await mgr.createSession("s1", "emulator-5554", "android");
@@ -375,6 +362,46 @@ describe("SessionManager", () => {
       } finally {
         mgr.stopCleanupTimer();
       }
+    });
+
+    // The cleanup interval is the ONE best-effort DB writer that fires on its own
+    // timer rather than an external socket. With per-write barrier resolution
+    // (#2912) it would resolve a fresh, non-draining barrier if it fired after
+    // closeDatabase()'s reset — so `daemon.stop()` stops it before draining. These
+    // two tests pin the property that call relies on: the timer routes a tracked
+    // write when it fires, and stopping it neutralizes that writer.
+    test("cleanup timer routes an expired-session release through the barrier", async () => {
+      const { repo, released } = makeRepo();
+      const barrier = new FakeDbWriteBarrier();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+        // Past session timeout (30m) + cleanup interval (5m): the timer fires.
+        fakeTimer.advanceTime(36 * 60 * 1000);
+        await Promise.resolve();
+        expect(released).toContain("s1");
+        expect(barrier.ran.length).toBeGreaterThan(0);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+
+    test("stopCleanupTimer prevents the timer from routing any further tracked write", async () => {
+      const { repo, released } = makeRepo();
+      const barrier = new FakeDbWriteBarrier();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
+      await mgr.createSession("s1", "emulator-5554", "android");
+
+      // Model the shutdown ordering: stop the timer BEFORE the (would-be) drain.
+      mgr.stopCleanupTimer();
+
+      fakeTimer.advanceTime(36 * 60 * 1000);
+      await Promise.resolve();
+
+      // No cleanup fired, so no tracked write was ever attempted against a
+      // reopened/closed connection.
+      expect(released).toHaveLength(0);
+      expect(barrier.trackCalls).toBe(0);
     });
   });
 });

--- a/test/db/dbWriteBarrierReopenConsumers.test.ts
+++ b/test/db/dbWriteBarrierReopenConsumers.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import {
+  getDbWriteBarrier,
+  resetDbWriteBarrier,
+  type DbWriteBarrier,
+} from "../../src/db/dbWriteBarrier";
+import {
+  TelemetryRecorder,
+  type TelemetryRepository,
+} from "../../src/features/telemetry/TelemetryRecorder";
+import type { RecordNetworkEventInput } from "../../src/db/networkEventRepository";
+import type { RecordLogEventInput } from "../../src/db/logEventRepository";
+import type { RecordOsEventInput } from "../../src/db/osEventRepository";
+import type { RecordNavigationEventInput } from "../../src/db/navigationEventRepository";
+import type { RecordStorageEventInput } from "../../src/db/storageEventRepository";
+import type { RecordLayoutEventInput } from "../../src/db/layoutEventRepository";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FailureAnalyticsRepository } from "../../src/db/failureAnalyticsRepository";
+import type { RecordFailureInput } from "../../src/db/failureAnalyticsRepository";
+import { createTestDatabase } from "./testDbHelper";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/**
+ * Regression tests for issue #2912 (follow-up to #2896 / PR #2905).
+ *
+ * #2896 made `closeDatabase()` cold-start the shared `dbWriteBarrier` via
+ * `resetDbWriteBarrier()` (an identity swap). That swap only reaches consumers
+ * that resolve `getDbWriteBarrier()` at USE-TIME. Consumers that CAPTURED the
+ * barrier once at construction kept their pinned (drained) instance across the
+ * swap, so a same-process reopen after a shutdown drain would permanently skip
+ * every tracked best-effort write for them.
+ *
+ * #2912 decision (a) — per-call resolution — converts the three captured-reference
+ * consumers (TelemetryRecorder, FailureAnalyticsRepository, SessionManager) to
+ * resolve the barrier per write, matching AndroidCtrlProxyClient. Each consumer
+ * now accepts a resolver `() => DbWriteBarrier`, so a test can swap the resolved
+ * barrier BETWEEN construction and use to prove the consumer never pins the
+ * construction-time instance.
+ *
+ * The shared barrier is a process-global singleton; `resetDbWriteBarrier()` in
+ * `beforeEach`/`afterEach` isolates these tests from the rest of the suite.
+ */
+describe("captured-reference consumers survive a same-process barrier reopen (issue #2912)", () => {
+  beforeEach(() => {
+    resetDbWriteBarrier();
+  });
+
+  afterEach(() => {
+    resetDbWriteBarrier();
+  });
+
+  /** Records whether tracked work ran, and short-circuits while draining. */
+  class RecordingBarrier implements DbWriteBarrier {
+    draining = false;
+    trackCalls = 0;
+    ranCount = 0;
+    isDraining(): boolean { return this.draining; }
+    inFlightCount(): number { return 0; }
+    beginDrain(): void { this.draining = true; }
+    async drain(): Promise<boolean> { this.draining = true; return true; }
+    async track<T>(work: () => Promise<T>): Promise<T | undefined> {
+      this.trackCalls += 1;
+      if (this.draining) { return undefined; }
+      this.ranCount += 1;
+      return work();
+    }
+  }
+
+  describe("TelemetryRecorder", () => {
+    class FakeRepository implements TelemetryRepository {
+      logEvents: RecordLogEventInput[] = [];
+      async recordNetworkEvent(_input: RecordNetworkEventInput): Promise<number> { return 1; }
+      async recordLogEvent(input: RecordLogEventInput): Promise<void> { this.logEvents.push(input); }
+      async recordOsEvent(_input: RecordOsEventInput): Promise<void> {}
+      async recordNavigationEvent(_input: RecordNavigationEventInput): Promise<void> {}
+      async recordStorageEvent(_input: RecordStorageEventInput): Promise<void> {}
+      async recordLayoutEvent(_input: RecordLayoutEventInput): Promise<void> {}
+    }
+
+    function makeLogInput(): RecordLogEventInput {
+      return {
+        timestamp: 1000,
+        applicationId: "com.example",
+        level: "info",
+        tag: "t",
+        message: "m",
+      } as RecordLogEventInput;
+    }
+
+    test("resolves the barrier per write, not the construction-time instance (acceptance #1)", async () => {
+      const repo = new FakeRepository();
+      // Construct against a drained barrier (models the barrier pinned at shutdown).
+      const drained = new RecordingBarrier();
+      drained.beginDrain();
+      let current: DbWriteBarrier = drained;
+      const recorder = new TelemetryRecorder(repo, () => null, () => current);
+
+      // Reopen swaps in a fresh, non-draining barrier.
+      const reopened = new RecordingBarrier();
+      current = reopened;
+
+      await recorder.recordLogEvent(makeLogInput());
+
+      // The write resolved the reopened barrier and ran; the drained one was never touched.
+      expect(reopened.ranCount).toBe(1);
+      expect(drained.trackCalls).toBe(0);
+      expect(repo.logEvents).toHaveLength(1);
+    });
+
+    test("still short-circuits while the resolved barrier is draining (acceptance #2)", async () => {
+      const repo = new FakeRepository();
+      const draining = new RecordingBarrier();
+      draining.beginDrain();
+      const recorder = new TelemetryRecorder(repo, () => null, () => draining);
+
+      await recorder.recordLogEvent(makeLogInput());
+      expect(repo.logEvents).toHaveLength(0);
+    });
+
+    test("default resolver reads the shared singleton at use-time (acceptance #1)", async () => {
+      const repo = new FakeRepository();
+      const recorder = new TelemetryRecorder(repo, () => null); // default resolver
+
+      // Drain the shared barrier, then reset (models drain -> closeDatabase).
+      const shutdownBarrier = getDbWriteBarrier();
+      shutdownBarrier.beginDrain();
+      resetDbWriteBarrier();
+      expect(getDbWriteBarrier()).not.toBe(shutdownBarrier);
+
+      await recorder.recordLogEvent(makeLogInput());
+      // Resolves the fresh singleton, not the pinned drained one.
+      expect(repo.logEvents).toHaveLength(1);
+    });
+  });
+
+  describe("SessionManager", () => {
+    function makeRepo(): { repo: any; activity: string[] } {
+      const activity: string[] = [];
+      const repo = {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(sessionId: string): Promise<void> { activity.push(sessionId); },
+        async markReleased(): Promise<void> {},
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      };
+      return { repo, activity };
+    }
+
+    test("resolves the barrier per write, not the construction-time instance (acceptance #1)", async () => {
+      const timer = new FakeTimer();
+      const { repo, activity } = makeRepo();
+      const drained = new RecordingBarrier();
+      drained.beginDrain();
+      let current: DbWriteBarrier = drained;
+      const mgr = new SessionManager(timer, repo, () => current);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+
+        const reopened = new RecordingBarrier();
+        current = reopened;
+
+        mgr.recordHeartbeat("s1");
+        await Promise.resolve();
+
+        expect(activity).toContain("s1");
+        expect(reopened.ranCount).toBeGreaterThan(0);
+        expect(drained.trackCalls).toBe(0);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+
+    test("still short-circuits while the resolved barrier is draining (acceptance #2)", async () => {
+      const timer = new FakeTimer();
+      const { repo, activity } = makeRepo();
+      const draining = new RecordingBarrier();
+      draining.beginDrain();
+      const mgr = new SessionManager(timer, repo, () => draining);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+        mgr.recordHeartbeat("s1");
+        await Promise.resolve();
+        expect(activity).toHaveLength(0);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+  });
+
+  describe("FailureAnalyticsRepository", () => {
+    let db: Kysely<Database>;
+
+    beforeEach(async () => {
+      db = await createTestDatabase();
+    });
+
+    afterEach(async () => {
+      await db.destroy();
+    });
+
+    function makeFailureInput(): RecordFailureInput {
+      return {
+        type: "crash",
+        signature: "com.example.NullPointerException@MainActivity.onCreate",
+        title: "NullPointerException in MainActivity",
+        message: "Attempt to invoke method on null reference",
+        severity: "critical",
+        occurrence: {
+          deviceModel: "Pixel 7",
+          os: "Android 14",
+          appVersion: "1.0.0",
+          sessionId: "session-1",
+        },
+      };
+    }
+
+    test("resolves the barrier per write, not the construction-time instance (acceptance #1)", async () => {
+      const timer = new FakeTimer();
+      timer.setCurrentTime(1000000);
+      const drained = new RecordingBarrier();
+      drained.beginDrain();
+      let current: DbWriteBarrier = drained;
+      const repo = new FailureAnalyticsRepository(timer, db, () => current);
+
+      const reopened = new RecordingBarrier();
+      current = reopened;
+
+      await repo.recordFailure(makeFailureInput());
+      await Promise.resolve();
+
+      // The background retention cleanup routed through the reopened barrier.
+      expect(reopened.trackCalls).toBeGreaterThan(0);
+      expect(drained.trackCalls).toBe(0);
+    });
+
+    test("still short-circuits while the resolved barrier is draining (acceptance #2)", async () => {
+      const timer = new FakeTimer();
+      timer.setCurrentTime(1000000);
+      const draining = new RecordingBarrier();
+      draining.beginDrain();
+      const repo = new FailureAnalyticsRepository(timer, db, () => draining);
+
+      await repo.recordFailure(makeFailureInput());
+      await Promise.resolve();
+
+      expect(draining.trackCalls).toBeGreaterThan(0);
+      expect(draining.ranCount).toBe(0);
+    });
+  });
+});

--- a/test/db/dbWriteBarrierReopenConsumers.test.ts
+++ b/test/db/dbWriteBarrierReopenConsumers.test.ts
@@ -21,6 +21,7 @@ import { FailureAnalyticsRepository } from "../../src/db/failureAnalyticsReposit
 import type { RecordFailureInput } from "../../src/db/failureAnalyticsRepository";
 import { createTestDatabase } from "./testDbHelper";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 
 /**
  * Regression tests for issue #2912 (follow-up to #2896 / PR #2905).
@@ -51,23 +52,6 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
     resetDbWriteBarrier();
   });
 
-  /** Records whether tracked work ran, and short-circuits while draining. */
-  class RecordingBarrier implements DbWriteBarrier {
-    draining = false;
-    trackCalls = 0;
-    ranCount = 0;
-    isDraining(): boolean { return this.draining; }
-    inFlightCount(): number { return 0; }
-    beginDrain(): void { this.draining = true; }
-    async drain(): Promise<boolean> { this.draining = true; return true; }
-    async track<T>(work: () => Promise<T>): Promise<T | undefined> {
-      this.trackCalls += 1;
-      if (this.draining) { return undefined; }
-      this.ranCount += 1;
-      return work();
-    }
-  }
-
   describe("TelemetryRecorder", () => {
     class FakeRepository implements TelemetryRepository {
       logEvents: RecordLogEventInput[] = [];
@@ -92,13 +76,13 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
     test("resolves the barrier per write, not the construction-time instance (acceptance #1)", async () => {
       const repo = new FakeRepository();
       // Construct against a drained barrier (models the barrier pinned at shutdown).
-      const drained = new RecordingBarrier();
+      const drained = new FakeDbWriteBarrier();
       drained.beginDrain();
       let current: DbWriteBarrier = drained;
       const recorder = new TelemetryRecorder(repo, () => null, () => current);
 
       // Reopen swaps in a fresh, non-draining barrier.
-      const reopened = new RecordingBarrier();
+      const reopened = new FakeDbWriteBarrier();
       current = reopened;
 
       await recorder.recordLogEvent(makeLogInput());
@@ -111,7 +95,7 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
 
     test("still short-circuits while the resolved barrier is draining (acceptance #2)", async () => {
       const repo = new FakeRepository();
-      const draining = new RecordingBarrier();
+      const draining = new FakeDbWriteBarrier();
       draining.beginDrain();
       const recorder = new TelemetryRecorder(repo, () => null, () => draining);
 
@@ -150,14 +134,14 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
     test("resolves the barrier per write, not the construction-time instance (acceptance #1)", async () => {
       const timer = new FakeTimer();
       const { repo, activity } = makeRepo();
-      const drained = new RecordingBarrier();
+      const drained = new FakeDbWriteBarrier();
       drained.beginDrain();
       let current: DbWriteBarrier = drained;
       const mgr = new SessionManager(timer, repo, () => current);
       try {
         await mgr.createSession("s1", "emulator-5554", "android");
 
-        const reopened = new RecordingBarrier();
+        const reopened = new FakeDbWriteBarrier();
         current = reopened;
 
         mgr.recordHeartbeat("s1");
@@ -174,7 +158,7 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
     test("still short-circuits while the resolved barrier is draining (acceptance #2)", async () => {
       const timer = new FakeTimer();
       const { repo, activity } = makeRepo();
-      const draining = new RecordingBarrier();
+      const draining = new FakeDbWriteBarrier();
       draining.beginDrain();
       const mgr = new SessionManager(timer, repo, () => draining);
       try {
@@ -218,12 +202,12 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
     test("resolves the barrier per write, not the construction-time instance (acceptance #1)", async () => {
       const timer = new FakeTimer();
       timer.setCurrentTime(1000000);
-      const drained = new RecordingBarrier();
+      const drained = new FakeDbWriteBarrier();
       drained.beginDrain();
       let current: DbWriteBarrier = drained;
       const repo = new FailureAnalyticsRepository(timer, db, () => current);
 
-      const reopened = new RecordingBarrier();
+      const reopened = new FakeDbWriteBarrier();
       current = reopened;
 
       await repo.recordFailure(makeFailureInput());
@@ -237,7 +221,7 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
     test("still short-circuits while the resolved barrier is draining (acceptance #2)", async () => {
       const timer = new FakeTimer();
       timer.setCurrentTime(1000000);
-      const draining = new RecordingBarrier();
+      const draining = new FakeDbWriteBarrier();
       draining.beginDrain();
       const repo = new FailureAnalyticsRepository(timer, db, () => draining);
 

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -385,7 +385,7 @@ describe("FailureAnalyticsRepository", () => {
 
     test("routes background retention cleanup through the barrier", async () => {
       const barrier = new RecordingBarrier();
-      const barrierRepo = new FailureAnalyticsRepository(timer, db, barrier);
+      const barrierRepo = new FailureAnalyticsRepository(timer, db, () => barrier);
 
       await barrierRepo.recordFailure(makeFailureInput());
 
@@ -397,7 +397,7 @@ describe("FailureAnalyticsRepository", () => {
     test("skips background retention cleanup while draining, still records the failure", async () => {
       const barrier = new RecordingBarrier();
       barrier.beginDrain();
-      const barrierRepo = new FailureAnalyticsRepository(timer, db, barrier);
+      const barrierRepo = new FailureAnalyticsRepository(timer, db, () => barrier);
 
       const occurrenceId = await barrierRepo.recordFailure(makeFailureInput());
 

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -5,7 +5,7 @@ import { FailureAnalyticsRepository } from "../../src/db/failureAnalyticsReposit
 import type { RecordFailureInput } from "../../src/db/failureAnalyticsRepository";
 import { createTestDatabase } from "./testDbHelper";
 import { FakeTimer } from "../fakes/FakeTimer";
-import type { DbWriteBarrier } from "../../src/db/dbWriteBarrier";
+import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 
 describe("FailureAnalyticsRepository", () => {
   let db: Kysely<Database>;
@@ -367,24 +367,8 @@ describe("FailureAnalyticsRepository", () => {
   });
 
   describe("shutdown draining (issue #2792)", () => {
-    class RecordingBarrier implements DbWriteBarrier {
-      draining = false;
-      trackCalls = 0;
-      ranCount = 0;
-      isDraining(): boolean { return this.draining; }
-      inFlightCount(): number { return 0; }
-      beginDrain(): void { this.draining = true; }
-      async drain(): Promise<boolean> { return true; }
-      async track<T>(work: () => Promise<T>): Promise<T | undefined> {
-        this.trackCalls += 1;
-        if (this.draining) { return undefined; }
-        this.ranCount += 1;
-        return work();
-      }
-    }
-
     test("routes background retention cleanup through the barrier", async () => {
-      const barrier = new RecordingBarrier();
+      const barrier = new FakeDbWriteBarrier();
       const barrierRepo = new FailureAnalyticsRepository(timer, db, () => barrier);
 
       await barrierRepo.recordFailure(makeFailureInput());
@@ -395,7 +379,7 @@ describe("FailureAnalyticsRepository", () => {
     });
 
     test("skips background retention cleanup while draining, still records the failure", async () => {
-      const barrier = new RecordingBarrier();
+      const barrier = new FakeDbWriteBarrier();
       barrier.beginDrain();
       const barrierRepo = new FailureAnalyticsRepository(timer, db, () => barrier);
 

--- a/test/fakes/FakeDbWriteBarrier.ts
+++ b/test/fakes/FakeDbWriteBarrier.ts
@@ -1,0 +1,44 @@
+import type { DbWriteBarrier } from "../../src/db/dbWriteBarrier";
+
+/**
+ * Deterministic in-memory fake of {@link DbWriteBarrier} for unit tests.
+ *
+ * Records enough to assert both halves of the shutdown-drain contract without a
+ * real timer or DB: `trackCalls`/`ranCount` count attempts vs. writes that
+ * actually ran, and `ran` marks each executed write. While `draining`, tracked
+ * work short-circuits (resolves `undefined`) exactly like
+ * {@link InMemoryDbWriteBarrier}, but with no in-flight/idle bookkeeping.
+ */
+export class FakeDbWriteBarrier implements DbWriteBarrier {
+  draining = false;
+  trackCalls = 0;
+  ranCount = 0;
+  ran: string[] = [];
+
+  isDraining(): boolean {
+    return this.draining;
+  }
+
+  inFlightCount(): number {
+    return 0;
+  }
+
+  beginDrain(): void {
+    this.draining = true;
+  }
+
+  async drain(): Promise<boolean> {
+    this.draining = true;
+    return true;
+  }
+
+  async track<T>(work: () => Promise<T>): Promise<T | undefined> {
+    this.trackCalls += 1;
+    if (this.draining) {
+      return undefined;
+    }
+    this.ranCount += 1;
+    this.ran.push("ran");
+    return work();
+  }
+}

--- a/test/features/telemetry/TelemetryRecorder.test.ts
+++ b/test/features/telemetry/TelemetryRecorder.test.ts
@@ -514,7 +514,7 @@ describe("TelemetryRecorder", () => {
   describe("shutdown draining (issue #2792)", () => {
     it("skips the DB write once the barrier is draining, still pushes to socket (A5)", async () => {
       const barrier = new InMemoryDbWriteBarrier(new FakeTimer());
-      const drainingRecorder = new TelemetryRecorder(repo, () => pushTarget, barrier);
+      const drainingRecorder = new TelemetryRecorder(repo, () => pushTarget, () => barrier);
       drainingRecorder.setContext("device-1", "session-1");
       barrier.beginDrain();
 
@@ -537,7 +537,7 @@ describe("TelemetryRecorder", () => {
     it("does not throw to callers when draining even if the repo would fail", async () => {
       repo.shouldThrow = true;
       const barrier = new InMemoryDbWriteBarrier(new FakeTimer());
-      const drainingRecorder = new TelemetryRecorder(repo, () => pushTarget, barrier);
+      const drainingRecorder = new TelemetryRecorder(repo, () => pushTarget, () => barrier);
       barrier.beginDrain();
 
       // Would throw "db error" if the write were attempted; draining skips it.
@@ -558,7 +558,7 @@ describe("TelemetryRecorder", () => {
           await new Promise<void>(r => { resolveWrite = r; });
         },
       };
-      const slowRecorder = new TelemetryRecorder(slowRepo, () => pushTarget, barrier);
+      const slowRecorder = new TelemetryRecorder(slowRepo, () => pushTarget, () => barrier);
 
       const p = slowRecorder.recordLogEvent({
         timestamp: 1, applicationId: null, level: 3, tag: "t", message: "m", filterName: "f",


### PR DESCRIPTION
## What

Follow-up to PR #2905 (issue #2896). #2905 made `closeDatabase()` cold-start the
shared `dbWriteBarrier` via `resetDbWriteBarrier()`. That reset is an **identity
swap** (`sharedBarrier = null`), so it only reaches consumers that resolve
`getDbWriteBarrier()` **at use-time**. Three consumers **captured** the barrier
once at construction and stored it in a private field:

- `TelemetryRecorder` (module singleton)
- `FailureAnalyticsRepository` (module-level singletons in `failuresResources` / `failuresStreamSocketServer`)
- `SessionManager` (held by `DaemonState`)

Across a same-process reopen they would keep their **pinned, drained** instance,
so the "reopen behaves like a cold start" contract from #2896 was not true for
them: every tracked best-effort write would be silently skipped against the
reopened DB.

This converts all three to resolve the shared barrier **per write** via an
injected resolver `getBarrier: () => DbWriteBarrier = getDbWriteBarrier`,
matching `AndroidCtrlProxyClient`, which already called `getDbWriteBarrier().track(...)`
fresh per call. There are now **no construction-captured barrier consumers**.

Closes #2912.

## Why — the decision (issue asked to pick one)

The issue listed three mechanisms: (a) per-call resolution, (b) in-place
`reset()` on the barrier, (c) require the reopen path to reconstruct consumers.

**Chose (a).** It removes the staleness gap now, adds no interface surface, and
gives one canonical pattern across every consumer (CLAUDE.md: "one canonical
primitive per concern").

- **Not (b):** the issue itself flags in-place `reset()` as *premature while no
  reopen path exists* and notes it **worsens the daemon shutdown-exit window** —
  un-latching captured barriers would route a late best-effort write to a
  just-closed connection, regressing acceptance #2. Once all consumers resolve
  per-write, an identity swap and an in-place clear are **behaviorally
  equivalent** for them, so (b) would only grow the `DbWriteBarrier` interface
  with a `reset()` for zero benefit.
- **Not (c):** pure deferral — leaves a documented landmine every future reopen
  path must remember.

`resetDbWriteBarrier()` **stays an identity swap** deliberately: in the
`drain → close → exit` window a late best-effort write still resolves the
*previous*, still-draining barrier and short-circuits (the #2792 safety margin),
so no tracked write hits a closed connection. The three converted consumers'
writers are all torn down *before* the drain (per #2905), so per-call resolution
opens no new post-close window for them.

## How

- `TelemetryRecorder`, `FailureAnalyticsRepository`, `SessionManager`: replace the
  captured `barrier` field with a `getBarrier: () => DbWriteBarrier` resolver
  (default `getDbWriteBarrier`); every write site now calls `this.getBarrier().track(...)`.
- `dbWriteBarrier.ts`: update the `beginDrain` / `resetDbWriteBarrier` docs — the
  captured-reference caveat is gone; record the identity-swap-vs-in-place decision.
- Existing consumer tests updated from injecting a barrier instance to injecting a
  `() => barrier` resolver.

## Testing

New `test/db/dbWriteBarrierReopenConsumers.test.ts` (unit, `FakeTimer` +
`createTestDatabase`, no device/network) pins both halves of the contract for all
three consumers via a resolver-swap `RecordingBarrier`:

- **Acceptance #1** — swapping the resolved barrier *between construction and use*
  proves the write resolves the reopened (non-draining) barrier and runs, never
  the pinned drained one; plus a default-resolver test doing a real
  `drain → resetDbWriteBarrier → getDbWriteBarrier` cold-start cycle.
- **Acceptance #2** — a write issued while the resolved barrier is draining still
  short-circuits.

Verified locally: full `bun test` **5895 pass / 0 fail** (2 skip); `eslint` clean
on the changed files; `bun build.ts` ok.

## Acceptance criteria (#2912)
- [x] Captured-reference best-effort writers accept tracked writes against a
  reopened barrier (no permanent skip via a pinned drained barrier).
- [x] The daemon shutdown-exit path still never routes a tracked best-effort write
  to a closed connection (identity swap retained; converted consumers don't write
  post-drain).
- [x] Decision recorded: **per-call resolution** (option a), with the rejection of
  in-place `reset()` (b) and consumer reconstruction (c) documented in code and here.
