### PR TITLE
feat(observe): internal no-diff for nav/setup + element-diff size guard + structural-id prototype (#3087, #3064, #3088)

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -4,6 +4,7 @@ import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { ToolRegistry } from "../../server/toolRegistry";
+import { markInternalToolCall } from "../../server/internalToolCall";
 import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
@@ -157,8 +158,11 @@ export class DefaultUIStateSetup implements UIStateSetup {
         swipeOnArgs.speed = scrollPosition.speed;
       }
 
-      // Execute swipeOn with lookFor
-      const result = await swipeOnTool.handler(swipeOnArgs);
+      // Execute swipeOn with lookFor. Marked internal (#3087) so that under
+      // `--actions-diff-observe` this setup scroll neither diffs its observation
+      // nor advances the agent-facing diff baseline — the `found` read below still
+      // sees the full (unstripped) result.
+      const result = await swipeOnTool.handler(markInternalToolCall(swipeOnArgs));
 
       // `swipeOn` pre-serializes into an MCP envelope via createStructuredToolResponse,
       // which hoists only `success`/`error` to the top level — `found` lives under
@@ -269,7 +273,8 @@ export class DefaultUIStateSetup implements UIStateSetup {
         args.elementId = element.resourceId;
       }
 
-      await tapTool.handler(args);
+      // Internal setup tap (#3087): no diff/strip, no baseline advance.
+      await tapTool.handler(markInternalToolCall(args));
 
       // Small delay for UI to update
       await this.sleep(100);
@@ -352,12 +357,13 @@ export class DefaultUIStateSetup implements UIStateSetup {
       try {
         const swipeTool = ToolRegistry.getTool("swipe");
         if (swipeTool) {
-          // Swipe down from middle of screen to dismiss bottom sheet
-          await swipeTool.handler({
+          // Swipe down from middle of screen to dismiss bottom sheet.
+          // Internal setup swipe (#3087): no diff/strip, no baseline advance.
+          await swipeTool.handler(markInternalToolCall({
             action: "swipe",
             direction: "down",
             platform
-          });
+          }));
           await this.sleep(200);
 
           // Verify dismissal
@@ -456,11 +462,12 @@ export class DefaultUIStateSetup implements UIStateSetup {
 
     for (const text of closeTexts) {
       try {
-        await tapTool.handler({
+        // Internal close-button tap (#3087): no diff/strip, no baseline advance.
+        await tapTool.handler(markInternalToolCall({
           action: "tap",
           text,
           platform
-        });
+        }));
         logger.debug(`[UI_STATE_SETUP] Tapped close button: "${text}"`);
         return true;
       } catch (error) {

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -5,6 +5,7 @@ import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { ToolRegistry } from "../../server/toolRegistry";
+import { markInternalToolCall } from "../../server/internalToolCall";
 import {
   NavigationGraphManager,
   ToolCallInteraction,
@@ -313,8 +314,11 @@ export class NavigateTo {
 
     logger.info(`[NAVIGATE_TO] Replaying tool call: ${interaction.toolName}`);
 
-    // Call the tool handler with the original args
-    await tool.handler(interaction.args);
+    // Call the tool handler with the original args, marked internal (#3087):
+    // `markInternalToolCall` returns a copy, so the stored edge `interaction.args`
+    // is never mutated. Under `--actions-diff-observe` this replay neither diffs
+    // its observation nor advances the agent-facing diff baseline.
+    await tool.handler(markInternalToolCall(interaction.args as Record<string, unknown>));
   }
 
   /**

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -315,6 +315,22 @@ export interface DiffObserveConfig {
    * by the path key. Set `false` for exact positional-only behavior.
    */
   contentIdentity?: boolean;
+  /**
+   * Structural-only node identity (issue #3088 — **prototype**, default **off**).
+   * Requires `contentIdentity` (has no effect when that is off). When on, the
+   * re-pair identity key is keyed on the *structural* id alone (`resource-id` /
+   * `view-id`), with `text` / `content-desc` demoted to ordinary *changed*
+   * attributes rather than identity. This lets a node whose **label changes in
+   * place** (same position, edited text) collapse to a single `changed` delta
+   * instead of remove+add — a real compaction win for list rows whose text
+   * updates. The trade-off is a larger false-merge surface: recycled/reused
+   * `resource-id`s (common for RecyclerView rows) are far more likely to be
+   * non-unique among the leftovers, so most fall back to positional matching, but
+   * a lone reused id that is unique-on-both-sides *can* mis-merge two unrelated
+   * nodes. Off by default and not wired to any CLI flag pending a real-device
+   * token-win vs. false-merge measurement (see the #3088 tests + issue #3051).
+   */
+  structuralIdentity?: boolean;
 }
 
 /**
@@ -548,11 +564,33 @@ function contentIdentityKey(attrs: Record<string, unknown>): string | null {
   return [resourceId, viewId, contentDesc, text].join(" ");
 }
 
-/** Index leftover diff nodes by their content-identity key, dropping keyless nodes. */
-function indexByContentKey(nodes: ObserveDiffNode[]): Map<string, number[]> {
+/**
+ * A node's *structural* identity key (issue #3088 prototype): `resource-id /
+ * view-id` only, NUL-joined — `text` and `content-desc` are deliberately excluded
+ * so a node keeps this key across an in-place label edit (they become ordinary
+ * `changed` attributes instead). Returns `null` when the node carries no
+ * structural id (both empty) — the same "empty key is not identity" rule as
+ * `contentIdentityKey`. Distinct key space from `contentIdentityKey`; only one is
+ * ever used per diff (selected by `DiffObserveConfig.structuralIdentity`).
+ */
+function structuralIdentityKey(attrs: Record<string, unknown>): string | null {
+  const resourceId = String(attrs["resource-id"] ?? "");
+  const viewId = String(attrs["view-id"] ?? "");
+  if (resourceId === "" && viewId === "") {
+    return null;
+  }
+  // NUL-joined, matching `contentIdentityKey`'s convention.
+  return [resourceId, viewId].join(" ");
+}
+
+/** Identity-key function for a diff node's attributes; `null` = no stable identity. */
+type IdentityKeyFn = (attrs: Record<string, unknown>) => string | null;
+
+/** Index leftover diff nodes by an identity key, dropping keyless nodes. */
+function indexByContentKey(nodes: ObserveDiffNode[], keyFn: IdentityKeyFn): Map<string, number[]> {
   const byKey = new Map<string, number[]>();
   nodes.forEach((node, index) => {
-    const key = contentIdentityKey(node.attributes);
+    const key = keyFn(node.attributes);
     if (key === null) {
       return;
     }
@@ -580,10 +618,11 @@ function indexByContentKey(nodes: ObserveDiffNode[]): Map<string, number[]> {
 function repairByContentIdentity(
   added: ObserveDiffNode[],
   removed: ObserveDiffNode[],
-  changed: ObserveDiffNodeChange[]
+  changed: ObserveDiffNodeChange[],
+  keyFn: IdentityKeyFn
 ): { added: ObserveDiffNode[]; removed: ObserveDiffNode[] } {
-  const addedByKey = indexByContentKey(added);
-  const removedByKey = indexByContentKey(removed);
+  const addedByKey = indexByContentKey(added, keyFn);
+  const removedByKey = indexByContentKey(removed, keyFn);
   const consumedAdded = new Set<number>();
   const consumedRemoved = new Set<number>();
 
@@ -693,7 +732,11 @@ export function diffObserveResult(
   let finalAdded = added;
   let finalRemoved = removed;
   if (cfg?.contentIdentity !== false) {
-    const repaired = repairByContentIdentity(added, removed, changed);
+    // #3088 prototype: structural-only identity (resource-id/view-id) demotes
+    // text/content-desc to changed attributes, collapsing in-place label edits;
+    // default keeps the full content key (text/content-desc part of identity).
+    const keyFn = cfg?.structuralIdentity ? structuralIdentityKey : contentIdentityKey;
+    const repaired = repairByContentIdentity(added, removed, changed, keyFn);
     finalAdded = repaired.added;
     finalRemoved = repaired.removed;
   }

--- a/src/features/record/McpCallRecorder.ts
+++ b/src/features/record/McpCallRecorder.ts
@@ -1,5 +1,6 @@
 import { PlanStep } from "../../models/Plan";
 import { logger } from "../../utils/logger";
+import { INTERNAL_NO_DIFF_PARAM } from "../../server/internalToolCall";
 
 /**
  * Set of MCP tool names that are relevant for test plan recording.
@@ -39,7 +40,7 @@ export const INTERNAL_PARAMS = new Set([
   "devices",
   "keepScreenAwake",
   "__mcpSessionId",
-  "__internalNoDiff",
+  INTERNAL_NO_DIFF_PARAM,
 ]);
 
 export function stripInternalParams(args: Record<string, unknown>): Record<string, unknown> {

--- a/src/server/internalToolCall.ts
+++ b/src/server/internalToolCall.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared marker for internal tool-to-tool calls (issues #3053 / #3087).
+ *
+ * Some tools invoke the *wrapped* `tool.handler` (the one that runs
+ * `finalizeToolResponse`) on behalf of an internal caller rather than the agent —
+ * PlanExecutor steps, and the navigation/setup replays in
+ * `DefaultUIStateSetup` / `NavigateTo`. Under `--actions-diff-observe` /
+ * `--actions-no-observe` those calls would otherwise be diffed or stripped and,
+ * worse, would advance the agent-facing diff baseline
+ * (`SessionCacheData.lastRenderedObservation`) with an observation the agent never
+ * saw. Marking the call opts it out: finalize emits the full sanitized
+ * observation and never touches the baseline.
+ *
+ * The wrapped handler reads `INTERNAL_NO_DIFF_PARAM` off its args at entry (see
+ * `toolRegistry.registerDeviceAware`), and `McpCallRecorder.INTERNAL_PARAMS`
+ * strips it from recordings. Both reference this constant so the literal has a
+ * single source of truth.
+ */
+export const INTERNAL_NO_DIFF_PARAM = "__internalNoDiff";
+
+/**
+ * Return a shallow copy of `args` marked as an internal tool-to-tool call. Every
+ * internal wrapped-handler invocation should route its args through this helper
+ * so the opt-in is uniform and the per-call-site footgun (forgetting the marker,
+ * or mis-typing the key) is removed.
+ *
+ * Non-mutating on purpose: navigation replays reuse a nav-graph edge's stored
+ * `interaction.args`, so setting the marker in place would permanently taint
+ * shared graph state. Returning a copy keeps the caller's object untouched.
+ */
+export function markInternalToolCall<T extends Record<string, unknown>>(
+  args: T
+): T & { [INTERNAL_NO_DIFF_PARAM]: true } {
+  return { ...args, [INTERNAL_NO_DIFF_PARAM]: true };
+}

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -27,6 +27,7 @@ import { formatToolResultLog } from "./toolResultLog";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
 import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
+import { INTERNAL_NO_DIFF_PARAM } from "./internalToolCall";
 import { getStructuredField } from "../utils/toolUtils";
 
 // Re-exported for backward compatibility; the implementation now lives in
@@ -181,10 +182,12 @@ class ToolRegistryClass {
       const deviceLabel = typeof args.device === "string" ? args.device : undefined;
       const declaredDeviceLabels = Array.isArray(args.devices) ? args.devices : undefined;
       const mcpSessionId = typeof args.__mcpSessionId === "string" ? args.__mcpSessionId : undefined;
-      // Internal tool-to-tool marker (#3053): PlanExecutor sets this on the parsed
-      // params so a plan step's finalized envelope is never diffed/stripped (a
-      // future internal `.observation.viewHierarchy` reader stays correct).
-      const internalCall = args.__internalNoDiff === true;
+      // Internal tool-to-tool marker (#3053 / #3087): internal callers (PlanExecutor
+      // steps, navigation/setup replays) set this via `markInternalToolCall` so a
+      // plan/navigation step's finalized envelope is never diffed/stripped and never
+      // advances the agent-facing diff baseline (a future internal
+      // `.observation.viewHierarchy` reader stays correct).
+      const internalCall = args[INTERNAL_NO_DIFF_PARAM] === true;
       let sessionUuid = baseSessionUuid;
       const keepScreenAwake = typeof args.keepScreenAwake === "boolean" ? args.keepScreenAwake : undefined;
 

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -8,6 +8,7 @@ import {
 } from "../../models/Plan";
 import { logger } from "../logger";
 import { ToolRegistry } from "../../server/toolRegistry";
+import { markInternalToolCall } from "../../server/internalToolCall";
 import { ActionableError } from "../../models";
 import { isDebugModeEnabled } from "../debug";
 import {
@@ -213,11 +214,12 @@ export class DefaultPlanExecutor implements PlanExecutor {
       if (sessionUuid) {
         enhancedParams.sessionUuid = sessionUuid;
       }
-      const parsedParams = observeTool.schema.parse(enhancedParams);
       // Internal failure-recovery observe (#3053): mark internal so it does not
       // overwrite the agent-facing diff baseline (`observe` always resets it).
       // This capture is for the plan's failure summary, not shown to the agent.
-      (parsedParams as Record<string, unknown>).__internalNoDiff = true;
+      const parsedParams = markInternalToolCall(
+        observeTool.schema.parse(enhancedParams) as Record<string, unknown>
+      );
 
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       const response = await Promise.race([
@@ -453,15 +455,15 @@ export class DefaultPlanExecutor implements PlanExecutor {
             }
           }
 
-          // Parse and validate the parameters
-          const parsedParams = tool.schema.parse(enhancedParams);
-
-          // Mark this as an internal tool-to-tool call (#3053) so finalize emits
-          // the full observation on the step envelope — never a diff or a stripped
-          // payload — regardless of `--actions-diff-observe`/`--actions-no-observe`.
-          // Set AFTER schema.parse (which strips unknown keys) so it reaches the
-          // wrapped handler; mirrors the `__mcpSessionId` internal-param convention.
-          (parsedParams as Record<string, unknown>).__internalNoDiff = true;
+          // Parse and validate the parameters, then mark this as an internal
+          // tool-to-tool call (#3053) so finalize emits the full observation on the
+          // step envelope — never a diff or a stripped payload — regardless of
+          // `--actions-diff-observe`/`--actions-no-observe`. Marked AFTER schema.parse
+          // (which strips unknown keys) so it reaches the wrapped handler; mirrors
+          // the `__mcpSessionId` internal-param convention.
+          const parsedParams = markInternalToolCall(
+            tool.schema.parse(enhancedParams) as Record<string, unknown>
+          );
 
           if (deviceId) {
             ScreenshotJobTracker.cancelJob(deviceId);
@@ -948,13 +950,13 @@ export class DefaultPlanExecutor implements PlanExecutor {
             }
           }
 
-          // Parse and validate parameters
-          const parsedParams = tool.schema.parse(enhancedParams);
-
-          // Internal tool-to-tool call (#3053): same guard as the sequential path
-          // — a plan step's finalized envelope is never diffed/stripped, so a
-          // future internal `.observation` reader stays correct under the flags.
-          (parsedParams as Record<string, unknown>).__internalNoDiff = true;
+          // Parse and validate parameters, then mark internal (#3053): same guard
+          // as the sequential path — a plan step's finalized envelope is never
+          // diffed/stripped, so a future internal `.observation` reader stays
+          // correct under the flags.
+          const parsedParams = markInternalToolCall(
+            tool.schema.parse(enhancedParams) as Record<string, unknown>
+          );
 
           if (deviceId) {
             ScreenshotJobTracker.cancelJob(deviceId);

--- a/test/features/navigation/navigateToInternalNoDiffE2E.test.ts
+++ b/test/features/navigation/navigateToInternalNoDiffE2E.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { registerInteractionTools } from "../../../src/server/interactionTools";
+import { NavigateTo } from "../../../src/features/navigation/NavigateTo";
+import { FakeDeviceSessionManager } from "../../fakes/FakeDeviceSessionManager";
+import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { BootedDevice } from "../../../src/models";
+import { DaemonState } from "../../../src/daemon/daemonState";
+import { SessionManager } from "../../../src/daemon/sessionManager";
+import { DevicePool } from "../../../src/daemon/devicePool";
+import { createStructuredToolResponse } from "../../../src/utils/toolUtils";
+import { serverConfig } from "../../../src/utils/ServerConfig";
+import type { ObserveResult } from "../../../src/models/ObserveResult";
+import type { NavigationGraphService } from "../../../src/features/navigation/NavigationGraphManager";
+import type { UIStateSetup } from "../../../src/features/navigation/interfaces/UIStateSetup";
+import type { ScreenTransitionWaiter } from "../../../src/features/navigation/interfaces/ScreenTransitionWaiter";
+
+/**
+ * End-to-end guard for issue #3087 (the NavigateTo half): run a real `NavigateTo`
+ * replay through the wrapped `tool.handler` → `finalizeToolResponse` chain with
+ * `--actions-diff-observe` on, and prove the replayed navigation step's
+ * observation NEVER advances the agent-facing diff baseline
+ * (`lastRenderedObservation`). This mirrors the PlanExecutor E2E
+ * (test/plan/planExecutorInternalNoDiffE2E.test.ts) for the navigation call site,
+ * closing the gap that a spy-on-args test cannot: it exercises the actual
+ * wrapper+finalize+baseline seam, so if a future refactor stopped routing
+ * NavigateTo's replay through `markInternalToolCall`, this fails while the plan
+ * E2E stays green.
+ *
+ * The replayed `interaction.args` carry an explicit `sessionUuid` so the wrapper
+ * resolves the session and `canDiff` would be true — which is exactly what makes
+ * the "advances the baseline" bug observable: without the internal marker the
+ * baseline WOULD be overwritten with this internal observation.
+ */
+describe("NavigateTo → finalize internal no-diff (end-to-end, #3087)", () => {
+  const androidA: BootedDevice = { name: "Pixel A", deviceId: "emulator-5554", platform: "android" };
+
+  let fakeDeviceSessionManager: FakeDeviceSessionManager;
+  let originalDeviceSessionManager: unknown;
+  let daemonSessionManager: SessionManager | undefined;
+  let originalDiff: boolean;
+  let originalDrop: boolean;
+  let originalCompact: boolean;
+
+  function sameScreenObserve(): ObserveResult {
+    return {
+      updatedAt: 1,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      activeWindow: { appId: "com.example", activityName: ".Main", layoutSeqSum: 1 },
+      viewHierarchy: {
+        packageName: "com.example",
+        hierarchy: { node: { "resource-id": "com.example:id/root", "content-desc": "keep" } as any },
+      },
+    } as ObserveResult;
+  }
+
+  const baseSchema = {
+    parse: (v: Record<string, unknown>) => v,
+  } as any;
+
+  async function setupAutolockedSession(): Promise<string> {
+    fakeDeviceSessionManager.setConnectedDevices([androidA]);
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA]);
+    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([androidA]);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    return (await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1"))!;
+  }
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+    originalDiff = serverConfig.isActionsDiffObserveEnabled();
+    originalDrop = serverConfig.isObserveResultDropElementsEnabled();
+    originalCompact = serverConfig.isObserveResultCompactEnabled();
+    serverConfig.setObserveResultDropElementsEnabled(false);
+    serverConfig.setObserveResultCompactEnabled(false);
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+  });
+
+  afterEach(() => {
+    (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
+    daemonSessionManager?.stopCleanupTimer();
+    serverConfig.setActionsDiffObserveEnabled(originalDiff);
+    serverConfig.setObserveResultDropElementsEnabled(originalDrop);
+    serverConfig.setObserveResultCompactEnabled(originalCompact);
+    delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    delete process.env.AUTO_MOBILE_DEVICE_POOL_AUTOLOCK;
+    registerInteractionTools();
+  });
+
+  test("a NavigateTo tapOn replay neither diffs its observation nor advances the agent baseline", async () => {
+    serverConfig.setActionsDiffObserveEnabled(true);
+    const sessionId = await setupAutolockedSession();
+
+    ToolRegistry.registerDeviceAware("observe", "observe", baseSchema,
+                                     async () => createStructuredToolResponse(sameScreenObserve()));
+    ToolRegistry.registerDeviceAware("tapOn", "tapOn", baseSchema,
+                                     async () => createStructuredToolResponse({ success: true, observation: sameScreenObserve() }));
+
+    // Seed the agent-facing baseline via a normal (non-nav) observe call.
+    await ToolRegistry.getTool("observe")!.handler({ platform: "android", __mcpSessionId: "mcp-session-1" });
+    const baselineAfterObserve = daemonSessionManager!.getLastRenderedObservation(sessionId);
+    expect(baselineAfterObserve).toBeDefined();
+
+    // A single-edge path whose replayed interaction resolves to the same session
+    // (sessionUuid in the stored args) — so absent the internal marker the tapOn
+    // observation WOULD overwrite the baseline.
+    const edge = {
+      from: "Home",
+      to: "Detail",
+      edgeType: "tool" as const,
+      timestamp: 0,
+      interaction: {
+        toolName: "tapOn",
+        args: { action: "tap", text: "Go", platform: "android", sessionUuid: sessionId },
+        timestamp: 0,
+      },
+    };
+    const navManager = {
+      getCurrentScreen: () => "Home",
+      getNode: async () => ({ screenName: "Home", firstSeenAt: 0, lastSeenAt: 0, visitCount: 1, backStackDepth: 0 }),
+      findPath: async () => ({ found: true, path: [edge], startScreen: "Home", targetScreen: "Detail" }),
+      getKnownScreens: async () => ["Home", "Detail"],
+    } as unknown as NavigationGraphService;
+    const uiStateSetup: UIStateSetup = {
+      setupUIState: async () => [],
+      setupScrollPosition: async () => null,
+    };
+    const screenWaiter: ScreenTransitionWaiter = {
+      waitForScreen: async () => true,
+    };
+
+    const navigateTo = new NavigateTo(androidA, undefined, uiStateSetup, screenWaiter, navManager);
+    const result = await navigateTo.execute({ targetScreen: "Detail", platform: "android" });
+    expect(result.success).toBe(true);
+
+    // The internal nav replay must NOT have advanced the agent-facing baseline —
+    // it emitted the full observation (not a diff) and left the baseline for the
+    // agent's own next action. Identity check: same object as before the replay.
+    expect(daemonSessionManager!.getLastRenderedObservation(sessionId)).toBe(baselineAfterObserve);
+  });
+});

--- a/test/features/navigation/navigationInternalNoDiff.test.ts
+++ b/test/features/navigation/navigationInternalNoDiff.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
+import { DefaultUIStateSetup } from "../../../src/features/navigation/DefaultUIStateSetup";
+import { NavigateTo } from "../../../src/features/navigation/NavigateTo";
+import { createStructuredToolResponse } from "../../../src/utils/toolUtils";
+import type { BootedDevice } from "../../../src/models";
+import type { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import type { ScrollPosition } from "../../../src/utils/interfaces/NavigationGraph";
+import type {
+  NavigationGraphService,
+} from "../../../src/features/navigation/NavigationGraphManager";
+import type { UIStateSetup } from "../../../src/features/navigation/interfaces/UIStateSetup";
+import type { ScreenTransitionWaiter } from "../../../src/features/navigation/interfaces/ScreenTransitionWaiter";
+
+/**
+ * Guard for issue #3087: the navigation/setup paths call the *wrapped*
+ * `tool.handler` (which runs `finalizeToolResponse`) on behalf of an internal
+ * caller. Under `--actions-diff-observe` those calls must not diff/strip their
+ * observation and — the actual bug — must not advance the agent-facing diff
+ * baseline. Every such site now routes its args through `markInternalToolCall`,
+ * which sets `INTERNAL_NO_DIFF_PARAM`; the wrapped handler reads that at entry and
+ * passes `internal: true` to finalize (already end-to-end proven for PlanExecutor
+ * in test/plan/planExecutorInternalNoDiffE2E.test.ts).
+ *
+ * These tests register the target tool as a plain (unwrapped) registry tool so
+ * the handler receives exactly the args the navigation code passed, and assert
+ * the internal marker is present — the necessary-and-sufficient new guarantee for
+ * each call site — while also proving the caller's own result reads still work and
+ * shared nav-graph args are never mutated.
+ */
+describe("navigation internal no-diff marking (#3087)", () => {
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  describe("DefaultUIStateSetup.setupScrollPosition", () => {
+    const device: BootedDevice = { name: "Pixel", deviceId: "emulator-5554", platform: "android" };
+    const dummyAdb = {} as AdbClient;
+
+    const scrollPosition: ScrollPosition = {
+      targetElement: { text: "Settings" },
+      direction: "down",
+    };
+
+    test("marks the swipeOn replay internal and still reads `found` off the full result", async () => {
+      let capturedArgs: Record<string, unknown> | undefined;
+      ToolRegistry.clearTools();
+      // Plain-register so the handler sees the exact args navigation passed.
+      ToolRegistry.register("swipeOn", "swipeOn", {}, async (args: any) => {
+        capturedArgs = args;
+        // A successful scroll: `found: true` must be readable off the full result
+        // (proves the internal path is not stripped for the caller's own read).
+        return createStructuredToolResponse({ success: true, found: true });
+      });
+
+      const setup = new DefaultUIStateSetup(device, dummyAdb);
+      const action = await setup.setupScrollPosition(scrollPosition, "android");
+
+      expect(capturedArgs).toBeDefined();
+      expect(capturedArgs![INTERNAL_NO_DIFF_PARAM]).toBe(true);
+      // `found` read still works → the success branch fires and returns the action.
+      expect(action).not.toBeNull();
+    });
+  });
+
+  describe("NavigateTo tool-call replay", () => {
+    const device: BootedDevice = { name: "Pixel", deviceId: "emulator-5554", platform: "android" };
+
+    function makeFakes(interactionArgs: Record<string, any>) {
+      const edge = {
+        from: "Home",
+        to: "Detail",
+        edgeType: "tool" as const,
+        timestamp: 0,
+        interaction: { toolName: "tapOn", args: interactionArgs, timestamp: 0 },
+      };
+      const navManager = {
+        getCurrentScreen: () => "Home",
+        getNode: async () => ({ screenName: "Home", firstSeenAt: 0, lastSeenAt: 0, visitCount: 1, backStackDepth: 0 }),
+        findPath: async () => ({ found: true, path: [edge], startScreen: "Home", targetScreen: "Detail" }),
+        getKnownScreens: async () => ["Home", "Detail"],
+      } as unknown as NavigationGraphService;
+      const uiStateSetup: UIStateSetup = {
+        setupUIState: async () => [],
+        setupScrollPosition: async () => null,
+      };
+      const screenWaiter: ScreenTransitionWaiter = {
+        waitForScreen: async () => true,
+      };
+      return { edge, navManager, uiStateSetup, screenWaiter };
+    }
+
+    test("marks the replayed tool call internal without mutating the stored edge args", async () => {
+      const interactionArgs: Record<string, any> = { action: "tap", text: "Open", platform: "android" };
+      const before = JSON.stringify(interactionArgs);
+      const { navManager, uiStateSetup, screenWaiter } = makeFakes(interactionArgs);
+
+      let capturedArgs: Record<string, unknown> | undefined;
+      ToolRegistry.clearTools();
+      ToolRegistry.register("tapOn", "tapOn", {}, async (args: any) => {
+        capturedArgs = args;
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const navigateTo = new NavigateTo(device, undefined, uiStateSetup, screenWaiter, navManager);
+      const result = await navigateTo.execute({ targetScreen: "Detail", platform: "android" });
+
+      expect(result.success).toBe(true);
+      expect(capturedArgs).toBeDefined();
+      expect(capturedArgs![INTERNAL_NO_DIFF_PARAM]).toBe(true);
+      // Original args (the shared nav-graph edge) must not be tainted with the marker.
+      expect(interactionArgs[INTERNAL_NO_DIFF_PARAM]).toBeUndefined();
+      expect(JSON.stringify(interactionArgs)).toBe(before);
+    });
+  });
+});

--- a/test/features/navigation/navigationInternalNoDiff.test.ts
+++ b/test/features/navigation/navigationInternalNoDiff.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
 import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
 import { DefaultUIStateSetup } from "../../../src/features/navigation/DefaultUIStateSetup";

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -407,6 +407,39 @@ describe("diffObserveResult", () => {
     expect(diff.fields).toBeUndefined();
   });
 
+  test("#3064: a focus change carrying a deep-node element does not re-embed the subtree (size guard)", () => {
+    // Structural guard (#3059) proven by `.node`-absent assertions is turned into a
+    // measured, regression-proof one here: if `leanElementForDiff` ever stops
+    // stripping `.node`, both `{from,to}` re-embed ~the whole hierarchy and the diff
+    // balloons past the full observation — exactly what --actions-diff-observe exists
+    // to prevent. This fails the moment the subtree comes back.
+    const { observe } = loadAndroidHomeObserve();
+    const base = sanitizeObserveResult(observe, { dropElements: false });
+    // A rich focused *container* carrying the entire hierarchy as its `node` subtree —
+    // the case `parseNodeBounds` (shallow-copies the source node, keeping children)
+    // can produce.
+    const heavyElement = (rid: string) => ({
+      "resource-id": rid,
+      "bounds": { left: 0, top: 0, right: 1080, bottom: 1920 },
+      "node": JSON.parse(JSON.stringify(base.viewHierarchy!.hierarchy.node)),
+    });
+    const baseline = { ...base, focusedElement: heavyElement("focus-a") } as ObserveResult;
+    const next = {
+      ...(JSON.parse(JSON.stringify(base)) as ObserveResult),
+      focusedElement: heavyElement("focus-b"),
+    } as ObserveResult;
+
+    const diff = diffObserveResult(baseline, next);
+    // The focus change is reported (only the mirror changed; the hierarchy is identical).
+    expect(diff.fields?.focusedElement).toBeDefined();
+    expect((diff.fields!.focusedElement.to as any)["resource-id"]).toBe("focus-b");
+    expect((diff.fields!.focusedElement.from as any).node).toBeUndefined();
+    expect((diff.fields!.focusedElement.to as any).node).toBeUndefined();
+    // The whole diff stays a tiny fraction of the full observation: the deep subtree
+    // is stripped from both sides, so it is never re-embedded.
+    expect(measureValue(diff).bytes).toBeLessThan(measureValue(base).bytes * 0.1);
+  });
+
   test("scalar, element, and node changes all coexist in one diff", () => {
     const baseChild = { "resource-id": "child", "bounds": { left: 1, top: 1, right: 2, bottom: 2 }, "text": "x" };
     const baseline = obs(

--- a/test/features/observe/output/structuralIdentityDiff.test.ts
+++ b/test/features/observe/output/structuralIdentityDiff.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult } from "../../../../src/models/ObserveResult";
+import { diffObserveResult } from "../../../../src/features/observe/output/ObserveResultOutput";
+import { measureValue } from "../../../fixtures/observe/observeFixture";
+
+/**
+ * Issue #3088 — structural-id content identity (PROTOTYPE, off by default).
+ *
+ * Limitation 1 deferred in #3080: because `text`/`content-desc` are part of the
+ * default content-identity key, a node whose *label changes in place* (same
+ * position, edited text) gets a different key on each side and reads as
+ * remove+add, not `changed`. This prototype keys identity on the STRUCTURAL id
+ * only (`resource-id`/`view-id`), demoting `text`/`content-desc` to ordinary
+ * changed attributes, so an in-place edit collapses to one `changed` delta.
+ *
+ * These tests (1) prove the compaction win, (2) measure it against the default,
+ * and (3) pin the trade-off: recycled `resource-id`s (RecyclerView rows) raise
+ * the false-merge surface — the uniqueness-on-both-sides guard still prevents a
+ * merge when the id is ambiguous, but a lone reused id unique on both sides will
+ * merge two logically-distinct nodes.
+ *
+ * DECISION (documented for #3088): keep the flag OFF by default and unwired from
+ * any CLI flag. The additional win over the shipped content-identity diff is
+ * marginal (only in-place edits, which the default already handles as a small
+ * remove+add), while the false-merge risk on recycled ids is real. Revisit only
+ * with the real-device measurement in #3051. Limitation 2 (pre-move `fromKey`)
+ * stays deferred — no consumer needs it (YAGNI).
+ */
+
+/** Build a minimal ObserveResult around a single root node. */
+function obs(node: Record<string, unknown>): ObserveResult {
+  return {
+    updatedAt: 1,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    activeWindow: { appId: "com.example", activityName: ".MainActivity", layoutSeqSum: 1 },
+    viewHierarchy: { packageName: "com.example", hierarchy: { node: node as any } },
+  } as ObserveResult;
+}
+
+/** A vertical list of `count` rows, each with a distinct resource-id, offset by `dy`. */
+function list(
+  count: number,
+  dy: number,
+  text: (i: number) => string = i => `Item ${i}`,
+  rid: (i: number) => string = i => `row-${i}`
+): Record<string, unknown> {
+  const rows = Array.from({ length: count }, (_, i) => ({
+    "resource-id": rid(i),
+    "text": text(i),
+    "bounds": { left: 0, top: i * 10 + dy, right: 100, bottom: i * 10 + dy + 10 },
+  }));
+  return { "resource-id": "list", "bounds": { left: 0, top: 0, right: 100, bottom: 1000 }, "node": rows };
+}
+
+describe("structuralIdentity diff (#3088 prototype)", () => {
+  test("off by default: an in-place text edit still reads as remove+add", () => {
+    // Reproduces the deferred limitation 1 (also pinned in diffObserveResult.test.ts).
+    const baseline = obs({ "resource-id": "row", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "Was here" });
+    const next = obs({ "resource-id": "row", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "Now this" });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+  });
+
+  test("on: an in-place text edit collapses to one `changed` carrying the text delta", () => {
+    const baseline = obs({ "resource-id": "row", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "Was here" });
+    const next = obs({ "resource-id": "row", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "Now this" });
+
+    const diff = diffObserveResult(baseline, next, { structuralIdentity: true });
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes.text).toEqual({ from: "Was here", to: "Now this" });
+  });
+
+  test("on: content-desc is also demoted to a changed attribute", () => {
+    const baseline = obs({ "resource-id": "btn", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "content-desc": "Play" });
+    const next = obs({ "resource-id": "btn", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "content-desc": "Pause" });
+
+    const diff = diffObserveResult(baseline, next, { structuralIdentity: true });
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes["content-desc"]).toEqual({ from: "Play", to: "Pause" });
+  });
+
+  test("on: view-id alone is enough structural identity to re-pair", () => {
+    const baseline = obs({ "view-id": "com.x:id/title", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "A" });
+    const next = obs({ "view-id": "com.x:id/title", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "B" });
+
+    const diff = diffObserveResult(baseline, next, { structuralIdentity: true });
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes.text).toEqual({ from: "A", to: "B" });
+  });
+
+  test("on: a node with no structural id (only text) never re-pairs", () => {
+    // text is not identity under structural keying, so a text-only node has an
+    // empty structural key and must fall back to positional remove+add.
+    const baseline = obs({ "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "A" });
+    const next = obs({ "bounds": { left: 0, top: 50, right: 10, bottom: 60 }, "text": "A" });
+
+    const diff = diffObserveResult(baseline, next, { structuralIdentity: true });
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+  });
+
+  test("GUARD: recycled/ambiguous resource-ids do NOT false-merge (uniqueness on both sides)", () => {
+    // Two rows share resource-id "recycled" with different text — a RecyclerView
+    // pattern. Both are leftovers on each side, so the structural key is non-unique
+    // (2 candidates) and the uniqueness guard blocks any merge.
+    const row = (rid: string, top: number, text: string) => ({ "resource-id": rid, "text": text, "bounds": { left: 0, top, right: 10, bottom: top + 10 } });
+    const baseline = obs({ "resource-id": "list", "bounds": { left: 0, top: 0, right: 10, bottom: 100 }, "node": [
+      row("recycled", 0, "Alpha"), row("recycled", 20, "Beta"),
+    ] });
+    const next = obs({ "resource-id": "list", "bounds": { left: 0, top: 0, right: 10, bottom: 100 }, "node": [
+      row("recycled", 40, "Gamma"), row("recycled", 60, "Delta"),
+    ] });
+
+    const diff = diffObserveResult(baseline, next, { structuralIdentity: true });
+    // No unique structural key ⇒ no re-pair ⇒ positional remove+add preserved.
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(2);
+    expect(diff.removed).toHaveLength(2);
+  });
+
+  test("RISK: a lone reused resource-id unique on both sides DOES merge (the trade-off)", () => {
+    // Same recycled id, but only one leftover per side. Structural keying cannot
+    // tell an in-place edit apart from two unrelated nodes that reused the id, so it
+    // merges them. Under the DEFAULT content identity this correctly stays
+    // remove+add — this test measures the added false-merge surface.
+    const baseline = obs({ "resource-id": "recycled", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "Alpha" });
+    const next = obs({ "resource-id": "recycled", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "Unrelated" });
+
+    const structural = diffObserveResult(baseline, next, { structuralIdentity: true });
+    expect(structural.changed).toHaveLength(1); // merged (may be a false-merge)
+
+    const contentDefault = diffObserveResult(baseline, next);
+    expect(contentDefault.changed).toEqual([]); // default keeps them distinct
+    expect(contentDefault.added).toHaveLength(1);
+    expect(contentDefault.removed).toHaveLength(1);
+  });
+
+  test("MEASURE: on a scroll+in-place-edit, structural churns less and is smaller than the default", () => {
+    // 10 uniquely-id'd rows scrolled up by 15px; row 3's label is edited in place.
+    const N = 10;
+    const baseline = obs(list(N, 0));
+    const next = obs(list(N, -15, i => (i === 3 ? "Item 3 (edited in place)" : `Item ${i}`)));
+
+    const structural = diffObserveResult(baseline, next, { structuralIdentity: true });
+    const content = diffObserveResult(baseline, next); // default content identity
+
+    const churn = (d: typeof content) => d.added.length + d.removed.length + d.changed.length;
+
+    // Default: 9 rows re-pair by content (bounds change) + the edited row cannot
+    // re-pair (text is identity) → 1 removed + 1 added. Structural: all 10 rows
+    // re-pair; the edited row is a single bounds+text `changed`.
+    expect(content.added).toHaveLength(1);
+    expect(content.removed).toHaveLength(1);
+    expect(structural.added).toEqual([]);
+    expect(structural.removed).toEqual([]);
+    expect(structural.changed).toHaveLength(N);
+    const editedRow = structural.changed.find(c => "text" in c.changes)!;
+    expect(Object.keys(editedRow.changes).sort()).toEqual(["bounds", "text"]);
+
+    // The compaction win: fewer entries and a smaller payload than the default.
+    expect(churn(structural)).toBeLessThan(churn(content));
+    expect(measureValue(structural).bytes).toBeLessThan(measureValue(content).bytes);
+  });
+
+  test("structuralIdentity has no effect when contentIdentity is off", () => {
+    // structuralIdentity only chooses the re-pair key function; with re-pairing
+    // disabled entirely it is a no-op (pure positional).
+    const baseline = obs({ "resource-id": "row", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "A" });
+    const next = obs({ "resource-id": "row", "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "text": "B" });
+
+    const withStructural = diffObserveResult(baseline, next, { contentIdentity: false, structuralIdentity: true });
+    const positional = diffObserveResult(baseline, next, { contentIdentity: false });
+    expect(withStructural).toEqual(positional);
+  });
+
+  test("does not mutate either input", () => {
+    const baseline = obs(list(4, 0));
+    const next = obs(list(4, -20, i => (i === 1 ? "edited" : `Item ${i}`)));
+    const beforeBaseline = JSON.stringify(baseline);
+    const beforeNext = JSON.stringify(next);
+
+    diffObserveResult(baseline, next, { structuralIdentity: true });
+
+    expect(JSON.stringify(baseline)).toBe(beforeBaseline);
+    expect(JSON.stringify(next)).toBe(beforeNext);
+  });
+});

--- a/test/server/internalToolCall.test.ts
+++ b/test/server/internalToolCall.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  INTERNAL_NO_DIFF_PARAM,
+  markInternalToolCall,
+} from "../../src/server/internalToolCall";
+
+/**
+ * Unit guard for the shared internal-tool-call helper (#3087). Every internal
+ * wrapped-handler invocation (PlanExecutor steps, navigation/setup replays) must
+ * opt into the no-diff guard through this one helper so a plan/navigation step's
+ * finalized envelope is never diffed/stripped and never advances the agent-facing
+ * diff baseline. Centralizing the marker removes the per-call-site footgun the
+ * issue flagged.
+ */
+describe("markInternalToolCall (#3087)", () => {
+  test("sets the internal no-diff marker to true", () => {
+    const marked = markInternalToolCall({ text: "Go" });
+    expect(marked[INTERNAL_NO_DIFF_PARAM]).toBe(true);
+  });
+
+  test("the marker constant matches the param the wrapped handler reads", () => {
+    // The toolRegistry wrapper reads this exact key at entry; a drift here would
+    // silently disable the guard, so pin the literal.
+    expect(INTERNAL_NO_DIFF_PARAM).toBe("__internalNoDiff");
+  });
+
+  test("returns a shallow copy — does not mutate the caller's args", () => {
+    // Navigation replays reuse a nav-graph edge's stored `interaction.args`;
+    // mutating it in place would permanently taint shared graph state.
+    const original: Record<string, unknown> = { text: "Go", platform: "android" };
+    const before = JSON.stringify(original);
+    const marked = markInternalToolCall(original);
+
+    expect(marked).not.toBe(original);
+    expect(original[INTERNAL_NO_DIFF_PARAM]).toBeUndefined();
+    expect(JSON.stringify(original)).toBe(before);
+  });
+
+  test("preserves all existing args", () => {
+    const marked = markInternalToolCall({ text: "Go", platform: "android", direction: "down" });
+    expect(marked.text).toBe("Go");
+    expect(marked.platform).toBe("android");
+    expect(marked.direction).toBe("down");
+  });
+});


### PR DESCRIPTION
Closes #3087. Closes #3064. Closes #3088.

_#3051 (real-device sign-off) stays open — see its thread. Follow-ups filed: #3106 (pre-existing `getTool("swipe")` dead code), #3107 (structural-id adoption revisit, gated on #3051), #3108 (optional `callInternal` seam)._

## Summary

Three follow-ups to the `--actions-diff-observe` output-reduction work, all in the observe-diff / finalize path:

- **#3087** — Internal navigation/setup tool calls were advancing the agent-facing diff baseline.
- **#3064** — No CI guard against re-embedding an element's `node` subtree in an element-field diff.
- **#3088** — Prototype + measure + decide on structural-id content identity for in-place edits.

A fourth follow-up, **#3051** (real-device diff-format sign-off), is addressed with findings in the Non-goals section — it needs a fully live flag-enabled run that this shared/worktree setup can't provide.

## What changed

### #3087 — Mark navigation/setup internal tool calls no-diff
`DefaultUIStateSetup` and `NavigateTo` call the **wrapped** `tool.handler` (the one that runs `finalizeToolResponse`) on behalf of an internal caller. Under `--actions-diff-observe` each such call ran through finalize's diff machinery and — the actual bug — called `baselineStore.set`, **advancing the agent-facing baseline** (`SessionCacheData.lastRenderedObservation`) with a post-action observation the agent never saw. So the agent's next real action diffed against an internal setup step instead of the last thing it actually saw (same baseline-pollution class fixed for the failure-recovery `observe` in #3080).

- New `src/server/internalToolCall.ts`: `INTERNAL_NO_DIFF_PARAM` constant + non-mutating `markInternalToolCall(args)` helper (single source of truth for the marker).
- `toolRegistry.ts` (the wrapper reader) and `McpCallRecorder.INTERNAL_PARAMS` now reference the constant instead of a bare literal.
- Routed the **5** navigation/setup sites through the helper — `DefaultUIStateSetup` (setup scroll swipe, setup tap, bottom-sheet dismiss swipe, close-button tap) and `NavigateTo` (tool-call replay).
- Refactored PlanExecutor's **3** existing sites (sequential step, parallel-exec step, failure-recovery `observe`) to the same helper — removing the per-call-site footgun the issue called out.
- `markInternalToolCall` returns a **shallow copy**, so `NavigateTo`'s shared nav-graph `interaction.args` is never mutated.

Result: a `DefaultUIStateSetup` / `NavigateTo` internal call no longer advances `lastRenderedObservation`, and the caller's own `success`/`found` reads still see the full (unstripped) observation.

### #3064 — Byte-size regression guard for element-field diffs
The `node`-subtree strip (`leanElementForDiff`, #3059) was proven only structurally (`.node` absent on the emitted `{from,to}`). Added a **measured** guard: a focus change whose `focusedElement` carries the entire hierarchy as its `node` subtree must diff to `< 10%` of the full observation. If the strip ever regresses, both `{from,to}` re-embed ~the whole tree and the assertion fails (verified red by temporarily disabling the strip).

### #3088 — Structural-id content identity (prototype, off by default)
Added `DiffObserveConfig.structuralIdentity` (default **off**, unwired from any CLI flag). When on, the re-pair identity key is `resource-id`/`view-id` only, with `text`/`content-desc` demoted to ordinary `changed` attributes — so a node whose **label changes in place** collapses to one `changed` delta instead of remove+add. Tests measure the compaction win on a scroll+edit fixture and pin the trade-off: the uniqueness-on-both-sides guard still blocks a merge on ambiguous recycled ids, but a lone reused id unique on both sides **will** merge two logically-distinct nodes.

**Decision:** keep the flag off/unwired. The additional win over the shipped content-identity diff is marginal (only in-place edits) while the false-merge surface on recycled `resource-id`s is real; revisit with the real-device measurement in #3051. Limitation 2 (pre-move `fromKey`) stays deferred — no consumer needs it (YAGNI).

`finalizeToolResponse` calls `diffObserveResult` with **no cfg**, so `structuralIdentity` is unreachable in production and this PR is behaviorally inert there except the intended #3087 baseline fix.

## Verification

- New/changed tests: `test/server/internalToolCall.test.ts` (4), `test/features/navigation/navigationInternalNoDiff.test.ts` (2), `test/features/observe/output/structuralIdentityDiff.test.ts` (10), and the #3064 size guard in `diffObserveResult.test.ts`.
- `bun test test/features/observe/output/ test/features/navigation/ test/plan/ test/server/ test/features/record/` -> **1347 pass / 0 fail**.
- The #3064 guard verified **red** with the strip disabled, **green** with it restored.
- `bun run build.ts` -> OK. `bunx eslint` on all changed files -> clean. `tsc --noEmit` -> no new errors in touched files.
- Full `bun test`: the only failures (39) are the pre-existing `@jimp/wasm-webp`-missing image failures on this machine (JimpBackend / ContrastChecker / memory-leak), independent of this change — none of my files touch image/jimp code.
- Live emulator `observe` confirmed real device output is shape-identical to what `diffObserveResult` consumes.

## Non-goals / follow-ups

- **#3051 (real-device diff-format sign-off):** the shared MCP daemon runs the **main** build with the flag off, so a true end-to-end `--actions-diff-observe` run against this branch isn't possible here. The real-captured `android-home.json` fixture already drives the byte-reduction (`< 10%`) and `changed {from,to}` assertions, and live `observe` output was confirmed shape-compatible. The residual — a local flag-enabled daemon driven through a real `tapOn`/`swipeOn`/`inputText` loop with an LLM acting on the diff — stays open on #3051.
- **#3088 adoption / CLI wiring:** deliberately deferred pending the #3051 real-device token-win vs false-merge data.
- **#3088 limitation 2** (optional pre-move `fromKey` on re-paired `changed` entries): deferred — no diff `changed`-by-key consumer exists (YAGNI).
