### PR TITLE
fix(db): fence stale in-flight migration completions across close+reopen (#2898)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -107,6 +107,16 @@ let migrationsPromise: Promise<void> | null = null;
 // `ensureMigrations`) can re-check and rethrow it. The failure is sticky: we
 // never null `migrationsPromise` to auto-retry (see issues #2784/#2786/#2796).
 let migrationsError: Error | null = null;
+// Monotonic generation token fencing off stale migration completions. Nulling
+// `migrationsPromise` in `closeDatabase()` does NOT cancel the still-running
+// detached `startMigrations().then(...)` chain — it runs on its own
+// `migrationDb` and settles independently. If a `getDatabase()` reopen starts a
+// NEW generation of migration state before the old chain settles, the stale
+// handler would overwrite the new generation's `migrationsRun`/`migrationsError`.
+// `ensureMigrationsStarted()` captures this counter when it creates the promise;
+// its handlers only write the globals if their captured generation still matches.
+// `closeDatabase()` bumps it, so any handler from a superseded run no-ops (#2898).
+let migrationsGeneration = 0;
 
 export const DATABASE_STARTUP_MIGRATION_FAILURE =
   "Database startup migrations failed; refusing to run queries until the daemon restarts.";
@@ -192,7 +202,9 @@ async function startMigrations(dbPath: string): Promise<void> {
       lock: createFileMigrationLock(dbPath),
       backup: () => backupDatabaseFile(migrationDb, dbPath),
     });
