### PR TITLE
fix(db): transactionalize promoteSuggestion + recordHierarchyNavigation graph writes (#2968)

### DIFF
--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -523,7 +523,7 @@ export class NavigationGraphManager implements NavigationGraphService {
 
       // Persist the counter writes atomically: updateNodeVisit + coverage recordNodeVisit +
       // touchApp span two repos on the shared connection. Enlist both onto one `trx` via
-      // withExecutor so a mid-sequence throw (e.g. the coverage upsert) rolls back the node-visit
+      // withExecutor so a mid-sequence throw (e.g. the coverage recordNodeVisit) rolls back the node-visit
       // increment too, instead of leaving the graph partially applied. Assert the shared-connection
       // precondition first (the coverage repo is enlisted onto the navigation `trx`). In-memory
       // field updates and notifyGraphUpdated stay OUTSIDE so they never run on rollback and the

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -519,18 +519,37 @@ export class NavigationGraphManager implements NavigationGraphService {
     // Case 1: Check if fingerprint is already correlated to a named node (scoped to this app)
     const existingNode = await this.repository.getNodeByFingerprint(this.currentAppId, fingerprintHash);
     if (existingNode) {
-      // Update the existing node's visit count and last_seen_at
-      await this.repository.updateNodeVisit(existingNode.id, timestamp);
+      const appId = this.currentAppId;
 
-      // Record node visit for test coverage if session is active
-      if (this.activeTestSession) {
-        await this.testCoverageRepository.recordNodeVisit(
-          this.activeTestSession.id,
-          existingNode.id,
-          timestamp
-        );
-      }
+      // Persist the counter writes atomically: updateNodeVisit + coverage recordNodeVisit +
+      // touchApp span two repos on the shared connection. Enlist both onto one `trx` via
+      // withExecutor so a mid-sequence throw (e.g. the coverage upsert) rolls back the node-visit
+      // increment too, instead of leaving the graph partially applied. Assert the shared-connection
+      // precondition first (the coverage repo is enlisted onto the navigation `trx`). In-memory
+      // field updates and notifyGraphUpdated stay OUTSIDE so they never run on rollback and the
+      // exclusive connection is not held across non-DB work.
+      this.assertSharedConnection();
 
+      await this.repository.runInTransaction(async trx => {
+        const repository = this.repository.withExecutor(trx);
+        const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);
+
+        // Update the existing node's visit count and last_seen_at
+        await repository.updateNodeVisit(existingNode.id, timestamp);
+
+        // Record node visit for test coverage if session is active
+        if (this.activeTestSession) {
+          await testCoverageRepository.recordNodeVisit(
+            this.activeTestSession.id,
+            existingNode.id,
+            timestamp
+          );
+        }
+
+        await repository.touchApp(appId);
+      });
+
+      // ---- Post-commit side effects (never inside the transaction) ----
       // Update current screen to the named screen
       this.currentScreen = existingNode.screen_name;
 
@@ -538,7 +557,6 @@ export class NavigationGraphManager implements NavigationGraphService {
         `[NAVIGATION_GRAPH] Hierarchy fingerprint matched node: ${existingNode.screen_name}`
       );
 
-      await this.repository.touchApp(this.currentAppId);
       this.notifyGraphUpdated();
       return;
     }
@@ -1394,22 +1412,33 @@ export class NavigationGraphManager implements NavigationGraphService {
       throw new Error("No current app set");
     }
 
+    const appId = this.currentAppId;
     const timestamp = this.timer.now();
 
-    // Get or create the named node
-    const node = await this.repository.getOrCreateNode(
-      this.currentAppId,
-      screenName,
-      timestamp
-    );
+    // Persist the node creation + suggestion promotion atomically. repository.promoteSuggestion
+    // does getOrCreateFingerprint + an UPDATE to link the suggestion; without a transaction a
+    // throw after getOrCreateNode/getOrCreateFingerprint leaves an orphaned node/fingerprint with
+    // the suggestion still unpromoted (partial write). Bind the whole repo to `trx` via
+    // withExecutor so every statement — including the nested getOrCreateFingerprint upsert — runs
+    // on the transaction; a stray singleton query would deadlock the daemon's only connection
+    // (bunSqliteDialect). Only the navigation repo participates here, so no coverage enlistment /
+    // shared-connection assertion is needed. Keep notifyGraphUpdated OUTSIDE so it never fires on
+    // rollback and the exclusive connection is not held across it.
+    await this.repository.runInTransaction(async trx => {
+      const repository = this.repository.withExecutor(trx);
 
-    // Promote the suggestion (creates fingerprint and links suggestion)
-    await this.repository.promoteSuggestion(suggestionId, node.id, timestamp);
+      // Get or create the named node
+      const node = await repository.getOrCreateNode(appId, screenName, timestamp);
+
+      // Promote the suggestion (creates fingerprint and links suggestion)
+      await repository.promoteSuggestion(suggestionId, node.id, timestamp);
+    });
 
     logger.info(
       `[NAVIGATION_GRAPH] Promoted suggestion ${suggestionId} to screen: ${screenName}`
     );
 
+    // Post-commit side effect (never inside the transaction).
     this.notifyGraphUpdated();
   }
 

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1187,3 +1187,246 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
     expect(manager.getCurrentScreen()).toBe("Screen1");
   });
 });
