### PR TITLE
fix(ios): reject non-finite gesture coordinates at the handler boundary (#2928)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -345,7 +345,27 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Gestures
 
+    /// Reject a non-finite gesture coordinate (`NaN` / `±Infinity`) at the
+    /// handler boundary before it flows into `CGVector` / `XCUICoordinate`.
+    ///
+    /// JSON has no `NaN`/`Infinity` literal and Apple's `JSONDecoder` rejects an
+    /// overflow literal (`1e309`) at pre-parse, so a non-finite value cannot
+    /// arrive over the wire today. This guard is defense-in-depth for the
+    /// non-wire path — a caller constructing a request directly, or a computed
+    /// coordinate (division, `hypot`, normalized offset) that yields a non-finite
+    /// `Double`. Throwing `CommandError.invalidParameter` makes `handle`'s catch
+    /// return a clean, actionable per-command error response (see #2909's thesis
+    /// that the runner must never surface an opaque failure for unusual input)
+    /// rather than the silent no-op XCUITest would produce.
+    private func requireFinite(_ value: Double, field: String) throws {
+        guard value.isFinite else {
+            throw CommandError.invalidParameter(field, value.description)
+        }
+    }
+
     private func handleTapCoordinates(_ request: RequestTapCoordinates, startTime: Date) throws -> WebSocketResponse {
+        try requireFinite(request.x, field: "x")
+        try requireFinite(request.y, field: "y")
         let duration = request.duration ?? 0
         try gesturePerformer.tap(x: request.x, y: request.y, duration: TimeInterval(duration) / 1000.0)
 
@@ -357,6 +377,10 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleSwipe(_ request: RequestSwipe, startTime: Date) throws -> WebSocketResponse {
+        try requireFinite(request.x1, field: "x1")
+        try requireFinite(request.y1, field: "y1")
+        try requireFinite(request.x2, field: "x2")
+        try requireFinite(request.y2, field: "y2")
         let duration = request.duration ?? 300
         try gesturePerformer.swipe(
             startX: request.x1, startY: request.y1,
@@ -377,6 +401,10 @@ public class CommandHandler: CommandHandling {
     )
         throws -> WebSocketResponse
     {
+        try requireFinite(request.x1, field: "x1")
+        try requireFinite(request.y1, field: "y1")
+        try requireFinite(request.x2, field: "x2")
+        try requireFinite(request.y2, field: "y2")
         // Both request_two_finger_swipe and request_multi_finger_swipe route here;
         // fingerCount defaults to 2 when the client omits it (two-finger never sends it).
         let fingerCount = request.fingerCount ?? 2
@@ -401,6 +429,10 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleDrag(_ request: RequestDrag, startTime: Date) throws -> WebSocketResponse {
+        try requireFinite(request.x1, field: "x1")
+        try requireFinite(request.y1, field: "y1")
+        try requireFinite(request.x2, field: "x2")
+        try requireFinite(request.y2, field: "y2")
         let pressDuration = request.pressDurationMs ?? request.holdTime ?? 600
         let dragDuration = request.dragDurationMs ?? 300
         let holdDuration = request.holdDurationMs ?? 100
@@ -421,6 +453,10 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handlePinch(_ request: RequestPinch, startTime: Date) throws -> WebSocketResponse {
+        try requireFinite(request.centerX, field: "centerX")
+        try requireFinite(request.centerY, field: "centerY")
+        try requireFinite(request.distanceStart, field: "distanceStart")
+        try requireFinite(request.distanceEnd, field: "distanceEnd")
         let path = try gesturePerformer.pinch(
             centerX: request.centerX,
             centerY: request.centerY,

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -708,4 +708,223 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             XCTAssertEqual(key.stringValue, "type")
         }
     }
+
+    // MARK: - Non-finite coordinate rejection (#2928)
+
+    /// Assert that a gesture handler rejected a non-finite coordinate: the
+    /// response is a clean, actionable structured error (`success == false`, the
+    /// command's own result `type`, an `invalidParameter`-style message naming
+    /// the field) rather than an opaque failure — and that nothing was dispatched
+    /// into the gesture engine.
+    private func assertRejectedNonFinite(
+        _ response: WebSocketResponse?,
+        type: String,
+        field: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard let response = response else {
+            return XCTFail("Expected a WebSocketResponse, got nil", file: file, line: line)
+        }
+        XCTAssertEqual(response.type, type, "wrong result type", file: file, line: line)
+        XCTAssertEqual(response.success, false, "expected failure response", file: file, line: line)
+        let message = response.error ?? ""
+        XCTAssertTrue(
+            message.contains("Invalid value") && message.contains(field),
+            "error should name the invalid field '\(field)', got: \(message)",
+            file: file,
+            line: line
+        )
+    }
+
+    /// A non-finite coordinate reaching each gesture handler is rejected with a
+    /// clean per-command error response and never dispatched to the gesture
+    /// engine — one case per gesture family, covering `+Infinity`, `-Infinity`,
+    /// and `NaN`.
+    ///
+    /// Wire note: Apple's `JSONDecoder` rejects an overflow literal like `1e309`
+    /// at pre-parse (see `testOverflowCoordinateLiteralIsRejectedAtDecode`), so a
+    /// non-finite `Double` cannot arrive over the wire today. This guard is
+    /// defense-in-depth for the typed-initializer / computed-coordinate path
+    /// (division, `hypot`, normalized offsets) where a non-finite value can
+    /// legitimately originate.
+    func testNonFiniteTapCoordinateIsRejected() {
+        let response = commandHandler.handle(.tapCoordinates(
+            RequestTapCoordinates(requestId: "tap-inf", x: .infinity, y: 200)
+        )) as? WebSocketResponse
+        assertRejectedNonFinite(response, type: "tap_coordinates_result", field: "x")
+        XCTAssertTrue(fakeGesturePerformer.getTapHistory().isEmpty, "tap must not reach the engine")
+    }
+
+    func testNonFiniteSwipeCoordinateIsRejected() {
+        let response = commandHandler.handle(.swipe(
+            RequestSwipe(requestId: "swipe-inf", x1: 10, y1: 20, x2: 30, y2: -.infinity)
+        )) as? WebSocketResponse
+        assertRejectedNonFinite(response, type: "swipe_result", field: "y2")
+        XCTAssertTrue(fakeGesturePerformer.getSwipeHistory().isEmpty, "swipe must not reach the engine")
+    }
+
+    func testNonFiniteMultiFingerSwipeCoordinateIsRejected() {
+        let response = commandHandler.handle(.multiFingerSwipe(
+            RequestMultiFingerSwipe(requestId: "mfs-nan", x1: .nan, y1: 20, x2: 30, y2: 40, fingerCount: 3)
+        )) as? WebSocketResponse
+        assertRejectedNonFinite(response, type: "multi_finger_swipe_result", field: "x1")
+        XCTAssertTrue(
+            fakeGesturePerformer.getMultiFingerSwipeHistory().isEmpty,
+            "multi-finger swipe must not reach the engine"
+        )
+    }
+
+    func testNonFiniteDragCoordinateIsRejected() {
+        let response = commandHandler.handle(.drag(
+            RequestDrag(requestId: "drag-inf", x1: 10, y1: 20, x2: .infinity, y2: 40)
+        )) as? WebSocketResponse
+        assertRejectedNonFinite(response, type: "drag_result", field: "x2")
+        XCTAssertTrue(fakeGesturePerformer.getDragHistory().isEmpty, "drag must not reach the engine")
+    }
+
+    func testNonFinitePinchCoordinateIsRejected() {
+        let response = commandHandler.handle(.pinch(
+            RequestPinch(requestId: "pinch-nan", centerX: 100, centerY: 200, distanceStart: 40, distanceEnd: .nan)
+        )) as? WebSocketResponse
+        assertRejectedNonFinite(response, type: "pinch_result", field: "distanceEnd")
+        XCTAssertTrue(fakeGesturePerformer.getPinchHistory().isEmpty, "pinch must not reach the engine")
+    }
+
+    /// The two-finger alias routes through the same multi-finger handler, so it
+    /// gets the same guard.
+    func testNonFiniteTwoFingerSwipeCoordinateIsRejected() {
+        let response = commandHandler.handle(.twoFingerSwipe(
+            RequestMultiFingerSwipe(requestId: "tfs-inf", x1: 10, y1: .infinity, x2: 30, y2: 40)
+        )) as? WebSocketResponse
+        assertRejectedNonFinite(response, type: "multi_finger_swipe_result", field: "y1")
+        XCTAssertTrue(
+            fakeGesturePerformer.getMultiFingerSwipeHistory().isEmpty,
+            "two-finger swipe must not reach the engine"
+        )
+    }
+
+    /// Exhaustively pin *every* coordinate field of *every* gesture family: set
+    /// exactly one coordinate non-finite (all others valid) and assert the guard
+    /// rejects that specific field and dispatches nothing — across `+Infinity`,
+    /// `-Infinity`, and `NaN`. Because `requireFinite` short-circuits on the first
+    /// bad field, the per-family tests above only prove the first-checked field;
+    /// this loop proves each trailing `requireFinite` call is load-bearing (a
+    /// deleted `requireFinite(request.y…)` line would fail here).
+    func testEveryCoordinateFieldIsIndividuallyGuarded() {
+        let base: [Double] = [11, 22, 33, 44]
+
+        func check(
+            family: String,
+            fields: [String],
+            resultType: String,
+            make: ([Double]) -> WebSocketRequest,
+            dispatched: () -> Bool,
+            line: UInt = #line
+        ) {
+            for (index, field) in fields.enumerated() {
+                for bad in [Double.infinity, -.infinity, .nan] {
+                    var coords = base
+                    coords[index] = bad
+                    let response = commandHandler.handle(make(coords)) as? WebSocketResponse
+                    assertRejectedNonFinite(response, type: resultType, field: field, line: line)
+                    XCTAssertFalse(dispatched(), "\(family) \(field)=\(bad) must not dispatch", line: line)
+                }
+            }
+        }
+
+        check(
+            family: "tap",
+            fields: ["x", "y"],
+            resultType: "tap_coordinates_result",
+            make: { .tapCoordinates(RequestTapCoordinates(x: $0[0], y: $0[1])) },
+            dispatched: { !self.fakeGesturePerformer.getTapHistory().isEmpty }
+        )
+        check(
+            family: "swipe",
+            fields: ["x1", "y1", "x2", "y2"],
+            resultType: "swipe_result",
+            make: { .swipe(RequestSwipe(x1: $0[0], y1: $0[1], x2: $0[2], y2: $0[3])) },
+            dispatched: { !self.fakeGesturePerformer.getSwipeHistory().isEmpty }
+        )
+        check(
+            family: "multiFingerSwipe",
+            fields: ["x1", "y1", "x2", "y2"],
+            resultType: "multi_finger_swipe_result",
+            make: { .multiFingerSwipe(RequestMultiFingerSwipe(x1: $0[0], y1: $0[1], x2: $0[2], y2: $0[3])) },
+            dispatched: { !self.fakeGesturePerformer.getMultiFingerSwipeHistory().isEmpty }
+        )
+        check(
+            family: "drag",
+            fields: ["x1", "y1", "x2", "y2"],
+            resultType: "drag_result",
+            make: { .drag(RequestDrag(x1: $0[0], y1: $0[1], x2: $0[2], y2: $0[3])) },
+            dispatched: { !self.fakeGesturePerformer.getDragHistory().isEmpty }
+        )
+        check(
+            family: "pinch",
+            fields: ["centerX", "centerY", "distanceStart", "distanceEnd"],
+            resultType: "pinch_result",
+            make: {
+                .pinch(RequestPinch(centerX: $0[0], centerY: $0[1], distanceStart: $0[2], distanceEnd: $0[3]))
+            },
+            dispatched: { !self.fakeGesturePerformer.getPinchHistory().isEmpty }
+        )
+    }
+
+    /// Documents the decode-boundary reality behind #2928: an overflow numeric
+    /// literal is rejected by `JSONDecoder` during pre-parse (`dataCorrupted`,
+    /// empty codingPath) — it does NOT coerce to `Double.infinity`. So no wire
+    /// payload can deliver a non-finite coordinate to the handler on Apple
+    /// Foundation; the `isFinite` guard defends the non-wire construction path.
+    func testOverflowCoordinateLiteralIsRejectedAtDecode() {
+        XCTAssertThrowsError(
+            try decodeWebSocketRequest(#"{"type":"request_tap_coordinates","x":1e309,"y":2}"#)
+        ) { error in
+            guard case DecodingError.dataCorrupted = error else {
+                return XCTFail("Expected dataCorrupted for an overflow literal, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Finite fractional / negative coordinates unaffected (#2909 happy path)
+
+    /// Fractional coordinates decode and reach the engine with the fraction
+    /// intact — the widening's whole point — and are not rejected by the guard.
+    func testFractionalTapCoordinateIsPreserved() {
+        let response = dispatch(
+            #"{"type":"request_tap_coordinates","requestId":"tap-frac","x":100.5,"y":200.25}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.success, true)
+        let history = fakeGesturePerformer.getTapHistory()
+        XCTAssertEqual(history.first?.x ?? -1, 100.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.y ?? -1, 200.25, accuracy: 0.0001)
+    }
+
+    func testFractionalPinchCoordinatesArePreserved() {
+        let response = dispatch(
+            #"""
+            {"type":"request_pinch","requestId":"pinch-frac","centerX":100.5,"centerY":200.5,"distanceStart":40.25,"distanceEnd":120.75}
+            """#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.success, true)
+        let history = fakeGesturePerformer.getPinchHistory()
+        XCTAssertEqual(history.first?.centerX ?? -1, 100.5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.distanceEnd ?? -1, 120.75, accuracy: 0.0001)
+    }
+
+    /// Negative coordinates are finite and legitimate (off-screen anchors); the
+    /// guard must not reject them.
+    func testNegativeSwipeCoordinatesArePreserved() {
+        let response = dispatch(
+            #"{"type":"request_swipe","requestId":"swipe-neg","x1":-5,"y1":-10.5,"x2":30,"y2":40}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.success, true)
+        let history = fakeGesturePerformer.getSwipeHistory()
+        XCTAssertEqual(history.first?.startX ?? .nan, -5, accuracy: 0.0001)
+        XCTAssertEqual(history.first?.startY ?? .nan, -10.5, accuracy: 0.0001)
+    }
 }


### PR DESCRIPTION
## What

Reject **non-finite gesture coordinates** (`NaN` / `±Infinity`) at the iOS CtrlProxy runner's gesture handler boundary, and widen the gesture request coordinate fields `Int → Double` so the guard has a `Double` field to guard (and fractional coordinates decode cleanly).

Closes #2928. The prerequisite `Int → Double` widening (#2909 / PR #2919) **merged to `main` while this PR was in flight**, so after rebase this PR is now purely the guard + tests — the widening dropped out cleanly (identical change), exactly as planned for the self-contained approach.

Affected files (`ios/control-proxy/`):
- `Sources/CtrlProxy/CommandHandler.swift` — shared `requireFinite(_:field:)` helper + guard calls in the five gesture handlers.
- `Tests/CtrlProxyTests/TypedRequestDecodeTests.swift` — non-finite rejection + decode-boundary + fractional/negative happy-path tests.

## Why

Widening the coordinate fields to `Double` (required to accept the fractional coordinates the TS wire path sends with `roundCoordinates: false`, #2909) means the fields can now *hold* a non-finite value. A `NaN`/`Infinity` coordinate flowing unchecked into `CGVector` / `XCUICoordinate.withOffset` / the ObjC synthesizers is undefined behavior — for `tap`/`swipe`/`drag` (not exception-wrapped) it is a silent no-op. Per #2909's thesis, the runner should be robust to any client and never surface an opaque failure for unusual input.

## How

- `requireFinite(_ value: Double, field: String)` throws `CommandError.invalidParameter(field, value.description)` when `!value.isFinite`. `handle`'s existing `catch` turns that into a clean, per-command structured error response (e.g. `tap_coordinates_result`, `success:false`, `"Invalid value 'inf' for parameter 'x'"`) with the correct result `type`, instead of dispatching into XCUITest.
- Called for every coordinate in `handleTapCoordinates` (`x`,`y`), `handleSwipe`/`handleMultiFingerSwipe`/`handleDrag` (`x1`,`y1`,`x2`,`y2`), `handlePinch` (`centerX`,`centerY`,`distanceStart`,`distanceEnd`). The `request_two_finger_swipe` alias routes through the multi-finger handler and inherits the guard.
- The now-redundant `Double(request.x)` wrappers in the handlers are dropped (fields are already `Double`); `GesturePerformer` / `FakeGesturePerformer` already operate in `Double`, so nothing downstream changed.

### Empirical finding (important — the issue's stated mechanism does not hold on Apple Foundation)

The issue assumes `1e309` (valid JSON) decodes to `Double.infinity` into the widened fields. It does **not**. Apple's `JSONDecoder` (Swift 6.2 / macOS 15, and iOS) rejects an overflow literal during **top-level pre-parse** with `DecodingError.dataCorrupted`, empty `codingPath`, underlying *"Number 1e309 is not representable in Swift"* — the value never reaches the field, and `nonConformingFloatDecodingStrategy` (default `.throw`) also rejects the `"Infinity"`/`"NaN"` string forms. So **no wire JSON can deliver a non-finite `Double`** to a handler today, and because the failure is at pre-parse (before any `Decodable` runs) it cannot be attributed to a field.

**Non-Darwin note:** this pre-parse rejection is *Apple/Darwin* Foundation behaviour. `swift-corelibs-Foundation` (Linux) has historically coerced `1e309` → `Double.infinity` at decode instead of throwing — on that decoder the guard would be **load-bearing on the wire**, not merely defense-in-depth. The XCUITest runner only ships on Darwin, so the "cannot arrive over the wire" premise holds for production; the guard simply stays correct on any decoder.

The `isFinite` guard is therefore correct and valuable as **defense-in-depth** for the non-wire path — a caller constructing a request via the typed memberwise initializer, or a *computed* coordinate (division, `hypot`, normalized offset) that yields a non-finite `Double` before hitting the gesture engine. This is documented in the helper's doc comment and proved by a decode-boundary test.

### Deliberate scope

- Only **coordinate** fields are guarded — matching the #2919 widened set. `offset`/`fingerSpacing` and `rotationDegrees` (`Float?`) are not coordinates, were not widened, and the multi-finger/pinch ObjC synthesis is already `@try/@catch`-wrapped. Left out intentionally; noted as a possible follow-up.
- Magnitude is **not** clamped — only finiteness is checked. Exposure to huge finite / negative magnitudes is pre-existing and explicitly out of scope per the issue.

## Testing

`TypedRequestDecodeTests.swift`:
- Non-finite rejection, one per gesture family (`+Infinity`, `-Infinity`, `NaN`, incl. the two-finger alias): asserts a clean per-command error response **and** that nothing reached the fake gesture performer. (Red→green: fails without the guard.)
- `testOverflowCoordinateLiteralIsRejectedAtDecode`: documents that `1e309` is rejected at the decode boundary (`dataCorrupted`).
- Fractional (`100.5`, `120.75`) and negative (`-5`, `-10.5`) happy-path decode+dispatch tests: the #2909 path is unaffected and preserved to `accuracy: 0.0001`.
- `testEveryCoordinateFieldIsIndividuallyGuarded`: exhaustively pins **every** coordinate field of every family × {`+Inf`, `-Inf`, `NaN`} so each `requireFinite` call is proven load-bearing (a deleted trailing guard line fails here), not just the first-checked field.

Verified locally:
- `./scripts/ios/swift-test.sh` — **all packages pass**; control-proxy **307 tests, 0 failures**.
- `swift test -Xswiftc -warnings-as-errors` — clean.
- `swiftformat --lint` clean on touched files; `swiftlint` clean (the two pre-existing `ok` identifier warnings in `SetNetworkMockRulesResponse` are on `main` too, unrelated).

## Acceptance criteria (#2928)
- [x] A gesture request with a non-finite coordinate returns a clean, actionable error response instead of flowing into XCUITest. *(Reachable path is direct/computed construction; wire `1e309` is already rejected at decode — see empirical finding.)*
- [x] Swift test covering a non-finite payload per gesture family (shared parametrized assertion).
- [x] Finite fractional/negative coordinates (the #2909 happy path) are unaffected.

## Relationship to #2919

#2919 (the `Int → Double` widening) **merged to `main`** at 16:40Z on 2026-07-03, mid-flight. This branch was rebased onto that; the only conflict was a duplicate rationale comment in `Models.swift`, resolved in favour of main's. The gesture request coordinate fields are `Double` on `main`; this PR adds the `isFinite` guard on top. `RequestPinch.rotationDegrees` (`Float?`), `offset`/`fingerSpacing`, and runner-output `ElementBounds`/`HighlightBounds` remain unchanged — out of scope, same as #2919.

## Deployment note

This lives in the iOS runner source. It reaches deployed sessions only once the pinned iOS runner release + checksum registry (`src/constants/release.ts`) is re-cut. No interim regression: the shipped TS path still rounds, and non-finite coordinates were never a working input.
