### PR TITLE
fix(daemon): typed SessionCacheData slots as observe-cache source of truth (#2917)

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -14,13 +14,18 @@ import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
  *
  * The observe cache lives in the typed top-level slots below — they are the
  * canonical source of truth (issue #2917). Write them through the dedicated
- * `setLastHierarchy` / `setLastScreenshot` setters. `customData` is reserved
- * for genuinely ad-hoc tool state (e.g. keep-awake, device-label maps).
+ * `setLastHierarchy` / `setLastScreenshot` setters.
+ *
+ * `customData` still holds other keyed tool state accessed via well-known
+ * constants (keep-awake `KeepScreenAwakeState`, the device-label map, the
+ * ad-hoc `lastActionTime`). Those remain untyped and are candidates for the
+ * same typed-slot treatment — the `Record<string, any>` shape is an escape
+ * hatch that can reintroduce the #2917 decoy bug for any future key.
  */
 export interface SessionCacheData {
   lastHierarchy?: ViewHierarchyResult; // Last observed view hierarchy (full, untrimmed)
   lastScreenshot?: string;     // Base64 encoded last screenshot
-  lastObserveTime?: number;    // Timestamp of last hierarchy observation
+  lastObserveTime?: number;    // Timestamp of last hierarchy observation (hierarchy only, not screenshot)
   customData?: Record<string, any>; // Custom data set by tools
 }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -4,15 +4,21 @@ import { BootedDevice, Platform } from "../models";
 import { KeepScreenAwakeManager, KEEP_SCREEN_AWAKE_STATE_KEY, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
 import { DeviceSessionRepository } from "../db/deviceSessionRepository";
 import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
+import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 
 /**
  * Session Cache Data
  *
  * Stores data that can be reused across multiple tool calls
  * within the same test session, reducing redundant API calls.
+ *
+ * The observe cache lives in the typed top-level slots below — they are the
+ * canonical source of truth (issue #2917). Write them through the dedicated
+ * `setLastHierarchy` / `setLastScreenshot` setters. `customData` is reserved
+ * for genuinely ad-hoc tool state (e.g. keep-awake, device-label maps).
  */
 export interface SessionCacheData {
-  lastHierarchy?: string;      // Last observed view hierarchy
+  lastHierarchy?: ViewHierarchyResult; // Last observed view hierarchy (full, untrimmed)
   lastScreenshot?: string;     // Base64 encoded last screenshot
   lastObserveTime?: number;    // Timestamp of last hierarchy observation
   customData?: Record<string, any>; // Custom data set by tools
@@ -305,6 +311,29 @@ export class SessionManager {
       .catch(error => logger.warn(`[SessionManager] Failed to record session activity: ${error}`));
 
     logger.debug(`Updated cache for session ${sessionId}`);
+  }
+
+  /**
+   * Cache the most recent observed view hierarchy for a session.
+   *
+   * Writes the typed top-level `lastHierarchy` slot (the canonical source of
+   * truth per issue #2917) and stamps `lastObserveTime`. Consumers such as the
+   * hierarchy-diff baseline (#2761) read the typed slot directly rather than
+   * fishing a differently-typed value out of `customData`.
+   */
+  setLastHierarchy(sessionId: string, hierarchy: ViewHierarchyResult): void {
+    this.updateSessionCache(sessionId, {
+      lastHierarchy: hierarchy,
+      lastObserveTime: this.timer.now(),
+    });
+  }
+
+  /**
+   * Cache the most recent base64-encoded screenshot for a session in the typed
+   * top-level `lastScreenshot` slot (canonical source of truth per #2917).
+   */
+  setLastScreenshot(sessionId: string, screenshot: string): void {
+    this.updateSessionCache(sessionId, { lastScreenshot: screenshot });
   }
 
   /**

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toJSONSchema } from "zod";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { ActionableError, BootedDevice, SomePlatform } from "../models";
+import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { UIStateExtractor } from "../features/navigation/UIStateExtractor";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
@@ -444,15 +445,17 @@ class ToolRegistryClass {
             // lives under `structuredContent`, not on `response` directly (the
             // former read of `response.viewHierarchy` was always undefined, so
             // `lastHierarchy` never populated — the #2761 diff baseline needs it).
-            // Runs before finalizeToolResponse, so the cache keeps the full,
-            // untrimmed hierarchy while the wire copy is sanitized.
-            const observeHierarchy = name === "observe" ? getStructuredField(response, "viewHierarchy") : undefined;
+            // Route through the typed setters so the canonical top-level slots
+            // are the source of truth rather than the untyped `customData` bag
+            // (issue #2917). Runs before finalizeToolResponse, so the cache keeps
+            // the full, untrimmed hierarchy while the wire copy is sanitized.
+            const observeHierarchy = name === "observe" ? getStructuredField<ViewHierarchyResult>(response, "viewHierarchy") : undefined;
             if (observeHierarchy) {
-              await updateSessionCache(context, "lastHierarchy", observeHierarchy);
+              sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);
             }
-            const observeScreenshot = name === "observe" ? getStructuredField(response, "screenshot") : undefined;
+            const observeScreenshot = name === "observe" ? getStructuredField<string>(response, "screenshot") : undefined;
             if (observeScreenshot) {
-              await updateSessionCache(context, "lastScreenshot", observeScreenshot);
+              sessionManager.setLastScreenshot(sessionUuid, observeScreenshot);
             }
 
             // Update last action timestamp for interaction tools

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -458,7 +458,11 @@ class ToolRegistryClass {
               sessionManager.setLastScreenshot(sessionUuid, observeScreenshot);
             }
 
-            // Update last action timestamp for interaction tools
+            // Update last action timestamp for interaction tools. Unlike the
+            // observe hierarchy/screenshot above, `lastActionTime` is ad-hoc
+            // interaction bookkeeping with no typed slot or consumer, so it
+            // intentionally stays on the generic `customData` path (see #2917
+            // follow-up to type or remove it).
             if (["tapOn", "swipeOn", "pinchOn", "dragAndDrop", "scroll", "inputText", "clearText", "pressButton"].includes(name)) {
               await updateSessionCache(context, "lastActionTime", this.timer.now());
             }

--- a/test/daemon/integration/parallelExecution.test.ts
+++ b/test/daemon/integration/parallelExecution.test.ts
@@ -5,6 +5,7 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { BootedDevice } from "../../../src/models";
 import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
+import type { ViewHierarchyResult } from "../../../src/models/ViewHierarchyResult";
 
 describe("Parallel Execution Across Multiple Devices", function() {
   let sessionManager: SessionManager;
@@ -183,13 +184,15 @@ describe("Parallel Execution Across Multiple Devices", function() {
       await devicePool.assignDeviceToSession(session2Id);
 
       // Set different cache data for each session
+      const hierarchy1: ViewHierarchyResult = { hierarchy: { node: { "$": {}, "view-id": "session-1" } } };
+      const hierarchy2: ViewHierarchyResult = { hierarchy: { node: { "$": {}, "view-id": "session-2" } } };
       sessionManager.updateSessionCache(session1Id, {
-        lastHierarchy: "hierarchy-session-1",
+        lastHierarchy: hierarchy1,
         lastScreenshot: "screenshot-session-1",
       });
 
       sessionManager.updateSessionCache(session2Id, {
-        lastHierarchy: "hierarchy-session-2",
+        lastHierarchy: hierarchy2,
         lastScreenshot: "screenshot-session-2",
       });
 
@@ -197,9 +200,9 @@ describe("Parallel Execution Across Multiple Devices", function() {
       const cache1 = sessionManager.getSessionCache(session1Id);
       const cache2 = sessionManager.getSessionCache(session2Id);
 
-      expect(cache1?.lastHierarchy).toBe("hierarchy-session-1");
+      expect(cache1?.lastHierarchy).toEqual(hierarchy1);
       expect(cache1?.lastScreenshot).toBe("screenshot-session-1");
-      expect(cache2?.lastHierarchy).toBe("hierarchy-session-2");
+      expect(cache2?.lastHierarchy).toEqual(hierarchy2);
       expect(cache2?.lastScreenshot).toBe("screenshot-session-2");
 
       // Verify caches are different
@@ -222,7 +225,7 @@ describe("Parallel Execution Across Multiple Devices", function() {
 
       // Update cache and verify device assignment persists
       sessionManager.updateSessionCache(sessionId, {
-        lastHierarchy: "test-hierarchy",
+        lastHierarchy: { hierarchy: { node: { $: {} } } },
       });
 
       const device3 = sessionManager.getDeviceForSession(sessionId);

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
+import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
+
+function makeHierarchy(label: string): ViewHierarchyResult {
+  return {
+    hierarchy: {
+      node: {
+        "$": { "resource-id": `com.example:id/${label}` },
+        "view-id": `com.example:id/${label}`,
+      },
+    },
+  };
+}
 
 const HEARTBEAT_ENV_KEYS = [
   "AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS",
@@ -144,13 +156,45 @@ describe("SessionManager", () => {
   describe("cache management", () => {
     test("should update session cache data", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");
+      const hierarchy = makeHierarchy("root");
       sessionManager.updateSessionCache("session-1", {
-        lastHierarchy: "test-hierarchy",
+        lastHierarchy: hierarchy,
         lastScreenshot: "base64-data",
       });
       const cache = sessionManager.getSessionCache("session-1");
-      expect(cache?.lastHierarchy).toBe("test-hierarchy");
+      expect(cache?.lastHierarchy).toEqual(hierarchy);
       expect(cache?.lastScreenshot).toBe("base64-data");
+    });
+
+    test("setLastHierarchy stores a ViewHierarchyResult in the typed top-level slot and stamps lastObserveTime (#2917)", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+      fakeTimer.setCurrentTime(123456);
+      const hierarchy = makeHierarchy("root");
+
+      sessionManager.setLastHierarchy("session-1", hierarchy);
+
+      const session = sessionManager.getSession("session-1")!;
+      // Canonical slot is the typed top-level field, NOT customData.
+      expect(session.cacheData.lastHierarchy).toEqual(hierarchy);
+      expect(session.cacheData.lastHierarchy?.hierarchy.node?.["view-id"]).toBe("com.example:id/root");
+      expect(session.cacheData.lastObserveTime).toBe(123456);
+      // The dormant-decoy key must not reappear under customData.
+      expect(session.cacheData.customData?.lastHierarchy).toBeUndefined();
+    });
+
+    test("setLastScreenshot stores the base64 string in the typed top-level slot (#2917)", async () => {
+      await sessionManager.createSession("session-1", "emulator-5554", "android");
+
+      sessionManager.setLastScreenshot("session-1", "base64-screenshot");
+
+      const session = sessionManager.getSession("session-1")!;
+      expect(session.cacheData.lastScreenshot).toBe("base64-screenshot");
+      expect(session.cacheData.customData?.lastScreenshot).toBeUndefined();
+    });
+
+    test("setLastHierarchy on a missing session is a no-op (no throw)", () => {
+      expect(() => sessionManager.setLastHierarchy("nope", makeHierarchy("x"))).not.toThrow();
+      expect(sessionManager.getSession("nope")).toBeNull();
     });
 
     test("should get session cache without modifying other fields", async () => {
@@ -170,7 +214,7 @@ describe("SessionManager", () => {
     test("should clear specific cache key", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");
       sessionManager.updateSessionCache("session-1", {
-        lastHierarchy: "test-hierarchy",
+        lastHierarchy: makeHierarchy("root"),
         lastScreenshot: "base64-data",
       });
       sessionManager.clearSessionCache("session-1", "lastHierarchy");
@@ -182,7 +226,7 @@ describe("SessionManager", () => {
     test("should clear all cache when no key specified", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");
       sessionManager.updateSessionCache("session-1", {
-        lastHierarchy: "test-hierarchy",
+        lastHierarchy: makeHierarchy("root"),
         lastScreenshot: "base64-data",
         customData: { key: "value" },
       });

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -120,13 +120,19 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     });
 
     // Caches are populated (were dormant before the fix) with the FULL hierarchy.
-    const cache = daemonSessionManager!.getSession(sessionId)!.cacheData.customData!;
-    const cachedHierarchy = cache.lastHierarchy as any;
+    // #2917: the canonical slots are the typed top-level fields, NOT customData.
+    const cacheData = daemonSessionManager!.getSession(sessionId)!.cacheData;
+    const cachedHierarchy = cacheData.lastHierarchy as any;
     expect(cachedHierarchy).toBeDefined();
     expect(cachedHierarchy.hierarchy.node["view-id"]).toBe("com.example:id/root");
     expect(cachedHierarchy.hierarchy.node.clickable).toBe("false");
+    // Observe timestamp is stamped alongside the hierarchy.
+    expect(typeof cacheData.lastObserveTime).toBe("number");
     // Screenshot cache repair (symmetric structuredContent read).
-    expect(cache.lastScreenshot).toBe("base64-screenshot-data");
+    expect(cacheData.lastScreenshot).toBe("base64-screenshot-data");
+    // The dormant-decoy keys must NOT be written under customData anymore (#2917).
+    expect(cacheData.customData?.lastHierarchy).toBeUndefined();
+    expect(cacheData.customData?.lastScreenshot).toBeUndefined();
 
     // Returned wire response is sanitized at the chokepoint.
     const returnedRoot = (response.structuredContent as ObserveResult).viewHierarchy!.hierarchy.node as any;


### PR DESCRIPTION
## What

Make the typed `SessionCacheData` slots the canonical source of truth for the
observe cache (issue #2917, **Option A** — the issue's preferred fix).

`SessionCacheData` declared typed slots that **nothing wrote**, while the real
observe cache landed in the untyped `customData` map under same-named keys but a
**different type**:

```ts
// before — src/daemon/sessionManager.ts
lastHierarchy?: string;   // typed string, never written
lastScreenshot?: string;  // typed string, never written
lastObserveTime?: number; // never written
customData?: Record<string, any>; // where the data ACTUALLY landed
```

- `customData.lastHierarchy` held a **`ViewHierarchyResult` object**, not the declared `string`.
- `customData.lastScreenshot` held the base64 string.

The typed `lastHierarchy: string` was a **type lie**: any consumer trusting the
interface (e.g. the #2761 hierarchy-diff baseline) reads `undefined`, or worse
assumes the wrong shape.

Closes #2917.

## Why

The observe-cache write was repaired in #2758 / PR #2891 so the cache is finally
populated — but into `customData` under a decoy-shadowed key. A reader coded
against `session.cacheData.lastHierarchy` (the typed slot) still sees nothing.
The keying is correct (per-session `cacheData.customData`); only the type/slot
modelling was wrong.

## How

- **Retype** `SessionCacheData.lastHierarchy?: ViewHierarchyResult`. `lastScreenshot?: string`
  and `lastObserveTime?: number` were already correct and are kept.
- **Add first-class setters** on `SessionManager`:
  - `setLastHierarchy(sessionId, hierarchy: ViewHierarchyResult)` — writes the typed
    top-level slot and stamps `lastObserveTime`.
  - `setLastScreenshot(sessionId, b64: string)` — writes the typed top-level slot.
  Both route through the existing `updateSessionCache`, so session activity/heartbeat
  bookkeeping is unchanged and a missing session is a logged no-op (not a throw).
- **Route** `src/server/toolRegistry.ts` observe caching through the setters instead of
  the generic `updateSessionCache(context, "lastHierarchy"/"lastScreenshot", …)` that
  wrote to `customData`. Still runs before `finalizeToolResponse`, so the cache keeps
  the **full untrimmed** hierarchy while the wire copy is sanitized (#2758 behavior intact).
- `lastActionTime` stays ad-hoc in `customData` (not part of the typed interface).
  `customData` is now reserved for genuinely ad-hoc tool state (keep-awake, device-label maps).

**Blast radius:** no production reader referenced `cacheData.lastHierarchy`/`lastScreenshot`
before this change (grep-verified); `customData` readers are only the keep-awake and
device-label keys, both untouched. `cacheData` is in-memory only — no DB/schema impact.

## Testing

- `test/daemon/sessionManager.test.ts` — new unit coverage: `setLastHierarchy` stores a
  `ViewHierarchyResult` in the typed top-level slot and stamps `lastObserveTime`;
  `setLastScreenshot` stores the base64 string; missing-session is a no-op; the
  `customData` decoy key is asserted absent. Existing cache tests retyped off the string decoy.
- `test/server/toolRegistry.lastHierarchyCache.test.ts` — the observe integration test now
  asserts the canonical **top-level** slots (`cacheData.lastHierarchy`/`lastScreenshot`/
  `lastObserveTime`), the full untrimmed hierarchy, sanitized wire response, and the
  **absence** of the `customData` decoy.
- `test/daemon/integration/parallelExecution.test.ts` — per-session isolation retyped to
  `ViewHierarchyResult`.

Verified: `bun test test/daemon/ test/server/` **1290 pass, 0 fail**; `eslint --fix` clean;
`bun build.ts` ok.

## Acceptance criteria (#2917)
- [x] `SessionCacheData.lastHierarchy` typed `ViewHierarchyResult` — no `string` decoy remains.
- [x] After `observe`, the canonical top-level slot holds a `ViewHierarchyResult` (has `.hierarchy.node`); `lastObserveTime` stamped.
- [x] `lastScreenshot` base64 lands in the typed top-level slot.
- [x] No dormant string decoy and no `customData.lastHierarchy`/`lastScreenshot` written.
- [x] Grep guard: no reader references `cacheData.lastHierarchy` as a string.
- [x] Full untrimmed hierarchy cached while the wire copy stays sanitized (#2758 intact).
