### PR TITLE
test(nav): pin assertSharedConnection guard in recordHierarchyNavigation Case 1 (#2980)

### DIFF
--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1272,6 +1272,44 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
       })
     ).rejects.toThrow(/different database connections/i);
   });
+
+  test("recordHierarchyNavigation Case 1 with an active test session fails with ActionableError, not a downstream split-write error", async () => {
+    // With a session active the coverage-enlistment write (recordNodeVisit) becomes
+    // reachable inside the transaction. Without the guard, withExecutor would rebind
+    // the coverage repo onto the navigation trx and recordNodeVisit would write a
+    // test_node_coverage row referencing a session that lives only on coverageDb — an
+    // FK violation surfacing as an opaque SqliteError. The guard turns that into a
+    // clear, pre-transaction ActionableError instead. This makes the coverage-row
+    // assertion discriminating (the split path is genuinely reachable here) and mirrors
+    // the recordNavigationEvent twin above.
+    const navRepo = await seedCorrelatedHome();
+    const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+    // startTestSession writes the session on the coverage connection, whose
+    // test_coverage_sessions.app_id FKs navigation_apps — seed the app there.
+    await coverageDb
+      .insertInto("navigation_apps")
+      .values({ app_id: APP_ID, updated_at: "2024-01-01T00:00:00.000Z" })
+      .execute();
+    await manager.startTestSession("session-hier-guard");
+
+    const visitsBefore = await homeVisitCount(navDb);
+
+    await expect(
+      manager.recordHierarchyNavigation({
+        fromFingerprint: null,
+        toFingerprint: "fp_home",
+        timestamp: 900000,
+        packageName: APP_ID,
+      })
+    ).rejects.toBeInstanceOf(ActionableError);
+
+    // No coverage row leaked onto the navigation connection and the visit increment
+    // never applied — the guard stopped the transaction before it opened.
+    expect(await countNodeCoverage(navDb)).toBe(0);
+    expect(await homeVisitCount(navDb)).toBe(visitsBefore);
+  });
 });
 
 /**

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1186,6 +1186,92 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
     expect(await countNodes(navDb)).toBe(1);
     expect(manager.getCurrentScreen()).toBe("Screen1");
   });
+
+  // ---- recordHierarchyNavigation Case 1 (#2980) ----
+  // #2968/PR #2987 transactionalized recordHierarchyNavigation Case 1 and added the
+  // assertSharedConnection() call, but the rollback tests seed with a shared
+  // connection so the guard never fires — deleting it kept the suite green. These
+  // tests pin the guard in the sibling path: a foreign-bound coverage repo must fail
+  // loudly here exactly as it does for recordNavigationEvent.
+
+  async function homeVisitCount(db: Kysely<Database>): Promise<number> {
+    const row = await db
+      .selectFrom("navigation_nodes")
+      .select(["visit_count"])
+      .where("app_id", "=", APP_ID)
+      .where("screen_name", "=", "Home")
+      .executeTakeFirst();
+    return Number(row?.visit_count ?? 0);
+  }
+
+  // Seed a named node "Home" + a correlated fingerprint "fp_home" on the navigation
+  // connection so a later hierarchy event carrying "fp_home" resolves via
+  // getNodeByFingerprint into Case 1 (the existing-node branch), where the guard is
+  // asserted before the transaction opens.
+  async function seedCorrelatedHome(): Promise<NavigationRepository> {
+    const navRepo = new NavigationRepository(navDb);
+    await navRepo.getOrCreateApp(APP_ID);
+    const home = await navRepo.getOrCreateNode(APP_ID, "Home", 1000);
+    await navRepo.getOrCreateFingerprint(
+      APP_ID,
+      home.id,
+      "fp_home",
+      JSON.stringify({ layout: "home" }),
+      1000
+    );
+    return navRepo;
+  }
+
+  test("recordHierarchyNavigation Case 1 throws ActionableError on a foreign-bound coverage repo", async () => {
+    const navRepo = await seedCorrelatedHome();
+    // Coverage repo bound to a DIFFERENT connection — the foreign bind the guard exists to catch.
+    const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    let notifyCount = 0;
+    manager.setGraphUpdateListener(() => {
+      notifyCount++;
+    });
+
+    const visitsBefore = await homeVisitCount(navDb);
+
+    // The event's fingerprint already resolves to a named node, so this takes Case 1
+    // (the existing-node branch, checked before the active-navigation window). The
+    // guard must fire there BEFORE the transaction opens, mirroring recordNavigationEvent.
+    await expect(
+      manager.recordHierarchyNavigation({
+        fromFingerprint: null,
+        toFingerprint: "fp_home",
+        timestamp: 900000,
+        packageName: APP_ID,
+      })
+    ).rejects.toBeInstanceOf(ActionableError);
+
+    // The node-visit increment never applied (the transaction never opened); no
+    // coverage row leaked onto the navigation connection; the post-commit side
+    // effects (currentScreen assignment, notifyGraphUpdated) never ran.
+    expect(await homeVisitCount(navDb)).toBe(visitsBefore);
+    expect(await countNodeCoverage(navDb)).toBe(0);
+    expect(manager.getCurrentScreen()).toBeNull();
+    expect(notifyCount).toBe(0);
+  });
+
+  test("recordHierarchyNavigation Case 1 guard names the connection-identity invariant", async () => {
+    const navRepo = await seedCorrelatedHome();
+    const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+    const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+    await manager.setCurrentApp(APP_ID);
+
+    await expect(
+      manager.recordHierarchyNavigation({
+        fromFingerprint: null,
+        toFingerprint: "fp_home",
+        timestamp: 900000,
+        packageName: APP_ID,
+      })
+    ).rejects.toThrow(/different database connections/i);
+  });
 });
 
 /**


### PR DESCRIPTION
## What

Test-only. Pins the `assertSharedConnection()` guard in
`NavigationGraphManager.recordHierarchyNavigation` **Case 1** — the sibling path
#2980 flags as under-covered.

Closes #2980.

## Why

#2968 / PR #2987 already transactionalized `recordHierarchyNavigation` Case 1
and added the `assertSharedConnection()` call before the transaction opens
(landed on `main` ~40 min *after* #2980 was filed), so the issue's AC #1
(wrap-in-transaction + guard) is satisfied in code. But every existing rollback
test in the "Case-1 transaction (#2968)" block seeds with a **shared**
connection, so the guard branch is never exercised: deleting the
`this.assertSharedConnection();` line from `recordHierarchyNavigation`
(`src/features/navigation/NavigationGraphManager.ts:545`) keeps the entire suite
green. The connection-identity invariant #2980 cares about was enforced but
**unpinned** in the sibling path — a silent-regression risk. The guard-firing
tests that do exist only exercise `recordNavigationEvent`.

## How

Two regression tests added to the existing
`NavigationGraphManager - shared-connection guard (#2968)` describe block
(which already stands up separate `navDb` + `coverageDb` in-memory connections):

- **`recordHierarchyNavigation Case 1 throws ActionableError on a foreign-bound
  coverage repo`** — seeds a named node `Home` + correlated fingerprint
  `fp_home` on the navigation connection so the hierarchy event resolves via
  `getNodeByFingerprint` into Case 1, then fires it with a coverage repo bound to
  a **different** connection. Asserts the guard throws `ActionableError` **before
  the transaction opens**: `visit_count` unchanged, no coverage row on the nav
  connection, `currentScreen` stays `null`, no `notifyGraphUpdated`.
- **`recordHierarchyNavigation Case 1 guard names the connection-identity
  invariant`** — asserts the error message matches `/different database
  connections/i` (mirrors the existing `recordNavigationEvent` guard tests at
  lines 1110/1121).

No `src/` change — the guard already exists; this only proves it.

## Testing

- `bun test test/features/navigation/NavigationGraphManager.test.ts` →
  **62 pass, 0 fail** (~0.55s); the 2 new tests run in ~41ms / ~58ms each.
- `bunx eslint test/features/navigation/NavigationGraphManager.test.ts` → clean.
- `bun build.ts` → clean; `schemas/tool-definitions.json` no drift.
- **TDD teeth verified**: temporarily commenting out `this.assertSharedConnection();`
  in `recordHierarchyNavigation` makes **only** these 2 tests fail (the other 60
  still pass), then restoring it returns the suite to green. The tests fail iff
  the guard is absent.

New tests use real in-memory `createTestDatabase({ foreignKeys: true })` + repo
fakes, no device/network, <100ms each — per `CLAUDE.md` conventions.

## Acceptance criteria (#2980)

- [x] `recordHierarchyNavigation` Case 1 wraps its DB writes in one transaction
      with the shared-connection guard (already true on `main` via #2987 —
      verified, no code change needed).
- [x] Unit test proving the chosen behavior — **the guard firing on a
      foreign-bound coverage repo** — following repo test conventions (in-memory
      DB + fakes, <100ms, no device). Rollback-on-throw was already covered by
      #2987; this closes the remaining, un-pinned guard branch.

## Notes

- Sibling/guard coverage for [[reference_navgraph_withexecutor_txn]];
  `recordNavigationEvent`'s guard is tested at lines 1110–1176, this extends the
  same coverage to `recordHierarchyNavigation`.
- The issue's optional "promote the bind-both-repos + assert preamble into a
  shared two-repo `runInTransaction` helper" is left deferred under YAGNI
  (`recordNavigationEvent` + `recordHierarchyNavigation` are the two both-repos
  callers today); filed as a follow-up.
