### PR TITLE
test(db): mechanical guard for the file-backed DB flake-avoidance pattern + drop harness generic (#3081)

### DIFF
--- a/test/db/fileBackedDbAntiPattern.test.ts
+++ b/test/db/fileBackedDbAntiPattern.test.ts
@@ -88,6 +88,36 @@ describe("findFileBackedDbAntiPatterns detector (issue #3081)", () => {
       expect(rules(source)).toContain("hand-rolled-temp-dir-retry");
     });
 
+    test("flags a `while (attempt < n)` retry-shaped loop that removes a dir and gates on a lock code", () => {
+      const source = [
+        "let attempt = 0;",
+        "while (attempt < 100) {",
+        "  attempt += 1;",
+        "  try {",
+        "    await rm(dir, { recursive: true });",
+        "    break;",
+        "  } catch (error) {",
+        '    if (error.code !== "ENOTEMPTY") throw error;',
+        "  }",
+        "}",
+      ].join("\n");
+      expect(rules(source)).toContain("hand-rolled-temp-dir-retry");
+    });
+
+    test("does NOT flag a generic `while (cond)` poll even with a lock code and rm nearby", () => {
+      // A generic poll condition is not retry/attempt/backoff-shaped, so the
+      // structural conjunction must not fire — this guards tempDbDir.test.ts (the
+      // bounded remover's own test, which holds the quoted lock codes) from a
+      // false positive if it ever grows a real-fs poll + cleanup case.
+      const source = [
+        "while (!ready) {",
+        "  await rmSync(dir);",
+        '  if (lastCode === "EBUSY") ready = check();',
+        "}",
+      ].join("\n");
+      expect(rules(source)).not.toContain("hand-rolled-temp-dir-retry");
+    });
+
     test("does NOT flag a long POLL loop that never removes a dir or gates on a lock code", () => {
       const source = [
         "for (let attempt = 0; attempt < 500; attempt += 1) {",
@@ -163,6 +193,49 @@ describe("findFileBackedDbAntiPatterns detector (issue #3081)", () => {
     });
   });
 
+  describe("sanctioned primitive homes are exempted (they ARE the primitive)", () => {
+    test("freshDatabaseModule.ts may hold the raw cache-busted import", () => {
+      const source = "return import(`../../src/db/database.ts?fresh-db-module=${moduleCounter}`);";
+      const found = findFileBackedDbAntiPatterns("test/db/freshDatabaseModule.ts", source);
+      expect(found).toEqual([]);
+    });
+
+    test("tempDbDir.ts may hold the bounded attempt-loop + lock codes", () => {
+      const source = [
+        'const codes = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);',
+        "for (let attempt = 0; attempt < maxAttempts; attempt += 1) {",
+        "  try { await rm(dir); return; } catch (e) { if (!codes.has(e.code)) throw e; }",
+        "}",
+      ].join("\n");
+      const found = findFileBackedDbAntiPatterns("test/db/tempDbDir.ts", source);
+      expect(found).toEqual([]);
+    });
+
+    test("withFileBackedDb.ts may call mkdtemp for its tracked makeTempDbDir", () => {
+      const source = [
+        'import { importFreshDatabaseModule } from "./freshDatabaseModule";',
+        "const dir = await mkdtemp(path.join(tmpdir(), prefix));",
+      ].join("\n");
+      const found = findFileBackedDbAntiPatterns("test/db/withFileBackedDb.ts", source);
+      expect(found).toEqual([]);
+    });
+
+    test("the exemption is per-rule: freshDatabaseModule.ts still flags an UNfunneled mkdtemp", () => {
+      // It's exempt only for the cache-busted import it owns — a different
+      // anti-pattern in the same file must still be caught.
+      const source = [
+        "return import(`../../src/db/database.ts?fresh=${n}`);",
+        "await importFreshDatabaseModule();",
+        'const dir = await mkdtemp("am-");',
+      ].join("\n");
+      const rulesFound = findFileBackedDbAntiPatterns("test/db/freshDatabaseModule.ts", source).map(
+        v => v.rule
+      );
+      expect(rulesFound).not.toContain("raw-cache-busted-import");
+      expect(rulesFound).toContain("unfunneled-mkdtemp");
+    });
+  });
+
   test("a clean lifecycle suite that uses the harness produces zero violations", () => {
     const source = [
       'import { createFileBackedDbHarness } from "./withFileBackedDb";',
@@ -176,28 +249,37 @@ describe("findFileBackedDbAntiPatterns detector (issue #3081)", () => {
 });
 
 /**
- * Meta-test: the real `test/db/*.test.ts` tree must be free of every deleted
- * anti-pattern. This is the enforcement teeth issue #3081 asked for — it fails
- * the moment a new suite hand-rolls what the harness centralizes.
+ * Meta-test: the real `test/db` tree must be free of every deleted anti-pattern.
+ * This is the enforcement teeth issue #3081 asked for — it fails the moment a new
+ * suite hand-rolls what the harness centralizes.
+ *
+ * It scans EVERY `test/db/*.ts` (the `*.test.ts` suites AND the non-test `.ts`
+ * helpers), not just the suites, so extracting a hand-rolled loop into a sibling
+ * helper — the refactor this harness promotes — is covered too. The sanctioned
+ * primitive homes (freshDatabaseModule.ts, tempDbDir.ts, withFileBackedDb.ts) are
+ * exempted per-rule inside the detector.
  */
-describe("test/db suites are free of file-backed DB anti-patterns (issue #3081)", () => {
+describe("test/db is free of file-backed DB anti-patterns (issue #3081)", () => {
   const dbDir = import.meta.dir;
-  // This detector's OWN test file embeds each anti-pattern as a string fixture to
-  // prove the detector fires; it is not a lifecycle suite, so exclude it from the
-  // real-tree scan (otherwise the fixtures self-flag).
-  const SELF = "fileBackedDbAntiPattern.test.ts";
-  const testFiles = readdirSync(dbDir).filter(
-    name => name.endsWith(".test.ts") && name !== SELF
+  // The guard does not guard itself: this detector and its fixture test embed
+  // every anti-pattern as data (regexes / string fixtures) inherent to their
+  // purpose, so both are excluded from the real-tree scan.
+  const GUARD_OWN_FILES = new Set(["fileBackedDbAntiPattern.ts", "fileBackedDbAntiPattern.test.ts"]);
+  const scanned = readdirSync(dbDir).filter(
+    name => name.endsWith(".ts") && !GUARD_OWN_FILES.has(name)
   );
 
-  test("the guard actually scans the DB test suite (non-empty)", () => {
+  test("the guard actually scans the DB tree (suites + helpers, non-empty)", () => {
     // A guard that scans nothing is a false sense of security.
-    expect(testFiles.length).toBeGreaterThan(10);
-    expect(testFiles).toContain("withFileBackedDb.test.ts");
+    expect(scanned.length).toBeGreaterThan(10);
+    expect(scanned).toContain("withFileBackedDb.test.ts");
+    // Non-test helpers are in scope too — the sibling-helper blind spot is closed.
+    expect(scanned).toContain("tempDbDir.ts");
+    expect(scanned).toContain("freshDatabaseModule.ts");
   });
 
-  test("no test/db suite reintroduces a hand-rolled flake-avoidance anti-pattern", () => {
-    const violations = testFiles.flatMap(name =>
+  test("no test/db file reintroduces a hand-rolled flake-avoidance anti-pattern", () => {
+    const violations = scanned.flatMap(name =>
       findFileBackedDbAntiPatterns(name, readFileSync(join(dbDir, name), "utf8"))
     );
     const rendered = violations

--- a/test/db/fileBackedDbAntiPattern.test.ts
+++ b/test/db/fileBackedDbAntiPattern.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  findFileBackedDbAntiPatterns,
+  type FileBackedDbAntiPatternRule,
+} from "./fileBackedDbAntiPattern";
+
+/**
+ * Guard for the file-backed DB-lifecycle flake-avoidance pattern (issue #3081).
+ *
+ * Two layers:
+ *   - Unit tests of the pure `findFileBackedDbAntiPatterns` detector against
+ *     hand-written fixtures — each of the three deleted anti-pattern signatures
+ *     (raw cache-busted import, hand-rolled temp-dir retry, unfunneled mkdtemp)
+ *     plus the legitimate patterns that must NOT trip it.
+ *   - A meta-test that runs the detector over the real `test/db/*.test.ts` tree
+ *     and asserts it is clean, so a reintroduction fails HERE (a <100ms unit
+ *     test) instead of on a `windows-latest` CI run three rounds later.
+ */
+describe("findFileBackedDbAntiPatterns detector (issue #3081)", () => {
+  function rules(source: string): FileBackedDbAntiPatternRule[] {
+    return findFileBackedDbAntiPatterns("test/db/example.test.ts", source).map(v => v.rule);
+  }
+
+  describe("1. raw-cache-busted-import", () => {
+    test("flags a template-literal `database.ts?…` dynamic import", () => {
+      const source = "const m = await import(`../../src/db/database.ts?fresh=${n}`);";
+      expect(rules(source)).toContain("raw-cache-busted-import");
+    });
+
+    test("flags the `Date.now()-Math.random()` guard-test cache-buster shape", () => {
+      const source =
+        "return import(`../../src/db/database.ts?guard-test=${Date.now()}-${Math.random()}`);";
+      const found = findFileBackedDbAntiPatterns("test/db/example.test.ts", source);
+      expect(found).toHaveLength(1);
+      expect(found[0].rule).toBe("raw-cache-busted-import");
+      expect(found[0].line).toBe(1);
+      expect(found[0].message).toContain("importFreshDatabaseModule");
+    });
+
+    test("flags a single-quoted `database?` import with no `.ts`", () => {
+      const source = "await import('../../src/db/database?bust=' + n);";
+      expect(rules(source)).toContain("raw-cache-busted-import");
+    });
+
+    test("does NOT flag a plain static import of database.ts", () => {
+      const source = 'import { getDatabase } from "../../src/db/database";';
+      expect(rules(source)).not.toContain("raw-cache-busted-import");
+    });
+
+    test("does NOT flag a dynamic import with no cache-bust query", () => {
+      const source = 'const m = await import("../../src/db/database");';
+      expect(rules(source)).not.toContain("raw-cache-busted-import");
+    });
+
+    test("does NOT flag importing a DIFFERENT `?…` module (not database)", () => {
+      const source = "await import(`../../src/db/migrator.ts?fresh=${n}`);";
+      expect(rules(source)).not.toContain("raw-cache-busted-import");
+    });
+  });
+
+  describe("2. hand-rolled-temp-dir-retry", () => {
+    test("flags a `removeTempDirWithRetry` helper by name", () => {
+      const source = [
+        "async function removeTempDirWithRetry(dir) {",
+        "  await someRemove(dir);",
+        "}",
+      ].join("\n");
+      const found = findFileBackedDbAntiPatterns("test/db/example.test.ts", source);
+      expect(found.map(v => v.rule)).toContain("hand-rolled-temp-dir-retry");
+      expect(found[0].line).toBe(1);
+    });
+
+    test("flags a structural EBUSY/attempt-loop/rm reimplementation with a different name", () => {
+      const source = [
+        "async function cleanupDir(dir) {",
+        "  for (let attempt = 0; attempt < 100; attempt += 1) {",
+        "    try {",
+        "      await rm(dir, { recursive: true });",
+        "      return;",
+        "    } catch (error) {",
+        '      if (error.code !== "EBUSY" && error.code !== "EPERM") throw error;',
+        "    }",
+        "  }",
+        "}",
+      ].join("\n");
+      expect(rules(source)).toContain("hand-rolled-temp-dir-retry");
+    });
+
+    test("does NOT flag a long POLL loop that never removes a dir or gates on a lock code", () => {
+      const source = [
+        "for (let attempt = 0; attempt < 500; attempt += 1) {",
+        "  if (module.getMigrationsError()) break;",
+        "  await timer.sleep(1);",
+        "}",
+      ].join("\n");
+      expect(rules(source)).not.toContain("hand-rolled-temp-dir-retry");
+    });
+
+    test("does NOT flag error-classification code that only mentions EBUSY in a string message", () => {
+      const source =
+        'expect(classifyDatabaseFailure(new Error("EBUSY: resource busy"))).toBe("transient");';
+      expect(rules(source)).not.toContain("hand-rolled-temp-dir-retry");
+    });
+
+    test("does NOT flag a call to the canonical `removeTempDbDir`", () => {
+      const source = 'import { removeTempDbDir } from "./tempDbDir";\nawait removeTempDbDir(dir);';
+      expect(rules(source)).not.toContain("hand-rolled-temp-dir-retry");
+    });
+
+    test("does NOT flag Node's bounded `rmSync(..., { maxRetries })` with EBUSY only in a comment", () => {
+      const source = [
+        "// the temp dir can transiently hit EBUSY — retry, best-effort",
+        "rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });",
+      ].join("\n");
+      expect(rules(source)).not.toContain("hand-rolled-temp-dir-retry");
+    });
+  });
+
+  describe("3. unfunneled-mkdtemp", () => {
+    test("flags a fresh-module lifecycle suite that calls mkdtemp directly", () => {
+      const source = [
+        'import { importFreshDatabaseModule } from "./freshDatabaseModule";',
+        'const dir = await mkdtemp(join(tmpdir(), "am-"));',
+        "const module = await importFreshDatabaseModule();",
+      ].join("\n");
+      const found = findFileBackedDbAntiPatterns("test/db/example.test.ts", source);
+      expect(found.map(v => v.rule)).toContain("unfunneled-mkdtemp");
+    });
+
+    test("flags a harness-using suite that hand-rolls mkdtempSync for its DB dir", () => {
+      const source = [
+        'import { createFileBackedDbHarness } from "./withFileBackedDb";',
+        'const dir = mkdtempSync(join(tmpdir(), "am-"));',
+      ].join("\n");
+      expect(rules(source)).toContain("unfunneled-mkdtemp");
+    });
+
+    test("does NOT flag mkdtemp in a file that never imports a fresh DB module (e.g. a lock-path test)", () => {
+      const source = [
+        'import { mkdtempSync } from "fs";',
+        'const dir = mkdtempSync(join(tmpdir(), "migration-lock-"));',
+        'const lockPath = join(dir, "auto-mobile.db.migrate.lock");',
+      ].join("\n");
+      expect(rules(source)).not.toContain("unfunneled-mkdtemp");
+    });
+
+    test("does NOT flag a lifecycle suite that funnels through harness.makeTempDbDir (no raw mkdtemp)", () => {
+      const source = [
+        'import { createFileBackedDbHarness } from "./withFileBackedDb";',
+        "const dir = await harness.makeTempDbDir(\"am-\");",
+      ].join("\n");
+      expect(rules(source)).not.toContain("unfunneled-mkdtemp");
+    });
+
+    test("does NOT match a camelCase identifier like `makeFakeMkdtemp`", () => {
+      const source = [
+        'import { createFileBackedDbHarness } from "./withFileBackedDb";',
+        "const { mkdtemp } = makeFakeMkdtemp();",
+      ].join("\n");
+      expect(rules(source)).not.toContain("unfunneled-mkdtemp");
+    });
+  });
+
+  test("a clean lifecycle suite that uses the harness produces zero violations", () => {
+    const source = [
+      'import { createFileBackedDbHarness } from "./withFileBackedDb";',
+      "const harness = createFileBackedDbHarness();",
+      'const opened = await harness.openLifecycleTestDb("am-");',
+      "await opened.close();",
+      "await harness.cleanup();",
+    ].join("\n");
+    expect(findFileBackedDbAntiPatterns("test/db/example.test.ts", source)).toEqual([]);
+  });
+});
+
+/**
+ * Meta-test: the real `test/db/*.test.ts` tree must be free of every deleted
+ * anti-pattern. This is the enforcement teeth issue #3081 asked for — it fails
+ * the moment a new suite hand-rolls what the harness centralizes.
+ */
+describe("test/db suites are free of file-backed DB anti-patterns (issue #3081)", () => {
+  const dbDir = import.meta.dir;
+  // This detector's OWN test file embeds each anti-pattern as a string fixture to
+  // prove the detector fires; it is not a lifecycle suite, so exclude it from the
+  // real-tree scan (otherwise the fixtures self-flag).
+  const SELF = "fileBackedDbAntiPattern.test.ts";
+  const testFiles = readdirSync(dbDir).filter(
+    name => name.endsWith(".test.ts") && name !== SELF
+  );
+
+  test("the guard actually scans the DB test suite (non-empty)", () => {
+    // A guard that scans nothing is a false sense of security.
+    expect(testFiles.length).toBeGreaterThan(10);
+    expect(testFiles).toContain("withFileBackedDb.test.ts");
+  });
+
+  test("no test/db suite reintroduces a hand-rolled flake-avoidance anti-pattern", () => {
+    const violations = testFiles.flatMap(name =>
+      findFileBackedDbAntiPatterns(name, readFileSync(join(dbDir, name), "utf8"))
+    );
+    const rendered = violations
+      .map(v => `  - ${v.file}:${v.line} [${v.rule}] ${v.message}`)
+      .join("\n");
+    expect(rendered).toBe("");
+  });
+});

--- a/test/db/fileBackedDbAntiPattern.ts
+++ b/test/db/fileBackedDbAntiPattern.ts
@@ -1,0 +1,197 @@
+/**
+ * Mechanical guard for the file-backed DB-lifecycle flake-avoidance pattern
+ * (issue #3081, follow-up to the `withFileBackedDb.ts` harness in #3046/PR #3078).
+ *
+ * The harness (`createFileBackedDbHarness()`) made the correct pattern the
+ * *documented* path of least resistance, but it was still opt-in prose: a new
+ * `test/db/*.test.ts` suite could hand-roll the anti-pattern and never touch the
+ * harness. Since this is the THIRD recurrence of the same `windows-latest`
+ * file-backed sqlite flake class (#2916 -> #2923, #2992 -> #3040, #3046), "prose
+ * hasn't stopped the recurrence" applies to the harness too. This module turns
+ * the three deleted anti-pattern signatures into a fast, purely-textual guard so
+ * the next reintroduction fails a unit test instead of a Windows CI run.
+ *
+ * It is a pure `(fileName, source) -> violations` function so it is unit-tested
+ * with string fixtures (no filesystem) and then applied to the real
+ * `test/db/*.test.ts` tree by the accompanying meta-test — both stay <100ms.
+ *
+ * The three signatures (each is exactly what #3046 removed from the migrated
+ * suites):
+ *
+ *   1. `raw-cache-busted-import` — a raw cache-busted `import(".../database.ts?…")`
+ *      dynamic import. The fresh-module import must go through the single
+ *      canonical primitive `importFreshDatabaseModule()`
+ *      ({@link file://./freshDatabaseModule.ts}) — which the harness wraps — so
+ *      the cache-bust key is the collision-proof monotonic counter and not an
+ *      ad-hoc `Date.now()-Math.random()`. `freshDatabaseModule.ts` and
+ *      `withFileBackedDb.ts` are the only sanctioned homes for the raw import and
+ *      are not `*.test.ts`, so no test file may contain it.
+ *
+ *   2. `hand-rolled-temp-dir-retry` — a locally re-implemented bounded/unbounded
+ *      temp-dir removal retry loop (the `removeTempDirWithRetry` /
+ *      `attempt < 100` EBUSY/EPERM/ENOTEMPTY loop #3046 deleted three copies of).
+ *      Cleanup must go through the ONE bounded {@link file://./tempDbDir.ts}
+ *      `removeTempDbDir` so a Windows file-handle livelock can never stall
+ *      `afterEach`.
+ *
+ *   3. `unfunneled-mkdtemp` — a file-backed lifecycle suite (one that imports a
+ *      fresh `database.ts` module) that also calls `mkdtemp`/`mkdtempSync`
+ *      directly instead of funneling its DB dir through the harness's tracked
+ *      `makeTempDbDir` / `openLifecycleTestDb`. An untracked temp dir escapes the
+ *      bounded cleanup, reopening the same flake surface.
+ *
+ * Scope of the guard: it is a fast *textual* backstop for the exact three
+ * signatures #3046 deleted, not a full parser. It deliberately matches only
+ * inline literals: an `import()` whose specifier is assembled from a variable, a
+ * removal via `unlink`/`rimraf` rather than `rm`, or a fresh module reached
+ * transitively through an un-named helper can slip through. That is an accepted
+ * trade — the recurring anti-pattern has always been an inline copy of the
+ * deleted code, and a stricter AST guard is not warranted until a variant
+ * actually recurs (CLAUDE.md YAGNI). The primitives it points at
+ * (`importFreshDatabaseModule`, `removeTempDbDir`, the harness) remain the real
+ * enforcement; this just makes the common reintroduction fail fast.
+ */
+
+export type FileBackedDbAntiPatternRule =
+  | "raw-cache-busted-import"
+  | "hand-rolled-temp-dir-retry"
+  | "unfunneled-mkdtemp";
+
+export interface FileBackedDbAntiPatternViolation {
+  /** The scanned file (as passed in; the meta-test passes a repo-relative path). */
+  file: string;
+  /** Which anti-pattern signature matched. */
+  rule: FileBackedDbAntiPatternRule;
+  /** 1-based line number of the first offending match. */
+  line: number;
+  /** Human-readable explanation + the sanctioned alternative. */
+  message: string;
+}
+
+/**
+ * Per-file, per-rule exemptions. Keyed by BASENAME so the allowlist is stable
+ * regardless of how the caller spells the path. Kept intentionally tiny — every
+ * entry is a file that legitimately embodies the sanctioned primitive itself, not
+ * a suite that re-hand-rolls the pattern.
+ */
+const RULE_EXEMPTIONS: Readonly<Record<string, ReadonlySet<FileBackedDbAntiPatternRule>>> = {
+  // The harness's OWN unit test injects fake `mkdtemp`s and drives the real
+  // `openLifecycleTestDb` — it is the reference consumer, not an unfunneled suite.
+  "withFileBackedDb.test.ts": new Set(["unfunneled-mkdtemp"]),
+};
+
+// A raw cache-busted dynamic import whose specifier targets `database`/`database.ts`
+// followed by a `?` query string (any quote style, incl. template literals).
+const RAW_CACHE_BUSTED_IMPORT =
+  /\bimport\s*\(\s*(['"`])(?:(?!\1)[\s\S])*?database(?:\.ts)?\?/;
+
+// The exact deleted helper-name family. `removeTempDbDir` (the canonical bounded
+// remover) contains no "Retry" and never matches.
+const HAND_ROLLED_RETRY_NAME = /removeTempDir\w*Retry/;
+
+// A transient-lock code as a *quoted literal* — the fingerprint of code that
+// gates removal retries on it. A bareword in a comment ("...hits EBUSY...") or a
+// classification message (`new Error("EBUSY: ...")`) is intentionally excluded
+// from the retry-loop conjunction below.
+const QUOTED_TRANSIENT_LOCK_CODE = /["'](?:EBUSY|EPERM|ENOTEMPTY)["']/;
+
+// A manual retry loop.
+const MANUAL_RETRY_LOOP = /\bfor\s*\(\s*let\s+attempt\b|\bwhile\s*\(/;
+
+// An actual filesystem removal call (not the canonical `removeTempDbDir`).
+const FS_REMOVAL_CALL = /\brm(?:Sync)?\s*\(/;
+
+// Any signal that a file imports/uses a fresh `database.ts` module — i.e. it is a
+// file-backed lifecycle suite subject to the harness contract.
+const FRESH_MODULE_USE =
+  /importFreshDatabaseModule|createFileBackedDbHarness|openLifecycleTestDb|withFileBackedDb/;
+
+// A direct `mkdtemp`/`mkdtempSync` call (lowercase leading `m`, so `makeFakeMkdtemp`
+// and other camelCase identifiers are not matched).
+const RAW_MKDTEMP_CALL = /\bmkdtemp(?:Sync)?\s*\(/;
+
+function lineOf(source: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < source.length; i += 1) {
+    if (source[i] === "\n") {
+      line += 1;
+    }
+  }
+  return line;
+}
+
+/** First 1-based line matching `pattern`, or 1 if the caller only needs a marker. */
+function firstMatchLine(source: string, pattern: RegExp): number {
+  const match = pattern.exec(source);
+  return match ? lineOf(source, match.index) : 1;
+}
+
+function isExempt(fileName: string, rule: FileBackedDbAntiPatternRule): boolean {
+  const base = fileName.split(/[\\/]/).pop() ?? fileName;
+  return RULE_EXEMPTIONS[base]?.has(rule) ?? false;
+}
+
+/**
+ * Return every file-backed DB-lifecycle anti-pattern in `source`. Pure and
+ * synchronous: the meta-test reads each `test/db/*.test.ts` and calls this; the
+ * unit tests call it with hand-written fixtures.
+ */
+export function findFileBackedDbAntiPatterns(
+  fileName: string,
+  source: string
+): FileBackedDbAntiPatternViolation[] {
+  const violations: FileBackedDbAntiPatternViolation[] = [];
+
+  // 1. Raw cache-busted `database.ts?…` import.
+  if (!isExempt(fileName, "raw-cache-busted-import") && RAW_CACHE_BUSTED_IMPORT.test(source)) {
+    violations.push({
+      file: fileName,
+      rule: "raw-cache-busted-import",
+      line: firstMatchLine(source, RAW_CACHE_BUSTED_IMPORT),
+      message:
+        "raw cache-busted `import(\".../database.ts?…\")`; import a fresh module " +
+        "via `importFreshDatabaseModule()` (freshDatabaseModule.ts) or the " +
+        "`createFileBackedDbHarness()` harness instead.",
+    });
+  }
+
+  // 2. Hand-rolled temp-dir removal retry loop.
+  if (!isExempt(fileName, "hand-rolled-temp-dir-retry")) {
+    const named = HAND_ROLLED_RETRY_NAME.test(source);
+    const structural =
+      QUOTED_TRANSIENT_LOCK_CODE.test(source) &&
+      MANUAL_RETRY_LOOP.test(source) &&
+      FS_REMOVAL_CALL.test(source);
+    if (named || structural) {
+      const marker = named ? HAND_ROLLED_RETRY_NAME : FS_REMOVAL_CALL;
+      violations.push({
+        file: fileName,
+        rule: "hand-rolled-temp-dir-retry",
+        line: firstMatchLine(source, marker),
+        message:
+          "hand-rolled temp-dir removal retry loop (EBUSY/EPERM/ENOTEMPTY); use " +
+          "the single bounded `removeTempDbDir` (tempDbDir.ts) — via the harness's " +
+          "tracked cleanup — so a Windows handle livelock can never stall afterEach.",
+      });
+    }
+  }
+
+  // 3. Unfunneled `mkdtemp` in a fresh-module lifecycle suite.
+  if (
+    !isExempt(fileName, "unfunneled-mkdtemp") &&
+    FRESH_MODULE_USE.test(source) &&
+    RAW_MKDTEMP_CALL.test(source)
+  ) {
+    violations.push({
+      file: fileName,
+      rule: "unfunneled-mkdtemp",
+      line: firstMatchLine(source, RAW_MKDTEMP_CALL),
+      message:
+        "a file-backed lifecycle suite calling `mkdtemp` directly; funnel the DB " +
+        "dir through the harness's tracked `makeTempDbDir` / `openLifecycleTestDb` " +
+        "so the temp dir is bounded-cleanup tracked.",
+    });
+  }
+
+  return violations;
+}

--- a/test/db/fileBackedDbAntiPattern.ts
+++ b/test/db/fileBackedDbAntiPattern.ts
@@ -41,15 +41,20 @@
  *      bounded cleanup, reopening the same flake surface.
  *
  * Scope of the guard: it is a fast *textual* backstop for the exact three
- * signatures #3046 deleted, not a full parser. It deliberately matches only
- * inline literals: an `import()` whose specifier is assembled from a variable, a
- * removal via `unlink`/`rimraf` rather than `rm`, or a fresh module reached
- * transitively through an un-named helper can slip through. That is an accepted
- * trade — the recurring anti-pattern has always been an inline copy of the
- * deleted code, and a stricter AST guard is not warranted until a variant
- * actually recurs (CLAUDE.md YAGNI). The primitives it points at
- * (`importFreshDatabaseModule`, `removeTempDbDir`, the harness) remain the real
- * enforcement; this just makes the common reintroduction fail fast.
+ * signatures #3046 deleted, not a full parser. The meta-test scans every
+ * `test/db/*.ts` — both the `*.test.ts` suites AND the non-test helpers — so a
+ * hand-rolled loop *extracted into a sibling helper* (the very refactor this
+ * harness promotes) is covered too, not just an inline copy in a suite; the
+ * sanctioned primitive homes are named in {@link RULE_EXEMPTIONS}. It still
+ * matches only inline literals, so a few textual escapes remain by design: an
+ * `import()` whose specifier is assembled from a variable, a removal via
+ * `unlink`/`rmdir`/`rimraf` rather than `rm`, or lock codes gated through an
+ * imported constant rather than an inline literal. That is an accepted trade —
+ * the recurring anti-pattern has always been an inline copy of the deleted code,
+ * and a stricter AST guard is not warranted until a variant actually recurs
+ * (CLAUDE.md YAGNI). The primitives it points at (`importFreshDatabaseModule`,
+ * `removeTempDbDir`, the harness) remain the real enforcement; this just makes
+ * the common reintroduction fail fast.
  */
 
 export type FileBackedDbAntiPatternRule =
@@ -71,10 +76,23 @@ export interface FileBackedDbAntiPatternViolation {
 /**
  * Per-file, per-rule exemptions. Keyed by BASENAME so the allowlist is stable
  * regardless of how the caller spells the path. Kept intentionally tiny — every
- * entry is a file that legitimately embodies the sanctioned primitive itself, not
- * a suite that re-hand-rolls the pattern.
+ * entry is a file that legitimately IS the sanctioned primitive for that rule (so
+ * it necessarily contains the pattern the rule flags), not a suite that
+ * re-hand-rolls it. Scanning the non-test `.ts` helpers too (not just
+ * `*.test.ts`) closes the "extract the hand-rolled loop into a sibling helper"
+ * blind spot — the exact refactor this harness promotes — so these homes must be
+ * named here or they would flag themselves.
  */
 const RULE_EXEMPTIONS: Readonly<Record<string, ReadonlySet<FileBackedDbAntiPatternRule>>> = {
+  // The canonical fresh-module importer — the ONE sanctioned home for the raw
+  // cache-busted `database.ts?…` import (with the collision-proof counter).
+  "freshDatabaseModule.ts": new Set(["raw-cache-busted-import"]),
+  // The ONE bounded temp-dir remover (#2916); it necessarily contains the
+  // attempt-loop + transient-lock-code handling every suite must route THROUGH it
+  // instead of re-implementing.
+  "tempDbDir.ts": new Set(["hand-rolled-temp-dir-retry"]),
+  // The harness itself owns the tracked `mkdtemp` that `makeTempDbDir` wraps.
+  "withFileBackedDb.ts": new Set(["unfunneled-mkdtemp"]),
   // The harness's OWN unit test injects fake `mkdtemp`s and drives the real
   // `openLifecycleTestDb` — it is the reference consumer, not an unfunneled suite.
   "withFileBackedDb.test.ts": new Set(["unfunneled-mkdtemp"]),
@@ -95,8 +113,13 @@ const HAND_ROLLED_RETRY_NAME = /removeTempDir\w*Retry/;
 // from the retry-loop conjunction below.
 const QUOTED_TRANSIENT_LOCK_CODE = /["'](?:EBUSY|EPERM|ENOTEMPTY)["']/;
 
-// A manual retry loop.
-const MANUAL_RETRY_LOOP = /\bfor\s*\(\s*let\s+attempt\b|\bwhile\s*\(/;
+// A manual *retry* loop specifically — a `for (let attempt …)` header, or a
+// `while (…)` whose condition is retry/attempt/backoff-shaped. A generic
+// `while (cond)` poll does NOT count: keying the structural rule on any `while`
+// would leave it one edit away from false-positiving on `tempDbDir.test.ts` (the
+// bounded remover's own test), which already holds the quoted lock codes and
+// could grow a real `rm` + poll case.
+const MANUAL_RETRY_LOOP = /\bfor\s*\(\s*let\s+attempt\b|\bwhile\s*\([^)]*\b(?:attempt|retr|backoff)/i;
 
 // An actual filesystem removal call (not the canonical `removeTempDbDir`).
 const FS_REMOVAL_CALL = /\brm(?:Sync)?\s*\(/;

--- a/test/db/unitTestDbGuard.test.ts
+++ b/test/db/unitTestDbGuard.test.ts
@@ -4,6 +4,7 @@ import os from "os";
 import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
 import { IN_MEMORY_DB_OPT_IN_ENV } from "../../src/db/migrationLock";
 import { ActionableError } from "../../src/models/ActionableError";
+import { importFreshDatabaseModule } from "./freshDatabaseModule";
 
 /**
  * Unit tests for the real-DB guard (issue #3067).
@@ -50,11 +51,12 @@ describe("unit-test real-DB guard (issue #3067)", () => {
     }
   });
 
-  // A fresh module instance so the cached `resolvedDbPath` from a prior case
-  // does not mask the env we set here.
-  async function importFreshDatabaseModule() {
-    return import(`../../src/db/database.ts?guard-test=${Date.now()}-${Math.random()}`);
-  }
+  // Each case needs a fresh module instance so the cached `resolvedDbPath` from a
+  // prior case does not mask the env we set here. Use the single canonical
+  // primitive (freshDatabaseModule.ts) — its collision-proof monotonic cache-bust
+  // key replaces this suite's old ad-hoc `Date.now()-Math.random()` import (which
+  // the repo bans as a randomness source) and keeps the raw cache-busted import in
+  // exactly one place (enforced by fileBackedDbAntiPattern.test.ts, issue #3081).
 
   test("getDatabasePath() throws an ActionableError on the default real path when armed", async () => {
     setEnv(UNIT_TEST_DB_GUARD_ENV, "1");

--- a/test/db/withFileBackedDb.test.ts
+++ b/test/db/withFileBackedDb.test.ts
@@ -7,7 +7,18 @@ import {
   createFileBackedDbHarness,
   WINDOWS_FILE_DB_TEST_TIMEOUT_MS as HARNESS_TIMEOUT_REEXPORT,
 } from "./withFileBackedDb";
-import type { LifecycleDatabaseModule } from "./withFileBackedDb";
+import type { FreshDatabaseModule, LifecycleDatabaseModule } from "./withFileBackedDb";
+
+/**
+ * The harness's `importDatabaseModule` dep is typed as the full
+ * {@link FreshDatabaseModule} (the only real module). The fakes here implement
+ * just the narrow {@link LifecycleDatabaseModule} contract the harness actually
+ * drives, so they cast at this ONE injection helper — the deliberate trade
+ * (issue #3081, item 2) for dropping the `<M>` generic that previously threaded
+ * through four interfaces.
+ */
+const asFreshModule = (module: LifecycleDatabaseModule): FreshDatabaseModule =>
+  module as unknown as FreshDatabaseModule;
 
 /**
  * Unit tests for the shared file-backed DB-lifecycle harness (issue #3046).
@@ -123,7 +134,7 @@ describe("createFileBackedDbHarness (issue #3046)", () => {
       mkdtemp,
       removeTempDir,
       env,
-      importDatabaseModule: async () => fake,
+      importDatabaseModule: async () => asFreshModule(fake),
     });
 
     const opened = await harness.openLifecycleTestDb("am-life-");
@@ -149,7 +160,7 @@ describe("createFileBackedDbHarness (issue #3046)", () => {
       mkdtemp,
       removeTempDir,
       env: {},
-      importDatabaseModule: async () => fake,
+      importDatabaseModule: async () => asFreshModule(fake),
     });
 
     await harness.openLifecycleTestDb("am-life-");
@@ -171,7 +182,7 @@ describe("createFileBackedDbHarness (issue #3046)", () => {
       mkdtemp,
       removeTempDir,
       env: {},
-      importDatabaseModule: async () => fake,
+      importDatabaseModule: async () => asFreshModule(fake),
     });
 
     const opened = await harness.openLifecycleTestDb("am-life-");
@@ -196,7 +207,7 @@ describe("createFileBackedDbHarness (issue #3046)", () => {
       env: {},
       importDatabaseModule: async () => {
         importCount += 1;
-        return fake;
+        return asFreshModule(fake);
       },
     });
 

--- a/test/db/withFileBackedDb.ts
+++ b/test/db/withFileBackedDb.ts
@@ -63,9 +63,9 @@ export interface LifecycleDatabaseModule {
 export type FreshDatabaseModule = Awaited<ReturnType<typeof importFreshDatabaseModule>>;
 
 /** A single open+migrated file-backed DB, with a self-cleaning `close()`. */
-export interface OpenLifecycleTestDb<M extends LifecycleDatabaseModule = FreshDatabaseModule> {
+export interface OpenLifecycleTestDb {
   /** The fresh `database.ts` module instance backing this DB. */
-  module: M;
+  module: FreshDatabaseModule;
   /** The tracked temp dir holding the `.db` file. */
   dir: string;
   /** The resolved `auto-mobile.db` path inside {@link dir}. */
@@ -74,22 +74,22 @@ export interface OpenLifecycleTestDb<M extends LifecycleDatabaseModule = FreshDa
   close(): Promise<void>;
 }
 
-export interface FileBackedDbHarness<M extends LifecycleDatabaseModule = FreshDatabaseModule> {
+export interface FileBackedDbHarness {
   /** `mkdtemp` a tracked temp dir under the OS temp dir for the given prefix. */
   makeTempDbDir(prefix: string): Promise<string>;
   /** Import a fresh, isolated `database.ts` module instance. */
-  importFreshDatabaseModule(): Promise<M>;
+  importFreshDatabaseModule(): Promise<FreshDatabaseModule>;
   /**
    * Open a file-backed DB the correct way: fresh module + tracked temp dir +
    * `AUTOMOBILE_DB_DIR` pointed at it (path/migration overrides cleared) +
    * `getDatabase()` then `await ensureMigrations()`.
    */
-  openLifecycleTestDb(prefix: string): Promise<OpenLifecycleTestDb<M>>;
+  openLifecycleTestDb(prefix: string): Promise<OpenLifecycleTestDb>;
   /** Remove every still-tracked temp dir (bounded) and restore the env snapshot. */
   cleanup(): Promise<void>;
 }
 
-export interface FileBackedDbHarnessDeps<M extends LifecycleDatabaseModule = FreshDatabaseModule> {
+export interface FileBackedDbHarnessDeps {
   /**
    * Create a temp dir at an absolute path. Defaults to `fs.mkdtemp`; the harness
    * always passes an absolute `tmpdir()`-joined prefix, so the injected fake
@@ -98,8 +98,13 @@ export interface FileBackedDbHarnessDeps<M extends LifecycleDatabaseModule = Fre
   mkdtemp?: (fullPrefix: string) => Promise<string>;
   /** Remove a temp dir. Defaults to the BOUNDED {@link removeTempDbDir} (#2916). */
   removeTempDir?: (dir: string) => Promise<void>;
-  /** Import a fresh `database.ts` module. Defaults to {@link importFreshDatabaseModule}. */
-  importDatabaseModule?: () => Promise<M>;
+  /**
+   * Import a fresh `database.ts` module. Defaults to {@link importFreshDatabaseModule}.
+   * Typed as the full {@link FreshDatabaseModule} (the only real module); a fake
+   * that implements just the narrow {@link LifecycleDatabaseModule} contract casts
+   * at this single injection site (see `withFileBackedDb.test.ts`).
+   */
+  importDatabaseModule?: () => Promise<FreshDatabaseModule>;
   /** The environment object to snapshot/restore. Defaults to `process.env`. */
   env?: NodeJS.ProcessEnv;
 }
@@ -118,14 +123,14 @@ const LIFECYCLE_OVERRIDE_ENV_KEYS = [
   DAEMON_LAUNCH_CWD_ENV,
 ] as const;
 
-export function createFileBackedDbHarness<M extends LifecycleDatabaseModule = FreshDatabaseModule>(
-  deps: FileBackedDbHarnessDeps<M> = {}
-): FileBackedDbHarness<M> {
+export function createFileBackedDbHarness(
+  deps: FileBackedDbHarnessDeps = {}
+): FileBackedDbHarness {
   const mkdtemp = deps.mkdtemp ?? (fullPrefix => fsMkdtemp(fullPrefix));
   const removeTempDir = deps.removeTempDir ?? (dir => removeTempDbDir(dir));
-  const importModule =
-    deps.importDatabaseModule ??
-    (importFreshDatabaseModule as unknown as () => Promise<M>);
+  // `importFreshDatabaseModule` already returns `Promise<FreshDatabaseModule>`, so
+  // no cast is needed now that the surface is non-generic.
+  const importModule = deps.importDatabaseModule ?? importFreshDatabaseModule;
   const env = deps.env ?? process.env;
 
   // Full-env snapshot taken at creation so every mutated key is restored
@@ -162,7 +167,7 @@ export function createFileBackedDbHarness<M extends LifecycleDatabaseModule = Fr
     await removeTempDir(dir);
   }
 
-  async function openLifecycleTestDb(prefix: string): Promise<OpenLifecycleTestDb<M>> {
+  async function openLifecycleTestDb(prefix: string): Promise<OpenLifecycleTestDb> {
     const dir = await makeTempDbDir(prefix);
 
     // Bind the fresh temp dir and clear every override that could redirect the


### PR DESCRIPTION
## Summary

Closes #3081. Follow-up to the `withFileBackedDb` harness (#3046 / PR #3078), the third round of the `windows-latest` file-backed sqlite test flake class (#2916 → #2923, #2992 → #3040). The harness made the correct pattern the *documented* path of least resistance but was still opt-in prose — a new `test/db/*.test.ts` suite could hand-roll the anti-pattern and never touch it. Since "prose hasn't stopped the recurrence" applies to the harness too, this adds the **mechanical enforcement** the issue flagged as highest value, plus the generic cleanup. Item 3 (the optional hooks binder) is intentionally left unbuilt per the issue (YAGNI).

## What changed

### Item 1 — mechanical anti-pattern guard (highest value)
- **`test/db/fileBackedDbAntiPattern.ts`** (new) — a pure `(fileName, source) → violations` detector for the exact three signatures #3046 deleted:
  1. `raw-cache-busted-import` — a raw `import(".../database.ts?…")` (must go through the canonical `importFreshDatabaseModule()` / harness);
  2. `hand-rolled-temp-dir-retry` — a local `removeTempDirWithRetry` / `attempt < 100` EBUSY·EPERM·ENOTEMPTY loop (must use the one bounded `removeTempDbDir`);
  3. `unfunneled-mkdtemp` — a fresh-module lifecycle suite calling `mkdtemp`/`mkdtempSync` directly instead of the harness's tracked `makeTempDbDir` / `openLifecycleTestDb`.
- **`test/db/fileBackedDbAntiPattern.test.ts`** (new) — fixture unit tests for each signature (positive + the legitimate patterns that must NOT trip it, e.g. a long poll loop, `EBUSY` in a classification string, Node's bounded `rmSync({ maxRetries })`, the canonical `removeTempDbDir`, `makeFakeMkdtemp`), **plus a meta-test** that runs the detector over the real `test/db/*.test.ts` tree and asserts it is clean. The detector's own fixture file is excluded from the tree scan.
- **`test/db/unitTestDbGuard.test.ts`** — migrated off its ad-hoc `database.ts?guard-test=${Date.now()}-${Math.random()}` import onto the canonical `importFreshDatabaseModule()`. Removes the last raw cache-busted import in `test/db` and a repo-banned `Math.random()` randomness source.

### Item 2 — drop the `<M>` generic (cleanup)
- **`test/db/withFileBackedDb.ts`** — removes the `<M extends LifecycleDatabaseModule = FreshDatabaseModule>` generic threaded through four interfaces plus the `as unknown as () => Promise<M>` cast on the default importer. There is one real module type; the surface is now concrete on `FreshDatabaseModule` and the default importer is `importFreshDatabaseModule` with no cast. The narrow `LifecycleDatabaseModule` interface stays as the documented minimal contract + fake target.
- **`test/db/withFileBackedDb.test.ts`** — the fakes now cast at a single `asFreshModule()` injection helper (the sanctioned trade for dropping the generic).

## Non-goals / notes
- **Item 3 (`bindFileBackedDbHarness()` hooks binder)** — intentionally NOT built; the issue marks it YAGNI until the ~4-line boilerplate actually causes a bug or a second concrete need. Tracked for follow-up.
- The guard is a fast *textual* backstop for the recurring inline copy, not a full AST parser — variable-assembled specifiers, `unlink`/`rimraf` removals, or transitively-reached fresh modules can slip through (documented in the detector). The real enforcement remains the primitives it points at; a stricter AST guard is unwarranted until a variant recurs.
- `dbWriteBarrierResetOnClose` (`:memory:` sentinel, #3047) and `backupDatabaseFile` (`BunDatabase` directly) are not file-backed lifecycle suites and are untouched.

## Verification
- `bun test test/db/` → **595 pass, 0 fail** (55 files).
- **Mutation-verified**: reintroducing all three anti-patterns into a throwaway scanned file turns the meta-test red with all three flagged; removing it returns to green.
- `bun run build.ts` clean; `tsc --noEmit` reports only the pre-existing `moduleResolution` deprecation; eslint clean on all changed files.
- Detector + meta-test run purely textually (no real DB/fs/clock), well under the 100ms budget.
