### PR TITLE
fix(ios): add public pinch(withScale:velocity:) fallback for pinchOn (#2910)

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		5458E55CB48475D2487A49C3 /* HierarchyDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */; };
 		5651AAF00833750D1DFD55CE /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF23F10C24C9F40E5CEC303 /* Logging.swift */; };
 		5BD7FFA4EE2841F197219322 /* DefaultStorageInspecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */; };
+		5BE77C31B3E127345E3830A6 /* PinchFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB521226F4C469CBFE7296 /* PinchFallback.swift */; };
 		5DF6CF60A8796BBB8C80341C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0CDD96577EB9823B5FCF2585 /* Assets.xcassets */; };
 		5FDF9AE29841625DD7EFB7EC /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
 		6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */; };
@@ -49,6 +50,7 @@
 		96ED92C8F268021CE148C4FF /* CtrlProxy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; };
 		9E975A4E407F93A21BD80EB4 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
 		9FE4564D1819768FEFD62606 /* ElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95565999DC108319DEED894A /* ElementLocator.swift */; };
+		9FED7BF37AFE34ADDF4E730A /* PinchFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB521226F4C469CBFE7296 /* PinchFallback.swift */; };
 		A603343B94D35DDF48F7AA4D /* Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1B2931E58B158EE51C5F4F /* Fakes.swift */; };
 		A9D79278D7A9C7ED3E7E4F8C /* CtrlProxy.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9E8300EE35B13DED1A0E579 /* MainThreadRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */; };
@@ -71,6 +73,7 @@
 		E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */; };
 		EA65C486C9E6DBB5BFE9CA41 /* HierarchyDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */; };
 		EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */; };
+		F428A1892AAF5D4F83AD4C1B /* PinchFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */; };
 		F469E7EF16C59A99DBD519DA /* DisplayLinkFPSMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */; };
 		F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184CFC1280E0802EBF53965F /* ModelsTests.swift */; };
 /* End PBXBuildFile section */
@@ -156,6 +159,7 @@
 		0EE277596991C059142C485B /* CtrlProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlProxy.swift; sourceTree = "<group>"; };
 		0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyMergerTests.swift; sourceTree = "<group>"; };
 		0F9D7B74C318EE243B225B95 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
+		0FEB521226F4C469CBFE7296 /* PinchFallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchFallback.swift; sourceTree = "<group>"; };
 		1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLinkFPSMonitor.swift; sourceTree = "<group>"; };
 		184CFC1280E0802EBF53965F /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStorageInspecting.swift; sourceTree = "<group>"; };
@@ -169,6 +173,7 @@
 		649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridgeTests.swift; sourceTree = "<group>"; };
 		652F5687D2FC57F3D6D4629C /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadRunner.swift; sourceTree = "<group>"; };
+		6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchFallbackTests.swift; sourceTree = "<group>"; };
 		73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridge.swift; sourceTree = "<group>"; };
 		77305F40F85694E983987E68 /* CommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHandler.swift; sourceTree = "<group>"; };
 		802717F6B1F37809C4806C23 /* CtrlProxyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlProxyUITests.swift; sourceTree = "<group>"; };
@@ -251,6 +256,7 @@
 				184CFC1280E0802EBF53965F /* ModelsTests.swift */,
 				649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */,
 				DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */,
+				6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */,
 				5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */,
 				EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */,
 			);
@@ -328,6 +334,7 @@
 				DBA97A6C3A1240A055D9876C /* OSLogReader.swift */,
 				B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */,
 				A284B6FFBE969931BB03A2FF /* PerfProvider.swift */,
+				0FEB521226F4C469CBFE7296 /* PinchFallback.swift */,
 				0F9D7B74C318EE243B225B95 /* Protocols.swift */,
 				0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */,
 				043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */,
@@ -546,6 +553,7 @@
 				2DD69FF84C0520EED9B77AFF /* ObjCExceptionBridge.swift in Sources */,
 				D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */,
 				E8327D679D58C8F804C064B1 /* PerformanceMetrics.swift in Sources */,
+				9FED7BF37AFE34ADDF4E730A /* PinchFallback.swift in Sources */,
 				47A050F2D8153251E395B7B9 /* Protocols.swift in Sources */,
 				6798190F766D01F963F6DFD0 /* SdkDatabaseClient.swift in Sources */,
 				0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */,
@@ -575,6 +583,7 @@
 				F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */,
 				6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */,
 				0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */,
+				F428A1892AAF5D4F83AD4C1B /* PinchFallbackTests.swift in Sources */,
 				2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */,
 				0F29D59ABFB52692F62B434F /* TypedRequestDecodeTests.swift in Sources */,
 			);
@@ -600,6 +609,7 @@
 				416E49D98E779D4D7D060F16 /* ObjCExceptionBridge.swift in Sources */,
 				4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */,
 				B55A16F80CE62B998CEBC6E0 /* PerformanceMetrics.swift in Sources */,
