### PR TITLE
feat(image): ImageBackend seam + declarative ImageTransformer + FakeImageBackend (#3008)

### DIFF
--- a/src/utils/image/ImageTransformer.ts
+++ b/src/utils/image/ImageTransformer.ts
@@ -191,6 +191,9 @@ export class Image {
       return await this.backend.metadata(this.buffer);
     } catch (e: unknown) {
       const errorMessage = e instanceof Error ? e.message : String(e);
+      // Log before rethrowing so the underlying decode error leaves a trace,
+      // mirroring toBuffer's catch (the summarized message loses the original).
+      logger.warn(`[IMAGE] Metadata read failed: ${errorMessage}`, e);
       throw new Error(`Failed to get image metadata: ${errorMessage}`);
     }
   }

--- a/src/utils/image/ImageTransformer.ts
+++ b/src/utils/image/ImageTransformer.ts
@@ -2,57 +2,35 @@ import { logger } from "../logger";
 import { NodeCryptoService } from "../crypto";
 import { ImageCache } from "./ImageCache";
 import { defaultTimer, type Timer } from "../SystemTimer";
-import { loadJimp, type JimpImage } from "./loadJimp";
+import type { ImageBackend, ImageMetadata, ImagePipeline } from "./backend/ImageBackend";
+import { resolveImageBackend } from "./backend/resolveImageBackend";
 
 const DEFAULT_JPEG_QUALITY = 75;
 
-interface ImageOptions {
-  format?: "png" | "webp";
-  quality?: number; // 1-100, for webp
-  lossless?: boolean;
-  nearLossless?: boolean;
-  resize?: {
-    width?: number;
-    height?: number;
-    maintainAspectRatio?: boolean;
-  };
-  crop?: {
-    width: number;
-    height: number;
-    x: number;
-    y: number;
-  };
-}
+// Re-exported from the backend seam so existing importers keep the same path.
+export type { ImageMetadata };
 
