### PR TITLE
feat(ios): openLink opens URLs/deep links on physical iOS devices via devicectl

### DIFF
--- a/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
+++ b/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
@@ -306,8 +306,9 @@ Opens a URL or deep link.
   `http(s)://` URLs launch Safari (which resolves universal links and hands off
   to the owning app); custom-scheme deep links (`yourapp://…`) launch the target
   app previously selected by `launchApp`, falling back to Safari when no target
-  is known. On an older device / missing `devicectl`, `openLink` returns an
-  explicit error rather than silently failing.
+  is known. `mailto:`/`tel:`/`sms:` are opened best-effort via the same fallback.
+  On an older device / missing `devicectl`, `openLink` returns an explicit error
+  rather than silently failing.
 
 ```yaml
 - tool: openLink

--- a/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
+++ b/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
@@ -298,7 +298,16 @@ Swipes in a direction within an element or the whole screen.
 
 ### `openLink`
 
-Opens a URL or deep link via `simctl openurl`.
+Opens a URL or deep link.
+
+- **Simulators** use `simctl openurl`.
+- **Physical devices** use `devicectl` (`device process launch --payload-url`),
+  which requires **Xcode 15+** on a **macOS host** and **iOS 17+** on the device.
+  `http(s)://` URLs launch Safari (which resolves universal links and hands off
+  to the owning app); custom-scheme deep links (`yourapp://…`) launch the target
+  app previously selected by `launchApp`, falling back to Safari when no target
+  is known. On an older device / missing `devicectl`, `openLink` returns an
+  explicit error rather than silently failing.
 
 ```yaml
 - tool: openLink

--- a/src/features/action/OpenURL.ts
+++ b/src/features/action/OpenURL.ts
@@ -213,10 +213,14 @@ export class OpenURL extends BaseVisualChange {
     }
 
     try {
-      // http(s) → Safari resolves universal links; custom schemes → owning/target app, else Safari.
+      // http(s) → Safari resolves universal links and hands off to the owning
+      // app. Non-http (custom scheme, and best-effort mailto:/tel:) → the app
+      // targeted by a prior launchApp, else Safari. We read the target with the
+      // non-constructing getExistingTargetBundleId so a bare openLink can't
+      // spin up a CtrlProxy manager (and reserve a service port) just to read it.
       const bundleId = /^https?:\/\//i.test(url.trim())
         ? SAFARI_BUNDLE_ID
-        : (IOSCtrlProxyManager.getInstance(this.device).getTargetBundleId() ?? SAFARI_BUNDLE_ID);
+        : (IOSCtrlProxyManager.getExistingTargetBundleId(this.device) ?? SAFARI_BUNDLE_ID);
       await devicectl.launchWithPayloadUrl(this.device.deviceId, bundleId, url);
       return {
         success: true,

--- a/src/features/action/OpenURL.ts
+++ b/src/features/action/OpenURL.ts
@@ -2,15 +2,36 @@ import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange } from "./BaseVisualChange";
 import { BootedDevice, OpenURLResult } from "../../models";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { DeviceCtlClient, DeviceUrlLauncher } from "../../utils/ios-cmdline-tools/DeviceCtlClient";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import { logger } from "../../utils/logger";
 import { LaunchApp } from "./LaunchApp";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 
+const SAFARI_BUNDLE_ID = "com.apple.mobilesafari";
+
 export class OpenURL extends BaseVisualChange {
 
-  constructor(device: BootedDevice, adb: AdbClient | null = null) {
+  private readonly simctl: SimCtlClient | null;
+  private readonly devicectl: DeviceUrlLauncher | null;
+
+  /**
+   * @param device - The target device
+   * @param adb - Optional AdbClient instance (for testing)
+   * @param simctl - Optional SimCtlClient for the iOS simulator path (for testing)
+   * @param devicectl - Optional DeviceUrlLauncher for the iOS physical-device path (for testing)
+   */
+  constructor(
+    device: BootedDevice,
+    adb: AdbClient | null = null,
+    simctl: SimCtlClient | null = null,
+    devicectl: DeviceUrlLauncher | null = null
+  ) {
     super(device, adb);
     this.device = device;
+    this.simctl = simctl;
+    this.devicectl = devicectl;
   }
 
   async execute(
@@ -131,13 +152,28 @@ export class OpenURL extends BaseVisualChange {
   }
 
   /**
-   * Execute iOS-specific URL opening using simctl
+   * Execute iOS-specific URL opening. Branches on the canonical
+   * {@link isIosSimulatorUdid} signal: simulators keep the simulator-only
+   * `simctl openurl` path, while physical devices (iOS 17+) go through
+   * `devicectl`, since `simctl` cannot target a physical-device UDID.
    * @param url - URL to open
    * @returns Result of the URL opening operation
    */
   private async executeiOSOpenURL(url: string): Promise<OpenURLResult> {
+    if (isIosSimulatorUdid(this.device.deviceId)) {
+      return this.executeiOSSimulatorOpenURL(url);
+    }
+    return this.executeiOSPhysicalOpenURL(url);
+  }
+
+  /**
+   * Open a URL on an iOS simulator via `xcrun simctl openurl`.
+   * @param url - URL to open
+   * @returns Result of the URL opening operation
+   */
+  private async executeiOSSimulatorOpenURL(url: string): Promise<OpenURLResult> {
     try {
-      const simctl = new SimCtlClient();
+      const simctl = this.simctl ?? new SimCtlClient();
       // Use simctl openurl command: xcrun simctl openurl <device> <url>
       await simctl.executeCommand(`openurl ${this.device.deviceId} "${url}"`);
 
@@ -147,6 +183,47 @@ export class OpenURL extends BaseVisualChange {
       };
     } catch (error) {
       logger.error(`[OpenURL] simctl openurl failed: ${error}`);
+      return {
+        success: false,
+        url,
+        error: String(error)
+      };
+    }
+  }
+
+  /**
+   * Open a URL on a physical iOS device (iOS 17+) via `devicectl`. http(s) URLs
+   * launch Safari (which resolves universal links and hands off to the owning
+   * app); custom-scheme deep links launch the resolved target app bundle
+   * (the app targeted by a prior launchApp), falling back to Safari when no
+   * target is known.
+   * @param url - URL to open
+   * @returns Result of the URL opening operation
+   */
+  private async executeiOSPhysicalOpenURL(url: string): Promise<OpenURLResult> {
+    const devicectl = this.devicectl ?? new DeviceCtlClient();
+
+    if (!(await devicectl.isAvailable())) {
+      return {
+        success: false,
+        url,
+        error: "Opening URLs on a physical iOS device requires Xcode 15+ and iOS 17+ (devicectl). " +
+               "Update Xcode/iOS, or open the URL on a simulator."
+      };
+    }
+
+    try {
+      // http(s) → Safari resolves universal links; custom schemes → owning/target app, else Safari.
+      const bundleId = /^https?:\/\//i.test(url.trim())
+        ? SAFARI_BUNDLE_ID
+        : (IOSCtrlProxyManager.getInstance(this.device).getTargetBundleId() ?? SAFARI_BUNDLE_ID);
+      await devicectl.launchWithPayloadUrl(this.device.deviceId, bundleId, url);
+      return {
+        success: true,
+        url
+      };
+    } catch (error) {
+      logger.error(`[OpenURL] devicectl open URL failed: ${error}`);
       return {
         success: false,
         url,

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -390,6 +390,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
+   * Resolve the currently-targeted app bundle ID (explicit
+   * {@link setTargetBundleId} value > `CTRL_PROXY_IOS_BUNDLE_ID` env var >
+   * undefined). Public read-only companion to {@link setTargetBundleId}; used by
+   * OpenURL to route a custom-scheme deep link into the owning/target app on a
+   * physical device. Does not mutate state.
+   */
+  public getTargetBundleId(): string | undefined {
+    return this.resolveTargetBundleId();
+  }
+
+  /**
    * Resolve the target bundle ID: explicit property > env var > undefined.
    */
   private resolveTargetBundleId(): string | undefined {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -401,6 +401,22 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
+   * Read the target bundle ID for a device **without constructing** a manager
+   * instance. Prefer this over `getInstance(device).getTargetBundleId()` for a
+   * pure read: `getInstance` builds the whole per-device proxy stack and
+   * {@link allocateServicePort reserves a global service port} as a side effect,
+   * which is wrong for a caller (e.g. OpenURL's custom-scheme branch) that only
+   * needs to know the currently-targeted app. Returns the explicit target from a
+   * pre-existing instance (set by a prior `launchApp`) > `CTRL_PROXY_IOS_BUNDLE_ID`
+   * env var > undefined.
+   */
+  public static getExistingTargetBundleId(device: BootedDevice): string | undefined {
+    return IOSCtrlProxyManager.instances.get(device.deviceId)?.getTargetBundleId()
+      ?? process.env.CTRL_PROXY_IOS_BUNDLE_ID
+      ?? undefined;
+  }
+
+  /**
    * Resolve the target bundle ID: explicit property > env var > undefined.
    */
   private resolveTargetBundleId(): string | undefined {

--- a/src/utils/ios-cmdline-tools/DeviceCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/DeviceCtlClient.ts
@@ -1,0 +1,132 @@
+import type { ExecResult } from "../../models";
+import { isRunningInDocker } from "../dockerEnv";
+import { shouldUseHostControl } from "../hostControlClient";
+
+/**
+ * Single-quote a value for safe interpolation into a `/bin/sh -c` command,
+ * matching {@link DeviceAppInspector}'s convention. `--device <udid>` is passed
+ * unquoted (UDIDs are `[0-9A-F-]`), while user-controlled url + bundle id are
+ * quoted to prevent shell injection.
+ */
+const quoteShell = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
+
+/**
+ * Narrow seam OpenURL depends on to open a URL on a *physical* iOS device.
+ * Implemented by {@link DeviceCtlClient}; faked in tests so the URL path never
+ * shells out. Kept minimal (YAGNI): OpenURL only needs to know whether the
+ * physical-device path is usable and how to launch a bundle with a payload URL.
+ */
+export interface DeviceUrlLauncher {
+  /** True when `devicectl` can service a physical-device open-URL request. */
+  isAvailable(): Promise<boolean>;
+  /**
+   * Open `url` on a physical iOS device by launching `bundleId` with the URL as
+   * its launch payload. Throws with actionable context on failure (unsupported
+   * host, host-control mode, or an underlying devicectl error).
+   */
+  launchWithPayloadUrl(deviceUdid: string, bundleId: string, url: string): Promise<void>;
+}
+
+export interface DeviceCtlDependencies {
+  platform: () => NodeJS.Platform;
+  exec: (command: string) => Promise<ExecResult>;
+  hostControl: {
+    shouldUseHostControl: () => boolean;
+    isRunningInDocker: () => boolean;
+  };
+}
+
+const defaultDependencies: DeviceCtlDependencies = {
+  platform: () => process.platform,
+  exec: async command => {
+    const { exec } = await import("child_process");
+    const { promisify } = await import("util");
+    const result = await promisify(exec)(command);
+    const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
+    const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
+    return {
+      stdout,
+      stderr,
+      toString() { return stdout; },
+      trim() { return stdout.trim(); },
+      includes(searchString: string) { return stdout.includes(searchString); }
+    };
+  },
+  hostControl: {
+    shouldUseHostControl,
+    isRunningInDocker,
+  }
+};
+
+/**
+ * Thin, injectable wrapper over `xcrun devicectl` for opening URLs / deep links
+ * on a *physical* iOS device (Xcode 15+/iOS 17+). Mirrors
+ * {@link DeviceAppInspector}'s dependency-injection + `process.platform ===
+ * "darwin"` guard so it stays unit-testable with a fake `exec`, and returns the
+ * same explicit "not supported under host control" posture for Docker.
+ *
+ * Simulators are handled by the `simctl openurl` path in OpenURL and never reach
+ * this client.
+ */
+export class DeviceCtlClient implements DeviceUrlLauncher {
+  private readonly deps: DeviceCtlDependencies;
+
+  constructor(deps: DeviceCtlDependencies = defaultDependencies) {
+    this.deps = deps;
+  }
+
+  private isHostControlMode(): boolean {
+    return this.deps.hostControl.shouldUseHostControl() && this.deps.hostControl.isRunningInDocker();
+  }
+
+  /**
+   * True when the physical-device open-URL path is usable.
+   *
+   * Under Docker host control we report `true` even though `devicectl` isn't
+   * reachable locally: the host-control bridge exposes no launch-with-URL
+   * primitive yet, so we let the caller proceed to {@link launchWithPayloadUrl},
+   * which returns the precise "not supported under host control" error rather
+   * than the generic missing-devicectl message. Otherwise this requires a macOS
+   * host with a working `devicectl` (Xcode 15+).
+   */
+  async isAvailable(): Promise<boolean> {
+    if (this.isHostControlMode()) {
+      return true;
+    }
+    if (this.deps.platform() !== "darwin") {
+      return false;
+    }
+    try {
+      await this.deps.exec("xcrun devicectl --version");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Open a URL on a physical iOS device (Xcode 15+/iOS 17+) by launching
+   * `bundleId` with the URL as its launch payload. For http(s) URLs the caller
+   * passes `com.apple.mobilesafari` so Safari resolves universal links;
+   * custom-scheme URLs pass the owning/target app bundle id.
+   */
+  async launchWithPayloadUrl(deviceUdid: string, bundleId: string, url: string): Promise<void> {
+    if (this.isHostControlMode()) {
+      throw new Error(
+        "Opening a URL on a physical iOS device is not supported under host control: " +
+        "the host-control bridge exposes no devicectl launch-with-URL primitive."
+      );
+    }
+    if (this.deps.platform() !== "darwin") {
+      throw new Error("Opening URLs on a physical iOS device requires macOS");
+    }
+    const command = [
+      "xcrun", "devicectl", "device", "process", "launch",
+      "--device", deviceUdid,            // unquoted, matching DeviceAppInspector
+      "--payload-url", quoteShell(url),
+      "--terminate-existing",
+      quoteShell(bundleId)
+    ].join(" ");
+    await this.deps.exec(command);
+  }
+}

--- a/test/fakes/FakeDeviceCtlClient.ts
+++ b/test/fakes/FakeDeviceCtlClient.ts
@@ -1,0 +1,34 @@
+import type { DeviceUrlLauncher } from "../../src/utils/ios-cmdline-tools/DeviceCtlClient";
+
+/**
+ * Test double for {@link DeviceCtlClient} implementing the narrow
+ * {@link DeviceUrlLauncher} seam OpenURL depends on. Records every
+ * launchWithPayloadUrl call so tests can assert the exact
+ * (deviceUdid, bundleId, url) devicectl would receive without shelling out.
+ */
+export class FakeDeviceCtlClient implements DeviceUrlLauncher {
+  private available = true;
+  private launchError: Error | null = null;
+  public readonly launchCalls: Array<{ deviceUdid: string; bundleId: string; url: string }> = [];
+  public availabilityChecks = 0;
+
+  setAvailable(available: boolean): void {
+    this.available = available;
+  }
+
+  setLaunchError(error: Error | null): void {
+    this.launchError = error;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    this.availabilityChecks++;
+    return this.available;
+  }
+
+  async launchWithPayloadUrl(deviceUdid: string, bundleId: string, url: string): Promise<void> {
+    this.launchCalls.push({ deviceUdid, bundleId, url });
+    if (this.launchError) {
+      throw this.launchError;
+    }
+  }
+}

--- a/test/features/action/OpenURL.test.ts
+++ b/test/features/action/OpenURL.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test, spyOn } from "bun:test";
+import { OpenURL } from "../../../src/features/action/OpenURL";
+import { LaunchApp } from "../../../src/features/action/LaunchApp";
+import { IOSCtrlProxyManager } from "../../../src/utils/IOSCtrlProxyManager";
+import { BootedDevice } from "../../../src/models";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { FakeDeviceCtlClient } from "../../fakes/FakeDeviceCtlClient";
+
+const SIMULATOR_UDID = "ABCDEF01-1234-1234-1234-1234567890AB";
+const PHYSICAL_UDID = "00008110-000A4D8E1234567E";
+
+const iosDevice = (deviceId: string): BootedDevice => ({
+  name: "iPhone",
+  platform: "ios",
+  deviceId,
+});
+
+// Directly exercise the iOS routing (executeiOSOpenURL) so we assert the
+// sim-vs-physical branch without spinning up the observe/visual-change machinery.
+const openIos = (
+  device: BootedDevice,
+  simctl: FakeSimCtlClient,
+  devicectl: FakeDeviceCtlClient,
+  url: string
+) => {
+  const openURL = new OpenURL(device, new FakeAdbExecutor() as unknown as any, simctl as any, devicectl as any);
+  return (openURL as any).executeiOSOpenURL(url) as Promise<{ success: boolean; url: string; error?: string }>;
+};
+
+describe("OpenURL iOS routing", () => {
+  const restores: Array<() => void> = [];
+  afterEach(() => {
+    while (restores.length) { restores.pop()!(); }
+  });
+
+  test("(a) simulator UDID routes to `simctl openurl` and never touches devicectl", async () => {
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+
+    const result = await openIos(iosDevice(SIMULATOR_UDID), simctl, devicectl, "https://example.com/x");
+
+    expect(result).toEqual({ success: true, url: "https://example.com/x" });
+    const calls = simctl.getMethodCalls("executeCommand");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe(`openurl ${SIMULATOR_UDID} "https://example.com/x"`);
+    expect(devicectl.launchCalls).toHaveLength(0);
+  });
+
+  test("(b) physical UDID + http URL launches Safari with the payload URL", async () => {
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+
+    const result = await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "https://example.com/order/123");
+
+    expect(result).toEqual({ success: true, url: "https://example.com/order/123" });
+    expect(devicectl.launchCalls).toEqual([
+      { deviceUdid: PHYSICAL_UDID, bundleId: "com.apple.mobilesafari", url: "https://example.com/order/123" },
+    ]);
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+  });
+
+  test("(c) physical UDID + custom scheme launches the resolved target bundle id", async () => {
+    const managerSpy = spyOn(IOSCtrlProxyManager, "getInstance").mockReturnValue({
+      getTargetBundleId: () => "com.example.MyApp",
+    } as unknown as IOSCtrlProxyManager);
+    restores.push(() => managerSpy.mockRestore());
+
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+
+    const result = await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "myapp://order/123");
+
+    expect(result.success).toBe(true);
+    expect(devicectl.launchCalls).toEqual([
+      { deviceUdid: PHYSICAL_UDID, bundleId: "com.example.MyApp", url: "myapp://order/123" },
+    ]);
+  });
+
+  test("(c2) physical UDID + custom scheme with no target bundle falls back to Safari", async () => {
+    const managerSpy = spyOn(IOSCtrlProxyManager, "getInstance").mockReturnValue({
+      getTargetBundleId: () => undefined,
+    } as unknown as IOSCtrlProxyManager);
+    restores.push(() => managerSpy.mockRestore());
+
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+
+    await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "myapp://order/123");
+
+    expect(devicectl.launchCalls[0].bundleId).toBe("com.apple.mobilesafari");
+  });
+
+  test("(d) unavailable devicectl returns an explicit iOS 17+/Xcode 15+ error (no throw, no simctl)", async () => {
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+    devicectl.setAvailable(false);
+
+    const result = await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "https://example.com");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Xcode 15\+ and iOS 17\+/);
+    expect(devicectl.launchCalls).toHaveLength(0);
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+  });
+
+  test("(e) devicectl launch failure returns { success:false, error }", async () => {
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+    devicectl.setLaunchError(new Error("device locked"));
+
+    const result = await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "https://example.com");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("device locked");
+  });
+
+  test("(a-neg) simulator simctl failure returns { success:false, error }", async () => {
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandError(`openurl ${SIMULATOR_UDID} "https://example.com"`, new Error("Invalid device"));
+    const devicectl = new FakeDeviceCtlClient();
+
+    const result = await openIos(iosDevice(SIMULATOR_UDID), simctl, devicectl, "https://example.com");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid device");
+  });
+});
+
+describe("OpenURL package: delegation is unchanged", () => {
+  const restores: Array<() => void> = [];
+  afterEach(() => {
+    while (restores.length) { restores.pop()!(); }
+  });
+
+  test("(f) package: URL delegates to LaunchApp on iOS without touching simctl/devicectl", async () => {
+    const launchSpy = spyOn(LaunchApp.prototype, "execute").mockResolvedValue({ success: true } as any);
+    restores.push(() => launchSpy.mockRestore());
+
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+    const openURL = new OpenURL(
+      iosDevice(PHYSICAL_UDID),
+      new FakeAdbExecutor() as unknown as any,
+      simctl as any,
+      devicectl as any
+    );
+
+    const result = await openURL.execute("package:com.example.MyApp");
+
+    expect(result.success).toBe(true);
+    expect(launchSpy).toHaveBeenCalledTimes(1);
+    expect(launchSpy.mock.calls[0][0]).toBe("com.example.MyApp");
+    expect(devicectl.launchCalls).toHaveLength(0);
+    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+  });
+});

--- a/test/features/action/OpenURL.test.ts
+++ b/test/features/action/OpenURL.test.ts
@@ -61,10 +61,10 @@ describe("OpenURL iOS routing", () => {
   });
 
   test("(c) physical UDID + custom scheme launches the resolved target bundle id", async () => {
-    const managerSpy = spyOn(IOSCtrlProxyManager, "getInstance").mockReturnValue({
-      getTargetBundleId: () => "com.example.MyApp",
-    } as unknown as IOSCtrlProxyManager);
-    restores.push(() => managerSpy.mockRestore());
+    // The physical custom-scheme branch reads the target with the
+    // non-constructing static, so it never spins up a CtrlProxy manager.
+    const targetSpy = spyOn(IOSCtrlProxyManager, "getExistingTargetBundleId").mockReturnValue("com.example.MyApp");
+    restores.push(() => targetSpy.mockRestore());
 
     const simctl = new FakeSimCtlClient();
     const devicectl = new FakeDeviceCtlClient();
@@ -78,10 +78,8 @@ describe("OpenURL iOS routing", () => {
   });
 
   test("(c2) physical UDID + custom scheme with no target bundle falls back to Safari", async () => {
-    const managerSpy = spyOn(IOSCtrlProxyManager, "getInstance").mockReturnValue({
-      getTargetBundleId: () => undefined,
-    } as unknown as IOSCtrlProxyManager);
-    restores.push(() => managerSpy.mockRestore());
+    const targetSpy = spyOn(IOSCtrlProxyManager, "getExistingTargetBundleId").mockReturnValue(undefined);
+    restores.push(() => targetSpy.mockRestore());
 
     const simctl = new FakeSimCtlClient();
     const devicectl = new FakeDeviceCtlClient();
@@ -89,6 +87,23 @@ describe("OpenURL iOS routing", () => {
     await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "myapp://order/123");
 
     expect(devicectl.launchCalls[0].bundleId).toBe("com.apple.mobilesafari");
+  });
+
+  test("(c3) physical UDID + mailto: with no target routes to Safari (best-effort, pinned behavior)", async () => {
+    const targetSpy = spyOn(IOSCtrlProxyManager, "getExistingTargetBundleId").mockReturnValue(undefined);
+    restores.push(() => targetSpy.mockRestore());
+
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+
+    const result = await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "mailto:a@b.com");
+
+    // mailto:/tel: are not http(s), so they take the non-http branch. With no
+    // target app they fall back to Safari — pinned so a routing change is caught.
+    expect(result.success).toBe(true);
+    expect(devicectl.launchCalls).toEqual([
+      { deviceUdid: PHYSICAL_UDID, bundleId: "com.apple.mobilesafari", url: "mailto:a@b.com" },
+    ]);
   });
 
   test("(d) unavailable devicectl returns an explicit iOS 17+/Xcode 15+ error (no throw, no simctl)", async () => {
@@ -153,5 +168,47 @@ describe("OpenURL package: delegation is unchanged", () => {
     expect(launchSpy.mock.calls[0][0]).toBe("com.example.MyApp");
     expect(devicectl.launchCalls).toHaveLength(0);
     expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+  });
+});
+
+describe("OpenURL Android parity (regression guard)", () => {
+  test("executeAndroidOpenURL issues the exact VIEW-intent am start command", async () => {
+    const fakeAdb = new FakeAdbExecutor();
+    const openURL = new OpenURL(
+      { name: "pixel", platform: "android", deviceId: "emulator-5554" },
+      fakeAdb as unknown as any
+    );
+
+    const result = await (openURL as any).executeAndroidOpenURL("https://example.com/x") as { success: boolean; url: string };
+
+    expect(result).toEqual({ success: true, url: "https://example.com/x" });
+    expect(fakeAdb.getExecutedCommands()).toContain(
+      'shell am start -a android.intent.action.VIEW -d "https://example.com/x"'
+    );
+  });
+});
+
+describe("OpenURL input validation", () => {
+  const openAndroid = (url: string) =>
+    new OpenURL(
+      { name: "pixel", platform: "android", deviceId: "emulator-5554" },
+      new FakeAdbExecutor() as unknown as any
+    ).execute(url);
+
+  test("empty URL returns an explicit error without dispatching", async () => {
+    const result = await openAndroid("");
+    expect(result).toEqual({ success: false, url: "", error: "Invalid URL provided" });
+  });
+
+  test("whitespace-only URL returns an explicit error", async () => {
+    const result = await openAndroid("   ");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Invalid URL provided");
+  });
+
+  test("bare package: URL (no package name) returns an explicit error", async () => {
+    const result = await openAndroid("package:");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Invalid package URL - no package name specified");
   });
 });

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -307,6 +307,53 @@ describe("IOSCtrlProxyManager", function() {
     });
   });
 
+  describe("target bundle id resolution", function() {
+    const ENV_KEY = "CTRL_PROXY_IOS_BUNDLE_ID";
+    let prevEnv: string | undefined;
+
+    beforeEach(function() {
+      prevEnv = process.env[ENV_KEY];
+      delete process.env[ENV_KEY];
+    });
+
+    afterEach(function() {
+      if (prevEnv === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = prevEnv;
+      }
+    });
+
+    test("getTargetBundleId precedence: explicit > env var > undefined", function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      expect(manager.getTargetBundleId()).toBeUndefined();
+
+      process.env[ENV_KEY] = "com.env.fallback";
+      expect(manager.getTargetBundleId()).toBe("com.env.fallback");
+
+      manager.setTargetBundleId("com.explicit.app");
+      expect(manager.getTargetBundleId()).toBe("com.explicit.app");
+    });
+
+    test("getExistingTargetBundleId reads env without constructing a manager (no port reserved)", function() {
+      // No instance exists for this device after resetInstances() in beforeEach.
+      expect(IOSCtrlProxyManager.getExistingTargetBundleId(testDevice)).toBeUndefined();
+      // Proof it didn't build a manager: no service port got reserved for the device.
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+
+      process.env[ENV_KEY] = "com.env.fallback";
+      expect(IOSCtrlProxyManager.getExistingTargetBundleId(testDevice)).toBe("com.env.fallback");
+      expect(PortManager.getPort(testDevice.deviceId)).toBeUndefined();
+    });
+
+    test("getExistingTargetBundleId returns an existing instance's explicit target (precedence over env)", function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      manager.setTargetBundleId("com.explicit.app");
+      process.env[ENV_KEY] = "com.env.fallback";
+      expect(IOSCtrlProxyManager.getExistingTargetBundleId(testDevice)).toBe("com.explicit.app");
+    });
+  });
+
   describe("getReportedRunnerPort", function() {
     let fakeExecutor: FakeProcessExecutor;
 

--- a/test/utils/ios-cmdline-tools/DeviceCtlClient.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceCtlClient.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { DeviceCtlClient, type DeviceCtlDependencies } from "../../../src/utils/ios-cmdline-tools/DeviceCtlClient";
+import type { ExecResult } from "../../../src/models";
+
+const execResult = (stdout = ""): ExecResult => ({
+  stdout,
+  stderr: "",
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (value: string) => stdout.includes(value),
+});
+
+interface Harness {
+  client: DeviceCtlClient;
+  commands: string[];
+}
+
+const makeClient = (overrides: Partial<DeviceCtlDependencies> = {}): Harness => {
+  const commands: string[] = [];
+  const deps: DeviceCtlDependencies = {
+    platform: () => "darwin",
+    exec: async (command: string) => {
+      commands.push(command);
+      return execResult();
+    },
+    hostControl: {
+      shouldUseHostControl: () => false,
+      isRunningInDocker: () => false,
+    },
+    ...overrides,
+  };
+  return { client: new DeviceCtlClient(deps), commands };
+};
+
+describe("DeviceCtlClient.isAvailable", () => {
+  test("returns false on a non-darwin host without probing", async () => {
+    const { client, commands } = makeClient({ platform: () => "linux" });
+    expect(await client.isAvailable()).toBe(false);
+    expect(commands).toHaveLength(0);
+  });
+
+  test("returns true on darwin when `devicectl --version` succeeds", async () => {
+    const { client, commands } = makeClient();
+    expect(await client.isAvailable()).toBe(true);
+    expect(commands[0]).toContain("devicectl");
+    expect(commands[0]).toContain("--version");
+  });
+
+  test("returns false on darwin when the devicectl probe throws", async () => {
+    const { client } = makeClient({
+      exec: async () => { throw new Error("xcrun: devicectl not found"); },
+    });
+    expect(await client.isAvailable()).toBe(false);
+  });
+
+  test("reports available under host control so the caller reaches the explicit launch error", async () => {
+    const { client, commands } = makeClient({
+      platform: () => "linux",
+      hostControl: { shouldUseHostControl: () => true, isRunningInDocker: () => true },
+    });
+    expect(await client.isAvailable()).toBe(true);
+    expect(commands).toHaveLength(0);
+  });
+});
+
+describe("DeviceCtlClient.launchWithPayloadUrl", () => {
+  test("builds the devicectl command: device unquoted, url + bundle quoted, terminate-existing", async () => {
+    const { client, commands } = makeClient();
+    await client.launchWithPayloadUrl("00008110-000A4D", "com.apple.mobilesafari", "https://example.com/order/123");
+
+    expect(commands).toHaveLength(1);
+    const cmd = commands[0];
+    expect(cmd).toContain("xcrun devicectl device process launch");
+    expect(cmd).toContain("--device 00008110-000A4D");
+    expect(cmd).toContain("--payload-url 'https://example.com/order/123'");
+    expect(cmd).toContain("--terminate-existing");
+    expect(cmd).toContain("'com.apple.mobilesafari'");
+  });
+
+  test("single-quote-escapes a url to prevent shell injection", async () => {
+    const { client, commands } = makeClient();
+    await client.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://x/'; rm -rf /");
+    expect(commands[0]).toContain("--payload-url 'https://x/'\\''; rm -rf /'");
+  });
+
+  test("throws an explicit macOS error on a non-darwin host", async () => {
+    const { client, commands } = makeClient({ platform: () => "linux" });
+    await expect(
+      client.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
+    ).rejects.toThrow(/macOS/);
+    expect(commands).toHaveLength(0);
+  });
+
+  test("throws an explicit host-control error under Docker host control", async () => {
+    const { client, commands } = makeClient({
+      hostControl: { shouldUseHostControl: () => true, isRunningInDocker: () => true },
+    });
+    await expect(
+      client.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
+    ).rejects.toThrow(/host control/i);
+    expect(commands).toHaveLength(0);
+  });
+
+  test("propagates an underlying devicectl exec failure", async () => {
+    const { client } = makeClient({
+      exec: async () => { throw new Error("device locked"); },
+    });
+    await expect(
+      client.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
+    ).rejects.toThrow(/device locked/);
+  });
+});


### PR DESCRIPTION
## Summary

`openLink` on iOS only worked on **simulators**. `OpenURL.executeiOSOpenURL` routed
*every* iOS device to `xcrun simctl openurl`, which is simulator-only, so opening an
`http(s)://`, universal-link, or custom-scheme URL on a **physical** iPhone/iPad failed
(`simctl` can't target a physical-device UDID). This adds a first-party physical-device
path via `xcrun devicectl device process launch --payload-url` (Xcode 15+/iOS 17+),
bringing iOS to parity with Android's `am start -a android.intent.action.VIEW`.

## Changes

- **`OpenURL.executeiOSOpenURL` now branches on `isIosSimulatorUdid(deviceId)`** — the
  repo-canonical simctl-vs-devicectl signal:
  - **Simulator** → existing `simctl openurl` path, unchanged (renamed
    `executeiOSSimulatorOpenURL`).
  - **Physical** → new `executeiOSPhysicalOpenURL`: `http(s)://` launches Safari
    (`com.apple.mobilesafari`, which resolves universal links / hands off to the owning
    app); custom schemes launch the resolved target bundle id
    (`IOSCtrlProxyManager.getTargetBundleId()`), falling back to Safari when no target is
    known.
  - Missing `devicectl` / iOS < 17 returns an **explicit** error result (no silent simctl
    failure, no raw exec stack).
  - Docker **host-control** returns an explicit "not supported under host control" error.
- **NEW `src/utils/ios-cmdline-tools/DeviceCtlClient.ts`** — thin, injectable `devicectl`
  wrapper (`DeviceUrlLauncher` seam + `DeviceCtlClient`) mirroring `DeviceAppInspector`'s
  DI + `process.platform === "darwin"` gating. `--device <udid>` unquoted; url + bundle id
  `quoteShell`'d; `--terminate-existing`.
- **NEW `IOSCtrlProxyManager.getTargetBundleId()`** — public read-only companion to
  `setTargetBundleId`, reusing the private `resolveTargetBundleId()` (explicit > env >
  undefined). No change to `setTargetBundleId`.
- `OpenURL` constructor accepts optional `simctl` + `devicectl` for injection (mirrors
  `LaunchApp`'s optional `SimCtlClient`).
- Docs: iOS `openLink` support matrix notes physical-device support + Xcode 15+/iOS 17+.

No `ios/control-proxy` runner or `release.ts` change → **no runner re-cut required**.

## Acceptance criteria (issue #2490 Definition of Done)

- [x] Physical iOS device (iOS 17+): `http(s)://` opens via Safari; custom-scheme opens the owning/target app.
- [x] `executeiOSOpenURL` branches on `isIosSimulatorUdid(deviceId)`; simulator `simctl openurl` path unchanged (no regression).
- [x] `package:` URLs still delegate to `LaunchApp` on both device types.
- [x] `DeviceCtlClient.launchWithPayloadUrl()` guards on `process.platform === "darwin"`, injectable (DI deps + fake `exec`); `--device` unquoted, url + bundle id `quoteShell`'d.
- [x] `IOSCtrlProxyManager.getTargetBundleId()` returns the resolved target; `setTargetBundleId` unchanged.
- [x] iOS < 17 / missing `devicectl` → explicit `OpenURLResult.error` (no silent simctl failure).
- [x] Host-control / Docker → explicit "not supported under host control" error (no crash).
- [x] Unit tests (interface + fake, no device): (a) simulator→simctl; (b) physical http→Safari payload; (c) physical custom scheme→resolved target; (c2) no target→Safari fallback; (d) unavailable→error result; (e) exec failure→`{success:false,error}`; plus simulator-failure + `package:` delegation.
- [x] Parity with Android `executeAndroidOpenURL` and `OpenURLResult` shape.
- [x] Docs updated.
- [x] Lint + build pass.

## Testing

- `bun test test/features/action/OpenURL.test.ts test/utils/ios-cmdline-tools/DeviceCtlClient.test.ts` — 17 pass (all new, interface+fake, <100ms each).
- `bun test test/features/action/LaunchApp.test.ts test/utils/IOSCtrlProxyManager.test.ts test/utils/ios-cmdline-tools/DeviceAppInspector.test.ts` — 166 pass (no regressions in siblings).
- `bunx eslint <touched>` — clean; `bun build.ts` — clean.
- Full `bun test`: only pre-existing `@jimp/wasm-webp` module-resolution failures locally (unrelated dependency, installed in CI); no failures from this change.

## Manual test plan

See issue #2490 — physical iPhone (iOS 17+) + Xcode 15+ host; `http(s)://` opens Safari, `myapp://…` opens the target app, iOS 16 device returns the explicit error, simulator regression unchanged.

Closes #2490
