### PR TITLE
fix(android): surface runner error text from requestHierarchySync via diagnostics (#3062)

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -126,6 +126,7 @@ import type {
   A11yLaunchIntentResult,
   InstalledPackageRecord,
   AndroidPerfTiming,
+  HierarchySyncDiagnostics,
 } from "./types";
 
 
@@ -1177,9 +1178,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     disableAllFiltering: boolean = false,
     signal?: AbortSignal,
-    timeoutMs: number = 10000
+    timeoutMs: number = 10000,
+    diagnostics?: HierarchySyncDiagnostics
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null> {
-    return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs);
+    return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs, diagnostics);
   }
 
   async requestHierarchySyncWithoutObservationStreamPush(
@@ -1748,14 +1750,20 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       async attempt => {
         logger.debug(`[CTRL_PROXY] Verifying service ready (attempt ${attempt}/${maxAttempts})`);
 
-        const hierarchyResult = await this.requestHierarchySync(new NoOpPerformanceTracker(), false, undefined, timeoutMs);
+        // Capture the runner's structured error text (issue #3062) so a deterministic handler
+        // failure is attributable in the retry log, not collapsed into an anonymous "no hierarchy".
+        const diagnostics: HierarchySyncDiagnostics = {};
+        const hierarchyResult = await this.requestHierarchySync(new NoOpPerformanceTracker(), false, undefined, timeoutMs, diagnostics);
 
         if (hierarchyResult && hierarchyResult.hierarchy) {
           logger.debug(`[CTRL_PROXY] Service verified ready after ${attempt} attempt(s)`);
           return true;
         }
 
-        throw new Error(`Verification attempt ${attempt} returned no hierarchy`);
+        const runnerErrorSuffix = diagnostics.runnerError
+          ? `: runner error: ${diagnostics.runnerError}`
+          : "";
+        throw new Error(`Verification attempt ${attempt} returned no hierarchy${runnerErrorSuffix}`);
       },
       {
         maxAttempts,

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -650,7 +650,8 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
     perf?: PerformanceTracker,
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
-    timeoutMs?: number
+    timeoutMs?: number,
+    diagnostics?: HierarchySyncDiagnostics
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null>;
 
   requestHierarchySyncWithoutObservationStreamPush(

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1747,12 +1747,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   async verifyServiceReady(maxAttempts: number = 5, delayMs: number = 500, timeoutMs: number = 3000): Promise<boolean> {
+    // Remember the most recent runner error text across attempts (issue #3062) so the terminal
+    // warn — the one visible at the default log level — attributes the deterministic handler
+    // failure, rather than collapsing every attempt into an anonymous "no hierarchy" (a runner
+    // error and a plain timeout previously both surfaced identically here).
+    let lastRunnerError: string | undefined;
     const result = await this.retryExecutor.execute(
       async attempt => {
         logger.debug(`[CTRL_PROXY] Verifying service ready (attempt ${attempt}/${maxAttempts})`);
 
-        // Capture the runner's structured error text (issue #3062) so a deterministic handler
-        // failure is attributable in the retry log, not collapsed into an anonymous "no hierarchy".
         const diagnostics: HierarchySyncDiagnostics = {};
         const hierarchyResult = await this.requestHierarchySync(new NoOpPerformanceTracker(), false, undefined, timeoutMs, diagnostics);
 
@@ -1761,6 +1764,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           return true;
         }
 
+        if (diagnostics.runnerError) {
+          lastRunnerError = diagnostics.runnerError;
+        }
         const runnerErrorSuffix = diagnostics.runnerError
           ? `: runner error: ${diagnostics.runnerError}`
           : "";
@@ -1777,7 +1783,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     );
 
     if (!result.success) {
-      logger.warn(`[CTRL_PROXY] Service not ready after ${maxAttempts} verification attempts`);
+      const runnerErrorSuffix = lastRunnerError ? ` (last runner error: ${lastRunnerError})` : "";
+      logger.warn(`[CTRL_PROXY] Service not ready after ${maxAttempts} verification attempts${runnerErrorSuffix}`);
       return false;
     }
 

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -20,6 +20,7 @@ import type {
   AccessibilityNode,
   CachedHierarchy,
   AndroidPerfTiming,
+  HierarchySyncDiagnostics,
 } from "./types";
 import { generateSecureId } from "./types";
 import { ctrlProxyRequests, serializeCtrlProxyRequest } from "./ctrlProxyProtocol";
@@ -36,6 +37,22 @@ const WEBSOCKET_TIMEOUT_COOLDOWN_MS = 500;
  *  100ms was too aggressive: under contention pushes routinely exceeded
  *  it, silently degrading results to stale cache. See issue #2285. */
 const DEFAULT_FRESH_WAIT_MS = 1000;
+
+/**
+ * Rejection carrier for a correlated runner `type:"error"` frame (issue #3062).
+ *
+ * `waitForFreshData` rejects with this (instead of a bare `Error`) when a runner error frame
+ * unblocks the wait, so `requestHierarchySync`'s catch can distinguish a runner-reported handler
+ * failure from any other thrown cause (abort, connection failure) and surface only the former to
+ * the caller via the `HierarchySyncDiagnostics` out-parameter. Module-private: it is an internal
+ * control-flow signal, not part of any public contract.
+ */
+class HierarchyRunnerError extends Error {
+  constructor(readonly runnerError: string) {
+    super(runnerError);
+    this.name = "HierarchyRunnerError";
+  }
+}
 
 /**
  * Delegate class for handling hierarchy retrieval and caching.
@@ -296,8 +313,9 @@ export class CtrlProxyHierarchy {
       if (needsSync) {
         logger.debug(`[CTRL_PROXY] WebSocket returned ${hierarchyData ? "stale" : "no"} data (fresh=${isFresh}), syncing for fresh data`);
 
+        const syncDiagnostics: HierarchySyncDiagnostics = {};
         const syncResult = await perf.track("syncRequest", () =>
-          this.requestHierarchySync(perf, disableAllFiltering, signal)
+          this.requestHierarchySync(perf, disableAllFiltering, signal, undefined, syncDiagnostics)
         );
 
         if (syncResult) {
@@ -311,7 +329,12 @@ export class CtrlProxyHierarchy {
           }
           logger.debug("[CTRL_PROXY] Successfully retrieved hierarchy via sync ADB method");
         } else if (!hierarchyData) {
-          logger.warn("[CTRL_PROXY] Both WebSocket and sync methods failed, will use fallback");
+          // Surface the runner's structured error text when the sync failed on a correlated runner
+          // error frame, so the fallback is attributable rather than an anonymous timeout (#3062).
+          const runnerErrorSuffix = syncDiagnostics.runnerError
+            ? ` (runner error: ${syncDiagnostics.runnerError})`
+            : "";
+          logger.warn(`[CTRL_PROXY] Both WebSocket and sync methods failed, will use fallback${runnerErrorSuffix}`);
           perf.end();
           return null;
         }
@@ -355,7 +378,8 @@ export class CtrlProxyHierarchy {
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     disableAllFiltering: boolean = false,
     signal?: AbortSignal,
-    timeoutMs: number = 10000
+    timeoutMs: number = 10000,
+    diagnostics?: HierarchySyncDiagnostics
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null> {
     const startTime = this.context.timer.now();
     const effectiveTimeoutMs = Math.max(0, timeoutMs);
@@ -408,6 +432,12 @@ export class CtrlProxyHierarchy {
       return null;
     } catch (error) {
       const duration = this.context.timer.now() - startTime;
+      // A correlated runner type:"error" frame (issue #3032 / #3061) rejects the wait with a typed
+      // HierarchyRunnerError. Surface its text on the caller-provided diagnostics so the caller can
+      // tell this deterministic handler failure apart from a plain timeout `null` (issue #3062).
+      if (error instanceof HierarchyRunnerError && diagnostics) {
+        diagnostics.runnerError = error.runnerError;
+      }
       logger.warn(`[CTRL_PROXY] Sync hierarchy request failed after ${duration}ms: ${error}`);
       return null;
     }
@@ -615,7 +645,9 @@ export class CtrlProxyHierarchy {
         this.pendingHierarchyRejectors.set(id, {
           reject: (error: string) => {
             logger.warn(`[CTRL_PROXY] ${label} ${id} failed via runner error: ${error}`);
-            settleReject(new Error(error));
+            // Reject with a typed carrier so requestHierarchySync's catch can tell a runner-reported
+            // handler failure apart from other thrown causes and surface it via diagnostics (#3062).
+            settleReject(new HierarchyRunnerError(error));
           }
         });
       };

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -122,6 +122,23 @@ export interface AccessibilityHierarchy {
 export type AndroidPerfTiming = PerfTiming;
 
 /**
+ * Per-call diagnostics out-parameter for `CtrlProxyHierarchy.requestHierarchySync` (issue #3062).
+ *
+ * `requestHierarchySync` returns `null` on BOTH a plain timeout (the runner never pushed a
+ * hierarchy) and a correlated runner `type:"error"` frame (#3032 / #3061 fail the wait fast).
+ * The two are indistinguishable from the return value alone. Callers that care can pass a fresh
+ * `{}` and inspect `runnerError` afterward: it is populated with the runner's structured error
+ * text ONLY on the runner-error path, and left `undefined` on timeout or success. Passing no
+ * object preserves the original behavior — this is a purely additive, per-call channel with no
+ * shared state (so concurrent syncs cannot misattribute one another's errors).
+ */
+export interface HierarchySyncDiagnostics {
+  /** The runner's structured error text when the sync failed fast on a correlated runner
+   *  `type:"error"` frame; `undefined` on a plain timeout or a successful sync. */
+  runnerError?: string;
+}
+
+/**
  * Interface for cached hierarchy with metadata
  */
 export interface CachedHierarchy {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -16,6 +16,7 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 import type { DeviceConnectionLostNotifier } from "../../../src/features/observe/DeviceConnectionLostNotifier";
 import { PortManager } from "../../../src/utils/PortManager";
 import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
+import type { HierarchySyncDiagnostics } from "../../../src/features/observe/android/types";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -1413,6 +1414,204 @@ describe("AndroidCtrlProxyClient", function() {
         expect(result.hierarchy).not.toBeNull();
         expect(result.hierarchy!.hierarchy.text).toBe("Stale cache preserved");
         expect(result.fresh).toBe(false);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
+  describe("runner error surfacing via diagnostics (issue #3062)", function() {
+    // Follow-up to #3032 / #3061. Those made a correlated runner type:"error" frame fail the
+    // hierarchy wait fast, but requestHierarchySync still collapsed the rejection to `null` —
+    // indistinguishable from a plain timeout `null`. #3062 threads a per-call `diagnostics`
+    // out-parameter so a caller can tell "runner reported a structured handler failure" (text
+    // populated) apart from "the push never arrived" (timeout: null result, diagnostics untouched).
+
+    const findSentMessageOfType = (socket: CapturingWebSocket, type: string): any | undefined => {
+      const raw = socket.sentMessages.find(m => {
+        try { return JSON.parse(m).type === type; } catch { return false; }
+      });
+      return raw ? JSON.parse(raw) : undefined;
+    };
+
+    const driveUntilStaleNudge = async (socket: CapturingWebSocket, timer: FakeTimer): Promise<any> => {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await flushPromises();
+        timer.advanceTime(2100);
+        await flushPromises();
+        const staleMsg = findSentMessageOfType(socket, "request_hierarchy_if_stale");
+        if (staleMsg) {
+          return staleMsg;
+        }
+      }
+      return undefined;
+    };
+
+    test("a correlated runner error populates diagnostics.runnerError while still returning null", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const diagnostics: HierarchySyncDiagnostics = {};
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000, diagnostics);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const hierarchyMsg = findSentMessageOfType(socket, "request_hierarchy");
+        expect(hierarchyMsg).toBeDefined();
+        expect(hierarchyMsg.requestId).toBeDefined();
+
+        const runnerText = "request_hierarchy handler failed: view hierarchy extraction threw";
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: hierarchyMsg.requestId,
+          success: false,
+          error: runnerText,
+          timestamp: errorTimer.now()
+        }));
+
+        await flushPromises();
+        const result = await syncPromise;
+
+        // Contract unchanged: still null so existing callers keep working.
+        expect(result).toBeNull();
+        // But the runner text is now surfaced to the caller, distinct from a timeout.
+        expect(diagnostics.runnerError).toBe(runnerText);
+        // Fast-fail: no sitting through the 10s timeout.
+        expect(errorTimer.getCurrentTime()).toBeLessThan(10000);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a plain timeout leaves diagnostics.runnerError undefined (no misattribution)", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const diagnostics: HierarchySyncDiagnostics = {};
+        // Short timeout; never deliver a push or an error frame -> genuine timeout.
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 3000, diagnostics);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const result = await errorTimer.resolvePromise(syncPromise);
+
+        expect(result).toBeNull();
+        // Crucially: a timeout must NOT surface a runner error.
+        expect(diagnostics.runnerError).toBeUndefined();
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("an uncorrelated error id leaves diagnostics.runnerError undefined and the push still resolves", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const diagnostics: HierarchySyncDiagnostics = {};
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000, diagnostics);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: "some-unrelated-id",
+          success: false,
+          error: "Malformed request: the payload is not valid JSON",
+          timestamp: errorTimer.now()
+        }));
+
+        socket.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: errorTimer.now(),
+          data: {
+            updatedAt: errorTimer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Recovered after uncorrelated error" }
+          }
+        }));
+
+        const result = await errorTimer.resolvePromise(syncPromise);
+
+        expect(result).not.toBeNull();
+        expect(result!.hierarchy.hierarchy.text).toBe("Recovered after uncorrelated error");
+        expect(diagnostics.runnerError).toBeUndefined();
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a correlated stale-nudge runner error also populates diagnostics.runnerError", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const diagnostics: HierarchySyncDiagnostics = {};
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000, diagnostics);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const staleMsg = await driveUntilStaleNudge(socket, errorTimer);
+        expect(staleMsg).toBeDefined();
+        expect(String(staleMsg.requestId).startsWith("stale_")).toBe(true);
+
+        const runnerText = "request_hierarchy_if_stale handler failed: view hierarchy extraction threw";
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: staleMsg.requestId,
+          success: false,
+          error: runnerText,
+          timestamp: errorTimer.now()
+        }));
+
+        await flushPromises();
+        const result = await syncPromise;
+
+        expect(result).toBeNull();
+        expect(diagnostics.runnerError).toBe(runnerText);
+        expect(errorTimer.getCurrentTime()).toBeLessThan(10000);
       } finally {
         await testClient.close();
       }

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -17,6 +17,7 @@ import type { DeviceConnectionLostNotifier } from "../../../src/features/observe
 import { PortManager } from "../../../src/utils/PortManager";
 import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
 import type { HierarchySyncDiagnostics } from "../../../src/features/observe/android/types";
