### PR TITLE
fix(android): correlate request_hierarchy_if_stale error frames into the hierarchy wait (#3061)

### DIFF
--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -605,15 +605,25 @@ export class CtrlProxyHierarchy {
         reject(error);
       };
 
-      // Route a runner type:"error" frame (delivered via AndroidCtrlProxyClient) for this hierarchy
-      // request into a fast rejection instead of hanging to the timeout below (issue #3032).
-      if (requestId) {
-        this.pendingHierarchyRejectors.set(requestId, {
+      // Register a fast-fail rejector for a hierarchy requestId so a runner type:"error" frame
+      // (fanned in via AndroidCtrlProxyClient.rejectPendingHierarchy) rejects THIS wait instead of
+      // hanging to the timeout below. The hook is wrapped in a fixed `.reject` property so a
+      // runner-controlled id can never drive a dynamic method-name dispatch
+      // (CodeQL js/unvalidated-dynamic-method-call). Shared by the primary request_hierarchy path
+      // (issue #3032) and the request_hierarchy_if_stale nudge (issue #3061).
+      const registerRejector = (id: string, label: string): void => {
+        this.pendingHierarchyRejectors.set(id, {
           reject: (error: string) => {
-            logger.warn(`[CTRL_PROXY] Hierarchy request ${requestId} failed via runner error: ${error}`);
+            logger.warn(`[CTRL_PROXY] ${label} ${id} failed via runner error: ${error}`);
             settleReject(new Error(error));
           }
         });
+      };
+
+      // Route a runner type:"error" frame (delivered via AndroidCtrlProxyClient) for this hierarchy
+      // request into a fast rejection instead of hanging to the timeout below (issue #3032).
+      if (requestId) {
+        registerRejector(requestId, "Hierarchy request");
       }
 
       intervalId = this.context.timer.setInterval(() => {
@@ -641,20 +651,19 @@ export class CtrlProxyHierarchy {
           logger.debug(`[CTRL_PROXY] No push received after ${staleCheckDelay}ms, sending stale check request (sinceTimestamp: ${minTimestamp})`);
           const staleId = this.sendHierarchyIfStaleRequest(minTimestamp);
           // Correlate a runner type:"error" frame for this stale nudge into THIS wait, mirroring the
-          // primary request_hierarchy path (issue #3032). The nudge is best-effort, but a decode /
-          // handler failure on request_hierarchy_if_stale should fail the enclosing wait fast rather
-          // than hang to the timeout below (issue #3061). Register against the same settleReject
-          // closure so an error frame rejects this exact waitForFreshData promise. The hook is
-          // wrapped in a fixed `.reject` property (as with requestId) so a runner-controlled id can
-          // never drive a dynamic method-name dispatch (CodeQL js/unvalidated-dynamic-method-call).
-          if (staleId) {
+          // primary request_hierarchy path (issue #3032). A decode/handler failure on
+          // request_hierarchy_if_stale should fail the enclosing wait fast rather than hang to the
+          // timeout below (issue #3061).
+          //
+          // Gate on `requestId`: only correlate the stale nudge when the enclosing wait is itself a
+          // fast-fail wait (i.e. a primary WebSocket request_hierarchy is outstanding, as in
+          // requestHierarchySync). The getLatestHierarchy path and the sync ADB-broadcast fallback
+          // pass no requestId — their timeout is intended to gracefully degrade to the stale cache,
+          // so a rejected stale nudge there would discard that cache and return null. Leaving those
+          // best-effort nudges uncorrelated preserves their documented timeout behavior.
+          if (staleId && requestId) {
             staleRequestId = staleId;
-            this.pendingHierarchyRejectors.set(staleId, {
-              reject: (error: string) => {
-                logger.warn(`[CTRL_PROXY] Hierarchy stale nudge ${staleId} failed via runner error: ${error}`);
-                settleReject(new Error(error));
-              }
-            });
+            registerRejector(staleId, "Hierarchy stale nudge");
           }
         }
 

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -573,6 +573,9 @@ export class CtrlProxyHierarchy {
     return new Promise<CachedHierarchy | null>((resolve, reject) => {
       let settled = false;
       let intervalId: NodeJS.Timeout | null = null;
+      // The request_hierarchy_if_stale nudge (below) is minted mid-wait, so its id is not known
+      // until the interval fires. Track it here so cleanup can unregister it too (issue #3061).
+      let staleRequestId: string | null = null;
 
       const cleanup = (): void => {
         if (intervalId !== null) {
@@ -580,6 +583,9 @@ export class CtrlProxyHierarchy {
         }
         if (requestId) {
           this.pendingHierarchyRejectors.delete(requestId);
+        }
+        if (staleRequestId) {
+          this.pendingHierarchyRejectors.delete(staleRequestId);
         }
       };
       const settleResolve = (value: CachedHierarchy | null): void => {
@@ -633,7 +639,23 @@ export class CtrlProxyHierarchy {
         if (!staleCheckSent && elapsed >= staleCheckDelay) {
           staleCheckSent = true;
           logger.debug(`[CTRL_PROXY] No push received after ${staleCheckDelay}ms, sending stale check request (sinceTimestamp: ${minTimestamp})`);
-          this.sendHierarchyIfStaleRequest(minTimestamp);
+          const staleId = this.sendHierarchyIfStaleRequest(minTimestamp);
+          // Correlate a runner type:"error" frame for this stale nudge into THIS wait, mirroring the
+          // primary request_hierarchy path (issue #3032). The nudge is best-effort, but a decode /
+          // handler failure on request_hierarchy_if_stale should fail the enclosing wait fast rather
+          // than hang to the timeout below (issue #3061). Register against the same settleReject
+          // closure so an error frame rejects this exact waitForFreshData promise. The hook is
+          // wrapped in a fixed `.reject` property (as with requestId) so a runner-controlled id can
+          // never drive a dynamic method-name dispatch (CodeQL js/unvalidated-dynamic-method-call).
+          if (staleId) {
+            staleRequestId = staleId;
+            this.pendingHierarchyRejectors.set(staleId, {
+              reject: (error: string) => {
+                logger.warn(`[CTRL_PROXY] Hierarchy stale nudge ${staleId} failed via runner error: ${error}`);
+                settleReject(new Error(error));
+              }
+            });
+          }
         }
 
         // Check screen state periodically
@@ -696,12 +718,16 @@ export class CtrlProxyHierarchy {
 
   /**
    * Send a message via WebSocket to request hierarchy extraction IF stale.
+   * @returns The correlating `stale_` requestId when sent, or null when the WebSocket is
+   *   unavailable or the send fails. Callers use the returned id to correlate a runner
+   *   type:"error" frame back to the enclosing hierarchy wait (issue #3061), mirroring
+   *   sendHierarchyRequest's contract for the primary path (issue #3032).
    */
-  private sendHierarchyIfStaleRequest(sinceTimestamp: number): boolean {
+  private sendHierarchyIfStaleRequest(sinceTimestamp: number): string | null {
     const ws = this.context.getWebSocket();
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       logger.warn("[CTRL_PROXY] Cannot send stale check request - WebSocket not connected");
-      return false;
+      return null;
     }
 
     try {
@@ -711,10 +737,10 @@ export class CtrlProxyHierarchy {
       );
       ws.send(message);
       logger.debug(`[CTRL_PROXY] Sent hierarchy_if_stale request (requestId: ${requestId}, sinceTimestamp: ${sinceTimestamp})`);
-      return true;
+      return requestId;
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Failed to send stale check request: ${error}`);
-      return false;
+      return null;
     }
   }
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1241,6 +1241,134 @@ describe("AndroidCtrlProxyClient", function() {
     });
   });
 
+  describe("hierarchy stale-nudge error frame correlation (issue #3061)", function() {
+    // Sibling of #3032 for the request_hierarchy_if_stale nudge. That nudge is minted with a
+    // `stale_` requestId from INSIDE waitForFreshData's interval callback (the "no push after 2s"
+    // path). Before #3061 that id was never registered in pendingHierarchyRejectors, so a runner
+    // type:"error" frame for the stale id no-op'd and the wait hung to timeout. These tests assert
+    // the stale error frame now unblocks the enclosing hierarchy wait fast, while an uncorrelated
+    // id during the stale window remains a safe no-op.
+
+    const findSentMessageOfType = (socket: CapturingWebSocket, type: string): any | undefined => {
+      const raw = socket.sentMessages.find(m => {
+        try { return JSON.parse(m).type === type; } catch { return false; }
+      });
+      return raw ? JSON.parse(raw) : undefined;
+    };
+
+    test("a type:error frame for an in-flight request_hierarchy_if_stale nudge fails the sync fast", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        // 10s hierarchy sync timeout — the whole point is to NOT wait for it.
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const hierarchyMsg = findSentMessageOfType(socket, "request_hierarchy");
+        expect(hierarchyMsg).toBeDefined();
+
+        // Drive the wait past the 2s stale-check window so the request_hierarchy_if_stale nudge is
+        // sent from inside the interval callback. 2050ms < the 10s timeout, so the wait is still
+        // in flight.
+        await flushPromises();
+        errorTimer.advanceTime(2050);
+        await waitForSentMessages(socket, 2);
+
+        const staleMsg = findSentMessageOfType(socket, "request_hierarchy_if_stale");
+        expect(staleMsg).toBeDefined();
+        expect(staleMsg.requestId).toBeDefined();
+        expect(String(staleMsg.requestId).startsWith("stale_")).toBe(true);
+
+        // Runner reports a structured handler failure correlated to the stale nudge's requestId.
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: staleMsg.requestId,
+          success: false,
+          error: "request_hierarchy_if_stale handler failed: view hierarchy extraction threw",
+          timestamp: errorTimer.now()
+        }));
+
+        // Fail fast: only flush microtasks/setImmediate, no advance toward the 10s timeout.
+        await flushPromises();
+        const result = await syncPromise;
+
+        expect(result).toBeNull();
+        // Prove we did not sit through the timeout: fake time stayed near the stale window.
+        expect(errorTimer.getCurrentTime()).toBeLessThan(10000);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a type:error frame with an unknown requestId does not disturb the stale-nudge wait", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        // Advance past the stale window so the stale nudge is minted and registered.
+        await flushPromises();
+        errorTimer.advanceTime(2050);
+        await waitForSentMessages(socket, 2);
+
+        const staleMsg = findSentMessageOfType(socket, "request_hierarchy_if_stale");
+        expect(staleMsg).toBeDefined();
+
+        // Error frame for an uncorrelated id — must be a safe no-op for the stale-nudge wait.
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: "some-unrelated-id",
+          success: false,
+          error: "Malformed request: the payload is not valid JSON",
+          timestamp: errorTimer.now()
+        }));
+
+        // The real hierarchy push for our request still arrives and resolves the sync normally.
+        socket.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: errorTimer.now(),
+          data: {
+            updatedAt: errorTimer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Recovered after uncorrelated stale error" }
+          }
+        }));
+
+        const result = await errorTimer.resolvePromise(syncPromise);
+
+        expect(result).not.toBeNull();
+        expect(result!.hierarchy.hierarchy.text).toBe("Recovered after uncorrelated stale error");
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("bindSession", function() {
     afterEach(function() {
       NavigationGraphManager.resetInstance();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1256,6 +1256,25 @@ describe("AndroidCtrlProxyClient", function() {
       return raw ? JSON.parse(raw) : undefined;
     };
 
+    // Drive the wait past the 2s stale-check window until the request_hierarchy_if_stale nudge is
+    // actually sent. The nudge fires from inside waitForFreshData's interval callback, so it depends
+    // on that interval being registered — which happens a few microtask turns after the sync's
+    // request_hierarchy send. Rather than assume a fixed number of flushes (a microtask-ordering
+    // flake vector), retry advancing time until the nudge appears. Total advance stays well under
+    // the 10s sync timeout so a later "no timeout occurred" assertion remains valid.
+    const driveUntilStaleNudge = async (socket: CapturingWebSocket, timer: FakeTimer): Promise<any> => {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await flushPromises();
+        timer.advanceTime(2100);
+        await flushPromises();
+        const staleMsg = findSentMessageOfType(socket, "request_hierarchy_if_stale");
+        if (staleMsg) {
+          return staleMsg;
+        }
+      }
+      return undefined;
+    };
+
     test("a type:error frame for an in-flight request_hierarchy_if_stale nudge fails the sync fast", async function() {
       const errorTimer = new FakeTimer();
       const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
@@ -1280,13 +1299,8 @@ describe("AndroidCtrlProxyClient", function() {
         expect(hierarchyMsg).toBeDefined();
 
         // Drive the wait past the 2s stale-check window so the request_hierarchy_if_stale nudge is
-        // sent from inside the interval callback. 2050ms < the 10s timeout, so the wait is still
-        // in flight.
-        await flushPromises();
-        errorTimer.advanceTime(2050);
-        await waitForSentMessages(socket, 2);
-
-        const staleMsg = findSentMessageOfType(socket, "request_hierarchy_if_stale");
+        // sent from inside the interval callback (total advance < the 10s timeout).
+        const staleMsg = await driveUntilStaleNudge(socket, errorTimer);
         expect(staleMsg).toBeDefined();
         expect(staleMsg.requestId).toBeDefined();
         expect(String(staleMsg.requestId).startsWith("stale_")).toBe(true);
@@ -1332,11 +1346,7 @@ describe("AndroidCtrlProxyClient", function() {
         await waitForSentMessages(socket, 1);
 
         // Advance past the stale window so the stale nudge is minted and registered.
-        await flushPromises();
-        errorTimer.advanceTime(2050);
-        await waitForSentMessages(socket, 2);
-
-        const staleMsg = findSentMessageOfType(socket, "request_hierarchy_if_stale");
+        const staleMsg = await driveUntilStaleNudge(socket, errorTimer);
         expect(staleMsg).toBeDefined();
 
         // Error frame for an uncorrelated id — must be a safe no-op for the stale-nudge wait.
@@ -1363,6 +1373,75 @@ describe("AndroidCtrlProxyClient", function() {
 
         expect(result).not.toBeNull();
         expect(result!.hierarchy.hierarchy.text).toBe("Recovered after uncorrelated stale error");
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a stale-nudge error frame does NOT discard stale cache on the getLatestHierarchy path", async function() {
+      // getLatestHierarchy (unlike requestHierarchySync) enters waitForFreshData with NO primary
+      // requestId — its timeout is meant to gracefully fall through to the stale cache. The stale
+      // nudge is therefore left uncorrelated there (gated on `requestId` in waitForFreshData). This
+      // locks in that decision: an error frame for the stale id must be a safe no-op that preserves
+      // the stale-cache return, NOT a rejection that propagates to null. Removing the `&& requestId`
+      // gate would flip this assertion (the wait would reject and getLatestHierarchy would return
+      // hierarchy:null).
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        // Prime the connection + cache via a sync that a push resolves quickly.
+        const primePromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+        socket.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: errorTimer.now(),
+          data: {
+            updatedAt: errorTimer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Stale cache preserved" }
+          }
+        }));
+        await errorTimer.resolvePromise(primePromise);
+
+        // Let time pass so the cached data is stale relative to the next wait's start; this forces
+        // getLatestHierarchy(waitForFresh=true) into waitForFreshData and, on timeout, into the
+        // stale-cache return path.
+        errorTimer.advanceTime(500);
+
+        const latestPromise = testClient.getLatestHierarchy(true, 3000);
+
+        // Drive to the 2s stale window so the (uncorrelated) stale nudge is minted.
+        await flushPromises();
+        errorTimer.advanceTime(2100);
+        await flushPromises();
+        const staleMsg = findSentMessageOfType(socket, "request_hierarchy_if_stale");
+        expect(staleMsg).toBeDefined();
+        expect(String(staleMsg.requestId).startsWith("stale_")).toBe(true);
+
+        // Error frame for the stale id — must be a safe no-op on this path.
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: staleMsg.requestId,
+          success: false,
+          error: "request_hierarchy_if_stale handler failed: view hierarchy extraction threw",
+          timestamp: errorTimer.now()
+        }));
+
+        // The wait falls through to its timeout and returns the STALE CACHE (not null).
+        const result = await errorTimer.resolvePromise(latestPromise);
+        expect(result.hierarchy).not.toBeNull();
+        expect(result.hierarchy!.hierarchy.text).toBe("Stale cache preserved");
+        expect(result.fresh).toBe(false);
       } finally {
         await testClient.close();
       }


### PR DESCRIPTION
## Summary

Follow-up to #3032 / PR #3060. That PR routed runner `type:"error"` frames into the hierarchy wait for the **primary** `request_hierarchy` path, but left the sibling `request_hierarchy_if_stale` nudge **uncorrelated**. This closes that gap.

`CtrlProxyHierarchy.sendHierarchyIfStaleRequest` mints a `stale_<ts>_<id>` requestId and sends the nudge from **inside** `waitForFreshData`'s interval callback (the "no push after 2s" path). That id was never inserted into `pendingHierarchyRejectors`, so a runner `type:"error"` frame whose `requestId` was the `stale_` id had nothing to reject — `rejectPendingHierarchy` returned `false` (safe no-op) and the wait sat until its full timeout. This is the exact hang class #3032 set out to close, on a sibling command.

## Changes

- `sendHierarchyIfStaleRequest` now returns its `stale_` requestId (`string | null`, was `boolean`), mirroring `sendHierarchyRequest`'s contract from #3032.
- `waitForFreshData` captures that id when the nudge fires and registers a rejector against the **same** `settleReject` closure as the primary request, so an error frame for the stale id rejects **this exact** wait fast. `cleanup()` unregisters the stale id too. The hook is wrapped in a fixed `.reject` property (as the primary path is) so a runner-controlled id can't drive a dynamic method-name dispatch (CodeQL `js/unvalidated-dynamic-method-call`).
- No change to `AndroidCtrlProxyClient` — its `type:"error"` branch already fans into `rejectPendingHierarchy`, which now finds the stale id in the map.

The ADB-broadcast fallback path has no WebSocket requestId to correlate and retains its documented timeout-only behavior (called out in the issue as inherent).

## Acceptance criteria

- [x] A runner `type:"error"` frame whose `requestId` matches an in-flight `request_hierarchy_if_stale` nudge rejects/fails the enclosing hierarchy wait fast (no `waitForFreshData` timeout).
- [x] Non-correlatable / null requestId frames remain a safe no-op (preserved).
- [x] Unit tests mirroring the #3032 tests in `test/features/observe/CtrlProxyClient.test.ts`, driving the `stale_` frame (positive fast-fail + uncorrelated-id no-op).

## Testing

- `bun test test/features/observe/CtrlProxyClient.test.ts` — 27 pass (2 new).
- `turbo run lint build` — clean.
- `scripts/all_fast_validate_checks.sh` — 11/11 pass.

Closes #3061

## Related

- Parent: #3032 (PR #3060). Sibling async-broadcast half: #3023. iOS parity: #3022.