### PR TITLE
fix(ci): inject an in-memory test DB into the XCTestRunner videoRecording integration test (#3109)

### DIFF
--- a/test/integration/iosVideoRecordingStartStop.integration.test.ts
+++ b/test/integration/iosVideoRecordingStartStop.integration.test.ts
@@ -5,9 +5,15 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { registerVideoRecordingTools } from "../../src/server/videoRecordingTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
-import { resetVideoRecordingManagerDependencies } from "../../src/server/videoRecordingManager";
+import {
+  resetVideoRecordingManagerDependencies,
+  setVideoRecordingManagerDependencies,
+} from "../../src/server/videoRecordingManager";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { createTestDatabase } from "../db/testDbHelper";
+import { VideoRecordingRepository } from "../../src/db/videoRecordingRepository";
+import { VideoRecordingConfigRepository } from "../../src/db/videoRecordingConfigRepository";
 
 const execFileAsync = promisify(execFile);
 const RUN_INTEGRATION = process.env.AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION === "1";
@@ -104,6 +110,23 @@ describeIntegration("iOS videoRecording start-stop integration", () => {
     }
 
     serverConfig.setSkipCtrlProxyDownload(true);
+
+    // Inject an in-memory test DB through the manager's DI seam so the real
+    // videoRecording start/stop handlers never resolve the default file-backed
+    // getDatabase() (~/.auto-mobile/auto-mobile.db). The bun-test preload
+    // (test/setup/unitTestDbGuard.ts) arms AUTOMOBILE_UNIT_TEST_DB_GUARD, which
+    // makes that resolution throw "Unit test resolved the real file-backed
+    // database ..." (issues #3067/#3082, root cause of #3109). createTestDatabase()
+    // opens a fresh migrated `:memory:` bun:sqlite connection that never routes
+    // through resolveDbPath(), so the guard is never reached. TRADEOFF: this test
+    // now exercises an in-memory DB instead of the real file-backed one the daemon
+    // uses at runtime (see the PR body).
+    const testDb = await createTestDatabase();
+    await setVideoRecordingManagerDependencies({
+      recordingRepository: new VideoRecordingRepository(testDb),
+      configRepository: new VideoRecordingConfigRepository(testDb),
+    });
+
     const tool = ToolRegistry.getTool("videoRecording");
     expect(tool).toBeDefined();
 


### PR DESCRIPTION
## Summary

Fixes the deterministic failure of the **"XCTestRunner Simulator Tests"** CI job at the *"Run videoRecording MP4 integration test"* step:

```
Error: Failed to start video recordings: Error: Unit test resolved the real file-backed
database at /Users/runner/.auto-mobile/auto-mobile.db ...
```

**Root cause.** The bun-test preload `test/setup/unitTestDbGuard.ts` (wired via `bunfig.toml` `[test].preload`) arms `AUTOMOBILE_UNIT_TEST_DB_GUARD`, so `assertUnitTestDbAccessAllowed` in `src/db/database.ts:149` throws whenever a test resolves the **default** `~/.auto-mobile/auto-mobile.db` path (issues #3067 / #3082). The integration test `test/integration/iosVideoRecordingStartStop.integration.test.ts` drives the real `videoRecording` start handler, which reaches the DB through the manager's default repositories:

- `src/server/videoRecordingManager.ts:142-143` construct `new VideoRecordingRepository()` / `new VideoRecordingConfigRepository()` with no injected db,
- `src/db/videoRecordingRepository.ts:138-144` (and the config repo's `getDb`) then call `ensureMigrations()` + `getDatabase()`,
- which resolves the default path and trips the guard at `src/db/database.ts:156`.

## This fix (option **A2** — inject an in-memory DB via the existing DI seam)

The manager already exposes a DI seam: `setVideoRecordingManagerDependencies(...)` / `resetVideoRecordingManagerDependencies()` (`src/server/videoRecordingManager.ts:154,191`), and both repositories accept an injected Kysely instance in their constructors (`videoRecordingRepository.ts:134`, `videoRecordingConfigRepository.ts:12`).

Before the start handler runs, the test now injects repositories backed by `createTestDatabase()` (`test/db/testDbHelper.ts`), which opens a fresh **migrated** `:memory:` `bun:sqlite` connection directly — it never routes through `resolveDbPath()`, so `getDatabase()`'s default path (and therefore the guard) is never reached. `resetVideoRecordingManagerDependencies()` remains in the existing `finally` block to restore global state.

Why A2: the DI seam and injectable-db constructors already exist, so the fix is a few lines in the test with no production-code change and no new helper.

## TRADEOFF (honest, vs option A1)

This makes the integration test run against an **in-memory** DB instead of the real **file-backed** one the daemon actually uses at runtime. It therefore **stops exercising real file-DB semantics** on this path — WAL mode / `busy_timeout` pragmas, on-disk migration lifecycle, and the daemon's real `getDatabase()` path resolution are no longer touched by this test. The alternative option **A1** keeps a real temp-dir file DB (via `AUTOMOBILE_DB_DIR`), preserving file-DB semantics at the cost of temp-dir setup/cleanup. This PR is the **A2** option among competing PRs for #3109; pick A1 if preserving real file-DB coverage on this test matters more than minimal test-only wiring. File-DB semantics remain covered by the dedicated file-backed DB harness suites (`test/db/withFileBackedDb.ts`), so the loss here is scoped to this one MP4 pipeline test whose actual purpose is the start -> stop -> non-empty playable MP4 assertion (unchanged).

## Testing

The integration test body itself is gated on `AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION=1` and needs a booted simulator + ffmpeg, so it cannot run to completion in a plain CI/dev shell.

- `bunx eslint test/integration/iosVideoRecordingStartStop.integration.test.ts --fix` — passes.
- `bunx turbo run build` — passes.
- **DI-wiring validation** (throwaway, not committed): with the guard armed by the bunfig preload, injecting `createTestDatabase()`-backed repos via `setVideoRecordingManagerDependencies` and then driving `listActiveVideoRecordings()` / `listVideoRecordings()` (which run `getVideoRecordingDependencies` -> `initializeVideoRecordingState` -> `recordingRepository.listRecordings()`, the exact read that resolves `getDatabase()`) does **not** throw. A negative control confirmed that **without** the injection the same call **does** throw `/real file-backed database/`, proving the fix is load-bearing rather than a no-op.
- Did not run the full `bun test` suite (~39 pre-existing unrelated image-backend failures — JimpBackend/ContrastChecker/etc.).

Refs #3082, #3067, #2632.

Refs #3109
