### PR TITLE
feat(mcp): wire toolResultsNoStructuredContent flag into finalizeToolResponse (#2899)

### DIFF
--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -38,7 +38,7 @@ Part of the MCP output-context reduction effort. Each flag can be set either as 
 |---|---|---|
 | **`--observe-result-drop-elements`** | `AUTOMOBILE_OBSERVE_RESULT_DROP_ELEMENTS` | Omit the flattened `elements` array from `observe` results. |
 | **`--observe-result-compact`** | `AUTOMOBILE_OBSERVE_RESULT_COMPACT` | Emit `observe` results in a compact form. |
-| **`--tool-results-no-structured-content`** | `AUTOMOBILE_TOOL_RESULTS_NO_STRUCTURED_CONTENT` | Omit the `structuredContent` field from tool results. |
+| **`--tool-results-no-structured-content`** | `AUTOMOBILE_TOOL_RESULTS_NO_STRUCTURED_CONTENT` | Omit the `structuredContent` field from tool results (the serialized `content[0].text` still carries the full payload, so no data is lost). Also drops the advertised `outputSchema` from `tools/list` so the server does not declare structured output it will not return. |
 | **`--actions-diff-observe`** | `AUTOMOBILE_ACTIONS_DIFF_OBSERVE` | Return only the diff of the post-action observation instead of the full observation. |
 | **`--actions-no-observe`** | `AUTOMOBILE_ACTIONS_NO_OBSERVE` | Skip returning the post-action observation entirely. |
 

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -61,40 +61,47 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         payload = parsed as Record<string, unknown>;
       }
     } catch {
-      // Not JSON — nothing to sanitize, leave the response as-is.
-      return response;
+      // Not JSON — nothing to sanitize. Still fall through so the
+      // structuredContent strip below runs (a no-op when it is absent).
     }
   }
 
-  if (!payload) {
-    return response;
-  }
-
-  const cfg: SanitizeObserveConfig = {
-    dropElements: serverConfig.isObserveResultDropElementsEnabled(),
-  };
-
-  // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
-  let sanitizedPayload: Record<string, unknown> | undefined;
-  if (ctx.name === "observe" && isObserveResult(payload)) {
-    sanitizedPayload = sanitizeObserveResult(payload as unknown as ObserveResult, cfg) as unknown as Record<string, unknown>;
-  } else if (isObserveResult(payload.observation)) {
-    sanitizedPayload = {
-      ...payload,
-      observation: sanitizeObserveResult(payload.observation as ObserveResult, cfg),
+  if (payload) {
+    const cfg: SanitizeObserveConfig = {
+      dropElements: serverConfig.isObserveResultDropElementsEnabled(),
     };
+
+    // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
+    let sanitizedPayload: Record<string, unknown> | undefined;
+    if (ctx.name === "observe" && isObserveResult(payload)) {
+      sanitizedPayload = sanitizeObserveResult(payload as unknown as ObserveResult, cfg) as unknown as Record<string, unknown>;
+    } else if (isObserveResult(payload.observation)) {
+      sanitizedPayload = {
+        ...payload,
+        observation: sanitizeObserveResult(payload.observation as ObserveResult, cfg),
+      };
+    }
+
+    // Rewrite both representations from the same object so they cannot diverge.
+    if (sanitizedPayload) {
+      if (hasStructured) {
+        envelope.structuredContent = sanitizedPayload;
+      }
+      if (textPart) {
+        textPart.text = stringifyToolResponse(sanitizedPayload);
+      }
+    }
   }
 
-  if (!sanitizedPayload) {
-    return response;
-  }
-
-  // Rewrite both representations from the same object so they cannot diverge.
-  if (hasStructured) {
-    envelope.structuredContent = sanitizedPayload;
-  }
-  if (textPart) {
-    textPart.text = stringifyToolResponse(sanitizedPayload);
+  // Strip `structuredContent` when the gate is enabled (issue #2899). This runs
+  // AFTER the sanitize step, so `content[0].text` already carries the sanitized
+  // payload and remains the single source of truth — dropping the redundant
+  // duplicate halves the wire payload with no information loss. Applies to every
+  // envelope shape (observe, action, and plain payloads alike); the matching
+  // `outputSchema` is dropped from `tools/list` so the server never advertises
+  // structured output it will not return.
+  if (serverConfig.isToolResultsNoStructuredContentEnabled() && "structuredContent" in envelope) {
+    delete envelope.structuredContent;
   }
 
   return response;

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -61,47 +61,40 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         payload = parsed as Record<string, unknown>;
       }
     } catch {
-      // Not JSON — nothing to sanitize. Still fall through so the
-      // structuredContent strip below runs (a no-op when it is absent).
+      // Not JSON — nothing to sanitize, leave the response as-is.
+      return response;
     }
   }
 
