### PR TITLE
ci(ios): trigger XCTestRunner job on bunfig/test-setup/integration-test changes (#3109)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -280,6 +280,15 @@ jobs:
               # The XCTestRunner job runs these readiness scripts directly, so
               # changes to them must exercise the job (they were skipped before).
               - 'scripts/ci/**'
+              # This job runs a bun-side integration test (iosVideoRecordingStartStop),
+              # so the bun test config and any test-setup preload affect it. bunfig.toml
+              # wires a [test].preload that runs before EVERY bun test the job invokes,
+              # and test/setup/** holds those preloaded modules; a change to either can
+              # break the integration test deterministically (issue #3109), so they
+              # must exercise this job pre-merge instead of landing latent.
+              - 'bunfig.toml'
+              - 'test/setup/**'
+              - 'test/integration/iosVideoRecordingStartStop.integration.test.ts'
               - 'package.json'
               - 'bun.lock'
 


### PR DESCRIPTION
## Summary

This is the **A3 (prevention)** fix for #3109 — one of several competing/complementary PRs. It closes a CI **detection gap**; it does **not** fix the current red (that is what options A1/A2 do). It complements them.

The `native_integration` path filter in `.github/workflows/pull_request.yml` gates the expensive (~45 min) macOS `ios-xctest-runner-simulator-tests` job (via `filter-native-integration` → `native_integration` output → `ios_integration_should_run` → the job's `if:`). That job runs a **bun-side** integration test, `test/integration/iosVideoRecordingStartStop.integration.test.ts`.

PR #3082 added a bun-test DB guard preload wired through `bunfig.toml` (`[test].preload` → `test/setup/unitTestDbGuard.ts`), which runs before **every** bun test that job invokes. That preload broke the videoRecording integration test **deterministically** — but the break landed **latent**, because neither `bunfig.toml` nor `test/**` were in the `native_integration` filter, so #3082's own CI **skipped the job entirely** and never surfaced the failure pre-merge.

This PR adds the missing paths so future preload / test-infra changes exercise the job before merge:

- `bunfig.toml` — wires the `[test].preload` that runs ahead of every bun test in the job
- `test/setup/**` — holds those preloaded modules (currently `unitTestDbGuard.ts`)
- `test/integration/iosVideoRecordingStartStop.integration.test.ts` — the exact bun test this job runs

I chose the **narrow, specific** integration-test path rather than `test/integration/**` deliberately: the job is expensive, and unrelated integration-test edits should not trigger it. `bunfig.toml` and `test/setup/**` are broad enough to matter (they affect every bun test) without over-triggering.

### Precedent

This mirrors **PR #2834**, which added `scripts/ci/**` to this exact `native_integration` filter for the same class of reason (the job runs those scripts directly, so changes to them must exercise it). I followed the same placement and comment style — an explanatory `#` block directly above the new entries.

## Testing

- `actionlint .github/workflows/pull_request.yml` — exit 0. (The 4 "could not parse action metadata" notes are pre-existing composite-action-metadata warnings on the base branch, unrelated to this change; verified identical count before/after via `git stash`.)
- `bunx js-yaml .github/workflows/pull_request.yml` — parses OK.
- PyYAML `safe_load` + programmatic assertion that all three new paths resolve under the `native_integration` key (and nowhere else); confirmed no other filter/job trigger was altered.
- `git diff --name-only origin/main...HEAD` → only `.github/workflows/pull_request.yml` (9 insertions: comment + 3 globs).

Did not run the full test suite — irrelevant to a YAML-only workflow change (and the tree has pre-existing unrelated image-backend failures).

Refs #3109
