### PR TITLE
fix(ios): surface actionable decode-boundary error for out-of-range numeric literals (#2965)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -282,7 +282,7 @@ public class WebSocketServer: WebSocketServing {
         let errorResponse = WebSocketResponse.error(
             type: "error",
             requestId: requestId,
-            error: error.localizedDescription
+            error: wireErrorMessage(for: error)
         )
 
         do {
@@ -309,6 +309,41 @@ public class WebSocketServer: WebSocketServing {
             print("[WebSocketServer] Error response encoding failed, using fallback")
             return fallbackJSON.data(using: .utf8) ?? Data()
         }
+    }
+
+    /// Maps a caught error into the message surfaced on the wire.
+    ///
+    /// Most errors pass through `localizedDescription` unchanged — deliberately so:
+    /// this preserves `CommandError.unknownCommand`'s "Unknown command type: <type>"
+    /// contract (a `LocalizedError`, matched by the TS `rewriteUnknownCommandError`)
+    /// and `DecodingError.keyNotFound`'s required-field rejection messages.
+    ///
+    /// The single rewrite is for `DecodingError.dataCorrupted`, whose
+    /// `localizedDescription` collapses to the opaque "The data couldn't be read
+    /// because it isn't in the correct format." Apple's `JSONDecoder` reports this
+    /// class of failure at top-level pre-parse with an *empty* `codingPath` — most
+    /// notably for an out-of-range numeric literal (e.g. `1e309`) — so a per-field
+    /// message is infeasible, but the real cause survives in the underlying Cocoa
+    /// error's `NSDebugDescription`. Surfacing it turns an opaque decode failure
+    /// into an actionable one. See issue #2965.
+    static func wireErrorMessage(for error: Error) -> String {
+        guard case let DecodingError.dataCorrupted(context) = error else {
+            return error.localizedDescription
+        }
+        let underlyingDetail = (context.underlyingError as NSError?)?
+            .userInfo[NSDebugDescriptionErrorKey] as? String
+
+        if let detail = underlyingDetail, detail.localizedCaseInsensitiveContains("not representable") {
+            // e.g. underlying "Number 1e309 is not representable in Swift."
+            return "Malformed request: a numeric value is out of range or not representable."
+        }
+        if let detail = underlyingDetail, !detail.isEmpty {
+            // e.g. underlying "Unexpected character ',' around line 1, column 6."
+            return "Malformed request: the payload is not valid JSON (\(detail))"
+        }
+        // No underlying detail available — the decoder's own context description is
+        // still more specific than the opaque `localizedDescription`.
+        return "Malformed request: \(context.debugDescription)"
     }
 
     /// Best-effort extraction of requestId from raw JSON data for error correlation.

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -333,8 +333,7 @@ public class WebSocketServer: WebSocketServing {
         let underlyingDetail = (context.underlyingError as NSError?)?
             .userInfo[NSDebugDescriptionErrorKey] as? String
 
-        if let detail = underlyingDetail, detail.localizedCaseInsensitiveContains("not representable") {
-            // e.g. underlying "Number 1e309 is not representable in Swift."
+        if let detail = underlyingDetail, isNumberOutOfRangeDetail(detail) {
             return "Malformed request: a numeric value is out of range or not representable."
         }
         if let detail = underlyingDetail, !detail.isEmpty {
@@ -344,6 +343,18 @@ public class WebSocketServer: WebSocketServing {
         // No underlying detail available — the decoder's own context description is
         // still more specific than the opaque `localizedDescription`.
         return "Malformed request: \(context.debugDescription)"
+    }
+
+    /// Whether a Cocoa 3840 `NSDebugDescription` denotes an out-of-range / non-
+    /// representable numeric literal (rather than a JSON syntax error). The exact
+    /// phrasing differs by the `JSONDecoder` backend the runner is running on:
+    /// - swift-foundation (iOS 18+, macOS 15+): "Number 1e309 is not representable in Swift."
+    /// - classic Foundation (iOS 15–17, `JSONSerialization`-backed): "Number wound up as NaN around line 1, column 5."
+    /// `Package.swift` deploys to `.iOS(.v15)`, so both must be recognized — matching
+    /// only "not representable" would silently miss the overflow case on iOS 15–17.
+    private static func isNumberOutOfRangeDetail(_ detail: String) -> Bool {
+        detail.localizedCaseInsensitiveContains("not representable")
+            || detail.localizedCaseInsensitiveContains("wound up as nan")
     }
 
     /// Best-effort extraction of requestId from raw JSON data for error correlation.

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -889,10 +889,25 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
 
     // MARK: - Decode-boundary wire-message legibility (#2965)
 
-    /// The generic decode-failure message `JSONDecoder` produces for a
-    /// `dataCorrupted` error via `localizedDescription`. Rewriting this opaque
-    /// string into something actionable is the whole point of #2965.
-    private static let opaqueDecodeMessage = "isn't in the correct format"
+    /// Build a synthetic `DecodingError.dataCorrupted` whose underlying Cocoa 3840
+    /// error carries `debugDescription` in `NSDebugDescription` — mirroring exactly
+    /// what `JSONDecoder` attaches. This lets a test pin the rewrite of a *specific*
+    /// backend phrasing (e.g. the classic iOS 15–17 "wound up as NaN" overflow text)
+    /// deterministically on any host, independent of which `JSONDecoder` backend the
+    /// test machine happens to run.
+    private func syntheticDataCorrupted(underlyingDebugDescription: String) -> DecodingError {
+        let underlying = NSError(
+            domain: NSCocoaErrorDomain,
+            code: 3840,
+            userInfo: [NSDebugDescriptionErrorKey: underlyingDebugDescription]
+        )
+        let context = DecodingError.Context(
+            codingPath: [],
+            debugDescription: "The given data was not valid JSON.",
+            underlyingError: underlying
+        )
+        return DecodingError.dataCorrupted(context)
+    }
 
     /// Feed a caught error through the real `WebSocketServer.buildErrorResponseData`
     /// wire encoder (the same path `handleMessage`'s catch block uses) and return
@@ -949,9 +964,13 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
     func testOverflowLiteralWireMessageIsActionable() {
         let error = decodeError(#"{"type":"request_tap_coordinates","requestId":"ovf-1","x":1e309,"y":2}"#)
         let message = wireErrorMessage(for: error, requestId: "ovf-1")
-        XCTAssertFalse(
-            message.contains(Self.opaqueDecodeMessage),
-            "overflow message must not stay opaque, got: \(message)"
+        // The rewrite must change the surfaced string from the decoder's opaque
+        // default. Compared against the *actual* `localizedDescription` (whose exact
+        // wording/apostrophe is Foundation-controlled), not a hand-typed literal.
+        XCTAssertNotEqual(
+            message,
+            error.localizedDescription,
+            "overflow message must not stay the opaque decoder default, got: \(message)"
         )
         let lowered = message.lowercased()
         XCTAssertTrue(
@@ -966,11 +985,45 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
     func testLargerOverflowLiteralWireMessageIsActionable() {
         let error = decodeError(#"{"type":"request_swipe","requestId":"ovf-2","x1":1,"y1":2,"x2":1e400,"y2":4}"#)
         let message = wireErrorMessage(for: error, requestId: "ovf-2")
-        XCTAssertFalse(message.contains(Self.opaqueDecodeMessage), "got: \(message)")
+        XCTAssertNotEqual(message, error.localizedDescription, "got: \(message)")
         let lowered = message.lowercased()
         XCTAssertTrue(
             lowered.contains("out of range") || lowered.contains("not representable"),
             "got: \(message)"
+        )
+    }
+
+    /// The runner deploys to `.iOS(.v15)` (`Package.swift`), where `JSONDecoder` is
+    /// backed by classic `JSONSerialization`, which phrases an overflow literal as
+    /// "Number wound up as NaN around line 1, column 5." — NOT "not representable"
+    /// (the swift-foundation phrasing on iOS 18+/macOS 15+). Both must map to the
+    /// same actionable out-of-range message; matching only "not representable" would
+    /// silently miss the overflow case on iOS 15–17. This test pins the classic
+    /// phrasing deterministically regardless of the CI host's decoder backend.
+    func testClassicFoundationOverflowPhrasingIsActionable() {
+        let classic = syntheticDataCorrupted(
+            underlyingDebugDescription: "Number wound up as NaN around line 1, column 5."
+        )
+        let message = wireErrorMessage(for: classic, requestId: "ovf-classic")
+        let lowered = message.lowercased()
+        XCTAssertTrue(
+            lowered.contains("out of range") || lowered.contains("not representable"),
+            "classic-Foundation overflow phrasing must map to the out-of-range message, got: \(message)"
+        )
+    }
+
+    /// The swift-foundation (iOS 18+/macOS 15+) overflow phrasing maps to the same
+    /// actionable message — pinned deterministically alongside the classic one so a
+    /// change to either backend's handling is caught regardless of the test host.
+    func testModernFoundationOverflowPhrasingIsActionable() {
+        let modern = syntheticDataCorrupted(
+            underlyingDebugDescription: "Number 1e309 is not representable in Swift."
+        )
+        let message = wireErrorMessage(for: modern, requestId: "ovf-modern")
+        let lowered = message.lowercased()
+        XCTAssertTrue(
+            lowered.contains("out of range") || lowered.contains("not representable"),
+            "swift-foundation overflow phrasing must map to the out-of-range message, got: \(message)"
         )
     }
 
@@ -1006,7 +1059,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
     func testMalformedJsonWireMessageIsActionable() {
         let error = decodeError(#"{"type":"request_tap_coordinates","x":,}"#)
         let message = wireErrorMessage(for: error, requestId: nil)
-        XCTAssertFalse(message.contains(Self.opaqueDecodeMessage), "got: \(message)")
+        XCTAssertNotEqual(message, error.localizedDescription, "got: \(message)")
         XCTAssertTrue(
             message.lowercased().contains("not valid json") || message.lowercased().contains("malformed"),
             "malformed JSON should surface an actionable cause, got: \(message)"

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -887,6 +887,132 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         }
     }
 
+    // MARK: - Decode-boundary wire-message legibility (#2965)
+
+    /// The generic decode-failure message `JSONDecoder` produces for a
+    /// `dataCorrupted` error via `localizedDescription`. Rewriting this opaque
+    /// string into something actionable is the whole point of #2965.
+    private static let opaqueDecodeMessage = "isn't in the correct format"
+
+    /// Feed a caught error through the real `WebSocketServer.buildErrorResponseData`
+    /// wire encoder (the same path `handleMessage`'s catch block uses) and return
+    /// the surfaced `error` string, asserting the envelope is a well-formed
+    /// structured error along the way.
+    private func wireErrorMessage(
+        for error: Error,
+        requestId: String?,
+        file: StaticString = #file,
+        line: UInt = #line
+    )
+        -> String
+    {
+        let data = WebSocketServer.buildErrorResponseData(requestId: requestId, error: error)
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("error response was not valid JSON", file: file, line: line)
+            return ""
+        }
+        XCTAssertEqual(json["type"] as? String, "error", "wrong envelope type", file: file, line: line)
+        XCTAssertEqual(json["success"] as? Bool, false, "error envelope must be success=false", file: file, line: line)
+        if let requestId = requestId {
+            XCTAssertEqual(json["requestId"] as? String, requestId, "requestId preserved", file: file, line: line)
+        }
+        guard let message = json["error"] as? String else {
+            XCTFail("error envelope missing 'error' string", file: file, line: line)
+            return ""
+        }
+        return message
+    }
+
+    /// Capture the error `JSONDecoder` throws for a raw command string. Fails the
+    /// test if decoding unexpectedly succeeds.
+    private func decodeError(
+        _ json: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    )
+        -> Error
+    {
+        do {
+            _ = try decodeWebSocketRequest(json)
+            XCTFail("expected \(json) to fail decoding", file: file, line: line)
+            return NSError(domain: "test", code: 0)
+        } catch {
+            return error
+        }
+    }
+
+    /// AC1: an out-of-range numeric literal (`1e309`) — rejected by `JSONDecoder`
+    /// at pre-parse with an empty `codingPath` — surfaces an *actionable* wire
+    /// message ("out of range" / "not representable"), not the opaque
+    /// "…isn't in the correct format." The value is still rejected (this is
+    /// diagnostic legibility only), and the requestId is preserved for correlation.
+    func testOverflowLiteralWireMessageIsActionable() {
+        let error = decodeError(#"{"type":"request_tap_coordinates","requestId":"ovf-1","x":1e309,"y":2}"#)
+        let message = wireErrorMessage(for: error, requestId: "ovf-1")
+        XCTAssertFalse(
+            message.contains(Self.opaqueDecodeMessage),
+            "overflow message must not stay opaque, got: \(message)"
+        )
+        let lowered = message.lowercased()
+        XCTAssertTrue(
+            lowered.contains("out of range") || lowered.contains("not representable"),
+            "overflow message should name the out-of-range/non-representable cause, got: \(message)"
+        )
+    }
+
+    /// A larger overflow literal decodes to the same class of failure and is
+    /// rewritten the same way — proves the detection keys off the underlying Cocoa
+    /// error, not a hard-coded `1e309` string.
+    func testLargerOverflowLiteralWireMessageIsActionable() {
+        let error = decodeError(#"{"type":"request_swipe","requestId":"ovf-2","x1":1,"y1":2,"x2":1e400,"y2":4}"#)
+        let message = wireErrorMessage(for: error, requestId: "ovf-2")
+        XCTAssertFalse(message.contains(Self.opaqueDecodeMessage), "got: \(message)")
+        let lowered = message.lowercased()
+        XCTAssertTrue(
+            lowered.contains("out of range") || lowered.contains("not representable"),
+            "got: \(message)"
+        )
+    }
+
+    /// AC2: a missing-required-field rejection (`keyNotFound`) is NOT a
+    /// `dataCorrupted` error, so the rewrite must leave its wire message exactly
+    /// equal to `error.localizedDescription` — the `keyNotFound` contract that
+    /// `TypedRequestDecodeTests` relies on stays byte-for-byte unchanged.
+    func testKeyNotFoundWireMessageUnchanged() {
+        let error = decodeError(#"{"type":"request_tap_coordinates","requestId":"kn-1","y":2}"#)
+        guard case DecodingError.keyNotFound = error else {
+            return XCTFail("expected keyNotFound, got \(error)")
+        }
+        let message = wireErrorMessage(for: error, requestId: "kn-1")
+        XCTAssertEqual(
+            message,
+            error.localizedDescription,
+            "keyNotFound wire message must be untouched by the dataCorrupted rewrite"
+        )
+    }
+
+    /// AC3: an unknown command type throws `CommandError.unknownCommand` (a
+    /// `LocalizedError`, not a `DecodingError`) at decode; its wire text must stay
+    /// exactly "Unknown command type: <type>" so the TS client's
+    /// `rewriteUnknownCommandError` regex still matches it.
+    func testUnknownCommandWireMessageUntouched() {
+        let error = decodeError(#"{"type":"unknown_command","requestId":"uc-1"}"#)
+        let message = wireErrorMessage(for: error, requestId: "uc-1")
+        XCTAssertEqual(message, "Unknown command type: unknown_command")
+    }
+
+    /// Generic malformed JSON (also `dataCorrupted`) becomes actionable too — it
+    /// names "not valid JSON" instead of the opaque decoder default.
+    func testMalformedJsonWireMessageIsActionable() {
+        let error = decodeError(#"{"type":"request_tap_coordinates","x":,}"#)
+        let message = wireErrorMessage(for: error, requestId: nil)
+        XCTAssertFalse(message.contains(Self.opaqueDecodeMessage), "got: \(message)")
+        XCTAssertTrue(
+            message.lowercased().contains("not valid json") || message.lowercased().contains("malformed"),
+            "malformed JSON should surface an actionable cause, got: \(message)"
+        )
+    }
+
     // MARK: - Finite fractional / negative coordinates unaffected (#2909 happy path)
 
     /// Fractional coordinates decode and reach the engine with the fraction


### PR DESCRIPTION
## What

Rewrite the **opaque decode-boundary error** the iOS CtrlProxy runner surfaces when a client sends a malformed / out-of-range numeric literal (e.g. `1e309`, `1e400`) in **any** command — from *"The data couldn't be read because it isn't in the correct format."* to an actionable message naming the cause.

Closes #2965. Follow-up from the #2928 / PR #2957 multi-agent review (the decode-boundary counterpart to #2928's *handler*-boundary hardening).

Affected files (`ios/control-proxy/`):
- `Sources/CtrlProxy/WebSocketServer.swift` — new `wireErrorMessage(for:)` routed into `buildErrorResponseData`.
- `Tests/CtrlProxyTests/TypedRequestDecodeTests.swift` — decode-boundary wire-message legibility tests.

## Why

Apple's `JSONDecoder` rejects an overflow numeric literal during **top-level pre-parse** with `DecodingError.dataCorrupted` and an **empty `codingPath`** — *before* any `Decodable`/`init(from:)` runs (verified in #2957's `testOverflowCoordinateLiteralIsRejectedAtDecode`). `buildErrorResponseData` surfaced `error.localizedDescription`, which for `dataCorrupted` collapses to the generic *"The data couldn't be read…"* — no field, no hint a number was out of range. Because the failure is at pre-parse with an empty `codingPath`, a per-field message (like #2928's) is **infeasible** at the `Decodable` layer for this input class; the only lever is the generic decode-error surfacing at the catch boundary.

The value is already **rejected** (never dispatched into XCUITest), so this is purely diagnostic legibility for a client that sends deliberately malformed numbers — low risk.

## How

New `static func wireErrorMessage(for error: Error) -> String`, used by `buildErrorResponseData` in place of `error.localizedDescription`:

- **Non-`dataCorrupted` errors pass through `localizedDescription` UNCHANGED.** This is deliberate and load-bearing: it keeps `CommandError.unknownCommand`'s `"Unknown command type: <type>"` contract (a `LocalizedError`, matched by the TS `rewriteUnknownCommandError`) and `DecodingError.keyNotFound`'s required-field rejection messages byte-for-byte identical.
- **`dataCorrupted`** recovers the real cause from the underlying Cocoa error's `NSDebugDescription` (empirically where the detail lives — `localizedDescription` is generic for the whole class):
  - contains `"not representable"` (e.g. *"Number 1e309 is not representable in Swift."*) → `"Malformed request: a numeric value is out of range or not representable."`
  - otherwise, with a detail (e.g. *"Unexpected character ',' around line 1, column 6."*) → `"Malformed request: the payload is not valid JSON (<detail>)"`
  - no underlying detail → `"Malformed request: <context.debugDescription>"` (still more specific than the opaque default).

The fallback hand-crafted-JSON path in `buildErrorResponseData` reads the same `errorResponse.error`, so it carries the improved message too. The runner defines **no** custom `DecodingError.dataCorrupted` throws (verified by grep), so only Foundation's generic pre-parse error is affected — no attributed error loses its `codingPath`.

### Empirical decode shape (Swift 6.2.4 / macOS 15, verified in worktree)

`{"x":1e309}` → `DecodingError.dataCorrupted(Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: NSCocoaErrorDomain 3840))`, with the *real* reason in `underlyingError.userInfo[NSDebugDescription]` = *"Number 1e309 is not representable in Swift."* Malformed JSON (`{"x":,}`) has the same shape with `NSDebugDescription` = *"Unexpected character ',' …"*. `localizedDescription` is generic for both — hence keying off `NSDebugDescription`.

## Testing

`TypedRequestDecodeTests.swift` — new "Decode-boundary wire-message legibility (#2965)" section, each test feeds the **real** decode error (from the same `JSONDecoder().decode(WebSocketRequest.self, …)` wire path) through the **real** `WebSocketServer.buildErrorResponseData` and asserts the surfaced `error` string:
- `testOverflowLiteralWireMessageIsActionable` / `testLargerOverflowLiteralWireMessageIsActionable` — `1e309` / `1e400` no longer opaque; names "out of range" / "not representable"; requestId preserved, `success:false`, `type:error`. (Red→green.)
- `testKeyNotFoundWireMessageUnchanged` — a missing-required-field (`keyNotFound`) wire message equals `error.localizedDescription` exactly (rewrite doesn't touch it).
- `testUnknownCommandWireMessageUntouched` — unknown-type wire message stays exactly `"Unknown command type: unknown_command"` (TS `rewriteUnknownCommandError` contract).
- `testMalformedJsonWireMessageIsActionable` — generic malformed JSON becomes actionable ("not valid JSON").

Verified locally:
- `swift test` in `ios/control-proxy` — **324 tests, 0 failures**.
- `swiftformat --lint` clean on the touched lines (pre-existing violations flagged only by the newer local 0.61.1 on untouched lines are unchanged from `main`).

## Acceptance criteria (#2965)
- [x] A command carrying an out-of-range numeric literal (`1e309`) returns a clearer, actionable decode-error message instead of the generic *"data couldn't be read."*
- [x] Existing `keyNotFound` required-field rejection messages (relied on by `TypedRequestDecodeTests`) are unchanged.
- [x] The `Unknown command type: <type>` contract (matched by the TS `rewriteUnknownCommandError`) is untouched.

## Deployment note

This lives in the iOS runner source. It reaches deployed sessions only once the pinned iOS runner release + checksum registry (`src/constants/release.ts`) is re-cut. No interim regression: the value was already rejected; this only improves the diagnostic message.
