### PR TITLE
test(db): shared withFileBackedDb harness to enforce the DB-lifecycle flake-avoidance pattern (#3046)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,20 @@ bun test --bail        # Stop on first failure (no cache)
 bun test <file>        # Run specific test file (no cache)
 ```
 
+## File-backed DB lifecycle tests
+
+Any test suite that opens a real `auto-mobile.db` (module close/reopen, migration
+lifecycle, path resolution) MUST go through the shared
+`createFileBackedDbHarness()` in `test/db/withFileBackedDb.ts` — never hand-roll a
+`mkdtemp` + raw `import("database.ts?...")` + env restore. The harness centralizes
+the four-part Windows-flake-avoidance pattern (fresh isolated module import,
+tracked temp dirs cleaned with the bounded `removeTempDbDir`, `getDatabase()` then
+`await ensureMigrations()` before close, and the `WINDOWS_FILE_DB_TEST_TIMEOUT_MS`
+ceiling). Use `openLifecycleTestDb(prefix)` for the common open→migrate→close flow;
+use the `makeTempDbDir` / `importFreshDatabaseModule` primitives for suites that
+must control the migration lifecycle mid-flight. `:memory:`-backed suites (e.g.
+`dbWriteBarrierResetOnClose`) are deliberately exempt — they carry no file handle.
+
 # Validate Shell Scripts
 
 Shell scripts under `scripts/` are tested with [BATS](https://github.com/bats-core/bats-core) and linted with shellcheck.

--- a/test/db/databaseIncompleteExtraction.test.ts
+++ b/test/db/databaseIncompleteExtraction.test.ts
@@ -1,10 +1,9 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import { isIncompleteExtractionError } from "../../src/db/migrationDependencyIntegrity";
-import { removeTempDbDir } from "./tempDbDir";
+import { createFileBackedDbHarness } from "./withFileBackedDb";
 
 /**
  * Issue #2833: the incomplete-extraction mapping is scoped to KNOWN migration
@@ -19,33 +18,20 @@ import { removeTempDbDir } from "./tempDbDir";
  * isMissingMigrationDependencyError + createIncompleteExtractionError.)
  */
 describe("startup migration failure does not mislabel a genuine bad import", () => {
-  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
-  const originalMigrationsDir = process.env.AUTOMOBILE_MIGRATIONS_DIR;
-  let tempDir: string | undefined;
+  // Shared harness: fresh module import, tracked temp dirs cleaned with the
+  // bounded `removeTempDbDir`, and full-env snapshot/restore (issue #3046).
+  let harness = createFileBackedDbHarness();
 
-  function restore(key: string, value: string | undefined): void {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-
-  afterEach(async () => {
-    restore("AUTOMOBILE_DB_PATH", originalDbPath);
-    restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
-    if (tempDir) {
-      await removeTempDbDir(tempDir);
-      tempDir = undefined;
-    }
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
   });
 
-  async function importFreshDatabaseModule() {
-    return import(`../../src/db/database.ts?incomplete-extraction-test=${Date.now()}-${Math.random()}`);
-  }
+  afterEach(async () => {
+    await harness.cleanup();
+  });
 
   test("an unknown missing package surfaces the generic error, not incomplete-extraction", async () => {
-    tempDir = await mkdtemp(path.join(tmpdir(), "am-bad-import-"));
+    const tempDir = await harness.makeTempDbDir("am-bad-import-");
     const migrationsDir = path.join(tempDir, "migrations");
     await mkdir(migrationsDir, { recursive: true });
 
@@ -67,9 +53,9 @@ describe("startup migration failure does not mislabel a genuine bad import", () 
     };
     process.on("unhandledRejection", onUnhandled);
 
-    let db: Awaited<ReturnType<typeof importFreshDatabaseModule>> | undefined;
+    let db: Awaited<ReturnType<typeof harness.importFreshDatabaseModule>> | undefined;
     try {
-      db = await importFreshDatabaseModule();
+      db = await harness.importFreshDatabaseModule();
 
       let thrown: unknown;
       try {

--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -1,10 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
-import { removeTempDbDir } from "./tempDbDir";
-import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
+import { createFileBackedDbHarness, WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./withFileBackedDb";
 
 /**
  * Regression test for the module-load-time-vs-runtime path hazard.
@@ -17,30 +14,17 @@ import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
  * Daemon.start() records after import — matching migrator.ts's runtime resolution.
  */
 describe("database path lazy resolution", () => {
-  const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
-  const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
-  const originalMigrationsDir = process.env.AUTOMOBILE_MIGRATIONS_DIR;
-  const originalLegacyMigrationsDir = process.env.AUTO_MOBILE_MIGRATIONS_DIR;
+  // Shared harness: fresh module import, tracked temp dirs cleaned with the
+  // bounded `removeTempDbDir`, and full-env snapshot/restore (issue #3046).
+  let harness = createFileBackedDbHarness();
 
-  function restore(key: string, value: string | undefined): void {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-
-  afterEach(() => {
-    restore(DAEMON_LAUNCH_CWD_ENV, originalLaunchCwd);
-    restore("AUTOMOBILE_DB_DIR", originalDbDir);
-    restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
-    restore("AUTO_MOBILE_MIGRATIONS_DIR", originalLegacyMigrationsDir);
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
   });
 
-  async function importFreshDatabaseModule() {
-    // Fresh module instance so its lazy cache is not shared with other tests.
-    return import(`../../src/db/database.ts?lazy-db-path-test=${Date.now()}-${Math.random()}`);
-  }
+  afterEach(async () => {
+    await harness.cleanup();
+  });
 
   test("resolves relative AUTOMOBILE_DB_DIR against the launch cwd set AFTER import", async () => {
     const importTimeCwd = process.cwd();
@@ -51,7 +35,7 @@ describe("database path lazy resolution", () => {
     process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
 
     // Daemon.start() records the launch cwd only after import / before first use.
     process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
@@ -67,7 +51,7 @@ describe("database path lazy resolution", () => {
     process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
 
     process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
     const first = databaseModule.getDatabasePath();
@@ -80,11 +64,11 @@ describe("database path lazy resolution", () => {
   });
 
   test("queries issued immediately after getDatabase wait for startup migrations", async () => {
-    const dbDir = await mkdtemp(path.join(tmpdir(), "auto-mobile-db-startup-"));
+    const dbDir = await harness.makeTempDbDir("auto-mobile-db-startup-");
     process.env.AUTOMOBILE_DB_DIR = dbDir;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
     const db = databaseModule.getDatabase();
 
     try {
@@ -96,7 +80,6 @@ describe("database path lazy resolution", () => {
       expect(rows).toEqual([]);
     } finally {
       await databaseModule.closeDatabase();
-      await removeTempDbDir(dbDir);
     }
     // Opens a real temp DB and runs the full startup migration set. A cold,
     // loaded windows-latest runner legitimately needs more than bun's 5s
@@ -105,13 +88,13 @@ describe("database path lazy resolution", () => {
   }, WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
 
   test("queries fail clearly and consistently when startup migrations fail", async () => {
-    const dbDir = await mkdtemp(path.join(tmpdir(), "auto-mobile-db-startup-fail-"));
+    const dbDir = await harness.makeTempDbDir("auto-mobile-db-startup-fail-");
     process.env.AUTOMOBILE_DB_DIR = dbDir;
     process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(dbDir, "missing-migrations");
     delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
     const db = databaseModule.getDatabase();
     const query = () =>
       db
@@ -128,7 +111,6 @@ describe("database path lazy resolution", () => {
       );
     } finally {
       await databaseModule.closeDatabase();
-      await removeTempDbDir(dbDir);
     }
     // File-backed like the sibling above; the same generous ceiling covers a
     // slow Windows startup-migration attempt before it fails clearly (#2992).

--- a/test/db/databaseLifecycleReset.test.ts
+++ b/test/db/databaseLifecycleReset.test.ts
@@ -1,9 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
-import { defaultTimer } from "../../src/utils/SystemTimer";
+import { createFileBackedDbHarness, WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./withFileBackedDb";
 
 /**
  * Structural guard for issue #2900.
@@ -31,59 +29,17 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
  * internals.
  */
 describe("closeDatabase resets the migration/path lifecycle as one set (issue #2900)", () => {
-  const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
-  const originalDbDir = process.env.AUTOMOBILE_DB_DIR;
-  const originalDbPath = process.env.AUTOMOBILE_DB_PATH;
-  const originalMigrationsDir = process.env.AUTOMOBILE_MIGRATIONS_DIR;
-  const originalLegacyMigrationsDir = process.env.AUTO_MOBILE_MIGRATIONS_DIR;
+  // Shared harness: fresh module import, tracked temp dirs cleaned with the
+  // bounded `removeTempDbDir`, and full-env snapshot/restore (issue #3046).
+  let harness = createFileBackedDbHarness();
 
-  function restore(key: string, value: string | undefined): void {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-
-  const tempDirs: string[] = [];
-
-  afterEach(async () => {
-    restore(DAEMON_LAUNCH_CWD_ENV, originalLaunchCwd);
-    restore("AUTOMOBILE_DB_DIR", originalDbDir);
-    restore("AUTOMOBILE_DB_PATH", originalDbPath);
-    restore("AUTOMOBILE_MIGRATIONS_DIR", originalMigrationsDir);
-    restore("AUTO_MOBILE_MIGRATIONS_DIR", originalLegacyMigrationsDir);
-    for (const dir of tempDirs.splice(0)) {
-      await removeTempDirWithRetry(dir);
-    }
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
   });
 
-  async function importFreshDatabaseModule() {
-    // Fresh module instance so its lazy globals are not shared with other tests.
-    return import(`../../src/db/database.ts?lifecycle-reset-test=${Date.now()}-${Math.random()}`);
-  }
-
-  async function makeTempDbDir(prefix: string): Promise<string> {
-    const dir = await mkdtemp(path.join(tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
-  }
-
-  async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await rm(dir, { recursive: true, force: true });
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
-          throw error;
-        }
-        await defaultTimer.sleep(50);
-      }
-    }
-    await rm(dir, { recursive: true, force: true });
-  }
+  afterEach(async () => {
+    await harness.cleanup();
+  });
 
   function queryToolCalls(db: any) {
     return db
@@ -99,14 +55,14 @@ describe("closeDatabase resets the migration/path lifecycle as one set (issue #2
     // `migrationsError` reset would go undetected — the axis would be un-proven.
     // Booting failed-then-healthy exercises all four axes in one flow so a
     // partial `reset()` that skips ANY single field fails here.
-    const failDir = await makeTempDbDir("auto-mobile-lifecycle-fail-");
+    const failDir = await harness.makeTempDbDir("auto-mobile-lifecycle-fail-");
     process.env.AUTOMOBILE_DB_DIR = failDir;
     // Force a startup-migration failure: a migrations dir that does not exist.
     process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(failDir, "missing-migrations");
     delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
 
     // Cold start on the first DB: path resolves + caches, migrations START and
     // FAIL, so migrationsPromise settles and migrationsError is cached non-null.
@@ -128,7 +84,7 @@ describe("closeDatabase resets the migration/path lifecycle as one set (issue #2
     //   - stale migrationsPromise -> ditto (re-arm is gated on it being null)
     //   - stale migrationsError -> the cached failed-boot error rethrows on query
     //                              against the otherwise-healthy reopened DB
-    const healthyDir = await makeTempDbDir("auto-mobile-lifecycle-healthy-");
+    const healthyDir = await harness.makeTempDbDir("auto-mobile-lifecycle-healthy-");
     process.env.AUTOMOBILE_DB_DIR = healthyDir;
     delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
 
@@ -146,5 +102,5 @@ describe("closeDatabase resets the migration/path lifecycle as one set (issue #2
     expect(databaseModule.getMigrationsError()).toBeNull();
 
     await databaseModule.closeDatabase();
-  });
+  }, WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
 });

--- a/test/db/databaseMigrationFailure.test.ts
+++ b/test/db/databaseMigrationFailure.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import path from "path";
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { defaultTimer } from "../../src/utils/SystemTimer";
-import { removeTempDbDir } from "./tempDbDir";
-import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
+import { createFileBackedDbHarness } from "./withFileBackedDb";
 
 /**
  * Verifies the cached-error migration contract that issue #2784 depends on and
@@ -21,24 +17,21 @@ import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatab
  * instance so the module globals are isolated from other tests.
  */
 describe("database startup migration failure contract", () => {
-  let tempDir: string | undefined;
-  let envSnapshot: NodeJS.ProcessEnv;
+  // Shared harness: fresh module import, tracked temp dirs cleaned with the
+  // bounded `removeTempDbDir`, and full-env snapshot/restore (issue #3046).
+  let harness = createFileBackedDbHarness();
 
   beforeEach(() => {
-    envSnapshot = snapshotEnv();
+    harness = createFileBackedDbHarness();
   });
 
   afterEach(async () => {
-    restoreEnv(envSnapshot);
-    if (tempDir) {
-      await removeTempDbDir(tempDir);
-      tempDir = undefined;
-    }
+    await harness.cleanup();
   });
 
   test("ensureMigrations rethrows the cached startup error without floating a rejection", async () => {
     // Point the DB path at a directory so opening the sqlite file fails.
-    tempDir = await mkdtemp(path.join(tmpdir(), "am-db-fail-"));
+    const tempDir = await harness.makeTempDbDir("am-db-fail-");
     process.env.AUTOMOBILE_DB_PATH = tempDir; // a directory, not a file
 
     const unhandled: unknown[] = [];
@@ -48,7 +41,7 @@ describe("database startup migration failure contract", () => {
     process.on("unhandledRejection", onUnhandled);
 
     try {
-      const db = await importFreshDatabaseModule();
+      const db = await harness.importFreshDatabaseModule();
 
       await expect(db.ensureMigrations()).rejects.toThrow(
         /refusing to run queries until the daemon restarts/i

--- a/test/db/databaseMigrationGenerationFence.test.ts
+++ b/test/db/databaseMigrationGenerationFence.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { createFileBackedDbHarness } from "./withFileBackedDb";
 
 /**
  * Regression tests for issue #2898 (follow-up to #2889 / #2796).
@@ -29,20 +29,17 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
  * lazy globals, matching databaseReset.test.ts / databaseMigrationFailure.test.ts.
  */
 describe("closeDatabase fences stale in-flight migration completions (issue #2898)", () => {
-  const savedEnv = new Map<string, string | undefined>();
-  const trackedEnvKeys = [
-    DAEMON_LAUNCH_CWD_ENV,
-    "AUTOMOBILE_DB_DIR",
-    "AUTOMOBILE_DB_PATH",
-    "AUTO_MOBILE_DB_PATH",
-    "AUTOMOBILE_MIGRATIONS_DIR",
-    "AUTO_MOBILE_MIGRATIONS_DIR",
-  ];
-  const tempDirs: string[] = [];
+  // Shared harness: fresh module import, tracked temp dirs cleaned with the
+  // bounded `removeTempDbDir`, and full-env snapshot/restore (issue #3046).
+  let harness = createFileBackedDbHarness();
 
-  for (const key of trackedEnvKeys) {
-    savedEnv.set(key, process.env[key]);
-  }
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
 
   function setEnv(key: string, value: string | undefined): void {
     if (value === undefined) {
@@ -52,40 +49,7 @@ describe("closeDatabase fences stale in-flight migration completions (issue #289
     }
   }
 
-  afterEach(async () => {
-    for (const key of trackedEnvKeys) {
-      setEnv(key, savedEnv.get(key));
-    }
-    for (const dir of tempDirs.splice(0)) {
-      await removeTempDirWithRetry(dir);
-    }
-  });
-
-  async function importFreshDatabaseModule() {
-    return import(`../../src/db/database.ts?gen-fence-test=${Date.now()}-${Math.random()}`);
-  }
-
-  async function makeTempDir(prefix: string): Promise<string> {
-    const dir = await mkdtemp(path.join(tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
-  }
-
-  async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await rm(dir, { recursive: true, force: true });
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
-          throw error;
-        }
-        await defaultTimer.sleep(50);
-      }
-    }
-    await rm(dir, { recursive: true, force: true });
-  }
+  const makeTempDir = (prefix: string): Promise<string> => harness.makeTempDbDir(prefix);
 
   /**
    * A migrations dir with a single migration whose `up()` blocks until a
@@ -181,7 +145,7 @@ export async function down(db) {
       setEnv("AUTOMOBILE_DB_DIR", dbDir1);
       setEnv("AUTOMOBILE_MIGRATIONS_DIR", slowFailDir);
 
-      const db = await importFreshDatabaseModule();
+      const db = await harness.importFreshDatabaseModule();
 
       // Generation 0: start the slow, will-fail migration and hold it in flight.
       db.getDatabase();
@@ -245,7 +209,7 @@ export async function down(db) {
       setEnv("AUTOMOBILE_DB_DIR", dbDir1);
       setEnv("AUTOMOBILE_MIGRATIONS_DIR", slowSucceedDir);
 
-      const db = await importFreshDatabaseModule();
+      const db = await harness.importFreshDatabaseModule();
 
       // Generation 0: start the slow, will-succeed migration and hold it.
       db.getDatabase();
@@ -326,7 +290,7 @@ export async function down(db) {
       setEnv("AUTOMOBILE_DB_DIR", sharedDbDir);
       setEnv("AUTOMOBILE_MIGRATIONS_DIR", slowFailDir);
 
-      const db = await importFreshDatabaseModule();
+      const db = await harness.importFreshDatabaseModule();
 
       // Generation 0: slow, will-fail migration on the shared DB path, held in flight.
       db.getDatabase();

--- a/test/db/databaseMigrationLockReopen.test.ts
+++ b/test/db/databaseMigrationLockReopen.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { createFileBackedDbHarness } from "./withFileBackedDb";
 
 /**
  * Regression test for issue #2947 (sibling of the #2898 generation fence).
@@ -30,20 +30,17 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
  * A fresh module instance per case isolates the lazy globals.
  */
 describe("in-process same-path reopen cannot steal an in-flight migration's lock (issue #2947)", () => {
-  const savedEnv = new Map<string, string | undefined>();
-  const trackedEnvKeys = [
-    DAEMON_LAUNCH_CWD_ENV,
-    "AUTOMOBILE_DB_DIR",
-    "AUTOMOBILE_DB_PATH",
-    "AUTO_MOBILE_DB_PATH",
-    "AUTOMOBILE_MIGRATIONS_DIR",
-    "AUTO_MOBILE_MIGRATIONS_DIR",
-  ];
-  const tempDirs: string[] = [];
+  // Shared harness: fresh module import, tracked temp dirs cleaned with the
+  // bounded `removeTempDbDir`, and full-env snapshot/restore (issue #3046).
+  let harness = createFileBackedDbHarness();
 
-  for (const key of trackedEnvKeys) {
-    savedEnv.set(key, process.env[key]);
-  }
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
 
   function setEnv(key: string, value: string | undefined): void {
     if (value === undefined) {
@@ -53,40 +50,7 @@ describe("in-process same-path reopen cannot steal an in-flight migration's lock
     }
   }
 
-  afterEach(async () => {
-    for (const key of trackedEnvKeys) {
-      setEnv(key, savedEnv.get(key));
-    }
-    for (const dir of tempDirs.splice(0)) {
-      await removeTempDirWithRetry(dir);
-    }
-  });
-
-  async function importFreshDatabaseModule() {
-    return import(`../../src/db/database.ts?lock-reopen-test=${Date.now()}-${Math.random()}`);
-  }
-
-  async function makeTempDir(prefix: string): Promise<string> {
-    const dir = await mkdtemp(path.join(tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
-  }
-
-  async function removeTempDirWithRetry(dir: string): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await rm(dir, { recursive: true, force: true });
-        return;
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
-          throw error;
-        }
-        await defaultTimer.sleep(50);
-      }
-    }
-    await rm(dir, { recursive: true, force: true });
-  }
+  const makeTempDir = (prefix: string): Promise<string> => harness.makeTempDbDir(prefix);
 
   /**
    * A migrations dir with one migration that WRITES to the DB (creates `probe`
@@ -175,7 +139,7 @@ export async function down(db) {
       // concurrent-migration collision scenario.
       setEnv("AUTOMOBILE_MIGRATIONS_DIR", migrationsDir);
 
-      const db = await importFreshDatabaseModule();
+      const db = await harness.importFreshDatabaseModule();
 
       // Generation 0: start the slow, WRITING migration and hold it in flight
       // (mid-run, still holding the migrate lock).

--- a/test/db/databaseReset.test.ts
+++ b/test/db/databaseReset.test.ts
@@ -55,17 +55,15 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
   }
 
   test("reopen after close re-runs migrations against a fresh DB (migrationsRun reset)", async () => {
-    const firstDir = await makeTempDbDir("auto-mobile-reset-first-");
-    process.env.AUTOMOBILE_DB_DIR = firstDir;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+    // Cold start on the first DB via the shared open helper — fresh module +
+    // tracked temp dir + `getDatabase()` then awaited migrations (the #2992/#3040
+    // ordering). Querying a migrated table proves migrations actually ran
+    // (migrationsRun became true).
+    const first = await harness.openLifecycleTestDb("auto-mobile-reset-first-");
+    const databaseModule = first.module;
+    expect(await queryToolCalls(databaseModule.getDatabase())).toEqual([]);
 
-    const databaseModule = await harness.importFreshDatabaseModule();
-
-    // Cold start on the first DB: migrations run, migrationsRun becomes true.
-    const firstDb = databaseModule.getDatabase();
-    expect(await queryToolCalls(firstDb)).toEqual([]);
-
-    await databaseModule.closeDatabase();
+    await first.close();
 
     // Point at a brand-new, empty DB dir and reopen in the same process.
     const secondDir = await makeTempDbDir("auto-mobile-reset-second-");

--- a/test/db/databaseReset.test.ts
+++ b/test/db/databaseReset.test.ts
@@ -1,11 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
-import { removeTempDbDir } from "./tempDbDir";
-import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
-import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
+import { createFileBackedDbHarness, WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./withFileBackedDb";
 
 /**
  * Regression tests for issue #2796.
@@ -35,27 +31,21 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
   // hook timeout. Shares the one canonical file-backed ceiling (issue #2992).
   const FILE_BACKED_TEST_TIMEOUT_MS = WINDOWS_FILE_DB_TEST_TIMEOUT_MS;
 
-  const tempDirs: string[] = [];
-  let envSnapshot: NodeJS.ProcessEnv;
+  // Shared harness: fresh module import, tracked temp dirs cleaned with the
+  // bounded `removeTempDbDir`, and full-env snapshot/restore (issue #3046). The
+  // snapshot is taken per test (in `beforeEach`) so every mutated key is restored
+  // regardless of which ones a given test touches.
+  let harness = createFileBackedDbHarness();
 
   beforeEach(() => {
-    // Snapshot the full env so every mutated key is restored regardless of which
-    // ones a given test touches (avoids a hand-maintained key list going stale).
-    envSnapshot = snapshotEnv();
+    harness = createFileBackedDbHarness();
   });
 
   afterEach(async () => {
-    restoreEnv(envSnapshot);
-    for (const dir of tempDirs.splice(0)) {
-      await removeTempDbDir(dir);
-    }
+    await harness.cleanup();
   });
 
-  async function makeTempDbDir(prefix: string): Promise<string> {
-    const dir = await mkdtemp(path.join(tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
-  }
+  const makeTempDbDir = (prefix: string): Promise<string> => harness.makeTempDbDir(prefix);
 
   function queryToolCalls(db: any) {
     return db
@@ -69,7 +59,7 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     process.env.AUTOMOBILE_DB_DIR = firstDir;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
 
     // Cold start on the first DB: migrations run, migrationsRun becomes true.
     const firstDb = databaseModule.getDatabase();
@@ -107,7 +97,7 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     process.env.AUTOMOBILE_DB_DIR = firstDir;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
 
     // Resolve once so resolvedDbPath is cached (no DB file opened).
     expect(databaseModule.getDatabasePath()).toBe(path.join(firstDir, "auto-mobile.db"));
@@ -129,7 +119,7 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+    const databaseModule = await harness.importFreshDatabaseModule();
 
     const failingDb = databaseModule.getDatabase();
     await expect(queryToolCalls(failingDb)).rejects.toThrow(

--- a/test/db/withFileBackedDb.test.ts
+++ b/test/db/withFileBackedDb.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import path from "path";
+import { tmpdir } from "node:os";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
+import {
+  createFileBackedDbHarness,
+  WINDOWS_FILE_DB_TEST_TIMEOUT_MS as HARNESS_TIMEOUT_REEXPORT,
+} from "./withFileBackedDb";
+import type { LifecycleDatabaseModule } from "./withFileBackedDb";
+
+/**
+ * Unit tests for the shared file-backed DB-lifecycle harness (issue #3046).
+ *
+ * The harness centralizes the flake-avoidance pattern the file-backed DB
+ * lifecycle suites otherwise re-apply by hand (#2916/#2992/#3040). These tests
+ * inject fakes for every side effect — `mkdtemp`, temp-dir removal, the fresh
+ * `database.ts` module, and the environment object — so the orchestration is
+ * proven with no real filesystem, DB, or wall-clock and stays <100ms. The real
+ * migrated suites exercise the un-injected path against a real temp DB.
+ */
+describe("createFileBackedDbHarness (issue #3046)", () => {
+  /** A fake `database.ts` module that records the order of lifecycle calls. */
+  function makeFakeModule(dbPath = "/fake/db/auto-mobile.db"): LifecycleDatabaseModule & {
+    calls: string[];
+  } {
+    const calls: string[] = [];
+    return {
+      calls,
+      getDatabase() {
+        calls.push("getDatabase");
+        return {} as never;
+      },
+      async ensureMigrations() {
+        calls.push("ensureMigrations");
+      },
+      async closeDatabase() {
+        calls.push("closeDatabase");
+      },
+      getDatabasePath() {
+        calls.push("getDatabasePath");
+        return dbPath;
+      },
+    };
+  }
+
+  /** A fake mkdtemp that returns a deterministic unique dir per call. */
+  function makeFakeMkdtemp() {
+    const received: string[] = [];
+    let counter = 0;
+    const mkdtemp = async (prefix: string): Promise<string> => {
+      received.push(prefix);
+      counter += 1;
+      return `/fake-tmp/${prefix}${counter}`;
+    };
+    return { mkdtemp, received };
+  }
+
+  /** A fake temp-dir remover that records each dir it was asked to remove. */
+  function makeFakeRemover() {
+    const removed: string[] = [];
+    const removeTempDir = async (dir: string): Promise<void> => {
+      removed.push(dir);
+    };
+    return { removeTempDir, removed };
+  }
+
+  test("re-exports the canonical file-backed timeout constant", () => {
+    expect(HARNESS_TIMEOUT_REEXPORT).toBe(WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
+  });
+
+  test("makeTempDbDir joins tmpdir onto the prefix, tracks, and returns the dir", async () => {
+    const { mkdtemp, received } = makeFakeMkdtemp();
+    const { removeTempDir, removed } = makeFakeRemover();
+    const harness = createFileBackedDbHarness({ mkdtemp, removeTempDir, env: {} });
+
+    const dir = await harness.makeTempDbDir("am-x-");
+
+    // The tmpdir join is the harness's responsibility, so the fake receives an
+    // absolute path under the OS temp dir — not the bare prefix.
+    expect(received).toEqual([path.join(tmpdir(), "am-x-")]);
+    expect(dir).toBe(`/fake-tmp/${path.join(tmpdir(), "am-x-")}1`);
+
+    // Tracked: cleanup removes exactly what makeTempDbDir handed out.
+    await harness.cleanup();
+    expect(removed).toEqual([dir]);
+  });
+
+  test("cleanup removes every tracked dir and restores the env to its creation snapshot", async () => {
+    const { mkdtemp } = makeFakeMkdtemp();
+    const { removeTempDir, removed } = makeFakeRemover();
+    const env: NodeJS.ProcessEnv = { KEEP: "1", CHANGE: "old", REMOVE: "x" };
+
+    // Snapshot is taken at creation.
+    const harness = createFileBackedDbHarness({ mkdtemp, removeTempDir, env });
+
+    const a = await harness.makeTempDbDir("a-");
+    const b = await harness.makeTempDbDir("b-");
+
+    // Mutate the env the way a test would: add, change, and delete keys.
+    env.ADDED = "new";
+    env.CHANGE = "new";
+    delete env.REMOVE;
+
+    await harness.cleanup();
+
+    expect(removed).toEqual([a, b]);
+    expect(env).toEqual({ KEEP: "1", CHANGE: "old", REMOVE: "x" });
+  });
+
+  test("openLifecycleTestDb points env at a fresh tracked dir and clears overrides", async () => {
+    const { mkdtemp } = makeFakeMkdtemp();
+    const { removeTempDir } = makeFakeRemover();
+    const fake = makeFakeModule();
+    const env: NodeJS.ProcessEnv = {
+      AUTOMOBILE_DB_PATH: "/stale/path",
+      AUTO_MOBILE_DB_PATH: "/stale/legacy",
+      AUTOMOBILE_MIGRATIONS_DIR: "/stale/migrations",
+      AUTO_MOBILE_MIGRATIONS_DIR: "/stale/legacy-migrations",
+      [DAEMON_LAUNCH_CWD_ENV]: "/stale/cwd",
+    };
+    const harness = createFileBackedDbHarness({
+      mkdtemp,
+      removeTempDir,
+      env,
+      importDatabaseModule: async () => fake,
+    });
+
+    const opened = await harness.openLifecycleTestDb("am-life-");
+
+    // Bound to the fresh temp dir; every path/migration override that could
+    // derail a healthy boot is cleared.
+    expect(env.AUTOMOBILE_DB_DIR).toBe(opened.dir);
+    expect(env.AUTOMOBILE_DB_PATH).toBeUndefined();
+    expect(env.AUTO_MOBILE_DB_PATH).toBeUndefined();
+    expect(env.AUTOMOBILE_MIGRATIONS_DIR).toBeUndefined();
+    expect(env.AUTO_MOBILE_MIGRATIONS_DIR).toBeUndefined();
+    expect(env[DAEMON_LAUNCH_CWD_ENV]).toBeUndefined();
+
+    expect(opened.module).toBe(fake);
+    expect(opened.dbPath).toBe("/fake/db/auto-mobile.db");
+  });
+
+  test("openLifecycleTestDb runs getDatabase() BEFORE ensureMigrations() (the #2992 ordering)", async () => {
+    const { mkdtemp } = makeFakeMkdtemp();
+    const { removeTempDir } = makeFakeRemover();
+    const fake = makeFakeModule();
+    const harness = createFileBackedDbHarness({
+      mkdtemp,
+      removeTempDir,
+      env: {},
+      importDatabaseModule: async () => fake,
+    });
+
+    await harness.openLifecycleTestDb("am-life-");
+
+    // The whole point of the harness: the detached migration connection is armed
+    // (getDatabase) and then awaited (ensureMigrations) before any close, so a
+    // close-time WAL checkpoint can't contend on Windows.
+    const getIdx = fake.calls.indexOf("getDatabase");
+    const ensureIdx = fake.calls.indexOf("ensureMigrations");
+    expect(getIdx).toBeGreaterThanOrEqual(0);
+    expect(ensureIdx).toBeGreaterThan(getIdx);
+  });
+
+  test("openLifecycleTestDb close() closes the DB and removes+untracks its dir (no double-remove)", async () => {
+    const { mkdtemp } = makeFakeMkdtemp();
+    const { removeTempDir, removed } = makeFakeRemover();
+    const fake = makeFakeModule();
+    const harness = createFileBackedDbHarness({
+      mkdtemp,
+      removeTempDir,
+      env: {},
+      importDatabaseModule: async () => fake,
+    });
+
+    const opened = await harness.openLifecycleTestDb("am-life-");
+    await opened.close();
+
+    expect(fake.calls).toContain("closeDatabase");
+    expect(removed).toEqual([opened.dir]);
+
+    // cleanup must not remove the same dir a second time.
+    await harness.cleanup();
+    expect(removed).toEqual([opened.dir]);
+  });
+
+  test("importFreshDatabaseModule delegates to the injected importer", async () => {
+    const { mkdtemp } = makeFakeMkdtemp();
+    const { removeTempDir } = makeFakeRemover();
+    const fake = makeFakeModule();
+    let importCount = 0;
+    const harness = createFileBackedDbHarness({
+      mkdtemp,
+      removeTempDir,
+      env: {},
+      importDatabaseModule: async () => {
+        importCount += 1;
+        return fake;
+      },
+    });
+
+    const mod = await harness.importFreshDatabaseModule();
+
+    expect(mod).toBe(fake);
+    expect(importCount).toBe(1);
+  });
+
+  test("cleanup restores the env even if a temp-dir removal throws", async () => {
+    const { mkdtemp } = makeFakeMkdtemp();
+    const env: NodeJS.ProcessEnv = { CHANGE: "old" };
+    const removeTempDir = async (): Promise<void> => {
+      throw new Error("boom");
+    };
+    const harness = createFileBackedDbHarness({ mkdtemp, removeTempDir, env });
+
+    await harness.makeTempDbDir("a-");
+    env.CHANGE = "new";
+    env.ADDED = "leak";
+
+    await expect(harness.cleanup()).rejects.toThrow("boom");
+    // The env restore runs in a finally so a flaky removal never leaks env state
+    // into the next test.
+    expect(env).toEqual({ CHANGE: "old" });
+  });
+
+  test("cleanup is a no-op-safe call when nothing was tracked", async () => {
+    const { mkdtemp } = makeFakeMkdtemp();
+    const { removeTempDir, removed } = makeFakeRemover();
+    const harness = createFileBackedDbHarness({ mkdtemp, removeTempDir, env: {} });
+
+    await harness.cleanup();
+    expect(removed).toEqual([]);
+  });
+});
+
+/**
+ * Integration test for the un-injected `openLifecycleTestDb` path (issue #3046).
+ *
+ * The fake-based unit tests above prove the orchestration; this one drives the
+ * real convenience method end-to-end against a genuine temp `.db` — a fresh
+ * `database.ts` module, the full startup migration set on a real file, then a
+ * self-cleaning `close()`. It both guards the real integration the fakes cannot
+ * (a migrated schema is actually queryable) and doubles as the reference example
+ * a new file-backed suite copies. It is the one file-backed body here, so it
+ * carries the shared `WINDOWS_FILE_DB_TEST_TIMEOUT_MS` ceiling.
+ *
+ * It deliberately does NOT assert the temp dir is gone after `close()`:
+ * `removeTempDbDir` is bounded/best-effort and GIVES UP (leaving the dir for the
+ * OS sweeper) when Windows holds the sqlite handle past `destroy()` — asserting
+ * removal would reintroduce the exact flake class this harness exists to avoid
+ * (#2916). The Windows-safe contract is that `close()` resolves and the dir is
+ * untracked so a following `cleanup()` never double-removes it.
+ */
+describe("openLifecycleTestDb against a real file-backed DB (issue #3046)", () => {
+  let harness = createFileBackedDbHarness();
+
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  test(
+    "opens + migrates a real temp DB, exposes a queryable migrated schema, and self-cleans on close",
+    async () => {
+      const opened = await harness.openLifecycleTestDb("am-harness-int-");
+
+      // dbPath resolves inside the fresh temp dir the harness created.
+      expect(opened.dbPath).toBe(path.join(opened.dir, "auto-mobile.db"));
+      expect(process.env.AUTOMOBILE_DB_DIR).toBe(opened.dir);
+
+      // The migrated schema is genuinely present: `ensureMigrations()` already
+      // ran the full startup set, so a query against a migrated table returns
+      // rows (empty) rather than "no such table: tool_calls".
+      const db = opened.module.getDatabase() as ReturnType<
+        Awaited<ReturnType<typeof harness.importFreshDatabaseModule>>["getDatabase"]
+      >;
+      const rows = await db
+        .selectFrom("tool_calls" as never)
+        .selectAll()
+        .execute();
+      expect(rows).toEqual([]);
+
+      // close() destroys the connection and removes+untracks its temp dir
+      // (best-effort: it may survive on a Windows handle livelock, which is why
+      // we assert close() resolves rather than that the dir is gone).
+      await expect(opened.close()).resolves.toBeUndefined();
+
+      // Untracked by close(): a subsequent cleanup() must not throw trying to
+      // remove it a second time.
+      await expect(harness.cleanup()).resolves.toBeUndefined();
+    },
+    WINDOWS_FILE_DB_TEST_TIMEOUT_MS
+  );
+});

--- a/test/db/withFileBackedDb.ts
+++ b/test/db/withFileBackedDb.ts
@@ -1,0 +1,214 @@
+import path from "path";
+import { mkdtemp as fsMkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { importFreshDatabaseModule } from "./freshDatabaseModule";
+import { removeTempDbDir } from "./tempDbDir";
+import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
+
+/**
+ * Shared harness that enforces the file-backed DB-lifecycle flake-avoidance
+ * pattern in ONE place (issue #3046).
+ *
+ * This is the third round of the same Windows file-backed DB test flake class
+ * (#2916 -> #2923, #2992 -> #3040). Each prior round hardened the *instances*
+ * that were flaking; nothing enforced the pattern, so the next engineer who
+ * added a file-backed close/reopen suite re-hit it. The knowledge lived only in
+ * prose comments across ~5 files, and prose did not stop the recurrence.
+ *
+ * Every file-backed DB lifecycle suite must independently remember to:
+ *   1. import a FRESH `database.ts` module so its lazy module-globals
+ *      (`resolvedDbPath`, the migration state machine, ...) are isolated
+ *      ({@link importFreshDatabaseModule}, #2916),
+ *   2. track its temp dirs and clean them with the BOUNDED {@link removeTempDbDir}
+ *      so a Windows file-handle livelock can never stall `afterEach` (#2916),
+ *   3. call `getDatabase()` and THEN `await ensureMigrations()` before
+ *      `closeDatabase()`, so the detached migration connection settles instead of
+ *      contending with the close-time WAL checkpoint on Windows (#2992/#3040),
+ *   4. apply {@link WINDOWS_FILE_DB_TEST_TIMEOUT_MS} to the slow-but-correct
+ *      migration body.
+ *
+ * A suite wires `createFileBackedDbHarness()` into `beforeEach` (fresh env
+ * snapshot per test) and `harness.cleanup()` into `afterEach`. It then either
+ * drives the module directly via the primitives ({@link makeTempDbDir},
+ * {@link importFreshDatabaseModule}) for tests that control the migration
+ * lifecycle mid-flight, or uses {@link openLifecycleTestDb} for the common
+ * open+migrate+close flow. Correct ordering is now the path of least resistance
+ * and a new suite gets the whole pattern for free.
+ *
+ * Every side effect is injectable (`mkdtemp`, `removeTempDir`,
+ * `importDatabaseModule`, `env`) so the orchestration is unit-tested with fakes —
+ * no real filesystem, DB, or wall-clock — keeping those tests <100ms. The real
+ * migrated suites exercise the un-injected path against a temp DB.
+ */
+
+/**
+ * The narrow slice of `database.ts` the harness drives. Kept minimal (YAGNI):
+ * suites that need the wider module surface (`getMigrationsError`,
+ * `getMigrationsPromiseForTest`, ...) use the fuller type returned by
+ * {@link importFreshDatabaseModule} directly.
+ */
+export interface LifecycleDatabaseModule {
+  getDatabase(): unknown;
+  ensureMigrations(): Promise<void>;
+  closeDatabase(): Promise<void>;
+  getDatabasePath(): string;
+}
+
+/**
+ * The full fresh `database.ts` module type (the default the harness hands back),
+ * so suites can reach beyond the narrow lifecycle slice — `getMigrationsError`,
+ * `getMigrationsPromiseForTest`, ... — without a cast.
+ */
+export type FreshDatabaseModule = Awaited<ReturnType<typeof importFreshDatabaseModule>>;
+
+/** A single open+migrated file-backed DB, with a self-cleaning `close()`. */
+export interface OpenLifecycleTestDb<M extends LifecycleDatabaseModule = FreshDatabaseModule> {
+  /** The fresh `database.ts` module instance backing this DB. */
+  module: M;
+  /** The tracked temp dir holding the `.db` file. */
+  dir: string;
+  /** The resolved `auto-mobile.db` path inside {@link dir}. */
+  dbPath: string;
+  /** Close the connection and remove (and untrack) this DB's temp dir. */
+  close(): Promise<void>;
+}
+
+export interface FileBackedDbHarness<M extends LifecycleDatabaseModule = FreshDatabaseModule> {
+  /** `mkdtemp` a tracked temp dir under the OS temp dir for the given prefix. */
+  makeTempDbDir(prefix: string): Promise<string>;
+  /** Import a fresh, isolated `database.ts` module instance. */
+  importFreshDatabaseModule(): Promise<M>;
+  /**
+   * Open a file-backed DB the correct way: fresh module + tracked temp dir +
+   * `AUTOMOBILE_DB_DIR` pointed at it (path/migration overrides cleared) +
+   * `getDatabase()` then `await ensureMigrations()`.
+   */
+  openLifecycleTestDb(prefix: string): Promise<OpenLifecycleTestDb<M>>;
+  /** Remove every still-tracked temp dir (bounded) and restore the env snapshot. */
+  cleanup(): Promise<void>;
+}
+
+export interface FileBackedDbHarnessDeps<M extends LifecycleDatabaseModule = FreshDatabaseModule> {
+  /**
+   * Create a temp dir at an absolute path. Defaults to `fs.mkdtemp`; the harness
+   * always passes an absolute `tmpdir()`-joined prefix, so the injected fake
+   * receives that full path.
+   */
+  mkdtemp?: (fullPrefix: string) => Promise<string>;
+  /** Remove a temp dir. Defaults to the BOUNDED {@link removeTempDbDir} (#2916). */
+  removeTempDir?: (dir: string) => Promise<void>;
+  /** Import a fresh `database.ts` module. Defaults to {@link importFreshDatabaseModule}. */
+  importDatabaseModule?: () => Promise<M>;
+  /** The environment object to snapshot/restore. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Env override keys that could redirect a healthy `openLifecycleTestDb` boot away
+ * from the fresh temp dir (a stale `AUTOMOBILE_DB_PATH` wins over
+ * `AUTOMOBILE_DB_DIR`; a stale migrations dir would fail the migration). Cleared
+ * before each open so the only binding is the tracked temp dir.
+ */
+const LIFECYCLE_OVERRIDE_ENV_KEYS = [
+  "AUTOMOBILE_DB_PATH",
+  "AUTO_MOBILE_DB_PATH",
+  "AUTOMOBILE_MIGRATIONS_DIR",
+  "AUTO_MOBILE_MIGRATIONS_DIR",
+  DAEMON_LAUNCH_CWD_ENV,
+] as const;
+
+export function createFileBackedDbHarness<M extends LifecycleDatabaseModule = FreshDatabaseModule>(
+  deps: FileBackedDbHarnessDeps<M> = {}
+): FileBackedDbHarness<M> {
+  const mkdtemp = deps.mkdtemp ?? (fullPrefix => fsMkdtemp(fullPrefix));
+  const removeTempDir = deps.removeTempDir ?? (dir => removeTempDbDir(dir));
+  const importModule =
+    deps.importDatabaseModule ??
+    (importFreshDatabaseModule as unknown as () => Promise<M>);
+  const env = deps.env ?? process.env;
+
+  // Full-env snapshot taken at creation so every mutated key is restored
+  // regardless of which keys a given test touches — no hand-maintained key list
+  // can go stale (mirrors freshDatabaseModule's snapshotEnv/restoreEnv, but on
+  // the injected env object so unit tests never touch the real process.env).
+  const envSnapshot: NodeJS.ProcessEnv = { ...env };
+  const tempDirs: string[] = [];
+
+  async function makeTempDbDir(prefix: string): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function restoreEnv(): void {
+    for (const key of Object.keys(env)) {
+      if (!(key in envSnapshot)) {
+        delete env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value !== undefined) {
+        env[key] = value;
+      }
+    }
+  }
+
+  async function removeTracked(dir: string): Promise<void> {
+    const index = tempDirs.indexOf(dir);
+    if (index !== -1) {
+      tempDirs.splice(index, 1);
+    }
+    await removeTempDir(dir);
+  }
+
+  async function openLifecycleTestDb(prefix: string): Promise<OpenLifecycleTestDb<M>> {
+    const dir = await makeTempDbDir(prefix);
+
+    // Bind the fresh temp dir and clear every override that could redirect the
+    // boot elsewhere, so the healthy migration always targets this file.
+    env.AUTOMOBILE_DB_DIR = dir;
+    for (const key of LIFECYCLE_OVERRIDE_ENV_KEYS) {
+      delete env[key];
+    }
+
+    const module = await importModule();
+
+    // The #2992/#3040 ordering: arm the detached migration connection, then AWAIT
+    // it, before any close — so the close-time WAL checkpoint has nothing left to
+    // contend with on Windows.
+    module.getDatabase();
+    await module.ensureMigrations();
+
+    const dbPath = module.getDatabasePath();
+
+    return {
+      module,
+      dir,
+      dbPath,
+      async close() {
+        await module.closeDatabase();
+        await removeTracked(dir);
+      },
+    };
+  }
+
+  async function cleanup(): Promise<void> {
+    try {
+      for (const dir of tempDirs.splice(0)) {
+        await removeTempDir(dir);
+      }
+    } finally {
+      restoreEnv();
+    }
+  }
+
+  return {
+    makeTempDbDir,
+    importFreshDatabaseModule: importModule,
+    openLifecycleTestDb,
+    cleanup,
+  };
+}
+
+export { WINDOWS_FILE_DB_TEST_TIMEOUT_MS };


### PR DESCRIPTION
## Summary

Closes #3046. Follow-up from the direction/alternatives review of #3040 (the third round of the same Windows file-backed DB test flake class: #2916 → #2923, #2992 → #3040). Each prior round hardened the *instances* that were flaking; nothing enforced the pattern, so the next engineer who added a file-backed close/reopen suite re-hit it. The knowledge lived only in prose comments spread across ~5 files — and prose did not stop the recurrence.

This adds a shared harness so **correct ordering is the path of least resistance** and a new suite gets the whole pattern for free.

## Sequencing (per the issue's blocker note)

#3046 was blocked by #3047, which moved `dbWriteBarrierResetOnClose` **off files onto a `:memory:` sentinel**. #3047 has landed (main `fa69e26a9`), so this PR is **re-scoped to exclude `dbWriteBarrierResetOnClose`** — it is no longer file-backed. The remaining file-backed lifecycle suites are migrated.

## What changed

- **`test/db/withFileBackedDb.ts`** (new) — `createFileBackedDbHarness(deps?)` centralizes the 4-part pattern in one place:
  1. fresh, isolated `database.ts` module import (collision-proof counter via the existing `importFreshDatabaseModule`, replacing the duplicated `Date.now()-Math.random()` cache-bust keys),
  2. tracked temp dirs cleaned with the **bounded** `removeTempDbDir` (#2916) — replacing three copies of an **unbounded** 100×50ms `removeTempDirWithRetry` that could stall `afterEach`,
  3. `openLifecycleTestDb(prefix)` — the common open path that does `getDatabase()` **then** `await ensureMigrations()` before any close (#2992/#3040 ordering),
  4. full-env snapshot/restore + the shared `WINDOWS_FILE_DB_TEST_TIMEOUT_MS` (re-exported).
  Every side effect (`mkdtemp`, `removeTempDir`, `importDatabaseModule`, `env`) is injectable so the orchestration is unit-tested with fakes.
- **`test/db/withFileBackedDb.test.ts`** (new) — fake-injected unit tests for the orchestration (tracking, env restore, the getDatabase→ensureMigrations ordering, close() untracking, env-restore-in-`finally`), **plus one real-DB integration test** that drives the un-injected `openLifecycleTestDb` end-to-end (fresh module → full startup migration set on a real temp file → queryable migrated `tool_calls` → self-cleaning `close()`). The integration test deliberately does **not** assert the temp dir is gone after close — `removeTempDbDir` is best-effort and gives up on a Windows handle livelock, so asserting removal would reintroduce the flake class; it asserts `close()`/`cleanup()` resolve and the dir is untracked.
- **Migrated onto the harness** (behavior-preserving): `databaseLazyPath`, `databaseReset`, `databaseMigrationFailure`, `databaseMigrationLockReopen`, `databaseLifecycleReset`, `databaseMigrationGenerationFence`, and the same-pattern `databaseIncompleteExtraction`. Each drops its private `importFreshDatabaseModule` / `removeTempDirWithRetry` / env-restore boilerplate. The delicate mid-flight concurrency tests (gen-fence, lock-reopen) keep driving the module directly via the harness primitives; only the simple open+migrate+close flow uses `openLifecycleTestDb`.

## Non-goals / notes

- `dbWriteBarrierResetOnClose` stays on the `:memory:` sentinel from #3047 (excluded here, per the issue).
- `backupDatabaseFile` uses `BunDatabase` directly (not the `database.ts` module), so it is not a lifecycle suite and is left alone.

## Verification

- `bun test test/db/` → **556 pass, 0 fail** (52 files).
- `turbo run lint build` → clean.
- Harness unit tests run with fakes only (no real DB/fs/clock) — well under the 100ms budget; the one real-DB integration test carries the shared file-backed timeout.
- No remaining inline `Date.now()-${Math.random()` fresh-import or unbounded `removeTempDirWithRetry` in `test/db/`.
