### PR TITLE
feat(android): close raw serviceScope.launch silent-hang gap via ServiceScopeGuard (#3104)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
@@ -53,32 +53,39 @@ class AsyncActionRunner(
     requestId: String?,
     action: String,
     block: suspend CoroutineScope.() -> Unit,
-  ): Job = scope.launch {
-    try {
-      block()
-    } catch (e: CancellationException) {
-      // Cooperative cancellation means the service scope is shutting down — never convert it into
-      // a client-facing error frame; let it propagate so the coroutine unwinds cleanly.
-      throw e
-    } catch (e: Exception) {
-      val cause = e.message ?: e::class.simpleName ?: "unknown error"
-      logError("Async action '$action' failed (requestId=$requestId)", e)
+  ): Job =
+    // Tag the launched coroutine with [RequestIdContext] so that a throwable this handler does
+    // *not*
+    // catch — a non-[Exception] [Throwable] such as an [Error]/[AssertionError] — still escapes
+    // with
+    // the correlation id attached, letting the scope-level [ServiceScopeGuard] emit a *correlated*
+    // error frame instead of a null-id one. The common `Exception` case is handled below directly.
+    scope.launch(RequestIdContext(requestId)) {
       try {
-        broadcastResponse(
-          ErrorResponse(requestId = requestId, error = "Action '$action' failed: $cause")
-        )
-      } catch (broadcastError: CancellationException) {
-        throw broadcastError
-      } catch (broadcastError: Exception) {
-        // A failure while reporting the error must not escape and crash the launch (which would
-        // defeat the whole point). Log and swallow — the client will fall back to its timeout.
-        logError(
-          "Failed to broadcast async error for action '$action' (requestId=$requestId)",
-          broadcastError,
-        )
+        block()
+      } catch (e: CancellationException) {
+        // Cooperative cancellation means the service scope is shutting down — never convert it into
+        // a client-facing error frame; let it propagate so the coroutine unwinds cleanly.
+        throw e
+      } catch (e: Exception) {
+        val cause = e.message ?: e::class.simpleName ?: "unknown error"
+        logError("Async action '$action' failed (requestId=$requestId)", e)
+        try {
+          broadcastResponse(
+            ErrorResponse(requestId = requestId, error = "Action '$action' failed: $cause")
+          )
+        } catch (broadcastError: CancellationException) {
+          throw broadcastError
+        } catch (broadcastError: Exception) {
+          // A failure while reporting the error must not escape and crash the launch (which would
+          // defeat the whole point). Log and swallow — the client will fall back to its timeout.
+          logError(
+            "Failed to broadcast async error for action '$action' (requestId=$requestId)",
+            broadcastError,
+          )
+        }
       }
     }
-  }
 
   companion object {
     private const val TAG = "AsyncActionRunner"

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -111,7 +111,28 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     const val ACTION_OPERATION_RESULT = "dev.jasonpearson.automobile.OPERATION_RESULT"
   }
 
-  private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+  /**
+   * Emits a correlated `type:"error"` frame when *any* raw `serviceScope.launch { … }` throws
+   * uncaught — closing the raw-launch half of the silent-hang gap by construction (issue #3104).
+   * Its [ServiceScopeGuard.handler] is installed on [serviceScope] below. `emitScope` resolves
+   * [serviceScope] lazily to break the scope↔handler construction cycle (the handler re-launches
+   * its fallback broadcast on the same scope); the broadcast sink resolves [webSocketServer] lazily
+   * because it is `lateinit` (assigned in [onServiceConnected]). See [AsyncActionRunner] /
+   * [ResultBroadcaster] for the sibling seams on the dispatch and result-send paths.
+   */
+  private val serviceScopeGuard: ServiceScopeGuard =
+    ServiceScopeGuard(
+      emitScope = { serviceScope },
+      broadcastResponse = { response ->
+        if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
+          webSocketServer.broadcast(response)
+        }
+      },
+      logError = { message, error -> Log.e(TAG, message, error) },
+    )
+
+  private val serviceScope: CoroutineScope =
+    CoroutineScope(Dispatchers.IO + SupervisorJob() + serviceScopeGuard.handler)
 
   /**
    * Wraps fire-and-forget action launches so a throw inside the launched coroutine broadcasts a

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/RequestIdContext.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/RequestIdContext.kt
@@ -1,0 +1,31 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A [CoroutineContext] element carrying the originating request's correlation id into a
+ * fire-and-forget `serviceScope.launch { … }`, so [ServiceScopeGuard]'s [CoroutineExceptionHandler]
+ * can emit a *correlated* error frame when that launch throws uncaught.
+ *
+ * Mirrors [kotlinx.coroutines.CoroutineName]: attach it at the launch site of a
+ * requestId-correlated action dispatched via a raw launch (i.e. not through [AsyncActionRunner],
+ * which already threads the id itself):
+ * ```
+ * serviceScope.launch(RequestIdContext(requestId)) {
+ *   val result = doExpensiveActionAsync() // may throw before the guarded broadcast is reached
+ *   broadcastActionResult(requestId, result)
+ * }
+ * ```
+ *
+ * When absent, [ServiceScopeGuard] still emits a best-effort error frame with a null requestId — a
+ * safe no-op on the daemon (`AndroidCtrlProxyClient` only resolves when the id is present) — plus a
+ * log trace, so a raw launch that forgot to thread the id never dies silently.
+ *
+ * @param requestId correlation id from the originating request; null when the request carried none.
+ */
+class RequestIdContext(val requestId: String?) : AbstractCoroutineContextElement(RequestIdContext) {
+
+  /** Key identifying this element in a [CoroutineContext]; used by [ServiceScopeGuard]. */
+  companion object Key : CoroutineContext.Key<RequestIdContext>
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuard.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuard.kt
@@ -1,0 +1,89 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.util.Log
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.WebSocketResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Builds the [CoroutineExceptionHandler] installed on `serviceScope` so that *any* exception
+ * escaping a fire-and-forget `serviceScope.launch { … }` still yields a correlated `type:"error"`
+ * frame instead of dying silently on the scope's [kotlinx.coroutines.SupervisorJob] and hanging the
+ * daemon awaiter to its `RequestManager` timeout.
+ *
+ * This closes the raw-launch half of the silent-hang gap **by construction** (issue #3104),
+ * complementing the two sibling seams that centralize the same guarantee on their own paths:
+ * [AsyncActionRunner] (a throw inside a launched action coroutine, #3023) and [ResultBroadcaster]
+ * (a throw while *sending* a result, #3045). Those two only cover launches routed through them; a
+ * brand-new action dispatched via a *raw* `serviceScope.launch` that throws before reaching its
+ * guarded broadcast is invisible to both — and to the #3085 source-scanning backstop, which cannot
+ * distinguish such an action from the ~30 legitimate raw launches without false positives.
+ * Installing the handler on the scope itself catches every one of them for free.
+ *
+ * A side benefit: an uncaught exception in a scope-root `launch` is otherwise delivered to the
+ * platform's default handler, which on Android crashes the process. Routing it here logs it and
+ * emits a best-effort frame instead.
+ *
+ * The correlation id is recovered from a [RequestIdContext] element on the failed coroutine's
+ * context when present; absent it, the frame carries a null requestId (a safe no-op on the daemon,
+ * exactly as the synchronous decode path does) and still leaves a log trace.
+ *
+ * @param emitScope supplies the scope the best-effort fallback broadcast is re-launched on. A
+ *   [CoroutineExceptionHandler] runs synchronously on the failing thread, so the suspend broadcast
+ *   must be dispatched onto a live scope — `serviceScope` in production (resolved lazily to break
+ *   the scope↔handler construction cycle), a `TestScope` in tests.
+ * @param broadcastResponse sink for the correlated error frame — `webSocketServer.broadcast(…)` in
+ *   production (lazily resolving the `lateinit` server, exactly like [AsyncActionRunner]), a
+ *   capturing lambda in tests.
+ * @param logError diagnostic sink; defaults to `Log.e` so tests can stay Android-free by
+ *   overriding.
+ */
+class ServiceScopeGuard(
+  private val emitScope: () -> CoroutineScope,
+  private val broadcastResponse: suspend (WebSocketResponse) -> Unit,
+  private val logError: (String, Throwable) -> Unit = { message, error ->
+    Log.e(TAG, message, error)
+  },
+) {
+
+  /**
+   * The handler to add to the `serviceScope` context. On any uncaught throwable other than a
+   * cooperative [CancellationException], it logs the failure and re-launches a best-effort
+   * [ErrorResponse] broadcast correlated by the [RequestIdContext] on the failed coroutine's
+   * context.
+   */
+  val handler: CoroutineExceptionHandler = CoroutineExceptionHandler { context, throwable ->
+    // Defense-in-depth: kotlinx never routes a CancellationException here, but a cooperative
+    // cancellation must never be converted into a client-facing error frame if it ever did.
+    if (throwable is CancellationException) return@CoroutineExceptionHandler
+
+    val requestId = context[RequestIdContext]?.requestId
+    val cause = throwable.message ?: throwable::class.simpleName ?: "unknown error"
+    logError("Uncaught exception in a serviceScope launch (requestId=$requestId)", throwable)
+
+    emitScope().launch {
+      try {
+        broadcastResponse(
+          ErrorResponse(requestId = requestId, error = "Uncaught async failure: $cause")
+        )
+      } catch (broadcastError: CancellationException) {
+        throw broadcastError
+      } catch (broadcastError: Exception) {
+        // A failure while reporting the uncaught exception must not escape — it would re-enter this
+        // same handler and loop. Log and swallow; the client then falls back to its timeout, but
+        // only for this genuinely-unrecoverable double-failure tail.
+        logError(
+          "Failed to broadcast uncaught-exception error frame (requestId=$requestId)",
+          broadcastError,
+        )
+      }
+    }
+  }
+
+  companion object {
+    private const val TAG = "ServiceScopeGuard"
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunnerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunnerTest.kt
@@ -105,6 +105,24 @@ class AsyncActionRunnerTest {
   }
 
   @Test
+  fun `tags the launched coroutine with a RequestIdContext so the scope guard can correlate`() =
+    runTest {
+      var recovered: String? = "sentinel"
+      val runner = AsyncActionRunner(scope = this, broadcastResponse = {}, logError = { _, _ -> })
+
+      // The correlation id must be present on the launched coroutine's context so that a throwable
+      // AsyncActionRunner does not catch (an Error/AssertionError) still escapes with the id
+      // attached
+      // for ServiceScopeGuard to recover.
+      runner.launch(requestId = "req-async", action = "screenshot") {
+        recovered = coroutineContext[RequestIdContext]?.requestId
+      }
+      advanceUntilIdle()
+
+      assertEquals("req-async", recovered)
+    }
+
+  @Test
   fun `swallows a failure raised while broadcasting the error frame`() = runTest {
     val logged = mutableListOf<String>()
     val runner =

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/BroadcastGuardAdoptionTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/BroadcastGuardAdoptionTest.kt
@@ -28,8 +28,12 @@ import org.junit.Test
  * swallow). [AsyncActionRunner] coverage is the swallow-regression check only — detecting that a
  * brand-new async action forgot `asyncActionRunner.launch` entirely is not structurally feasible
  * without false positives (raw `serviceScope.launch { … }` is used pervasively for legitimate
- * non-action work, e.g. wrapping already-guarded `broadcast*Result` calls), so that is tracked
- * separately per the issue's acceptance criteria.
+ * non-action work, e.g. wrapping already-guarded `broadcast*Result` calls). That residual half is
+ * now closed *by construction* rather than by source-scanning: [ServiceScopeGuard]'s
+ * [kotlinx.coroutines.CoroutineExceptionHandler] on `serviceScope` emits a correlated error frame
+ * for any raw launch that throws uncaught (issue #3104). This class enforces that wiring can't
+ * silently regress (the `serviceScope installs the ServiceScopeGuard CoroutineExceptionHandler`
+ * test below).
  */
 class BroadcastGuardAdoptionTest {
 
@@ -76,6 +80,31 @@ class BroadcastGuardAdoptionTest {
         "logs-and-swallows (issue #3023/#3085). Offenders:\n" +
         swallows.joinToString("\n") { "  - ${it.symbol} (CtrlProxy.kt:${it.line})" },
       swallows.isEmpty(),
+    )
+  }
+
+  @Test
+  fun `serviceScope installs the ServiceScopeGuard CoroutineExceptionHandler`() {
+    // Enforcement backstop for issue #3104: the raw-`serviceScope.launch` silent-hang gap is closed
+    // *by construction* only if the guard's handler is actually part of the scope's context. If the
+    // `serviceScope = CoroutineScope(...)` initializer ever drops `serviceScopeGuard.handler`, a
+    // throw in a raw launch would again escape to the bare SupervisorJob with no correlated error
+    // frame — so fail CI the moment the wiring regresses.
+    val source = readCtrlProxySource()
+
+    // Match the `val serviceScope[: Type] = CoroutineScope(` declaration, then take the initializer
+    // text up to the end of that statement's line-continuation. Nested parens (`SupervisorJob()`)
+    // make a `[^)]*` capture unreliable, so scan a bounded window after the declaration instead.
+    val decl = Regex("""val\s+serviceScope\s*(?::[^=]+)?=\s*CoroutineScope\(""").find(source)
+    if (decl == null) {
+      fail("could not find the `serviceScope = CoroutineScope(...)` initializer in CtrlProxy.kt")
+    }
+
+    val window = source.substring(decl!!.range.last, minOf(source.length, decl.range.last + 200))
+    assertTrue(
+      "serviceScope must be built with `serviceScopeGuard.handler` so uncaught throws in raw " +
+        "launches emit a correlated error frame (issue #3104). Initializer window was: $window",
+      window.contains("serviceScopeGuard.handler"),
     )
   }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuardTest.kt
@@ -1,0 +1,138 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.WebSocketResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Fast, Android-free unit tests for [ServiceScopeGuard] — the
+ * [kotlinx.coroutines.CoroutineExceptionHandler] installed on `serviceScope` that closes the
+ * raw-`serviceScope.launch` half of the silent-hang gap (issue #3104). Complements
+ * [AsyncActionRunnerTest] (dispatch/async path) and [ResultBroadcasterTest] (result-send path).
+ *
+ * Each test builds a real child [CoroutineScope] carrying the guard's handler and a
+ * [StandardTestDispatcher] tied to `runTest`'s scheduler, so a throw inside a launched coroutine
+ * exercises the handler exactly as it would in production — without Robolectric or real network
+ * I/O. The scope is deliberately *not* parented to the `runTest` job so an uncaught throw is
+ * delivered to the guard's handler (the unit under test) rather than failing the test harness.
+ */
+class ServiceScopeGuardTest {
+
+  @Test
+  fun `broadcasts a correlated error frame when a raw launch throws`() = runTest {
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    val guard =
+      ServiceScopeGuard(
+        emitScope = { this },
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+    val scope =
+      CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + guard.handler)
+
+    scope.launch(RequestIdContext("req-1")) { throw RuntimeException("boom") }
+    advanceUntilIdle()
+
+    assertEquals("exactly one error frame should be broadcast", 1, broadcasts.size)
+    val error = broadcasts.single() as ErrorResponse
+    assertEquals("req-1", error.requestId)
+    assertFalse("error frame should mark success=false", error.success)
+    assertTrue(
+      "error should surface the underlying cause, was: ${error.error}",
+      error.error.contains("boom"),
+    )
+  }
+
+  @Test
+  fun `carries a null requestId when the launch has no RequestIdContext`() = runTest {
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    val guard =
+      ServiceScopeGuard(
+        emitScope = { this },
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+    val scope =
+      CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + guard.handler)
+
+    // A raw launch that forgot to thread the correlation id still yields an error frame + a log
+    // trace — just with a null requestId, which the daemon no-ops on (a safe fallback to timeout).
+    scope.launch { throw IllegalStateException("no id") }
+    advanceUntilIdle()
+
+    val error = broadcasts.single() as ErrorResponse
+    assertEquals("uncorrelated failures pass a null requestId through", null, error.requestId)
+  }
+
+  @Test
+  fun `does not broadcast an error frame on cooperative cancellation`() = runTest {
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    val guard =
+      ServiceScopeGuard(
+        emitScope = { this },
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+    val scope =
+      CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + guard.handler)
+
+    // Cancellation means the scope is shutting down — the handler is not invoked for a
+    // CancellationException, so no client-facing error frame is emitted.
+    scope.launch(RequestIdContext("req-cancel")) { throw CancellationException("shutting down") }
+    advanceUntilIdle()
+
+    assertTrue("cancellation must not produce an error frame", broadcasts.isEmpty())
+  }
+
+  @Test
+  fun `swallows a failure raised while broadcasting the fallback frame`() = runTest {
+    val logged = mutableListOf<String>()
+    val guard =
+      ServiceScopeGuard(
+        emitScope = { this },
+        broadcastResponse = { throw RuntimeException("socket closed") },
+        logError = { message, _ -> logged.add(message) },
+      )
+    val scope =
+      CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + guard.handler)
+
+    // A failure while reporting the uncaught exception must not itself escape (which would re-enter
+    // the handler and loop). It is logged and swallowed.
+    scope.launch(RequestIdContext("req-2")) { throw RuntimeException("original failure") }
+    advanceUntilIdle()
+
+    // Exactly two: the original uncaught failure, then the failure raised while broadcasting it.
+    assertEquals(
+      "both the original failure and the broadcast failure should be logged: $logged",
+      2,
+      logged.size,
+    )
+    assertTrue(
+      "the guard must not spin into a re-entrant broadcast loop",
+      logged.size < 10,
+    )
+  }
+
+  @Test
+  fun `RequestIdContext exposes its correlation id via the context key`() = runTest {
+    var recovered: String? = "sentinel"
+    val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+
+    scope.launch(RequestIdContext("req-7")) {
+      recovered = coroutineContext[RequestIdContext]?.requestId
+    }
+    advanceUntilIdle()
+
+    assertEquals("req-7", recovered)
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuardTest.kt
@@ -124,6 +124,70 @@ class ServiceScopeGuardTest {
   }
 
   @Test
+  fun `a failing fallback broadcast on the guarded scope does not spin into a loop`() = runTest {
+    // Production wires `emitScope = { serviceScope }`, i.e. the fallback broadcast is re-launched
+    // on
+    // the *same* scope that carries the guard. If the guard's inner catch ever stopped swallowing,
+    // the failing re-broadcast would escape back into this handler and loop forever. Point
+    // emitScope
+    // at the guarded scope (as production does) and make the broadcast throw — the log count must
+    // stay bounded, proving the loop is closed by the inner catch, not merely by a handler-free
+    // scope.
+    val logged = mutableListOf<String>()
+    var guardedScope: CoroutineScope? = null
+    val guard =
+      ServiceScopeGuard(
+        emitScope = { guardedScope!! },
+        broadcastResponse = { throw RuntimeException("socket closed") },
+        logError = { message, _ -> logged.add(message) },
+      )
+    val scope =
+      CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + guard.handler)
+    guardedScope = scope
+
+    scope.launch(RequestIdContext("req-loop")) { throw RuntimeException("original failure") }
+    advanceUntilIdle()
+
+    // Exactly two logs: the original uncaught failure and the single failed re-broadcast. A
+    // re-entrant loop would produce an unbounded (or hanging) count.
+    assertEquals("re-entrancy must be closed: $logged", 2, logged.size)
+  }
+
+  @Test
+  fun `correlates an Error that escapes AsyncActionRunner through to the guard`() = runTest {
+    // AsyncActionRunner catches Exception but not a bare Throwable (Error/AssertionError). Such a
+    // throw escapes its launch and lands in the scope guard — and because AsyncActionRunner tags
+    // the
+    // coroutine with RequestIdContext, the guard recovers the correlation id rather than emitting a
+    // null-id (daemon-no-op) frame. This is the end-to-end proof the two seams compose.
+    val broadcasts = mutableListOf<WebSocketResponse>()
+    var guardedScope: CoroutineScope? = null
+    val guard =
+      ServiceScopeGuard(
+        emitScope = { guardedScope!! },
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+    val scope =
+      CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + guard.handler)
+    guardedScope = scope
+    val runner =
+      AsyncActionRunner(
+        scope = scope,
+        broadcastResponse = { broadcasts.add(it) },
+        logError = { _, _ -> },
+      )
+
+    runner.launch(requestId = "req-err", action = "screenshot") {
+      throw AssertionError("assertion tripped")
+    }
+    advanceUntilIdle()
+
+    val error = broadcasts.single() as ErrorResponse
+    assertEquals("the escaped Error must be correlated by the guard", "req-err", error.requestId)
+  }
+
+  @Test
   fun `RequestIdContext exposes its correlation id via the context key`() = runTest {
     var recovered: String? = "sentinel"
     val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))


### PR DESCRIPTION
## Summary

Closes #3104 — the raw-`serviceScope.launch` half of the silent-hang gap that PR #3095 (closing #3085) explicitly scoped out.

`CtrlProxy.kt` dispatches almost every command fire-and-forget on `serviceScope`. Two seams already close the silent-hang class on their own paths: `AsyncActionRunner` (a throw inside a launched action coroutine, #3023) and `ResultBroadcaster` (a throw while *sending* a result, #3045). But a **brand-new** requestId-correlated action dispatched via a **raw** `serviceScope.launch { … }` that throws *before* reaching its guarded broadcast is invisible to both:

```kotlin
serviceScope.launch {
  val r = doExpensiveActionAsync()      // throws
  broadcastActionResult(requestId, r)   // never reached -> client hangs to RequestManager timeout
}
```

The throw escapes to the scope's `SupervisorJob` with only a log line — no correlated `type:"error"` frame — and the daemon awaiter hangs. (Worse: an uncaught throw in a scope-root `launch` is otherwise delivered to Android's default handler, which crashes the process.) The #3085 source-scanning backstop deliberately can't flag this: `CtrlProxy.kt` has ~30 legitimate raw `serviceScope.launch` sites (logcat streaming, wrapping already-guarded `broadcast*Result` calls), so a blanket rule would be all false positives.

This implements **Direction 1** from the issue — close the gap *by construction* with a scope-level `CoroutineExceptionHandler`.

## What changed

**Production (`android/control-proxy/.../ctrlproxy/`):**

- **`ServiceScopeGuard.kt`** (new) — builds the `CoroutineExceptionHandler` installed on `serviceScope`. On any uncaught throwable other than a cooperative `CancellationException`, it logs the failure and re-launches a best-effort `ErrorResponse` broadcast, recovering the correlation id from a `RequestIdContext` element on the failed coroutine's context. A secondary failure while broadcasting the fallback is logged-and-swallowed (never re-enters the handler → no loop). Injectable broadcast sink + `logError` → Android-free and unit-tested, exactly like `AsyncActionRunner`/`ResultBroadcaster`.
- **`RequestIdContext.kt`** (new) — a `CoroutineContext.Element` (mirrors `CoroutineName`) that threads a request's correlation id into a raw launch: `serviceScope.launch(RequestIdContext(requestId)) { … }`. When absent, the guard still emits a best-effort frame with a **null** requestId — a safe no-op on the daemon (`AndroidCtrlProxyClient` only resolves when the id is present) — plus a log trace, so a raw launch that forgot to thread the id never dies silently.
- **`CtrlProxy.kt`** — construct `serviceScopeGuard` and install its handler: `serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob() + serviceScopeGuard.handler)`. `emitScope` resolves `serviceScope` lazily to break the scope↔handler construction cycle.

**Tests:**

- **`ServiceScopeGuardTest.kt`** (new) — fast, Android-free (`runTest` + `StandardTestDispatcher`): correlated error frame on throw, null requestId when no `RequestIdContext`, no frame on `CancellationException`, secondary-failure swallow (no re-entrant loop), and `RequestIdContext` key recovery.
- **`BroadcastGuardAdoptionTest.kt`** — added `serviceScope installs the ServiceScopeGuard CoroutineExceptionHandler`, a source-scan **enforcement** test so the wiring can't silently regress; updated the class KDoc scope note (the raw-launch half is now closed by construction here, not "tracked separately").

## Acceptance criteria

- [x] A new fire-and-forget action dispatched via a raw `serviceScope.launch` that throws before broadcasting no longer hangs the awaiter silently — the scope handler emits a correlated (or best-effort null-id) `type:"error"` frame and logs. *(Verified by `ServiceScopeGuardTest`.)*
- [x] Correlation id recoverable at the handler boundary — via the `RequestIdContext` context element (the issue's suggested `CoroutineName`/context-element approach).
- [x] Cooperative cancellation is never converted into a client-facing error frame.
- [x] The wiring is enforced against silent regression (source-scan test), replacing the source-scanning approach the issue noted was infeasible for this half.
- [x] No regression to the existing seams: the handler only fires on a genuinely *uncaught* throw; existing raw launches wrap guarded broadcasts or catch-and-broadcast their own error, so none double-emit.

## Testing

- `./gradlew -p android :control-proxy:testDebugUnitTest --tests "*ServiceScopeGuardTest" --tests "*BroadcastGuardAdoptionTest"` → **26 pass / 0 fail** (<1s; no Robolectric, no device).
- Full `:control-proxy:testDebugUnitTest` → green. `:control-proxy:assembleDebug` → compiles. ktfmt `--google-style` clean.

## Non-goals / follow-ups

- **Structural correlation for raw `serviceScope.launch` (Direction 2) — tracked in #3128.** `AsyncActionRunner.launch` now tags its coroutine with `RequestIdContext(requestId)`, so correlation is *live* for the recommended dispatch path (including the non-`Exception` `Throwable` tail that escapes AsyncActionRunner's own catch). Correlation for a *raw* `serviceScope.launch` is still opt-in via `RequestIdContext`; today no raw-launch site is a live silent-hang path (they wrap already-guarded `broadcast*Result` helpers or are legitimately non-correlated), so a choke point / lint that makes it structural is future-proofing, filed as #3128.


## Related

- Follow-up from PR #3095 (closes #3085); raised by the adversarial regression-hunter (finding FN-3).
- Sibling seams: `AsyncActionRunner` (#3023), `ResultBroadcaster` (#3045 / PR #3073).
