### PR TITLE
test(ios): add executable guard for iOS pinch geometry (#2979)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometry.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometry.kt
@@ -23,10 +23,11 @@ internal data class PinchPoints(
  * move to an axis rotated by [rotationDegrees]. A non-zero value therefore produces a combined
  * pinch+rotate. For the common `rotationDegrees == 0` zoom case the start and end axes coincide.
  *
- * This convention is shared with the iOS runner
- * (`ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m`) so cross-platform pinch
- * results match. See issue #2911. Pure trig with no Android dependencies so it stays unit testable
- * — see `PinchGeometryTest`.
+ * This convention is shared with the iOS runner's `ObjCExceptionCatcher_computePinchPoints`
+ * (`ios/control-proxy/Sources/ObjCExceptionCatcher/`) so cross-platform pinch results match. Both
+ * sides are now pinned by executable tests — `PinchGeometryTest` here and `PinchGeometryTests` on
+ * iOS — which share a golden-vector table so a silent divergence in either fails loudly. See
+ * issues #2911 / #2979. Pure trig with no Android dependencies so it stays unit testable.
  */
 internal fun computePinchPoints(
   centerX: Double,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
@@ -164,6 +164,17 @@ class PinchGeometryTest {
           -30f,
           listOf(150f to 400f, 250f to 400f, 156.698730f to 425f, 243.301270f to 375f),
         ),
+        // A second asymmetric negative angle so drop-rotation-sign / sin-cos-swap detection is not
+        // a single point of failure on the -30 row (the +45 / rot-0 rows are blind to a dropped
+        // sign). distanceStart != distanceEnd also exercises unequal radii.
+        Vector(
+          300.0,
+          500.0,
+          200.0,
+          80.0,
+          -60f,
+          listOf(200f to 500f, 400f to 500f, 280f to 534.641016f, 320f to 465.358984f),
+        ),
         Vector(
           0.0,
           0.0,
@@ -192,6 +203,31 @@ class PinchGeometryTest {
         assertEquals("y mismatch for $v", e.second, a.second, delta)
       }
     }
+  }
+
+  @Test
+  fun `computePinchPoints does not clamp degenerate distances`() {
+    // The pure function must NOT floor a zero distance: radius 0 collapses all four endpoints
+    // onto the center. The iOS runner mirrors this — any minimum-distance floor is an
+    // iOS-synthesis-wrapper concern, not part of the shared convention. See #2979.
+    val p =
+      computePinchPoints(
+        centerX = 320.0,
+        centerY = 480.0,
+        distanceStart = 0.0,
+        distanceEnd = 0.0,
+        rotationDegrees = 45f,
+      )
+    listOf(
+        p.startX1 to p.startY1,
+        p.startX2 to p.startY2,
+        p.endX1 to p.endY1,
+        p.endX2 to p.endY2,
+      )
+      .forEach { (x, y) ->
+        assertEquals(320f, x, delta)
+        assertEquals(480f, y, delta)
+      }
   }
 
   /** Deterministic order-independent sort so the golden comparison ignores finger labeling. */

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
@@ -113,4 +113,88 @@ class PinchGeometryTest {
     assertEquals(100f, p.endX1, delta)
     assertEquals(-100f, p.endX2, delta)
   }
+
+  /**
+   * SHARED GOLDEN TABLE — keep byte-identical with the iOS runner's `PinchGeometryTests.swift`
+   * (`testGoldenVectorsMatchAndroidParity`). Each row is an input tuple and its expected
+   * *unordered* set of four endpoints. The comparison is order-independent because the two runners
+   * label which finger is "first" oppositely (Android builds center±offset, iOS center∓offset
+   * first) while producing the same two touch points. If either platform's endpoint math changes,
+   * its golden assertion fails loudly here or in the Swift mirror — closing the silent-divergence
+   * gap from issues #2911 / #2979.
+   */
+  @Test
+  fun `golden vectors match iOS parity`() {
+    data class Vector(
+      val centerX: Double,
+      val centerY: Double,
+      val distanceStart: Double,
+      val distanceEnd: Double,
+      val rotationDegrees: Float,
+      val expected: List<Pair<Float, Float>>,
+    )
+    val vectors =
+      listOf(
+        Vector(
+          100.0,
+          200.0,
+          80.0,
+          300.0,
+          0f,
+          listOf(60f to 200f, 140f to 200f, -50f to 200f, 250f to 200f),
+        ),
+        Vector(
+          540.0,
+          960.0,
+          100.0,
+          300.0,
+          45f,
+          listOf(
+            490f to 960f,
+            590f to 960f,
+            433.933983f to 853.933983f,
+            646.066017f to 1066.066017f,
+          ),
+        ),
+        Vector(
+          200.0,
+          400.0,
+          100.0,
+          100.0,
+          -30f,
+          listOf(150f to 400f, 250f to 400f, 156.698730f to 425f, 243.301270f to 375f),
+        ),
+        Vector(
+          0.0,
+          0.0,
+          200.0,
+          200.0,
+          0f,
+          listOf(-100f to 0f, 100f to 0f, -100f to 0f, 100f to 0f),
+        ),
+      )
+
+    for (v in vectors) {
+      val p =
+        computePinchPoints(v.centerX, v.centerY, v.distanceStart, v.distanceEnd, v.rotationDegrees)
+      val actual =
+        sortedPoints(
+          listOf(
+            p.startX1 to p.startY1,
+            p.startX2 to p.startY2,
+            p.endX1 to p.endY1,
+            p.endX2 to p.endY2,
+          )
+        )
+      val expected = sortedPoints(v.expected)
+      actual.zip(expected).forEach { (a, e) ->
+        assertEquals("x mismatch for $v", e.first, a.first, delta)
+        assertEquals("y mismatch for $v", e.second, a.second, delta)
+      }
+    }
+  }
+
+  /** Deterministic order-independent sort so the golden comparison ignores finger labeling. */
+  private fun sortedPoints(points: List<Pair<Float, Float>>): List<Pair<Float, Float>> =
+    points.sortedWith(compareBy({ it.first }, { it.second }))
 }

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */; };
 		6798190F766D01F963F6DFD0 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
 		714A3E41ACE47ACF314E0FC2 /* ClipboardResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D131E590A0CF8F9674B0E /* ClipboardResolutionTests.swift */; };
