### PR TITLE
ci(ktfmt): scope PR format check to changed files; harden unresolvable-base fallback

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -532,6 +532,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          # Full history so the ktfmt check can diff the PR head against its base
+          # SHA (git diff <base>...HEAD). The default shallow clone would not
+          # contain the base commit and the diff would fail.
+          fetch-depth: 0
 
       # Pin the JDK so the ktfmt check formats deterministically (project targets
       # Java 21) instead of relying on the runner image's default JDK.
@@ -557,6 +561,19 @@ jobs:
         shell: bash
         env:
           INSTALL_KTFMT_WHEN_MISSING: "true"
+          # Scope the Kotlin format check to files this PR changed. validate_ktfmt.sh
+          # diffs `git diff <base>...HEAD` (three-dot, i.e. relative to the merge
+          # base), so it flags only the PR's own changes, not base-branch commits.
+          # The full tree is already conformant and is re-checked in full
+          # post-merge by the `ktfmt` job in merge.yml -- the backstop for any
+          # tool/style/JDK drift a scoped PR check would miss.
+          ONLY_CHANGED_SINCE_SHA: ${{ github.event.pull_request.base.sha }}
+          # Safety net for the degenerate cases: an empty base SHA, or a
+          # non-empty base SHA that does not resolve (base force-pushed/rebased),
+          # both fall back to a full-tree check. KTFMT_ONLY_TOUCHED_FILES=false
+          # ensures that fallback is the full tree, not the working-tree "touched"
+          # mode -- which sees no changes on a clean CI checkout and would
+          # silently pass without validating anything.
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \

--- a/scripts/ktfmt/validate_ktfmt.sh
+++ b/scripts/ktfmt/validate_ktfmt.sh
@@ -135,6 +135,20 @@ if builtin help mapfile >/dev/null 2>&1; then
     supports_mapfile=true
 fi
 
+# If a base SHA was requested but does not resolve in this checkout (base branch
+# force-pushed/rebased, or its commit was never fetched), fall back to a
+# full-tree check instead of silently passing. get_changed_files_since_sha also
+# guards the SHA, but its `exit 1` runs inside the `< <(...)` process
+# substitution below and only kills that subshell -- the main script would
+# continue with an empty file list and exit 0, a false green (the worst outcome
+# for a linter). Verifying here, in the main shell, keeps the failure fatal to
+# the scoped path while still validating every file via the full-tree fallback.
+if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]] \
+    && ! git rev-parse --verify -q "${ONLY_CHANGED_SINCE_SHA}^{commit}" >/dev/null 2>&1; then
+    echo -e "${YELLOW}Base SHA '${ONLY_CHANGED_SINCE_SHA}' does not resolve; falling back to a full-tree ktfmt check.${NC}"
+    ONLY_CHANGED_SINCE_SHA=""
+fi
+
 if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]]; then
     echo -e "${YELLOW}Processing files changed since SHA: $ONLY_CHANGED_SINCE_SHA${NC}"
 

