### PR TITLE
fix(android): route two-finger swipe through RequestManager (#2988)

### DIFF
--- a/src/features/observe/android/CtrlProxyGestures.ts
+++ b/src/features/observe/android/CtrlProxyGestures.ts
@@ -8,15 +8,10 @@
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import { NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { SharedGestureDelegate } from "../shared/SharedGestureDelegate";
+import { sendCommand } from "../DeviceServiceUtils";
 import type { DelegateContext, A11ySwipeResult } from "./types";
-import { generateSecureId } from "./types";
-import { ctrlProxyRequests, serializeCtrlProxyRequest } from "./ctrlProxyProtocol";
 
 export class CtrlProxyGestures extends SharedGestureDelegate {
-  // Legacy pending request state for two-finger swipe (uses manual promise pattern)
-  private pendingSwipeRequestId: string | null = null;
-  private pendingSwipeResolve: ((result: A11ySwipeResult) => void) | null = null;
-
   constructor(context: DelegateContext) {
     // `roundCoordinates: true` centralizes coordinate rounding for Android at the delegate layer
     // (SharedGestureDelegate.coord()), so integer coordinates reach the runner wire. This is
@@ -28,8 +23,12 @@ export class CtrlProxyGestures extends SharedGestureDelegate {
   }
 
   /**
-   * Request a two-finger swipe gesture for TalkBack mode.
-   * This is Android-only and uses a legacy manual promise pattern.
+   * Request a two-finger swipe gesture for TalkBack mode. Android-only.
+   *
+   * Routed through `sendCommand`/`RequestManager` like every other gesture (#2988): the runner's
+   * `swipe_result` frame is correlated by requestId and resolves this promise as soon as it
+   * arrives, instead of the promise only ever settling via its timeout. The requestId keeps the
+   * `two_finger_swipe_` prefix so callers/loggers that key on it are unaffected.
    */
   async requestTwoFingerSwipe(
     x1: number,
@@ -39,65 +38,27 @@ export class CtrlProxyGestures extends SharedGestureDelegate {
     duration: number = 300,
     offset: number = 100,
     timeoutMs: number = 5000,
-    _perf: PerformanceTracker = new NoOpPerformanceTracker()
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<A11ySwipeResult> {
-    this.context.cancelScreenshotBackoff();
-
-    if (!await this.context.ensureConnected()) {
-      return { success: false, totalTimeMs: 0, error: "Not connected" };
-    }
-
-    const requestId = `two_finger_swipe_${this.context.timer.now()}_${generateSecureId()}`;
-    this.pendingSwipeRequestId = requestId;
-
-    const swipePromise = new Promise<A11ySwipeResult>(resolve => {
-      this.pendingSwipeResolve = resolve;
-
-      this.context.timer.setTimeout(() => {
-        if (this.pendingSwipeResolve === resolve) {
-          this.pendingSwipeResolve = null;
-          this.pendingSwipeRequestId = null;
-          resolve({
-            success: false,
-            totalTimeMs: timeoutMs,
-            error: `Two-finger swipe timeout after ${timeoutMs}ms`
-          });
-        }
-      }, timeoutMs);
-    });
-
-    // The two-finger path hard-rounds coordinates here (in addition to the delegate's
-    // roundCoordinates rounding) so TalkBack two-finger swipes land on whole pixels. Intentional
-    // and not to be regressed — the runner accepts fractional coordinates (#2927), but this path
-    // deliberately sends integers. See the constructor note.
-    const message = serializeCtrlProxyRequest(
-      ctrlProxyRequests.requestTwoFingerSwipe({
-        requestId,
+    // The two-finger path hard-rounds coordinates here (matching the delegate's roundCoordinates
+    // rounding) so TalkBack two-finger swipes land on whole pixels. Intentional and not to be
+    // regressed — the runner accepts fractional coordinates (#2927), but this path deliberately
+    // sends integers. See the constructor note.
+    return sendCommand<A11ySwipeResult>(this.context, {
+      idPrefix: "two_finger_swipe",
+      responseType: "swipe",
+      messageType: "request_two_finger_swipe",
+      params: {
         x1: Math.round(x1),
         y1: Math.round(y1),
         x2: Math.round(x2),
         y2: Math.round(y2),
         duration,
-        offset
-      })
-    );
-    this.context.getWebSocket()?.send(message);
-
-    return swipePromise;
-  }
-
-  /**
-   * Handle two-finger swipe result from WebSocket message.
-   * Called by the main client when a two_finger_swipe result is received.
-   */
-  handleTwoFingerSwipeResult(requestId: string, result: A11ySwipeResult): boolean {
-    if (this.pendingSwipeRequestId === requestId && this.pendingSwipeResolve) {
-      const resolve = this.pendingSwipeResolve;
-      this.pendingSwipeResolve = null;
-      this.pendingSwipeRequestId = null;
-      resolve(result);
-      return true;
-    }
-    return false;
+        offset,
+      },
+      timeoutMs,
+      perf,
+      errorLabel: "Two-finger swipe",
+    });
   }
 }

--- a/src/features/observe/android/ctrlProxyProtocol.ts
+++ b/src/features/observe/android/ctrlProxyProtocol.ts
@@ -16,9 +16,9 @@
  * a possible follow-up (it would need to unify the delegates' differing not-connected semantics).
  *
  * SCOPE — Android control-proxy only.
- * - The gesture/text commands (`request_tap_coordinates`, `request_swipe`, `request_drag`,
- *   `request_pinch`, `request_set_text`, `request_ime_action`, `request_select_all`) are emitted
- *   through the cross-platform shared `sendCommand()` / `createMessage()` path in
+ * - The gesture/text commands (`request_tap_coordinates`, `request_swipe`, `request_two_finger_swipe`,
+ *   `request_drag`, `request_pinch`, `request_set_text`, `request_ime_action`, `request_select_all`)
+ *   are emitted through the cross-platform shared `sendCommand()` / `createMessage()` path in
  *   `src/features/observe/DeviceServiceUtils.ts`. They are typed here for contract completeness
  *   (drift cross-check) but intentionally NOT re-routed, to avoid coupling the shared iOS client
  *   to the Android contract. Unifying that path is a possible follow-up.
@@ -635,27 +635,6 @@ export const ctrlProxyRequests = {
 
   requestScreenshot(args: { requestId: string }): RequestScreenshotMessage {
     return { type: "request_screenshot", requestId: args.requestId };
-  },
-
-  requestTwoFingerSwipe(args: {
-    requestId: string;
-    x1: number;
-    y1: number;
-    x2: number;
-    y2: number;
-    duration: number;
-    offset: number;
-  }): RequestTwoFingerSwipeMessage {
-    return {
-      type: "request_two_finger_swipe",
-      requestId: args.requestId,
-      x1: args.x1,
-      y1: args.y1,
-      x2: args.x2,
-      y2: args.y2,
-      duration: args.duration,
-      offset: args.offset,
-    };
   },
 
   requestAction(args: { requestId: string; action: string; resourceId?: string }): RequestActionMessage {

--- a/test/features/observe/android/CtrlProxyGestures.test.ts
+++ b/test/features/observe/android/CtrlProxyGestures.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "bun:test";
+import { CtrlProxyGestures } from "../../../../src/features/observe/android/CtrlProxyGestures";
+import type { DelegateContext } from "../../../../src/features/observe/shared/types";
+import type { A11ySwipeResult } from "../../../../src/features/observe/android/types";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+
+/**
+ * Tests for the Android two-finger swipe result correlation (#2988).
+ *
+ * The two-finger swipe must resolve from the real `swipe_result` frame the runner returns
+ * (routed through RequestManager, exactly like the sibling swipe/tap/drag/pinch gestures),
+ * NOT only via its timeout.
+ */
+function createFakeContext(overrides?: Partial<DelegateContext>): {
+  context: DelegateContext;
+  sent: string[];
+  timer: FakeTimer;
+  requestManager: RequestManager;
+} {
+  const timer = new FakeTimer();
+  const requestManager = new RequestManager(timer);
+  const sent: string[] = [];
+  const context: DelegateContext = {
+    getWebSocket: () => ({
+      send: (data: string) => { sent.push(data); },
+      readyState: 1,
+    } as any),
+    requestManager,
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => { /* no-op */ },
+    ...overrides,
+  };
+  return { context, sent, timer, requestManager };
+}
+
+/** Let the async ensureConnected chain flush so the request is registered + sent. */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("CtrlProxyGestures.requestTwoFingerSwipe (#2988)", () => {
+  it("resolves from a swipe_result frame before the timeout fires (success)", async () => {
+    const { context, sent, timer, requestManager } = createFakeContext();
+    const gestures = new CtrlProxyGestures(context);
+
+    const promise = gestures.requestTwoFingerSwipe(10, 20, 30, 40, 300, 100, 5000);
+    await flush();
+
+    // The request must have been registered with RequestManager (not sent raw).
+    expect(requestManager.getPendingCount()).toBe(1);
+    const sentMsg = JSON.parse(sent[sent.length - 1]);
+    expect(sentMsg.requestId).toBeDefined();
+    expect(String(sentMsg.requestId).startsWith("two_finger_swipe_")).toBe(true);
+
+    // Deliver the runner's swipe_result BEFORE any timer advance.
+    const resolved = requestManager.resolve<A11ySwipeResult>(sentMsg.requestId as string, {
+      success: true,
+      totalTimeMs: 123,
+      gestureTimeMs: 100,
+    });
+    expect(resolved).toBe(true);
+
+    const result = await promise;
+    expect(result.success).toBe(true);
+    expect(result.totalTimeMs).toBe(123);
+    // Timer never advanced → resolution did not come from the timeout.
+    expect(timer.getCurrentTime()).toBe(0);
+    // No dangling pending request nor timeout left behind.
+    expect(requestManager.getPendingCount()).toBe(0);
+  });
+
+  it("propagates a runner-reported failure promptly (no timeout wait)", async () => {
+    const { context, sent, timer, requestManager } = createFakeContext();
+    const gestures = new CtrlProxyGestures(context);
+
+    const promise = gestures.requestTwoFingerSwipe(1, 2, 3, 4, 300, 100, 5000);
+    await flush();
+
+    const sentMsg = JSON.parse(sent[sent.length - 1]);
+    requestManager.resolve<A11ySwipeResult>(sentMsg.requestId as string, {
+      success: false,
+      totalTimeMs: 5,
+      error: "Non-finite coordinate rejected",
+    });
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Non-finite coordinate rejected");
+    expect(timer.getCurrentTime()).toBe(0);
+  });
+
+  it("sends the correct wire message with rounded coordinates and offset", async () => {
+    const { context, sent, requestManager } = createFakeContext();
+    const gestures = new CtrlProxyGestures(context);
+
+    const promise = gestures.requestTwoFingerSwipe(10.7, 20.3, 30.4, 40.9, 250, 80, 5000);
+    await flush();
+
+    const sentMsg = JSON.parse(sent[sent.length - 1]);
+    expect(sentMsg.type).toBe("request_two_finger_swipe");
+    expect(sentMsg.x1).toBe(11);
+    expect(sentMsg.y1).toBe(20);
+    expect(sentMsg.x2).toBe(30);
+    expect(sentMsg.y2).toBe(41);
+    expect(sentMsg.duration).toBe(250);
+    expect(sentMsg.offset).toBe(80);
+
+    // Resolve so the promise settles (avoid a dangling pending request).
+    requestManager.resolve<A11ySwipeResult>(sentMsg.requestId as string, { success: true, totalTimeMs: 1 });
+    await promise;
+  });
+
+  it("still times out when the runner never replies", async () => {
+    const { context, timer } = createFakeContext();
+    const gestures = new CtrlProxyGestures(context);
+
+    const promise = gestures.requestTwoFingerSwipe(0, 0, 100, 100, 300, 100, 100);
+    await flush();
+
+    timer.advanceTime(101);
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("timed out");
+  });
+
+  it("returns Not connected without sending when the connection cannot be established", async () => {
+    const { context, sent } = createFakeContext({ ensureConnected: async () => false });
+    const gestures = new CtrlProxyGestures(context);
+
+    const result = await gestures.requestTwoFingerSwipe(0, 0, 100, 100);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Not connected");
+    expect(sent.length).toBe(0);
+  });
+});

--- a/test/features/observe/android/ctrlProxyProtocol.test.ts
+++ b/test/features/observe/android/ctrlProxyProtocol.test.ts
@@ -119,11 +119,10 @@ describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
       .toBe('{"type":"request_screenshot","requestId":"s-1"}');
   });
 
-  test("request_two_finger_swipe", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestTwoFingerSwipe({
-      requestId: "tf-1", x1: 1, y1: 2, x2: 3, y2: 4, duration: 300, offset: 100,
-    }))).toBe('{"type":"request_two_finger_swipe","requestId":"tf-1","x1":1,"y1":2,"x2":3,"y2":4,"duration":300,"offset":100}');
-  });
+  // `request_two_finger_swipe` has no builder here: like the other gesture commands
+  // (request_swipe/tap/drag/pinch), it is emitted through the shared sendCommand()/createMessage()
+  // path (#2988), and its field-level wire shape is asserted in CtrlProxyGestures.test.ts. The type
+  // stays in the union + KOTLIN_SERIAL_NAMES drift check above.
 
   test("request_action — resourceId included when present, omitted when undefined", () => {
     expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({ requestId: "a-1", action: "long_click", resourceId: "res" })))


### PR DESCRIPTION
## What

Route the Android **two-finger swipe** (`CtrlProxyGestures.requestTwoFingerSwipe`) through the shared `sendCommand` → `RequestManager.register` path that every sibling gesture already uses, and delete the dead bespoke promise mechanism.

Closes #2988.

Affected files:
- `src/features/observe/android/CtrlProxyGestures.ts` — rewrite `requestTwoFingerSwipe`; remove `pendingSwipeRequestId` / `pendingSwipeResolve` / `handleTwoFingerSwipeResult`.
- `test/features/observe/android/CtrlProxyGestures.test.ts` — new TDD coverage.

## Why

The two-finger swipe result correlation was **orphaned**. `requestTwoFingerSwipe` sent its request via a **raw** `getWebSocket()?.send(message)` and stored `pendingSwipeRequestId`/`pendingSwipeResolve` for a resolver — `handleTwoFingerSwipeResult` — that had **zero callers** (`grep -rn handleTwoFingerSwipeResult src/ test/` returned only the definition). The runner replies with a `swipe_result` frame, which `AndroidCtrlProxyClient` resolves through `RequestManager` **by requestId**; but the two-finger id was never registered there, so the frame was dropped and the promise settled **only via its 5s timeout** — returning `{ success:false, error:"Two-finger swipe timeout…" }` even when the runner succeeded.

Impact: every two-finger swipe (TalkBack-mode scrolling, `TalkBackSwipeExecutor`) blocked ~5s and reported a timeout error, even on success.

## How

Option 1 from the issue (the DRY choice):

- `requestTwoFingerSwipe` now calls `sendCommand<A11ySwipeResult>(...)` with `idPrefix: "two_finger_swipe"`, `messageType: "request_two_finger_swipe"`, and the `{x1,y1,x2,y2,duration,offset}` params. `sendCommand` runs the same `cancelScreenshotBackoff → ensureConnected → register → send → await` flow as swipe/tap/drag/pinch.
- The Android runner **shares the `swipe_result` response type** for two-finger swipes (`android/.../CtrlProxyMessageHandler.kt:124-125`; `SwipeResult` is `@SerialName("swipe_result")` with a `requestId`). So the existing `AndroidCtrlProxyClient` `swipe_result` handler resolves the two-finger promise by requestId as soon as the runner replies — success **or** the #2964 non-finite guard failure — with no timeout wait.
- Deleted the dead `pendingSwipeRequestId` / `pendingSwipeResolve` / `handleTwoFingerSwipeResult` members. No orphaned resolver remains.

Preserved behavior:
- **Wire format** — `createMessage` emits `{"type":"request_two_finger_swipe","requestId":…,"x1":…,"y1":…,"x2":…,"y2":…,"duration":…,"offset":…}`, byte-identical field order to the old serializer.
- **Integer coordinate rounding** — explicit `Math.round(...)` retained (intentional per the existing comments).
- **requestId prefix** — still `two_finger_swipe_…`.
- **Not-connected** — still returns `{success:false, error:"Not connected"}` without sending.
- `perf` is now threaded through `sendCommand` instead of ignored (minor improvement).

## Testing

New `test/features/observe/android/CtrlProxyGestures.test.ts` (Interface + Fake WebSocket + `FakeTimer` + real `RequestManager`, per CLAUDE.md; <100ms):

- Resolves from a `swipe_result` frame **before** the timeout fires (`success:true`), timer never advanced, no dangling pending request.
- Propagates a runner-reported failure (`success:false` + error, incl. the #2964 non-finite guard error) promptly, no timeout wait.
- Sends the correct wire message with rounded coordinates + `offset`.
- Still times out when the runner never replies.
- Returns `Not connected` without sending when the connection can't be established.

```
bun test test/features/observe/android/CtrlProxyGestures.test.ts   # 5 pass
bun test test/features/observe/ test/features/action/swipeon/       # green (see note)
npx eslint <changed files>                                          # clean
bun build.ts                                                        # ok
```

Note: `test/features/observe/CtrlProxyClient.test.ts > getLatestHierarchy > should preserve SDK screen names…` fails **identically on `origin/main` without this change** (verified via `git stash`) — pre-existing and unrelated to this PR.

## Related

- #2964 (Android non-finite gesture guard), PR #2946 / #2927 (Double widening), iOS #2928 / PR #2957.