### PR TITLE
test(db): fix intermittent test-isolation flake in DB lifecycle tests

### DIFF
--- a/test/db/databaseMigrationFailure.test.ts
+++ b/test/db/databaseMigrationFailure.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import { removeTempDbDir } from "./tempDbDir";
+import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
 
 /**
  * Verifies the cached-error migration contract that issue #2784 depends on and
@@ -20,28 +21,20 @@ import { removeTempDbDir } from "./tempDbDir";
  * instance so the module globals are isolated from other tests.
  */
 describe("database startup migration failure contract", () => {
-  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
   let tempDir: string | undefined;
+  let envSnapshot: NodeJS.ProcessEnv;
 
-  function restore(key: string, value: string | undefined): void {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
+  beforeEach(() => {
+    envSnapshot = snapshotEnv();
+  });
 
   afterEach(async () => {
-    restore("AUTOMOBILE_DB_PATH", originalDbPath);
+    restoreEnv(envSnapshot);
     if (tempDir) {
       await removeTempDbDir(tempDir);
       tempDir = undefined;
     }
   });
-
-  async function importFreshDatabaseModule() {
-    return import(`../../src/db/database.ts?migration-failure-test=${Date.now()}-${Math.random()}`);
-  }
 
   test("ensureMigrations rethrows the cached startup error without floating a rejection", async () => {
     // Point the DB path at a directory so opening the sqlite file fails.

--- a/test/db/databaseReset.test.ts
+++ b/test/db/databaseReset.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { removeTempDbDir } from "./tempDbDir";
+import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
 
 /**
  * Regression tests for issue #2796.
@@ -33,37 +34,21 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
   // hook timeout.
   const FILE_BACKED_TEST_TIMEOUT_MS = 30000;
 
-  const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
-  const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
-  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
-  const originalMigrationsDir = process.env.AUTOMOBILE_MIGRATIONS_DIR;
-  const originalLegacyMigrationsDir = process.env.AUTO_MOBILE_MIGRATIONS_DIR;
-
-  function restore(key: string, value: string | undefined): void {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-
   const tempDirs: string[] = [];
+  let envSnapshot: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    // Snapshot the full env so every mutated key is restored regardless of which
+    // ones a given test touches (avoids a hand-maintained key list going stale).
+    envSnapshot = snapshotEnv();
+  });
 
   afterEach(async () => {
-    restore(DAEMON_LAUNCH_CWD_ENV, originalLaunchCwd);
-    restore("AUTOMOBILE_DB_DIR", originalDbDir);
-    restore("AUTOMOBILE_DB_PATH", originalDbPath);
-    restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
-    restore("AUTO_MOBILE_MIGRATIONS_DIR", originalLegacyMigrationsDir);
+    restoreEnv(envSnapshot);
     for (const dir of tempDirs.splice(0)) {
       await removeTempDbDir(dir);
     }
   });
-
-  async function importFreshDatabaseModule() {
-    // Fresh module instance so its lazy globals are not shared with other tests.
-    return import(`../../src/db/database.ts?reset-test=${Date.now()}-${Math.random()}`);
-  }
 
   async function makeTempDbDir(prefix: string): Promise<string> {
     const dir = await mkdtemp(path.join(tmpdir(), prefix));

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
 import { removeTempDbDir } from "./tempDbDir";
+import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
 
 /**
  * Regression tests for issue #2896 (follow-up to #2796).
@@ -36,21 +37,11 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
   // (best-effort, ~200ms/dir).
   const FILE_BACKED_TEST_TIMEOUT_MS = 30000;
 
-  const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
-  const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
-  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
-
   const tempDirs: string[] = [];
-
-  function restore(key: string, value: string | undefined): void {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
+  let envSnapshot: NodeJS.ProcessEnv;
 
   beforeEach(() => {
+    envSnapshot = snapshotEnv();
     // Start every test from a fresh, non-draining shared barrier so a latched
     // barrier leaked by another test cannot mask the reset under test.
     resetDbWriteBarrier();
@@ -58,22 +49,11 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
 
   afterEach(async () => {
     resetDbWriteBarrier();
-    restore(DAEMON_LAUNCH_CWD_ENV, originalLaunchCwd);
-    restore("AUTOMOBILE_DB_DIR", originalDbDir);
-    restore("AUTOMOBILE_DB_PATH", originalDbPath);
+    restoreEnv(envSnapshot);
     for (const dir of tempDirs.splice(0)) {
       await removeTempDbDir(dir);
     }
   });
-
-  // Fresh `database.ts` instance per test so its lazy migration globals are not
-  // shared with other tests. The fresh module still imports the same shared
-  // `dbWriteBarrier` singleton this test reads (relative imports resolve without
-  // the cache-busting query string), so `closeDatabase()` and
-  // `getDbWriteBarrier()` operate on one barrier instance.
-  async function importFreshDatabaseModule() {
-    return import(`../../src/db/database.ts?barrier-reset-test=${Date.now()}-${Math.random()}`);
-  }
 
   async function makeTempDbDir(prefix: string): Promise<string> {
     const dir = await mkdtemp(path.join(tmpdir(), prefix));

--- a/test/db/freshDatabaseModule.ts
+++ b/test/db/freshDatabaseModule.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared isolation helper for the DB-lifecycle regression tests
+ * (`databaseReset`, `databaseMigrationFailure`, `dbWriteBarrierResetOnClose`).
+ *
+ * Each of those tests needs a *fresh* `database.ts` module instance so its lazy
+ * module-globals (`resolvedDbPath`, `migrationsRun`, `migrationsError`, ...) are
+ * isolated, while still sharing the transitive singleton graph (notably the
+ * process-global `dbWriteBarrier`, which the barrier test asserts against).
+ *
+ * They share two cross-file isolation hazards, and this helper closes both:
+ *
+ * 1. Cache-bust key collisions. `bun test test/db/` runs every file in ONE
+ *    process with a shared module registry. A `Date.now()-Math.random()` query
+ *    key can (rarely) collide across the ~hundreds of imports the suite does; a
+ *    collision makes `import()` hand back an already-booted module whose lazy
+ *    globals belong to another test, which surfaces as a stale `resolvedDbPath`
+ *    (e.g. a reopen resolving to the previous test's DB dir). A
+ *    process-monotonic counter is unique by construction and deterministic — no
+ *    `Math.random()`, which the repo bans as an ad-hoc randomness source.
+ *
+ * 2. Shared mutable `process.env`. All three files mutate the same
+ *    `AUTOMOBILE_DB_*` / `*_MIGRATIONS_DIR` keys and each hand-restores its own
+ *    subset in `afterEach`. Restoring the WHOLE env removes any dependence on
+ *    keeping those key lists complete, so no env state can bleed between tests.
+ */
+
+// Shared across all importers (this module is imported without a cache-busting
+// query string, so it is a single instance), giving a key that is unique across
+// every fresh-module import in the process.
+let moduleCounter = 0;
+
+/**
+ * Import a fresh `database.ts` module instance with a collision-proof key.
+ * The relative transitive imports (e.g. `dbWriteBarrier`) are NOT cache-busted,
+ * so they remain the shared singletons the tests rely on.
+ */
+export function importFreshDatabaseModule(): Promise<typeof import("../../src/db/database")> {
+  moduleCounter += 1;
+  return import(`../../src/db/database.ts?fresh-db-module=${moduleCounter}`);
+}
+
+/** Capture the full environment so it can be restored verbatim after a test. */
+export function snapshotEnv(): NodeJS.ProcessEnv {
+  return { ...process.env };
+}
+
+/** Restore `process.env` to a snapshot: drop added keys, reinstate removed/changed ones. */
+export function restoreEnv(snapshot: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value !== undefined) {
+      process.env[key] = value;
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The three DB-lifecycle regression files — `databaseReset.test.ts`, `databaseMigrationFailure.test.ts`, `dbWriteBarrierResetOnClose.test.ts` — intermittently fail (~1 in 6 full-suite runs of `bun test test/db/`) with a test-isolation bug. Each passes 100% in isolation; only the combined run is flaky.

Symptom: `databaseReset.test.ts` "reopen after close re-resolves the DB path under a changed env" asserts the second dir's path but receives the **first** dir's path (stale `resolvedDbPath`).

Root cause — two shared-state hazards across files that run in one bun process:
1. **Cache-bust key collisions.** All three used a `import('.../database.ts?x=${Date.now()}-${Math.random()}')` key. Across the hundreds of imports in a full-suite run a key can collide, handing back an already-booted `database.ts` module whose lazy globals (`resolvedDbPath`, `migrationsRun`, …) belong to another test.
2. **Shared mutable `process.env`.** Each file mutated the same `AUTOMOBILE_DB_*` / `*_MIGRATIONS_DIR` keys and hand-restored its own subset in `afterEach` (`databaseMigrationFailure` only restored `AUTOMOBILE_DB_PATH`), so env state could bleed between tests.

This is pre-existing and unrelated to PR #2930's `MigrationLifecycleState` refactor.

## Fix

New shared helper `test/db/freshDatabaseModule.ts`:
- `importFreshDatabaseModule()` uses a **process-monotonic counter** for the cache-bust key — unique by construction across the whole one-process run, and drops `Math.random()` (banned as an ad-hoc randomness source per CLAUDE.md). Transitive relative imports (e.g. `dbWriteBarrier`) stay un-busted, preserving the shared-singleton contract the barrier test relies on.
- `snapshotEnv()` / `restoreEnv()` snapshot and restore the **whole** `process.env`, removing the hand-maintained per-file key lists.

All three files route through the helper and snapshot/restore env in `beforeEach`/`afterEach`.

## Verification

- All 6 target-file tests pass; full `test/db/` (517 tests) green across 12 consecutive runs.
- `eslint` clean on all four files.