+				5BE77C31B3E127345E3830A6 /* PinchFallback.swift in Sources */,
 				2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */,
 				9E975A4E407F93A21BD80EB4 /* SdkDatabaseClient.swift in Sources */,
 				EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -421,7 +421,7 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handlePinch(_ request: RequestPinch, startTime: Date) throws -> WebSocketResponse {
-        try gesturePerformer.pinch(
+        let path = try gesturePerformer.pinch(
             centerX: Double(request.centerX),
             centerY: Double(request.centerY),
             distanceStart: Double(request.distanceStart),
@@ -433,7 +433,8 @@ public class CommandHandler: CommandHandling {
         return WebSocketResponse.success(
             type: ResponseType.pinchResult.rawValue,
             requestId: request.requestId,
-            totalTimeMs: totalTimeMs(from: startTime)
+            totalTimeMs: totalTimeMs(from: startTime),
+            pinchPath: path.rawValue
         )
     }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -437,6 +437,11 @@ public class FakeGesturePerformer: GesturePerforming {
         ))
     }
 
+    /// Path returned by `pinch`; defaults to the private event-path synthesis.
+    /// Set to `.elementAnchored` to simulate the public-API fallback (issue #2910).
+    public var pinchPathToReturn: PinchGesturePath = .eventPath
+
+    @discardableResult
     public func pinch(
         centerX: Double,
         centerY: Double,
@@ -445,7 +450,7 @@ public class FakeGesturePerformer: GesturePerforming {
         rotationDegrees: Double,
         duration: TimeInterval
     )
-        throws
+        throws -> PinchGesturePath
     {
         try checkFailure("pinch")
         pinchHistory.append(PinchCall(
@@ -456,6 +461,7 @@ public class FakeGesturePerformer: GesturePerforming {
             rotationDegrees: rotationDegrees,
             duration: duration
         ))
+        return pinchPathToReturn
     }
 
     public func typeText(text: String) throws {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -471,6 +471,7 @@ public class GesturePerformer: GesturePerforming {
 
         // MARK: - Pinch Gestures
 
+        @discardableResult
         public func pinch(
             centerX: Double,
             centerY: Double,
@@ -479,15 +480,16 @@ public class GesturePerformer: GesturePerforming {
             rotationDegrees: Double,
             duration: TimeInterval
         )
-            throws
+            throws -> PinchGesturePath
         {
-            guard application != nil else {
+            guard let app = application else {
                 throw GestureError.noApplication
             }
 
-            try runOnMainThread {
+            return try runOnMainThread {
                 let orientation = GesturePerformer.currentInterfaceOrientation()
                 var errorMessage: NSString?
+                var symbolsUnavailable: ObjCBool = false
                 let succeeded = ObjCExceptionCatcher_synthesizePinch(
                     CGFloat(centerX),
                     CGFloat(centerY),
@@ -496,12 +498,30 @@ public class GesturePerformer: GesturePerforming {
                     CGFloat(rotationDegrees),
                     duration,
                     orientation.rawValue,
+                    &symbolsUnavailable,
                     &errorMessage
                 )
 
-                if !succeeded {
+                if succeeded {
+                    return .eventPath
+                }
+
+                // Only degrade to the public API when the private symbols are
+                // genuinely absent. A real synthesis error still surfaces as a
+                // structured failure (issue #2910).
+                guard symbolsUnavailable.boolValue else {
                     throw GestureError.gestureFailed(errorMessage as String? ?? "pinch synthesis failed")
                 }
+
+                // Public element-anchored fallback: honors scale/velocity but
+                // centers on the SpringBoard anchor, ignoring centerX/centerY.
+                let params = PinchFallback.parameters(
+                    distanceStart: distanceStart,
+                    distanceEnd: distanceEnd,
+                    duration: duration
+                )
+                app.pinch(withScale: params.scale, velocity: params.velocity)
+                return .elementAnchored
             }
         }
 
@@ -1314,6 +1334,7 @@ public class GesturePerformer: GesturePerforming {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 
+        @discardableResult
         public func pinch(
             centerX _: Double,
             centerY _: Double,
@@ -1322,7 +1343,7 @@ public class GesturePerformer: GesturePerforming {
             rotationDegrees _: Double,
             duration _: TimeInterval
         )
-            throws
+            throws -> PinchGesturePath
         {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -514,7 +514,13 @@ public class GesturePerformer: GesturePerforming {
                 }
 
                 // Public element-anchored fallback: honors scale/velocity but
-                // centers on the SpringBoard anchor, ignoring centerX/centerY.
+                // centers on the SpringBoard anchor, so it ignores centerX/centerY
+                // and rotationDegrees (the public API has no center or rotation).
+                //
+                // This branch runs only on-device. Off-device coverage is split
+                // across PinchFallbackTests (the scale/velocity math) and
+                // ObjCExceptionBridgeTests (the symbolsUnavailable signal that
+                // routes here); the live app.pinch call itself is device-only.
                 let params = PinchFallback.parameters(
                     distanceStart: distanceStart,
                     distanceEnd: distanceEnd,

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -522,6 +522,10 @@ public struct WebSocketResponse: Codable {
     public let error: String?
     public let text: String?
     public let perfTiming: PerfTiming?
+    /// Which mechanism performed a pinch: `"event-path"` (private synthesis,
+    /// honors center) or `"element-anchored"` (public fallback, center-less).
+    /// Only set on `pinch_result` responses (issue #2910); nil elsewhere.
+    public let pinchPath: String?
 
     public init(
         type: String,
@@ -531,7 +535,8 @@ public struct WebSocketResponse: Codable {
         totalTimeMs: Int64? = nil,
         error: String? = nil,
         text: String? = nil,
-        perfTiming: PerfTiming? = nil
+        perfTiming: PerfTiming? = nil,
+        pinchPath: String? = nil
     ) {
         self.type = type
         self.timestamp = timestamp
@@ -541,13 +546,15 @@ public struct WebSocketResponse: Codable {
         self.error = error
         self.text = text
         self.perfTiming = perfTiming
+        self.pinchPath = pinchPath
     }
 
     public static func success(
         type: String,
         requestId: String?,
         totalTimeMs: Int64,
-        text: String? = nil
+        text: String? = nil,
+        pinchPath: String? = nil
     )
         -> WebSocketResponse
     {
@@ -556,7 +563,8 @@ public struct WebSocketResponse: Codable {
             requestId: requestId,
             success: true,
             totalTimeMs: totalTimeMs,
-            text: text
+            text: text,
+            pinchPath: pinchPath
         )
     }
 

--- a/ios/control-proxy/Sources/CtrlProxy/PinchFallback.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/PinchFallback.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import Foundation
+
+/// Which mechanism performed a pinch gesture.
+///
+/// `pinchOn` prefers the private XCTest event-path synthesis because it honors an
+/// arbitrary `centerX`/`centerY`. When those private symbols are unavailable it
+/// falls back to the public, element-anchored `pinch(withScale:velocity:)`, which
+/// still zooms but centers on the anchor element (the SpringBoard full screen).
+/// Callers use this to know whether the requested center was respected. See
+/// issue #2910.
+public enum PinchGesturePath: String, Codable, Equatable {
+    /// Private `XCPointerEventPath`/`XCSynthesizedEventRecord` synthesis — honors center.
+    case eventPath = "event-path"
+    /// Public `XCUIElement.pinch(withScale:velocity:)` — center-less, anchor-centered.
+    case elementAnchored = "element-anchored"
+}
+
+/// Platform-agnostic math for the public-API pinch fallback.
+///
+/// Extracted from the iOS-only `GesturePerformer` so the geometry → scale/velocity
+/// mapping is unit-testable off-device (the real `app.pinch(...)` call cannot run
+/// in a macOS test host). See issue #2910.
+public enum PinchFallback {
+    /// Clamp bounds keep `scale` a sane, strictly-positive multiplier even for
+    /// degenerate geometry. Apple: `scale` in (0,1) zooms out, `> 1` zooms in.
+    private static let minScale: CGFloat = 0.01
+    private static let maxScale: CGFloat = 100
+    /// XCUITest rejects a zero velocity; keep magnitude above this floor.
+    private static let minVelocityMagnitude: CGFloat = 0.1
+    private static let defaultDuration: TimeInterval = 0.3
+
+    /// Compute the public-API `pinch(withScale:velocity:)` parameters from the
+    /// requested pinch geometry.
+    ///
+    /// - `scale`   = `distanceEnd / distanceStart`, clamped to a positive range.
+    /// - `velocity` = `(scale - 1) / duration`, floored to a nonzero magnitude.
+    ///   Sign follows zoom direction: zoom-in (`scale > 1`) is positive,
+    ///   zoom-out (`scale < 1`) is negative — matching Apple's requirement that
+    ///   velocity be negative when zooming out.
+    public static func parameters(
+        distanceStart: Double,
+        distanceEnd: Double,
+        duration: TimeInterval
+    ) -> (scale: CGFloat, velocity: CGFloat) {
+        let safeStart = distanceStart > 0 ? distanceStart : 1
+        let safeEnd = distanceEnd > 0 ? distanceEnd : safeStart * Double(minScale)
+        let rawScale = CGFloat(safeEnd / safeStart)
+        let scale = min(max(rawScale, minScale), maxScale)
+
+        let safeDuration = duration > 0 ? duration : defaultDuration
+        var velocity = (scale - 1) / CGFloat(safeDuration)
+        if abs(velocity) < minVelocityMagnitude {
+            // Degenerate / no-op pinch: preserve a valid nonzero velocity whose
+            // sign still matches the (possibly absent) zoom direction.
+            velocity = (scale >= 1 ? 1 : -1) * minVelocityMagnitude
+        }
+        return (scale, velocity)
+    }
+}

--- a/ios/control-proxy/Sources/CtrlProxy/PinchFallback.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/PinchFallback.swift
@@ -23,10 +23,13 @@ public enum PinchGesturePath: String, Codable, Equatable {
 /// in a macOS test host). See issue #2910.
 public enum PinchFallback {
     /// Clamp bounds keep `scale` a sane, strictly-positive multiplier even for
-    /// degenerate geometry. Apple: `scale` in (0,1) zooms out, `> 1` zooms in.
+    /// degenerate geometry. Apple documents `scale` in (0,1) as zoom-out and
+    /// `> 1` as zoom-in.
     private static let minScale: CGFloat = 0.01
     private static let maxScale: CGFloat = 100
-    /// XCUITest rejects a zero velocity; keep magnitude above this floor.
+    /// Apple documents `velocity` only as "scale factor per second" — it does not
+    /// specify a nonzero requirement, but a zero velocity is a degenerate no-op,
+    /// so we defensively floor the magnitude to stay clear of it.
     private static let minVelocityMagnitude: CGFloat = 0.1
     private static let defaultDuration: TimeInterval = 0.3
 
@@ -35,9 +38,10 @@ public enum PinchFallback {
     ///
     /// - `scale`   = `distanceEnd / distanceStart`, clamped to a positive range.
     /// - `velocity` = `(scale - 1) / duration`, floored to a nonzero magnitude.
-    ///   Sign follows zoom direction: zoom-in (`scale > 1`) is positive,
-    ///   zoom-out (`scale < 1`) is negative — matching Apple's requirement that
-    ///   velocity be negative when zooming out.
+    ///   Deriving velocity as the scale-factor rate of change makes its sign
+    ///   follow the zoom direction (zoom-in `scale > 1` positive, zoom-out
+    ///   `scale < 1` negative), the natural reading of Apple's "scale factor per
+    ///   second"; the floor keeps it clear of a degenerate zero velocity.
     public static func parameters(
         distanceStart: Double,
         distanceEnd: Double,

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -105,6 +105,10 @@ public protocol GesturePerforming {
     // MARK: - Pinch Gestures
 
     /// Pinch at center with explicit starting and ending finger distances.
+    /// Returns which mechanism performed the gesture: the private event-path
+    /// synthesis (honors center) or the public element-anchored fallback
+    /// (center-less). See issue #2910.
+    @discardableResult
     func pinch(
         centerX: Double,
         centerY: Double,
@@ -113,7 +117,7 @@ public protocol GesturePerforming {
         rotationDegrees: Double,
         duration: TimeInterval
     )
-        throws
+        throws -> PinchGesturePath
 
     // MARK: - Text Input
 

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -100,29 +100,39 @@ BOOL ObjCExceptionCatcher_synthesizePinch(
     CGFloat rotationDegrees,
     NSTimeInterval duration,
     NSInteger interfaceOrientation,
+    BOOL *_Nullable symbolsUnavailable,
     NSString *_Nullable *_Nullable errorMessage
 ) {
+    // Default: symbols are assumed present until a guard proves otherwise, so a
+    // genuine synthesis error is not misreported as an availability gap.
+    if (symbolsUnavailable != NULL) {
+        *symbolsUnavailable = NO;
+    }
 #if TARGET_OS_IOS
     __block BOOL success = NO;
     __block NSString *failure = nil;
+    __block BOOL unavailable = NO;
 
     NSException *exception = ObjCExceptionCatcher_tryBlock(^{
         Class pathClass = NSClassFromString(@"XCPointerEventPath");
         Class recordClass = NSClassFromString(@"XCSynthesizedEventRecord");
 
         if (pathClass == Nil || recordClass == Nil) {
+            unavailable = YES;
             failure = @"XCTest private pinch event synthesis classes are unavailable";
             return;
         }
         if (![pathClass instancesRespondToSelector:@selector(initForTouchAtPoint:offset:)] ||
             ![pathClass instancesRespondToSelector:@selector(moveToPoint:atOffset:)] ||
             ![pathClass instancesRespondToSelector:@selector(liftUpAtOffset:)]) {
+            unavailable = YES;
             failure = @"XCPointerEventPath does not support the expected pinch selectors";
             return;
         }
         if (![recordClass instancesRespondToSelector:@selector(initWithName:interfaceOrientation:)] ||
             ![recordClass instancesRespondToSelector:@selector(addPointerEventPath:)] ||
             ![recordClass instancesRespondToSelector:@selector(synthesizeWithError:)]) {
+            unavailable = YES;
             failure = @"XCSynthesizedEventRecord does not support the expected pinch synthesis selectors";
             return;
         }
@@ -170,16 +180,28 @@ BOOL ObjCExceptionCatcher_synthesizePinch(
     });
 
     if (exception != nil) {
+        // A caught exception is a genuine synthesis failure, not an availability
+        // gap, so leave `unavailable` as-is (NO unless a guard already set it).
         NSString *reason = exception.reason != nil ? exception.reason : @"no reason";
         failure = [NSString stringWithFormat:@"Objective-C exception during pinch synthesis: %@ - %@",
                    exception.name, reason];
     }
-    if (!success && errorMessage != NULL) {
-        *errorMessage = failure != nil ? failure : @"pinch synthesis failed";
+    if (!success) {
+        if (symbolsUnavailable != NULL) {
+            *symbolsUnavailable = unavailable;
+        }
+        if (errorMessage != NULL) {
+            *errorMessage = failure != nil ? failure : @"pinch synthesis failed";
+        }
     }
 
     return success;
 #else
+    // Off-iOS the private symbols are definitionally unavailable, so signal the
+    // caller to take the public-API fallback path.
+    if (symbolsUnavailable != NULL) {
+        *symbolsUnavailable = YES;
+    }
     if (errorMessage != NULL) {
         *errorMessage = @"XCTest private pinch event synthesis is only available on iOS";
     }

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -46,6 +46,13 @@ FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
 /// Synthesizes a two-finger pinch through XCTest private event APIs.
 /// Returns NO with a descriptive error message when the private symbols are unavailable
 /// or synthesis fails. Objective-C exceptions are caught and reported through errorMessage.
+///
+/// `symbolsUnavailable` distinguishes the two failure modes so the caller can degrade
+/// gracefully (see issue #2910): it is set to YES only when the required private
+/// classes/selectors are missing (or the platform is not iOS), and left NO for a
+/// genuine synthesis error or a caught Objective-C exception. When YES, the caller
+/// should fall back to the public element-anchored `pinch(withScale:velocity:)`
+/// rather than surfacing a hard failure.
 FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizePinch(
     CGFloat centerX,
     CGFloat centerY,
@@ -54,6 +61,7 @@ FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizePinch(
     CGFloat rotationDegrees,
     NSTimeInterval duration,
     NSInteger interfaceOrientation,
+    BOOL *_Nullable symbolsUnavailable,
     NSString *_Nullable *_Nullable errorMessage
 );
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -555,6 +555,8 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertTrue(response.success ?? false)
         XCTAssertEqual(response.type, "pinch_result")
         XCTAssertEqual(response.requestId, "test-pinch")
+        // Default path is the private event-path synthesis (honors center).
+        XCTAssertEqual(response.pinchPath, "event-path")
 
         let history = fakeGesturePerformer.getPinchHistory()
         XCTAssertEqual(history.count, 1)
@@ -584,6 +586,27 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertFalse(response.success ?? true)
         XCTAssertEqual(response.type, "pinch_result")
         XCTAssertTrue(response.error?.contains("pinch synthesis failed") ?? false)
+    }
+
+    /// When the performer falls back to the public element-anchored pinch (private
+    /// XCTest symbols unavailable), the success response must report the
+    /// `element-anchored` path so callers know the center was not honored. See
+    /// issue #2910.
+    func testPinchFallbackSurfacesElementAnchoredPath() {
+        fakeGesturePerformer.pinchPathToReturn = .elementAnchored
+        let request = WebSocketRequest.pinch(RequestPinch(
+            requestId: "test-pinch-fallback",
+            centerX: 100,
+            centerY: 200,
+            distanceStart: 40,
+            distanceEnd: 120
+        ))
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertTrue(response.success ?? false)
+        XCTAssertEqual(response.type, "pinch_result")
+        XCTAssertEqual(response.pinchPath, "element-anchored")
     }
 
     // MARK: - Text Input Tests

--- a/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
@@ -1,4 +1,5 @@
 @testable import CtrlProxy
+import ObjCExceptionCatcher
 import XCTest
 
 final class ObjCExceptionBridgeTests: XCTestCase {
@@ -140,5 +141,22 @@ final class ObjCExceptionBridgeTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(ts, beforeMs)
             XCTAssertLessThanOrEqual(ts, afterMs)
         }
+    }
+
+    // MARK: - Pinch Symbol Availability (issue #2910)
+
+    /// Off-device (this test host is macOS, not iOS), the private XCTest pinch
+    /// symbols are definitionally unavailable, so `synthesizePinch` must report
+    /// `symbolsUnavailable == true` and fail — this is exactly the signal that
+    /// tells `GesturePerformer.pinch` to take the public-API fallback path.
+    func testSynthesizePinchReportsSymbolsUnavailableOffDevice() {
+        var symbolsUnavailable: ObjCBool = false
+        var errorMessage: NSString?
+        let succeeded = ObjCExceptionCatcher_synthesizePinch(
+            100, 200, 40, 120, 0, 0.3, 0, &symbolsUnavailable, &errorMessage
+        )
+        XCTAssertFalse(succeeded, "private synthesis cannot succeed off-device")
+        XCTAssertTrue(symbolsUnavailable.boolValue, "must flag the private symbols as unavailable")
+        XCTAssertNotNil(errorMessage)
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/PinchFallbackTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/PinchFallbackTests.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import XCTest
+
+@testable import CtrlProxy
+
+/// Unit tests for the platform-agnostic pinch public-API fallback math.
+///
+/// These exercise the decision that keeps `pinchOn` working (center-less) when
+/// the private XCTest event-synthesis symbols are unavailable — see issue #2910.
+/// The real iOS `app.pinch(withScale:velocity:)` call cannot run off-device, so
+/// the geometry → scale/velocity mapping is extracted here to be verifiable.
+final class PinchFallbackTests: XCTestCase {
+    private let accuracy: CGFloat = 0.0001
+
+    func testZoomInProducesScaleAboveOneAndPositiveVelocity() {
+        let params = PinchFallback.parameters(distanceStart: 40, distanceEnd: 120, duration: 0.3)
+        // distanceEnd/distanceStart = 3.0 → zoom in
+        XCTAssertEqual(params.scale, 3.0, accuracy: accuracy)
+        XCTAssertGreaterThan(params.velocity, 0, "zoom-in must use positive velocity")
+    }
+
+    func testZoomOutProducesScaleBelowOneAndNegativeVelocity() {
+        let params = PinchFallback.parameters(distanceStart: 120, distanceEnd: 40, duration: 0.3)
+        // distanceEnd/distanceStart ≈ 0.333 → zoom out
+        XCTAssertEqual(params.scale, 1.0 / 3.0, accuracy: accuracy)
+        XCTAssertLessThan(params.velocity, 0, "zoom-out must use negative velocity")
+    }
+
+    func testVelocityScalesWithDuration() {
+        // A shorter duration must yield a larger-magnitude velocity for the same scale.
+        let fast = PinchFallback.parameters(distanceStart: 40, distanceEnd: 120, duration: 0.2)
+        let slow = PinchFallback.parameters(distanceStart: 40, distanceEnd: 120, duration: 1.0)
+        XCTAssertGreaterThan(abs(fast.velocity), abs(slow.velocity))
+    }
+
+    func testNonPositiveDistanceStartDoesNotDivideByZero() {
+        let params = PinchFallback.parameters(distanceStart: 0, distanceEnd: 120, duration: 0.3)
+        XCTAssertTrue(params.scale.isFinite)
+        XCTAssertTrue(params.velocity.isFinite)
+        XCTAssertGreaterThan(params.scale, 0)
+    }
+
+    func testNonPositiveDurationStillYieldsFiniteNonzeroVelocity() {
+        let params = PinchFallback.parameters(distanceStart: 40, distanceEnd: 120, duration: 0)
+        XCTAssertTrue(params.velocity.isFinite)
+        XCTAssertNotEqual(params.velocity, 0)
+    }
+
+    func testNoOpPinchStillYieldsNonzeroVelocity() {
+        // XCUITest rejects a zero velocity; a degenerate (equal-distance) pinch must
+        // still produce valid, nonzero params.
+        let params = PinchFallback.parameters(distanceStart: 80, distanceEnd: 80, duration: 0.3)
+        XCTAssertEqual(params.scale, 1.0, accuracy: accuracy)
+        XCTAssertNotEqual(params.velocity, 0)
+        XCTAssertTrue(params.velocity.isFinite)
+    }
+
+    func testScaleClampedToPositiveRange() {
+        // Absurd geometry must not produce a non-positive or infinite scale.
+        let tiny = PinchFallback.parameters(distanceStart: 1_000_000, distanceEnd: 1, duration: 0.3)
+        XCTAssertGreaterThan(tiny.scale, 0)
+        XCTAssertTrue(tiny.scale.isFinite)
+    }
+
+    func testPathRawValues() {
+        XCTAssertEqual(PinchGesturePath.eventPath.rawValue, "event-path")
+        XCTAssertEqual(PinchGesturePath.elementAnchored.rawValue, "element-anchored")
+    }
+}

--- a/src/features/action/PinchOn.ts
+++ b/src/features/action/PinchOn.ts
@@ -205,6 +205,15 @@ export class PinchOn extends BaseVisualChange {
         };
       }
 
+      // iOS may fall back to the public element-anchored pinch when the private
+      // XCTest event-synthesis symbols are unavailable; that path zooms from the
+      // screen center and ignores the requested centerX/centerY (and rotation).
+      // Surface it so callers know the center was not honored (#2910).
+      const fallbackWarning = pinchResult.pinchPath === "element-anchored"
+        ? "pinchOn used the iOS public element-anchored fallback; the gesture zoomed from the screen center and did not honor the requested center/rotation."
+        : undefined;
+      const warning = [target.warning, fallbackWarning].filter(Boolean).join(" ") || undefined;
+
       return {
         success: true,
         direction: options.direction,
@@ -217,7 +226,7 @@ export class PinchOn extends BaseVisualChange {
         centerY,
         targetType: target.targetType,
         container: target.container,
-        warning: target.warning,
+        warning,
         observation: pinchResult.observation,
         a11yTotalTimeMs: pinchResult.totalTimeMs,
         a11yGestureTimeMs: pinchResult.gestureTimeMs

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -65,10 +65,21 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
       };
       break;
 
+    case "pinch_result":
+      // Carry the runner's pinchPath so PinchOn can warn when the center-less
+      // public fallback was used instead of the center-honoring synthesis (#2910).
+      result = {
+        success: message.success ?? true,
+        totalTimeMs: message.totalTimeMs ?? 0,
+        error: message.error,
+        perfTiming: message.perfTiming,
+        pinchPath: message.pinchPath,
+      };
+      break;
+
     case "tap_coordinates_result":
     case "swipe_result":
     case "drag_result":
-    case "pinch_result":
     case "set_text_result":
     case "clear_text_result":
     case "select_all_result":

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -123,6 +123,10 @@ export interface WebSocketMessage {
   currentOrientation?: string;
   value?: number;
   rotationPerformed?: boolean;
+  // Pinch-only: which mechanism performed the gesture — "event-path" (private
+  // synthesis, honors center) or "element-anchored" (public fallback, center-less).
+  // See issue #2910.
+  pinchPath?: string;
 }
 
 /**

--- a/src/features/observe/shared/types.ts
+++ b/src/features/observe/shared/types.ts
@@ -46,6 +46,13 @@ export interface BaseResult {
  */
 export interface GestureTimingResult extends BaseResult {
   gestureTimeMs?: number;
+  /**
+   * Pinch-only (iOS): which mechanism performed the gesture —
+   * "event-path" (private synthesis, honors center) or "element-anchored"
+   * (public fallback, center-less). Undefined for Android and non-pinch
+   * gestures. See issue #2910.
+   */
+  pinchPath?: string;
 }
 
 /**

--- a/test/features/action/PinchOn.test.ts
+++ b/test/features/action/PinchOn.test.ts
@@ -227,4 +227,54 @@ describe("PinchOn", () => {
     expect(fakeIosService.getPinchHistory()).toHaveLength(1);
     expect(fakeA11yService.getPinchHistory()).toHaveLength(0);
   });
+
+  test("warns when iOS pinch used the center-less element-anchored fallback (#2910)", async () => {
+    const iosDevice: BootedDevice = {
+      deviceId: "11111111-2222-3333-4444-555555555555",
+      platform: "ios",
+      name: "iPhone 16 Pro"
+    };
+    fakeIosService.setPinchResult({
+      success: true,
+      totalTimeMs: 300,
+      gestureTimeMs: 300,
+      pinchPath: "element-anchored"
+    });
+    pinchOn = new PinchOn(iosDevice);
+    (pinchOn as any).observeScreen = fakeObserveScreen;
+    (pinchOn as any).awaitIdle = fakeAwaitIdle;
+    (pinchOn as any).window = fakeWindow;
+    (pinchOn as any).adb = fakeAdb;
+    (pinchOn as any).timer = fakeTimer;
+
+    const result = await pinchOn.execute({ direction: "out", autoTarget: false });
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toContain("element-anchored fallback");
+  });
+
+  test("does not warn when iOS pinch used the center-honoring event-path (#2910)", async () => {
+    const iosDevice: BootedDevice = {
+      deviceId: "11111111-2222-3333-4444-555555555555",
+      platform: "ios",
+      name: "iPhone 16 Pro"
+    };
+    fakeIosService.setPinchResult({
+      success: true,
+      totalTimeMs: 300,
+      gestureTimeMs: 300,
+      pinchPath: "event-path"
+    });
+    pinchOn = new PinchOn(iosDevice);
+    (pinchOn as any).observeScreen = fakeObserveScreen;
+    (pinchOn as any).awaitIdle = fakeAwaitIdle;
+    (pinchOn as any).window = fakeWindow;
+    (pinchOn as any).adb = fakeAdb;
+    (pinchOn as any).timer = fakeTimer;
+
+    const result = await pinchOn.execute({ direction: "out", autoTarget: false });
+
+    expect(result.success).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
 });

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -44,7 +44,6 @@ describe("decodeCtrlProxyMessage", () => {
     "tap_coordinates_result",
     "swipe_result",
     "drag_result",
-    "pinch_result",
     "set_text_result",
     "clear_text_result",
     "select_all_result",
@@ -66,6 +65,27 @@ describe("decodeCtrlProxyMessage", () => {
       });
     });
   }
+
+  test("pinch_result carries element-anchored pinchPath through (#2910)", () => {
+    const decoded = decodeCtrlProxyMessage(
+      msg({ type: "pinch_result", totalTimeMs: 7, pinchPath: "element-anchored" })
+    );
+    expect(decoded).toEqual({
+      requestId: REQ,
+      result: {
+        success: true,
+        totalTimeMs: 7,
+        error: undefined,
+        perfTiming: undefined,
+        pinchPath: "element-anchored",
+      },
+    });
+  });
+
+  test("pinch_result pinchPath is undefined when the runner omits it", () => {
+    const decoded = decodeCtrlProxyMessage(msg({ type: "pinch_result", totalTimeMs: 5 }));
+    expect((decoded?.result as { pinchPath?: string }).pinchPath).toBeUndefined();
+  });
 
   test("base result respects explicit success=false and totalTimeMs default", () => {
     const decoded = decodeCtrlProxyMessage(msg({ type: "swipe_result", success: false, error: "boom" }));


### PR DESCRIPTION
## What

Adds a public-API fallback to iOS coordinate-based `pinchOn`. Closes #2910.

Before this, `GesturePerformer.pinch` relied **entirely** on the Apple-private
XCTest symbols `XCPointerEventPath` / `XCSynthesizedEventRecord`. When those
undocumented selectors are unavailable, `pinchOn` returned a hard `success:false`
with zero degraded behavior — a single point of failure for a first-class
gesture. Issue #2482 recommended a public `pinch(withScale:velocity:)` fallback;
the shipped implementation (PR #2653) omitted it.

## How

- **Distinguish "symbols unavailable" from "genuine synthesis failure"** at the
  ObjC boundary. `ObjCExceptionCatcher_synthesizePinch` gains a
  `BOOL *symbolsUnavailable` out-param, set `YES` only when the private
  classes/selectors are missing (the availability guards) — and on the non-iOS
  `#else` branch. A genuine synthesis error or a caught ObjC exception leaves it
  `NO`, preserving the existing structured-failure behavior.
  (`Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m`, `.../include/ObjCExceptionCatcher.h`)

- **New platform-agnostic `PinchFallback`** computes the public-API
  `scale`/`velocity` from the pinch geometry
  (`scale = distanceEnd/distanceStart`, velocity floored to a nonzero magnitude
  with sign following zoom direction — Apple requires negative velocity to zoom
  out). Extracted out of the iOS-only performer so the math is **unit-testable
  off-device**. Also defines `PinchGesturePath` (`event-path` / `element-anchored`).
  (`Sources/CtrlProxy/PinchFallback.swift`)

- **`GesturePerforming.pinch` now returns `PinchGesturePath`.** The iOS impl
  returns `.eventPath` on private-synth success; on `symbolsUnavailable`, falls
  back to the SpringBoard-anchored public `app.pinch(withScale:velocity:)` and
  returns `.elementAnchored`; on a genuine failure, still throws.
  (`Sources/CtrlProxy/GesturePerformer.swift`, `Protocols.swift`, `Fakes.swift`)

- **Result metadata** surfaces the path used via a new optional
  `WebSocketResponse.pinchPath` (`event-path` vs `element-anchored`), so callers
  know whether the requested center was honored. The field is omitted (not
  `null`) on every non-pinch response — Swift's synthesized Codable uses
  `encodeIfPresent` for optionals — so the wire format for other responses is
  unchanged. (`Sources/CtrlProxy/Models.swift`, `CommandHandler.swift`)

## Acceptance criteria (issue #2910)

- [x] Private symbols unavailable ⇒ `pinchOn` still performs a (center-less) zoom
      via the public API rather than returning `success:false`.
- [x] Genuine synthesis errors still surface as structured `success:false`.
- [x] Result metadata notes which path was used (`pinchPath`).
- [x] Swift test for the fallback branch via `FakeGesturePerformer`.

## Testing

- `swift test` (macOS host): 300 tests pass, including:
  - `PinchFallbackTests` — scale/velocity/sign for zoom-in, zoom-out, degenerate
    inputs (zero distance, zero duration, no-op equal-distance, extreme geometry).
  - `ObjCExceptionBridgeTests.testSynthesizePinchReportsSymbolsUnavailableOffDevice`
    — off-device, `synthesizePinch` reports `symbolsUnavailable == true` (the
    exact signal that drives the fallback).
  - `CommandHandlerTests` — success response reports `pinchPath == "event-path"`
    by default and `== "element-anchored"` when the fake simulates the fallback;
    genuine failure still returns a typed `success:false`.
- `xcodebuild build-for-testing -scheme CtrlProxyApp -destination 'generic/platform=iOS Simulator'`:
  **TEST BUILD SUCCEEDED** (compiles the iOS-only branch, including the real
  `app.pinch(...)` fallback call).
- `CtrlProxy.xcodeproj` regenerated via `xcodegen generate` to register the two
  new Swift files (committed; the IPA CI build uses the committed project).

## Notes / follow-ups

- The real `app.pinch(...)` fallback call cannot run in a macOS test host, so the
  live gesture is verified by compile + the availability-signal bridge test + the
  metadata plumbing test. The geometry math it depends on is fully unit-tested.
- `rotationDegrees` is inherently dropped in the public fallback (the public API
  has no rotation) — signalled by the `element-anchored` path metadata.
- `multiFingerSwipe` (`ObjCExceptionCatcher_synthesizeMultiFingerSwipe`) has the
  same private-symbol single-point-of-failure and could take the same treatment —
  filed as a follow-up.
