### PR TITLE
fix(db): make NavigationGraphManager.recordNavigationEvent graph write transactional (#2791)

### DIFF
--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -38,6 +38,35 @@ export class NavigationRepository {
     }
     return getDatabase();
   }
+
+  /**
+   * Return a repository instance whose every read and write runs on the supplied
+   * executor (a Kysely transaction handle) instead of the shared singleton
+   * connection.
+   *
+   * This is the safe way to enlist navigation writes in a caller-owned
+   * transaction: binding the whole instance means no method can accidentally fall
+   * back to `getDatabase()` mid-transaction. A stray singleton query while a
+   * transaction holds the single bun:sqlite connection deadlocks the daemon —
+   * `#enterQuery` (bunSqliteDialect) spins forever for a non-owner and there is no
+   * busy_timeout escape (the in-process JS mutex, not SQLite's lock).
+   */
+  withExecutor(executor: Kysely<Database>): NavigationRepository {
+    return new NavigationRepository(executor);
+  }
+
+  /**
+   * Run `fn` inside a single transaction on this repository's connection, passing
+   * the transaction executor to thread into `withExecutor`. Mirrors
+   * `installedAppsRepository`'s in-repo transaction so callers never touch a raw
+   * database handle. Keep the callback body to DB statements only — the
+   * transaction takes exclusive ownership of the single connection, so any awaited
+   * non-DB IO inside it stalls every other daemon writer for its duration.
+   */
+  async runInTransaction<T>(fn: (trx: Kysely<Database>) => Promise<T>): Promise<T> {
+    return this.getDb().transaction().execute(fn);
+  }
+
   /**
    * Get or create a navigation app record.
    */
