### PR TITLE
feat(observe): compact/TOON observe encoding (--observe-result-compact)

### DIFF
--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -125,7 +125,9 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
   {
     key: "observe-result-compact",
     label: "Observe result: compact",
-    description: "Emit observe results in a compact form to reduce output size.",
+    description:
+      "Emit the observe result text block in a compact form (no-indent JSON tree + TOON " +
+      "element tables) to reduce output size. structuredContent stays valid JSON.",
     defaultValue: false,
   },
   {

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -126,8 +126,12 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     key: "observe-result-compact",
     label: "Observe result: compact",
     description:
-      "Emit the observe result text block in a compact form (no-indent JSON tree + TOON " +
-      "element tables) to reduce output size. structuredContent stays valid JSON.",
+      "Experimental. Emit the observe result text block in a compact form (no-indent JSON " +
+      "tree + TOON element tables) to reduce output size. structuredContent stays valid JSON, " +
+      "so this only reduces wire tokens when combined with --tool-results-no-structured-content " +
+      "(otherwise the JSON duplicate negates the saving). Note: the text block is no longer " +
+      "JSON when enabled — programmatic consumers that parse content[].text should read " +
+      "structuredContent instead.",
     defaultValue: false,
   },
   {

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -1,5 +1,7 @@
 import type { ObserveResult } from "../../../models/ObserveResult";
 import type { ViewHierarchyNode } from "../../../models/ViewHierarchyResult";
+import { encodeToonTable, type ToonScalar } from "../../../utils/toon";
+import { compactStringifyToolResponse } from "../../../utils/toolUtils";
 
 /**
  * Output-only shrinking of a single `ObserveResult` for serialization
@@ -167,4 +169,121 @@ function trimHierarchyNodes(node: ViewHierarchyNode | undefined): void {
   for (const child of toNodeArray(node.node)) {
     trimHierarchyNodes(child);
   }
+}
+
+/**
+ * Order the `elements` sub-arrays are emitted as TOON blocks. Fixed so the
+ * compact output is deterministic regardless of key order on the source object.
+ */
+const ELEMENT_ARRAY_NAMES = ["clickable", "scrollable", "text", "media"] as const;
+
+/**
+ * One-line, self-describing legend prepended to every compact observe payload so
+ * the model can parse the hybrid JSON+TOON format without out-of-band docs.
+ */
+export const OBSERVE_COMPACT_LEGEND =
+  "# observe-compact (--observe-result-compact): line 2 = compact JSON of the result " +
+  "(viewHierarchy tree inline) with `elements` moved below as TOON. Each block: " +
+  "`name[count]{columns}:` header then one 2-space-indented CSV row per element; " +
+  "bounds flattened to bounds.left/top/right/bottom, nested node/objects kept as JSON " +
+  "cells; a cell is quoted when it holds a comma, double-quote, or newline (\"\" = a " +
+  "literal quote), and an empty cell means the field is absent.";
+
+/**
+ * True when `value` is a plain object whose own values are all scalar — the
+ * shape (`bounds`) that flattens cleanly to dotted columns. Nested objects
+ * (`node` subtrees) return false so they are preserved as a single JSON cell.
+ */
+function isFlatScalarObject(value: unknown): value is Record<string, ToonScalar> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value as Record<string, unknown>).every(
+    v => v === null || (typeof v !== "object" && typeof v !== "function")
+  );
+}
+
+/**
+ * Project one element to a flat TOON record. Scalars pass through; a flat-scalar
+ * object (`bounds`) is expanded to `key.subkey` columns; anything else (arrays,
+ * nested `node` subtrees) is preserved losslessly as a compact-JSON cell. The
+ * accessibility `extras` bag is dropped to match the production formatter.
+ */
+function flattenElementRecord(element: Record<string, unknown>): Record<string, ToonScalar> {
+  const row: Record<string, ToonScalar> = {};
+  for (const [key, value] of Object.entries(element)) {
+    if (key === "extras" || value === undefined || value === null) {
+      continue;
+    }
+    if (isFlatScalarObject(value)) {
+      for (const [subKey, subValue] of Object.entries(value)) {
+        row[`${key}.${subKey}`] = subValue as ToonScalar;
+      }
+    } else if (typeof value === "object") {
+      // A nested `node` subtree (or other array/object) is kept losslessly as a
+      // compact-JSON cell. Route through the shared formatter — not raw
+      // JSON.stringify — so the accessibility `extras` bag is stripped here too,
+      // matching the JSON tree and the production formatter.
+      row[key] = compactStringifyToolResponse(value);
+    } else {
+      row[key] = value as ToonScalar;
+    }
+  }
+  return row;
+}
+
+/**
+ * Encode an observe payload in the experimental compact/TOON text form
+ * (issue #2760), gated by `--observe-result-compact` at the call site.
+ *
+ * Output-only and PURE: the input payload is never mutated. `observePath` locates
+ * the `ObserveResult` — `""` when the payload itself is the result (the `observe`
+ * tool), or a key (e.g. `"observation"`) when it is nested under an action
+ * result. The result:
+ *  1. legend line,
+ *  2. compact JSON of the payload with the located result's `elements` detached
+ *     (the ragged `viewHierarchy` tree stays inline — least TOON benefit, highest
+ *     escaping risk),
+ *  3. one TOON block per `elements.*` array (uniform tabular data — TOON's win).
+ *
+ * `structuredContent` is intentionally NOT produced here; the caller keeps that
+ * representation as valid JSON so the two never have to agree on format.
+ */
+export function encodeObserveCompact(
+  payload: Record<string, unknown>,
+  observePath: string
+): string {
+  const observe = (observePath === "" ? payload : payload[observePath]) as
+    | (ObserveResult & Record<string, unknown>)
+    | undefined;
+
+  // Detach `elements` without mutating the input: shallow-copy the result object
+  // (and, for the nested case, its container) omitting the `elements` key.
+  const elements = observe?.elements;
+  let treeContainer: unknown;
+  if (observePath === "") {
+    const rest = { ...(payload as Record<string, unknown>) };
+    delete rest.elements;
+    treeContainer = rest;
+  } else if (observe) {
+    const restObserve = { ...(observe as Record<string, unknown>) };
+    delete restObserve.elements;
+    treeContainer = { ...payload, [observePath]: restObserve };
+  } else {
+    treeContainer = payload;
+  }
+
+  const blocks: string[] = [OBSERVE_COMPACT_LEGEND, compactStringifyToolResponse(treeContainer)];
+
+  if (elements) {
+    for (const name of ELEMENT_ARRAY_NAMES) {
+      const arr = (elements as Record<string, unknown>)[name];
+      const records = Array.isArray(arr)
+        ? arr.map(el => flattenElementRecord(el as Record<string, unknown>))
+        : [];
+      blocks.push(encodeToonTable(name, records));
+    }
+  }
+
+  return blocks.join("\n");
 }

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -182,12 +182,9 @@ const ELEMENT_ARRAY_NAMES = ["clickable", "scrollable", "text", "media"] as cons
  * the model can parse the hybrid JSON+TOON format without out-of-band docs.
  */
 export const OBSERVE_COMPACT_LEGEND =