+
+/**
+ * A TestCoverageRepository that throws on recordNodeVisit to simulate a
+ * mid-sequence write failure inside recordHierarchyNavigation's Case-1
+ * transaction. Overrides withExecutor so the throw survives the manager
+ * rebinding the repo onto the transaction executor.
+ */
+class ThrowingNodeVisitCoverageRepo extends TestCoverageRepository {
+  constructor(
+    private readonly injectedTimer: Timer,
+    db?: Kysely<Database>
+  ) {
+    super(injectedTimer, db);
+  }
+
+  override withExecutor(executor: Kysely<Database>): TestCoverageRepository {
+    return new ThrowingNodeVisitCoverageRepo(this.injectedTimer, executor);
+  }
+
+  override async recordNodeVisit(): Promise<void> {
+    throw new Error("injected recordNodeVisit failure");
+  }
+}
+
+describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () => {
+  const APP_ID = "com.test.promo";
+
+  let db: Kysely<Database>;
+
+  async function countNodes(screenName?: string): Promise<number> {
+    let q = db
+      .selectFrom("navigation_nodes")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .where("app_id", "=", APP_ID);
+    if (screenName !== undefined) {
+      q = q.where("screen_name", "=", screenName);
+    }
+    const row = await q.executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  async function countFingerprints(): Promise<number> {
+    const row = await db
+      .selectFrom("navigation_node_fingerprints")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .where("app_id", "=", APP_ID)
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  beforeEach(async () => {
+    db = await createTestDatabase({ foreignKeys: true });
+    TelemetryRecorder.resetInstance();
+  });
+
+  afterEach(async () => {
+    TelemetryRecorder.resetInstance();
+    await db.destroy();
+  });
+
+  function makeManager(): NavigationGraphManager {
+    const navRepo = new NavigationRepository(db);
+    const coverage = new TestCoverageRepository(defaultTimer, db);
+    return NavigationGraphManager.createForTesting(navRepo, coverage);
+  }
+
+  // Seed a promotable suggestion: one named node (so the app "has named nodes")
+  // plus an uncorrelated fingerprint suggestion.
+  async function seedSuggestion(manager: NavigationGraphManager): Promise<number> {
+    await manager.recordNavigationEvent(createEvent("HomeScreen", 1000));
+    await manager.recordHierarchyNavigation({
+      fromFingerprint: null,
+      toFingerprint: "fp_settings",
+      fingerprintData: JSON.stringify({ layout: "settings" }),
+      timestamp: 5000, // outside the active-navigation window → becomes a suggestion
+      packageName: APP_ID,
+    });
+    const suggestions = await manager.getSuggestions();
+    const suggestion = suggestions.find(s => s.fingerprintHash === "fp_settings");
+    expect(suggestion).toBeDefined();
+    return suggestion!.id;
+  }
+
+  test("happy path persists the named node, fingerprint, and suggestion link", async () => {
+    const manager = makeManager();
+    await manager.setCurrentApp(APP_ID);
+    const suggestionId = await seedSuggestion(manager);
+
+    await manager.promoteSuggestion(suggestionId, "SettingsScreen");
+
+    expect(await countNodes("SettingsScreen")).toBe(1);
+    // The promoted fingerprint now points at a named node; the suggestion is gone
+    // from the unpromoted list.
+    const remaining = await manager.getSuggestions();
+    expect(remaining.find(s => s.fingerprintHash === "fp_settings")).toBeUndefined();
+  });
+
+  test("rolls back the created node when the suggestion link fails mid-sequence", async () => {
+    const manager = makeManager();
+    await manager.setCurrentApp(APP_ID);
+    await seedSuggestion(manager);
+
+    const nodesBefore = await countNodes();
+    const fingerprintsBefore = await countFingerprints();
+
+    // A non-existent suggestion id: getOrCreateNode creates the "OrphanScreen"
+    // node first, then repository.promoteSuggestion throws "Suggestion not found"
+    // during the multi-write promotion. Without a transaction the node would be
+    // left orphaned; the transaction must roll it back.
+    await expect(
+      manager.promoteSuggestion(999999, "OrphanScreen")
+    ).rejects.toThrow(/Suggestion not found/i);
+
+    // Zero new nodes/fingerprints persisted for the failed promotion.
+    expect(await countNodes("OrphanScreen")).toBe(0);
+    expect(await countNodes()).toBe(nodesBefore);
+    expect(await countFingerprints()).toBe(fingerprintsBefore);
+  });
+});
+
+describe("NavigationGraphManager - recordHierarchyNavigation Case-1 transaction (#2968)", () => {
+  const APP_ID = "com.test.hiernav";
+
+  let db: Kysely<Database>;
+
+  async function nodeVisitCount(screenName: string): Promise<number> {
+    const row = await db
+      .selectFrom("navigation_nodes")
+      .select(["visit_count"])
+      .where("app_id", "=", APP_ID)
+      .where("screen_name", "=", screenName)
+      .executeTakeFirst();
+    return Number(row?.visit_count ?? 0);
+  }
+
+  async function countNodeCoverageRows(): Promise<number> {
+    const row = await db
+      .selectFrom("test_node_coverage")
+      .select(eb => eb.fn.countAll<number>().as("count"))
+      .executeTakeFirst();
+    return Number(row?.count ?? 0);
+  }
+
+  async function sessionNodeTotal(sessionId: number): Promise<number> {
+    const row = await db
+      .selectFrom("test_coverage_sessions")
+      .select(["total_nodes_visited"])
+      .where("id", "=", sessionId)
+      .executeTakeFirstOrThrow();
+    return Number(row.total_nodes_visited);
+  }
+
+  beforeEach(async () => {
+    db = await createTestDatabase({ foreignKeys: true });
+    TelemetryRecorder.resetInstance();
+    spyOn(TelemetryRecorder.getInstance(), "recordNavigationEvent").mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    TelemetryRecorder.resetInstance();
+    await db.destroy();
+  });
+
+  // Seed a named node ("Home") with a correlated fingerprint ("fp_home") WITHOUT
+  // an active test session (so the throwing coverage repo is never touched during
+  // setup), then navigate away so currentScreen != "Home". A later hierarchy event
+  // carrying "fp_home" takes Case 1 (existing-node branch).
+  async function seedCorrelatedNode(manager: NavigationGraphManager): Promise<void> {
+    await manager.recordNavigationEvent(createEvent("Home", 1000));
+    await manager.recordHierarchyNavigation({
+      fromFingerprint: null,
+      toFingerprint: "fp_home",
+      fingerprintData: JSON.stringify({ layout: "home" }),
+      timestamp: 1200, // within ACTIVE_NAVIGATION_WINDOW_MS → correlates fp_home → Home
+      packageName: APP_ID,
+    });
+    await manager.recordNavigationEvent(createEvent("Other", 3000)); // currentScreen → "Other"
+  }
+
+  test("happy path records the visit + coverage and updates currentScreen", async () => {
+    const navRepo = new NavigationRepository(db);
+    const coverage = new TestCoverageRepository(defaultTimer, db);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+    await seedCorrelatedNode(manager);
+    await manager.startTestSession("session-hier-happy");
+    const sessionId = manager.getActiveTestSession()!.id;
+
+    const visitsBefore = await nodeVisitCount("Home");
+
+    await manager.recordHierarchyNavigation({
+      fromFingerprint: null,
+      toFingerprint: "fp_home",
+      timestamp: 8000, // well outside the window → Case 1 (existing-node match)
+      packageName: APP_ID,
+    });
+
+    expect(await nodeVisitCount("Home")).toBe(visitsBefore + 1);
+    expect(await countNodeCoverageRows()).toBe(1);
+    expect(await sessionNodeTotal(sessionId)).toBe(1);
+    expect(manager.getCurrentScreen()).toBe("Home");
+  });
+
+  test("rolls back the node-visit + coverage counters when recordNodeVisit throws", async () => {
+    const navRepo = new NavigationRepository(db);
+    const coverage = new ThrowingNodeVisitCoverageRepo(defaultTimer, db);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+    await seedCorrelatedNode(manager);
+    await manager.startTestSession("session-hier-rollback");
+    const sessionId = manager.getActiveTestSession()!.id;
+
+    const visitsBefore = await nodeVisitCount("Home");
+    const coverageBefore = await countNodeCoverageRows();
+    const sessionTotalBefore = await sessionNodeTotal(sessionId);
+
+    let notifyCount = 0;
+    manager.setGraphUpdateListener(() => {
+      notifyCount++;
+    });
+
+    // Case 1: updateNodeVisit succeeds inside the transaction, then the coverage
+    // recordNodeVisit throws → the whole thing must roll back.
+    await expect(
+      manager.recordHierarchyNavigation({
+        fromFingerprint: null,
+        toFingerprint: "fp_home",
+        timestamp: 8000,
+        packageName: APP_ID,
+      })
+    ).rejects.toThrow(/injected recordNodeVisit failure/);
+
+    // updateNodeVisit's increment is rolled back; coverage rows/counters unchanged.
+    expect(await nodeVisitCount("Home")).toBe(visitsBefore);
+    expect(await countNodeCoverageRows()).toBe(coverageBefore);
+    expect(await sessionNodeTotal(sessionId)).toBe(sessionTotalBefore);
+
+    // In-memory field rollback invariant: currentScreen stays "Other" (the
+    // post-commit assignment to "Home" never runs), and no notify fires.
+    expect(manager.getCurrentScreen()).toBe("Other");
+    expect(notifyCount).toBe(0);
+  });
+});

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1211,6 +1211,38 @@ class ThrowingNodeVisitCoverageRepo extends TestCoverageRepository {
   }
 }
 
