### PR TITLE
perf(db): add storage_events key-lookup seek index + thread previousValue (#2798)

### DIFF
--- a/src/db/migrations/2026_07_04_000_storage_events_key_lookup.ts
+++ b/src/db/migrations/2026_07_04_000_storage_events_key_lookup.ts
@@ -1,0 +1,60 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Seek-reduction index for `recordStorageEvent`'s per-insert previous-value
+ * lookup (#2798).
+ *
+ * On every storage telemetry insert that doesn't already carry `previousValue`,
+ * `storageEventRepository.recordStorageEvent` runs:
+ *
+ *   SELECT value FROM storage_events
+ *   WHERE device_id=? AND file_name=? AND key=?
+ *   ORDER BY timestamp DESC LIMIT 1
+ *
+ * #2798 was filed against the pre-#2788 schema, where the only usable index was
+ * the standalone `idx_storage_events_device` and the plan showed
+ * `USE TEMP B-TREE FOR ORDER BY`. That temp B-tree is ALREADY gone: PR #2890
+ * (#2788) added `idx_storage_events_device_timestamp (device_id, timestamp)` and
+ * PR #2904 (#2893) dropped the standalone device index, so the composite's
+ * `device_id` prefix now supplies the DESC order for free.
+ *
+ * What remains — and what this index fixes — is the SEEK width. With only the
+ * `(device_id, timestamp)` composite the planner seeks on `device_id=?` and then
+ * scans every row for that device in timestamp order, applying the `file_name=?`
+ * and `key=?` filters row-by-row until the first match. A device with many
+ * distinct keys makes that scan arbitrarily long. `(device_id, file_name, key,
+ * timestamp)` turns the three equality predicates into a single prefix seek that
+ * descends straight to the target key's rows, and the trailing `timestamp` column
+ * still yields the newest row without a sort (SQLite walks the ascending index
+ * backward for `ORDER BY timestamp DESC`).
+ *
+ * NOT a covering index (per Mira Kessler's review on #2798): the query selects
+ * `value`, which is deliberately NOT in the index — `value` is an arbitrarily
+ * large TEXT blob, and widening the index to make the read index-only is a bad
+ * trade. The plan is a prefix seek + one rowid lookup for `value`; the name is
+ * `_key_lookup` (a seek-reduction index), NOT `_covering`.
+ *
+ * Distinct from `idx_storage_events_device_timestamp` (#2788), not a
+ * planner-redundant near-duplicate: that composite serves the device-scoped
+ * getter (`WHERE device_id=? ORDER BY timestamp DESC`) and cannot serve this
+ * three-equality predicate as a prefix seek; this index cannot serve the
+ * device-only getter's ordering as efficiently. The planner picks each for its
+ * own shape.
+ *
+ * Additive and forward-only, `.ifNotExists()` / `.ifExists()` so the migration
+ * survives #2785's destructive-recovery replay (drop-all then replay every
+ * migration on an empty DB) in unusual orders. Sorts after
+ * `2026_07_03_*`, so `storage_events` exists when it runs during a full replay.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex("idx_storage_events_key_lookup")
+    .ifNotExists()
+    .on("storage_events")
+    .columns(["device_id", "file_name", "key", "timestamp"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_storage_events_key_lookup").ifExists().execute();
+}

--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
+import { logger } from "../utils/logger";
 
 export interface RecordStorageEventInput {
   deviceId: string | null;
@@ -28,9 +29,21 @@ export async function recordStorageEvent(
 ): Promise<void> {
   const d = getDb(db);
 
-  // Look up the previous value for this key if not already provided
+  // Look up the previous value for this key only when the caller did not supply
+  // one. `!== undefined` (not `?? null`) is deliberate: a caller that passes an
+  // explicit `previousValue: null` is asserting "there is no prior value" and
+  // must NOT trigger the lookup — otherwise a stale older row would silently
+  // override that intent. Omitting the field (undefined) is the only auto-lookup
+  // trigger.
+  //
+  // The lookup predicate (device_id=? AND file_name=? AND key=? ORDER BY
+  // timestamp DESC LIMIT 1) is served by idx_storage_events_key_lookup as a
+  // prefix seek (#2798). `file_name` is a non-null column on both the table and
+  // RecordStorageEventInput, so it never binds NULL here (a NULL bind would make
+  // `file_name = ?` match nothing regardless of the index).
   let previousValue: string | null = input.previousValue ?? null;
-  if (previousValue === null && input.key !== null && input.deviceId !== null) {
+  const previousValueSupplied = input.previousValue !== undefined;
+  if (!previousValueSupplied && input.key !== null && input.deviceId !== null) {
     try {
       const q = d
         .selectFrom("storage_events")
@@ -44,8 +57,10 @@ export async function recordStorageEvent(
       if (prev) {
         previousValue = prev.value;
       }
-    } catch {
-      // best-effort lookup
+    } catch (error) {
+      // Best-effort lookup: a failure here must not block the insert, but log so
+      // it leaves a trace (CLAUDE.md error-handling convention — no bare swallow).
+      logger.warn(`storage_events previous-value lookup failed: ${error}`, error);
     }
   }
 
@@ -124,8 +139,11 @@ async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
           .execute();
       }
     }
-  } catch {
-    // best-effort cleanup
+  } catch (error) {
+    // Best-effort retention cleanup: a failure must not surface to the telemetry
+    // write path, but log so it leaves a trace (CLAUDE.md error-handling
+    // convention — no bare swallow).
+    logger.warn(`storage_events retention cleanup failed: ${error}`, error);
   } finally {
     cleanupInProgress = false;
   }

--- a/src/features/telemetry/TelemetryRecorder.ts
+++ b/src/features/telemetry/TelemetryRecorder.ts
@@ -241,6 +241,9 @@ export class TelemetryRecorder {
     value: string | null;
     valueType: string | null;
     changeType: string;
+    // When the source already knows the prior value, thread it through to skip
+    // the repository's per-insert previous-value lookup (#2798).
+    previousValue?: string | null;
   }): Promise<void> {
     const { deviceId, sessionId } = this.snapshotContext();
     const input: RecordStorageEventInput = { deviceId, sessionId, ...event };

--- a/test/db/storageEventRepository.test.ts
+++ b/test/db/storageEventRepository.test.ts
@@ -46,6 +46,87 @@ describe("StorageEventRepository", () => {
     expect(events[0].previousValue).toBe("v1");
   });
 
+  test("recordStorageEvent skips the lookup when previousValue is supplied, even if a prior row exists", async () => {
+    // A prior event for the same (device, file, key) would be found by the
+    // auto-lookup. Supplying previousValue must short-circuit that lookup and
+    // store the supplied value verbatim rather than the prior row's value.
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "light", valueType: null, changeType: "add",
+    }, db);
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 2000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "dark", valueType: null, changeType: "modify",
+      previousValue: "caller-knows",
+    }, db);
+    const events = await getStorageEvents({ deviceId: "d1" }, db);
+    // Most-recent first; supplied value wins over the "light" the lookup would find.
+    expect(events[0].previousValue).toBe("caller-knows");
+  });
+
+  test("recordStorageEvent honors an explicit previousValue: null and skips the lookup", async () => {
+    // A prior row exists that the auto-lookup would find. Passing an EXPLICIT
+    // null means "there is no prior value" — it must be stored verbatim, not
+    // overwritten by the stale prior row. Explicit null must be distinguishable
+    // from an omitted field (guarded via `input.previousValue !== undefined`).
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "light", valueType: null, changeType: "add",
+    }, db);
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 2000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "dark", valueType: null, changeType: "modify",
+      previousValue: null,
+    }, db);
+    const events = await getStorageEvents({ deviceId: "d1", limit: 10 }, db);
+    // Most-recent first; explicit null wins over the "light" the lookup would find.
+    expect(events[0].previousValue).toBeNull();
+  });
+
+  test("recordStorageEvent picks the max-timestamp prior row regardless of insertion order", async () => {
+    // Insert out of timestamp order: the newest row (timestamp 3000) is inserted
+    // in the middle. The lookup must return its value by MAX(timestamp), not by
+    // insertion/rowid order — this is exactly what the trailing timestamp column
+    // of idx_storage_events_key_lookup guarantees.
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "oldest", valueType: null, changeType: "add",
+    }, db);
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 3000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "newest", valueType: null, changeType: "modify",
+    }, db);
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 2000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "middle", valueType: null, changeType: "modify",
+    }, db);
+    // A fourth event whose auto-lookup should see "newest" as the previous value.
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 4000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "current", valueType: null, changeType: "modify",
+    }, db);
+    const events = await getStorageEvents({ deviceId: "d1", limit: 10 }, db);
+    expect(events[0].value).toBe("current");
+    expect(events[0].previousValue).toBe("newest");
+  });
+
+  test("recordStorageEvent scopes the previous-value lookup by file_name and key", async () => {
+    // Same device, different (file_name, key) tuples must not leak previous values
+    // across each other — the seek prefix is (device_id, file_name, key).
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+      fileName: "a.xml", key: "k", value: "from-a", valueType: null, changeType: "add",
+    }, db);
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 2000, applicationId: null, sessionId: null,
+      fileName: "b.xml", key: "k", value: "from-b", valueType: null, changeType: "add",
+    }, db);
+    const events = await getStorageEvents({ deviceId: "d1", limit: 10 }, db);
+    const b = events.find(e => e.fileName === "b.xml");
+    // b.xml/k has no prior row of its own → no previous value leaks from a.xml/k.
+    expect(b?.previousValue).toBeNull();
+  });
+
   test("recordStorageEvent skips previous value lookup when key is null", async () => {
     await recordStorageEvent({
       deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,

--- a/test/db/storageEventsKeyLookup.test.ts
+++ b/test/db/storageEventsKeyLookup.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { runMigrations } from "../../src/db/migrator";
+import { up as telemetryUp } from "../../src/db/migrations/2026_03_15_000_telemetry_events";
+import { up as navigationUp } from "../../src/db/migrations/2026_03_18_000_navigation_events";
+import { up as storageUp } from "../../src/db/migrations/2026_03_19_000_storage_events";
+import { up as layoutUp } from "../../src/db/migrations/2026_03_19_001_layout_events";
+import { up as storagePreviousValueUp } from "../../src/db/migrations/2026_03_19_002_storage_events_previous_value";
+import { up as compositeUp } from "../../src/db/migrations/2026_07_02_000_event_composite_indexes";
+import { up as dropRedundantUp } from "../../src/db/migrations/2026_07_03_000_drop_redundant_device_indexes";
+import {
+  up as keyLookupUp,
+  down as keyLookupDown,
+} from "../../src/db/migrations/2026_07_04_000_storage_events_key_lookup";
+
+/**
+ * Migration coverage for #2798. `recordStorageEvent` runs a per-insert
+ * previous-value lookup:
+ *
+ *   SELECT value FROM storage_events
+ *   WHERE device_id=? AND file_name=? AND key=?
+ *   ORDER BY timestamp DESC LIMIT 1
+ *
+ * The issue was originally filed against the pre-#2788 schema, where the only
+ * usable index was the standalone `idx_storage_events_device` and the plan showed
+ * `USE TEMP B-TREE FOR ORDER BY`. By the time this lands, #2788 (PR #2890) has
+ * added `idx_storage_events_device_timestamp (device_id, timestamp)` and #2893
+ * (PR #2904) dropped the standalone device index, so the temp B-tree is ALREADY
+ * gone — the composite's `device_id` prefix satisfies the DESC order. The
+ * remaining, real win this migration delivers is narrowing the SEEK: without it
+ * the planner seeks only on `device_id=?` and then scans every row for that device
+ * (in timestamp order) applying `file_name=?`/`key=?` row-by-row until the first
+ * match; with `(device_id, file_name, key, timestamp)` it does a full three-column
+ * equality prefix seek straight to the target key's newest row.
+ *
+ * These tests pin: the index exists with the correct ordered columns, the planner
+ * switches to the three-column prefix seek, the temp B-tree stays absent, results
+ * are unchanged, and the migration is idempotent / reversible / replay-safe.
+ */
+const INDEX = "idx_storage_events_key_lookup";
+
+/**
+ * Reproduce the storage_events index state as it exists in production
+ * immediately BEFORE this migration: base table + timestamp index, the
+ * previous_value column, the #2788 composite, and the #2893 device-index drop.
+ * The composite/drop migrations touch all six event tables, so every event
+ * table must exist first.
+ */
+async function buildPreMigrationSchema(db: Kysely<unknown>): Promise<void> {
+  await telemetryUp(db); // network_events, log_events, os_events
+  await navigationUp(db); // navigation_events
+  await storageUp(db); // storage_events (+ timestamp + device indexes)
+  await layoutUp(db); // layout_events
+  await storagePreviousValueUp(db); // previous_value column
+  await compositeUp(db); // idx_<table>_device_timestamp on all six
+  await dropRedundantUp(db); // drop idx_<table>_device on all six
+}
+
+async function indexExists(db: Kysely<unknown>, name: string): Promise<boolean> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'index' AND name = ${name}
+  `.execute(db);
+  return result.rows.length > 0;
+}
+
+/** Ordered list of column names participating in an index (PRAGMA index_info). */
+async function indexColumns(db: Kysely<unknown>, name: string): Promise<string[]> {
+  const result = await sql<{ seqno: number; name: string }>`
+    SELECT seqno, name FROM pragma_index_info(${name}) ORDER BY seqno
+  `.execute(db);
+  return result.rows.map(r => r.name);
+}
+
+/**
+ * EXPLAIN QUERY PLAN detail lines for the real previous-value lookup predicate
+ * (matches `storageEventRepository.ts`). Runs against the raw bun:sqlite handle:
+ * kysely's `sql` execute returns no rows for EXPLAIN QUERY PLAN.
+ */
+function lookupPlan(bunDb: BunDatabase): string[] {
+  const rows = bunDb
+    .query(
+      "EXPLAIN QUERY PLAN SELECT value FROM storage_events " +
+        "WHERE device_id = 'dev-1' AND file_name = 'prefs.xml' AND key = 'theme' " +
+        "ORDER BY timestamp DESC LIMIT 1"
+    )
+    .all() as Array<{ detail: string }>;
+  return rows.map(r => r.detail);
+}
+
+describe("2026_07_04_000_storage_events_key_lookup migration", () => {
+  let bunDb: BunDatabase;
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    bunDb = new BunDatabase(":memory:");
+    db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    await buildPreMigrationSchema(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("up creates the composite seek index with ordered columns", async () => {
+    expect(await indexExists(db, INDEX)).toBe(false);
+
+    await keyLookupUp(db);
+
+    expect(await indexExists(db, INDEX)).toBe(true);
+    expect(await indexColumns(db, INDEX)).toEqual([
+      "device_id",
+      "file_name",
+      "key",
+      "timestamp",
+    ]);
+  });
+
+  test("planner switches to the three-column prefix seek; no temp B-tree either way", async () => {
+    // Before: #2788's composite already kills the sort, but the seek is only on
+    // device_id — file_name/key are filtered row-by-row, and the plan does NOT
+    // reference the key-lookup index.
+    const before = lookupPlan(bunDb).join("\n");
+    expect(before).not.toContain(INDEX);
+    expect(before).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+
+    await keyLookupUp(db);
+
+    const after = lookupPlan(bunDb).join("\n");
+    // The three equality columns are now the seek prefix — a direct descent to
+    // the target key's rows instead of a device-wide scan.
+    expect(after).toContain(INDEX);
+    expect(after).toMatch(
+      new RegExp(`SEARCH .*USING INDEX ${INDEX} \\(device_id=\\? AND file_name=\\? AND key=\\?\\)`)
+    );
+    // The sort stays gone (trailing timestamp column supplies the DESC order).
+    expect(after).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+  });
+
+  test("lookup returns the same most-recent value before and after the migration", async () => {
+    await sql`INSERT INTO storage_events (device_id, timestamp, file_name, key, value, change_type)
+      VALUES ('dev-1', 100, 'prefs.xml', 'theme', 'light', 'add'),
+             ('dev-1', 300, 'prefs.xml', 'theme', 'dark', 'modify'),
+             ('dev-1', 200, 'prefs.xml', 'theme', 'sepia', 'modify'),
+             ('dev-1', 400, 'prefs.xml', 'other', 'x', 'add'),
+             ('dev-2', 500, 'prefs.xml', 'theme', 'other-device', 'add')`.execute(db);
+
+    const read = async (): Promise<Array<{ value: string }>> => {
+      const result = await sql<{ value: string }>`
+        SELECT value FROM storage_events
+        WHERE device_id = 'dev-1' AND file_name = 'prefs.xml' AND key = 'theme'
+        ORDER BY timestamp DESC LIMIT 1
+      `.execute(db);
+      return result.rows;
+    };
+
+    const before = await read();
+    await keyLookupUp(db);
+    const after = await read();
+
+    expect(after).toEqual(before);
+    // Sanity: newest matching row for (dev-1, prefs.xml, theme) is timestamp 300.
+    expect(after[0].value).toBe("dark");
+  });
+
+  test("up is idempotent (safe to re-run, as destructive-recovery replay would)", async () => {
+    await keyLookupUp(db);
+    await expect(keyLookupUp(db)).resolves.toBeUndefined();
+    expect(await indexExists(db, INDEX)).toBe(true);
+  });
+
+  test("down drops the index", async () => {
+    await keyLookupUp(db);
+    await keyLookupDown(db);
+    expect(await indexExists(db, INDEX)).toBe(false);
+  });
+
+  test("down is idempotent — a partial-up followed by down does not throw", async () => {
+    await expect(keyLookupDown(db)).resolves.toBeUndefined();
+    await keyLookupUp(db);
+    await keyLookupDown(db);
+    await expect(keyLookupDown(db)).resolves.toBeUndefined();
+  });
+
+  test("does not touch the #2788 composite or the retention timestamp index", async () => {
+    await keyLookupUp(db);
+    expect(await indexExists(db, "idx_storage_events_device_timestamp")).toBe(true);
+    expect(await indexExists(db, "idx_storage_events_timestamp")).toBe(true);
+  });
+});
+
+describe("2026_07_04_000_storage_events_key_lookup migration — full replay", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    // Full forward replay of every on-disk migration (the #2785
+    // destructive-recovery path). Proves the migration is discovered/wired.
+    await runMigrations(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("the key-lookup index exists after a fresh full migration chain", async () => {
+    expect(await indexExists(db, INDEX)).toBe(true);
+    expect(await indexColumns(db, INDEX)).toEqual([
+      "device_id",
+      "file_name",
+      "key",
+      "timestamp",
+    ]);
+  });
+});

--- a/test/db/telemetryEventIndexInventory.test.ts
+++ b/test/db/telemetryEventIndexInventory.test.ts
@@ -73,6 +73,10 @@ const CANONICAL_INDEXES: Record<string, Record<string, string[]>> = {
   storage_events: {
     idx_storage_events_timestamp: ["timestamp"],
     idx_storage_events_device_timestamp: ["device_id", "timestamp"],
+    // #2798: three-column equality prefix + trailing timestamp for the
+    // per-insert previous-value lookup
+    // (WHERE device_id=? AND file_name=? AND key=? ORDER BY timestamp DESC LIMIT 1).
+    idx_storage_events_key_lookup: ["device_id", "file_name", "key", "timestamp"],
   },
   layout_events: {
     idx_layout_events_timestamp: ["timestamp"],

--- a/test/features/telemetry/TelemetryRecorder.test.ts
+++ b/test/features/telemetry/TelemetryRecorder.test.ts
@@ -357,6 +357,38 @@ describe("TelemetryRecorder", () => {
     expect(repo.storageEvents[0].key).toBe("theme");
   });
 
+  it("recordStorageEvent threads an explicit previousValue through to the repository", async () => {
+    await recorder.recordStorageEvent({
+      timestamp: 6000,
+      applicationId: null,
+      fileName: "prefs.xml",
+      key: "theme",
+      value: "dark",
+      valueType: "string",
+      changeType: "put",
+      previousValue: "light",
+    });
+
+    expect(repo.storageEvents).toHaveLength(1);
+    expect(repo.storageEvents[0].previousValue).toBe("light");
+  });
+
+  it("recordStorageEvent leaves previousValue undefined when the caller omits it", async () => {
+    await recorder.recordStorageEvent({
+      timestamp: 6000,
+      applicationId: null,
+      fileName: "prefs.xml",
+      key: "theme",
+      value: "dark",
+      valueType: "string",
+      changeType: "put",
+    });
+
+    expect(repo.storageEvents).toHaveLength(1);
+    // Absent field → repository falls back to its auto-lookup path.
+    expect(repo.storageEvents[0].previousValue).toBeUndefined();
+  });
+
   it("recordStorageEvent pushes category storage to socket", async () => {
     await recorder.recordStorageEvent({
       timestamp: 6000,


### PR DESCRIPTION
## What

Adds one forward-only migration creating a composite **seek-reduction** index `idx_storage_events_key_lookup (device_id, file_name, key, timestamp)` on `storage_events`, threads an optional `previousValue` through `TelemetryRecorder.recordStorageEvent`, and fixes both bare-swallow `catch` blocks in the repository.

Closes #2798.

## Why

On every storage telemetry insert that doesn't already carry `previousValue`, `recordStorageEvent` runs a lookup:

```sql
SELECT value FROM storage_events
WHERE device_id=? AND file_name=? AND key=?
ORDER BY timestamp DESC LIMIT 1
```

**The issue's original premise is now stale — reframed honestly.** #2798 was filed against the pre-#2788 schema, where the only usable index was the standalone `idx_storage_events_device` and the plan showed `USE TEMP B-TREE FOR ORDER BY`. That temp B-tree is **already gone**: PR #2890 (#2788) added `idx_storage_events_device_timestamp (device_id, timestamp)` and PR #2904 (#2893) dropped the standalone device index, so the composite's `device_id` prefix now supplies the DESC order for free. Verified empirically — the current "before" plan is `SEARCH storage_events USING INDEX idx_storage_events_device_timestamp (device_id=?)` with **no** temp B-tree.

What remains is the **seek width**. With only `(device_id, timestamp)` the planner seeks on `device_id=?` and then scans that device's rows in timestamp order applying `file_name=?`/`key=?` row-by-row until the first match. For a device with many distinct keys, that scan dominates.

**Benchmark (10 000 rows, one device, 500 keys × 20 timestamps, 20 000 lookups, `:memory:`):**

| | plan | per lookup |
|---|---|---|
| before (`device_timestamp` composite only) | `SEARCH … idx_storage_events_device_timestamp (device_id=?)` | **~670 µs** |
| after (`key_lookup` index) | `SEARCH … idx_storage_events_key_lookup (device_id=? AND file_name=? AND key=?)` | **~0.96 µs** |

≈ **700× faster** per insert's lookup — the "before" is effectively an O(device-rows) scan, the "after" a direct 3-column prefix seek. One extra index on a 10k-capped table is clearly worth it.

## How

- **New migration** `src/db/migrations/2026_07_04_000_storage_events_key_lookup.ts` — auto-discovered by `FileMigrationProvider`; sorts after `2026_07_03_*` so `storage_events` exists on a full replay. `.ifNotExists()` up / `.ifExists()` down for #2785 destructive-recovery replay safety.
- **Seek-reduction, NOT covering** (per Mira Kessler's review on #2798): `value` is deliberately excluded — it's an arbitrarily large TEXT blob, so widening the index for an index-only read is a bad trade. Plan = prefix seek + one rowid lookup for `value`. Named `_key_lookup`, not `_covering`.
- **Distinct from #2788's composite, not planner-redundant**: `idx_storage_events_device_timestamp` serves the device-scoped getter; this index serves the three-equality lookup. The planner picks each for its own shape. (#2788 already merged, so the issue's "land them in one file" note is moot.)
- **Thread optional `previousValue`** through `TelemetryRecorder.recordStorageEvent` → `RecordStorageEventInput`. The guard is `input.previousValue !== undefined` (not `?? null`), so an **explicit `previousValue: null`** ("there is no prior value") is honored verbatim and does **not** trigger the lookup — only an omitted field does. This closes the mutex-released read-then-insert stale-read window for callers that supply the value. **Forward-looking hook**: no runner emits a prior value on the wire today (`AndroidCtrlProxyClient.ts`, `IosSdkEventIngestor.ts` both omit it), so the practical win in this PR is the index; wiring a source to emit `oldValue` is a filed follow-up.
- **Fix both bare-swallow `catch` blocks** (the lookup *and* the retention `cleanupIfNeeded` twin one function away) to `logger.warn` — CLAUDE.md error-handling convention, leaves a trace at the default level. Confirmed `file_name` is non-null at the call site.

## Not in scope (follow-ups filed)

- Having the Android/iOS CtrlProxy runners emit the prior value on the wire so the `previousValue` skip path activates (release-gated runner protocol change).
- Pre-existing: the iOS `recordStorageEvent` call passes an undeclared `operation` and omits `valueType`/`changeType` — a latent type error masked only by Bun skipping type-checking.

## Testing

- **New** `test/db/storageEventsKeyLookup.test.ts` — index columns via `pragma_index_info`; **`EXPLAIN QUERY PLAN`** against the real predicate (no index-reference + no temp B-tree before; 3-column prefix seek + no temp B-tree after); same most-recent value before/after; idempotent `up`, reversible `down`, partial-up→`down` no-op; #2788 composite + retention `timestamp` index untouched; full `runMigrations` replay leaves the index present.
- **`test/db/storageEventRepository.test.ts`** — supplied `previousValue` skips the lookup even with a competing prior row; **explicit `previousValue: null` honored verbatim** (not overwritten by a stale row); max-timestamp row chosen regardless of insertion order; lookup scoped by `file_name`/`key`.
- **`test/features/telemetry/TelemetryRecorder.test.ts`** — explicit `previousValue` threads through; absent field stays `undefined` (auto-lookup path).
- **`test/db/telemetryEventIndexInventory.test.ts`** (#2908 drift guard) updated for the new index.
- `bun test test/db/` + `test/features/telemetry/` green; changed files lint clean.

## Reviewed

Ran `/auto-mobile-code-review` plus three independent adversarial reviewers (SQLite-correctness, regression/completeness, architecture-direction). All three reproduced the EXPLAIN plan change and confirmed the index is correct, replay-safe, and distinct from #2788's composite. Their substantive findings are all addressed here: the explicit-`null` ambiguity (now guarded on `!== undefined`), the missing perf measurement (benchmark above), and the `cleanupIfNeeded` bare-catch twin (now logged). Remaining items are filed as follow-ups.
