### PR TITLE
fix(db): guard against production AUTOMOBILE_DB_PATH=:memory: (#3065)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -4,9 +4,14 @@ import * as os from "os";
 import * as fs from "fs";
 import type { Database as DatabaseSchema } from "./types";
 import { runMigrations } from "./migrator";
-import { createMigrationLock, isInMemoryDatabasePath } from "./migrationLock";
+import {
+  isInMemoryDatabaseOptInEnabled,
+  isInMemoryDatabasePath,
+  IN_MEMORY_DB_OPT_IN_ENV,
+  selectMigrationLock,
+} from "./migrationLock";
 import { logger } from "../utils/logger";
-import { toActionableError } from "../models/ActionableError";
+import { ActionableError, toActionableError } from "../models/ActionableError";
 import { BunSqliteDialect } from "./bunSqliteDialect";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import {
@@ -67,11 +72,29 @@ export function resolveDatabasePathFromEnvironment(
   if (envDbPath) {
     // The `:memory:` sentinel is not a filesystem path: routing it through the
     // daemon-launch-cwd resolver would `path.resolve(":memory:")` into a bogus
-    // absolute path (and `createFileMigrationLock` would then try to create a
+    // absolute path (and `selectMigrationLock` would then try to create a
     // `:memory:.migrate.lock` file). Pass it through un-resolved (issue #3047).
-    return isInMemoryDatabasePath(envDbPath)
-      ? envDbPath
-      : resolvePathFromDaemonLaunchWorkingDirectory(envDbPath);
+    if (isInMemoryDatabasePath(envDbPath)) {
+      // `:memory:` is a test-only seam: it is private per connection, so the app
+      // connection never sees the migration connection's schema — migrations
+      // report success while the daemon queries a migrated-but-empty DB and the
+      // first schema-dependent read/write fails with `no such table`. Reject it
+      // outside an explicit opt-in so a production `AUTOMOBILE_DB_PATH=:memory:`
+      // fails fast and legibly instead of silently breaking (issue #3065).
+      if (!isInMemoryDatabaseOptInEnabled(env)) {
+        throw new ActionableError(
+          `AUTOMOBILE_DB_PATH=:memory: is not a valid production database. A ` +
+            `SQLite \`:memory:\` DB is private per connection, so startup migrations ` +
+            `run on a separate in-memory database and the daemon's connection is left ` +
+            `migrated-but-empty — the first query (e.g. \`tool_calls\`) would fail with ` +
+            `\`no such table\`. Point AUTOMOBILE_DB_PATH at a real file (or unset it to use ` +
+            `~/.auto-mobile/auto-mobile.db). The \`:memory:\` sentinel is for lifecycle ` +
+            `tests only; set ${IN_MEMORY_DB_OPT_IN_ENV}=1 to opt in from a test.`
+        );
+      }
+      return envDbPath;
+    }
+    return resolvePathFromDaemonLaunchWorkingDirectory(envDbPath);
   }
 
   const envDbDir = env.AUTOMOBILE_DB_DIR ?? env.AUTO_MOBILE_DB_DIR;
@@ -259,7 +282,7 @@ async function startMigrations(dbPath: string): Promise<void> {
       // file (override env / --no-proxy alongside a daemon) must not both enter
       // migrateToLatest() and collide on the kysely_migration PRIMARY KEY (#2794).
       // A `:memory:` DB is private per connection, so it gets a no-op lock (#3047).
-      lock: createMigrationLock(dbPath),
+      lock: selectMigrationLock(dbPath),
       backup: () => backupDatabaseFile(migrationDb, dbPath),
     });
     // `migrationsRun` is NOT set here: it is a fenced global written only by the

--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -200,7 +200,9 @@ export function migrationLockPathFor(dbPath: string): string {
  * open/close/reopen contract without querying migrated schema — not a production
  * DB configuration. (Sharing one connection across the app and the migrator would
  * break the migration failure-isolation the separate `migrationDb` provides, so
- * it is deliberately out of scope.)
+ * it is deliberately out of scope.) A production `AUTOMOBILE_DB_PATH=:memory:` is
+ * now rejected at path-resolution time unless {@link IN_MEMORY_DB_OPT_IN_ENV} is
+ * set, so this footgun fails fast instead of silently (issue #3065).
  */
 export const IN_MEMORY_DATABASE_PATH = ":memory:";
 
@@ -210,13 +212,38 @@ export function isInMemoryDatabasePath(dbPath: string): boolean {
 }
 
 /**
+ * Explicit opt-in that permits the test-only `:memory:` sentinel DB path.
+ *
+ * `:memory:` is private per connection, so a real daemon that set it would get a
+ * migrated-but-empty app connection (see {@link IN_MEMORY_DATABASE_PATH}). The
+ * runtime guard in `database.ts#resolveDatabasePathFromEnvironment` rejects
+ * `:memory:` unless this flag is truthy, so production misuse fails fast and
+ * legibly while lifecycle tests keep the fast, file-free seam (issue #3065).
+ */
+export const IN_MEMORY_DB_OPT_IN_ENV = "AUTOMOBILE_ALLOW_IN_MEMORY_DB";
+
+/**
+ * True when {@link IN_MEMORY_DB_OPT_IN_ENV} is set to a truthy value
+ * (`1`/`true`/`yes`, case- and whitespace-insensitive). Anything else — absent,
+ * empty, `0`/`false`/`no` — is treated as disabled so the guard fails safe: a
+ * typo'd or empty flag never silently opts a production daemon into the
+ * migrated-but-empty `:memory:` footgun (issue #3065).
+ */
+export function isInMemoryDatabaseOptInEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const normalized = env[IN_MEMORY_DB_OPT_IN_ENV]?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+/**
  * Select the migration lock for a resolved DB path: a {@link NoOpMigrationLock}
  * for the `:memory:` sentinel (private per-connection, no file to guard, and
  * `:memory:.migrate.lock` would be a bogus file), a {@link FileMigrationLock}
  * keyed to the file otherwise. This is the single decision point so every opener
  * (currently `database.ts#startMigrations`) can stay DB-path-agnostic (#3047).
+ * Named for its role as the chooser — it dispatches to
+ * {@link createFileMigrationLock} for the file branch (issue #3065 nit).
  */
-export function createMigrationLock(dbPath: string): MigrationLock {
+export function selectMigrationLock(dbPath: string): MigrationLock {
   return isInMemoryDatabasePath(dbPath)
     ? new NoOpMigrationLock()
     : createFileMigrationLock(dbPath);

--- a/test/db/databasePath.test.ts
+++ b/test/db/databasePath.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import path from "path";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { resolveDatabasePathFromEnvironment } from "../../src/db/database";
+import { IN_MEMORY_DB_OPT_IN_ENV } from "../../src/db/migrationLock";
+import { ActionableError } from "../../src/models/ActionableError";
 
 describe("database path resolution", () => {
   const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
@@ -41,23 +43,83 @@ describe("database path resolution", () => {
     })).toBe(dbPath);
   });
 
-  test("passes the `:memory:` sentinel through un-resolved (issue #3047)", () => {
+  test("passes the `:memory:` sentinel through un-resolved when opted in (issue #3047)", () => {
     // A `:memory:` DB is not a filesystem path: routing it through the
     // daemon-launch-cwd resolver would `path.resolve(":memory:")` into a bogus
-    // absolute path (and later create a `:memory:.migrate.lock` file). It must be
-    // returned verbatim even with a daemon launch cwd set.
+    // absolute path (and later create a `:memory:.migrate.lock` file). With the
+    // explicit test opt-in set, it must be returned verbatim even with a daemon
+    // launch cwd set.
     process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
 
     expect(resolveDatabasePathFromEnvironment({
       AUTOMOBILE_DB_PATH: ":memory:",
+      [IN_MEMORY_DB_OPT_IN_ENV]: "1",
     })).toBe(":memory:");
   });
 
-  test("passes the `:memory:` sentinel through the legacy AUTO_MOBILE_DB_PATH alias", () => {
+  test("passes the `:memory:` sentinel through the legacy AUTO_MOBILE_DB_PATH alias when opted in", () => {
     process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
 
     expect(resolveDatabasePathFromEnvironment({
       AUTO_MOBILE_DB_PATH: ":memory:",
+      [IN_MEMORY_DB_OPT_IN_ENV]: "true",
     })).toBe(":memory:");
+  });
+
+  describe("guards production `:memory:` misuse (issue #3065)", () => {
+    test("rejects `AUTOMOBILE_DB_PATH=:memory:` without the opt-in flag", () => {
+      // Without the opt-in, `:memory:` on a real daemon yields a
+      // migrated-but-empty app connection (migrations run on a separate private
+      // in-memory DB), so the first schema-dependent query fails with
+      // `no such table`. Fail fast and legibly instead.
+      expect(() =>
+        resolveDatabasePathFromEnvironment({ AUTOMOBILE_DB_PATH: ":memory:" })
+      ).toThrow(ActionableError);
+    });
+
+    test("rejects the legacy `AUTO_MOBILE_DB_PATH=:memory:` alias without the opt-in flag", () => {
+      expect(() =>
+        resolveDatabasePathFromEnvironment({ AUTO_MOBILE_DB_PATH: ":memory:" })
+      ).toThrow(ActionableError);
+    });
+
+    test("rejects `:memory:` when the opt-in flag is present but false-ish", () => {
+      for (const value of ["", "0", "false"]) {
+        expect(() =>
+          resolveDatabasePathFromEnvironment({
+            AUTOMOBILE_DB_PATH: ":memory:",
+            [IN_MEMORY_DB_OPT_IN_ENV]: value,
+          })
+        ).toThrow(ActionableError);
+      }
+    });
+
+    test("the error message is actionable: names the env vars and the fix", () => {
+      let caught: unknown;
+      try {
+        resolveDatabasePathFromEnvironment({ AUTOMOBILE_DB_PATH: ":memory:" });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ActionableError);
+      const message = (caught as Error).message;
+      // Points at the misused path, the real cause, the opt-in flag, and the fix.
+      expect(message).toContain(":memory:");
+      expect(message).toContain("AUTOMOBILE_DB_PATH");
+      expect(message).toContain(IN_MEMORY_DB_OPT_IN_ENV);
+    });
+
+    test("does not affect real file paths regardless of the opt-in flag", () => {
+      const dbPath = path.resolve("/tmp/auto-mobile.db");
+      // Flag absent.
+      expect(resolveDatabasePathFromEnvironment({ AUTOMOBILE_DB_PATH: dbPath })).toBe(dbPath);
+      // Flag present — must not change a real-file resolution.
+      expect(
+        resolveDatabasePathFromEnvironment({
+          AUTOMOBILE_DB_PATH: dbPath,
+          [IN_MEMORY_DB_OPT_IN_ENV]: "1",
+        })
+      ).toBe(dbPath);
+    });
   });
 });

--- a/test/db/databasePath.test.ts
+++ b/test/db/databasePath.test.ts
@@ -43,19 +43,25 @@ describe("database path resolution", () => {
     })).toBe(dbPath);
   });
 
-  test("passes the `:memory:` sentinel through un-resolved when opted in (issue #3047)", () => {
-    // A `:memory:` DB is not a filesystem path: routing it through the
-    // daemon-launch-cwd resolver would `path.resolve(":memory:")` into a bogus
-    // absolute path (and later create a `:memory:.migrate.lock` file). With the
-    // explicit test opt-in set, it must be returned verbatim even with a daemon
-    // launch cwd set.
-    process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
+  // Exercise the resolver end-to-end for every truthy opt-in spelling, not just
+  // `"1"`, so the guard's integration with `isInMemoryDatabaseOptInEnabled`
+  // (whitespace/case-insensitive `1`/`true`/`yes`) is proven through the real
+  // path, not only at the pure-function level.
+  for (const optIn of ["1", "true", "yes", "  Yes  "]) {
+    test(`passes the \`:memory:\` sentinel through un-resolved when opted in with "${optIn}" (issue #3047)`, () => {
+      // A `:memory:` DB is not a filesystem path: routing it through the
+      // daemon-launch-cwd resolver would `path.resolve(":memory:")` into a bogus
+      // absolute path (and later create a `:memory:.migrate.lock` file). With the
+      // explicit test opt-in set, it must be returned verbatim even with a daemon
+      // launch cwd set.
+      process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
 
-    expect(resolveDatabasePathFromEnvironment({
-      AUTOMOBILE_DB_PATH: ":memory:",
-      [IN_MEMORY_DB_OPT_IN_ENV]: "1",
-    })).toBe(":memory:");
-  });
+      expect(resolveDatabasePathFromEnvironment({
+        AUTOMOBILE_DB_PATH: ":memory:",
+        [IN_MEMORY_DB_OPT_IN_ENV]: optIn,
+      })).toBe(":memory:");
+    });
+  }
 
   test("passes the `:memory:` sentinel through the legacy AUTO_MOBILE_DB_PATH alias when opted in", () => {
     process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -4,7 +4,11 @@ import { existsSync } from "node:fs";
 import { sql } from "kysely";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
-import { IN_MEMORY_DATABASE_PATH, migrationLockPathFor } from "../../src/db/migrationLock";
+import {
+  IN_MEMORY_DATABASE_PATH,
+  IN_MEMORY_DB_OPT_IN_ENV,
+  migrationLockPathFor,
+} from "../../src/db/migrationLock";
 import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
 
 /**
@@ -55,6 +59,9 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
   /** Point the fresh database module at a private in-memory sentinel DB. */
   function useInMemoryDatabase(): void {
     process.env.AUTOMOBILE_DB_PATH = IN_MEMORY_DATABASE_PATH;
+    // `:memory:` is test-only and now runtime-guarded (issue #3065): a real
+    // daemon that set it would fail fast. Lifecycle tests opt in explicitly.
+    process.env[IN_MEMORY_DB_OPT_IN_ENV] = "1";
     delete process.env.AUTOMOBILE_DB_DIR;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
   }
@@ -150,5 +157,20 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     const fresh = getDbWriteBarrier();
     expect(fresh).not.toBe(latched);
     expect(fresh.isDraining()).toBe(false);
+  });
+
+  test("getDatabase() fails fast when `:memory:` is set without the opt-in (issue #3065)", async () => {
+    // A real daemon that set AUTOMOBILE_DB_PATH=:memory: without the test opt-in
+    // must fail legibly at open time, not silently run against a
+    // migrated-but-empty app connection. The guard lives at the single path-
+    // resolution choke point, so getDatabase() surfaces it.
+    process.env.AUTOMOBILE_DB_PATH = IN_MEMORY_DATABASE_PATH;
+    delete process.env[IN_MEMORY_DB_OPT_IN_ENV];
+    delete process.env.AUTOMOBILE_DB_DIR;
+    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+
+    const databaseModule = await importFreshDatabaseModule();
+
+    expect(() => databaseModule.getDatabase()).toThrow(/:memory:/);
   });
 });

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -5,10 +5,12 @@ import { join } from "path";
 import {
   FileMigrationLock,
   IN_MEMORY_DATABASE_PATH,
+  IN_MEMORY_DB_OPT_IN_ENV,
   NoOpMigrationLock,
-  createMigrationLock,
+  isInMemoryDatabaseOptInEnabled,
   isInMemoryDatabasePath,
   migrationLockPathFor,
+  selectMigrationLock,
 } from "../../src/db/migrationLock";
 import { ActionableError } from "../../src/models/ActionableError";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -329,17 +331,35 @@ describe("isInMemoryDatabasePath", () => {
   });
 });
 
