### PR TITLE
fix(daemon): don't gate readiness on iOS warm-up so cold startup fits the budget (#3110)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -116,6 +116,10 @@ export class Daemon {
   private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
+  // Detached iOS CtrlProxy warm-up started AFTER readiness (socket + PID). Kept
+  // as a handle purely so tests (and, if ever needed, shutdown) can await the
+  // best-effort warm-up; readiness never depends on it. See start().
+  private iosServicesWarmup: Promise<void> = Promise.resolve();
 
   constructor(
     options: DaemonOptions = {},
@@ -243,14 +247,25 @@ export class Daemon {
     // Initialize device pool BEFORE starting socket server
     // This ensures clients connecting via socket will see initialized device pool
     // Wait up to 5 seconds - emulators should already be running
+    //
+    // The device pool stays on the readiness critical path deliberately: the
+    // socket-server contract below is that a client connecting right after
+    // readiness sees a populated pool (git blame 811381b7/0a01f468). Its warm-up
+    // is bounded (initializeDevicePoolWithTimeout(5000)).
+    //
+    // iOS CtrlProxy warm-up (initializeIosServices) is NOT gated here anymore.
+    // It is a pure latency optimization ("so observe calls are fast") whose own
+    // contract already says failures are non-fatal and the service is set up on
+    // the first tool call if needed (see initializeIosServices below). Awaiting
+    // it added up to 5s/device to the readiness path, so on a cold macOS CI
+    // runner the serial bring-up (Bun cold start + migrations + device pool +
+    // iOS warm-up) could blow the 10s DAEMON_STARTUP_TIMEOUT_MS budget and fail
+    // with "Daemon failed to start within 10000ms". It is now started detached
+    // AFTER the socket + PID file are up (issue #3110, structural fix "B2").
     logger.info("Initializing device pool...");
     startupBenchmark.startPhase("deviceDiscovery");
     await this.initializeDevicePoolWithTimeout(5000);
     startupBenchmark.endPhase("deviceDiscovery");
-
-    // Initialize iOS CtrlProxy iOS connections for discovered iOS devices
-    // This establishes WebSocket connections early so observe calls are fast
-    await this.initializeIosServices();
 
     // Start Unix socket server AFTER device pool is ready
     logger.info(`Daemon host: "${this.host}", port: ${this.port}`);
@@ -290,6 +305,19 @@ export class Daemon {
 
     // Write PID file
     await this.writePidFile();
+
+    // Readiness is now reached: the socket server is listening AND the PID file
+    // is written, which is exactly what DaemonManager.waitForReady() checks
+    // (socket exists + status().running + a successful connect probe). Only now
+    // do we kick off the best-effort iOS CtrlProxy warm-up, detached, so its
+    // per-device 5s cap can never delay readiness (issue #3110).
+    //
+    // This runs after readiness on purpose. An early iOS tool call arriving in
+    // the warm-up window is already handled by initializeIosServices' contract:
+    // the service is (re)established on first use, so a not-yet-warm connection
+    // is a latency cost, not a correctness bug — the same behavior an iOS device
+    // discovered after startup already gets.
+    this.startIosServicesWarmup();
 
     // Verify DaemonState is initialized
     const isInitialized = DaemonState.getInstance().isInitialized();
@@ -1088,6 +1116,25 @@ export class Daemon {
       // Continue daemon startup even if device discovery fails
       // Tools will handle "no devices" errors when sessions are created
     }
+  }
+
+  /**
+   * Kick off the best-effort iOS CtrlProxy warm-up WITHOUT awaiting it, so its
+   * per-device timeout can never delay daemon readiness (issue #3110). Called
+   * only after the socket server is listening and the PID file is written — i.e.
+   * after DaemonManager.waitForReady()'s conditions are already satisfiable.
+   *
+   * The detached promise must never surface as an unhandled rejection.
+   * initializeIosServices already swallows per-device failures (logging via the
+   * shared logger), but we still attach a defensive catch so any unforeseen throw
+   * is logged rather than crashing the process via the daemon's unhandled-rejection
+   * fatal handler (per the repo error-handling convention). The promise is retained
+   * on `iosServicesWarmup` so tests (and, if ever needed, shutdown) can await it.
+   */
+  private startIosServicesWarmup(): void {
+    this.iosServicesWarmup = this.initializeIosServices().catch(error => {
+      logger.warn(`[Daemon] Detached iOS CtrlProxy warm-up failed: ${error}`);
+    });
   }
 
   /**

--- a/test/daemon/daemonIosWarmupDetached.test.ts
+++ b/test/daemon/daemonIosWarmupDetached.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+
+/**
+ * Pins the issue #3110 invariant: iOS CtrlProxy warm-up
+ * (initializeIosServices) is started DETACHED and must NOT block the code path
+ * that reaches daemon readiness (socket listening + PID file written). If a slow
+ * or maxed-out iOS warm-up could delay readiness, a cold macOS CI runner would
+ * intermittently blow DAEMON_STARTUP_TIMEOUT_MS.
+ *
+ * We exercise the exact seam start() uses — startIosServicesWarmup() — rather
+ * than the heavyweight start(), keeping the test <100ms and free of real
+ * sockets/DB.
+ */
+describe("Daemon iOS warm-up is detached from readiness (#3110)", function() {
+  function makeDaemon(): Daemon {
+    return new Daemon(
+      {},
+      undefined,
+      new FakeTimer(),
+      new DeviceSessionRepository(),
+      new CountingIdGenerator("daemon-session")
+    );
+  }
+
+  afterEach(() => {
+    // Constructing a Daemon initializes the global DaemonState singleton; reset
+    // it so this file does not leak initialized state into other test files.
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("startIosServicesWarmup returns without awaiting the warm-up", async () => {
+    const daemon = makeDaemon();
+
+    // Replace the real per-device warm-up with a promise we control, so we can
+    // prove the caller does not block on it.
+    let resolveWarmup: (() => void) | undefined;
+    let warmupStarted = false;
+    (daemon as unknown as { initializeIosServices: () => Promise<void> }).initializeIosServices =
+      () => {
+        warmupStarted = true;
+        return new Promise<void>(resolve => {
+          resolveWarmup = resolve;
+        });
+      };
+
+    // start() calls this synchronously; it must return immediately even
+    // though the warm-up is still pending.
+    (daemon as unknown as { startIosServicesWarmup: () => void }).startIosServicesWarmup();
+
+    expect(warmupStarted).toBe(true);
+
+    const warmup = (daemon as unknown as { iosServicesWarmup: Promise<void> }).iosServicesWarmup;
+
+    // The warm-up must still be pending: races the detached promise against an
+    // already-resolved sentinel. If the caller had awaited the warm-up, control
+    // would not have returned here at all, but this also guards a mistaken
+    // synchronous resolution.
+    const pendingSentinel = Symbol("pending");
+    const settledFirst = await Promise.race([
+      warmup.then(() => "settled"),
+      Promise.resolve(pendingSentinel),
+    ]);
+    expect(settledFirst).toBe(pendingSentinel);
+
+    // Draining the warm-up must resolve cleanly (readiness never depended on it).
+    resolveWarmup!();
+    await expect(warmup).resolves.toBeUndefined();
+  });
+
+  test("a detached warm-up rejection is swallowed, never an unhandled rejection", async () => {
+    const daemon = makeDaemon();
+
+    (daemon as unknown as { initializeIosServices: () => Promise<void> }).initializeIosServices =
+      () => Promise.reject(new Error("boom"));
+
+    (daemon as unknown as { startIosServicesWarmup: () => void }).startIosServicesWarmup();
+
+    const warmup = (daemon as unknown as { iosServicesWarmup: Promise<void> }).iosServicesWarmup;
+
+    // The defensive .catch() in startIosServicesWarmup must turn the rejection
+    // into a logged, resolved promise so the daemon's unhandled-rejection fatal
+    // handler never fires.
+    await expect(warmup).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Structural fix ("B2") for the intermittent `Daemon failed to start within 10000ms` CI flake (#3110).

**Root cause.** Daemon readiness is gated on the socket server + PID file, which `Daemon.start()` writes *last*. `DaemonManager.waitForReady()` (`src/daemon/manager.ts:806-831`) requires all three of: `existsSync(socketPath)`, `status().running` (PID file present + process alive), and a successful connect probe. Everything before those must finish inside the 10s `DAEMON_STARTUP_TIMEOUT_MS` (`src/daemon/constants.ts:96-99`) budget. The serial bring-up in `start()` was: Bun cold start -> `initializeDatabase()` (all migrations) -> `initializeDevicePoolWithTimeout(5000)` (`daemon.ts:248`) -> `initializeIosServices()` (`daemon.ts:253`, up to 5s/device) -> socket start -> PID write. On a cold macOS CI runner the device-pool + iOS warm-up caps (5s + 5s) can consume the whole budget, so readiness misses the deadline even though the daemon is otherwise fine.

**What I reordered, and why it's safe.** I moved **only** `initializeIosServices()` off the readiness critical path. It now runs *detached* (not awaited) **after** the socket server is listening and the PID file is written (new `startIosServicesWarmup()` call after `writePidFile()`), so its per-device 5s cap can no longer delay readiness.

- **Device pool stays gated (unchanged).** `git blame` (811381b7 / 0a01f468) shows device-pool-before-socket is a deliberate contract: "clients connecting via socket will see initialized device pool." Moving it could let an early client see an empty pool -- a real bug -- so I left it awaited before the socket. iOS warm-up carries no such contract: its own comment (`daemon.ts:1132-1134`) already states failures are non-fatal and "service will be set up on first tool call if needed." Detaching it is the *smallest* reordering that removes the iOS cap from the critical path.
- **No early-client race.** `initializeIosServices()` reads `this.devicePool.getAllDevices()`, and the pool is still fully populated *before* the socket opens. An iOS tool call arriving during the warm-up window is handled by the existing first-use (re)establishment path -- a latency cost, not a correctness change; it is exactly the behavior an iOS device discovered *after* startup already gets.
- **Detached-promise error handling.** The detached promise can never become an unhandled rejection: `initializeIosServices()` already swallows per-device failures via the shared `logger`, and `startIosServicesWarmup()` adds a defensive `.catch()` that logs via `logger.warn` (per the CLAUDE.md error-handling convention) so an unforeseen throw is logged, not routed to the daemon's unhandled-rejection fatal handler. The promise is retained on `iosServicesWarmup` so tests (and, if ever needed, shutdown) can await it.

This is the **B2** structural option -- stop gating readiness on non-essential warm-up work. It is orthogonal to **B1** (a separate PR that just raises `AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS`); B2 removes the iOS cap from the critical path regardless of the budget value. Consistent with the lifecycle work in #2829 (made DB bring-up fatal-and-awaited -- DB stays awaited here), #2834, and #2847.

## Testing

- `bunx turbo run build` -- pass.
- `bunx eslint src/daemon/daemon.ts test/daemon/daemonIosWarmupDetached.test.ts --fix` -- clean.
- `bun test test/daemon/` -- **592 pass / 0 fail** (includes the 2 new tests). No existing test asserted the old iOS-before-socket ordering (grep for `initializeIosServices` / `initializeDevicePool` / `DAEMON_STARTUP` across `test/` found only the timeout-constant and env-var-pattern references, untouched).
- Added `test/daemon/daemonIosWarmupDetached.test.ts` (Interface+Fake+FakeTimer, <100ms/test) pinning the new invariant via the `startIosServicesWarmup()` seam: (1) the warm-up is started detached and does **not** block its caller (proved by racing the retained promise against an already-resolved sentinel), and (2) a detached warm-up rejection is swallowed to a resolved promise, never an unhandled rejection.

Did not run the full `bun test` suite (it has ~39 pre-existing unrelated image-backend failures); scoped to daemon + lifecycle.

**Top regression risk considered:** a `stop()` overlapping the still-running detached warm-up (previously the warm-up always completed before readiness). Assessed acceptable -- `verifyIosDevice` failures are already tolerated/logged, the per-device timeout is `unref()`'d and bounded, and the DB write-barrier drain in `stop()` covers in-flight writes. Awaiting `iosServicesWarmup` in `stop()` would only re-introduce a shutdown delay for no correctness gain, so it was deliberately left out.

Refs #3110