-  if (payload) {
-    const cfg: SanitizeObserveConfig = {
-      dropElements: serverConfig.isObserveResultDropElementsEnabled(),
+  if (!payload) {
+    return response;
+  }
+
+  const cfg: SanitizeObserveConfig = {
+    dropElements: serverConfig.isObserveResultDropElementsEnabled(),
+  };
+
+  // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
+  let sanitizedPayload: Record<string, unknown> | undefined;
+  if (ctx.name === "observe" && isObserveResult(payload)) {
+    sanitizedPayload = sanitizeObserveResult(payload as unknown as ObserveResult, cfg) as unknown as Record<string, unknown>;
+  } else if (isObserveResult(payload.observation)) {
+    sanitizedPayload = {
+      ...payload,
+      observation: sanitizeObserveResult(payload.observation as ObserveResult, cfg),
     };
-
-    // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
-    let sanitizedPayload: Record<string, unknown> | undefined;
-    if (ctx.name === "observe" && isObserveResult(payload)) {
-      sanitizedPayload = sanitizeObserveResult(payload as unknown as ObserveResult, cfg) as unknown as Record<string, unknown>;
-    } else if (isObserveResult(payload.observation)) {
-      sanitizedPayload = {
-        ...payload,
-        observation: sanitizeObserveResult(payload.observation as ObserveResult, cfg),
-      };
-    }
-
-    // Rewrite both representations from the same object so they cannot diverge.
-    if (sanitizedPayload) {
-      if (hasStructured) {
-        envelope.structuredContent = sanitizedPayload;
-      }
-      if (textPart) {
-        textPart.text = stringifyToolResponse(sanitizedPayload);
-      }
-    }
   }
 
-  // Strip `structuredContent` when the gate is enabled (issue #2899). This runs
-  // AFTER the sanitize step, so `content[0].text` already carries the sanitized
-  // payload and remains the single source of truth — dropping the redundant
-  // duplicate halves the wire payload with no information loss. Applies to every
-  // envelope shape (observe, action, and plain payloads alike); the matching
-  // `outputSchema` is dropped from `tools/list` so the server never advertises
-  // structured output it will not return.
-  if (serverConfig.isToolResultsNoStructuredContentEnabled() && "structuredContent" in envelope) {
-    delete envelope.structuredContent;
+  if (!sanitizedPayload) {
+    return response;
+  }
+
+  // Rewrite both representations from the same object so they cannot diverge.
+  if (hasStructured) {
+    envelope.structuredContent = sanitizedPayload;
+  }
+  if (textPart) {
+    textPart.text = stringifyToolResponse(sanitizedPayload);
   }
 
   return response;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,6 +13,7 @@ import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanEx
 
 // Import the tool registry
 import { ToolRegistry } from "./toolRegistry";
+import { stripToolResultStructuredContent } from "./stripToolResultStructuredContent";
 
 // Import the resource registry
 import { ResourceRegistry } from "./resourceRegistry";
@@ -336,10 +337,15 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       : undefined;
 
     try {
-      return await runWithAbortSignal(
+      const result = await runWithAbortSignal(
         execution.abortController.signal,
         () => tool.handler(handlerParams, progressCallback, execution.abortController.signal)
       );
+      // Wire-boundary output policy: strip `structuredContent` when the
+      // `--tool-results-no-structured-content` flag is on (issue #2899). Applied
+      // here — not inside a tool handler — so internal handler callers keep
+      // reading `structuredContent`, and so plain-registered tools are covered.
+      return stripToolResultStructuredContent(result);
     } finally {
       executionTracker.endExecution(execution.id);
     }

--- a/src/server/stripToolResultStructuredContent.ts
+++ b/src/server/stripToolResultStructuredContent.ts
@@ -1,0 +1,37 @@
+import { serverConfig } from "../utils/ServerConfig";
+
+/**
+ * Wire-boundary output policy for the `--tool-results-no-structured-content`
+ * flag (issue #2899). When enabled, drops the `structuredContent` field from the
+ * MCP tool-result envelope. Handlers pre-serialize the payload into
+ * `content[0].text` alongside `structuredContent` (see
+ * `createStructuredToolResponse`), so the two are byte-identical duplicates —
+ * removing `structuredContent` halves the wire payload with no information loss.
+ *
+ * This is applied at the MCP CallTool serialization boundary, NOT inside a tool's
+ * handler, and that placement is deliberate:
+ *
+ * - Internal callers that invoke a tool's handler directly (e.g.
+ *   `DefaultUIStateSetup`'s `swipeOn` `found` detection) still receive
+ *   `structuredContent` and keep working — the strip only affects what leaves the
+ *   server toward the MCP client.
+ * - It covers every tool regardless of registration path, including plain
+ *   `register()` tools (`exportPlan`, `recordSteps`) that bypass
+ *   `finalizeToolResponse`. That keeps the stripped set aligned with the
+ *   `outputSchema` omitted from `tools/list` by `getToolDefinitions`, so the
+ *   server never advertises structured output it will not return.
+ *
+ * Non-envelope, primitive, and already-`structuredContent`-free responses pass
+ * through unchanged — a safe no-op.
+ */
+export function stripToolResultStructuredContent<T>(response: T): T {
+  if (
+    serverConfig.isToolResultsNoStructuredContentEnabled() &&
+    response !== null &&
+    typeof response === "object" &&
+    "structuredContent" in (response as Record<string, unknown>)
+  ) {
+    delete (response as Record<string, unknown>).structuredContent;
+  }
+  return response;
+}

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -724,8 +724,13 @@ class ToolRegistryClass {
   // Get tools in MCP format
   getToolDefinitions(options: ToolListingOptions = {}) {
     const alwaysLoad = process.env.AUTOMOBILE_ALWAYS_LOAD_TOOLS === "true";
+    // When tool results are stripped of `structuredContent` (issue #2899), do not
+    // advertise an `outputSchema` in `tools/list`: an MCP server that declares an
+    // output schema is expected to return matching `structuredContent`, so keeping
+    // both consistent avoids advertising output the finalize step will strip.
+    const suppressOutputSchema = serverConfig.isToolResultsNoStructuredContentEnabled();
     return this.getAllTools(options).map(tool => {
-      const outputSchema = tool.outputSchema
+      const outputSchema = tool.outputSchema && !suppressOutputSchema
         ? flattenTopLevelUnion(toJSONSchema(tool.outputSchema))
         : undefined;
 

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -215,110 +215,21 @@ describe("finalizeToolResponse", () => {
     expect(root["view-id"]).toBeUndefined();
     expect(root.clickable).toBeUndefined();
   });
-});
 
-/**
- * toolResultsNoStructuredContent gate (issue #2899). When enabled,
- * finalizeToolResponse strips `structuredContent` from the envelope, leaving
- * `content[0].text` as the single source of truth. `content[0].text` and
- * `structuredContent` are kept in sync by the sanitize step, so they are
- * redundant duplicates — dropping one halves the payload with no data loss.
- */
-describe("finalizeToolResponse — toolResultsNoStructuredContent gate", () => {
-  let originalStrip: boolean;
-  let originalDropElements: boolean;
-
-  beforeEach(() => {
-    originalStrip = serverConfig.isToolResultsNoStructuredContentEnabled();
-    originalDropElements = serverConfig.isObserveResultDropElementsEnabled();
-    serverConfig.setObserveResultDropElementsEnabled(false);
+  test("EC-B: finalize never strips structuredContent (that is a wire-boundary concern)", () => {
+    // Even with the strip flag on, finalizeToolResponse keeps structuredContent so
+    // internal handler callers (e.g. DefaultUIStateSetup's swipeOn found-detection)
+    // can still read it — the strip is applied later, only at the MCP boundary.
+    const originalStrip = serverConfig.isToolResultsNoStructuredContentEnabled();
     serverConfig.setToolResultsNoStructuredContentEnabled(true);
-  });
-
-  afterEach(() => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(originalStrip);
-    serverConfig.setObserveResultDropElementsEnabled(originalDropElements);
-  });
-
-  test("EC-A: observe response drops structuredContent, keeps sanitized text", () => {
-    const finalized = finalizeToolResponse(
-      createStructuredToolResponse(makeObserveResult()),
-      { name: "observe" }
-    );
-
-    expect("structuredContent" in finalized).toBe(false);
-    expect(finalized.content[0].type).toBe("text");
-    // EC-G: the retained text is the sanitized payload (view-id was dropped).
-    const root = JSON.parse(finalized.content[0].text).viewHierarchy.hierarchy.node;
-    expect(root["view-id"]).toBeUndefined();
-    expect(root["content-desc"]).toBe("keep-me");
-  });
-
-  test("EC-B: with the gate disabled, structuredContent is preserved", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(false);
-    const finalized = finalizeToolResponse(
-      createStructuredToolResponse(makeObserveResult()),
-      { name: "observe" }
-    );
-    expect(finalized.structuredContent).toBeDefined();
-  });
-
-  test("EC-C: action tool (outputSchema) drops structuredContent, keeps nested observation text", () => {
-    const finalized = finalizeToolResponse(
-      createStructuredToolResponse({ success: true, observation: makeObserveResult() }),
-      { name: "tapOn" }
-    );
-
-    expect("structuredContent" in finalized).toBe(false);
-    const parsed = JSON.parse(finalized.content[0].text);
-    expect(parsed.success).toBe(true);
-    // Nested observation still sanitized in the retained text.
-    expect(parsed.observation.viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
-  });
-
-  test("EC-D: non-observe payload also drops structuredContent, keeps text", () => {
-    const payload = { success: true, message: "done" };
-    const finalized = finalizeToolResponse(createStructuredToolResponse(payload), { name: "pressButton" });
-    expect("structuredContent" in finalized).toBe(false);
-    expect(JSON.parse(finalized.content[0].text)).toEqual(payload);
-  });
-
-  test("EC-E: text-only response (no structuredContent) is an unchanged no-op", () => {
-    const obs = makeObserveResult();
-    const textOnly: any = { content: [{ type: "text", text: JSON.stringify(obs) }] };
-    const finalized = finalizeToolResponse(textOnly, { name: "observe" });
-    expect("structuredContent" in finalized).toBe(false);
-    // Still sanitized.
-    expect(JSON.parse(finalized.content[0].text).viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
-  });
-
-  test("EC-E: image response (no structuredContent) passes through unchanged", () => {
-    const imageResponse: any = { content: [{ type: "image", data: "base64==", mimeType: "image/png" }] };
-    const finalized = finalizeToolResponse(imageResponse, { name: "observe" });
-    expect(finalized).toBe(imageResponse);
-    expect("structuredContent" in finalized).toBe(false);
-  });
-
-  test("EC-F: caller's in-memory ObserveResult is not mutated by the strip", () => {
-    const obs = makeObserveResult();
-    finalizeToolResponse(createStructuredToolResponse(obs), { name: "observe" });
-    expect(obs.viewHierarchy!.hierarchy.node as any).toHaveProperty("view-id");
-    expect(obs.elements).toBeDefined();
-  });
-
-  test("EC-I: interoperates with observeResultDropElements when both are enabled", () => {
-    serverConfig.setObserveResultDropElementsEnabled(true);
-    const finalized = finalizeToolResponse(
-      createStructuredToolResponse(makeObserveResult()),
-      { name: "observe" }
-    );
-    expect("structuredContent" in finalized).toBe(false);
-    // elements dropped in the retained text.
-    expect(JSON.parse(finalized.content[0].text).elements).toBeUndefined();
-  });
-
-  test("null / primitive responses are returned as-is with the gate on", () => {
-    expect(finalizeToolResponse(null, { name: "observe" })).toBeNull();
-    expect(finalizeToolResponse("plain", { name: "observe" })).toBe("plain");
+    try {
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(makeObserveResult()),
+        { name: "observe" }
+      );
+      expect(finalized.structuredContent).toBeDefined();
+    } finally {
+      serverConfig.setToolResultsNoStructuredContentEnabled(originalStrip);
+    }
   });
 });

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -216,3 +216,109 @@ describe("finalizeToolResponse", () => {
     expect(root.clickable).toBeUndefined();
   });
 });
+
+/**
+ * toolResultsNoStructuredContent gate (issue #2899). When enabled,
+ * finalizeToolResponse strips `structuredContent` from the envelope, leaving
+ * `content[0].text` as the single source of truth. `content[0].text` and
+ * `structuredContent` are kept in sync by the sanitize step, so they are
+ * redundant duplicates — dropping one halves the payload with no data loss.
+ */
+describe("finalizeToolResponse — toolResultsNoStructuredContent gate", () => {
+  let originalStrip: boolean;
+  let originalDropElements: boolean;
+
+  beforeEach(() => {
+    originalStrip = serverConfig.isToolResultsNoStructuredContentEnabled();
+    originalDropElements = serverConfig.isObserveResultDropElementsEnabled();
+    serverConfig.setObserveResultDropElementsEnabled(false);
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+  });
+
+  afterEach(() => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(originalStrip);
+    serverConfig.setObserveResultDropElementsEnabled(originalDropElements);
+  });
+
+  test("EC-A: observe response drops structuredContent, keeps sanitized text", () => {
+    const finalized = finalizeToolResponse(
+      createStructuredToolResponse(makeObserveResult()),
+      { name: "observe" }
+    );
+
+    expect("structuredContent" in finalized).toBe(false);
+    expect(finalized.content[0].type).toBe("text");
+    // EC-G: the retained text is the sanitized payload (view-id was dropped).
+    const root = JSON.parse(finalized.content[0].text).viewHierarchy.hierarchy.node;
+    expect(root["view-id"]).toBeUndefined();
+    expect(root["content-desc"]).toBe("keep-me");
+  });
+
+  test("EC-B: with the gate disabled, structuredContent is preserved", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const finalized = finalizeToolResponse(
+      createStructuredToolResponse(makeObserveResult()),
+      { name: "observe" }
+    );
+    expect(finalized.structuredContent).toBeDefined();
+  });
+
+  test("EC-C: action tool (outputSchema) drops structuredContent, keeps nested observation text", () => {
+    const finalized = finalizeToolResponse(
+      createStructuredToolResponse({ success: true, observation: makeObserveResult() }),
+      { name: "tapOn" }
+    );
+
+    expect("structuredContent" in finalized).toBe(false);
+    const parsed = JSON.parse(finalized.content[0].text);
+    expect(parsed.success).toBe(true);
+    // Nested observation still sanitized in the retained text.
+    expect(parsed.observation.viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+  });
+
+  test("EC-D: non-observe payload also drops structuredContent, keeps text", () => {
+    const payload = { success: true, message: "done" };
+    const finalized = finalizeToolResponse(createStructuredToolResponse(payload), { name: "pressButton" });
+    expect("structuredContent" in finalized).toBe(false);
+    expect(JSON.parse(finalized.content[0].text)).toEqual(payload);
+  });
+
+  test("EC-E: text-only response (no structuredContent) is an unchanged no-op", () => {
+    const obs = makeObserveResult();
+    const textOnly: any = { content: [{ type: "text", text: JSON.stringify(obs) }] };
+    const finalized = finalizeToolResponse(textOnly, { name: "observe" });
+    expect("structuredContent" in finalized).toBe(false);
+    // Still sanitized.
+    expect(JSON.parse(finalized.content[0].text).viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+  });
+
+  test("EC-E: image response (no structuredContent) passes through unchanged", () => {
+    const imageResponse: any = { content: [{ type: "image", data: "base64==", mimeType: "image/png" }] };
+    const finalized = finalizeToolResponse(imageResponse, { name: "observe" });
+    expect(finalized).toBe(imageResponse);
+    expect("structuredContent" in finalized).toBe(false);
+  });
+
+  test("EC-F: caller's in-memory ObserveResult is not mutated by the strip", () => {
+    const obs = makeObserveResult();
+    finalizeToolResponse(createStructuredToolResponse(obs), { name: "observe" });
+    expect(obs.viewHierarchy!.hierarchy.node as any).toHaveProperty("view-id");
+    expect(obs.elements).toBeDefined();
+  });
+
+  test("EC-I: interoperates with observeResultDropElements when both are enabled", () => {
+    serverConfig.setObserveResultDropElementsEnabled(true);
+    const finalized = finalizeToolResponse(
+      createStructuredToolResponse(makeObserveResult()),
+      { name: "observe" }
+    );
+    expect("structuredContent" in finalized).toBe(false);
+    // elements dropped in the retained text.
+    expect(JSON.parse(finalized.content[0].text).elements).toBeUndefined();
+  });
+
+  test("null / primitive responses are returned as-is with the gate on", () => {
+    expect(finalizeToolResponse(null, { name: "observe" })).toBeNull();
+    expect(finalizeToolResponse("plain", { name: "observe" })).toBe("plain");
+  });
+});

--- a/test/server/stripToolResultStructuredContent.test.ts
+++ b/test/server/stripToolResultStructuredContent.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { stripToolResultStructuredContent } from "../../src/server/stripToolResultStructuredContent";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import { serverConfig } from "../../src/utils/ServerConfig";
+
+/**
+ * Wire-boundary strip for the `--tool-results-no-structured-content` flag
+ * (issue #2899). `content[0].text` and `structuredContent` are byte-identical
+ * duplicates, so dropping the latter halves the wire payload with no data loss.
+ */
+describe("stripToolResultStructuredContent", () => {
+  let original: boolean;
+
+  beforeEach(() => {
+    original = serverConfig.isToolResultsNoStructuredContentEnabled();
+  });
+
+  afterEach(() => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(original);
+  });
+
+  test("EC-A: drops structuredContent when the gate is enabled, keeps content text", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const payload = { success: true, message: "done", nested: { a: 1 } };
+    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload));
+
+    expect("structuredContent" in response).toBe(false);
+    expect(response.content[0].type).toBe("text");
+    // Full payload is still recoverable from the retained text — no data loss.
+    expect(JSON.parse(response.content[0].text)).toEqual(payload);
+  });
+
+  test("EC-B: preserves structuredContent when the gate is disabled", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const response = stripToolResultStructuredContent(createStructuredToolResponse({ success: true }));
+    expect(response.structuredContent).toEqual({ success: true });
+  });
+
+  test("EC-D: strips regardless of payload shape (covers plain-registered tools)", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    // e.g. exportPlan/recordSteps: declare an outputSchema, bypass finalizeToolResponse.
+    const response = stripToolResultStructuredContent(
+      createStructuredToolResponse({ success: true, plan: "steps:\n  - tapOn: {}" })
+    );
+    expect("structuredContent" in response).toBe(false);
+    expect(JSON.parse(response.content[0].text).plan).toBe("steps:\n  - tapOn: {}");
+  });
+
+  test("EC-E: response without structuredContent is an unchanged no-op", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const imageResponse: any = { content: [{ type: "image", data: "b64", mimeType: "image/png" }] };
+    const result = stripToolResultStructuredContent(imageResponse);
+    expect(result).toBe(imageResponse);
+    expect("structuredContent" in result).toBe(false);
+  });
+
+  test("null / primitive responses pass through untouched", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    expect(stripToolResultStructuredContent(null)).toBeNull();
+    expect(stripToolResultStructuredContent(undefined)).toBeUndefined();
+    expect(stripToolResultStructuredContent("plain")).toBe("plain");
+    expect(stripToolResultStructuredContent(42)).toBe(42);
+  });
+});

