### PR TITLE
fix(android): guard non-finite gesture coordinates at CtrlProxy handler boundary (#2964)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.ctrlproxy
 import dev.jasonpearson.automobile.ctrlproxy.storage.StorageSubscription
 import dev.jasonpearson.automobile.protocol.AddHighlight
 import dev.jasonpearson.automobile.protocol.ClearPreferences
+import dev.jasonpearson.automobile.protocol.DragResult
 import dev.jasonpearson.automobile.protocol.GetCurrentFocus
 import dev.jasonpearson.automobile.protocol.GetDeviceOwnerStatus
 import dev.jasonpearson.automobile.protocol.GetPermission
@@ -13,6 +14,7 @@ import dev.jasonpearson.automobile.protocol.InstallCaCert
 import dev.jasonpearson.automobile.protocol.InstallCaCertFromPath
 import dev.jasonpearson.automobile.protocol.ListPreferenceFiles
 import dev.jasonpearson.automobile.protocol.NetworkMockRuleDto
+import dev.jasonpearson.automobile.protocol.PinchResult
 import dev.jasonpearson.automobile.protocol.RemoveCaCert
 import dev.jasonpearson.automobile.protocol.RemovePreference
 import dev.jasonpearson.automobile.protocol.RequestAction
@@ -45,6 +47,8 @@ import dev.jasonpearson.automobile.protocol.SetRecompositionTracking
 import dev.jasonpearson.automobile.protocol.StartRecording
 import dev.jasonpearson.automobile.protocol.StopRecording
 import dev.jasonpearson.automobile.protocol.SubscribeStorage
+import dev.jasonpearson.automobile.protocol.SwipeResult
+import dev.jasonpearson.automobile.protocol.TapCoordinatesResult
 import dev.jasonpearson.automobile.protocol.UnsubscribeStorage
 import dev.jasonpearson.automobile.protocol.WebSocketMessageHandler
 import dev.jasonpearson.automobile.protocol.WebSocketRequest
@@ -59,18 +63,24 @@ import kotlinx.serialization.json.Json
  * hierarchy, so the compiler fails the build if a new request type is added without a branch here.
  *
  * The handler performs no Android I/O — it only decodes fields and calls [actions] — so it can be
- * unit-tested without Robolectric. Every current command is fire-and-forget (the action broadcasts
- * its own response asynchronously), so [handleMessage] always returns `null`.
+ * unit-tested without Robolectric. Almost every command is fire-and-forget (the action broadcasts
+ * its own response asynchronously), so [handleMessage] returns `null`. The one exception is the
+ * non-finite gesture-coordinate guard (see [firstNonFinite]), which returns a synchronous
+ * per-command error response that [WebSocketServer] broadcasts to the client — the Android analog
+ * of iOS `CommandHandler.requireFinite` (#2964, mirror of #2928 / PR #2957).
  *
  * @param actions the device actions to dispatch to (the [CtrlProxy] service in production, a fake
  *   in tests).
  * @param log diagnostic sink for the few requests with no wired action (an ahead-of-need request
  *   type, or a malformed storage message the device can't resolve). Defaults to a no-op so tests
  *   stay Android-free; production wires it to `Log`.
+ * @param now clock for the `timestamp` of the synchronous guard error responses; injectable so
+ *   those responses are deterministic in tests. Defaults to the wall clock.
  */
 class CtrlProxyMessageHandler(
   private val actions: CtrlProxyActions,
   private val log: (String) -> Unit = {},
+  private val now: () -> Long = { System.currentTimeMillis() },
 ) : WebSocketMessageHandler {
 
   /** JSON used to re-encode the typed network mock rules into the string the SDK store expects. */
@@ -83,7 +93,16 @@ class CtrlProxyMessageHandler(
       is RequestHierarchy -> actions.requestHierarchy(request.disableAllFiltering)
       is RequestHierarchyIfStale -> actions.requestHierarchyIfStale(request.sinceTimestamp)
       is RequestScreenshot -> actions.requestScreenshot(request.requestId)
-      is RequestSwipe ->
+      is RequestSwipe -> {
+        firstNonFinite(
+            "x1" to request.x1,
+            "y1" to request.y1,
+            "x2" to request.x2,
+            "y2" to request.y2,
+          )
+          ?.let { (field, value) ->
+            return swipeError(request.requestId, field, value)
+          }
         actions.requestSwipe(
           request.requestId,
           request.x1,
@@ -92,9 +111,31 @@ class CtrlProxyMessageHandler(
           request.y2,
           request.duration,
         )
-      is RequestTapCoordinates ->
+      }
+      is RequestTapCoordinates -> {
+        firstNonFinite("x" to request.x, "y" to request.y)?.let { (field, value) ->
+          return TapCoordinatesResult(
+            timestamp = now(),
+            requestId = request.requestId,
+            success = false,
+            totalTimeMs = 0L,
+            error = nonFiniteError(field, value),
+          )
+        }
         actions.requestTapCoordinates(request.requestId, request.x, request.y, request.duration)
-      is RequestTwoFingerSwipe ->
+      }
+      is RequestTwoFingerSwipe -> {
+        // Two-finger swipe shares the swipe_result response type. `offset` is an Int (a pixel gap),
+        // so it cannot be non-finite and is not guarded.
+        firstNonFinite(
+            "x1" to request.x1,
+            "y1" to request.y1,
+            "x2" to request.x2,
+            "y2" to request.y2,
+          )
+          ?.let { (field, value) ->
+            return swipeError(request.requestId, field, value)
+          }
         actions.requestTwoFingerSwipe(
           request.requestId,
           request.x1,
@@ -104,7 +145,23 @@ class CtrlProxyMessageHandler(
           request.duration,
           request.offset,
         )
-      is RequestDrag ->
+      }
+      is RequestDrag -> {
+        firstNonFinite(
+            "x1" to request.x1,
+            "y1" to request.y1,
+            "x2" to request.x2,
+            "y2" to request.y2,
+          )
+          ?.let { (field, value) ->
+            return DragResult(
+              timestamp = now(),
+              requestId = request.requestId,
+              success = false,
+              totalTimeMs = 0L,
+              error = nonFiniteError(field, value),
+            )
+          }
         actions.requestDrag(
           request.requestId,
           request.x1,
@@ -115,7 +172,26 @@ class CtrlProxyMessageHandler(
           request.resolvedDragDurationMs,
           request.holdDurationMs,
         )
-      is RequestPinch ->
+      }
+      is RequestPinch -> {
+        // `rotationDegrees` is a Float (not a coordinate) but still flows into the gesture-path
+        // math, so a computed non-finite value is guarded too (AC #4 of #2964).
+        firstNonFinite(
+            "centerX" to request.centerX,
+            "centerY" to request.centerY,
+            "distanceStart" to request.distanceStart,
+            "distanceEnd" to request.distanceEnd,
+            "rotationDegrees" to request.rotationDegrees.toDouble(),
+          )
+          ?.let { (field, value) ->
+            return PinchResult(
+              timestamp = now(),
+              requestId = request.requestId,
+              success = false,
+              totalTimeMs = 0L,
+              error = nonFiniteError(field, value),
+            )
+          }
         actions.requestPinch(
           request.requestId,
           request.centerX,
@@ -125,6 +201,7 @@ class CtrlProxyMessageHandler(
           request.rotationDegrees,
           request.duration,
         )
+      }
       is RequestSetText ->
         actions.requestSetText(
           request.requestId,
@@ -271,8 +348,42 @@ class CtrlProxyMessageHandler(
       is RequestLaunchIntent -> actions.requestLaunchIntent(request.requestId, request.packageName)
     }
 
-    // Every command above is fire-and-forget: the action broadcasts its own response
+    // Every non-guarded command above is fire-and-forget: the action broadcasts its own response
     // asynchronously, so there is no synchronous response to return here.
     return null
   }
+
+  /**
+   * Reject a non-finite gesture coordinate (`NaN` / `±Infinity`) at the handler boundary before it
+   * flows into the accessibility [android.accessibilityservice.GestureDescription] engine — the
+   * Android analog of iOS `CommandHandler.requireFinite` (#2964, mirror of #2928 / PR #2957).
+   *
+   * A non-finite value cannot arrive over the wire: kotlinx.serialization's default config
+   * (`allowSpecialFloatingPointValues = false`, used by [WebSocketServer.protocolJson]) rejects a
+   * JSON overflow literal like `1e309` at decode ("Unexpected special floating-point value
+   * Infinity") rather than coercing it into the widened `Double` field, and standard JSON has no
+   * `NaN`/`Infinity` literal. So this is defense-in-depth for the non-wire construction path — an
+   * in-process caller building a request from a computed `Double` (division, `hypot`, a normalized
+   * offset) that yields a non-finite value — where it prevents a silent no-op / bogus gesture.
+   *
+   * @return the first non-finite `(field name, value)` among [fields], or null when all are finite.
+   */
+  private fun firstNonFinite(vararg fields: Pair<String, Double>): Pair<String, Double>? =
+    fields.firstOrNull {
+      !it.second.isFinite()
+    }
+
+  /** Actionable message for a rejected non-finite coordinate, naming the offending [field]. */
+  private fun nonFiniteError(field: String, value: Double): String =
+    "Non-finite gesture coordinate: $field=$value. Coordinates must be finite (not NaN or Infinity)."
+
+  /** Build a `swipe_result` failure — shared by [RequestSwipe] and [RequestTwoFingerSwipe]. */
+  private fun swipeError(requestId: String?, field: String, value: Double): SwipeResult =
+    SwipeResult(
+      timestamp = now(),
+      requestId = requestId,
+      success = false,
+      totalTimeMs = 0L,
+      error = nonFiniteError(field, value),
+    )
 }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -74,13 +74,10 @@ import kotlinx.serialization.json.Json
  * @param log diagnostic sink for the few requests with no wired action (an ahead-of-need request
  *   type, or a malformed storage message the device can't resolve). Defaults to a no-op so tests
  *   stay Android-free; production wires it to `Log`.
- * @param now clock for the `timestamp` of the synchronous guard error responses; injectable so
- *   those responses are deterministic in tests. Defaults to the wall clock.
  */
 class CtrlProxyMessageHandler(
   private val actions: CtrlProxyActions,
   private val log: (String) -> Unit = {},
-  private val now: () -> Long = { System.currentTimeMillis() },
 ) : WebSocketMessageHandler {
 
   /** JSON used to re-encode the typed network mock rules into the string the SDK store expects. */
@@ -115,7 +112,7 @@ class CtrlProxyMessageHandler(
       is RequestTapCoordinates -> {
         firstNonFinite("x" to request.x, "y" to request.y)?.let { (field, value) ->
           return TapCoordinatesResult(
-            timestamp = now(),
+            timestamp = System.currentTimeMillis(),
             requestId = request.requestId,
             success = false,
             totalTimeMs = 0L,
@@ -155,7 +152,7 @@ class CtrlProxyMessageHandler(
           )
           ?.let { (field, value) ->
             return DragResult(
-              timestamp = now(),
+              timestamp = System.currentTimeMillis(),
               requestId = request.requestId,
               success = false,
               totalTimeMs = 0L,
@@ -185,7 +182,7 @@ class CtrlProxyMessageHandler(
           )
           ?.let { (field, value) ->
             return PinchResult(
-              timestamp = now(),
+              timestamp = System.currentTimeMillis(),
               requestId = request.requestId,
               success = false,
               totalTimeMs = 0L,
@@ -380,7 +377,7 @@ class CtrlProxyMessageHandler(
   /** Build a `swipe_result` failure — shared by [RequestSwipe] and [RequestTwoFingerSwipe]. */
   private fun swipeError(requestId: String?, field: String, value: Double): SwipeResult =
     SwipeResult(
-      timestamp = now(),
+      timestamp = System.currentTimeMillis(),
       requestId = requestId,
       success = false,
       totalTimeMs = 0L,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -1,12 +1,26 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightShape
+import dev.jasonpearson.automobile.protocol.DragResult
 import dev.jasonpearson.automobile.protocol.NetworkMockRuleDto
+import dev.jasonpearson.automobile.protocol.PinchResult
+import dev.jasonpearson.automobile.protocol.RequestDrag
+import dev.jasonpearson.automobile.protocol.RequestPinch
+import dev.jasonpearson.automobile.protocol.RequestSwipe
+import dev.jasonpearson.automobile.protocol.RequestTapCoordinates
+import dev.jasonpearson.automobile.protocol.RequestTwoFingerSwipe
+import dev.jasonpearson.automobile.protocol.SwipeResult
+import dev.jasonpearson.automobile.protocol.TapCoordinatesResult
 import dev.jasonpearson.automobile.protocol.WebSocketRequest
+import dev.jasonpearson.automobile.protocol.WebSocketResponse
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecodingException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -39,6 +53,10 @@ class CtrlProxyMessageHandlerTest {
   private suspend fun dispatch(message: String) {
     handler.handleMessage(json.decodeFromString<WebSocketRequest>(message))
   }
+
+  /** Dispatch and return the synchronous response (non-null only for the guard/error paths). */
+  private suspend fun dispatchForResponse(message: String): WebSocketResponse? =
+    handler.handleMessage(json.decodeFromString<WebSocketRequest>(message))
 
   // ---------------------------------------------------------------------------
   // Hierarchy / screenshot
@@ -136,6 +154,236 @@ class CtrlProxyMessageHandlerTest {
     )
     assertEquals(
       "requestSwipe" to listOf<Any?>("sw-frac", 0.5, 100.25, 10.75, 500.125, 400L),
+      lastCall,
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Non-finite gesture-coordinate guard (#2964 — mirror of iOS #2928 / PR #2957)
+  //
+  // WIRE REALITY (empirically verified, correcting the #2964 premise): kotlinx.serialization's
+  // default config (`allowSpecialFloatingPointValues = false`, used by
+  // WebSocketServer.protocolJson)
+  // REJECTS a JSON overflow literal like `1e309` at decode with a JsonDecodingException
+  // ("Unexpected special floating-point value Infinity") — it does NOT coerce it to
+  // Double.POSITIVE_INFINITY into the widened field. This is the same posture as Apple's
+  // JSONDecoder
+  // on iOS (#2928), so a non-finite coordinate cannot arrive over the wire on either runner, and
+  // standard JSON has no NaN/Infinity literal for the TS client to send anyway.
+  //
+  // The `isFinite` guard is therefore defense-in-depth for the NON-WIRE construction path — an
+  // in-process caller building a request data class from a computed Double (division, hypot,
+  // normalized offset) that yields NaN/±Infinity — exactly as iOS framed its guard. These tests
+  // drive that reachable path by constructing the sealed requests directly, plus one test pinning
+  // the wire decode-rejection behavior so a future kotlinx/config change that flips it is caught.
+  // ---------------------------------------------------------------------------
+
+  /** Assert a guarded error response was returned, no gesture dispatched, and it names [field]. */
+  private fun assertGuarded(response: WebSocketResponse?, field: String) {
+    assertTrue(
+      "expected a non-null guard response, got null (request was dispatched)",
+      response != null,
+    )
+    assertTrue("guard must not dispatch to the gesture engine", calls.isEmpty())
+    val (success, error) =
+      when (response) {
+        is TapCoordinatesResult -> response.success to response.error
+        is SwipeResult -> response.success to response.error
+        is DragResult -> response.success to response.error
+        is PinchResult -> response.success to response.error
+        else -> throw AssertionError("unexpected guard response type: $response")
+      }
+    assertFalse("guard response must have success=false", success)
+    assertTrue("error must be actionable", !error.isNullOrBlank())
+    assertTrue("error must name the offending field ($field): $error", error!!.contains(field))
+    assertTrue(
+      "error must mention finiteness: $error",
+      error.contains("finite", ignoreCase = true),
+    )
+  }
+
+  // --- Non-wire construction path: the reachable path the guard actually protects. ---
+
+  @Test
+  fun `rejects tap with NaN coordinate`() = runTest {
+    val response =
+      handler.handleMessage(RequestTapCoordinates(requestId = "t", x = Double.NaN, y = 200.0))
+    assertGuarded(response, "x")
+    assertTrue(response is TapCoordinatesResult)
+    assertEquals("t", (response as TapCoordinatesResult).requestId)
+  }
+
+  @Test
+  fun `rejects swipe with positive-infinity coordinate`() = runTest {
+    val response =
+      handler.handleMessage(
+        RequestSwipe(requestId = "s", x1 = 0.0, y1 = 0.0, x2 = Double.POSITIVE_INFINITY, y2 = 500.0)
+      )
+    assertGuarded(response, "x2")
+    assertTrue(response is SwipeResult)
+  }
+
+  @Test
+  fun `rejects two-finger swipe with negative-infinity coordinate`() = runTest {
+    // Two-finger swipe shares the swipe_result response type.
+    val response =
+      handler.handleMessage(
+        RequestTwoFingerSwipe(
+          requestId = "tf",
+          x1 = 0.0,
+          y1 = Double.NEGATIVE_INFINITY,
+          x2 = 10.0,
+          y2 = 20.0,
+        )
+      )
+    assertGuarded(response, "y1")
+    assertTrue(response is SwipeResult)
+  }
+
+  @Test
+  fun `rejects drag with NaN coordinate`() = runTest {
+    val response =
+      handler.handleMessage(
+        RequestDrag(requestId = "d", x1 = 50.0, y1 = 50.0, x2 = 150.0, y2 = Double.NaN)
+      )
+    assertGuarded(response, "y2")
+    assertTrue(response is DragResult)
+  }
+
+  @Test
+  fun `rejects pinch with positive-infinity coordinate`() = runTest {
+    val response =
+      handler.handleMessage(
+        RequestPinch(
+          requestId = "p",
+          centerX = Double.POSITIVE_INFINITY,
+          centerY = 960.0,
+          distanceStart = 100.0,
+          distanceEnd = 300.0,
+        )
+      )
+    assertGuarded(response, "centerX")
+    assertTrue(response is PinchResult)
+  }
+
+  // AC #4: rotationDegrees is a non-coordinate Float that flows to the gesture-path math; a
+  // computed
+  // non-finite value must be rejected too (Android-specific — iOS decode-rejects the wire literal).
+  @Test
+  fun `rejects pinch with non-finite rotationDegrees`() = runTest {
+    val response =
+      handler.handleMessage(
+        RequestPinch(
+          requestId = "p",
+          centerX = 540.0,
+          centerY = 960.0,
+          distanceStart = 100.0,
+          distanceEnd = 300.0,
+          rotationDegrees = Float.POSITIVE_INFINITY,
+        )
+      )
+    assertGuarded(response, "rotationDegrees")
+    assertTrue(response is PinchResult)
+  }
+
+  // Parametrized: pin EVERY coordinate field across every family — each field, individually forced
+  // non-finite via direct construction, must be rejected and must name that field.
+  @Test
+  fun `rejects every coordinate field of every gesture family`() = runTest {
+    val inf = Double.POSITIVE_INFINITY
+    val cases: List<Pair<String, WebSocketRequest>> =
+      listOf(
+        "x" to RequestTapCoordinates(x = inf, y = 200.0),
+        "y" to RequestTapCoordinates(x = 100.0, y = inf),
+        "x1" to RequestSwipe(x1 = inf, y1 = 0.0, x2 = 10.0, y2 = 20.0),
+        "y1" to RequestSwipe(x1 = 0.0, y1 = inf, x2 = 10.0, y2 = 20.0),
+        "x2" to RequestSwipe(x1 = 0.0, y1 = 0.0, x2 = inf, y2 = 20.0),
+        "y2" to RequestSwipe(x1 = 0.0, y1 = 0.0, x2 = 10.0, y2 = inf),
+        "x1" to RequestTwoFingerSwipe(x1 = inf, y1 = 0.0, x2 = 10.0, y2 = 20.0),
+        "y1" to RequestTwoFingerSwipe(x1 = 0.0, y1 = inf, x2 = 10.0, y2 = 20.0),
+        "x2" to RequestTwoFingerSwipe(x1 = 0.0, y1 = 0.0, x2 = inf, y2 = 20.0),
+        "y2" to RequestTwoFingerSwipe(x1 = 0.0, y1 = 0.0, x2 = 10.0, y2 = inf),
+        "x1" to RequestDrag(x1 = inf, y1 = 0.0, x2 = 10.0, y2 = 20.0),
+        "y1" to RequestDrag(x1 = 0.0, y1 = inf, x2 = 10.0, y2 = 20.0),
+        "x2" to RequestDrag(x1 = 0.0, y1 = 0.0, x2 = inf, y2 = 20.0),
+        "y2" to RequestDrag(x1 = 0.0, y1 = 0.0, x2 = 10.0, y2 = inf),
+        "centerX" to
+          RequestPinch(centerX = inf, centerY = 960.0, distanceStart = 100.0, distanceEnd = 300.0),
+        "centerY" to
+          RequestPinch(centerX = 540.0, centerY = inf, distanceStart = 100.0, distanceEnd = 300.0),
+        "distanceStart" to
+          RequestPinch(centerX = 540.0, centerY = 960.0, distanceStart = inf, distanceEnd = 300.0),
+        "distanceEnd" to
+          RequestPinch(centerX = 540.0, centerY = 960.0, distanceStart = 100.0, distanceEnd = inf),
+      )
+    for ((field, request) in cases) {
+      actions.calls.clear()
+      val response = handler.handleMessage(request)
+      assertGuarded(response, field)
+    }
+  }
+
+  // --- Wire reality: the `1e309` overflow literal is rejected at DECODE, not coerced to Infinity.
+  // This is the truthful analog of iOS PR #2957's testOverflowCoordinateLiteralIsRejectedAtDecode,
+  // and correcting the #2964 premise that kotlinx would coerce it into the widened field. A future
+  // kotlinx/config change that flips this to coercion trips this test and re-arms the guard's role.
+  @Test
+  fun `overflow coordinate literal is rejected at decode not coerced to infinity`() {
+    // Match production's protocolJson posture (allowSpecialFloatingPointValues defaults to false).
+    val protocolJson = Json {
+      classDiscriminator = "type"
+      ignoreUnknownKeys = true
+    }
+    val ex =
+      assertThrows(JsonDecodingException::class.java) {
+        protocolJson.decodeFromString<WebSocketRequest>(
+          """{"type":"request_tap_coordinates","requestId":"t","x":1e309,"y":200}"""
+        )
+      }
+    assertTrue(
+      "decode must reject the overflow literal as a special float: ${ex.message}",
+      ex.message!!.contains("special floating-point", ignoreCase = true),
+    )
+  }
+
+  // AC #3: the #2927 happy path (finite fractional + negative coordinates) is unaffected — the
+  // guard returns null and the gesture dispatches exactly as before.
+  @Test
+  fun `finite fractional and negative coordinates still dispatch`() = runTest {
+    val response =
+      dispatchForResponse(
+        """{"type":"request_swipe","requestId":"ok","x1":-0.5,"y1":100.25,"x2":10.75,"y2":500.125,"duration":400}"""
+      )
+    assertNull("finite coordinates must not be guarded", response)
+    assertEquals(
+      "requestSwipe" to listOf<Any?>("ok", -0.5, 100.25, 10.75, 500.125, 400L),
+      lastCall,
+    )
+  }
+
+  @Test
+  fun `finite pinch with rotationDegrees still dispatches`() = runTest {
+    val response =
+      dispatchForResponse(
+        """{"type":"request_pinch","requestId":"okp","centerX":540,"centerY":960,"distanceStart":100,"distanceEnd":300,"rotationDegrees":45.0,"duration":500}"""
+      )
+    assertNull(response)
+    assertEquals(
+      "requestPinch" to listOf<Any?>("okp", 540.0, 960.0, 100.0, 300.0, 45.0f, 500L),
+      lastCall,
+    )
+  }
+
+  // A huge but finite two-finger `offset` (Int, cannot be non-finite) is unaffected by the guard.
+  @Test
+  fun `large finite two-finger offset still dispatches`() = runTest {
+    val response =
+      dispatchForResponse(
+        """{"type":"request_two_finger_swipe","requestId":"tfo","x1":0,"y1":0,"x2":10,"y2":20,"duration":300,"offset":100000}"""
+      )
+    assertNull(response)
+    assertEquals(
+      "requestTwoFingerSwipe" to listOf<Any?>("tfo", 0.0, 0.0, 10.0, 20.0, 300L, 100000),
       lastCall,
     )
   }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -14,9 +14,9 @@ import dev.jasonpearson.automobile.protocol.TapCoordinatesResult
 import dev.jasonpearson.automobile.protocol.WebSocketRequest
 import dev.jasonpearson.automobile.protocol.WebSocketResponse
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonDecodingException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -329,20 +329,19 @@ class CtrlProxyMessageHandlerTest {
   // kotlinx/config change that flips this to coercion trips this test and re-arms the guard's role.
   @Test
   fun `overflow coordinate literal is rejected at decode not coerced to infinity`() {
-    // Match production's protocolJson posture (allowSpecialFloatingPointValues defaults to false).
-    val protocolJson = Json {
-      classDiscriminator = "type"
-      ignoreUnknownKeys = true
-    }
+    // The class-level [json] matches production's protocolJson posture
+    // (allowSpecialFloatingPointValues defaults to false), so this is the production decode path.
+    // SerializationException is the stable supertype of the (experimental) JsonDecodingException
+    // kotlinx throws here; the message assertion below pins the exact special-float rejection.
     val ex =
-      assertThrows(JsonDecodingException::class.java) {
-        protocolJson.decodeFromString<WebSocketRequest>(
+      assertThrows(SerializationException::class.java) {
+        json.decodeFromString<WebSocketRequest>(
           """{"type":"request_tap_coordinates","requestId":"t","x":1e309,"y":200}"""
         )
       }
     assertTrue(
       "decode must reject the overflow literal as a special float: ${ex.message}",
-      ex.message!!.contains("special floating-point", ignoreCase = true),
+      ex.message.orEmpty().contains("special floating-point", ignoreCase = true),
     )
   }
 


### PR DESCRIPTION
## What

Reject **non-finite gesture coordinates** (`NaN` / `±Infinity`) at the **Android** CtrlProxy runner's message-handler dispatch boundary — the direct analog of the iOS guard (#2928 / PR #2957). A gesture request carrying a non-finite coordinate now returns a clean, per-command `*_result` with `success:false` and an actionable `error`, instead of dispatching a bogus gesture into the accessibility `GestureDescription` engine.

Closes #2964. The prerequisite `Int → Double` widening (#2927 / PR #2946) already **merged to `main`**, so this PR is purely the guard + tests.

Affected files (`android/control-proxy/`):
- `src/main/kotlin/.../CtrlProxyMessageHandler.kt` — shared `firstNonFinite` / `nonFiniteError` / `swipeError` helpers + guard in the five gesture branches; injected `now` clock for deterministic guard-response timestamps.
- `src/test/kotlin/.../CtrlProxyMessageHandlerTest.kt` — non-finite rejection per family, a parametrized every-coordinate-field test, `rotationDegrees`, a decode-boundary test, and fractional/negative happy-path regressions.

## Why

#2946 widened the gesture request coordinate fields `Int → Double` (so fractional coordinates from the TS wire path decode cleanly, symmetric to iOS #2909). That means the fields can now *hold* a non-finite value. A `NaN`/`Infinity` coordinate flowing unchecked into `Path.moveTo` / `GestureDescription.StrokeDescription` is a silent no-op or opaque failure. Per #2909/#2927's thesis, the runner should be robust to any client and never surface an opaque failure for unusual input.

### ⚠️ Empirical finding — the issue's stated mechanism does not hold (mirrors the iOS #2928 finding)

The issue premise is that **kotlinx.serialization coerces `1e309` → `Double.POSITIVE_INFINITY` directly into the widened field**, making the guard "load-bearing on the wire" (and claiming Android is *more* exposed than iOS). **This is empirically false for the production config.** kotlinx's default `allowSpecialFloatingPointValues = false` (used by `WebSocketServer.protocolJson`) **rejects** the overflow literal at decode:

```
kotlinx.serialization.json.JsonDecodingException: Unexpected JSON token at offset 55:
Unexpected special floating-point value Infinity. By default, non-finite floating point values
are prohibited because they do not conform JSON specification. at path: $.centerX
```

So the value never reaches the widened field — the **same posture as Apple's `JSONDecoder`** on iOS. Standard JSON has no `NaN`/`Infinity` literal, and `JSON.stringify(Infinity)` → `"null"` (which then fails the required-`Double` decode), so **no wire JSON can deliver a non-finite coordinate to a handler** on Android either.

The `isFinite` guard is therefore correct and valuable as **defense-in-depth for the non-wire construction path** — an in-process caller building a request from a *computed* `Double` (division, `hypot`, a normalized offset) that yields a non-finite value before hitting the gesture engine — exactly as iOS framed its guard. This is documented in the helper's KDoc and pinned by a decode-boundary test (the Android analog of iOS `testOverflowCoordinateLiteralIsRejectedAtDecode`).

## How

- `firstNonFinite(vararg fields: Pair<String, Double>)` returns the first non-finite `(field, value)`, or null. When non-null, the gesture branch **returns** a typed `*_result` (`success:false`, `error = nonFiniteError(...)`) **before** calling `actions.requestX(...)`. `WebSocketServer.handleClientMessage` already broadcasts any non-null `handleMessage` return, so the error reaches the client — wire-**identical** to the existing success/failure broadcasts (`broadcastSwipeResult(success=false, ...)` etc.), which the TS client (`AndroidCtrlProxyClient`) resolves by `requestId` reading `success`/`error`.
- Guarded fields: tap (`x`,`y`); swipe / two-finger swipe / drag (`x1`,`y1`,`x2`,`y2`); pinch (`centerX`,`centerY`,`distanceStart`,`distanceEnd`, **and `rotationDegrees`**). Two-finger swipe shares the `swipe_result` type via the shared `swipeError` helper.
- The `now: () -> Long = { System.currentTimeMillis() }` ctor param (default = wall clock; production untouched) makes guard-response timestamps deterministic in tests.

### Deliberate scope

- **`rotationDegrees` (`Float`) IS guarded on Android** (AC #4). Unlike iOS — where the wire literal is decode-rejected and rotation was left out of #2928 — it is a real Float that flows into the gesture-path math, so a computed non-finite value is caught. Converted via `.toDouble()` for the shared check.
- **`offset` (`Int`) is not guarded** — an `Int` cannot be non-finite, and kotlinx rejects `1e309` into an `Int` field. A huge *finite* offset is unaffected (regression-tested).
- Magnitude is **not** clamped — only finiteness is checked. Huge finite / negative magnitudes are pre-existing behavior and out of scope.

## Testing

`CtrlProxyMessageHandlerTest` (pure-JVM, no Robolectric, <100ms):
- Non-finite rejection, one per gesture family, via **direct construction** (`NaN`, `+Infinity`, `-Infinity`) — the reachable path: asserts the correct `*_result` type, `success:false`, an actionable `error` naming the field, **and** that nothing dispatched to the fake actions. (Red→green: fails without the guard.)
- `rejects every coordinate field of every gesture family` — parametrized, pins **every** coordinate field of every family so each guard call is proven load-bearing (not just the first-checked field).
- `rejects pinch with non-finite rotationDegrees` — AC #4.
- `overflow coordinate literal is rejected at decode not coerced to infinity` — documents the wire truth; a future kotlinx/config change that flips this to coercion trips this test and re-arms the guard's wire role.
- Happy-path regressions: finite fractional + **negative** coordinates still dispatch (the #2927 path is unaffected); finite pinch with `rotationDegrees`; large finite two-finger `offset`.

Verified locally (JDK 21):
- `./android/gradlew -p android :control-proxy:testDebugUnitTest` — **all pass** (71 tests in `CtrlProxyMessageHandlerTest`).
- `scripts/ktfmt/apply_ktfmt.sh` on touched files; ktfmt validation clean.

## Acceptance criteria (#2964)
- [x] A gesture request with a non-finite coordinate returns a clean, actionable error response instead of dispatching a gesture. *(Reachable path is direct/computed construction; the wire `1e309` is already rejected at decode — see empirical finding correcting the issue premise.)*
- [x] Test per gesture family + a shared parametrized test pinning **every** coordinate field, plus a decode-boundary test for the `1e309` wire case.
- [x] Finite fractional/negative coordinates (the #2927 happy path) are unaffected.
- [x] `rotationDegrees` non-finite is guarded on Android (the non-coordinate float that reaches the gesture engine).

## Deployment note

This lives in the Android runner source (`android/control-proxy`). Per the CtrlProxy release-delivery gate, it reaches default installs only once the pinned Android runner release is re-cut. No interim regression: the shipped TS path still rounds, and non-finite coordinates were never a working input.