@@ -343,74 +372,100 @@ export class NavigationRepository {
     // callers for the same element serialize rather than both inserting duplicate rows
     // (R2356). Keep the body to DB reads/writes only — no IO — since it blocks the daemon
     // for its duration.
-    return db.transaction().execute(async trx => {
-      // Try to find existing element with same properties
-      let query = trx
-        .selectFrom("ui_elements")
-        .selectAll()
-        .where("app_id", "=", appId);
+    //
+    // When this repo is already bound to a caller's transaction (via withExecutor),
+    // opening another transaction would be a nested BEGIN on the same connection —
+    // `#reserveTransaction` throws "Nested transactions are not supported". Run the
+    // body directly on the existing executor instead; it is already serialized and
+    // atomic under the enclosing transaction.
+    if (db.isTransaction) {
+      return this.getOrCreateUIElementWithin(db, appId, element, timestamp);
+    }
+    return db.transaction().execute(trx =>
+      this.getOrCreateUIElementWithin(trx, appId, element, timestamp)
+    );
+  }
 
-      if (element.text !== undefined) {
-        query = query.where("text", "=", element.text);
-      }
-      if (element.resourceId !== undefined) {
-        query = query.where("resource_id", "=", element.resourceId);
-      }
-      if (element.contentDescription !== undefined) {
-        query = query.where("content_description", "=", element.contentDescription);
-      }
-      if (element.className !== undefined) {
-        query = query.where("class_name", "=", element.className);
-      }
-      if (element.bounds) {
-        query = query
-          .where("bounds_left", "=", element.bounds.left)
-          .where("bounds_top", "=", element.bounds.top)
-          .where("bounds_right", "=", element.bounds.right)
-          .where("bounds_bottom", "=", element.bounds.bottom);
-      }
+  private async getOrCreateUIElementWithin(
+    trx: Kysely<Database>,
+    appId: string,
+    element: {
+      text?: string;
+      resourceId?: string;
+      contentDescription?: string;
+      className?: string;
+      bounds?: { left: number; top: number; right: number; bottom: number };
+      clickable?: boolean;
+      scrollable?: boolean;
+    },
+    timestamp: number
+  ): Promise<UIElement> {
+    // Try to find existing element with same properties
+    let query = trx
+      .selectFrom("ui_elements")
+      .selectAll()
+      .where("app_id", "=", appId);
 
-      const existing = await query.executeTakeFirst();
+    if (element.text !== undefined) {
+      query = query.where("text", "=", element.text);
+    }
+    if (element.resourceId !== undefined) {
+      query = query.where("resource_id", "=", element.resourceId);
+    }
+    if (element.contentDescription !== undefined) {
+      query = query.where("content_description", "=", element.contentDescription);
+    }
+    if (element.className !== undefined) {
+      query = query.where("class_name", "=", element.className);
+    }
+    if (element.bounds) {
+      query = query
+        .where("bounds_left", "=", element.bounds.left)
+        .where("bounds_top", "=", element.bounds.top)
+        .where("bounds_right", "=", element.bounds.right)
+        .where("bounds_bottom", "=", element.bounds.bottom);
+    }
 
-      if (existing) {
-        // Update last_seen_at
-        await trx
-          .updateTable("ui_elements")
-          .set({ last_seen_at: timestamp })
-          .where("id", "=", existing.id)
-          .execute();
+    const existing = await query.executeTakeFirst();
 
-        return {
-          ...existing,
-          last_seen_at: timestamp,
-        };
-      }
+    if (existing) {
+      // Update last_seen_at
+      await trx
+        .updateTable("ui_elements")
+        .set({ last_seen_at: timestamp })
+        .where("id", "=", existing.id)
+        .execute();
 
-      // Create new UI element
-      const newElement: NewUIElement = {
-        app_id: appId,
-        text: element.text || null,
-        resource_id: element.resourceId || null,
-        content_description: element.contentDescription || null,
-        class_name: element.className || null,
-        bounds_left: element.bounds?.left || null,
-        bounds_top: element.bounds?.top || null,
-        bounds_right: element.bounds?.right || null,
-        bounds_bottom: element.bounds?.bottom || null,
-        clickable: element.clickable !== undefined ? (element.clickable ? 1 : 0) : null,
-        scrollable: element.scrollable !== undefined ? (element.scrollable ? 1 : 0) : null,
-        first_seen_at: timestamp,
+      return {
+        ...existing,
         last_seen_at: timestamp,
       };
+    }
 
-      const result = await trx
-        .insertInto("ui_elements")
-        .values(newElement)
-        .returningAll()
-        .executeTakeFirstOrThrow();
+    // Create new UI element
+    const newElement: NewUIElement = {
+      app_id: appId,
+      text: element.text || null,
+      resource_id: element.resourceId || null,
+      content_description: element.contentDescription || null,
+      class_name: element.className || null,
+      bounds_left: element.bounds?.left || null,
+      bounds_top: element.bounds?.top || null,
+      bounds_right: element.bounds?.right || null,
+      bounds_bottom: element.bounds?.bottom || null,
+      clickable: element.clickable !== undefined ? (element.clickable ? 1 : 0) : null,
+      scrollable: element.scrollable !== undefined ? (element.scrollable ? 1 : 0) : null,
+      first_seen_at: timestamp,
+      last_seen_at: timestamp,
+    };
 
-      return result;
-    });
+    const result = await trx
+      .insertInto("ui_elements")
+      .values(newElement)
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    return result;
   }
 
   /**

--- a/src/db/testCoverageRepository.ts
+++ b/src/db/testCoverageRepository.ts
@@ -37,6 +37,20 @@ export class TestCoverageRepository {
   }
 
   /**
+   * Return a repository instance whose every read and write runs on the supplied
+   * executor (a Kysely transaction handle) instead of the shared singleton
+   * connection, so coverage writes can enlist in a caller-owned transaction
+   * alongside navigation writes on the same connection.
+   *
+   * Binding the whole instance means no method can fall back to `getDatabase()`
+   * mid-transaction — a stray singleton query while a transaction holds the single
+   * bun:sqlite connection deadlocks the daemon (see `NavigationRepository.withExecutor`).
+   */
+  withExecutor(executor: Kysely<Database>): TestCoverageRepository {
+    return new TestCoverageRepository(this.timer, executor);
+  }
+
+  /**
    * Start a new test coverage session for an app.
    */
   async startSession(sessionUuid: string, appId: string): Promise<TestCoverageSession> {

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -202,6 +202,15 @@ export class NavigationGraphManager implements NavigationGraphService {
 
   /**
    * Create a new instance for testing with injected dependencies.
+   *
+   * Precondition for recordNavigationEvent's atomicity: `repository` and
+   * `testCoverageRepository` MUST resolve to the same underlying connection
+   * (the default is both unbound → shared `getDatabase()` singleton). The
+   * transactional write opens one transaction on the navigation connection and
+   * enlists the coverage repo onto it via withExecutor; injecting a coverage
+   * repo bound to a DIFFERENT Kysely handle would split writes across
+   * connections and silently defeat the rollback guarantee. Tests that inject a
+   * db must pass the SAME instance to both repositories.
    */
   public static createForTesting(
     repository?: NavigationRepository,
@@ -332,6 +341,13 @@ export class NavigationGraphManager implements NavigationGraphService {
     // to DB statements only: telemetry push, notifications, screenshot capture and
     // in-memory field assignments stay OUTSIDE so the exclusive connection is not
     // held across non-DB IO, and so they never run when the transaction rolls back.
+    //
+    // Atomicity precondition: this.repository and this.testCoverageRepository must
+    // share the same underlying connection (both default to the getDatabase()
+    // singleton). The transaction is opened on the navigation connection and the
+    // coverage repo is enlisted onto that same `trx`; a coverage repo bound to a
+    // different connection would split writes and defeat the rollback. See
+    // createForTesting.
     const node = await this.repository.runInTransaction(async trx => {
       const repository = this.repository.withExecutor(trx);
       const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -312,115 +312,135 @@ export class NavigationGraphManager implements NavigationGraphService {
       return;
     }
 
+    const appId = this.currentAppId;
     const screenName = event.destination;
     const timestamp = event.timestamp ?? this.timer.now();
 
-    // Get or create node and update visit count
-    const node = await this.repository.getOrCreateNode(
-      this.currentAppId,
-      screenName,
-      timestamp
-    );
+    // Capture the previous screen up front. The edge is computed from it and the
+    // in-memory field assignments below only happen AFTER the transaction commits,
+    // so on rollback `this.currentScreen` stays the previous screen and the next
+    // event still computes the correct edge.
+    const previousScreen = this.currentScreen;
 
-    // Record node visit for test coverage if session is active
-    if (this.activeTestSession) {
-      await this.testCoverageRepository.recordNodeVisit(
-        this.activeTestSession.id,
-        node.id,
-        timestamp
-      );
-    }
+    // Get modal stack from the most recent tool call (if any)
+    const recentToolCall = this.findCorrelatedToolCall(timestamp);
+    const currentModalStack = recentToolCall?.uiState?.modalStack;
 
-    // Set active navigation state for fingerprint correlation
-    // Fingerprints seen within ACTIVE_NAVIGATION_WINDOW_MS will be correlated to this node
+    // Persist the whole graph write atomically. Every read and write inside the
+    // callback runs on `trx` (via withExecutor) — a stray singleton query here
+    // would deadlock the daemon's only connection (bunSqliteDialect). Keep the body
+    // to DB statements only: telemetry push, notifications, screenshot capture and
+    // in-memory field assignments stay OUTSIDE so the exclusive connection is not
+    // held across non-DB IO, and so they never run when the transaction rolls back.
+    const node = await this.repository.runInTransaction(async trx => {
+      const repository = this.repository.withExecutor(trx);
+      const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);
+
+      // Get or create node and update visit count
+      const n = await repository.getOrCreateNode(appId, screenName, timestamp);
+
+      // Record node visit for test coverage if session is active
+      if (this.activeTestSession) {
+        await testCoverageRepository.recordNodeVisit(
+          this.activeTestSession.id,
+          n.id,
+          timestamp
+        );
+      }
+
+      // Update node modals if present
+      if (currentModalStack && currentModalStack.length > 0) {
+        const modalIds = currentModalStack.map(m => m.identifier || `${m.type}-${m.layer}`);
+        await repository.setNodeModals(n.id, modalIds);
+
+        logger.info(
+          `[NAVIGATION_GRAPH] Screen ${screenName} has ${modalIds.length} modal(s)`
+        );
+      }
+
+      // Create edge from previous screen to current screen
+      if (previousScreen && previousScreen !== screenName) {
+        const interaction = this.findCorrelatedToolCall(timestamp);
+
+        const toolName = interaction?.toolName || null;
+        const toolArgs = interaction?.args || null;
+
+        const edge = await repository.createEdge(
+          appId,
+          previousScreen,
+          screenName,
+          toolName,
+          toolArgs,
+          timestamp
+        );
+
+        // Record edge traversal for test coverage if session is active
+        if (this.activeTestSession) {
+          await testCoverageRepository.recordEdgeTraversal(
+            this.activeTestSession.id,
+            edge.id,
+            timestamp
+          );
+        }
+
+        // Store UI elements if present in interaction
+        if (interaction?.uiState?.selectedElements) {
+          await this.storeUIElements(
+            repository,
+            edge.id,
+            interaction.uiState.selectedElements,
+            timestamp
+          );
+        }
+
+        // Store modal stacks for from/to
+        const fromNode = await repository.getNode(appId, previousScreen);
+        if (fromNode) {
+          const fromModals = await repository.getNodeModals(fromNode.id);
+          if (fromModals.length > 0) {
+            await repository.setEdgeModals(edge.id, "from", fromModals);
+          }
+        }
+
+        if (currentModalStack && currentModalStack.length > 0) {
+          const toModalIds = currentModalStack.map(
+            m => m.identifier || `${m.type}-${m.layer}`
+          );
+          await repository.setEdgeModals(edge.id, "to", toModalIds);
+        }
+
+        // Store scroll position if present
+        if (interaction?.uiState?.scrollPosition) {
+          await this.storeScrollPosition(
+            repository,
+            edge.id,
+            interaction.uiState.scrollPosition,
+            timestamp
+          );
+        }
+      }
+
+      await repository.touchApp(appId);
+      return n;
+    });
+
+    // ---- Post-commit side effects (never inside the transaction) ----
+
+    // Set active navigation state for fingerprint correlation. Fingerprints seen
+    // within ACTIVE_NAVIGATION_WINDOW_MS will be correlated to this node.
     this.activeNavigation = {
       nodeId: node.id,
       screenName: screenName,
       startTime: timestamp,
     };
 
-    // Get modal stack from the most recent tool call (if any)
-    const recentToolCall = this.findCorrelatedToolCall(timestamp);
-    const currentModalStack = recentToolCall?.uiState?.modalStack;
-
-    // Update node modals if present
-    if (currentModalStack && currentModalStack.length > 0) {
-      const modalIds = currentModalStack.map(m => m.identifier || `${m.type}-${m.layer}`);
-      await this.repository.setNodeModals(node.id, modalIds);
-
-      logger.info(
-        `[NAVIGATION_GRAPH] Screen ${screenName} has ${modalIds.length} modal(s)`
-      );
-    }
-
-    // Create edge from previous screen to current screen
-    if (this.currentScreen && this.currentScreen !== screenName) {
-      const interaction = this.findCorrelatedToolCall(timestamp);
-
-      const toolName = interaction?.toolName || null;
-      const toolArgs = interaction?.args || null;
-
-      const edge = await this.repository.createEdge(
-        this.currentAppId,
-        this.currentScreen,
-        screenName,
-        toolName,
-        toolArgs,
-        timestamp
-      );
-
-      // Record edge traversal for test coverage if session is active
-      if (this.activeTestSession) {
-        await this.testCoverageRepository.recordEdgeTraversal(
-          this.activeTestSession.id,
-          edge.id,
-          timestamp
-        );
-      }
-
-      // Store UI elements if present in interaction
-      if (interaction?.uiState?.selectedElements) {
-        await this.storeUIElements(
-          edge.id,
-          interaction.uiState.selectedElements,
-          timestamp
-        );
-      }
-
-      // Store modal stacks for from/to
-      const fromNode = await this.repository.getNode(this.currentAppId, this.currentScreen);
-      if (fromNode) {
-        const fromModals = await this.repository.getNodeModals(fromNode.id);
-        if (fromModals.length > 0) {
-          await this.repository.setEdgeModals(edge.id, "from", fromModals);
-        }
-      }
-
-      if (currentModalStack && currentModalStack.length > 0) {
-        const toModalIds = currentModalStack.map(
-          m => m.identifier || `${m.type}-${m.layer}`
-        );
-        await this.repository.setEdgeModals(edge.id, "to", toModalIds);
-      }
-
-      // Store scroll position if present
-      if (interaction?.uiState?.scrollPosition) {
-        await this.storeScrollPosition(
-          edge.id,
-          interaction.uiState.scrollPosition,
-          timestamp
-        );
-      }
-    }
-
     this.currentScreen = screenName;
-    await this.repository.touchApp(this.currentAppId);
     this.notifyGraphUpdated();
 
     // Push to telemetry dashboard via TelemetryRecorder (has device context for subscriber filtering)
     TelemetryRecorder.getInstance().recordNavigationEvent({
       timestamp,
-      applicationId: this.currentAppId,
+      applicationId: appId,
       destination: screenName,
       source: event.source ?? null,
       arguments: event.arguments ?? null,
@@ -531,8 +551,14 @@ export class NavigationGraphManager implements NavigationGraphService {
 
   /**
    * Store UI elements used in an edge transition.
+   *
+   * `repository` is the transaction-bound repository from the enclosing
+   * recordNavigationEvent write, so these element writes are part of the same
+   * atomic transaction. getOrCreateUIElement runs directly on the executor (it
+   * detects it is already inside a transaction) rather than opening a nested one.
    */
   private async storeUIElements(
+    repository: NavigationRepository,
     edgeId: number,
     selectedElements: SelectedElement[],
     timestamp: number
@@ -544,7 +570,7 @@ export class NavigationGraphManager implements NavigationGraphService {
     const elementIds: number[] = [];
 
     for (const selected of selectedElements) {
-      const element = await this.repository.getOrCreateUIElement(
+      const element = await repository.getOrCreateUIElement(
         this.currentAppId,
         {
           text: selected.text,
@@ -556,13 +582,18 @@ export class NavigationGraphManager implements NavigationGraphService {
       elementIds.push(element.id);
     }
 
-    await this.repository.linkUIElementsToEdge(edgeId, elementIds);
+    await repository.linkUIElementsToEdge(edgeId, elementIds);
   }
 
   /**
    * Store scroll position for an edge.
+   *
+   * `repository` is the transaction-bound repository from the enclosing
+   * recordNavigationEvent write, so these writes are part of the same atomic
+   * transaction.
    */
   private async storeScrollPosition(
+    repository: NavigationRepository,
     edgeId: number,
     scrollPosition: ScrollPosition,
     timestamp: number
@@ -572,7 +603,7 @@ export class NavigationGraphManager implements NavigationGraphService {
     }
 
     // Store the target element
-    const targetElement = await this.repository.getOrCreateUIElement(
+    const targetElement = await repository.getOrCreateUIElement(
       this.currentAppId,
       {
         text: scrollPosition.targetElement.text,
@@ -585,7 +616,7 @@ export class NavigationGraphManager implements NavigationGraphService {
     // Store the container element if present
     let containerElementId: number | undefined;
     if (scrollPosition.container) {
-      const containerElement = await this.repository.getOrCreateUIElement(
+      const containerElement = await repository.getOrCreateUIElement(
         this.currentAppId,
         {
           text: scrollPosition.container.text,
@@ -597,7 +628,7 @@ export class NavigationGraphManager implements NavigationGraphService {
       containerElementId = containerElement.id;
     }
 
-    await this.repository.setScrollPosition(
+    await repository.setScrollPosition(
       edgeId,
       targetElement.id,
       scrollPosition.direction,

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1,9 +1,16 @@
-import { expect, describe, test, beforeEach, afterEach, beforeAll, it } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach, beforeAll, it, spyOn } from "bun:test";
+import type { Kysely } from "kysely";
 import {
   NavigationGraphManager,
   NavigationEvent
 } from "../../../src/features/navigation/NavigationGraphManager";
 import { runMigrations } from "../../helpers/database";
+import { createTestDatabase } from "../../db/testDbHelper";
+import { NavigationRepository } from "../../../src/db/navigationRepository";
+import { TestCoverageRepository } from "../../../src/db/testCoverageRepository";
+import { TelemetryRecorder } from "../../../src/features/telemetry/TelemetryRecorder";
+import { defaultTimer, type Timer } from "../../../src/utils/SystemTimer";
+import type { Database } from "../../../src/db/types";
 
 describe("NavigationGraphManager", () => {
   let manager: NavigationGraphManager;
@@ -824,5 +831,213 @@ describe("NavigationGraphManager - Named Nodes Only", () => {
       const freshSession = NavigationGraphManager.getInstanceForSession("session-reset");
       expect(freshSession.getCurrentAppId()).toBeNull();
     });
+  });
+});
+
+/**
+ * A TestCoverageRepository that throws on recordEdgeTraversal to simulate a
+ * mid-sequence write failure inside recordNavigationEvent's transaction. It also
+ * overrides withExecutor so the throwing behavior survives the manager rebinding
+ * the repo to the transaction executor (a base-class instance would silently drop
+ * the override and run recordNodeVisit on the singleton connection — a deadlock).
+ */
+class ThrowingEdgeTraversalCoverageRepo extends TestCoverageRepository {
+  constructor(
+    private readonly injectedTimer: Timer,
+    db?: Kysely<Database>
+  ) {
+    super(injectedTimer, db);
+  }
+
+  override withExecutor(executor: Kysely<Database>): TestCoverageRepository {
+    return new ThrowingEdgeTraversalCoverageRepo(this.injectedTimer, executor);
+  }
+
+  override async recordEdgeTraversal(): Promise<void> {
+    throw new Error("injected recordEdgeTraversal failure");
+  }
+}
+
+describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", () => {
+  const APP_ID = "com.test.txn";
+
+  let db: Kysely<Database>;
+  let telemetrySpy: ReturnType<typeof spyOn>;
+
+  async function countNodes(screenName?: string): Promise<number> {
+    let q = db
+      .selectFrom("navigation_nodes")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .where("app_id", "=", APP_ID);
+    if (screenName !== undefined) {
+      q = q.where("screen_name", "=", screenName);
+    }
+    const row = await q.executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  async function countEdges(): Promise<number> {
+    const row = await db
+      .selectFrom("navigation_edges")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .where("app_id", "=", APP_ID)
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  async function countEdgeCoverageRows(): Promise<number> {
+    const row = await db
+      .selectFrom("test_edge_coverage")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  beforeEach(async () => {
+    db = await createTestDatabase({ foreignKeys: true });
+    // Replace the telemetry singleton method so recordNavigationEvent's
+    // fire-and-forget telemetry push is observable and never touches a real DB.
+    TelemetryRecorder.resetInstance();
+    telemetrySpy = spyOn(
+      TelemetryRecorder.getInstance(),
+      "recordNavigationEvent"
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    telemetrySpy.mockRestore();
+    TelemetryRecorder.resetInstance();
+    await db.destroy();
+  });
+
+  function makeManager(coverage: TestCoverageRepository): NavigationGraphManager {
+    const navRepo = new NavigationRepository(db);
+    return NavigationGraphManager.createForTesting(navRepo, coverage);
+  }
+
+  test("happy path persists node + visit + edge + traversal rows", async () => {
+    const coverage = new TestCoverageRepository(defaultTimer, db);
+    const manager = makeManager(coverage);
+    await manager.setCurrentApp(APP_ID);
+    await manager.startTestSession("session-happy");
+
+    await manager.recordNavigationEvent(createEvent("Screen1", 1000));
+    await manager.recordNavigationEvent(createEvent("Screen2", 2000));
+
+    expect(await countNodes("Screen1")).toBe(1);
+    expect(await countNodes("Screen2")).toBe(1);
+    expect(await countEdges()).toBe(1);
+    // Two node visits + one edge traversal recorded for the session.
+    const nodeCoverage = await coverage.getCoveredNodes(
+      manager.getActiveTestSession()!.id
+    );
+    expect(nodeCoverage.length).toBe(2);
+    expect(await countEdgeCoverageRows()).toBe(1);
+
+    expect(manager.getCurrentScreen()).toBe("Screen2");
+    expect(telemetrySpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("rolls back all rows when a mid-sequence write throws", async () => {
+    const coverage = new ThrowingEdgeTraversalCoverageRepo(defaultTimer, db);
+    const manager = makeManager(coverage);
+    await manager.setCurrentApp(APP_ID);
+    await manager.startTestSession("session-rollback");
+
+    // First event: no edge (previousScreen null) → recordEdgeTraversal not hit → commits.
+    await manager.recordNavigationEvent(createEvent("Screen1", 1000));
+    expect(manager.getCurrentScreen()).toBe("Screen1");
+
+    const nodesBefore = await countNodes();
+    const edgesBefore = await countEdges();
+    const edgeCoverageBefore = await countEdgeCoverageRows();
+    telemetrySpy.mockClear();
+
+    let notifyCount = 0;
+    manager.setGraphUpdateListener(() => {
+      notifyCount++;
+    });
+
+    // Second event creates an edge, so recordEdgeTraversal fires and throws.
+    await expect(
+      manager.recordNavigationEvent(createEvent("Screen2", 2000))
+    ).rejects.toThrow("injected recordEdgeTraversal failure");
+
+    // Zero new node/edge/coverage rows persisted for the failed event.
+    expect(await countNodes()).toBe(nodesBefore);
+    expect(await countNodes("Screen2")).toBe(0);
+    expect(await countEdges()).toBe(edgesBefore);
+    expect(await countEdgeCoverageRows()).toBe(edgeCoverageBefore);
+
+    // In-memory field rollback invariant: currentScreen (and therefore the
+    // together-assigned activeNavigation) is unchanged from before the call.
+    expect(manager.getCurrentScreen()).toBe("Screen1");
+
+    // Side effects are NOT invoked when the transaction rolls back.
+    expect(telemetrySpy).not.toHaveBeenCalled();
+    expect(notifyCount).toBe(0);
+  });
+
+  test("side effects fire only after the transaction commits", async () => {
+    const coverage = new TestCoverageRepository(defaultTimer, db);
+    const manager = makeManager(coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    // touchApp is the final write inside the transaction; assert it has already
+    // run by the time the post-commit side effects (notify + telemetry) fire.
+    const touchSpy = spyOn(NavigationRepository.prototype, "touchApp");
+
+    let notifyTouchCountAtFire = -1;
+    manager.setGraphUpdateListener(() => {
+      notifyTouchCountAtFire = touchSpy.mock.calls.length;
+    });
+
+    let telemetryTouchCountAtFire = -1;
+    telemetrySpy.mockImplementation(async () => {
+      telemetryTouchCountAtFire = touchSpy.mock.calls.length;
+    });
+
+    await manager.recordNavigationEvent(createEvent("Screen1", 1000));
+
+    expect(touchSpy).toHaveBeenCalled();
+    // notify + telemetry both observed touchApp already invoked → they run after
+    // the transaction body, never inside it.
+    expect(notifyTouchCountAtFire).toBeGreaterThanOrEqual(1);
+    expect(telemetryTouchCountAtFire).toBeGreaterThanOrEqual(1);
+
+    touchSpy.mockRestore();
+  });
+
+  test("does not deadlock a concurrent writer on the shared connection", async () => {
+    const coverage = new TestCoverageRepository(defaultTimer, db);
+    const manager = makeManager(coverage);
+    await manager.setCurrentApp(APP_ID);
+    await manager.recordNavigationEvent(createEvent("Screen1", 1000));
+
+    // A second repository bound to the SAME connection issues an independent write
+    // concurrently with the transactional recordNavigationEvent. If the transaction
+    // held the connection past its body (or a stray singleton query escaped it), the
+    // in-process mutex would deadlock with no busy_timeout escape.
+    const otherRepo = new NavigationRepository(db);
+
+    const work = Promise.all([
+      manager.recordNavigationEvent(createEvent("Screen2", 2000)),
+      otherRepo.getOrCreateApp("com.test.other"),
+      otherRepo.getOrCreateNode("com.test.other", "OtherScreen", 3000),
+    ]);
+
+    const timeout = new Promise((_resolve, reject) =>
+      defaultTimer.setTimeout(
+        () => reject(new Error("deadlock: concurrent writers did not complete")),
+        2000
+      )
+    );
+
+    await Promise.race([work, timeout]);
+
+    // Both writers succeeded.
+    expect(await countEdges()).toBe(1);
+    const otherNode = await otherRepo.getNode("com.test.other", "OtherScreen");
+    expect(otherNode).toBeDefined();
   });
 });

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -893,6 +893,20 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     return Number(row?.count ?? 0);
   }
 
+  async function sessionTotals(
+    sessionId: number
+  ): Promise<{ nodes: number; edges: number }> {
+    const row = await db
+      .selectFrom("test_coverage_sessions")
+      .select(["total_nodes_visited", "total_edges_traversed"])
+      .where("id", "=", sessionId)
+      .executeTakeFirstOrThrow();
+    return {
+      nodes: Number(row.total_nodes_visited),
+      edges: Number(row.total_edges_traversed),
+    };
+  }
+
   beforeEach(async () => {
     db = await createTestDatabase({ foreignKeys: true });
     // Replace the telemetry singleton method so recordNavigationEvent's
@@ -948,9 +962,11 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     await manager.recordNavigationEvent(createEvent("Screen1", 1000));
     expect(manager.getCurrentScreen()).toBe("Screen1");
 
+    const sessionId = manager.getActiveTestSession()!.id;
     const nodesBefore = await countNodes();
     const edgesBefore = await countEdges();
     const edgeCoverageBefore = await countEdgeCoverageRows();
+    const totalsBefore = await sessionTotals(sessionId);
     telemetrySpy.mockClear();
 
     let notifyCount = 0;
@@ -969,6 +985,10 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     expect(await countEdges()).toBe(edgesBefore);
     expect(await countEdgeCoverageRows()).toBe(edgeCoverageBefore);
 
+    // The session total counters (bumped by recordNodeVisit before the throw)
+    // are rolled back too — they run on the same transaction.
+    expect(await sessionTotals(sessionId)).toEqual(totalsBefore);
+
     // In-memory field rollback invariant: currentScreen (and therefore the
     // together-assigned activeNavigation) is unchanged from before the call.
     expect(manager.getCurrentScreen()).toBe("Screen1");
@@ -983,27 +1003,30 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     const manager = makeManager(coverage);
     await manager.setCurrentApp(APP_ID);
 
-    // touchApp is the final write inside the transaction; assert it has already
-    // run by the time the post-commit side effects (notify + telemetry) fire.
+    // touchApp is the final write inside the transaction. Record the number of
+    // times it had run at EVERY notify/telemetry fire (not just the last), so a
+    // stray side effect firing BEFORE the transaction — when touchApp's call count
+    // is still 0 — is caught rather than masked by a later post-commit fire.
     const touchSpy = spyOn(NavigationRepository.prototype, "touchApp");
 
-    let notifyTouchCountAtFire = -1;
+    const notifyTouchCounts: number[] = [];
     manager.setGraphUpdateListener(() => {
-      notifyTouchCountAtFire = touchSpy.mock.calls.length;
+      notifyTouchCounts.push(touchSpy.mock.calls.length);
     });
 
-    let telemetryTouchCountAtFire = -1;
+    const telemetryTouchCounts: number[] = [];
     telemetrySpy.mockImplementation(async () => {
-      telemetryTouchCountAtFire = touchSpy.mock.calls.length;
+      telemetryTouchCounts.push(touchSpy.mock.calls.length);
     });
 
     await manager.recordNavigationEvent(createEvent("Screen1", 1000));
 
-    expect(touchSpy).toHaveBeenCalled();
-    // notify + telemetry both observed touchApp already invoked → they run after
-    // the transaction body, never inside it.
-    expect(notifyTouchCountAtFire).toBeGreaterThanOrEqual(1);
-    expect(telemetryTouchCountAtFire).toBeGreaterThanOrEqual(1);
+    // touchApp runs exactly once (one event), and notify + telemetry each fire
+    // exactly once, each AFTER that final in-transaction write completed — never
+    // inside the transaction and never before it.
+    expect(touchSpy).toHaveBeenCalledTimes(1);
+    expect(notifyTouchCounts).toEqual([1]);
+    expect(telemetryTouchCounts).toEqual([1]);
 
     touchSpy.mockRestore();
   });


### PR DESCRIPTION
## What

`NavigationGraphManager.recordNavigationEvent` wrote node + node-visit + node-modals + edge + edge-traversal + UI-elements + edge-modals + scroll-position + `touchApp` as a sequence of **separately-awaited** statements with **no enclosing transaction**. A mid-sequence throw (e.g. a UNIQUE conflict) or a daemon interrupted mid-`await` left the on-disk navigation graph **partially applied** — a node/edge persisted while its coverage/metadata rows were missing, so `getNavigationGraph`/coverage queries under- or mis-count traversals for edges that visibly exist.

This wraps **only the DB writes** in a single `db.transaction()`, so the graph write is all-or-nothing.

Closes #2791.

## Why

Per finding R4 of the 2026-07-01 DB concurrency/migration audit (P1). All navigation repositories resolve to the **same singleton `getDatabase()`** connection, so one transaction can cover both `NavigationRepository` and `TestCoverageRepository`, but today none of these writes are transactional.

The daemon runs a **single** `bun:sqlite` connection guarded by a hand-rolled async mutex that serializes *individual* queries but **releases across every `await`**. So between (say) `createEdge` and `recordEdgeTraversal` the event loop yields; if the next statement throws, the node + edge are already committed with no rollback.

**Headline risk this design defends against (per reviews — Mira Kessler & Sam Whitfield):** getting the transaction threading wrong doesn't degrade performance — it **deadlocks the entire daemon**, which is strictly worse than the partial-write bug. A `db.transaction()` reserves the one connection under an owner symbol (`bunSqliteDialect.ts` `#reserveTransaction`). Any query NOT dispatched through that same `trx` gets a different owner and `#enterQuery` loops forever — there is **no `busy_timeout` escape** (in-process JS mutex, not SQLite's lock). Every repo method resolves its handle via `this.getDb()` → singleton, so a single stray call inside the transaction wedges the daemon's only connection.

## How

**Structural safety over per-call-site threading.** Rather than thread a `trx` param through ~35 `getDb()` call sites (a single miss = silent deadlock), the whole repository instance is rebound to the transaction:

- **`NavigationRepository.withExecutor(trx)` / `TestCoverageRepository.withExecutor(trx)`** return an instance whose `getDb()` returns `trx`, so **every** read and write on it uses the transaction automatically — it is *impossible* for a bound instance to touch the singleton. This eliminates the stray-`getDb()` deadlock class the reviewers flagged, at the instance level.
- **`NavigationRepository.runInTransaction(fn)`** → `getDb().transaction().execute(fn)`, mirroring `installedAppsRepository`'s in-repo transaction so the manager never handles a raw db.
- **`getOrCreateUIElement` is now transaction-aware** via Kysely's `db.isTransaction`. It opens its own transaction on the singleton path (it's a dynamic-match SELECT-then-INSERT that can't be a single upsert), but when already bound to a caller's `trx` it runs the body **directly on the executor** — a nested `BEGIN` on the same connection is rejected by `#reserveTransaction` ("Nested transactions are not supported").
- **`recordNavigationEvent`** now wraps only the DB writes in `runInTransaction`, using `withExecutor(trx)`-bound repos for every call inside — including the reads (`getNode`, `getNodeModals`) and the final `touchApp`. `storeUIElements`/`storeScrollPosition` take the bound repo so their writes join the same transaction.
- **Side effects moved OUTSIDE the transaction** (only after commit): `TelemetryRecorder.recordNavigationEvent(...)`, `notifyGraphUpdated()`, and the in-memory `this.currentScreen` / `this.activeNavigation` assignments. `previousScreen` is captured before the transaction so the edge is computed correctly and, on rollback, `currentScreen` stays the previous screen.

## Testing

- `bun test test/features/navigation/NavigationGraphManager.test.ts` → **49 pass, 0 fail** (~0.27s), including 4 new transaction tests.
- `bun test test/db/navigationRepository.test.ts test/db/testCoverageRepository.test.ts` → **57 pass, 0 fail**.
- Full suite: `bun test` → **5925 pass, 2 skip, 0 fail**.
- `turbo run lint build` → clean; `schemas/tool-definitions.json` regenerated, no drift.

New tests (real in-memory `createTestDatabase()` + a fake `TestCoverageRepository` that throws on `recordEdgeTraversal` and overrides `withExecutor` so the throw survives rebinding, <100ms, no device):
- **Rollback** — injected throw in `recordEdgeTraversal` → zero new `navigation_nodes`/`navigation_edges`/`test_edge_coverage` rows (counts before/after), and `currentScreen` unchanged.
- **Happy path** — node + visit + edge + traversal rows all present.
- **Side-effect ordering** — telemetry + `notifyGraphUpdated` observe `touchApp` (final in-txn write) already called → they run after commit, never inside; and neither fires on rollback.
- **Concurrent writer** — `recordNavigationEvent` run alongside an independent writer on the same connection completes (guarded by a timeout that fails on deadlock).
- The existing scroll-position tests already route `getOrCreateUIElement` through the new transaction, so the `isTransaction` nested-avoidance path is exercised end-to-end.

## Acceptance criteria (#2791)
- [x] Mid-sequence throw → `recordNavigationEvent` rolls back; zero new node/edge/coverage rows persisted (counts before/after).
- [x] On success, node + visit + edge + traversal rows all present (happy path preserved).
- [x] `TelemetryRecorder.recordNavigationEvent` / `notifyGraphUpdated()` NOT invoked on rollback; not held open across them on success.
- [x] No statement in the sequence uses `this.getDb()` — all go through `trx` (enforced structurally by `withExecutor` binding the whole instance); `touchApp` is inside the txn.
- [x] Concurrent-writer regression test proves completion (no daemon stall).
- [x] In-memory field rollback invariant: `currentScreen`/`activeNavigation` unchanged on rollback.
- [x] Txn body issues only DB statements — side effects asserted to fire only after the `trx` callback returns.
- [x] Regression/unit tests in `NavigationGraphManager.test.ts` using real in-memory DB + fakes, <100ms, non-flaky, no real device.
- [x] lint + build + tests green.

## Notes
- **Sequenced after #2790** (atomic upserts remove the most common mid-sequence throw); this transaction is independently warranted for the crash/shutdown-interruption case.