--- a/test/server/stripToolResultWireBoundary.test.ts
+++ b/test/server/stripToolResultWireBoundary.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+
+/**
+ * End-to-end proof that the `--tool-results-no-structured-content` strip runs at
+ * the real MCP CallTool boundary (`src/server/index.ts`). Uses a plain
+ * `ToolRegistry.register()` probe — the same non-device registration path as
+ * `exportPlan`/`recordSteps` — so this also covers the tools that bypass
+ * `finalizeToolResponse`.
+ */
+describe("CallTool wire boundary strips structuredContent (issue #2899)", () => {
+  let fixture: McpTestFixture;
+  const TOOL = "__strip_probe_2899__";
+
+  beforeAll(async () => {
+    ToolRegistry.register(
+      TOOL,
+      "probe tool for structuredContent strip",
+      z.object({}).passthrough(),
+      async () => createStructuredToolResponse({ success: true, marker: "probe" })
+    );
+    fixture = new McpTestFixture();
+    await fixture.setup();
+  });
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.teardown();
+    }
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+  });
+
+  afterEach(() => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+  });
+
+  test("gate off: structuredContent is present on the wire", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const { client } = fixture.getContext();
+    const res: any = await client.callTool({ name: TOOL, arguments: {} });
+    expect(res.structuredContent).toBeDefined();
+    expect(res.structuredContent.marker).toBe("probe");
+  });
+
+  test("gate on: structuredContent stripped, content text retains the full payload", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const { client } = fixture.getContext();
+    const res: any = await client.callTool({ name: TOOL, arguments: {} });
+    expect(res.structuredContent).toBeUndefined();
+    // No data lost: the full payload is still recoverable from content[0].text.
+    expect(JSON.parse(res.content[0].text).marker).toBe("probe");
+  });
+});

