### PR TITLE
fix(android): broadcast correlated error on async CtrlProxy action failure (#3023)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
@@ -1,0 +1,86 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.util.Log
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.WebSocketResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Launches a fire-and-forget action coroutine so that a throw *inside* the launched coroutine still
+ * yields a correlated failure frame instead of dying silently.
+ *
+ * [CtrlProxyMessageHandler.handleMessage] dispatches almost every command as fire-and-forget: the
+ * action returns `null` immediately and does its real work inside `serviceScope.launch { … }`,
+ * broadcasting its own `*_result` later. [WebSocketServer]'s handler `catch` (added in #2985 /
+ * PR #3019) only wraps the *synchronous* portion of dispatch, so an exception raised in a launched
+ * action coroutine — a screenshot-capture failure, a storage read that throws — escapes to the
+ * scope's [kotlinx.coroutines.SupervisorJob] with only a log line. No error frame is emitted and
+ * the daemon request awaiting that `requestId` hangs to its `RequestManager` timeout — the exact
+ * symptom #2985 set out to eliminate, just on the async path. See issue #3023.
+ *
+ * Routing those launches through [launch] centralizes the correlated-error-on-throw behavior, so
+ * new actions get it for free. Actions that already broadcast a `success:false` result on their own
+ * error path are unaffected and need not use this helper.
+ *
+ * @param scope the (supervisor) scope launched action coroutines run on — `serviceScope` in
+ *   production, a `TestScope` in tests.
+ * @param broadcastResponse sink for the correlated error frame — `webSocketServer.broadcast(…)` in
+ *   production, a capturing lambda in tests.
+ * @param logError diagnostic sink; defaults to `Log.e` so tests can stay Android-free by
+ *   overriding.
+ */
+class AsyncActionRunner(
+  private val scope: CoroutineScope,
+  private val broadcastResponse: suspend (WebSocketResponse) -> Unit,
+  private val logError: (String, Throwable) -> Unit = { message, error ->
+    Log.e(TAG, message, error)
+  },
+) {
+  /**
+   * Launch [block] on [scope]. If it throws anything other than a cooperative
+   * [CancellationException], broadcast an [ErrorResponse] correlated by [requestId] so the awaiting
+   * client fails fast instead of hanging.
+   *
+   * @param requestId correlation id from the originating request; null when the request carried
+   *   none (the error frame then carries a null requestId, exactly as the synchronous decode path
+   *   does).
+   * @param action human-readable action name, surfaced in the error message for triage.
+   */
+  fun launch(
+    requestId: String?,
+    action: String,
+    block: suspend CoroutineScope.() -> Unit,
+  ): Job = scope.launch {
+    try {
+      block()
+    } catch (e: CancellationException) {
+      // Cooperative cancellation means the service scope is shutting down — never convert it into
+      // a client-facing error frame; let it propagate so the coroutine unwinds cleanly.
+      throw e
+    } catch (e: Exception) {
+      val cause = e.message ?: e::class.simpleName ?: "unknown error"
+      logError("Async action '$action' failed (requestId=$requestId)", e)
+      try {
+        broadcastResponse(
+          ErrorResponse(requestId = requestId, error = "Action '$action' failed: $cause")
+        )
+      } catch (broadcastError: CancellationException) {
+        throw broadcastError
+      } catch (broadcastError: Exception) {
+        // A failure while reporting the error must not escape and crash the launch (which would
+        // defeat the whole point). Log and swallow — the client will fall back to its timeout.
+        logError(
+          "Failed to broadcast async error for action '$action' (requestId=$requestId)",
+          broadcastError,
+        )
+      }
+    }
+  }
+
+  companion object {
+    private const val TAG = "AsyncActionRunner"
+  }
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -112,6 +112,23 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+  /**
+   * Wraps fire-and-forget action launches so a throw inside the launched coroutine broadcasts a
+   * correlated `type:"error"` frame instead of dying silently and hanging the daemon awaiter. See
+   * [AsyncActionRunner] and issue #3023. The broadcast lambda resolves [webSocketServer] lazily
+   * because it is `lateinit` (assigned in [onServiceConnected]).
+   */
+  private val asyncActionRunner =
+    AsyncActionRunner(
+      scope = serviceScope,
+      broadcastResponse = { response ->
+        if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
+          webSocketServer.broadcast(response)
+        }
+      },
+      logError = { message, error -> Log.e(TAG, message, error) },
+    )
   private val recompositionStore = RecompositionStore()
   private val viewHierarchyExtractor = ViewHierarchyExtractor(recompositionStore)
   private val json = Json {
@@ -1686,7 +1703,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     val startTime = System.currentTimeMillis()
     val success = executeGlobalAction(action)
     val totalTimeMs = System.currentTimeMillis() - startTime
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "request_global_action") {
       webSocketServer?.broadcast(
         dev.jasonpearson.automobile.protocol.GlobalActionResult(
           timestamp = System.currentTimeMillis(),
@@ -1706,7 +1723,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     val screenDimensions = getScreenDimensions()
     val foreground = getForegroundActivity()
     val totalTimeMs = System.currentTimeMillis() - startTime
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "request_device_info") {
       webSocketServer?.broadcast(
         dev.jasonpearson.automobile.protocol.DeviceInfoResult(
           timestamp = System.currentTimeMillis(),
@@ -4932,31 +4949,30 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    serviceScope.launch {
-      try {
-        val base64Image = takeScreenshotAsync()
-        if (base64Image != null) {
-          val message = buildString {
-            append("""{"type":"screenshot","timestamp":${System.currentTimeMillis()}""")
-            if (requestId != null) {
-              append(""","requestId":"$requestId"""")
-            }
-            append(""","format":"jpeg","data":"$base64Image"}""")
+    // Routed through asyncActionRunner: a throw in takeScreenshotAsync() (or the broadcast) would
+    // otherwise be logged-and-swallowed here, emitting neither `screenshot` nor `screenshot_error`
+    // and hanging the awaiting client until timeout (issue #3023).
+    asyncActionRunner.launch(requestId, "screenshot") {
+      val base64Image = takeScreenshotAsync()
+      if (base64Image != null) {
+        val message = buildString {
+          append("""{"type":"screenshot","timestamp":${System.currentTimeMillis()}""")
+          if (requestId != null) {
+            append(""","requestId":"$requestId"""")
           }
-          webSocketServer.broadcast(message)
-          Log.d(TAG, "Broadcasted screenshot to ${webSocketServer.getConnectionCount()} clients")
-        } else {
-          val errorMessage = buildString {
-            append("""{"type":"screenshot_error","timestamp":${System.currentTimeMillis()}""")
-            if (requestId != null) {
-              append(""","requestId":"$requestId"""")
-            }
-            append(""","error":"Failed to capture screenshot"}""")
-          }
-          webSocketServer.broadcast(errorMessage)
+          append(""","format":"jpeg","data":"$base64Image"}""")
         }
-      } catch (e: Exception) {
-        Log.e(TAG, "Error broadcasting screenshot", e)
+        webSocketServer.broadcast(message)
+        Log.d(TAG, "Broadcasted screenshot to ${webSocketServer.getConnectionCount()} clients")
+      } else {
+        val errorMessage = buildString {
+          append("""{"type":"screenshot_error","timestamp":${System.currentTimeMillis()}""")
+          if (requestId != null) {
+            append(""","requestId":"$requestId"""")
+          }
+          append(""","error":"Failed to capture screenshot"}""")
+        }
+        webSocketServer.broadcast(errorMessage)
       }
     }
   }
@@ -5246,7 +5262,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       "handleGetPermission (requestId: $requestId, permission: $permission, requestPermission: $requestPermission)",
     )
 
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "get_permission") {
       val result = permissionManager.getPermissionState(permission, requestPermission ?: true)
       val totalTime = System.currentTimeMillis() - startTime
       broadcastPermissionResult(requestId, result, totalTime)
@@ -5559,7 +5575,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
   private fun handleListPreferenceFiles(requestId: String?, packageName: String) {
     Log.d(TAG, "handleListPreferenceFiles: requestId=$requestId, packageName=$packageName")
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "list_preference_files") {
       Log.d(TAG, "handleListPreferenceFiles: coroutine started, calling listPreferenceFiles")
       val result = storageSubscriptionManager.listPreferenceFiles(packageName)
       Log.d(TAG, "handleListPreferenceFiles: result=$result")
@@ -5577,7 +5593,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   private fun handleGetPreferences(requestId: String?, packageName: String, fileName: String) {
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "get_preferences") {
       val result = storageSubscriptionManager.getPreferences(packageName, fileName)
       result.fold(
         onSuccess = { entries ->
@@ -5591,7 +5607,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   private fun handleSubscribeStorage(requestId: String?, packageName: String, fileName: String) {
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "subscribe_storage") {
       val result = storageSubscriptionManager.subscribe(packageName, fileName)
       result.fold(
         onSuccess = { subscription ->
@@ -5611,7 +5627,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   private fun handleUnsubscribeStorage(requestId: String?, packageName: String, fileName: String) {
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "unsubscribe_storage") {
       val success = storageSubscriptionManager.unsubscribe(packageName, fileName)
       broadcastUnsubscribeStorageResult(requestId, packageName, fileName, success)
     }
@@ -5623,7 +5639,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     fileName: String,
     key: String,
   ) {
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "get_preference") {
       val result = storageSubscriptionManager.getPreference(packageName, fileName, key)
       result.fold(
         onSuccess = { entry ->
@@ -5644,7 +5660,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     value: String?,
     type: String,
   ) {
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "set_preference") {
       val result = storageSubscriptionManager.setPreference(packageName, fileName, key, value, type)
       result.fold(
         onSuccess = { broadcastSetPreferenceResult(requestId, packageName, fileName, key, null) },
@@ -5661,7 +5677,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     fileName: String,
     key: String,
   ) {
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "remove_preference") {
       val result = storageSubscriptionManager.removePreference(packageName, fileName, key)
       result.fold(
         onSuccess = {
@@ -5679,7 +5695,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     packageName: String,
     fileName: String,
   ) {
-    serviceScope.launch {
+    asyncActionRunner.launch(requestId, "clear_preferences") {
       val result = storageSubscriptionManager.clearPreferences(packageName, fileName)
       result.fold(
         onSuccess = { broadcastClearPreferencesResult(requestId, packageName, fileName, null) },

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunnerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunnerTest.kt
@@ -121,9 +121,12 @@ class AsyncActionRunnerTest {
     }
     advanceUntilIdle()
 
-    assertTrue(
-      "both the original failure and the broadcast failure should be logged",
-      logged.size >= 2,
+    // Exactly two: the original action failure, then the failure raised while broadcasting it.
+    // Neither escapes the coroutine (which would crash the launch and defeat the fix).
+    assertEquals(
+      "both the original failure and the broadcast failure should be logged: $logged",
+      2,
+      logged.size,
     )
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunnerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunnerTest.kt
@@ -1,0 +1,129 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.WebSocketResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Fast, Android-free unit tests for [AsyncActionRunner] — the shared helper that closes the async
+ * silent-hang gap from issue #3023. Uses a [runTest] [kotlinx.coroutines.test.TestScope] as the
+ * launch scope and a capturing broadcast lambda, so no Robolectric or real network I/O is needed.
+ */
+class AsyncActionRunnerTest {
+
+  @Test
+  fun `broadcasts correlated error frame when block throws`() = runTest {
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    val runner =
+      AsyncActionRunner(
+        scope = this,
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+
+    runner.launch(requestId = "req-1", action = "screenshot") {
+      throw RuntimeException("boom")
+    }
+    advanceUntilIdle()
+
+    assertEquals("exactly one error frame should be broadcast", 1, broadcasts.size)
+    val error = broadcasts.single() as ErrorResponse
+    assertEquals("req-1", error.requestId)
+    assertFalse("error frame should mark success=false", error.success)
+    assertTrue(
+      "error should name the failing action, was: ${error.error}",
+      error.error.contains("screenshot"),
+    )
+    assertTrue(
+      "error should surface the underlying cause, was: ${error.error}",
+      error.error.contains("boom"),
+    )
+  }
+
+  @Test
+  fun `does not broadcast when block succeeds`() = runTest {
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    val runner =
+      AsyncActionRunner(
+        scope = this,
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+
+    runner.launch(requestId = "req-ok", action = "get_permission") {
+      // Successful action: broadcasts its own result elsewhere, so the runner must stay silent.
+    }
+    advanceUntilIdle()
+
+    assertTrue("no error frame should be broadcast on success", broadcasts.isEmpty())
+  }
+
+  @Test
+  fun `propagates cancellation without broadcasting an error`() = runTest {
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    val runner =
+      AsyncActionRunner(
+        scope = this,
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+
+    // Cooperative cancellation means the service scope is shutting down — it must not be reported
+    // to
+    // the client as an action failure.
+    runner.launch(requestId = "req-cancel", action = "list_preference_files") {
+      throw CancellationException("scope shutting down")
+    }
+    advanceUntilIdle()
+
+    assertTrue("cancellation must not produce an error frame", broadcasts.isEmpty())
+  }
+
+  @Test
+  fun `carries a null requestId through to the error frame`() = runTest {
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    val runner =
+      AsyncActionRunner(
+        scope = this,
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+
+    runner.launch(requestId = null, action = "get_preferences") {
+      throw IllegalStateException("no prefs")
+    }
+    advanceUntilIdle()
+
+    val error = broadcasts.single() as ErrorResponse
+    assertEquals("null requestId should pass through uncorrelated", null, error.requestId)
+  }
+
+  @Test
+  fun `swallows a failure raised while broadcasting the error frame`() = runTest {
+    val logged = mutableListOf<String>()
+    val runner =
+      AsyncActionRunner(
+        scope = this,
+        broadcastResponse = { throw RuntimeException("socket closed") },
+        logError = { message, _ -> logged.add(message) },
+      )
+
+    // A broadcast failure during error reporting must not escape the coroutine (which would crash
+    // the launch and defeat the whole point). It is logged and swallowed.
+    runner.launch(requestId = "req-2", action = "subscribe_storage") {
+      throw RuntimeException("original failure")
+    }
+    advanceUntilIdle()
+
+    assertTrue(
+      "both the original failure and the broadcast failure should be logged",
+      logged.size >= 2,
+    )
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -602,4 +602,65 @@ class WebSocketServerIntegrationTest {
       orderedServer.stop()
     }
   }
+
+  @Test
+  fun `async action failure yields correlated error frame`() = runBlocking {
+    // Issue #3023: an action that throws INSIDE its launched coroutine — after the synchronous
+    // handleMessage has already returned null — must still yield a correlated type:"error" frame,
+    // not leave the daemon awaiter hanging to timeout. This is the async analog of the synchronous
+    // handler-throw case covered by `handler exception returns structured error response` (#2985).
+    // The fake action routes its fire-and-forget work through a real AsyncActionRunner, exactly as
+    // CtrlProxy does in production.
+    lateinit var asyncServer: WebSocketServer
+    val runnerHolder = arrayOfNulls<AsyncActionRunner>(1)
+    asyncServer =
+      WebSocketServer(
+        port = 0,
+        scope = testScope,
+        messageHandler =
+          CtrlProxyMessageHandler(
+            object : NoOpCtrlProxyActions() {
+              override fun requestScreenshot(requestId: String?) {
+                // Fire-and-forget: the real work runs in a launched coroutine that throws after
+                // this method (and handleMessage) has already returned.
+                runnerHolder[0]!!.launch(requestId, "screenshot") {
+                  throw RuntimeException("async boom")
+                }
+              }
+            }
+          ),
+      )
+    runnerHolder[0] =
+      AsyncActionRunner(scope = testScope, broadcastResponse = { asyncServer.broadcast(it) })
+    asyncServer.start()
+    try {
+      val client = HttpClient(CIO) { install(WebSockets) }
+      client.use { c ->
+        c.webSocket(
+          method = HttpMethod.Get,
+          host = "localhost",
+          port = asyncServer.getActualPort() ?: error("Server not running"),
+          path = "/ws",
+        ) {
+          incoming.receive() // Connection message
+
+          send(Frame.Text("""{"type":"request_screenshot","requestId":"req-async"}"""))
+
+          val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+          val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+
+          assertEquals("error", responseJson["type"]?.jsonPrimitive?.content)
+          assertEquals("req-async", responseJson["requestId"]?.jsonPrimitive?.content)
+          assertEquals("false", responseJson["success"]?.jsonPrimitive?.content)
+          val error = responseJson["error"]?.jsonPrimitive?.content ?: ""
+          assertTrue(
+            "error should name the failing action, was: $error",
+            error.contains("screenshot"),
+          )
+        }
+      }
+    } finally {
+      asyncServer.stop()
+    }
+  }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -609,8 +609,14 @@ class WebSocketServerIntegrationTest {
     // handleMessage has already returned null — must still yield a correlated type:"error" frame,
     // not leave the daemon awaiter hanging to timeout. This is the async analog of the synchronous
     // handler-throw case covered by `handler exception returns structured error response` (#2985).
-    // The fake action routes its fire-and-forget work through a real AsyncActionRunner, exactly as
-    // CtrlProxy does in production.
+    //
+    // Scope note: this exercises a *real* AsyncActionRunner end-to-end over a live WebSocket (the
+    // fake action routes its fire-and-forget work through it, the same helper CtrlProxy uses). It
+    // proves the runner's correlated-error-on-throw contract on the wire; it does NOT instantiate
+    // the production CtrlProxy AccessibilityService, so it cannot by itself catch a regression that
+    // unwires a specific CtrlProxy launch site from the runner. That production-wiring guard is
+    // tracked as a follow-up (a full CtrlProxy service is impractical to drive in a fast unit
+    // test).
     lateinit var asyncServer: WebSocketServer
     val runnerHolder = arrayOfNulls<AsyncActionRunner>(1)
     asyncServer =


### PR DESCRIPTION
## What

Close the **async** silent-hang gap left by #2985 / PR #3019: an Android CtrlProxy action that throws **inside its own launched coroutine** — after the synchronous `handleMessage` has already returned `null` — now broadcasts a correlated `type:"error"` frame instead of dying silently and hanging the daemon awaiter to timeout.

Closes #3023 (follow-up from the PR #3019 multi-agent review, architecture reviewer).

Affected files:
- `android/control-proxy/.../AsyncActionRunner.kt` — **new** shared helper.
- `android/control-proxy/.../CtrlProxy.kt` — route the vulnerable fire-and-forget launches through it.
- `android/control-proxy/.../AsyncActionRunnerTest.kt` — **new** fast unit tests.
- `android/control-proxy/.../WebSocketServerIntegrationTest.kt` — end-to-end async-throw Robolectric test.

## Why

PR #3019 wrapped only the **synchronous** portion of dispatch in `WebSocketServer.handleClientMessage`:

```kotlin
try {
  val response = handler.handleMessage(request)   // returns null immediately for async actions
  if (response != null) broadcast(response)
} catch (e: CancellationException) { throw e }
  catch (e: Exception) { /* broadcast ErrorResponse */ }
```

`CtrlProxyMessageHandler.handleMessage` dispatches almost every command as fire-and-forget — the action returns `null` and does its real work inside `serviceScope.launch { … }`, broadcasting its own `*_result` later. An exception raised in that launched coroutine escapes to the scope's `SupervisorJob` with only a log line: **no error frame, and the daemon request awaiting that `requestId` hangs to its `RequestManager` timeout** — the exact symptom #2985 set out to eliminate, just on the async path.

Concrete gaps found by auditing `CtrlProxy.kt` for `serviceScope.launch` action bodies with `catch { Log… }` (or no catch) and no failure broadcast:
- `broadcastScreenshot` — a throw in `takeScreenshotAsync()` was logged-and-swallowed, emitting **neither** `screenshot` nor `screenshot_error`.
- The 8 storage handlers (`handleListPreferenceFiles`, `handleGetPreferences`, `handleSubscribeStorage`, `handleUnsubscribeStorage`, `handleGetPreference`, `handleSetPreference`, `handleRemovePreference`, `handleClearPreferences`) — launched with **no** inner try/catch.
- `handleGetPermission`, `performDeviceInfoRequest`, `performGlobalActionRequest` — deferred work / broadcast inside a bare launch.

Actions that **already** broadcast a `success:false` result on their own error path (gesture `perform*`, `handleGetCurrentFocus`, `handleGetTraversalOrder`, `handleAddHighlight`) are explicitly **out of scope** per the issue and are left untouched.

## How

New `AsyncActionRunner(scope, broadcastResponse, logError)` with `launch(requestId, action, block)`:
- Runs `block` on the injected scope; on any non-`CancellationException` throw it broadcasts an `ErrorResponse(requestId, error = "Action '<action>' failed: <cause>")` — reusing the `type:"error"` envelope added in #2985 / PR #3019.
- Re-throws `CancellationException` first, so cooperative shutdown unwinds cleanly and is never reported as an action failure.
- Guards the error broadcast itself (a broadcast failure during error reporting is logged and swallowed, never crashing the launch).
- Centralizing this means **new actions get correlated-error-on-throw for free**.

`CtrlProxy` wires it once (`asyncActionRunner`) with `broadcastResponse` resolving the `lateinit webSocketServer` lazily, and converts the vulnerable launch sites to `asyncActionRunner.launch(requestId, "<action>") { … }`.

The TS consumer already handles this: `AndroidCtrlProxyClient.handleWebSocketMessage`'s `type:"error"` branch calls `RequestManager.resolveError(requestId, …)`, which resolves the single `pending` map by id for **every** command type (screenshot, storage, device-info, permission, …) — so the awaiter fails fast instead of hanging. No TS change needed.

## Testing

All no-device (JUnit + Robolectric), following repo conventions.

- `AsyncActionRunnerTest.kt` (fast, Android-free, `runTest`/`TestScope`): throw → one correlated `ErrorResponse` (names action + cause, `success=false`); success → silent; `CancellationException` → no error frame; null `requestId` passes through; a throw **while broadcasting** the error is logged and swallowed.
- `WebSocketServerIntegrationTest.kt`: `async action failure yields correlated error frame` — drives `request_screenshot` over a real WebSocket against a fake action that routes fire-and-forget work through a real `AsyncActionRunner` (exactly as `CtrlProxy` does) and throws asynchronously; asserts a `type:"error"` frame with the echoed `requestId`, `success:false`, naming the action.

Local runs (JDK 21): `:control-proxy:testDebugUnitTest` all green (full module suite + the two new/updated classes).

> **Delivery note:** `android/control-proxy` ships as a pinned release APK the daemon downloads, so this reaches default installs only after the runner release is re-cut — same delivery gate as other runner-source changes (#2985/#3019).
