### PR TITLE
ci(ios): raise daemon startup timeout to 60s for the XCTestRunner job (#3110)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1206,6 +1206,12 @@ jobs:
     env:
       AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS: "240"
       AUTOMOBILE_OBSERVE_MCP_TIMEOUT_MS: "150000"
+      # Daemon readiness is gated on the PID file written LAST in Daemon.start(), so
+      # the startup budget must cover Bun cold start + DB migrations +
+      # initializeDevicePoolWithTimeout(5000) + initializeIosServices (5s/device). On a
+      # cold macOS runner that serial bring-up exceeds the 10s default and the daemon
+      # gives up ("Daemon failed to start within 10000ms"). Raise it to 60s (#3110).
+      AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "60000"
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The **XCTestRunner Simulator Tests** job (`ios-xctest-runner-simulator-tests`) intermittently fails with `Error: Daemon failed to start within 10000ms`.

**Root cause.** Daemon readiness is gated on the PID file, which is written **last** in `Daemon.start()` (`src/daemon/daemon.ts`). The wait budget is `DAEMON_STARTUP_TIMEOUT_MS`, derived in `src/daemon/constants.ts:90-99` from the env var (default **10000ms**), and consumed by the readiness waiters:

- `src/daemon/manager.ts:583` → `waitForDaemonStartup(..., DAEMON_STARTUP_TIMEOUT_MS)`, whose failure emits `Daemon failed to start within ${timeoutMs}ms` at `src/daemon/manager.ts:640`.
- `src/daemon/daemonMcpProxy.ts:562-565` → same message on the proxy-initiated start path.

That 10s must cover, serially: Bun cold start → all DB migrations → `initializeDevicePoolWithTimeout(5000)` → `initializeIosServices` (5s/device cap). On a cold `macos-26` runner phases 3+4 alone can consume the whole budget, so the daemon reports failure (and the guard then kill+respawns a runner that was still coming up).

**Fix (B1 — tactical budget raise).** Add a job-level env var alongside the two budget raises already present on this job from #2834:

```yaml
AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "60000"
```

Placed at the job-level `env:` block so it applies to **every** daemon start in the job, including the Swift-test-triggered ones. `constants.ts` reads `AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS` (with an `AUTO_MOBILE_...` alias) via `Number.parseInt`; `"60000"` is finite and > 0, so it cleanly overrides the 10000 default.

**Caveat / risk.** The env name must match the code **exactly** — a typo makes `Number.parseInt` yield `NaN` and the value silently falls back to 10000, re-introducing the flake with no error. Verified against `src/daemon/constants.ts:91`.

**Tactical vs structural.** This treats the *symptom* (budget) not the *cause* (readiness is gated on the last-written artifact). The structural alternative tracked in the same issue is **B2**: reorder `Daemon.start()` so readiness is signaled once the socket is actually serving, before the long device/iOS init, rather than after the PID write. B1 is the low-risk immediate stabilizer; B2 is the real fix. This is the **B1** option among competing PRs for #3110.

## Testing

- Confirmed env derivation: re-imported `src/daemon/constants.ts` fresh with `AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS="60000"` set → `DAEMON_STARTUP_TIMEOUT_MS === 60000` (PASS; throwaway, not committed).
- Confirmed the env var actually governs the failing message: traced `DAEMON_STARTUP_TIMEOUT_MS` from `constants.ts:96` → `manager.ts:583`/`:640` and `daemonMcpProxy.ts:562-565`.
- Validated the workflow YAML parses (`yaml.safe_load`) and asserted the new key sits under `jobs.ios-xctest-runner-simulator-tests.env` with value `"60000"`.
- Did not run the full test suite (pre-existing unrelated image-backend failures).

Precedent: #2834 raised the two sibling budgets on this same job. Related: #2829, #2721.

Refs #3110
