### PR TITLE
fix(db): tag migration lock with a per-process token so an in-process reopen can't steal an in-flight lock (#2947)

### DIFF
--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -5,6 +5,18 @@ import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../utils/fileLock";
+import { defaultIdGenerator } from "../utils/IdGenerator";
+
+/**
+ * A per-process-instance nonce written into every migration lock this process
+ * takes. Generated ONCE at module load (so every generation within one process
+ * shares it), unique per process start (a crashed prior incarnation, even after
+ * PID recycling, had a different one). This lets {@link FileMigrationLock}
+ * distinguish a lock still held by a LIVE in-flight run of this process — which an
+ * in-process same-path reopen must wait for — from a genuine stale leak to reclaim
+ * (issue #2947). See `ownerToken` in `src/utils/fileLock.ts`.
+ */
+const PROCESS_MIGRATION_TOKEN = defaultIdGenerator.next();
 
 /**
  * Cross-process lock guarding {@link runMigrations}.
@@ -58,6 +70,13 @@ export interface FileMigrationLockOptions {
   isProcessRunning?: (pid: number) => boolean;
   /** Owner pid written into the lock file (injectable for tests). */
   pid?: number;
+  /**
+   * Per-process-instance token distinguishing a lock held by a live in-flight run
+   * of THIS process from a recycled-PID leak (issue #2947). Defaults to the shared
+   * {@link PROCESS_MIGRATION_TOKEN} so every generation in one process agrees;
+   * injectable for tests.
+   */
+  ownerToken?: string;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 100;
@@ -78,6 +97,7 @@ export class FileMigrationLock implements MigrationLock {
   private readonly timeoutMs: number;
   private readonly isProcessRunning: ((pid: number) => boolean) | undefined;
   private readonly pid: number;
+  private readonly ownerToken: string;
 
   constructor(
     private readonly lockFilePath: string,
@@ -90,6 +110,7 @@ export class FileMigrationLock implements MigrationLock {
     this.timeoutMs = options.timeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS;
     this.isProcessRunning = options.isProcessRunning;
     this.pid = options.pid ?? process.pid;
+    this.ownerToken = options.ownerToken ?? PROCESS_MIGRATION_TOKEN;
   }
 
   async acquire(): Promise<void> {
@@ -123,11 +144,14 @@ export class FileMigrationLock implements MigrationLock {
     return tryAcquireExclusiveLock(this.lockFilePath, {
       pid: this.pid,
       isProcessRunning: this.isProcessRunning,
-      // The migration run is a per-process singleton (`migrationsPromise` in
-      // database.ts), so a lock file bearing our own PID can only be a stale leak
-      // from a crashed prior incarnation whose PID the OS recycled — reclaim it
-      // rather than hang for the full timeout.
+      // A lock file bearing our own PID is normally a stale leak from a crashed
+      // prior incarnation whose PID the OS recycled — reclaim it rather than hang
+      // for the full timeout. But an in-process same-path reopen while a prior
+      // generation's migration is still in flight would ALSO see our own PID; the
+      // owner token below tells the two apart so we wait for a live sibling run
+      // instead of stealing its lock and running two migrators on one DB (#2947).
       reclaimOwnPid: true,
+      ownerToken: this.ownerToken,
     });
   }
 }

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -5,18 +5,6 @@ import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../utils/fileLock";
-import { defaultIdGenerator } from "../utils/IdGenerator";
-
-/**
- * A per-process-instance nonce written into every migration lock this process
- * takes. Generated ONCE at module load (so every generation within one process
- * shares it), unique per process start (a crashed prior incarnation, even after
- * PID recycling, had a different one). This lets {@link FileMigrationLock}
- * distinguish a lock still held by a LIVE in-flight run of this process — which an
- * in-process same-path reopen must wait for — from a genuine stale leak to reclaim
- * (issue #2947). See `ownerToken` in `src/utils/fileLock.ts`.
- */
-const PROCESS_MIGRATION_TOKEN = defaultIdGenerator.next();
 
 /**
  * Cross-process lock guarding {@link runMigrations}.
@@ -70,13 +58,6 @@ export interface FileMigrationLockOptions {
   isProcessRunning?: (pid: number) => boolean;
   /** Owner pid written into the lock file (injectable for tests). */
   pid?: number;
-  /**
-   * Per-process-instance token distinguishing a lock held by a live in-flight run
-   * of THIS process from a recycled-PID leak (issue #2947). Defaults to the shared
-   * {@link PROCESS_MIGRATION_TOKEN} so every generation in one process agrees;
-   * injectable for tests.
-   */
-  ownerToken?: string;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 100;
@@ -97,7 +78,6 @@ export class FileMigrationLock implements MigrationLock {
   private readonly timeoutMs: number;
   private readonly isProcessRunning: ((pid: number) => boolean) | undefined;
   private readonly pid: number;
-  private readonly ownerToken: string;
 
   constructor(
     private readonly lockFilePath: string,
@@ -110,7 +90,6 @@ export class FileMigrationLock implements MigrationLock {
     this.timeoutMs = options.timeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS;
     this.isProcessRunning = options.isProcessRunning;
     this.pid = options.pid ?? process.pid;
-    this.ownerToken = options.ownerToken ?? PROCESS_MIGRATION_TOKEN;
   }
 
   async acquire(): Promise<void> {
@@ -144,14 +123,11 @@ export class FileMigrationLock implements MigrationLock {
     return tryAcquireExclusiveLock(this.lockFilePath, {
       pid: this.pid,
       isProcessRunning: this.isProcessRunning,
-      // A lock file bearing our own PID is normally a stale leak from a crashed
-      // prior incarnation whose PID the OS recycled — reclaim it rather than hang
-      // for the full timeout. But an in-process same-path reopen while a prior
-      // generation's migration is still in flight would ALSO see our own PID; the
-      // owner token below tells the two apart so we wait for a live sibling run
-      // instead of stealing its lock and running two migrators on one DB (#2947).
+      // The migration run is a per-process singleton (`migrationsPromise` in
+      // database.ts), so a lock file bearing our own PID can only be a stale leak
+      // from a crashed prior incarnation whose PID the OS recycled — reclaim it
+      // rather than hang for the full timeout.
       reclaimOwnPid: true,
-      ownerToken: this.ownerToken,
     });
   }
 }

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -53,6 +53,12 @@ export interface ExclusiveLockOptions {
    * behaves exactly as it did before this token existed (any same-PID lock is a
    * reclaimable leak). The PID stays on the first line so daemon liveness reads and
    * {@link releaseExclusiveLock}'s `parseInt` are unaffected.
+   *
+   * Must be a NON-EMPTY, single-line, whitespace-free token (a UUID satisfies
+   * this). The lock body is `trim()`-ed on read to tolerate a trailing newline, so
+   * a token with surrounding whitespace — or an empty string — would be mangled or
+   * dropped and read back as "no token". The only caller passes a `randomUUID()`
+   * from `IdGenerator`; a future caller must uphold the same shape.
    */
   ownerToken?: string;
 }

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -29,8 +29,32 @@ export interface ExclusiveLockOptions {
    * occur when a supervisor restarts a crashed process and the OS recycles the
    * same PID. The daemon coordinator leaves this `false` so a same-PID probe from
    * another manager instance still reads as held.
+   *
+   * See {@link ownerToken}: pairing this with a per-process-instance token narrows
+   * the reclaim to a *genuine* recycled-PID leak, so an in-process reopen while
+   * this process still holds the lock waits instead of stealing it (#2947).
    */
   reclaimOwnPid?: boolean;
+
+  /**
+   * A per-process-instance token written on the second line of the lock file
+   * (below the PID). It disambiguates the two ways a same-PID lock can arise under
+   * {@link reclaimOwnPid}:
+   *
+   * - token matches ours → a *live in-flight* acquire by THIS same process
+   *   instance (e.g. an in-process same-path reopen while the prior generation's
+   *   migration still holds the lock). Read as held so the reopen WAITS rather
+   *   than stealing it and running two migrators on one DB file (#2947).
+   * - token differs (or is absent, a pre-token incarnation) → a genuine stale leak
+   *   from a crashed prior incarnation whose PID the OS recycled. Reclaimed, exactly
+   *   as before (#2794 behavior preserved).
+   *
+   * Only consulted for the same-PID reclaim decision. When omitted, `reclaimOwnPid`
+   * behaves exactly as it did before this token existed (any same-PID lock is a
+   * reclaimable leak). The PID stays on the first line so daemon liveness reads and
+   * {@link releaseExclusiveLock}'s `parseInt` are unaffected.
+   */
+  ownerToken?: string;
 }
 
 /**
@@ -44,8 +68,9 @@ export function tryAcquireExclusiveLock(
   const pid = options.pid ?? process.pid;
   const isProcessRunning = options.isProcessRunning ?? defaultIsProcessRunning;
   const reclaimOwnPid = options.reclaimOwnPid ?? false;
+  const ownerToken = options.ownerToken;
 
-  if (writeExclusiveLockFile(lockFilePath, pid)) {
+  if (writeExclusiveLockFile(lockFilePath, pid, ownerToken)) {
     return true;
   }
 
@@ -69,13 +94,24 @@ export function tryAcquireExclusiveLock(
     return false;
   }
 
-  const ownerPid = Number.parseInt(content, 10);
+  // The PID is the first line; a per-process-instance token (if any) is the
+  // second (see `writeExclusiveLockFile`). `parseInt` reads only the PID.
+  const [pidLine, tokenLine] = content.split("\n", 2);
+  const ownerPid = Number.parseInt(pidLine, 10);
   if (Number.isNaN(ownerPid)) {
     // Unreadable PID — a writer may still be filling it in; treat as held.
     return false;
   }
 
-  const isOwnStaleLeak = reclaimOwnPid && ownerPid === pid;
+  // A same-PID lock is a reclaimable stale leak ONLY when its owner token differs
+  // from ours (a crashed prior incarnation whose PID the OS recycled) or is absent
+  // (a pre-token incarnation). A MATCHING token means this same process instance
+  // still holds it live — an in-process reopen must wait, not steal it (#2947).
+  // With no token supplied the pre-token semantics stand: any same-PID lock leaks.
+  const isOwnStaleLeak =
+    reclaimOwnPid &&
+    ownerPid === pid &&
+    (ownerToken === undefined || (tokenLine ?? "") !== ownerToken);
   if (isProcessRunning(ownerPid) && !isOwnStaleLeak) {
     return false;
   }
@@ -104,7 +140,7 @@ export function tryAcquireExclusiveLock(
   } catch {
     // Best-effort: the consumed stale marker is ours to remove.
   }
-  return writeExclusiveLockFile(lockFilePath, pid);
+  return writeExclusiveLockFile(lockFilePath, pid, ownerToken);
 }
 
 /**
@@ -135,13 +171,16 @@ export function releaseExclusiveLock(lockFilePath: string, pid: number = process
 
 /**
  * Atomically create the lock file with `pid` via `O_CREAT | O_EXCL` (`wx`).
- * Returns true on success, false if the file already exists.
+ * Returns true on success, false if the file already exists. When `ownerToken` is
+ * given it is written on a second line below the PID so a same-PID reader can tell
+ * this process instance's live lock from a recycled-PID leak (#2947); the PID
+ * stays on the first line so `parseInt`-based readers are unaffected.
  */
-function writeExclusiveLockFile(lockFilePath: string, pid: number): boolean {
+function writeExclusiveLockFile(lockFilePath: string, pid: number, ownerToken?: string): boolean {
   try {
     mkdirSync(dirname(lockFilePath), { recursive: true });
     const fd = openSync(lockFilePath, "wx", 0o600);
-    writeFileSync(fd, String(pid));
+    writeFileSync(fd, ownerToken === undefined ? String(pid) : `${pid}\n${ownerToken}`);
     closeSync(fd);
     return true;
   } catch {

--- a/test/db/databaseMigrationGenerationFence.test.ts
+++ b/test/db/databaseMigrationGenerationFence.test.ts
@@ -297,15 +297,15 @@ export async function down(db) {
     // and gen-1 use the same `AUTOMOBILE_DB_DIR` (identical DB path), only the
     // migrations dir differs, so the fence is proven on the same-file axis.
     //
-    // NOTE — this also exercises the lock-stealing hazard tracked separately in
-    // issue #2947: while gen-0 is blocked mid-migration it still holds
-    // `${path}.migrate.lock` (owner = our PID), and gen-1 reclaims that lock via
-    // `FileMigrationLock`'s `reclaimOwnPid: true`. The generation fence only
-    // protects the module globals; it does NOT serialize the two migration runs.
-    // This case is benign — gen-0's fail migration throws WITHOUT writing, so the
-    // stolen-lock concurrent access touches no schema — which is exactly why it is
-    // a clean fence proof rather than a lock-safety proof. #2947 covers the
-    // writes-during-reopen concurrency.
+    // NOTE — with issue #2947 fixed, gen-1 no longer STEALS gen-0's still-held
+    // own-PID migrate lock: the per-process owner token marks it as a live
+    // in-flight run, so gen-1 WAITS for gen-0 to release before migrating. This
+    // test therefore kicks gen-1's migrations off without awaiting, releases gen-0
+    // (which throws and frees the lock), and only then awaits gen-1 — otherwise
+    // awaiting gen-1 first would deadlock on the lock gen-0 still holds. The fence
+    // proof is unchanged: gen-0's stale FAILURE completion must not corrupt gen-1's
+    // globals. The dedicated lock-safety proof (a gen-0 migration that WRITES) lives
+    // in databaseMigrationLockReopen.test.ts.
     const unhandled: unknown[] = [];
     const onUnhandled = (reason: unknown): void => {
       unhandled.push(reason);
@@ -339,20 +339,23 @@ export async function down(db) {
       await db.closeDatabase();
 
       // Generation 1: reopen at the SAME DB path (env unchanged except a healthy
-      // migrations dir). It reclaims gen-0's still-held own-PID lock and migrates
-      // cleanly, so migrationsError must be null.
+      // migrations dir). gen-0 still holds the migrate lock, so gen-1 must WAIT for
+      // it (#2947) — kick migrations off WITHOUT awaiting.
       setEnv("AUTOMOBILE_MIGRATIONS_DIR", await makeHealthyMigrationsDir());
 
       db.getDatabase();
       expect(db.getDatabasePath()).toBe(gen0DbPath); // same file across generations
-      await db.ensureMigrations();
+      const gen1 = db.ensureMigrations() as Promise<void>;
+
+      // Release the stale gen-0 migration so it throws and frees the lock; gen-1
+      // then acquires it and migrates cleanly, so migrationsError must be null.
+      await writeFile(markers.release, "1");
+      await gen1;
       expect(db.getMigrationsError()).toBeNull();
 
-      // Release the stale gen-0 migration so it throws, then await its detached
-      // chain deterministically. The fence must keep gen-1's clean state.
-      await writeFile(markers.release, "1");
+      // Await gen-0's detached (superseded) chain deterministically. Its stale
+      // FAILURE handler must no-op under the fence and leave gen-1's clean state.
       await staleCompletion;
-
       expect(db.getMigrationsError()).toBeNull();
 
       await db.closeDatabase();

--- a/test/db/databaseMigrationLockReopen.test.ts
+++ b/test/db/databaseMigrationLockReopen.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+
+/**
+ * Regression test for issue #2947 (sibling of the #2898 generation fence).
+ *
+ * `FileMigrationLock` reclaims a lock file bearing our OWN pid immediately
+ * (`reclaimOwnPid: true`) on the assumption that "the migration run is a
+ * per-process singleton", so a same-pid lock can only be a stale leak from a
+ * crashed prior incarnation. An in-process SAME-PATH reopen while the previous
+ * generation's migration is still IN FLIGHT breaks that assumption: gen-0 still
+ * holds `${dbPath}.migrate.lock` (owner = our pid) and gen-1 would steal it, so
+ * two migrators could enter `migrateToLatest()` on the same DB file — the exact
+ * `kysely_migration` PRIMARY KEY collision the lock exists to prevent (#2794).
+ *
+ * The generation fence (#2898) only protects the module globals; it does NOT
+ * serialize the on-disk migration runs. The fix tags the lock with a
+ * per-process-instance token: a same-pid lock bearing OUR token is a live
+ * in-flight run to WAIT for, while a different (or absent) token is the genuine
+ * recycled-pid leak to reclaim.
+ *
+ * Unlike `databaseMigrationGenerationFence.test.ts` (whose gen-0 migration throws
+ * WITHOUT writing, so a stolen-lock concurrent run is benign), this gen-0
+ * migration WRITES to the shared DB file, so a stolen lock would corrupt it.
+ * A fresh module instance per case isolates the lazy globals.
+ */
+describe("in-process same-path reopen cannot steal an in-flight migration's lock (issue #2947)", () => {
+  const savedEnv = new Map<string, string | undefined>();
+  const trackedEnvKeys = [
+    DAEMON_LAUNCH_CWD_ENV,
+    "AUTOMOBILE_DB_DIR",
+    "AUTOMOBILE_DB_PATH",
+    "AUTO_MOBILE_DB_PATH",
+    "AUTOMOBILE_MIGRATIONS_DIR",
+    "AUTO_MOBILE_MIGRATIONS_DIR",
+  ];
+  const tempDirs: string[] = [];
+
+  for (const key of trackedEnvKeys) {
+    savedEnv.set(key, process.env[key]);
+  }
+
+  function setEnv(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  afterEach(async () => {
+    for (const key of trackedEnvKeys) {
+      setEnv(key, savedEnv.get(key));
+    }
+    for (const dir of tempDirs.splice(0)) {
+      await removeTempDirWithRetry(dir);
+    }
+  });
+
+  async function importFreshDatabaseModule() {
+    return import(`../../src/db/database.ts?lock-reopen-test=${Date.now()}-${Math.random()}`);
+  }
+
+  async function makeTempDir(prefix: string): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function removeTempDirWithRetry(dir: string): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        await rm(dir, { recursive: true, force: true });
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
+          throw error;
+        }
+        await defaultTimer.sleep(50);
+      }
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  /**
+   * A migrations dir with one migration that WRITES to the DB (creates `probe`
+   * and inserts row id=1) BEFORE blocking on a `release` marker, holding the
+   * migration — and its `${dbPath}.migrate.lock` — in flight across a
+   * `closeDatabase()`. `probe`'s single-row PRIMARY KEY makes a concurrent second
+   * migrator's re-insert collide, so a stolen lock corrupts observably.
+   */
+  async function makeSlowWritingMigrationsDir(markers: {
+    started: string;
+    release: string;
+  }): Promise<string> {
+    const dir = await makeTempDir("auto-mobile-lock-reopen-mig-");
+    const content = `import { promises as fsp } from "fs";
+import { existsSync } from "fs";
+
+export async function up(db) {
+  await db.schema
+    .createTable("probe")
+    .ifNotExists()
+    .addColumn("id", "integer", col => col.primaryKey())
+    .execute();
+  await db.insertInto("probe").values({ id: 1 }).execute();
+  await fsp.writeFile(${JSON.stringify(markers.started)}, "1");
+  for (let i = 0; i < 5000; i += 1) {
+    if (existsSync(${JSON.stringify(markers.release)})) break;
+    await new Promise(resolve => setTimeout(resolve, 2));
+  }
+}
+
+export async function down(db) {
+  await db.schema.dropTable("probe").ifExists().execute();
+}
+`;
+    await writeFile(path.join(dir, "0001_slow_writing_migration.ts"), content, "utf8");
+    return dir;
+  }
+
+  async function waitForMarker(marker: string, label: string): Promise<void> {
+    for (let attempt = 0; attempt < 2000; attempt += 1) {
+      if (existsSync(marker)) {
+        return;
+      }
+      await defaultTimer.sleep(2);
+    }
+    throw new Error(`Timed out waiting for ${label} marker: ${marker}`);
+  }
+
+  test("gen-1 waits for the in-flight gen-0 migration instead of stealing its lock; no corruption", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const markerRoot = await makeTempDir("auto-mobile-lock-reopen-markers-");
+      const markers = {
+        started: path.join(markerRoot, "started"),
+        release: path.join(markerRoot, "release"),
+      };
+      const migrationsDir = await makeSlowWritingMigrationsDir(markers);
+      // One DB dir shared by BOTH generations -> the same DB file path on reopen.
+      const sharedDbDir = await makeTempDir("auto-mobile-lock-reopen-db-");
+
+      setEnv(DAEMON_LAUNCH_CWD_ENV, undefined);
+      setEnv("AUTOMOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_DB_PATH", undefined);
+      setEnv("AUTO_MOBILE_MIGRATIONS_DIR", undefined);
+      setEnv("AUTOMOBILE_DB_DIR", sharedDbDir);
+      // Both generations use the SAME migrations dir + SAME DB path, the truest
+      // concurrent-migration collision scenario.
+      setEnv("AUTOMOBILE_MIGRATIONS_DIR", migrationsDir);
+
+      const db = await importFreshDatabaseModule();
+
+      // Generation 0: start the slow, WRITING migration and hold it in flight
+      // (mid-run, still holding the migrate lock).
+      db.getDatabase();
+      const gen0DbPath = db.getDatabasePath();
+      await waitForMarker(markers.started, "generation-0 started");
+
+      const staleCompletion = db.getMigrationsPromiseForTest() as Promise<void> | null;
+      expect(staleCompletion).not.toBeNull();
+
+      // Close mid-flight: nulls globals + bumps the generation. The detached gen-0
+      // migration is still blocked on `release` and STILL HOLDS the migrate lock.
+      await db.closeDatabase();
+
+      // Generation 1: reopen at the SAME DB path, kick off migrations but do NOT
+      // await yet.
+      db.getDatabase();
+      expect(db.getDatabasePath()).toBe(gen0DbPath);
+
+      let gen1Settled = false;
+      const gen1 = (db.ensureMigrations() as Promise<void>).then(
+        () => {
+          gen1Settled = true;
+        },
+        () => {
+          gen1Settled = true;
+        }
+      );
+
+      // Give a would-be lock thief ample time to steal the lock and run
+      // migrateToLatest() concurrently. With the fix gen-1 is parked on the still-
+      // held same-token lock, so it CANNOT settle until gen-0 releases; without
+      // the fix it steals the lock and settles here.
+      await defaultTimer.sleep(400);
+      expect(gen1Settled).toBe(false);
+
+      // Release gen-0: its migration finishes, records `0001`, and releases the
+      // lock. gen-1 then acquires, sees `0001` already applied, and no-ops.
+      await writeFile(markers.release, "1");
+      await staleCompletion;
+      await gen1;
+
+      expect(gen1Settled).toBe(true);
+      expect(db.getMigrationsError()).toBeNull();
+
+      // No corruption: the write ran exactly once (single `probe` row, single
+      // `0001` history row) — a stolen concurrent run would have collided.
+      const database = db.getDatabase();
+      const probeRows = await database.selectFrom("probe").selectAll().execute();
+      expect(probeRows).toHaveLength(1);
+      const historyRows = await database
+        .selectFrom("kysely_migration")
+        .select("name")
+        .execute();
+      expect(historyRows.map((row: { name: string }) => row.name)).toEqual([
+        "0001_slow_writing_migration",
+      ]);
+
+      await db.closeDatabase();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/test/db/databaseMigrationLockReopen.test.ts
+++ b/test/db/databaseMigrationLockReopen.test.ts
@@ -98,12 +98,23 @@ describe("in-process same-path reopen cannot steal an in-flight migration's lock
   async function makeSlowWritingMigrationsDir(markers: {
     started: string;
     release: string;
+    active: string;
+    violation: string;
   }): Promise<string> {
     const dir = await makeTempDir("auto-mobile-lock-reopen-mig-");
     const content = `import { promises as fsp } from "fs";
-import { existsSync } from "fs";
+import { existsSync, openSync, closeSync, unlinkSync } from "fs";
 
 export async function up(db) {
+  // Timing-INDEPENDENT concurrency probe: hold an exclusive "migration active"
+  // marker for the whole run via an O_EXCL ('wx') create. A second migrator that
+  // stole the lock (#2947) and entered up() concurrently fails this create and
+  // records a violation — detectable regardless of scheduling.
+  try {
+    closeSync(openSync(${JSON.stringify(markers.active)}, "wx"));
+  } catch {
+    await fsp.writeFile(${JSON.stringify(markers.violation)}, "1");
+  }
   await db.schema
     .createTable("probe")
     .ifNotExists()
@@ -115,6 +126,7 @@ export async function up(db) {
     if (existsSync(${JSON.stringify(markers.release)})) break;
     await new Promise(resolve => setTimeout(resolve, 2));
   }
+  try { unlinkSync(${JSON.stringify(markers.active)}); } catch {}
 }
 
 export async function down(db) {
@@ -147,6 +159,8 @@ export async function down(db) {
       const markers = {
         started: path.join(markerRoot, "started"),
         release: path.join(markerRoot, "release"),
+        active: path.join(markerRoot, "active"),
+        violation: path.join(markerRoot, "violation"),
       };
       const migrationsDir = await makeSlowWritingMigrationsDir(markers);
       // One DB dir shared by BOTH generations -> the same DB file path on reopen.
@@ -191,11 +205,18 @@ export async function down(db) {
         }
       );
 
-      // Give a would-be lock thief ample time to steal the lock and run
-      // migrateToLatest() concurrently. With the fix gen-1 is parked on the still-
-      // held same-token lock, so it CANNOT settle until gen-0 releases; without
-      // the fix it steals the lock and settles here.
-      await defaultTimer.sleep(400);
+      // No fixed wall-clock wait: this bounded loop early-exits the moment a
+      // would-be lock thief manifests. On the pre-fix (stealing) code gen-1 enters
+      // migrateToLatest() concurrently, so it settles and/or trips the exclusive
+      // in-flight `active` marker (recording a `violation`) within a poll or two.
+      // On the fixed code gen-1 stays parked on gen-0's still-held same-token lock
+      // and produces NEITHER signal (gen-1 cannot settle until gen-0 releases,
+      // which the test controls), so the loop runs its short bounded budget.
+      for (let i = 0; i < 40 && !gen1Settled && !existsSync(markers.violation); i += 1) {
+        await defaultTimer.sleep(5);
+      }
+      // Serialization proof: gen-1 has not run migrateToLatest() concurrently.
+      expect(existsSync(markers.violation)).toBe(false);
       expect(gen1Settled).toBe(false);
 
       // Release gen-0: its migration finishes, records `0001`, and releases the
@@ -205,6 +226,7 @@ export async function down(db) {
       await gen1;
 
       expect(gen1Settled).toBe(true);
+      expect(existsSync(markers.violation)).toBe(false);
       expect(db.getMigrationsError()).toBeNull();
 
       // No corruption: the write ran exactly once (single `probe` row, single

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -140,6 +140,15 @@ describe("FileMigrationLock", () => {
     expect(timer.getPendingSleepCount()).toBe(1);
     expect(lockPid(lockPath)).toBe("4242");
 
+    // It must STAY parked across further poll cycles while the same-token holder is
+    // still live — never reclaim after N polls.
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      timer.advanceTime(100);
+      await flush();
+      expect(acquired).toBe(false);
+      expect(lockPid(lockPath)).toBe("4242");
+    }
+
     // Gen-0 releases; gen-1 then acquires cleanly on the next poll.
     rmSync(lockPath);
     timer.advanceTime(100);

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -11,6 +11,11 @@ async function flush(): Promise<void> {
   await new Promise<void>(resolve => setImmediate(resolve));
 }
 
+/** The pid line of a lock file — the token (if any) trails on line 2 (#2947). */
+function lockPid(path: string): string {
+  return readFileSync(path, "utf-8").split("\n")[0];
+}
+
 describe("FileMigrationLock", () => {
   let dir: string;
   let lockPath: string;
@@ -35,7 +40,7 @@ describe("FileMigrationLock", () => {
     await lock.acquire();
 
     expect(existsSync(lockPath)).toBe(true);
-    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+    expect(lockPid(lockPath)).toBe("4242");
 
     await lock.release();
     expect(existsSync(lockPath)).toBe(false);
@@ -84,7 +89,7 @@ describe("FileMigrationLock", () => {
     await pending;
 
     expect(acquired).toBe(true);
-    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+    expect(lockPid(lockPath)).toBe("4242");
     await lock.release();
   });
 
@@ -103,9 +108,66 @@ describe("FileMigrationLock", () => {
     await lock.acquire();
 
     expect(timer.getSleepCallCount()).toBe(0);
-    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+    expect(lockPid(lockPath)).toBe("4242");
     await lock.release();
     expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("does NOT steal a same-PID lock still held by a live in-flight run of THIS process (#2947)", async () => {
+    // Gen-0 of this process instance holds the lock (its own PID + our process
+    // token). An in-process same-path reopen (gen-1) must WAIT for gen-0 to
+    // release rather than reclaim under reclaimOwnPid — otherwise two migrators
+    // enter migrateToLatest() on one DB file (the #2794 collision this lock exists
+    // to prevent).
+    const timer = new FakeTimer();
+    writeFileSync(lockPath, "4242\nprocess-token-A");
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      pollIntervalMs: 100,
+      isProcessRunning: () => true, // gen-0 (our process) is alive
+      ownerToken: "process-token-A", // same instance token as the held lock
+    });
+
+    let acquired = false;
+    const pending = lock.acquire().then(() => {
+      acquired = true;
+    });
+
+    // First attempt sees a live same-token holder -> parks on sleep, does NOT steal.
+    await flush();
+    expect(acquired).toBe(false);
+    expect(timer.getPendingSleepCount()).toBe(1);
+    expect(lockPid(lockPath)).toBe("4242");
+
+    // Gen-0 releases; gen-1 then acquires cleanly on the next poll.
+    rmSync(lockPath);
+    timer.advanceTime(100);
+    await flush();
+    await pending;
+    expect(acquired).toBe(true);
+    expect(lockPid(lockPath)).toBe("4242");
+    await lock.release();
+  });
+
+  test("reclaims a same-PID lock from a crashed prior incarnation (different token) without waiting (#2947/#2794)", async () => {
+    // A crashed prior incarnation held the lock and the OS recycled its PID; its
+    // process token differs from ours, so this is a genuine stale leak — reclaim it
+    // immediately instead of hanging for the full timeout.
+    const timer = new FakeTimer();
+    writeFileSync(lockPath, "4242\nprocess-token-OLD");
+    const lock = new FileMigrationLock(lockPath, {
+      timer,
+      pid: 4242,
+      isProcessRunning: () => true,
+      ownerToken: "process-token-A",
+    });
+
+    await lock.acquire();
+
+    expect(timer.getSleepCallCount()).toBe(0);
+    expect(lockPid(lockPath)).toBe("4242");
+    await lock.release();
   });
 
   test("release does not delete a lock owned by a different opener", async () => {
@@ -144,7 +206,7 @@ describe("FileMigrationLock", () => {
     await lock.acquire();
 
     expect(timer.getSleepCallCount()).toBe(0);
-    expect(readFileSync(lockPath, "utf-8").trim()).toBe("4242");
+    expect(lockPid(lockPath)).toBe("4242");
     await lock.release();
   });
 
@@ -202,8 +264,7 @@ describe("FileMigrationLock", () => {
 
     // A reclaims the stale lock first.
     await lockA.acquire();
-    const owner = readFileSync(lockPath, "utf-8").trim();
-    expect(owner).toBe("100");
+    expect(lockPid(lockPath)).toBe("100");
 
     // B must NOT be able to steal it while A (pid 100) is alive.
     let bAcquired = false;
@@ -214,7 +275,7 @@ describe("FileMigrationLock", () => {
     timer.advanceTime(50);
     await flush();
     expect(bAcquired).toBe(false);
-    expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
+    expect(lockPid(lockPath)).toBe("100");
 
     // Once A releases, B acquires cleanly.
     await lockA.release();
@@ -222,7 +283,7 @@ describe("FileMigrationLock", () => {
     await flush();
     await bPending;
     expect(bAcquired).toBe(true);
-    expect(readFileSync(lockPath, "utf-8").trim()).toBe("200");
+    expect(lockPid(lockPath)).toBe("200");
     await lockB.release();
   });
 });

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -77,6 +77,78 @@ describe("fileLock primitive", () => {
     expect(readFileSync(lockPath, "utf-8").trim()).toBe("100");
   });
 
+  describe("ownerToken distinguishes a live in-flight run from a stale recycled-PID leak (#2947)", () => {
+    test("writes the owner token beneath the pid when provided", () => {
+      expect(
+        tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true, ownerToken: "tok-A" })
+      ).toBe(true);
+      // PID stays parseable as the first line so the daemon liveness reader and
+      // releaseExclusiveLock (parseInt) keep working; the token trails on line 2.
+      const content = readFileSync(lockPath, "utf-8");
+      expect(content.split("\n")[0]).toBe("100");
+      expect(content).toContain("tok-A");
+      expect(Number.parseInt(content, 10)).toBe(100);
+    });
+
+    test("a same-PID lock bearing OUR token is a live in-flight run → held, not stolen", () => {
+      // Gen-0 (this same process instance) holds the lock. An in-process same-path
+      // reopen (gen-1) must NOT reclaim it under reclaimOwnPid — that would let two
+      // migrators run migrateToLatest() on the same DB file (#2947).
+      writeFileSync(lockPath, "100\ntok-A");
+      expect(
+        tryAcquireExclusiveLock(lockPath, {
+          pid: 100,
+          isProcessRunning: () => true,
+          reclaimOwnPid: true,
+          ownerToken: "tok-A",
+        })
+      ).toBe(false);
+      expect(readFileSync(lockPath, "utf-8")).toBe("100\ntok-A");
+    });
+
+    test("a same-PID lock bearing a DIFFERENT token is a crashed-incarnation leak → reclaimed (#2794 preserved)", () => {
+      // A prior incarnation crashed holding the lock and the OS recycled its PID;
+      // its token differs from ours, so reclaim it immediately instead of hanging.
+      writeFileSync(lockPath, "100\ntok-OLD");
+      expect(
+        tryAcquireExclusiveLock(lockPath, {
+          pid: 100,
+          isProcessRunning: () => true,
+          reclaimOwnPid: true,
+          ownerToken: "tok-A",
+        })
+      ).toBe(true);
+      expect(readFileSync(lockPath, "utf-8").split("\n")[0]).toBe("100");
+    });
+
+    test("a same-PID lock with NO token (legacy incarnation) is reclaimed under reclaimOwnPid", () => {
+      // A lock left by a pre-token incarnation carries only the pid; treat it as a
+      // recycled-PID leak so the #2794 stale-reclaim behavior is unchanged.
+      writeFileSync(lockPath, "100");
+      expect(
+        tryAcquireExclusiveLock(lockPath, {
+          pid: 100,
+          isProcessRunning: () => true,
+          reclaimOwnPid: true,
+          ownerToken: "tok-A",
+        })
+      ).toBe(true);
+    });
+
+    test("without reclaimOwnPid, our token on a live same-PID lock still reads as held (daemon default)", () => {
+      writeFileSync(lockPath, "100\ntok-A");
+      expect(
+        tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true, ownerToken: "tok-A" })
+      ).toBe(false);
+    });
+
+    test("release honors a pid+token lock (parseInt reads the pid line)", () => {
+      writeFileSync(lockPath, "100\ntok-A");
+      releaseExclusiveLock(lockPath, 100);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+  });
+
   describe("releaseExclusiveLock (compare-and-delete)", () => {
     test("removes the file when it holds our pid", () => {
       writeFileSync(lockPath, "100");

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -135,6 +135,23 @@ describe("fileLock primitive", () => {
       ).toBe(true);
     });
 
+    test("a same-PID lock whose owner is DEAD is reclaimed even when the token matches", () => {
+      // A matching token normally means a live in-flight sibling to wait for, but a
+      // dead owner has no live run — the liveness check wins, so it is reclaimed.
+      // (Unreachable in production, where our own live PID is always alive and a
+      // dead incarnation had a different token; pins the predicate branch anyway.)
+      writeFileSync(lockPath, "100\ntok-A");
+      expect(
+        tryAcquireExclusiveLock(lockPath, {
+          pid: 100,
+          isProcessRunning: () => false,
+          reclaimOwnPid: true,
+          ownerToken: "tok-A",
+        })
+      ).toBe(true);
+      expect(readFileSync(lockPath, "utf-8").split("\n")[0]).toBe("100");
+    });
+
     test("without reclaimOwnPid, our token on a live same-PID lock still reads as held (daemon default)", () => {
       writeFileSync(lockPath, "100\ntok-A");
       expect(


### PR DESCRIPTION
## What

Tags every migration lock this process takes (`${dbPath}.migrate.lock`) with a
**per-process-instance token** so `FileMigrationLock`'s `reclaimOwnPid` no longer
steals a lock still held by a **live** in-flight migration of this same process.
A same-PID lock is reclaimed only when it is a genuine stale leak (different or
absent token from a crashed prior incarnation); a lock bearing our own live token
is waited for instead.

Closes #2947.

## Why

`FileMigrationLock` reclaims a lock file bearing our **own** PID immediately
(`reclaimOwnPid: true`, `src/db/migrationLock.ts`). The justifying comment assumed
*"the migration run is a per-process singleton, so a same-PID lock can only be a
stale leak from a crashed prior incarnation whose PID the OS recycled."* An
in-process **same-path** reopen while the previous generation's migration is still
in flight breaks that assumption:

1. Gen-0 opens DB file `P`, acquires `P.migrate.lock` (owner = our PID), enters
   `migrateToLatest()`; a migration is still running.
2. `closeDatabase()` nulls the globals + bumps the generation fence (#2898/#2936).
   It does **not** cancel the detached gen-0 run, which still holds the lock.
3. A `getDatabase()` reopen at the same path `P` starts generation 1 →
   `FileMigrationLock.acquire()` sees a lock owned by our PID and, because
   `reclaimOwnPid: true`, **reclaims it immediately** instead of waiting.
4. Both migrators now assume the lock and can write `P` concurrently → possible
   `kysely_migration` PRIMARY KEY collision or torn schema (the exact #2794 hazard
   the lock exists to prevent).

The generation fence (#2898) protects the module **globals** from stale writes; it
does **not** serialize the on-disk migration run. This is the sibling hazard it
left open, flagged by the PR #2936 review (ChatGPT Codex, P2) and deferred to keep
that fix narrow.

Reachability is the same profile as #2898: **unreachable today** (the only
`closeDatabase()` caller is daemon shutdown-then-exit, with no reopen). This lands
the guard so the hazard cannot surface when an in-process reopen path
(config reload / DB-path switch / restart-without-exit) arrives.

## How

- **`src/utils/fileLock.ts`** — new optional `ownerToken` written on a **second
  line** below the PID. The PID stays on line 1 so daemon liveness reads and
  `releaseExclusiveLock`'s `parseInt` are unaffected. The token is consulted
  **only** for the same-PID reclaim decision: `isOwnStaleLeak` now also requires
  the stored token to differ from ours (or be absent). Omitting `ownerToken`
  preserves the pre-token semantics exactly, so the daemon coordinator lock
  (`reclaimOwnPid: false`, no token) is byte-for-byte unchanged.
- **`src/db/migrationLock.ts`** — `PROCESS_MIGRATION_TOKEN`, a per-process nonce
  from `defaultIdGenerator` generated once at module load (shared across
  generations in one process, unique per process start), threaded into
  `tryAcquire`. Injectable via `FileMigrationLockOptions.ownerToken` for tests.
- **Tests**
  - `test/utils/fileLock.test.ts` — primitive-level token cases (matching token →
    held; different/absent token → reclaimed; write format; release honors
    pid+token).
  - `test/db/migrationLock.test.ts` — `FileMigrationLock` waits for a live
    same-token sibling and reclaims a different-token crashed-incarnation leak;
    existing exact-content assertions updated to read the PID line.
  - `test/db/databaseMigrationLockReopen.test.ts` — **new** integration regression:
    a gen-0 migration that **writes** is held in flight; a same-path reopen (gen-1)
    must wait for gen-0's lock rather than steal it, with no concurrent-migration
    corruption (single `probe` row, single history row). Fails on the pre-fix code.
  - `test/db/databaseMigrationGenerationFence.test.ts` — the #2898 same-path fence
    test is updated to the new serialized behavior (its comment already flagged
    this hazard and pointed at #2947); it now kicks gen-1 off without awaiting,
    releases gen-0, then awaits gen-1.

## Testing

- `bun test test/db/ test/utils/fileLock.test.ts` → 544 pass
- `bun test test/daemon/` → 583 pass (daemon lock path unaffected)
- `bunx eslint` on changed files → clean; `bun run build.ts` → success
- The new integration test was verified RED against the pre-fix source (gen-1
  settles by stealing the lock) and GREEN after the fix (gen-1 waits).