### PR TITLE
test(observe): deterministically preserve SDK screen names via in-memory nav DB (#3063)

### DIFF
--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -202,6 +202,20 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
+   * Install a pre-built instance as the singleton (for testing only).
+   *
+   * Lets a test back the singleton with an in-memory database so consumers that
+   * resolve the manager via `getInstance()` (e.g. AndroidCtrlProxyClient) exercise
+   * deterministic, migration-gate-free DB writes instead of the real file DB. Using
+   * `getInstance()` alone would lazily build a manager on the shared `getDatabase()`
+   * singleton, whose first-use migration + file IO run on real wall-clock time and
+   * make async writes race the assertions. Pair with `resetInstance()` in teardown.
+   */
+  public static setInstanceForTesting(instance: NavigationGraphManager): void {
+    NavigationGraphManager.instance = instance;
+  }
+
+  /**
    * Create a new instance for testing with injected dependencies.
    *
    * Precondition for recordNavigationEvent's atomicity: `repository` and

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -144,10 +144,14 @@ describe("AndroidCtrlProxyClient", function() {
   // getInstance(); the default getDatabase() singleton runs migrations + file IO on
   // real wall-clock time, so its async writes never settle within these tests'
   // microtask-only drains and race the assertions (issue #3063). An in-memory DB has
-  // no migration gate and no file IO, so recordNavigationEvent's writes commit within
-  // a deterministic number of setImmediate/microtask turns. Both repositories share
-  // the one connection to satisfy NavigationGraphManager's shared-connection
-  // precondition. Callers must destroy the returned db and resetInstance() in cleanup.
+  // no migration gate and no file IO, so recordNavigationEvent's *graph* writes — the
+  // ones that assign currentScreen, which the assertions read — commit within a
+  // deterministic number of setImmediate/microtask turns. (recordNavigationEvent's
+  // post-commit fire-and-forget TelemetryRecorder write still targets the real DB, but
+  // it runs after currentScreen is assigned and is never awaited, so it cannot affect
+  // determinism here.) Both repositories share the one connection to satisfy
+  // NavigationGraphManager's shared-connection precondition. Callers must destroy the
+  // returned db and resetInstance() in cleanup.
   const installInMemoryNavManager = async (): Promise<{
     navManager: NavigationGraphManager;
     navDb: Kysely<Database>;

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -15,6 +15,11 @@ import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsReposi
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { DeviceConnectionLostNotifier } from "../../../src/features/observe/DeviceConnectionLostNotifier";
 import { PortManager } from "../../../src/utils/PortManager";
+import { NavigationRepository } from "../../../src/db/navigationRepository";
+import { TestCoverageRepository } from "../../../src/db/testCoverageRepository";
+import { createTestDatabase } from "../../db/testDbHelper";
+import type { Kysely } from "kysely";
+import type { Database } from "../../../src/db/types";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -132,6 +137,27 @@ describe("AndroidCtrlProxyClient", function() {
     for (let i = 0; i < iterations; i += 1) {
       await new Promise(resolve => setImmediate(resolve));
     }
+  };
+
+  // Back the NavigationGraphManager singleton with an in-memory, already-migrated
+  // database. AndroidCtrlProxyClient records navigation into the singleton via
+  // getInstance(); the default getDatabase() singleton runs migrations + file IO on
+  // real wall-clock time, so its async writes never settle within these tests'
+  // microtask-only drains and race the assertions (issue #3063). An in-memory DB has
+  // no migration gate and no file IO, so recordNavigationEvent's writes commit within
+  // a deterministic number of setImmediate/microtask turns. Both repositories share
+  // the one connection to satisfy NavigationGraphManager's shared-connection
+  // precondition. Callers must destroy the returned db and resetInstance() in cleanup.
+  const installInMemoryNavManager = async (): Promise<{
+    navManager: NavigationGraphManager;
+    navDb: Kysely<Database>;
+  }> => {
+    const navDb = await createTestDatabase();
+    const navRepo = new NavigationRepository(navDb);
+    const coverageRepo = new TestCoverageRepository(undefined, navDb);
+    const navManager = NavigationGraphManager.createForTesting(navRepo, coverageRepo);
+    NavigationGraphManager.setInstanceForTesting(navManager);
+    return { navManager, navDb };
   };
 
   test("setupPortForwarding reallocates when the current local port becomes busy before adb forward", async function() {
@@ -473,7 +499,7 @@ describe("AndroidCtrlProxyClient", function() {
 
     test("should seed navigation graph from hierarchy updates", async function() {
       NavigationGraphManager.resetInstance();
-      const navManager = NavigationGraphManager.getInstance();
+      const { navManager, navDb } = await installInMemoryNavManager();
 
       const testTimer = new FakeTimer();
       testTimer.enableAutoAdvance();
@@ -526,12 +552,13 @@ describe("AndroidCtrlProxyClient", function() {
       } finally {
         await testClient.close();
         NavigationGraphManager.resetInstance();
+        await navDb.destroy();
       }
     });
 
     test("should preserve SDK screen names when hierarchy updates follow navigation events", async function() {
       NavigationGraphManager.resetInstance();
-      const navManager = NavigationGraphManager.getInstance();
+      const { navManager, navDb } = await installInMemoryNavManager();
 
       const testTimer = new FakeTimer();
       testTimer.enableAutoAdvance();
@@ -576,12 +603,20 @@ describe("AndroidCtrlProxyClient", function() {
         }));
 
         await resultPromise;
-        await testTimer.advanceTimersByTimeAsync(1);
+        // recordNavigationEvent (fired from the navigation_event handler) commits its
+        // in-memory writes across several async query hops before assigning
+        // currentScreen. Drain setImmediate + microtasks so those settle
+        // deterministically (issue #3063).
+        for (let i = 0; i < 10; i++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+          await testTimer.advanceTimersByTimeAsync(1);
+        }
 
         expect(navManager.getCurrentScreen()).toBe("SdkHome");
       } finally {
         await testClient.close();
         NavigationGraphManager.resetInstance();
+        await navDb.destroy();
       }
     });
   });


### PR DESCRIPTION
## Summary

Closes #3063. The test `AndroidCtrlProxyClient > getLatestHierarchy > should preserve SDK screen names when hierarchy updates follow navigation events` failed **deterministically on `main`** (`Expected "SdkHome", Received null`).

Root cause is **test determinism, not a behavior regression.** `currentScreen` is set by `recordNavigationEvent` only *after* its async DB writes commit (`setCurrentApp` → `getOrCreateApp`, then `runInTransaction`). The test drove the singleton `NavigationGraphManager.getInstance()`, which is backed by the **real file database** (`getDatabase()`), whose first-use path runs migrations + file IO on **real wall-clock time**. After awaiting the hierarchy promise the test only yielded microtasks (`advanceTimersByTimeAsync(1)`), so the navigation write had not landed when the assertion ran → `currentScreen` was still `null`.

Confirmed it is a race, not a regression:
- A direct `recordNavigationEvent({ destination: "SdkHome", applicationId: "com.example.sdk" })` on a fresh singleton sets `currentScreen = "SdkHome"` — production behavior is correct.
- Replacing the microtask yield with a real `setTimeout(1500)` makes the test pass.
- A trace showed the handler reaching `recordNavigationEvent` and blocking inside `setCurrentApp` → `getOrCreateApp` (the real-DB async write) until real time elapsed.

The sibling test `should seed navigation graph from hierarchy updates` only passed because it asserts the `null` **pre-write** state — it was racy-by-luck against the same real DB.

## What changed

- `src/features/navigation/NavigationGraphManager.ts` — added a **test-only** `static setInstanceForTesting(instance)` (documented, mirrors `resetInstance` / `createForTesting`) so a test can back the singleton with an in-memory manager. **No production behavior change.**
- `test/features/observe/CtrlProxyClient.test.ts` — added an `installInMemoryNavManager()` helper that builds a `:memory:` DB via `createTestDatabase`, wires `NavigationRepository` + `TestCoverageRepository` on the **same** connection (satisfies `assertSharedConnection`), and registers it as the singleton. Rewrote the failing test **and its racy sibling** to use it, drain deterministically (`setImmediate` + `advanceTimersByTimeAsync`), and destroy the DB in cleanup. The in-memory DB has no migration gate and no file IO, so `recordNavigationEvent`'s writes settle within a deterministic number of microtask/immediate turns.

## Verification

- `bun test test/features/observe/CtrlProxyClient.test.ts` → **23 pass / 0 fail** (was 22 pass / 1 fail). Stable across **5 consecutive runs**.
- `bun test test/features/observe/` → all pass.
- `bun test test/features/navigation/ test/db/` → 833 pass / 0 fail (new test-only helper causes no regression).
- `turbo run lint` → clean. `bun build.ts` → OK.
- No wall-clock sleeps; determinism comes from the injected in-memory DB + microtask drain.

## Non-goals / follow-ups

- Other tests in `CtrlProxyClient.test.ts` (and elsewhere) that drive the singleton `NavigationGraphManager` against the real file DB but only assert pre-write state are not affected today; a broader sweep to route all such tests through an injected in-memory DB could be a follow-up.
- The post-commit fire-and-forget `TelemetryRecorder` write still targets the real DB (unchanged, pre-existing); not awaited, so it does not affect determinism here.
