### PR TITLE
refactor(image): trim dead ImageUtils/Image surface after jimp migration (#2938)

### DIFF
--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -5,8 +5,6 @@ export { Image } from "./image/ImageTransformer";
 import { Image, ImageMetadata } from "./image/ImageTransformer";
 import { ImageUtils as ImageUtilsInterface } from "./interfaces/ImageUtils";
 
-const DEFAULT_JPEG_QUALITY = 75;
-
 /**
  * Jimp-based implementation for image utilities
  * Provides a functional API for common image operations using the Jimp library
@@ -38,29 +36,6 @@ export class JimpImageUtils implements ImageUtilsInterface {
     return image.crop(width, height, x, y).toBuffer();
   }
 
-  public async rotate(buffer: Buffer, degrees: number): Promise<Buffer> {
-    const image = Image.fromBuffer(buffer);
-    return image.rotate(degrees).toBuffer();
-  }
-
-  public async flip(
-    buffer: Buffer,
-    direction: "horizontal" | "vertical" | "both"
-  ): Promise<Buffer> {
-    const image = Image.fromBuffer(buffer);
-    return image.flip(direction).toBuffer();
-  }
-
-  public async blur(buffer: Buffer, radius: number): Promise<Buffer> {
-    const image = Image.fromBuffer(buffer);
-    return image.blur(radius).toBuffer();
-  }
-
-  public async toJpeg(buffer: Buffer, quality = DEFAULT_JPEG_QUALITY): Promise<Buffer> {
-    const image = Image.fromBuffer(buffer);
-    return image.jpeg({ quality }).toBuffer();
-  }
-
   public async toPng(buffer: Buffer): Promise<Buffer> {
     const image = Image.fromBuffer(buffer);
     return image.png().toBuffer();
@@ -81,11 +56,6 @@ export class JimpImageUtils implements ImageUtilsInterface {
   public async getMetadata(buffer: Buffer): Promise<ImageMetadata> {
     const image = Image.fromBuffer(buffer);
     return image.getMetadata();
-  }
-
-  public async getExifMetadata(buffer: Buffer): Promise<Record<string, any>> {
-    const image = Image.fromBuffer(buffer);
-    return image.getExifMetadata();
   }
 
   public clearCache(): void {

--- a/src/utils/image/ImageTransformer.ts
+++ b/src/utils/image/ImageTransformer.ts
@@ -7,8 +7,8 @@ import { loadJimp, type JimpImage } from "./loadJimp";
 const DEFAULT_JPEG_QUALITY = 75;
 
 interface ImageOptions {
-  format?: "jpg" | "png" | "webp";
-  quality?: number; // 1-100, for jpg and webp
+  format?: "png" | "webp";
+  quality?: number; // 1-100, for webp
   lossless?: boolean;
   nearLossless?: boolean;
   resize?: {
@@ -22,9 +22,6 @@ interface ImageOptions {
     x: number;
     y: number;
   };
-  rotate?: number; // degrees
-  flip?: "horizontal" | "vertical" | "both";
-  blur?: number; // radius
 }
 
 export interface ImageMetadata {
@@ -32,13 +29,10 @@ export interface ImageMetadata {
   height: number;
   format: string;
   size: number;
-  colorSpace?: string;
-  hasAlpha?: boolean;
-  exif?: Record<string, any>;
 }
 
 type OutputFormat = {
-  mime: "image/png" | "image/jpeg" | "image/webp";
+  mime: "image/png" | "image/webp";
   opts?: Record<string, unknown>;
 };
 
@@ -103,44 +97,6 @@ class JimpImageTransformer {
 
     this.options.crop = { width, height, x, y };
     this.operations.push(image => image.crop({ x, y, w: width, h: height }));
-    return this;
-  }
-
-  public rotate(degrees: number): JimpImageTransformer {
-    this.options.rotate = degrees;
-    this.operations.push(image => image.rotate(degrees));
-    return this;
-  }
-
-  public flip(direction: "horizontal" | "vertical" | "both"): JimpImageTransformer {
-    this.options.flip = direction;
-    this.operations.push(image => image.flip({
-      horizontal: direction === "horizontal" || direction === "both",
-      vertical: direction === "vertical" || direction === "both"
-    }));
-    return this;
-  }
-
-  public blur(radius: number): JimpImageTransformer {
-    if (radius < 0) {
-      throw new Error("Blur radius must be a non-negative number");
-    }
-
-    this.options.blur = radius;
-    this.operations.push(image => image.blur(radius));
-    return this;
-  }
-
-  public jpeg(options?: { quality: number }): JimpImageTransformer {
-    const quality = options?.quality || DEFAULT_JPEG_QUALITY;
-
-    if (quality < 1 || quality > 100) {
-      throw new Error("JPEG quality must be between 1 and 100");
-    }
-
-    this.options.format = "jpg";
-    this.options.quality = quality;
-    this.outputFormat = { mime: "image/jpeg", opts: { quality } };
     return this;
   }
 
@@ -266,22 +222,6 @@ export class Image {
     return new JimpImageTransformer(this.buffer, this.timer).crop(width, height, x, y);
   }
 
-  public rotate(degrees: number): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).rotate(degrees);
-  }
-
-  public flip(direction: "horizontal" | "vertical" | "both"): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).flip(direction);
-  }
-
-  public blur(radius: number): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).blur(radius);
-  }
-
-  public jpeg(options?: { quality: number }): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).jpeg(options);
-  }
-
   public png(): JimpImageTransformer {
     return new JimpImageTransformer(this.buffer, this.timer).png();
   }
@@ -315,16 +255,6 @@ export class Image {
       const errorMessage = e instanceof Error ? e.message : String(e);
       throw new Error(`Failed to get image metadata: ${errorMessage}`);
     }
-  }
-
-  /**
-   * Extract EXIF metadata if available
-   *
-   * Note: the previous sharp-based implementation also always returned an
-   * empty object; jimp does not parse EXIF, so this stays a stub.
-   */
-  public async getExifMetadata(): Promise<Record<string, any>> {
-    return {};
   }
 
   // Enhanced utility methods

--- a/src/utils/interfaces/ImageUtils.ts
+++ b/src/utils/interfaces/ImageUtils.ts
@@ -1,7 +1,7 @@
 /**
- * Interface for image utilities
- * Provides image manipulation, transformation, and metadata extraction capabilities.
- * Implemented by JimpImageUtils in ../image-utils.ts.
+ * Interface for image utilities.
+ * Provides resize/crop, PNG/WebP encoding, and basic metadata
+ * (dimensions/format/size). Implemented by JimpImageUtils in ../image-utils.ts.
  */
 export interface ImageUtils {
   /**
@@ -44,41 +44,6 @@ export interface ImageUtils {
   ): Promise<Buffer>;
 
   /**
-   * Rotate an image
-   * @param buffer Image buffer
-   * @param degrees Rotation degrees
-   * @returns Promise with rotated buffer
-   */
-  rotate(buffer: Buffer, degrees: number): Promise<Buffer>;
-
-  /**
-   * Flip an image
-   * @param buffer Image buffer
-   * @param direction Flip direction (horizontal, vertical, or both)
-   * @returns Promise with flipped buffer
-   */
-  flip(
-    buffer: Buffer,
-    direction: "horizontal" | "vertical" | "both"
-  ): Promise<Buffer>;
-
-  /**
-   * Blur an image
-   * @param buffer Image buffer
-   * @param radius Blur radius
-   * @returns Promise with blurred buffer
-   */
-  blur(buffer: Buffer, radius: number): Promise<Buffer>;
-
-  /**
-   * Convert image to JPEG format
-   * @param buffer Image buffer
-   * @param quality JPEG quality (1-100, default 75)
-   * @returns Promise with JPEG buffer
-   */
-  toJpeg(buffer: Buffer, quality?: number): Promise<Buffer>;
-
-  /**
    * Convert image to PNG format
    * @param buffer Image buffer
    * @returns Promise with PNG buffer
@@ -112,17 +77,7 @@ export interface ImageUtils {
     height: number;
     format: string;
     size: number;
-    colorSpace?: string;
-    hasAlpha?: boolean;
-    exif?: Record<string, any>;
   }>;
-
-  /**
-   * Get EXIF metadata from an image
-   * @param buffer Image buffer
-   * @returns Promise with EXIF metadata
-   */
-  getExifMetadata(buffer: Buffer): Promise<Record<string, any>>;
 
   /**
    * Clear the image cache

--- a/test/fakes/FakeImageUtils.ts
+++ b/test/fakes/FakeImageUtils.ts
@@ -9,36 +9,23 @@ export class FakeImageUtils implements ImageUtils {
   private originalBufferResult: Buffer = Buffer.from("original buffer data");
   private resizeResult: Buffer = Buffer.from("resized buffer data");
   private cropResult: Buffer = Buffer.from("cropped buffer data");
-  private rotateResult: Buffer = Buffer.from("rotated buffer data");
-  private flipResult: Buffer = Buffer.from("flipped buffer data");
-  private blurResult: Buffer = Buffer.from("blurred buffer data");
-  private jpegResult: Buffer = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]); // JPEG magic bytes
   private pngResult: Buffer = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]); // PNG magic bytes
   private webpResult: Buffer = Buffer.from("RIFF");
   private metadataResult = {
     width: 1080,
     height: 2400,
     format: "png",
-    size: 1024000,
-    colorSpace: "srgb",
-    hasAlpha: false,
-    exif: undefined
+    size: 1024000
   };
-  private exifMetadataResult: Record<string, any> = {};
   private batchProcessResult: Buffer[] = [];
 
   // Error injection
   private shouldThrowOnGetOriginalBuffer: boolean = false;
   private shouldThrowOnResize: boolean = false;
   private shouldThrowOnCrop: boolean = false;
-  private shouldThrowOnRotate: boolean = false;
-  private shouldThrowOnFlip: boolean = false;
-  private shouldThrowOnBlur: boolean = false;
-  private shouldThrowOnToJpeg: boolean = false;
   private shouldThrowOnToPng: boolean = false;
   private shouldThrowOnToWebp: boolean = false;
   private shouldThrowOnGetMetadata: boolean = false;
-  private shouldThrowOnGetExifMetadata: boolean = false;
   private shouldThrowOnBatchProcess: boolean = false;
 
   // Call tracking
@@ -66,34 +53,6 @@ export class FakeImageUtils implements ImageUtils {
   }
 
   /**
-   * Configure rotate result
-   */
-  setRotateResult(buffer: Buffer): void {
-    this.rotateResult = buffer;
-  }
-
-  /**
-   * Configure flip result
-   */
-  setFlipResult(buffer: Buffer): void {
-    this.flipResult = buffer;
-  }
-
-  /**
-   * Configure blur result
-   */
-  setBlurResult(buffer: Buffer): void {
-    this.blurResult = buffer;
-  }
-
-  /**
-   * Configure JPEG result
-   */
-  setJpegResult(buffer: Buffer): void {
-    this.jpegResult = buffer;
-  }
-
-  /**
    * Configure PNG result
    */
   setPngResult(buffer: Buffer): void {
@@ -115,18 +74,8 @@ export class FakeImageUtils implements ImageUtils {
     height: number;
     format: string;
     size: number;
-    colorSpace?: string;
-    hasAlpha?: boolean;
-    exif?: Record<string, any>;
   }): void {
     this.metadataResult = metadata;
-  }
-
-  /**
-   * Configure EXIF metadata result
-   */
-  setExifMetadataResult(exif: Record<string, any>): void {
-    this.exifMetadataResult = exif;
   }
 
   /**
@@ -158,34 +107,6 @@ export class FakeImageUtils implements ImageUtils {
   }
 
   /**
-   * Enable error throwing for rotate
-   */
-  setShouldThrowOnRotate(shouldThrow: boolean): void {
-    this.shouldThrowOnRotate = shouldThrow;
-  }
-
-  /**
-   * Enable error throwing for flip
-   */
-  setShouldThrowOnFlip(shouldThrow: boolean): void {
-    this.shouldThrowOnFlip = shouldThrow;
-  }
-
-  /**
-   * Enable error throwing for blur
-   */
-  setShouldThrowOnBlur(shouldThrow: boolean): void {
-    this.shouldThrowOnBlur = shouldThrow;
-  }
-
-  /**
-   * Enable error throwing for toJpeg
-   */
-  setShouldThrowOnToJpeg(shouldThrow: boolean): void {
-    this.shouldThrowOnToJpeg = shouldThrow;
-  }
-
-  /**
    * Enable error throwing for toPng
    */
   setShouldThrowOnToPng(shouldThrow: boolean): void {
@@ -204,13 +125,6 @@ export class FakeImageUtils implements ImageUtils {
    */
   setShouldThrowOnGetMetadata(shouldThrow: boolean): void {
     this.shouldThrowOnGetMetadata = shouldThrow;
-  }
-
-  /**
-   * Enable error throwing for getExifMetadata
-   */
-  setShouldThrowOnGetExifMetadata(shouldThrow: boolean): void {
-    this.shouldThrowOnGetExifMetadata = shouldThrow;
   }
 
   /**
@@ -297,41 +211,6 @@ export class FakeImageUtils implements ImageUtils {
     return this.cropResult;
   }
 
-  async rotate(buffer: Buffer, degrees: number): Promise<Buffer> {
-    this.recordCall("rotate", { bufferLength: buffer.length, degrees });
-    if (this.shouldThrowOnRotate) {
-      throw new Error("Simulated error in rotate");
-    }
-    return this.rotateResult;
-  }
-
-  async flip(
-    buffer: Buffer,
-    direction: "horizontal" | "vertical" | "both"
-  ): Promise<Buffer> {
-    this.recordCall("flip", { bufferLength: buffer.length, direction });
-    if (this.shouldThrowOnFlip) {
-      throw new Error("Simulated error in flip");
-    }
-    return this.flipResult;
-  }
-
-  async blur(buffer: Buffer, radius: number): Promise<Buffer> {
-    this.recordCall("blur", { bufferLength: buffer.length, radius });
-    if (this.shouldThrowOnBlur) {
-      throw new Error("Simulated error in blur");
-    }
-    return this.blurResult;
-  }
-
-  async toJpeg(buffer: Buffer, quality = 75): Promise<Buffer> {
-    this.recordCall("toJpeg", { bufferLength: buffer.length, quality });
-    if (this.shouldThrowOnToJpeg) {
-      throw new Error("Simulated error in toJpeg");
-    }
-    return this.jpegResult;
-  }
-
   async toPng(buffer: Buffer): Promise<Buffer> {
     this.recordCall("toPng", { bufferLength: buffer.length });
     if (this.shouldThrowOnToPng) {
@@ -365,23 +244,12 @@ export class FakeImageUtils implements ImageUtils {
     height: number;
     format: string;
     size: number;
-    colorSpace?: string;
-    hasAlpha?: boolean;
-    exif?: Record<string, any>;
   }> {
     this.recordCall("getMetadata", { bufferLength: buffer.length });
     if (this.shouldThrowOnGetMetadata) {
       throw new Error("Simulated error in getMetadata");
     }
     return this.metadataResult;
-  }
-
-  async getExifMetadata(buffer: Buffer): Promise<Record<string, any>> {
-    this.recordCall("getExifMetadata", { bufferLength: buffer.length });
-    if (this.shouldThrowOnGetExifMetadata) {
-      throw new Error("Simulated error in getExifMetadata");
-    }
-    return this.exifMetadataResult;
   }
 
   clearCache(): void {

--- a/test/utils/image-utils.test.ts
+++ b/test/utils/image-utils.test.ts
@@ -47,21 +47,26 @@ describe("ImageUtils", () => {
   });
 
   describe("interface implementation", () => {
-    test("should implement ImageUtils interface", () => {
+    test("should implement the trimmed ImageUtils interface", () => {
       expect(imageUtils).toHaveProperty("getOriginalBuffer");
       expect(imageUtils).toHaveProperty("resize");
       expect(imageUtils).toHaveProperty("crop");
-      expect(imageUtils).toHaveProperty("rotate");
-      expect(imageUtils).toHaveProperty("flip");
-      expect(imageUtils).toHaveProperty("blur");
-      expect(imageUtils).toHaveProperty("toJpeg");
       expect(imageUtils).toHaveProperty("toPng");
       expect(imageUtils).toHaveProperty("toWebp");
       expect(imageUtils).toHaveProperty("getMetadata");
-      expect(imageUtils).toHaveProperty("getExifMetadata");
       expect(imageUtils).toHaveProperty("clearCache");
       expect(imageUtils).toHaveProperty("setCacheSize");
       expect(imageUtils).toHaveProperty("batchProcess");
+    });
+
+    test("should no longer expose the dead image-transform surface", () => {
+      // Removed as dead wrapper surface in the sharp->jimp cleanup (#2938):
+      // zero production consumers existed for any of these.
+      expect(imageUtils).not.toHaveProperty("rotate");
+      expect(imageUtils).not.toHaveProperty("flip");
+      expect(imageUtils).not.toHaveProperty("blur");
+      expect(imageUtils).not.toHaveProperty("toJpeg");
+      expect(imageUtils).not.toHaveProperty("getExifMetadata");
     });
   });
 });
@@ -80,6 +85,17 @@ describe("FakeImageUtils", () => {
       expect(metadata.width).toBe(1080);
       expect(metadata.height).toBe(2400);
       expect(metadata.format).toBe("png");
+    });
+
+    test("Fake metadata stays in parity with the real jimp shape", async () => {
+      // Guards the Fake's defaults, not the real path (which is type-constrained
+      // to width/height/format/size). The real getMetadata only yields those
+      // four fields, so the Fake must not be more capable than production (#2938).
+      const metadata = await fakeImageUtils.getMetadata(Buffer.from("test"));
+
+      expect(metadata).not.toHaveProperty("colorSpace");
+      expect(metadata).not.toHaveProperty("hasAlpha");
+      expect(metadata).not.toHaveProperty("exif");
     });
 
     test("should allow configuring metadata", async () => {
@@ -184,50 +200,6 @@ describe("FakeImageUtils", () => {
       }
     });
 
-    test("should throw on rotate when configured", async () => {
-      fakeImageUtils.setShouldThrowOnRotate(true);
-
-      try {
-        await fakeImageUtils.rotate(Buffer.from("test"), 90);
-        throw new Error("Should have thrown");
-      } catch (error: any) {
-        expect(error.message).toBe("Simulated error in rotate");
-      }
-    });
-
-    test("should throw on flip when configured", async () => {
-      fakeImageUtils.setShouldThrowOnFlip(true);
-
-      try {
-        await fakeImageUtils.flip(Buffer.from("test"), "horizontal");
-        throw new Error("Should have thrown");
-      } catch (error: any) {
-        expect(error.message).toBe("Simulated error in flip");
-      }
-    });
-
-    test("should throw on blur when configured", async () => {
-      fakeImageUtils.setShouldThrowOnBlur(true);
-
-      try {
-        await fakeImageUtils.blur(Buffer.from("test"), 5);
-        throw new Error("Should have thrown");
-      } catch (error: any) {
-        expect(error.message).toBe("Simulated error in blur");
-      }
-    });
-
-    test("should throw on toJpeg when configured", async () => {
-      fakeImageUtils.setShouldThrowOnToJpeg(true);
-
-      try {
-        await fakeImageUtils.toJpeg(Buffer.from("test"));
-        throw new Error("Should have thrown");
-      } catch (error: any) {
-        expect(error.message).toBe("Simulated error in toJpeg");
-      }
-    });
-
     test("should throw on toPng when configured", async () => {
       fakeImageUtils.setShouldThrowOnToPng(true);
 
@@ -261,17 +233,6 @@ describe("FakeImageUtils", () => {
       }
     });
 
-    test("should throw on getExifMetadata when configured", async () => {
-      fakeImageUtils.setShouldThrowOnGetExifMetadata(true);
-
-      try {
-        await fakeImageUtils.getExifMetadata(Buffer.from("test"));
-        throw new Error("Should have thrown");
-      } catch (error: any) {
-        expect(error.message).toBe("Simulated error in getExifMetadata");
-      }
-    });
-
     test("should throw on batchProcess when configured", async () => {
       fakeImageUtils.setShouldThrowOnBatchProcess(true);
 
@@ -290,12 +251,12 @@ describe("FakeImageUtils", () => {
 
       await fakeImageUtils.resize(buffer, 100);
       await fakeImageUtils.crop(buffer, 50, 50);
-      await fakeImageUtils.rotate(buffer, 90);
+      await fakeImageUtils.toWebp(buffer);
       await fakeImageUtils.toPng(buffer);
 
       expect(fakeImageUtils.getMethodCallCount("resize")).toBe(1);
       expect(fakeImageUtils.getMethodCallCount("crop")).toBe(1);
-      expect(fakeImageUtils.getMethodCallCount("rotate")).toBe(1);
+      expect(fakeImageUtils.getMethodCallCount("toWebp")).toBe(1);
       expect(fakeImageUtils.getMethodCallCount("toPng")).toBe(1);
     });
 
@@ -326,21 +287,24 @@ describe("FakeImageUtils", () => {
   });
 
   describe("all methods existence", () => {
-    test("should have all ImageUtils methods", () => {
+    test("should have all retained ImageUtils methods", () => {
       expect(fakeImageUtils).toHaveProperty("getOriginalBuffer");
       expect(fakeImageUtils).toHaveProperty("resize");
       expect(fakeImageUtils).toHaveProperty("crop");
-      expect(fakeImageUtils).toHaveProperty("rotate");
-      expect(fakeImageUtils).toHaveProperty("flip");
-      expect(fakeImageUtils).toHaveProperty("blur");
-      expect(fakeImageUtils).toHaveProperty("toJpeg");
       expect(fakeImageUtils).toHaveProperty("toPng");
       expect(fakeImageUtils).toHaveProperty("toWebp");
       expect(fakeImageUtils).toHaveProperty("getMetadata");
-      expect(fakeImageUtils).toHaveProperty("getExifMetadata");
       expect(fakeImageUtils).toHaveProperty("clearCache");
       expect(fakeImageUtils).toHaveProperty("setCacheSize");
       expect(fakeImageUtils).toHaveProperty("batchProcess");
+    });
+
+    test("should not expose the removed image-transform surface", () => {
+      expect(fakeImageUtils).not.toHaveProperty("rotate");
+      expect(fakeImageUtils).not.toHaveProperty("flip");
+      expect(fakeImageUtils).not.toHaveProperty("blur");
+      expect(fakeImageUtils).not.toHaveProperty("toJpeg");
+      expect(fakeImageUtils).not.toHaveProperty("getExifMetadata");
     });
   });
 });


### PR DESCRIPTION
## What

Trim the dead `ImageUtils` / `Image` wrapper surface left over from the sharp→jimp migration (#2920, now merged). Removes methods with **zero production consumers** and metadata fields the real jimp path never populates.

Closes #2938.

## Why

The #2920 port preserved the existing `ImageUtils` / `Image` public shape to keep that diff scoped to "remove sharp." Post-migration audit (issue #2938, re-confirmed here by grep across `src/`) shows a chunk of that surface has no callers, so it's the right moment to apply YAGNI (per `CLAUDE.md`: "grow the interface when the second consumer arrives").

**What's actually live** (retained, untouched): `resize`, `crop` (`SelectionStateDetector.ts:216` — the only `imageUtils.*` production call), `png`/`webp` encode, `getMetadata` (width/height), plus the direct-jimp paths in `PerceptualHasher`/`ScreenshotComparator`.

**What's dead** (removed): `rotate`, `flip`, `blur`, `toJpeg`, `getExifMetadata` — referenced only by tests / `FakeImageUtils` / the interface. `getExifMetadata` was a pure `{}` stub (jimp parses no EXIF; sharp's old impl also always returned `{}`) — a latent trap for a future caller trusting the name. `ImageMetadata.colorSpace`/`hasAlpha`/`exif` were **never populated** by the jimp `getMetadata` (width/height/format/size only), yet `FakeImageUtils` still set `colorSpace: "srgb"`/`hasAlpha` — the Fake was *more capable than the real impl*, so a test could pass against the Fake while production returns `undefined`.

## How

- **`src/utils/interfaces/ImageUtils.ts`** — drop `rotate`/`flip`/`blur`/`toJpeg`/`getExifMetadata`; drop `colorSpace`/`hasAlpha`/`exif` from the `getMetadata` return type.
- **`src/utils/image-utils.ts`** (`JimpImageUtils`) — drop the same five wrappers; drop now-unused `DEFAULT_JPEG_QUALITY`.
- **`src/utils/image/ImageTransformer.ts`** — drop `rotate`/`flip`/`blur`/`jpeg` from the `Image` facade and `JimpImageTransformer`; drop `getExifMetadata`; drop `colorSpace`/`hasAlpha`/`exif` from `ImageMetadata`; prune now-unreachable `ImageOptions.rotate`/`flip`/`blur` and the `"jpg"`/`"image/jpeg"` format branches.
- **`test/fakes/FakeImageUtils.ts`** — remove the five methods, their result fields, setters, and error flags; align default metadata to width/height/format/size.

Net: **−350/+36 lines**, no live path touched.

## Testing

- TDD: updated `test/utils/image-utils.test.ts` **first** to assert the removed surface is gone (`not.toHaveProperty`) and metadata carries no `colorSpace`/`hasAlpha`/`exif` — confirmed red, then implemented removals to green. **28 pass / 0 fail.**
- `SelectionStateDetector` (the only production consumer, uses `crop`) — **green**.
- `bun run build` ok; `eslint --fix` 0 issues.

## Acceptance criteria (#2938)
- [x] Dead methods `rotate`/`flip`/`blur`/`toJpeg` removed from the interface, `JimpImageUtils`, `Image`/`JimpImageTransformer`, `FakeImageUtils`, and their tests.
- [x] `getExifMetadata` stub deleted (was always `{}`; no consumer).
- [x] `ImageMetadata.colorSpace`/`hasAlpha`/`exif` dropped from the type and the Fake aligned, closing the Fake-more-capable-than-real gap.
- [x] No production consumer references any removed symbol (grep-verified across `src/`); live surface (`resize`/`crop`/`png`/`webp`/`getMetadata`) unchanged.
