### PR TITLE
fix(db): assert nav + coverage repos share one connection before txn (#2968)

### DIFF
--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -40,6 +40,17 @@ export class NavigationRepository {
   }
 
   /**
+   * The Kysely connection this repository resolves to: the executor bound via
+   * `withExecutor`/the constructor, or the shared `getDatabase()` singleton when
+   * unbound. Exposed so a caller enlisting a second repository in one transaction
+   * can assert both resolve to the SAME connection before opening it — two unbound
+   * repositories share the singleton, so identity (`===`) holds by construction.
+   */
+  resolveConnection(): Kysely<Database> {
+    return this.getDb();
+  }
+
+  /**
    * Return a repository instance whose every read and write runs on the supplied
    * executor (a Kysely transaction handle) instead of the shared singleton
    * connection.

--- a/src/db/testCoverageRepository.ts
+++ b/src/db/testCoverageRepository.ts
@@ -37,6 +37,18 @@ export class TestCoverageRepository {
   }
 
   /**
+   * The Kysely connection this repository resolves to: the executor bound via
+   * `withExecutor`/the constructor, or the shared `getDatabase()` singleton when
+   * unbound. Exposed so a transaction owner (NavigationGraphManager) can assert
+   * this coverage repo shares the navigation repo's connection before enlisting
+   * both in one transaction — a foreign-bound coverage repo would otherwise split
+   * writes and silently defeat the rollback guarantee.
+   */
+  resolveConnection(): Kysely<Database> {
+    return this.getDb();
+  }
+
+  /**
    * Return a repository instance whose every read and write runs on the supplied
    * executor (a Kysely transaction handle) instead of the shared singleton
    * connection, so coverage writes can enlist in a caller-owned transaction

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -4,6 +4,7 @@ import { BackStackInfo } from "../../models";
 import { NavigationRepository } from "../../db/navigationRepository";
 import { TelemetryRecorder } from "../telemetry/TelemetryRecorder";
 import { TestCoverageRepository } from "../../db/testCoverageRepository";
+import { ActionableError } from "../../models/ActionableError";
 import type { NavigationEdge as DBNavigationEdge, NavigationNode as DBNavigationNode, TestCoverageSession } from "../../db/types";
 import {
   NavigationGraph,
@@ -211,6 +212,10 @@ export class NavigationGraphManager implements NavigationGraphService {
    * repo bound to a DIFFERENT Kysely handle would split writes across
    * connections and silently defeat the rollback guarantee. Tests that inject a
    * db must pass the SAME instance to both repositories.
+   *
+   * This precondition is now enforced at runtime: recordNavigationEvent calls
+   * assertSharedConnection() before opening the transaction, so a foreign-bound
+   * coverage repo throws an ActionableError instead of silently splitting writes.
    */
   public static createForTesting(
     repository?: NavigationRepository,
@@ -348,6 +353,14 @@ export class NavigationGraphManager implements NavigationGraphService {
     // coverage repo is enlisted onto that same `trx`; a coverage repo bound to a
     // different connection would split writes and defeat the rollback. See
     // createForTesting.
+    // Fail loudly BEFORE reserving the connection if the atomicity precondition
+    // is violated: the transaction is opened on the navigation connection and the
+    // coverage repo is enlisted onto that same `trx`, so a coverage repo bound to a
+    // DIFFERENT connection would split writes and silently defeat the rollback. In
+    // production both default to the getDatabase() singleton, so this holds by
+    // construction; the guard catches a mistakenly foreign-bound injected repo.
+    this.assertSharedConnection();
+
     const node = await this.repository.runInTransaction(async trx => {
       const repository = this.repository.withExecutor(trx);
       const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);
@@ -464,6 +477,28 @@ export class NavigationGraphManager implements NavigationGraphService {
       triggeringInteraction: event.triggeringInteraction ?? null,
       screenshotUri: `automobile:navigation/nodes/${node.id}/screenshot`,
     });
+  }
+
+  /**
+   * Assert that the navigation and test-coverage repositories resolve to the same
+   * underlying connection — the precondition for recordNavigationEvent's single
+   * transaction to cover both repos' writes atomically.
+   *
+   * Both default to the getDatabase() singleton, so this holds by construction in
+   * production; the guard exists so a mistakenly foreign-bound coverage repo
+   * (e.g. injected in a test or a future refactor) fails loudly here instead of
+   * silently splitting writes across connections and defeating the rollback.
+   */
+  private assertSharedConnection(): void {
+    if (this.repository.resolveConnection() !== this.testCoverageRepository.resolveConnection()) {
+      throw new ActionableError(
+        "NavigationGraphManager: the navigation and test-coverage repositories resolve to " +
+        "different database connections. recordNavigationEvent opens one transaction on the " +
+        "navigation connection and enlists coverage writes onto it; a foreign-bound coverage " +
+        "repo would split writes across connections and silently defeat the rollback guarantee. " +
+        "Both repositories must share the same connection (both default to the getDatabase() singleton)."
+      );
+    }
   }
 
   /**

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -340,27 +340,19 @@ export class NavigationGraphManager implements NavigationGraphService {
     const recentToolCall = this.findCorrelatedToolCall(timestamp);
     const currentModalStack = recentToolCall?.uiState?.modalStack;
 
+    // Enforce the shared-connection precondition BEFORE reserving the connection:
+    // the transaction below is opened on the navigation connection and the coverage
+    // repo is enlisted onto that same `trx`, so a coverage repo bound to a DIFFERENT
+    // connection would split writes and defeat the rollback. Holds by construction in
+    // production (both default to the getDatabase() singleton); see assertSharedConnection.
+    this.assertSharedConnection();
+
     // Persist the whole graph write atomically. Every read and write inside the
     // callback runs on `trx` (via withExecutor) — a stray singleton query here
     // would deadlock the daemon's only connection (bunSqliteDialect). Keep the body
     // to DB statements only: telemetry push, notifications, screenshot capture and
     // in-memory field assignments stay OUTSIDE so the exclusive connection is not
     // held across non-DB IO, and so they never run when the transaction rolls back.
-    //
-    // Atomicity precondition: this.repository and this.testCoverageRepository must
-    // share the same underlying connection (both default to the getDatabase()
-    // singleton). The transaction is opened on the navigation connection and the
-    // coverage repo is enlisted onto that same `trx`; a coverage repo bound to a
-    // different connection would split writes and defeat the rollback. See
-    // createForTesting.
-    // Fail loudly BEFORE reserving the connection if the atomicity precondition
-    // is violated: the transaction is opened on the navigation connection and the
-    // coverage repo is enlisted onto that same `trx`, so a coverage repo bound to a
-    // DIFFERENT connection would split writes and silently defeat the rollback. In
-    // production both default to the getDatabase() singleton, so this holds by
-    // construction; the guard catches a mistakenly foreign-bound injected repo.
-    this.assertSharedConnection();
-
     const node = await this.repository.runInTransaction(async trx => {
       const repository = this.repository.withExecutor(trx);
       const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);

--- a/test/db/navigationRepository.test.ts
+++ b/test/db/navigationRepository.test.ts
@@ -411,4 +411,24 @@ describe("NavigationRepository", () => {
       expect(app).toBeDefined();
     });
   });
+
+  describe("resolveConnection", () => {
+    test("returns the bound executor for a repo constructed with a db", () => {
+      const bound = new NavigationRepository(db);
+      expect(bound.resolveConnection()).toBe(db);
+    });
+
+    test("returns the shared singleton for an unbound repo", () => {
+      // Two independently-constructed unbound repos must resolve to the SAME
+      // getDatabase() singleton so a connection-identity check between them holds.
+      const a = new NavigationRepository();
+      const b = new NavigationRepository();
+      expect(a.resolveConnection()).toBe(b.resolveConnection());
+    });
+
+    test("withExecutor rebinds the resolved connection", () => {
+      const bound = repo.withExecutor(db);
+      expect(bound.resolveConnection()).toBe(db);
+    });
+  });
 });

--- a/test/db/testCoverageRepository.test.ts
+++ b/test/db/testCoverageRepository.test.ts
@@ -456,4 +456,22 @@ describe("TestCoverageRepository", () => {
       expect(rows).toHaveLength(0);
     });
   });
+
+  describe("resolveConnection", () => {
+    test("returns the bound executor for a repo constructed with a db", () => {
+      const bound = new TestCoverageRepository(timer, db);
+      expect(bound.resolveConnection()).toBe(db);
+    });
+
+    test("returns the shared singleton for an unbound repo", () => {
+      const a = new TestCoverageRepository(timer);
+      const b = new TestCoverageRepository(timer);
+      expect(a.resolveConnection()).toBe(b.resolveConnection());
+    });
+
+    test("withExecutor rebinds the resolved connection", () => {
+      const bound = repo.withExecutor(db);
+      expect(bound.resolveConnection()).toBe(db);
+    });
+  });
 });

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -11,6 +11,7 @@ import { TestCoverageRepository } from "../../../src/db/testCoverageRepository";
 import { TelemetryRecorder } from "../../../src/features/telemetry/TelemetryRecorder";
 import { defaultTimer, type Timer } from "../../../src/utils/SystemTimer";
 import type { Database } from "../../../src/db/types";
+import { ActionableError } from "../../../src/models/ActionableError";
 
 describe("NavigationGraphManager", () => {
   let manager: NavigationGraphManager;
@@ -1062,5 +1063,89 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     expect(await countEdges()).toBe(1);
     const otherNode = await otherRepo.getNode("com.test.other", "OtherScreen");
     expect(otherNode).toBeDefined();
+  });
+});
+
+describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
+  const APP_ID = "com.test.guard";
+
+  let navDb: Kysely<Database>;
+  let coverageDb: Kysely<Database>;
+  let telemetrySpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    navDb = await createTestDatabase({ foreignKeys: true });
+    coverageDb = await createTestDatabase({ foreignKeys: true });
+    TelemetryRecorder.resetInstance();
+    telemetrySpy = spyOn(
+      TelemetryRecorder.getInstance(),
+      "recordNavigationEvent"
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    telemetrySpy.mockRestore();
+    TelemetryRecorder.resetInstance();
+    await navDb.destroy();
+    await coverageDb.destroy();
+  });
+
+  async function countNodes(db: Kysely<Database>): Promise<number> {
+    const row = await db
+      .selectFrom("navigation_nodes")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .where("app_id", "=", APP_ID)
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  test("throws a clear error when the coverage repo is bound to a different connection", async () => {
+    const navRepo = new NavigationRepository(navDb);
+    const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    await expect(
+      manager.recordNavigationEvent(createEvent("Screen1", 1000))
+    ).rejects.toBeInstanceOf(ActionableError);
+  });
+
+  test("mentions the connection-identity invariant in the error message", async () => {
+    const navRepo = new NavigationRepository(navDb);
+    const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    await expect(
+      manager.recordNavigationEvent(createEvent("Screen1", 1000))
+    ).rejects.toThrow(/connection/i);
+  });
+
+  test("guard fires before the transaction opens — no rows are written on either connection", async () => {
+    const navRepo = new NavigationRepository(navDb);
+    const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    await manager.recordNavigationEvent(createEvent("Screen1", 1000)).catch(() => undefined);
+
+    expect(await countNodes(navDb)).toBe(0);
+    expect(await countNodes(coverageDb)).toBe(0);
+    // currentScreen stays null — the post-commit field assignment never runs.
+    expect(manager.getCurrentScreen()).toBeNull();
+    // Telemetry side effect never fires on a guard failure.
+    expect(telemetrySpy).not.toHaveBeenCalled();
+  });
+
+  test("allows the write when both repos share the same connection", async () => {
+    const navRepo = new NavigationRepository(navDb);
+    const coverage = new TestCoverageRepository(defaultTimer, navDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    await manager.recordNavigationEvent(createEvent("Screen1", 1000));
+
+    expect(await countNodes(navDb)).toBe(1);
+    expect(manager.getCurrentScreen()).toBe("Screen1");
   });
 });

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1099,6 +1099,14 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
     return Number(row?.count ?? 0);
   }
 
+  async function countNodeCoverage(db: Kysely<Database>): Promise<number> {
+    const row = await db
+      .selectFrom("test_node_coverage")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
   test("throws a clear error when the coverage repo is bound to a different connection", async () => {
     const navRepo = new NavigationRepository(navDb);
     const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
@@ -1110,7 +1118,7 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
     ).rejects.toBeInstanceOf(ActionableError);
   });
 
-  test("mentions the connection-identity invariant in the error message", async () => {
+  test("names the connection-identity invariant in the error message", async () => {
     const navRepo = new NavigationRepository(navDb);
     const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
     const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
@@ -1118,10 +1126,10 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
 
     await expect(
       manager.recordNavigationEvent(createEvent("Screen1", 1000))
-    ).rejects.toThrow(/connection/i);
+    ).rejects.toThrow(/different database connections/i);
   });
 
-  test("guard fires before the transaction opens — no rows are written on either connection", async () => {
+  test("guard fires before the transaction opens — the navigation write is not applied", async () => {
     const navRepo = new NavigationRepository(navDb);
     const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
     const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
@@ -1129,12 +1137,42 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
 
     await manager.recordNavigationEvent(createEvent("Screen1", 1000)).catch(() => undefined);
 
+    // Without the guard, getOrCreateNode would commit a node on the navigation
+    // connection; the guard prevents the transaction from ever opening.
     expect(await countNodes(navDb)).toBe(0);
-    expect(await countNodes(coverageDb)).toBe(0);
     // currentScreen stays null — the post-commit field assignment never runs.
     expect(manager.getCurrentScreen()).toBeNull();
     // Telemetry side effect never fires on a guard failure.
     expect(telemetrySpy).not.toHaveBeenCalled();
+  });
+
+  test("with an active test session, fails with ActionableError rather than a downstream split-write error", async () => {
+    // With a session active, the coverage enlistment path (recordNodeVisit) is
+    // reachable inside the transaction. If the guard were absent, withExecutor would
+    // rebind the coverage repo to the navigation trx and recordNodeVisit would write a
+    // test_node_coverage row referencing a session that lives only on coverageDb — a
+    // FK violation surfacing as an opaque SqliteError. The guard turns that into a
+    // clear, pre-transaction ActionableError instead.
+    const navRepo = new NavigationRepository(navDb);
+    const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+    // startTestSession writes the session on the coverage connection, whose
+    // test_coverage_sessions.app_id FKs navigation_apps — seed the app there.
+    await coverageDb
+      .insertInto("navigation_apps")
+      .values({ app_id: APP_ID, updated_at: "2024-01-01T00:00:00.000Z" })
+      .execute();
+    await manager.startTestSession("session-guard");
+
+    await expect(
+      manager.recordNavigationEvent(createEvent("Screen1", 1000))
+    ).rejects.toBeInstanceOf(ActionableError);
+
+    // No coverage row leaked onto the navigation connection; the session row stays
+    // on its own connection.
+    expect(await countNodeCoverage(navDb)).toBe(0);
+    expect(await countNodes(navDb)).toBe(0);
   });
 
   test("allows the write when both repos share the same connection", async () => {


### PR DESCRIPTION
## What

Adds a lightweight runtime assertion that `NavigationGraphManager`'s navigation
repository (`this.repository`) and test-coverage repository
(`this.testCoverageRepository`) resolve to the **same** underlying database
connection **before** `recordNavigationEvent` opens its shared transaction. A
mistakenly foreign-bound coverage repo now fails loudly with an `ActionableError`
instead of silently splitting writes across connections.

Closes #2968.

## Why

Deferred hardening from the PR #2959 architecture review (Devin Osei). #2959 made
`recordNavigationEvent` transactional by opening one `db.transaction()` on the
navigation connection and enlisting the coverage repo onto that same `trx` via
`withExecutor`. Its atomicity guarantee rests on a precondition — **both
repositories share one connection** — that until now was enforced only by
convention (both default to the `getDatabase()` singleton) plus doc comments at
the transaction site and `createForTesting`.

If a coverage repo were bound to a *different* connection, `withExecutor(trx)`
silently rebinds it to the navigation `trx`, so its writes land on the navigation
connection rather than where the injected repo pointed — quietly ignoring caller
intent and, if the `withExecutor` rebinding were ever removed in a future
extension, splitting the write and defeating the rollback. The guard makes this
misconfiguration fail loudly at the point it matters.

## How

- **`NavigationRepository.resolveConnection()` / `TestCoverageRepository.resolveConnection()`**
  — narrow public accessors returning the bound executor (constructor/`withExecutor`)
  or the shared `getDatabase()` singleton when unbound. Two unbound repositories
  resolve to the same memoized singleton, so identity (`===`) holds by construction.
- **`NavigationGraphManager.assertSharedConnection()`** — throws `ActionableError`
  (error-handling convention strategy 1) when the two repos resolve to different
  connections. Called at the top of `recordNavigationEvent`'s write section,
  **before** `runInTransaction`, so the single bun:sqlite connection is never
  reserved on a guard failure.
- Kept to the issue's primary "lightweight runtime assertion" option rather than a
  speculative generic `runInTransactionWith` helper — there is exactly one
  transaction site today (YAGNI; grow the interface when a second arrives).
- Updated the `createForTesting` doc comment to note the precondition is now
  runtime-enforced.

## Testing

- `bun test test/features/navigation/NavigationGraphManager.test.ts test/db/navigationRepository.test.ts test/db/testCoverageRepository.test.ts` → **116 pass, 0 fail** (~1.2s), including the new guard + `resolveConnection` tests.
- `turbo run lint build` → clean.
- Full `bun test` → 5979 pass, 2 skip; the 6 failures are pre-existing and
  unrelated (jimp/wasm image + memory-leak tests fail identically on `main` with
  my changes stashed).

New tests (real in-memory `createTestDatabase()`, injected repos, no device/network, <100ms):
- **`resolveConnection`** (both repo test files) — returns the bound executor for a
  bound repo; two unbound repos resolve to the same singleton; `withExecutor` rebinds.
- **Guard** (`NavigationGraphManager.test.ts`, new `#2968` describe) — coverage repo
  on a *different* connection → `recordNavigationEvent` rejects with `ActionableError`
  whose message names the connection invariant; **zero** rows written on either
  connection, `currentScreen` stays null, telemetry never fires (guard precedes the
  transaction); and the happy path still persists the node when both share a
  connection.

## Acceptance criteria (#2968)

- [x] Runtime assertion of connection identity between `this.repository` and
      `this.testCoverageRepository` before the transaction opens.
- [x] A foreign-bound coverage repo fails loudly (`ActionableError`) instead of
      silently splitting writes.
- [x] Production path unaffected — both repos default to the `getDatabase()`
      singleton, invariant holds by construction; existing transaction tests green.
- [x] Guard fires before the connection is reserved (no partial writes on failure).
- [x] Unit tests follow Interface+Fake conventions, <100ms, non-flaky, no real device.
- [x] lint + build + tests green.
