### PR TITLE
fix(ios): retry-wrap RemindersLaunchPlanTests to stop transient observe timeout reding non-required CI

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
@@ -46,6 +46,25 @@ final class RemindersLaunchPlanTests: RemindersIntegrationBase {
             ?? "launch-reminders-app.yaml"
     }
 
+    // #2998: cold Reminders bring-up on a CI simulator intermittently pushes the plan's
+    // `observe waitFor "Reminders"` past its 20s bound, timing out during app launch rather than in
+    // any code under test. The observe timeout surfaces as a retryable `.executionFailed`, so a single
+    // retry re-runs the whole launch→observe→terminate plan and absorbs the transient flake, while a
+    // genuine observe regression times out on every attempt and still fails (the launch plan keeps its
+    // bounded waitFor — see RemindersPlanContentTests). Mirrors the sibling add-flow retry (#2811). An
+    // explicit AUTOMOBILE_TEST_RETRY_COUNT always wins; the retry is tracked for removal once the
+    // iOS-observe bring-up flake is fixed (#2910/#2926/#2952).
+    override var retryCount: Int {
+        // Honor an explicit override — including 0 to disable retries — and default to 1 only when
+        // no override is set. (super.retryCount can't distinguish an explicit 0 from the unset
+        // default, so read the env directly.)
+        let environment = AutoMobileEnvironment()
+        if let explicit = environment.intValue(["AUTOMOBILE_TEST_RETRY_COUNT", "RETRY_COUNT"]) {
+            return explicit
+        }
+        return 1
+    }
+
     func testLaunchRemindersPlan() throws {
         PerfTimer.log("testLaunchRemindersPlan START - planPath: \(planPath)")
         let result = try executePlan()

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -117,12 +117,14 @@ final class RemindersPlanContentTests: XCTestCase {
         XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 1)
     }
 
