### PR TITLE
fix(ci): give the XCTestRunner videoRecording integration test its own temp DB dir (#3109)

### DIFF
--- a/scripts/ios/video-recording-start-stop-integration.sh
+++ b/scripts/ios/video-recording-start-stop-integration.sh
@@ -48,5 +48,19 @@ fi
 export AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION=1
 export AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID="${DEVICE_ID}"
 
+# This integration test legitimately drives the real videoRecording start/stop
+# handler, which resolves the file-backed database (VideoRecordingRepository ->
+# getDatabase() -> resolveDbPath()). The bun-test preload
+# (test/setup/unitTestDbGuard.ts, #3082/#3067) arms a guard that throws when a
+# test resolves the DEFAULT ~/.auto-mobile DB. We are not a unit test and must
+# not touch the runner's home DB, so we point the DB at a fresh temp dir: this
+# is exactly the guard's documented opt-out (an explicit AUTOMOBILE_DB_DIR /
+# AUTOMOBILE_DB_PATH override). A temp dir — not AUTOMOBILE_DB_PATH=':memory:' —
+# is used deliberately, since :memory: additionally trips the #3071 production
+# in-memory guard unless AUTOMOBILE_ALLOW_IN_MEMORY_DB is set.
+INTEGRATION_DB_DIR="$(mktemp -d)"
+export AUTOMOBILE_DB_DIR="${INTEGRATION_DB_DIR}"
+trap 'rm -rf "${INTEGRATION_DB_DIR}"' EXIT
+
 cd "${PROJECT_ROOT}"
 bun test test/integration/iosVideoRecordingStartStop.integration.test.ts


### PR DESCRIPTION
## Summary

The **XCTestRunner Simulator Tests** CI job fails deterministically at the
"Run videoRecording MP4 integration test" step (issue #3109):

```
Error: Failed to start video recordings: Error: Unit test resolved the real
file-backed database at /Users/runner/.auto-mobile/auto-mobile.db ...
```

**Root cause.** The bun-test preload `test/setup/unitTestDbGuard.ts` (wired via
`bunfig.toml` `[test].preload`, introduced by PR #3082 / issue #3067) sets
`AUTOMOBILE_UNIT_TEST_DB_GUARD=1`. That arms the guard in
`src/db/database.ts:149` (`assertUnitTestDbAccessAllowed`), which throws when a
test resolves the **default** `~/.auto-mobile/auto-mobile.db` with no explicit
DB-path override.

The video step runs `bun test test/integration/iosVideoRecordingStartStop.integration.test.ts`
via `scripts/ios/video-recording-start-stop-integration.sh`. That integration
test (#2632) drives the **real** videoRecording start handler, which reaches:

`VideoRecordingRepository.getDb()` (`src/db/videoRecordingRepository.ts:143`) →
`getDatabase()` → `resolveDbPath()` (`src/db/database.ts:254`) →
`assertUnitTestDbAccessAllowed()` (`src/db/database.ts:257`).

Because the job sets no `AUTOMOBILE_DB_DIR` / `AUTOMOBILE_DB_PATH` override, the
guard fires. This test legitimately exercises the real file-backed DB path — it
is just not a unit test and must not touch the runner's home DB.

**The fix (option A1).** Before the final `bun test` invocation in
`scripts/ios/video-recording-start-stop-integration.sh`, export a fresh temp DB
dir so the guard's documented opt-out applies:

```bash
INTEGRATION_DB_DIR="$(mktemp -d)"
export AUTOMOBILE_DB_DIR="${INTEGRATION_DB_DIR}"
trap 'rm -rf "${INTEGRATION_DB_DIR}"' EXIT
```

`AUTOMOBILE_DB_DIR` is a recognized override key
(`DB_PATH_OVERRIDE_ENV_KEYS`, `src/db/database.ts:117-122`); a non-empty value
makes `hasExplicitDbPathOverride` (`src/db/database.ts:124-129`) return true, so
`assertUnitTestDbAccessAllowed` (`src/db/database.ts:153`) returns early. The
temp dir is cleaned up in an EXIT trap.

**Why `AUTOMOBILE_DB_DIR` (temp dir) and not `AUTOMOBILE_DB_PATH=':memory:'`.**
`:memory:` additionally trips the #3071 production in-memory guard
(`src/db/database.ts:84-94`) unless `AUTOMOBILE_ALLOW_IN_MEMORY_DB=1` is also
set. A per-run temp dir is the correct, self-contained opt-out and matches the
guard's own remediation text (`src/db/database.ts:162-163`).

**Why A1 over the alternatives.** This is the "A1" option in a set of competing
PRs for issue #3109:
- **A1 (this PR)** — scope the override to the one integration script that needs
  the real file DB. Minimal, local, and it uses the guard exactly as designed.
- **A2 (DI-inject)** — thread a database dependency into the videoRecording
  start handler so the test can inject a controlled DB. Larger production-code
  change for a CI-only failure.
- **A3 (filter prevention)** — teach the guard to auto-exempt integration tests
  (e.g. by filename/dir). Broadens the guard's behavior and weakens the very
  invariant #3067/#3082 established.

A1 changes only the failing script, does not touch production code or relax the
guard, and keeps the real DB off the runner's home directory.

## Testing

- `shellcheck scripts/ios/video-recording-start-stop-integration.sh` — passes.
- `bunx turbo run build` — passes.
- **Mechanism proof (throwaway, not committed).** A temp bun test run from the
  repo root (so the `bunfig` preload arms the guard) exercised the exact CI
  chain via `VideoRecordingRepository.listRecordings({ status: "recording" })`:
  - **(a)** no override → threw `Unit test resolved the real file-backed
    database ...` (reproduces the CI failure).
  - **(b)** `AUTOMOBILE_DB_DIR` set to a `mktemp -d` dir → succeeded, returning
    an array.
  - Result: `2 pass, 0 fail`.

Refs #3109