-export interface ImageMetadata {
-  width: number;
-  height: number;
-  format: string;
-  size: number;
-}
-
-type OutputFormat = {
-  mime: "image/png" | "image/webp";
-  opts?: Record<string, unknown>;
-};
-
+/**
+ * Fluent builder that records resize/crop/encode requests into a declarative
+ * `ImagePipeline` and delegates execution to an injected `ImageBackend`. The
+ * backend owns all decode/encode; this class only validates inputs, records the
+ * pipeline, and manages the (backend-agnostic) result cache.
+ */
 class JimpImageTransformer {
-  private options: ImageOptions = {};
+  private pipeline: ImagePipeline = { operations: [], encoding: null };
   private cacheKey: string | null = null;
   private useCache: boolean = true;
   private timer: Timer;
-  private operations: Array<(image: JimpImage) => JimpImage> = [];
-  private outputFormat: OutputFormat | null = null;
 
-  constructor(private buffer: Buffer, timer: Timer = defaultTimer) {
+  constructor(private buffer: Buffer, private backend: ImageBackend, timer: Timer = defaultTimer) {
     this.timer = timer;
   }
 
   private generateCacheKey(): string {
-    // Create a unique key based on buffer content hash and options
-    const optionsStr = JSON.stringify(this.options);
+    // Create a unique key based on buffer content hash and the recorded pipeline.
+    const pipelineStr = JSON.stringify(this.pipeline);
     const bufferHash = NodeCryptoService.generateCacheKey(this.buffer);
-    return `${bufferHash}_${optionsStr}`;
+    return `${bufferHash}_${pipelineStr}`;
   }
 
   public disableCache(): JimpImageTransformer {
@@ -69,24 +47,7 @@ class JimpImageTransformer {
       throw new Error("Height must be a positive number");
     }
 
-    this.options.resize = {
-      width,
-      height,
-      maintainAspectRatio
-    };
-
-    this.operations.push(image => {
-      if (height === undefined) {
-        // Width only: scale preserving aspect ratio
-        return image.resize({ w: width });
-      }
-      if (maintainAspectRatio) {
-        // Match sharp's default fit "cover": exact WxH, center-cropped
-        return image.cover({ w: width, h: height });
-      }
-      // fit "fill": stretch to exact WxH
-      return image.resize({ w: width, h: height });
-    });
+    this.pipeline.operations.push({ type: "resize", width, height, maintainAspectRatio });
     return this;
   }
 
@@ -95,14 +56,12 @@ class JimpImageTransformer {
       throw new Error("Crop dimensions must be positive numbers");
     }
 
-    this.options.crop = { width, height, x, y };
-    this.operations.push(image => image.crop({ x, y, w: width, h: height }));
+    this.pipeline.operations.push({ type: "crop", x, y, width, height });
     return this;
   }
 
   public png(): JimpImageTransformer {
-    this.options.format = "png";
-    this.outputFormat = { mime: "image/png" };
+    this.pipeline.encoding = { mime: "image/png" };
     return this;
   }
 
@@ -120,11 +79,6 @@ class JimpImageTransformer {
       throw new Error("WebP quality must be between 1 and 100");
     }
 
-    this.options.format = "webp";
-    this.options.quality = quality;
-    this.options.lossless = options?.lossless;
-    this.options.nearLossless = options?.nearLossless;
-
     // The wasm-webp encoder takes libwebp-style numeric flags. Keys are
     // camelCase (validated by the plugin's zod schema — an unknown key is
     // silently dropped, and `quality` defaults to 100). In lossless mode
@@ -137,13 +91,13 @@ class JimpImageTransformer {
         ? { lossless: 1, nearLossless: quality }
         : { quality };
 
-    this.outputFormat = { mime: "image/webp", opts: webpOptions };
+    this.pipeline.encoding = { mime: "image/webp", options: webpOptions };
     return this;
   }
 
   public async toBuffer(): Promise<Buffer> {
     const startTime = this.timer.now();
-    const formatInfo = this.options.format || "unknown";
+    const formatInfo = this.pipeline.encoding?.mime.replace("image/", "") ?? "unknown";
     logger.debug(`[IMAGE] Starting image processing (format: ${formatInfo})`);
 
     // Check cache first if cache is enabled
@@ -164,17 +118,7 @@ class JimpImageTransformer {
 
     try {
       const processStartTime = this.timer.now();
-      const Jimp = await loadJimp();
-      let image = await Jimp.fromBuffer(this.buffer) as JimpImage;
-      for (const operation of this.operations) {
-        image = operation(image);
-      }
-      // Fall back to the decoded input format when no output format was requested
-      const mime = this.outputFormat?.mime ?? image.mime ?? "image/png";
-      const resultBuffer = await (image.getBuffer as (m: string, o?: Record<string, unknown>) => Promise<Buffer>)(
-        mime,
-        this.outputFormat?.opts
-      );
+      const resultBuffer = await this.backend.execute(this.buffer, this.pipeline);
       const processDuration = this.timer.now() - processStartTime;
 
       // Store result in cache if caching is enabled
@@ -198,16 +142,18 @@ class JimpImageTransformer {
 
 export class Image {
   private timer: Timer;
+  private backend: ImageBackend;
 
-  constructor(private buffer: Buffer, timer: Timer = defaultTimer) {
+  constructor(private buffer: Buffer, timer: Timer = defaultTimer, backend: ImageBackend = resolveImageBackend()) {
     this.timer = timer;
+    this.backend = backend;
   }
 
-  public static fromBuffer(buffer: Buffer, timer: Timer = defaultTimer): Image {
+  public static fromBuffer(buffer: Buffer, timer: Timer = defaultTimer, backend: ImageBackend = resolveImageBackend()): Image {
     if (!Buffer.isBuffer(buffer)) {
       throw new Error("Input must be a Buffer");
     }
-    return new Image(buffer, timer);
+    return new Image(buffer, timer, backend);
   }
 
   public getOriginalBuffer(): Buffer {
@@ -215,26 +161,26 @@ export class Image {
   }
 
   public resize(width: number, height?: number, maintainAspectRatio = true): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).resize(width, height, maintainAspectRatio);
+    return new JimpImageTransformer(this.buffer, this.backend, this.timer).resize(width, height, maintainAspectRatio);
   }
 
   public crop(width: number, height: number, x = 0, y = 0): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).crop(width, height, x, y);
+    return new JimpImageTransformer(this.buffer, this.backend, this.timer).crop(width, height, x, y);
   }
 
   public png(): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).png();
+    return new JimpImageTransformer(this.buffer, this.backend, this.timer).png();
   }
 
   /**
    * Convert the image to WebP format
    */
   public webp(options?: { quality?: number; lossless?: boolean; nearLossless?: boolean }): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer).webp(options);
+    return new JimpImageTransformer(this.buffer, this.backend, this.timer).webp(options);
   }
 
   public transform(): JimpImageTransformer {
-    return new JimpImageTransformer(this.buffer, this.timer);
+    return new JimpImageTransformer(this.buffer, this.backend, this.timer);
   }
 
   /**
@@ -242,15 +188,7 @@ export class Image {
    */
   public async getMetadata(): Promise<ImageMetadata> {
     try {
-      const Jimp = await loadJimp();
-      const image = await Jimp.fromBuffer(this.buffer);
-
-      return {
-        width: image.bitmap.width,
-        height: image.bitmap.height,
-        format: image.mime ? image.mime.replace("image/", "") : "",
-        size: this.buffer.length
-      };
+      return await this.backend.metadata(this.buffer);
     } catch (e: unknown) {
       const errorMessage = e instanceof Error ? e.message : String(e);
       throw new Error(`Failed to get image metadata: ${errorMessage}`);

--- a/src/utils/image/backend/ImageBackend.ts
+++ b/src/utils/image/backend/ImageBackend.ts
@@ -1,0 +1,65 @@
+/**
+ * Backend seam for image processing.
+ *
+ * `ImageTransformer` records the caller's resize/crop/encode requests into a
+ * declarative `ImagePipeline`, then hands the source buffer + pipeline to an
+ * `ImageBackend` for execution. This decouples the fluent transform API from
+ * the concrete decoder/encoder (jimp today; sharp + cwebp later — see the
+ * "Sharp + CWebP" milestone), so later issues can swap backends without
+ * touching call sites. Behavior-preserving: the jimp backend reproduces the
+ * exact operations the transformer used to run inline.
+ */
+
+/** Basic image metadata surfaced by every backend. */
+export interface ImageMetadata {
+  width: number;
+  height: number;
+  format: string;
+  size: number;
+}
+
+/**
+ * A single declarative transform step. Backends interpret these rather than
+ * receiving pre-bound closures, so the same pipeline can run on any backend.
+ */
+export type ImageOperation =
+  | { type: "resize"; width: number; height?: number; maintainAspectRatio: boolean }
+  | { type: "crop"; x: number; y: number; width: number; height: number };
+
+/**
+ * The requested output encoding. `null` (on the pipeline) means "re-encode in
+ * the decoded input format", matching the transformer's historical fallback.
+ * `options` carries backend-agnostic encoder flags (e.g. the libwebp-style
+ * numeric flags the jimp wasm-webp encoder expects).
+ */
+export interface ImageEncoding {
+  mime: "image/png" | "image/webp";
+  options?: Record<string, unknown>;
+}
+
+/** Declarative description of a transform: ordered operations + output encoding. */
+export interface ImagePipeline {
+  operations: ImageOperation[];
+  encoding: ImageEncoding | null;
+}
+
+/** Decoded raw pixels (RGBA, row-major) for pixel-level consumers. */
+export interface RawImage {
+  width: number;
+  height: number;
+  /** RGBA bytes, length === width * height * 4. */
+  data: Buffer;
+}
+
+/**
+ * Executes declarative image pipelines and exposes metadata / raw pixels.
+ * Implemented by `JimpBackend` (production) and `FakeImageBackend` (tests).
+ */
+export interface ImageBackend {
+  /** Decode `source`, apply `pipeline.operations`, encode per `pipeline.encoding`. */
+  execute(source: Buffer, pipeline: ImagePipeline): Promise<Buffer>;
+  /** Decode `source` and report dimensions/format/size without re-encoding. */
+  metadata(source: Buffer): Promise<ImageMetadata>;
+  /** Decode `source` to raw RGBA pixels. */
+  rawPixels(source: Buffer): Promise<RawImage>;
+}

--- a/src/utils/image/backend/JimpBackend.ts
+++ b/src/utils/image/backend/JimpBackend.ts
@@ -1,0 +1,64 @@
+import { loadJimp, type JimpImage } from "../loadJimp";
+import type { ImageBackend, ImageMetadata, ImageOperation, ImagePipeline, RawImage } from "./ImageBackend";
+
+/**
+ * Jimp-backed `ImageBackend`. Reproduces exactly what `ImageTransformer` used
+ * to run inline, including WebP encode/decode via the `@jimp/wasm-webp` plugin
+ * (wired in `loadJimp`). Kept pure-jimp for now; sharp/cwebp backends land in
+ * later issues (#3010/#3011).
+ */
+export class JimpBackend implements ImageBackend {
+  private applyOperation(image: JimpImage, op: ImageOperation): JimpImage {
+    switch (op.type) {
+      case "resize":
+        if (op.height === undefined) {
+          // Width only: scale preserving aspect ratio.
+          return image.resize({ w: op.width });
+        }
+        if (op.maintainAspectRatio) {
+          // Match sharp's default fit "cover": exact WxH, center-cropped.
+          return image.cover({ w: op.width, h: op.height });
+        }
+        // fit "fill": stretch to exact WxH.
+        return image.resize({ w: op.width, h: op.height });
+      case "crop":
+        return image.crop({ x: op.x, y: op.y, w: op.width, h: op.height });
+    }
+  }
+
+  public async execute(source: Buffer, pipeline: ImagePipeline): Promise<Buffer> {
+    const Jimp = await loadJimp();
+    let image = await Jimp.fromBuffer(source) as JimpImage;
+    for (const operation of pipeline.operations) {
+      image = this.applyOperation(image, operation);
+    }
+    // Fall back to the decoded input format when no output encoding was requested.
+    const mime = pipeline.encoding?.mime ?? image.mime ?? "image/png";
+    return (image.getBuffer as (m: string, o?: Record<string, unknown>) => Promise<Buffer>)(
+      mime,
+      pipeline.encoding?.options
+    );
+  }
+
+  public async metadata(source: Buffer): Promise<ImageMetadata> {
+    const Jimp = await loadJimp();
+    const image = await Jimp.fromBuffer(source);
+    return {
+      width: image.bitmap.width,
+      height: image.bitmap.height,
+      format: image.mime ? image.mime.replace("image/", "") : "",
+      size: source.length
+    };
+  }
+
+  public async rawPixels(source: Buffer): Promise<RawImage> {
+    const Jimp = await loadJimp();
+    const image = await Jimp.fromBuffer(source);
+    return {
+      width: image.bitmap.width,
+      height: image.bitmap.height,
+      // Copy out of the jimp-owned bitmap so callers can't mutate its internals.
+      data: Buffer.from(image.bitmap.data)
+    };
+  }
+}

--- a/src/utils/image/backend/resolveImageBackend.ts
+++ b/src/utils/image/backend/resolveImageBackend.ts
@@ -1,0 +1,14 @@
+import type { ImageBackend } from "./ImageBackend";
+import { JimpBackend } from "./JimpBackend";
+
+/**
+ * Selects the image backend for the current platform.
+ *
+ * Returns `JimpBackend` unconditionally for now — platform-aware selection
+ * (sharp on most platforms, cwebp on Windows) lands with later issues in the
+ * "Sharp + CWebP" milestone (#3010/#3011). Kept as a function seam so those
+ * issues change selection here without touching `ImageTransformer`.
+ */
+export function resolveImageBackend(): ImageBackend {
+  return new JimpBackend();
+}

--- a/test/fakes/FakeImageBackend.test.ts
+++ b/test/fakes/FakeImageBackend.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { FakeImageBackend } from "./FakeImageBackend";
+import type { ImagePipeline } from "../../src/utils/image/backend/ImageBackend";
+
+describe("FakeImageBackend", () => {
+  let backend: FakeImageBackend;
+  const source = Buffer.from("src");
+  const pipeline: ImagePipeline = {
+    operations: [{ type: "resize", width: 10, height: 10, maintainAspectRatio: false }],
+    encoding: { mime: "image/png" }
+  };
+
+  beforeEach(() => {
+    backend = new FakeImageBackend();
+  });
+
+  describe("defaults", () => {
+    test("execute returns a canned buffer", async () => {
+      expect((await backend.execute(source, pipeline)).length).toBeGreaterThan(0);
+    });
+
+    test("metadata returns canned metadata", async () => {
+      const meta = await backend.metadata(source);
+      expect(meta).toEqual({ width: 1080, height: 2400, format: "png", size: 1024000 });
+    });
+
+    test("rawPixels returns RGBA data sized width*height*4", async () => {
+      const raw = await backend.rawPixels(source);
+      expect(raw.width).toBe(2);
+      expect(raw.height).toBe(2);
+      expect(raw.data.length).toBe(2 * 2 * 4);
+    });
+  });
+
+  describe("configuration", () => {
+    test("setExecuteResult overrides the execute buffer", async () => {
+      backend.setExecuteResult(Buffer.from([1, 2, 3]));
+      expect([...(await backend.execute(source, pipeline))]).toEqual([1, 2, 3]);
+    });
+
+    test("setMetadataResult overrides metadata", async () => {
+      backend.setMetadataResult({ width: 1, height: 1, format: "webp", size: 9 });
+      expect((await backend.metadata(source)).format).toBe("webp");
+    });
+
+    test("setRawPixelsResult overrides raw pixels", async () => {
+      backend.setRawPixelsResult({ width: 1, height: 1, data: Buffer.from([9, 9, 9, 9]) });
+      expect((await backend.rawPixels(source)).width).toBe(1);
+    });
+  });
+
+  describe("call tracking", () => {
+    test("records execute calls with source and pipeline", async () => {
+      await backend.execute(source, pipeline);
+      expect(backend.executeCalls).toHaveLength(1);
+      expect(backend.executeCalls[0].source).toBe(source);
+      expect(backend.executeCalls[0].pipeline).toBe(pipeline);
+      expect(backend.lastPipeline).toBe(pipeline);
+    });
+
+    test("records metadata and rawPixels calls", async () => {
+      await backend.metadata(source);
+      await backend.rawPixels(source);
+      expect(backend.metadataCalls).toEqual([source]);
+      expect(backend.rawPixelsCalls).toEqual([source]);
+    });
+  });
+
+  describe("error injection", () => {
+    test("execute throws when configured", async () => {
+      backend.setShouldThrowOnExecute(true);
+      await expect(backend.execute(source, pipeline)).rejects.toThrow("Simulated error in execute");
+    });
+
+    test("metadata throws when configured", async () => {
+      backend.setShouldThrowOnMetadata(true);
+      await expect(backend.metadata(source)).rejects.toThrow("Simulated error in metadata");
+    });
+
+    test("rawPixels throws when configured", async () => {
+      backend.setShouldThrowOnRawPixels(true);
+      await expect(backend.rawPixels(source)).rejects.toThrow("Simulated error in rawPixels");
+    });
+  });
+});

--- a/test/fakes/FakeImageBackend.ts
+++ b/test/fakes/FakeImageBackend.ts
@@ -1,0 +1,99 @@
+import type {
+  ImageBackend,
+  ImageMetadata,
+  ImagePipeline,
+  RawImage
+} from "../../src/utils/image/backend/ImageBackend";
+
+/**
+ * Fake `ImageBackend` for fast, deterministic tests.
+ *
+ * Returns canned buffers / metadata / raw pixels and records every call so
+ * tests can assert what pipeline the transformer handed to the backend without
+ * decoding real images. Mirrors the configure/track/error-inject shape of the
+ * other repo fakes (see FakeImageUtils).
+ */
+export class FakeImageBackend implements ImageBackend {
+  // Canned results.
+  private executeResult: Buffer = Buffer.from("fake-execute-result");
+  private metadataResult: ImageMetadata = {
+    width: 1080,
+    height: 2400,
+    format: "png",
+    size: 1024000
+  };
+  private rawPixelsResult: RawImage = {
+    width: 2,
+    height: 2,
+    // 2x2 RGBA: red, green, blue, white.
+    data: Buffer.from([
+      255, 0, 0, 255,
+      0, 255, 0, 255,
+      0, 0, 255, 255,
+      255, 255, 255, 255
+    ])
+  };
+
+  // Error injection.
+  private shouldThrowOnExecute = false;
+  private shouldThrowOnMetadata = false;
+  private shouldThrowOnRawPixels = false;
+
+  // Call tracking.
+  public readonly executeCalls: Array<{ source: Buffer; pipeline: ImagePipeline }> = [];
+  public readonly metadataCalls: Buffer[] = [];
+  public readonly rawPixelsCalls: Buffer[] = [];
+
+  setExecuteResult(buffer: Buffer): void {
+    this.executeResult = buffer;
+  }
+
+  setMetadataResult(metadata: ImageMetadata): void {
+    this.metadataResult = metadata;
+  }
+
+  setRawPixelsResult(raw: RawImage): void {
+    this.rawPixelsResult = raw;
+  }
+
+  setShouldThrowOnExecute(shouldThrow: boolean): void {
+    this.shouldThrowOnExecute = shouldThrow;
+  }
+
+  setShouldThrowOnMetadata(shouldThrow: boolean): void {
+    this.shouldThrowOnMetadata = shouldThrow;
+  }
+
+  setShouldThrowOnRawPixels(shouldThrow: boolean): void {
+    this.shouldThrowOnRawPixels = shouldThrow;
+  }
+
+  /** The pipeline handed to the most recent `execute` call, if any. */
+  get lastPipeline(): ImagePipeline | undefined {
+    return this.executeCalls[this.executeCalls.length - 1]?.pipeline;
+  }
+
+  async execute(source: Buffer, pipeline: ImagePipeline): Promise<Buffer> {
+    this.executeCalls.push({ source, pipeline });
+    if (this.shouldThrowOnExecute) {
+      throw new Error("Simulated error in execute");
+    }
+    return this.executeResult;
+  }
+
+  async metadata(source: Buffer): Promise<ImageMetadata> {
+    this.metadataCalls.push(source);
+    if (this.shouldThrowOnMetadata) {
+      throw new Error("Simulated error in metadata");
+    }
+    return this.metadataResult;
+  }
+
+  async rawPixels(source: Buffer): Promise<RawImage> {
+    this.rawPixelsCalls.push(source);
+    if (this.shouldThrowOnRawPixels) {
+      throw new Error("Simulated error in rawPixels");
+    }
+    return this.rawPixelsResult;
+  }
+}

--- a/test/utils/image/ImageTransformer.test.ts
+++ b/test/utils/image/ImageTransformer.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Image } from "../../../src/utils/image/ImageTransformer";
+import { FakeImageBackend } from "../../fakes/FakeImageBackend";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+describe("ImageTransformer (declarative pipeline + backend delegation)", () => {
+  let backend: FakeImageBackend;
+  let timer: FakeTimer;
+  const source = Buffer.from("source-image-bytes");
+
+  const imageOf = (buffer: Buffer = source) => Image.fromBuffer(buffer, timer, backend);
+
+  beforeEach(() => {
+    backend = new FakeImageBackend();
+    timer = new FakeTimer();
+    Image.clearCache();
+  });
+
+  describe("pipeline recording", () => {
+    test("resize records a resize operation and no encoding", async () => {
+      await imageOf().resize(100, 200, false).disableCache().toBuffer();
+
+      const pipeline = backend.lastPipeline!;
+      expect(pipeline.operations).toEqual([
+        { type: "resize", width: 100, height: 200, maintainAspectRatio: false }
+      ]);
+      expect(pipeline.encoding).toBeNull();
+    });
+
+    test("width-only resize records height as undefined and default aspect ratio", async () => {
+      await imageOf().resize(100).disableCache().toBuffer();
+
+      expect(backend.lastPipeline!.operations).toEqual([
+        { type: "resize", width: 100, height: undefined, maintainAspectRatio: true }
+      ]);
+    });
+
+    test("crop records a crop operation with defaults for x/y", async () => {
+      await imageOf().crop(50, 40).disableCache().toBuffer();
+
+      expect(backend.lastPipeline!.operations).toEqual([
+        { type: "crop", x: 0, y: 0, width: 50, height: 40 }
+      ]);
+    });
+
+    test("chained operations record in call order", async () => {
+      await imageOf().crop(50, 40, 5, 6).resize(20, 20, false).png().disableCache().toBuffer();
+
+      const pipeline = backend.lastPipeline!;
+      expect(pipeline.operations).toEqual([
+        { type: "crop", x: 5, y: 6, width: 50, height: 40 },
+        { type: "resize", width: 20, height: 20, maintainAspectRatio: false }
+      ]);
+      expect(pipeline.encoding).toEqual({ mime: "image/png" });
+    });
+
+    test("png records png encoding", async () => {
+      await imageOf().png().disableCache().toBuffer();
+      expect(backend.lastPipeline!.encoding).toEqual({ mime: "image/png" });
+    });
+
+    test("webp default records quality 75", async () => {
+      await imageOf().webp().disableCache().toBuffer();
+      expect(backend.lastPipeline!.encoding).toEqual({
+        mime: "image/webp",
+        options: { quality: 75 }
+      });
+    });
+
+    test("webp lossless records libwebp lossless flags", async () => {
+      await imageOf().webp({ lossless: true, quality: 90 }).disableCache().toBuffer();
+      expect(backend.lastPipeline!.encoding).toEqual({
+        mime: "image/webp",
+        options: { lossless: 1, quality: 90 }
+      });
+    });
+
+    test("webp nearLossless records nearLossless preprocessing level", async () => {
+      await imageOf().webp({ nearLossless: true, quality: 40 }).disableCache().toBuffer();
+      expect(backend.lastPipeline!.encoding).toEqual({
+        mime: "image/webp",
+        options: { lossless: 1, nearLossless: 40 }
+      });
+    });
+  });
+
+  describe("delegation", () => {
+    test("toBuffer returns the backend result", async () => {
+      backend.setExecuteResult(Buffer.from("encoded-output"));
+      const result = await imageOf().png().disableCache().toBuffer();
+      expect(result.toString()).toBe("encoded-output");
+    });
+
+    test("toBuffer passes the original source buffer to the backend", async () => {
+      await imageOf().png().disableCache().toBuffer();
+      expect(backend.executeCalls[0].source).toBe(source);
+    });
+
+    test("toBuffer wraps backend failures in an 'Image processing error' message", async () => {
+      backend.setShouldThrowOnExecute(true);
+      await expect(imageOf().png().disableCache().toBuffer()).rejects.toThrow(
+        "Image processing error: Simulated error in execute"
+      );
+    });
+
+    test("getMetadata delegates to backend.metadata", async () => {
+      backend.setMetadataResult({ width: 320, height: 480, format: "webp", size: 42 });
+      const meta = await imageOf().getMetadata();
+      expect(meta).toEqual({ width: 320, height: 480, format: "webp", size: 42 });
+      expect(backend.metadataCalls[0]).toBe(source);
+    });
+
+    test("getMetadata wraps backend failures", async () => {
+      backend.setShouldThrowOnMetadata(true);
+      await expect(imageOf().getMetadata()).rejects.toThrow(
+        "Failed to get image metadata: Simulated error in metadata"
+      );
+    });
+  });
+
+  describe("validation (unchanged public contract)", () => {
+    test("resize rejects non-positive width", () => {
+      expect(() => imageOf().resize(0)).toThrow("Width must be a positive number");
+    });
+
+    test("resize rejects non-positive height", () => {
+      expect(() => imageOf().resize(10, -1)).toThrow("Height must be a positive number");
+    });
+
+    test("crop rejects non-positive dimensions", () => {
+      expect(() => imageOf().crop(0, 10)).toThrow("Crop dimensions must be positive numbers");
+    });
+
+    test("webp rejects out-of-range quality", () => {
+      expect(() => imageOf().webp({ quality: 101 })).toThrow("WebP quality must be between 1 and 100");
+      expect(() => imageOf().webp({ quality: -1 })).toThrow("WebP quality must be between 1 and 100");
+    });
+
+    test("webp quality 0 falls back to the default (preserved || quirk)", async () => {
+      // `quality || DEFAULT_JPEG_QUALITY` treats 0 as falsy, so it becomes 75
+      // rather than throwing. Preserving this pre-existing behavior verbatim.
+      await imageOf().webp({ quality: 0 }).disableCache().toBuffer();
+      expect(backend.lastPipeline!.encoding).toEqual({
+        mime: "image/webp",
+        options: { quality: 75 }
+      });
+    });
+
+    test("fromBuffer rejects a non-buffer input", () => {
+      expect(() => Image.fromBuffer("nope" as unknown as Buffer)).toThrow("Input must be a Buffer");
+    });
+  });
+
+  describe("caching (backend-agnostic)", () => {
+    test("identical pipeline hits cache and only calls the backend once", async () => {
+      backend.setExecuteResult(Buffer.from("cached-output"));
+
+      const first = await imageOf().resize(10, 10, false).png().toBuffer();
+      const second = await imageOf().resize(10, 10, false).png().toBuffer();
+
+      expect(first.toString()).toBe("cached-output");
+      expect(second.toString()).toBe("cached-output");
+      expect(backend.executeCalls.length).toBe(1);
+    });
+
+    test("different pipelines do not collide in the cache", async () => {
+      await imageOf().resize(10, 10, false).png().toBuffer();
+      await imageOf().resize(20, 20, false).png().toBuffer();
+      expect(backend.executeCalls.length).toBe(2);
+    });
+
+    test("disableCache always calls the backend", async () => {
+      await imageOf().png().disableCache().toBuffer();
+      await imageOf().png().disableCache().toBuffer();
+      expect(backend.executeCalls.length).toBe(2);
+    });
+  });
+});

--- a/test/utils/image/backend/JimpBackend.test.ts
+++ b/test/utils/image/backend/JimpBackend.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import { JimpBackend } from "../../../../src/utils/image/backend/JimpBackend";
+import type { ImagePipeline } from "../../../../src/utils/image/backend/ImageBackend";
+
+// Build a small, non-uniform source PNG. Solid colors survive any resize kernel
+// or WebP mode identically and would mask regressions, so use a gradient.
+async function makeSourcePng(width = 8, height = 8): Promise<Buffer> {
+  const { Jimp, rgbaToInt } = await import("jimp");
+  const image = new Jimp({ width, height, color: 0x000000ff });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      image.setPixelColor(rgbaToInt((x * 16) % 256, (y * 16) % 256, (x * y) % 256, 255), x, y);
+    }
+  }
+  return image.getBuffer("image/png");
+}
+
+const PNG_MAGIC = "89504e47";
+
+describe("JimpBackend", () => {
+  describe("execute", () => {
+    test("resize with fill (no aspect ratio) produces exact target dimensions", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 8);
+      const pipeline: ImagePipeline = {
+        operations: [{ type: "resize", width: 4, height: 2, maintainAspectRatio: false }],
+        encoding: { mime: "image/png" }
+      };
+
+      const out = await backend.execute(source, pipeline);
+      const meta = await backend.metadata(out);
+
+      expect(meta.width).toBe(4);
+      expect(meta.height).toBe(2);
+      expect(out.subarray(0, 4).toString("hex")).toBe(PNG_MAGIC);
+    });
+
+    test("resize with maintainAspectRatio covers to exact WxH", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 4);
+      const pipeline: ImagePipeline = {
+        operations: [{ type: "resize", width: 6, height: 6, maintainAspectRatio: true }],
+        encoding: { mime: "image/png" }
+      };
+
+      const meta = await backend.metadata(await backend.execute(source, pipeline));
+
+      expect(meta.width).toBe(6);
+      expect(meta.height).toBe(6);
+    });
+
+    test("width-only resize preserves aspect ratio", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 4);
+      const pipeline: ImagePipeline = {
+        operations: [{ type: "resize", width: 4, maintainAspectRatio: true }],
+        encoding: { mime: "image/png" }
+      };
+
+      const meta = await backend.metadata(await backend.execute(source, pipeline));
+
+      expect(meta.width).toBe(4);
+      expect(meta.height).toBe(2);
+    });
+
+    test("crop produces the requested region size", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 8);
+      const pipeline: ImagePipeline = {
+        operations: [{ type: "crop", x: 1, y: 1, width: 3, height: 2 }],
+        encoding: { mime: "image/png" }
+      };
+
+      const meta = await backend.metadata(await backend.execute(source, pipeline));
+
+      expect(meta.width).toBe(3);
+      expect(meta.height).toBe(2);
+    });
+
+    test("webp encoding produces a RIFF/WEBP container", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng();
+      const pipeline: ImagePipeline = {
+        operations: [],
+        encoding: { mime: "image/webp", options: { quality: 60 } }
+      };
+
+      const out = await backend.execute(source, pipeline);
+
+      expect(out.subarray(0, 4).toString()).toBe("RIFF");
+      expect(out.subarray(8, 12).toString()).toBe("WEBP");
+    });
+
+    test("nearLossless webp is distinct from lossless (option not dropped)", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng();
+
+      const lossless = await backend.execute(source, {
+        operations: [],
+        encoding: { mime: "image/webp", options: { lossless: 1, quality: 75 } }
+      });
+      const nearLossless = await backend.execute(source, {
+        operations: [],
+        encoding: { mime: "image/webp", options: { lossless: 1, nearLossless: 40 } }
+      });
+
+      expect(nearLossless.length).not.toBe(lossless.length);
+    });
+
+    test("null encoding falls back to the decoded input format", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng();
+      const pipeline: ImagePipeline = { operations: [], encoding: null };
+
+      const out = await backend.execute(source, pipeline);
+
+      // Source was PNG, so a null encoding round-trips back to PNG.
+      expect(out.subarray(0, 4).toString("hex")).toBe(PNG_MAGIC);
+    });
+  });
+
+  describe("metadata", () => {
+    test("reports dimensions, format, and source byte size", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 4);
+
+      const meta = await backend.metadata(source);
+
+      expect(meta.width).toBe(8);
+      expect(meta.height).toBe(4);
+      expect(meta.format).toBe("png");
+      expect(meta.size).toBe(source.length);
+    });
+
+    test("rejects a non-image buffer", async () => {
+      const backend = new JimpBackend();
+      await expect(backend.metadata(Buffer.from("not an image"))).rejects.toThrow();
+    });
+  });
+
+  describe("rawPixels", () => {
+    test("returns RGBA data sized width*height*4", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 4);
+
+      const raw = await backend.rawPixels(source);
+
+      expect(raw.width).toBe(8);
+      expect(raw.height).toBe(4);
+      expect(raw.data.length).toBe(8 * 4 * 4);
+    });
+
+    test("returns a copy that does not alias jimp's bitmap", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(2, 2);
+
+      const first = await backend.rawPixels(source);
+      first.data[0] = first.data[0] ^ 0xff;
+      const second = await backend.rawPixels(source);
+
+      // Mutating the returned buffer must not affect a fresh decode.
+      expect(second.data[0]).not.toBe(first.data[0]);
+    });
+  });
+});

