### PR TITLE
test(ios): add control-proxy wire-parity drift tripwire + fix request_voiceover_action mismatch

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -779,7 +779,9 @@ public class GesturePerformer: GesturePerforming {
 
             try runOnMainThread {
                 switch action.lowercased() {
-                case "click", "tap":
+                case "click", "tap", "activate":
+                    // "activate" is the VoiceOver activation gesture (issue #2857); for an
+                    // element located by label it resolves to a tap, matching "click"/"tap".
                     found.tap()
                 case "long_click", "long_press":
                     found.press(forDuration: 1.0)

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -905,6 +905,45 @@ final class CommandHandlerTests: XCTestCase {
         )
     }
 
+    // MARK: - Node Action Tests
+
+    /// VoiceOver activation (issue #2857) rides `request_action` with action "activate"
+    /// and an accessibility label. The command must decode and reach `performAction`
+    /// with the label preserved, replying `action_result`.
+    func testActionActivateByLabelReachesPerformAction() {
+        let request = WebSocketRequest.action(RequestAction(
+            requestId: "act-activate-1",
+            action: "activate",
+            resourceId: nil,
+            label: "Submit"
+        ))
+
+        guard let actionResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
+        XCTAssertEqual(actionResponse.success, true)
+        XCTAssertEqual(actionResponse.type, "action_result")
+
+        let history = fakeGesturePerformer.getActionHistory()
+        XCTAssertEqual(history.count, 1)
+        XCTAssertEqual(history[0].action, "activate")
+        XCTAssertEqual(history[0].label, "Submit")
+        XCTAssertNil(history[0].resourceId)
+    }
+
+    /// `request_action` decoded straight from the wire the TS client now emits for
+    /// VoiceOver long-press activation.
+    func testActionLongPressDecodesFromWire() throws {
+        let request = try decodeWebSocketRequest(
+            #"{"type":"request_action","requestId":"act-lp-1","action":"long_press","label":"Row"}"#
+        )
+
+        guard let actionResponse = handleRequest(request, as: WebSocketResponse.self) else { return }
+        XCTAssertEqual(actionResponse.success, true)
+
+        let history = fakeGesturePerformer.getActionHistory()
+        XCTAssertEqual(history[0].action, "long_press")
+        XCTAssertEqual(history[0].label, "Row")
+    }
+
     // MARK: - Device Control Tests
 
     func testPressHomeSuccess() {

--- a/src/features/observe/ios/CtrlProxyVoiceOver.ts
+++ b/src/features/observe/ios/CtrlProxyVoiceOver.ts
@@ -78,13 +78,20 @@ export class CtrlProxyVoiceOver {
   }
 
   /**
-   * Request VoiceOver accessibility action on an element by label.
+   * Activate an element by its accessibility label via the runner's node-action path.
+   *
+   * Rides the existing `request_action` command (element lookup by label, then
+   * `activate`→tap / `long_press`→press in the Swift `performAction`) rather than a
+   * dedicated `request_voiceover_action` command, which never existed in the Swift
+   * `RequestType` and so failed to decode on-device — always falling back to a
+   * coordinate tap (issue #2857). The runner replies `action_result`, which decodes
+   * into the same shape as `CtrlProxyVoiceOverActionResult`.
    *
    * @param label - The accessibility label of the target element
    * @param action - The action to perform: "activate" or "long_press"
    * @param timeoutMs - Request timeout in milliseconds (default: 5000)
    * @param perf - Optional performance tracker
-   * @returns VoiceOver action result
+   * @returns Action result
    */
   async requestVoiceOverActivate(
     label: string,
@@ -94,14 +101,14 @@ export class CtrlProxyVoiceOver {
   ): Promise<CtrlProxyVoiceOverActionResult> {
     return sendCommand<CtrlProxyVoiceOverActionResult>(this.context, {
       idPrefix: "voiceover_action",
-      responseType: "voiceover_action",
-      messageType: "request_voiceover_action",
+      responseType: "action",
+      messageType: "request_action",
       params: { label, action },
       timeoutMs,
       perf,
       cancelScreenshotBackoff: false,
       notConnectedError: () => ({ success: false, error: "Not connected to CtrlProxy" }),
-      timeoutError: () => ({ success: false, error: "Timeout waiting for voiceover_action_result" }),
+      timeoutError: () => ({ success: false, error: "Timeout waiting for action_result" }),
     });
   }
 }

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -1,0 +1,83 @@
+/**
+ * Checked-in copy of the iOS CtrlProxy runner's inbound command contract.
+ *
+ * The Swift runner locks its own inbound set with `RequestType` (a
+ * `String, CaseIterable` enum in `ios/control-proxy/Sources/CtrlProxy/Models.swift`)
+ * and `TypedRequestDecodeTests.testEveryRequestTypeDecodesToMatchingCase` fails a
+ * test if an enum case is dropped or renamed. But nothing asserted that the set of
+ * command `type` strings the **TS client emits** stays a subset of those rawValues,
+ * so a new/renamed TS command compiled cleanly and only failed at runtime on-device
+ * with an "Unknown command type: <type>" error (issue #2857).
+ *
+ * This list is the authoritative device contract the TS iOS client mirrors — the
+ * iOS analog of Android's `KNOWN_REQUEST_TYPES` (#2835). It is transcribed by hand
+ * from the Swift `RequestType` enum; `ctrlProxyWireParity.test.ts` reads the actual
+ * rawValues out of `Models.swift` and fails if this list drifts from them, and also
+ * fails if any command string the iOS client can emit is not a member of this set.
+ *
+ * Keep this in lockstep with the Swift `RequestType` enum. Adding a TS command
+ * without a matching rawValue here (and in Swift) is a test failure by design.
+ */
+export const IOS_KNOWN_REQUEST_TYPES = [
+  // View hierarchy
+  "request_hierarchy",
+  "request_hierarchy_if_stale",
+  "request_screenshot",
+
+  // Gestures
+  "request_tap_coordinates",
+  "request_swipe",
+  "request_two_finger_swipe",
+  "request_multi_finger_swipe",
+  "request_drag",
+  "request_pinch",
+
+  // Text input
+  "request_set_text",
+  "request_clear_text",
+  "request_ime_action",
+  "request_select_all",
+  "request_keyboard",
+  "request_press_button",
+  "request_press_home",
+  "request_press_back",
+  "request_shake",
+  "request_recent_apps",
+
+  // Node actions
+  "request_action",
+  "request_launch_app",
+
+  // Device control
+  "request_rotate",
+
+  // Clipboard
+  "request_clipboard",
+
+  // Accessibility features
+  "get_current_focus",
+  "get_traversal_order",
+  "add_highlight",
+  "get_voiceover_state",
+
+  // Storage inspection
+  "list_preference_files",
+  "get_preferences",
+  "get_preference",
+  "set_preference",
+  "remove_preference",
+  "clear_preferences",
+
+  // Network mocking
+  "set_network_mock_rules",
+
+  // Database inspection
+  "execute_sql",
+  "list_databases",
+  "list_tables",
+  "get_table_data",
+  "get_table_structure",
+] as const;
+
+/** Set form for O(1) membership checks in the wire-parity guard. */
+export const IOS_KNOWN_REQUEST_TYPE_SET: ReadonlySet<string> = new Set(IOS_KNOWN_REQUEST_TYPES);

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -128,15 +128,6 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
       };
       break;
 
-    case "voiceover_action_result":
-      result = {
-        success: message.success ?? true,
-        action: (message as { action?: string }).action,
-        totalTimeMs: message.totalTimeMs ?? 0,
-        error: message.error,
-      };
-      break;
-
     case "highlight_response":
       result = {
         success: message.success ?? false,

--- a/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
+++ b/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
@@ -188,4 +188,69 @@ describe("CtrlProxyVoiceOver", function() {
       }
     });
   });
