### PR TITLE
test(db): fail loudly if the unit-test DB guard preload is skipped (#3083)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,11 @@
 [test]
+# LOAD-BEARING: this preload arms the unit-test real-DB guard by setting
+# AUTOMOBILE_UNIT_TEST_DB_GUARD=1 (see test/setup/unitTestDbGuard.ts and
+# assertUnitTestDbAccessAllowed in src/db/database.ts). Removing this line — or
+# running `bun test` in a way that doesn't read this bunfig — SILENTLY disables
+# the guard, letting a real-DB race (the #3063 class) flake unguarded while the
+# suite reports a false green. test/db/unitTestDbGuardPreloadArmed.test.ts is the
+# tripwire that fails loudly if this preload ever stops running (issue #3083).
 preload = ["./test/setup/unitTestDbGuard.ts"]
 coverageReporter = ["text", "lcov"]
 coverageDir = "./coverage"

--- a/test/db/unitTestDbGuardPreloadArmed.test.ts
+++ b/test/db/unitTestDbGuardPreloadArmed.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
+
+/**
+ * Positive "the arming machinery is intact" tripwire for the real-DB guard
+ * (issue #3083, follow-up to #3067 / PR #3082).
+ *
+ * The guard in `src/db/database.ts` (`assertUnitTestDbAccessAllowed`) only fires
+ * when `process.env[UNIT_TEST_DB_GUARD_ENV] === "1"`, and that flag is set solely
+ * by the bun test preload `test/setup/unitTestDbGuard.ts` (wired via
+ * `bunfig.toml` `[test].preload`). If the preload never runs — a `bun test
+ * --config other.toml`, a future CI job that doesn't pick up `bunfig.toml`, or an
+ * accidentally-deleted `[test].preload` line — the guard silently disables itself
+ * and the suite can report a false green while a real-DB race (the #3063 class)
+ * flakes unguarded. The guard "fails open".
+ *
+ * These two assertions turn that silent failure LOUD:
+ *   1. Ambient-env: the preload actually ran in THIS test process. This test does
+ *      NOT set the flag itself (that would be vacuous) — it reads the ambient
+ *      value, so it goes red if the preload was skipped for ANY reason.
+ *   2. Wiring: `bunfig.toml` still lists the preload, so removing the line trips a
+ *      targeted failure that names the exact cause.
+ */
+describe("unit-test DB guard preload is armed (issue #3083)", () => {
+  test("the bun test preload ran: UNIT_TEST_DB_GUARD_ENV is set to \"1\" in this process", () => {
+    // Read the AMBIENT value — deliberately not set here, so this fails loudly if
+    // the preload (test/setup/unitTestDbGuard.ts) did not run for this process.
+    expect(process.env[UNIT_TEST_DB_GUARD_ENV]).toBe("1");
+  });
+
+  test("bunfig.toml still wires the guard preload via [test].preload", () => {
+    // Resolve bunfig.toml relative to this file (repo root is two levels up from
+    // test/db/) so the assertion is independent of the runner's cwd.
+    const repoRoot = join(import.meta.dir, "..", "..");
+    const bunfig = readFileSync(join(repoRoot, "bunfig.toml"), "utf8");
+
+    // The preload path exactly as bun resolves it from bunfig.toml. If this line
+    // is removed the guard silently disables — catch it here with a precise cause.
+    expect(bunfig).toContain("./test/setup/unitTestDbGuard.ts");
+    // And confirm it lives under the [test].preload key, not merely mentioned in a
+    // comment somewhere, so the wiring — not just the string — is what's asserted.
+    expect(bunfig).toMatch(/preload\s*=\s*\[[^\]]*\.\/test\/setup\/unitTestDbGuard\.ts/);
+  });
+});

--- a/test/db/unitTestDbGuardPreloadArmed.test.ts
+++ b/test/db/unitTestDbGuardPreloadArmed.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+// Structural import: Bun parses bunfig.toml, so `bunfigConfig.test.preload` is the
+// actual parsed array — immune to comments, quote style, and whitespace/multi-line
+// reformats that a raw text/regex match would mishandle (a commented-out preload
+// entry is simply absent from the array rather than falsely matching).
+import bunfigConfig from "../../bunfig.toml";
 import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
+
+const bunfigPreload: string[] = (bunfigConfig as { test?: { preload?: string[] } }).test?.preload ?? [];
 
 /**
  * Positive "the arming machinery is intact" tripwire for the real-DB guard
@@ -27,20 +32,22 @@ describe("unit-test DB guard preload is armed (issue #3083)", () => {
   test("the bun test preload ran: UNIT_TEST_DB_GUARD_ENV is set to \"1\" in this process", () => {
     // Read the AMBIENT value — deliberately not set here, so this fails loudly if
     // the preload (test/setup/unitTestDbGuard.ts) did not run for this process.
+    // This assumes no sibling test clobbers this key without restoring it; today
+    // test/db/unitTestDbGuard.test.ts is the only mutator and it restores the whole
+    // tracked-env set in afterEach, so the ambient read is a faithful "preload ran"
+    // signal. Any future test that mutates AUTOMOBILE_UNIT_TEST_DB_GUARD MUST keep
+    // that invariant, or it would mis-blame the preload here.
     expect(process.env[UNIT_TEST_DB_GUARD_ENV]).toBe("1");
   });
 
   test("bunfig.toml still wires the guard preload via [test].preload", () => {
-    // Resolve bunfig.toml relative to this file (repo root is two levels up from
-    // test/db/) so the assertion is independent of the runner's cwd.
-    const repoRoot = join(import.meta.dir, "..", "..");
-    const bunfig = readFileSync(join(repoRoot, "bunfig.toml"), "utf8");
-
-    // The preload path exactly as bun resolves it from bunfig.toml. If this line
-    // is removed the guard silently disables — catch it here with a precise cause.
-    expect(bunfig).toContain("./test/setup/unitTestDbGuard.ts");
-    // And confirm it lives under the [test].preload key, not merely mentioned in a
-    // comment somewhere, so the wiring — not just the string — is what's asserted.
-    expect(bunfig).toMatch(/preload\s*=\s*\[[^\]]*\.\/test\/setup\/unitTestDbGuard\.ts/);
+    // Structural check against the parsed [test].preload array (see the import
+    // note above): a removed OR commented-out entry is simply absent from the
+    // array, so this fails loudly with a precise cause. `endsWith` tolerates a
+    // future formatter dropping the leading `./` (bun resolves either form) while
+    // still pinning the exact preload module.
+    expect(
+      bunfigPreload.some(entry => entry.endsWith("test/setup/unitTestDbGuard.ts"))
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #3067 / PR #3082, which added the unit-test real-DB guard
(`assertUnitTestDbAccessAllowed`, `src/db/database.ts:149`) that throws when a
unit test resolves the real file-backed `~/.auto-mobile/auto-mobile.db`.

**Problem.** That guard is armed **only** by the bun test preload
`test/setup/unitTestDbGuard.ts` (wired via `bunfig.toml` `[test].preload`), which
sets `AUTOMOBILE_UNIT_TEST_DB_GUARD=1`. `assertUnitTestDbAccessAllowed` early-returns
unless that flag is `"1"` (`src/db/database.ts:150`). So if the preload never runs —
a `bun test --config other.toml`, a future CI job that doesn't read `bunfig.toml`, or
the `[test].preload` line accidentally removed — the guard **silently disables
itself**. Worst case: a real-DB race (the #3063 class) flakes again with no tripwire
and the suite reports a false green. The guard **fails open**.

**Fix.** Add a positive assertion that the arming machinery is intact, so a
misconfigured runner fails **loudly** rather than going unguarded (issue #3083).

- `test/db/unitTestDbGuardPreloadArmed.test.ts` — two independent assertions:
  1. **Ambient env** — `process.env[AUTOMOBILE_UNIT_TEST_DB_GUARD] === "1"`, read
     from ambient process state. The test deliberately does **not** set the flag
     itself (that would be vacuous), so it goes red if the preload was skipped for
     **any** reason (wrong `--config`, CI not reading bunfig, line removed).
  2. **Wiring** — parse `bunfig.toml` and assert `[test].preload` still lists
     `./test/setup/unitTestDbGuard.ts`, so an accidental line removal trips a
     targeted failure that names the exact cause, independent of ambient env.
- A **load-bearing comment** in `bunfig.toml` next to `[test].preload` documenting
  that the line arms the guard and that removing it silently disables the tripwire.

**Teeth verified.** Running the new test from a cwd without `bunfig.toml` (so the
preload never runs) makes the ambient-env assertion fail loudly with
`Expected: "1" / Received: undefined`, while the wiring assertion still passes
(it reads the file directly) — confirming the two assertions isolate the
"runner skipped the preload" mode from the "line removed from bunfig" mode.

## Testing

- `bun test test/db/unitTestDbGuardPreloadArmed.test.ts` — 2 pass
- `bun test test/db/` — 603 pass, 0 fail (no regressions; anti-pattern meta-test
  and existing `unitTestDbGuard.test.ts` stay green with the new file present)
- `bun run lint` — clean
- `bun run build` — succeeds

## Notes

Purely additive test-infra + a comment; no production code changes. The new test
opens no database, so it does not trip the file-backed-DB anti-pattern guard (#3081).

Closes #3083.
