### PR TITLE
docs(pinch): document rotationDegrees axis convention + pin geometry (#2911)

### DIFF
--- a/.claude-plugin/skills/gesture.md
+++ b/.claude-plugin/skills/gesture.md
@@ -92,7 +92,9 @@ pinchOn with direction: "out"
 pinchOn with direction: "in"
 ```
 
-**With rotation:**
+**With rotation** — `rotationDegrees` is a *combined pinch + rotate*: the two-finger axis
+starts horizontal and ends rotated by this amount (not a pinch along a fixed rotated axis).
+Default is `0` (a plain pinch/zoom). Same convention on Android and iOS.
 ```
 pinchOn with direction: "out", rotationDegrees: 45
 ```

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -2604,31 +2604,20 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
     try {
       perfProvider.startOperation("buildPath")
-      val startRadius = distanceStart / 2.0
-      val endRadius = distanceEnd / 2.0
-      val startAngle = 0.0
-      val endAngle = Math.toRadians(rotationDegrees.toDouble())
-
-      fun pointAt(radius: Double, angleRad: Double): Pair<Float, Float> {
-        val x = (centerX + radius * kotlin.math.cos(angleRad)).toFloat()
-        val y = (centerY + radius * kotlin.math.sin(angleRad)).toFloat()
-        return x to y
-      }
-
-      val (startX1, startY1) = pointAt(startRadius, startAngle)
-      val (startX2, startY2) = pointAt(startRadius, Math.PI + startAngle)
-      val (endX1, endY1) = pointAt(endRadius, endAngle)
-      val (endX2, endY2) = pointAt(endRadius, Math.PI + endAngle)
+      // Geometry is extracted into computePinchPoints so it stays unit testable (see
+      // PinchGeometryTest) and stays in sync with the iOS runner. rotationDegrees rotates the
+      // finger axis *during* the pinch (start horizontal, end rotated); see issue #2911.
+      val points = computePinchPoints(centerX, centerY, distanceStart, distanceEnd, rotationDegrees)
 
       val path1 =
         Path().apply {
-          moveTo(startX1, startY1)
-          lineTo(endX1, endY1)
+          moveTo(points.startX1, points.startY1)
+          lineTo(points.endX1, points.endY1)
         }
       val path2 =
         Path().apply {
-          moveTo(startX2, startY2)
-          lineTo(endX2, endY2)
+          moveTo(points.startX2, points.startY2)
+          lineTo(points.endX2, points.endY2)
         }
 
       val gesture =

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometry.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometry.kt
@@ -1,0 +1,55 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import kotlin.math.cos
+import kotlin.math.sin
+
+/** The four touch endpoints of a two-finger pinch: two start points and two end points. */
+internal data class PinchPoints(
+  val startX1: Float,
+  val startY1: Float,
+  val startX2: Float,
+  val startY2: Float,
+  val endX1: Float,
+  val endY1: Float,
+  val endX2: Float,
+  val endY2: Float,
+)
+
+/**
+ * Computes the two-finger pinch endpoints around [centerX], [centerY].
+ *
+ * `rotationDegrees` describes how far the finger axis rotates *during* the pinch, NOT the
+ * orientation of a fixed pinch axis: the two fingers start on the horizontal axis (angle 0) and
+ * move to an axis rotated by [rotationDegrees]. A non-zero value therefore produces a combined
+ * pinch+rotate. For the common `rotationDegrees == 0` zoom case the start and end axes coincide.
+ *
+ * This convention is shared with the iOS runner
+ * (`ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m`) so cross-platform pinch
+ * results match. See issue #2911. Pure trig with no Android dependencies so it stays unit testable
+ * — see `PinchGeometryTest`.
+ */
+internal fun computePinchPoints(
+  centerX: Double,
+  centerY: Double,
+  distanceStart: Double,
+  distanceEnd: Double,
+  rotationDegrees: Float,
+): PinchPoints {
+  val startRadius = distanceStart / 2.0
+  val endRadius = distanceEnd / 2.0
+  val startAngle = 0.0
+  val endAngle = Math.toRadians(rotationDegrees.toDouble())
+
+  fun pointAt(radius: Double, angleRad: Double): Pair<Float, Float> {
+    val x = (centerX + radius * cos(angleRad)).toFloat()
+    val y = (centerY + radius * sin(angleRad)).toFloat()
+    return x to y
+  }
+
+  val (startX1, startY1) = pointAt(startRadius, startAngle)
+  val (startX2, startY2) = pointAt(startRadius, Math.PI + startAngle)
+  val (endX1, endY1) = pointAt(endRadius, endAngle)
+  val (endX2, endY2) = pointAt(endRadius, Math.PI + endAngle)
+
+  return PinchPoints(startX1, startY1, startX2, startY2, endX1, endY1, endX2, endY2)
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
@@ -1,0 +1,116 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import kotlin.math.cos
+import kotlin.math.sin
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the two-finger pinch geometry convention shared by the Android and iOS runners (see
+ * issue #2911). `rotationDegrees` describes how far the finger axis rotates *during* the pinch: the
+ * axis starts horizontal (angle 0) and ends rotated by `rotationDegrees`. This is a combined
+ * pinch+rotate, not a pinch along a fixed rotated axis. Both platforms must keep this convention so
+ * cross-platform results match; this test is the executable guard.
+ *
+ * Pure trig, no Android dependencies, so it runs as a fast pure-JVM test — no Robolectric.
+ */
+class PinchGeometryTest {
+
+  private val delta = 1e-3f
+
+  @Test
+  fun `radii are half the requested distances`() {
+    val p =
+      computePinchPoints(
+        centerX = 100.0,
+        centerY = 200.0,
+        distanceStart = 80.0,
+        distanceEnd = 300.0,
+        rotationDegrees = 0f,
+      )
+    // Start axis horizontal: finger 1 sits startRadius to the right of center, finger 2 to the
+    // left.
+    assertEquals(100f + 40f, p.startX1, delta)
+    assertEquals(100f - 40f, p.startX2, delta)
+    // End radius is half of distanceEnd.
+    assertEquals(100f + 150f, p.endX1, delta)
+    assertEquals(100f - 150f, p.endX2, delta)
+  }
+
+  @Test
+  fun `start axis is always horizontal regardless of rotation`() {
+    val p =
+      computePinchPoints(
+        centerX = 540.0,
+        centerY = 960.0,
+        distanceStart = 100.0,
+        distanceEnd = 300.0,
+        rotationDegrees = 45f,
+      )
+    // Start fingers stay on the horizontal axis (y == centerY) even when rotationDegrees is
+    // non-zero.
+    assertEquals(960f, p.startY1, delta)
+    assertEquals(960f, p.startY2, delta)
+    assertEquals(540f + 50f, p.startX1, delta)
+    assertEquals(540f - 50f, p.startX2, delta)
+  }
+
+  @Test
+  fun `end axis is rotated by rotationDegrees`() {
+    val rotation = 45f
+    val p =
+      computePinchPoints(
+        centerX = 540.0,
+        centerY = 960.0,
+        distanceStart = 100.0,
+        distanceEnd = 300.0,
+        rotationDegrees = rotation,
+      )
+    val endRadius = 150.0
+    val theta = Math.toRadians(rotation.toDouble())
+    // End fingers lie on the axis rotated by `rotationDegrees` from horizontal.
+    assertEquals((540.0 + endRadius * cos(theta)).toFloat(), p.endX1, delta)
+    assertEquals((960.0 + endRadius * sin(theta)).toFloat(), p.endY1, delta)
+    assertEquals((540.0 - endRadius * cos(theta)).toFloat(), p.endX2, delta)
+    assertEquals((960.0 - endRadius * sin(theta)).toFloat(), p.endY2, delta)
+  }
+
+  @Test
+  fun `negative rotation rotates the end axis the opposite way`() {
+    val rotation = -30f
+    val p =
+      computePinchPoints(
+        centerX = 200.0,
+        centerY = 400.0,
+        distanceStart = 100.0,
+        distanceEnd = 100.0,
+        rotationDegrees = rotation,
+      )
+    val radius = 50.0
+    val theta = Math.toRadians(rotation.toDouble())
+    // Sign of rotationDegrees must flow through to the end axis — cross-platform parity relies on
+    // it. A negative angle puts endY1 below center, mirroring the positive case.
+    assertEquals((400.0 + radius * sin(theta)).toFloat(), p.endY1, delta)
+    assertEquals((200.0 + radius * cos(theta)).toFloat(), p.endX1, delta)
+    // Start axis stays horizontal regardless of the sign.
+    assertEquals(400f, p.startY1, delta)
+    assertEquals(400f, p.startY2, delta)
+  }
+
+  @Test
+  fun `zero rotation keeps both fingers on the horizontal axis`() {
+    val p =
+      computePinchPoints(
+        centerX = 0.0,
+        centerY = 0.0,
+        distanceStart = 200.0,
+        distanceEnd = 200.0,
+        rotationDegrees = 0f,
+      )
+    // No rotation: start and end axes coincide, both horizontal — the common pinch/zoom case.
+    assertEquals(0f, p.startY1, delta)
+    assertEquals(0f, p.endY1, delta)
+    assertEquals(100f, p.endX1, delta)
+    assertEquals(-100f, p.endX2, delta)
+  }
+}

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -115,6 +115,11 @@ data class RequestPinch(
   val centerY: Double,
   val distanceStart: Double,
   val distanceEnd: Double,
+  /**
+   * Degrees the two-finger axis rotates *during* the pinch (default 0): the axis starts horizontal
+   * and ends rotated by this amount — a combined pinch+rotate, not a pinch along a fixed rotated
+   * axis. Shared convention with the iOS runner. See issue #2911.
+   */
   val rotationDegrees: Float = 0f,
   val duration: Long = 300L,
 ) : WebSocketRequest()

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -16,6 +16,8 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 
 All Interactions tools — including `pinchOn`, which routes coordinate-based pinch/zoom through the runner's synthesized two-finger events — run on **Android** (physical devices and emulators) and **iOS** via the XCUITest CtrlProxy runner. iOS support is currently <kbd>📱 Simulator Only</kbd> (see the [iOS overview](../plat/ios/index.md)). `shake` is the one exception with no physical-iOS path even once physical support lands, because XCTest exposes no shake API for real devices — it returns an actionable error there.
 
+> **`pinchOn` `rotationDegrees` semantics.** `rotationDegrees` (default `0`) is how far the two-finger axis rotates *during* the pinch: the fingers start on the horizontal axis and finish on an axis rotated by `rotationDegrees`. A non-zero value therefore performs a combined **pinch + rotate**, not a pinch along a fixed rotated axis. The default `0` is a plain pinch/zoom and is unaffected. Both the Android and iOS runners deliberately share this convention so pinch results match across platforms — if you ever change it, change both runners together (see issue #2911). **Decision (#2911):** this start-horizontal / end-rotated behavior is intentional and documented rather than changed, to preserve existing cross-platform pinch results; revisit only if a concrete caller needs a pinch along a fixed rotated axis, and then only as a coordinated Android + iOS change.
+
 #### App Management
 
 - 📱 Installed apps are exposed via the `automobile:apps` resource with query filters.

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -142,6 +142,12 @@ BOOL ObjCExceptionCatcher_synthesizePinch(
         // and the target builds with -pedantic -Werror.
         CGFloat startRadius = (distanceStart > 1 ? distanceStart : 1) / 2.0;
         CGFloat endRadius = (distanceEnd > 1 ? distanceEnd : 1) / 2.0;
+        // rotationDegrees rotates the finger axis *during* the pinch, NOT the orientation of a
+        // fixed pinch axis: the fingers start on the horizontal axis (dyStart == 0) and move to an
+        // axis rotated by rotationDegrees. A non-zero value therefore produces a combined
+        // pinch+rotate; rotationDegrees == 0 (the common zoom case) keeps both axes horizontal.
+        // This matches the Android runner's computePinchPoints so cross-platform results agree.
+        // See issue #2911.
         CGFloat endRadians = rotationDegrees * (CGFloat)M_PI / 180.0;
         CGFloat dxStart = startRadius;
         CGFloat dyStart = 0;

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3382,7 +3382,7 @@
           "type": "number"
         },
         "rotationDegrees": {
-          "description": "Rotation during pinch (degrees)",
+          "description": "Degrees the two-finger axis rotates during the pinch (default: 0). The axis starts horizontal and ends rotated by this amount — a combined pinch+rotate, not a pinch along a fixed rotated axis. Same convention on Android and iOS.",
           "type": "number"
         },
         "includeSystemInsets": {

--- a/src/features/observe/shared/SharedGestureDelegate.ts
+++ b/src/features/observe/shared/SharedGestureDelegate.ts
@@ -101,6 +101,11 @@ export class SharedGestureDelegate {
     });
   }
 
+  /**
+   * Sends a two-finger pinch to the runner. `rotationDegrees` rotates the finger axis *during* the
+   * pinch (start horizontal, end rotated) — a combined pinch+rotate, not a pinch along a fixed
+   * rotated axis. `0` is a plain zoom. Same convention on Android and iOS. See issue #2911.
+   */
   async requestPinch(
     centerX: number,
     centerY: number,

--- a/src/models/PinchOnOptions.ts
+++ b/src/models/PinchOnOptions.ts
@@ -4,6 +4,14 @@ export interface PinchOnOptions {
   distanceEnd?: number;
   scale?: number;
   duration?: number;
+  /**
+   * Degrees the two-finger axis rotates *during* the pinch (default: 0).
+   *
+   * The axis starts horizontal and ends rotated by this amount, i.e. a combined pinch+rotate —
+   * NOT a pinch along a fixed rotated axis. `0` (the common zoom case) keeps the axis horizontal
+   * throughout. This convention is shared by the Android and iOS runners so results match across
+   * platforms. See issue #2911.
+   */
   rotationDegrees?: number;
   includeSystemInsets?: boolean;
   container?: {

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -230,7 +230,9 @@ export const pinchOnSchema = addDeviceTargetingToSchema(z.object({
   distanceEnd: z.number().optional().describe("Final finger distance (px, default: 100)"),
   scale: z.number().optional().describe("Scale factor (overrides distances)"),
   duration: z.number().optional().describe("Gesture duration (ms)"),
-  rotationDegrees: z.number().optional().describe("Rotation during pinch (degrees)"),
+  rotationDegrees: z.number().optional().describe(
+    "Degrees the two-finger axis rotates during the pinch (default: 0). The axis starts horizontal and ends rotated by this amount — a combined pinch+rotate, not a pinch along a fixed rotated axis. Same convention on Android and iOS."
+  ),
   includeSystemInsets: z.boolean().optional().describe("Use full screen including status/nav bars"),
   container: elementContainerSchema.optional().describe(
     "Scope search to a container"


### PR DESCRIPTION
## What

Resolves #2911 by **recording the decision (Option 1: document)** and documenting the `pinchOn` `rotationDegrees` axis convention across the tool reference, MCP schema, and both runners — plus an executable regression guard that pins the geometry.

`rotationDegrees` (default `0`) is how far the two-finger axis rotates *during* the pinch: the fingers start on the **horizontal** axis and finish on an axis **rotated by `rotationDegrees`**. A non-zero value therefore performs a combined **pinch + rotate**, not a pinch along a fixed rotated axis. The default `0` is a plain pinch/zoom and is unaffected.

Closes #2911.

## Why

The convention was undocumented and arguably surprising. It is **deliberately shared** by the Android (`CtrlProxy.performPinch`) and iOS (`ObjCExceptionCatcher` pinch synthesis) runners, so cross-platform pinch results already match — there is no divergence to fix. Per the issue's recommendation, changing the geometry would risk breaking that parity for zero concrete caller need, so the decision is to **document and leave behavior as-is** (Option 1). To keep the convention from silently regressing, the Android endpoint math is pinned by a unit test.

## How

- **Decision recorded** (Option 1: document) in this PR and in the tool reference note.
- **Tool reference** — `docs/design-docs/mcp/tools.md` gains a `rotationDegrees` semantics note, including "if you ever change it, change both runners together."
- **MCP schema** — the zod `.describe()` for `rotationDegrees` in `src/server/interactionTools.ts` now states the convention; `schemas/tool-definitions.json` regenerated via `scripts/generate-tool-definitions.ts` to match.
- **Type + delegate docs** — JSDoc added to `PinchOnOptions.rotationDegrees` and `SharedGestureDelegate.requestPinch`.
- **Runner code comments** — Android `performPinch` and iOS `ObjCExceptionCatcher` pinch synthesis both describe the start-horizontal / end-rotated convention and cross-reference each other + #2911.
- **Testability refactor (behavior-identical)** — the Android pinch endpoint trig is extracted from `performPinch` into a pure `internal fun computePinchPoints()` (`PinchGeometry.kt`), byte-for-byte the original math, so it can be unit tested without Android/Robolectric.

## Testing

- **New** `PinchGeometryTest.kt` (pure-JVM, no Robolectric) asserts the convention as an executable guard: radii are half the requested distances, the **start axis is always horizontal regardless of rotation**, the **end axis is rotated by `rotationDegrees`**, and `rotationDegrees == 0` keeps both fingers horizontal. Passes under JDK 21.
- `CtrlProxyMessageHandlerTest` still green — the `performPinch` refactor is behavior-preserving.
- TS: `bun test test/features/action/PinchOn.test.ts test/server/toolSchemaHelpers.test.ts` → 149 pass. `bun build.ts` ok; changed TS files lint clean. Regenerated `tool-definitions.json` verified in-sync by the pre-commit hook.
- The only failing tests in the full suite (ffmpeg/process-executor/executePlan) are **pre-existing environment artifacts** — they reproduce identically with this branch stashed.

## Acceptance criteria (#2911)

- [x] Decision recorded (document vs change) — **document (Option 1)**, parity preserved.
- [x] Documented: tool reference + code comments on **both** runners describe the rotation semantics.
- [x] MCP tool schema (zod + generated `tool-definitions.json`) describes the semantics.
- [x] Executable regression guard pins the start-horizontal / end-rotated geometry (`PinchGeometryTest`).
