### PR TITLE
fix(nav): assert shared connection before recordNavigationEvent transaction (#2968)

### DIFF
--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -40,6 +40,19 @@ export class NavigationRepository {
   }
 
   /**
+   * Resolve the underlying Kysely connection this repository will execute
+   * against (the injected handle, or the shared `getDatabase()` singleton when
+   * unbound). Exposed so a caller enlisting multiple repositories in one
+   * transaction can assert they share a connection before opening it — a
+   * coverage repo bound to a different connection would split writes and defeat
+   * the enclosing transaction's rollback guarantee. Reference identity is the
+   * intended comparison.
+   */
+  getConnection(): Kysely<Database> {
+    return this.getDb();
+  }
+
+  /**
    * Return a repository instance whose every read and write runs on the supplied
    * executor (a Kysely transaction handle) instead of the shared singleton
    * connection.

--- a/src/db/testCoverageRepository.ts
+++ b/src/db/testCoverageRepository.ts
@@ -37,6 +37,19 @@ export class TestCoverageRepository {
   }
 
   /**
+   * Resolve the underlying Kysely connection this repository will execute
+   * against (the injected handle, or the shared `getDatabase()` singleton when
+   * unbound). Exposed so a caller enlisting this repo alongside a navigation repo
+   * in one transaction can assert they share a connection before opening it — a
+   * coverage repo bound to a different connection would split writes and defeat
+   * the enclosing transaction's rollback guarantee. Reference identity is the
+   * intended comparison.
+   */
+  getConnection(): Kysely<Database> {
+    return this.getDb();
+  }
+
+  /**
    * Return a repository instance whose every read and write runs on the supplied
    * executor (a Kysely transaction handle) instead of the shared singleton
    * connection, so coverage writes can enlist in a caller-owned transaction

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -1,4 +1,5 @@
 import { logger } from "../../utils/logger";
+import { ActionableError } from "../../models/ActionableError";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { BackStackInfo } from "../../models";
 import { NavigationRepository } from "../../db/navigationRepository";
@@ -335,6 +336,16 @@ export class NavigationGraphManager implements NavigationGraphService {
     const recentToolCall = this.findCorrelatedToolCall(timestamp);
     const currentModalStack = recentToolCall?.uiState?.modalStack;
 
+    // Enforce the atomicity precondition loudly before opening the transaction:
+    // the coverage repo is enlisted onto the navigation repo's `trx`, so both
+    // must resolve to the same underlying connection. A coverage repo bound to a
+    // different connection would split its writes onto a separate connection —
+    // silently defeating the rollback guarantee. Fail fast here (before any row
+    // is written) rather than let a misconfigured repo corrupt the graph. The
+    // invariant holds by construction in production (both default to the
+    // getDatabase() singleton); this guards test wiring and future refactors.
+    this.assertSharedConnection();
+
     // Persist the whole graph write atomically. Every read and write inside the
     // callback runs on `trx` (via withExecutor) — a stray singleton query here
     // would deadlock the daemon's only connection (bunSqliteDialect). Keep the body
@@ -563,6 +574,27 @@ export class NavigationGraphManager implements NavigationGraphService {
     logger.debug(
       `[NAVIGATION_GRAPH] Ignoring hierarchy navigation - app has no named nodes`
     );
+  }
+
+  /**
+   * Assert that the navigation and coverage repositories resolve to the same
+   * underlying connection, the precondition for recordNavigationEvent's atomic
+   * write. The transaction is opened on the navigation connection and the
+   * coverage repo is enlisted onto that same `trx`; if the two repos were wired
+   * to different connections, coverage writes would land on a separate
+   * connection and the rollback guarantee would silently split. Throws before
+   * the transaction opens so a misconfiguration fails loudly rather than
+   * corrupting the graph. See createForTesting.
+   */
+  private assertSharedConnection(): void {
+    if (this.repository.getConnection() !== this.testCoverageRepository.getConnection()) {
+      throw new ActionableError(
+        "[NAVIGATION_GRAPH] NavigationRepository and TestCoverageRepository resolve to different " +
+        "database connections; recordNavigationEvent requires a shared connection so coverage writes " +
+        "enlist in the same transaction. Construct both repositories with the same Kysely handle " +
+        "(both default to the getDatabase() singleton)."
+      );
+    }
   }
 
   /**

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1064,3 +1064,74 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     expect(otherNode).toBeDefined();
   });
 });
+
+describe("NavigationGraphManager - shared-connection assertion (#2968)", () => {
+  const APP_ID = "com.test.conn";
+
+  let dbA: Kysely<Database>;
+  let dbB: Kysely<Database>;
+  let telemetrySpy: ReturnType<typeof spyOn>;
+
+  async function countNodesOn(db: Kysely<Database>): Promise<number> {
+    const row = await db
+      .selectFrom("navigation_nodes")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .where("app_id", "=", APP_ID)
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  beforeEach(async () => {
+    dbA = await createTestDatabase({ foreignKeys: true });
+    dbB = await createTestDatabase({ foreignKeys: true });
+    TelemetryRecorder.resetInstance();
+    telemetrySpy = spyOn(
+      TelemetryRecorder.getInstance(),
+      "recordNavigationEvent"
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    telemetrySpy.mockRestore();
+    TelemetryRecorder.resetInstance();
+    await dbA.destroy();
+    await dbB.destroy();
+  });
+
+  test("records normally when both repositories share the same connection", async () => {
+    const navRepo = new NavigationRepository(dbA);
+    const coverage = new TestCoverageRepository(defaultTimer, dbA);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+
+    await manager.setCurrentApp(APP_ID);
+    await manager.recordNavigationEvent(createEvent("Screen1", 1000));
+
+    expect(await countNodesOn(dbA)).toBe(1);
+    expect(manager.getCurrentScreen()).toBe("Screen1");
+  });
+
+  test("throws before opening the transaction when the coverage repo is bound to a foreign connection", async () => {
+    // Coverage repo bound to a DIFFERENT connection than the navigation repo.
+    // Its writes would silently land on dbB while the transaction runs on dbA,
+    // splitting the write and defeating the rollback guarantee. The assertion
+    // must catch this loudly before any row is written.
+    const navRepo = new NavigationRepository(dbA);
+    const coverage = new TestCoverageRepository(defaultTimer, dbB);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+
+    await manager.setCurrentApp(APP_ID);
+
+    await expect(
+      manager.recordNavigationEvent(createEvent("Screen1", 1000))
+    ).rejects.toThrow(/connection/i);
+
+    // Nothing was written on either connection — the assertion fires before the
+    // transaction opens, so there is no partial state to roll back.
+    expect(await countNodesOn(dbA)).toBe(0);
+    expect(await countNodesOn(dbB)).toBe(0);
+
+    // In-memory state and post-commit side effects are untouched.
+    expect(manager.getCurrentScreen()).toBeNull();
+    expect(telemetrySpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds a lightweight runtime assertion that `NavigationGraphManager`'s navigation and coverage repositories resolve to the **same** underlying database connection **before** `recordNavigationEvent` opens its write transaction. If they don't, it throws an `ActionableError` immediately — before any row is written — instead of silently splitting writes across two connections and defeating the transaction's rollback guarantee.

Closes #2968.

## Why

Deferred hardening from the PR #2959 architecture review (Devin Osei). `recordNavigationEvent` opens a transaction on the navigation repo's connection and enlists the coverage repo onto that same `trx` via `withExecutor`. The "both repositories share the same connection" precondition was enforced only by convention (both default to the `getDatabase()` singleton) plus doc comments at the transaction site and `createForTesting`.

A coverage repo mistakenly constructed against a *different* Kysely handle would split its writes onto a separate connection, so a mid-sequence rollback would no longer be atomic across node + coverage rows. The invariant holds by construction in production (both default to the singleton), but nothing made a misconfiguration fail loudly. This closes that gap with a cheap reference-identity check.

## How

- **`NavigationRepository.getConnection()` / `TestCoverageRepository.getConnection()`** — a narrow accessor that returns the repository's resolved executor (the injected handle, or the shared `getDatabase()` singleton when unbound). Reference identity is the intended comparison.
- **`NavigationGraphManager.assertSharedConnection()`** — compares the two repos' resolved connections and throws an `ActionableError` on mismatch, naming the split-connection cause and the fix (construct both with the same handle).
- **`recordNavigationEvent`** calls `assertSharedConnection()` after computing the modal stack and **before** `runInTransaction`, so a misconfiguration fails before the transaction opens (no partial state to roll back).

This is the "runtime assertion" option from the issue rather than a shared multi-repo `runInTransaction` helper — the base `withExecutor` already rebinds the coverage repo onto `trx`, so the assertion is defense-in-depth that catches wiring mistakes and future subclass `withExecutor` overrides early, exactly as #2968 requested ("fails loudly instead of silently splitting writes").

## Testing

- `bun test test/features/navigation/NavigationGraphManager.test.ts` → **51 pass, 0 fail** (~0.3s), including 2 new tests.
- `bun test test/db/navigationRepository.test.ts test/db/testCoverageRepository.test.ts` → **57 pass, 0 fail**.
- `bunx turbo run lint build` → clean; `schemas/tool-definitions.json` regenerated, no drift.
- Full suite: 6 pre-existing failures only, all in image-processing modules (`PerceptualHasher`, `ScreenshotUtils`) + one memory-leak test — confirmed failing on a clean `git stash` of this branch, unrelated to this change.

New tests (real in-memory `createTestDatabase()`, <100ms, no device):
- **Shared connection happy path** — both repos bound to the same in-memory db → `recordNavigationEvent` records normally.
- **Foreign connection** — coverage repo bound to a *different* connection → `recordNavigationEvent` rejects with a `/connection/i` error, **zero** rows written on either connection, `currentScreen` still null, and telemetry not invoked (assertion fires before the transaction opens).

## Acceptance criteria (#2968)
- [x] Runtime assertion of connection identity between `this.repository` and `this.testCoverageRepository` before opening the transaction.
- [x] A foreign-bound coverage repo fails loudly (`ActionableError`) instead of silently splitting writes.
- [x] No behavior change when both repos share a connection (production default + existing tests unaffected).
- [x] Assertion fires before any write — no partial state on failure.
- [x] lint + build + navigation/repository tests green.

## Notes
- Follow-up from #2791 / PR #2959. The sibling `recordHierarchyNavigation` path is intentionally out of scope: its writes are not wrapped in a transaction, so the cross-connection atomicity invariant doesn't apply there.