-    /// An explicit retry override wins for the launch flow too — including 0 to disable retries so a
-    /// CI/local repro run can force a single attempt and surface the transient timeout deterministically.
-    func testLaunchRemindersPlanExplicitZeroRetryOverrideIsHonored() {
+    /// An explicit retry override wins for the launch flow too — 0 disables retries so a CI/local
+    /// repro run can force a single attempt and surface the transient timeout deterministically, and a
+    /// non-default value is passed through verbatim. The non-`0` case is load-bearing: it diverges from
+    /// both the base default (`0`) and this class's default (`1`), so it fails if the override is ever
+    /// reverted to the base implementation — whereas a `0`-only assertion would pass either way.
+    func testLaunchRemindersPlanExplicitRetryOverrideIsHonored() {
         let key = "AUTOMOBILE_TEST_RETRY_COUNT"
         let original = ProcessInfo.processInfo.environment[key]
-        setenv(key, "0", 1)
         defer {
             if let original = original {
                 setenv(key, original, 1)
@@ -131,7 +133,15 @@ final class RemindersPlanContentTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 0)
+        setenv(key, "0", 1)
+        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 0, "Explicit 0 must disable retries")
+
+        setenv(key, "3", 1)
+        XCTAssertEqual(
+            RemindersLaunchPlanTests().retryCount,
+            3,
+            "A non-default explicit override must be honored verbatim, proving the override reads env"
+        )
     }
 
     /// Regression guard preserving acceptance criterion 2 (#2998): the retry only masks a *transient*

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -16,6 +16,10 @@ final class RemindersPlanContentTests: XCTestCase {
         return try DefaultPlanLoader().loadPlan(at: "add-reminder.yaml", bundle: Bundle.module)
     }
 
+    private func loadLaunchRemindersPlan() throws -> String {
+        return try DefaultPlanLoader().loadPlan(at: "launch-reminders-app.yaml", bundle: Bundle.module)
+    }
+
     /// The save tap must be immediately preceded by an `observe`/`waitFor` guard on "Done", so the
     /// executor polls for the control (and its `awaitTimeout` path fails fast on genuine absence)
     /// instead of racing a bare tap.
@@ -99,6 +103,68 @@ final class RemindersPlanContentTests: XCTestCase {
         }
 
         XCTAssertEqual(RemindersAddPlanTests().retryCount, 0)
+    }
+
+    /// The launch-flow test retry-wraps itself (#2998) so a transient cold-bring-up `observe waitFor`
+    /// timeout on a CI simulator doesn't red-flag an otherwise-green PR, while a genuine observe
+    /// regression still fails on every attempt. Mirrors the sibling add-flow retry (#2811).
+    func testLaunchRemindersPlanDefaultsToOneRetry() {
+        // An explicit env override legitimately wins, so only assert the default when unset.
+        let env = ProcessInfo.processInfo.environment
+        if env["AUTOMOBILE_TEST_RETRY_COUNT"] != nil || env["RETRY_COUNT"] != nil {
+            return
+        }
+        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 1)
+    }
+
+    /// An explicit retry override wins for the launch flow too — including 0 to disable retries so a
+    /// CI/local repro run can force a single attempt and surface the transient timeout deterministically.
+    func testLaunchRemindersPlanExplicitZeroRetryOverrideIsHonored() {
+        let key = "AUTOMOBILE_TEST_RETRY_COUNT"
+        let original = ProcessInfo.processInfo.environment[key]
+        setenv(key, "0", 1)
+        defer {
+            if let original = original {
+                setenv(key, original, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 0)
+    }
+
+    /// Regression guard preserving acceptance criterion 2 (#2998): the retry only masks a *transient*
+    /// bring-up flake, so the launch plan must keep its bounded `observe`/`waitFor` guard — a genuinely
+    /// broken observe still times out on every attempt and fails, instead of hanging or silently
+    /// passing. The plan must launch Reminders first, gate the launch on a bounded wait, and terminate
+    /// last.
+    func testLaunchRemindersPlanIsGuardedAndBounded() throws {
+        let content = try loadLaunchRemindersPlan()
+        let steps = PlanStepSequence.parse(content)
+
+        XCTAssertTrue(content.contains("platform: ios"), "Plan must declare the ios platform")
+        XCTAssertEqual(steps.first?.tool, "launchApp", "Plan must launch Reminders first")
+        XCTAssertEqual(steps.last?.tool, "terminateApp", "Plan must terminate Reminders last")
+
+        guard let observeIndex = steps.firstIndex(where: { $0.tool == "observe" }) else {
+            XCTFail("Plan must gate bring-up on an observe step")
+            return
+        }
+        let observeStep = steps[observeIndex]
+        XCTAssertGreaterThan(observeIndex, 0, "The observe guard must follow the launch")
+        XCTAssertTrue(observeStep.hasWaitFor, "The observe guard must use waitFor")
+
+        guard let timeout = observeStep.waitForTimeoutMs else {
+            XCTFail("The observe waitFor guard must declare a timeout so a real regression fails fast")
+            return
+        }
+        XCTAssertGreaterThan(timeout, 0, "waitFor timeout must be positive")
+        XCTAssertLessThanOrEqual(
+            timeout,
+            30000,
+            "waitFor timeout should stay bounded so a genuinely-broken observe fails fast per attempt"
+        )
     }
 
     /// The intermittent "Enable iCloud Syncing?" alert must be dismissed best-effort before the


### PR DESCRIPTION
## What

Give `RemindersLaunchPlanTests` a `retryCount` override (default **1**, honoring an explicit
`AUTOMOBILE_TEST_RETRY_COUNT`/`RETRY_COUNT` including `0`), mirroring the sibling
`RemindersAddPlanTests` retry added in #2811. Adds fast, no-simulator structural/behavioral tests in
`RemindersPlanContentTests` covering the default, the explicit-zero override, and a regression guard
that the launch plan keeps its bounded `observe`/`waitFor`.

Closes #2998.

## Why

The **XCTestRunner Simulator Tests** job intermittently fails on
`RemindersLaunchPlanTests testLaunchRemindersPlan` with `observe waitFor timed out after ~20s` during
cold Reminders bring-up on a CI simulator — exercising none of the code under test (it reproduced on
#2989, a pure-trig pinch change). The job is non-required (branch `main` is unprotected), but its red
status adds noise and can mask a genuine iOS-observe regression.

`RemindersLaunchPlanTests` inherited the base `retryCount` default of `0`, so a single transient
timeout red-flagged the whole run — unlike its sibling `RemindersAddPlanTests`, which already
retry-wraps the same class of cross-run flake (#2811).

## How

- **Retry override** — `RemindersLaunchPlanTests.retryCount` now defaults to `1`, reading the env
  directly so an explicit `AUTOMOBILE_TEST_RETRY_COUNT=0` still forces a single attempt for CI/local
  repro. The launch plan's `observe` timeout surfaces as a **retryable** `ExecutorError.executionFailed`
  (`AutoMobilePlanExecutor.swift:922-925`, `isRetryable` at `:766`), so the executor re-runs the whole
  `launch → observe → terminate` plan once. A transient bring-up flake passes on attempt 2; a **genuine
  observe regression times out on every attempt and still fails**, preserving the flake-vs-regression
  distinction (acceptance criterion 2).
- **Regression guard** — `testLaunchRemindersPlanIsGuardedAndBounded` asserts the plan launches
  Reminders first, gates on a bounded (`> 0`, `<= 30000ms`) `observe`/`waitFor`, and terminates last,
  so the retry can only mask a *transient* flake — a broken observe still fails fast per attempt rather
  than hanging or silently passing.

## Testing

- New `RemindersPlanContentTests` cases (`testLaunchRemindersPlanDefaultsToOneRetry`,
  `testLaunchRemindersPlanExplicitZeroRetryOverrideIsHonored`, `testLaunchRemindersPlanIsGuardedAndBounded`)
  run on the macOS test host without a simulator or daemon.
- Full `XCTestRunner` package suite green via `swift test`: **30 tests, 2 sim-integration tests skipped
  (no booted simulator), 0 failures** in ~0.28s.
- TDD: the default-retry test was confirmed red (`0` != `1`) before the override, green after.
- SwiftFormat clean on the changed lines (CI-pinned 0.54.6); no new violations introduced.