### PR TITLE
fix(ktfmt): enforce the pinned formatter version so drift can't silently land on red main

### DIFF
--- a/scripts/ktfmt/apply_ktfmt.sh
+++ b/scripts/ktfmt/apply_ktfmt.sh
@@ -5,7 +5,7 @@ ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 
 # Pinned ktfmt version + shared enforcement helpers -- single source of truth
 # shared with install_ktfmt.sh and validate_ktfmt.sh.
-# shellcheck source=scripts/ktfmt/ktfmt_version.sh
+# shellcheck source=scripts/ktfmt/ktfmt_version.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
 # Colors for output

--- a/scripts/ktfmt/apply_ktfmt.sh
+++ b/scripts/ktfmt/apply_ktfmt.sh
@@ -3,6 +3,11 @@
 INSTALL_KTFMT_WHEN_MISSING=${INSTALL_KTFMT_WHEN_MISSING:-false}
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 
+# Pinned ktfmt version + shared enforcement helpers -- single source of truth
+# shared with install_ktfmt.sh and validate_ktfmt.sh.
+# shellcheck source=scripts/ktfmt/ktfmt_version.sh
+source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -57,14 +62,13 @@ for cmd in find xargs git; do
     fi
 done
 
-# Ensure the ktfmt on PATH runs and accepts --google-style before formatting.
-# If an older/broken ktfmt is already on PATH, fail fast with an actionable
-# message rather than staging files it never formatted.
-if ! printf 'fun probe() {}\n' | ktfmt --google-style - >/dev/null 2>&1; then
-    echo -e "${RED}The ktfmt on PATH does not run with --google-style (this repo pins 0.64).${NC}"
-    echo -e "${RED}Update ktfmt ('brew upgrade ktfmt' or re-run scripts/ktfmt/install_ktfmt.sh) and retry.${NC}"
-    exit 1
-fi
+# Fingerprint gate (issue #2966): this script *mutates* files, so a ktfmt whose
+# version differs from the pin would reformat the whole tree with the wrong
+# formatter and could get committed -- the exact drift #2966 guards against, on
+# the write path. Assert the pinned version before formatting anything. A
+# matching version implies --google-style support, so this subsumes the old
+# flag probe.
+require_pinned_ktfmt_version
 
 # Start the timer
 if [[ -f "$PROJECT_ROOT/scripts/utils/get_timestamp.sh" ]]; then

--- a/scripts/ktfmt/install_ktfmt.sh
+++ b/scripts/ktfmt/install_ktfmt.sh
@@ -2,7 +2,7 @@
 
 # Pinned ktfmt version -- single source of truth shared with validate_ktfmt.sh.
 # Bump the version in scripts/ktfmt/ktfmt_version.sh (one line) to change it.
-# shellcheck source=scripts/ktfmt/ktfmt_version.sh
+# shellcheck source=scripts/ktfmt/ktfmt_version.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
 # Colors for output

