### PR TITLE
refactor(image): migrate pixel consumers to ImageBackend seam (#3009)

### DIFF
--- a/src/features/accessibility/ContrastChecker.ts
+++ b/src/features/accessibility/ContrastChecker.ts
@@ -4,13 +4,14 @@
  * Optimized with multi-level caching for performance
  */
 
-import { Jimp, intToRGBA } from "jimp";
 import fs from "fs/promises";
 import { Element } from "../../models/Element";
 import { WcagLevel } from "../../models/AccessibilityAudit";
 import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { clamp } from "../../utils/bounds";
+import type { ImageBackend, RawImage } from "../../utils/image/backend/ImageBackend";
+import { resolveImageBackend } from "../../utils/image/backend/resolveImageBackend";
 
 interface RGB {
   r: number;
@@ -128,7 +129,7 @@ interface CacheStats {
  * Screenshot cache entry
  */
 interface ScreenshotCacheEntry {
-  image: Jimp;
+  image: RawImage;
   timestamp: number;
   fingerprint: string;
 }
@@ -145,6 +146,7 @@ interface ElementCacheEntry {
 export class ContrastChecker {
   private config: Required<ContrastCheckConfig>;
   private timer: Timer;
+  private backend: ImageBackend;
 
   // Phase 1: Screenshot cache
   private screenshotCache = new Map<string, ScreenshotCacheEntry>();
@@ -166,8 +168,13 @@ export class ContrastChecker {
   private bgColorHits = 0;
   private bgColorMisses = 0;
 
-  constructor(config: ContrastCheckConfig = {}, timer: Timer = defaultTimer) {
+  constructor(
+    config: ContrastCheckConfig = {},
+    timer: Timer = defaultTimer,
+    backend: ImageBackend = resolveImageBackend()
+  ) {
     this.timer = timer;
+    this.backend = backend;
     this.config = {
       useMultiPointSampling: config.useMultiPointSampling ?? true,
       detectGradients: config.detectGradients ?? true,
@@ -323,7 +330,7 @@ export class ContrastChecker {
    * Calculate contrast with a pre-loaded Jimp image
    */
   private async checkContrastWithImage(
-    image: Jimp,
+    image: RawImage,
     element: Element,
     wcagLevel: WcagLevel
   ): Promise<ContrastResult | null> {
@@ -439,9 +446,9 @@ export class ContrastChecker {
   /**
    * Phase 1: Get or load screenshot from cache
    */
-  private async getOrLoadScreenshot(path: string): Promise<Jimp> {
+  private async getOrLoadScreenshot(path: string): Promise<RawImage> {
     if (!this.config.enableScreenshotCache) {
-      return await Jimp.read(path);
+      return await this.decodeScreenshot(path);
     }
 
     const cached = this.screenshotCache.get(path);
@@ -459,7 +466,7 @@ export class ContrastChecker {
 
     // Cache miss or expired - load fresh image
     this.screenshotMisses++;
-    const image = await Jimp.read(path);
+    const image = await this.decodeScreenshot(path);
     const fingerprint = await this.getScreenshotFingerprint(path);
 
     this.screenshotCache.set(path, {
@@ -472,6 +479,44 @@ export class ContrastChecker {
     this.cleanupCache(this.screenshotCache, this.config.maxCacheSize.screenshots);
 
     return image;
+  }
+
+  /**
+   * Decode a screenshot file to raw RGBA pixels via the image backend.
+   * Replaces the former `Jimp.read(path)`; pixel values are identical (both
+   * decode the same PNG), so contrast sampling is byte-for-byte unchanged.
+   */
+  private async decodeScreenshot(path: string): Promise<RawImage> {
+    const buffer = await fs.readFile(path);
+    return this.backend.rawPixels(buffer);
+  }
+
+  /**
+   * Read a pixel as RGBA from a decoded raw image, reproducing jimp's
+   * `getPixelColor` semantics: coordinates are rounded and edge-extended
+   * (clamped to the image bounds) so out-of-range samples return the nearest
+   * edge pixel rather than throwing.
+   */
+  private pixelRGBA(image: RawImage, x: number, y: number): RGBA {
+    let xi = Math.round(x);
+    let yi = Math.round(y);
+    if (xi < 0) {
+      xi = 0;
+    } else if (xi >= image.width) {
+      xi = image.width - 1;
+    }
+    if (yi < 0) {
+      yi = 0;
+    } else if (yi >= image.height) {
+      yi = image.height - 1;
+    }
+    const idx = (image.width * yi + xi) * 4;
+    return {
+      r: image.data[idx],
+      g: image.data[idx + 1],
+      b: image.data[idx + 2],
+      a: image.data[idx + 3],
+    };
   }
 
   /**
@@ -611,7 +656,7 @@ export class ContrastChecker {
   /**
    * Sample the text color from the center of the element
    */
-  private async sampleTextColor(image: Jimp, bounds: Element["bounds"]): Promise<RGB> {
+  private async sampleTextColor(image: RawImage, bounds: Element["bounds"]): Promise<RGB> {
     const { left, top, right, bottom } = bounds;
     const centerX = Math.floor((left + right) / 2);
     const centerY = Math.floor((top + bottom) / 2);
@@ -641,7 +686,7 @@ export class ContrastChecker {
    * Sample background colors for a set of points
    */
   private async sampleBackgroundColors(
-    image: Jimp,
+    image: RawImage,
     bounds: Element["bounds"],
     textColor: RGB,
     points: Array<{ x: number; y: number }>
@@ -660,7 +705,7 @@ export class ContrastChecker {
   }
 
   private async sampleBackgroundAtPoint(
-    image: Jimp,
+    image: RawImage,
     bounds: Element["bounds"],
     textColor: RGB,
     x: number,
@@ -694,7 +739,7 @@ export class ContrastChecker {
     return await this.sampleBackgroundEdgeColor(image, bounds);
   }
 
-  private async sampleBackgroundEdgeColor(image: Jimp, bounds: Element["bounds"]): Promise<RGB> {
+  private async sampleBackgroundEdgeColor(image: RawImage, bounds: Element["bounds"]): Promise<RGB> {
     const cached = this.config.enableBackgroundCache ? this.getBackgroundCache(bounds) : null;
     if (cached) {
       return cached;
@@ -781,8 +826,8 @@ export class ContrastChecker {
     }
   }
 
-  private resolvePixelColor(image: Jimp, x: number, y: number): RGB {
-    const pixel = intToRGBA(image.getPixelColor(x, y)) as RGBA;
+  private resolvePixelColor(image: RawImage, x: number, y: number): RGB {
+    const pixel = this.pixelRGBA(image, x, y);
     if (!this.config.compositeOverlays || pixel.a === 255) {
       return { r: pixel.r, g: pixel.g, b: pixel.b };
     }
@@ -794,13 +839,13 @@ export class ContrastChecker {
     return this.compositeColors(baseColor, pixel);
   }
 
-  private findUnderlyingColor(image: Jimp, x: number, y: number): RGB | null {
+  private findUnderlyingColor(image: RawImage, x: number, y: number): RGB | null {
     for (let radius = 1; radius <= 12; radius++) {
       for (let dx = -radius; dx <= radius; dx++) {
         for (let dy = -radius; dy <= radius; dy++) {
-          const sampleX = clamp(x + dx, 0, image.bitmap.width - 1);
-          const sampleY = clamp(y + dy, 0, image.bitmap.height - 1);
-          const pixel = intToRGBA(image.getPixelColor(sampleX, sampleY)) as RGBA;
+          const sampleX = clamp(x + dx, 0, image.width - 1);
+          const sampleY = clamp(y + dy, 0, image.height - 1);
+          const pixel = this.pixelRGBA(image, sampleX, sampleY);
           if (pixel.a === 255) {
             return { r: pixel.r, g: pixel.g, b: pixel.b };
           }
@@ -1014,7 +1059,7 @@ export class ContrastChecker {
   }
 
   private detectTextShadow(
-    image: Jimp,
+    image: RawImage,
     bounds: Element["bounds"],
     textColor: RGB,
     backgroundColor: RGB

--- a/src/utils/image/backend/ImageBackend.ts
+++ b/src/utils/image/backend/ImageBackend.ts
@@ -32,10 +32,11 @@ export type ImageOperation =
        * Resampling kernel. `"nearest"` maps every destination pixel to a single
        * source pixel (no interpolation) — required by consumers that must not
        * introduce averaged colors (pHash 8×8 downscale, comparator resize).
-       * Omitted / `"auto"` keeps the backend default (jimp: bilinear), matching
-       * historical behavior for general-purpose resizes.
+       * Omitted keeps the backend default (jimp: bilinear), matching historical
+       * behavior for general-purpose resizes. (Only the non-default kernel needs
+       * a name; a second mode can be added when a consumer needs it.)
        */
-      mode?: "nearest" | "auto";
+      mode?: "nearest";
     }
   | { type: "crop"; x: number; y: number; width: number; height: number };
 

--- a/src/utils/image/backend/ImageBackend.ts
+++ b/src/utils/image/backend/ImageBackend.ts
@@ -23,7 +23,20 @@ export interface ImageMetadata {
  * receiving pre-bound closures, so the same pipeline can run on any backend.
  */
 export type ImageOperation =
-  | { type: "resize"; width: number; height?: number; maintainAspectRatio: boolean }
+  | {
+      type: "resize";
+      width: number;
+      height?: number;
+      maintainAspectRatio: boolean;
+      /**
+       * Resampling kernel. `"nearest"` maps every destination pixel to a single
+       * source pixel (no interpolation) — required by consumers that must not
+       * introduce averaged colors (pHash 8×8 downscale, comparator resize).
+       * Omitted / `"auto"` keeps the backend default (jimp: bilinear), matching
+       * historical behavior for general-purpose resizes.
+       */
+      mode?: "nearest" | "auto";
+    }
   | { type: "crop"; x: number; y: number; width: number; height: number };
 
 /**

--- a/src/utils/image/backend/JimpBackend.ts
+++ b/src/utils/image/backend/JimpBackend.ts
@@ -13,7 +13,7 @@ export class JimpBackend implements ImageBackend {
     switch (op.type) {
       case "resize": {
         // `"nearest"` forces the nearest-neighbor kernel (no interpolation);
-        // omitted/`"auto"` leaves `mode` undefined so jimp uses its default.
+        // omitting `mode` leaves it undefined so jimp uses its default kernel.
         const mode = op.mode === "nearest" ? ResizeStrategy.NEAREST_NEIGHBOR : undefined;
         if (op.height === undefined) {
           // Width only: scale preserving aspect ratio.

--- a/src/utils/image/backend/JimpBackend.ts
+++ b/src/utils/image/backend/JimpBackend.ts
@@ -1,3 +1,4 @@
+import { ResizeStrategy } from "jimp";
 import { loadJimp, type JimpImage } from "../loadJimp";
 import type { ImageBackend, ImageMetadata, ImageOperation, ImagePipeline, RawImage } from "./ImageBackend";
 
@@ -10,17 +11,21 @@ import type { ImageBackend, ImageMetadata, ImageOperation, ImagePipeline, RawIma
 export class JimpBackend implements ImageBackend {
   private applyOperation(image: JimpImage, op: ImageOperation): JimpImage {
     switch (op.type) {
-      case "resize":
+      case "resize": {
+        // `"nearest"` forces the nearest-neighbor kernel (no interpolation);
+        // omitted/`"auto"` leaves `mode` undefined so jimp uses its default.
+        const mode = op.mode === "nearest" ? ResizeStrategy.NEAREST_NEIGHBOR : undefined;
         if (op.height === undefined) {
           // Width only: scale preserving aspect ratio.
-          return image.resize({ w: op.width });
+          return image.resize({ w: op.width, mode });
         }
         if (op.maintainAspectRatio) {
           // Match sharp's default fit "cover": exact WxH, center-cropped.
-          return image.cover({ w: op.width, h: op.height });
+          return image.cover({ w: op.width, h: op.height, mode });
         }
         // fit "fill": stretch to exact WxH.
-        return image.resize({ w: op.width, h: op.height });
+        return image.resize({ w: op.width, h: op.height, mode });
+      }
       case "crop":
         return image.crop({ x: op.x, y: op.y, w: op.width, h: op.height });
     }

--- a/src/utils/image/backend/JimpBackend.ts
+++ b/src/utils/image/backend/JimpBackend.ts
@@ -1,6 +1,16 @@
-import { ResizeStrategy } from "jimp";
 import { loadJimp, type JimpImage } from "../loadJimp";
+import type { ResizeStrategy } from "jimp";
 import type { ImageBackend, ImageMetadata, ImageOperation, ImagePipeline, RawImage } from "./ImageBackend";
+
+/**
+ * jimp's `ResizeStrategy.NEAREST_NEIGHBOR` value, inlined as a literal. Importing
+ * the enum *value* from `jimp` would pull the full package in at module-evaluation
+ * time — any module that wires the default backend via `resolveImageBackend()`
+ * would then load jimp eagerly, defeating `loadJimp.ts`'s contract that keeps jimp
+ * off the MCP startup path. The `import type` above is erased at build time, so the
+ * cast stays a pure type reference and adds no runtime dependency.
+ */
+const NEAREST_NEIGHBOR = "nearestNeighbor" as ResizeStrategy;
 
 /**
  * Jimp-backed `ImageBackend`. Reproduces exactly what `ImageTransformer` used
@@ -14,7 +24,7 @@ export class JimpBackend implements ImageBackend {
       case "resize": {
         // `"nearest"` forces the nearest-neighbor kernel (no interpolation);
         // omitting `mode` leaves it undefined so jimp uses its default kernel.
-        const mode = op.mode === "nearest" ? ResizeStrategy.NEAREST_NEIGHBOR : undefined;
+        const mode = op.mode === "nearest" ? NEAREST_NEIGHBOR : undefined;
         if (op.height === undefined) {
           // Width only: scale preserving aspect ratio.
           return image.resize({ w: op.width, mode });

--- a/src/utils/screenshot/PerceptualHasher.ts
+++ b/src/utils/screenshot/PerceptualHasher.ts
@@ -1,32 +1,54 @@
-import { ResizeStrategy } from "jimp";
 import { logger } from "../logger";
-import { loadJimp } from "../image/loadJimp";
+import type { ImageBackend } from "../image/backend/ImageBackend";
+import { resolveImageBackend } from "../image/backend/resolveImageBackend";
+
+/** Side length of the downscaled grid used for the perceptual hash (8×8 = 64 bits). */
+const HASH_SIZE = 8;
 
 export class PerceptualHasher {
   /**
    * Generate a perceptual hash from image buffer for fast similarity checking
    * @param buffer Image buffer
+   * @param backend Image backend used to decode raw pixels (injectable for tests)
    * @returns Promise with perceptual hash string
    */
-  static async generatePerceptualHash(buffer: Buffer): Promise<string> {
+  static async generatePerceptualHash(
+    buffer: Buffer,
+    backend: ImageBackend = resolveImageBackend()
+  ): Promise<string> {
     try {
-      const Jimp = await loadJimp();
-      // Resize to small standard size for consistent hashing
-      const image = await Jimp.fromBuffer(buffer);
-      image.resize({ w: 8, h: 8, mode: ResizeStrategy.NEAREST_NEIGHBOR }).greyscale();
-
-      // bitmap.data is RGBA; after greyscale r=g=b, so sample the red channel
-      const data = image.bitmap.data;
-      const totalPixels = 64; // 8x8
+      // Decode once to raw RGBA, then reproduce the former jimp pipeline in place:
+      // an 8×8 nearest-neighbor downscale followed by an ITU-R greyscale, so the
+      // hash is byte-identical to the pre-seam jimp path (no cache-invalidating drift).
+      const raw = await backend.rawPixels(buffer);
+      const totalPixels = HASH_SIZE * HASH_SIZE;
+      const greys = new Array<number>(totalPixels);
       let sum = 0;
-      for (let i = 0; i < totalPixels; i++) {
-        sum += data[i * 4];
+
+      for (let row = 0; row < HASH_SIZE; row++) {
+        // Nearest-neighbor source index, matching jimp's resize2.nearestNeighbor:
+        // src = floor(dst * srcDim / dstDim).
+        const srcY = Math.floor((row * raw.height) / HASH_SIZE);
+        for (let col = 0; col < HASH_SIZE; col++) {
+          const srcX = Math.floor((col * raw.width) / HASH_SIZE);
+          const idx = (srcY * raw.width + srcX) * 4;
+          // ITU Rec 709 luminance, truncated exactly as jimp's greyscale does when
+          // it writes the float back into a Uint8 buffer (trunc-toward-zero).
+          const grey = Math.trunc(
+            0.2126 * raw.data[idx] +
+            0.7152 * raw.data[idx + 1] +
+            0.0722 * raw.data[idx + 2]
+          );
+          greys[row * HASH_SIZE + col] = grey;
+          sum += grey;
+        }
       }
+
       const averageValue = sum / totalPixels;
 
       let hash = "";
       for (let i = 0; i < totalPixels; i++) {
-        hash += data[i * 4] > averageValue ? "1" : "0";
+        hash += greys[i] > averageValue ? "1" : "0";
       }
 
       return hash;

--- a/src/utils/screenshot/ScreenshotComparator.ts
+++ b/src/utils/screenshot/ScreenshotComparator.ts
@@ -1,8 +1,8 @@
 import { PNG } from "pngjs";
-import { ResizeStrategy } from "jimp";
 import { logger } from "../logger";
 import { Timer, defaultTimer } from "../SystemTimer";
-import { loadJimp } from "../image/loadJimp";
+import type { ImageBackend } from "../image/backend/ImageBackend";
+import { resolveImageBackend } from "../image/backend/resolveImageBackend";
 
 // Add dynamic import function for pixelmatch
 async function getPixelmatch() {
@@ -35,13 +35,15 @@ export class ScreenshotComparator {
   /**
    * Convert image buffer to PNG format
    * @param buffer Input image buffer
+   * @param backend Image backend (injectable for tests)
    * @returns Promise with PNG buffer
    */
-  static async convertToPng(buffer: Buffer): Promise<Buffer> {
+  static async convertToPng(
+    buffer: Buffer,
+    backend: ImageBackend = resolveImageBackend()
+  ): Promise<Buffer> {
     try {
-      const Jimp = await loadJimp();
-      const image = await Jimp.fromBuffer(buffer);
-      return await image.getBuffer("image/png");
+      return await backend.execute(buffer, { operations: [], encoding: { mime: "image/png" } });
     } catch (error) {
       throw new Error(`Failed to convert image to PNG: ${(error as Error).message}`);
     }
@@ -50,10 +52,16 @@ export class ScreenshotComparator {
   /**
    * Get image dimensions from buffer
    * @param buffer Image buffer
+   * @param backend Image backend (injectable for tests)
    * @returns Promise with width and height
    */
-  static async getImageDimensions(buffer: Buffer): Promise<{ width: number; height: number }> {
-    // Fast path: PNG stores dimensions in the IHDR chunk, no full decode needed
+  static async getImageDimensions(
+    buffer: Buffer,
+    backend: ImageBackend = resolveImageBackend()
+  ): Promise<{ width: number; height: number }> {
+    // Fast path: PNG stores dimensions in the IHDR chunk, no full decode needed.
+    // Kept ahead of backend.metadata() (which does a full decode) so the hot PNG
+    // path never pays for a decode it doesn't need.
     if (ScreenshotComparator.isPngBuffer(buffer) && buffer.length >= 24) {
       return {
         width: buffer.readUInt32BE(16),
@@ -62,12 +70,8 @@ export class ScreenshotComparator {
     }
 
     try {
-      const Jimp = await loadJimp();
-      const image = await Jimp.fromBuffer(buffer);
-      return {
-        width: image.bitmap.width,
-        height: image.bitmap.height
-      };
+      const { width, height } = await backend.metadata(buffer);
+      return { width, height };
     } catch (error) {
       throw new Error(`Failed to get image dimensions: ${(error as Error).message}`);
     }
@@ -78,14 +82,16 @@ export class ScreenshotComparator {
    * @param buffer Image buffer to resize
    * @param targetWidth Target width
    * @param targetHeight Target height
+   * @param backend Image backend (injectable for tests)
    * @returns Promise with resized buffer
    */
   static async resizeImageIfNeeded(
     buffer: Buffer,
     targetWidth: number,
-    targetHeight: number
+    targetHeight: number,
+    backend: ImageBackend = resolveImageBackend()
   ): Promise<Buffer> {
-    const { width, height } = await ScreenshotComparator.getImageDimensions(buffer);
+    const { width, height } = await ScreenshotComparator.getImageDimensions(buffer, backend);
 
     if (width === targetWidth && height === targetHeight) {
       return buffer;
@@ -94,11 +100,15 @@ export class ScreenshotComparator {
     logger.debug(`Resizing image from ${width}x${height} to ${targetWidth}x${targetHeight}`);
 
     try {
-      const Jimp = await loadJimp();
-      const image = await Jimp.fromBuffer(buffer);
-      // Nearest-neighbor stretch to exact target size — fast resize for comparison purposes
-      image.resize({ w: targetWidth, h: targetHeight, mode: ResizeStrategy.NEAREST_NEIGHBOR });
-      return await image.getBuffer("image/png");
+      // Nearest-neighbor stretch to exact target size — fast resize for comparison
+      // purposes. `mode: "nearest"` is required: a bilinear resize here would blend
+      // neighboring pixels and quietly shift the pixelmatch diff.
+      return await backend.execute(buffer, {
+        operations: [
+          { type: "resize", width: targetWidth, height: targetHeight, maintainAspectRatio: false, mode: "nearest" }
+        ],
+        encoding: { mime: "image/png" }
+      });
     } catch (error) {
       throw new Error(`Failed to resize image: ${(error as Error).message}`);
     }
@@ -117,19 +127,20 @@ export class ScreenshotComparator {
     buffer2: Buffer,
     threshold: number = 0.1,
     fastMode: boolean = false,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    backend: ImageBackend = resolveImageBackend()
   ): Promise<ScreenshotComparisonResult> {
     const comparisonStart = timer.now();
     logger.debug(`Starting image comparison with threshold ${threshold}${fastMode ? " (fast mode)" : ""}`);
 
     try {
       // Ensure both images are PNG format
-      let png1Buffer = ScreenshotComparator.isPngBuffer(buffer1) ? buffer1 : await ScreenshotComparator.convertToPng(buffer1);
-      let png2Buffer = ScreenshotComparator.isPngBuffer(buffer2) ? buffer2 : await ScreenshotComparator.convertToPng(buffer2);
+      let png1Buffer = ScreenshotComparator.isPngBuffer(buffer1) ? buffer1 : await ScreenshotComparator.convertToPng(buffer1, backend);
+      let png2Buffer = ScreenshotComparator.isPngBuffer(buffer2) ? buffer2 : await ScreenshotComparator.convertToPng(buffer2, backend);
 
       // Get dimensions
-      const dims1 = await ScreenshotComparator.getImageDimensions(png1Buffer);
-      const dims2 = await ScreenshotComparator.getImageDimensions(png2Buffer);
+      const dims1 = await ScreenshotComparator.getImageDimensions(png1Buffer, backend);
+      const dims2 = await ScreenshotComparator.getImageDimensions(png2Buffer, backend);
 
       logger.debug(`Image 1 dimensions: ${dims1.width}x${dims1.height}`);
       logger.debug(`Image 2 dimensions: ${dims2.width}x${dims2.height}`);
@@ -144,10 +155,10 @@ export class ScreenshotComparator {
 
       // Resize images to match if needed (use the smaller dimensions for performance)
       if (dims1.width !== targetWidth || dims1.height !== targetHeight) {
-        png1Buffer = await ScreenshotComparator.resizeImageIfNeeded(png1Buffer, targetWidth, targetHeight);
+        png1Buffer = await ScreenshotComparator.resizeImageIfNeeded(png1Buffer, targetWidth, targetHeight, backend);
       }
       if (dims2.width !== targetWidth || dims2.height !== targetHeight) {
-        png2Buffer = await ScreenshotComparator.resizeImageIfNeeded(png2Buffer, targetWidth, targetHeight);
+        png2Buffer = await ScreenshotComparator.resizeImageIfNeeded(png2Buffer, targetWidth, targetHeight, backend);
       }
 
       // Parse PNG data

--- a/test/features/accessibility/ContrastChecker.test.ts
+++ b/test/features/accessibility/ContrastChecker.test.ts
@@ -7,6 +7,21 @@ import { expect, describe, it, beforeEach } from "bun:test";
 import * as path from "path";
 import { ContrastChecker } from "../../../src/features/accessibility/ContrastChecker";
 import type { Element } from "../../../src/models/Element";
+import { FakeImageBackend } from "../../fakes/FakeImageBackend";
+
+/** Build a uniform RGBA raw image for backend-seam tests. */
+function uniformRaw(width: number, height: number, r: number, g: number, b: number): {
+  width: number; height: number; data: Buffer;
+} {
+  const data = Buffer.alloc(width * height * 4);
+  for (let i = 0; i < width * height; i++) {
+    data[i * 4] = r;
+    data[i * 4 + 1] = g;
+    data[i * 4 + 2] = b;
+    data[i * 4 + 3] = 255;
+  }
+  return { width, height, data };
+}
 
 describe("ContrastChecker", function() {
   let checker: ContrastChecker;
@@ -377,6 +392,44 @@ describe("ContrastChecker", function() {
       expect(result).not.toBeNull();
       expect(result!.shadowDetected).toBe(true);
       expect(result!.requiredRatio).toBeLessThan(result!.baseRequiredRatio);
+    });
+  });
+
+  describe("Backend seam", function() {
+    it("decodes screenshots through the injected ImageBackend.rawPixels", async function() {
+      const backend = new FakeImageBackend();
+      backend.setRawPixelsResult(uniformRaw(100, 50, 255, 255, 255));
+      const seamChecker = new ContrastChecker({}, undefined, backend);
+      // A real file must exist for fs.readFile; its bytes are ignored because the
+      // fake backend returns canned pixels regardless of buffer content.
+      const screenshotPath = path.join(fixturesDir, "black-on-white.png");
+      const element: Element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+        text: "Sample",
+      };
+
+      const result = await seamChecker.checkContrast(screenshotPath, element, "AA");
+
+      expect(result).not.toBeNull();
+      // Decoded exactly once via the seam (screenshot cache holds the RawImage).
+      expect(backend.rawPixelsCalls).toHaveLength(1);
+    });
+
+    it("tolerates element bounds beyond the image via edge clamping", async function() {
+      const backend = new FakeImageBackend();
+      backend.setRawPixelsResult(uniformRaw(20, 20, 0, 0, 0));
+      const seamChecker = new ContrastChecker({}, undefined, backend);
+      const screenshotPath = path.join(fixturesDir, "black-on-white.png");
+      // Bounds extend past the 20x20 image; jimp getPixelColor edge-extends, so
+      // sampling must not throw and should resolve to the (uniform black) edge.
+      const element: Element = {
+        bounds: { left: 10, top: 10, right: 40, bottom: 40 },
+        text: "Sample",
+      };
+
+      const result = await seamChecker.checkContrast(screenshotPath, element, "AA");
+
+      expect(result).not.toBeNull();
     });
   });
 });

--- a/test/utils/image/backend/JimpBackend.test.ts
+++ b/test/utils/image/backend/JimpBackend.test.ts
@@ -141,6 +141,48 @@ describe("JimpBackend", () => {
       expect(nearLossless.length).not.toBe(lossless.length);
     });
 
+    test("resize mode:nearest picks source pixels (distinct from default kernel)", async () => {
+      const backend = new JimpBackend();
+      // A 4x4 checkerboard-ish gradient downscaled 4x4 -> 2x2. Nearest samples
+      // exact source pixels (floor((i*4)/2)=0/2), while the default (bilinear)
+      // kernel averages neighbors, so the two must differ on at least one channel.
+      const source = await makeSourcePng(4, 4);
+
+      const nearest = await backend.rawPixels(await backend.execute(source, {
+        operations: [{ type: "resize", width: 2, height: 2, maintainAspectRatio: false, mode: "nearest" }],
+        encoding: { mime: "image/png" }
+      }));
+      const dflt = await backend.rawPixels(await backend.execute(source, {
+        operations: [{ type: "resize", width: 2, height: 2, maintainAspectRatio: false }],
+        encoding: { mime: "image/png" }
+      }));
+
+      // Nearest top-left must equal the exact source top-left pixel (16-color
+      // gradient at (0,0) = rgba(0,0,0,255)); the source's (1,1) is rgba(16,16,1)
+      // so a 2x1-block bilinear average differs from the pure source sample.
+      const src = await backend.rawPixels(source);
+      expect([nearest.data[0], nearest.data[1], nearest.data[2], nearest.data[3]])
+        .toEqual([src.data[0], src.data[1], src.data[2], src.data[3]]);
+      const sameAsDefault =
+        nearest.data[0] === dflt.data[0] &&
+        nearest.data[1] === dflt.data[1] &&
+        nearest.data[2] === dflt.data[2];
+      expect(sameAsDefault).toBe(false);
+    });
+
+    test("cover honors mode:nearest", async () => {
+      const backend = new JimpBackend();
+      const source = await makeSourcePng(8, 8);
+      // maintainAspectRatio:true routes through jimp cover(); assert mode flows
+      // through by producing exact target dims without throwing.
+      const meta = await backend.metadata(await backend.execute(source, {
+        operations: [{ type: "resize", width: 4, height: 4, maintainAspectRatio: true, mode: "nearest" }],
+        encoding: { mime: "image/png" }
+      }));
+      expect(meta.width).toBe(4);
+      expect(meta.height).toBe(4);
+    });
+
     test("null encoding falls back to the decoded input format", async () => {
       const backend = new JimpBackend();
       const source = await makeSourcePng();

--- a/test/utils/screenshot/PerceptualHasher.test.ts
+++ b/test/utils/screenshot/PerceptualHasher.test.ts
@@ -5,6 +5,11 @@ import { FakeImageBackend } from "../../fakes/FakeImageBackend";
 // Compute the hash the way the pre-seam PerceptualHasher did — via the real jimp
 // resize(8x8, NEAREST)+greyscale+red-channel pipeline — so the backend-routed
 // implementation can be pinned byte-for-byte against jimp (no silent drift).
+//
+// TODO(#3010): this jimp-golden pin is intentional ONLY for the JimpBackend
+// phase. When the sharp backend lands, its resize kernel produces different
+// pHash values by design — retire this byte-identity assertion and replace it
+// with backend-relative checks (A vs A′ similarity, A vs B distinctness).
 async function jimpGoldenHash(buffer: Buffer): Promise<string> {
   const { Jimp, ResizeStrategy } = await import("jimp");
   const image = await Jimp.fromBuffer(buffer);

--- a/test/utils/screenshot/PerceptualHasher.test.ts
+++ b/test/utils/screenshot/PerceptualHasher.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, test } from "bun:test";
 import { PerceptualHasher } from "../../../src/utils/screenshot/PerceptualHasher";
+import { FakeImageBackend } from "../../fakes/FakeImageBackend";
+
+// Compute the hash the way the pre-seam PerceptualHasher did — via the real jimp
+// resize(8x8, NEAREST)+greyscale+red-channel pipeline — so the backend-routed
+// implementation can be pinned byte-for-byte against jimp (no silent drift).
+async function jimpGoldenHash(buffer: Buffer): Promise<string> {
+  const { Jimp, ResizeStrategy } = await import("jimp");
+  const image = await Jimp.fromBuffer(buffer);
+  image.resize({ w: 8, h: 8, mode: ResizeStrategy.NEAREST_NEIGHBOR }).greyscale();
+  const data = image.bitmap.data;
+  let sum = 0;
+  for (let i = 0; i < 64; i++) {
+    sum += data[i * 4];
+  }
+  const avg = sum / 64;
+  let hash = "";
+  for (let i = 0; i < 64; i++) {
+    hash += data[i * 4] > avg ? "1" : "0";
+  }
+  return hash;
+}
+
+async function gradientPng(width = 24, height = 24): Promise<Buffer> {
+  const { Jimp, rgbaToInt } = await import("jimp");
+  const image = new Jimp({ width, height, color: 0x000000ff });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      image.setPixelColor(rgbaToInt((x * 10) % 256, (y * 10) % 256, (x * y) % 256, 255), x, y);
+    }
+  }
+  return image.getBuffer("image/png");
+}
 
 describe("PerceptualHasher", () => {
   describe("calculateHammingDistance", () => {
@@ -85,6 +117,47 @@ describe("PerceptualHasher", () => {
       const hash2 = await PerceptualHasher.generatePerceptualHash(buffer2);
       const similarity = PerceptualHasher.getPerceptualSimilarity(hash1, hash2);
       expect(similarity).toBeGreaterThan(80);
+    });
+
+    test("matches the jimp nearest+greyscale pipeline byte-for-byte (no drift)", async () => {
+      // Non-uniform gradient so the hash exercises both 0 and 1 bits and any
+      // downscale/greyscale rounding divergence would flip a bit.
+      const buffer = await gradientPng(24, 24);
+      const golden = await jimpGoldenHash(buffer);
+
+      const hash = await PerceptualHasher.generatePerceptualHash(buffer);
+
+      expect(hash).toBe(golden);
+      expect(hash).toMatch(/[1]/); // sanity: not an all-zero degenerate hash
+    });
+
+    test("routes decode through backend.rawPixels (no direct jimp dependency)", async () => {
+      // 8x8 raw image where the top half is bright and the bottom half is dark:
+      // the resulting hash must be the top-32 bits set, bottom-32 clear.
+      const backend = new FakeImageBackend();
+      const data = Buffer.alloc(8 * 8 * 4);
+      for (let i = 0; i < 8 * 8; i++) {
+        const v = i < 32 ? 255 : 0;
+        data[i * 4] = v;
+        data[i * 4 + 1] = v;
+        data[i * 4 + 2] = v;
+        data[i * 4 + 3] = 255;
+      }
+      backend.setRawPixelsResult({ width: 8, height: 8, data });
+
+      const hash = await PerceptualHasher.generatePerceptualHash(Buffer.from("src"), backend);
+
+      expect(backend.rawPixelsCalls).toHaveLength(1);
+      expect(hash).toBe("1".repeat(32) + "0".repeat(32));
+    });
+
+    test("returns empty string when the backend fails to decode", async () => {
+      const backend = new FakeImageBackend();
+      backend.setShouldThrowOnRawPixels(true);
+
+      const result = await PerceptualHasher.generatePerceptualHash(Buffer.from("bad"), backend);
+
+      expect(result).toBe("");
     });
   });
 });

--- a/test/utils/screenshot/ScreenshotComparator.test.ts
+++ b/test/utils/screenshot/ScreenshotComparator.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { ScreenshotComparator } from "../../../src/utils/screenshot/ScreenshotComparator";
+import { FakeImageBackend } from "../../fakes/FakeImageBackend";
+
+// A minimal valid-looking PNG header + IHDR width/height so the IHDR fast path
+// and isPngBuffer() are exercised without a real encoder.
+function pngWithDimensions(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(24);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0);
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+describe("ScreenshotComparator backend routing", () => {
+  describe("getImageDimensions", () => {
+    test("PNG IHDR fast path avoids a backend decode", async () => {
+      const backend = new FakeImageBackend();
+      const png = pngWithDimensions(320, 640);
+
+      const dims = await ScreenshotComparator.getImageDimensions(png, backend);
+
+      expect(dims).toEqual({ width: 320, height: 640 });
+      // Fast path must not call the backend at all (no full decode).
+      expect(backend.metadataCalls).toHaveLength(0);
+    });
+
+    test("non-PNG buffer falls through to backend.metadata", async () => {
+      const backend = new FakeImageBackend();
+      backend.setMetadataResult({ width: 111, height: 222, format: "webp", size: 10 });
+      const notPng = Buffer.from("RIFF....WEBP");
+
+      const dims = await ScreenshotComparator.getImageDimensions(notPng, backend);
+
+      expect(dims).toEqual({ width: 111, height: 222 });
+      expect(backend.metadataCalls).toHaveLength(1);
+    });
+
+    test("wraps backend decode failures with a stable message", async () => {
+      const backend = new FakeImageBackend();
+      backend.setShouldThrowOnMetadata(true);
+
+      await expect(ScreenshotComparator.getImageDimensions(Buffer.from("nope"), backend))
+        .rejects.toThrow("Failed to get image dimensions");
+    });
+  });
+
+  describe("convertToPng", () => {
+    test("routes through backend.execute with a png encoding and no operations", async () => {
+      const backend = new FakeImageBackend();
+      backend.setExecuteResult(Buffer.from("png-bytes"));
+
+      const out = await ScreenshotComparator.convertToPng(Buffer.from("src"), backend);
+
+      expect(out.toString()).toBe("png-bytes");
+      expect(backend.executeCalls).toHaveLength(1);
+      expect(backend.lastPipeline).toEqual({ operations: [], encoding: { mime: "image/png" } });
+    });
+
+    test("wraps backend failures with a stable message", async () => {
+      const backend = new FakeImageBackend();
+      backend.setShouldThrowOnExecute(true);
+
+      await expect(ScreenshotComparator.convertToPng(Buffer.from("bad"), backend))
+        .rejects.toThrow("Failed to convert image to PNG");
+    });
+  });
+
+  describe("resizeImageIfNeeded", () => {
+    test("resizes via backend.execute using a nearest-mode resize + png encoding", async () => {
+      const backend = new FakeImageBackend();
+      backend.setExecuteResult(Buffer.from("resized"));
+      // Source is 320x640 (IHDR), target differs so a resize is required.
+      const png = pngWithDimensions(320, 640);
+
+      const out = await ScreenshotComparator.resizeImageIfNeeded(png, 160, 320, backend);
+
+      expect(out.toString()).toBe("resized");
+      expect(backend.lastPipeline).toEqual({
+        operations: [
+          { type: "resize", width: 160, height: 320, maintainAspectRatio: false, mode: "nearest" }
+        ],
+        encoding: { mime: "image/png" }
+      });
+    });
+
+    test("returns the original buffer untouched when already at the target size", async () => {
+      const backend = new FakeImageBackend();
+      const png = pngWithDimensions(200, 200);
+
+      const out = await ScreenshotComparator.resizeImageIfNeeded(png, 200, 200, backend);
+
+      expect(out).toBe(png);
+      expect(backend.executeCalls).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Migrates the remaining direct-jimp pixel consumers onto the **`ImageBackend`** seam introduced in #3008 / PR #3024. **Behavior-preserving refactor — no user-visible change.** Closes #3009.

Design milestone: **Sharp + CWebP** (#24). This is the consumer half of Phase 1 (the seam itself landed in #3024).

## What changed (this PR's scope)
- **`ImageBackend.ts`** — `resize` `ImageOperation` gains an optional `mode?: "nearest" | "auto"`. Omitted/`"auto"` = today's backend default (jimp bilinear); `"nearest"` selects nearest-neighbor. This is **carry-forward finding #1** from PR #3024's review — without it, routing a nearest resize through `execute()` would silently become bilinear.
- **`JimpBackend.ts`** — maps `mode:"nearest"` → `ResizeStrategy.NEAREST_NEIGHBOR` on the width-only `resize`, `cover` (aspect), and fill `resize` paths. `undefined` is passed through as omitted, so all existing resizes are byte-for-byte unchanged.
- **`PerceptualHasher.ts`** — drops `loadJimp`; decodes via `backend.rawPixels()` then reproduces the former jimp pipeline in pure JS: 8×8 **nearest** downscale (`floor(dst·src/8)`, matching jimp's `resize2.nearestNeighbor`) + ITU-R **greyscale** (`trunc(0.2126r+0.7152g+0.0722b)`, matching jimp's byte-truncating write). Backend is injectable (default `resolveImageBackend()`).
- **`ScreenshotComparator.ts`** — `convertToPng` → `backend.execute({encoding: png})`; `resizeImageIfNeeded` → `backend.execute({resize mode:"nearest", encoding: png})`; `getImageDimensions` **keeps the PNG-IHDR fast path** and only falls through to `backend.metadata()` for non-PNG buffers (**carry-forward finding #2** — `metadata()` does a full decode). `compareImages` threads the backend through. Error-message contracts preserved.
- **`ContrastChecker.ts`** — drops `import { Jimp, intToRGBA }`; `Jimp.read(path)` → `fs.readFile()` + `backend.rawPixels()`; caches `RawImage` instead of `Jimp`; new `pixelRGBA()` reproduces jimp `getPixelColor` semantics exactly (round coords + edge-extend clamp). Backend is a 3rd constructor arg (default `resolveImageBackend()`).
- **`image-utils.ts`** — already routes entirely through `Image`/the seam; **no change needed** (confirmed no jimp import).

## Explicitly out of scope (no overreach)
- No sharp (#3010), no cwebp (#3011), no `@jimp/wasm-webp` removal (#3012), no platform selection changes in `resolveImageBackend()`.
- No new backend operations (e.g. greyscale) — the hasher does its per-pixel greyscale itself, per the design doc.

## Behavior preservation (the core risk)
`PerceptualHasher` and `ContrastChecker` operate on decoded pixels, so a resize-kernel or rounding divergence would be a silent drift. Both are pinned:
- **pHash**: a golden cross-check test computes the hash via the real jimp `resize(8×8 NEAREST)+greyscale+red-channel` pipeline and asserts the backend-routed implementation is **byte-for-byte identical** on a non-uniform gradient.
- **Contrast**: all 23 existing real-fixture tests pass with **unchanged expectations** (identical ratios), proving `pixelRGBA` matches `intToRGBA(getPixelColor(...))`.

## Tests (TDD)
- `JimpBackend.test.ts` — `mode:"nearest"` picks exact source pixels (distinct from the default kernel); `cover` honors the mode.
- `PerceptualHasher.test.ts` — jimp-golden byte-identity; `backend.rawPixels` is used (FakeImageBackend); decode-failure → `""`; existing property tests unchanged.
- `ScreenshotComparator.test.ts` (new) — IHDR fast path skips `backend.metadata`; non-PNG falls through; `convertToPng`/`resizeImageIfNeeded` pipelines (nearest + png); already-target-size short-circuit; error-wrap messages.
- `ContrastChecker.test.ts` — decodes once through `backend.rawPixels`; edge-clamp tolerance for out-of-image bounds; all 23 fixture tests unchanged.

## Acceptance / validation
- `bun run build` ✓ · `eslint` (changed files) ✓ · `tsc --noEmit` (no new errors in changed files) ✓
- `bun test` across `screenshot` / `accessibility` / `image` / `navigation` — **508 pass, 0 fail**.

## Dependencies
- Blocked by: #3008 (merged, PR #3024) · Enables: #3010, #3011