+/**
+ * A NavigationRepository whose promoteSuggestion creates the fingerprint (a real
+ * write) and then throws, simulating the suggestion-link UPDATE failing AFTER the
+ * node + fingerprint already exist — the exact "orphaned node/fingerprint" partial
+ * write #2968 describes. Overrides withExecutor so the throw survives the manager
+ * rebinding the repo onto the transaction executor. Returns Promise<never> (only
+ * ever throws), which is assignable to the base method's return type.
+ */
+class ThrowingLinkPromoteRepo extends NavigationRepository {
+  constructor(
+    private readonly appId: string,
+    db?: Kysely<Database>
+  ) {
+    super(db);
+  }
+
+  override withExecutor(executor: Kysely<Database>): NavigationRepository {
+    return new ThrowingLinkPromoteRepo(this.appId, executor);
+  }
+
+  override async promoteSuggestion(
+    _suggestionId: number,
+    nodeId: number,
+    timestamp: number
+  ): Promise<never> {
+    // Create the fingerprint first (a real write on the transaction), then throw as
+    // if the suggestion-link UPDATE failed.
+    await this.getOrCreateFingerprint(this.appId, nodeId, "fp_orphan", "{}", timestamp);
+    throw new Error("injected suggestion-link failure");
+  }
+}
+
 describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () => {
   const APP_ID = "com.test.promo";
 
@@ -1305,7 +1337,50 @@ describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () =>
     expect(await countNodes()).toBe(nodesBefore);
     expect(await countFingerprints()).toBe(fingerprintsBefore);
   });
