### PR TITLE
fix(ios): route system URL schemes (mailto:/tel:/sms:) to Safari on physical devices

### DIFF
--- a/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
+++ b/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
@@ -306,9 +306,9 @@ Opens a URL or deep link.
   `http(s)://` URLs launch Safari (which resolves universal links and hands off
   to the owning app); custom-scheme deep links (`yourapp://…`) launch the target
   app previously selected by `launchApp`, falling back to Safari when no target
-  is known. `mailto:`/`tel:`/`sms:` are opened best-effort via the same fallback.
-  On an older device / missing `devicectl`, `openLink` returns an explicit error
-  rather than silently failing.
+  is known. System schemes (`mailto:`/`tel:`/`sms:`/…) always go through
+  Safari/the system resolver, never the target app. On an older device / missing
+  `devicectl`, `openLink` returns an explicit error rather than silently failing.
 
 ```yaml
 - tool: openLink

--- a/src/features/action/OpenURL.ts
+++ b/src/features/action/OpenURL.ts
@@ -11,6 +11,28 @@ import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 
 const SAFARI_BUNDLE_ID = "com.apple.mobilesafari";
 
+/**
+ * URL schemes that iOS resolves to a *system* handler (Mail, Phone, Messages,
+ * Maps, …) rather than an arbitrary app. On a physical device these must go
+ * through the system/Safari resolver — never the `launchApp`-cached target
+ * bundle, which almost certainly can't open a `mailto:`/`tel:` payload. The
+ * simulator path already gets this for free via `simctl openurl`.
+ */
+const SYSTEM_URL_SCHEMES = new Set([
+  "mailto",
+  "tel",
+  "sms",
+  "facetime",
+  "facetime-audio",
+  "maps",
+]);
+
+/** True when `url`'s scheme is one iOS routes to a built-in system handler. */
+const isSystemUrlScheme = (url: string): boolean => {
+  const match = url.trim().match(/^([a-z][a-z0-9+.-]*):/i);
+  return match ? SYSTEM_URL_SCHEMES.has(match[1].toLowerCase()) : false;
+};
+
 export class OpenURL extends BaseVisualChange {
 
   private readonly simctl: SimCtlClient | null;
@@ -193,10 +215,11 @@ export class OpenURL extends BaseVisualChange {
 
   /**
    * Open a URL on a physical iOS device (iOS 17+) via `devicectl`. http(s) URLs
-   * launch Safari (which resolves universal links and hands off to the owning
-   * app); custom-scheme deep links launch the resolved target app bundle
-   * (the app targeted by a prior launchApp), falling back to Safari when no
-   * target is known.
+   * and system schemes (`mailto:`/`tel:`/`sms:`/…) launch Safari, which resolves
+   * universal links and hands off to the owning system handler. App-specific
+   * custom-scheme deep links launch the resolved target app bundle (the app
+   * targeted by a prior launchApp), falling back to Safari when no target is
+   * known.
    * @param url - URL to open
    * @returns Result of the URL opening operation
    */
@@ -213,12 +236,15 @@ export class OpenURL extends BaseVisualChange {
     }
 
     try {
-      // http(s) → Safari resolves universal links and hands off to the owning
-      // app. Non-http (custom scheme, and best-effort mailto:/tel:) → the app
-      // targeted by a prior launchApp, else Safari. We read the target with the
-      // non-constructing getExistingTargetBundleId so a bare openLink can't
-      // spin up a CtrlProxy manager (and reserve a service port) just to read it.
-      const bundleId = /^https?:\/\//i.test(url.trim())
+      // http(s) and system schemes (mailto:/tel:/sms:/…) → Safari, so iOS
+      // resolves universal links / hands off to Mail/Phone/etc. Only an
+      // app-specific custom scheme (myapp://) targets the launchApp-cached
+      // bundle — never a system scheme, which the app-under-test can't open.
+      // We read the target with the non-constructing getExistingTargetBundleId
+      // so a bare openLink can't spin up a CtrlProxy manager (and reserve a
+      // service port) just to read it.
+      const useSystemResolver = /^https?:\/\//i.test(url.trim()) || isSystemUrlScheme(url);
+      const bundleId = useSystemResolver
         ? SAFARI_BUNDLE_ID
         : (IOSCtrlProxyManager.getExistingTargetBundleId(this.device) ?? SAFARI_BUNDLE_ID);
       await devicectl.launchWithPayloadUrl(this.device.deviceId, bundleId, url);

--- a/test/features/action/OpenURL.test.ts
+++ b/test/features/action/OpenURL.test.ts
@@ -89,8 +89,11 @@ describe("OpenURL iOS routing", () => {
     expect(devicectl.launchCalls[0].bundleId).toBe("com.apple.mobilesafari");
   });
 
-  test("(c3) physical UDID + mailto: with no target routes to Safari (best-effort, pinned behavior)", async () => {
-    const targetSpy = spyOn(IOSCtrlProxyManager, "getExistingTargetBundleId").mockReturnValue(undefined);
+  test("(c3) physical UDID + system scheme (mailto:) routes to Safari even when a target app is set", async () => {
+    // Regression guard: a prior launchApp sets a cached target bundle. System
+    // schemes (mailto:/tel:/sms:) must STILL go to Safari/system resolution —
+    // never the app-under-test, which can't open a mailto: payload.
+    const targetSpy = spyOn(IOSCtrlProxyManager, "getExistingTargetBundleId").mockReturnValue("com.example.MyApp");
     restores.push(() => targetSpy.mockRestore());
 
     const simctl = new FakeSimCtlClient();
@@ -98,12 +101,22 @@ describe("OpenURL iOS routing", () => {
 
     const result = await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "mailto:a@b.com");
 
-    // mailto:/tel: are not http(s), so they take the non-http branch. With no
-    // target app they fall back to Safari — pinned so a routing change is caught.
     expect(result.success).toBe(true);
     expect(devicectl.launchCalls).toEqual([
       { deviceUdid: PHYSICAL_UDID, bundleId: "com.apple.mobilesafari", url: "mailto:a@b.com" },
     ]);
+  });
+
+  test("(c4) physical UDID + tel: routes to Safari/system resolver, not the target app", async () => {
+    const targetSpy = spyOn(IOSCtrlProxyManager, "getExistingTargetBundleId").mockReturnValue("com.example.MyApp");
+    restores.push(() => targetSpy.mockRestore());
+
+    const simctl = new FakeSimCtlClient();
+    const devicectl = new FakeDeviceCtlClient();
+
+    await openIos(iosDevice(PHYSICAL_UDID), simctl, devicectl, "tel:+15551234567");
+
+    expect(devicectl.launchCalls[0].bundleId).toBe("com.apple.mobilesafari");
   });
 
   test("(d) unavailable devicectl returns an explicit iOS 17+/Xcode 15+ error (no throw, no simctl)", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #3093 (physical-iOS `openLink` via `devicectl`). Addresses the **P2 review finding** from the Codex reviewer on that PR: *"Preserve system handling for mailto/tel URLs."*

After a `launchApp` on a physical device sets a cached target bundle, `OpenURL.executeiOSPhysicalOpenURL` sent **every** non-`http(s)` URL to that bundle — including system schemes like `mailto:`/`tel:`/`sms:`, which the app-under-test almost certainly can't open. That regressed the simulator behavior, where `simctl openurl` lets iOS resolve those to Mail/Phone/Messages.

## Changes

- `src/features/action/OpenURL.ts`: added `SYSTEM_URL_SCHEMES` (`mailto`, `tel`, `sms`, `facetime`, `facetime-audio`, `maps`) + `isSystemUrlScheme(url)`. The physical path now routes **http(s) AND system schemes** to Safari/the system resolver; only an **app-specific** custom scheme (`myapp://`) targets the `launchApp`-cached bundle.
- Tests: `(c3)`/`(c4)` now assert `mailto:`/`tel:` go to Safari **even when a target app is set** (the exact regression), while the existing `(c)` still proves `myapp://` targets the cached bundle.
- Docs: corrected the `openLink` note — system schemes always use Safari/system resolution, never the target app.

## Acceptance criteria

- [x] Physical device: `mailto:`/`tel:`/`sms:` route to Safari/system resolver regardless of a cached target bundle.
- [x] App-specific `myapp://` still targets the `launchApp` bundle (unchanged).
- [x] http(s) unchanged (Safari). Simulator path unchanged.
- [x] `bun test test/features/action/OpenURL.test.ts` — 14 pass; lint + build clean.

## Related

- Reviewed in #3093. The remaining physical-hardware items (real `--json-output` launch verification, on-device `mailto:`/`tel:` delivery, and the `--terminate-existing` cold-relaunch trade-off) stay tracked in #3100.
