### PR TITLE
fix(android): emit correlated error frame when a result-broadcast helper's broadcast() throws (#3045)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -129,6 +129,24 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       },
       logError = { message, error -> Log.e(TAG, message, error) },
     )
+
+  /**
+   * Guards every `broadcast*Result` / `broadcast*Error` / `broadcast*Response` helper so a throw
+   * while *sending* a result (a socket write or serialization failure) emits a correlated
+   * `type:"error"` frame instead of being logged and swallowed — closing the one-layer-down
+   * silent-hang gap from issue #3045. The `broadcastError` sink resolves [webSocketServer] lazily
+   * because it is `lateinit` (assigned in [onServiceConnected]), and no-ops when the server is not
+   * running (there is then no socket to send the fallback on either). See [ResultBroadcaster].
+   */
+  private val resultBroadcaster =
+    ResultBroadcaster(
+      broadcastError = { response ->
+        if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
+          webSocketServer.broadcast(response)
+        }
+      },
+      logError = { message, error -> Log.e(TAG, message, error) },
+    )
   private val recompositionStore = RecompositionStore()
   private val viewHierarchyExtractor = ViewHierarchyExtractor(recompositionStore)
   private val json = Json {
@@ -4265,7 +4283,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "set text result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"set_text_result","timestamp":${System.currentTimeMillis()}""")
@@ -4284,8 +4302,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted set text result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting set text result", e)
     }
   }
 
@@ -4302,7 +4318,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "IME action result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"ime_action_result","timestamp":${System.currentTimeMillis()}""")
@@ -4322,8 +4338,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted IME action result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting IME action result", e)
     }
   }
 
@@ -4339,7 +4353,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "select all result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"select_all_result","timestamp":${System.currentTimeMillis()}""")
@@ -4358,8 +4372,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted select all result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting select all result", e)
     }
   }
 
@@ -4376,7 +4388,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "action result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"action_result","timestamp":${System.currentTimeMillis()}""")
@@ -4396,8 +4408,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted action result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting action result", e)
     }
   }
 
@@ -4415,7 +4425,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "clipboard result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"clipboard_result","timestamp":${System.currentTimeMillis()}""")
@@ -4454,8 +4464,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted clipboard result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting clipboard result", e)
     }
   }
 
@@ -4470,7 +4478,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     totalTimeMs: Long,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
-    try {
+    resultBroadcaster.guard(requestId, "settings_get_result") {
       webSocketServer.broadcast(
         dev.jasonpearson.automobile.protocol.SettingsGetResult(
           timestamp = System.currentTimeMillis(),
@@ -4484,8 +4492,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           error = error,
         )
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting settings_get_result", e)
     }
   }
 
@@ -4498,7 +4504,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     totalTimeMs: Long,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
-    try {
+    resultBroadcaster.guard(requestId, "settings_put_result") {
       webSocketServer.broadcast(
         dev.jasonpearson.automobile.protocol.SettingsPutResult(
           timestamp = System.currentTimeMillis(),
@@ -4510,8 +4516,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           error = error,
         )
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting settings_put_result", e)
     }
   }
 
@@ -4524,7 +4528,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     totalTimeMs: Long,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
-    try {
+    resultBroadcaster.guard(requestId, "settings_list_result") {
       webSocketServer.broadcast(
         dev.jasonpearson.automobile.protocol.SettingsListResult(
           timestamp = System.currentTimeMillis(),
@@ -4536,8 +4540,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           error = error,
         )
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting settings_list_result", e)
     }
   }
 
@@ -4559,7 +4561,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     totalTimeMs: Long,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
-    try {
+    resultBroadcaster.guard(requestId, "installed_packages_result") {
       webSocketServer.broadcast(
         dev.jasonpearson.automobile.protocol.InstalledPackagesResult(
           timestamp = System.currentTimeMillis(),
@@ -4571,8 +4573,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           error = error,
         )
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting installed_packages_result", e)
     }
   }
 
@@ -4595,7 +4595,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     totalTimeMs: Long,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
-    try {
+    resultBroadcaster.guard(requestId, "package_info_result") {
       webSocketServer.broadcast(
         dev.jasonpearson.automobile.protocol.PackageInfoResult(
           timestamp = System.currentTimeMillis(),
@@ -4617,8 +4617,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           error = error,
         )
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting package_info_result", e)
     }
   }
 
@@ -4631,7 +4629,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     totalTimeMs: Long,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
-    try {
+    resultBroadcaster.guard(requestId, "launch_intent_result") {
       webSocketServer.broadcast(
         dev.jasonpearson.automobile.protocol.LaunchIntentResult(
           timestamp = System.currentTimeMillis(),
@@ -4643,8 +4641,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           error = error,
         )
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting launch_intent_result", e)
     }
   }
 
@@ -4662,7 +4658,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "ca_cert_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"ca_cert_result","timestamp":${System.currentTimeMillis()}""")
@@ -4685,8 +4681,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted ca_cert_result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting ca_cert_result", e)
     }
   }
 
@@ -4703,7 +4697,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "device owner status result") {
       val success = error == null
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
@@ -4731,8 +4725,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted device_owner_status_result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting device owner status result", e)
     }
   }
 
@@ -4747,7 +4739,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "permission result") {
       val success = result.error == null
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
@@ -4778,8 +4770,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted permission result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting permission result", e)
     }
   }
 