-describe("createMigrationLock", () => {
+describe("selectMigrationLock", () => {
   test("selects a NoOpMigrationLock for the `:memory:` sentinel", () => {
     // A `:memory:` DB is private per connection, has no file to guard, and
     // `:memory:.migrate.lock` would be a bogus file — so it must NOT get a
     // FileMigrationLock (issue #3047).
-    expect(createMigrationLock(IN_MEMORY_DATABASE_PATH)).toBeInstanceOf(NoOpMigrationLock);
+    expect(selectMigrationLock(IN_MEMORY_DATABASE_PATH)).toBeInstanceOf(NoOpMigrationLock);
   });
 
   test("selects a FileMigrationLock for a real DB path", () => {
     const dbPath = join(tmpdir(), "auto-mobile-createlock", "auto-mobile.db");
-    expect(createMigrationLock(dbPath)).toBeInstanceOf(FileMigrationLock);
+    expect(selectMigrationLock(dbPath)).toBeInstanceOf(FileMigrationLock);
+  });
+});
+
+describe("isInMemoryDatabaseOptInEnabled", () => {
+  test("is disabled when the opt-in env var is absent", () => {
+    expect(isInMemoryDatabaseOptInEnabled({})).toBe(false);
+  });
+
+  test("recognizes the truthy opt-in values (case/whitespace-insensitive)", () => {
+    for (const value of ["1", "true", "TRUE", "yes", "  Yes  "]) {
+      expect(isInMemoryDatabaseOptInEnabled({ [IN_MEMORY_DB_OPT_IN_ENV]: value })).toBe(true);
+    }
+  });
+
+  test("treats empty/false-ish values as disabled (fail-safe: no silent opt-in)", () => {
+    for (const value of ["", "0", "false", "no", "off", "nope"]) {
+      expect(isInMemoryDatabaseOptInEnabled({ [IN_MEMORY_DB_OPT_IN_ENV]: value })).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## What

Add a **runtime guard** that rejects a production `AUTOMOBILE_DB_PATH=:memory:` with a clear `ActionableError` instead of silently running against a migrated-but-empty database.

Closes #3065. Follow-up to PR #3058 (closed #3047) and its Codex P2 review comment on `src/db/database.ts:74`.

Affected files:
- `src/db/migrationLock.ts` — new `AUTOMOBILE_ALLOW_IN_MEMORY_DB` opt-in (`IN_MEMORY_DB_OPT_IN_ENV` + `isInMemoryDatabaseOptInEnabled`); dispatcher `createMigrationLock` → `selectMigrationLock` (issue's secondary nit).
- `src/db/database.ts` — guard in `resolveDatabasePathFromEnvironment`; import rename.
- `test/db/databasePath.test.ts`, `test/db/migrationLock.test.ts`, `test/db/dbWriteBarrierResetOnClose.test.ts` — guard + opt-in coverage; existing `:memory:` lifecycle tests opt in.

## Why

A SQLite `:memory:` DB is **private per connection**. `getDatabase()` opens its own `new Database(":memory:")`, while `startMigrations()` runs migrations on a **separate** `migrationDb` Kysely instance — two distinct empty in-memory DBs. This separation is deliberate for real files (migration failure-isolation), but for `:memory:` it means the app connection never sees the migrated schema.

Before #3058, `AUTOMOBILE_DB_PATH=:memory:` was `path.resolve`'d into a literal file named `:memory:` (a working, oddly-named file DB on POSIX). After #3058 the `:memory:` sentinel is a private in-memory DB, so `ensureMigrations()` reports **success** while the daemon's app connection has **none** of the migrated tables — the first schema-dependent read/write (`tool_calls`, …) fails with `no such table`, a silently-broken DB rather than a clear error. The sentinel is documented test-only, but there was no runtime backstop.

## How

Implemented the issue's **option 1 (runtime guard)** — the recommended choice — with the test seam preserved via an explicit opt-in:

- **Single choke point.** The guard lives in `resolveDatabasePathFromEnvironment()`, the one place `:memory:` is passed through. Both `getDatabase()` and `ensureMigrations()` reach it via `resolveDbPath()`, and the daemon-startup DB touchpoints (`directModeGuard` / `daemon.ts` `getDatabasePath()`) reach it too — so production misuse fails fast at bring-up, before any query.
- **Explicit opt-in, fail-safe.** `AUTOMOBILE_ALLOW_IN_MEMORY_DB` must be truthy (`1`/`true`/`yes`, case/whitespace-insensitive) for `:memory:` to pass. Anything else — absent, empty, `0`/`false` — is treated as disabled, so a typo'd flag never silently re-opens the footgun. An explicit env flag is preferred over auto-detecting the test runner, which a stray `NODE_ENV=test` could leak into production.
- **Actionable error.** Names the misused path, explains the private-per-connection cause and the migrated-but-empty consequence, and gives the fix (point at a real file / unset it, or set the opt-in from a test).
- **Secondary nit.** Renamed the migration-lock dispatcher `createMigrationLock` → `selectMigrationLock` so it self-signals as the chooser vs `createFileMigrationLock` (the branch). The issue explicitly invited this when touching the area.

**Preserved behavior:** real-file path resolution is untouched (verified with and without the flag). The `:memory:` sentinel remains fully usable for lifecycle tests — they now opt in explicitly. The separate-`migrationDb` failure-isolation (option 2, sharing one connection) was left out of scope, as in #3058.

## Testing

All no-device (bun, injected `env` object / `importFreshDatabaseModule`), <100ms per unit test.

- `databasePath.test.ts` — new `guards production :memory: misuse (#3065)` suite:
  - bare `AUTOMOBILE_DB_PATH=:memory:` and legacy `AUTO_MOBILE_DB_PATH=:memory:` throw `ActionableError`;
  - opt-in present-but-false-ish (`""`/`0`/`false`) still throws;
  - the error message names `:memory:`, `AUTOMOBILE_DB_PATH`, and the opt-in flag;
  - real file paths resolve unchanged with **and** without the flag.
  - Existing `:memory:` passthrough tests updated to opt in.
- `migrationLock.test.ts` — `isInMemoryDatabaseOptInEnabled` truthy/false-ish matrix; `selectMigrationLock` still returns `NoOp` for `:memory:` / `File` otherwise.
- `dbWriteBarrierResetOnClose.test.ts` — lifecycle tests opt in; new integration test proves `getDatabase()` throws `/:memory:/` when the flag is absent.
- Full `bun test test/db/` → **555 pass / 0 fail**; `turbo run lint build` green.