+import { logger } from "../../../src/utils/logger";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -1613,6 +1614,59 @@ describe("AndroidCtrlProxyClient", function() {
         expect(diagnostics.runnerError).toBe(runnerText);
         expect(errorTimer.getCurrentTime()).toBeLessThan(10000);
       } finally {
+        await testClient.close();
+      }
+    });
+
+    test("verifyServiceReady surfaces the runner error text in its terminal warn", async function() {
+      // Consumption test: prove the diagnostics text actually reaches an observable, default-level
+      // log line (not just the dropped per-attempt debug), attributing the deterministic handler
+      // failure instead of an anonymous "no hierarchy". Spy on the module logger's warn.
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      const warnMessages: string[] = [];
+      const originalWarn = logger.warn;
+      logger.warn = (message: string) => {
+        warnMessages.push(message);
+      };
+
+      try {
+        testClient.invalidateCache();
+        // Single attempt so one correlated error frame drives it straight to the terminal warn.
+        const verifyPromise = testClient.verifyServiceReady(1, 10, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const hierarchyMsg = findSentMessageOfType(socket, "request_hierarchy");
+        expect(hierarchyMsg).toBeDefined();
+
+        const runnerText = "request_hierarchy handler failed: view hierarchy extraction threw";
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: hierarchyMsg.requestId,
+          success: false,
+          error: runnerText,
+          timestamp: errorTimer.now()
+        }));
+
+        const ready = await errorTimer.resolvePromise(verifyPromise);
+
+        expect(ready).toBe(false);
+        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
+        expect(terminalWarn).toBeDefined();
+        expect(terminalWarn).toContain(runnerText);
+      } finally {
+        logger.warn = originalWarn;
         await testClient.close();
       }
     });


