### PR TITLE
refactor(ios): extract shared "process already gone" terminate-error matcher (#3076)

### DIFF
--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -4,6 +4,7 @@ import { BootedDevice, TerminateAppResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppInspector } from "../../utils/ios-cmdline-tools/DeviceAppInspector";
+import { isProcessAlreadyGoneError } from "../../utils/ios-cmdline-tools/iosProcessErrors";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { logger } from "../../utils/logger";
@@ -239,7 +240,13 @@ export class TerminateApp extends BaseVisualChange {
       await perf.track("terminateApp", () => this.simctl.terminateApp(bundleId, this.device.deviceId));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (this.isSimctlNotRunningError(message)) {
+      // Shared already-gone matcher (issue #3076): a simctl "found nothing to
+      // terminate" / process-scoped "not running" means the app was already
+      // stopped, so report wasRunning:false rather than a hard error. Any other
+      // failure (e.g. device-level) surfaces as errorMessage. The simulator path
+      // has no tool-specific extras today; add them here (OR-ing the shared
+      // helper) if simctl error text ever diverges.
+      if (isProcessAlreadyGoneError(message)) {
         wasRunning = false;
       } else {
         errorMessage = message;
@@ -299,17 +306,6 @@ export class TerminateApp extends BaseVisualChange {
         error: message
       };
     }
-  }
-
-  // Simulator-path sibling of DeviceAppInspector.isDevicectlProcessGoneError:
-  // both treat an "already gone" terminate failure as an effectively-terminated
-  // app. Kept separate because simctl and devicectl surface distinct, Apple-
-  // undocumented error text that may diverge (see #3054).
-  private isSimctlNotRunningError(message: string): boolean {
-    const normalized = message.toLowerCase();
-    return normalized.includes("no such process")
-      || normalized.includes("not running")
-      || normalized.includes("found nothing to terminate");
   }
 
   private getBundleId(app: any): string | undefined {

--- a/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppInspector.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import type { ExecResult } from "../../models";
 import { hashAppBundle } from "./AppBundleHasher";
+import { isProcessAlreadyGoneError } from "./iosProcessErrors";
 import { logger } from "../logger";
 import { isRunningInDocker } from "../dockerEnv";
 import { getDeviceAppBundleHash, installDeviceApp, isHostControlAvailable, shouldUseHostControl, uninstallDeviceApp } from "../hostControlClient";
@@ -179,9 +180,13 @@ const getExecErrorText = (error: unknown): string => {
  * already gone — it exited between our `info processes` resolution and the kill
  * (a real on-device race, issue #3054). devicectl surfaces ESRCH either as the
  * localized "No such process" strerror text or, on some builds, the bare
- * `NSPOSIXErrorDomain error 3` code without the strerror gloss. This mirrors
- * `TerminateApp.isSimctlNotRunningError` on the simulator path, so a raced exit
- * reports an effectively-terminated app instead of a false `success:false`.
+ * `NSPOSIXErrorDomain error 3` code without the strerror gloss.
+ *
+ * The shared already-gone phrasings live in {@link isProcessAlreadyGoneError}
+ * (used by the simulator path too, issue #3076); here we OR-in the two
+ * devicectl-specific extras so a raced exit reports an effectively-terminated
+ * app instead of a false `success:false`. Together these preserve the exact
+ * prior devicectl behavior: shared `not running` ∪ extra `no longer running`.
  *
  * Deliberately narrow: unrelated failures (device locked, not connected,
  * permission denied) must still propagate as hard errors. The "not running"
@@ -190,10 +195,9 @@ const getExecErrorText = (error: unknown): string => {
  */
 export const isDevicectlProcessGoneError = (message: string): boolean => {
   const normalized = message.toLowerCase();
-  return normalized.includes("no such process")            // ESRCH strerror
-    || normalized.includes("nsposixerrordomain error 3")   // bare ESRCH code
-    || normalized.includes("found nothing to terminate")   // simctl parity
-    || /process (?:is )?(?:no longer |not )running/.test(normalized);
+  return isProcessAlreadyGoneError(message)
+    || normalized.includes("nsposixerrordomain error 3")     // bare ESRCH code
+    || /process (?:is )?no longer running/.test(normalized);  // devicectl-only phrasing
 };
 
 /**

--- a/src/utils/ios-cmdline-tools/iosProcessErrors.ts
+++ b/src/utils/ios-cmdline-tools/iosProcessErrors.ts
@@ -1,0 +1,28 @@
+/**
+ * Canonical "the app's process was already gone, so terminating it is an
+ * effective no-op success" matcher for iOS terminate paths (issue #3076).
+ *
+ * Both the simulator path (`simctl terminate`, see `TerminateApp`) and the
+ * physical-device path (`devicectl device process terminate`, see
+ * `DeviceAppInspector`) can fail because the target process exited on its own
+ * between the moment we resolved it and the moment we tried to kill it. That is
+ * not a real failure — the app is gone either way — so the caller reports an
+ * effectively-terminated app instead of a false `success:false`.
+ *
+ * This helper covers only the phrasings shared by both tools. Tool-specific
+ * error text (e.g. devicectl's bare `NSPOSIXErrorDomain error 3` ESRCH code)
+ * is OR-ed in at the call site rather than re-listed here, so a new shared
+ * phrasing is added in exactly one place.
+ *
+ * Deliberately narrow: unrelated failures (device locked, not connected,
+ * permission denied) must still propagate as hard errors. The "not running"
+ * family is scoped to the *process* — a device- or CoreDevice-level "not
+ * running" must never be mistaken for an already-exited PID, otherwise a
+ * disconnected device would masquerade as a terminated app.
+ */
+export const isProcessAlreadyGoneError = (message: string): boolean => {
+  const normalized = message.toLowerCase();
+  return normalized.includes("no such process")            // ESRCH strerror
+    || normalized.includes("found nothing to terminate")   // simctl "nothing to kill"
+    || /process (?:is )?not running/.test(normalized);      // process-scoped, not device-scoped
+};

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -56,6 +56,45 @@ describe("TerminateApp (iOS)", () => {
     expect(result.wasRunning).toBe(false);
   });
 
+  test("marks app as not running when simctl reports a process-scoped 'not running' (shared matcher)", async () => {
+    class NotRunningSimctl extends FakeSimctl {
+      override async terminateApp(bundleId: string, deviceId?: string): Promise<void> {
+        await super.terminateApp(bundleId, deviceId);
+        throw new Error("The process is not running.");
+      }
+    }
+
+    const notRunningSimctl = new NotRunningSimctl();
+    notRunningSimctl.setInstalledApps([{ bundleId: "com.example.app" }]);
+
+    const terminateApp = new TerminateApp(iosDevice, null, notRunningSimctl, fakeTimer);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(true);
+    expect(result.wasRunning).toBe(false);
+  });
+
+  test("still surfaces an unrelated simctl terminate failure (device-level 'not running' is not swallowed)", async () => {
+    class DeviceDownSimctl extends FakeSimctl {
+      override async terminateApp(bundleId: string, deviceId?: string): Promise<void> {
+        await super.terminateApp(bundleId, deviceId);
+        throw new Error("The device is not running.");
+      }
+    }
+
+    const deviceDownSimctl = new DeviceDownSimctl();
+    deviceDownSimctl.setInstalledApps([{ bundleId: "com.example.app" }]);
+
+    const terminateApp = new TerminateApp(iosDevice, null, deviceDownSimctl, fakeTimer);
+    const result = await terminateApp.execute("com.example.app", { skipObservation: true });
+
+    // A device-level failure is a real error, not an already-terminated app.
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/device is not running/i);
+    expect(result.wasRunning).toBe(true);
+  });
+
   test("returns not installed when bundle id is missing", async () => {
     fakeSimctl.setInstalledApps([{ bundleId: "com.example.other" }]);
 

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { DeviceAppInspector, findProcessIdentifier, findRunningProcessPid, isDevicectlProcessGoneError, parseDevicectlJsonOutputPath } from "../../../src/utils/ios-cmdline-tools/DeviceAppInspector";
+import { isProcessAlreadyGoneError } from "../../../src/utils/ios-cmdline-tools/iosProcessErrors";
 import { hashAppBundle } from "../../../src/utils/ios-cmdline-tools/AppBundleHasher";
 import { FakeHostControlDeviceAppInspector } from "../../fakes/FakeHostControlDeviceAppInspector";
 
@@ -1059,5 +1060,16 @@ describe("isDevicectlProcessGoneError", () => {
     // "not running" must NOT be swallowed as an already-exited PID.
     expect(isDevicectlProcessGoneError("The device is not running.")).toBe(false);
     expect(isDevicectlProcessGoneError("CoreDevice tunnel is not running")).toBe(false);
+  });
+
+  // Drift guard (issue #3076): devicectl must stay a *superset* of the shared
+  // matcher. If someone drops the `isProcessAlreadyGoneError(...)` delegation,
+  // a shared phrasing that isn't a devicectl-only extra would stop matching and
+  // this fails.
+  test("subsumes every shared already-gone phrasing", () => {
+    for (const shared of ["no such process", "found nothing to terminate", "the process is not running"]) {
+      expect(isProcessAlreadyGoneError(shared)).toBe(true);
+      expect(isDevicectlProcessGoneError(shared)).toBe(true);
+    }
   });
 });

--- a/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts
@@ -976,8 +976,8 @@ describe("DeviceAppInspector terminate (devicectl)", () => {
   // Issue #3054: the PID can exit between `info processes` resolution and the
   // kill (a real on-device race). devicectl then exits non-zero and promisified
   // exec rejects; the app is nonetheless effectively terminated, so we must not
-  // surface a false success:false — mirroring the simulator path's
-  // isSimctlNotRunningError tolerance.
+  // surface a false success:false — mirroring the simulator path's shared
+  // isProcessAlreadyGoneError tolerance (#3076).
   const runningProcessesExec = (
     commands: string[],
     onTerminate: (command: string) => void
@@ -1070,6 +1070,21 @@ describe("isDevicectlProcessGoneError", () => {
     for (const shared of ["no such process", "found nothing to terminate", "the process is not running"]) {
       expect(isProcessAlreadyGoneError(shared)).toBe(true);
       expect(isDevicectlProcessGoneError(shared)).toBe(true);
+    }
+  });
+
+  // Equivalence guard: before #3076 the process-state phrasings were one regex,
+  // `/process (?:is )?(?:no longer |not )running/`. The refactor split it into a
+  // shared `not running` half and a devicectl-only `no longer running` half, so
+  // assert the union still matches — with and without the optional "is".
+  test("preserves the old combined 'no longer|not running' union on the devicectl path", () => {
+    for (const phrasing of [
+      "process not running",
+      "The process is not running",
+      "process no longer running",
+      "The process is no longer running"
+    ]) {
+      expect(isDevicectlProcessGoneError(phrasing)).toBe(true);
     }
   });
 });

--- a/test/utils/ios-cmdline-tools/iosProcessErrors.test.ts
+++ b/test/utils/ios-cmdline-tools/iosProcessErrors.test.ts
@@ -1,0 +1,44 @@
+import { expect, describe, test } from "bun:test";
+import { isProcessAlreadyGoneError } from "../../../src/utils/ios-cmdline-tools/iosProcessErrors";
+
+// Shared canonical matcher for "the app's process was already gone, so the
+// terminate is an effective no-op success" (issue #3076). It covers the
+// phrasings common to both the simulator (`simctl terminate`) and the physical
+// device (`devicectl device process terminate`) paths. Each call site OR-s in
+// its own tool-specific extras on top of this.
+describe("isProcessAlreadyGoneError", () => {
+  test("matches the shared already-gone phrasings (case-insensitive)", () => {
+    expect(isProcessAlreadyGoneError("No such process")).toBe(true);
+    expect(isProcessAlreadyGoneError("The operation couldn’t be completed. No such process")).toBe(true);
+    expect(isProcessAlreadyGoneError("found nothing to terminate")).toBe(true);
+    expect(isProcessAlreadyGoneError("Unable to terminate: found nothing to terminate")).toBe(true);
+    // Process-scoped "not running": with and without the "is".
+    expect(isProcessAlreadyGoneError("The process is not running")).toBe(true);
+    expect(isProcessAlreadyGoneError("process not running")).toBe(true);
+    // Case-insensitive.
+    expect(isProcessAlreadyGoneError("NO SUCH PROCESS")).toBe(true);
+    expect(isProcessAlreadyGoneError("FOUND NOTHING TO TERMINATE")).toBe(true);
+  });
+
+  test("does not match unrelated failures", () => {
+    expect(isProcessAlreadyGoneError("The device is locked.")).toBe(false);
+    expect(isProcessAlreadyGoneError("Could not connect to the device.")).toBe(false);
+    expect(isProcessAlreadyGoneError("Unable to terminate: permission denied")).toBe(false);
+    expect(isProcessAlreadyGoneError("")).toBe(false);
+  });
+
+  test("scopes 'not running' to the process, never the device/CoreDevice", () => {
+    // A device-level "not running" must NOT be swallowed as an already-exited
+    // process — otherwise a disconnected device would masquerade as terminated.
+    expect(isProcessAlreadyGoneError("The device is not running.")).toBe(false);
+    expect(isProcessAlreadyGoneError("device not running")).toBe(false);
+    expect(isProcessAlreadyGoneError("CoreDevice tunnel is not running")).toBe(false);
+  });
+
+  test("does NOT include devicectl-only extras (those OR-in at the call site)", () => {
+    // The bare POSIX ESRCH code and the "no longer running" phrasing are
+    // devicectl-specific; the shared helper stays minimal and simctl-safe.
+    expect(isProcessAlreadyGoneError("NSPOSIXErrorDomain error 3")).toBe(false);
+    expect(isProcessAlreadyGoneError("The process is no longer running")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the duplicated "the app's process is already gone → terminate is a no-op success" matcher shared by the two iOS terminate paths into a single canonical helper, per issue #3076 (follow-up to #3054 / PRs #3069, #3074).

Two near-identical matchers had begun to drift:

- `TerminateApp.isSimctlNotRunningError` — simulator path (`simctl terminate`)
- `isDevicectlProcessGoneError` — physical-device path (`devicectl device process terminate`)

### Changes

- **New `src/utils/ios-cmdline-tools/iosProcessErrors.ts`** exporting `isProcessAlreadyGoneError(message)`, covering the phrasings common to both tools: `no such process`, `found nothing to terminate`, and a **process-scoped** `not running`.
- **`isDevicectlProcessGoneError`** now delegates to the shared helper and OR-s in its two devicectl-specific extras: the bare `NSPOSIXErrorDomain error 3` ESRCH code and the `no longer running` phrasing. Behavior is preserved exactly — the old regex `/process (?:is )?(?:no longer |not )running/` decomposes into the shared `not running` ∪ the devicectl-only `no longer running`.
- **`TerminateApp` (simulator path)** now calls the shared helper directly; the private `isSimctlNotRunningError` method is removed.
- Both call sites are kept so tool-specific tolerance can still diverge intentionally (per the issue's guidance).

### Intentional behavior change (safe tightening)

The shared `not running` is **process-scoped** (the narrow devicectl form), not simctl's previous bare `includes("not running")`. This means the simulator path no longer swallows a device-level `"The device is not running"` as an already-terminated app — the safer canonical direction devicectl already took in #3054, and arguably a latent bug fix. No existing simctl test relied on the bare form (real simctl emits `found nothing to terminate`, which is still matched).

## Testing

- New `test/utils/ios-cmdline-tools/iosProcessErrors.test.ts` — shared matcher: matches the three shared phrasings (case-insensitive), rejects unrelated failures (`device locked`, empty, `permission denied`), scopes `not running` to the process (rejects `device`/`CoreDevice`), and excludes the devicectl-only extras.
- `test/features/action/TerminateApp.test.ts` — simulator `"process is not running"` → `wasRunning:false`; device-level `"The device is not running"` now surfaces as a real `success:false` error (not swallowed).
- `test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts` — existing devicectl phrasing tests unchanged (regression parity) + a new drift guard asserting `isDevicectlProcessGoneError` subsumes every shared phrasing.
- `bun test` on the three affected suites: 59 pass / 0 fail. `turbo run lint build`: clean. Pre-existing image-backend failures on `main` (JimpBackend/ContrastChecker) are unrelated to this change.

Closes #3076
