### PR TITLE
fix(ktfmt): mirror the brew drift→pinned-JAR fallback for Windows scoop (follow-up to #2993)

### DIFF
--- a/scripts/ktfmt/install_ktfmt.sh
+++ b/scripts/ktfmt/install_ktfmt.sh
@@ -36,6 +36,29 @@ command_exists() {
 
 # Note: installed_ktfmt_version() is provided by the sourced ktfmt_version.sh.
 
+# Install the pinned fat JAR and make it the ktfmt that resolves. Used by every
+# package-manager path (brew, scoop) when the manager installs a version that
+# drifts from the pin -- package managers have no `ktfmt@<version>` formula, so
+# the pinned JAR is the authoritative install (issue #2966). Returns
+# install_manual's status.
+fallback_to_pinned_jar() {
+    echo -e "${YELLOW}Falling back to the pinned JAR so the pin is honored...${NC}"
+    install_manual
+    local manual_status=$?
+
+    # install_manual writes the pinned wrapper to ~/.local/bin. Two things must
+    # happen before verify_installation (or any later ktfmt call) or the pinned
+    # install won't actually resolve:
+    #  1. Ensure ~/.local/bin is on PATH for this process -- it is NOT on the
+    #     default macOS/MSYS PATH, so otherwise the wrapper is invisible.
+    #  2. Clear bash's command hash: the version probe above already ran (and
+    #     hashed) the package manager's ktfmt, which may have just been unlinked,
+    #     so a stale hash entry would keep resolving the old/removed binary.
+    export PATH="$HOME/.local/bin:$PATH"
+    hash -r 2>/dev/null || true
+    return "$manual_status"
+}
+
 # Install ktfmt on macOS
 install_macos() {
     echo -e "${YELLOW}Installing ktfmt on macOS...${NC}"
@@ -47,8 +70,7 @@ install_macos() {
         # Homebrew has no ktfmt@<version> formula, so `brew install ktfmt`
         # installs whatever the current formula ships -- which may drift from the
         # pin (issue #2966). Verify it; if it differs, unlink brew's copy so it
-        # can't shadow ~/.local/bin on PATH, then install the pinned fat JAR so
-        # the pin is actually honored on macOS.
+        # can't shadow ~/.local/bin on PATH, then install the pinned fat JAR.
         local installed
         installed="$(installed_ktfmt_version)"
         if [[ "$installed" == "$KTFMT_VERSION" ]]; then
@@ -56,22 +78,9 @@ install_macos() {
         fi
 
         echo -e "${YELLOW}brew installed ktfmt '${installed:-unknown}', but this repo pins '${KTFMT_VERSION}'.${NC}"
-        echo -e "${YELLOW}Falling back to the pinned JAR so the pin is honored...${NC}"
         brew unlink ktfmt >/dev/null 2>&1 || true
-        install_manual
-        local manual_status=$?
-
-        # install_manual writes the pinned wrapper to ~/.local/bin. Two things
-        # must happen before verify_installation (or any later ktfmt call) or the
-        # pinned install won't actually resolve:
-        #  1. Ensure ~/.local/bin is on PATH for this process -- it is NOT on the
-        #     default macOS PATH, so otherwise the wrapper is invisible.
-        #  2. Clear bash's command hash: the version probe above already ran (and
-        #     hashed) brew's ktfmt, which `brew unlink` just removed, so a stale
-        #     hash entry would keep resolving the deleted binary.
-        export PATH="$HOME/.local/bin:$PATH"
-        hash -r 2>/dev/null || true
-        return "$manual_status"
+        fallback_to_pinned_jar
+        return $?
     else
         echo -e "${YELLOW}Homebrew not found. Install Homebrew first or use manual installation.${NC}"
         echo "To install Homebrew: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
@@ -118,6 +127,19 @@ install_windows() {
     if command_exists scoop; then
         echo -e "${GREEN}Using Scoop to install ktfmt${NC}"
         scoop install ktfmt
+
+        # Like brew, scoop installs whatever version its manifest ships, which may
+        # drift from the pin (issue #2966). Verify and fall back to the pinned JAR
+        # on drift instead of leaving a mismatched formatter that verify_installation
+        # would then hard-fail with no recourse.
+        local installed
+        installed="$(installed_ktfmt_version)"
+        if [[ "$installed" == "$KTFMT_VERSION" ]]; then
+            return 0
+        fi
+
+        echo -e "${YELLOW}scoop installed ktfmt '${installed:-unknown}', but this repo pins '${KTFMT_VERSION}'.${NC}"
+        fallback_to_pinned_jar
         return $?
     elif command_exists choco; then
         echo -e "${YELLOW}Chocolatey detected, but ktfmt may not be available. Falling back to manual installation...${NC}"

--- a/test/bats/install-ktfmt.bats
+++ b/test/bats/install-ktfmt.bats
@@ -25,15 +25,20 @@ setup() {
   # JAR (v0.64) was fetched on the fallback path.
   export CURL_LOG="$TEST_DIR/curl.log"
 
-  # Force detect_os -> macos regardless of the real host.
+  # detect_os reads `uname -s`; default macOS, override with UNAME_S (e.g.
+  # MINGW64_NT-10.0 to exercise the Windows path).
   cat > "$STUB_BIN/uname" <<'STUB'
 #!/usr/bin/env bash
-echo "Darwin"
+echo "${UNAME_S:-Darwin}"
 STUB
 
-  # brew: `install`/`unlink` succeed and do nothing. The version brew "installed"
-  # is whatever the ktfmt stub reports (see BREW_KTFMT_VERSION below).
+  # brew / scoop: `install`/`unlink` succeed and do nothing. The version the
+  # package manager "installed" is whatever the ktfmt stub reports (BREW_KTFMT_VERSION).
   cat > "$STUB_BIN/brew" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > "$STUB_BIN/scoop" <<'STUB'
 #!/usr/bin/env bash
 exit 0
 STUB
@@ -112,6 +117,23 @@ teardown() {
   [ -x "$HOME/.local/bin/ktfmt" ]
   # verify_installation confirmed the resolved ktfmt is now the pin, not brew's.
   [[ "$output" == *"ktfmt 0.64 is installed"* ]]
+}
+
+@test "Windows: scoop version != pin falls back to the pinned JAR (honors pin)" {
+  # Regression guard: before this, the scoop path installed with no version check
+  # or fallback, so the strict verify would hard-fail a drifted scoop install with
+  # no recourse. It must mirror the brew drift path.
+  run env UNAME_S="MINGW64_NT-10.0" BREW_KTFMT_VERSION="0.66" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -s "$CURL_LOG" ]
+  grep -q "v0.64/ktfmt-0.64-with-dependencies.jar" "$CURL_LOG"
+  [[ "$output" == *"ktfmt 0.64 is installed"* ]]
+}
+
+@test "Windows: scoop version matching the pin does NOT trigger a manual JAR download" {
+  run env UNAME_S="MINGW64_NT-10.0" BREW_KTFMT_VERSION="0.64" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CURL_LOG" ]
 }
 
 @test "macOS: install FAILS loudly if the resolved ktfmt still isn't the pin (verify guard)" {


### PR DESCRIPTION
## What

Follow-up to #2966 / #2993. Mirrors the brew drift → pinned-JAR fallback for the **Windows `scoop`** install path so a drifted scoop install doesn't hard-fail the newly-strict `verify_installation` with no recourse.

## Why

#2993 made `verify_installation` assert the *resolved* ktfmt equals the pin (not just present). The macOS `brew` path was updated to fall back to the pinned fat JAR on drift, but the Windows `scoop` path still ran `scoop install ktfmt; return $?` with **no version check and no fallback**. So on Windows, if scoop's manifest ships a version other than the pin, the install now fails at verification — a regression the strict check introduced.

This was flagged as a P2 on #2993 by the Codex reviewer (reproduced with `uname` forced to MINGW and a scoop stub returning `0.66`). The fix landed after #2993 had already auto-merged, so it comes as this follow-up.

## How

- Extract the shared **`fallback_to_pinned_jar`** helper (`install_manual` + prepend `~/.local/bin` to PATH + `hash -r`) from the macOS branch so both package-manager paths use identical, correct fallback logic.
- After `scoop install ktfmt`, verify the version; on drift, `fallback_to_pinned_jar` (scoop has no per-version manifest to pin, so the JAR is authoritative). The PATH prepend + `hash -r` also cover MSYS/MINGW, where `~/.local/bin` isn't on the default PATH.

## Testing

- `bats test/bats/install-ktfmt.bats test/bats/validate-ktfmt.bats test/bats/apply-ktfmt.bats` → **17 pass** (all stubbed, fast, no network):
  - Windows: scoop version != pin → falls back to the pinned `v0.64` JAR and makes it resolve
  - Windows: scoop version == pin → no manual JAR download
  - (plus the existing macOS brew/verify-guard and validate/apply gate tests)
- `shellcheck scripts/ktfmt/*.sh` → clean.

## References
- #2966 (enforcement issue), #2993 (merged PR this follows up), Codex P2 comment on `install_ktfmt.sh` scoop path.
