### PR TITLE
feat(mcp): gate structuredContent duplication (drop for no-schema tools) (#2759)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -3,6 +3,7 @@ import { DaemonManager, type DaemonManagerLike } from "./manager";
 import { logger } from "../utils/logger";
 import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "./constants";
 import type { DaemonOptions } from "./types";
+import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
@@ -184,6 +185,43 @@ export interface ProxiedResourceTemplate {
   name: string;
   description?: string;
   mimeType?: string;
+}
+
+/**
+ * The daemon startup options that change its observable MCP behavior and so must
+ * match before a running daemon can be reused: `embeddedSdk` plus every
+ * output-reduction flag. A same-build MCP client that requests one of these
+ * against an already-running daemon started without it (or vice versa) would
+ * otherwise silently get the wrong tool-output contract until a manual restart
+ * (issue #2759 — the `toolResultsNoStructuredContent` case). The output-reduction
+ * fields are derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose `field` names map
+ * 1:1 to `DaemonOptions`) so a new flag is covered automatically.
+ */
+const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
+  "embeddedSdk",
+  ...OUTPUT_REDUCTION_FLAG_SPECS.map(spec => spec.field),
+];
+
+/**
+ * Boolean-valued startup options that differ between the requested MCP config
+ * and the running daemon. Each option is compared as a strict boolean
+ * (`=== true`), so `undefined` and `false` are treated identically. Returns a
+ * human-readable list (empty when everything matches) for logging and error
+ * messages.
+ */
+function startupOptionMismatches(
+  requested: DaemonOptions | undefined,
+  running: DaemonOptions | undefined
+): string[] {
+  const mismatches: string[] = [];
+  for (const key of REUSE_CRITICAL_OPTION_KEYS) {
+    const want = requested?.[key] === true;
+    const have = running?.[key] === true;
+    if (want !== have) {
+      mismatches.push(`${key} (requested=${want}, running=${have})`);
+    }
+  }
+  return mismatches;
 }
 
 /**
@@ -477,20 +515,20 @@ export class DaemonMcpProxy {
       return;
     }
 
-    const requestedEmbeddedSdk = this.config.daemonOptions?.embeddedSdk === true;
-    const runningEmbeddedSdk = status.options?.embeddedSdk === true;
-    if (requestedEmbeddedSdk === runningEmbeddedSdk) {
+    const requested = this.config.daemonOptions;
+    const mismatches = startupOptionMismatches(requested, status.options);
+    if (mismatches.length === 0) {
       return;
     }
 
     if (!this.config.autoStartDaemon) {
       throw new DaemonUnavailableError(
-        "Daemon startup options differ from MCP server options and auto-start is disabled"
+        `Daemon startup options differ from MCP server options (${mismatches.join(", ")}) and auto-start is disabled`
       );
     }
 
     logger.info(
-      `[DaemonMcpProxy] Daemon embeddedSdk=${runningEmbeddedSdk} differs from MCP server embeddedSdk=${requestedEmbeddedSdk}, restarting daemon`
+      `[DaemonMcpProxy] Daemon startup options differ (${mismatches.join(", ")}), restarting daemon`
     );
     await this.daemonManager.restart(this.config.daemonOptions ?? {});
     const ready = await this.daemonManager.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
@@ -501,10 +539,10 @@ export class DaemonMcpProxy {
     }
 
     const restartedStatus = await this.daemonManager.status();
-    const restartedEmbeddedSdk = restartedStatus.options?.embeddedSdk === true;
-    if (!restartedStatus.running || restartedEmbeddedSdk !== requestedEmbeddedSdk) {
+    const remaining = startupOptionMismatches(requested, restartedStatus.options);
+    if (!restartedStatus.running || remaining.length > 0) {
       throw new DaemonUnavailableError(
-        "Daemon restart completed but startup options still differ"
+        `Daemon restart completed but startup options still differ (${remaining.join(", ")})`
       );
     }
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,7 +12,7 @@ import { runWithAbortSignal } from "../utils/AbortContext";
 import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanExecutionLock";
 
 // Import the tool registry
-import { ToolRegistry } from "./toolRegistry";
+import { ToolRegistry, toolHasOutputSchema } from "./toolRegistry";
 import { stripToolResultStructuredContent } from "./stripToolResultStructuredContent";
 
 // Import the resource registry
@@ -341,11 +341,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         execution.abortController.signal,
         () => tool.handler(handlerParams, progressCallback, execution.abortController.signal)
       );
-      // Wire-boundary output policy: strip `structuredContent` when the
-      // `--tool-results-no-structured-content` flag is on (issue #2899). Applied
-      // here — not inside a tool handler — so internal handler callers keep
-      // reading `structuredContent`, and so plain-registered tools are covered.
-      return stripToolResultStructuredContent(result);
+      // Wire-boundary output policy: strip the duplicated `structuredContent`
+      // tree for no-schema tools unconditionally (issue #2759) and for schema
+      // tools when the `--tool-results-no-structured-content` flag is on (issue
+      // #2899). Applied here — not inside a tool handler — so internal handler
+      // callers keep reading `structuredContent`, and so plain-registered tools
+      // are covered.
+      return stripToolResultStructuredContent(result, toolHasOutputSchema(tool));
     } finally {
       executionTracker.endExecution(execution.id);
     }

--- a/src/server/stripToolResultStructuredContent.ts
+++ b/src/server/stripToolResultStructuredContent.ts
@@ -1,12 +1,24 @@
 import { serverConfig } from "../utils/ServerConfig";
 
 /**
- * Wire-boundary output policy for the `--tool-results-no-structured-content`
- * flag (issue #2899). When enabled, drops the `structuredContent` field from the
- * MCP tool-result envelope. Handlers pre-serialize the payload into
+ * Wire-boundary policy for the duplicated `structuredContent` tree on MCP
+ * tool-result envelopes. Handlers pre-serialize the payload into
  * `content[0].text` alongside `structuredContent` (see
  * `createStructuredToolResponse`), so the two are byte-identical duplicates —
- * removing `structuredContent` halves the wire payload with no information loss.
+ * dropping `structuredContent` halves the wire payload with no information loss.
+ *
+ * `structuredContent` is dropped when EITHER (issue #2899 + #2759):
+ * - the tool declares no `outputSchema` — per MCP (2025-06-18) `structuredContent`
+ *   is only meaningful for a tool that advertises an `outputSchema`, so it is
+ *   pure duplication for no-schema tools (`observe`, the largest payload, is one)
+ *   and is dropped **unconditionally**; or
+ * - the `--tool-results-no-structured-content` flag is set — which also drops it
+ *   for schema tools (and `getToolDefinitions` drops their `outputSchema`
+ *   advertisement under the same flag, so the server never advertises structured
+ *   output it will not return).
+ *
+ * Equivalently, `structuredContent` is kept only for a schema tool while the flag
+ * is off.
  *
  * This is applied at the MCP CallTool serialization boundary, NOT inside a tool's
  * handler, and that placement is deliberate:
@@ -17,16 +29,19 @@ import { serverConfig } from "../utils/ServerConfig";
  *   server toward the MCP client.
  * - It covers every tool regardless of registration path, including plain
  *   `register()` tools (`exportPlan`, `recordSteps`) that bypass
- *   `finalizeToolResponse`. That keeps the stripped set aligned with the
- *   `outputSchema` omitted from `tools/list` by `getToolDefinitions`, so the
- *   server never advertises structured output it will not return.
+ *   `finalizeToolResponse`.
  *
  * Non-envelope, primitive, and already-`structuredContent`-free responses pass
  * through unchanged — a safe no-op.
+ *
+ * @param response        The MCP tool-call envelope (or anything envelope-shaped).
+ * @param hasOutputSchema Whether the tool declares an `outputSchema`
+ *                        (`toolHasOutputSchema(tool)` at the call site).
  */