--- a/test/utils/image/backend/JimpBackend.test.ts
+++ b/test/utils/image/backend/JimpBackend.test.ts
@@ -17,6 +17,13 @@ async function makeSourcePng(width = 8, height = 8): Promise<Buffer> {
 
 const PNG_MAGIC = "89504e47";
 
+// Executing @jimp/wasm-webp encode/decode under `bun test` on Windows can
+// segfault via the JSC Wasm OSR/JIT path (bun#26366). CI keeps the invariant
+// "no bun-test unit executes WebP on Windows" (WebP is covered on ubuntu by the
+// image-runtime smoke), so gate the WebP-executing cases the same way. PNG
+// decode/encode does not hit the WebP WASM hot path and runs on all platforms.
+const skipWebpOnWindows = process.platform === "win32" ? test.skip : test;
+
 describe("JimpBackend", () => {
   describe("execute", () => {
     test("resize with fill (no aspect ratio) produces exact target dimensions", async () => {
@@ -63,7 +70,7 @@ describe("JimpBackend", () => {
       expect(meta.height).toBe(2);
     });
 
-    test("crop produces the requested region size", async () => {
+    test("crop produces the requested region at the requested offset", async () => {
       const backend = new JimpBackend();
       const source = await makeSourcePng(8, 8);
       const pipeline: ImagePipeline = {
@@ -71,13 +78,40 @@ describe("JimpBackend", () => {
         encoding: { mime: "image/png" }
       };
 
-      const meta = await backend.metadata(await backend.execute(source, pipeline));
+      const out = await backend.execute(source, pipeline);
+      const meta = await backend.metadata(out);
 
       expect(meta.width).toBe(3);
       expect(meta.height).toBe(2);
+
+      // Prove x/y are honored (not cropped from 0,0): the cropped output's top-left
+      // pixel must equal the source gradient at (1,1) = rgba(16, 16, 1, 255).
+      // (PNG is lossless and crop does no resampling, so bytes match exactly.)
+      const cropped = await backend.rawPixels(out);
+      expect([cropped.data[0], cropped.data[1], cropped.data[2], cropped.data[3]]).toEqual([16, 16, 1, 255]);
     });
 
-    test("webp encoding produces a RIFF/WEBP container", async () => {
+    test("applies operations in recorded order (crop then resize)", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 4);
+      // crop 8x4 -> 4x4, then width-only resize -> aspect-preserving 2x2.
+      // Order/only-last-op regressions produce distinct dims: crop-only=4x4,
+      // resize-only=2x1, reversed=degenerate — only the correct order yields 2x2.
+      const pipeline: ImagePipeline = {
+        operations: [
+          { type: "crop", x: 0, y: 0, width: 4, height: 4 },
+          { type: "resize", width: 2, maintainAspectRatio: true }
+        ],
+        encoding: { mime: "image/png" }
+      };
+
+      const meta = await backend.metadata(await backend.execute(source, pipeline));
+
+      expect(meta.width).toBe(2);
+      expect(meta.height).toBe(2);
+    });
+
+    skipWebpOnWindows("webp encoding produces a RIFF/WEBP container", async () => {
       const backend = new JimpBackend();
       const source = await makeSourcePng();
       const pipeline: ImagePipeline = {
@@ -91,7 +125,7 @@ describe("JimpBackend", () => {
       expect(out.subarray(8, 12).toString()).toBe("WEBP");
     });
 
-    test("nearLossless webp is distinct from lossless (option not dropped)", async () => {
+    skipWebpOnWindows("nearLossless webp is distinct from lossless (option not dropped)", async () => {
       const backend = new JimpBackend();
       const source = await makeSourcePng();
 

--- a/test/utils/image/backend/resolveImageBackend.test.ts
+++ b/test/utils/image/backend/resolveImageBackend.test.ts
@@ -6,7 +6,9 @@ describe("resolveImageBackend", () => {
   const originalPlatform = process.platform;
 
   afterEach(() => {
-    Object.defineProperty(process, "platform", { value: originalPlatform });
+    // Keep `configurable: true` explicit so a future runtime that defaults it to
+    // false on redefine can't wedge process.platform for the rest of the run.
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
   });
 
   test("returns a JimpBackend on the current platform", () => {
@@ -15,7 +17,7 @@ describe("resolveImageBackend", () => {
 
   test("returns a JimpBackend on every platform (selection logic lands later)", () => {
     for (const platform of ["win32", "darwin", "linux"]) {
-      Object.defineProperty(process, "platform", { value: platform });
+      Object.defineProperty(process, "platform", { value: platform, configurable: true });
       expect(resolveImageBackend()).toBeInstanceOf(JimpBackend);
     }
   });

--- a/test/utils/image/backend/resolveImageBackend.test.ts
+++ b/test/utils/image/backend/resolveImageBackend.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { resolveImageBackend } from "../../../../src/utils/image/backend/resolveImageBackend";
+import { JimpBackend } from "../../../../src/utils/image/backend/JimpBackend";
+
+describe("resolveImageBackend", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  test("returns a JimpBackend on the current platform", () => {
+    expect(resolveImageBackend()).toBeInstanceOf(JimpBackend);
+  });
+
+  test("returns a JimpBackend on every platform (selection logic lands later)", () => {
+    for (const platform of ["win32", "darwin", "linux"]) {
+      Object.defineProperty(process, "platform", { value: platform });
+      expect(resolveImageBackend()).toBeInstanceOf(JimpBackend);
+    }
+  });
+
+  test("returns a fresh instance per call", () => {
+    expect(resolveImageBackend()).not.toBe(resolveImageBackend());
+  });
+});


### PR DESCRIPTION
## Summary

Introduces the image **backend abstraction** that every later image-backend issue builds on. **Behavior-preserving refactor — no user-visible change.** Closes #3008.

Design milestone: **Sharp + CWebP** (#24).

## What changed (this PR's scope)
- **`src/utils/image/backend/ImageBackend.ts`** — `ImageBackend` interface (`execute(source, pipeline)`, `metadata(source)`, `rawPixels(source)`) plus `ImagePipeline` / `ImageOperation` / `ImageEncoding` / `RawImage` / `ImageMetadata` types.
- **`ImageTransformer`** refactored so `resize()/crop()/png()/webp()` record into a declarative `ImagePipeline`; `toBuffer()` delegates to `backend.execute()` and `getMetadata()` to `backend.metadata()`. The backend is injected (defaults to `resolveImageBackend()`). `ImageCache` stays backend-agnostic (untouched).
- **`JimpBackend`** — pure-jimp `ImageBackend`, reproduces current behavior verbatim **including** `@jimp/wasm-webp`. Width-only→`resize`, aspect→`cover`, fill→`resize`, crop→`crop`, output mime falls back to the decoded input format when no encoding is requested.
- **`resolveImageBackend()`** returns `JimpBackend` on all platforms (platform selection lands later).
- **`FakeImageBackend`** in `test/fakes/` — canned buffers + `rawPixels` + call tracking (mirrors `FakeImageUtils`' configure/track/error-inject shape).

## Explicitly out of scope (no overreach)
- Not migrating `PerceptualHasher`/`ScreenshotComparator`/`ContrastChecker`/`image-utils` → #3009.
- Not adding sharp → #3010. Not adding cwebp → #3011. Not removing `@jimp/wasm-webp` → #3012.

## Tests (TDD)
- `test/utils/image/backend/JimpBackend.test.ts` — real-decode: resize (fill/cover/width-only), crop, PNG/WebP encode, near-lossless ≠ lossless (option-drop guard), null-encoding fallback, metadata, `rawPixels` size + non-aliasing copy.
- `test/utils/image/ImageTransformer.test.ts` — pipeline recording, delegation, error wrapping, validation contract (incl. preserved `quality:0 → default` `||` quirk), cache hit/miss — all via `FakeImageBackend` + `FakeTimer` (no real decode, fast).
- `test/fakes/FakeImageBackend.test.ts` — fake defaults/config/tracking/error-injection.
- `test/utils/image/backend/resolveImageBackend.test.ts` — returns `JimpBackend` on every platform.

## Acceptance / validation
- Existing image tests green with **unchanged expectations** (`test/utils/image-utils.test.ts` untouched).
- Local: `bun test` (image/screenshot/accessibility suites — 128 pass), `bun run test:image:bun` (smoke), `bun run build`, `eslint` — all pass.

## Dependencies
- Blocked by: _none_ · Enables: #3009, #3011