### PR TITLE
test(db): guard unit tests against resolving the real file-backed getDatabase() (#3067)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Node TypeScript MCP server providing Android Debug Bridge (ADB) capabilities thr
 - Unit tests should pass in 100ms or less. Do not assume that a failing test can be allowed to fail.
 - One canonical primitive per concern: UUIDs come from `IdGenerator`, randomness from `Random` (`pick`/`next`), backoff from `Backoff`. Inject these (interface + fake) rather than spawning a new `randomUUID()`/`Math.random()` path.
 - Prefer narrow interfaces that expose exactly what consumers need (YAGNI); grow the interface when the second consumer arrives, not ahead of need.
+- Unit tests must never resolve the real file-backed `getDatabase()`. A bun-test preload (`test/setup/unitTestDbGuard.ts`) arms a guard that throws when a test resolves the default `~/.auto-mobile` DB (issue #3067). Inject an in-memory DB via `createTestDatabase()`, or use a helper: `test/helpers/navigationTestHarness.ts` (in-memory `NavigationGraphManager` singleton + telemetry spy), `test/db/inMemorySingletonDatabase.ts` (`:memory:` singleton for identity checks), or `test/helpers/tempFileDatabase.ts` (temp-dir file DB for real `getInstance`/`getInstanceForSession` semantics). Resolve `getDatabase()` lazily (a getter), never in a field initializer, so construction alone can't trip the guard.
 
 # Error Handling Convention
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,4 @@
 [test]
+preload = ["./test/setup/unitTestDbGuard.ts"]
 coverageReporter = ["text", "lcov"]
 coverageDir = "./coverage"

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -105,6 +105,66 @@ export function resolveDatabasePathFromEnvironment(
 }
 
 /**
+ * Env var, set only by the bun test preload (`test/setup/unitTestDbGuard.ts`),
+ * that arms {@link assertUnitTestDbAccessAllowed}. It is never set in production,
+ * so the guard is inert outside `bun test`.
+ */
+export const UNIT_TEST_DB_GUARD_ENV = "AUTOMOBILE_UNIT_TEST_DB_GUARD";
+
+// The four env vars that redirect the database off the default `~/.auto-mobile`
+// location. A test that sets any of these has explicitly opted into a real
+// file-backed (or `:memory:`) DB it controls, so the guard leaves it alone.
+const DB_PATH_OVERRIDE_ENV_KEYS = [
+  "AUTOMOBILE_DB_PATH",
+  "AUTO_MOBILE_DB_PATH",
+  "AUTOMOBILE_DB_DIR",
+  "AUTO_MOBILE_DB_DIR",
+] as const;
+
+function hasExplicitDbPathOverride(env: NodeJS.ProcessEnv): boolean {
+  return DB_PATH_OVERRIDE_ENV_KEYS.some(key => {
+    const value = env[key];
+    return value !== undefined && value !== "";
+  });
+}
+
+/**
+ * Fail loudly when a unit test resolves the DEFAULT, file-backed `getDatabase()`
+ * — i.e. the user's real `~/.auto-mobile/auto-mobile.db` — instead of injecting
+ * an in-memory DB (`createTestDatabase`) or explicitly redirecting to a temp/
+ * `:memory:` path.
+ *
+ * `getDatabase()`'s first-use path runs migrations + file IO on real wall-clock
+ * time, so any test that asserts on the *result* of an async DB write races that
+ * write and flakes (issue #3063). It also silently mutates the developer's real
+ * DB. This guard turns both failure modes into a loud, actionable throw at the
+ * exact call site that reached for the real DB, forcing the test to inject an
+ * in-memory DB instead — the durable fix for the whole class (issue #3067).
+ *
+ * The guard is armed only under the bun test preload ({@link UNIT_TEST_DB_GUARD_ENV})
+ * and deliberately fires ONLY on the default path: a test that sets
+ * AUTOMOBILE_DB_PATH / AUTOMOBILE_DB_DIR (the DB-lifecycle tests that must
+ * exercise real file behavior) or `:memory:` has explicitly opted in and passes.
+ */
+function assertUnitTestDbAccessAllowed(env: NodeJS.ProcessEnv, resolvedPath: string): void {
+  if (env[UNIT_TEST_DB_GUARD_ENV] !== "1") {
+    return;
+  }
+  if (isInMemoryDatabasePath(resolvedPath) || hasExplicitDbPathOverride(env)) {
+    return;
+  }
+  throw new ActionableError(
+    `Unit test resolved the real file-backed database at ${resolvedPath}. ` +
+      "Unit tests must not touch the user's real ~/.auto-mobile DB: its first-use " +
+      "migrations + file IO run on real wall-clock time and race async-write " +
+      "assertions (issue #3063). Inject an in-memory DB via createTestDatabase() " +
+      "(and NavigationGraphManager.setInstanceForTesting / TelemetryRecorder spies " +
+      "for singletons), or, if the test must exercise real file behavior, set " +
+      "AUTOMOBILE_DB_DIR to a temp dir or AUTOMOBILE_DB_PATH=':memory:' explicitly."
+  );
+}
+
+/**
  * The migration/path lifecycle state that outlives a single DB connection.
  *
  * These were five bare module globals (`resolvedDbPath` plus the
@@ -193,7 +253,9 @@ const lifecycle = new MigrationLifecycleState();
  */
 function resolveDbPath(): string {
   if (lifecycle.resolvedDbPath === null) {
-    lifecycle.resolvedDbPath = resolveDatabasePathFromEnvironment();
+    const resolvedPath = resolveDatabasePathFromEnvironment();
+    assertUnitTestDbAccessAllowed(process.env, resolvedPath);
+    lifecycle.resolvedDbPath = resolvedPath;
   }
   return lifecycle.resolvedDbPath;
 }

--- a/src/features/memory/MemoryAudit.ts
+++ b/src/features/memory/MemoryAudit.ts
@@ -6,8 +6,9 @@ import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/Performa
 import { MemoryMetricsCollector, MemoryMetrics } from "./MemoryMetricsCollector";
 import { MemoryThresholdManager } from "./MemoryThresholdManager";
 import { MemoryBaselineManager } from "./MemoryBaselineManager";
+import type { Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
-import { NewMemoryAuditResult } from "../../db/types";
+import { Database, NewMemoryAuditResult } from "../../db/types";
 
 /**
  * Represents a single memory threshold violation
@@ -40,14 +41,32 @@ export class MemoryAudit {
   private metricsCollector: MemoryMetricsCollector;
   private thresholdManager: MemoryThresholdManager;
   private baselineManager: MemoryBaselineManager;
-  private db = getDatabase();
+  private readonly injectedDb: Kysely<Database> | null;
 
-  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+  /**
+   * @param db Optional Kysely handle, resolved LAZILY (per use, via {@link db})
+   * so constructing an audit for pure-logic tests (`validateMetrics`,
+   * `generateDiagnostics`) does not open the real file-backed database. Inject an
+   * in-memory DB (`createTestDatabase`) for tests exercising the persistence
+   * path (issue #3067); it is threaded to the baseline manager for a shared
+   * connection.
+   */
+  constructor(
+    device: BootedDevice,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    db?: Kysely<Database>
+  ) {
     this.device = device;
     this.adb = adbFactory.create(device);
     this.metricsCollector = new MemoryMetricsCollector(device, adbFactory);
-    this.thresholdManager = new MemoryThresholdManager();
-    this.baselineManager = new MemoryBaselineManager();
+    this.thresholdManager = new MemoryThresholdManager(db);
+    this.baselineManager = new MemoryBaselineManager(db);
+    this.injectedDb = db ?? null;
+  }
+
+  /** The injected DB, or the shared singleton resolved on first use. */
+  private get db(): Kysely<Database> {
+    return this.injectedDb ?? getDatabase();
   }
 
   /**

--- a/src/features/memory/MemoryBaselineManager.ts
+++ b/src/features/memory/MemoryBaselineManager.ts
@@ -1,5 +1,6 @@
+import type { Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
-import { MemoryBaseline, NewMemoryBaseline, MemoryBaselineUpdate } from "../../db/types";
+import { Database, MemoryBaseline, NewMemoryBaseline, MemoryBaselineUpdate } from "../../db/types";
 import { logger } from "../../utils/logger";
 import { MemoryMetrics } from "./MemoryMetricsCollector";
 import {
@@ -14,7 +15,23 @@ import {
  * Manages adaptive memory baselines per app/device/tool combination
  */
 export class MemoryBaselineManager {
-  private db = getDatabase();
+  private readonly injectedDb: Kysely<Database> | null;
+
+  /**
+   * @param db Optional Kysely handle. Resolved LAZILY (per use, via {@link db})
+   * rather than in a field initializer so merely constructing a manager — e.g.
+   * for a pure-logic test of {@link calculateAnomalyMultiplier} — does not open
+   * the real file-backed database. Inject an in-memory DB (`createTestDatabase`)
+   * for tests that exercise the query paths (issue #3067).
+   */
+  constructor(db?: Kysely<Database>) {
+    this.injectedDb = db ?? null;
+  }
+
+  /** The injected DB, or the shared singleton resolved on first use. */
+  private get db(): Kysely<Database> {
+    return this.injectedDb ?? getDatabase();
+  }
 
   /**
    * Get baseline for a specific device/package/tool combination

--- a/src/features/memory/MemoryThresholdManager.ts
+++ b/src/features/memory/MemoryThresholdManager.ts
@@ -1,5 +1,6 @@
+import type { Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
-import { NewMemoryThresholds, MemoryThresholds } from "../../db/types";
+import { Database, NewMemoryThresholds, MemoryThresholds } from "../../db/types";
 import { logger } from "../../utils/logger";
 import { sql } from "kysely";
 import { MemoryBaseline } from "../../db/types";
@@ -44,7 +45,22 @@ const DEFAULT_THRESHOLDS = {
  * Manages memory thresholds with TTL, per-app profiles, and weighted averaging
  */
 export class MemoryThresholdManager {
-  private db = getDatabase();
+  private readonly injectedDb: Kysely<Database> | null;
+
+  /**
+   * @param db Optional Kysely handle, resolved LAZILY (per use, via {@link db})
+   * so constructing a manager does not open the real file-backed database.
+   * Inject an in-memory DB (`createTestDatabase`) for tests exercising the query
+   * paths (issue #3067).
+   */
+  constructor(db?: Kysely<Database>) {
+    this.injectedDb = db ?? null;
+  }
+
+  /** The injected DB, or the shared singleton resolved on first use. */
+  private get db(): Kysely<Database> {
+    return this.injectedDb ?? getDatabase();
+  }
 
   /**
    * Clean up expired thresholds based on TTL

--- a/src/features/performance/ThresholdManager.ts
+++ b/src/features/performance/ThresholdManager.ts
@@ -1,5 +1,6 @@
+import type { Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
-import { NewPerformanceThresholds, PerformanceThresholds } from "../../db/types";
+import { Database, NewPerformanceThresholds, PerformanceThresholds } from "../../db/types";
 import { logger } from "../../utils/logger";
 import { DeviceCapabilities, DeviceCapabilitiesDetector } from "../../utils/DeviceCapabilities";
 import { sql } from "kysely";
@@ -15,7 +16,22 @@ import {
  * Manages performance thresholds with TTL and weighted averaging
  */
 export class ThresholdManager {
-  private db = getDatabase();
+  private readonly injectedDb: Kysely<Database> | null;
+
+  /**
+   * @param db Optional Kysely handle, resolved LAZILY (per use, via {@link db})
+   * so constructing a manager does not open the real file-backed database at
+   * construction time. Inject an in-memory DB (`createTestDatabase`) for tests
+   * exercising the query paths (issue #3067).
+   */
+  constructor(db?: Kysely<Database>) {
+    this.injectedDb = db ?? null;
+  }
+
+  /** The injected DB, or the shared singleton resolved on first use. */
+  private get db(): Kysely<Database> {
+    return this.injectedDb ?? getDatabase();
+  }
 
   /**
    * Get the current session ID

--- a/test/db/inMemorySingletonDatabase.ts
+++ b/test/db/inMemorySingletonDatabase.ts
@@ -1,0 +1,34 @@
+import { closeDatabase } from "../../src/db/database";
+
+/**
+ * Run `fn` with the process-wide `getDatabase()` singleton pointed at an
+ * in-memory (`:memory:`) database, then restore the prior state.
+ *
+ * A handful of tests must assert on the REAL `getDatabase()` singleton itself —
+ * e.g. that two independently-constructed unbound repositories resolve to the
+ * SAME connection. Under the unit-test DB guard (issue #3067) a bare
+ * `getDatabase()` throws because it would resolve the user's real
+ * `~/.auto-mobile` file DB. Redirecting the singleton to `:memory:` satisfies the
+ * guard's explicit opt-out while keeping the singleton semantics the test needs.
+ *
+ * `closeDatabase()` is called before (to clear any cached path/instance so the
+ * `:memory:` override actually takes effect) and after (so the transient
+ * `:memory:` singleton never leaks into a sibling test).
+ */
+export async function withInMemorySingletonDatabase(
+  fn: () => void | Promise<void>
+): Promise<void> {
+  const savedDbPath = process.env.AUTOMOBILE_DB_PATH;
+  process.env.AUTOMOBILE_DB_PATH = ":memory:";
+  await closeDatabase();
+  try {
+    await fn();
+  } finally {
+    await closeDatabase();
+    if (savedDbPath === undefined) {
+      delete process.env.AUTOMOBILE_DB_PATH;
+    } else {
+      process.env.AUTOMOBILE_DB_PATH = savedDbPath;
+    }
+  }
+}

--- a/test/db/inMemorySingletonDatabase.ts
+++ b/test/db/inMemorySingletonDatabase.ts
@@ -1,4 +1,5 @@
 import { closeDatabase } from "../../src/db/database";
+import { IN_MEMORY_DB_OPT_IN_ENV } from "../../src/db/migrationLock";
 
 /**
  * Run `fn` with the process-wide `getDatabase()` singleton pointed at an
@@ -11,6 +12,12 @@ import { closeDatabase } from "../../src/db/database";
  * `~/.auto-mobile` file DB. Redirecting the singleton to `:memory:` satisfies the
  * guard's explicit opt-out while keeping the singleton semantics the test needs.
  *
+ * Routing `:memory:` through the real `getDatabase()` also requires the #3065
+ * production opt-in (`IN_MEMORY_DB_OPT_IN_ENV`): without it,
+ * `resolveDatabasePathFromEnvironment` rejects `:memory:` as an invalid
+ * production DB before the #3067 guard is even reached. Both env vars are
+ * saved/restored.
+ *
  * `closeDatabase()` is called before (to clear any cached path/instance so the
  * `:memory:` override actually takes effect) and after (so the transient
  * `:memory:` singleton never leaks into a sibling test).
@@ -19,16 +26,23 @@ export async function withInMemorySingletonDatabase(
   fn: () => void | Promise<void>
 ): Promise<void> {
   const savedDbPath = process.env.AUTOMOBILE_DB_PATH;
+  const savedOptIn = process.env[IN_MEMORY_DB_OPT_IN_ENV];
   process.env.AUTOMOBILE_DB_PATH = ":memory:";
+  process.env[IN_MEMORY_DB_OPT_IN_ENV] = "1";
   await closeDatabase();
   try {
     await fn();
   } finally {
     await closeDatabase();
-    if (savedDbPath === undefined) {
-      delete process.env.AUTOMOBILE_DB_PATH;
-    } else {
-      process.env.AUTOMOBILE_DB_PATH = savedDbPath;
-    }
+    restoreEnv("AUTOMOBILE_DB_PATH", savedDbPath);
+    restoreEnv(IN_MEMORY_DB_OPT_IN_ENV, savedOptIn);
+  }
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
   }
 }

--- a/test/db/navigationRepository.test.ts
+++ b/test/db/navigationRepository.test.ts
@@ -3,6 +3,7 @@ import type { Kysely } from "kysely";
 import type { Database } from "../../src/db/types";
 import { NavigationRepository } from "../../src/db/navigationRepository";
 import { createTestDatabase } from "./testDbHelper";
+import { withInMemorySingletonDatabase } from "./inMemorySingletonDatabase";
 
 describe("NavigationRepository", () => {
   let db: Kysely<Database>;
@@ -418,12 +419,17 @@ describe("NavigationRepository", () => {
       expect(bound.resolveConnection()).toBe(db);
     });
 
-    test("returns the shared singleton for an unbound repo", () => {
+    test("returns the shared singleton for an unbound repo", async () => {
       // Two independently-constructed unbound repos must resolve to the SAME
       // getDatabase() singleton so a connection-identity check between them holds.
-      const a = new NavigationRepository();
-      const b = new NavigationRepository();
-      expect(a.resolveConnection()).toBe(b.resolveConnection());
+      // Redirect the singleton to `:memory:` so the unit-test DB guard (issue
+      // #3067) permits resolving it here (the assertion is about singleton
+      // identity, not the on-disk file).
+      await withInMemorySingletonDatabase(() => {
+        const a = new NavigationRepository();
+        const b = new NavigationRepository();
+        expect(a.resolveConnection()).toBe(b.resolveConnection());
+      });
     });
 
     test("withExecutor rebinds the resolved connection", () => {

--- a/test/db/testCoverageRepository.test.ts
+++ b/test/db/testCoverageRepository.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, describe, expect, test } from "bun:test";
 import type { Kysely } from "kysely";
 import type { Database } from "../../src/db/types";
 import { createTestDatabase } from "./testDbHelper";
+import { withInMemorySingletonDatabase } from "./inMemorySingletonDatabase";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
 
@@ -463,10 +464,15 @@ describe("TestCoverageRepository", () => {
       expect(bound.resolveConnection()).toBe(db);
     });
 
-    test("returns the shared singleton for an unbound repo", () => {
-      const a = new TestCoverageRepository(timer);
-      const b = new TestCoverageRepository(timer);
-      expect(a.resolveConnection()).toBe(b.resolveConnection());
+    test("returns the shared singleton for an unbound repo", async () => {
+      // Redirect the getDatabase() singleton to `:memory:` so the unit-test DB
+      // guard (issue #3067) permits resolving it — the assertion is about
+      // singleton identity, not the on-disk file.
+      await withInMemorySingletonDatabase(() => {
+        const a = new TestCoverageRepository(timer);
+        const b = new TestCoverageRepository(timer);
+        expect(a.resolveConnection()).toBe(b.resolveConnection());
+      });
     });
 
     test("withExecutor rebinds the resolved connection", () => {

--- a/test/db/unitTestDbGuard.test.ts
+++ b/test/db/unitTestDbGuard.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import path from "path";
 import os from "os";
 import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
+import { IN_MEMORY_DB_OPT_IN_ENV } from "../../src/db/migrationLock";
 import { ActionableError } from "../../src/models/ActionableError";
 
 /**
@@ -17,6 +18,7 @@ import { ActionableError } from "../../src/models/ActionableError";
 describe("unit-test real-DB guard (issue #3067)", () => {
   const trackedKeys = [
     UNIT_TEST_DB_GUARD_ENV,
+    IN_MEMORY_DB_OPT_IN_ENV,
     "AUTOMOBILE_DB_PATH",
     "AUTO_MOBILE_DB_PATH",
     "AUTOMOBILE_DB_DIR",
@@ -39,6 +41,7 @@ describe("unit-test real-DB guard (issue #3067)", () => {
     setEnv("AUTO_MOBILE_DB_PATH", undefined);
     setEnv("AUTOMOBILE_DB_DIR", undefined);
     setEnv("AUTO_MOBILE_DB_DIR", undefined);
+    setEnv(IN_MEMORY_DB_OPT_IN_ENV, undefined);
   }
 
   afterEach(() => {
@@ -76,6 +79,9 @@ describe("unit-test real-DB guard (issue #3067)", () => {
     setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
     clearOverrides();
     setEnv("AUTOMOBILE_DB_PATH", ":memory:");
+    // `:memory:` via the real singleton also needs the #3065 production opt-in,
+    // which the guard's own `:memory:` opt-out branch relies on being present.
+    setEnv(IN_MEMORY_DB_OPT_IN_ENV, "1");
     const db = await importFreshDatabaseModule();
 
     expect(db.getDatabasePath()).toBe(":memory:");
@@ -89,6 +95,25 @@ describe("unit-test real-DB guard (issue #3067)", () => {
     const db = await importFreshDatabaseModule();
 
     expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
+  });
+
+  test("allows the legacy AUTO_MOBILE_DB_DIR alias override without throwing", async () => {
+    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+    clearOverrides();
+    const tempDir = path.join(os.tmpdir(), "auto-mobile-guard-test-legacy");
+    setEnv("AUTO_MOBILE_DB_DIR", tempDir);
+    const db = await importFreshDatabaseModule();
+
+    expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
+  });
+
+  test("an empty-string override is NOT an override — still throws on the default path", async () => {
+    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+    clearOverrides();
+    setEnv("AUTOMOBILE_DB_DIR", "");
+    const db = await importFreshDatabaseModule();
+
+    expect(() => db.getDatabasePath()).toThrow(ActionableError);
   });
 
   test("allows an explicit AUTOMOBILE_DB_PATH override without throwing", async () => {

--- a/test/db/unitTestDbGuard.test.ts
+++ b/test/db/unitTestDbGuard.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import path from "path";
+import os from "os";
+import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
+import { ActionableError } from "../../src/models/ActionableError";
+
+/**
+ * Unit tests for the real-DB guard (issue #3067).
+ *
+ * The guard is armed process-wide by the bun test preload
+ * (`test/setup/unitTestDbGuard.ts`), so `process.env[UNIT_TEST_DB_GUARD_ENV]`
+ * is already "1" here. These tests import a FRESH copy of `src/db/database.ts`
+ * per case (its resolved-path cache is a module global) and drive it purely via
+ * env: no real DB is ever opened because every resolve either throws or targets
+ * an explicit override.
+ */
+describe("unit-test real-DB guard (issue #3067)", () => {
+  const trackedKeys = [
+    UNIT_TEST_DB_GUARD_ENV,
+    "AUTOMOBILE_DB_PATH",
+    "AUTO_MOBILE_DB_PATH",
+    "AUTOMOBILE_DB_DIR",
+    "AUTO_MOBILE_DB_DIR",
+  ];
+  const saved = new Map<string, string | undefined>(
+    trackedKeys.map(key => [key, process.env[key]])
+  );
+
+  function setEnv(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  function clearOverrides(): void {
+    setEnv("AUTOMOBILE_DB_PATH", undefined);
+    setEnv("AUTO_MOBILE_DB_PATH", undefined);
+    setEnv("AUTOMOBILE_DB_DIR", undefined);
+    setEnv("AUTO_MOBILE_DB_DIR", undefined);
+  }
+
+  afterEach(() => {
+    for (const key of trackedKeys) {
+      setEnv(key, saved.get(key));
+    }
+  });
+
+  // A fresh module instance so the cached `resolvedDbPath` from a prior case
+  // does not mask the env we set here.
+  async function importFreshDatabaseModule() {
+    return import(`../../src/db/database.ts?guard-test=${Date.now()}-${Math.random()}`);
+  }
+
+  test("getDatabasePath() throws an ActionableError on the default real path when armed", async () => {
+    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+    clearOverrides();
+    const db = await importFreshDatabaseModule();
+
+    let thrown: unknown;
+    try {
+      db.getDatabasePath();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ActionableError);
+    const message = (thrown as Error).message;
+    // Names the real path and the required remediation so the failure is actionable.
+    expect(message).toContain(path.join(os.homedir(), ".auto-mobile", "auto-mobile.db"));
+    expect(message).toContain("createTestDatabase");
+  });
+
+  test("allows the `:memory:` sentinel without throwing", async () => {
+    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+    clearOverrides();
+    setEnv("AUTOMOBILE_DB_PATH", ":memory:");
+    const db = await importFreshDatabaseModule();
+
+    expect(db.getDatabasePath()).toBe(":memory:");
+  });
+
+  test("allows an explicit AUTOMOBILE_DB_DIR override without throwing", async () => {
+    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+    clearOverrides();
+    const tempDir = path.join(os.tmpdir(), "auto-mobile-guard-test");
+    setEnv("AUTOMOBILE_DB_DIR", tempDir);
+    const db = await importFreshDatabaseModule();
+
+    expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
+  });
+
+  test("allows an explicit AUTOMOBILE_DB_PATH override without throwing", async () => {
+    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+    clearOverrides();
+    const dbPath = path.join(os.tmpdir(), "auto-mobile-guard-test", "explicit.db");
+    setEnv("AUTOMOBILE_DB_PATH", dbPath);
+    const db = await importFreshDatabaseModule();
+
+    expect(db.getDatabasePath()).toBe(dbPath);
+  });
+
+  test("is inert (no throw) when the guard flag is not set — production safety", async () => {
+    setEnv(UNIT_TEST_DB_GUARD_ENV, undefined);
+    clearOverrides();
+    const db = await importFreshDatabaseModule();
+
+    // Resolves the default real path silently, exactly like production.
+    expect(db.getDatabasePath()).toBe(
+      path.join(os.homedir(), ".auto-mobile", "auto-mobile.db")
+    );
+  });
+});

--- a/test/features/navigation/HierarchyNavigationDetector.test.ts
+++ b/test/features/navigation/HierarchyNavigationDetector.test.ts
@@ -1,24 +1,27 @@
-import { expect, describe, test, beforeEach, afterEach, beforeAll } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach } from "bun:test";
 import {
   HierarchyNavigationDetector,
 } from "../../../src/features/navigation/HierarchyNavigationDetector";
 import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { AccessibilityHierarchy } from "../../../src/features/navigation/ScreenFingerprint";
 import { FakeTimer } from "../../fakes/FakeTimer";
-import { runMigrations } from "../../helpers/database";
+import {
+  installInMemoryNavManager,
+  type InMemoryNavManagerHarness,
+} from "../../helpers/navigationTestHarness";
 
 describe("HierarchyNavigationDetector", () => {
   let manager: NavigationGraphManager;
   let detector: HierarchyNavigationDetector;
   let fakeTimer: FakeTimer;
-
-  beforeAll(async () => {
-    await runMigrations();
-  });
+  let navHarness: InMemoryNavManagerHarness;
 
   beforeEach(async () => {
-    NavigationGraphManager.resetInstance();
-    manager = NavigationGraphManager.getInstance();
+    // Back the singleton with an in-memory, already-migrated DB (and silence the
+    // fire-and-forget telemetry write) so the detector's navigation writes are
+    // deterministic and never touch the real ~/.auto-mobile DB (issues #3063/#3067).
+    navHarness = await installInMemoryNavManager();
+    manager = navHarness.manager;
     await manager.setCurrentApp("com.test.app");
     await manager.clearCurrentGraph();
     await manager.setCurrentApp("com.test.app");
@@ -33,10 +36,10 @@ describe("HierarchyNavigationDetector", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     detector.dispose();
     fakeTimer.reset();
-    NavigationGraphManager.resetInstance();
+    await navHarness.dispose();
   });
 
   describe("initial state", () => {

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, test, beforeEach, afterEach, beforeAll, it, spyOn } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach, beforeAll, afterAll, it, spyOn } from "bun:test";
 import type { Kysely } from "kysely";
 import {
   NavigationGraphManager,
@@ -12,6 +12,24 @@ import { TelemetryRecorder } from "../../../src/features/telemetry/TelemetryReco
 import { defaultTimer, type Timer } from "../../../src/utils/SystemTimer";
 import type { Database } from "../../../src/db/types";
 import { ActionableError } from "../../../src/models/ActionableError";
+import { useTempFileDatabase, type TempFileDatabaseHandle } from "../../helpers/tempFileDatabase";
+
+// The older suites below drive the REAL getDatabase() singleton via getInstance()
+// and getInstanceForSession() (session instances have no in-memory injection seam),
+// so back it with a temp-dir file DB for the whole file. The tests await their
+// writes, so the #3063 real-DB race does not apply; this just keeps them off the
+// user's ~/.auto-mobile DB and satisfies the unit-test guard (issue #3067). The
+// newer createForTesting-based suites inject their own in-memory DBs and never
+// touch getDatabase(), so this is inert for them.
+let tempFileDb: TempFileDatabaseHandle;
+
+beforeAll(async () => {
+  tempFileDb = await useTempFileDatabase();
+});
+
+afterAll(async () => {
+  await tempFileDb.cleanup();
+});
 
 describe("NavigationGraphManager", () => {
   let manager: NavigationGraphManager;

--- a/test/features/navigation/SmartNavigationHelper.test.ts
+++ b/test/features/navigation/SmartNavigationHelper.test.ts
@@ -1,23 +1,27 @@
-import { expect, describe, test, beforeEach, afterEach, beforeAll } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach } from "bun:test";
 import { SmartNavigationHelper } from "../../../src/features/navigation/SmartNavigationHelper";
 import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
-import { runMigrations } from "../../helpers/database";
+import {
+  installInMemoryNavManager,
+  type InMemoryNavManagerHarness,
+} from "../../helpers/navigationTestHarness";
 
 describe("SmartNavigationHelper", function() {
   let navGraph: NavigationGraphManager;
-
-  beforeAll(async function() {
-    await runMigrations();
-  });
+  let navHarness: InMemoryNavManagerHarness;
 
   beforeEach(async function() {
-    navGraph = NavigationGraphManager.getInstance();
+    // Back the singleton with an in-memory, already-migrated DB (and silence the
+    // fire-and-forget telemetry write) so navigation writes are deterministic and
+    // never touch the real ~/.auto-mobile DB (issues #3063/#3067).
+    navHarness = await installInMemoryNavManager();
+    navGraph = navHarness.manager;
     await navGraph.setCurrentApp("com.example.app");
     await navGraph.clearCurrentGraph();
   });
 
   afterEach(async function() {
-    NavigationGraphManager.resetInstance();
+    await navHarness.dispose();
     SmartNavigationHelper.resetOptimizer();
   });
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -15,11 +15,7 @@ import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsReposi
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { DeviceConnectionLostNotifier } from "../../../src/features/observe/DeviceConnectionLostNotifier";
 import { PortManager } from "../../../src/utils/PortManager";
-import { NavigationRepository } from "../../../src/db/navigationRepository";
-import { TestCoverageRepository } from "../../../src/db/testCoverageRepository";
-import { createTestDatabase } from "../../db/testDbHelper";
-import type { Kysely } from "kysely";
-import type { Database } from "../../../src/db/types";
+import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -137,31 +133,6 @@ describe("AndroidCtrlProxyClient", function() {
     for (let i = 0; i < iterations; i += 1) {
       await new Promise(resolve => setImmediate(resolve));
     }
-  };
-
-  // Back the NavigationGraphManager singleton with an in-memory, already-migrated
-  // database. AndroidCtrlProxyClient records navigation into the singleton via
-  // getInstance(); the default getDatabase() singleton runs migrations + file IO on
-  // real wall-clock time, so its async writes never settle within these tests'
-  // microtask-only drains and race the assertions (issue #3063). An in-memory DB has
-  // no migration gate and no file IO, so recordNavigationEvent's *graph* writes — the
-  // ones that assign currentScreen, which the assertions read — commit within a
-  // deterministic number of setImmediate/microtask turns. (recordNavigationEvent's
-  // post-commit fire-and-forget TelemetryRecorder write still targets the real DB, but
-  // it runs after currentScreen is assigned and is never awaited, so it cannot affect
-  // determinism here.) Both repositories share the one connection to satisfy
-  // NavigationGraphManager's shared-connection precondition. Callers must destroy the
-  // returned db and resetInstance() in cleanup.
-  const installInMemoryNavManager = async (): Promise<{
-    navManager: NavigationGraphManager;
-    navDb: Kysely<Database>;
-  }> => {
-    const navDb = await createTestDatabase();
-    const navRepo = new NavigationRepository(navDb);
-    const coverageRepo = new TestCoverageRepository(undefined, navDb);
-    const navManager = NavigationGraphManager.createForTesting(navRepo, coverageRepo);
-    NavigationGraphManager.setInstanceForTesting(navManager);
-    return { navManager, navDb };
   };
 
   test("setupPortForwarding reallocates when the current local port becomes busy before adb forward", async function() {
@@ -503,7 +474,8 @@ describe("AndroidCtrlProxyClient", function() {
 
     test("should seed navigation graph from hierarchy updates", async function() {
       NavigationGraphManager.resetInstance();
-      const { navManager, navDb } = await installInMemoryNavManager();
+      const navHarness = await installInMemoryNavManager();
+      const navManager = navHarness.manager;
 
       const testTimer = new FakeTimer();
       testTimer.enableAutoAdvance();
@@ -555,14 +527,14 @@ describe("AndroidCtrlProxyClient", function() {
         expect(navManager.getCurrentScreen()).toBeNull();
       } finally {
         await testClient.close();
-        NavigationGraphManager.resetInstance();
-        await navDb.destroy();
+        await navHarness.dispose();
       }
     });
 
     test("should preserve SDK screen names when hierarchy updates follow navigation events", async function() {
       NavigationGraphManager.resetInstance();
-      const { navManager, navDb } = await installInMemoryNavManager();
+      const navHarness = await installInMemoryNavManager();
+      const navManager = navHarness.manager;
 
       const testTimer = new FakeTimer();
       testTimer.enableAutoAdvance();
@@ -619,8 +591,7 @@ describe("AndroidCtrlProxyClient", function() {
         expect(navManager.getCurrentScreen()).toBe("SdkHome");
       } finally {
         await testClient.close();
-        NavigationGraphManager.resetInstance();
-        await navDb.destroy();
+        await navHarness.dispose();
       }
     });
   });
@@ -1246,13 +1217,13 @@ describe("AndroidCtrlProxyClient", function() {
       NavigationGraphManager.resetInstance();
     });
 
-    test("should use session-scoped NavigationGraphManager after binding", async function() {
-      // Set different state on the global vs session-scoped instances
+    test("should use session-scoped NavigationGraphManager after binding", function() {
+      // This test asserts only on instance ROUTING/identity, not on per-instance
+      // navigation state, so it deliberately does not call setCurrentApp: that
+      // would resolve the real getDatabase() (session instances have no in-memory
+      // injection seam) and trip the unit-test DB guard (issue #3067).
       const globalNav = NavigationGraphManager.getInstance();
-      await globalNav.setCurrentApp("com.global.app");
-
       const sessionNav = NavigationGraphManager.getInstanceForSession("test-session-123");
-      await sessionNav.setCurrentApp("com.session.app");
 
       // Before binding: client uses global instance
       // After binding: client should use session instance

--- a/test/helpers/navigationTestHarness.ts
+++ b/test/helpers/navigationTestHarness.ts
@@ -1,0 +1,61 @@
+import { spyOn } from "bun:test";
+import type { Kysely } from "kysely";
+import { createTestDatabase } from "../db/testDbHelper";
+import { NavigationRepository } from "../../src/db/navigationRepository";
+import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
+import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import { TelemetryRecorder } from "../../src/features/telemetry/TelemetryRecorder";
+import type { Database } from "../../src/db/types";
+
+export interface InMemoryNavManagerHarness {
+  /** The NavigationGraphManager installed as the `getInstance()` singleton. */
+  manager: NavigationGraphManager;
+  /** The in-memory, already-migrated DB backing both repositories. */
+  db: Kysely<Database>;
+  /** The stubbed post-commit telemetry write (asserts/inspection if needed). */
+  telemetrySpy: ReturnType<typeof spyOn>;
+  /** Restore telemetry, reset singletons, and destroy the DB. Await in teardown. */
+  dispose: () => Promise<void>;
+}
+
+/**
+ * Install a `NavigationGraphManager` singleton backed by a fresh in-memory,
+ * already-migrated database, and silence its post-commit fire-and-forget
+ * `TelemetryRecorder.recordNavigationEvent` write.
+ *
+ * Consumers that resolve the manager via `getInstance()` (AndroidCtrlProxyClient,
+ * HierarchyNavigationDetector, SmartNavigationHelper, …) then exercise
+ * deterministic, migration-gate-free DB writes instead of the real `getDatabase()`
+ * file DB — whose first-use migrations + file IO run on real wall-clock time and
+ * race async-write assertions (issue #3063). The telemetry stub keeps
+ * `recordNavigationEvent`'s post-commit floating promise from resolving the real
+ * `~/.auto-mobile` DB, which the unit-test guard would otherwise reject (#3067).
+ *
+ * Both repositories share the one connection to satisfy NavigationGraphManager's
+ * shared-connection precondition. Callers MUST `await dispose()` in teardown.
+ */
+export async function installInMemoryNavManager(): Promise<InMemoryNavManagerHarness> {
+  const db = await createTestDatabase();
+  const navRepo = new NavigationRepository(db);
+  const coverageRepo = new TestCoverageRepository(undefined, db);
+  const manager = NavigationGraphManager.createForTesting(navRepo, coverageRepo);
+  NavigationGraphManager.setInstanceForTesting(manager);
+
+  TelemetryRecorder.resetInstance();
+  const telemetrySpy = spyOn(
+    TelemetryRecorder.getInstance(),
+    "recordNavigationEvent"
+  ).mockResolvedValue(undefined);
+
+  return {
+    manager,
+    db,
+    telemetrySpy,
+    dispose: async () => {
+      telemetrySpy.mockRestore();
+      TelemetryRecorder.resetInstance();
+      NavigationGraphManager.resetInstance();
+      await db.destroy();
+    },
+  };
+}

--- a/test/helpers/tempFileDatabase.ts
+++ b/test/helpers/tempFileDatabase.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "path";
+import { closeDatabase } from "../../src/db/database";
+
+export interface TempFileDatabaseHandle {
+  /** The temp directory holding `auto-mobile.db`. */
+  dir: string;
+  /** Restore env, close the DB singleton, and remove the temp dir. Await in teardown. */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Point the process-wide `getDatabase()` singleton at a fresh temp-dir file DB
+ * for the lifetime of a test file, then tear it down.
+ *
+ * For tests that must exercise the REAL `getDatabase()` singleton/session
+ * semantics (`getInstance()`, `getInstanceForSession()`) — which an injected
+ * in-memory DB cannot back because those construct unbound managers — and that
+ * AWAIT their writes (so the real-DB-race in issue #3063 does not apply). This
+ * satisfies the unit-test DB guard's explicit `AUTOMOBILE_DB_DIR` opt-out
+ * (issue #3067) without ever touching the user's real `~/.auto-mobile` DB.
+ *
+ * `AUTOMOBILE_DB_PATH` is cleared because it would take precedence over
+ * `AUTOMOBILE_DB_DIR`. `closeDatabase()` runs before (so the override takes
+ * effect against a clean lifecycle) and during cleanup (so the temp singleton
+ * never leaks into a sibling file that shares the test process).
+ */
+export async function useTempFileDatabase(): Promise<TempFileDatabaseHandle> {
+  const savedDir = process.env.AUTOMOBILE_DB_DIR;
+  const savedPath = process.env.AUTOMOBILE_DB_PATH;
+
+  const dir = await mkdtemp(path.join(tmpdir(), "auto-mobile-unit-test-db-"));
+  process.env.AUTOMOBILE_DB_DIR = dir;
+  delete process.env.AUTOMOBILE_DB_PATH;
+  await closeDatabase();
+
+  return {
+    dir,
+    cleanup: async () => {
+      await closeDatabase();
+      restoreEnv("AUTOMOBILE_DB_DIR", savedDir);
+      restoreEnv("AUTOMOBILE_DB_PATH", savedPath);
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/test/helpers/tempFileDatabase.ts
+++ b/test/helpers/tempFileDatabase.ts
@@ -2,6 +2,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "path";
 import { closeDatabase } from "../../src/db/database";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+import { logger } from "../../src/utils/logger";
 
 export interface TempFileDatabaseHandle {
   /** The temp directory holding `auto-mobile.db`. */
@@ -41,9 +43,36 @@ export async function useTempFileDatabase(): Promise<TempFileDatabaseHandle> {
       await closeDatabase();
       restoreEnv("AUTOMOBILE_DB_DIR", savedDir);
       restoreEnv("AUTOMOBILE_DB_PATH", savedPath);
-      await rm(dir, { recursive: true, force: true });
+      await removeTempDirBestEffort(dir);
     },
   };
+}
+
+/**
+ * Remove the temp DB dir, tolerating Windows's transient file locks.
+ *
+ * Even after `closeDatabase()`, Windows can hold the sqlite `.db`/`-wal`/`-shm`
+ * handles for a beat (and a post-commit fire-and-forget telemetry write may still
+ * be draining), so a bare `rm` throws `EBUSY`/`EPERM`/`ENOTEMPTY` and fails the
+ * suite in CI even though every test passed (issue #2849). Retry with backoff,
+ * then give up quietly: a leftover dir under the OS temp is harmless and reclaimed
+ * by the OS — a cleanup failure must never fail a test.
+ */
+async function removeTempDirBestEffort(dir: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      await rm(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") {
+        throw error;
+      }
+      await defaultTimer.sleep(50);
+    }
+  }
+  // Windows never released the lock; leave the temp dir for the OS to reclaim.
+  logger.debug(`useTempFileDatabase: could not remove temp DB dir ${dir} (left for OS cleanup)`);
 }
 
 function restoreEnv(key: string, value: string | undefined): void {

--- a/test/setup/unitTestDbGuard.ts
+++ b/test/setup/unitTestDbGuard.ts
@@ -1,0 +1,18 @@
+import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
+
+/**
+ * Bun test preload (wired via `bunfig.toml` `[test].preload`) that arms the
+ * unit-test database guard for the whole suite.
+ *
+ * Setting {@link UNIT_TEST_DB_GUARD_ENV} makes `getDatabase()` throw when a test
+ * resolves the DEFAULT, real file-backed DB (`~/.auto-mobile/auto-mobile.db`)
+ * instead of injecting an in-memory DB via `createTestDatabase` — the durable
+ * fix for the real-DB-race flake class (issues #3063 / #3067). Tests that must
+ * exercise real file behavior opt out by setting AUTOMOBILE_DB_DIR to a temp dir
+ * or AUTOMOBILE_DB_PATH=':memory:' explicitly (see the guard in
+ * `src/db/database.ts`).
+ *
+ * A preload runs once per test process before any test file is imported, so the
+ * flag is set before the first lazy `resolveDbPath()`.
+ */
+process.env[UNIT_TEST_DB_GUARD_ENV] = "1";


### PR DESCRIPTION
## Summary

Closes #3067 — the **durable** follow-up to #3066 (which was the tactical fix for the #3063 flake).

Several unit tests silently exercised the **real file-backed database** (`getDatabase()` → `~/.auto-mobile/auto-mobile.db`) instead of an injected in-memory DB. `getDatabase()`'s first-use path runs migrations + file IO on **real wall-clock time**, so any test that asserts on the *result* of an async DB write races that write and flakes (exactly how #3063 failed). It also silently mutates the developer's real DB (a reviewer proved the post-commit fire-and-forget `TelemetryRecorder` write in `NavigationGraphManager` creates `auto-mobile.db` + a ~2.9 MB WAL under `AUTOMOBILE_DB_DIR=$tmp`).

This adds a **unit-test guard** that fails loudly the moment a test resolves the default real DB, forcing tests to inject an in-memory DB — the durable fix for the whole class.

## What changed

**Guard (`src/db/database.ts`)**
- `assertUnitTestDbAccessAllowed(env, resolvedPath)` throws an `ActionableError` from `resolveDbPath()` when the guard is armed **and** the path resolves to the default real DB with no explicit override. It sits on the single singleton resolution path, so `getDatabase()` / `getDatabasePath()` / `ensureMigrations()` are all covered.
- Armed **only** by a bun test preload via `UNIT_TEST_DB_GUARD_ENV`, so it is completely inert in production (the env is never set outside `bun test`).
- Escape hatches (explicit opt-in): the `:memory:` sentinel, or an `AUTOMOBILE_DB_PATH` / `AUTOMOBILE_DB_DIR` override — the exact pattern the DB-lifecycle tests already use.
- `test/setup/unitTestDbGuard.ts` preload + `bunfig.toml` `[test].preload`.
- `test/db/unitTestDbGuard.test.ts` covers: default-path throw (with actionable message), `:memory:` pass, `AUTOMOBILE_DB_DIR`/`AUTOMOBILE_DB_PATH` pass, and flag-unset inert (production safety).

**Fixing the tests the guard exposed (8 files)**
- `MemoryAudit` / `MemoryBaselineManager` / `MemoryThresholdManager` — stopped eagerly resolving `getDatabase()` in a **field initializer**; now resolve lazily via a getter and accept an optional injected `Kysely<Database>`. Constructing an audit for pure-logic tests no longer opens the real DB. Fully backward-compatible (`toolRegistry.ts` `new MemoryAudit(device)` keeps the lazy default).
- Nav consumers (`HierarchyNavigationDetector`, `SmartNavigationHelper`) and `CtrlProxyClient` — back the `NavigationGraphManager` singleton with an in-memory DB and silence the fire-and-forget `TelemetryRecorder` write, via a new shared `test/helpers/navigationTestHarness.ts` `installInMemoryNavManager()` (generalizes the local helper #3066 added to `CtrlProxyClient.test.ts`).
- `NavigationGraphManager.test.ts` — its older suites drive the **real** `getInstance()` / `getInstanceForSession()` (session instances have no in-memory injection seam) and await their writes, so they’re pointed at a temp-dir file DB for the file via a new `test/helpers/tempFileDatabase.ts` `useTempFileDatabase()`. The newer `createForTesting` suites already inject in-memory DBs and are untouched.
- `navigationRepository` / `testCoverageRepository` singleton-identity tests run under a `:memory:` singleton via a new `test/db/inMemorySingletonDatabase.ts` `withInMemorySingletonDatabase()`.
- One `CtrlProxyClient` `bindSession` test dropped two `setCurrentApp` calls that were dead setup (state was never asserted; the assertions check instance identity only).

## Verification

- `bun test` → **6186 pass / 0 guard failures**. The only remaining failures (39) are pre-existing `@jimp/wasm-webp`-missing image failures on this machine (ContrastChecker / JimpBackend / screenshot-utils / PerceptualHasher / memory-leak.stress) — confirmed identical on a clean stash of `main`, independent of this change.
- Cross-file isolation stress: `bun test test/db/ test/features/navigation/ test/features/observe/CtrlProxyClient.test.ts test/features/memory/` → **893 pass / 0 fail across 71 files in one process** (the temp-dir / `:memory:` / in-memory helpers all restore env + `closeDatabase()`).
- `bunx eslint` on all changed files → clean. `bun build.ts` → OK. `tsc --noEmit` → no new errors (only the pre-existing `moduleResolution` deprecation).

## Non-goals / follow-ups

- The older `NavigationGraphManager.test.ts` suites use a temp-dir **file** DB rather than in-memory injection because `getInstanceForSession()` has no injection seam. Adding a session-scoped injection seam so those can move to in-memory (faster, no file IO) is a good follow-up.
- The guard fires only on the **default** path; a test that explicitly points `AUTOMOBILE_DB_PATH` at a real absolute file is trusted (intentional opt-in). Narrowing that further is out of scope.
