### PR TITLE
test(pinch): single-source golden vectors with cross-platform drift guard (#2997)

### DIFF
--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/PinchGeometryTest.kt
@@ -115,13 +115,16 @@ class PinchGeometryTest {
   }
 
   /**
-   * SHARED GOLDEN TABLE — keep byte-identical with the iOS runner's `PinchGeometryTests.swift`
-   * (`testGoldenVectorsMatchAndroidParity`). Each row is an input tuple and its expected
-   * *unordered* set of four endpoints. The comparison is order-independent because the two runners
-   * label which finger is "first" oppositely (Android builds center±offset, iOS center∓offset
-   * first) while producing the same two touch points. If either platform's endpoint math changes,
-   * its golden assertion fails loudly here or in the Swift mirror — closing the silent-divergence
-   * gap from issues #2911 / #2979.
+   * SHARED GOLDEN TABLE — the single source of truth is `test/fixtures/pinch-golden-vectors.json`;
+   * `test/parity/pinchGoldenVectorParity.test.ts` verifies this table and the iOS mirror
+   * (`PinchGeometryTests.swift`'s `testGoldenVectorsMatchAndroidParity`) against it. Each row is an
+   * input tuple and its expected *unordered* set of four endpoints. The comparison is
+   * order-independent because the two runners label which finger is "first" oppositely (Android
+   * builds center±offset, iOS center∓offset first) while producing the same two touch points. If
+   * either platform's endpoint math changes, its golden assertion fails loudly here or in the Swift
+   * mirror. If the two tables silently diverge — including a coordinated one-sided convention edit
+   * (change math + golden on one platform only) — the parity guard fails. Edit the JSON and both
+   * platform tables together. See issues #2911 / #2979 / #2997.
    */
   @Test
   fun `golden vectors match iOS parity`() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/PinchGeometryTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/PinchGeometryTests.swift
@@ -93,13 +93,16 @@ final class PinchGeometryTests: XCTestCase {
 
     // MARK: - Cross-platform golden parity (issue #2979, Option 2)
 
-    /// SHARED GOLDEN TABLE — keep byte-identical with `PinchGeometryTest.kt`
-    /// (`goldenVectorsMatchIosParity`). Each row is an input tuple and its expected *unordered*
-    /// set of four endpoints (start1, start2, end1, end2). We compare as an order-independent set
-    /// because the two runners label which finger is "first" oppositely (iOS builds center∓offset
-    /// first, Android center±offset first) while producing the same two touch points. If either
-    /// platform's endpoint math changes, its golden assertion fails loudly here or in the Kotlin
-    /// mirror — closing the silent-divergence gap from #2911.
+    /// SHARED GOLDEN TABLE — the single source of truth is `test/fixtures/pinch-golden-vectors.json`;
+    /// `test/parity/pinchGoldenVectorParity.test.ts` verifies this table and the Android mirror
+    /// (`PinchGeometryTest.kt`'s `golden vectors match iOS parity`) against it. Each row is an input
+    /// tuple and its expected *unordered* set of four endpoints (start1, start2, end1, end2). We
+    /// compare as an order-independent set because the two runners label which finger is "first"
+    /// oppositely (iOS builds center∓offset first, Android center±offset first) while producing the
+    /// same two touch points. If either platform's endpoint math changes, its golden assertion fails
+    /// loudly here or in the Kotlin mirror. If the two tables silently diverge — including a
+    /// coordinated one-sided convention edit (change math + golden on one platform only) — the
+    /// parity guard fails. Edit the JSON and both platform tables together. See #2911 / #2979 / #2997.
     func testGoldenVectorsMatchAndroidParity() {
         struct Vector {
             let centerX: CGFloat

--- a/test/fixtures/pinch-golden-vectors.json
+++ b/test/fixtures/pinch-golden-vectors.json
@@ -1,0 +1,70 @@
+{
+  "description": "Single source of truth for the cross-platform two-finger pinch endpoint geometry (issues #2911 / #2979 / #2997). Each row is an input tuple (centerX, centerY, distanceStart, distanceEnd, rotationDegrees) and the expected UNORDERED set of four endpoints [x, y]: start finger 1, start finger 2, end finger 1, end finger 2. rotationDegrees describes how far the finger axis rotates DURING the pinch (starts horizontal, ends rotated). The iOS runner's PinchGeometryTests.swift and Android runner's PinchGeometryTest.kt inline golden tables are verified byte-for-value against this file by test/parity/pinchGoldenVectorParity.test.ts — edit all three together or CI fails.",
+  "vectors": [
+    {
+      "centerX": 100,
+      "centerY": 200,
+      "distanceStart": 80,
+      "distanceEnd": 300,
+      "rotationDegrees": 0,
+      "expected": [
+        [60, 200],
+        [140, 200],
+        [-50, 200],
+        [250, 200]
+      ]
+    },
+    {
+      "centerX": 540,
+      "centerY": 960,
+      "distanceStart": 100,
+      "distanceEnd": 300,
+      "rotationDegrees": 45,
+      "expected": [
+        [490, 960],
+        [590, 960],
+        [433.933983, 853.933983],
+        [646.066017, 1066.066017]
+      ]
+    },
+    {
+      "centerX": 200,
+      "centerY": 400,
+      "distanceStart": 100,
+      "distanceEnd": 100,
+      "rotationDegrees": -30,
+      "expected": [
+        [150, 400],
+        [250, 400],
+        [156.698730, 425],
+        [243.301270, 375]
+      ]
+    },
+    {
+      "centerX": 300,
+      "centerY": 500,
+      "distanceStart": 200,
+      "distanceEnd": 80,
+      "rotationDegrees": -60,
+      "expected": [
+        [200, 500],
+        [400, 500],
+        [280, 534.641016],
+        [320, 465.358984]
+      ]
+    },
+    {
+      "centerX": 0,
+      "centerY": 0,
+      "distanceStart": 200,
+      "distanceEnd": 200,
+      "rotationDegrees": 0,
+      "expected": [
+        [-100, 0],
+        [100, 0],
+        [-100, 0],
+        [100, 0]
+      ]
+    }
+  ]
+}

--- a/test/parity/pinchGoldenVectorParity.test.ts
+++ b/test/parity/pinchGoldenVectorParity.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Drift guard for the cross-platform pinch golden vectors (issue #2997).
+ *
+ * Before this guard, the Android and iOS golden-vector tables were hand-duplicated and kept in
+ * sync only by a comment. That caught the *common* regression (edit one platform's math without
+ * updating its own literals -> that platform's assertion fails) but NOT a *coordinated one-sided
+ * edit* (change one platform's math AND its golden literals): the other platform kept its stale
+ * math + stale literals and both suites stayed green while the runners diverged in production.
+ *
+ * These tests establish a single source of truth — `test/fixtures/pinch-golden-vectors.json` — and
+ * assert that BOTH platforms' committed literals match it. A coordinated one-sided edit now leaves
+ * the untouched platform's literals disagreeing with the JSON, failing here regardless of which
+ * side was changed.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  diffGoldenTables,
+  loadCanonicalVectors,
+  parseKotlinGoldenTable,
+  parseSwiftGoldenTable,
+  type GoldenVector,
+} from "./pinchGoldenVectors";
+
+describe("pinch golden vector parity (issue #2997)", function() {
+  const canonical = loadCanonicalVectors();
+  const swift = parseSwiftGoldenTable();
+  const kotlin = parseKotlinGoldenTable();
+
+  test("canonical JSON exposes the full golden table", function() {
+    // Parsing succeeded and the fixture is non-trivial. Guards against an empty/renamed fixture
+    // silently making every parity assertion vacuous.
+    expect(canonical.length).toBeGreaterThanOrEqual(5);
+    for (const row of canonical) {
+      expect(row.expected.length).toBe(4);
+    }
+  });
+
+  test("both platform tables parse to the same number of rows as the source", function() {
+    // If a platform table drops or gains rows relative to the canonical source, the parser row
+    // count diverges — a coarse but decisive first-line check.
+    expect(swift.length).toBe(canonical.length);
+    expect(kotlin.length).toBe(canonical.length);
+  });
+
+  test("AC1: iOS golden literals are verified against the single source", function() {
+    const diffs = diffGoldenTables(swift, canonical);
+    expect(diffs).toEqual([]);
+  });
+
+  test("AC1: Android golden literals are verified against the single source", function() {
+    const diffs = diffGoldenTables(kotlin, canonical);
+    expect(diffs).toEqual([]);
+  });
+
+  test("transitively, the two platform tables agree with each other", function() {
+    expect(diffGoldenTables(swift, kotlin)).toEqual([]);
+  });
+
+  test("AC2: a coordinated one-sided convention edit is detected", function() {
+    // Simulate the exact failure mode the issue targets: someone changes ONE platform's endpoint
+    // math and updates ONLY that platform's golden literals (here modeled as a mutation to the
+    // parsed Swift table). The untouched canonical source no longer matches, so the guard trips.
+    const tampered: GoldenVector[] = swift.map(row => ({ ...row, expected: [...row.expected] }));
+    // Nudge one endpoint of the first row well past tolerance — a plausible "flipped rotation
+    // sign" / "swapped sin & cos" convention drift.
+    tampered[0] = {
+      ...tampered[0],
+      expected: [
+        [tampered[0].expected[0][0] + 5, tampered[0].expected[0][1] - 5],
+        ...tampered[0].expected.slice(1),
+      ],
+    };
+
+    const diffs = diffGoldenTables(tampered, canonical);
+    expect(diffs.length).toBeGreaterThan(0);
+    expect(diffs.some(d => d.includes("row 0 point"))).toBe(true);
+  });
+
+  test("AC2: an input-tuple divergence is also detected", function() {
+    // The other half of a one-sided edit: changing an input row (e.g. a different rotationDegrees)
+    // on one platform only. The set-based point comparison must not mask an input mismatch.
+    const tampered: GoldenVector[] = kotlin.map(row => ({ ...row }));
+    tampered[1] = { ...tampered[1], rotationDegrees: tampered[1].rotationDegrees + 15 };
+
+    const diffs = diffGoldenTables(tampered, canonical);
+    expect(diffs.some(d => d.includes("rotationDegrees"))).toBe(true);
+  });
+
+  test("the guard ignores finger-label ordering differences (no false drift)", function() {
+    // The two runners label which finger is "first" oppositely. Reversing a row's point order must
+    // NOT register as drift, or the guard would flag a cosmetic, semantically-identical change.
+    const reordered: GoldenVector[] = canonical.map(row => ({
+      ...row,
+      expected: [...row.expected].reverse() as GoldenVector["expected"],
+    }));
+    expect(diffGoldenTables(reordered, canonical)).toEqual([]);
+  });
+});

--- a/test/parity/pinchGoldenVectorParity.test.ts
+++ b/test/parity/pinchGoldenVectorParity.test.ts
@@ -13,11 +13,14 @@
  * side was changed.
  */
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
 import {
   diffGoldenTables,
+  KOTLIN_TEST_PATH,
   loadCanonicalVectors,
   parseKotlinGoldenTable,
   parseSwiftGoldenTable,
+  SWIFT_TEST_PATH,
   type GoldenVector,
 } from "./pinchGoldenVectors";
 
@@ -84,6 +87,21 @@ describe("pinch golden vector parity (issue #2997)", function() {
 
     const diffs = diffGoldenTables(tampered, canonical);
     expect(diffs.some(d => d.includes("rotationDegrees"))).toBe(true);
+  });
+
+  test("the per-platform math<->literals runtime golden loops still exist", function() {
+    // This guard only proves literals <-> JSON. The other half of the parity chain — that each
+    // platform's endpoint MATH is asserted against those literals — lives in the runtime golden
+    // loops of the platform test files (`computePinchPoints`/`ObjCExceptionCatcher_computePinchPoints`
+    // driving `assertEquals`/`XCTAssertEqual`). If someone deleted those loops but kept the literal
+    // tables, this guard would still pass and the math could silently drift. Assert the
+    // assertion-driving symbols are present so the math<->literals half cannot be quietly neutered.
+    const swiftSource = readFileSync(SWIFT_TEST_PATH, "utf8");
+    const kotlinSource = readFileSync(KOTLIN_TEST_PATH, "utf8");
+    expect(swiftSource).toContain("ObjCExceptionCatcher_computePinchPoints(");
+    expect(swiftSource).toContain("XCTAssertEqual");
+    expect(kotlinSource).toContain("computePinchPoints(");
+    expect(kotlinSource).toContain("assertEquals");
   });
 
   test("the guard ignores finger-label ordering differences (no false drift)", function() {

--- a/test/parity/pinchGoldenVectors.ts
+++ b/test/parity/pinchGoldenVectors.ts
@@ -1,0 +1,227 @@
+/**
+ * Single-source drift-guard helpers for the cross-platform pinch golden vectors (issue #2997).
+ *
+ * The Android (`PinchGeometryTest.kt`) and iOS (`PinchGeometryTests.swift`) runners each pin the
+ * two-finger pinch endpoint geometry with an inline golden-vector table. Historically those two
+ * tables were hand-duplicated and kept in sync only by a cross-reference comment, so a
+ * *coordinated one-sided edit* (change one platform's math AND its golden literals) could leave the
+ * runners diverging in production while both test suites stayed green.
+ *
+ * This module closes that gap by parsing both platforms' committed literals out of source and
+ * verifying them against the canonical single source, `test/fixtures/pinch-golden-vectors.json`.
+ * It is deliberately build-system-agnostic — it reads the test files as plain text, so it needs no
+ * SPM / xcodegen / Gradle resource wiring and runs offline under `bun test` in well under 100ms.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/** Repo root, relative to this file (`test/parity/pinchGoldenVectors.ts`). */
+export const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+export const CANONICAL_JSON_PATH = join(
+  REPO_ROOT,
+  "test",
+  "fixtures",
+  "pinch-golden-vectors.json",
+);
+export const SWIFT_TEST_PATH = join(
+  REPO_ROOT,
+  "ios",
+  "control-proxy",
+  "Tests",
+  "CtrlProxyTests",
+  "PinchGeometryTests.swift",
+);
+export const KOTLIN_TEST_PATH = join(
+  REPO_ROOT,
+  "android",
+  "control-proxy",
+  "src",
+  "test",
+  "kotlin",
+  "dev",
+  "jasonpearson",
+  "automobile",
+  "ctrlproxy",
+  "PinchGeometryTest.kt",
+);
+
+/** One golden row: five inputs plus the expected *unordered* set of four endpoints. */
+export interface GoldenVector {
+  centerX: number;
+  centerY: number;
+  distanceStart: number;
+  distanceEnd: number;
+  rotationDegrees: number;
+  expected: Array<[number, number]>;
+}
+
+/** 5 scalar inputs + 4 endpoints × 2 coords. Every golden row has exactly this shape. */
+const NUMBERS_PER_ROW = 13;
+
+// Strip block and line comments so digits inside them never leak into number extraction. (Written
+// as line comments so the delimiter tokens below can be described without closing this comment.)
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+/**
+ * Return the balanced substring that starts at the first `open` delimiter at or after `fromIndex`
+ * and ends at its matching `close` delimiter (inclusive). Used to carve out just the golden table
+ * literal from a larger test function body.
+ */
+function extractBalanced(
+  source: string,
+  fromIndex: number,
+  open: string,
+  close: string,
+): string {
+  const start = source.indexOf(open, fromIndex);
+  if (start < 0) {
+    throw new Error(`could not find '${open}' after index ${fromIndex}`);
+  }
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === open) {
+      depth++;
+    } else if (source[i] === close) {
+      depth--;
+      if (depth === 0) {
+        return source.slice(start, i + 1);
+      }
+    }
+  }
+  throw new Error(`unbalanced '${open}${close}' starting at index ${start}`);
+}
+
+/** Every numeric literal in `source`, in order. Handles negatives and decimals; ignores `f`/`.0`
+ *  type suffixes because it captures only the numeric core (`0f` -> `0`, `433.9f` -> `433.9`). */
+function extractNumbers(source: string): number[] {
+  const matches = source.match(/-?\d+(?:\.\d+)?/g) ?? [];
+  return matches.map(Number);
+}
+
+/** Chunk a flat number sequence into golden rows, asserting a clean multiple of the row width. */
+function rowsFromNumbers(numbers: number[], label: string): GoldenVector[] {
+  if (numbers.length === 0 || numbers.length % NUMBERS_PER_ROW !== 0) {
+    throw new Error(
+      `${label}: expected a positive multiple of ${NUMBERS_PER_ROW} numbers, got ${numbers.length}`,
+    );
+  }
+  const rows: GoldenVector[] = [];
+  for (let i = 0; i < numbers.length; i += NUMBERS_PER_ROW) {
+    const [cx, cy, ds, de, rot, ...pts] = numbers.slice(i, i + NUMBERS_PER_ROW);
+    rows.push({
+      centerX: cx,
+      centerY: cy,
+      distanceStart: ds,
+      distanceEnd: de,
+      rotationDegrees: rot,
+      expected: [
+        [pts[0], pts[1]],
+        [pts[2], pts[3]],
+        [pts[4], pts[5]],
+        [pts[6], pts[7]],
+      ],
+    });
+  }
+  return rows;
+}
+
+/**
+ * Parse the golden table out of a platform test file. `assignmentMarker` anchors the search to the
+ * table (e.g. `let vectors` / `val vectors`); `open`/`close` are the array delimiters that platform
+ * uses (`[` `]` for Swift, `(` `)` for Kotlin's `listOf`).
+ */
+export function parseGoldenTable(
+  filePath: string,
+  assignmentMarker: string,
+  open: string,
+  close: string,
+): GoldenVector[] {
+  const source = readFileSync(filePath, "utf8");
+  const markerIndex = source.indexOf(assignmentMarker);
+  if (markerIndex < 0) {
+    throw new Error(`marker '${assignmentMarker}' not found in ${filePath}`);
+  }
+  // Start after the marker so a type annotation in the marker (e.g. Swift's `[Vector]`) is not
+  // mistaken for the opening delimiter of the literal.
+  const region = extractBalanced(
+    source,
+    markerIndex + assignmentMarker.length,
+    open,
+    close,
+  );
+  const numbers = extractNumbers(stripComments(region));
+  return rowsFromNumbers(numbers, filePath);
+}
+
+export function parseSwiftGoldenTable(): GoldenVector[] {
+  // Anchor past the `[Vector]` type annotation to the `= [ ... ]` literal.
+  return parseGoldenTable(SWIFT_TEST_PATH, "let vectors: [Vector] =", "[", "]");
+}
+
+export function parseKotlinGoldenTable(): GoldenVector[] {
+  // `val vectors =` is followed by the `listOf( ... )` literal.
+  return parseGoldenTable(KOTLIN_TEST_PATH, "val vectors =", "(", ")");
+}
+
+export function loadCanonicalVectors(): GoldenVector[] {
+  const parsed = JSON.parse(readFileSync(CANONICAL_JSON_PATH, "utf8")) as {
+    vectors: GoldenVector[];
+  };
+  if (!Array.isArray(parsed.vectors) || parsed.vectors.length === 0) {
+    throw new Error(`${CANONICAL_JSON_PATH}: missing non-empty "vectors" array`);
+  }
+  return parsed.vectors;
+}
+
+/** Deterministic order-independent point sort — mirrors the Swift/Kotlin `sortedPoints` helpers so
+ *  the parity comparison ignores which finger each runner labels "first". */
+function sortPoints(points: Array<[number, number]>): Array<[number, number]> {
+  return [...points].sort((a, b) => (a[0] !== b[0] ? a[0] - b[0] : a[1] - b[1]));
+}
+
+/**
+ * Compare two golden tables and return human-readable mismatch strings (empty array === identical).
+ * Inputs are matched in order; the four expected endpoints are matched as an order-independent set
+ * (same semantics the runtime assertions use). This is the drift detector: feed it a table with a
+ * one-sided edit and it reports exactly what diverged.
+ */
+export function diffGoldenTables(
+  actual: GoldenVector[],
+  expected: GoldenVector[],
+  tolerance = 1e-3,
+): string[] {
+  const diffs: string[] = [];
+  if (actual.length !== expected.length) {
+    diffs.push(`row count ${actual.length} !== ${expected.length}`);
+    return diffs;
+  }
+  const near = (a: number, b: number) => Math.abs(a - b) <= tolerance;
+  for (let i = 0; i < expected.length; i++) {
+    const a = actual[i];
+    const e = expected[i];
+    for (const key of [
+      "centerX",
+      "centerY",
+      "distanceStart",
+      "distanceEnd",
+      "rotationDegrees",
+    ] as const) {
+      if (!near(a[key], e[key])) {
+        diffs.push(`row ${i} input ${key}: ${a[key]} !== ${e[key]}`);
+      }
+    }
+    const ap = sortPoints(a.expected);
+    const ep = sortPoints(e.expected);
+    for (let j = 0; j < ep.length; j++) {
+      if (!near(ap[j][0], ep[j][0]) || !near(ap[j][1], ep[j][1])) {
+        diffs.push(
+          `row ${i} point ${j}: (${ap[j]}) !== (${ep[j]})`,
+        );
+      }
+    }
+  }
+  return diffs;
+}

--- a/test/parity/pinchGoldenVectors.ts
+++ b/test/parity/pinchGoldenVectors.ts
@@ -94,8 +94,12 @@ function extractBalanced(
   throw new Error(`unbalanced '${open}${close}' starting at index ${start}`);
 }
 
-/** Every numeric literal in `source`, in order. Handles negatives and decimals; ignores `f`/`.0`
- *  type suffixes because it captures only the numeric core (`0f` -> `0`, `433.9f` -> `433.9`). */
+/** Every numeric literal in `source`, in order. Handles plain integers and decimals, negatives,
+ *  and trailing type suffixes (`0f` -> `0`, `433.9f` -> `433.9`), which is every form the golden
+ *  tables use. Exotic forms the tables never contain (exponent `2e2`, underscore `6_0`, hex
+ *  `0x10`) are deliberately NOT parsed specially: they split into extra tokens and trip the
+ *  `NUMBERS_PER_ROW` alignment check in `rowsFromNumbers`, which fails closed rather than silently
+ *  mis-parsing. */
 function extractNumbers(source: string): number[] {
   const matches = source.match(/-?\d+(?:\.\d+)?/g) ?? [];
   return matches.map(Number);
@@ -139,7 +143,9 @@ export function parseGoldenTable(
   open: string,
   close: string,
 ): GoldenVector[] {
-  const source = readFileSync(filePath, "utf8");
+  // Strip comments BEFORE the balanced-delimiter scan so a stray `[`/`]`/`(`/`)` inside a comment
+  // between the marker and the literal (or within it) can never mis-terminate the walk.
+  const source = stripComments(readFileSync(filePath, "utf8"));
   const markerIndex = source.indexOf(assignmentMarker);
   if (markerIndex < 0) {
     throw new Error(`marker '${assignmentMarker}' not found in ${filePath}`);
@@ -152,7 +158,7 @@ export function parseGoldenTable(
     open,
     close,
   );
-  const numbers = extractNumbers(stripComments(region));
+  const numbers = extractNumbers(region);
   return rowsFromNumbers(numbers, filePath);
 }
 


### PR DESCRIPTION
## What

Replaces the **hand-duplicated** pinch golden-vector tables (identical literals in
`ios/control-proxy/Tests/CtrlProxyTests/PinchGeometryTests.swift` and
`android/control-proxy/.../PinchGeometryTest.kt`, kept in sync only by a cross-reference comment)
with a **single source of truth** — `test/fixtures/pinch-golden-vectors.json` — plus a
build-system-agnostic drift guard (`test/parity/pinchGoldenVectorParity.test.ts`) that verifies
**both** platforms' committed literals against the JSON.

Closes #2997.

## Why

Follow-up to #2979 / PR #2989. The duplicated table caught the **common** regression (edit one
platform's math without updating its own golden literals → that platform's assertion fails loudly).
It did **not** catch a **coordinated one-sided edit**: change the convention on platform A *and*
update only A's golden literals, and platform B keeps its old math + old (now-divergent) literals
while **both suites stay green** — the runners diverge in production undetected. Two of three
reviewers on #2989 flagged this as a real (if well-flagged) maintainability hazard. Low severity,
hardening only (`rotationDegrees` defaults to 0; no production caller passes a non-zero value —
verified in #2931/#2979).

## How

The issue's recommended **Option 1 (canonical JSON) + Option 3 (drift guard)**, implemented as a TS
test so it sidesteps the "can't cleanly load a shared fixture across SPM + xcodegen `.xcodeproj` +
Gradle" problem the issue called out:

- **`test/fixtures/pinch-golden-vectors.json`** — the single source: 5 rows of inputs
  (`centerX, centerY, distanceStart, distanceEnd, rotationDegrees`) + expected unordered 4-point
  set. Values are exactly the current Swift/Kotlin literals.
- **`test/parity/pinchGoldenVectorParity.test.ts` + `pinchGoldenVectors.ts`** — parse each
  platform's inline golden table out of source (balanced-delimiter extraction, comment-stripped
  number sequence, chunked into rows) and `diffGoldenTables` each against the canonical JSON.
  Inputs compared in order; the four endpoints compared as an **order-independent set** (mirrors the
  runtime `sortedPoints`/`sortPoints`), so the runners' opposite finger-labeling isn't false drift.
  A coordinated one-sided edit now leaves the untouched platform's literals disagreeing with the
  JSON → guard fails **regardless of which side changed**. Negative tests model both a point-set
  edit and an input-tuple edit.
- **Platform headers** — the `SHARED GOLDEN TABLE` KDoc/doc comments in both files now point at the
  JSON + guard and say "edit all three together"; the inline tables stay (fast, no runtime resource
  IO) but are no longer the source of truth.

Verify-against, not generate-from — satisfies AC1 ("derive from, **or are verified against**, a
single source"). The guard reads the test files as plain text, so it needs no SPM/xcodegen/Gradle
wiring and runs offline under `bun test` in <30ms (AC3). The per-platform runtime golden tests still
enforce *math↔literals*; this guard adds *literals↔JSON across both platforms* — together they close
the silent-divergence gap (AC2).

## Testing

- **New** `test/parity/pinchGoldenVectorParity.test.ts` — 8 cases, `bun test`, ~20ms.
- End-to-end teeth check: temporarily mutating a real Swift golden literal (`60`→`61`) on disk fails
  `AC1: iOS…` + the transitive-agreement test; reverted cleanly.
- Full suite green: **6032 pass, 0 fail, 2 skip** (`bun test`, 468 files).
- `eslint` clean on new files; `ktfmt --google-style` clean on the Kotlin file; `swiftformat --lint`
  clean on the Swift file (comment-only platform edits); `bun build.ts` OK.

### Known limitation

The guard verifies literals agree with the JSON; it does not execute platform math or assert the
per-platform runtime golden test functions still exist — those tests are the precondition for the
*math↔literals* half of the chain. Guarding their existence too is possible but low value; noted as
a potential follow-up.