### PR DESCRIPTION
## Summary

Follow-up to #3032 / PR #3060 (and sibling #3061 / PR #3070). Those routed a correlated runner `type:"error"` frame into the hierarchy wait so it fails fast instead of hanging to the `waitForFreshData` timeout — but `CtrlProxyHierarchy.requestHierarchySync` still collapses **both** a plain timeout and a runner-reported handler failure into a `null` return. Callers (`getAccessibilityHierarchy`, `verifyServiceReady`) therefore cannot tell "the runner reported a structured handler failure" apart from "the push never arrived (timeout)" — both become `null` → fallback.

This surfaces the runner's error text without widening the primary return contract.

## Approach

The issue's Option 1 (discriminated result) has a large blast radius — every caller of `requestHierarchySync` checks `if (result)` truthiness then `result.hierarchy`, so a new error shape would break them. Option 2 literal (stash on the client) is racy: a later timeout could read a **stale** runner error from a previous call and misattribute it, defeating the whole point of distinguishing the two.

Instead: a **per-call `HierarchySyncDiagnostics` out-parameter**.

- **Race-free** — per call, no shared instance state, so concurrent syncs can't misattribute one another's errors.
- **Backward compatible** — optional trailing param; the `null` return is unchanged, existing callers untouched.
- **Narrow / YAGNI** — only the callers that care opt in.
- The distinction is already made **per-call inside** `requestHierarchySync`: a correlated runner error rejects the wait (reaches the `catch`), while a timeout resolves `null` (reaches the `try` return). A typed `HierarchyRunnerError` carrier lets the `catch` tell a runner-reported failure apart from any other thrown cause (abort, connection failure) and write only the former to `diagnostics.runnerError`.