+		74B1E8F78E9FF807417ABC2D /* PinchGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */; };
 		74CA22BFA1779993CDCF59AE /* CtrlProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE277596991C059142C485B /* CtrlProxy.swift */; };
 		7F0A1FBC49EE6CFD37F53294 /* CtrlProxyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802717F6B1F37809C4806C23 /* CtrlProxyUITests.swift */; };
 		818C27D4C9349EE5D7B46AC4 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F9D3D13C3FE12BA2CD012082 /* ObjCExceptionCatcher.m */; };
@@ -168,6 +169,7 @@
 		3BF23F10C24C9F40E5CEC303 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncerTests.swift; sourceTree = "<group>"; };
 		42C53A4D56EE97B5BD11EC63 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchGeometryTests.swift; sourceTree = "<group>"; };
 		5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyCacheTests.swift; sourceTree = "<group>"; };
 		637A2A05C90AA6E64D224651 /* CtrlProxyTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CtrlProxyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridgeTests.swift; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 				649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */,
 				DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */,
 				6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */,
+				4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */,
 				5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */,
 				EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */,
 			);
@@ -584,6 +587,7 @@
 				6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */,
 				0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */,
 				F428A1892AAF5D4F83AD4C1B /* PinchFallbackTests.swift in Sources */,
+				74B1E8F78E9FF807417ABC2D /* PinchGeometryTests.swift in Sources */,
 				2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */,
 				0F29D59ABFB52692F62B434F /* TypedRequestDecodeTests.swift in Sources */,
 			);

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -1,6 +1,34 @@
 #import "ObjCExceptionCatcher.h"
 #import <math.h>
 