-    migrationsRun = true;
+    // `migrationsRun` is NOT set here: it is a fenced global written only by the
+    // generation-guarded success handler in `ensureMigrationsStarted()`, so a
+    // superseded run (closeDatabase()+reopen) can't flip it on the new generation.
   } catch (error) {
     logger.error("Failed to run migrations on database initialization:", error);
     throw error;
@@ -203,13 +215,24 @@ async function startMigrations(dbPath: string): Promise<void> {
 
 function ensureMigrationsStarted(dbPath: string): void {
   if (!migrationsRun && !migrationsPromise) {
+    // Capture the generation so a completion that lands after a
+    // closeDatabase()+reopen (which bumps the counter) is dropped instead of
+    // stomping the newer generation's `migrationsRun`/`migrationsError` (#2898).
+    const generation = migrationsGeneration;
     // Resolve (never reject) so a failed migration does not float an unhandled
     // rejection; cache the error for synchronous re-checking by awaiters.
     migrationsPromise = startMigrations(dbPath).then(
       () => {
+        if (generation !== migrationsGeneration) {
+          return; // Superseded run; its DB is already destroyed. Drop silently.
+        }
+        migrationsRun = true;
         migrationsError = null;
       },
       error => {
+        if (generation !== migrationsGeneration) {
+          return; // Superseded run; do not resurrect a stale failure.
+        }
         migrationsError = createStartupMigrationError(error);
       }
     );
@@ -303,6 +326,13 @@ export async function closeDatabase(): Promise<void> {
   migrationsPromise = null;
   migrationsError = null;
   resolvedDbPath = null;
+
+  // Bump the generation so any still-in-flight `startMigrations().then(...)` from
+  // the just-closed generation no-ops when it settles instead of overwriting the
+  // globals a subsequent reopen establishes. Nulling `migrationsPromise` above
+  // drops our reference but cannot cancel the detached chain (it runs on its own
+  // `migrationDb`); the fence is what makes the stale completion inert (#2898).
+  migrationsGeneration += 1;
 
   // Cold-start the write barrier too (issue #2896, follow-up to #2796). Its
   // draining flag latches for the process lifetime, so shutdown's

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -298,6 +298,19 @@ export function getMigrationsError(): Error | null {
 }
 
 /**
+ * Test-only handle on the in-flight migration promise (the resolve-never-reject
+ * `.then` chain built in {@link ensureMigrationsStarted}), or null when no run is
+ * in flight. Exposed so the generation-fence regression test can capture a
+ * generation's promise while it is blocked, then deterministically `await` its
+ * completion after a `closeDatabase()` + reopen — proving the settled stale
+ * handler no-ops instead of racing a fixed delay. Not part of the daemon
+ * contract; do not use in production paths (issue #2898).
+ */
+export function getMigrationsPromiseForTest(): Promise<void> | null {
+  return migrationsPromise;
+}
+
+/**
  * Close the database connection.
  * Call this during graceful shutdown.
  */

--- a/test/db/databaseMigrationGenerationFence.test.ts
+++ b/test/db/databaseMigrationGenerationFence.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+
+/**
+ * Regression tests for issue #2898 (follow-up to #2889 / #2796).
+ *
+ * `ensureMigrationsStarted()` builds `migrationsPromise` with `.then` handlers
+ * that mutate the module globals `migrationsRun` / `migrationsError`. Nulling
+ * those globals in `closeDatabase()` does NOT cancel the still-running detached
+ * `startMigrations().then(...)` chain — it runs on its own `migrationDb` and
+ * completes independently. If a `getDatabase()` reopen starts a NEW generation
+ * of migration state before the old chain settles, the stale handler would
+ * overwrite the new generation's `migrationsError`/`migrationsRun`.
+ *
+ * The fix captures a monotonic generation token when `migrationsPromise` is
+ * created; both handlers no-op when their captured generation no longer matches
+ * the current one (a `closeDatabase()` bumped it). These tests force a slow
+ * migration, `closeDatabase()` mid-flight, reopen a fresh generation, then let
+ * the stale completion fire and assert it cannot corrupt the new generation.
+ *
+ * The globals are module-scoped and not exported, so each assertion drives the
+ * fence through observable behavior (`getMigrationsError()` / query gating)
+ * rather than reading internals. A fresh module instance per case isolates the
+ * lazy globals, matching databaseReset.test.ts / databaseMigrationFailure.test.ts.
+ */
+describe("closeDatabase fences stale in-flight migration completions (issue #2898)", () => {
+  const savedEnv = new Map<string, string | undefined>();
+  const trackedEnvKeys = [
+    DAEMON_LAUNCH_CWD_ENV,
+    "AUTOMOBILE_DB_DIR",
+    "AUTOMOBILE_DB_PATH",
+    "AUTO_MOBILE_DB_PATH",
+    "AUTOMOBILE_MIGRATIONS_DIR",
+    "AUTO_MOBILE_MIGRATIONS_DIR",
+  ];
+  const tempDirs: string[] = [];
+
+  for (const key of trackedEnvKeys) {
+    savedEnv.set(key, process.env[key]);
+  }
+
+  function setEnv(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  afterEach(async () => {
+    for (const key of trackedEnvKeys) {
+      setEnv(key, savedEnv.get(key));
+    }
+    for (const dir of tempDirs.splice(0)) {
+      await removeTempDirWithRetry(dir);
+    }
+  });
+
+  async function importFreshDatabaseModule() {
+    return import(`../../src/db/database.ts?gen-fence-test=${Date.now()}-${Math.random()}`);
+  }
+
+  async function makeTempDir(prefix: string): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function removeTempDirWithRetry(dir: string): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        await rm(dir, { recursive: true, force: true });
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
+          throw error;
+        }
+        await defaultTimer.sleep(50);
+      }
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  /**
+   * A migrations dir with a single migration whose `up()` blocks until a
+   * `release` marker appears, letting the test hold the migration "in flight"
+   * across a `closeDatabase()`. It signals entry via a `started` marker and exit
+   * via a `done` marker. In "fail" mode it throws after release; in "succeed"
+   * mode it returns normally.
+   */
+  async function makeSlowMigrationsDir(
+    mode: "fail" | "succeed",
+    markers: { started: string; release: string; done: string }
+  ): Promise<string> {
+    const dir = await makeTempDir(`auto-mobile-gen-fence-mig-${mode}-`);
+    const throwLine =
+      mode === "fail"
+        ? 'throw new Error("intentional slow migration failure (#2898 gen-fence test)");'
+        : "";
+    const content = `import { promises as fsp } from "fs";
+import { existsSync } from "fs";
+
+export async function up() {
+  await fsp.writeFile(${JSON.stringify(markers.started)}, "1");
+  for (let i = 0; i < 5000; i += 1) {
+    if (existsSync(${JSON.stringify(markers.release)})) break;
+    await new Promise(resolve => setTimeout(resolve, 2));
+  }
+  await fsp.writeFile(${JSON.stringify(markers.done)}, "1");
+  ${throwLine}
+}
+
+export async function down() {}
+`;
+    await writeFile(path.join(dir, "0001_slow_test_migration.ts"), content, "utf8");
+    return dir;
+  }
+
+  /**
+   * A migrations dir with one trivial, fast, always-succeeding migration. It
+   * uses only the injected Kysely `db` (no bare `import`), so it resolves cleanly
+   * even though the generated file lives in a temp dir with no node_modules.
+   */
+  async function makeHealthyMigrationsDir(): Promise<string> {
+    const dir = await makeTempDir("auto-mobile-gen-fence-healthy-");
+    const content = `export async function up(db) {
+  await db.schema
+    .createTable("gen_fence_probe")
+    .ifNotExists()
+    .addColumn("id", "integer", col => col.primaryKey())
+    .execute();
+}
+
+export async function down(db) {
+  await db.schema.dropTable("gen_fence_probe").ifExists().execute();
+}
+`;
+    await writeFile(path.join(dir, "0001_healthy_test_migration.ts"), content, "utf8");
+    return dir;
+  }
+
+  async function waitForMarker(marker: string, label: string): Promise<void> {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (existsSync(marker)) {
+        return;
+      }
+      await defaultTimer.sleep(2);
+    }
+    throw new Error(`Timed out waiting for ${label} marker: ${marker}`);
+  }
+
+  function markerPaths(root: string): { started: string; release: string; done: string } {
+    return {
+      started: path.join(root, "started"),
+      release: path.join(root, "release"),
+      done: path.join(root, "done"),
+    };
+  }
+
+  test("stale FAILURE after close+reopen cannot set the new generation's migrationsError", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const markerRoot = await makeTempDir("auto-mobile-gen-fence-markers-");
+      const markers = markerPaths(markerRoot);
+      const slowFailDir = await makeSlowMigrationsDir("fail", markers);
+      const dbDir1 = await makeTempDir("auto-mobile-gen-fence-db1-");
+
+      setEnv(DAEMON_LAUNCH_CWD_ENV, undefined);
+      setEnv("AUTOMOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_MIGRATIONS_DIR", undefined);
+      setEnv("AUTOMOBILE_DB_DIR", dbDir1);
+      setEnv("AUTOMOBILE_MIGRATIONS_DIR", slowFailDir);
+
+      const db = await importFreshDatabaseModule();
+
+      // Generation 0: start the slow, will-fail migration and hold it in flight.
+      db.getDatabase();
+      await waitForMarker(markers.started, "generation-0 started");
+
+      // Close mid-flight: resets globals + bumps the generation. The detached
+      // gen-0 chain is still blocked on the release marker.
+      await db.closeDatabase();
+
+      // Generation 1: reopen against a fresh, healthy DB + migrations. It runs to
+      // completion cleanly, so migrationsError must be null.
+      const dbDir2 = await makeTempDir("auto-mobile-gen-fence-db2-");
+      setEnv("AUTOMOBILE_DB_DIR", dbDir2);
+      setEnv("AUTOMOBILE_MIGRATIONS_DIR", await makeHealthyMigrationsDir());
+
+      db.getDatabase();
+      await db.ensureMigrations();
+      expect(db.getMigrationsError()).toBeNull();
+
+      // Release the stale gen-0 migration so it proceeds and THROWS.
+      await writeFile(markers.release, "1");
+      await waitForMarker(markers.done, "generation-0 done");
+
+      // Let the detached gen-0 `.then(onRejected)` settle. Without the fence it
+      // would set migrationsError, corrupting the healthy generation 1.
+      await defaultTimer.sleep(60);
+
+      expect(db.getMigrationsError()).toBeNull();
+
+      await db.closeDatabase();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  test("stale SUCCESS after close+reopen cannot clear the new generation's cached error", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const markerRoot = await makeTempDir("auto-mobile-gen-fence-markers2-");
+      const markers = markerPaths(markerRoot);
+      const slowSucceedDir = await makeSlowMigrationsDir("succeed", markers);
+      const dbDir1 = await makeTempDir("auto-mobile-gen-fence-db1s-");
+
+      setEnv(DAEMON_LAUNCH_CWD_ENV, undefined);
+      setEnv("AUTOMOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_MIGRATIONS_DIR", undefined);
+      setEnv("AUTOMOBILE_DB_DIR", dbDir1);
+      setEnv("AUTOMOBILE_MIGRATIONS_DIR", slowSucceedDir);
+
+      const db = await importFreshDatabaseModule();
+
+      // Generation 0: start the slow, will-succeed migration and hold it.
+      db.getDatabase();
+      await waitForMarker(markers.started, "generation-0 started");
+
+      await db.closeDatabase();
+
+      // Generation 1: reopen against a path that fails to open (a directory), so
+      // this generation caches a startup-migration error.
+      const failDir = await makeTempDir("auto-mobile-gen-fence-faildir-");
+      setEnv("AUTOMOBILE_DB_PATH", failDir); // a directory, not a file
+      setEnv("AUTOMOBILE_DB_DIR", undefined);
+
+      db.getDatabase();
+      await expect(db.ensureMigrations()).rejects.toThrow(
+        /refusing to run queries until the daemon restarts/i
+      );
+      expect(db.getMigrationsError()).not.toBeNull();
+
+      // Release the stale gen-0 migration so it SUCCEEDS.
+      await writeFile(markers.release, "1");
+      await waitForMarker(markers.done, "generation-0 done");
+
+      // Let the detached gen-0 `.then(onFulfilled)` settle. Without the fence it
+      // would set migrationsRun=true and clear migrationsError, wrongly reviving a
+      // generation whose boot actually failed.
+      await defaultTimer.sleep(60);
+
+      expect(db.getMigrationsError()).not.toBeNull();
+      // The new generation is still query-dead — a stale success did not revive it.
+      await expect(db.ensureMigrations()).rejects.toThrow(
+        /refusing to run queries until the daemon restarts/i
+      );
+
+      await db.closeDatabase();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/test/db/databaseMigrationGenerationFence.test.ts
+++ b/test/db/databaseMigrationGenerationFence.test.ts
@@ -289,4 +289,76 @@ export async function down(db) {
       process.off("unhandledRejection", onUnhandled);
     }
   });
+
+  test("stale FAILURE cannot corrupt a SAME-DB-PATH reopen's generation (default reopen axis)", async () => {
+    // The two tests above switch the DB directory between generations, so they
+    // never exercise the default close+reopen case where the environment is
+    // unchanged and both generations target the SAME database file. Here gen-0
+    // and gen-1 use the same `AUTOMOBILE_DB_DIR` (identical DB path), only the
+    // migrations dir differs, so the fence is proven on the same-file axis.
+    //
+    // NOTE — this also exercises the lock-stealing hazard tracked separately in
+    // issue #2947: while gen-0 is blocked mid-migration it still holds
+    // `${path}.migrate.lock` (owner = our PID), and gen-1 reclaims that lock via
+    // `FileMigrationLock`'s `reclaimOwnPid: true`. The generation fence only
+    // protects the module globals; it does NOT serialize the two migration runs.
+    // This case is benign — gen-0's fail migration throws WITHOUT writing, so the
+    // stolen-lock concurrent access touches no schema — which is exactly why it is
+    // a clean fence proof rather than a lock-safety proof. #2947 covers the
+    // writes-during-reopen concurrency.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const markerRoot = await makeTempDir("auto-mobile-gen-fence-markers3-");
+      const markers = markerPaths(markerRoot);
+      const slowFailDir = await makeSlowMigrationsDir("fail", markers);
+      // One DB dir shared by BOTH generations -> the same DB file path on reopen.
+      const sharedDbDir = await makeTempDir("auto-mobile-gen-fence-samepath-");
+
+      setEnv(DAEMON_LAUNCH_CWD_ENV, undefined);
+      setEnv("AUTOMOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_MIGRATIONS_DIR", undefined);
+      setEnv("AUTOMOBILE_DB_DIR", sharedDbDir);
+      setEnv("AUTOMOBILE_MIGRATIONS_DIR", slowFailDir);
+
+      const db = await importFreshDatabaseModule();
+
+      // Generation 0: slow, will-fail migration on the shared DB path, held in flight.
+      db.getDatabase();
+      const gen0DbPath = db.getDatabasePath();
+      await waitForMarker(markers.started, "generation-0 started");
+
+      const staleCompletion = db.getMigrationsPromiseForTest() as Promise<void> | null;
+      expect(staleCompletion).not.toBeNull();
+
+      await db.closeDatabase();
+
+      // Generation 1: reopen at the SAME DB path (env unchanged except a healthy
+      // migrations dir). It reclaims gen-0's still-held own-PID lock and migrates
+      // cleanly, so migrationsError must be null.
+      setEnv("AUTOMOBILE_MIGRATIONS_DIR", await makeHealthyMigrationsDir());
+
+      db.getDatabase();
+      expect(db.getDatabasePath()).toBe(gen0DbPath); // same file across generations
+      await db.ensureMigrations();
+      expect(db.getMigrationsError()).toBeNull();
+
+      // Release the stale gen-0 migration so it throws, then await its detached
+      // chain deterministically. The fence must keep gen-1's clean state.
+      await writeFile(markers.release, "1");
+      await staleCompletion;
+
+      expect(db.getMigrationsError()).toBeNull();
+
+      await db.closeDatabase();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
 });

--- a/test/db/databaseMigrationGenerationFence.test.ts
+++ b/test/db/databaseMigrationGenerationFence.test.ts
@@ -96,7 +96,7 @@ describe("closeDatabase fences stale in-flight migration completions (issue #289
    */
   async function makeSlowMigrationsDir(
     mode: "fail" | "succeed",
-    markers: { started: string; release: string; done: string }
+    markers: { started: string; release: string }
   ): Promise<string> {
     const dir = await makeTempDir(`auto-mobile-gen-fence-mig-${mode}-`);
     const throwLine =
@@ -112,7 +112,6 @@ export async function up() {
     if (existsSync(${JSON.stringify(markers.release)})) break;
     await new Promise(resolve => setTimeout(resolve, 2));
   }
-  await fsp.writeFile(${JSON.stringify(markers.done)}, "1");
   ${throwLine}
 }
 
@@ -155,11 +154,10 @@ export async function down(db) {
     throw new Error(`Timed out waiting for ${label} marker: ${marker}`);
   }
 
-  function markerPaths(root: string): { started: string; release: string; done: string } {
+  function markerPaths(root: string): { started: string; release: string } {
     return {
       started: path.join(root, "started"),
       release: path.join(root, "release"),
-      done: path.join(root, "done"),
     };
   }
 
@@ -189,6 +187,12 @@ export async function down(db) {
       db.getDatabase();
       await waitForMarker(markers.started, "generation-0 started");
 
+      // Capture gen-0's resolve-never-reject `.then` chain while it is blocked so
+      // we can deterministically await its completion later (the chain resolves
+      // only after its stale handler runs) instead of racing a fixed delay.
+      const staleCompletion = db.getMigrationsPromiseForTest() as Promise<void> | null;
+      expect(staleCompletion).not.toBeNull();
+
       // Close mid-flight: resets globals + bumps the generation. The detached
       // gen-0 chain is still blocked on the release marker.
       await db.closeDatabase();
@@ -205,11 +209,12 @@ export async function down(db) {
 
       // Release the stale gen-0 migration so it proceeds and THROWS.
       await writeFile(markers.release, "1");
-      await waitForMarker(markers.done, "generation-0 done");
 
-      // Let the detached gen-0 `.then(onRejected)` settle. Without the fence it
-      // would set migrationsError, corrupting the healthy generation 1.
-      await defaultTimer.sleep(60);
+      // Deterministically await the detached gen-0 chain: it resolves (never
+      // rejects) only after its `.then(onRejected)` handler has run. Without the
+      // fence that handler would set migrationsError, corrupting the healthy
+      // generation 1. Awaiting the promise removes any reliance on a fixed delay.
+      await staleCompletion;
 
       expect(db.getMigrationsError()).toBeNull();
 
@@ -246,6 +251,9 @@ export async function down(db) {
       db.getDatabase();
       await waitForMarker(markers.started, "generation-0 started");
 
+      const staleCompletion = db.getMigrationsPromiseForTest() as Promise<void> | null;
+      expect(staleCompletion).not.toBeNull();
+
       await db.closeDatabase();
 
       // Generation 1: reopen against a path that fails to open (a directory), so
@@ -262,12 +270,12 @@ export async function down(db) {
 
       // Release the stale gen-0 migration so it SUCCEEDS.
       await writeFile(markers.release, "1");
-      await waitForMarker(markers.done, "generation-0 done");
 
-      // Let the detached gen-0 `.then(onFulfilled)` settle. Without the fence it
-      // would set migrationsRun=true and clear migrationsError, wrongly reviving a
+      // Deterministically await the detached gen-0 chain (resolves only after its
+      // `.then(onFulfilled)` handler runs). Without the fence that handler would
+      // set migrationsRun=true and clear migrationsError, wrongly reviving a
       // generation whose boot actually failed.
-      await defaultTimer.sleep(60);
+      await staleCompletion;
 
       expect(db.getMigrationsError()).not.toBeNull();
       // The new generation is still query-dead — a stale success did not revive it.


### PR DESCRIPTION
## What

Adds a **generation fence** to the migration state machine in `src/db/database.ts` so an in-flight `startMigrations().then(...)` chain that settles *after* a `closeDatabase()` + reopen can no longer stomp the new generation's `migrationsRun`/`migrationsError`.

Closes #2898 (follow-up to #2889 / #2796; found by the PR #2889 correctness audit — Mira Kessler persona, finding #2 caveat).

## Why

`ensureMigrationsStarted()` builds `migrationsPromise` with `.then(onFulfilled, onRejected)` handlers that mutate the module globals. `closeDatabase()` (post-#2796) nulls `migrationsPromise`/`migrationsRun`/`migrationsError`/`resolvedDbPath`, but **nulling the JS reference does not cancel the detached chain** — it runs on its own `migrationDb` and completes independently. If a `getDatabase()` reopen starts a **new** generation of migration state before the old chain settles, the stale handler eventually fires and overwrites the newer generation's error/run state. There was no generation token to drop stale completions.

Latent today (the only `closeDatabase()` caller is daemon shutdown-then-exit, with no reopen), P3 — filed so it isn't lost when an in-process reopen path lands.

## How

- Add a monotonically-increasing module global `migrationsGeneration` (starts at 0).
- `ensureMigrationsStarted()` captures `const generation = migrationsGeneration` when it creates the promise. Both `.then` handlers **no-op when `generation !== migrationsGeneration`** (a superseded run).
- Move `migrationsRun = true` **out of** `startMigrations()` (where it was set unconditionally) **into** the generation-guarded success handler, so the success flag is fenced too — otherwise a stale success would flip `migrationsRun` on the new generation even with the error guard in place.
- `closeDatabase()` bumps `migrationsGeneration += 1` alongside the existing reset. Any handler captured before the close now sees a mismatch and drops.

**Invariant that makes bumping only in `closeDatabase()` sufficient:** the only path that starts a new generation is `ensureMigrationsStarted()`'s `!migrationsRun && !migrationsPromise` guard, and the only way to clear `migrationsPromise` (after either success or a cached failure) is `closeDatabase()`. So every new generation is preceded by exactly one bump — no window has two live generations that both match.

The fence is **inert on the normal cold-start / no-reopen path** (generation stays stable, writes land as before) and in the daemon (shutdown-then-`process.exit`, one extra integer increment).

## Testing

New `test/db/databaseMigrationGenerationFence.test.ts` (mirrors `databaseReset.test.ts`: fresh module instance per case, real file DBs, EBUSY-retry temp cleanup). It generates a temp migration whose `up()` blocks on a filesystem `release` marker to hold a migration **in flight** across a `closeDatabase()`, then reopens a fresh generation and releases the stale one:

- **Stale FAILURE** after close+reopen cannot set the new generation's `migrationsError` (gen-0 slow-fail, reopen healthy gen-1, release gen-0 → `getMigrationsError()` stays null).
- **Stale SUCCESS** after close+reopen cannot clear the new generation's cached error (gen-0 slow-succeed, reopen at a bad path so gen-1 fails, release gen-0 → error preserved, generation still query-dead).
- Both assert no `unhandledRejection` fires.

Confirmed **red before the fix** (stale completion corrupted the new generation), **green after**. Verified locally:
- `bun test test/db/` — 480 pass, 0 fail
- `bun test` (full) — 5890 pass, 2 skip, 0 fail
- `eslint` (changed files) — 0
- `bun build.ts` — ok

## Acceptance criteria (#2898)
- [x] A migration completing after a `closeDatabase()` + reopen cannot mutate the newer generation's `migrationsError`/`migrationsRun`.
- [x] Regression test for reopen-during-in-flight-migration (both stale-failure and stale-success directions).
