### PR TITLE
fix(navigation): dismissTopModal bottom-sheet uses swipeOn, not unregistered swipe (#3106)

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -11,7 +11,7 @@ import { UIStateExtractor } from "./UIStateExtractor";
 import { RealObserveScreen } from "../observe/ObserveScreen";
 import { getStructuredField } from "../../utils/toolUtils";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
-import { defaultTimer } from "../../utils/SystemTimer";
+import { defaultTimer, Timer } from "../../utils/SystemTimer";
 
 /**
  * Default implementation of UIStateSetup that handles UI state alignment
@@ -29,14 +29,17 @@ export class DefaultUIStateSetup implements UIStateSetup {
   private device: BootedDevice;
   private adb: AdbClient;
   private observeScreenProvider: () => ObserveScreenLike;
+  private timer: Timer;
 
   constructor(
     device: BootedDevice,
     adb: AdbClient,
-    observeScreenProvider?: () => ObserveScreenLike
+    observeScreenProvider?: () => ObserveScreenLike,
+    timer: Timer = defaultTimer
   ) {
     this.device = device;
     this.adb = adb;
+    this.timer = timer;
     // The setup holds a resolved AdbClient (not a factory), so wrap it in a
     // trivial factory to satisfy ObserveScreen's factory-only contract (matches
     // the AndroidCtrlProxyClient.getInstance call below).
@@ -355,12 +358,17 @@ export class DefaultUIStateSetup implements UIStateSetup {
     // Strategy 2: Swipe down for bottom sheets
     if (modal.type === "bottomsheet") {
       try {
-        const swipeTool = ToolRegistry.getTool("swipe");
+        // The registered interaction tool is `swipeOn`, not `swipe` (see
+        // src/server/interactionTools.ts). Resolving `getTool("swipe")` always
+        // returned undefined, so this whole branch was dead code and bottom
+        // sheets that only dismiss via swipe-down silently fell through to the
+        // back-button fallback below (issue #3106).
+        const swipeTool = ToolRegistry.getTool("swipeOn");
         if (swipeTool) {
-          // Swipe down from middle of screen to dismiss bottom sheet.
-          // Internal setup swipe (#3087): no diff/strip, no baseline advance.
+          // Swipe down to dismiss the bottom sheet. `swipeOn` takes `direction`
+          // (no `action` field). Internal setup swipe (#3087): no diff/strip, no
+          // baseline advance.
           await swipeTool.handler(markInternalToolCall({
-            action: "swipe",
             direction: "down",
             platform
           }));
@@ -501,6 +509,6 @@ export class DefaultUIStateSetup implements UIStateSetup {
    * Sleep for the specified duration.
    */
   private sleep(ms: number): Promise<void> {
-    return defaultTimer.sleep(ms);
+    return this.timer.sleep(ms);
   }
 }

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -365,11 +365,17 @@ export class DefaultUIStateSetup implements UIStateSetup {
         // back-button fallback below (issue #3106).
         const swipeTool = ToolRegistry.getTool("swipeOn");
         if (swipeTool) {
-          // Swipe down to dismiss the bottom sheet. `swipeOn` takes `direction`
-          // (no `action` field). Internal setup swipe (#3087): no diff/strip, no
+          // Swipe down from mid-screen to drag the sheet down and dismiss it.
+          // `swipeOn` takes `direction` (no `action` field). `autoTarget: false`
+          // is essential here: with the default (true) and no lookFor/container,
+          // swipeOn targets a scrollable child and would scroll the sheet's inner
+          // list instead of dragging the sheet itself down (SwipeOn.execute). We
+          // want the full-screen downward swipe (executeScreenSwipe) that a
+          // dismissal needs. Internal setup swipe (#3087): no diff/strip, no
           // baseline advance.
           await swipeTool.handler(markInternalToolCall({
             direction: "down",
+            autoTarget: false,
             platform
           }));
           await this.sleep(200);

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -171,6 +171,10 @@ describe("DefaultUIStateSetup", () => {
       expect(capturedArgs).toBeDefined();
       expect(capturedArgs!.direction).toBe("down");
       expect(capturedArgs!.platform).toBe("android");
+      // Must force a full-screen swipe: with the default (autoTarget true) and no
+      // lookFor/container, swipeOn targets a scrollable child and would scroll the
+      // sheet's inner list instead of dragging the sheet down to dismiss it.
+      expect(capturedArgs!.autoTarget).toBe(false);
       // The old dead-code path passed a bogus `action: "swipe"` shape that the
       // `swipeOn` schema does not accept — the fixed call must not carry it.
       expect(capturedArgs!.action).toBeUndefined();

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { DefaultUIStateSetup, type ObserveScreenLike } from "../../../src/features/navigation/DefaultUIStateSetup";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
 import type { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import type { BootedDevice } from "../../../src/models";
 import type { ObserveResult } from "../../../src/models/ObserveResult";
 import type { NavigationEdge } from "../../../src/features/navigation/NavigationGraphManager";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
 import { createStructuredToolResponse } from "../../../src/utils/toolUtils";
-import type { ScrollPosition } from "../../../src/utils/interfaces/NavigationGraph";
+import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
+import type { ModalState, ScrollPosition } from "../../../src/utils/interfaces/NavigationGraph";
 
 const device: BootedDevice = {
   deviceId: "test-device",
@@ -19,7 +21,11 @@ function makeSetup(
   observeScreenProvider?: () => ObserveScreenLike
 ): DefaultUIStateSetup {
   const fakeAdb = new FakeAdbClient() as unknown as AdbClient;
-  return new DefaultUIStateSetup(device, fakeAdb, observeScreenProvider);
+  // Auto-advancing fake timer so the internal `sleep()` delays resolve
+  // immediately — keeps these unit tests fast (<100ms) and non-flaky.
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  return new DefaultUIStateSetup(device, fakeAdb, observeScreenProvider, timer);
 }
 
 describe("DefaultUIStateSetup", () => {
@@ -120,6 +126,77 @@ describe("DefaultUIStateSetup", () => {
       const action = await setup.setupScrollPosition(scrollPosition, "android");
 
       expect(action).toBeNull();
+    });
+  });
+
+  // Regression for issue #3106: the bottomsheet branch of `dismissTopModal`
+  // resolved `ToolRegistry.getTool("swipe")`, but no tool is registered under
+  // that name — the interaction tool is `swipeOn`. So the swipe-down dismissal
+  // was dead code that silently fell through to the back-button fallback. These
+  // tests pin that the branch resolves and invokes the registered `swipeOn`
+  // handler with the correct arg shape so a wrong tool name regresses loudly.
+  describe("dismissTopModal bottomsheet swipe-down (#3106)", () => {
+    afterEach(() => {
+      ToolRegistry.clearTools();
+    });
+
+    // A null hierarchy makes getCurrentUIState() return undefined, so the
+    // post-swipe dismissal check (`!currentState?.modalStack?.some(...)`) treats
+    // the sheet as gone — the swipe branch resolves as dismissed without ever
+    // reaching the back-button fallback.
+    const nullObserve = (): ObserveScreenLike => ({
+      execute: async () => ({ viewHierarchy: null } as unknown as ObserveResult),
+    });
+
+    const bottomSheet: ModalState = { type: "bottomsheet", layer: 1, windowId: 42 };
+
+    test("invokes the registered `swipeOn` handler (not `swipe`) with direction down", async () => {
+      let swipeOnCalls = 0;
+      let capturedArgs: Record<string, unknown> | undefined;
+      ToolRegistry.register("swipeOn", "swipeOn", {}, async (args: any) => {
+        swipeOnCalls++;
+        capturedArgs = args;
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const setup = makeSetup(nullObserve);
+      const dismissed = await (
+        setup as unknown as {
+          dismissTopModal: (modal: ModalState, platform: string) => Promise<boolean>;
+        }
+      ).dismissTopModal(bottomSheet, "android");
+
+      expect(dismissed).toBe(true);
+      expect(swipeOnCalls).toBe(1);
+      expect(capturedArgs).toBeDefined();
+      expect(capturedArgs!.direction).toBe("down");
+      expect(capturedArgs!.platform).toBe("android");
+      // The old dead-code path passed a bogus `action: "swipe"` shape that the
+      // `swipeOn` schema does not accept — the fixed call must not carry it.
+      expect(capturedArgs!.action).toBeUndefined();
+      // Marked internal (#3087) so navigation setup neither diffs/strips its
+      // observation nor advances the agent-facing diff baseline.
+      expect(capturedArgs![INTERNAL_NO_DIFF_PARAM]).toBe(true);
+    });
+
+    test("does not mistakenly resolve a tool registered under the old name `swipe`", async () => {
+      let legacySwipeCalls = 0;
+      // Register ONLY the wrong name. With the bug this would be the tool the
+      // branch resolves; after the fix it must be ignored (no swipeOn present →
+      // the branch skips straight to the back-button fallback).
+      ToolRegistry.register("swipe", "swipe", {}, async () => {
+        legacySwipeCalls++;
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const setup = makeSetup(nullObserve);
+      await (
+        setup as unknown as {
+          dismissTopModal: (modal: ModalState, platform: string) => Promise<boolean>;
+        }
+      ).dismissTopModal(bottomSheet, "android");
+
+      expect(legacySwipeCalls).toBe(0);
     });
   });
 });


### PR DESCRIPTION
Closes #3106.

## Summary

`DefaultUIStateSetup.dismissTopModal` resolved the swipe tool in its bottom-sheet branch via `ToolRegistry.getTool("swipe")`, but **no tool is registered under the name `"swipe"`** — the registered interaction tool is `"swipeOn"` (`src/server/interactionTools.ts`). So `getTool("swipe")` always returned `undefined`, the `if (swipeTool)` block never ran, and swipe-down dismissal of bottom sheets was **dead code** that silently fell through to the back-button fallback below it. A bottom sheet that only dismisses by swipe-down (not by back) would fail to dismiss during navigation setup.

Surfaced during the multi-perspective review of #3096; pre-existing and unrelated to that PR, so filed and fixed separately.

## What changed

### Fix the tool name + arg shape (`src/features/navigation/DefaultUIStateSetup.ts`)
- Resolve `ToolRegistry.getTool("swipeOn")` instead of the never-registered `"swipe"`.
- Pass the correct `swipeOn` arg shape — `{ direction: "down", platform }`, dropping the bogus `action: "swipe"` field that `swipeOn`'s schema does not accept.
- Keep the `markInternalToolCall(...)` wrapper (#3087) so this setup swipe neither diffs/strips its observation nor advances the agent-facing diff baseline.

### Inject a `Timer` (test speed)
- `DefaultUIStateSetup` now takes an optional `Timer` (default `defaultTimer`), used by the private `sleep()`. This lets the new unit tests drive an auto-advancing `FakeTimer` so the `dismissTopModal` `sleep(200)` delays resolve immediately, keeping them <100ms and non-flaky. Backward-compatible — no production call site changes.

### Regression tests (`test/features/navigation/DefaultUIStateSetup.test.ts`)
- Spy on the registered `swipeOn` handler and assert the bottom-sheet branch invokes it exactly once with `direction: "down"`, `platform`, the `__internalNoDiff` marker, and **no** `action` field — so a wrong tool name regresses loudly.
- A second test registers a tool under the old name `"swipe"` and asserts it is **never** resolved.

## Verification

- `bun test test/features/navigation/DefaultUIStateSetup.test.ts` -> **7 pass / 0 fail**; both new tests verified **red** against the pre-fix `getTool("swipe")` and **green** after the fix.
- `bun test test/features/navigation/` -> **303 pass / 0 fail**.
- `bunx turbo run lint build` -> clean.

## Non-goals / follow-ups

- No production call site passes a custom `Timer`; the injection exists purely as a test seam (YAGNI-sized to the one consumer).
