### PR TITLE
test(db): cover promoteSuggestion notifyGraphUpdated commit/rollback (#2981)

### DIFF
--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1528,19 +1528,24 @@ describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () =>
     // prototype, so the trx-bound write is counted too.
     const promoteSpy = spyOn(NavigationRepository.prototype, "promoteSuggestion");
 
-    const notifyPromoteCounts: number[] = [];
-    manager.setGraphUpdateListener(() => {
-      notifyPromoteCounts.push(promoteSpy.mock.calls.length);
-    });
+    // try/finally so a failing assertion can never leave this prototype spy armed
+    // for sibling suites in the same process (spyOn calls through, but restore is
+    // still the hygienic contract).
+    try {
+      const notifyPromoteCounts: number[] = [];
+      manager.setGraphUpdateListener(() => {
+        notifyPromoteCounts.push(promoteSpy.mock.calls.length);
+      });
 
-    await manager.promoteSuggestion(suggestionId, "SettingsScreen");
+      await manager.promoteSuggestion(suggestionId, "SettingsScreen");
 
-    // promoteSuggestion ran exactly once, and notify fired exactly once, AFTER that
-    // final in-transaction write completed — never inside or before the transaction.
-    expect(promoteSpy).toHaveBeenCalledTimes(1);
-    expect(notifyPromoteCounts).toEqual([1]);
-
-    promoteSpy.mockRestore();
+      // promoteSuggestion ran exactly once, and notify fired exactly once, AFTER that
+      // final in-transaction write completed — never inside or before the transaction.
+      expect(promoteSpy).toHaveBeenCalledTimes(1);
+      expect(notifyPromoteCounts).toEqual([1]);
+    } finally {
+      promoteSpy.mockRestore();
+    }
   });
 });
 

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1466,6 +1466,12 @@ describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () =>
     const nodesBefore = await countNodes();
     const fingerprintsBefore = await countFingerprints();
 
+    // notifyGraphUpdated must fire only after commit — never on rollback (#2981 AC).
+    let notifyCount = 0;
+    manager.setGraphUpdateListener(() => {
+      notifyCount++;
+    });
+
     // A non-existent suggestion id: getOrCreateNode creates the "OrphanScreen"
     // node first, then repository.promoteSuggestion throws "Suggestion not found"
     // during the multi-write promotion. Without a transaction the node would be
@@ -1478,6 +1484,9 @@ describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () =>
     expect(await countNodes("OrphanScreen")).toBe(0);
     expect(await countNodes()).toBe(nodesBefore);
     expect(await countFingerprints()).toBe(fingerprintsBefore);
+
+    // The post-commit side effect never fired because the transaction threw.
+    expect(notifyCount).toBe(0);
   });
 
   test("rolls back BOTH the node and the fingerprint when the link fails after the fingerprint is created", async () => {
@@ -1488,6 +1497,12 @@ describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () =>
     const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
     await manager.setCurrentApp(APP_ID);
 
+    // notifyGraphUpdated must not fire when the fingerprint-then-link write throws.
+    let notifyCount = 0;
+    manager.setGraphUpdateListener(() => {
+      notifyCount++;
+    });
+
     await expect(
       manager.promoteSuggestion(42, "OrphanScreen")
     ).rejects.toThrow(/injected suggestion-link failure/);
@@ -1495,6 +1510,37 @@ describe("NavigationGraphManager - promoteSuggestion transaction (#2968)", () =>
     // Both writes rolled back together — no orphan node, no orphan fingerprint.
     expect(await countNodes("OrphanScreen")).toBe(0);
     expect(await countFingerprints()).toBe(0);
+
+    // No post-commit notification on the rolled-back promotion.
+    expect(notifyCount).toBe(0);
+  });
+
+  test("notifies graph listeners exactly once, only after the transaction commits", async () => {
+    const manager = makeManager();
+    await manager.setCurrentApp(APP_ID);
+    const suggestionId = await seedSuggestion(manager);
+
+    // repository.promoteSuggestion is the LAST write inside the transaction. Record
+    // its call count at every notify fire (not just the last) so a notification
+    // firing BEFORE the transaction completes — when the count is still 0 — is
+    // caught rather than masked by a later post-commit fire. spyOn calls through,
+    // and withExecutor rebinds onto a new NavigationRepository sharing this
+    // prototype, so the trx-bound write is counted too.
+    const promoteSpy = spyOn(NavigationRepository.prototype, "promoteSuggestion");
+
+    const notifyPromoteCounts: number[] = [];
+    manager.setGraphUpdateListener(() => {
+      notifyPromoteCounts.push(promoteSpy.mock.calls.length);
+    });
+
+    await manager.promoteSuggestion(suggestionId, "SettingsScreen");
+
+    // promoteSuggestion ran exactly once, and notify fired exactly once, AFTER that
+    // final in-transaction write completed — never inside or before the transaction.
+    expect(promoteSpy).toHaveBeenCalledTimes(1);
+    expect(notifyPromoteCounts).toEqual([1]);
+
+    promoteSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #2981 — the last uncovered acceptance criterion for making
`NavigationGraphManager.promoteSuggestion` atomic.

The production transaction #2981 asks for **already landed** via PR #2987 (for the
sibling #2968): `promoteSuggestion`'s node-create + promote sequence runs inside a
single `runInTransaction` with a `withExecutor(trx)`-bound repo, and
`notifyGraphUpdated()` is placed **outside** the transaction. Its test block, however,
asserted only on **AC #1/#3** (DB-row rollback on a mid-sequence throw) and never on
**AC #2** — that `notifyGraphUpdated()` fires *only after commit, never on rollback*.

This PR is **test-only** and closes that AC #2 gap.

## What changed

`test/features/navigation/NavigationGraphManager.test.ts` — three assertions added to
the existing `promoteSuggestion transaction` block:

- **Both mid-sequence-throw rollback tests** now register a graph-update listener and
  assert it **never fires** (`notifyCount === 0`) — one for the `Suggestion not found`
  path (link fails after the node is created) and one for the `ThrowingLinkPromoteRepo`
  path (link fails after the fingerprint is created).
- **New happy-path test** asserts the listener fires **exactly once, after** the final
  in-transaction write (`repository.promoteSuggestion`) completes — using the
  call-count-at-notify pattern already established for `recordNavigationEvent` (#2791):
  spy on `NavigationRepository.prototype.promoteSuggestion`, record its call count at
  every notify fire, assert `[1]`. A notification firing *before* the transaction
  completes (count still 0) would be caught, not masked by a later post-commit fire.

No production code changed — the transaction from #2987 is untouched.

## Verification

- `bun test test/features/navigation/NavigationGraphManager.test.ts` → **64 pass / 0 fail**
  (was 63; +1 new test), 843ms for the whole file.
- **Teeth proven** (TDD): temporarily misplacing `notifyGraphUpdated()` inside the
  transaction fails the new tests — at the end of the txn body the "exactly once" test
  fails (`[1,1]` ≠ `[1]`); at the start of the txn body both rollback tests fail
  (listener fires before the throw). Reverted; all green.
- `bunx turbo run lint build` → clean. `scripts/all_fast_validate_checks.sh` → 11/11 pass.
- Unit-test conventions: Interface + Fake, real in-memory DB (`createTestDatabase`), no
  device/network, <100ms.

## Non-goals / follow-ups

- The `describe` block is titled `(#2968)` because that PR seeded it; the new assertions
  are kept co-located with the rollback tests they extend rather than split into a
  near-duplicate `(#2981)` block.
- #2980 (sibling `recordHierarchyNavigation` coverage-enlistment guard) is tracked
  separately and unaffected here.
