### PR TITLE
refactor(navigation): extract shared two-repo runInTransaction helper (#3075)

### DIFF
--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -354,23 +354,15 @@ export class NavigationGraphManager implements NavigationGraphService {
     const recentToolCall = this.findCorrelatedToolCall(timestamp);
     const currentModalStack = recentToolCall?.uiState?.modalStack;
 
-    // Enforce the shared-connection precondition BEFORE reserving the connection:
-    // the transaction below is opened on the navigation connection and the coverage
-    // repo is enlisted onto that same `trx`, so a coverage repo bound to a DIFFERENT
-    // connection would split writes and defeat the rollback. Holds by construction in
-    // production (both default to the getDatabase() singleton); see assertSharedConnection.
-    this.assertSharedConnection();
-
-    // Persist the whole graph write atomically. Every read and write inside the
-    // callback runs on `trx` (via withExecutor) — a stray singleton query here
-    // would deadlock the daemon's only connection (bunSqliteDialect). Keep the body
-    // to DB statements only: telemetry push, notifications, screenshot capture and
-    // in-memory field assignments stay OUTSIDE so the exclusive connection is not
-    // held across non-DB IO, and so they never run when the transaction rolls back.
-    const node = await this.repository.runInTransaction(async trx => {
-      const repository = this.repository.withExecutor(trx);
-      const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);
-
+    // Persist the whole graph write atomically across BOTH repos via the shared helper,
+    // which owns the assertSharedConnection() precondition and the bind-both-repos
+    // preamble (#3075). Every read and write inside the callback runs on the transaction
+    // (via withExecutor) — a stray singleton query here would deadlock the daemon's only
+    // connection (bunSqliteDialect). Keep the body to DB statements only: telemetry push,
+    // notifications, screenshot capture and in-memory field assignments stay OUTSIDE so
+    // the exclusive connection is not held across non-DB IO, and so they never run when
+    // the transaction rolls back.
+    const node = await this.runBothReposInTransaction(async (repository, testCoverageRepository) => {
       // Get or create node and update visit count
       const n = await repository.getOrCreateNode(appId, screenName, timestamp);
 
@@ -486,9 +478,51 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
+   * Run a graph write that spans BOTH the navigation and test-coverage repositories
+   * inside a single transaction, owning the shared-connection precondition so no
+   * caller can forget it (#3075). This is the one place the assert + bind-both-repos
+   * preamble lives, so a future third both-repos writer inherits the guard for free
+   * (the exact failure mode #2968/#2980 guard against).
+   *
+   * It (1) asserts assertSharedConnection() once, (2) opens a transaction on the
+   * navigation connection, and (3) enlists both repos onto that same `trx` via
+   * withExecutor before invoking `fn` with the two bound repos. Every read and write
+   * inside `fn` runs on `trx` — a stray singleton query would deadlock the daemon's
+   * only connection (bunSqliteDialect).
+   *
+   * Callers keep in-memory field updates, notifyGraphUpdated and telemetry OUTSIDE
+   * `fn` (post-commit): this helper owns only the DB-atomic preamble, matching the
+   * convention that side effects never run inside the transaction or on rollback.
+   *
+   * Not for the single-repo writers: promoteSuggestion enlists only the navigation
+   * repo and deliberately carries no coverage binding or shared-connection assertion,
+   * so it stays on its own runInTransaction path.
+   */
+  private async runBothReposInTransaction<T>(
+    fn: (
+      navigationRepository: NavigationRepository,
+      testCoverageRepository: TestCoverageRepository
+    ) => Promise<T>
+  ): Promise<T> {
+    // Enforce the shared-connection precondition BEFORE reserving the connection: the
+    // transaction is opened on the navigation connection and the coverage repo is
+    // enlisted onto that same `trx`, so a coverage repo bound to a DIFFERENT connection
+    // would split writes and defeat the rollback. Holds by construction in production
+    // (both default to the getDatabase() singleton); see assertSharedConnection.
+    this.assertSharedConnection();
+
+    return this.repository.runInTransaction(async trx => {
+      const navigationRepository = this.repository.withExecutor(trx);
+      const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);
+      return fn(navigationRepository, testCoverageRepository);
+    });
+  }
+
+  /**
    * Assert that the navigation and test-coverage repositories resolve to the same
-   * underlying connection — the precondition for recordNavigationEvent's single
-   * transaction to cover both repos' writes atomically.
+   * underlying connection — the precondition for the two-repo graph writes' single
+   * transaction to cover both repos' writes atomically. Invoked from
+   * runBothReposInTransaction, which is the sole owner of this precondition.
    *
    * Both default to the getDatabase() singleton, so this holds by construction in
    * production; the guard exists so a mistakenly foreign-bound coverage repo
@@ -499,8 +533,8 @@ export class NavigationGraphManager implements NavigationGraphService {
     if (this.repository.resolveConnection() !== this.testCoverageRepository.resolveConnection()) {
       throw new ActionableError(
         "NavigationGraphManager: the navigation and test-coverage repositories resolve to " +
-        "different database connections. recordNavigationEvent opens one transaction on the " +
-        "navigation connection and enlists coverage writes onto it; a foreign-bound coverage " +
+        "different database connections. The two-repo graph writes open one transaction on the " +
+        "navigation connection and enlist coverage writes onto it; a foreign-bound coverage " +
         "repo would split writes across connections and silently defeat the rollback guarantee. " +
         "Both repositories must share the same connection (both default to the getDatabase() singleton)."
       );
@@ -535,19 +569,15 @@ export class NavigationGraphManager implements NavigationGraphService {
     if (existingNode) {
       const appId = this.currentAppId;
 
-      // Persist the counter writes atomically: updateNodeVisit + coverage recordNodeVisit +
-      // touchApp span two repos on the shared connection. Enlist both onto one `trx` via
-      // withExecutor so a mid-sequence throw (e.g. the coverage recordNodeVisit) rolls back the node-visit
-      // increment too, instead of leaving the graph partially applied. Assert the shared-connection
-      // precondition first (the coverage repo is enlisted onto the navigation `trx`). In-memory
-      // field updates and notifyGraphUpdated stay OUTSIDE so they never run on rollback and the
-      // exclusive connection is not held across non-DB work.
-      this.assertSharedConnection();
-
-      await this.repository.runInTransaction(async trx => {
-        const repository = this.repository.withExecutor(trx);
-        const testCoverageRepository = this.testCoverageRepository.withExecutor(trx);
-
+      // Persist the counter writes atomically across BOTH repos via the shared helper,
+      // which owns the assertSharedConnection() precondition and the bind-both-repos
+      // preamble (#3075): updateNodeVisit + coverage recordNodeVisit + touchApp span two
+      // repos on the shared connection, so a mid-sequence throw (e.g. the coverage
+      // recordNodeVisit) rolls back the node-visit increment too instead of leaving the
+      // graph partially applied. In-memory field updates and notifyGraphUpdated stay
+      // OUTSIDE so they never run on rollback and the exclusive connection is not held
+      // across non-DB work.
+      await this.runBothReposInTransaction(async (repository, testCoverageRepository) => {
         // Update the existing node's visit count and last_seen_at
         await repository.updateNodeVisit(existingNode.id, timestamp);
 

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -13,6 +13,8 @@ import { defaultTimer, type Timer } from "../../../src/utils/SystemTimer";
 import type { Database } from "../../../src/db/types";
 import { ActionableError } from "../../../src/models/ActionableError";
 import { useTempFileDatabase, type TempFileDatabaseHandle } from "../../helpers/tempFileDatabase";
+import { readFileSync } from "fs";
+import { join } from "path";
 
 // The older suites below drive the REAL getDatabase() singleton via getInstance()
 // and getInstanceForSession() (session instances have no in-memory injection seam),
@@ -1028,26 +1030,30 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     // is still 0 — is caught rather than masked by a later post-commit fire.
     const touchSpy = spyOn(NavigationRepository.prototype, "touchApp");
 
-    const notifyTouchCounts: number[] = [];
-    manager.setGraphUpdateListener(() => {
-      notifyTouchCounts.push(touchSpy.mock.calls.length);
-    });
+    // try/finally so a throwing assertion below cannot leak this prototype spy into
+    // sibling suites in the same bun test process (#3075 fold-in from #3090 review).
+    try {
+      const notifyTouchCounts: number[] = [];
+      manager.setGraphUpdateListener(() => {
+        notifyTouchCounts.push(touchSpy.mock.calls.length);
+      });
 
-    const telemetryTouchCounts: number[] = [];
-    telemetrySpy.mockImplementation(async () => {
-      telemetryTouchCounts.push(touchSpy.mock.calls.length);
-    });
+      const telemetryTouchCounts: number[] = [];
+      telemetrySpy.mockImplementation(async () => {
+        telemetryTouchCounts.push(touchSpy.mock.calls.length);
+      });
 
-    await manager.recordNavigationEvent(createEvent("Screen1", 1000));
+      await manager.recordNavigationEvent(createEvent("Screen1", 1000));
 
-    // touchApp runs exactly once (one event), and notify + telemetry each fire
-    // exactly once, each AFTER that final in-transaction write completed — never
-    // inside the transaction and never before it.
-    expect(touchSpy).toHaveBeenCalledTimes(1);
-    expect(notifyTouchCounts).toEqual([1]);
-    expect(telemetryTouchCounts).toEqual([1]);
-
-    touchSpy.mockRestore();
+      // touchApp runs exactly once (one event), and notify + telemetry each fire
+      // exactly once, each AFTER that final in-transaction write completed — never
+      // inside the transaction and never before it.
+      expect(touchSpy).toHaveBeenCalledTimes(1);
+      expect(notifyTouchCounts).toEqual([1]);
+      expect(telemetryTouchCounts).toEqual([1]);
+    } finally {
+      touchSpy.mockRestore();
+    }
   });
 
   test("does not deadlock a concurrent writer on the shared connection", async () => {
@@ -1327,6 +1333,64 @@ describe("NavigationGraphManager - shared-connection guard (#2968)", () => {
     // never applied — the guard stopped the transaction before it opened.
     expect(await countNodeCoverage(navDb)).toBe(0);
     expect(await homeVisitCount(navDb)).toBe(visitsBefore);
+  });
+});
+
+// #3075: the assertSharedConnection() + runInTransaction + bind-both-repos preamble
+// used to be inlined in both recordNavigationEvent and recordHierarchyNavigation
+// Case 1 (two sites, two copies of the guard). It is now consolidated into a single
+// shared helper that owns the invariant, so a future third both-repos writer cannot
+// forget the guard. These tests pin that consolidation structurally (the guard is
+// invoked from exactly one place) and behaviorally (the generalized error names no
+// specific method). The teeth from the guard suite above are preserved: because both
+// call sites now flow through the single guard, deleting that one call fails the
+// foreign-bound-connection tests for BOTH methods, not just one.
+describe("NavigationGraphManager - shared two-repo transaction helper (#3075)", () => {
+  const managerSource = readFileSync(
+    join(import.meta.dir, "../../../src/features/navigation/NavigationGraphManager.ts"),
+    "utf8"
+  );
+
+  test("assertSharedConnection is invoked from exactly one place (the shared helper)", () => {
+    // Two inline copies (the pre-#3075 state) would make this 2 and fail. Consolidating
+    // into a single helper is what makes the guard un-forgettable for a future site:
+    // there is one call, and both both-repos writers route through it.
+    const callSites = managerSource.match(/this\.assertSharedConnection\(\)/g) ?? [];
+    expect(callSites.length).toBe(1);
+  });
+
+  test("both both-repos writers delegate to the shared helper (no inline runInTransaction bind-both)", () => {
+    // The helper name is asserted from the issue's proposed shape; both writers call it.
+    const delegations = managerSource.match(/this\.runBothReposInTransaction[<(]/g) ?? [];
+    expect(delegations.length).toBe(2);
+  });
+
+  test("guard error message names no specific method (generalized in #3075)", async () => {
+    // A foreign-bound coverage repo trips the guard. The message must still name the
+    // connection-identity invariant (the stable substring guard tests match on) but must
+    // NOT name a single method — the guard now fires from more than one call site.
+    const navDb = await createTestDatabase({ foreignKeys: true });
+    const coverageDb = await createTestDatabase({ foreignKeys: true });
+    try {
+      const navRepo = new NavigationRepository(navDb);
+      const coverage = new TestCoverageRepository(defaultTimer, coverageDb);
+      const manager = NavigationGraphManager.createForTesting(navRepo, coverage);
+      await manager.setCurrentApp("com.test.msg");
+
+      let caught: unknown;
+      await manager.recordNavigationEvent(createEvent("Screen1", 1000)).catch(e => {
+        caught = e;
+      });
+
+      expect(caught).toBeInstanceOf(ActionableError);
+      const message = (caught as Error).message;
+      expect(message).toMatch(/different database connections/i);
+      expect(message).not.toMatch(/recordNavigationEvent/);
+      expect(message).not.toMatch(/recordHierarchyNavigation/);
+    } finally {
+      await navDb.destroy();
+      await coverageDb.destroy();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #3075 — the now-met YAGNI trigger #2980/PR #3072 deferred: extract a shared
two-repo `runInTransaction` helper on `NavigationGraphManager` so the
`assertSharedConnection()` + bind-both-repos preamble lives in **one** place and a
future third both-repos writer can't forget the guard (the exact failure mode
#2968/#2980 guard against).

Before this change the preamble was duplicated across two methods:

- `recordNavigationEvent` (`:362` guard + `:370` `runInTransaction`)
- `recordHierarchyNavigation` Case 1 (`:545` guard + `:547` `runInTransaction`)

## What changed

**`src/features/navigation/NavigationGraphManager.ts`**

- New private helper `runBothReposInTransaction<T>(fn)` that (1) calls
  `assertSharedConnection()` once, (2) opens `this.repository.runInTransaction`, and
  (3) binds **both** `this.repository` and `this.testCoverageRepository` onto the same
  `trx` via `withExecutor` before invoking `fn(navRepo, coverageRepo)`. Side effects
  (in-memory field updates, `notifyGraphUpdated`, telemetry) stay with the caller,
  post-commit — matching the existing convention.
- `recordNavigationEvent` and `recordHierarchyNavigation` Case 1 refactored onto it;
  neither inlines the guard/bind-both any more.
- Guard `ActionableError` message generalized — it no longer names
  `recordNavigationEvent` (it now fires from more than one call site). The stable
  `/different database connections/i` substring the guard tests match on is preserved.
- `promoteSuggestion` is left untouched on its own **single-repo** `runInTransaction`
  path (no coverage enlistment, no `assertSharedConnection()`), per the #2994 design
  constraint carried into this issue.

**`test/features/navigation/NavigationGraphManager.test.ts`**

- New `shared two-repo transaction helper (#3075)` suite pins the consolidation:
  - **structural** — `assertSharedConnection()` is invoked from exactly one place;
    both both-repos writers delegate to the helper;
  - **behavioral** — the generalized error still matches
    `/different database connections/i` but names **neither** method.
- `#2791` `touchSpy` hardened with `try/finally` so a throwing assertion can't leak the
  prototype spy into sibling suites (fold-in requested in the #3090 review; #3075
  refactors this test region so it's fixed in-place here).

## Acceptance criteria (from #3075)

- [x] A single helper owns the `assertSharedConnection()` + bind-both-repos preamble;
      both existing call sites use it and no longer inline the guard.
- [x] Guard `ActionableError` message no longer names a specific method.
- [x] Existing guard + rollback tests still pass unchanged; **TDD teeth preserved** —
      removing the guard from the helper fails the guard tests **for both call sites**.

## Verification

- `bun test test/features/navigation/NavigationGraphManager.test.ts` → **67 pass / 0
  fail** (was 64; +3 new), ~0.6s.
- `bun test test/features/navigation/ test/db/navigationRepository.test.ts` → **335 pass
  / 0 fail** (18 files).
- **Teeth proven (mutation test):** deleting the single `this.assertSharedConnection()`
  from the helper fails the foreign-bound-connection tests for **both**
  `recordNavigationEvent` **and** `recordHierarchyNavigation` Case 1 (9 fail), plus the
  two structural `#3075` tests. Reverted; all green.
- `bunx turbo run lint build` → clean; `schemas/tool-definitions.json` no drift.

## Non-goals / follow-ups

- `promoteSuggestion` stays single-repo by design (#2994) — not unified into the helper.
- Purely internal refactor + tests; no wire/runner/release surface, so no re-cut needed.