## Changes

- `types.ts`: new `HierarchySyncDiagnostics { runnerError?: string }`.
- `CtrlProxyHierarchy.ts`:
  - module-private `HierarchyRunnerError` carrier; `waitForFreshData`'s rejector now rejects with it instead of a bare `Error` (covers both the primary `request_hierarchy` and the `request_hierarchy_if_stale` nudge).
  - `requestHierarchySync(..., diagnostics?)`: on `error instanceof HierarchyRunnerError`, populates `diagnostics.runnerError`; still returns `null`.
  - `getAccessibilityHierarchy`: threads a diagnostics object and appends the runner text to its "Both WebSocket and sync methods failed" warn.
- `AndroidCtrlProxyClient.ts`: threads `diagnostics?` through the delegate wrapper and the `AndroidCtrlProxy` interface; `verifyServiceReady` captures it and includes the runner text in its per-attempt failure so the retry log/telemetry is attributable rather than an anonymous "no hierarchy".

No change to retry policy — whether a handler failure is deterministic-and-should-not-retry vs transient is intentionally out of scope (the issue framed it as optional).

## Acceptance criteria

- [x] A correlated runner `type:"error"` frame populates `diagnostics.runnerError` with the runner text while still returning `null` (fast-fail, no timeout).
- [x] A plain timeout leaves `diagnostics.runnerError` **undefined** — no misattribution.
- [x] An uncorrelated / unknown error id leaves `diagnostics.runnerError` undefined and the real push still resolves normally.
- [x] The `request_hierarchy_if_stale` nudge (#3061) runner error also populates `diagnostics.runnerError`.
- [x] Passing no diagnostics object preserves original behavior; all #3032 / #3061 tests remain green.
- [x] `verifyServiceReady` / `getAccessibilityHierarchy` attribute the runner text in their failure logs.

## Testing

- `bun test test/features/observe/CtrlProxyClient.test.ts` — 32 pass (4 new for #3062).
- `turbo run lint build` — clean.
- `tsc --noEmit` — no new type errors in touched files (only the pre-existing `moduleResolution` deprecation).
- Full `turbo run test` — the only failures are the pre-existing jimp/image-backend suites (`PerceptualHasher`, `JimpBackend`, `ScreenshotUtils`), untouched by this change.

Closes #3062

## Related

- Parent hang-class: #3032 (PR #3060). Sibling stale-nudge: #3061 (PR #3070). iOS surfacing/legibility: #2986 / #3017.