-  "# observe-compact (--observe-result-compact): line 2 = compact JSON of the result " +
-  "(viewHierarchy tree inline) with `elements` moved below as TOON. Each block: " +
-  "`name[count]{columns}:` header then one 2-space-indented CSV row per element; " +
-  "bounds flattened to bounds.left/top/right/bottom, nested node/objects kept as JSON " +
-  "cells; a cell is quoted when it holds a comma, double-quote, or newline (\"\" = a " +
-  "literal quote), and an empty cell means the field is absent.";
+  "# observe-compact: line 2 is compact JSON (viewHierarchy inline); elements.* follow as " +
+  "TOON tables `name[count]{cols}:` + one 2-space CSV row each (bounds->bounds.*, nested " +
+  'objects as JSON cells; cells quoted for , " or newline, "" = a quote, empty = absent).';
 
 /**
  * True when `value` is a plain object whose own values are all scalar — the
@@ -198,7 +195,13 @@ function isFlatScalarObject(value: unknown): value is Record<string, ToonScalar>
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }
-  return Object.values(value as Record<string, unknown>).every(
+  const entries = Object.values(value as Record<string, unknown>);
+  // An empty object has no columns to contribute; treat it as non-flat so it is
+  // preserved losslessly as a `{}` JSON cell rather than vanishing entirely.
+  if (entries.length === 0) {
+    return false;
+  }
+  return entries.every(
     v => v === null || (typeof v !== "object" && typeof v !== "function")
   );
 }
@@ -278,9 +281,12 @@ export function encodeObserveCompact(
   if (elements) {
     for (const name of ELEMENT_ARRAY_NAMES) {
       const arr = (elements as Record<string, unknown>)[name];
-      const records = Array.isArray(arr)
-        ? arr.map(el => flattenElementRecord(el as Record<string, unknown>))
-        : [];
+      // Skip empty arrays: a bare `name[0]{}:` header is pure noise/tokens and
+      // an absent block already reads as "no elements of this kind".
+      if (!Array.isArray(arr) || arr.length === 0) {
+        continue;
+      }
+      const records = arr.map(el => flattenElementRecord(el as Record<string, unknown>));
       blocks.push(encodeToonTable(name, records));
     }
   }

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -1,5 +1,9 @@
 import type { ObserveResult } from "../models/ObserveResult";
-import { sanitizeObserveResult, type SanitizeObserveConfig } from "../features/observe/output/ObserveResultOutput";
+import {
+  sanitizeObserveResult,
+  encodeObserveCompact,
+  type SanitizeObserveConfig,
+} from "../features/observe/output/ObserveResultOutput";
 import { serverConfig } from "../utils/ServerConfig";
 import { getStructuredPayload, stringifyToolResponse } from "../utils/toolUtils";
 
@@ -73,26 +77,35 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
   };
 
   // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
+  // `observePath` records WHERE it lives so the compact text encoder can detach
+  // the right `elements` block ("" = top-level, else the containing key).
   let sanitizedPayload: Record<string, unknown> | undefined;
+  let observePath: string | undefined;
   if (ctx.name === "observe" && isObserveResult(payload)) {
     sanitizedPayload = sanitizeObserveResult(payload as unknown as ObserveResult, cfg) as unknown as Record<string, unknown>;
+    observePath = "";
   } else if (isObserveResult(payload.observation)) {
     sanitizedPayload = {
       ...payload,
       observation: sanitizeObserveResult(payload.observation as ObserveResult, cfg),
     };
+    observePath = "observation";
   }
 
-  if (!sanitizedPayload) {
+  if (!sanitizedPayload || observePath === undefined) {
     return response;
   }
 
-  // Rewrite both representations from the same object so they cannot diverge.
+  // structuredContent MUST stay valid JSON (it is the schema-shaped duplicate),
+  // so the compact/TOON encoding only ever replaces the text block. When the
+  // compact flag is off, both representations are the same pretty JSON.
   if (hasStructured) {
     envelope.structuredContent = sanitizedPayload;
   }
   if (textPart) {
-    textPart.text = stringifyToolResponse(sanitizedPayload);
+    textPart.text = serverConfig.isObserveResultCompactEnabled()
+      ? encodeObserveCompact(sanitizedPayload, observePath)
+      : stringifyToolResponse(sanitizedPayload);
   }
 
   return response;

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -15,6 +15,16 @@ export const stringifyToolResponse = (content: unknown): string => {
 };
 
 /**
+ * No-indent variant of {@link stringifyToolResponse}. Same `extras` stripping so
+ * the two agree on content, but omits the 2-space pretty-printing — used by the
+ * `--observe-result-compact` text encoder (issue #2760) where indentation is
+ * pure token overhead.
+ */
+export const compactStringifyToolResponse = (content: unknown): string => {
+  return JSON.stringify(content, stripAccessibilityExtras);
+};
+
+/**
  * Interface for tool response formatter
  */
 export interface ToolResponseFormatter {

--- a/src/utils/toon.ts
+++ b/src/utils/toon.ts
@@ -1,0 +1,179 @@
+/**
+ * TOON (Token-Oriented Object Notation) writer/reader util for the MCP
+ * output-context reduction effort (issue #2760).
+ *
+ * TOON encodes a uniform array of objects as a single header row plus one data
+ * row per element, using indentation and a shared column list instead of
+ * repeating braces and keys on every element:
+ *
+ *   name[3]{col1,col2,col3}:
+ *     v1,v2,v3
+ *     v4,v5,v6
+ *
+ * On near-uniform tabular data (e.g. `observe` element arrays) this drops the
+ * per-element `{"key":...}` overhead JSON pays, for 30-60% fewer tokens. It is
+ * deliberately NOT used for ragged/variable-depth trees, where the header
+ * amortization never kicks in and the escaping risk is highest.
+ *
+ * Escaping (the acceptance-critical part): a cell is CSV-style quoted when it
+ * contains a comma, double quote, CR/LF, or edge whitespace, or when it is the
+ * empty string (so it can be told apart from an absent/`null` cell). Inside a
+ * quoted cell, a literal `"` is doubled. `null` / `undefined` / absent keys
+ * encode as an empty *unquoted* cell and decode back to `null`.
+ */
+
+/** Scalar cell inputs the encoder accepts. Objects/arrays must be pre-stringified. */
+export type ToonScalar = string | number | boolean | null | undefined;
+
+/** A decoded TOON block. `rows` cells are strings, or `null` for absent cells. */
+export interface ToonTable {
+  name: string;
+  columns: string[];
+  rows: (string | null)[][];
+}
+
+/** Table/array names must be bare identifiers so the header parses unambiguously. */
+const NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
+
+/**
+ * A token (cell or column name) must be quoted when it would otherwise be
+ * ambiguous: it holds a delimiter/quote/newline, has edge whitespace that a
+ * decoder would trim, or is the empty string (which must be distinguishable
+ * from an absent cell).
+ */
+function needsQuoting(value: string): boolean {
+  return value === "" || /[",\n\r]/.test(value) || /^\s|\s$/.test(value);
+}
+
+/** Escape a single token for a TOON header or row, quoting only when required. */
+function escapeToken(value: string): string {
+  if (!needsQuoting(value)) {
+    return value;
+  }
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/** Encode one cell: `null`/`undefined` -> empty unquoted cell; else escaped string. */
+function encodeCell(value: ToonScalar): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return escapeToken(String(value));
+}
+
+/**
+ * Split `input` on `sep` at the top level, honoring `"..."` quoting (with `""`
+ * as an escaped quote). Newlines inside quotes do not terminate a field, so the
+ * same routine splits both rows (sep = "\n") and cells (sep = ",").
+ */
+function splitTopLevel(input: string, sep: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (input[i + 1] === '"') {
+          current += '""';
+          i++;
+        } else {
+          current += '"';
+          inQuotes = false;
+        }
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"') {
+      current += '"';
+      inQuotes = true;
+    } else if (ch === sep) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Interpret a raw cell token: quoted -> unescaped string; empty -> null; else raw. */
+function decodeCell(raw: string): string | null {
+  if (raw.length === 0) {
+    return null;
+  }
+  if (raw.startsWith('"') && raw.endsWith('"') && raw.length >= 2) {
+    return raw.slice(1, -1).replace(/""/g, '"');
+  }
+  return raw;
+}
+
+/** Like `decodeCell` but for column names, which are always strings (never null). */
+function decodeColumn(raw: string): string {
+  return decodeCell(raw) ?? "";
+}
+
+/**
+ * Encode a uniform array of records as a TOON block. Columns are the union of
+ * all record keys in first-seen order, so ragged records still align to one
+ * grid. `name` must be a bare identifier (see {@link NAME_PATTERN}).
+ */
+export function encodeToonTable(name: string, records: Array<Record<string, ToonScalar>>): string {
+  if (!NAME_PATTERN.test(name)) {
+    throw new Error(`TOON table name must be a bare identifier, got: ${JSON.stringify(name)}`);
+  }
+
+  const columns: string[] = [];
+  const seen = new Set<string>();
+  for (const record of records) {
+    for (const key of Object.keys(record)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push(key);
+      }
+    }
+  }
+
+  const header = `${name}[${records.length}]{${columns.map(escapeToken).join(",")}}:`;
+  if (records.length === 0) {
+    return header;
+  }
+
+  const rows = records.map(record => "  " + columns.map(col => encodeCell(record[col])).join(","));
+  return [header, ...rows].join("\n");
+}
+
+/**
+ * Parse a TOON block back into `{ name, columns, rows }`. The inverse of
+ * {@link encodeToonTable}: cell strings round-trip byte-for-byte and absent
+ * cells come back as `null`.
+ */
+export function decodeToonTable(block: string): ToonTable {
+  const open = block.indexOf("[");
+  const name = block.slice(0, open);
+
+  const close = block.indexOf("]", open);
+  // Column list lives between the first `{` after `]` and the `}:` that ends the
+  // header line. Locate `}:` via the first top-level newline (or EOF) so a
+  // quoted `}` inside a column name cannot be mistaken for the terminator.
+  const braceOpen = block.indexOf("{", close);
+  const headerEnd = block.indexOf("\n");
+  const headerLine = headerEnd === -1 ? block : block.slice(0, headerEnd);
+  const braceClose = headerLine.lastIndexOf("}");
+  const colsRaw = block.slice(braceOpen + 1, braceClose);
+
+  const columns = colsRaw.length === 0 ? [] : splitTopLevel(colsRaw, ",").map(decodeColumn);
+
+  const rows: (string | null)[][] = [];
+  if (headerEnd !== -1) {
+    const region = block.slice(headerEnd + 1);
+    for (const rowStr of splitTopLevel(region, "\n")) {
+      // Strip the two-space structural indent, then split into cells.
+      const body = rowStr.startsWith("  ") ? rowStr.slice(2) : rowStr;
+      rows.push(splitTopLevel(body, ",").map(decodeCell));
+    }
+  }
+
+  return { name, columns, rows };
+}

--- a/src/utils/toon.ts
+++ b/src/utils/toon.ts
@@ -154,20 +154,39 @@ export function decodeToonTable(block: string): ToonTable {
   const name = block.slice(0, open);
 
   const close = block.indexOf("]", open);
-  // Column list lives between the first `{` after `]` and the `}:` that ends the
-  // header line. Locate `}:` via the first top-level newline (or EOF) so a
-  // quoted `}` inside a column name cannot be mistaken for the terminator.
+  // Column list lives between the first `{` after `]` and the `}` that closes it.
+  // Scan quote-aware for that closing brace so a quoted `}` OR a quoted newline
+  // inside a column name cannot be mistaken for the header terminator (a raw
+  // `indexOf('\n')` would truncate a column name that legitimately contains one).
   const braceOpen = block.indexOf("{", close);
-  const headerEnd = block.indexOf("\n");
-  const headerLine = headerEnd === -1 ? block : block.slice(0, headerEnd);
-  const braceClose = headerLine.lastIndexOf("}");
+  let braceClose = -1;
+  let inQuotes = false;
+  for (let i = braceOpen + 1; i < block.length; i++) {
+    const ch = block[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (block[i + 1] === '"') {
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === "}") {
+      braceClose = i;
+      break;
+    }
+  }
   const colsRaw = block.slice(braceOpen + 1, braceClose);
 
   const columns = colsRaw.length === 0 ? [] : splitTopLevel(colsRaw, ",").map(decodeColumn);
 
+  // The header ends at `}:`; data rows (if any) begin after the next newline.
+  const rowsStart = block.indexOf("\n", braceClose + 1);
   const rows: (string | null)[][] = [];
-  if (headerEnd !== -1) {
-    const region = block.slice(headerEnd + 1);
+  if (rowsStart !== -1) {
+    const region = block.slice(rowsStart + 1);
     for (const rowStr of splitTopLevel(region, "\n")) {
       // Strip the two-space structural indent, then split into cells.
       const body = rowStr.startsWith("  ") ? rowStr.slice(2) : rowStr;

--- a/test/features/observe/output/ObserveResultCompact.test.ts
+++ b/test/features/observe/output/ObserveResultCompact.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult } from "../../../../src/models/ObserveResult";
+import {
+  encodeObserveCompact,
+  OBSERVE_COMPACT_LEGEND,
+} from "../../../../src/features/observe/output/ObserveResultOutput";
+import { decodeToonTable } from "../../../../src/utils/toon";
+import {
+  loadAndroidHomeObserve,
+  measureValue,
+} from "../../../fixtures/observe/observeFixture";
+
+/**
+ * Tests for the `--observe-result-compact` text encoder (issue #2760).
+ *
+ * Format contract:
+ *  - line 1 is the self-describing legend.
+ *  - line 2 is compact (no-indent) JSON of the payload with `elements` detached
+ *    (the ragged `viewHierarchy` tree stays inline as JSON — highest escaping
+ *    risk, least TOON benefit).
+ *  - the uniform `elements.*` arrays follow as TOON blocks.
+ *  - the transform is pure: the input `ObserveResult` is never mutated.
+ */
+
+/** Split the compact text into { legend, treeJson, toonBlocks-by-name }. */
+function parseCompact(text: string): {
+  legend: string;
+  tree: Record<string, unknown>;
+  blocks: Record<string, ReturnType<typeof decodeToonTable>>;
+} {
+  const lines = text.split("\n");
+  const legend = lines[0];
+  const tree = JSON.parse(lines[1]) as Record<string, unknown>;
+  const blocks: Record<string, ReturnType<typeof decodeToonTable>> = {};
+  // Everything from line 2 onward is TOON; re-join and split on header lines.
+  const rest = lines.slice(2).join("\n");
+  // Header lines look like `name[count]{...}:` at column 0.
+  const headerRe = /^[A-Za-z0-9_.-]+\[\d+\]\{/;
+  let currentName: string | null = null;
+  let buffer: string[] = [];
+  const flush = () => {
+    if (currentName) {
+      blocks[currentName] = decodeToonTable(buffer.join("\n"));
+    }
+  };
+  for (const line of rest.split("\n")) {
+    if (headerRe.test(line)) {
+      flush();
+      currentName = line.slice(0, line.indexOf("["));
+      buffer = [line];
+    } else if (currentName) {
+      buffer.push(line);
+    }
+  }
+  flush();
+  return { legend, tree, blocks };
+}
+
+describe("encodeObserveCompact", () => {
+  test("first line is the legend", () => {
+    const { observe } = loadAndroidHomeObserve();
+    const text = encodeObserveCompact(observe, "");
+    expect(text.split("\n")[0]).toBe(OBSERVE_COMPACT_LEGEND);
+  });
+
+  test("second line is compact JSON with elements detached but viewHierarchy inline", () => {
+    const { observe } = loadAndroidHomeObserve();
+    const text = encodeObserveCompact(observe, "");
+    const { tree } = parseCompact(text);
+    expect(tree.elements).toBeUndefined();
+    expect(tree.viewHierarchy).toBeDefined();
+    // Compact JSON: no pretty-print newlines inside the tree line.
+    expect(text.split("\n")[1].startsWith("{")).toBe(true);
+  });
+
+  test("emits a TOON block per element array with matching counts", () => {
+    const { observe } = loadAndroidHomeObserve();
+    const text = encodeObserveCompact(observe, "");
+    const { blocks } = parseCompact(text);
+    expect(blocks.clickable.rows.length).toBe(observe.elements!.clickable.length);
+    expect(blocks.text.rows.length).toBe(observe.elements!.text.length);
+    expect(blocks.media.rows.length).toBe(observe.elements!.media.length);
+    expect(blocks.scrollable.rows.length).toBe(observe.elements!.scrollable.length);
+  });
+
+  test("flattens bounds to bounds.* columns and preserves values", () => {
+    const observe: ObserveResult = {
+      updatedAt: 1,
+      screenSize: { width: 1080, height: 2400 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      elements: {
+        clickable: [
+          { bounds: { left: 10, top: 20, right: 30, bottom: 40 }, text: "Go" },
+        ],
+        scrollable: [],
+        text: [],
+        media: [],
+      },
+    } as unknown as ObserveResult;
+    const { blocks } = parseCompact(encodeObserveCompact(observe, ""));
+    const t = blocks.clickable;
+    expect(t.columns).toContain("bounds.left");
+    expect(t.columns).toContain("bounds.bottom");
+    const row = Object.fromEntries(t.columns.map((c, i) => [c, t.rows[0][i]]));
+    expect(row["bounds.left"]).toBe("10");
+    expect(row["bounds.bottom"]).toBe("40");
+    expect(row["text"]).toBe("Go");
+  });
+
+  test("nested node subtree is preserved as a JSON cell (lossless)", () => {
+    const node = { "resource-id": "x", "bounds": { left: 1, top: 2, right: 3, bottom: 4 } };
+    const observe: ObserveResult = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      elements: {
+        clickable: [{ bounds: { left: 0, top: 0, right: 1, bottom: 1 }, node }],
+        scrollable: [],
+        text: [],
+        media: [],
+      },
+    } as unknown as ObserveResult;
+    const { blocks } = parseCompact(encodeObserveCompact(observe, ""));
+    const t = blocks.clickable;
+    const nodeCol = t.columns.indexOf("node");
+    expect(nodeCol).toBeGreaterThanOrEqual(0);
+    expect(JSON.parse(t.rows[0][nodeCol]!)).toEqual(node);
+  });
+
+  test("accessibility `extras` are stripped inside nested node cells (matches the tree)", () => {
+    const node = {
+      "resource-id": "x",
+      "extras": { "AccessibilityNodeInfo.roleDescription": "View" },
+      "node": { text: "leaf", extras: { foo: "bar" } },
+    };
+    const observe: ObserveResult = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      elements: {
+        clickable: [{ bounds: { left: 0, top: 0, right: 1, bottom: 1 }, node }],
+        scrollable: [],
+        text: [],
+        media: [],
+      },
+    } as unknown as ObserveResult;
+    const { blocks } = parseCompact(encodeObserveCompact(observe, ""));
+    const t = blocks.clickable;
+    const nodeCell = t.rows[0][t.columns.indexOf("node")]!;
+    expect(nodeCell).not.toContain("extras");
+    const parsed = JSON.parse(nodeCell);
+    expect(parsed.extras).toBeUndefined();
+    expect(parsed.node.extras).toBeUndefined();
+    // Non-extras data survives.
+    expect(parsed["resource-id"]).toBe("x");
+    expect(parsed.node.text).toBe("leaf");
+  });
+
+  test("adversarial text with commas/quotes/newlines round-trips through the TOON cell", () => {
+    const nasty = 'Buy 2, get "1" free\nnow';
+    const observe: ObserveResult = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      elements: {
+        clickable: [],
+        scrollable: [],
+        text: [{ bounds: { left: 0, top: 0, right: 1, bottom: 1 }, text: nasty }],
+        media: [],
+      },
+    } as unknown as ObserveResult;
+    const { blocks } = parseCompact(encodeObserveCompact(observe, ""));
+    const t = blocks.text;
+    const textCol = t.columns.indexOf("text");
+    expect(t.rows[0][textCol]).toBe(nasty);
+  });
+
+  test("strips accessibility `extras` from element rows", () => {
+    const observe: ObserveResult = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      elements: {
+        clickable: [
+          {
+            bounds: { left: 0, top: 0, right: 1, bottom: 1 },
+            text: "hi",
+            extras: { "AccessibilityNodeInfo.roleDescription": "View" },
+          },
+        ],
+        scrollable: [],
+        text: [],
+        media: [],
+      },
+    } as unknown as ObserveResult;
+    const { blocks } = parseCompact(encodeObserveCompact(observe, ""));
+    expect(blocks.clickable.columns).not.toContain("extras");
+  });
+
+  test("does not mutate the input ObserveResult", () => {
+    const { observe } = loadAndroidHomeObserve();
+    const before = JSON.stringify(observe);
+    encodeObserveCompact(observe, "");
+    expect(JSON.stringify(observe)).toBe(before);
+  });
+
+  test("wrapper path compacts the .observation elements and keeps sibling fields", () => {
+    const { observe } = loadAndroidHomeObserve();
+    const payload = { success: true, observation: observe } as unknown as Record<string, unknown>;
+    const text = encodeObserveCompact(payload, "observation");
+    const { tree, blocks } = parseCompact(text);
+    expect(tree.success).toBe(true);
+    expect((tree.observation as Record<string, unknown>).elements).toBeUndefined();
+    expect((tree.observation as Record<string, unknown>).viewHierarchy).toBeDefined();
+    expect(blocks.clickable.rows.length).toBe(observe.elements!.clickable.length);
+  });
+
+  test("compact text is meaningfully smaller than pretty JSON on the #2755 fixture", () => {
+    const { observe } = loadAndroidHomeObserve();
+    const prettyBytes = measureValue(observe).bytes;
+    const compactBytes = Buffer.byteLength(encodeObserveCompact(observe, ""), "utf8");
+    expect(compactBytes).toBeLessThan(prettyBytes);
+    // Expect a substantial win from de-indenting + TOON (guard against regressions).
+    expect(compactBytes).toBeLessThan(prettyBytes * 0.75);
+  });
+
+  test("compact text carries the same primitive top-level fields as pretty JSON", () => {
+    const { observe } = loadAndroidHomeObserve();
+    const { tree } = parseCompact(encodeObserveCompact(observe, ""));
+    // Spot-check that non-elements data survives the compact encoding intact.
+    expect(tree.updatedAt).toEqual(observe.updatedAt);
+    expect(tree.rotation).toEqual(observe.rotation as unknown);
+    expect(JSON.stringify(tree.screenSize)).toBe(JSON.stringify(observe.screenSize));
+  });
+});

--- a/test/features/observe/output/ObserveResultCompact.test.ts
+++ b/test/features/observe/output/ObserveResultCompact.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { ObserveResult } from "../../../../src/models/ObserveResult";
 import {
   encodeObserveCompact,
+  sanitizeObserveResult,
   OBSERVE_COMPACT_LEGEND,
 } from "../../../../src/features/observe/output/ObserveResultOutput";
 import { decodeToonTable } from "../../../../src/utils/toon";
@@ -215,13 +216,59 @@ describe("encodeObserveCompact", () => {
     expect(blocks.clickable.rows.length).toBe(observe.elements!.clickable.length);
   });
 
-  test("compact text is meaningfully smaller than pretty JSON on the #2755 fixture", () => {
+  test("compact text is smaller than the sanitized-pretty ship baseline on the #2755 fixture", () => {
+    // Honest baseline: finalizeToolResponse ALWAYS sanitizes before encoding
+    // (#2757), so the real comparison is compact vs sanitized-pretty, not raw
+    // pretty. Sanitize does most of the reduction; compact/TOON is the marginal
+    // win on top. Measuring against raw pretty would over-credit this change.
     const { observe } = loadAndroidHomeObserve();
-    const prettyBytes = measureValue(observe).bytes;
-    const compactBytes = Buffer.byteLength(encodeObserveCompact(observe, ""), "utf8");
-    expect(compactBytes).toBeLessThan(prettyBytes);
-    // Expect a substantial win from de-indenting + TOON (guard against regressions).
-    expect(compactBytes).toBeLessThan(prettyBytes * 0.75);
+    const sanitized = sanitizeObserveResult(observe, { dropElements: false });
+    const sanitizedPrettyBytes = measureValue(sanitized).bytes;
+    const compactBytes = Buffer.byteLength(
+      encodeObserveCompact(sanitized as unknown as Record<string, unknown>, ""),
+      "utf8"
+    );
+    expect(compactBytes).toBeLessThan(sanitizedPrettyBytes);
+    // De-indent + TOON should still land well under the sanitized-pretty text.
+    expect(compactBytes).toBeLessThan(sanitizedPrettyBytes * 0.6);
+  });
+
+  test("empty element arrays are omitted (no bare name[0]{}: noise)", () => {
+    const observe: ObserveResult = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      elements: {
+        clickable: [{ bounds: { left: 0, top: 0, right: 1, bottom: 1 }, text: "hi" }],
+        scrollable: [],
+        text: [],
+        media: [],
+      },
+    } as unknown as ObserveResult;
+    const text = encodeObserveCompact(observe, "");
+    expect(text).toContain("clickable[");
+    expect(text).not.toContain("scrollable[");
+    expect(text).not.toContain("text[");
+    expect(text).not.toContain("media[");
+  });
+
+  test("an empty-object element value is preserved as a {} cell, not dropped", () => {
+    const observe: ObserveResult = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      elements: {
+        clickable: [{ bounds: { left: 0, top: 0, right: 1, bottom: 1 }, meta: {} }],
+        scrollable: [],
+        text: [],
+        media: [],
+      },
+    } as unknown as ObserveResult;
+    const { blocks } = parseCompact(encodeObserveCompact(observe, ""));
+    const t = blocks.clickable;
+    const metaCol = t.columns.indexOf("meta");
+    expect(metaCol).toBeGreaterThanOrEqual(0);
+    expect(t.rows[0][metaCol]).toBe("{}");
   });
 
   test("compact text carries the same primitive top-level fields as pretty JSON", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -211,6 +211,37 @@ describe("finalizeToolResponse", () => {
       );
       expect(finalized.content[0].text).toBe(stringifyToolResponse(payload));
     });
+
+    test("compact + dropElements compose: no TOON blocks, elements gone from both reps", () => {
+      serverConfig.setObserveResultCompactEnabled(true);
+      serverConfig.setObserveResultDropElementsEnabled(true);
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(makeObserveResult()),
+        { name: "observe" }
+      );
+      // dropElements removes elements before the encoder runs → no TOON blocks,
+      // and structuredContent consistently omits elements too.
+      const text = finalized.content[0].text;
+      expect(text.split("\n")[0]).toContain("observe-compact");
+      expect(text).not.toContain("clickable[");
+      expect((finalized.structuredContent as ObserveResult).elements).toBeUndefined();
+      expect(JSON.parse(text.split("\n")[1]).elements).toBeUndefined();
+    });
+
+    test("compact text survives a later structuredContent strip (compact + no-structured-content)", () => {
+      // #2759 strips structuredContent at the wire boundary AFTER finalize. Here
+      // we simulate that ordering: finalize produces compact text, then the
+      // structuredContent is dropped — the compact text block is unaffected.
+      serverConfig.setObserveResultCompactEnabled(true);
+      const finalized: any = finalizeToolResponse(
+        createStructuredToolResponse(makeObserveResult()),
+        { name: "observe" }
+      );
+      const compactText = finalized.content[0].text;
+      delete finalized.structuredContent;
+      expect(finalized.content[0].text).toBe(compactText);
+      expect(compactText.split("\n")[0]).toContain("observe-compact");
+    });
   });
 
   test("EC5: non-JSON text-only responses pass through unchanged", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -4,6 +4,7 @@ import { createStructuredToolResponse, stringifyToolResponse } from "../../src/u
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { GFXINFO_DUMP_MARKER } from "../../src/features/observe/output/ObserveResultOutput";
 import type { ObserveResult } from "../../src/models/ObserveResult";
+import { loadAndroidHomeObserve } from "../fixtures/observe/observeFixture";
 
 /**
  * Build a minimal ObserveResult whose hierarchy carries trimmable attributes:
@@ -44,14 +45,19 @@ function makeObserveResult(): ObserveResult {
 
 describe("finalizeToolResponse", () => {
   let originalDropElements: boolean;
+  let originalCompact: boolean;
 
   beforeEach(() => {
     originalDropElements = serverConfig.isObserveResultDropElementsEnabled();
+    originalCompact = serverConfig.isObserveResultCompactEnabled();
     serverConfig.setObserveResultDropElementsEnabled(false);
+    // Compact defaults off; the JSON-mirror assertions below rely on it being off.
+    serverConfig.setObserveResultCompactEnabled(false);
   });
 
   afterEach(() => {
     serverConfig.setObserveResultDropElementsEnabled(originalDropElements);
+    serverConfig.setObserveResultCompactEnabled(originalCompact);
   });
 
   test("EC1: observe response is sanitized in both structuredContent and text", () => {
@@ -135,6 +141,76 @@ describe("finalizeToolResponse", () => {
     const finalized = finalizeToolResponse(imageResponse, { name: "observe" });
     expect(finalized).toBe(imageResponse);
     expect(finalized.content[0].type).toBe("image");
+  });
+
+  describe("--observe-result-compact", () => {
+    test("compact flag rewrites only the text block; structuredContent stays valid JSON", () => {
+      serverConfig.setObserveResultCompactEnabled(true);
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(makeObserveResult()),
+        { name: "observe" }
+      );
+
+      // structuredContent remains the sanitized JSON object (with elements intact).
+      const sc = finalized.structuredContent as ObserveResult;
+      expect(sc.viewHierarchy).toBeDefined();
+      expect(sc.elements).toBeDefined();
+
+      // The text block is the compact/TOON form — NOT the pretty JSON mirror.
+      const text = finalized.content[0].text;
+      expect(text).not.toBe(stringifyToolResponse(sc));
+      expect(text.split("\n")[0]).toContain("observe-compact");
+      // Line 2 is compact JSON with elements moved out to TOON blocks below.
+      expect(JSON.parse(text.split("\n")[1]).elements).toBeUndefined();
+      expect(text).toContain("clickable[");
+    });
+
+    test("compact flag shrinks the text block versus pretty JSON on the real fixture", () => {
+      // Measured on the #2755 baseline (not the trivial synthetic result): the
+      // fixed legend line only amortizes on a real-sized payload.
+      const pretty = finalizeToolResponse(
+        createStructuredToolResponse(loadAndroidHomeObserve().observe),
+        { name: "observe" }
+      ).content[0].text;
+
+      serverConfig.setObserveResultCompactEnabled(true);
+      const compact = finalizeToolResponse(
+        createStructuredToolResponse(loadAndroidHomeObserve().observe),
+        { name: "observe" }
+      ).content[0].text;
+
+      expect(Buffer.byteLength(compact, "utf8")).toBeLessThan(
+        Buffer.byteLength(pretty, "utf8")
+      );
+    });
+
+    test("compact flag applies to a nested .observation payload too", () => {
+      serverConfig.setObserveResultCompactEnabled(true);
+      const actionPayload = { success: true, observation: makeObserveResult() };
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(actionPayload),
+        { name: "tapOn" }
+      );
+
+      const text = finalized.content[0].text;
+      expect(text.split("\n")[0]).toContain("observe-compact");
+      const tree = JSON.parse(text.split("\n")[1]);
+      expect(tree.success).toBe(true);
+      expect(tree.observation.elements).toBeUndefined();
+      expect(tree.observation.viewHierarchy).toBeDefined();
+      // structuredContent is untouched valid JSON.
+      expect((finalized.structuredContent as any).observation.elements).toBeDefined();
+    });
+
+    test("compact flag leaves non-observe responses unchanged", () => {
+      serverConfig.setObserveResultCompactEnabled(true);
+      const payload = { success: true, message: "done" };
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(payload),
+        { name: "pressButton" }
+      );
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(payload));
+    });
   });
 
   test("EC5: non-JSON text-only responses pass through unchanged", () => {

--- a/test/utils/toon.test.ts
+++ b/test/utils/toon.test.ts
@@ -133,6 +133,16 @@ describe("encodeToonTable / decodeToonTable", () => {
     expect(table.rows[0]).toEqual(["v", "w"]);
   });
 
+  test("column names containing newlines / braces / colons round-trip", () => {
+    // The header terminator must be found quote-aware, not via a raw indexOf of
+    // the first newline or `}` — otherwise a quoted column name containing one
+    // would truncate the whole header.
+    const block = encodeToonTable("t", [{ "we\nird}:": "v", "a,b": "w" }]);
+    const table = decodeToonTable(block);
+    expect(table.columns).toEqual(["we\nird}:", "a,b"]);
+    expect(table.rows[0]).toEqual(["v", "w"]);
+  });
+
   test("rejects a name that is not a bare identifier", () => {
     expect(() => encodeToonTable("bad name", [{ a: 1 }])).toThrow();
   });

--- a/test/utils/toon.test.ts
+++ b/test/utils/toon.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { encodeToonTable, decodeToonTable, type ToonScalar } from "../../src/utils/toon";
+
+/**
+ * Round-trip and escaping tests for the TOON (Token-Oriented Object Notation)
+ * writer util (issue #2760). TOON encodes a uniform array of objects as a
+ * `name[count]{col,...}:` header plus one indented CSV-style row per record, so
+ * it drops the repeated braces/keys that JSON pays per element. The acceptance
+ * bar for the issue is adversarial escaping fidelity: node `text` /
+ * `content-desc` values carry arbitrary commas, quotes, and newlines, and none
+ * of them may corrupt the row grid.
+ *
+ * Contract exercised here:
+ *  - `null` / `undefined` / absent key  -> empty (unquoted) cell -> decodes to `null`.
+ *  - empty string `""`                  -> quoted empty cell     -> decodes to `""`.
+ *  - a cell needing quoting (`,`/`"`/newline/edge whitespace) is quoted, with
+ *    inner `"` doubled, and survives a decode round-trip byte-for-byte.
+ */
+
+/** Decode helper: map a record through encode -> decode, returning the single row. */
+function roundTripRow(record: Record<string, ToonScalar>): (string | null)[] {
+  const block = encodeToonTable("t", [record]);
+  const table = decodeToonTable(block);
+  return table.rows[0];
+}
+
+describe("encodeToonTable / decodeToonTable", () => {
+  test("header carries name, count, and union of columns in first-seen order", () => {
+    const block = encodeToonTable("clickable", [
+      { a: 1, b: 2 },
+      { a: 3, c: 4 },
+    ]);
+    const firstLine = block.split("\n")[0];
+    expect(firstLine).toBe("clickable[2]{a,b,c}:");
+  });
+
+  test("empty array yields a zero-count header and no data rows", () => {
+    const block = encodeToonTable("text", []);
+    expect(block).toBe("text[0]{}:");
+    const table = decodeToonTable(block);
+    expect(table.name).toBe("text");
+    expect(table.columns).toEqual([]);
+    expect(table.rows).toEqual([]);
+  });
+
+  test("data rows are indented and comma-joined in column order", () => {
+    const block = encodeToonTable("m", [{ x: 1, y: "hi" }]);
+    const lines = block.split("\n");
+    expect(lines[0]).toBe("m[1]{x,y}:");
+    expect(lines[1]).toBe("  1,hi");
+  });
+
+  test("scalars round-trip as their string form", () => {
+    expect(roundTripRow({ n: 42, f: 3.5, b: true, z: false })).toEqual([
+      "42",
+      "3.5",
+      "true",
+      "false",
+    ]);
+  });
+
+  test("null / undefined / absent decode to null; empty string decodes to \"\"", () => {
+    // Column union is {present, empty, nullish}; the third record omits `present`.
+    const block = encodeToonTable("t", [
+      { present: "v", empty: "", nullish: null },
+      { present: "w", empty: "", nullish: undefined },
+    ]);
+    const table = decodeToonTable(block);
+    expect(table.columns).toEqual(["present", "empty", "nullish"]);
+    expect(table.rows[0]).toEqual(["v", "", null]);
+    expect(table.rows[1]).toEqual(["w", "", null]);
+  });
+
+  test("values with commas are quoted and round-trip intact", () => {
+    const block = encodeToonTable("t", [{ label: "Wed, Jul 1" }]);
+    expect(block.split("\n")[1]).toBe('  "Wed, Jul 1"');
+    expect(roundTripRow({ label: "Wed, Jul 1" })).toEqual(["Wed, Jul 1"]);
+  });
+
+  test("embedded double quotes are doubled and round-trip intact", () => {
+    const value = 'say "hi" now';
+    const block = encodeToonTable("t", [{ label: value }]);
+    expect(block.split("\n")[1]).toBe('  "say ""hi"" now"');
+    expect(roundTripRow({ label: value })).toEqual([value]);
+  });
+
+  test("newlines and carriage returns survive a round-trip", () => {
+    const value = "line1\nline2\r\nline3";
+    expect(roundTripRow({ label: value })).toEqual([value]);
+  });
+
+  test("leading/trailing whitespace is preserved via quoting", () => {
+    expect(roundTripRow({ label: "  padded  " })).toEqual(["  padded  "]);
+  });
+
+  test("adversarial mixed record round-trips every cell", () => {
+    const record: Record<string, ToonScalar> = {
+      "text": 'a,b,"c",\nd',
+      "content-desc": "plain",
+      "count": 7,
+      "flag": false,
+      "missing": null,
+      "blank": "",
+    };
+    const block = encodeToonTable("clickable", [record]);
+    const table = decodeToonTable(block);
+    expect(table.columns).toEqual([
+      "text",
+      "content-desc",
+      "count",
+      "flag",
+      "missing",
+      "blank",
+    ]);
+    expect(table.rows[0]).toEqual(['a,b,"c",\nd', "plain", "7", "false", null, ""]);
+  });
+
+  test("multiple rows with ragged keys align to the shared column grid", () => {
+    const block = encodeToonTable("t", [
+      { a: "1", b: "2" },
+      { b: "3", c: "4" },
+    ]);
+    const table = decodeToonTable(block);
+    expect(table.columns).toEqual(["a", "b", "c"]);
+    expect(table.rows[0]).toEqual(["1", "2", null]);
+    expect(table.rows[1]).toEqual([null, "3", "4"]);
+  });
+
+  test("column names needing escaping round-trip", () => {
+    const block = encodeToonTable("t", [{ "weird,name": "v", "normal": "w" }]);
+    const table = decodeToonTable(block);
+    expect(table.columns).toEqual(["weird,name", "normal"]);
+    expect(table.rows[0]).toEqual(["v", "w"]);
+  });
+
+  test("rejects a name that is not a bare identifier", () => {
+    expect(() => encodeToonTable("bad name", [{ a: 1 }])).toThrow();
+  });
+});


### PR DESCRIPTION
## What

Implements the experimental compact/TOON observe encoding behind the
already-plumbed `--observe-result-compact` flag (issue #2760). When enabled,
the `observe` (and any `.observation`) **text block** is emitted as:

1. a one-line self-describing **legend**,
2. the payload as **compact (no-indent) JSON** with `elements` detached — the
   ragged `viewHierarchy` tree stays inline as JSON, and
3. one **TOON** table per non-empty `elements.clickable/scrollable/text/media` array.

`structuredContent` is left as valid JSON — only `content[0].text` changes.

Closes #2760.

## Why

An observe result exceeds the MCP tool-output token cap (#2755). The prior
issues in the series trimmed and de-duplicated the payload (#2757–#2759); this
one attacks serialization overhead of the text block.

TOON (Token-Oriented Object Notation) writes a uniform array of objects as a
`name[count]{columns}:` header plus one indented CSV-style row per element,
dropping the per-element `{"key":...}` braces JSON repeats. The `elements.*`
arrays are near-uniform tabular data — TOON's sweet spot — while the
variable-depth `viewHierarchy` tree is left as compact JSON (little TOON
benefit, highest escaping risk).

### Honest measurement (from the 3-persona review)

`finalizeToolResponse` **always sanitizes** (#2757) before encoding, so the real
ship-path baseline is *sanitized-pretty*, not raw pretty. On the #2755 fixture:

| representation | bytes | tokens |
|---|---|---|
| raw pretty | 84,527 | 21,911 |
| sanitized-pretty (ship baseline) | 64,225 | 13,789 |
| **compact/TOON** | **28,164** | **8,506** |

So compact is **43.9% of the sanitized-pretty bytes / 61.7% of its tokens**
(~38% token reduction over the real baseline). Most of that is de-indentation;
TOON itself is the marginal win on top (~2–3% of tokens on this fixture). See
follow-up below on whether TOON earns its complexity vs compact-JSON-only.

Note the flag only reduces **wire** tokens when combined with
`--tool-results-no-structured-content` (#2759) — otherwise the full JSON is
still sent under `structuredContent`. The flag description documents this.

## How

- **`src/utils/toon.ts`** — general TOON writer/reader for uniform arrays of
  flat scalar records. Columns are the first-seen union of keys; cells are
  CSV-quoted only for a comma, double-quote, CR/LF, or edge whitespace (`""`
  escapes a literal quote). `null`/absent → empty unquoted cell → decodes to
  `null`; empty string → quoted empty cell — distinguishable on round-trip.
  A quote-aware splitter handles newlines inside quoted cells for both rows and
  cells, and the header terminator is found quote-aware too.
- **`ObserveResultOutput.encodeObserveCompact`** — pure/output-only encoder.
  `bounds` flattens to `bounds.left/top/right/bottom`; nested `node` subtrees
  and other objects are kept losslessly as a compact-JSON cell routed through
  the extras-stripping formatter (drops the accessibility `extras` bag, matching
  the tree). Empty element arrays are skipped; an empty-object value is kept as
  a `{}` cell rather than dropped.
- **`finalizeToolResponse`** — when the flag is on, rewrites only the text block
  for the top-level `observe` payload and nested `.observation` payloads;
  `structuredContent` stays the sanitized JSON.

## Testing

- `test/utils/toon.test.ts` — round-trip + adversarial escaping (commas, quotes,
  newlines, edge whitespace, null-vs-empty, ragged columns, newline/brace/colon
  in column names).
- `test/features/observe/output/ObserveResultCompact.test.ts` — format contract,
  bounds flattening, lossless node cell, extras stripping in nested cells,
  empty-object preservation, empty-block skipping, purity, wrapper path, honest
  byte-delta vs sanitized-pretty.
- `test/server/finalizeToolResponse.test.ts` — flag rewrites only the text block,
  applies to `.observation`, shrinks vs pretty on the real fixture,
  compact+dropElements and compact+no-structured-content composition, and leaves
  non-observe responses untouched.

49 new/updated tests; full suite green (pre-existing PerceptualHasher/jimp image
failures on this machine are unrelated).

## Notes / follow-ups (to be filed)

- **Experimental, off by default.** The text block is no longer JSON when on, so
  a programmatic consumer that `JSON.parse`s `content[].text` should read
  `structuredContent` instead. The Swift XCTestRunner client only parses
  `executePlan` results, not `observe`, so it is unaffected; the TS `--cli`
  path try/catches and degrades gracefully.
- **Does TOON earn its keep?** The review measured TOON at ~2–3% of tokens over
  compact-JSON-only on this fixture, at the cost of ~180 lines of escaping
  machinery and a non-JSON text block. The issue mandates TOON; filing a
  follow-up so the maintainer can sign off on the format (per the issue's
  "Format signed off on first real output" acceptance) or opt for compact-JSON.
- **`elements.*.node` duplicates the hierarchy** — the higher-leverage lever is
  `--observe-result-drop-elements` (#2757), which removes the whole block.