+
+  test("rolls back BOTH the node and the fingerprint when the link fails after the fingerprint is created", async () => {
+    // The link failure happens AFTER getOrCreateNode + getOrCreateFingerprint both
+    // wrote — the exact orphaned node/fingerprint partial write #2968 calls out.
+    const navRepo = new ThrowingLinkPromoteRepo(APP_ID, db);
+    const coverage = new TestCoverageRepository(defaultTimer, db);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    await expect(
+      manager.promoteSuggestion(42, "OrphanScreen")
+    ).rejects.toThrow(/injected suggestion-link failure/);
+
+    // Both writes rolled back together — no orphan node, no orphan fingerprint.
+    expect(await countNodes("OrphanScreen")).toBe(0);
+    expect(await countFingerprints()).toBe(0);
+  });
 });
+
+/**
+ * A NavigationRepository that throws on touchApp only once a shared control flag is
+ * flipped, so setup writes (which also touchApp) succeed and only the write under
+ * test fails. The control object is threaded through withExecutor so the flag
+ * survives the manager rebinding the repo onto the transaction executor.
+ */
+class ConditionalTouchAppRepo extends NavigationRepository {
+  constructor(
+    private readonly control: { throwOnTouch: boolean },
+    db?: Kysely<Database>
+  ) {
+    super(db);
+  }
+
+  override withExecutor(executor: Kysely<Database>): NavigationRepository {
+    return new ConditionalTouchAppRepo(this.control, executor);
+  }
+
+  override async touchApp(appId: string): Promise<void> {
+    if (this.control.throwOnTouch) {
+      throw new Error("injected touchApp failure");
+    }
+    return super.touchApp(appId);
+  }
+}
 
 describe("NavigationGraphManager - recordHierarchyNavigation Case-1 transaction (#2968)", () => {
   const APP_ID = "com.test.hiernav";
@@ -1428,5 +1503,34 @@ describe("NavigationGraphManager - recordHierarchyNavigation Case-1 transaction 
     // post-commit assignment to "Home" never runs), and no notify fires.
     expect(manager.getCurrentScreen()).toBe("Other");
     expect(notifyCount).toBe(0);
+  });
+
+  test("rolls back updateNodeVisit with NO active session when touchApp throws", async () => {
+    // Case 1 with no test session still wraps two nav-repo writes (updateNodeVisit +
+    // touchApp). Prove that pair is atomic: touchApp throws → the visit increment
+    // rolls back. The control flag lets setup writes (which also touchApp) succeed.
+    const control = { throwOnTouch: false };
+    const navRepo = new ConditionalTouchAppRepo(control, db);
+    const coverage = new TestCoverageRepository(defaultTimer, db);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+    await seedCorrelatedNode(manager); // no startTestSession → activeTestSession stays null
+
+    const visitsBefore = await nodeVisitCount("Home");
+    control.throwOnTouch = true;
+
+    await expect(
+      manager.recordHierarchyNavigation({
+        fromFingerprint: null,
+        toFingerprint: "fp_home",
+        timestamp: 8000, // Case 1 (existing-node match)
+        packageName: APP_ID,
+      })
+    ).rejects.toThrow(/injected touchApp failure/);
+
+    // updateNodeVisit ran first inside the transaction; touchApp's throw rolls it back.
+    expect(await nodeVisitCount("Home")).toBe(visitsBefore);
+    // currentScreen unchanged — post-commit assignment never runs.
+    expect(manager.getCurrentScreen()).toBe("Other");
   });
 });


