### PR TITLE
fix(android): emit structured error envelope on CtrlProxy decode/handler failures (#2985)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.ctrlproxy
 
 import android.util.Log
 import dev.jasonpearson.automobile.ctrlproxy.perf.PerfProvider
+import dev.jasonpearson.automobile.protocol.ErrorResponse
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.WebSocketMessageHandler
 import dev.jasonpearson.automobile.protocol.WebSocketRequest as ProtocolRequest
@@ -23,6 +24,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * WebSocket server that streams view hierarchy updates to connected clients and dispatches inbound
@@ -41,6 +44,56 @@ class WebSocketServer(
 ) {
   companion object {
     private const val TAG = "WebSocketServer"
+
+    /** Lenient parser for best-effort field extraction from a raw (possibly malformed) payload. */
+    private val lenientJson = Json {
+      ignoreUnknownKeys = true
+      isLenient = true
+    }
+
+    /**
+     * Best-effort extraction of a top-level string [field] from a raw JSON payload. Returns null
+     * when the payload is unparseable, the field is absent, or the field is not a JSON string.
+     */
+    private fun extractStringField(raw: String, field: String): String? =
+      try {
+        (lenientJson.parseToJsonElement(raw) as? JsonObject)?.get(field)?.let { element ->
+          (element as? JsonPrimitive)?.takeIf { it.isString }?.content
+        }
+      } catch (e: Exception) {
+        // Expected for genuinely malformed payloads; correlation is best-effort by design.
+        null
+      }
+
+    /**
+     * Best-effort extraction of `requestId` from a raw JSON payload for error correlation,
+     * mirroring the iOS runner's `extractRequestId`. Returns null when it can't be determined.
+     * See #2985.
+     */
+    internal fun extractRequestId(raw: String): String? = extractStringField(raw, "requestId")
+
+    /**
+     * Maps an inbound-decode failure into an actionable, legible wire message. An unknown/
+     * unregistered command type surfaces "Unknown command type: <type>" (symmetric to the iOS
+     * `CommandError.unknownCommand` contract); everything else surfaces "Malformed request:
+     * <cause>" so an out-of-range numeric literal or a JSON syntax error is actionable rather than
+     * opaque. See #2985 (parallels the iOS #2965 legibility mapping).
+     */
+    internal fun describeDecodeFailure(raw: String, throwable: Throwable): String {
+      val cause =
+        throwable.message?.takeIf { it.isNotBlank() }
+          ?: throwable::class.simpleName
+          ?: "unknown error"
+      val looksLikeUnknownType =
+        cause.contains("polymorphic", ignoreCase = true) ||
+          cause.contains("class discriminator", ignoreCase = true)
+      if (looksLikeUnknownType) {
+        extractStringField(raw, "type")?.let { type ->
+          return "Unknown command type: $type"
+        }
+      }
+      return "Malformed request: $cause"
+    }
   }
 
   private var server: EmbeddedServer<*, *>? = null
@@ -302,7 +355,16 @@ class WebSocketServer(
       try {
         protocolJson.decodeFromString<ProtocolRequest>(message)
       } catch (e: Exception) {
+        // Surface a structured error (correlated by best-effort requestId) rather than swallowing
+        // the failure: a silent return leaves the daemon's awaiter hanging until timeout. See
+        // #2985.
         Log.w(TAG, "Failed to parse client message: $message", e)
+        broadcast(
+          ErrorResponse(
+            requestId = extractRequestId(message),
+            error = describeDecodeFailure(message, e),
+          )
+        )
         return
       }
 
@@ -317,8 +379,20 @@ class WebSocketServer(
       if (response != null) {
         broadcast(response)
       }
+    } catch (e: CancellationException) {
+      // Never convert cooperative cancellation into an error frame — it means the read loop /
+      // server scope is shutting down. Let it propagate so the coroutine unwinds cleanly.
+      throw e
     } catch (e: Exception) {
+      // Surface a structured error correlated by the decoded requestId instead of only logging, so
+      // the awaiting client fails fast rather than timing out. See #2985.
       Log.e(TAG, "Error handling message via handler", e)
+      broadcast(
+        ErrorResponse(
+          requestId = request.requestId,
+          error = "Handler error: ${e.message ?: e::class.simpleName ?: "unknown error"}",
+        )
+      )
     }
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -470,6 +470,12 @@ class WebSocketServerIntegrationTest {
         assertEquals("false", responseJson["success"]?.jsonPrimitive?.content)
         val error = responseJson["error"]?.jsonPrimitive?.content ?: ""
         assertTrue("error message should be non-empty", error.isNotEmpty())
+        // Proves the legibility mapping fires on the *real* kotlinx decode exception (not just a
+        // synthetic one): an unknown command type names the offending type on the wire.
+        assertTrue(
+          "expected the unknown type to be named, was: $error",
+          error.contains("totally_unknown_command"),
+        )
       }
     }
   }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -444,6 +444,111 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `malformed command returns structured error response`() = runBlocking {
+    // Issue #2985: an inbound command that fails to decode (here, an unknown command type) must
+    // produce a structured `type:"error"` frame correlated by requestId, not a silent return that
+    // leaves the daemon awaiter hanging until timeout.
+    server.start()
+
+    val client = HttpClient(CIO) { install(WebSockets) }
+    client.use { client ->
+      client.webSocket(
+        method = HttpMethod.Get,
+        host = "localhost",
+        port = getServerPort(),
+        path = "/ws",
+      ) {
+        incoming.receive() // Connection message
+
+        send(Frame.Text("""{"type":"totally_unknown_command","requestId":"req-bad"}"""))
+
+        val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+        val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+
+        assertEquals("error", responseJson["type"]?.jsonPrimitive?.content)
+        assertEquals("req-bad", responseJson["requestId"]?.jsonPrimitive?.content)
+        assertEquals("false", responseJson["success"]?.jsonPrimitive?.content)
+        val error = responseJson["error"]?.jsonPrimitive?.content ?: ""
+        assertTrue("error message should be non-empty", error.isNotEmpty())
+      }
+    }
+  }
+
+  @Test
+  fun `unparseable payload returns error response with null requestId`() = runBlocking {
+    // Best-effort requestId extraction (#2985): when the payload can't be parsed at all, the error
+    // frame is still emitted with a null requestId rather than swallowed.
+    server.start()
+
+    val client = HttpClient(CIO) { install(WebSockets) }
+    client.use { client ->
+      client.webSocket(
+        method = HttpMethod.Get,
+        host = "localhost",
+        port = getServerPort(),
+        path = "/ws",
+      ) {
+        incoming.receive() // Connection message
+
+        send(Frame.Text("""{"type":"request_screenshot", this is not json"""))
+
+        val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+        val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+
+        assertEquals("error", responseJson["type"]?.jsonPrimitive?.content)
+        assertEquals(kotlinx.serialization.json.JsonNull, responseJson["requestId"])
+        assertEquals("false", responseJson["success"]?.jsonPrimitive?.content)
+      }
+    }
+  }
+
+  @Test
+  fun `handler exception returns structured error response`() = runBlocking {
+    // Issue #2985: a handler that throws while processing a well-formed command must still yield a
+    // structured error frame correlated by requestId, not just a server-side log line.
+    val throwingServer =
+      WebSocketServer(
+        port = 0,
+        scope = testScope,
+        messageHandler =
+          CtrlProxyMessageHandler(
+            object : NoOpCtrlProxyActions() {
+              override fun requestScreenshot(requestId: String?) {
+                throw RuntimeException("kaboom")
+              }
+            }
+          ),
+      )
+    throwingServer.start()
+    try {
+      val client = HttpClient(CIO) { install(WebSockets) }
+      client.use { client ->
+        client.webSocket(
+          method = HttpMethod.Get,
+          host = "localhost",
+          port = throwingServer.getActualPort() ?: error("Server not running"),
+          path = "/ws",
+        ) {
+          incoming.receive() // Connection message
+
+          send(Frame.Text("""{"type":"request_screenshot","requestId":"req-throw"}"""))
+
+          val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+          val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+
+          assertEquals("error", responseJson["type"]?.jsonPrimitive?.content)
+          assertEquals("req-throw", responseJson["requestId"]?.jsonPrimitive?.content)
+          assertEquals("false", responseJson["success"]?.jsonPrimitive?.content)
+          val error = responseJson["error"]?.jsonPrimitive?.content ?: ""
+          assertTrue("error message should be non-empty", error.isNotEmpty())
+        }
+      }
+    } finally {
+      throwingServer.stop()
+    }
+  }
+
+  @Test
   fun `commands dispatch in wire order`() = runBlocking {
     // Regression guard for message ordering: two synchronous commands sent back-to-back must run
     // in the order they arrive on the wire. This holds only because the server dispatches inline on

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -85,6 +86,58 @@ class WebSocketServerTest {
 
     // Then
     assertEquals("Connection count should start at 0", 0, server.getConnectionCount())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error-envelope helpers (issue #2985) — pure, no network I/O.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `extractRequestId returns id when present in raw json`() {
+    assertEquals(
+      "abc-123",
+      WebSocketServer.extractRequestId("""{"type":"request_screenshot","requestId":"abc-123"}"""),
+    )
+  }
+
+  @Test
+  fun `extractRequestId returns null when absent`() {
+    assertNull(WebSocketServer.extractRequestId("""{"type":"request_screenshot"}"""))
+  }
+
+  @Test
+  fun `extractRequestId returns null for non-string requestId`() {
+    assertNull(WebSocketServer.extractRequestId("""{"type":"x","requestId":42}"""))
+  }
+
+  @Test
+  fun `extractRequestId returns null for unparseable payload`() {
+    assertNull(WebSocketServer.extractRequestId("""{not valid json"""))
+  }
+
+  @Test
+  fun `describeDecodeFailure surfaces unknown command type`() {
+    val message =
+      WebSocketServer.describeDecodeFailure(
+        """{"type":"totally_unknown_command","requestId":"r1"}""",
+        kotlinx.serialization.SerializationException(
+          "Serializer for subclass 'totally_unknown_command' is not found in the polymorphic scope of 'WebSocketRequest'."
+        ),
+      )
+    assertTrue(
+      "expected message to name the unknown type, was: $message",
+      message.contains("totally_unknown_command"),
+    )
+  }
+
+  @Test
+  fun `describeDecodeFailure returns non-empty message for malformed json`() {
+    val message =
+      WebSocketServer.describeDecodeFailure(
+        """{"type":"request_screenshot",""",
+        kotlinx.serialization.SerializationException("Unexpected end of input"),
+      )
+    assertTrue("expected non-empty message", message.isNotEmpty())
   }
 
   @Test

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -27,6 +27,25 @@ data class ConnectedResponse(
 ) : WebSocketResponse()
 
 // =============================================================================
+// Protocol Error
+// =============================================================================
+
+/**
+ * Structured protocol-boundary error, emitted when an inbound command fails to decode or a handler
+ * throws while processing it. Correlated by [requestId] (best-effort extracted from the raw payload
+ * when decode fails, so a client awaiting that id gets a fast, actionable failure instead of
+ * hanging until timeout). Mirrors the iOS runner's `type:"error"` envelope. See issue #2985.
+ */
+@Serializable
+@SerialName("error")
+data class ErrorResponse(
+  override val timestamp: Long = System.currentTimeMillis(),
+  val requestId: String? = null,
+  val success: Boolean = false,
+  val error: String,
+) : WebSocketResponse()
+
+// =============================================================================
 // Push Events (unsolicited messages)
 // =============================================================================
 

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponseTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponseTest.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.protocol
 
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
@@ -250,6 +252,48 @@ class WebSocketResponseTest {
     assertTrue(encoded.contains(""""mainActivity":"com.example.app/.MainActivity""""))
     assertTrue(encoded.contains(""""android.permission.CAMERA":true"""))
     assertTrue(encoded.contains(""""android.permission.INTERNET":false"""))
+  }
+
+  @Test
+  fun `serialize error response with requestId`() {
+    val response: WebSocketResponse =
+      ErrorResponse(
+        timestamp = 1234567890L,
+        requestId = "req-err",
+        error = "Malformed request: the payload is not valid JSON",
+      )
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"error""""))
+    assertTrue(encoded.contains(""""requestId":"req-err""""))
+    assertTrue(encoded.contains(""""success":false"""))
+    assertTrue(encoded.contains(""""error":"Malformed request: the payload is not valid JSON""""))
+  }
+
+  @Test
+  fun `serialize error response without requestId emits null`() {
+    val response: WebSocketResponse = ErrorResponse(timestamp = 1234567890L, error = "boom")
+
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), response)
+
+    assertTrue(encoded.contains(""""type":"error""""))
+    assertTrue(encoded.contains(""""requestId":null"""))
+    assertTrue(encoded.contains(""""success":false"""))
+    assertTrue(encoded.contains(""""error":"boom""""))
+  }
+
+  @Test
+  fun `error response round-trips through sealed serializer`() {
+    val original: WebSocketResponse =
+      ErrorResponse(timestamp = 42L, requestId = "r1", error = "nope")
+    val encoded = json.encodeToString(WebSocketResponse.serializer(), original)
+    val decoded = json.decodeFromString(WebSocketResponse.serializer(), encoded)
+    assertTrue(decoded is ErrorResponse, "expected ErrorResponse, was ${decoded::class.simpleName}")
+    val error = decoded as ErrorResponse
+    assertEquals("r1", error.requestId)
+    assertFalse(error.success)
+    assertEquals("nope", error.error)
   }
 
   @Test

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -222,6 +222,17 @@ interface WsScreenshotErrorMessage extends WsMessageBase {
   requestId: string;
 }
 
+/**
+ * Structured protocol-boundary error emitted by the runner when an inbound command fails to decode
+ * or a handler throws (issue #2985). `requestId` is best-effort: null when the runner could not
+ * correlate the failure (e.g. an unparseable payload).
+ */
+interface WsErrorMessage extends WsMessageBase {
+  type: "error";
+  requestId: string | null;
+  success: false;
+}
+
 interface WsSwipeResultMessage extends WsRequestBase {
   type: "swipe_result";
   gestureTimeMs?: number;
@@ -572,6 +583,7 @@ type WebSocketMessage =
   | WsHierarchyUpdateMessage
   | WsScreenshotMessage
   | WsScreenshotErrorMessage
+  | WsErrorMessage
   | WsSwipeResultMessage
   | WsTapCoordinatesResultMessage
   | WsDragResultMessage
@@ -1946,6 +1958,20 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
       if (message.type === "connected") {
         logger.debug(`[CTRL_PROXY] Received connection confirmation`);
+        return;
+      }
+
+      // Structured protocol-boundary error from the runner (issue #2985): a command failed to
+      // decode or its handler threw. Fail the correlated request fast instead of letting the
+      // awaiter hang to timeout. requestId is best-effort — when null the runner could not
+      // correlate it, so there is no pending request to resolve (resolveError no-ops on unknown
+      // ids anyway).
+      if (message.type === "error") {
+        const errorText = message.error || "Runner reported an unstructured protocol error";
+        logger.warn(`[CTRL_PROXY] Runner error (requestId: ${message.requestId ?? "none"}): ${errorText}`);
+        if (message.requestId) {
+          this.requestManager.resolveError(message.requestId, errorText);
+        }
         return;
       }
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -980,6 +980,117 @@ describe("AndroidCtrlProxyClient", function() {
 
   });
 
+  describe("error frame handling (issue #2985)", function() {
+    test("a type:error frame correlated by requestId fails the awaiting request fast", async function() {
+      // The Android runner now emits a structured `type:"error"` envelope on decode/handler
+      // failures (issue #2985). Without a consumer branch the awaiter would hang to timeout; this
+      // asserts the pending request resolves immediately with a failed result carrying the message.
+      const errorTimer = new FakeTimer();
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      const shape: HighlightShape = {
+        type: "box",
+        bounds: { x: 10, y: 20, width: 100, height: 80 },
+        style: { strokeColor: "#FF0000", strokeWidth: 4 }
+      };
+
+      try {
+        const requestPromise = testClient.requestAddHighlight("highlight-err", shape, 2000);
+
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket as CapturingWebSocket, 2);
+
+        const highlightMsg = (socket as CapturingWebSocket).sentMessages.find(m => {
+          try { return JSON.parse(m).type === "add_highlight"; } catch { return false; }
+        });
+        expect(highlightMsg).toBeDefined();
+        const payload = JSON.parse(highlightMsg!);
+
+        // Runner reports a structured error correlated by the request's id.
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: payload.requestId,
+          success: false,
+          error: "Malformed request: a numeric value is out of range or not representable.",
+          timestamp: errorTimer.now()
+        }));
+
+        const result = await errorTimer.resolvePromise(requestPromise);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("out of range");
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a type:error frame with a non-matching requestId does not disturb other requests", async function() {
+      // A null/unknown requestId (e.g. an unparseable payload the runner couldn't correlate) must
+      // be a safe no-op: it must not crash, and must not wrongly resolve an unrelated pending
+      // request. Here an in-flight highlight request must survive a mismatched error frame and
+      // still resolve normally from its own response.
+      const errorTimer = new FakeTimer();
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      const shape: HighlightShape = {
+        type: "box",
+        bounds: { x: 10, y: 20, width: 100, height: 80 },
+        style: { strokeColor: "#FF0000", strokeWidth: 4 }
+      };
+
+      try {
+        const requestPromise = testClient.requestAddHighlight("highlight-keep", shape, 2000);
+
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket as CapturingWebSocket, 2);
+
+        const highlightMsg = (socket as CapturingWebSocket).sentMessages.find(m => {
+          try { return JSON.parse(m).type === "add_highlight"; } catch { return false; }
+        });
+        const payload = JSON.parse(highlightMsg!);
+
+        // Error frame for an unrelated / uncorrelated request — must be ignored.
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: "some-other-id",
+          success: false,
+          error: "Malformed request: the payload is not valid JSON",
+          timestamp: errorTimer.now()
+        }));
+
+        // The real response for our request still arrives and resolves it.
+        socket!.simulateMessage(JSON.stringify({
+          type: "highlight_response",
+          requestId: payload.requestId,
+          success: true,
+          error: null
+        }));
+
+        const result = await errorTimer.resolvePromise(requestPromise);
+        expect(result.success).toBe(true);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("bindSession", function() {
     afterEach(function() {
       NavigationGraphManager.resetInstance();


### PR DESCRIPTION
## What

Make the **Android** CtrlProxy runner emit a structured `type:"error"` envelope when an inbound command fails to decode or its handler throws — instead of logging and silently `return`ing, which left the daemon's awaiter hanging until timeout.

Closes #2985. This is the Android counterpart to the iOS decode/handler-boundary work (#2965 / PR #2983). Android was arguably worse: iOS at least returned *some* structured error; Android returned **nothing**.

Affected files:
- `android/protocol/.../WebSocketResponse.kt` — new `ErrorResponse` sealed subtype (`type:"error"`).
- `android/control-proxy/.../WebSocketServer.kt` — emit on decode failure + handler exception; `extractRequestId` / `describeDecodeFailure` helpers.
- `src/features/observe/android/AndroidCtrlProxyClient.ts` — consume the `type:"error"` frame and fail the correlated request fast.

## Why

`WebSocketServer.handleClientMessage` had two swallow points (as flagged in #2985):

```kotlin
val request = try { protocolJson.decodeFromString<ProtocolRequest>(message) }
              catch (e: Exception) { Log.w(...); return }   // no reply
...
try { ... } catch (e: Exception) { Log.e(...) }             // no reply
```

A client awaiting a reply for that `requestId` never got one, so a malformed/unknown command turned into a slow timeout rather than a fast, actionable failure — and it violated the repo's error-handling convention (a protocol-boundary failure should surface a structured error to the client).

## How

**Runner (Kotlin):**
- Added `ErrorResponse(timestamp, requestId?, success=false, error)` (`@SerialName("error")`) to the `WebSocketResponse` sealed hierarchy — serializes to `{"type":"error","success":false,"requestId":…,"error":…,"timestamp":…}`, mirroring the iOS envelope.
- **Decode failure:** best-effort `extractRequestId(raw)` (lenient parse of the raw payload, mirroring iOS `extractRequestId`) + `describeDecodeFailure(raw, e)` → broadcast an `ErrorResponse`. `describeDecodeFailure` maps an unknown/unregistered command type to `"Unknown command type: <type>"` (symmetric to the iOS `CommandError.unknownCommand` contract) and everything else to `"Malformed request: <cause>"` — parallel to the #2965 legibility mapping for out-of-range / malformed-JSON input.
- **Handler exception:** broadcast an `ErrorResponse` correlated by the decoded `request.requestId`. `CancellationException` is re-thrown first so cooperative cancellation still unwinds the read loop cleanly (it is never converted into an error frame).

**Consumer (TS):** the runner frame is only useful if the daemon acts on it — `AndroidCtrlProxyClient.handleWebSocketMessage` now has a `type:"error"` branch that calls `RequestManager.resolveError(requestId, error)`, so the awaiting request fails fast instead of hanging. A null/uncorrelated `requestId` is a safe no-op (mirrors the iOS `decodeCtrlProxyMessage` default-case reject).

## Testing

All no-device (Robolectric/JUnit + bun), following repo conventions.

- `WebSocketResponseTest.kt` — `ErrorResponse` serializes with `type:"error"` / `success:false` / requestId (and `null` when absent) and round-trips through the sealed serializer.
- `WebSocketServerTest.kt` — pure unit tests for `extractRequestId` (present / absent / non-string / unparseable → null) and `describeDecodeFailure` (unknown-type names the type; malformed is non-empty).
- `WebSocketServerIntegrationTest.kt` — end-to-end over a real WebSocket:
  - malformed/unknown command → `type:"error"`, `requestId` echoed, `success:false`, and the wire error **names the offending type** (proves the legibility mapping fires on the *real* kotlinx `SerializationException`, not just a synthetic one).
  - unparseable payload → error frame with **null** requestId (best-effort correlation).
  - handler throw → structured error frame correlated by requestId.
- `CtrlProxyClient.test.ts` — a `type:"error"` frame correlated by requestId fails the awaiting request fast (was: hang to timeout); a non-matching/uncorrelated error frame does not disturb other in-flight requests.

Local runs: `:protocol:test`, `:control-proxy:testDebugUnitTest` (JDK 21), and the bun CtrlProxy/RequestManager suites all green. (One pre-existing, unrelated `preserve SDK screen names` nav-graph test fails on unmodified main too — not touched here.)

> **Delivery note:** `android/control-proxy` ships as a pinned release APK the daemon downloads, so this reaches default installs only after the runner release is re-cut — same delivery gate as other runner-source changes.
