### PR TITLE
feat(ios): terminateApp — physical-device termination via devicectl (#2488)

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -34,9 +34,18 @@ For `launchApp` specifically:
 
 - **Simulator** — `xcrun simctl launch` / `terminate` (unchanged). On cold boot the app is terminated first because `simctl launch` does not terminate an already-running instance.
 - **Physical device** — `xcrun devicectl device process launch --device <udid> --terminate-existing --json-output <file> --quiet <bundle-id>`; the launched PID is read from `result.process.processIdentifier` in the JSON output. `--terminate-existing` is the **authoritative cold-boot relaunch**: it terminates any already-running instance and starts a fresh process (which foregrounds). `devicectl` has no foreground-if-running verb, so a warm launch also relaunches this way. The device path therefore issues **no separate pre-terminate** — that would be a redundant round-trip.
-- **No standalone devicectl terminate here (deferred).** `devicectl` has no terminate-by-bundle-id verb, and its `device info processes` listing exposes only `executable` + `processIdentifier` — no stable bundle-id field to resolve a PID by bundle (only `install` / `info apps` carry `bundleIdentifier`). A reliable terminate-by-bundle needs the follow-up device app-listing work, so `launchApp` relies on `--terminate-existing` instead.
 - **`clearAppData` on a device** — wipes the sandbox via `devicectl` uninstall+reinstall (`clearAppDataViaReinstall`) before relaunching; a failed clear aborts the launch rather than launching with stale data.
 - **Docker / host control** — no `devicectl` launch bridge exists, so `launchApp` returns an explicit, actionable error instead of a confusing simctl failure.
+
+For `terminateApp` specifically:
+
+- **Simulator** — `xcrun simctl terminate <udid> <bundle-id>`; a "found nothing to terminate" error is treated as `wasRunning: false` rather than a failure.
+- **Physical device** — `devicectl` has no terminate-by-bundle-id verb, so termination is a **two-step** operation (`DeviceAppInspector.terminateApp`):
+  1. Resolve the on-device bundle path via `xcrun devicectl device info apps --device <udid> --bundle-id <id> --json-output <file> --quiet`. No matching bundle → `{ wasInstalled: false, wasRunning: false }` (no signal issued).
+  2. Enumerate running processes via `xcrun devicectl device info processes --device <udid> --json-output <file> --quiet` and match the process whose executable path lives **inside** the resolved bundle directory. No match → `{ wasInstalled: true, wasRunning: false }`.
+  3. Force-kill the matched PID: `xcrun devicectl device process signal --device <udid> --pid <pid> --signal SIGKILL` → `{ wasInstalled: true, wasRunning: true }`. This matches Android `am force-stop` semantics for `wasRunning` reporting.
+  - **JSON field-name caveat.** The `device info processes` envelope is **not formally documented by Apple**; `findRunningProcessPid` deep-walks it and accepts several spellings (executable as a string or `{ url | path }`; PID as `processIdentifier` / `pid` / `processID`). Pin the real field names against captured device output when possible.
+  - **iOS ≤16 / non-macOS / Docker (host control)** — `devicectl` process management requires iOS 17+ on a macOS host; unsupported combinations surface as a clear, non-crashing `success: false` error (thrown by `DeviceAppInspector.terminateApp`, mapped to a result by `TerminateApp`) rather than a silent failure.
 
 ## Live locale changes
 

--- a/scratchpad_uninstall.txt
+++ b/scratchpad_uninstall.txt
@@ -1,0 +1,140 @@
+import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { UninstallAppResult } from "../../models/UninstallAppResult";
+import { BootedDevice } from "../../models";
+import { ListInstalledApps } from "../observe/ListInstalledApps";
+import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { logger } from "../../utils/logger";
+
+export interface DeviceAppUninstaller {
+  uninstallApp(deviceUdid: string, bundleId: string, isSimulator?: boolean): Promise<void>;
+}
+
+export class UninstallApp {
+  private device: BootedDevice;
+  private adbFactory: AdbClientFactory;
+  private adb: AdbExecutor;
+  private simctl: SimCtlClient;
+  private deviceAppUninstaller: DeviceAppUninstaller;
+
+  constructor(
+    device: BootedDevice,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    simctl: SimCtlClient | null = null,
+    deviceAppUninstaller: DeviceAppUninstaller | null = null
+  ) {
+    this.device = device;
+    this.adbFactory = adbFactory;
+    this.adb = adbFactory.create(device);
+    this.simctl = simctl || new SimCtlClient(device);
+    this.deviceAppUninstaller = deviceAppUninstaller || new DeviceAppInspector();
+  }
+
+  private isSimulator(): boolean {
+    return isIosSimulatorUdid(this.device.deviceId);
+  }
+
+  /**
+   * Uninstall an app - routes to platform-specific implementation
+   * @param packageName - The package name or bundle identifier to uninstall
+   * @param keepData - Whether to keep app data (Android only, ignored on iOS)
+   * @param userId - Optional Android user ID (auto-detected if not provided)
+   */
+  async execute(
+    packageName: string,
+    keepData: boolean = false,
+    userId?: number
+  ): Promise<UninstallAppResult> {
+    const perf = createGlobalPerformanceTracker();
+    perf.serial("uninstallApp");
+
+    // Validate package name
+    if (!packageName || !packageName.trim()) {
+      perf.end();
+      return {
+        success: false,
+        packageName: packageName || "",
+        wasInstalled: false,
+        keepData,
+        error: "Invalid package name provided"
+      };
+    }
+
+    switch (this.device.platform) {
+      case "ios":
+        return perf.track("iOSUninstall", () => this.executeiOS(packageName));
+      case "android":
+        return perf.track("androidUninstall", () => this.executeAndroid(packageName, keepData, userId));
+      default:
+        perf.end();
+        throw new Error(`Unsupported platform: ${this.device.platform}`);
+    }
+  }
+
+  /**
+   * Uninstall an iOS app by bundle identifier
+   * @param bundleId - The bundle identifier to uninstall
+   */
+  private async executeiOS(bundleId: string): Promise<UninstallAppResult> {
+    try {
+      const simulator = this.isSimulator();
+
+      // Check if app is installed. Keep the cache disabled so the pre-uninstall
+      // check always reflects live device state (the previous executor-arg path
+      // left caching off; passing the default factory would silently enable it).
+      const listApps = new ListInstalledApps(this.device, this.adbFactory, this.simctl, { cacheEnabled: false });
+      const installed = (await listApps.execute()).find(app => app === bundleId) !== undefined;
+
+      if (!installed) {
+        return {
+          success: true,
+          packageName: bundleId,
+          wasInstalled: false,
+          keepData: false
+        };
+      }
+
+      // Terminate app if it's running before uninstalling
+      if (simulator) {
+        try {
+          await this.simctl.terminateApp(bundleId, this.device.deviceId);
+        } catch (error) {
+          logger.warn(`[UninstallApp] Failed to terminate iOS app before uninstall: ${error}`);
+        }
+      }
+
+      // Uninstall the app via simctl (simulator) or devicectl (physical)
+      await this.deviceAppUninstaller.uninstallApp(this.device.deviceId, bundleId, simulator);
+
+      // Verify the app was uninstalled
+      const isStillInstalled = (await listApps.execute()).find(app => app === bundleId) !== undefined;
+
+      if (isStillInstalled) {
+        return {
+          success: false,
+          packageName: bundleId,
+          wasInstalled: true,
+          keepData: false,
+          error: "Failed to uninstall application"
+        };
+      }
+
+      return {
+        success: true,
+        packageName: bundleId,
+        wasInstalled: true,
+        keepData: false // iOS doesn't support keeping data during uninstall
+      };
+    } catch (error) {
+      return {
+        success: false,
+        packageName: bundleId,
+        wasInstalled: true,
+        keepData: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -3,27 +3,45 @@ import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import { BootedDevice, TerminateAppResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
+
+/**
+ * Physical-device app terminator. `DeviceAppInspector` satisfies this
+ * structurally (via `xcrun devicectl device process signal`); tests inject a
+ * fake so the physical path is exercised without a real device. Mirrors the
+ * `DeviceAppUninstaller`/`DeviceAppLauncher` injection in the sibling tools.
+ */
+export interface DeviceAppTerminator {
+  terminateApp(deviceUdid: string, bundleId: string): Promise<{ wasInstalled: boolean; wasRunning: boolean }>;
+}
 
 export class TerminateApp extends BaseVisualChange {
   private simctl: SimCtlClient;
+  private deviceTerminator: DeviceAppTerminator;
 
   /**
    * Create an TerminateApp instance
    * @param device - Optional device
    * @param adb - Optional AdbClient instance for testing
    * @param simctl - Optional SimCtlClient instance for testing
+   * @param timer - Optional Timer instance for testing
+   * @param deviceTerminator - Optional physical-device terminator for testing
    */
   constructor(
     device: BootedDevice,
     adb: AdbClient | null = null,
     simctl: SimCtlClient | null = null,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    deviceTerminator: DeviceAppTerminator | null = null
   ) {
     super(device, adb, timer);
     this.device = device;
     this.simctl = simctl || new SimCtlClient(device);
+    this.deviceTerminator = deviceTerminator || new DeviceAppInspector();
   }
 
   /**
@@ -170,45 +188,11 @@ export class TerminateApp extends BaseVisualChange {
     const perf = createGlobalPerformanceTracker();
     perf.serial("terminateApp");
 
-    const terminateLogic = async (): Promise<TerminateAppResult> => {
-      const installedApps = await perf.track("checkInstalled", () => this.simctl.listApps(this.device.deviceId));
-      const wasInstalled = installedApps.some(app => this.getBundleId(app) === bundleId);
-
-      if (!wasInstalled) {
-        perf.end();
-        return {
-          success: true,
-          packageName: bundleId,
-          wasInstalled: false,
-          wasRunning: false,
-          wasForeground: false
-        };
-      }
-
-      let wasRunning = true;
-      let errorMessage: string | undefined;
-
-      try {
-        await perf.track("terminateApp", () => this.simctl.terminateApp(bundleId, this.device.deviceId));
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (this.isSimctlNotRunningError(message)) {
-          wasRunning = false;
-        } else {
-          errorMessage = message;
-        }
-      }
-
-      perf.end();
-      return {
-        success: !errorMessage,
-        packageName: bundleId,
-        wasInstalled: true,
-        wasRunning,
-        wasForeground: false,
-        ...(errorMessage ? { error: errorMessage } : {})
-      };
-    };
+    // Physical iOS devices (00008XXX / 40-char UDID) can't be driven by simctl;
+    // route them through devicectl instead. Simulators keep the simctl path.
+    const terminateLogic = isIosSimulatorUdid(this.device.deviceId)
+      ? () => this.terminateSimulator(bundleId, perf)
+      : () => this.terminatePhysicalDevice(bundleId, perf);
 
     if (options?.skipObservation) {
       return terminateLogic();
@@ -223,6 +207,96 @@ export class TerminateApp extends BaseVisualChange {
         perf
       }
     );
+  }
+
+  /**
+   * Simulator terminate via simctl (unchanged from the original iOS path):
+   * check install via `simctl listapps`, then `simctl terminate`, treating a
+   * "nothing to terminate" error as wasRunning=false.
+   */
+  private async terminateSimulator(
+    bundleId: string,
+    perf: ReturnType<typeof createGlobalPerformanceTracker>
+  ): Promise<TerminateAppResult> {
+    const installedApps = await perf.track("checkInstalled", () => this.simctl.listApps(this.device.deviceId));
+    const wasInstalled = installedApps.some(app => this.getBundleId(app) === bundleId);
+
+    if (!wasInstalled) {
+      perf.end();
+      return {
+        success: true,
+        packageName: bundleId,
+        wasInstalled: false,
+        wasRunning: false,
+        wasForeground: false
+      };
+    }
+
+    let wasRunning = true;
+    let errorMessage: string | undefined;
+
+    try {
+      await perf.track("terminateApp", () => this.simctl.terminateApp(bundleId, this.device.deviceId));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (this.isSimctlNotRunningError(message)) {
+        wasRunning = false;
+      } else {
+        errorMessage = message;
+      }
+    }
+
+    perf.end();
+    return {
+      success: !errorMessage,
+      packageName: bundleId,
+      wasInstalled: true,
+      wasRunning,
+      wasForeground: false,
+      ...(errorMessage ? { error: errorMessage } : {})
+    };
+  }
+
+  /**
+   * Physical iOS device terminate via devicectl (iOS 17+). The injected
+   * terminator resolves the bundle id to a PID and force-kills it (SIGKILL),
+   * reporting install/running status. Matches Android `am force-stop` semantics
+   * for `wasRunning`. A devicectl / macOS-guard / iOS<=16 failure surfaces as a
+   * clear, non-crashing `success:false` result rather than throwing.
+   */
+  private async terminatePhysicalDevice(
+    bundleId: string,
+    perf: ReturnType<typeof createGlobalPerformanceTracker>
+  ): Promise<TerminateAppResult> {
+    try {
+      const { wasInstalled, wasRunning } = await perf.track(
+        "terminateApp",
+        () => this.deviceTerminator.terminateApp(this.device.deviceId, bundleId)
+      );
+      perf.end();
+      return {
+        success: true,
+        packageName: bundleId,
+        wasInstalled,
+        wasRunning,
+        wasForeground: false
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Return a typed failure (matching the simulator path) instead of throwing,
+      // but log first so the trace survives even when the client only sees the
+      // summarized error (CLAUDE.md error-handling convention #2).
+      logger.warn(`[TerminateApp] Physical iOS terminate failed for ${bundleId}: ${message}`, error);
+      perf.end();
+      return {
+        success: false,
+        packageName: bundleId,
+        wasInstalled: false,
+        wasRunning: false,
+        wasForeground: false,
+        error: message
+      };
+    }
   }
 
   private isSimctlNotRunningError(message: string): boolean {

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -288,11 +288,12 @@ export class TerminateApp extends BaseVisualChange {
       // summarized error (CLAUDE.md error-handling convention #2).
       logger.warn(`[TerminateApp] Physical iOS terminate failed for ${bundleId}: ${message}`, error);
       perf.end();
+      // Omit wasInstalled/wasRunning: install state is unknown at throw time (a
+      // devicectl failure can occur after the app was confirmed installed), so
+      // reporting them as `false` would assert a fact we never established.
       return {
         success: false,
         packageName: bundleId,
-        wasInstalled: false,
-        wasRunning: false,
         wasForeground: false,
         error: message
       };

--- a/src/models/TerminateAppResult.ts
+++ b/src/models/TerminateAppResult.ts
@@ -5,8 +5,15 @@ import { BaseActionResult } from "./BaseActionResult";
  */
 export interface TerminateAppResult extends BaseActionResult {
   packageName: string;
-  wasInstalled: boolean;
-  wasRunning: boolean;
+  /**
+   * Whether the app was installed. Optional/omitted on a failed termination
+   * (`success:false`), where install state is genuinely unknown — a devicectl
+   * failure can occur after the app was confirmed installed. Always read
+   * `success` before trusting this field.
+   */
+  wasInstalled?: boolean;
+  /** Whether the app had a running process that was terminated. Omitted on `success:false` (unknown). */
+  wasRunning?: boolean;
   wasForeground: boolean;
   /** Android user ID where the app was terminated (0 for primary user, 10+ for work profiles) */
   userId?: number;

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -210,20 +210,50 @@ const extractExecutablePath = (record: Record<string, unknown>): string | null =
 
 const extractProcessPid = (record: Record<string, unknown>): number | undefined => {
   const raw = record.processIdentifier ?? record.pid ?? record.processID;
-  return typeof raw === "number" ? raw : undefined;
+  if (typeof raw === "number" && Number.isInteger(raw)) {
+    return raw;
+  }
+  // devicectl JSON is unverified; tolerate a stringified integer PID too.
+  if (typeof raw === "string" && /^\d+$/.test(raw.trim())) {
+    return Number(raw.trim());
+  }
+  return undefined;
+};
+
+/** Basename of a path (last `/`-separated segment), ignoring any trailing slash. */
+const pathBasename = (path: string): string => {
+  const trimmed = path.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
 };
 
 /**
- * Find the PID of a running process whose executable lives inside `bundlePath`,
- * from a devicectl `device info processes --json-output` payload.
+ * Find the PID of the app's **own** main process from a devicectl
+ * `device info processes --json-output` payload, given its installed
+ * `bundlePath`.
  *
  * The exact envelope is not formally documented by Apple (see simctl.md caveat),
  * so we deep-walk and accept several field-name spellings: the executable may be
  * a string or an object carrying `url`/`path`, and the PID may be spelled
- * `processIdentifier`, `pid`, or `processID`. A match requires the normalized
- * executable path to be strictly *inside* the bundle directory — comparing
- * against `"<bundle>/"` guards against a sibling like `MyApp.app.extension`
- * that merely shares a string prefix with `MyApp.app`.
+ * `processIdentifier`, `pid`, or `processID`.
+ *
+ * Matching is deliberately scoped to the **main app binary**, which is a *direct
+ * child* of the `.app` directory (`MyApp.app/MyApp` — CFBundleExecutable, whose
+ * name may differ from the bundle name, but always one level down). App
+ * extensions live *inside* the same bundle at `MyApp.app/PlugIns/Foo.appex/Foo`
+ * and their executables also start with `"<bundle>/"`, so a naive prefix match
+ * would SIGKILL an extension and falsely report the app terminated. We therefore
+ * require the path segment after `"<bundle>/"` to contain no further `/`. This
+ * also excludes a sibling like `MyApp.app.extension/...` (different prefix).
+ *
+ * Two-pass, per issue #2488: the strict inside-bundle match is preferred, but if
+ * it finds nothing we fall back to matching a process whose executable
+ * **basename** equals the bundle name (minus `.app`). The fallback guards the
+ * real-device risk that `info processes` executable paths don't nest under the
+ * `info apps` bundle URL (e.g. `/private` vs `/var` symlink, differing container
+ * roots) — without it a mismatch would silently report the app as not running.
+ * The basename fallback naturally still excludes extensions (a `Foo.appex`
+ * binary's basename won't equal the app name).
  */
 export const findRunningProcessPid = (data: unknown, bundlePath: string): number | null => {
   const normalizedBundle = normalizeDevicePath(bundlePath).replace(/\/+$/, "");
@@ -231,14 +261,24 @@ export const findRunningProcessPid = (data: unknown, bundlePath: string): number
     return null;
   }
   const insidePrefix = `${normalizedBundle}/`;
+  const appName = pathBasename(normalizedBundle).replace(/\.app$/i, "");
 
-  const walk = (node: unknown): number | null => {
+  const isMainBinaryOfBundle = (exe: string): boolean => {
+    if (!exe.startsWith(insidePrefix)) {
+      return false;
+    }
+    // Direct child only: no further path separator → the app's own binary,
+    // not a nested PlugIns/*.appex/* extension executable.
+    return !exe.slice(insidePrefix.length).includes("/");
+  };
+
+  const walk = (node: unknown, matches: (exe: string) => boolean): number | null => {
     if (!node || typeof node !== "object") {
       return null;
     }
     if (Array.isArray(node)) {
       for (const item of node) {
-        const found = walk(item);
+        const found = walk(item, matches);
         if (found !== null) {
           return found;
         }
@@ -248,11 +288,11 @@ export const findRunningProcessPid = (data: unknown, bundlePath: string): number
     const record = node as Record<string, unknown>;
     const exe = extractExecutablePath(record);
     const pid = extractProcessPid(record);
-    if (exe !== null && pid !== undefined && exe.startsWith(insidePrefix)) {
+    if (exe !== null && pid !== undefined && matches(exe)) {
       return pid;
     }
     for (const value of Object.values(record)) {
-      const found = walk(value);
+      const found = walk(value, matches);
       if (found !== null) {
         return found;
       }
@@ -260,7 +300,14 @@ export const findRunningProcessPid = (data: unknown, bundlePath: string): number
     return null;
   };
 
-  return walk(data);
+  const primary = walk(data, isMainBinaryOfBundle);
+  if (primary !== null) {
+    return primary;
+  }
+  if (!appName) {
+    return null;
+  }
+  return walk(data, exe => pathBasename(exe) === appName);
 };
 
 const isExpectedMissingLegacySimulatorApp = (bundleId: string, errorMessage: string): boolean =>

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -194,6 +194,75 @@ export const findProcessIdentifier = (data: unknown): number | undefined => {
   return walk(data);
 };
 
+const extractExecutablePath = (record: Record<string, unknown>): string | null => {
+  const raw = record.executable ?? record.executablePath ?? record.executableURL ?? record.path;
+  if (typeof raw === "string") {
+    return normalizeDevicePath(raw);
+  }
+  if (raw && typeof raw === "object") {
+    const inner = (raw as Record<string, unknown>).url ?? (raw as Record<string, unknown>).path;
+    if (typeof inner === "string") {
+      return normalizeDevicePath(inner);
+    }
+  }
+  return null;
+};
+
+const extractProcessPid = (record: Record<string, unknown>): number | undefined => {
+  const raw = record.processIdentifier ?? record.pid ?? record.processID;
+  return typeof raw === "number" ? raw : undefined;
+};
+
+/**
+ * Find the PID of a running process whose executable lives inside `bundlePath`,
+ * from a devicectl `device info processes --json-output` payload.
+ *
+ * The exact envelope is not formally documented by Apple (see simctl.md caveat),
+ * so we deep-walk and accept several field-name spellings: the executable may be
+ * a string or an object carrying `url`/`path`, and the PID may be spelled
+ * `processIdentifier`, `pid`, or `processID`. A match requires the normalized
+ * executable path to be strictly *inside* the bundle directory — comparing
+ * against `"<bundle>/"` guards against a sibling like `MyApp.app.extension`
+ * that merely shares a string prefix with `MyApp.app`.
+ */
+export const findRunningProcessPid = (data: unknown, bundlePath: string): number | null => {
+  const normalizedBundle = normalizeDevicePath(bundlePath).replace(/\/+$/, "");
+  if (!normalizedBundle) {
+    return null;
+  }
+  const insidePrefix = `${normalizedBundle}/`;
+
+  const walk = (node: unknown): number | null => {
+    if (!node || typeof node !== "object") {
+      return null;
+    }
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const found = walk(item);
+        if (found !== null) {
+          return found;
+        }
+      }
+      return null;
+    }
+    const record = node as Record<string, unknown>;
+    const exe = extractExecutablePath(record);
+    const pid = extractProcessPid(record);
+    if (exe !== null && pid !== undefined && exe.startsWith(insidePrefix)) {
+      return pid;
+    }
+    for (const value of Object.values(record)) {
+      const found = walk(value);
+      if (found !== null) {
+        return found;
+      }
+    }
+    return null;
+  };
+
+  return walk(data);
+};
+
 const isExpectedMissingLegacySimulatorApp = (bundleId: string, errorMessage: string): boolean =>
   bundleId.endsWith(".XCTestServiceApp") &&
   (errorMessage.includes("No such file or directory") ||
@@ -478,6 +547,128 @@ export class DeviceAppInspector {
       return { success: true, pid };
     } catch (error) {
       return { success: false, error: getErrorMessage(error) };
+    } finally {
+      await this.deps.rm(tempDir);
+    }
+  }
+
+  /**
+   * Force-terminate a running app on a physical iOS device (iOS 17+) via
+   * devicectl. There is no `terminate-by-bundle-id` verb, so this is a two-step
+   * operation: resolve the bundle id to a PID (by matching the on-device bundle
+   * path against `device info processes` executables) then `device process
+   * signal --signal SIGKILL` that PID.
+   *
+   * Returns:
+   * - `{ wasInstalled: false, wasRunning: false }` when the bundle isn't installed
+   *   (no process query, no signal),
+   * - `{ wasInstalled: true, wasRunning: false }` when installed but no matching
+   *   process is running (no signal),
+   * - `{ wasInstalled: true, wasRunning: true }` after SIGKILL of a running process.
+   *
+   * Throws on an underlying devicectl failure. Gated to macOS + local devicectl:
+   * host control (Docker) exposes no process-management bridge, and non-darwin
+   * hosts have no devicectl, so both throw an explicit, actionable error rather
+   * than a confusing simctl-style failure (iOS ≤16 devices reject the devicectl
+   * signal at the tool level and surface as a thrown devicectl error).
+   */
+  public async terminateApp(deviceUdid: string, bundleId: string): Promise<{ wasInstalled: boolean; wasRunning: boolean }> {
+    const useHostControl = this.deps.hostControl.shouldUseHostControl() && this.deps.hostControl.isRunningInDocker();
+    if (useHostControl) {
+      throw new Error(
+        `Terminating an app on a physical device is not supported under host control for ${bundleId}: ` +
+        "the host-control bridge exposes install/uninstall but no devicectl process-management primitive."
+      );
+    }
+
+    if (this.deps.platform() !== "darwin") {
+      throw new Error("Physical iOS device app termination requires macOS");
+    }
+
+    const bundlePath = await this.resolveInstalledBundlePathOnDevice(deviceUdid, bundleId);
+    if (!bundlePath) {
+      return { wasInstalled: false, wasRunning: false };
+    }
+
+    const pid = await this.resolveRunningPid(deviceUdid, bundlePath);
+    if (pid === null) {
+      return { wasInstalled: true, wasRunning: false };
+    }
+
+    const signalCommand = [
+      "xcrun",
+      "devicectl",
+      "device",
+      "process",
+      "signal",
+      "--device", deviceUdid,
+      "--pid", String(pid),
+      "--signal", "SIGKILL"
+    ].join(" ");
+    await this.deps.exec(signalCommand);
+    return { wasInstalled: true, wasRunning: true };
+  }
+
+  /**
+   * Resolve the on-device installed bundle path for `bundleId` via
+   * `devicectl device info apps --bundle-id`. Returns null when the app isn't
+   * installed (no matching bundle entry / no resolvable path); devicectl exec or
+   * JSON-read failures propagate so a broken devicectl surfaces rather than
+   * masquerading as "not installed". macOS-only (callers guard the platform).
+   */
+  private async resolveInstalledBundlePathOnDevice(deviceUdid: string, bundleId: string): Promise<string | null> {
+    const tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-"));
+    const jsonPath = join(tempDir, "apps.json");
+    try {
+      const infoCommand = [
+        "xcrun",
+        "devicectl",
+        "device",
+        "info",
+        "apps",
+        "--device", deviceUdid,
+        "--bundle-id", bundleId,
+        "--json-output", quoteShell(jsonPath),
+        "--quiet"
+      ].join(" ");
+      await this.deps.exec(infoCommand);
+
+      const raw = await this.deps.readFile(jsonPath);
+      const data = JSON.parse(raw) as unknown;
+      const entry = findBundleEntry(data, bundleId);
+      if (!entry) {
+        return null;
+      }
+      return extractBundlePath(entry);
+    } finally {
+      await this.deps.rm(tempDir);
+    }
+  }
+
+  /**
+   * Map an on-device bundle path to a running PID via
+   * `devicectl device info processes`, matching the process whose executable
+   * lives inside `bundlePath`. Returns null when nothing is running for that
+   * bundle. devicectl exec / JSON-read failures propagate. macOS-only.
+   */
+  private async resolveRunningPid(deviceUdid: string, bundlePath: string): Promise<number | null> {
+    const tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-"));
+    const jsonPath = join(tempDir, "processes.json");
+    try {
+      const command = [
+        "xcrun",
+        "devicectl",
+        "device",
+        "info",
+        "processes",
+        "--device", deviceUdid,
+        "--json-output", quoteShell(jsonPath),
+        "--quiet"
+      ].join(" ");
+      await this.deps.exec(command);
+
+      const raw = await this.deps.readFile(jsonPath);
+      return findRunningProcessPid(JSON.parse(raw), bundlePath);
     } finally {
       await this.deps.rm(tempDir);
     }

--- a/test/fakes/FakeDeviceAppTerminator.ts
+++ b/test/fakes/FakeDeviceAppTerminator.ts
@@ -1,0 +1,44 @@
+import { DeviceAppTerminator } from "../../src/features/action/TerminateApp";
+
+type TerminateCall = { deviceUdid: string; bundleId: string };
+
+type FakeDeviceAppTerminatorOptions = {
+  result?: { wasInstalled: boolean; wasRunning: boolean };
+  error?: Error;
+};
+
+/**
+ * Records devicectl terminate calls so TerminateApp tests can assert the
+ * physical-device path was taken without shelling out. Parallels the injected
+ * simctl fake used for the simulator path and FakeDeviceAppLauncher for launch.
+ */
+export class FakeDeviceAppTerminator implements DeviceAppTerminator {
+  readonly terminateCalls: TerminateCall[] = [];
+  private result: { wasInstalled: boolean; wasRunning: boolean };
+  private error: Error | undefined;
+
+  constructor(options: FakeDeviceAppTerminatorOptions = {}) {
+    this.result = options.result ?? { wasInstalled: true, wasRunning: true };
+    this.error = options.error;
+  }
+
+  setResult(result: { wasInstalled: boolean; wasRunning: boolean }): void {
+    this.result = result;
+    this.error = undefined;
+  }
+
+  setError(error: Error): void {
+    this.error = error;
+  }
+
+  async terminateApp(
+    deviceUdid: string,
+    bundleId: string
+  ): Promise<{ wasInstalled: boolean; wasRunning: boolean }> {
+    this.terminateCalls.push({ deviceUdid, bundleId });
+    if (this.error) {
+      throw this.error;
+    }
+    return this.result;
+  }
+}

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -148,6 +148,10 @@ describe("TerminateApp (iOS physical device)", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("macOS");
+    // Install/running state is unknown on failure — must be omitted, not a
+    // fabricated `false` that a caller could misread as "not installed".
+    expect(result.wasInstalled).toBeUndefined();
+    expect(result.wasRunning).toBeUndefined();
     // A failure must not crash and must not fall back to simctl.
     expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(false);
   });

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -4,10 +4,13 @@ import type { BootedDevice } from "../../../src/models";
 import { FakeSimctl } from "../../fakes/FakeSimctl";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeDeviceAppTerminator } from "../../fakes/FakeDeviceAppTerminator";
 
 describe("TerminateApp (iOS)", () => {
+  // Simulator UDIDs are 8-4-4-4-12 UUIDs; isIosSimulatorUdid keys the simctl vs
+  // devicectl transport off this shape (see UninstallApp/LaunchApp).
   const iosDevice: BootedDevice = {
-    deviceId: "ios-sim-123",
+    deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
     name: "iPhone 15",
     platform: "ios"
   };
@@ -74,6 +77,97 @@ describe("TerminateApp (iOS)", () => {
     expect(result.success).toBe(true);
     expect(result.wasInstalled).toBe(true);
     expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(true);
+  });
+});
+
+describe("TerminateApp (iOS physical device)", () => {
+  // Physical-device UDID (00008XXX form) — isIosSimulatorUdid returns false.
+  const iosPhysicalDevice: BootedDevice = {
+    deviceId: "00008110-001A2B3C4D5E6F70",
+    name: "iPhone 15 Pro (physical)",
+    platform: "ios"
+  };
+
+  let fakeSimctl: FakeSimctl;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeSimctl = new FakeSimctl();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+  });
+
+  test("terminates a running app via devicectl (not simctl)", async () => {
+    const terminator = new FakeDeviceAppTerminator({ result: { wasInstalled: true, wasRunning: true } });
+
+    const terminateApp = new TerminateApp(iosPhysicalDevice, null, fakeSimctl, fakeTimer, terminator);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(true);
+    expect(result.wasRunning).toBe(true);
+    expect(result.wasForeground).toBe(false);
+    expect(result.packageName).toBe("com.example.app");
+    // Physical path must route through devicectl terminator, never simctl.
+    expect(terminator.terminateCalls).toEqual([
+      { deviceUdid: "00008110-001A2B3C4D5E6F70", bundleId: "com.example.app" }
+    ]);
+    expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(false);
+  });
+
+  test("reports wasRunning:false when the app is installed but not running", async () => {
+    const terminator = new FakeDeviceAppTerminator({ result: { wasInstalled: true, wasRunning: false } });
+
+    const terminateApp = new TerminateApp(iosPhysicalDevice, null, fakeSimctl, fakeTimer, terminator);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(true);
+    expect(result.wasRunning).toBe(false);
+    expect(terminator.terminateCalls).toHaveLength(1);
+  });
+
+  test("reports wasInstalled:false when the app is not installed", async () => {
+    const terminator = new FakeDeviceAppTerminator({ result: { wasInstalled: false, wasRunning: false } });
+
+    const terminateApp = new TerminateApp(iosPhysicalDevice, null, fakeSimctl, fakeTimer, terminator);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(false);
+    expect(result.wasRunning).toBe(false);
+    expect(terminator.terminateCalls).toHaveLength(1);
+  });
+
+  test("surfaces a clear error when devicectl termination is unsupported (iOS<=16 / non-macOS)", async () => {
+    const terminator = new FakeDeviceAppTerminator();
+    terminator.setError(new Error("Physical iOS device app termination requires macOS"));
+
+    const terminateApp = new TerminateApp(iosPhysicalDevice, null, fakeSimctl, fakeTimer, terminator);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("macOS");
+    // A failure must not crash and must not fall back to simctl.
+    expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(false);
+  });
+
+  test("simulator path never invokes the devicectl terminator", async () => {
+    const simDevice: BootedDevice = {
+      deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+      name: "iPhone 15",
+      platform: "ios"
+    };
+    const terminator = new FakeDeviceAppTerminator();
+    fakeSimctl.setInstalledApps([{ bundleId: "com.example.app" }]);
+
+    const terminateApp = new TerminateApp(simDevice, null, fakeSimctl, fakeTimer, terminator);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(true);
+    expect(result.wasRunning).toBe(true);
+    expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(true);
+    expect(terminator.terminateCalls).toHaveLength(0);
   });
 });
 

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -750,6 +750,59 @@ describe("findRunningProcessPid", () => {
     expect(findRunningProcessPid(data, bundlePath)).toBe(88);
   });
 
+  test("tolerates a stringified integer PID", () => {
+    const data = { runningProcesses: [{ processIdentifier: "88", executable: `${bundlePath}/MyApp` }] };
+    expect(findRunningProcessPid(data, bundlePath)).toBe(88);
+  });
+
+  test("matches the main app binary, never a nested .appex extension inside the bundle", () => {
+    // Extension listed FIRST — a naive prefix match would wrongly kill it.
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 200, executable: `${bundlePath}/PlugIns/Foo.appex/Foo` },
+          { processIdentifier: 100, executable: `${bundlePath}/MyApp` }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBe(100);
+  });
+
+  test("does not match when only a nested .appex extension is running (no main process)", () => {
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 200, executable: `${bundlePath}/PlugIns/Foo.appex/Foo` }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBeNull();
+  });
+
+  test("falls back to executable basename when the process path root differs from the bundle URL", () => {
+    // Real-device risk: info-processes reports a /var container root while
+    // info-apps reported /private/var — strict prefix misses, basename catches.
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 321, executable: "/var/containers/Bundle/Application/XYZ/MyApp.app/MyApp" }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBe(321);
+  });
+
+  test("basename fallback still excludes an extension binary with a different basename", () => {
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 9, executable: "/var/containers/Bundle/Application/XYZ/MyApp.app/PlugIns/Foo.appex/Foo" }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBeNull();
+  });
+
   test("returns null when no executable is inside the bundle path", () => {
     const data = {
       result: {

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { promises as fs } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { DeviceAppInspector, findProcessIdentifier, parseDevicectlJsonOutputPath } from "../../../src/utils/ios-cmdline-tools/DeviceAppInspector";
+import { DeviceAppInspector, findProcessIdentifier, findRunningProcessPid, parseDevicectlJsonOutputPath } from "../../../src/utils/ios-cmdline-tools/DeviceAppInspector";
 import { hashAppBundle } from "../../../src/utils/ios-cmdline-tools/AppBundleHasher";
 import { FakeHostControlDeviceAppInspector } from "../../fakes/FakeHostControlDeviceAppInspector";
 
@@ -705,5 +705,213 @@ describe("DeviceAppInspector launch (devicectl)", () => {
     expect(findProcessIdentifier({ result: { process: { processIdentifier: 7 } } })).toBe(7);
     expect(findProcessIdentifier({ a: { b: [{ processIdentifier: 9 }] } })).toBe(9);
     expect(findProcessIdentifier({ result: {} })).toBeUndefined();
+  });
+});
+
+describe("findRunningProcessPid", () => {
+  const bundlePath = "/private/var/containers/Bundle/Application/ABC/MyApp.app";
+
+  test("matches a process whose executable lives inside the bundle path", () => {
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 100, executable: "/usr/libexec/other" },
+          { processIdentifier: 4321, executable: `${bundlePath}/MyApp` }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBe(4321);
+  });
+
+  test("normalizes file:// executable URLs before matching", () => {
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 55, executable: `file://${bundlePath}/MyApp` }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBe(55);
+  });
+
+  test("supports executable given as an object with a url/path", () => {
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 77, executable: { url: `file://${bundlePath}/MyApp` } }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBe(77);
+  });
+
+  test("supports the `pid` field name as an alias for processIdentifier", () => {
+    const data = { runningProcesses: [{ pid: 88, executable: `${bundlePath}/MyApp` }] };
+    expect(findRunningProcessPid(data, bundlePath)).toBe(88);
+  });
+
+  test("returns null when no executable is inside the bundle path", () => {
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 1, executable: "/usr/libexec/other" },
+          { processIdentifier: 2, executable: "/private/var/containers/Bundle/Application/XYZ/Another.app/Another" }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBeNull();
+  });
+
+  test("does not match a different app whose path merely shares a prefix string", () => {
+    // MyApp.app vs MyApp.app.extension — must not be treated as inside MyApp.app.
+    const data = {
+      result: {
+        runningProcesses: [
+          { processIdentifier: 9, executable: `${bundlePath}.extension/Plugin` }
+        ]
+      }
+    };
+    expect(findRunningProcessPid(data, bundlePath)).toBeNull();
+  });
+
+  test("returns null for empty/invalid payloads", () => {
+    expect(findRunningProcessPid({}, bundlePath)).toBeNull();
+    expect(findRunningProcessPid({ result: { runningProcesses: [] } }, bundlePath)).toBeNull();
+    expect(findRunningProcessPid(null, bundlePath)).toBeNull();
+  });
+});
+
+describe("DeviceAppInspector terminate (devicectl)", () => {
+  const bundlePath = "/private/var/containers/Bundle/Application/ABC/CtrlProxyApp.app";
+  const makeExecResult = (stdout = "") => ({
+    stdout,
+    stderr: "",
+    toString() { return this.stdout; },
+    trim() { return this.stdout.trim(); },
+    includes(searchString: string) { return this.stdout.includes(searchString); }
+  });
+
+  const createInspector = (opts: {
+    platform?: NodeJS.Platform;
+    exec: (command: string) => Promise<ReturnType<typeof makeExecResult>>;
+    hostControl?: FakeHostControlDeviceAppInspector;
+  }) => new DeviceAppInspector({
+    platform: () => opts.platform ?? "darwin",
+    exec: opts.exec,
+    readFile: async path => fs.readFile(path, "utf-8"),
+    mkdtemp: async prefix => fs.mkdtemp(prefix),
+    rm: async path => fs.rm(path, { recursive: true, force: true }),
+    readdir: async path => fs.readdir(path),
+    stat: async path => fs.stat(path),
+    tmpdir,
+    logger: createFakeLogger(),
+    hostControl: opts.hostControl ?? new FakeHostControlDeviceAppInspector()
+  });
+
+  const writeAppsJson = async (command: string, installed: boolean) => {
+    const jsonPath = parseDevicectlJsonOutputPath(command);
+    if (jsonPath) {
+      const payload = installed
+        ? { apps: [{ bundleIdentifier: bundleId, bundleURL: `file://${bundlePath}` }] }
+        : { apps: [] };
+      await fs.writeFile(jsonPath, JSON.stringify(payload), "utf-8");
+    }
+  };
+
+  test("signals SIGKILL for a running app and reports {wasInstalled:true, wasRunning:true}", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info apps")) {
+        await writeAppsJson(command, true);
+      }
+      if (command.includes("device info processes")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({
+            result: { runningProcesses: [{ processIdentifier: 4321, executable: `${bundlePath}/CtrlProxyApp` }] }
+          }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const result = await inspector.terminateApp("device-udid", bundleId);
+
+    expect(result).toEqual({ wasInstalled: true, wasRunning: true });
+    const signalCommand = commands.find(c => c.includes("device process signal"));
+    expect(signalCommand).toBeDefined();
+    expect(signalCommand).toContain("xcrun devicectl device process signal");
+    expect(signalCommand).toContain("--device device-udid");
+    expect(signalCommand).toContain("--pid 4321");
+    expect(signalCommand).toContain("--signal SIGKILL");
+    // Simulator tool must never be invoked for a physical terminate.
+    expect(commands.every(c => !c.includes("simctl"))).toBe(true);
+  });
+
+  test("reports {wasInstalled:true, wasRunning:false} and issues no signal when not running", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info apps")) {
+        await writeAppsJson(command, true);
+      }
+      if (command.includes("device info processes")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({ result: { runningProcesses: [] } }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const result = await inspector.terminateApp("device-udid", bundleId);
+
+    expect(result).toEqual({ wasInstalled: true, wasRunning: false });
+    expect(commands.some(c => c.includes("device process signal"))).toBe(false);
+  });
+
+  test("reports {wasInstalled:false, wasRunning:false} and never queries processes when not installed", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info apps")) {
+        await writeAppsJson(command, false);
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const result = await inspector.terminateApp("device-udid", bundleId);
+
+    expect(result).toEqual({ wasInstalled: false, wasRunning: false });
+    expect(commands.some(c => c.includes("device info processes"))).toBe(false);
+    expect(commands.some(c => c.includes("device process signal"))).toBe(false);
+  });
+
+  test("throws a clear macOS error on non-darwin without shelling out", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => { commands.push(command); return makeExecResult(); };
+
+    const inspector = createInspector({ platform: "linux", exec });
+
+    await expect(inspector.terminateApp("device-udid", bundleId)).rejects.toThrow(/macOS/);
+    expect(commands).toEqual([]);
+  });
+
+  test("throws an explicit host-control error without shelling out", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => { commands.push(command); return makeExecResult(); };
+    const hostControl = new FakeHostControlDeviceAppInspector();
+    hostControl.setUseHostControl(true);
+    hostControl.setRunningInDocker(true);
+    hostControl.setAvailable(true);
+
+    const inspector = createInspector({ platform: "linux", exec, hostControl });
+
+    await expect(inspector.terminateApp("device-udid", bundleId)).rejects.toThrow(/host control/i);
+    expect(commands.every(c => !c.includes("devicectl"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #2488. Adds a **physical-device** path to `terminateApp` on iOS. Previously `TerminateApp.executeiOS()` unconditionally used `simctl` (simulator-only), so force-terminating an app on a physical iPhone/iPad was impossible — the one app-lifecycle tool with no `devicectl` path (Android `am force-stop` and iOS-simulator already worked). This closes that parity gap.

## What changed

**New `DeviceAppInspector.terminateApp(deviceUdid, bundleId)`** (`src/utils/ios-cmdline-tools/DeviceAppInspector.ts`) — implements the two-step devicectl terminate-by-bundle for iOS 17+:

1. Resolve the on-device bundle path via `xcrun devicectl device info apps --bundle-id` (reuses `findBundleEntry`/`extractBundlePath`). No match → `{ wasInstalled: false, wasRunning: false }`.
2. Enumerate processes via `xcrun devicectl device info processes` and match the one whose executable lives **inside** the resolved bundle dir (new exported `findRunningProcessPid`). No match → `{ wasInstalled: true, wasRunning: false }`.
3. Force-kill via `xcrun devicectl device process signal --signal SIGKILL` → `{ wasInstalled: true, wasRunning: true }`.

**`TerminateApp.executeiOS` branches on `isIosSimulatorUdid`** — simulator keeps the existing `simctl` path (unchanged); physical routes through an injected `DeviceAppTerminator` (default `DeviceAppInspector`), mapping the structured result to `TerminateAppResult` with Android-parity `wasRunning` semantics. macOS-guard / host-control / iOS≤16 failures surface as a clear, non-crashing `success:false` error (logged per CLAUDE.md convention #2).

## Design note (divergence from the issue sketch)

The issue sketched a `Promise<boolean>` terminator plus a separate install-check via `ListInstalledApps`. But `ListInstalledApps.execute()` on iOS calls `simctl.listApps()`, which is **simulator-only** — using it for the physical install-check would make `wasInstalled` always false on real hardware (green under fakes, broken on device). Instead the terminator resolves install status from the **same** `devicectl device info apps` call it already needs for PID matching, returning `{ wasInstalled, wasRunning }`. This keeps the physical path from ever touching `simctl` and is correct on real hardware.

## JSON-shape caveat

Apple does not formally document the `devicectl device info processes --json-output` envelope. `findRunningProcessPid` deep-walks it and accepts several spellings (executable as a string or `{ url | path }`; PID as `processIdentifier` / `pid` / `processID`). **The exact field names should be pinned against captured real-device output** per the issue's manual test plan before relying on it in production. The parser is defensive against reshuffles in the meantime.

## Testing

- `test/features/action/TerminateApp.test.ts` — physical success / not-running / not-installed / unsupported-error; asserts simulator path never invokes the terminator and physical path never invokes simctl. New `test/fakes/FakeDeviceAppTerminator.ts` (interface + fake, FakeTimer, no device, <100ms).
- `test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts` — `terminateApp` SIGKILL / not-running (no signal) / not-installed (no process query) / macOS guard / host-control guard, plus `findRunningProcessPid` pure-function cases (file:// URLs, object executables, `pid` alias, prefix-collision guard).
- Existing 4 iOS simctl tests still pass (fixture UDID updated to a real 8-4-4-4-12 simulator UUID so `isIosSimulatorUdid` keeps routing it to the simulator path).
- `turbo run lint build` green; full `bun test` green except 17 pre-existing `@jimp/wasm-webp` module-not-found failures (missing native dep in this environment, unrelated — no image files touched).

## Docs

`docs/design-docs/plat/ios/simctl.md` — replaced the stale "no standalone devicectl terminate (deferred)" bullet with the implemented two-step terminate-by-bundle flow + JSON caveat + iOS 17 / macOS / host-control gating.

## Evaluation criteria (from #2488)

- [x] Physical running app → SIGKILL, `{success, wasInstalled:true, wasRunning:true}`
- [x] Installed-not-running → `{true,false}`, no error, no signal
- [x] Not-installed → `{false,false}`, no signal
- [x] Simulator behavior unchanged (4 existing tests pass)
- [x] iOS≤16 / non-macOS → clear non-crashing error
- [x] Unit tests via injected fake, <100ms, FakeTimer
- [x] DeviceAppInspector PID-resolution own tests with canned JSON
- [x] Android `wasRunning` parity
- [x] `turbo run lint build` green + docs updated
- [ ] **`device info processes` field names verified against real device** — deferred to a device-capture follow-up (parser is defensive; see caveat)