### PR DESCRIPTION
## What

`NavigationGraphManager` had two remaining multi-write sequences with the same non-transactional partial-write bug class that #2791 fixed for `recordNavigationEvent`. This wraps both in a single `runInTransaction` / `withExecutor(trx)` transaction so each graph write is all-or-nothing.

Closes #2968.

### 1. `promoteSuggestion` (structural writes)
`getOrCreateNode` (creates the named node) + `repository.promoteSuggestion` (which does `getOrCreateFingerprint` + an `UPDATE` to link the suggestion) ran as separately-awaited statements. A throw during the link `UPDATE` — or a daemon interrupted mid-`await` — left an **orphaned node/fingerprint** with the suggestion still unpromoted.

### 2. `recordHierarchyNavigation` Case 1 (counters)
The existing-node branch did `updateNodeVisit` + coverage `recordNodeVisit` + `touchApp` across **two repos**, non-transactional. A mid-sequence throw left the node-visit increment applied while coverage counters were not (or vice-versa).

## Why

Per the architecture review (Devin Osei) on PR #2959, siblings of #2791. The daemon runs a **single** `bun:sqlite` connection guarded by an async mutex that serializes individual queries but **releases across every `await`** — so between two awaited statements the event loop yields and a throw leaves the graph partially applied with no rollback.

