### PR TITLE
feat(ios): terminateApp device kill via dedicated `process terminate --kill` verb (#2882)

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -34,6 +34,7 @@ For `launchApp` specifically:
 
 - **Simulator** — `xcrun simctl launch` / `terminate` (unchanged). On cold boot the app is terminated first because `simctl launch` does not terminate an already-running instance.
 - **Physical device** — `xcrun devicectl device process launch --device <udid> --terminate-existing --json-output <file> --quiet <bundle-id>`; the launched PID is read from `result.process.processIdentifier` in the JSON output. `--terminate-existing` is the **authoritative cold-boot relaunch**: it terminates any already-running instance and starts a fresh process (which foregrounds). `devicectl` has no foreground-if-running verb, so a warm launch also relaunches this way. The device path therefore issues **no separate pre-terminate** — that would be a redundant round-trip.
+- **No standalone devicectl terminate _within launch_.** `launchApp` relies on `--terminate-existing` for its cold-boot relaunch rather than a separate pre-terminate round-trip. The standalone `terminateApp` tool does implement a device terminate (see below).
 - **`clearAppData` on a device** — wipes the sandbox via `devicectl` uninstall+reinstall (`clearAppDataViaReinstall`) before relaunching; a failed clear aborts the launch rather than launching with stale data.
 - **Docker / host control** — no `devicectl` launch bridge exists, so `launchApp` returns an explicit, actionable error instead of a confusing simctl failure.
 
@@ -41,11 +42,11 @@ For `terminateApp` specifically:
 
 - **Simulator** — `xcrun simctl terminate <udid> <bundle-id>`; a "found nothing to terminate" error is treated as `wasRunning: false` rather than a failure.
 - **Physical device** — `devicectl` has no terminate-by-bundle-id verb, so termination is a **two-step** operation (`DeviceAppInspector.terminateApp`):
-  1. Resolve the on-device bundle path via `xcrun devicectl device info apps --device <udid> --bundle-id <id> --json-output <file> --quiet`. No matching bundle → `{ wasInstalled: false, wasRunning: false }` (no signal issued).
-  2. Enumerate running processes via `xcrun devicectl device info processes --device <udid> --json-output <file> --quiet` and match the process whose executable path lives **inside** the resolved bundle directory. No match → `{ wasInstalled: true, wasRunning: false }`.
-  3. Force-kill the matched PID: `xcrun devicectl device process signal --device <udid> --pid <pid> --signal SIGKILL` → `{ wasInstalled: true, wasRunning: true }`. This matches Android `am force-stop` semantics for `wasRunning` reporting.
-  - **JSON field-name caveat.** The `device info processes` envelope is **not formally documented by Apple**; `findRunningProcessPid` deep-walks it and accepts several spellings (executable as a string or `{ url | path }`; PID as `processIdentifier` / `pid` / `processID`). Pin the real field names against captured device output when possible.
-  - **iOS ≤16 / non-macOS / Docker (host control)** — `devicectl` process management requires iOS 17+ on a macOS host; unsupported combinations surface as a clear, non-crashing `success: false` error (thrown by `DeviceAppInspector.terminateApp`, mapped to a result by `TerminateApp`) rather than a silent failure.
+  1. Resolve the on-device bundle path via `xcrun devicectl device info apps --device <udid> --bundle-id <id> --json-output <file> --quiet`. No matching bundle → `{ wasInstalled: false, wasRunning: false }` (no terminate issued).
+  2. Enumerate running processes via `xcrun devicectl device info processes --device <udid> --json-output <file> --quiet` and match the process whose executable path lives **inside** the resolved bundle directory (the app's own main binary, a direct child of `<bundle>.app/` — nested `PlugIns/*.appex/*` extensions are excluded). No match → `{ wasInstalled: true, wasRunning: false }`.
+  3. Force-kill the matched PID with the dedicated verb: `xcrun devicectl device process terminate --device <udid> --pid <pid> --kill --quiet` → `{ wasInstalled: true, wasRunning: true }`. `--kill` sends SIGKILL (uncatchable), matching Android `am force-stop` semantics; the bare verb would send a catchable SIGTERM.
+  - **JSON field-name caveat.** The `device info processes` envelope is **not formally documented by Apple**; `findRunningProcessPid` deep-walks it and accepts several spellings (executable as a string or `{ url | path }`; PID as `processIdentifier` / `pid` / `processID`). A basename fallback matches when the process path root differs from the `info apps` bundle URL (e.g. `/var` vs `/private/var` symlink). Pin the real field names against captured device output when possible.
+  - **iOS ≤16 / non-macOS / Docker (host control)** — `devicectl` process management requires iOS 17+ on a macOS host; unsupported combinations surface as a clear, non-crashing `success: false` error (thrown by `DeviceAppInspector.terminateApp`, mapped to a result by `TerminateApp`) rather than a silent `success: true` no-op.
 
 ## Live locale changes
 

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -11,9 +11,9 @@ import { AndroidCtrlProxyClient } from "../observe/android";
 
 /**
  * Physical-device app terminator. `DeviceAppInspector` satisfies this
- * structurally (via `xcrun devicectl device process signal`); tests inject a
- * fake so the physical path is exercised without a real device. Mirrors the
- * `DeviceAppUninstaller`/`DeviceAppLauncher` injection in the sibling tools.
+ * structurally (via `xcrun devicectl device process terminate --kill`); tests
+ * inject a fake so the physical path is exercised without a real device. Mirrors
+ * the `DeviceAppUninstaller`/`DeviceAppLauncher` injection in the sibling tools.
  */
 export interface DeviceAppTerminator {
   terminateApp(deviceUdid: string, bundleId: string): Promise<{ wasInstalled: boolean; wasRunning: boolean }>;
@@ -259,9 +259,10 @@ export class TerminateApp extends BaseVisualChange {
 
   /**
    * Physical iOS device terminate via devicectl (iOS 17+). The injected
-   * terminator resolves the bundle id to a PID and force-kills it (SIGKILL),
-   * reporting install/running status. Matches Android `am force-stop` semantics
-   * for `wasRunning`. A devicectl / macOS-guard / iOS<=16 failure surfaces as a
+   * terminator resolves the bundle id to a PID and force-kills it via the
+   * dedicated `devicectl device process terminate --kill` verb, reporting
+   * install/running status. Matches Android `am force-stop` semantics for
+   * `wasRunning`. A devicectl / macOS-guard / iOS<=16 failure surfaces as a
    * clear, non-crashing `success:false` result rather than throwing.
    */
   private async terminatePhysicalDevice(

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -246,7 +246,7 @@ const pathBasename = (path: string): string => {
  * require the path segment after `"<bundle>/"` to contain no further `/`. This
  * also excludes a sibling like `MyApp.app.extension/...` (different prefix).
  *
- * Two-pass, per issue #2488: the strict inside-bundle match is preferred, but if
+ * Two-pass, per issue #2882: the strict inside-bundle match is preferred, but if
  * it finds nothing we fall back to matching a process whose executable
  * **basename** equals the bundle name (minus `.app`). The fallback guards the
  * real-device risk that `info processes` executable paths don't nest under the
@@ -603,21 +603,21 @@ export class DeviceAppInspector {
    * Force-terminate a running app on a physical iOS device (iOS 17+) via
    * devicectl. There is no `terminate-by-bundle-id` verb, so this is a two-step
    * operation: resolve the bundle id to a PID (by matching the on-device bundle
-   * path against `device info processes` executables) then `device process
-   * signal --signal SIGKILL` that PID.
+   * path against `device info processes` executables) then force-kill that PID
+   * with the dedicated `device process terminate --kill` verb (SIGKILL).
    *
    * Returns:
    * - `{ wasInstalled: false, wasRunning: false }` when the bundle isn't installed
-   *   (no process query, no signal),
+   *   (no process query, no terminate),
    * - `{ wasInstalled: true, wasRunning: false }` when installed but no matching
-   *   process is running (no signal),
-   * - `{ wasInstalled: true, wasRunning: true }` after SIGKILL of a running process.
+   *   process is running (no terminate),
+   * - `{ wasInstalled: true, wasRunning: true }` after terminating a running process.
    *
    * Throws on an underlying devicectl failure. Gated to macOS + local devicectl:
    * host control (Docker) exposes no process-management bridge, and non-darwin
    * hosts have no devicectl, so both throw an explicit, actionable error rather
    * than a confusing simctl-style failure (iOS ≤16 devices reject the devicectl
-   * signal at the tool level and surface as a thrown devicectl error).
+   * terminate at the tool level and surface as a thrown devicectl error).
    */
   public async terminateApp(deviceUdid: string, bundleId: string): Promise<{ wasInstalled: boolean; wasRunning: boolean }> {
     const useHostControl = this.deps.hostControl.shouldUseHostControl() && this.deps.hostControl.isRunningInDocker();
@@ -642,17 +642,18 @@ export class DeviceAppInspector {
       return { wasInstalled: true, wasRunning: false };
     }
 
-    const signalCommand = [
+    const terminateCommand = [
       "xcrun",
       "devicectl",
       "device",
       "process",
-      "signal",
+      "terminate",
       "--device", deviceUdid,
       "--pid", String(pid),
-      "--signal", "SIGKILL"
+      "--kill",
+      "--quiet"
     ].join(" ");
-    await this.deps.exec(signalCommand);
+    await this.deps.exec(terminateCommand);
     return { wasInstalled: true, wasRunning: true };
   }
 

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -871,7 +871,7 @@ describe("DeviceAppInspector terminate (devicectl)", () => {
     }
   };
 
-  test("signals SIGKILL for a running app and reports {wasInstalled:true, wasRunning:true}", async () => {
+  test("terminates a running app with `process terminate --kill --quiet` and reports {wasInstalled:true, wasRunning:true}", async () => {
     const commands: string[] = [];
     const exec = async (command: string) => {
       commands.push(command);
@@ -893,17 +893,21 @@ describe("DeviceAppInspector terminate (devicectl)", () => {
     const result = await inspector.terminateApp("device-udid", bundleId);
 
     expect(result).toEqual({ wasInstalled: true, wasRunning: true });
-    const signalCommand = commands.find(c => c.includes("device process signal"));
-    expect(signalCommand).toBeDefined();
-    expect(signalCommand).toContain("xcrun devicectl device process signal");
-    expect(signalCommand).toContain("--device device-udid");
-    expect(signalCommand).toContain("--pid 4321");
-    expect(signalCommand).toContain("--signal SIGKILL");
+    // 2882's dedicated terminate verb, not raw `process signal --signal SIGKILL`.
+    const terminateCommand = commands.find(c => c.includes("device process terminate"));
+    expect(terminateCommand).toBeDefined();
+    expect(terminateCommand).toContain("xcrun devicectl device process terminate");
+    expect(terminateCommand).toContain("--device device-udid");
+    expect(terminateCommand).toContain("--pid 4321");
+    expect(terminateCommand).toContain("--kill");
+    expect(terminateCommand).toContain("--quiet");
     // Simulator tool must never be invoked for a physical terminate.
     expect(commands.every(c => !c.includes("simctl"))).toBe(true);
+    // Must not shell out to the raw signal verb.
+    expect(commands.every(c => !c.includes("device process signal"))).toBe(true);
   });
 
-  test("reports {wasInstalled:true, wasRunning:false} and issues no signal when not running", async () => {
+  test("reports {wasInstalled:true, wasRunning:false} and issues no terminate when not running", async () => {
     const commands: string[] = [];
     const exec = async (command: string) => {
       commands.push(command);
@@ -923,7 +927,7 @@ describe("DeviceAppInspector terminate (devicectl)", () => {
     const result = await inspector.terminateApp("device-udid", bundleId);
 
     expect(result).toEqual({ wasInstalled: true, wasRunning: false });
-    expect(commands.some(c => c.includes("device process signal"))).toBe(false);
+    expect(commands.some(c => c.includes("device process terminate"))).toBe(false);
   });
 
   test("reports {wasInstalled:false, wasRunning:false} and never queries processes when not installed", async () => {
@@ -941,7 +945,7 @@ describe("DeviceAppInspector terminate (devicectl)", () => {
 
     expect(result).toEqual({ wasInstalled: false, wasRunning: false });
     expect(commands.some(c => c.includes("device info processes"))).toBe(false);
-    expect(commands.some(c => c.includes("device process signal"))).toBe(false);
+    expect(commands.some(c => c.includes("device process terminate"))).toBe(false);
   });
 
   test("throws a clear macOS error on non-darwin without shelling out", async () => {


### PR DESCRIPTION
## Summary

Closes #2882. Follow-up to #2488 (physical-device `terminateApp`, merged as #3033). That work force-kills the resolved PID with a **raw** `xcrun devicectl device process signal --signal SIGKILL`. Issue #2882 asks for the **dedicated** devicectl verb instead:

```
xcrun devicectl device process terminate --device <udid> --pid <pid> --kill --quiet
```

`process terminate` is the purpose-built subcommand for ending a process on a device; hand-rolling a signal number via `process signal` is the lower-level primitive. Behavior is identical: `--kill` sends **SIGKILL** (uncatchable), preserving the force-stop semantics that match Android `am force-stop`; the bare verb would send a catchable SIGTERM. `--quiet` matches the other `devicectl` call sites in this module.

## What changed

- `src/utils/ios-cmdline-tools/DeviceAppInspector.ts` — `terminateApp` now issues `device process terminate --pid <pid> --kill --quiet` instead of `device process signal --signal SIGKILL`. **Only the terminate command string changes.** The two-step resolution (`info apps` → `info processes` → `findRunningProcessPid` main-binary match, `.appex` exclusion, basename fallback), the macOS / host-control / not-installed / not-running guards, and the `{ wasInstalled, wasRunning }` contract are all unchanged.
- `test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts` — updated the running-app case to assert the `process terminate --kill --quiet` verb, and asserts the raw `process signal` verb is **never** shelled out.
- `src/features/action/TerminateApp.ts`, `docs/design-docs/plat/ios/simctl.md` — doc/comment updates to describe the dedicated verb.

## Verification

`devicectl device process terminate` is a real subcommand (Xcode / CoreDevice): `--device`, `--pid`, `--kill` (SIGKILL vs SIGTERM), `--quiet` all confirmed via `xcrun devicectl device process terminate --help`.

- `bun test ./test/features/action/TerminateApp.test.ts ./test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts` → 48 pass
- `bunx eslint` on touched files → clean
- `bun build.ts` → OK

## Non-goals / follow-ups

- Simulator-path `wasInstalled` accuracy (existing gap, inherited from #2488).
- Explicit iOS-version detection for ≤16 (still surfaces as a thrown devicectl error rather than a version-specific message).