+
+  describe("requestVoiceOverActivate", function() {
+    // Regression guard for #2857: VoiceOver activation must ride the existing
+    // `request_action` command (a real `RequestType`), not the phantom
+    // `request_voiceover_action` the runner rejected as "Unknown command type".
+    test("sends request_action (not request_voiceover_action) and passes label + action", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+      try {
+        const resultPromise = client.requestVoiceOverActivate("Submit", "activate");
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMsg.type).toBe("request_action");
+        expect(sentMsg.type).not.toBe("request_voiceover_action");
+        expect(sentMsg.label).toBe("Submit");
+        expect(sentMsg.action).toBe("activate");
+        expect(typeof sentMsg.requestId).toBe("string");
+
+        // The runner replies with action_result, which resolves the request.
+        socket!.simulateMessage(JSON.stringify({
+          type: "action_result",
+          requestId: sentMsg.requestId,
+          success: true,
+          action: "activate",
+          totalTimeMs: 3,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("maps long_press through the same request_action command", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+      try {
+        const resultPromise = client.requestVoiceOverActivate("Row", "long_press");
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        expect(sentMsg.type).toBe("request_action");
+        expect(sentMsg.action).toBe("long_press");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "action_result",
+          requestId: sentMsg.requestId,
+          success: true,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+      } finally {
+        await client.close();
+      }
+    });
+  });
 });

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Cross-language wire-parity tripwire for the iOS control-proxy TS client ↔ Swift runner.
+ *
+ * The Swift runner locks its inbound command set with the `RequestType` enum
+ * (`ios/control-proxy/Sources/CtrlProxy/Models.swift`), but before #2857 nothing on
+ * the TS side asserted that the command `type` strings the iOS client *emits* stay a
+ * subset of those rawValues. A new/renamed TS command compiled cleanly and only
+ * failed at runtime on-device as an "Unknown command type: <type>" error — the exact
+ * `request_voiceover_action` mismatch this test was added to catch (issue #2857).
+ *
+ * This is the iOS analog of Android's `ctrlProxyProtocol.test.ts` KNOWN_REQUEST_TYPES
+ * guard (#2835). Two independent guarantees:
+ *   1. `IOS_KNOWN_REQUEST_TYPES` equals the `RequestType` rawValues read live from
+ *      `Models.swift` — a case renamed/added/removed on the runner fails here.
+ *   2. Every command `type`/`messageType` the iOS client can emit (scanned from
+ *      source) is a member of `IOS_KNOWN_REQUEST_TYPES` — adding a TS command without
+ *      a matching runner rawValue fails here.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+import {
+  IOS_KNOWN_REQUEST_TYPES,
+  IOS_KNOWN_REQUEST_TYPE_SET,
+} from "../../../../src/features/observe/ios/ctrlProxyRequestTypes";
+import { IOS_RUNNER_FEATURE_COMMANDS } from "../../../../src/features/observe/ios/IOSCtrlProxyClient";
+
+const REPO_ROOT = resolve(import.meta.dir, "../../../..");
+const IOS_OBSERVE_DIR = resolve(REPO_ROOT, "src/features/observe/ios");
+const SHARED_OBSERVE_DIR = resolve(REPO_ROOT, "src/features/observe/shared");
+const MODELS_SWIFT = resolve(REPO_ROOT, "ios/control-proxy/Sources/CtrlProxy/Models.swift");
+
+/**
+ * Swift `RequestType` rawValues, transcribed by hand. The test below reads the real
+ * enum out of Models.swift and asserts it equals this list, so the transcription
+ * can't rot independently — but it makes the contract legible in one place.
+ */
+const SWIFT_REQUEST_TYPES = [
+  "request_hierarchy",
+  "request_hierarchy_if_stale",
+  "request_screenshot",
+  "request_tap_coordinates",
+  "request_swipe",
+  "request_two_finger_swipe",
+  "request_multi_finger_swipe",
+  "request_drag",
+  "request_pinch",
+  "request_set_text",
+  "request_clear_text",
+  "request_ime_action",
+  "request_select_all",
+  "request_keyboard",
+  "request_press_button",
+  "request_press_home",
+  "request_press_back",
+  "request_shake",
+  "request_recent_apps",
+  "request_action",
+  "request_launch_app",
+  "request_rotate",
+  "request_clipboard",
+  "get_current_focus",
+  "get_traversal_order",
+  "add_highlight",
+  "get_voiceover_state",
+  "list_preference_files",
+  "get_preferences",
+  "get_preference",
+  "set_preference",
+  "remove_preference",
+  "clear_preferences",
+  "set_network_mock_rules",
+  "execute_sql",
+  "list_databases",
+  "list_tables",
+  "get_table_data",
+  "get_table_structure",
+];
+
+/**
+ * Response-payload discriminators that share the `type:` JSON key with outbound
+ * requests but are *inbound* shapes, not wire commands. `CtrlProxyDatabase.executeSQL`
+ * classifies its result as `{ type: "mutation" }` / `{ type: "query" }`. They must be
+ * excluded from the emit scan; a new non-request `type:` literal that is not listed
+ * here will (correctly) fail the subset assertion and force a decision.
+ */
+const NON_REQUEST_TYPE_LITERALS = new Set(["mutation", "query"]);
+
+/** Outbound-emit source files to scan. Excludes inbound decode + type/registry files. */
+const EXCLUDED_IOS_FILES = new Set([
+  "decodeCtrlProxyMessage.ts",
+  "ctrlProxyRequestTypes.ts",
+  "types.ts",
+]);
+
+function iosEmitSourceFiles(): string[] {
+  const iosFiles = readdirSync(IOS_OBSERVE_DIR)
+    .filter(f => f.endsWith(".ts") && !f.endsWith(".test.ts") && !EXCLUDED_IOS_FILES.has(f))
+    .map(f => resolve(IOS_OBSERVE_DIR, f));
+  // The iOS text + gesture paths go through the shared delegates; scan them too.
+  const sharedFiles = ["SharedTextDelegate.ts", "SharedGestureDelegate.ts"]
+    .map(f => resolve(SHARED_OBSERVE_DIR, f));
+  return [...iosFiles, ...sharedFiles];
+}
+
+/** Extract every command `type` string a source file can put on the wire. */
+function extractEmittedTypes(source: string): Set<string> {
+  const found = new Set<string>();
+
+  // 1. `messageType: "..."` — the shared sendCommand discriminator (never anything else).
+  for (const m of source.matchAll(/messageType:\s*"([a-z_]+)"/g)) {
+    found.add(m[1]);
+  }
+  // 2. Any snake_case string literal on a line carrying the `type:` JSON key. Captures
+  //    object-literal sends (`type: "get_preferences"`), the hierarchy ternary
+  //    (`type: cond ? "request_hierarchy" : "request_hierarchy_if_stale"`) and the
+  //    network send. `messageType:`/`responseType:` (capital T) are not matched by \btype:.
+  for (const line of source.split("\n")) {
+    if (!/\btype:/.test(line)) { continue; }
+    for (const m of line.matchAll(/"([a-z_]+)"/g)) {
+      found.add(m[1]);
+    }
+  }
+  // 3. `CtrlProxyDatabase.request(<T>)("execute_sql", ...)` first-arg sends.
+  for (const m of source.matchAll(/\.request<[^>]*>\(\s*"([a-z_]+)"/g)) {
+    found.add(m[1]);
+  }
+
+  for (const denied of NON_REQUEST_TYPE_LITERALS) {
+    found.delete(denied);
+  }
+  return found;
+}
+
+function readSwiftRequestTypeRawValues(): string[] {
+  const source = readFileSync(MODELS_SWIFT, "utf8");
+  const block = source.match(/public enum RequestType: String, CaseIterable \{([\s\S]*?)\n\}/);
+  if (!block) {
+    throw new Error("Could not locate `enum RequestType` in Models.swift");
+  }
+  return [...block[1].matchAll(/case\s+\w+\s*=\s*"([a-z_]+)"/g)].map(m => m[1]);
+}
+
+describe("iOS control-proxy — RequestType contract coverage", () => {
+  test("IOS_KNOWN_REQUEST_TYPES matches the transcribed Swift rawValue list", () => {
+    expect([...IOS_KNOWN_REQUEST_TYPES].sort()).toEqual([...SWIFT_REQUEST_TYPES].sort());
+  });
+
+  test("no duplicate discriminators", () => {
+    expect(new Set(IOS_KNOWN_REQUEST_TYPES).size).toBe(IOS_KNOWN_REQUEST_TYPES.length);
+  });
+
+  // Authoritative cross-language guard: read the real rawValues out of the Swift enum
+  // and assert they equal ours. Unlike the hand-transcribed list, this fails when a
+  // case is renamed/added/removed on the runner — the drift the module exists to
+  // prevent. Skipped only if Models.swift is unreachable (never in CI).
+  test.skipIf(!existsSync(MODELS_SWIFT))(
+    "IOS_KNOWN_REQUEST_TYPES matches the RequestType rawValues read from Models.swift",
+    () => {
+      const rawValues = readSwiftRequestTypeRawValues();
+      expect(rawValues.length).toBeGreaterThan(0);
+      expect([...new Set(rawValues)].sort()).toEqual([...IOS_KNOWN_REQUEST_TYPES].sort());
+      // The transcribed list must also match source, so it can't rot independently.
+      expect([...new Set(rawValues)].sort()).toEqual([...SWIFT_REQUEST_TYPES].sort());
+    }
+  );
+});
+
+describe("iOS control-proxy — emitted commands are a subset of the runner contract", () => {
+  const files = iosEmitSourceFiles();
+  const allEmitted = new Set<string>();
+  for (const file of files) {
+    for (const type of extractEmittedTypes(readFileSync(file, "utf8"))) {
+      allEmitted.add(type);
+    }
+  }
+
+  test("the scan actually finds emit sites (guards against a broken scanner)", () => {
+    // Anchors that must always be present, spanning all three emit patterns.
+    expect(allEmitted.has("request_tap_coordinates")).toBe(true); // messageType via shared delegate
+    expect(allEmitted.has("get_preferences")).toBe(true); // type: object literal
+    expect(allEmitted.has("request_hierarchy")).toBe(true); // type: ternary
+    expect(allEmitted.has("execute_sql")).toBe(true); // .request(...) first arg
+    expect(allEmitted.size).toBeGreaterThan(20);
+  });
+
+  test("every emitted command type is a known RequestType rawValue", () => {
+    const unknown = [...allEmitted].filter(t => !IOS_KNOWN_REQUEST_TYPE_SET.has(t)).sort();
+    // A non-empty list here is a drift: a TS command the runner cannot decode. Fix by
+    // adding a matching `RequestType` case (and rawValue here), or repairing the sender.
+    expect(unknown).toEqual([]);
+  });
+
+  test("IOS_RUNNER_FEATURE_COMMANDS is a subset of the known RequestType set", () => {
+    const unknown = IOS_RUNNER_FEATURE_COMMANDS.filter(c => !IOS_KNOWN_REQUEST_TYPE_SET.has(c));
+    expect(unknown).toEqual([]);
+  });
+});

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -94,36 +94,61 @@ const EXCLUDED_IOS_FILES = new Set([
   "types.ts",
 ]);
 
+/**
+ * Shared delegates the iOS text + gesture paths route through. These files serve BOTH
+ * platforms, so every command they emit must be valid on the iOS runner too — an
+ * Android-only command added to a shared delegate would (correctly) fail this guard.
+ * The list is hardcoded because iOS routes through exactly these two today; a new
+ * shared delegate the iOS client adopts must be added here (tracked follow-up: derive
+ * this from the iOS import graph so a missed delegate can't silently go unscanned).
+ */
+const SHARED_EMIT_FILES = ["SharedTextDelegate.ts", "SharedGestureDelegate.ts"];
+
 function iosEmitSourceFiles(): string[] {
   const iosFiles = readdirSync(IOS_OBSERVE_DIR)
     .filter(f => f.endsWith(".ts") && !f.endsWith(".test.ts") && !EXCLUDED_IOS_FILES.has(f))
     .map(f => resolve(IOS_OBSERVE_DIR, f));
-  // The iOS text + gesture paths go through the shared delegates; scan them too.
-  const sharedFiles = ["SharedTextDelegate.ts", "SharedGestureDelegate.ts"]
-    .map(f => resolve(SHARED_OBSERVE_DIR, f));
+  const sharedFiles = SHARED_EMIT_FILES.map(f => resolve(SHARED_OBSERVE_DIR, f));
   return [...iosFiles, ...sharedFiles];
 }
 
-/** Extract every command `type` string a source file can put on the wire. */
+// A wire command discriminator: lowercase snake_case, may contain digits (e.g. a
+// hypothetical `request_swipe_v2`). Must match the Swift-side rawValue class so a
+// digit-bearing command can't slip past either side of the guard.
+const COMMAND_TOKEN = "[a-z][a-z0-9_]*";
+
+/**
+ * Extract every command `type` string a source file can put on the wire.
+ *
+ * This is a textual scan, not a full parse, so it recognizes only *literal* command
+ * discriminators in three syntactic shapes (below). It deliberately cannot follow a
+ * value hoisted into a `const` or built from a template — see `guardAgainstDynamicCommandTypes`,
+ * which fails loudly on the template case, and the tracked follow-up for a structural
+ * (AST/lint) replacement.
+ */
 function extractEmittedTypes(source: string): Set<string> {
   const found = new Set<string>();
 
   // 1. `messageType: "..."` — the shared sendCommand discriminator (never anything else).
-  for (const m of source.matchAll(/messageType:\s*"([a-z_]+)"/g)) {
+  for (const m of source.matchAll(new RegExp(`messageType:\\s*"(${COMMAND_TOKEN})"`, "g"))) {
     found.add(m[1]);
   }
-  // 2. Any snake_case string literal on a line carrying the `type:` JSON key. Captures
-  //    object-literal sends (`type: "get_preferences"`), the hierarchy ternary
-  //    (`type: cond ? "request_hierarchy" : "request_hierarchy_if_stale"`) and the
-  //    network send. `messageType:`/`responseType:` (capital T) are not matched by \btype:.
+  // 2a. A string literal directly after the `type:` JSON key, tolerating a line break
+  //     between key and value (`type:\n  "get_preferences"`). `messageType:`/
+  //     `responseType:` (capital T) are not matched by \btype:.
+  for (const m of source.matchAll(new RegExp(`\\btype:\\s*"(${COMMAND_TOKEN})"`, "g"))) {
+    found.add(m[1]);
+  }
+  // 2b. Any string literal on a line carrying the `type:` key — catches the hierarchy
+  //     ternary (`type: cond ? "request_hierarchy" : "request_hierarchy_if_stale"`).
   for (const line of source.split("\n")) {
     if (!/\btype:/.test(line)) { continue; }
-    for (const m of line.matchAll(/"([a-z_]+)"/g)) {
+    for (const m of line.matchAll(new RegExp(`"(${COMMAND_TOKEN})"`, "g"))) {
       found.add(m[1]);
     }
   }
   // 3. `CtrlProxyDatabase.request(<T>)("execute_sql", ...)` first-arg sends.
-  for (const m of source.matchAll(/\.request<[^>]*>\(\s*"([a-z_]+)"/g)) {
+  for (const m of source.matchAll(new RegExp(`\\.request<[^>]*>\\(\\s*"(${COMMAND_TOKEN})"`, "g"))) {
     found.add(m[1]);
   }
 
@@ -133,13 +158,25 @@ function extractEmittedTypes(source: string): Set<string> {
   return found;
 }
 
+/**
+ * The scan only understands *literal* command strings. A template-literal discriminator
+ * (`` type: `request_${kind}` ``) would evade it entirely, silently dropping coverage.
+ * Rather than parse it, forbid it in the scanned files so the scan's assumption is
+ * enforced: a build using a dynamic command `type` must be made statically analyzable
+ * (or this guard updated deliberately). Ternaries-of-literals and `{ type }` shorthand
+ * (a variable, covered by rule 3) are intentionally allowed.
+ */
+function findDynamicCommandTypes(source: string): string[] {
+  return [...source.matchAll(/\b(?:messageType|type):\s*`/g)].map(m => m[0]);
+}
+
 function readSwiftRequestTypeRawValues(): string[] {
   const source = readFileSync(MODELS_SWIFT, "utf8");
   const block = source.match(/public enum RequestType: String, CaseIterable \{([\s\S]*?)\n\}/);
   if (!block) {
     throw new Error("Could not locate `enum RequestType` in Models.swift");
   }
-  return [...block[1].matchAll(/case\s+\w+\s*=\s*"([a-z_]+)"/g)].map(m => m[1]);
+  return [...block[1].matchAll(new RegExp(`case\\s+\\w+\\s*=\\s*"(${COMMAND_TOKEN})"`, "g"))].map(m => m[1]);
 }
 
 describe("iOS control-proxy — RequestType contract coverage", () => {
@@ -190,6 +227,15 @@ describe("iOS control-proxy — emitted commands are a subset of the runner cont
     // A non-empty list here is a drift: a TS command the runner cannot decode. Fix by
     // adding a matching `RequestType` case (and rawValue here), or repairing the sender.
     expect(unknown).toEqual([]);
+  });
+
+  test("no scanned file builds a command type from a template literal", () => {
+    // The literal scan can't follow `` type: `request_${kind}` `` and would silently
+    // drop coverage for it. Forbid the pattern so the scan's assumption stays valid.
+    const offenders = files.flatMap(file =>
+      findDynamicCommandTypes(readFileSync(file, "utf8")).map(hit => `${file}: ${hit}`)
+    );
+    expect(offenders).toEqual([]);
   });
 
   test("IOS_RUNNER_FEATURE_COMMANDS is a subset of the known RequestType set", () => {

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -146,10 +146,6 @@ describe("decodeCtrlProxyMessage", () => {
     expect((decoded?.result as { enabled: boolean }).enabled).toBe(false);
   });
 
-  test("voiceover_action_result includes action", () => {
-    const decoded = decodeCtrlProxyMessage(msg({ type: "voiceover_action_result", action: "activate" } as never));
-    expect(decoded?.result).toEqual({ success: true, action: "activate", totalTimeMs: 0, error: undefined });
-  });
 
   test("highlight_response defaults success to false and echoes requestId/timestamp", () => {
     const decoded = decodeCtrlProxyMessage(msg({ type: "highlight_response", timestamp: 42 }));


### PR DESCRIPTION
## What

Adds a **cross-language wire-parity tripwire** for the iOS `control-proxy` TS client ↔ Swift runner — the iOS analog of the Android/TS guard from #2835 — and fixes the one **live** mismatch it immediately surfaces: `request_voiceover_action`.

Closes #2857.

## Why

The Swift runner locks its own inbound set (`TypedRequestDecodeTests` iterates `RequestType.allCases`), but **nothing** asserted that the command `type` strings the **TS client emits** stay a subset of the Swift `RequestType` rawValues. A new/renamed TS command compiled cleanly and only failed at runtime on-device as an `Unknown command type: <type>` error. This is the "three parallel implementations drift" #2846 warns about.

The tripwire immediately caught a **live** mismatch: `src/features/observe/ios/CtrlProxyVoiceOver.ts` sent `messageType: "request_voiceover_action"`, but **no such case has ever existed in the Swift `RequestType`**. It is reached (not dormant): `TapOnElement.ts:1518` (`executeIOSTapWithVoiceOver`, the iOS VoiceOver-activation tap/longPress path) → the runner rejected it → `result.success` was false → it always logged a warning and fell back to a coordinate tap. The VoiceOver activation path was **dead-on-arrival**.

## How

**1. Tripwire (the durable win).** New `src/features/observe/ios/ctrlProxyRequestTypes.ts` exports `IOS_KNOWN_REQUEST_TYPES` — a checked-in copy of the Swift `RequestType` rawValues (the iOS analog of Android's `KNOWN_REQUEST_TYPES`). New `test/features/observe/ios/ctrlProxyWireParity.test.ts` asserts two independent guarantees:
- `IOS_KNOWN_REQUEST_TYPES` equals the `RequestType` rawValues **read live out of `Models.swift`** (plus a hand-transcribed list that must also match, so neither can rot independently) — a case renamed/added/removed on the runner fails here.
- Every command `type`/`messageType` the iOS client can emit — scanned from `observe/ios/*.ts` + the shared `SharedTextDelegate`/`SharedGestureDelegate` (all three emit shapes: `messageType:`, `type:` object/ternary literals, and `CtrlProxyDatabase.request(...)` first-args) — is a member of `IOS_KNOWN_REQUEST_TYPES`. Adding a TS command the runner can't decode now fails a test.

**2. Resolve `request_voiceover_action` (issue option b — consolidate).** Rather than add a second near-identical runner command, VoiceOver activation now rides the **existing** `request_action` command, which already finds an element by label and dispatches `activate`/`tap` / `long_press` in the Swift `performAction`. This *reduces* the wire surface (serving the anti-drift goal and the repo's "one canonical primitive per concern" rule) instead of adding a parallel command that can itself drift. #2265 (custom accessibility actions via a macOS AXUIElement bridge) is a genuinely different future mechanism that would not reuse this command, so keeping the phantom "for #2265" is not justified.
- `CtrlProxyVoiceOver.requestVoiceOverActivate` now sends `request_action` (was the phantom `request_voiceover_action`); the runner replies `action_result`, which decodes into the same shape.
- Swift `GesturePerformer.performAction` gains an `"activate"` case (→ tap for an element located by label), grouped with `click`/`tap`.
- Removed the now-dead `voiceover_action_result` decoder branch (no runner ever emitted it; `action_result` decoding is already covered).

## Testing

- **New** `ctrlProxyWireParity.test.ts` (6 tests): live Swift-enum read, no-dupes, `IOS_RUNNER_FEATURE_COMMANDS` subset, and the emit-subset guard. Confirmed it goes **RED** on the pre-fix tree with exactly `["request_voiceover_action"]` as the sole unknown, then GREEN after the fix.
- **New** `CtrlProxyVoiceOver.test.ts` cases: `requestVoiceOverActivate` sends `request_action` (not the phantom), carries `label`+`action`, and resolves from `action_result`, for both `activate` and `long_press`.
- **New** Swift `CommandHandlerTests`: `request_action` with `action:"activate"`/`"long_press"` + a label decodes and reaches `performAction` with the label preserved, replying `action_result`.
- Existing `TapOnElement.voiceover.test.ts` (action-mapping) and `decodeCtrlProxyMessage.test.ts` pass; removed the obsolete `voiceover_action_result` decode test.
- Verified locally: `eslint --fix` 0 issues, `bun build.ts` ok, full `bun test` **5895 pass / 0 fail / 2 skip**, `./scripts/ios/swift-test.sh` all packages pass (control-proxy incl. the new tests).

## Acceptance criteria (#2857)
- [x] TS-side contract test: every command string the iOS client can emit is a member of a checked-in copy of the Swift `RequestType` rawValues; adding an unlisted TS command fails a test.
- [x] The checked-in list is verified against the **live** `Models.swift` enum, not just a transcription.
- [x] `request_voiceover_action` resolved: routed through the existing `request_action` command; the VoiceOver activation path is now functional instead of always falling back.
- [ ] *(Deferred, issue's optional item 3)* field-name wire-parity backstop (JSON snapshot fixtures) — filed as a follow-up.

## Delivery note
The `activate` case is compiled into the iOS XCUITest runner, so the on-device VoiceOver fix only reaches end users after the next iOS runner release is cut (the pinned-release checksum registry `src/constants/release.ts` is CI-generated, not edited here). The TS-side wire fix + tripwire land immediately on merge.

## Post-open hardening (commit af73b2d)
Follow-up commit hardens the tripwire scanner per the 3-perspective review: widened the command-token class to allow digits (`[a-z][a-z0-9_]*`) on both the emit-scan and the Swift-enum read; tolerate a `type:` key/value line-break; and a new guard test forbids template-literal command discriminators (the one dynamic shape the literal scan cannot follow). Residual const-hoist / import-graph coverage tracked as follow-ups.