### PR TITLE
fix(android): route runner type:"error" frames into hierarchy wait path (#3032)

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1966,11 +1966,17 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       // awaiter hang to timeout. requestId is best-effort — when null the runner could not
       // correlate it, so there is no pending request to resolve (resolveError no-ops on unknown
       // ids anyway).
+      //
+      // Fan the error out to ALL wait mechanisms, not just RequestManager: request_hierarchy does
+      // not await through RequestManager, so an error frame for a hierarchy requestId must also be
+      // routed into CtrlProxyHierarchy's bespoke wait or the hierarchy caller hangs to timeout
+      // (issue #3032). Both calls are safe no-ops on unknown ids.
       if (message.type === "error") {
         const errorText = message.error || "Runner reported an unstructured protocol error";
         logger.warn(`[CTRL_PROXY] Runner error (requestId: ${message.requestId ?? "none"}): ${errorText}`);
         if (message.requestId) {
           this.requestManager.resolveError(message.requestId, errorText);
+          this._hierarchy?.rejectPendingHierarchy(message.requestId, errorText);
         }
         return;
       }

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -57,7 +57,11 @@ export class CtrlProxyHierarchy {
   // NOT await through RequestManager (it blocks in waitForFreshData for a hierarchy_update push), so
   // a runner type:"error" frame must be fanned into this map to unblock the correct waiter fast
   // instead of hanging to timeout. See issue #3032.
-  private readonly pendingHierarchyRejectors = new Map<string, (error: string) => void>();
+  //
+  // The hook is wrapped in an object and invoked via the fixed `.reject` property (mirroring
+  // RequestManager's `request.reject(...)`) rather than calling the map value directly — a
+  // user-controlled requestId must never drive a dynamic method-name dispatch.
+  private readonly pendingHierarchyRejectors = new Map<string, { reject: (error: string) => void }>();
 
   constructor(context: HierarchyDelegateContext) {
     this.context = context;
@@ -76,7 +80,7 @@ export class CtrlProxyHierarchy {
     if (!rejector) {
       return false;
     }
-    rejector(error);
+    rejector.reject(error);
     return true;
   }
 
@@ -598,9 +602,11 @@ export class CtrlProxyHierarchy {
       // Route a runner type:"error" frame (delivered via AndroidCtrlProxyClient) for this hierarchy
       // request into a fast rejection instead of hanging to the timeout below (issue #3032).
       if (requestId) {
-        this.pendingHierarchyRejectors.set(requestId, (error: string) => {
-          logger.warn(`[CTRL_PROXY] Hierarchy request ${requestId} failed via runner error: ${error}`);
-          settleReject(new Error(error));
+        this.pendingHierarchyRejectors.set(requestId, {
+          reject: (error: string) => {
+            logger.warn(`[CTRL_PROXY] Hierarchy request ${requestId} failed via runner error: ${error}`);
+            settleReject(new Error(error));
+          }
         });
       }
 

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -53,8 +53,31 @@ export class CtrlProxyHierarchy {
   private recompositionTrackingConfigured: boolean = false;
   private recompositionTrackingEnabled: boolean = false;
 
+  // Outstanding hierarchy request IDs mapped to their error-rejection hook. request_hierarchy does
+  // NOT await through RequestManager (it blocks in waitForFreshData for a hierarchy_update push), so
+  // a runner type:"error" frame must be fanned into this map to unblock the correct waiter fast
+  // instead of hanging to timeout. See issue #3032.
+  private readonly pendingHierarchyRejectors = new Map<string, (error: string) => void>();
+
   constructor(context: HierarchyDelegateContext) {
     this.context = context;
+  }
+
+  /**
+   * Reject an in-flight hierarchy wait whose requestId matches a runner type:"error" frame,
+   * surfacing the runner's error text so the caller fails fast instead of hanging to the
+   * waitForFreshData timeout (issue #3032).
+   *
+   * Returns false (safe no-op) when the id is not an outstanding hierarchy request — e.g. a
+   * null/unknown requestId the runner could not correlate — preserving existing behavior.
+   */
+  rejectPendingHierarchy(requestId: string, error: string): boolean {
+    const rejector = this.pendingHierarchyRejectors.get(requestId);
+    if (!rejector) {
+      return false;
+    }
+    rejector(error);
+    return true;
   }
 
   /**
@@ -339,13 +362,14 @@ export class CtrlProxyHierarchy {
       // Ensure WebSocket connection is established
       await this.context.ensureConnected(perf);
 
-      // Try WebSocket request first (faster path)
-      const sentViaWebSocket = await perf.track("sendWsRequest", async () => {
+      // Try WebSocket request first (faster path). Returns the correlating requestId when sent so a
+      // runner type:"error" frame for this hierarchy request can reject the wait fast (issue #3032).
+      const hierarchyRequestId = await perf.track("sendWsRequest", async () => {
         return this.sendHierarchyRequest(disableAllFiltering);
       });
 
       // Fall back to ADB broadcast if WebSocket failed
-      if (!sentViaWebSocket) {
+      if (hierarchyRequestId === null) {
         logger.debug("[CTRL_PROXY] Falling back to ADB broadcast");
         const uuid = `sync_${this.context.timer.now()}_${generateSecureId()}`;
         await perf.track("sendBroadcast", async () => {
@@ -359,9 +383,12 @@ export class CtrlProxyHierarchy {
         });
       }
 
-      // Wait for WebSocket push
+      // Wait for WebSocket push. When we sent over WebSocket, correlate the wait with the request id
+      // so a runner error frame unblocks it fast instead of hanging to timeout (issue #3032). The
+      // ADB-broadcast fallback has no WebSocket requestId to correlate, so it retains timeout-only
+      // behavior.
       const freshData = await perf.track("waitForPush", () =>
-        this.waitForFreshData(effectiveTimeoutMs, startTime, false, signal)
+        this.waitForFreshData(effectiveTimeoutMs, startTime, false, signal, hierarchyRequestId ?? undefined)
       );
 
       if (freshData) {
@@ -528,7 +555,8 @@ export class CtrlProxyHierarchy {
     timeout: number,
     minTimestamp: number,
     useDeviceTimestamp: boolean,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    requestId?: string
   ): Promise<CachedHierarchy | null> {
     const startTime = this.context.timer.now();
     const checkInterval = 50;
@@ -538,11 +566,47 @@ export class CtrlProxyHierarchy {
     let screenCheckInProgress = false;
     let staleCheckSent = false;
 
-    return new Promise(resolve => {
-      const intervalId = this.context.timer.setInterval(() => {
-        if (signal?.aborted) {
+    return new Promise<CachedHierarchy | null>((resolve, reject) => {
+      let settled = false;
+      let intervalId: NodeJS.Timeout | null = null;
+
+      const cleanup = (): void => {
+        if (intervalId !== null) {
           this.context.timer.clearInterval(intervalId);
-          resolve(null);
+        }
+        if (requestId) {
+          this.pendingHierarchyRejectors.delete(requestId);
+        }
+      };
+      const settleResolve = (value: CachedHierarchy | null): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(value);
+      };
+      const settleReject = (error: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+
+      // Route a runner type:"error" frame (delivered via AndroidCtrlProxyClient) for this hierarchy
+      // request into a fast rejection instead of hanging to the timeout below (issue #3032).
+      if (requestId) {
+        this.pendingHierarchyRejectors.set(requestId, (error: string) => {
+          logger.warn(`[CTRL_PROXY] Hierarchy request ${requestId} failed via runner error: ${error}`);
+          settleReject(new Error(error));
+        });
+      }
+
+      intervalId = this.context.timer.setInterval(() => {
+        if (signal?.aborted) {
+          settleResolve(null);
           return;
         }
         const elapsed = this.context.timer.now() - startTime;
@@ -553,9 +617,8 @@ export class CtrlProxyHierarchy {
           const freshness = this.evaluateMinTimestamp(cachedHierarchy, minTimestamp, useDeviceTimestamp);
 
           if (freshness.isFresh) {
-            this.context.timer.clearInterval(intervalId);
             logger.debug(`[CTRL_PROXY] Fresh data received: receivedAt=${cachedHierarchy.receivedAt}, updatedAt=${cachedHierarchy.hierarchy.updatedAt}, minTimestamp=${minTimestamp}, elapsed=${elapsed}ms`);
-            resolve(cachedHierarchy);
+            settleResolve(cachedHierarchy);
             return;
           }
         }
@@ -576,9 +639,8 @@ export class CtrlProxyHierarchy {
           this.context.adb.isScreenOn(signal).then(isOn => {
             screenCheckInProgress = false;
             if (!isOn) {
-              this.context.timer.clearInterval(intervalId);
               logger.warn("[CTRL_PROXY] Screen is off - failing fast instead of waiting for timeout");
-              resolve(null);
+              settleResolve(null);
             }
           }).catch(() => {
             screenCheckInProgress = false;
@@ -587,14 +649,13 @@ export class CtrlProxyHierarchy {
 
         // Check if timeout exceeded
         if (elapsed >= timeout) {
-          this.context.timer.clearInterval(intervalId);
           const cached = this.context.getCachedHierarchy();
           if (cached) {
             logger.debug(`[CTRL_PROXY] waitForFreshData TIMEOUT after ${elapsed}ms: cached receivedAt=${cached.receivedAt}, updatedAt=${cached.hierarchy.updatedAt}, minTimestamp=${minTimestamp}, useDeviceTimestamp=${useDeviceTimestamp}`);
           } else {
             logger.debug(`[CTRL_PROXY] waitForFreshData TIMEOUT after ${elapsed}ms: no cached data, minTimestamp=${minTimestamp}`);
           }
-          resolve(null);
+          settleResolve(null);
         }
       }, checkInterval);
     });
@@ -602,12 +663,15 @@ export class CtrlProxyHierarchy {
 
   /**
    * Send a message via WebSocket to request hierarchy extraction.
+   * @returns The correlating requestId when sent, or null when the WebSocket is unavailable or the
+   *   send fails. Callers use the returned id to correlate a runner type:"error" frame back to this
+   *   request's wait (issue #3032).
    */
-  private sendHierarchyRequest(disableAllFiltering: boolean = false): boolean {
+  private sendHierarchyRequest(disableAllFiltering: boolean = false): string | null {
     const ws = this.context.getWebSocket();
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       logger.warn("[CTRL_PROXY] Cannot send request - WebSocket not connected");
-      return false;
+      return null;
     }
 
     try {
@@ -617,10 +681,10 @@ export class CtrlProxyHierarchy {
       );
       ws.send(message);
       logger.debug(`[CTRL_PROXY] Sent hierarchy request via WebSocket (requestId: ${requestId}, disableAllFiltering: ${disableAllFiltering})`);
-      return true;
+      return requestId;
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Failed to send WebSocket request: ${error}`);
-      return false;
+      return null;
     }
   }
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1091,6 +1091,117 @@ describe("AndroidCtrlProxyClient", function() {
     });
   });
 
+  describe("hierarchy error frame correlation (issue #3032)", function() {
+    // request_hierarchy does NOT await through RequestManager — it blocks in
+    // CtrlProxyHierarchy.waitForFreshData for a hierarchy_update push. Before #3032 a runner
+    // type:"error" frame for a hierarchy requestId no-op'd in resolveError and the caller hung to
+    // the waitForFreshData timeout. These tests assert the error frame now unblocks the hierarchy
+    // wait fast, while remaining a safe no-op for uncorrelated ids.
+
+    const findSentMessageOfType = (socket: CapturingWebSocket, type: string): any | undefined => {
+      const raw = socket.sentMessages.find(m => {
+        try { return JSON.parse(m).type === type; } catch { return false; }
+      });
+      return raw ? JSON.parse(raw) : undefined;
+    };
+
+    test("a type:error frame for an in-flight hierarchy requestId fails requestHierarchySync fast", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        // 10s hierarchy sync timeout — the whole point is to NOT wait for it.
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const hierarchyMsg = findSentMessageOfType(socket, "request_hierarchy");
+        expect(hierarchyMsg).toBeDefined();
+        expect(hierarchyMsg.requestId).toBeDefined();
+
+        // Runner reports a structured handler failure correlated to the hierarchy requestId.
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: hierarchyMsg.requestId,
+          success: false,
+          error: "request_hierarchy handler failed: view hierarchy extraction threw",
+          timestamp: errorTimer.now()
+        }));
+
+        // Fail fast: no timer advance toward the 10s timeout. Only flush microtasks/setImmediate.
+        await flushPromises();
+        const result = await syncPromise;
+
+        expect(result).toBeNull();
+        // Prove we did not sit through the timeout: virtually no fake time elapsed.
+        expect(errorTimer.getCurrentTime()).toBeLessThan(10000);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a type:error frame with an unknown requestId does not disturb an in-flight hierarchy sync", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const hierarchyMsg = findSentMessageOfType(socket, "request_hierarchy");
+        expect(hierarchyMsg).toBeDefined();
+
+        // Error frame for an uncorrelated id — must be a safe no-op for the hierarchy wait.
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: "some-unrelated-id",
+          success: false,
+          error: "Malformed request: the payload is not valid JSON",
+          timestamp: errorTimer.now()
+        }));
+
+        // The real hierarchy push for our request still arrives and resolves the sync normally.
+        socket.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: errorTimer.now(),
+          data: {
+            updatedAt: errorTimer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Recovered after uncorrelated error" }
+          }
+        }));
+
+        const result = await errorTimer.resolvePromise(syncPromise);
+
+        expect(result).not.toBeNull();
+        expect(result!.hierarchy.hierarchy.text).toBe("Recovered after uncorrelated error");
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("bindSession", function() {
     afterEach(function() {
       NavigationGraphManager.resetInstance();


### PR DESCRIPTION
## What

Route the Android CtrlProxy runner's structured `type:"error"` frame into the **hierarchy** wait path so a `request_hierarchy` handler/decode failure fails fast instead of hanging to the `waitForFreshData` timeout.

Closes #3032. Follow-up to #2985 / PR #3019, which added the `type:"error"` envelope and wired `AndroidCtrlProxyClient.handleWebSocketMessage` to call `RequestManager.resolveError`. That closed the hang for commands that await through `RequestManager` — but **`request_hierarchy` does not**, so a hierarchy failure still hung. This is the un-addressed **P2** review comment from PR #3019 (on `AndroidCtrlProxyClient.ts:1975`).

Affected files:
- `src/features/observe/android/CtrlProxyHierarchy.ts` — track outstanding hierarchy request IDs + `rejectPendingHierarchy`; `waitForFreshData` races a runner-error rejection.
- `src/features/observe/android/AndroidCtrlProxyClient.ts` — `type:"error"` branch fans out to the hierarchy delegate in addition to `RequestManager`.
- `test/features/observe/CtrlProxyClient.test.ts` — new #3032 correlation tests.

## Why

`CtrlProxyHierarchy.sendHierarchyRequest` generates and sends its **own** requestId and does **not** register with `RequestManager`. Hierarchy callers block in `CtrlProxyHierarchy.waitForFreshData` until a fresh `hierarchy_update` push arrives — not on a `RequestManager` promise. So the `type:"error"` branch's `resolveError(requestId, …)` **no-op'd** for a hierarchy requestId, and the caller sat in `waitForFreshData` until timeout — the exact slow-hang #2985 set out to eliminate, on the hierarchy path.

## How

Implemented the issue's **option 2** (self-tracked pending map), keeping it local to the delegate that owns the bespoke wait:

- **`CtrlProxyHierarchy`** gains a `pendingHierarchyRejectors: Map<requestId, (error) => void>` and a public `rejectPendingHierarchy(requestId, error): boolean` — a safe no-op (`false`) on unknown/uncorrelated ids.
- **`sendHierarchyRequest`** now returns its `requestId` (was `boolean`) so `requestHierarchySync` can correlate the wait. `null` still signals the ADB-broadcast fallback.
- **`waitForFreshData`** takes an optional `requestId`; when present it registers a rejector that fails the wait fast when a runner error arrives. All settle paths (fresh / timeout / abort / screen-off / error) route through single-shot `settleResolve`/`settleReject` helpers that `cleanup()` the interval **and** the rejector — no leak, no double-settle.
- **`AndroidCtrlProxyClient`** `type:"error"` branch calls both `requestManager.resolveError(...)` and `this._hierarchy?.rejectPendingHierarchy(...)`. They key on disjoint maps (a hierarchy id is never in `RequestManager.pending`; a gesture id is never in `pendingHierarchyRejectors`), so there is no double-resolution and each is a no-op on the other's ids.

**Preserved behavior:** `getLatestHierarchy`'s passive wait calls `waitForFreshData` **without** a requestId, so it never registers a rejector and is byte-for-byte unchanged. The ADB-broadcast fallback (no WS requestId) deliberately retains timeout-only behavior. The `null` return of `requestHierarchySync` is unchanged — callers just get it fast now instead of after 10s.

**Scope note:** the mid-wait `request_hierarchy_if_stale` nudge uses an uncorrelated `stale_` id, so an error on *that* frame still waits out the timeout — outside this issue's acceptance criteria (which targets the primary `request_hierarchy` path). The iOS-parity half is tracked separately in #3022; the Kotlin async-broadcast half in #3023.

## Testing

All no-device (bun + Interface/Fake/FakeTimer), following repo conventions.

- `CtrlProxyClient.test.ts` (new `issue #3032` suite):
  - A `type:"error"` frame whose requestId matches an in-flight hierarchy request fails `requestHierarchySync` **fast** — asserted by resolving with no timer advance and `getCurrentTime() < 10000` (proves it does not sit through the 10s timeout). This test **hangs to timeout without the fix** (TDD red confirmed).
  - A `type:"error"` frame with an **unknown** requestId is a safe no-op: an in-flight hierarchy sync still resolves normally from its own `hierarchy_update`.
- Regression guard: the existing #3019 `error frame handling` suite (RequestManager path) still passes — 4 tests / 146ms.
- `bun test test/features/observe/` → 769 pass, 1 fail. The single failure (`getLatestHierarchy > should preserve SDK screen names …`) is **pre-existing** — it fails on unmodified `main` in isolation, and is untouched here.
- `bun build.ts` and `eslint` on the changed files are green.

> **Delivery note:** this is a pure TS/daemon-side change — no runner re-cut required. It takes effect against any runner that already emits the `type:"error"` frame from #3019.