## How

Same structural-safety vehicle as `recordNavigationEvent` (#2791 / PR #2959):

- **`promoteSuggestion`** wraps `getOrCreateNode` + `promoteSuggestion` in `this.repository.runInTransaction(trx => …)`, binding the repo via `withExecutor(trx)` so every statement — including the nested `getOrCreateFingerprint` upsert — runs on the transaction. Only the navigation repo participates, so **no coverage enlistment / shared-connection assertion** is needed. `notifyGraphUpdated()` stays **outside** (post-commit).
- **`recordHierarchyNavigation` Case 1** wraps `updateNodeVisit` + coverage `recordNodeVisit` + `touchApp` in the same transaction, binding **both** repos via `withExecutor(trx)`. Because two repos are enlisted onto one connection, it calls the existing `assertSharedConnection()` (added by #2977) **before** opening the transaction. The in-memory `this.currentScreen` assignment and `notifyGraphUpdated()` move **outside** the transaction (post-commit), so on rollback `currentScreen` is unchanged and no notify fires.
- Branch-selector reads (`getNodeByFingerprint`) stay outside the write transaction, matching the issue's specified write boundary and the `recordNavigationEvent` precedent.

The other `recordHierarchyNavigation` cases (2/3/4) each issue a single write on one repo, so there is no multi-write sequence to make atomic.

## Testing

- `bun test test/features/navigation/NavigationGraphManager.test.ts` → **58 pass, 0 fail** (~0.46s), including 4 new tests.
- `bun test test/db/navigationRepository.test.ts test/db/testCoverageRepository.test.ts` → **63 pass, 0 fail**.
- `bunx turbo run lint build` → clean; `schemas/tool-definitions.json` regenerated, no drift.
- Full suite: 6 pre-existing failures only, all in image-processing modules (`PerceptualHasher`, `ScreenshotUtils`) + one memory-leak test — confirmed failing on a clean checkout, unrelated to this change.

New tests (real in-memory `createTestDatabase({ foreignKeys: true })`, <100ms, no device; TDD — the rollback tests fail on `main`'s non-transactional code and pass after the fix):
- **promoteSuggestion happy path** — node + fingerprint + suggestion-link all persisted; suggestion leaves the unpromoted list.
- **promoteSuggestion rollback** — an invalid `suggestionId` makes `repository.promoteSuggestion` throw *after* `getOrCreateNode` created the node; asserts **zero** new nodes/fingerprints persist (on `main` the orphan node survives → 1).
- **recordHierarchyNavigation Case 1 happy path** — visit_count +1, one coverage row, session total +1, `currentScreen` updated to the matched screen.
- **recordHierarchyNavigation Case 1 rollback** — a coverage repo that throws on `recordNodeVisit` (with an active session) → asserts `visit_count`, coverage rows, and session total all **unchanged**, `currentScreen` stays the pre-event screen, and no `notifyGraphUpdated` fires (on `main` the visit increment leaks → 2).

## Acceptance criteria (#2968)
- [x] `promoteSuggestion` DB writes are atomic (node + fingerprint + suggestion-link all-or-nothing); rollback test with an injected mid-sequence throw asserts zero new rows.
- [x] `recordHierarchyNavigation` Case 1 writes are atomic; rollback leaves node visit/coverage counters unchanged.
- [x] No statement inside either transaction uses the singleton `getDb()` — all go through `withExecutor(trx)`.
- [x] Side effects (`notifyGraphUpdated`, in-memory field updates) stay outside the transaction.
- [x] Tests in `NavigationGraphManager.test.ts` using real in-memory `createTestDatabase()` + fakes, <100ms, non-flaky.
- [x] lint + build + tests green.

## Notes
- Sibling of #2791 (PR #2959); same `withExecutor` / `runInTransaction` vehicle. The shared-connection precondition is enforced by `assertSharedConnection()` (#2977) for the two-repo Case-1 transaction.
- Convention note (Devin §4): no new repo method here opens its own transaction while also being enlisted in an outer one, so the `getOrCreateUIElement` `isTransaction` dual-path guard is not needed for these call sites.