--- a/scripts/ktfmt/install_ktfmt.sh
+++ b/scripts/ktfmt/install_ktfmt.sh
@@ -59,7 +59,19 @@ install_macos() {
         echo -e "${YELLOW}Falling back to the pinned JAR so the pin is honored...${NC}"
         brew unlink ktfmt >/dev/null 2>&1 || true
         install_manual
-        return $?
+        local manual_status=$?
+
+        # install_manual writes the pinned wrapper to ~/.local/bin. Two things
+        # must happen before verify_installation (or any later ktfmt call) or the
+        # pinned install won't actually resolve:
+        #  1. Ensure ~/.local/bin is on PATH for this process -- it is NOT on the
+        #     default macOS PATH, so otherwise the wrapper is invisible.
+        #  2. Clear bash's command hash: the version probe above already ran (and
+        #     hashed) brew's ktfmt, which `brew unlink` just removed, so a stale
+        #     hash entry would keep resolving the deleted binary.
+        export PATH="$HOME/.local/bin:$PATH"
+        hash -r 2>/dev/null || true
+        return "$manual_status"
     else
         echo -e "${YELLOW}Homebrew not found. Install Homebrew first or use manual installation.${NC}"
         echo "To install Homebrew: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
@@ -221,7 +233,7 @@ verify_installation() {
     resolved="$(installed_ktfmt_version)"
     if [[ "$resolved" != "$KTFMT_VERSION" ]]; then
         echo -e "${RED}ktfmt on PATH is '${resolved:-unknown}', but this repo pins '${KTFMT_VERSION}'.${NC}"
-        echo -e "${RED}A drifted ktfmt is shadowing the pinned install. Ensure the pinned ktfmt (\$HOME/.local/bin) precedes it on PATH, or remove the drifted one, then retry.${NC}"
+        echo -e "${RED}The pinned install isn't the one resolving -- a drifted ktfmt is shadowing it on PATH, or the download is wrong. Ensure the pinned ktfmt (\$HOME/.local/bin) precedes any other on PATH, or remove the drifted one, then retry.${NC}"
         return 1
     fi
 

--- a/scripts/ktfmt/install_ktfmt.sh
+++ b/scripts/ktfmt/install_ktfmt.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-KTFMT_VERSION="0.64" # Change this to the desired version
+# Pinned ktfmt version -- single source of truth shared with validate_ktfmt.sh.
+# Bump the version in scripts/ktfmt/ktfmt_version.sh (one line) to change it.
+# shellcheck source=scripts/ktfmt/ktfmt_version.sh
+source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -31,6 +34,14 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Parse the numeric version from `ktfmt --version` (e.g. "ktfmt version 0.64").
+# Filter to ktfmt's own version line first so a JVM warning on stderr (the
+# manual install runs `java -jar`) can't have its version grabbed instead.
+# Empty string if ktfmt is absent or emits nothing parseable.
+installed_ktfmt_version() {
+    ktfmt --version 2>&1 | grep -i 'ktfmt version' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1
+}
+
 # Install ktfmt on macOS
 install_macos() {
     echo -e "${YELLOW}Installing ktfmt on macOS...${NC}"
@@ -38,6 +49,22 @@ install_macos() {
     if command_exists brew; then
         echo -e "${GREEN}Using Homebrew to install ktfmt${NC}"
         brew install ktfmt
+
+        # Homebrew has no ktfmt@<version> formula, so `brew install ktfmt`
+        # installs whatever the current formula ships -- which may drift from the
+        # pin (issue #2966). Verify it; if it differs, unlink brew's copy so it
+        # can't shadow ~/.local/bin on PATH, then install the pinned fat JAR so
+        # the pin is actually honored on macOS.
+        local installed
+        installed="$(installed_ktfmt_version)"
+        if [[ "$installed" == "$KTFMT_VERSION" ]]; then
+            return 0
+        fi
+
+        echo -e "${YELLOW}brew installed ktfmt '${installed:-unknown}', but this repo pins '${KTFMT_VERSION}'.${NC}"
+        echo -e "${YELLOW}Falling back to the pinned JAR so the pin is honored...${NC}"
+        brew unlink ktfmt >/dev/null 2>&1 || true
+        install_manual
         return $?
     else
         echo -e "${YELLOW}Homebrew not found. Install Homebrew first or use manual installation.${NC}"

--- a/scripts/ktfmt/install_ktfmt.sh
+++ b/scripts/ktfmt/install_ktfmt.sh
@@ -34,13 +34,7 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
-# Parse the numeric version from `ktfmt --version` (e.g. "ktfmt version 0.64").
-# Filter to ktfmt's own version line first so a JVM warning on stderr (the
-# manual install runs `java -jar`) can't have its version grabbed instead.
-# Empty string if ktfmt is absent or emits nothing parseable.
-installed_ktfmt_version() {
-    ktfmt --version 2>&1 | grep -i 'ktfmt version' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1
-}
+# Note: installed_ktfmt_version() is provided by the sourced ktfmt_version.sh.
 
 # Install ktfmt on macOS
 install_macos() {
@@ -214,14 +208,25 @@ EOF
 verify_installation() {
     echo -e "${YELLOW}Verifying ktfmt installation...${NC}"
 
-    if command_exists ktfmt; then
-        echo -e "${GREEN}ktfmt is installed and available in PATH${NC}"
-        ktfmt --version 2>/dev/null || echo -e "${GREEN}ktfmt is ready to use${NC}"
-        return 0
-    else
+    if ! command_exists ktfmt; then
         echo -e "${RED}ktfmt is not available in PATH${NC}"
         return 1
     fi
+
+    # Presence isn't enough (issue #2966): if a drifted brew ktfmt still shadows
+    # ~/.local/bin on PATH, the pinned JAR we just installed isn't the one that
+    # resolves. Assert the ktfmt that actually resolves is the pin, so the
+    # installer can't print "success" while leaving a mismatched formatter live.
+    local resolved
+    resolved="$(installed_ktfmt_version)"
+    if [[ "$resolved" != "$KTFMT_VERSION" ]]; then
+        echo -e "${RED}ktfmt on PATH is '${resolved:-unknown}', but this repo pins '${KTFMT_VERSION}'.${NC}"
+        echo -e "${RED}A drifted ktfmt is shadowing the pinned install. Ensure the pinned ktfmt (\$HOME/.local/bin) precedes it on PATH, or remove the drifted one, then retry.${NC}"
+        return 1
+    fi
+
+    echo -e "${GREEN}ktfmt ${KTFMT_VERSION} is installed and available in PATH${NC}"
+    return 0
 }
 
 # Main installation function
@@ -251,13 +256,21 @@ main() {
 
     install_result=$?
 
-    if [[ $install_result -eq 0 ]]; then
-        echo -e "${GREEN}Installation completed successfully!${NC}"
-        verify_installation
-    else
+    if [[ $install_result -ne 0 ]]; then
         echo -e "${RED}Installation failed!${NC}"
         exit 1
     fi
+
+    # Gate "success" on verification: the install step can return 0 while a
+    # drifted ktfmt still shadows the pinned one on PATH (issue #2966), so only
+    # declare success once verify_installation confirms the resolved version is
+    # the pin -- otherwise fail loudly instead of a misleading green.
+    if ! verify_installation; then
+        echo -e "${RED}Installation failed verification!${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Installation completed successfully!${NC}"
 }
 
 # Run main function

--- a/scripts/ktfmt/ktfmt_version.sh
+++ b/scripts/ktfmt/ktfmt_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Single source of truth for the pinned ktfmt version.
+#
+# This file is *sourced* (not executed) by both install_ktfmt.sh and
+# validate_ktfmt.sh so the pin lives in exactly one place. Bumping the pinned
+# formatter version means editing this one line -- both the installer and the
+# validator's fingerprint gate pick it up automatically, so they can never drift
+# apart. See issue #2966: version/style-config drift silently reformats untouched
+# files under the scoped PR check and only surfaces as red main post-merge, so
+# the pin must be enforced, not merely declared.
+#
+# shellcheck disable=SC2034  # consumed by the scripts that source this file.
+KTFMT_VERSION="0.64"

--- a/scripts/ktfmt/ktfmt_version.sh
+++ b/scripts/ktfmt/ktfmt_version.sh
@@ -1,14 +1,44 @@
 #!/usr/bin/env bash
 #
-# Single source of truth for the pinned ktfmt version.
+# Single source of truth for the pinned ktfmt version *and* the helpers that
+# enforce it.
 #
-# This file is *sourced* (not executed) by both install_ktfmt.sh and
-# validate_ktfmt.sh so the pin lives in exactly one place. Bumping the pinned
-# formatter version means editing this one line -- both the installer and the
-# validator's fingerprint gate pick it up automatically, so they can never drift
-# apart. See issue #2966: version/style-config drift silently reformats untouched
-# files under the scoped PR check and only surfaces as red main post-merge, so
-# the pin must be enforced, not merely declared.
-#
-# shellcheck disable=SC2034  # consumed by the scripts that source this file.
+# This file is *sourced* (not executed) by install_ktfmt.sh, validate_ktfmt.sh
+# and apply_ktfmt.sh so the pin -- and the parse/gate logic around it -- lives in
+# exactly one place. Bumping the pinned formatter version means editing the one
+# KTFMT_VERSION line below; every consumer picks it up automatically, so they can
+# never drift apart. See issue #2966: version/style-config drift silently
+# reformats untouched files under the scoped PR check and only surfaces as red
+# main post-merge (or worse, gets committed by the apply/write path), so the pin
+# must be enforced, not merely declared.
+
 KTFMT_VERSION="0.64"
+
+# Parse the numeric version from `ktfmt --version` (e.g. "ktfmt version 0.64").
+# Filter to ktfmt's own version line first so a JVM warning on stderr (the manual
+# install runs `java -jar`) can't have *its* version grabbed instead. Prints the
+# empty string if ktfmt is absent or emits nothing parseable.
+installed_ktfmt_version() {
+    ktfmt --version 2>&1 | grep -i 'ktfmt version' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1
+}
+
+# Fingerprint gate (issue #2966): assert the ktfmt on PATH is EXACTLY the pinned
+# version, else print an actionable message and `exit 1`. Both the validate
+# (read) and apply (write) paths call this before touching any file, so a
+# formatter whose version differs from the pin fails loudly instead of silently
+# reformatting -- on the PR, post-merge, or on a developer's `apply` run. A
+# matching version also implies `--google-style` support, so this subsumes the
+# older flag probe. Colours are referenced via ${RED:-} so this is safe to call
+# even before the caller defines them.
+require_pinned_ktfmt_version() {
+    local found
+    found="$(installed_ktfmt_version)"
+    if [[ "$found" == "$KTFMT_VERSION" ]]; then
+        return 0
+    fi
+
+    echo -e "${RED:-}ktfmt version mismatch: found '${found:-unknown}', this repo pins '${KTFMT_VERSION}'.${NC:-}"
+    echo -e "${RED:-}A different formatter version reformats files differently than the pin (issue #2966), so this fails loudly instead of proceeding.${NC:-}"
+    echo -e "${RED:-}Install the pinned version: re-run scripts/ktfmt/install_ktfmt.sh, or install ktfmt ${KTFMT_VERSION} manually.${NC:-}"
+    exit 1
+}

--- a/scripts/ktfmt/validate_ktfmt.sh
+++ b/scripts/ktfmt/validate_ktfmt.sh
@@ -6,7 +6,7 @@ ONLY_CHANGED_SINCE_SHA=${ONLY_CHANGED_SINCE_SHA:-""}
 
 # Pinned ktfmt version -- single source of truth shared with install_ktfmt.sh so
 # the installer and this validator's fingerprint gate can never drift apart.
-# shellcheck source=scripts/ktfmt/ktfmt_version.sh
+# shellcheck source=scripts/ktfmt/ktfmt_version.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
 # Colors for output

--- a/scripts/ktfmt/validate_ktfmt.sh
+++ b/scripts/ktfmt/validate_ktfmt.sh
@@ -68,18 +68,10 @@ done
 # is EXACTLY the pinned version before doing any per-file work, so version /
 # style-config drift fails loudly here instead of silently scoped-passing.
 # INSTALL_KTFMT_WHEN_MISSING only installs when ktfmt is *absent*, so an
-# already-installed newer ktfmt would otherwise sail through. A matching version
-# also implies --google-style support, so this subsumes the old flag probe.
-# Filter to ktfmt's own "ktfmt version X.Y" line first, then extract the number.
-# The CI ktfmt is a `java -jar` wrapper, and 2>&1 merges stderr, so a JVM warning
-# carrying its own version (e.g. "11.0.2") could otherwise be grabbed by head -1.
-installed_ktfmt_version="$(ktfmt --version 2>&1 | grep -i 'ktfmt version' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)"
-if [[ "$installed_ktfmt_version" != "$KTFMT_VERSION" ]]; then
-    echo -e "${RED}ktfmt version mismatch: found '${installed_ktfmt_version:-unknown}', this repo pins '${KTFMT_VERSION}'.${NC}"
-    echo -e "${RED}A different formatter version reformats untouched files the scoped PR check never inspects (issue #2966), so this fails loudly instead of a silent scoped pass.${NC}"
-    echo -e "${RED}Install the pinned version: re-run scripts/ktfmt/install_ktfmt.sh, or install ktfmt ${KTFMT_VERSION} manually.${NC}"
-    exit 1
-fi
+# already-installed newer ktfmt would otherwise sail through. The shared gate
+# (require_pinned_ktfmt_version, from ktfmt_version.sh) also subsumes the old
+# --google-style probe: a matching version implies --google-style support.
+require_pinned_ktfmt_version
 
 # Start the timer
 if [[ -f "$PROJECT_ROOT/scripts/utils/get_timestamp.sh" ]]; then

--- a/scripts/ktfmt/validate_ktfmt.sh
+++ b/scripts/ktfmt/validate_ktfmt.sh
@@ -4,6 +4,11 @@ INSTALL_KTFMT_WHEN_MISSING=${INSTALL_KTFMT_WHEN_MISSING:-false}
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-false}
 ONLY_CHANGED_SINCE_SHA=${ONLY_CHANGED_SINCE_SHA:-""}
 
+# Pinned ktfmt version -- single source of truth shared with install_ktfmt.sh so
+# the installer and this validator's fingerprint gate can never drift apart.
+# shellcheck source=scripts/ktfmt/ktfmt_version.sh
+source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -56,14 +61,23 @@ for cmd in find xargs git; do
     fi
 done
 
-# Ensure the ktfmt on PATH runs and accepts --google-style before doing any
-# per-file work. If an older/broken ktfmt is already on PATH,
-# INSTALL_KTFMT_WHEN_MISSING won't replace it; probe once here so a bad
-# formatter fails fast with a clear message instead of per-file (where a
-# swallowed exit status could leave files unformatted and silently "pass").
-if ! printf 'fun probe() {}\n' | ktfmt --google-style - >/dev/null 2>&1; then
-    echo -e "${RED}The ktfmt on PATH does not run with --google-style (this repo pins 0.64).${NC}"
-    echo -e "${RED}Update ktfmt ('brew upgrade ktfmt' or re-run scripts/ktfmt/install_ktfmt.sh) and retry.${NC}"
+# Fingerprint gate (issue #2966): the scoped PR check only inspects a PR's
+# changed files, so a ktfmt whose version differs from the pin would reformat
+# *untouched* files this check never sees -- the PR passes, then main reddens
+# post-merge when merge.yml reformats the whole tree. Assert the ktfmt on PATH
+# is EXACTLY the pinned version before doing any per-file work, so version /
+# style-config drift fails loudly here instead of silently scoped-passing.
+# INSTALL_KTFMT_WHEN_MISSING only installs when ktfmt is *absent*, so an
+# already-installed newer ktfmt would otherwise sail through. A matching version
+# also implies --google-style support, so this subsumes the old flag probe.
+# Filter to ktfmt's own "ktfmt version X.Y" line first, then extract the number.
+# The CI ktfmt is a `java -jar` wrapper, and 2>&1 merges stderr, so a JVM warning
+# carrying its own version (e.g. "11.0.2") could otherwise be grabbed by head -1.
+installed_ktfmt_version="$(ktfmt --version 2>&1 | grep -i 'ktfmt version' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)"
+if [[ "$installed_ktfmt_version" != "$KTFMT_VERSION" ]]; then
+    echo -e "${RED}ktfmt version mismatch: found '${installed_ktfmt_version:-unknown}', this repo pins '${KTFMT_VERSION}'.${NC}"
+    echo -e "${RED}A different formatter version reformats untouched files the scoped PR check never inspects (issue #2966), so this fails loudly instead of a silent scoped pass.${NC}"
+    echo -e "${RED}Install the pinned version: re-run scripts/ktfmt/install_ktfmt.sh, or install ktfmt ${KTFMT_VERSION} manually.${NC}"
     exit 1
 fi
 

--- a/test/bats/apply-ktfmt.bats
+++ b/test/bats/apply-ktfmt.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ktfmt/apply_ktfmt.sh -- the *mutating* (write) formatter path.
+#
+# apply_ktfmt.sh reformats files in place, so a ktfmt whose version differs from
+# the pin would rewrite the tree with the wrong formatter and could get committed
+# -- the exact drift issue #2966 guards against, on the write side. These tests
+# lock in that the shared version fingerprint gate (require_pinned_ktfmt_version)
+# aborts BEFORE any file is touched when the version drifts.
+#
+# ktfmt is stubbed so the tests are fast and deterministic.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/ktfmt/apply_ktfmt.sh"
+
+  TEST_DIR="$(mktemp -d)"
+
+  # Stub ktfmt: `--version` reports KTFMT_STUB_VERSION (default 0.64 = pin). For
+  # an in-place format run (`--google-style <files...>` via xargs) it strips the
+  # FORMAT_ME marker so a test can observe whether formatting actually happened.
+  STUB_BIN="$TEST_DIR/bin"
+  mkdir -p "$STUB_BIN"
+  cat > "$STUB_BIN/ktfmt" <<'STUB'
+#!/usr/bin/env bash
+if [[ " $* " == *" --version "* ]]; then
+  echo "ktfmt version ${KTFMT_STUB_VERSION:-0.64}"
+  exit 0
+fi
+echo "Done formatting"
+for f in "$@"; do
+  [[ "$f" == "--google-style" ]] && continue
+  [[ -f "$f" ]] && sed -i.bak 's/FORMAT_ME//g' "$f" && rm -f "$f.bak"
+done
+exit 0
+STUB
+  chmod +x "$STUB_BIN/ktfmt"
+  export PATH="$STUB_BIN:$PATH"
+
+  REPO="$TEST_DIR/repo"
+  mkdir -p "$REPO/app/src"
+  cd "$REPO"
+  git init -q
+  git config user.email t@t.t
+  git config user.name t
+}
+
+teardown() {
+  cd /
+  rm -rf "$TEST_DIR"
+}
+
+@test "REGRESSION: apply aborts on a drifted ktfmt and does NOT reformat files" {
+  printf 'fun bad() { FORMAT_ME }\n' > app/src/Bad.kt
+  git add -A
+
+  run env KTFMT_STUB_VERSION="0.66" ONLY_TOUCHED_FILES=true bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"0.66"* ]]
+  [[ "$output" == *"0.64"* ]]
+  # It must abort at the gate, before ever formatting.
+  [[ "$output" != *"Applying ktfmt formatting"* ]]
+  # The file is untouched -- the wrong formatter never ran.
+  grep -q 'FORMAT_ME' app/src/Bad.kt
+}
+
+@test "apply with the pinned ktfmt passes the gate and formats touched files" {
+  printf 'fun bad() { FORMAT_ME }\n' > app/src/Bad.kt
+  git add -A
+
+  run env KTFMT_STUB_VERSION="0.64" ONLY_TOUCHED_FILES=true bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 1 Kotlin file(s) to process"* ]]
+  # The pinned formatter ran and stripped the marker.
+  ! grep -q 'FORMAT_ME' app/src/Bad.kt
+}

--- a/test/bats/install-ktfmt.bats
+++ b/test/bats/install-ktfmt.bats
@@ -38,10 +38,23 @@ STUB
 exit 0
 STUB
 
-  # java present and new enough for install_manual's Java >= 11 gate.
+  # java stub models BOTH uses:
+  #  * `java -version`  -> JDK banner on stderr (install_manual's Java >= 11 gate)
+  #  * `java -jar <ktfmt.jar> --version` -> the pinned wrapper's output. After the
+  #    fallback the real ~/.local/bin/ktfmt wrapper (which shells out to `java
+  #    -jar`) is what resolves, so this is what verify_installation sees. Defaults
+  #    to the pin; WRAPPER_VERSION overrides it to model a wrong/corrupt JAR.
   cat > "$STUB_BIN/java" <<'STUB'
 #!/usr/bin/env bash
-echo 'openjdk version "21.0.2" 2024-01-16' >&2
+if [[ " $* " == *" --version "* ]]; then
+  echo "ktfmt version ${WRAPPER_VERSION:-0.64}"
+  exit 0
+fi
+if [[ " $* " == *" -version "* ]]; then
+  echo 'openjdk version "21.0.2" 2024-01-16' >&2
+  exit 0
+fi
+exit 0
 STUB
 
   # curl: log the URL, write a non-empty file to the -o target, succeed.
@@ -58,19 +71,13 @@ echo "$*" >> "${CURL_LOG:-/dev/null}"
 exit 0
 STUB
 
-  # ktfmt --version reports the version brew "installed" (default 0.64 = matches).
-  # Once install_manual has written the pinned wrapper (~/.local/bin/ktfmt), model
-  # that the pinned 0.64 now resolves on PATH -- unless KTFMT_STUB_SHADOW is set,
-  # which models a drifted brew binary still shadowing ~/.local/bin (so verify
-  # must catch the mismatch).
+  # brew's ktfmt (on PATH via Homebrew) reports BREW_KTFMT_VERSION. This is what
+  # resolves BEFORE the fallback; after the fallback the installer prepends
+  # ~/.local/bin so the real pinned wrapper (-> java stub) resolves instead.
   cat > "$STUB_BIN/ktfmt" <<'STUB'
 #!/usr/bin/env bash
 if [[ " $* " == *" --version "* ]]; then
-  if [[ -f "$HOME/.local/bin/ktfmt" && -z "${KTFMT_STUB_SHADOW:-}" ]]; then
-    echo "ktfmt version 0.64"
-  else
-    echo "ktfmt version ${BREW_KTFMT_VERSION:-0.64}"
-  fi
+  echo "ktfmt version ${BREW_KTFMT_VERSION:-0.64}"
   exit 0
 fi
 exit 0
@@ -91,7 +98,11 @@ teardown() {
   [ ! -s "$CURL_LOG" ]
 }
 
-@test "macOS: brew version != pin falls back to the pinned manual JAR (honors pin)" {
+@test "macOS: brew version != pin falls back to the pinned JAR and makes it resolve (honors pin)" {
+  # brew ships 0.66; ~/.local/bin is NOT pre-seeded on PATH (STUB_BIN, where
+  # brew's ktfmt lives, is). If the installer didn't prepend ~/.local/bin +
+  # clear the command hash, verify would still resolve brew's 0.66 and fail --
+  # so a passing exit here proves the PATH/hash fix works.
   run env BREW_KTFMT_VERSION="0.66" bash "$SCRIPT"
   [ "$status" -eq 0 ]
   # Fallback fetched the pinned fat JAR from the v0.64 GitHub release.
@@ -103,14 +114,15 @@ teardown() {
   [[ "$output" == *"ktfmt 0.64 is installed"* ]]
 }
 
-@test "macOS: install FAILS loudly if a drifted brew ktfmt still shadows the pin on PATH" {
-  # Fallback installs the pinned JAR, but a drifted brew binary still resolves
-  # first on PATH -- verify_installation must catch it, not print success.
-  run env BREW_KTFMT_VERSION="0.66" KTFMT_STUB_SHADOW="1" bash "$SCRIPT"
+@test "macOS: install FAILS loudly if the resolved ktfmt still isn't the pin (verify guard)" {
+  # Defense in depth: even after the fallback, if the ktfmt that resolves reports
+  # a non-pin version (e.g. a wrong/corrupt JAR), verify_installation must fail
+  # loudly rather than print success. Model it by making the wrapper report 0.66.
+  run env BREW_KTFMT_VERSION="0.66" WRAPPER_VERSION="0.66" bash "$SCRIPT"
   [ "$status" -ne 0 ]
-  # Fallback still ran (pinned JAR fetched), but verification failed on the mismatch.
+  # Fallback still ran (pinned JAR fetched), but verification caught the mismatch.
   [ -s "$CURL_LOG" ]
   [[ "$output" == *"0.66"* ]]
-  [[ "$output" == *"shadowing"* ]]
+  [[ "$output" == *"0.64"* ]]
   [[ "$output" != *"Installation completed successfully"* ]]
 }

--- a/test/bats/install-ktfmt.bats
+++ b/test/bats/install-ktfmt.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ktfmt/install_ktfmt.sh -- specifically that the macOS path
+# HONORS THE PIN (issue #2966). Homebrew has no `ktfmt@<version>` formula, so
+# `brew install ktfmt` installs whatever the current formula ships. When that
+# differs from KTFMT_VERSION the installer must fall back to the pinned fat JAR
+# (install_manual) rather than leaving a drifted formatter in place.
+#
+# brew / java / curl / uname / ktfmt are all stubbed so the test is fast,
+# deterministic, and performs no network or system installs.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/ktfmt/install_ktfmt.sh"
+
+  TEST_DIR="$(mktemp -d)"
+  STUB_BIN="$TEST_DIR/bin"
+  mkdir -p "$STUB_BIN"
+
+  # Sandbox HOME so install_manual writes into the temp dir, not the real ~.
+  export HOME="$TEST_DIR/home"
+  mkdir -p "$HOME"
+
+  # Records what curl was asked to download, so a test can assert the pinned
+  # JAR (v0.64) was fetched on the fallback path.
+  export CURL_LOG="$TEST_DIR/curl.log"
+
+  # Force detect_os -> macos regardless of the real host.
+  cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo "Darwin"
+STUB
+
+  # brew: `install`/`unlink` succeed and do nothing. The version brew "installed"
+  # is whatever the ktfmt stub reports (see BREW_KTFMT_VERSION below).
+  cat > "$STUB_BIN/brew" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+  # java present and new enough for install_manual's Java >= 11 gate.
+  cat > "$STUB_BIN/java" <<'STUB'
+#!/usr/bin/env bash
+echo 'openjdk version "21.0.2" 2024-01-16' >&2
+STUB
+
+  # curl: log the URL, write a non-empty file to the -o target, succeed.
+  cat > "$STUB_BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+out=""
+prev=""
+for a in "$@"; do
+  if [[ "$prev" == "-o" ]]; then out="$a"; fi
+  prev="$a"
+done
+echo "$*" >> "${CURL_LOG:-/dev/null}"
+[[ -n "$out" ]] && printf 'FAKEJAR' > "$out"
+exit 0
+STUB
+
+  # ktfmt --version reports the version brew "installed" (default 0.64 = matches).
+  cat > "$STUB_BIN/ktfmt" <<'STUB'
+#!/usr/bin/env bash
+if [[ " $* " == *" --version "* ]]; then
+  echo "ktfmt version ${BREW_KTFMT_VERSION:-0.64}"
+  exit 0
+fi
+exit 0
+STUB
+
+  chmod +x "$STUB_BIN"/*
+  export PATH="$STUB_BIN:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+@test "macOS: brew version matching the pin does NOT trigger a manual JAR download" {
+  run env BREW_KTFMT_VERSION="0.64" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # No fallback -> curl was never invoked to fetch a JAR.
+  [ ! -s "$CURL_LOG" ]
+}
+
+@test "macOS: brew version != pin falls back to the pinned manual JAR (honors pin)" {
+  run env BREW_KTFMT_VERSION="0.66" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # Fallback fetched the pinned fat JAR from the v0.64 GitHub release.
+  [ -s "$CURL_LOG" ]
+  grep -q "v0.64/ktfmt-0.64-with-dependencies.jar" "$CURL_LOG"
+  # The pinned wrapper was installed into the sandboxed ~/.local/bin.
+  [ -x "$HOME/.local/bin/ktfmt" ]
+}

--- a/test/bats/install-ktfmt.bats
+++ b/test/bats/install-ktfmt.bats
@@ -59,10 +59,18 @@ exit 0
 STUB
 
   # ktfmt --version reports the version brew "installed" (default 0.64 = matches).
+  # Once install_manual has written the pinned wrapper (~/.local/bin/ktfmt), model
+  # that the pinned 0.64 now resolves on PATH -- unless KTFMT_STUB_SHADOW is set,
+  # which models a drifted brew binary still shadowing ~/.local/bin (so verify
+  # must catch the mismatch).
   cat > "$STUB_BIN/ktfmt" <<'STUB'
 #!/usr/bin/env bash
 if [[ " $* " == *" --version "* ]]; then
-  echo "ktfmt version ${BREW_KTFMT_VERSION:-0.64}"
+  if [[ -f "$HOME/.local/bin/ktfmt" && -z "${KTFMT_STUB_SHADOW:-}" ]]; then
+    echo "ktfmt version 0.64"
+  else
+    echo "ktfmt version ${BREW_KTFMT_VERSION:-0.64}"
+  fi
   exit 0
 fi
 exit 0
@@ -91,4 +99,18 @@ teardown() {
   grep -q "v0.64/ktfmt-0.64-with-dependencies.jar" "$CURL_LOG"
   # The pinned wrapper was installed into the sandboxed ~/.local/bin.
   [ -x "$HOME/.local/bin/ktfmt" ]
+  # verify_installation confirmed the resolved ktfmt is now the pin, not brew's.
+  [[ "$output" == *"ktfmt 0.64 is installed"* ]]
+}
+
+@test "macOS: install FAILS loudly if a drifted brew ktfmt still shadows the pin on PATH" {
+  # Fallback installs the pinned JAR, but a drifted brew binary still resolves
+  # first on PATH -- verify_installation must catch it, not print success.
+  run env BREW_KTFMT_VERSION="0.66" KTFMT_STUB_SHADOW="1" bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  # Fallback still ran (pinned JAR fetched), but verification failed on the mismatch.
+  [ -s "$CURL_LOG" ]
+  [[ "$output" == *"0.66"* ]]
+  [[ "$output" == *"shadowing"* ]]
+  [[ "$output" != *"Installation completed successfully"* ]]
 }

--- a/test/bats/validate-ktfmt.bats
+++ b/test/bats/validate-ktfmt.bats
@@ -208,7 +208,9 @@ clean_kt() { printf 'fun a() {}\n' > "$1"; }
   mkdir -p "$copy_dir"
   cp "$REPO_ROOT/scripts/ktfmt/validate_ktfmt.sh" "$copy_dir/"
   cp "$REPO_ROOT/scripts/ktfmt/ktfmt_version.sh" "$copy_dir/"
-  printf 'KTFMT_VERSION="0.99"\n' > "$copy_dir/ktfmt_version.sh"
+  # Bump ONLY the pin line in the copy, preserving the shared helper functions.
+  sed -i.bak 's/^KTFMT_VERSION=.*/KTFMT_VERSION="0.99"/' "$copy_dir/ktfmt_version.sh"
+  rm -f "$copy_dir/ktfmt_version.sh.bak"
 
   clean_kt app/src/Base.kt
   git add -A && git commit -qm base

--- a/test/bats/validate-ktfmt.bats
+++ b/test/bats/validate-ktfmt.bats
@@ -16,14 +16,32 @@ setup() {
 
   TEST_DIR="$(mktemp -d)"
 
-  # Stub ktfmt: exits 0 for the stdin probe (`--google-style -`) and dry-run.
-  # For an in-place `--google-style <file>` it "reformats" (mutating the copy the
-  # script made) only when the file contains the marker FORMAT_ME, letting a
-  # test simulate a misformatted file deterministically.
+  # Stub ktfmt:
+  #  * `--version` prints "ktfmt version <KTFMT_STUB_VERSION>" (default 0.64, the
+  #    pin). Tests override KTFMT_STUB_VERSION to simulate formatter-version drift,
+  #    or set KTFMT_STUB_VERSION="" to simulate an unparseable/failing --version.
+  #  * exits 0 for the stdin probe (`--google-style -`) and dry-run.
+  #  * for an in-place `--google-style <file>` it "reformats" (mutating the copy
+  #    the script made) only when the file contains the marker FORMAT_ME, letting
+  #    a test simulate a misformatted file deterministically.
   STUB_BIN="$TEST_DIR/bin"
   mkdir -p "$STUB_BIN"
   cat > "$STUB_BIN/ktfmt" <<'STUB'
 #!/usr/bin/env bash
+if [[ " $* " == *" --version "* ]]; then
+  # An empty override simulates a ktfmt whose --version emits no parseable
+  # version (or a broken binary); exit non-zero so the gate treats it as unknown.
+  if [[ -z "${KTFMT_STUB_VERSION-0.64}" ]]; then
+    exit 1
+  fi
+  # KTFMT_STUB_NOISE simulates a JVM warning printed to stderr *before* ktfmt's
+  # own line (the CI ktfmt runs `java -jar`); the gate must not parse its version.
+  if [[ -n "${KTFMT_STUB_NOISE:-}" ]]; then
+    echo "$KTFMT_STUB_NOISE" >&2
+  fi
+  echo "ktfmt version ${KTFMT_STUB_VERSION:-0.64}"
+  exit 0
+fi
 last="${@: -1}"
 if [[ "$last" == "-" || " $* " == *" --dry-run "* ]]; then
   cat >/dev/null 2>&1 || true
@@ -117,4 +135,85 @@ clean_kt() { printf 'fun a() {}\n' > "$1"; }
   [ "$status" -ne 0 ]
   [[ "$output" == *"Formatting issues found"* ]]
   [[ "$output" == *"Bad.kt"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Version fingerprint gate (issue #2966): the scoped PR check only looks at a
+# PR's changed files, so a formatter whose version differs from the pin would
+# reformat *untouched* files the scoped check never inspects -- passing the PR,
+# then reddening main when merge.yml reformats the whole tree. Enforce the pin
+# up front: a ktfmt whose version != KTFMT_VERSION must fail loudly, never
+# silently scoped-pass.
+# ---------------------------------------------------------------------------
+
+@test "version matching the pin passes the gate and processes files" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+
+  run env KTFMT_STUB_VERSION="0.64" ONLY_CHANGED_SINCE_SHA="" \
+    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 1 Kotlin file(s) to process"* ]]
+}
+
+@test "REGRESSION: a newer ktfmt (version != pin) fails loudly, does not scoped-pass" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+  local base; base="$(git rev-parse HEAD)"
+  clean_kt app/src/Feature.kt
+  git add -A && git commit -qm feature
+
+  run env KTFMT_STUB_VERSION="0.66" ONLY_CHANGED_SINCE_SHA="$base" \
+    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  # Names both the found and the pinned version so the failure is actionable.
+  [[ "$output" == *"0.66"* ]]
+  [[ "$output" == *"0.64"* ]]
+  # It must abort BEFORE doing any per-file work -- a scoped pass is the bug.
+  [[ "$output" != *"Kotlin file(s) to process"* ]]
+  [[ "$output" != *"properly formatted"* ]]
+}
+
+@test "an unparseable/failing --version fails loudly (treated as drift)" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+
+  run env KTFMT_STUB_VERSION="" ONLY_CHANGED_SINCE_SHA="" \
+    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"0.64"* ]]
+  [[ "$output" != *"Kotlin file(s) to process"* ]]
+}
+
+@test "a JVM warning before the version line is not mistaken for the ktfmt version" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+
+  # A stderr warning carrying its own version must not be grabbed by the parse;
+  # the gate should still read ktfmt's real 0.64 and pass.
+  run env KTFMT_STUB_VERSION="0.64" \
+    KTFMT_STUB_NOISE="OpenJDK 64-Bit Server VM warning: using JDK 11.0.2" \
+    ONLY_CHANGED_SINCE_SHA="" ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 1 Kotlin file(s) to process"* ]]
+  [[ "$output" != *"version mismatch"* ]]
+}
+
+@test "the gate reads the pin from the shared ktfmt_version.sh (single source)" {
+  # Prove single-sourcing without mutating the tracked tree: copy the validator
+  # and its sibling pin file into a temp dir, bump the *copy's* pin to 0.99, and
+  # confirm a 0.64 ktfmt now fails against that copy. If the validator hardcoded
+  # the version instead of sourcing the sibling, editing the copy would be inert.
+  local copy_dir="$TEST_DIR/ktfmt_copy"
+  mkdir -p "$copy_dir"
+  cp "$REPO_ROOT/scripts/ktfmt/validate_ktfmt.sh" "$copy_dir/"
+  cp "$REPO_ROOT/scripts/ktfmt/ktfmt_version.sh" "$copy_dir/"
+  printf 'KTFMT_VERSION="0.99"\n' > "$copy_dir/ktfmt_version.sh"
+
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+  run env KTFMT_STUB_VERSION="0.64" ONLY_CHANGED_SINCE_SHA="" \
+    ONLY_TOUCHED_FILES=false bash "$copy_dir/validate_ktfmt.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"0.99"* ]]
 }


### PR DESCRIPTION
## What

Enforces the pinned ktfmt version (`0.64`) so formatter/style-config drift can no longer silently land and redden `main` post-merge — or get committed via the auto-format path.

- Adds `scripts/ktfmt/ktfmt_version.sh` as the **single source of truth** for the pin *and* the shared enforcement helpers (`installed_ktfmt_version`, `require_pinned_ktfmt_version`), sourced by `install_ktfmt.sh`, `validate_ktfmt.sh`, and `apply_ktfmt.sh`.
- `validate_ktfmt.sh` (read path) and `apply_ktfmt.sh` (write/mutating path): both call the **version fingerprint gate** — assert `ktfmt --version` equals the pin before touching any file. A mismatch or unparseable/failing `--version` **fails loudly** instead of proceeding. This replaces the old `--google-style` probe (a matching version implies flag support).
- `install_ktfmt.sh` (macOS): verifies brew's installed version against the pin and, on drift, unlinks brew's copy and falls back to the pinned fat JAR; `verify_installation` then asserts the *resolved* ktfmt is the pin (not just present), and `main()` gates its success message on that — so a drifted brew binary shadowing `~/.local/bin` can't print a misleading green.

Closes #2966.

## Why

Follow-up from #2941, which scoped the **PR** ktfmt check to only a PR's changed files. That is sound for *file-content* drift but **not** for *formatter-version / style-config* drift: a drifted ktfmt reformats *untouched* files the scoped PR check never inspects, so the PR passes and the mismatch first surfaces **post-merge** when `merge.yml` reformats the whole tree — i.e. red `main`. The same drift on the **write** path (`apply_ktfmt.sh`) would reformat the tree with the wrong formatter and get committed.

Two concrete gaps meant the `0.64` pin was declared but not enforced:
1. The macOS installer ran `brew install ktfmt` with **no version constraint** (Homebrew has no `ktfmt@<version>` formula).
2. The scripts only installed when ktfmt was *missing*, and their only guard was a `--google-style` probe that passes for **any** version supporting the flag — an already-installed newer ktfmt sailed through.

This implements the two code-side suggestions from the issue (fingerprint gate + honor-the-pin-on-macOS). The third suggestion (making `merge.yml`'s `ktfmt` job a branch-protection *required* check) is a repo-admin setting, not code — see the follow-up note.

## How

- **Single source of truth.** `ktfmt_version.sh` holds `KTFMT_VERSION="0.64"` plus the shared helpers, `source`d via `"$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"`. Bumping the pin is a one-line edit all consumers pick up.
- **Fingerprint gate.** `installed_ktfmt_version` = `ktfmt --version 2>&1 | grep -i 'ktfmt version' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1` — filters to ktfmt's own line first so a JVM warning on stderr (the CI ktfmt runs `java -jar`) can't have *its* version grabbed. `require_pinned_ktfmt_version` exits 1 with an actionable message naming both versions if it differs from the pin.
- **macOS pin + shadow guard.** After `brew install`, compare to the pin; on drift `brew unlink ktfmt` + `install_manual` (pinned GitHub-release JAR). `verify_installation` re-checks the resolved version; `main()` only prints success when it matches.

## Testing

- `bats test/bats/validate-ktfmt.bats test/bats/install-ktfmt.bats test/bats/apply-ktfmt.bats` → **15 pass** (ktfmt/brew/java/curl all stubbed; fast, no network/device):
  - version matches pin → gate passes and files are processed
  - **REGRESSION**: version `!= pin` → fails loudly, names both versions, aborts **before** any per-file work (validate) / **before mutating** (apply)
  - unparseable/failing `--version` → fails loudly (treated as drift)
  - a JVM warning carrying its own version before the ktfmt line is **not** mistaken for the ktfmt version
  - single-source: bumping a *copy's* pin makes a `0.64` ktfmt fail (proves sourcing, not hardcoding)
  - macOS: brew == pin → **no** manual JAR download; brew != pin → falls back to the pinned `v0.64` JAR and verifies the resolved version is the pin; **shadow case** where a drifted brew binary still resolves → install **fails loudly**, no false success
- `shellcheck scripts/ktfmt/*.sh` → clean.
- Real end-to-end with the installed ktfmt `0.64`: full-tree `validate_ktfmt.sh` over all 602 Kotlin files → **all properly formatted**, gate passes.

## Follow-up

Making `merge.yml`'s `ktfmt` job a branch-protection **required** check (the issue's third suggestion) is a GitHub repo-settings change, not code — recommend a repo admin add it so drift that somehow lands still blocks the *next* merge.
