### PR TITLE
review: harden devicectl ESRCH matcher + stdout fallback (follow-up to #3069)

### DIFF
--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -301,6 +301,10 @@ export class TerminateApp extends BaseVisualChange {
     }
   }
 
+  // Simulator-path sibling of DeviceAppInspector.isDevicectlProcessGoneError:
+  // both treat an "already gone" terminate failure as an effectively-terminated
+  // app. Kept separate because simctl and devicectl surface distinct, Apple-
+  // undocumented error text that may diverge (see #3054).
   private isSimctlNotRunningError(message: string): boolean {
     const normalized = message.toLowerCase();
     return normalized.includes("no such process")

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -156,38 +156,44 @@ const getErrorMessage = (error: unknown): string =>
 /**
  * Full text of a failed `exec` rejection. Promisified `child_process.exec`
  * rejects with an Error whose `message` is "Command failed: <cmd>" and whose
- * `stderr` carries the tool's actual diagnostic — devicectl writes its ESRCH
- * "No such process" text to stderr, so we must inspect stderr, not just message.
+ * `stdout`/`stderr` carry the tool's actual diagnostic — devicectl writes its
+ * ESRCH "No such process" text to stderr, so we must inspect the captured
+ * streams, not just message. stdout is included as a cheap belt-and-suspenders:
+ * with `--quiet` devicectl uses stderr, but its error framing is undocumented.
  */
 const getExecErrorText = (error: unknown): string => {
-  const base = getErrorMessage(error);
+  const parts = [getErrorMessage(error)];
   if (error && typeof error === "object") {
-    const stderr = (error as { stderr?: unknown }).stderr;
-    if (typeof stderr === "string" && stderr.length > 0) {
-      return `${base}\n${stderr}`;
+    for (const field of ["stderr", "stdout"] as const) {
+      const value = (error as Record<string, unknown>)[field];
+      if (typeof value === "string" && value.length > 0) {
+        parts.push(value);
+      }
     }
   }
-  return base;
+  return parts.join("\n");
 };
 
 /**
  * True when a devicectl `process terminate` failure means the target PID was
  * already gone — it exited between our `info processes` resolution and the kill
- * (a real on-device race, issue #3054). devicectl surfaces ESRCH as the
- * localized "No such process" strerror text; we also tolerate a couple of
- * "not running" phrasings for robustness. This mirrors
+ * (a real on-device race, issue #3054). devicectl surfaces ESRCH either as the
+ * localized "No such process" strerror text or, on some builds, the bare
+ * `NSPOSIXErrorDomain error 3` code without the strerror gloss. This mirrors
  * `TerminateApp.isSimctlNotRunningError` on the simulator path, so a raced exit
  * reports an effectively-terminated app instead of a false `success:false`.
  *
  * Deliberately narrow: unrelated failures (device locked, not connected,
- * permission denied) must still propagate as hard errors.
+ * permission denied) must still propagate as hard errors. The "not running"
+ * family is scoped to the *process* so a device/CoreDevice-level "not running"
+ * message can never be mistaken for an already-exited PID.
  */
 export const isDevicectlProcessGoneError = (message: string): boolean => {
   const normalized = message.toLowerCase();
-  return normalized.includes("no such process")
-    || normalized.includes("no longer running")
-    || normalized.includes("not running")
-    || normalized.includes("found nothing to terminate");
+  return normalized.includes("no such process")            // ESRCH strerror
+    || normalized.includes("nsposixerrordomain error 3")   // bare ESRCH code
+    || normalized.includes("found nothing to terminate")   // simctl parity
+    || /process (?:is )?(?:no longer |not )running/.test(normalized);
 };
 
 /**

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -1045,6 +1045,9 @@ describe("isDevicectlProcessGoneError", () => {
     expect(isDevicectlProcessGoneError("The process is not running")).toBe(true);
     expect(isDevicectlProcessGoneError("The process is no longer running")).toBe(true);
     expect(isDevicectlProcessGoneError("found nothing to terminate")).toBe(true);
+    // Bare POSIX ESRCH code without the "No such process" strerror gloss —
+    // some devicectl/OS builds emit only this.
+    expect(isDevicectlProcessGoneError("Terminate failed: NSPOSIXErrorDomain error 3")).toBe(true);
   });
 
   test("does not match unrelated devicectl failures", () => {
@@ -1052,5 +1055,9 @@ describe("isDevicectlProcessGoneError", () => {
     expect(isDevicectlProcessGoneError("Could not connect to the device.")).toBe(false);
     expect(isDevicectlProcessGoneError("Unable to terminate: permission denied")).toBe(false);
     expect(isDevicectlProcessGoneError("")).toBe(false);
+    // The "not running" family is scoped to the *process* — a device/CoreDevice
+    // "not running" must NOT be swallowed as an already-exited PID.
+    expect(isDevicectlProcessGoneError("The device is not running.")).toBe(false);
+    expect(isDevicectlProcessGoneError("CoreDevice tunnel is not running")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up hardening for #3054. The original fix landed in #3069 (squash `1d8c3ea38`) — it auto-merged before this multi-perspective review pass could be folded into that PR, so these review-driven improvements land as a separate PR.

Three independent reviewers (a devicectl systems engineer, a TDD/test-quality reviewer, and an API-design reviewer) examined #3069. Nothing was a hard bug; the direction, layering, and `wasRunning:true` contract were all judged sound. These are the concrete improvements they surfaced.

## What changed

- **`isDevicectlProcessGoneError` — remove the over-broad bare `"not running"` match.** It could wrongly swallow a genuine device/CoreDevice-level failure (e.g. "the device is not running", "CoreDevice tunnel is not running") as an already-exited PID. The "not running" family is now **scoped to the process** via `/process (?:is )?(?:no longer |not )running/`, so only a process-gone message matches.
- **Add bare `NSPOSIXErrorDomain error 3` (code-only ESRCH).** Some devicectl/OS builds emit the POSIX ESRCH code without the localized "No such process" strerror gloss; the primary "no such process" anchor would miss those.
- **`getExecErrorText` — also fall back to `error.stdout`, not just `error.stderr`.** devicectl's error framing is Apple-undocumented; with `--quiet` it uses stderr, but stdout is cheap belt-and-suspenders against a build that routes the diagnostic there.
- **Cross-reference the two sibling matchers** (`isDevicectlProcessGoneError` ⇄ `TerminateApp.isSimctlNotRunningError`) in comments so future readers find both halves.
- **Tests:** true-case for the bare ESRCH code; false-cases documenting that "device is not running" / "tunnel is not running" are intentionally **not** tolerated.

## Verification

- `bun test ./test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts ./test/features/action/TerminateApp.test.ts` → 52 pass
- `bunx eslint` on touched files → clean
- `bun build.ts` → OK

## Deferred (filed as follow-ups)

- Extracting a single shared "process already gone" matcher for the simctl + devicectl paths (YAGNI until a third caller / divergent phrasing appears).
- `TerminateApp.terminatePhysicalDevice` surfaces `error.message` (uninformative "Command failed: …") for a genuine device-terminate failure while the real diagnostic lives on `error.stderr` — a pre-existing message-vs-stderr propagation nit.