+ObjCPinchPoints ObjCExceptionCatcher_computePinchPoints(
+    CGFloat centerX,
+    CGFloat centerY,
+    CGFloat distanceStart,
+    CGFloat distanceEnd,
+    CGFloat rotationDegrees
+) {
+    CGFloat startRadius = distanceStart / 2.0;
+    CGFloat endRadius = distanceEnd / 2.0;
+    // rotationDegrees rotates the finger axis *during* the pinch, NOT the orientation of a fixed
+    // pinch axis: the fingers start on the horizontal axis (dyStart == 0) and move to an axis
+    // rotated by rotationDegrees. A non-zero value therefore produces a combined pinch+rotate;
+    // rotationDegrees == 0 (the common zoom case) keeps both axes horizontal. This matches the
+    // Android runner's computePinchPoints so cross-platform results agree. See issues #2911/#2979.
+    CGFloat endRadians = rotationDegrees * (CGFloat)M_PI / 180.0;
+    CGFloat dxStart = startRadius;
+    CGFloat dyStart = 0;
+    CGFloat dxEnd = cos(endRadians) * endRadius;
+    CGFloat dyEnd = sin(endRadians) * endRadius;
+
+    ObjCPinchPoints points;
+    points.start1 = CGPointMake(centerX - dxStart, centerY - dyStart);
+    points.end1 = CGPointMake(centerX - dxEnd, centerY - dyEnd);
+    points.start2 = CGPointMake(centerX + dxStart, centerY + dyStart);
+    points.end2 = CGPointMake(centerX + dxEnd, centerY + dyEnd);
+    return points;
+}
+
 NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS_NOESCAPE ^block)(void)) {
     @try {
         block();
@@ -137,22 +165,13 @@ BOOL ObjCExceptionCatcher_synthesizePinch(
             return;
         }
 
-        // Avoid the MAX() macro: it expands to a GNU statement expression, which
-        // Xcode 26.3's clang flags under -Wgnu-statement-expression-from-macro-expansion
-        // and the target builds with -pedantic -Werror.
-        CGFloat startRadius = (distanceStart > 1 ? distanceStart : 1) / 2.0;
-        CGFloat endRadius = (distanceEnd > 1 ? distanceEnd : 1) / 2.0;
-        // rotationDegrees rotates the finger axis *during* the pinch, NOT the orientation of a
-        // fixed pinch axis: the fingers start on the horizontal axis (dyStart == 0) and move to an
-        // axis rotated by rotationDegrees. A non-zero value therefore produces a combined
-        // pinch+rotate; rotationDegrees == 0 (the common zoom case) keeps both axes horizontal.
-        // This matches the Android runner's computePinchPoints so cross-platform results agree.
-        // See issue #2911.
-        CGFloat endRadians = rotationDegrees * (CGFloat)M_PI / 180.0;
-        CGFloat dxStart = startRadius;
-        CGFloat dyStart = 0;
-        CGFloat dxEnd = cos(endRadians) * endRadius;
-        CGFloat dyEnd = sin(endRadians) * endRadius;
+        // Floor degenerate distances so a tiny/zero pinch still produces a non-collapsed radius.
+        // The endpoint trig itself lives in the pure, unit-tested ObjCExceptionCatcher_computePinchPoints
+        // (see PinchGeometryTests / issue #2979), which the Android computePinchPoints mirrors.
+        CGFloat safeDistanceStart = distanceStart > 1 ? distanceStart : 1;
+        CGFloat safeDistanceEnd = distanceEnd > 1 ? distanceEnd : 1;
+        ObjCPinchPoints points = ObjCExceptionCatcher_computePinchPoints(
+            centerX, centerY, safeDistanceStart, safeDistanceEnd, rotationDegrees);
 
         XCSynthesizedEventRecord *record = [[recordClass alloc]
             initWithName:@"AutoMobile pinch"
@@ -161,18 +180,18 @@ BOOL ObjCExceptionCatcher_synthesizePinch(
         NSTimeInterval liftOffset = duration > 0.05 ? duration : 0.05;
 
         XCPointerEventPath *firstPath = [[pathClass alloc]
-            initForTouchAtPoint:CGPointMake(centerX - dxStart, centerY - dyStart)
+            initForTouchAtPoint:points.start1
             offset:0
         ];
-        [firstPath moveToPoint:CGPointMake(centerX - dxEnd, centerY - dyEnd) atOffset:duration];
+        [firstPath moveToPoint:points.end1 atOffset:duration];
         [firstPath liftUpAtOffset:liftOffset];
         [record addPointerEventPath:firstPath];
 
         XCPointerEventPath *secondPath = [[pathClass alloc]
-            initForTouchAtPoint:CGPointMake(centerX + dxStart, centerY + dyStart)
+            initForTouchAtPoint:points.start2
             offset:0
         ];
-        [secondPath moveToPoint:CGPointMake(centerX + dxEnd, centerY + dyEnd) atOffset:duration];
+        [secondPath moveToPoint:points.end2 atOffset:duration];
         [secondPath liftUpAtOffset:liftOffset];
         [record addPointerEventPath:secondPath];
 

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -24,6 +24,36 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 #endif
 
+/// The four touch endpoints of a two-finger pinch: two start points and two end points.
+/// `start1`/`end1` are the center∓offset finger, `start2`/`end2` the center±offset finger.
+typedef struct ObjCPinchPoints {
+    CGPoint start1;
+    CGPoint end1;
+    CGPoint start2;
+    CGPoint end2;
+} ObjCPinchPoints;
+
+/// Computes the two-finger pinch endpoints around (centerX, centerY).
+///
+/// Pure trig with no XCTest/UIKit dependency (available on all platforms, not just iOS) so it is
+/// unit-testable off-device — see `PinchGeometryTests`. `synthesizePinch` calls this to build the
+/// event paths, so the test guards the real synthesis math rather than a mirror of it.
+///
+/// `rotationDegrees` rotates the finger axis *during* the pinch, NOT the orientation of a fixed
+/// pinch axis: the fingers start on the horizontal axis (start*.y == centerY) and move to an axis
+/// rotated by `rotationDegrees`. A non-zero value therefore produces a combined pinch+rotate;
+/// `rotationDegrees == 0` (the common zoom case) keeps both axes horizontal. Radii are
+/// distance/2. This convention is shared with the Android runner's `computePinchPoints` so
+/// cross-platform pinch results agree — see issues #2911 / #2979. This function does NOT clamp
+/// degenerate distances; `synthesizePinch` applies its own minimum-distance floor before calling.
+FOUNDATION_EXPORT ObjCPinchPoints ObjCExceptionCatcher_computePinchPoints(
+    CGFloat centerX,
+    CGFloat centerY,
+    CGFloat distanceStart,
+    CGFloat distanceEnd,
+    CGFloat rotationDegrees
+);
+
 /// Executes the given block, catching any NSException thrown.
 /// Returns the caught NSException, or nil if no exception was raised.
 FOUNDATION_EXPORT NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS_NOESCAPE ^block)(void));

--- a/ios/control-proxy/Tests/CtrlProxyTests/PinchGeometryTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/PinchGeometryTests.swift
@@ -1,0 +1,160 @@
+import CoreGraphics
+import ObjCExceptionCatcher
+import XCTest
+
+/// Pins the two-finger pinch endpoint geometry convention shared by the iOS and Android
+/// runners (see issues #2911 / #2979). `rotationDegrees` describes how far the finger axis
+/// rotates *during* the pinch: the axis starts horizontal (angle 0) and ends rotated by
+/// `rotationDegrees`. This is a combined pinch+rotate, not a pinch along a fixed rotated axis.
+///
+/// Before #2979 the iOS side of this convention was guarded only by a human-maintained code
+/// comment cross-referencing Android's `computePinchPoints`; nothing failed if the two
+/// implementations silently diverged. `ObjCExceptionCatcher_computePinchPoints` extracts the
+/// pure trig actually consumed by `synthesizePinch` so it is unit-testable off-device (the
+/// private XCTest event-synthesis path cannot run in a macOS test host). This is the direct
+/// analog of Android's `PinchGeometryTest`.
+///
+/// The `testGoldenVectorsMatchAndroidParity` case shares an identical input/output table with
+/// `PinchGeometryTest.kt` so that editing either platform's math fails loudly here or there.
+///
+/// The C function imports into Swift with positional (unlabeled) arguments; the argument order
+/// is `(centerX, centerY, distanceStart, distanceEnd, rotationDegrees)`.
+final class PinchGeometryTests: XCTestCase {
+    private let accuracy: CGFloat = 1e-3
+
+    // MARK: - Convention invariants (mirror of Android PinchGeometryTest)
+
+    func testRadiiAreHalfTheRequestedDistances() {
+        let points = ObjCExceptionCatcher_computePinchPoints(100, 200, 80, 300, 0)
+        // Start axis horizontal: one finger sits startRadius to the right of center, the other
+        // to the left. Labeling (start1 left / start2 right) is a runner detail; the set matters.
+        XCTAssertEqual(points.start1.x, 100 - 40, accuracy: accuracy)
+        XCTAssertEqual(points.start2.x, 100 + 40, accuracy: accuracy)
+        // End radius is half of distanceEnd.
+        XCTAssertEqual(points.end1.x, 100 - 150, accuracy: accuracy)
+        XCTAssertEqual(points.end2.x, 100 + 150, accuracy: accuracy)
+    }
+
+    func testStartAxisIsAlwaysHorizontalRegardlessOfRotation() {
+        let points = ObjCExceptionCatcher_computePinchPoints(540, 960, 100, 300, 45)
+        // Start fingers stay on the horizontal axis (y == centerY) even when rotationDegrees != 0.
+        XCTAssertEqual(points.start1.y, 960, accuracy: accuracy)
+        XCTAssertEqual(points.start2.y, 960, accuracy: accuracy)
+        XCTAssertEqual(points.start1.x, 540 - 50, accuracy: accuracy)
+        XCTAssertEqual(points.start2.x, 540 + 50, accuracy: accuracy)
+    }
+
+    func testEndAxisIsRotatedByRotationDegrees() {
+        let rotation: CGFloat = 45
+        let points = ObjCExceptionCatcher_computePinchPoints(540, 960, 100, 300, rotation)
+        let endRadius: CGFloat = 150
+        let theta = rotation * CGFloat.pi / 180
+        // End fingers lie on the axis rotated by `rotationDegrees` from horizontal, symmetric
+        // about the center.
+        XCTAssertEqual(points.end2.x, 540 + endRadius * cos(theta), accuracy: accuracy)
+        XCTAssertEqual(points.end2.y, 960 + endRadius * sin(theta), accuracy: accuracy)
+        XCTAssertEqual(points.end1.x, 540 - endRadius * cos(theta), accuracy: accuracy)
+        XCTAssertEqual(points.end1.y, 960 - endRadius * sin(theta), accuracy: accuracy)
+    }
+
+    func testNegativeRotationRotatesTheEndAxisTheOppositeWay() {
+        let rotation: CGFloat = -30
+        let points = ObjCExceptionCatcher_computePinchPoints(200, 400, 100, 100, rotation)
+        let radius: CGFloat = 50
+        let theta = rotation * CGFloat.pi / 180
+        // Sign of rotationDegrees must flow through to the end axis — cross-platform parity relies
+        // on it. A negative angle puts the +offset finger's y below center.
+        XCTAssertEqual(points.end2.y, 400 + radius * sin(theta), accuracy: accuracy)
+        XCTAssertEqual(points.end2.x, 200 + radius * cos(theta), accuracy: accuracy)
+        // Start axis stays horizontal regardless of the sign.
+        XCTAssertEqual(points.start1.y, 400, accuracy: accuracy)
+        XCTAssertEqual(points.start2.y, 400, accuracy: accuracy)
+    }
+
+    func testZeroRotationKeepsBothFingersOnTheHorizontalAxis() {
+        let points = ObjCExceptionCatcher_computePinchPoints(0, 0, 200, 200, 0)
+        // No rotation: start and end axes coincide, both horizontal — the common pinch/zoom case.
+        XCTAssertEqual(points.start1.y, 0, accuracy: accuracy)
+        XCTAssertEqual(points.end2.y, 0, accuracy: accuracy)
+        XCTAssertEqual(points.end2.x, 100, accuracy: accuracy)
+        XCTAssertEqual(points.end1.x, -100, accuracy: accuracy)
+    }
+
+    // MARK: - Cross-platform golden parity (issue #2979, Option 2)
+
+    /// SHARED GOLDEN TABLE — keep byte-identical with `PinchGeometryTest.kt`
+    /// (`goldenVectorsMatchIosParity`). Each row is an input tuple and its expected *unordered*
+    /// set of four endpoints (start1, start2, end1, end2). We compare as an order-independent set
+    /// because the two runners label which finger is "first" oppositely (iOS builds center∓offset
+    /// first, Android center±offset first) while producing the same two touch points. If either
+    /// platform's endpoint math changes, its golden assertion fails loudly here or in the Kotlin
+    /// mirror — closing the silent-divergence gap from #2911.
+    func testGoldenVectorsMatchAndroidParity() {
+        struct Vector {
+            let centerX: CGFloat
+            let centerY: CGFloat
+            let distanceStart: CGFloat
+            let distanceEnd: CGFloat
+            let rotationDegrees: CGFloat
+            let expected: [CGPoint]
+        }
+        let vectors: [Vector] = [
+            Vector(
+                centerX: 100, centerY: 200, distanceStart: 80, distanceEnd: 300, rotationDegrees: 0,
+                expected: [
+                    CGPoint(x: 60, y: 200), CGPoint(x: 140, y: 200),
+                    CGPoint(x: -50, y: 200), CGPoint(x: 250, y: 200),
+                ]
+            ),
+            Vector(
+                centerX: 540, centerY: 960, distanceStart: 100, distanceEnd: 300, rotationDegrees: 45,
+                expected: [
+                    CGPoint(x: 490, y: 960), CGPoint(x: 590, y: 960),
+                    CGPoint(x: 433.933983, y: 853.933983),
+                    CGPoint(x: 646.066017, y: 1066.066017),
+                ]
+            ),
+            Vector(
+                centerX: 200, centerY: 400, distanceStart: 100, distanceEnd: 100, rotationDegrees: -30,
+                expected: [
+                    CGPoint(x: 150, y: 400), CGPoint(x: 250, y: 400),
+                    CGPoint(x: 156.698730, y: 425), CGPoint(x: 243.301270, y: 375),
+                ]
+            ),
+            Vector(
+                centerX: 0, centerY: 0, distanceStart: 200, distanceEnd: 200, rotationDegrees: 0,
+                expected: [
+                    CGPoint(x: -100, y: 0), CGPoint(x: 100, y: 0),
+                    CGPoint(x: -100, y: 0), CGPoint(x: 100, y: 0),
+                ]
+            ),
+        ]
+
+        for vector in vectors {
+            let points = ObjCExceptionCatcher_computePinchPoints(
+                vector.centerX, vector.centerY,
+                vector.distanceStart, vector.distanceEnd, vector.rotationDegrees
+            )
+            let actual = sortedPoints([points.start1, points.start2, points.end1, points.end2])
+            let expected = sortedPoints(vector.expected)
+            for (actualPoint, expectedPoint) in zip(actual, expected) {
+                XCTAssertEqual(
+                    actualPoint.x, expectedPoint.x, accuracy: accuracy,
+                    "x mismatch for center (\(vector.centerX),\(vector.centerY)) rot \(vector.rotationDegrees)"
+                )
+                XCTAssertEqual(
+                    actualPoint.y, expectedPoint.y, accuracy: accuracy,
+                    "y mismatch for center (\(vector.centerX),\(vector.centerY)) rot \(vector.rotationDegrees)"
+                )
+            }
+        }
+    }
+
+    /// Deterministic order-independent sort so the golden comparison ignores finger labeling.
+    private func sortedPoints(_ points: [CGPoint]) -> [CGPoint] {
+        points.sorted { lhs, rhs in
+            if abs(lhs.x - rhs.x) > accuracy { return lhs.x < rhs.x }
+            return lhs.y < rhs.y
+        }
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/PinchGeometryTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/PinchGeometryTests.swift
@@ -80,6 +80,17 @@ final class PinchGeometryTests: XCTestCase {
         XCTAssertEqual(points.end1.x, -100, accuracy: accuracy)
     }
 
+    func testComputePinchPointsDoesNotClampDegenerateDistances() {
+        // The pure function must NOT apply synthesizePinch's minimum-distance floor: a zero
+        // distance yields radius 0, collapsing all four endpoints onto the center. The header
+        // documents this contract (the floor lives in the synthesis wrapper). See #2979.
+        let points = ObjCExceptionCatcher_computePinchPoints(320, 480, 0, 0, 45)
+        for point in [points.start1, points.start2, points.end1, points.end2] {
+            XCTAssertEqual(point.x, 320, accuracy: accuracy)
+            XCTAssertEqual(point.y, 480, accuracy: accuracy)
+        }
+    }
+
     // MARK: - Cross-platform golden parity (issue #2979, Option 2)
 
     /// SHARED GOLDEN TABLE — keep byte-identical with `PinchGeometryTest.kt`
@@ -121,6 +132,16 @@ final class PinchGeometryTests: XCTestCase {
                     CGPoint(x: 156.698730, y: 425), CGPoint(x: 243.301270, y: 375),
                 ]
             ),
+            // A second asymmetric negative angle so drop-rotation-sign / sin-cos-swap detection is
+            // not a single point of failure on the -30 row (the +45 / rot-0 rows are blind to a
+            // dropped sign). distanceStart != distanceEnd also exercises unequal radii.
+            Vector(
+                centerX: 300, centerY: 500, distanceStart: 200, distanceEnd: 80, rotationDegrees: -60,
+                expected: [
+                    CGPoint(x: 200, y: 500), CGPoint(x: 400, y: 500),
+                    CGPoint(x: 280, y: 534.641016), CGPoint(x: 320, y: 465.358984),
+                ]
+            ),
             Vector(
                 centerX: 0, centerY: 0, distanceStart: 200, distanceEnd: 200, rotationDegrees: 0,
                 expected: [
@@ -151,10 +172,13 @@ final class PinchGeometryTests: XCTestCase {
     }
 
     /// Deterministic order-independent sort so the golden comparison ignores finger labeling.
+    /// Uses exact (x, then y) ordering — identical to the Kotlin mirror's
+    /// `compareBy({ it.first }, { it.second })` — so the two platforms can never sort the same
+    /// point set into different orders. Golden inputs keep x-values separated well beyond the
+    /// comparison tolerance, so exact ordering is stable.
     private func sortedPoints(_ points: [CGPoint]) -> [CGPoint] {
         points.sorted { lhs, rhs in
-            if abs(lhs.x - rhs.x) > accuracy { return lhs.x < rhs.x }
-            return lhs.y < rhs.y
+            lhs.x != rhs.x ? lhs.x < rhs.x : lhs.y < rhs.y
         }
     }
 }


### PR DESCRIPTION
## What

Adds an **executable** guard for the iOS pinch endpoint geometry so it can no longer silently
diverge from the Android runner. Extracts the pure pinch trig out of `synthesizePinch` into a
platform-agnostic C function `ObjCExceptionCatcher_computePinchPoints` (no XCTest/UIKit
dependency), and adds `PinchGeometryTests.swift` — the direct analog of Android's
`PinchGeometryTest` — plus a **shared golden-vector parity table** mirrored byte-identically on
both platforms.

Closes #2979.

## Why

Follow-up to #2911 / PR #2931. `rotationDegrees` (default `0`) is how far the two-finger axis
rotates *during* the pinch: fingers start on the **horizontal** axis and finish on an axis
**rotated by `rotationDegrees`** (a combined pinch+rotate). This convention is deliberately shared
by both runners, but after #2931 only Android had an executable guard (`PinchGeometryTest` over the
extracted `computePinchPoints`). The iOS side was pinned by a **human-maintained code comment** in
`ObjCExceptionCatcher.m` — nothing failed if someone edited the iOS `dxStart/dyStart/dxEnd/dyEnd`
math (or Android's) without updating the other, which is exactly the silent-drift class #2911
worried about. This PR closes that asymmetry. Low severity, no default-path impact
(`rotationDegrees` defaults to 0; no production caller passes a non-zero value) — this is
hardening, not a bug fix.

## How

- **Extract (Option 1)** — the pinch endpoint trig (`endRadians`, `dxStart/dyStart`,
  `dxEnd/dyEnd`, and the `center ∓/± offset` point construction) moves from inside
  `ObjCExceptionCatcher_synthesizePinch` into a new pure `ObjCExceptionCatcher_computePinchPoints`
  returning an `ObjCPinchPoints` struct. Declared in the header **without** the `TARGET_OS_IOS`
  guard so it is callable from the macOS test host. `synthesizePinch` now **calls** this function,
  so the test guards the real synthesis math rather than a mirror of it. The iOS-specific
  minimum-distance floor (`distance > 1 ? distance : 1`) stays in the synthesis wrapper, so
  behavior is byte-identical.
- **Per-platform invariants** — `PinchGeometryTests.swift` asserts the same convention as
  Android: radii = distance/2, start axis always horizontal, end axis rotated by `rotationDegrees`,
  rotation sign respected, zero-rotation no-op.
- **Cross-platform parity (Option 2)** — a golden-vector table (`(centerX, centerY, distanceStart,
  distanceEnd, rotationDegrees)` → expected unordered 4-point set) is asserted on **both** sides
  (`testGoldenVectorsMatchAndroidParity` in Swift, `golden vectors match iOS parity` in Kotlin).
  The comparison is order-independent because the two runners label which finger is "first"
  oppositely while producing the same touch points. Editing either platform's math without
  updating its golden values now fails loudly. A single shared fixture file isn't cleanly loadable
  by both SPM and Gradle test targets, so the table is duplicated byte-identically with a
  cross-reference comment on each side.
- **Docs** — the Android `PinchGeometry.kt` KDoc now notes both sides are pinned by executable
  tests sharing a golden table; the iOS header/`.m` comments cross-reference `PinchGeometryTests`
  and #2979.
- **Xcode project** — regenerated via `xcodegen` so the committed `CtrlProxy.xcodeproj` includes
  the new test file (4-line pbxproj addition).

## Testing

- **New** `PinchGeometryTests.swift` (6 cases) — runs on the macOS test host via
  `./scripts/ios/swift-test.sh`. Full Swift suite green: **325 tests, 0 failures**.
- **New** `golden vectors match iOS parity` added to `PinchGeometryTest.kt`; `PinchGeometryTest`
  passes under JDK 21 (`:control-proxy:testDebugUnitTest`).
- `ObjCExceptionCatcher.m` compiles clean under the target's `-pedantic -Werror` for the real iOS
  target (`clang --sdk iphoneos -target arm64-apple-ios15.0`).
- SwiftFormat + SwiftLint clean on the new file; ktfmt (`--google-style`) clean on the Kotlin files.
- The refactor is behavior-preserving: `synthesizePinch` produces the same points as before
  (verified by reading the diff and the extracted-function equivalence — clamp → /2 → same radii).

## Acceptance criteria (#2979)

- [x] iOS pinch endpoint geometry is covered by an **executable test**, not only a code comment.
- [x] The test asserts the same convention as Android: start axis horizontal, end axis rotated by
      `rotationDegrees`, radii = distance/2, sign of rotation respected.
- [x] A shared golden-vector table proves Android/iOS parity so future edits to either side fail
      loudly on divergence (duplicated byte-identically per-platform; single shared fixture not
      cleanly feasible across SPM + Gradle).