--- a/test/bats/validate-ktfmt.bats
+++ b/test/bats/validate-ktfmt.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ktfmt/validate_ktfmt.sh file-selection modes.
+#
+# CI (pull_request.yml, fast-validation) now scopes the Kotlin format check to a
+# PR's changed files via ONLY_CHANGED_SINCE_SHA. These tests lock in that path
+# and, critically, the fallback behavior for an unresolvable base SHA -- which
+# must NOT silently pass (a false green is the worst outcome for a linter).
+#
+# ktfmt itself is stubbed so the tests are fast and deterministic and exercise
+# only the selection/dispatch logic, not the real formatter.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/ktfmt/validate_ktfmt.sh"
+
+  TEST_DIR="$(mktemp -d)"
+
+  # Stub ktfmt: exits 0 for the stdin probe (`--google-style -`) and dry-run.
+  # For an in-place `--google-style <file>` it "reformats" (mutating the copy the
+  # script made) only when the file contains the marker FORMAT_ME, letting a
+  # test simulate a misformatted file deterministically.
+  STUB_BIN="$TEST_DIR/bin"
+  mkdir -p "$STUB_BIN"
+  cat > "$STUB_BIN/ktfmt" <<'STUB'
+#!/usr/bin/env bash
+last="${@: -1}"
+if [[ "$last" == "-" || " $* " == *" --dry-run "* ]]; then
+  cat >/dev/null 2>&1 || true
+  exit 0
+fi
+if [[ -f "$last" ]]; then
+  if grep -q 'FORMAT_ME' "$last"; then
+    sed -i.bak 's/FORMAT_ME//g' "$last" && rm -f "$last.bak"
+  fi
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$STUB_BIN/ktfmt"
+  export PATH="$STUB_BIN:$PATH"
+
+  # A throwaway git repo that becomes PROJECT_ROOT (script uses `pwd`).
+  REPO="$TEST_DIR/repo"
+  mkdir -p "$REPO/app/src"
+  cd "$REPO"
+  git init -q
+  git config user.email t@t.t
+  git config user.name t
+}
+
+teardown() {
+  cd /
+  rm -rf "$TEST_DIR"
+}
+
+# Helper: write a clean (already-formatted) Kotlin file.
+clean_kt() { printf 'fun a() {}\n' > "$1"; }
+
+@test "empty SHA processes the whole tree" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+
+  run env ONLY_CHANGED_SINCE_SHA="" ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Processing all Kotlin files in the project"* ]]
+  [[ "$output" == *"Found 1 Kotlin file(s) to process"* ]]
+}
+
+@test "valid base SHA scopes to only the PR's changed Kotlin files" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+  local base; base="$(git rev-parse HEAD)"
+  clean_kt app/src/Feature.kt
+  git add -A && git commit -qm feature
+
+  run env ONLY_CHANGED_SINCE_SHA="$base" ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Processing files changed since SHA: $base"* ]]
+  # Only Feature.kt changed since base; Base.kt is untouched and must be skipped.
+  [[ "$output" == *"Found 1 Kotlin file(s) to process"* ]]
+}
+
+@test "a deleted .kt in the range is excluded (not sent to ktfmt)" {
+  clean_kt app/src/Old.kt
+  git add -A && git commit -qm base
+  local base; base="$(git rev-parse HEAD)"
+  git rm -q app/src/Old.kt
+  git commit -qm delete
+
+  run env ONLY_CHANGED_SINCE_SHA="$base" ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No Kotlin files to process"* ]]
+}
+
+@test "REGRESSION: unresolvable base SHA falls back to full-tree, never a silent pass" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+
+  run env ONLY_CHANGED_SINCE_SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
+    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"does not resolve; falling back to a full-tree ktfmt check"* ]]
+  # It must actually validate the tree, not report "No Kotlin files".
+  [[ "$output" == *"Found 1 Kotlin file(s) to process"* ]]
+  [[ "$output" != *"No Kotlin files to process"* ]]
+}
+
+@test "a misformatted changed file fails the scoped check (not a no-op)" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+  local base; base="$(git rev-parse HEAD)"
+  printf 'fun bad() { FORMAT_ME }\n' > app/src/Bad.kt
+  git add -A && git commit -qm bad
+
+  run env ONLY_CHANGED_SINCE_SHA="$base" ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Formatting issues found"* ]]
+  [[ "$output" == *"Bad.kt"* ]]
+}


### PR DESCRIPTION
## What & why

Format-checking all ~600 Kotlin files ran **~9 min on every PR** (the `ktfmt` step in `fast-validation`). Now that the tree is fully conformant (ktfmt 0.64, google style, #2831), this scopes the **PR** ktfmt check to the files a PR actually changed — `git diff <base>...HEAD` (three-dot, merge-base-relative) via `ONLY_CHANGED_SINCE_SHA`. The **full-tree** check is unchanged and still runs post-merge in `merge.yml` as the backstop.

## The trade-off (explicit)

`merge.yml`'s full-tree `ktfmt` job runs on `push` to `main` — i.e. **after** merge. So tool/style/JDK drift on *untouched* files is caught post-merge (red main), not blocked pre-merge. That's acceptable because file **content** can only drift when a file is touched (which the scoped check sees), and the tree was just normalized. The remaining exposure is *formatter-version* drift — see Follow-ups.

## Review

Ran a 3-perspective review (CI-semantics / shell-correctness / architecture). Two reviewers independently found the same blocker, now fixed:

- **[blocker] Unresolvable base SHA → silent green pass.** An unresolvable `ONLY_CHANGED_SINCE_SHA` (base force-pushed/rebased, or its commit not fetched) hit `exit 1` *inside* a `< <(...)` process substitution, which was swallowed → empty file list → `exit 0`. A false green is the worst outcome for a linter. Fixed by verifying the SHA in the main shell and **falling back to a full-tree check** (never silent-pass; never false-red on a transient base rebase).
- `fetch-depth: 0` on `fast-validation` so the base commit is reachable for the diff.
- Comments corrected to state the diff is merge-base-relative and that unresolvable SHAs fall back to full-tree.

Verified fine by review: env threading through `all_fast_validate_checks.sh`'s `eval`, precedence of `ONLY_CHANGED_SINCE_SHA` over `ONLY_TOUCHED_FILES`, three-dot diff against the merge ref (yields exactly the PR's files), rename/delete handling, exit-code propagation for real failures.

## Tests

New `test/bats/validate-ktfmt.bats` (5 tests, ktfmt stubbed) covering: empty-SHA full-tree, valid-SHA scoping, deleted-file exclusion, **unresolvable-SHA fallback (regression)**, and a real misformatted-file failure. Confirmed the regression test fails without the fix.

## Follow-ups (filed separately, not in this PR)

- **Formatter-version drift enforcement** — the macOS `brew install ktfmt` path doesn't honor the `0.64` pin, and an already-installed newer ktfmt bypasses it; with the full-tree PR check gone, version skew now lands on red main instead of being blocked. Wants a version-fingerprint gate and/or making `merge.yml`'s `ktfmt` a required check.
- `set -euo pipefail` + explicit process-substitution error handling in `validate_ktfmt.sh` (root enabler of the swallowed-exit class).