--- a/test/server/tools/registry.test.ts
+++ b/test/server/tools/registry.test.ts
@@ -1,6 +1,7 @@
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { createMcpServer } from "../../../src/server/index";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { serverConfig } from "../../../src/utils/ServerConfig";
 
 describe("MCP Tools Registry", () => {
   beforeAll(() => {
@@ -69,6 +70,27 @@ describe("MCP Tools Registry", () => {
       expect(tool!.outputSchema.properties).toHaveProperty("success");
       expect(tool!.outputSchema.required).toContain("success");
     }
+  });
+
+  describe("toolResultsNoStructuredContent gate (issue #2899)", () => {
+    afterEach(() => {
+      serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    });
+
+    test("EC-H: omits outputSchema from tool definitions when the gate is enabled", () => {
+      // Baseline: outputSchema advertised when the gate is off.
+      serverConfig.setToolResultsNoStructuredContentEnabled(false);
+      const withSchema = ToolRegistry.getToolDefinitions().find(t => t.name === "tapOn");
+      expect(withSchema).toHaveProperty("outputSchema");
+
+      // With the gate on, the server no longer advertises structuredContent output,
+      // keeping tools/list consistent with the stripped tool results.
+      serverConfig.setToolResultsNoStructuredContentEnabled(true);
+      const defs = ToolRegistry.getToolDefinitions();
+      for (const def of defs) {
+        expect(def.outputSchema).toBeUndefined();
+      }
+    });
   });
 
   test("should register all tool categories", () => {


### PR DESCRIPTION
## What

Wires the `--tool-results-no-structured-content` output-reduction flag (env: `AUTOMOBILE_TOOL_RESULTS_NO_STRUCTURED_CONTENT`) so it actually does something.

Closes #2899.

## Why

The flag was **fully plumbed but consumed by nothing**: it flowed CLI/env → `outputReductionFlags` → `ServerConfig`, but no production code read `serverConfig.isToolResultsNoStructuredContentEnabled()` (only tests referenced the getter). Enabling it had **no effect** on tool output.

`structuredContent` and `content[0].text` are byte-identical duplicates of the same payload (see `createStructuredToolResponse`), so the payload ships **twice** on the wire. Dropping `structuredContent` halves it with **zero information loss** — `content[0].text` remains the single source of truth.

## How

**1. Strip at the MCP wire boundary (`src/server/index.ts`).** When the gate is on, the CallTool serialization handler drops `structuredContent` from the returned envelope via a small pure helper, `stripToolResultStructuredContent` (`src/server/stripToolResultStructuredContent.ts`). Placing it at the boundary — not inside a tool handler — is deliberate:
- Internal callers that invoke a tool's handler directly (e.g. `DefaultUIStateSetup`'s `swipeOn` `found`-detection) still read `structuredContent` and keep working.
- It covers **every** tool regardless of registration path, including plain `register()` tools (`exportPlan`, `recordSteps`) that bypass `finalizeToolResponse`.

The daemon runs `createMcpServer`, so the strip runs in the process where the flag lives; the proxy relays the already-stripped result.

**2. Resolve the `outputSchema` interaction (`src/server/toolRegistry.ts`).** An MCP server advertising an `outputSchema` in `tools/list` is expected to return matching `structuredContent`. Rather than gate the strip to schema-less tools (which would make the flag near-useless — the token-heavy `observe`/`tapOn` tools all declare an `outputSchema`), `getToolDefinitions` **omits the advertised `outputSchema`** when the flag is on. The server no longer declares structured output it will not return, so `tools/list` stays consistent with the stripped results.

Also documents the behavior in `docs/design-docs/mcp/feature-flags.md`.

## Testing

TDD — tests written first (red), then implementation (green). After an adversarial 3-perspective review the strip was relocated from `finalizeToolResponse` to the wire boundary (see the review comment below); tests were updated accordingly.

- `test/server/stripToolResultStructuredContent.test.ts` — helper unit tests: strips when on / preserves when off / no-op on responses without `structuredContent` / primitive passthrough / covers plain-registered payloads.
- `test/server/stripToolResultWireBoundary.test.ts` — **end-to-end** through `McpTestFixture`: a plain `register()` probe tool, called via a real MCP client, returns no `structuredContent` when the flag is on (and the full payload survives in `content[0].text`), present when off.
- `test/server/finalizeToolResponse.test.ts` — asserts `finalizeToolResponse` **never** strips (protecting internal handler callers).
- `test/server/tools/registry.test.ts` (EC-H) — `getToolDefinitions` omits `outputSchema` when the gate is on, advertises it when off.

Verified: `bun test` **5897 pass, 0 fail** (full suite); `bun run lint` clean; `bun run build` ok; pre-commit `schemas/tool-definitions.json` regeneration confirms no drift (default-off flag).

## Acceptance criteria (#2899)
- [x] Gate enabled → the tool-result envelope has no `structuredContent`; `content[0].text` still carries the full payload.
- [x] Gate disabled → `structuredContent` present (regression guard).
- [x] A tool with an `outputSchema` is covered explicitly, and the `outputSchema` interaction is resolved (dropped from `tools/list` when the flag is on).
