### PR TITLE
fix(android): widen CtrlProxy gesture request coordinate fields to Double (#2927)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -932,32 +932,32 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
   override fun requestSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
   ) = performSwipe(requestId, x1, y1, x2, y2, duration)
 
-  override fun requestTapCoordinates(requestId: String?, x: Int, y: Int, duration: Long) =
+  override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long) =
     performTapCoordinates(requestId, x, y, duration)
 
   override fun requestTwoFingerSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
     offset: Int,
   ) = performTwoFingerSwipe(requestId, x1, y1, x2, y2, duration, offset)
 
   override fun requestDrag(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     pressDurationMs: Long,
     dragDurationMs: Long,
     holdDurationMs: Long,
@@ -965,10 +965,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
   override fun requestPinch(
     requestId: String?,
-    centerX: Int,
-    centerY: Int,
-    distanceStart: Int,
-    distanceEnd: Int,
+    centerX: Double,
+    centerY: Double,
+    distanceStart: Double,
+    distanceEnd: Double,
     rotationDegrees: Float,
     duration: Long,
   ) =
@@ -2070,7 +2070,14 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * Perform a swipe gesture using AccessibilityService's dispatchGesture API. This is significantly
    * faster than ADB's input swipe command.
    */
-  private fun performSwipe(requestId: String?, x1: Int, y1: Int, x2: Int, y2: Int, duration: Long) {
+  private fun performSwipe(
+    requestId: String?,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
+    duration: Long,
+  ) {
     val startTime = System.currentTimeMillis()
     Log.d(TAG, "performSwipe: ($x1, $y1) -> ($x2, $y2) duration=${duration}ms")
     perfProvider.serial("performSwipe")
@@ -2169,10 +2176,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    */
   private fun performDrag(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     pressDurationMs: Long,
     dragDurationMs: Long,
     holdDurationMs: Long,
@@ -2361,7 +2368,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * @param y Y coordinate to tap
    * @param duration Duration of the tap in milliseconds (default 10ms for a quick tap)
    */
-  private fun performTapCoordinates(requestId: String?, x: Int, y: Int, duration: Long = 10) {
+  private fun performTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long = 10) {
     val startTime = System.currentTimeMillis()
     Log.d(TAG, "performTapCoordinates: ($x, $y) duration=${duration}ms")
     perfProvider.serial("performTapCoordinates")
@@ -2474,10 +2481,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    */
   private fun performTwoFingerSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
     offset: Int = 100,
   ) {
@@ -2581,10 +2588,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   /** Perform a pinch gesture using AccessibilityService's dispatchGesture API. */
   private fun performPinch(
     requestId: String?,
-    centerX: Int,
-    centerY: Int,
-    distanceStart: Int,
-    distanceEnd: Int,
+    centerX: Double,
+    centerY: Double,
+    distanceStart: Double,
+    distanceEnd: Double,
     rotationDegrees: Float,
     duration: Long,
   ) {
@@ -2597,14 +2604,14 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
     try {
       perfProvider.startOperation("buildPath")
-      val startRadius = distanceStart / 2f
-      val endRadius = distanceEnd / 2f
+      val startRadius = distanceStart / 2.0
+      val endRadius = distanceEnd / 2.0
       val startAngle = 0.0
       val endAngle = Math.toRadians(rotationDegrees.toDouble())
 
-      fun pointAt(radius: Float, angleRad: Double): Pair<Float, Float> {
-        val x = centerX + (radius * kotlin.math.cos(angleRad)).toFloat()
-        val y = centerY + (radius * kotlin.math.sin(angleRad)).toFloat()
+      fun pointAt(radius: Double, angleRad: Double): Pair<Float, Float> {
+        val x = (centerX + radius * kotlin.math.cos(angleRad)).toFloat()
+        val y = (centerY + radius * kotlin.math.sin(angleRad)).toFloat()
         return x to y
       }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
@@ -21,26 +21,36 @@ interface CtrlProxyActions {
 
   fun requestScreenshot(requestId: String?)
 
-  fun requestSwipe(requestId: String?, x1: Int, y1: Int, x2: Int, y2: Int, duration: Long)
+  // Coordinate params are `Double` so fractional wire values pass through untruncated to the
+  // gesture engine (which builds float `Path`s). `offset`, durations, and `rotationDegrees` are not
+  // coordinates and stay their original types. Symmetric to iOS; see #2927 / WebSocketRequest.kt.
+  fun requestSwipe(
+    requestId: String?,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
+    duration: Long,
+  )
 
-  fun requestTapCoordinates(requestId: String?, x: Int, y: Int, duration: Long)
+  fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long)
 
   fun requestTwoFingerSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
     offset: Int,
   )
 
   fun requestDrag(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     pressDurationMs: Long,
     dragDurationMs: Long,
     holdDurationMs: Long,
@@ -48,10 +58,10 @@ interface CtrlProxyActions {
 
   fun requestPinch(
     requestId: String?,
-    centerX: Int,
-    centerY: Int,
-    distanceStart: Int,
-    distanceEnd: Int,
+    centerX: Double,
+    centerY: Double,
+    distanceStart: Double,
+    distanceEnd: Double,
     rotationDegrees: Float,
     duration: Long,
   )

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
@@ -15,31 +15,31 @@ open class NoOpCtrlProxyActions : CtrlProxyActions {
 
   override fun requestSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
   ) {}
 
-  override fun requestTapCoordinates(requestId: String?, x: Int, y: Int, duration: Long) {}
+  override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long) {}
 
   override fun requestTwoFingerSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
     offset: Int,
   ) {}
 
   override fun requestDrag(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     pressDurationMs: Long,
     dragDurationMs: Long,
     holdDurationMs: Long,
@@ -47,10 +47,10 @@ open class NoOpCtrlProxyActions : CtrlProxyActions {
 
   override fun requestPinch(
     requestId: String?,
-    centerX: Int,
-    centerY: Int,
-    distanceStart: Int,
-    distanceEnd: Int,
+    centerX: Double,
+    centerY: Double,
+    distanceStart: Double,
+    distanceEnd: Double,
     rotationDegrees: Float,
     duration: Long,
   ) {}
@@ -192,32 +192,32 @@ class RecordingCtrlProxyActions : CtrlProxyActions {
 
   override fun requestSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
   ) = record("requestSwipe", requestId, x1, y1, x2, y2, duration)
 
-  override fun requestTapCoordinates(requestId: String?, x: Int, y: Int, duration: Long) =
+  override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long) =
     record("requestTapCoordinates", requestId, x, y, duration)
 
   override fun requestTwoFingerSwipe(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     duration: Long,
     offset: Int,
   ) = record("requestTwoFingerSwipe", requestId, x1, y1, x2, y2, duration, offset)
 
   override fun requestDrag(
     requestId: String?,
-    x1: Int,
-    y1: Int,
-    x2: Int,
-    y2: Int,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
     pressDurationMs: Long,
     dragDurationMs: Long,
     holdDurationMs: Long,
@@ -236,10 +236,10 @@ class RecordingCtrlProxyActions : CtrlProxyActions {
 
   override fun requestPinch(
     requestId: String?,
-    centerX: Int,
-    centerY: Int,
-    distanceStart: Int,
-    distanceEnd: Int,
+    centerX: Double,
+    centerY: Double,
+    distanceStart: Double,
+    distanceEnd: Double,
     rotationDegrees: Float,
     duration: Long,
   ) =

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -71,13 +71,14 @@ class CtrlProxyMessageHandlerTest {
     dispatch(
       """{"type":"request_swipe","requestId":"sw1","x1":0,"y1":100,"x2":0,"y2":500,"duration":400}"""
     )
-    assertEquals("requestSwipe" to listOf<Any?>("sw1", 0, 100, 0, 500, 400L), lastCall)
+    // Coordinates dispatch as Double (#2927); integer JSON decodes to identical .0 values.
+    assertEquals("requestSwipe" to listOf<Any?>("sw1", 0.0, 100.0, 0.0, 500.0, 400L), lastCall)
   }
 
   @Test
   fun `dispatches request_tap_coordinates with default duration`() = runTest {
     dispatch("""{"type":"request_tap_coordinates","requestId":"t1","x":100,"y":200}""")
-    assertEquals("requestTapCoordinates" to listOf<Any?>("t1", 100, 200, 10L), lastCall)
+    assertEquals("requestTapCoordinates" to listOf<Any?>("t1", 100.0, 200.0, 10L), lastCall)
   }
 
   @Test
@@ -85,8 +86,9 @@ class CtrlProxyMessageHandlerTest {
     dispatch(
       """{"type":"request_two_finger_swipe","requestId":"tf1","x1":0,"y1":0,"x2":10,"y2":20,"duration":300,"offset":50}"""
     )
+    // offset stays Int (pixel offset, not a coordinate).
     assertEquals(
-      "requestTwoFingerSwipe" to listOf<Any?>("tf1", 0, 0, 10, 20, 300L, 50),
+      "requestTwoFingerSwipe" to listOf<Any?>("tf1", 0.0, 0.0, 10.0, 20.0, 300L, 50),
       lastCall,
     )
   }
@@ -98,7 +100,7 @@ class CtrlProxyMessageHandlerTest {
     )
     // holdTime resolves press duration, duration resolves drag duration, hold defaults to 100.
     assertEquals(
-      "requestDrag" to listOf<Any?>("d1", 50, 50, 150, 150, 800L, 500L, 100L),
+      "requestDrag" to listOf<Any?>("d1", 50.0, 50.0, 150.0, 150.0, 800L, 500L, 100L),
       lastCall,
     )
   }
@@ -109,7 +111,31 @@ class CtrlProxyMessageHandlerTest {
       """{"type":"request_pinch","requestId":"pi1","centerX":540,"centerY":960,"distanceStart":100,"distanceEnd":300,"rotationDegrees":45.0,"duration":500}"""
     )
     assertEquals(
-      "requestPinch" to listOf<Any?>("pi1", 540, 960, 100, 300, 45.0f, 500L),
+      "requestPinch" to listOf<Any?>("pi1", 540.0, 960.0, 100.0, 300.0, 45.0f, 500L),
+      lastCall,
+    )
+  }
+
+  @Test
+  fun `dispatches request_pinch preserving fractional coordinates`() = runTest {
+    // #2927: a fractional center/distance survives decode and reaches the action as Double,
+    // not truncated to Int.
+    dispatch(
+      """{"type":"request_pinch","requestId":"pi-frac","centerX":100.5,"centerY":200.25,"distanceStart":80.5,"distanceEnd":120.75,"rotationDegrees":45.0,"duration":500}"""
+    )
+    assertEquals(
+      "requestPinch" to listOf<Any?>("pi-frac", 100.5, 200.25, 80.5, 120.75, 45.0f, 500L),
+      lastCall,
+    )
+  }
+
+  @Test
+  fun `dispatches request_swipe preserving fractional coordinates`() = runTest {
+    dispatch(
+      """{"type":"request_swipe","requestId":"sw-frac","x1":0.5,"y1":100.25,"x2":10.75,"y2":500.125,"duration":400}"""
+    )
+    assertEquals(
+      "requestSwipe" to listOf<Any?>("sw-frac", 0.5, 100.25, 10.75, 500.125, 400L),
       lastCall,
     )
   }

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -45,12 +45,18 @@ data class RequestScreenshot(override val requestId: String? = null) : WebSocket
 // Gesture Requests
 // =============================================================================
 
+// Gesture coordinate fields are `Double` (not `Int`) so fractional/sub-pixel JSON numbers
+// deserialize cleanly instead of throwing an opaque kotlinx decode error, symmetric to the iOS
+// runner (#2909 / PR #2919). `Double` decodes both integer and fractional JSON, so the existing
+// TS rounded path (roundCoordinates:true + Math.round, see CtrlProxyGestures.ts) is unaffected —
+// integer payloads decode to identical `.0` values. Durations, `offset`, and `rotationDegrees` are
+// not coordinates and keep their original types. See #2927.
 @Serializable
 @SerialName("request_tap_coordinates")
 data class RequestTapCoordinates(
   override val requestId: String? = null,
-  val x: Int,
-  val y: Int,
+  val x: Double,
+  val y: Double,
   val duration: Long = 10L,
 ) : WebSocketRequest()
 
@@ -58,10 +64,10 @@ data class RequestTapCoordinates(
 @SerialName("request_swipe")
 data class RequestSwipe(
   override val requestId: String? = null,
-  val x1: Int,
-  val y1: Int,
-  val x2: Int,
-  val y2: Int,
+  val x1: Double,
+  val y1: Double,
+  val x2: Double,
+  val y2: Double,
   val duration: Long = 300L,
 ) : WebSocketRequest()
 
@@ -69,10 +75,10 @@ data class RequestSwipe(
 @SerialName("request_two_finger_swipe")
 data class RequestTwoFingerSwipe(
   override val requestId: String? = null,
-  val x1: Int,
-  val y1: Int,
-  val x2: Int,
-  val y2: Int,
+  val x1: Double,
+  val y1: Double,
+  val x2: Double,
+  val y2: Double,
   val duration: Long = 300L,
   val offset: Int = 100,
 ) : WebSocketRequest()
@@ -81,10 +87,10 @@ data class RequestTwoFingerSwipe(
 @SerialName("request_drag")
 data class RequestDrag(
   override val requestId: String? = null,
-  val x1: Int,
-  val y1: Int,
-  val x2: Int,
-  val y2: Int,
+  val x1: Double,
+  val y1: Double,
+  val x2: Double,
+  val y2: Double,
   val pressDurationMs: Long = 600L,
   val dragDurationMs: Long = 300L,
   val holdDurationMs: Long = 100L,
@@ -105,10 +111,10 @@ data class RequestDrag(
 @SerialName("request_pinch")
 data class RequestPinch(
   override val requestId: String? = null,
-  val centerX: Int,
-  val centerY: Int,
-  val distanceStart: Int,
-  val distanceEnd: Int,
+  val centerX: Double,
+  val centerY: Double,
+  val distanceStart: Double,
+  val distanceEnd: Double,
   val rotationDegrees: Float = 0f,
   val duration: Long = 300L,
 ) : WebSocketRequest()

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -1,7 +1,9 @@
 package dev.jasonpearson.automobile.protocol
 
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 
@@ -158,6 +160,16 @@ class WebSocketRequestTest {
     assertEquals(80.5, request.distanceStart)
     assertEquals(120.75, request.distanceEnd)
     assertEquals(45.0f, request.rotationDegrees)
+    assertEquals(500L, request.duration)
+  }
+
+  @Test
+  fun `request_pinch still rejects a missing required coordinate`() {
+    // Widening the coordinate fields to Double (#2927) must not weaken required-field decode:
+    // they stay non-null with no default, so an absent coordinate is still a decode error.
+    val message =
+      """{"type":"request_pinch","requestId":"pinch-missing","centerX":100.0,"centerY":200.0,"distanceStart":80.0,"rotationDegrees":45.0,"duration":500}"""
+    assertFailsWith<SerializationException> { json.decodeFromString<WebSocketRequest>(message) }
   }
 
   @Test

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -38,9 +38,22 @@ class WebSocketRequestTest {
 
     assertIs<RequestTapCoordinates>(request)
     assertEquals("tap-1", request.requestId)
-    assertEquals(100, request.x)
-    assertEquals(200, request.y)
+    assertEquals(100.0, request.x)
+    assertEquals(200.0, request.y)
     assertEquals(10L, request.duration) // default
+  }
+
+  @Test
+  fun `deserialize request_tap_coordinates with fractional coordinates`() {
+    // Coordinate fields are Double (#2927): a fractional JSON number must decode
+    // without a kotlinx decode error and preserve the fraction.
+    val message =
+      """{"type":"request_tap_coordinates","requestId":"tap-frac","x":100.5,"y":200.25}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestTapCoordinates>(request)
+    assertEquals(100.5, request.x)
+    assertEquals(200.25, request.y)
   }
 
   @Test
@@ -51,11 +64,38 @@ class WebSocketRequestTest {
 
     assertIs<RequestSwipe>(request)
     assertEquals("swipe-1", request.requestId)
-    assertEquals(0, request.x1)
-    assertEquals(100, request.y1)
-    assertEquals(0, request.x2)
-    assertEquals(500, request.y2)
+    assertEquals(0.0, request.x1)
+    assertEquals(100.0, request.y1)
+    assertEquals(0.0, request.x2)
+    assertEquals(500.0, request.y2)
     assertEquals(400L, request.duration)
+  }
+
+  @Test
+  fun `deserialize request_swipe with fractional coordinates`() {
+    val message =
+      """{"type":"request_swipe","requestId":"swipe-frac","x1":0.5,"y1":100.25,"x2":10.75,"y2":500.125,"duration":400}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestSwipe>(request)
+    assertEquals(0.5, request.x1)
+    assertEquals(100.25, request.y1)
+    assertEquals(10.75, request.x2)
+    assertEquals(500.125, request.y2)
+  }
+
+  @Test
+  fun `deserialize request_two_finger_swipe with fractional coordinates`() {
+    val message =
+      """{"type":"request_two_finger_swipe","requestId":"tfs-frac","x1":0.5,"y1":0.25,"x2":10.75,"y2":20.125,"duration":300,"offset":50}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestTwoFingerSwipe>(request)
+    assertEquals(0.5, request.x1)
+    assertEquals(0.25, request.y1)
+    assertEquals(10.75, request.x2)
+    assertEquals(20.125, request.y2)
+    assertEquals(50, request.offset) // offset stays Int (pixel offset, not a coordinate)
   }
 
   @Test
@@ -66,13 +106,26 @@ class WebSocketRequestTest {
 
     assertIs<RequestDrag>(request)
     assertEquals("drag-1", request.requestId)
-    assertEquals(50, request.x1)
-    assertEquals(50, request.y1)
-    assertEquals(150, request.x2)
-    assertEquals(150, request.y2)
+    assertEquals(50.0, request.x1)
+    assertEquals(50.0, request.y1)
+    assertEquals(150.0, request.x2)
+    assertEquals(150.0, request.y2)
     // Legacy fields are used as fallback
     assertEquals(800L, request.resolvedPressDurationMs)
     assertEquals(500L, request.resolvedDragDurationMs)
+  }
+
+  @Test
+  fun `deserialize request_drag with fractional coordinates`() {
+    val message =
+      """{"type":"request_drag","requestId":"drag-frac","x1":50.5,"y1":50.25,"x2":150.75,"y2":150.125}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestDrag>(request)
+    assertEquals(50.5, request.x1)
+    assertEquals(50.25, request.y1)
+    assertEquals(150.75, request.x2)
+    assertEquals(150.125, request.y2)
   }
 
   @Test
@@ -83,12 +136,28 @@ class WebSocketRequestTest {
 
     assertIs<RequestPinch>(request)
     assertEquals("pinch-1", request.requestId)
-    assertEquals(540, request.centerX)
-    assertEquals(960, request.centerY)
-    assertEquals(100, request.distanceStart)
-    assertEquals(300, request.distanceEnd)
+    assertEquals(540.0, request.centerX)
+    assertEquals(960.0, request.centerY)
+    assertEquals(100.0, request.distanceStart)
+    assertEquals(300.0, request.distanceEnd)
     assertEquals(45.0f, request.rotationDegrees)
     assertEquals(500L, request.duration)
+  }
+
+  @Test
+  fun `deserialize request_pinch with fractional coordinates`() {
+    // The iOS-symmetric case (#2927): sub-pixel center + computed fractional distance
+    // must decode without a kotlinx decode error and keep the fraction.
+    val message =
+      """{"type":"request_pinch","requestId":"pinch-frac","centerX":100.5,"centerY":200.25,"distanceStart":80.5,"distanceEnd":120.75,"rotationDegrees":45.0,"duration":500}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestPinch>(request)
+    assertEquals(100.5, request.centerX)
+    assertEquals(200.25, request.centerY)
+    assertEquals(80.5, request.distanceStart)
+    assertEquals(120.75, request.distanceEnd)
+    assertEquals(45.0f, request.rotationDegrees)
   }
 
   @Test

--- a/src/features/observe/android/CtrlProxyGestures.ts
+++ b/src/features/observe/android/CtrlProxyGestures.ts
@@ -18,6 +18,12 @@ export class CtrlProxyGestures extends SharedGestureDelegate {
   private pendingSwipeResolve: ((result: A11ySwipeResult) => void) | null = null;
 
   constructor(context: DelegateContext) {
+    // `roundCoordinates: true` centralizes coordinate rounding for Android at the delegate layer
+    // (SharedGestureDelegate.coord()), so integer coordinates reach the runner wire. This is
+    // intentional and must not be regressed to `false`: the Android runner's protocol accepts
+    // fractional coordinates as of #2927 (WebSocketRequest.kt fields are `Double`), but this
+    // rounding is what keeps the current shipped behavior pixel-aligned. The Double protocol is a
+    // robustness backstop for any client, not a signal that rounding here can be dropped.
     super(context, { logTag: "ACCESSIBILITY_SERVICE", roundCoordinates: true });
   }
 
@@ -60,6 +66,10 @@ export class CtrlProxyGestures extends SharedGestureDelegate {
       }, timeoutMs);
     });
 
+    // The two-finger path hard-rounds coordinates here (in addition to the delegate's
+    // roundCoordinates rounding) so TalkBack two-finger swipes land on whole pixels. Intentional
+    // and not to be regressed — the runner accepts fractional coordinates (#2927), but this path
+    // deliberately sends integers. See the constructor note.
     const message = serializeCtrlProxyRequest(
       ctrlProxyRequests.requestTwoFingerSwipe({
         requestId,


### PR DESCRIPTION
## What

Widen the Android CtrlProxy runner's gesture **request** coordinate fields from `Int` to `Double` so fractional coordinates deserialize and execute cleanly instead of throwing an opaque kotlinx `Decodable` error. Symmetric to the iOS fix in #2909 / PR #2919.

Affected request models in `android/protocol/.../WebSocketRequest.kt`:
- `RequestTapCoordinates.x/y`
- `RequestSwipe.x1/y1/x2/y2`
- `RequestTwoFingerSwipe.x1/y1/x2/y2`
- `RequestDrag.x1/y1/x2/y2`
- `RequestPinch.centerX/centerY/distanceStart/distanceEnd`

Closes #2927.

## Why

A fractional JSON number decoded into a kotlinx `@Serializable` `Int` field throws — the same opaque failure #2909 describes for Swift. Android's severity is **lower** than iOS because the shipped TS wire path rounds today (`roundCoordinates: true` in `CtrlProxyGestures.ts:21`, plus `Math.round(...)` on the Android-only two-finger path), so no fractional value reaches the wire from a current caller. But #2909's "repo-wide robustness gap" framing is only half-closed while the Android protocol stays asymmetric: the runner should be robust to any client regardless of the shared `coord()` rounding. This widens the runner so a direct/future caller passing sub-pixel centers or computed distances gets a gesture, not a decode exception.

`Double` deserializes both integer and fractional JSON, so integer payloads decode identically and the existing rounded path is unaffected.

## How

- **`WebSocketRequest.kt`** — the five gesture request `data class` structs type coordinate fields as `Double`. `offset` (a pixel offset), durations (`Long`), and `rotationDegrees` (`Float`) are **not** coordinates and keep their types. Fields stay non-optional, so required-field decode rejection (`keyNotFound`) is preserved.
- **`CtrlProxyActions.kt` / `CtrlProxy.kt`** — the action interface, its `CtrlProxy` overrides, and the private `perform*` methods take `Double` coordinates. The gesture engine already converts coordinates to `Float` via `.toFloat()` when building the accessibility `Path`, so the fraction now survives end-to-end to the dispatch boundary. Pinch geometry computes radius/endpoints in `Double` and converts once to `Float` for the `Path`.
- **`CtrlProxyActionsFakes.kt`** — `NoOp` + `Recording` fakes widened to `Double`.
- **`CtrlProxyGestures.ts`** — added comments documenting the `roundCoordinates: true` + `Math.round` centralization as **intentional and not to be regressed** (per the issue's AC3), now that the runner protocol tolerates fractions.

`RequestHitTest.x/y` (a separate pixel-grid hit test) is deliberately left `Int` — out of scope, mirroring iOS leaving `ElementBounds`/`HighlightBounds` `Int`; only gesture-request **inputs** are widened.

## Testing

- `WebSocketRequestTest.kt` — new fractional-coordinate decode tests for tap, swipe, two-finger swipe, drag, and pinch (e.g. `centerX:100.5`, `distanceEnd:120.75`) asserting the fraction is preserved. Existing integer decode assertions updated to `Double` literals (integer JSON decodes identically).
- `CtrlProxyMessageHandlerTest.kt` — new fractional dispatch tests asserting the `Double` fraction reaches the recording fake for pinch + swipe; existing integer arg-list assertions updated to `Double`.

Verified locally with JDK 21:
- `./gradlew -p android :protocol:test :control-proxy:test` — **BUILD SUCCESSFUL** (7 new tests, all green).
- `ktfmt --google-style` clean on all touched Kotlin; `eslint` clean on the touched TS.

## Acceptance criteria (#2927)
- [x] A `request_pinch` (and siblings tap/swipe/two-finger/drag) with fractional coordinates deserializes without a kotlinx decode error.
- [x] Kotlin decode test covering a fractional coordinate payload asserting the fraction survives.
- [x] No behavioral change to the existing rounded-input path; `roundCoordinates:true` + `Math.round` centralization documented as intentional, not to be regressed.

## Follow-up note

This fix lives in the Android runner source (`android/control-proxy`), which ships as a pinned release artifact. It reaches deployed sessions only after the next periodic `chore: bump versions` release (same delivery model as iOS). There is **no interim regression**: the shipped TS path still rounds today, so nothing that works now breaks — this purely removes a latent robustness gap for direct/future callers.