-export function stripToolResultStructuredContent<T>(response: T): T {
+export function stripToolResultStructuredContent<T>(response: T, hasOutputSchema: boolean): T {
+  const shouldStrip = !hasOutputSchema || serverConfig.isToolResultsNoStructuredContentEnabled();
   if (
-    serverConfig.isToolResultsNoStructuredContentEnabled() &&
+    shouldStrip &&
     response !== null &&
     typeof response === "object" &&
     "structuredContent" in (response as Record<string, unknown>)

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -74,6 +74,18 @@ export interface RegisteredTool {
   outputSchema?: any;
 }
 
+/**
+ * Whether a tool declares an `outputSchema`. The single source of truth for the
+ * `structuredContent` gate (issues #2899 + #2759): both the wire-boundary strip
+ * (`stripToolResultStructuredContent` in `index.ts`) and the `tools/list`
+ * advertisement (`getToolDefinitions`) key off this so the wire result and the
+ * advertised schema can never disagree. `outputSchema` is always either a Zod
+ * schema object or `undefined`.
+ */
+export function toolHasOutputSchema(tool: Pick<RegisteredTool, "outputSchema">): boolean {
+  return tool.outputSchema !== undefined && tool.outputSchema !== null;
+}
+
 // The registry that holds all tools
 class ToolRegistryClass {
   private tools: Map<string, RegisteredTool> = new Map();
@@ -740,7 +752,7 @@ class ToolRegistryClass {
     // both consistent avoids advertising output the finalize step will strip.
     const suppressOutputSchema = serverConfig.isToolResultsNoStructuredContentEnabled();
     return this.getAllTools(options).map(tool => {
-      const outputSchema = tool.outputSchema && !suppressOutputSchema
+      const outputSchema = toolHasOutputSchema(tool) && !suppressOutputSchema
         ? flattenTopLevelUnion(toJSONSchema(tool.outputSchema))
         : undefined;
 

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -430,7 +430,7 @@ describe("DaemonMcpProxy", () => {
     });
 
     describe("startup option mismatch handling", () => {
-      function runningStatus(options: { embeddedSdk?: boolean }) {
+      function runningStatus(options: { embeddedSdk?: boolean; toolResultsNoStructuredContent?: boolean }) {
         return {
           running: true,
           pid: 1234,
@@ -464,6 +464,60 @@ describe("DaemonMcpProxy", () => {
           await proxy.listTools();
           expect(fakeManager.restartCalled).toBe(true);
           expect(fakeManager.restartOptions).toEqual({ embeddedSdk: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts daemon when toolResultsNoStructuredContent differs (issue #2759)", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ toolResultsNoStructuredContent: false }), // ensureVersionMatches
+          runningStatus({ toolResultsNoStructuredContent: false }), // ensureBuildMatches
+          runningStatus({ toolResultsNoStructuredContent: false }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ toolResultsNoStructuredContent: true }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { toolResultsNoStructuredContent: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ toolResultsNoStructuredContent: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("does not restart daemon when output-reduction flags match", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ toolResultsNoStructuredContent: true }), // ensureVersionMatches
+          runningStatus({ toolResultsNoStructuredContent: true }), // ensureBuildMatches
+          runningStatus({ toolResultsNoStructuredContent: true }), // ensureStartupOptionsMatch
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { toolResultsNoStructuredContent: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/server/stripToolResultStructuredContent.test.ts
+++ b/test/server/stripToolResultStructuredContent.test.ts
@@ -4,9 +4,19 @@ import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 
 /**
- * Wire-boundary strip for the `--tool-results-no-structured-content` flag
- * (issue #2899). `content[0].text` and `structuredContent` are byte-identical
- * duplicates, so dropping the latter halves the wire payload with no data loss.
+ * Wire-boundary strip for the duplicated `structuredContent` tree.
+ * `content[0].text` and `structuredContent` are byte-identical duplicates, so
+ * dropping the latter halves the wire payload with no data loss. It is dropped
+ * for no-schema tools unconditionally (issue #2759) and for schema tools when
+ * the `--tool-results-no-structured-content` flag is set (issue #2899).
+ *
+ * Decision matrix (second arg = the tool's `hasOutputSchema`):
+ *   hasOutputSchema | flag  | keep structuredContent?
+ *   ----------------|-------|------------------------
+ *   false           | off   | NO  (#2759 no-schema unconditional)
+ *   false           | on    | NO
+ *   true            | off   | YES (#2899 schema tool, spec-conforming)
+ *   true            | on    | NO  (#2899 flag drops it too)
  */
 describe("stripToolResultStructuredContent", () => {
   let original: boolean;
@@ -19,10 +29,10 @@ describe("stripToolResultStructuredContent", () => {
     serverConfig.setToolResultsNoStructuredContentEnabled(original);
   });
 
-  test("EC-A: drops structuredContent when the gate is enabled, keeps content text", () => {
+  test("EC-A: drops structuredContent for a schema tool when the gate is enabled, keeps content text", () => {
     serverConfig.setToolResultsNoStructuredContentEnabled(true);
     const payload = { success: true, message: "done", nested: { a: 1 } };
-    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload));
+    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload), true);
 
     expect("structuredContent" in response).toBe(false);
     expect(response.content[0].type).toBe("text");
@@ -30,17 +40,33 @@ describe("stripToolResultStructuredContent", () => {
     expect(JSON.parse(response.content[0].text)).toEqual(payload);
   });
 
-  test("EC-B: preserves structuredContent when the gate is disabled", () => {
+  test("EC-B: preserves structuredContent for a schema tool when the gate is disabled", () => {
     serverConfig.setToolResultsNoStructuredContentEnabled(false);
-    const response = stripToolResultStructuredContent(createStructuredToolResponse({ success: true }));
+    const response = stripToolResultStructuredContent(createStructuredToolResponse({ success: true }), true);
     expect(response.structuredContent).toEqual({ success: true });
+  });
+
+  test("EC-2759a: drops structuredContent for a no-schema tool even when the gate is disabled", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const payload = { success: true, viewHierarchy: { node: [] } };
+    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload), false);
+    expect("structuredContent" in response).toBe(false);
+    // Text block is preserved — the model-facing surface is intact.
+    expect(JSON.parse(response.content[0].text)).toEqual(payload);
+  });
+
+  test("EC-2759b: drops structuredContent for a no-schema tool when the gate is enabled", () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const response = stripToolResultStructuredContent(createStructuredToolResponse({ success: true }), false);
+    expect("structuredContent" in response).toBe(false);
   });
 
   test("EC-D: strips regardless of payload shape (covers plain-registered tools)", () => {
     serverConfig.setToolResultsNoStructuredContentEnabled(true);
     // e.g. exportPlan/recordSteps: declare an outputSchema, bypass finalizeToolResponse.
     const response = stripToolResultStructuredContent(
-      createStructuredToolResponse({ success: true, plan: "steps:\n  - tapOn: {}" })
+      createStructuredToolResponse({ success: true, plan: "steps:\n  - tapOn: {}" }),
+      true
     );
     expect("structuredContent" in response).toBe(false);
     expect(JSON.parse(response.content[0].text).plan).toBe("steps:\n  - tapOn: {}");
@@ -49,16 +75,16 @@ describe("stripToolResultStructuredContent", () => {
   test("EC-E: response without structuredContent is an unchanged no-op", () => {
     serverConfig.setToolResultsNoStructuredContentEnabled(true);
     const imageResponse: any = { content: [{ type: "image", data: "b64", mimeType: "image/png" }] };
-    const result = stripToolResultStructuredContent(imageResponse);
+    const result = stripToolResultStructuredContent(imageResponse, false);
     expect(result).toBe(imageResponse);
     expect("structuredContent" in result).toBe(false);
   });
 
   test("null / primitive responses pass through untouched", () => {
     serverConfig.setToolResultsNoStructuredContentEnabled(true);
-    expect(stripToolResultStructuredContent(null)).toBeNull();
-    expect(stripToolResultStructuredContent(undefined)).toBeUndefined();
-    expect(stripToolResultStructuredContent("plain")).toBe("plain");
-    expect(stripToolResultStructuredContent(42)).toBe(42);
+    expect(stripToolResultStructuredContent(null, false)).toBeNull();
+    expect(stripToolResultStructuredContent(undefined, false)).toBeUndefined();
+    expect(stripToolResultStructuredContent("plain", false)).toBe("plain");
+    expect(stripToolResultStructuredContent(42, false)).toBe(42);
   });
 });

--- a/test/server/stripToolResultWireBoundary.test.ts
+++ b/test/server/stripToolResultWireBoundary.test.ts
@@ -10,7 +10,10 @@ import { createStructuredToolResponse } from "../../src/utils/toolUtils";
  * the real MCP CallTool boundary (`src/server/index.ts`). Uses a plain
  * `ToolRegistry.register()` probe — the same non-device registration path as
  * `exportPlan`/`recordSteps` — so this also covers the tools that bypass
- * `finalizeToolResponse`.
+ * `finalizeToolResponse`. The probe declares an `outputSchema` (like
+ * `exportPlan`/`recordSteps`) so its `structuredContent` survives the gate-off
+ * case; the no-schema unconditional strip (#2759) is covered separately in
+ * `structuredContentGating.test.ts`.
  */
 describe("CallTool wire boundary strips structuredContent (issue #2899)", () => {
   let fixture: McpTestFixture;
@@ -21,7 +24,10 @@ describe("CallTool wire boundary strips structuredContent (issue #2899)", () => 
       TOOL,
       "probe tool for structuredContent strip",
       z.object({}).passthrough(),
-      async () => createStructuredToolResponse({ success: true, marker: "probe" })
+      async () => createStructuredToolResponse({ success: true, marker: "probe" }),
+      false,
+      false,
+      z.object({ success: z.boolean(), marker: z.string() })
     );
     fixture = new McpTestFixture();
     await fixture.setup();
@@ -31,6 +37,7 @@ describe("CallTool wire boundary strips structuredContent (issue #2899)", () => 
     if (fixture) {
       await fixture.teardown();
     }
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(TOOL);
     serverConfig.setToolResultsNoStructuredContentEnabled(false);
   });
 

--- a/test/server/tools/structuredContentGating.test.ts
+++ b/test/server/tools/structuredContentGating.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry, toolHasOutputSchema } from "../../../src/server/toolRegistry";
+import { serverConfig } from "../../../src/utils/ServerConfig";
+import { createStructuredToolResponse } from "../../../src/utils/toolUtils";
+import { McpTestFixture } from "../../fixtures/mcpTestFixture";
+
+/**
+ * End-to-end gating of the duplicated `structuredContent` tree (issue #2759 —
+ * the no-schema unconditional strip — on top of the flag-gated #2899 strip).
+ *
+ * Exercises the real CallTool wire boundary (`createMcpServer` custom
+ * `CallToolRequestSchema` handler) and `tools/list` (`getToolDefinitions`) via
+ * an in-memory client, using two throwaway tools:
+ *   - `__test_no_schema__`  — no outputSchema (models `observe`)
+ *   - `__test_schema__`     — declares outputSchema (models `tapOn`)
+ */
+
+const NO_SCHEMA_TOOL = "__test_no_schema__";
+const SCHEMA_TOOL = "__test_schema__";
+
+// A deliberately chunky payload so the size-win assertion (EC4) is meaningful.
+const bigPayload = () => ({
+  success: true,
+  viewHierarchy: {
+    node: Array.from({ length: 40 }, (_, i) => ({
+      "resource-id": `com.example:id/node_${i}`,
+      "text": `label ${i} with some descriptive content to add bytes`,
+      "bounds": `[0,${i * 10}][1080,${i * 10 + 48}]`,
+      "clickable": i % 2 === 0,
+    })),
+  },
+});
+
+const schemaResult = z.object({ success: z.boolean(), value: z.string() });
+
+const permissiveCallResult = z.object({
+  content: z.array(z.object({}).passthrough()),
+  structuredContent: z.unknown().optional(),
+  success: z.boolean().optional(),
+  error: z.string().optional(),
+}).passthrough();
+
+const listResult = z.object({
+  tools: z.array(z.object({
+    name: z.string(),
+    inputSchema: z.object({}).passthrough(),
+    outputSchema: z.object({}).passthrough().optional(),
+  }).passthrough()),
+});
+
+describe("structuredContent gating (issue #2759)", () => {
+  let fixture: McpTestFixture;
+
+  beforeAll(async () => {
+    ToolRegistry.register(
+      NO_SCHEMA_TOOL,
+      "throwaway tool without outputSchema",
+      z.object({}),
+      async () => createStructuredToolResponse(bigPayload())
+    );
+    ToolRegistry.register(
+      SCHEMA_TOOL,
+      "throwaway tool with outputSchema",
+      z.object({}),
+      async () => createStructuredToolResponse({ success: true, value: "hello" }),
+      false,
+      false,
+      schemaResult
+    );
+
+    fixture = new McpTestFixture();
+    await fixture.setup();
+  });
+
+  afterEach(() => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+  });
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.teardown();
+    }
+    // Surgically remove the throwaway tools from the singleton registry.
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(NO_SCHEMA_TOOL);
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(SCHEMA_TOOL);
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+  });
+
+  const call = async (name: string) => {
+    const { client } = fixture.getContext();
+    return client.request(
+      { method: "tools/call", params: { name, arguments: {} } },
+      permissiveCallResult
+    );
+  };
+
+  const list = async () => {
+    const { client } = fixture.getContext();
+    return client.request({ method: "tools/list", params: {} }, listResult);
+  };
+
+  test("EC1: no-schema tool returns content only, no structuredContent key (flag off)", async () => {
+    const result = await call(NO_SCHEMA_TOOL);
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content.length).toBeGreaterThan(0);
+    expect("structuredContent" in result).toBe(false);
+  });
+
+  test("EC5: no-schema tool text block still carries the full payload", async () => {
+    const result = await call(NO_SCHEMA_TOOL);
+    const text = (result.content[0] as { text?: string }).text ?? "";
+    expect(text).toContain("viewHierarchy");
+    expect(text).toContain("com.example:id/node_0");
+  });
+
+  test("EC2: schema tool with flag off keeps conforming structuredContent", async () => {
+    const result = await call(SCHEMA_TOOL);
+    expect("structuredContent" in result).toBe(true);
+    expect(result.structuredContent).toEqual({ success: true, value: "hello" });
+  });
+
+  test("EC3: schema tool with flag on drops structuredContent", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const result = await call(SCHEMA_TOOL);
+    expect("structuredContent" in result).toBe(false);
+    // text block is preserved
+    expect((result.content[0] as { text?: string }).text).toContain("hello");
+  });
+
+  test("EC2/EC8: tools/list advertises outputSchema for schema tool, not for no-schema tool (flag off)", async () => {
+    const result = await list();
+    const schemaTool = result.tools.find(t => t.name === SCHEMA_TOOL);
+    const noSchemaTool = result.tools.find(t => t.name === NO_SCHEMA_TOOL);
+    expect(schemaTool?.outputSchema).toBeDefined();
+    expect(noSchemaTool?.outputSchema).toBeUndefined();
+  });
+
+  test("EC3/EC8: tools/list omits outputSchema for every tool when flag on", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const result = await list();
+    for (const tool of result.tools) {
+      expect(tool.outputSchema).toBeUndefined();
+    }
+  });
+
+  test("EC4: stripping the no-schema payload removes a substantial chunk of the wire size", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const stripped = await call(NO_SCHEMA_TOOL);
+    const strippedSize = JSON.stringify(stripped).length;
+    // Reconstruct what the un-stripped envelope would have serialized to: the
+    // same payload duplicated under structuredContent (compact JSON, which is
+    // what the SDK emits on the wire).
+    const payload = JSON.parse((stripped.content[0] as { text: string }).text);
+    const withStructured = { ...stripped, structuredContent: payload };
+    const fullSize = JSON.stringify(withStructured).length;
+    const savedBytes = fullSize - strippedSize;
+    // The duplicate is the compact serialization of the payload plus its
+    // `,"structuredContent":` key — a real, non-trivial fraction of the
+    // two-copy total (~40% here).
+    expect(savedBytes).toBeGreaterThanOrEqual(JSON.stringify(payload).length);
+    expect(savedBytes).toBeGreaterThan(1000);
+    expect(strippedSize).toBeLessThan(fullSize * 0.7);
+  });
+
+  test("shared predicate: toolHasOutputSchema is the single source both gate sites key off", () => {
+    // Both the wire-boundary strip and the tools/list advertisement resolve
+    // "has schema" through this one predicate, so they can never disagree.
+    expect(toolHasOutputSchema(ToolRegistry.getTool(SCHEMA_TOOL)!)).toBe(true);
+    expect(toolHasOutputSchema(ToolRegistry.getTool(NO_SCHEMA_TOOL)!)).toBe(false);
+    expect(toolHasOutputSchema({ outputSchema: undefined })).toBe(false);
+    expect(toolHasOutputSchema({ outputSchema: null })).toBe(false);
+  });
+
+  test("EC6: internal callers invoking handler directly still receive structuredContent (flag on)", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const tool = ToolRegistry.getTool(SCHEMA_TOOL);
+    const direct = await tool!.handler({}, undefined, undefined as unknown as AbortSignal);
+    expect((direct as { structuredContent?: unknown }).structuredContent).toEqual({ success: true, value: "hello" });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2759. Stops billing the same tree twice. Tool handlers pre-serialize into an MCP envelope carrying **both** `content[0].text` (pretty JSON, the universal model-facing surface) **and** a byte-for-byte `structuredContent` duplicate. Per MCP 2025-06-18, `structuredContent` is only meaningful when a tool declares an `outputSchema` — yet `observe` (the largest payload) declares none and still ships the duplicate.

The text block always stays. `structuredContent` is gated:

1. **No-schema tools (unconditional):** stop emitting `structuredContent` when the tool registers no `outputSchema`. Kills the duplicate on `observe`, the biggest payload.
2. **Schema tools (flag-gated):** `--tool-results-no-structured-content` drops `outputSchema` **and** `structuredContent` together (the spec forbids advertising one without the other).

## Changes

- **`src/server/stripToolResultStructuredContent.ts`** (new) — pure helper. Drops `structuredContent` when the tool has no `outputSchema` OR the flag is set; keeps it only for schema tools with the flag off. Preserves `content`/`success`/`error`; never mutates input; no-ops on non-envelope/image/text-only responses.
- **`src/server/index.ts`** — wire the strip at the **CallTool wire boundary**, not the shared handler. Internal `tool.handler(...)` callers (e.g. `DefaultUIStateSetup`, #2897) keep the full envelope.
- **`src/server/toolRegistry.ts`** — `getToolDefinitions` omits the `outputSchema` advertisement when the flag is on.

The flag was already plumbed through `OutputReductionFlags`/`ServerConfig`/daemon (#2756, #2933) but never consumed — this PR is the missing consumer.

## Why this precedes #2760

Compressed text output (TOON/compact) yields **zero** savings for clients that bill `structuredContent` unless this lands first — `structuredContent` must remain valid JSON, so it can't hold TOON.

## Transport coverage

Both paths gated: direct MCP calls hit the strip in `index.ts`; daemon mode runs `createMcpServer`, and `proxyServer.ts` forwards the daemon's already-stripped result + already-omitted `tools/list`.

## Test plan (TDD, EC1–EC8)

- `test/server/stripToolResultStructuredContent.test.ts` — the full keep/strip decision matrix, immutability, field preservation, non-envelope no-ops.
- `test/server/tools/structuredContentGating.test.ts` — end-to-end via in-memory MCP client:
  - EC1: no-schema tool → `content[]` only, no `structuredContent` key.
  - EC2: schema tool, flag off → conforming `structuredContent` kept; `tools/list` advertises `outputSchema`.
  - EC3: schema tool, flag on → `structuredContent` dropped; `tools/list` omits `outputSchema`.
  - EC4: large no-schema payload → serialized wire size drops ~40% (the compact duplicate).
  - EC5: text block preserved (model-facing surface intact).
  - EC6: internal `tool.handler(...)` callers still receive `structuredContent`.
  - EC8: never `structuredContent` without an advertised `outputSchema`.

`bunx turbo run lint build test` → 5938 pass, 0 fail.

## Acceptance (from issue)

- [x] `observe` response contains no `structuredContent`; MCP spec compliance preserved.
- [x] Schema tools unchanged unless the flag is set.
