### PR TITLE
test(db): move dbWriteBarrier reset test to a :memory: sentinel DB (#3047)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as fs from "fs";
 import type { Database as DatabaseSchema } from "./types";
 import { runMigrations } from "./migrator";
-import { createFileMigrationLock } from "./migrationLock";
+import { createMigrationLock, isInMemoryDatabasePath } from "./migrationLock";
 import { logger } from "../utils/logger";
 import { toActionableError } from "../models/ActionableError";
 import { BunSqliteDialect } from "./bunSqliteDialect";
@@ -65,7 +65,13 @@ export function resolveDatabasePathFromEnvironment(
 ): string {
   const envDbPath = env.AUTOMOBILE_DB_PATH ?? env.AUTO_MOBILE_DB_PATH;
   if (envDbPath) {
-    return resolvePathFromDaemonLaunchWorkingDirectory(envDbPath);
+    // The `:memory:` sentinel is not a filesystem path: routing it through the
+    // daemon-launch-cwd resolver would `path.resolve(":memory:")` into a bogus
+    // absolute path (and `createFileMigrationLock` would then try to create a
+    // `:memory:.migrate.lock` file). Pass it through un-resolved (issue #3047).
+    return isInMemoryDatabasePath(envDbPath)
+      ? envDbPath
+      : resolvePathFromDaemonLaunchWorkingDirectory(envDbPath);
   }
 
   const envDbDir = env.AUTOMOBILE_DB_DIR ?? env.AUTO_MOBILE_DB_DIR;
@@ -252,7 +258,8 @@ async function startMigrations(dbPath: string): Promise<void> {
       // Serialize the migration run across processes: two openers on the same DB
       // file (override env / --no-proxy alongside a daemon) must not both enter
       // migrateToLatest() and collide on the kysely_migration PRIMARY KEY (#2794).
-      lock: createFileMigrationLock(dbPath),
+      // A `:memory:` DB is private per connection, so it gets a no-op lock (#3047).
+      lock: createMigrationLock(dbPath),
       backup: () => backupDatabaseFile(migrationDb, dbPath),
     });
     // `migrationsRun` is NOT set here: it is a fenced global written only by the
@@ -293,6 +300,12 @@ function ensureMigrationsStarted(dbPath: string): void {
 }
 
 function ensureDatabaseDirectory(dbPath: string): void {
+  // The `:memory:` sentinel has no file or directory; `dirname(":memory:")` is a
+  // bogus `.` that must not be created (issue #3047).
+  if (isInMemoryDatabasePath(dbPath)) {
+    return;
+  }
+
   const dbDir = path.dirname(dbPath);
 
   if (!fs.existsSync(dbDir)) {

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -190,6 +190,17 @@ export function migrationLockPathFor(dbPath: string): string {
  * flake-free (issue #3047). `file::memory:?cache=shared` was considered and
  * rejected — it reintroduces the cross-process lock concern and carries bun
  * URI-filename risk for no benefit here.
+ *
+ * TEST-ONLY. Because `:memory:` is private per connection, the app connection
+ * (`getDatabase()`) and the migration connection (`startMigrations()`'s separate
+ * `migrationDb`) get DIFFERENT empty databases: `ensureMigrations()` reports
+ * success, yet the app connection has NONE of the migrated tables, so a real
+ * schema-dependent read/write (e.g. `tool_calls`) fails with `no such table`.
+ * This sentinel is therefore only for lifecycle tests that exercise the
+ * open/close/reopen contract without querying migrated schema — not a production
+ * DB configuration. (Sharing one connection across the app and the migrator would
+ * break the migration failure-isolation the separate `migrationDb` provides, so
+ * it is deliberately out of scope.)
  */
 export const IN_MEMORY_DATABASE_PATH = ":memory:";
 

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -181,6 +181,37 @@ export function migrationLockPathFor(dbPath: string): string {
 }
 
 /**
+ * SQLite in-memory sentinel path. A DB opened at this path is private to its
+ * connection and lives entirely in RAM — it has no file, no `-wal`/`-shm`
+ * sidecars, and no lock file. So it needs neither daemon-launch-cwd path
+ * resolution (which would `path.resolve(":memory:")` into a bogus absolute path)
+ * nor a cross-process migration lock (there is no shared file for a second
+ * process to reach). Used to make DB-lifecycle tests that don't need a real file
+ * flake-free (issue #3047). `file::memory:?cache=shared` was considered and
+ * rejected — it reintroduces the cross-process lock concern and carries bun
+ * URI-filename risk for no benefit here.
+ */
+export const IN_MEMORY_DATABASE_PATH = ":memory:";
+
+/** True for the plain `:memory:` sentinel (see {@link IN_MEMORY_DATABASE_PATH}). */
+export function isInMemoryDatabasePath(dbPath: string): boolean {
+  return dbPath === IN_MEMORY_DATABASE_PATH;
+}
+
+/**
+ * Select the migration lock for a resolved DB path: a {@link NoOpMigrationLock}
+ * for the `:memory:` sentinel (private per-connection, no file to guard, and
+ * `:memory:.migrate.lock` would be a bogus file), a {@link FileMigrationLock}
+ * keyed to the file otherwise. This is the single decision point so every opener
+ * (currently `database.ts#startMigrations`) can stay DB-path-agnostic (#3047).
+ */
+export function createMigrationLock(dbPath: string): MigrationLock {
+  return isInMemoryDatabasePath(dbPath)
+    ? new NoOpMigrationLock()
+    : createFileMigrationLock(dbPath);
+}
+
+/**
  * Default migration lock for a resolved DB file path. Keyed per-file (not
  * per-uid) because the trigger — two openers on one DB file — is per-file. The
  * busy-wait ceiling can be overridden via `AUTOMOBILE_MIGRATION_LOCK_TIMEOUT_MS`

--- a/test/db/databasePath.test.ts
+++ b/test/db/databasePath.test.ts
@@ -40,4 +40,24 @@ describe("database path resolution", () => {
       AUTOMOBILE_DB_PATH: dbPath,
     })).toBe(dbPath);
   });
+
+  test("passes the `:memory:` sentinel through un-resolved (issue #3047)", () => {
+    // A `:memory:` DB is not a filesystem path: routing it through the
+    // daemon-launch-cwd resolver would `path.resolve(":memory:")` into a bogus
+    // absolute path (and later create a `:memory:.migrate.lock` file). It must be
+    // returned verbatim even with a daemon launch cwd set.
+    process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
+
+    expect(resolveDatabasePathFromEnvironment({
+      AUTOMOBILE_DB_PATH: ":memory:",
+    })).toBe(":memory:");
+  });
+
+  test("passes the `:memory:` sentinel through the legacy AUTO_MOBILE_DB_PATH alias", () => {
+    process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
+
+    expect(resolveDatabasePathFromEnvironment({
+      AUTO_MOBILE_DB_PATH: ":memory:",
+    })).toBe(":memory:");
+  });
 });

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import { sql } from "kysely";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
-import { IN_MEMORY_DATABASE_PATH } from "../../src/db/migrationLock";
+import { IN_MEMORY_DATABASE_PATH, migrationLockPathFor } from "../../src/db/migrationLock";
 import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
 
 /**
@@ -64,8 +64,13 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
 
     const databaseModule = await importFreshDatabaseModule();
 
-    // Cold start on the first in-memory DB.
+    // Cold start on the first in-memory DB. Await migrations so the detached
+    // `:memory:` migration run is fully owned by the test rather than left in
+    // flight past teardown — cheap on an in-memory DB (no file/WAL/lock) and
+    // deterministic. The barrier assertions below need neither a real file nor a
+    // completed migration (issue #3047); this is purely lifecycle hygiene.
     databaseModule.getDatabase();
+    await databaseModule.ensureMigrations();
 
     // Model the daemon shutdown ordering: drain in-flight best-effort writes,
     // then close the connection (issue #2792).
@@ -79,6 +84,7 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     // path switch / restart-without-exit). Each `new Database(":memory:")` is a
     // brand-new private DB, so this naturally models a distinct reopened DB.
     databaseModule.getDatabase();
+    await databaseModule.ensureMigrations();
 
     // The barrier must have cold-started: a distinct, non-draining instance.
     const reopenedBarrier = getDbWriteBarrier();
@@ -118,9 +124,10 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     // The blocker this migration fixes: a `:memory:` opener must use a
     // NoOpMigrationLock, never `createFileMigrationLock`, so it must not create a
     // bogus `:memory:.migrate.lock` file (nor a `:memory:` DB file) in the cwd.
-    expect(existsSync(path.join(process.cwd(), `${IN_MEMORY_DATABASE_PATH}.migrate.lock`))).toBe(
-      false
-    );
+    // Assert against the EXACT path the production lock would derive
+    // (`migrationLockPathFor`) rather than a hand-rolled cwd join, so the guard
+    // can't drift from the code under a symlinked / non-canonical cwd.
+    expect(existsSync(migrationLockPathFor(IN_MEMORY_DATABASE_PATH))).toBe(false);
     expect(existsSync(path.join(process.cwd(), IN_MEMORY_DATABASE_PATH))).toBe(false);
 
     await databaseModule.closeDatabase();

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
+import { sql } from "kysely";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
-import { removeTempDbDir } from "./tempDbDir";
+import { IN_MEMORY_DATABASE_PATH } from "../../src/db/migrationLock";
 import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
-import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
 
 /**
- * Regression tests for issue #2896 (follow-up to #2796).
+ * Regression tests for issue #2896 (follow-up to #2796), on a `:memory:`
+ * sentinel DB (issue #3047).
  *
  * #2796 made `closeDatabase()` reset the migration/path module globals so a
  * same-process reopen behaves like a cold start. The one shutdown-state global
@@ -26,19 +26,18 @@ import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
  * clears the barrier via `resetDbWriteBarrier()` so the cold-start contract is
  * fully true.
  *
+ * These assertions are about `getDbWriteBarrier()` **identity** and
+ * `isDraining()` across the `getDatabase()`/`closeDatabase()` lifecycle — they
+ * need neither a real on-disk file nor cross-connection migration visibility, so
+ * a `:memory:` sentinel eliminates the temp-file / WAL-sidecar / EBUSY-cleanup
+ * flake class this test formerly carried (issues #3047, #2992, #2916). The
+ * sibling file-backed suites (`databaseReset`, `databaseLazyPath`) stay on real
+ * files because they genuinely assert a migrated schema across connections.
+ *
  * The shared barrier is a process-global singleton; `resetDbWriteBarrier()` in
  * `beforeEach`/`afterEach` isolates these tests from the rest of the suite.
  */
 describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)", () => {
-  // Opens a real file-backed DB (needs a shared on-disk file across the
-  // migration and app connections). This timeout only covers the test BODY
-  // (migrations + queries on slow Windows disk I/O). The cleanup stall from
-  // issue #2916 is bounded separately by `removeTempDbDir` (best-effort,
-  // ~200ms/dir); the `afterEach` hook is given the same generous ceiling below
-  // so a slow Windows temp-dir release cannot read as a hook timeout (#2992).
-  const FILE_BACKED_TEST_TIMEOUT_MS = WINDOWS_FILE_DB_TEST_TIMEOUT_MS;
-
-  const tempDirs: string[] = [];
   let envSnapshot: NodeJS.ProcessEnv;
 
   beforeEach(() => {
@@ -48,39 +47,25 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     resetDbWriteBarrier();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     resetDbWriteBarrier();
     restoreEnv(envSnapshot);
-    for (const dir of tempDirs.splice(0)) {
-      await removeTempDbDir(dir);
-    }
-    // Give the hook the same generous ceiling as the body: on windows-latest a
-    // just-released bun:sqlite handle can keep the temp dir locked long enough
-    // for the bounded `removeTempDbDir` retries to run, and the default 5s hook
-    // timeout would read that as a failure even though the body passed (#2992).
-  }, WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
+  });
 
-  async function makeTempDbDir(prefix: string): Promise<string> {
-    const dir = await mkdtemp(path.join(tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
+  /** Point the fresh database module at a private in-memory sentinel DB. */
+  function useInMemoryDatabase(): void {
+    process.env.AUTOMOBILE_DB_PATH = IN_MEMORY_DATABASE_PATH;
+    delete process.env.AUTOMOBILE_DB_DIR;
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
   }
 
   test("a tracked best-effort write after drain -> close -> reopen is NOT skipped", async () => {
-    const firstDir = await makeTempDbDir("auto-mobile-barrier-reset-first-");
-    process.env.AUTOMOBILE_DB_DIR = firstDir;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+    useInMemoryDatabase();
 
     const databaseModule = await importFreshDatabaseModule();
 
-    // Cold start on the first DB, then let startup migrations fully settle. The
-    // detached migration run opens its OWN connection to the same file and
-    // destroys it only when done; awaiting settle here means the later
-    // closeDatabase() checkpoint has no concurrent writer to contend with. On
-    // windows-latest that concurrency is exactly what produced the compounding
-    // busy_timeout stall that blew this test's body/hook timeouts (#2992).
+    // Cold start on the first in-memory DB.
     databaseModule.getDatabase();
-    await databaseModule.ensureMigrations();
 
     // Model the daemon shutdown ordering: drain in-flight best-effort writes,
     // then close the connection (issue #2792).
@@ -90,14 +75,10 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
 
     await databaseModule.closeDatabase();
 
-    // Reopen in the same process against a brand-new DB dir (config reload / DB
-    // path switch / restart-without-exit).
-    const secondDir = await makeTempDbDir("auto-mobile-barrier-reset-second-");
-    process.env.AUTOMOBILE_DB_DIR = secondDir;
+    // Reopen in the same process against a fresh in-memory DB (config reload / DB
+    // path switch / restart-without-exit). Each `new Database(":memory:")` is a
+    // brand-new private DB, so this naturally models a distinct reopened DB.
     databaseModule.getDatabase();
-    // Settle the reopened DB's migrations too, so the final closeDatabase() in
-    // this test closes cleanly instead of racing a detached migration (#2992).
-    await databaseModule.ensureMigrations();
 
     // The barrier must have cold-started: a distinct, non-draining instance.
     const reopenedBarrier = getDbWriteBarrier();
@@ -105,29 +86,48 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     expect(reopenedBarrier.isDraining()).toBe(false);
 
     // The core contract: a tracked best-effort write actually runs against the
-    // reopened DB instead of being silently skipped by a latched barrier. The
-    // closure issues a REAL query against the reopened connection so this also
-    // proves the awaited reopen migrations left a healthy, queryable schema —
-    // not merely that the migration promise settled (#2896/#2992).
+    // reopened barrier instead of being silently skipped by a latched barrier.
     let ran = false;
-    const rows = await reopenedBarrier.track(async () => {
+    const result = await reopenedBarrier.track(async () => {
       ran = true;
-      return databaseModule
-        .getDatabase()
-        .selectFrom("tool_calls" as any)
-        .selectAll()
-        .execute();
+      return "ok";
     });
     expect(ran).toBe(true);
-    expect(rows).toEqual([]);
+    expect(result).toBe("ok");
 
     await databaseModule.closeDatabase();
-  }, FILE_BACKED_TEST_TIMEOUT_MS);
+  });
+
+  test("reopens an in-memory DB with a live queryable connection and no bogus lock file", async () => {
+    useInMemoryDatabase();
+
+    const databaseModule = await importFreshDatabaseModule();
+
+    // Drive the full open + migration lifecycle on `:memory:`. This reconciles the
+    // reopen-query assertion added in #3040 for the file-backed test: with a
+    // private in-memory DB the app connection never sees the migration
+    // connection's schema, so instead of querying a migrated table we prove the
+    // reopened connection is live with a schema-independent `select 1` that still
+    // routes through `waitForMigrationsBeforeQuery` (proving migrations settle).
+    databaseModule.getDatabase();
+    await databaseModule.ensureMigrations();
+
+    const rows = await sql`select 1 as one`.execute(databaseModule.getDatabase());
+    expect(rows.rows).toEqual([{ one: 1 }]);
+
+    // The blocker this migration fixes: a `:memory:` opener must use a
+    // NoOpMigrationLock, never `createFileMigrationLock`, so it must not create a
+    // bogus `:memory:.migrate.lock` file (nor a `:memory:` DB file) in the cwd.
+    expect(existsSync(path.join(process.cwd(), `${IN_MEMORY_DATABASE_PATH}.migrate.lock`))).toBe(
+      false
+    );
+    expect(existsSync(path.join(process.cwd(), IN_MEMORY_DATABASE_PATH))).toBe(false);
+
+    await databaseModule.closeDatabase();
+  });
 
   test("closeDatabase clears a drain latch even with no open connection", async () => {
-    const dir = await makeTempDbDir("auto-mobile-barrier-reset-noconn-");
-    process.env.AUTOMOBILE_DB_DIR = dir;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+    useInMemoryDatabase();
 
     const databaseModule = await importFreshDatabaseModule();
 

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -2,7 +2,14 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { FileMigrationLock, NoOpMigrationLock, migrationLockPathFor } from "../../src/db/migrationLock";
+import {
+  FileMigrationLock,
+  IN_MEMORY_DATABASE_PATH,
+  NoOpMigrationLock,
+  createMigrationLock,
+  isInMemoryDatabasePath,
+  migrationLockPathFor,
+} from "../../src/db/migrationLock";
 import { ActionableError } from "../../src/models/ActionableError";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -303,6 +310,36 @@ describe("NoOpMigrationLock", () => {
     await lock.acquire();
     await lock.release();
     expect(true).toBe(true);
+  });
+});
+
+describe("isInMemoryDatabasePath", () => {
+  test("recognizes the `:memory:` sentinel", () => {
+    expect(isInMemoryDatabasePath(IN_MEMORY_DATABASE_PATH)).toBe(true);
+    expect(isInMemoryDatabasePath(":memory:")).toBe(true);
+  });
+
+  test("rejects real file paths", () => {
+    expect(isInMemoryDatabasePath("/tmp/auto-mobile.db")).toBe(false);
+    expect(isInMemoryDatabasePath("auto-mobile.db")).toBe(false);
+    // A `file::memory:?cache=shared` URI is deliberately NOT treated as the
+    // sentinel: it was rejected in favor of plain `:memory:` (issue #3047), so
+    // it must fall through to the file-lock branch rather than silently no-op.
+    expect(isInMemoryDatabasePath("file::memory:?cache=shared")).toBe(false);
+  });
+});
+
+describe("createMigrationLock", () => {
+  test("selects a NoOpMigrationLock for the `:memory:` sentinel", () => {
+    // A `:memory:` DB is private per connection, has no file to guard, and
+    // `:memory:.migrate.lock` would be a bogus file — so it must NOT get a
+    // FileMigrationLock (issue #3047).
+    expect(createMigrationLock(IN_MEMORY_DATABASE_PATH)).toBeInstanceOf(NoOpMigrationLock);
+  });
+
+  test("selects a FileMigrationLock for a real DB path", () => {
+    const dbPath = join(tmpdir(), "auto-mobile-createlock", "auto-mobile.db");
+    expect(createMigrationLock(dbPath)).toBeInstanceOf(FileMigrationLock);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #3047. Follow-up from the direction/alternatives review of #3040 (the #2992 stabilization). #3040 stabilized `dbWriteBarrierResetOnClose.test.ts` by keeping a real temp file and awaiting migrations before close — that removed the *race*, but the test still opened a real file (temp-dir cleanup, WAL sidecars, EBUSY-tolerant retry). For **this specific test** the file is not needed: its assertions are purely about `getDbWriteBarrier()` **identity** and `isDraining()` across the `getDatabase()`/`closeDatabase()` lifecycle — neither cross-connection migration visibility nor a completed migration. Pointing it at a plain `:memory:` sentinel eliminates the file-handle flake class (#2916/#2992) for it entirely.

`file::memory:?cache=shared` was considered and rejected (reintroduces the cross-process migration-lock concern + bun URI-filename risk for no benefit). Plain `:memory:` it is.

## Blocker fix

A `:memory:` sentinel is not a filesystem path, so two source paths had to learn to pass it through:

- `resolveDatabasePathFromEnvironment()` routed `AUTOMOBILE_DB_PATH` through `resolvePathFromDaemonLaunchWorkingDirectory()`, which would `path.resolve(":memory:")` into a bogus absolute path.
- `startMigrations()` always used `createFileMigrationLock(dbPath)`, which for `:memory:` would try to create a bogus `:memory:.migrate.lock` file.

## What changed

- **`src/db/migrationLock.ts`** — new canonical sentinel primitives: `IN_MEMORY_DATABASE_PATH`, `isInMemoryDatabasePath()`, and `createMigrationLock()` (selects `NoOpMigrationLock` for `:memory:`, `FileMigrationLock` for a real path — one decision point so openers stay DB-path-agnostic). Placed here to avoid an import cycle with `database.ts`, and because `NoOpMigrationLock`'s docstring already owns the `:memory:` rationale.
- **`src/db/database.ts`** — `resolveDatabasePathFromEnvironment()` passes a `:memory:` `AUTOMOBILE_DB_PATH` (and the legacy `AUTO_MOBILE_DB_PATH` alias) through un-resolved; `startMigrations()` uses `createMigrationLock(dbPath)`; `ensureDatabaseDirectory()` no-ops for `:memory:` (no file/dir to create). No behavior change for real file paths.
- **`test/db/dbWriteBarrierResetOnClose.test.ts`** — repointed at `:memory:`. Dropped the temp-dir machinery (`mkdtemp`/`removeTempDbDir`/file-backed 30s timeout) and the file-race migration awaits. Reconciled the reopen-query assertion added in #3040: with a private in-memory DB the app connection never sees the migration connection's schema, so instead of querying a migrated `tool_calls` table it now proves the reopened connection is live with a schema-independent `select 1` (still routed through `waitForMigrationsBeforeQuery`) plus a guard that **no** `:memory:.migrate.lock` / `:memory:` file is created in the cwd.
- **`test/db/migrationLock.test.ts`**, **`test/db/databasePath.test.ts`** — unit coverage for the new primitives and the `:memory:` passthrough (incl. the legacy alias; and that `file::memory:?cache=shared` is deliberately *not* treated as the sentinel).

`databaseReset` / `databaseLazyPath` intentionally stay file-backed — they genuinely assert a migrated schema across connections.

## Verification

- `bun test test/db/dbWriteBarrierResetOnClose.test.ts test/db/migrationLock.test.ts test/db/databasePath.test.ts` → 27 pass; no `:memory:*` artifact left in cwd.
- `bun test test/db/` → 546 pass, 0 fail.
- `turbo run lint build` → clean.

## Non-goals / follow-ups

- The remaining file-backed lifecycle suites keep the bounded-cleanup approach from #2916; this PR is scoped to the one test the issue named.
