### PR TITLE
fix(ios): field-attribute typeMismatch/valueNotFound decode wire messages (#2986)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -355,13 +355,32 @@ public class WebSocketServer: WebSocketServing {
         }
     }
 
-    /// The deepest `codingPath` key's `stringValue` — the offending field — or `nil`
-    /// when the path is empty (nothing to attribute).
+    /// A human-readable name for the offending field, derived from the deepest
+    /// `codingPath` key, or `nil` when the path is empty (nothing to attribute).
+    ///
+    /// A named leaf key (the common case — a wrong-typed *field* like `x`) is used
+    /// verbatim. When the leaf is an **array index** (a wrong-typed array *element*,
+    /// e.g. `rules[0]`), the synthetic "Index 0" key `stringValue` would be a poor
+    /// label, so it is attributed to the nearest named ancestor with the index
+    /// appended (`rules[0]`), or just `[0]` if there is no named ancestor.
     private static func fieldName(_ context: DecodingError.Context) -> String? {
-        guard let field = context.codingPath.last?.stringValue, !field.isEmpty else {
+        let path = context.codingPath
+        guard let last = path.last else {
             return nil
         }
-        return field
+        // Named leaf key — the common case (a wrong-typed field).
+        if last.intValue == nil {
+            return last.stringValue.isEmpty ? nil : last.stringValue
+        }
+        // The leaf is an array index — attribute to the nearest named ancestor.
+        guard let index = last.intValue else {
+            return nil
+        }
+        let parent = path.dropLast().last(where: { $0.intValue == nil })?.stringValue
+        if let parent = parent, !parent.isEmpty {
+            return "\(parent)[\(index)]"
+        }
+        return "[\(index)]"
     }
 
     /// Actionable message for a `DecodingError.dataCorrupted`. The overflow / malformed

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -313,23 +313,62 @@ public class WebSocketServer: WebSocketServing {
 
     /// Maps a caught error into the message surfaced on the wire.
     ///
-    /// Most errors pass through `localizedDescription` unchanged — deliberately so:
-    /// this preserves `CommandError.unknownCommand`'s "Unknown command type: <type>"
-    /// contract (a `LocalizedError`, matched by the TS `rewriteUnknownCommandError`)
-    /// and `DecodingError.keyNotFound`'s required-field rejection messages.
+    /// Two `DecodingError` contracts pass through `localizedDescription` **unchanged**
+    /// — deliberately, and load-bearing:
+    /// - `CommandError.unknownCommand`'s "Unknown command type: <type>" (a
+    ///   `LocalizedError`, matched by the TS `rewriteUnknownCommandError`).
+    /// - `DecodingError.keyNotFound`'s required-field rejection messages, which
+    ///   `TypedRequestDecodeTests` pins byte-for-byte (see #2965 AC2).
     ///
-    /// The single rewrite is for `DecodingError.dataCorrupted`, whose
-    /// `localizedDescription` collapses to the opaque "The data couldn't be read
-    /// because it isn't in the correct format." Apple's `JSONDecoder` reports this
-    /// class of failure at top-level pre-parse with an *empty* `codingPath` — most
-    /// notably for an out-of-range numeric literal (e.g. `1e309`) — so a per-field
-    /// message is infeasible, but the real cause survives in the underlying Cocoa
-    /// error's `NSDebugDescription`. Surfacing it turns an opaque decode failure
-    /// into an actionable one. See issue #2965.
+    /// The rewritten cases are the `DecodingError`s whose `localizedDescription`
+    /// collapses to an opaque default even though a more actionable cause is
+    /// recoverable:
+    /// - `dataCorrupted` — "The data couldn't be read because it isn't in the correct
+    ///   format." Apple's `JSONDecoder` reports this at top-level pre-parse with an
+    ///   *empty* `codingPath` (most notably an out-of-range numeric literal like
+    ///   `1e309`), so a per-field message is infeasible there, but the real cause
+    ///   survives in the underlying Cocoa error's `NSDebugDescription`. See #2965.
+    /// - `typeMismatch` / `valueNotFound` — same opaque string, but these carry a
+    ///   *non-empty* `codingPath`, so the offending field can be named. A string
+    ///   where a number is expected, or an explicit `null` for a required field,
+    ///   becomes "…wrong type for field 'x' (…)" / "…missing value for field 'x' (…)"
+    ///   instead of the decoder default. See #2986. (The value is already rejected;
+    ///   this is diagnostic legibility only.)
     static func wireErrorMessage(for error: Error) -> String {
-        guard case let DecodingError.dataCorrupted(context) = error else {
+        switch error {
+        case let DecodingError.typeMismatch(_, context):
+            if let field = fieldName(context) {
+                return "Malformed request: wrong type for field '\(field)' (\(context.debugDescription))"
+            }
+            return "Malformed request: wrong type (\(context.debugDescription))"
+        case let DecodingError.valueNotFound(_, context):
+            if let field = fieldName(context) {
+                return "Malformed request: missing value for field '\(field)' (\(context.debugDescription))"
+            }
+            return "Malformed request: missing value (\(context.debugDescription))"
+        case let DecodingError.dataCorrupted(context):
+            return dataCorruptedMessage(context)
+        default:
+            // keyNotFound + CommandError.unknownCommand + any other error: pass the
+            // localizedDescription through unchanged (the contracts noted above).
             return error.localizedDescription
         }
+    }
+
+    /// The deepest `codingPath` key's `stringValue` — the offending field — or `nil`
+    /// when the path is empty (nothing to attribute).
+    private static func fieldName(_ context: DecodingError.Context) -> String? {
+        guard let field = context.codingPath.last?.stringValue, !field.isEmpty else {
+            return nil
+        }
+        return field
+    }
+
+    /// Actionable message for a `DecodingError.dataCorrupted`. The overflow / malformed
+    /// -JSON cases (empty `codingPath`, cause in the underlying Cocoa error) are the
+    /// common ones; the final fallback also attributes a field when a *nested*
+    /// `dataCorrupted` carries a `codingPath` (#2986).
+    private static func dataCorruptedMessage(_ context: DecodingError.Context) -> String {
         let underlyingDetail = (context.underlyingError as NSError?)?
             .userInfo[NSDebugDescriptionErrorKey] as? String
 
@@ -341,7 +380,11 @@ public class WebSocketServer: WebSocketServing {
             return "Malformed request: the payload is not valid JSON (\(detail))"
         }
         // No underlying detail available — the decoder's own context description is
-        // still more specific than the opaque `localizedDescription`.
+        // still more specific than the opaque `localizedDescription`; attribute the
+        // field when a nested dataCorrupted carries one.
+        if let field = fieldName(context) {
+            return "Malformed request: field '\(field)' — \(context.debugDescription)"
+        }
         return "Malformed request: \(context.debugDescription)"
     }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -23,6 +23,17 @@ struct TestCodingKey: CodingKey {
         self.intValue = intValue
         stringValue = String(intValue)
     }
+
+    /// Non-failable convenience for building a synthetic array-index coding key
+    /// without a force-unwrap in tests.
+    static func index(_ value: Int) -> TestCodingKey {
+        TestCodingKey(stringValue: "Index \(value)", intValue: value)
+    }
+
+    private init(stringValue: String, intValue: Int?) {
+        self.stringValue = stringValue
+        self.intValue = intValue
+    }
 }
 
 /// Round-trip coverage for issue #2846: every inbound command decodes from its
@@ -1224,6 +1235,60 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         let error = decodeError(#"{"type":"unknown_command","requestId":"uc-2"}"#)
         let message = wireErrorMessage(for: error, requestId: "uc-2")
         XCTAssertEqual(message, "Unknown command type: unknown_command")
+    }
+
+    /// A wrong-typed *array element* (e.g. a bare string in `rules`, whose elements
+    /// are objects) yields a `codingPath` whose deepest key is a synthetic array
+    /// *index*, not a named field. The message attributes it to the nearest named
+    /// ancestor with the index appended (`rules[0]`) rather than the useless
+    /// "Index 0" key label. Uses the real `request_set_network_mock_rules` decode
+    /// path (`rules: [NetworkMockRuleDTO]`).
+    func testTypeMismatchOnArrayElementNamesParentWithIndex() {
+        let error = decodeError(#"{"type":"set_network_mock_rules","requestId":"arr-1","rules":["hi"]}"#)
+        guard case DecodingError.typeMismatch = error else {
+            return XCTFail("expected typeMismatch on the array element, got \(error)")
+        }
+        let message = wireErrorMessage(for: error, requestId: "arr-1")
+        XCTAssertTrue(
+            message.contains("rules[0]"),
+            "array-element typeMismatch should name the parent field with the index, got: \(message)"
+        )
+        XCTAssertFalse(
+            message.contains("Index 0"),
+            "message should not surface the synthetic 'Index 0' key label, got: \(message)"
+        )
+    }
+
+    /// A synthetic `typeMismatch` whose leaf `codingPath` key is a bare array index
+    /// (no named ancestor) falls back to `[<index>]` — pinned deterministically.
+    func testTypeMismatchOnTopLevelArrayElementUsesBracketIndex() {
+        let context = DecodingError.Context(
+            codingPath: [TestCodingKey.index(2)],
+            debugDescription: "Expected to decode Double but found a string instead."
+        )
+        let error = DecodingError.typeMismatch(Double.self, context)
+        let message = wireErrorMessage(for: error, requestId: "arr-top")
+        XCTAssertTrue(message.contains("[2]"), "got: \(message)")
+        XCTAssertFalse(message.contains("Index"), "got: \(message)")
+    }
+
+    /// Coverage for the `dataCorrupted` **field-attribution fallback** (#2986): a
+    /// *nested* `dataCorrupted` (non-empty `codingPath`, no underlying Cocoa detail)
+    /// — unlike the empty-path top-level overflow case — names the field it occurred
+    /// on instead of dropping it. Synthetic so it is host-independent and reaches the
+    /// no-underlying-detail branch the overflow/malformed-JSON tests never hit.
+    func testNestedDataCorruptedAttributesField() {
+        let context = DecodingError.Context(
+            codingPath: [TestCodingKey(stringValue: "y2")],
+            debugDescription: "Date string does not match format expected by formatter."
+        )
+        let error = DecodingError.dataCorrupted(context)
+        let message = wireErrorMessage(for: error, requestId: "dc-nested")
+        XCTAssertTrue(
+            message.contains("'y2'"),
+            "nested dataCorrupted should attribute the field, got: \(message)"
+        )
+        XCTAssertNotEqual(message, error.localizedDescription, "got: \(message)")
     }
 
     // MARK: - Finite fractional / negative coordinates unaffected (#2909 happy path)

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -8,6 +8,23 @@ func decodeWebSocketRequest(_ json: String) throws -> WebSocketRequest {
     try JSONDecoder().decode(WebSocketRequest.self, from: Data(json.utf8))
 }
 
+/// A minimal `CodingKey` for building synthetic `DecodingError`s whose `codingPath`
+/// pins a specific field name — used to test the field-attributed decode messages
+/// deterministically, independent of the host decoder backend (#2986).
+struct TestCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+    init(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.intValue = intValue
+        stringValue = String(intValue)
+    }
+}
+
 /// Round-trip coverage for issue #2846: every inbound command decodes from its
 /// on-the-wire JSON into the correct typed `WebSocketRequest` case with its
 /// fields intact, and dispatches through `CommandHandler.handle` to the correct
@@ -1064,6 +1081,149 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             message.lowercased().contains("not valid json") || message.lowercased().contains("malformed"),
             "malformed JSON should surface an actionable cause, got: \(message)"
         )
+    }
+
+    // MARK: - Field-attributed decode legibility: typeMismatch / valueNotFound (#2986)
+
+    /// Build a synthetic `DecodingError.typeMismatch` with a single-key
+    /// `codingPath` — mirroring what `JSONDecoder` throws when a field holds the
+    /// wrong JSON type. Lets a test pin the field-attributed rewrite deterministically
+    /// on any host regardless of the decoder backend's exact `debugDescription`.
+    private func syntheticTypeMismatch(field: String, debugDescription: String) -> DecodingError {
+        let context = DecodingError.Context(
+            codingPath: [TestCodingKey(stringValue: field)],
+            debugDescription: debugDescription
+        )
+        return DecodingError.typeMismatch(Double.self, context)
+    }
+
+    /// Build a synthetic `DecodingError.valueNotFound` with a single-key `codingPath`.
+    private func syntheticValueNotFound(field: String, debugDescription: String) -> DecodingError {
+        let context = DecodingError.Context(
+            codingPath: [TestCodingKey(stringValue: field)],
+            debugDescription: debugDescription
+        )
+        return DecodingError.valueNotFound(Double.self, context)
+    }
+
+    /// AC1 (#2986): a `typeMismatch` inbound command (a field holding the wrong JSON
+    /// type, e.g. a string where a number is expected) — which carries a non-empty
+    /// `codingPath` — surfaces a *field-attributed* actionable message naming the
+    /// offending field, instead of the opaque "…isn't in the correct format." The
+    /// value is still rejected (diagnostic legibility only) and the requestId is
+    /// preserved. Uses the *real* wire decode path so the codingPath is genuine.
+    func testTypeMismatchWireMessageIsFieldAttributed() {
+        let error = decodeError(#"{"type":"request_tap_coordinates","requestId":"tm-1","x":"hi","y":2}"#)
+        guard case DecodingError.typeMismatch = error else {
+            return XCTFail("expected typeMismatch, got \(error)")
+        }
+        let message = wireErrorMessage(for: error, requestId: "tm-1")
+        XCTAssertNotEqual(
+            message,
+            error.localizedDescription,
+            "typeMismatch message must not stay the opaque decoder default, got: \(message)"
+        )
+        XCTAssertTrue(
+            message.contains("'x'"),
+            "typeMismatch message should name the offending field 'x', got: \(message)"
+        )
+        XCTAssertTrue(
+            message.lowercased().contains("wrong type") || message.lowercased().contains("type"),
+            "typeMismatch message should indicate a wrong type, got: \(message)"
+        )
+    }
+
+    /// AC1 (#2986): a `valueNotFound` inbound command (a field present but `null`
+    /// where a non-optional value is required) surfaces a field-attributed message
+    /// naming the field. `valueNotFound` carries a non-empty `codingPath`, so it is
+    /// fair game for attribution (unlike `keyNotFound`).
+    func testValueNotFoundWireMessageIsFieldAttributed() {
+        let error = decodeError(#"{"type":"request_tap_coordinates","requestId":"vnf-1","x":null,"y":2}"#)
+        guard case DecodingError.valueNotFound = error else {
+            return XCTFail("expected valueNotFound, got \(error)")
+        }
+        let message = wireErrorMessage(for: error, requestId: "vnf-1")
+        XCTAssertNotEqual(
+            message,
+            error.localizedDescription,
+            "valueNotFound message must not stay the opaque decoder default, got: \(message)"
+        )
+        XCTAssertTrue(
+            message.contains("'x'"),
+            "valueNotFound message should name the offending field 'x', got: \(message)"
+        )
+        XCTAssertTrue(
+            message.lowercased().contains("missing") || message.lowercased().contains("null"),
+            "valueNotFound message should indicate a missing/null value, got: \(message)"
+        )
+    }
+
+    /// A `typeMismatch` on a *nested* field is attributed to the deepest key in the
+    /// `codingPath` (the actual field), pinned deterministically via a synthetic
+    /// error so it does not depend on the host decoder's `debugDescription` wording.
+    func testSyntheticTypeMismatchNamesDeepestField() {
+        let error = syntheticTypeMismatch(
+            field: "distanceStart",
+            debugDescription: "Expected to decode Double but found a string instead."
+        )
+        let message = wireErrorMessage(for: error, requestId: "syn-tm")
+        XCTAssertTrue(
+            message.contains("'distanceStart'"),
+            "should name the deepest coding-path field, got: \(message)"
+        )
+    }
+
+    /// A synthetic `valueNotFound` is likewise field-attributed and deterministic.
+    func testSyntheticValueNotFoundNamesField() {
+        let error = syntheticValueNotFound(
+            field: "x2",
+            debugDescription: "Expected Double value but found null instead."
+        )
+        let message = wireErrorMessage(for: error, requestId: "syn-vnf")
+        XCTAssertTrue(
+            message.contains("'x2'"),
+            "should name the coding-path field, got: \(message)"
+        )
+    }
+
+    /// A `typeMismatch` with an *empty* codingPath (no field to attribute) must still
+    /// produce an actionable, non-opaque message — just without a field name.
+    func testTypeMismatchWithoutFieldIsStillActionable() {
+        let context = DecodingError.Context(
+            codingPath: [],
+            debugDescription: "Expected to decode Array<Any> but found a dictionary instead."
+        )
+        let error = DecodingError.typeMismatch([Double].self, context)
+        let message = wireErrorMessage(for: error, requestId: "tm-nofield")
+        XCTAssertNotEqual(message, error.localizedDescription, "got: \(message)")
+        XCTAssertTrue(
+            message.lowercased().contains("malformed") || message.lowercased().contains("type"),
+            "empty-path typeMismatch should still be actionable, got: \(message)"
+        )
+    }
+
+    /// Regression guard (#2986 AC2): `keyNotFound` must remain byte-for-byte
+    /// `error.localizedDescription` even after typeMismatch/valueNotFound are mapped —
+    /// `TypedRequestDecodeTests`' required-field contract depends on it.
+    func testKeyNotFoundStaysUnchangedAfterTypeMismatchMapping() {
+        let error = decodeError(#"{"type":"request_tap_coordinates","requestId":"kn-2","y":2}"#)
+        guard case DecodingError.keyNotFound = error else {
+            return XCTFail("expected keyNotFound, got \(error)")
+        }
+        let message = wireErrorMessage(for: error, requestId: "kn-2")
+        XCTAssertEqual(
+            message,
+            error.localizedDescription,
+            "keyNotFound must stay untouched by the typeMismatch/valueNotFound mapping"
+        )
+    }
+
+    /// Regression guard (#2986 AC2): the `unknownCommand` wire contract still matches
+    /// exactly after the new mapping — the TS `rewriteUnknownCommandError` relies on it.
+    func testUnknownCommandStaysUnchangedAfterTypeMismatchMapping() {
+        let error = decodeError(#"{"type":"unknown_command","requestId":"uc-2"}"#)
+        let message = wireErrorMessage(for: error, requestId: "uc-2")
+        XCTAssertEqual(message, "Unknown command type: unknown_command")
     }
 
     // MARK: - Finite fractional / negative coordinates unaffected (#2909 happy path)


### PR DESCRIPTION
## What

Extend the iOS CtrlProxy runner's decode-error legibility (started in #2965 / PR #2983) from **`DecodingError.dataCorrupted`** to the *other* two common cases — **`typeMismatch`** and **`valueNotFound`** — so a malformed inbound command surfaces a **field-attributed** actionable message naming the offending field, instead of the opaque decoder default *"The data couldn't be read because it isn't in the correct format."*

Closes #2986. This is issue #2965's "option 2", deliberately left out of PR #2983's narrow scope.

Affected files (`ios/control-proxy/`):
- `Sources/CtrlProxy/WebSocketServer.swift` — `wireErrorMessage(for:)` refactored to a `switch`; new `typeMismatch` / `valueNotFound` mappings + `fieldName(_:)` / `dataCorruptedMessage(_:)` helpers.
- `Tests/CtrlProxyTests/TypedRequestDecodeTests.swift` — new "#2986" section pinning each mapped case; shared `TestCodingKey` helper for deterministic synthetic errors.

## Why

`typeMismatch` (e.g. a string where a number is expected, `{"x":"hi","y":2}`) and `valueNotFound` (an explicit `null` for a required field, `{"x":null,"y":2}`) both collapse `localizedDescription` to the **same opaque string** as `dataCorrupted` — but unlike the pre-parse overflow case, they carry a **non-empty `codingPath`**, so the offending field *can* be named. Before this change a client sending the wrong type for a field got no hint which field was wrong.

The value is already **rejected** at the decode boundary (never dispatched into XCUITest), so this is purely diagnostic legibility — low risk.

## How

`wireErrorMessage(for:)` becomes a `switch` over `DecodingError`:

- **`typeMismatch(_, context)`** → `"Malformed request: wrong type for field '<field>' (<debugDescription>)"` (or without the `for field` clause when `codingPath` is empty).
- **`valueNotFound(_, context)`** → `"Malformed request: missing value for field '<field>' (<debugDescription>)"` (likewise).
- **`dataCorrupted(context)`** → unchanged #2965 behavior (overflow / malformed-JSON via the underlying Cocoa `NSDebugDescription`); its *no-underlying-detail* fallback now also attributes a field when a **nested** `dataCorrupted` carries a `codingPath` (the drop-the-field gap noted in the issue).
- **`default`** (`keyNotFound` + `CommandError.unknownCommand` + anything else) → `localizedDescription` **unchanged** — load-bearing: preserves `keyNotFound`'s required-field rejection contract (#2965 AC2, pinned by `TypedRequestDecodeTests`) and the `"Unknown command type: <type>"` text the TS `rewriteUnknownCommandError` regex-matches.

Field name comes from `context.codingPath.last?.stringValue` (the deepest key = the actual field).

## Testing

`TypedRequestDecodeTests.swift` — new section, each test drives the **real** `JSONDecoder` wire path through the **real** `WebSocketServer.buildErrorResponseData`:
- `testTypeMismatchWireMessageIsFieldAttributed` / `testValueNotFoundWireMessageIsFieldAttributed` — real decode of a wrong-type / `null` field; message names `'x'`, differs from the opaque `localizedDescription`. (Red→green.)
- `testSyntheticTypeMismatchNamesDeepestField` / `testSyntheticValueNotFoundNamesField` — deterministic synthetic errors (via `TestCodingKey`) pin the deepest-field attribution independent of the host decoder backend.
- `testTypeMismatchWithoutFieldIsStillActionable` — empty-`codingPath` `typeMismatch` still yields a non-opaque message.
- `testKeyNotFoundStaysUnchangedAfterTypeMismatchMapping` / `testUnknownCommandStaysUnchangedAfterTypeMismatchMapping` — regression guards for the unchanged contracts.

Verified locally:
- `swift test` in `ios/control-proxy` — **340 tests, 0 failures** (was 324 on `main`).
- `swiftformat --lint` clean on the touched lines (the newer local 0.61.1 flags only pre-existing untouched-line violations, unchanged from `main`).

## Acceptance criteria (#2986)
- [x] A `typeMismatch` / `valueNotFound` inbound command surfaces a field-attributed actionable message naming the offending field, instead of the opaque decoder default.
- [x] `keyNotFound` and `Unknown command type: <type>` messages remain unchanged (existing tests still pass).
- [x] Unit tests pinning each mapped case.

## Delivery note

The iOS CtrlProxy runner ships as a **pinned, checksum-verified release** (`RELEASE_CHECKSUM_REGISTRY` in `src/constants/release.ts`), so this `ios/control-proxy` source change is **inert on default installs until the next runner release is re-cut** — consistent with prior iOS-runner PRs (e.g. #2953). This PR intentionally makes **no** checksum bump (feature PRs never bump; a periodic `chore: bump versions` PR does). Acceptable here because the change is diagnostic-legibility-only — the malformed value is already rejected pre-dispatch. To exercise it against local runner source, use the `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` override.

## Multi-agent review addendum

A three-perspective review (Swift-correctness / wire-contract-delivery / test-quality) confirmed: no downstream contract broken (`rewriteUnknownCommandError` and `keyNotFound` untouched), no Android parity gap (the Android runner sends no decode-error frame), all ACs met. Two follow-up items were addressed in the second commit: field-attributing malformed array *elements* as `<parent>[<index>]` (not `Index 0`), and adding the missing test for the nested-`dataCorrupted` field-attribution branch.