@@ -4796,7 +4786,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "swipe result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"swipe_result","timestamp":${System.currentTimeMillis()}""")
@@ -4818,8 +4808,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted swipe result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting swipe result", e)
     }
   }
 
@@ -4836,7 +4824,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "drag result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"drag_result","timestamp":${System.currentTimeMillis()}""")
@@ -4858,8 +4846,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted drag result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting drag result", e)
     }
   }
 
@@ -4875,7 +4861,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "tap coordinates result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"tap_coordinates_result","timestamp":${System.currentTimeMillis()}""")
@@ -4897,8 +4883,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted tap coordinates result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting tap coordinates result", e)
     }
   }
 
@@ -4915,7 +4899,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "pinch result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"pinch_result","timestamp":${System.currentTimeMillis()}""")
@@ -4937,8 +4921,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       }
       Log.d(TAG, "Broadcasted pinch result to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting pinch result", e)
     }
   }
 
@@ -5402,7 +5384,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "highlight response") {
       val errorJson = jsonCompact.encodeToString<String?>(error)
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
@@ -5422,8 +5404,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted highlight response to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting highlight response", e)
     }
   }
 
@@ -5438,7 +5418,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "current focus result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"current_focus_result","timestamp":${System.currentTimeMillis()}""")
@@ -5462,8 +5442,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted current focus result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting current focus result", e)
     }
   }
 
@@ -5478,7 +5456,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "current focus error") {
       webSocketServer.broadcast(
         buildString {
           append("""{"type":"current_focus_result","timestamp":${System.currentTimeMillis()}""")
@@ -5494,8 +5472,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted current focus error to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting current focus error", e)
     }
   }
 
@@ -5510,7 +5486,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "traversal order result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"traversal_order_result","timestamp":${System.currentTimeMillis()}""")
@@ -5534,8 +5510,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted traversal order result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting traversal order result", e)
     }
   }
 
@@ -5550,7 +5524,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "traversal order error") {
       webSocketServer.broadcast(
         buildString {
           append("""{"type":"traversal_order_result","timestamp":${System.currentTimeMillis()}""")
@@ -5566,8 +5540,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted traversal order error to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting traversal order error", e)
     }
   }
 
@@ -5717,7 +5689,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "preference files") {
       val message = buildString {
         append("""{"type":"preference_files","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5735,8 +5707,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       }
       webSocketServer.broadcast(message)
       Log.d(TAG, "Broadcasted preference files to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting preference files", e)
     }
   }
 
@@ -5752,7 +5722,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "preferences") {
       val message = buildString {
         append("""{"type":"preferences","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5771,8 +5741,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       }
       webSocketServer.broadcast(message)
       Log.d(TAG, "Broadcasted preferences to ${webSocketServer.getConnectionCount()} clients")
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting preferences", e)
     }
   }
 
@@ -5788,7 +5756,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "subscribe storage result") {
       val message = buildString {
         append("""{"type":"subscribe_storage_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5812,8 +5780,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted subscribe storage result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting subscribe storage result", e)
     }
   }
 
@@ -5828,7 +5794,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "unsubscribe storage result") {
       val message = buildString {
         append("""{"type":"unsubscribe_storage_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5844,8 +5810,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted unsubscribe storage result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting unsubscribe storage result", e)
     }
   }
 
@@ -5862,7 +5826,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "get preference result") {
       val message = buildString {
         append("""{"type":"get_preference_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5893,8 +5857,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted get preference result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting get preference result", e)
     }
   }
 
@@ -5910,7 +5872,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "set preference result") {
       val message = buildString {
         append("""{"type":"set_preference_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5931,8 +5893,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted set preference result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting set preference result", e)
     }
   }
 
@@ -5948,7 +5908,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "remove preference result") {
       val message = buildString {
         append("""{"type":"remove_preference_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5969,8 +5929,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted remove preference result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting remove preference result", e)
     }
   }
 
@@ -5985,7 +5943,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    try {
+    resultBroadcaster.guard(requestId, "clear preferences result") {
       val message = buildString {
         append("""{"type":"clear_preferences_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -6005,8 +5963,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         TAG,
         "Broadcasted clear preferences result to ${webSocketServer.getConnectionCount()} clients",
       )
-    } catch (e: Exception) {
-      Log.e(TAG, "Error broadcasting clear preferences result", e)
     }
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -136,7 +136,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * `type:"error"` frame instead of being logged and swallowed — closing the one-layer-down
    * silent-hang gap from issue #3045. The `broadcastError` sink resolves [webSocketServer] lazily
    * because it is `lateinit` (assigned in [onServiceConnected]), and no-ops when the server is not
-   * running (there is then no socket to send the fallback on either). See [ResultBroadcaster].
+   * running — there is then no socket to send the fallback on, so the awaiter falls back to its
+   * timeout, the same as the double-failure tail. See [ResultBroadcaster].
    */
   private val resultBroadcaster =
     ResultBroadcaster(
@@ -4283,7 +4284,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "set text result") {
+    resultBroadcaster.guard(requestId, "set_text_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"set_text_result","timestamp":${System.currentTimeMillis()}""")
@@ -4318,7 +4319,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "IME action result") {
+    resultBroadcaster.guard(requestId, "ime_action_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"ime_action_result","timestamp":${System.currentTimeMillis()}""")
@@ -4353,7 +4354,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "select all result") {
+    resultBroadcaster.guard(requestId, "select_all_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"select_all_result","timestamp":${System.currentTimeMillis()}""")
@@ -4388,7 +4389,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "action result") {
+    resultBroadcaster.guard(requestId, "action_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"action_result","timestamp":${System.currentTimeMillis()}""")
@@ -4425,7 +4426,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "clipboard result") {
+    resultBroadcaster.guard(requestId, "clipboard_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"clipboard_result","timestamp":${System.currentTimeMillis()}""")
@@ -4697,7 +4698,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "device owner status result") {
+    resultBroadcaster.guard(requestId, "device_owner_status_result") {
       val success = error == null
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
@@ -4739,7 +4740,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "permission result") {
+    resultBroadcaster.guard(requestId, "permission_result") {
       val success = result.error == null
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
@@ -4786,7 +4787,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "swipe result") {
+    resultBroadcaster.guard(requestId, "swipe_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"swipe_result","timestamp":${System.currentTimeMillis()}""")
@@ -4824,7 +4825,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "drag result") {
+    resultBroadcaster.guard(requestId, "drag_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"drag_result","timestamp":${System.currentTimeMillis()}""")
@@ -4861,7 +4862,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "tap coordinates result") {
+    resultBroadcaster.guard(requestId, "tap_coordinates_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"tap_coordinates_result","timestamp":${System.currentTimeMillis()}""")
@@ -4899,7 +4900,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "pinch result") {
+    resultBroadcaster.guard(requestId, "pinch_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"pinch_result","timestamp":${System.currentTimeMillis()}""")
@@ -5384,7 +5385,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "highlight response") {
+    resultBroadcaster.guard(requestId, "highlight_response") {
       val errorJson = jsonCompact.encodeToString<String?>(error)
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
@@ -5418,7 +5419,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "current focus result") {
+    resultBroadcaster.guard(requestId, "current_focus_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"current_focus_result","timestamp":${System.currentTimeMillis()}""")
@@ -5456,7 +5457,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "current focus error") {
+    resultBroadcaster.guard(requestId, "current_focus_error") {
       webSocketServer.broadcast(
         buildString {
           append("""{"type":"current_focus_result","timestamp":${System.currentTimeMillis()}""")
@@ -5486,7 +5487,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "traversal order result") {
+    resultBroadcaster.guard(requestId, "traversal_order_result") {
       webSocketServer.broadcastWithPerf { perfTiming ->
         buildString {
           append("""{"type":"traversal_order_result","timestamp":${System.currentTimeMillis()}""")
@@ -5524,7 +5525,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "traversal order error") {
+    resultBroadcaster.guard(requestId, "traversal_order_error") {
       webSocketServer.broadcast(
         buildString {
           append("""{"type":"traversal_order_result","timestamp":${System.currentTimeMillis()}""")
@@ -5689,7 +5690,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "preference files") {
+    resultBroadcaster.guard(requestId, "preference_files") {
       val message = buildString {
         append("""{"type":"preference_files","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5756,7 +5757,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "subscribe storage result") {
+    resultBroadcaster.guard(requestId, "subscribe_storage_result") {
       val message = buildString {
         append("""{"type":"subscribe_storage_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5794,7 +5795,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "unsubscribe storage result") {
+    resultBroadcaster.guard(requestId, "unsubscribe_storage_result") {
       val message = buildString {
         append("""{"type":"unsubscribe_storage_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5826,7 +5827,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "get preference result") {
+    resultBroadcaster.guard(requestId, "get_preference_result") {
       val message = buildString {
         append("""{"type":"get_preference_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5872,7 +5873,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "set preference result") {
+    resultBroadcaster.guard(requestId, "set_preference_result") {
       val message = buildString {
         append("""{"type":"set_preference_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5908,7 +5909,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "remove preference result") {
+    resultBroadcaster.guard(requestId, "remove_preference_result") {
       val message = buildString {
         append("""{"type":"remove_preference_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {
@@ -5943,7 +5944,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
-    resultBroadcaster.guard(requestId, "clear preferences result") {
+    resultBroadcaster.guard(requestId, "clear_preferences_result") {
       val message = buildString {
         append("""{"type":"clear_preferences_result","timestamp":${System.currentTimeMillis()}""")
         if (requestId != null) {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcaster.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcaster.kt
@@ -1,0 +1,81 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.util.Log
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Guards a result broadcast so that a throw while *sending* a result still yields a correlated
+ * failure frame instead of being logged and swallowed.
+ *
+ * Every `broadcast*Result` / `broadcast*Error` / `broadcast*Response` helper in [CtrlProxy]
+ * historically wrapped its `webSocketServer.broadcast(...)` (or `broadcastWithPerf { … }`) in a
+ * local `try { … } catch (e: Exception) { Log.e(…) }`. If that inner broadcast — or the
+ * serialization that builds its message — threw, the helper emitted nothing and the daemon request
+ * awaiting that `requestId` hung to its `RequestManager` timeout. This is the same silent-hang
+ * class that [AsyncActionRunner] / #2985 closed on the dispatch and async-launch paths, one layer
+ * further down (the throw is caught-and-swallowed *inside* the helper, so [AsyncActionRunner] never
+ * sees it). See issue #3045.
+ *
+ * Routing every result broadcast through [guard] centralizes the correlated-error-on-throw
+ * behavior: a broadcast failure emits a best-effort [ErrorResponse] keyed by the originating
+ * `requestId`, which the daemon fans into both `RequestManager.resolveError` and the hierarchy wait
+ * (see `AndroidCtrlProxyClient.handleWebSocketMessage`), failing the awaiter fast instead of
+ * hanging.
+ *
+ * @param broadcastError sink for the correlated fallback frame — `webSocketServer.broadcast(…)` in
+ *   production (lazily resolving the `lateinit` server, exactly like [AsyncActionRunner]), a
+ *   capturing lambda in tests.
+ * @param logError diagnostic sink; defaults to `Log.e` so tests can stay Android-free by
+ *   overriding.
+ */
+class ResultBroadcaster(
+  private val broadcastError: suspend (ErrorResponse) -> Unit,
+  private val logError: (String, Throwable) -> Unit = { message, error ->
+    Log.e(TAG, message, error)
+  },
+) {
+  /**
+   * Run [block] (which performs the actual result broadcast). If it throws anything other than a
+   * cooperative [CancellationException], broadcast an [ErrorResponse] correlated by [requestId] so
+   * the awaiting client fails fast instead of hanging.
+   *
+   * @param requestId correlation id from the originating request; null when the request carried
+   *   none (the fallback frame then carries a null requestId, exactly as the synchronous decode
+   *   path does — `resolveError` no-ops on an absent id).
+   * @param action human-readable action / result-type name, surfaced in the error message for
+   *   triage.
+   */
+  suspend fun guard(requestId: String?, action: String, block: suspend () -> Unit) {
+    try {
+      block()
+    } catch (e: CancellationException) {
+      // Cooperative cancellation means the service scope is shutting down — never convert it into a
+      // client-facing error frame; let it propagate so the coroutine unwinds cleanly.
+      throw e
+    } catch (e: Exception) {
+      val cause = e.message ?: e::class.simpleName ?: "unknown error"
+      logError("Error broadcasting $action (requestId=$requestId)", e)
+      try {
+        broadcastError(
+          ErrorResponse(requestId = requestId, error = "Broadcast failed for $action: $cause")
+        )
+      } catch (fallbackError: CancellationException) {
+        throw fallbackError
+      } catch (fallbackError: Exception) {
+        // A failure while reporting the broadcast failure must not escape (which would let the
+        // exception bubble to the launched coroutine and defeat the fix). Log and swallow — the
+        // client then falls back to its timeout, but only for this genuinely-unrecoverable
+        // double-failure tail.
+        logError(
+          "Failed to broadcast fallback error for $action (requestId=$requestId)",
+          fallbackError,
+        )
+      }
+    }
+  }
+
+  companion object {
+    private const val TAG = "ResultBroadcaster"
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcasterTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcasterTest.kt
@@ -1,0 +1,139 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Fast, Android-free unit tests for [ResultBroadcaster] — the shared guard that closes the
+ * one-layer-down silent-hang gap from issue #3045. Each `broadcast*Result` helper in [CtrlProxy]
+ * used to wrap its `webSocketServer.broadcast(...)` in a local `try/catch` that logged and
+ * swallowed; if that broadcast (or the serialization feeding it) threw, the helper emitted nothing
+ * and the daemon awaiter for that `requestId` hung to its `RequestManager` timeout. Routing every
+ * result broadcast through [ResultBroadcaster.guard] guarantees a correlated failure frame instead.
+ *
+ * Mirrors [AsyncActionRunnerTest]: a capturing broadcast lambda, so no Robolectric or network I/O.
+ */
+class ResultBroadcasterTest {
+
+  @Test
+  fun `broadcasts correlated error frame when the broadcast block throws`() = runTest {
+    val broadcasts = mutableListOf<ErrorResponse>()
+    val broadcaster =
+      ResultBroadcaster(broadcastError = { broadcasts.add(it) }, logError = { _, _ -> })
+
+    broadcaster.guard(requestId = "req-1", action = "swipe_result") {
+      throw RuntimeException("socket closed")
+    }
+
+    assertEquals("exactly one fallback error frame should be broadcast", 1, broadcasts.size)
+    val error = broadcasts.single()
+    assertEquals("req-1", error.requestId)
+    assertFalse("error frame should mark success=false", error.success)
+    assertTrue(
+      "error should name the failing action, was: ${error.error}",
+      error.error.contains("swipe_result"),
+    )
+    assertTrue(
+      "error should surface the underlying cause, was: ${error.error}",
+      error.error.contains("socket closed"),
+    )
+  }
+
+  @Test
+  fun `does not broadcast when the block succeeds`() = runTest {
+    val broadcasts = mutableListOf<ErrorResponse>()
+    val broadcaster =
+      ResultBroadcaster(broadcastError = { broadcasts.add(it) }, logError = { _, _ -> })
+
+    // A successful helper broadcasts its own *_result frame inside the block; the guard stays
+    // silent.
+    broadcaster.guard(requestId = "req-ok", action = "preference_files") {
+      // no-op: represents a successful broadcast
+    }
+
+    assertTrue("no error frame should be broadcast on success", broadcasts.isEmpty())
+  }
+
+  @Test
+  fun `propagates cancellation without broadcasting an error`() = runTest {
+    val broadcasts = mutableListOf<ErrorResponse>()
+    val broadcaster =
+      ResultBroadcaster(broadcastError = { broadcasts.add(it) }, logError = { _, _ -> })
+
+    // Cooperative cancellation means the service scope is shutting down — it must never be reported
+    // to the client as a broadcast failure; it must propagate so the coroutine unwinds cleanly.
+    try {
+      broadcaster.guard(requestId = "req-cancel", action = "highlight_response") {
+        throw CancellationException("scope shutting down")
+      }
+      fail("guard should re-throw CancellationException")
+    } catch (e: CancellationException) {
+      // expected
+    }
+
+    assertTrue("cancellation must not produce an error frame", broadcasts.isEmpty())
+  }
+
+  @Test
+  fun `carries a null requestId through to the error frame`() = runTest {
+    val broadcasts = mutableListOf<ErrorResponse>()
+    val broadcaster =
+      ResultBroadcaster(broadcastError = { broadcasts.add(it) }, logError = { _, _ -> })
+
+    broadcaster.guard(requestId = null, action = "get_preferences") {
+      throw IllegalStateException("boom")
+    }
+
+    val error = broadcasts.single()
+    assertEquals("null requestId should pass through uncorrelated", null, error.requestId)
+  }
+
+  @Test
+  fun `swallows a failure raised while broadcasting the fallback frame`() = runTest {
+    val logged = mutableListOf<String>()
+    val broadcaster =
+      ResultBroadcaster(
+        broadcastError = { throw RuntimeException("socket still closed") },
+        logError = { message, _ -> logged.add(message) },
+      )
+
+    // A broadcast failure during fallback reporting must not escape guard (which would defeat the
+    // fix by letting the exception bubble to the launched coroutine). It is logged and swallowed.
+    broadcaster.guard(requestId = "req-2", action = "drag_result") {
+      throw RuntimeException("original broadcast failure")
+    }
+
+    // Exactly two: the original broadcast failure, then the failure raised while reporting it.
+    assertEquals(
+      "both the original and the fallback failure should be logged: $logged",
+      2,
+      logged.size,
+    )
+  }
+
+  @Test
+  fun `re-throws cancellation raised while broadcasting the fallback frame`() = runTest {
+    val broadcaster =
+      ResultBroadcaster(
+        broadcastError = { throw CancellationException("scope shutting down mid-fallback") },
+        logError = { _, _ -> },
+      )
+
+    // If the scope is cancelled while we try to send the fallback, that cancellation must still
+    // propagate rather than being swallowed as a generic broadcast failure.
+    try {
+      broadcaster.guard(requestId = "req-3", action = "tap_coordinates_result") {
+        throw RuntimeException("original broadcast failure")
+      }
+      fail("guard should re-throw a CancellationException raised during fallback")
+    } catch (e: CancellationException) {
+      // expected
+    }
+  }
+}


### PR DESCRIPTION
## What

Close the one-layer-down silent-hang gap in `android/control-proxy`: when a
`broadcast*Result` / `broadcast*Error` / `broadcast*Response` helper in `CtrlProxy.kt`
throws **while sending its result**, emit a correlated `type:"error"` frame instead of
logging and swallowing. Closes #3045.

Affected files:
- `android/control-proxy/.../ResultBroadcaster.kt` — new guard helper (mirrors `AsyncActionRunner`).
- `android/control-proxy/.../CtrlProxy.kt` — new `resultBroadcaster` field; all 31
  requestId-correlated result-broadcast helpers routed through `resultBroadcaster.guard(...)`.
- `android/control-proxy/.../ResultBroadcasterTest.kt` — new Android-free unit tests.

## Why

Surfaced during the #3023 / PR #3039 multi-agent review. #3023 fixed throws in the **action
body** of a launched coroutine (`AsyncActionRunner`). But each `broadcast*` helper wrapped its
`webSocketServer.broadcast(...)` (or `broadcastWithPerf { … }`) in a local
`try { … } catch (e: Exception) { Log.e(…) }`. If that inner broadcast — or the serialization
that builds its message — threw, the helper emitted **nothing** and the daemon awaiter for that
`requestId` hung to its `RequestManager` timeout. `AsyncActionRunner` does not help here because
the throw is caught-and-swallowed **inside** the helper and never propagates to the runner. This
is the same silent-hang class #2985 / #3019 closed one layer up, one layer down.

## How

`ResultBroadcaster.guard(requestId, action, block)` runs `block()` (the real broadcast); on a
non-`CancellationException` throw it logs, then **best-effort** broadcasts
`ErrorResponse(requestId, "Broadcast failed for <action>: <cause>")`. The fallback is guarded
against recursive failure (a throw while sending it is logged and swallowed) and re-throws
`CancellationException` at both layers so cooperative shutdown never becomes a client-facing
error. This mirrors `AsyncActionRunner` exactly.

The daemon already correlates the fallback: `AndroidCtrlProxyClient.handleWebSocketMessage`
routes a `type:"error"` frame by `requestId` into **both** `RequestManager.resolveError` and
`CtrlProxyHierarchy.rejectPendingHierarchy` (both no-op on unknown ids), so the awaiter fails
fast regardless of the original expected result type. No TS/daemon change and no runner re-cut
of the protocol were needed for the correlation path.

In `CtrlProxy`, the `resultBroadcaster` field's `broadcastError` sink resolves the `lateinit`
`webSocketServer` lazily (like `asyncActionRunner`) and no-ops when the server is not running.
All 31 helpers keep their top-of-function `isInitialized/isRunning` early-return (no socket ⇒
nothing to send on) and drop their local swallow in favor of the guard.

**Scope:** the 9 remaining `Error broadcasting …` logs are **unsolicited push-event**
broadcasters (interaction / package / hierarchy / navigation / crash / ANR / SDK / storage
change) — they carry no `requestId` and no daemon awaits them, so they are intentionally left
unchanged. `broadcastScreenshot` is already covered by `asyncActionRunner` (its broadcasts run
inside `launch`), so it is also excluded.

## Testing

Android-free unit tests (mirror `AsyncActionRunnerTest`; no Robolectric/network, <100ms):

`ResultBroadcasterTest.kt`:
- a broadcast throw yields exactly one correlated `ErrorResponse` (requestId preserved,
  `success=false`, action + cause surfaced in the message)
- a successful broadcast stays silent (helpers that already broadcast `success:false` results
  are unaffected — the guard only fires on a *throw*)
- `CancellationException` in the block propagates, no error frame
- null `requestId` passes through uncorrelated
- a failure raised **while broadcasting the fallback** is logged and swallowed (does not escape)
- a `CancellationException` raised while broadcasting the fallback is re-thrown

Validation:
- `:control-proxy:testDebugUnitTest` green under JDK 21 (compiles main + all tests).
- `scripts/ktfmt/validate_ktfmt.sh` clean (google style, 2-space).

> **Delivery note:** the correlation consumer (`type:"error"` → `resolveError` +
> `rejectPendingHierarchy`) already shipped in #3019 / #3032, so this runner-side change takes
> effect once the runner is re-cut; it needs no TS change.
