### PR TITLE
perf(db): amortize per-insert retention COUNT(*) in event repositories (#2799)

### DIFF
--- a/src/db/layoutEventRepository.ts
+++ b/src/db/layoutEventRepository.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
+import { logger } from "../utils/logger";
 
 export interface RecordLayoutEventInput {
   deviceId: string | null;
@@ -81,34 +82,38 @@ export async function getLayoutEvents(
   }));
 }
 
-async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
+export async function cleanupIfNeeded(
+  db?: Kysely<Database>,
+  maxRows: number = RETENTION_MAX_ROWS
+): Promise<void> {
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    const count = await d
+    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
+    // via an indexed backward walk on idx_layout_events_timestamp instead of a
+    // full-table count(*) on every insert. If the probe returns a row the table
+    // is over cap and everything strictly older is pruned — byte-identical to the
+    // previous count-gated path, minus the hot-path scan.
+    const cutoff = await d
       .selectFrom("layout_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
+      .select("timestamp")
+      .orderBy("timestamp", "desc")
+      .offset(maxRows)
+      .limit(1)
+      .executeTakeFirst();
 
-    if (Number(count.count) > RETENTION_MAX_ROWS) {
-      const cutoff = await d
-        .selectFrom("layout_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(RETENTION_MAX_ROWS)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("layout_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
+    if (cutoff) {
+      await d
+        .deleteFrom("layout_events")
+        .where("timestamp", "<", cutoff.timestamp)
+        .execute();
     }
-  } catch {
-    // best-effort cleanup
+  } catch (error) {
+    // Best-effort retention cleanup: a failure must not surface to the telemetry
+    // write path, but log so it leaves a trace (CLAUDE.md error-handling
+    // convention — no bare swallow).
+    logger.warn(`layout_events retention cleanup failed: ${error}`, error);
   } finally {
     cleanupInProgress = false;
   }

--- a/src/db/layoutEventRepository.ts
+++ b/src/db/layoutEventRepository.ts
@@ -19,7 +19,12 @@ export interface RecordLayoutEventInput {
 }
 
 const RETENTION_MAX_ROWS = 10_000;
+// Amortize the retention scan (#2799): run the count(*) gate at most once per
+// this many inserts instead of on every insert. Worst-case overshoot is bounded
+// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
+const CLEANUP_CHECK_INTERVAL = 256;
 let cleanupInProgress = false;
+let insertsSinceCleanup = 0;
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -84,30 +89,45 @@ export async function getLayoutEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS
+  maxRows: number = RETENTION_MAX_ROWS,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
 ): Promise<void> {
+  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
+  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
+  // so retention still fires deterministically every N inserts without putting a
+  // scan on the hot path each time.
+  if (++insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  insertsSinceCleanup = 0;
+
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
-    // via an indexed backward walk on idx_layout_events_timestamp instead of a
-    // full-table count(*) on every insert. If the probe returns a row the table
-    // is over cap and everything strictly older is pruned — byte-identical to the
-    // previous count-gated path, minus the hot-path scan.
-    const cutoff = await d
+    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
+    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
+    // offset probe, which only runs on the rare insert that pushes over the cap.
+    const count = await d
       .selectFrom("layout_events")
-      .select("timestamp")
-      .orderBy("timestamp", "desc")
-      .offset(maxRows)
-      .limit(1)
-      .executeTakeFirst();
+      .select(d.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
 
-    if (cutoff) {
-      await d
-        .deleteFrom("layout_events")
-        .where("timestamp", "<", cutoff.timestamp)
-        .execute();
+    if (Number(count.count) > maxRows) {
+      const cutoff = await d
+        .selectFrom("layout_events")
+        .select("timestamp")
+        .orderBy("timestamp", "desc")
+        .offset(maxRows)
+        .limit(1)
+        .executeTakeFirst();
+
+      if (cutoff) {
+        await d
+          .deleteFrom("layout_events")
+          .where("timestamp", "<", cutoff.timestamp)
+          .execute();
+      }
     }
   } catch (error) {
     // Best-effort retention cleanup: a failure must not surface to the telemetry

--- a/src/db/logEventRepository.ts
+++ b/src/db/logEventRepository.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
+import { logger } from "../utils/logger";
 
 export interface RecordLogEventInput {
   deviceId: string | null;
@@ -72,34 +73,38 @@ export async function getLogEvents(
   }));
 }
 
-async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
+export async function cleanupIfNeeded(
+  db?: Kysely<Database>,
+  maxRows: number = RETENTION_MAX_ROWS
+): Promise<void> {
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    const count = await d
+    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
+    // via an indexed backward walk on idx_log_events_timestamp instead of a
+    // full-table count(*) on every insert. If the probe returns a row the table
+    // is over cap and everything strictly older is pruned — byte-identical to the
+    // previous count-gated path, minus the hot-path scan.
+    const cutoff = await d
       .selectFrom("log_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
+      .select("timestamp")
+      .orderBy("timestamp", "desc")
+      .offset(maxRows)
+      .limit(1)
+      .executeTakeFirst();
 
-    if (Number(count.count) > RETENTION_MAX_ROWS) {
-      const cutoff = await d
-        .selectFrom("log_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(RETENTION_MAX_ROWS)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("log_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
+    if (cutoff) {
+      await d
+        .deleteFrom("log_events")
+        .where("timestamp", "<", cutoff.timestamp)
+        .execute();
     }
-  } catch {
-    // best-effort cleanup
+  } catch (error) {
+    // Best-effort retention cleanup: a failure must not surface to the telemetry
+    // write path, but log so it leaves a trace (CLAUDE.md error-handling
+    // convention — no bare swallow).
+    logger.warn(`log_events retention cleanup failed: ${error}`, error);
   } finally {
     cleanupInProgress = false;
   }

--- a/src/db/logEventRepository.ts
+++ b/src/db/logEventRepository.ts
@@ -15,7 +15,12 @@ export interface RecordLogEventInput {
 }
 
 const RETENTION_MAX_ROWS = 10_000;
+// Amortize the retention scan (#2799): run the count(*) gate at most once per
+// this many inserts instead of on every insert. Worst-case overshoot is bounded
+// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
+const CLEANUP_CHECK_INTERVAL = 256;
 let cleanupInProgress = false;
+let insertsSinceCleanup = 0;
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -75,30 +80,45 @@ export async function getLogEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS
+  maxRows: number = RETENTION_MAX_ROWS,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
 ): Promise<void> {
+  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
+  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
+  // so retention still fires deterministically every N inserts without putting a
+  // scan on the hot path each time.
+  if (++insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  insertsSinceCleanup = 0;
+
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
-    // via an indexed backward walk on idx_log_events_timestamp instead of a
-    // full-table count(*) on every insert. If the probe returns a row the table
-    // is over cap and everything strictly older is pruned — byte-identical to the
-    // previous count-gated path, minus the hot-path scan.
-    const cutoff = await d
+    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
+    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
+    // offset probe, which only runs on the rare insert that pushes over the cap.
+    const count = await d
       .selectFrom("log_events")
-      .select("timestamp")
-      .orderBy("timestamp", "desc")
-      .offset(maxRows)
-      .limit(1)
-      .executeTakeFirst();
+      .select(d.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
 
-    if (cutoff) {
-      await d
-        .deleteFrom("log_events")
-        .where("timestamp", "<", cutoff.timestamp)
-        .execute();
+    if (Number(count.count) > maxRows) {
+      const cutoff = await d
+        .selectFrom("log_events")
+        .select("timestamp")
+        .orderBy("timestamp", "desc")
+        .offset(maxRows)
+        .limit(1)
+        .executeTakeFirst();
+
+      if (cutoff) {
+        await d
+          .deleteFrom("log_events")
+          .where("timestamp", "<", cutoff.timestamp)
+          .execute();
+      }
     }
   } catch (error) {
     // Best-effort retention cleanup: a failure must not surface to the telemetry

--- a/src/db/navigationEventRepository.ts
+++ b/src/db/navigationEventRepository.ts
@@ -15,7 +15,12 @@ export interface RecordNavigationEventInput {
 }
 
 const RETENTION_MAX_ROWS = 10_000;
+// Amortize the retention scan (#2799): run the count(*) gate at most once per
+// this many inserts instead of on every insert. Worst-case overshoot is bounded
+// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
+const CLEANUP_CHECK_INTERVAL = 256;
 let cleanupInProgress = false;
+let insertsSinceCleanup = 0;
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -72,30 +77,45 @@ export async function getNavigationEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS
+  maxRows: number = RETENTION_MAX_ROWS,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
 ): Promise<void> {
+  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
+  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
+  // so retention still fires deterministically every N inserts without putting a
+  // scan on the hot path each time.
+  if (++insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  insertsSinceCleanup = 0;
+
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
-    // via an indexed backward walk on idx_navigation_events_timestamp instead of a
-    // full-table count(*) on every insert. If the probe returns a row the table
-    // is over cap and everything strictly older is pruned — byte-identical to the
-    // previous count-gated path, minus the hot-path scan.
-    const cutoff = await d
+    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
+    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
+    // offset probe, which only runs on the rare insert that pushes over the cap.
+    const count = await d
       .selectFrom("navigation_events")
-      .select("timestamp")
-      .orderBy("timestamp", "desc")
-      .offset(maxRows)
-      .limit(1)
-      .executeTakeFirst();
+      .select(d.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
 
-    if (cutoff) {
-      await d
-        .deleteFrom("navigation_events")
-        .where("timestamp", "<", cutoff.timestamp)
-        .execute();
+    if (Number(count.count) > maxRows) {
+      const cutoff = await d
+        .selectFrom("navigation_events")
+        .select("timestamp")
+        .orderBy("timestamp", "desc")
+        .offset(maxRows)
+        .limit(1)
+        .executeTakeFirst();
+
+      if (cutoff) {
+        await d
+          .deleteFrom("navigation_events")
+          .where("timestamp", "<", cutoff.timestamp)
+          .execute();
+      }
     }
   } catch (error) {
     // Best-effort retention cleanup: a failure must not surface to the telemetry

--- a/src/db/navigationEventRepository.ts
+++ b/src/db/navigationEventRepository.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
+import { logger } from "../utils/logger";
 
 export interface RecordNavigationEventInput {
   deviceId: string | null;
@@ -69,34 +70,38 @@ export async function getNavigationEvents(
   }));
 }
 
-async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
+export async function cleanupIfNeeded(
+  db?: Kysely<Database>,
+  maxRows: number = RETENTION_MAX_ROWS
+): Promise<void> {
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    const count = await d
+    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
+    // via an indexed backward walk on idx_navigation_events_timestamp instead of a
+    // full-table count(*) on every insert. If the probe returns a row the table
+    // is over cap and everything strictly older is pruned — byte-identical to the
+    // previous count-gated path, minus the hot-path scan.
+    const cutoff = await d
       .selectFrom("navigation_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
+      .select("timestamp")
+      .orderBy("timestamp", "desc")
+      .offset(maxRows)
+      .limit(1)
+      .executeTakeFirst();
 
-    if (Number(count.count) > RETENTION_MAX_ROWS) {
-      const cutoff = await d
-        .selectFrom("navigation_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(RETENTION_MAX_ROWS)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("navigation_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
+    if (cutoff) {
+      await d
+        .deleteFrom("navigation_events")
+        .where("timestamp", "<", cutoff.timestamp)
+        .execute();
     }
-  } catch {
-    // best-effort cleanup
+  } catch (error) {
+    // Best-effort retention cleanup: a failure must not surface to the telemetry
+    // write path, but log so it leaves a trace (CLAUDE.md error-handling
+    // convention — no bare swallow).
+    logger.warn(`navigation_events retention cleanup failed: ${error}`, error);
   } finally {
     cleanupInProgress = false;
   }

--- a/src/db/networkEventRepository.ts
+++ b/src/db/networkEventRepository.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
+import { logger } from "../utils/logger";
 
 export interface RecordNetworkEventInput {
   deviceId: string | null;
@@ -170,34 +171,38 @@ export async function getNetworkEvents(
   return rows.map(mapRow);
 }
 
-async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
+export async function cleanupIfNeeded(
+  db?: Kysely<Database>,
+  maxRows: number = RETENTION_MAX_ROWS
+): Promise<void> {
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    const count = await d
+    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
+    // via an indexed backward walk on idx_network_events_timestamp instead of a
+    // full-table count(*) on every insert. If the probe returns a row the table
+    // is over cap and everything strictly older is pruned — byte-identical to the
+    // previous count-gated path, minus the hot-path scan.
+    const cutoff = await d
       .selectFrom("network_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
+      .select("timestamp")
+      .orderBy("timestamp", "desc")
+      .offset(maxRows)
+      .limit(1)
+      .executeTakeFirst();
 
-    if (Number(count.count) > RETENTION_MAX_ROWS) {
-      const cutoff = await d
-        .selectFrom("network_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(RETENTION_MAX_ROWS)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("network_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
+    if (cutoff) {
+      await d
+        .deleteFrom("network_events")
+        .where("timestamp", "<", cutoff.timestamp)
+        .execute();
     }
-  } catch {
-    // best-effort cleanup
+  } catch (error) {
+    // Best-effort retention cleanup: a failure must not surface to the telemetry
+    // write path, but log so it leaves a trace (CLAUDE.md error-handling
+    // convention — no bare swallow).
+    logger.warn(`network_events retention cleanup failed: ${error}`, error);
   } finally {
     cleanupInProgress = false;
   }

--- a/src/db/networkEventRepository.ts
+++ b/src/db/networkEventRepository.ts
@@ -26,7 +26,12 @@ export interface RecordNetworkEventInput {
 }
 
 const RETENTION_MAX_ROWS = 10_000;
+// Amortize the retention scan (#2799): run the count(*) gate at most once per
+// this many inserts instead of on every insert. Worst-case overshoot is bounded
+// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
+const CLEANUP_CHECK_INTERVAL = 256;
 let cleanupInProgress = false;
+let insertsSinceCleanup = 0;
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -173,30 +178,45 @@ export async function getNetworkEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS
+  maxRows: number = RETENTION_MAX_ROWS,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
 ): Promise<void> {
+  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
+  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
+  // so retention still fires deterministically every N inserts without putting a
+  // scan on the hot path each time.
+  if (++insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  insertsSinceCleanup = 0;
+
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
-    // via an indexed backward walk on idx_network_events_timestamp instead of a
-    // full-table count(*) on every insert. If the probe returns a row the table
-    // is over cap and everything strictly older is pruned — byte-identical to the
-    // previous count-gated path, minus the hot-path scan.
-    const cutoff = await d
+    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
+    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
+    // offset probe, which only runs on the rare insert that pushes over the cap.
+    const count = await d
       .selectFrom("network_events")
-      .select("timestamp")
-      .orderBy("timestamp", "desc")
-      .offset(maxRows)
-      .limit(1)
-      .executeTakeFirst();
+      .select(d.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
 
-    if (cutoff) {
-      await d
-        .deleteFrom("network_events")
-        .where("timestamp", "<", cutoff.timestamp)
-        .execute();
+    if (Number(count.count) > maxRows) {
+      const cutoff = await d
+        .selectFrom("network_events")
+        .select("timestamp")
+        .orderBy("timestamp", "desc")
+        .offset(maxRows)
+        .limit(1)
+        .executeTakeFirst();
+
+      if (cutoff) {
+        await d
+          .deleteFrom("network_events")
+          .where("timestamp", "<", cutoff.timestamp)
+          .execute();
+      }
     }
   } catch (error) {
     // Best-effort retention cleanup: a failure must not surface to the telemetry

--- a/src/db/osEventRepository.ts
+++ b/src/db/osEventRepository.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
+import { logger } from "../utils/logger";
 
 export interface RecordOsEventInput {
   deviceId: string | null;
@@ -69,34 +70,38 @@ export async function getOsEvents(
   }));
 }
 
-async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
+export async function cleanupIfNeeded(
+  db?: Kysely<Database>,
+  maxRows: number = RETENTION_MAX_ROWS
+): Promise<void> {
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    const count = await d
+    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
+    // via an indexed backward walk on idx_os_events_timestamp instead of a
+    // full-table count(*) on every insert. If the probe returns a row the table
+    // is over cap and everything strictly older is pruned — byte-identical to the
+    // previous count-gated path, minus the hot-path scan.
+    const cutoff = await d
       .selectFrom("os_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
+      .select("timestamp")
+      .orderBy("timestamp", "desc")
+      .offset(maxRows)
+      .limit(1)
+      .executeTakeFirst();
 
-    if (Number(count.count) > RETENTION_MAX_ROWS) {
-      const cutoff = await d
-        .selectFrom("os_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(RETENTION_MAX_ROWS)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("os_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
+    if (cutoff) {
+      await d
+        .deleteFrom("os_events")
+        .where("timestamp", "<", cutoff.timestamp)
+        .execute();
     }
-  } catch {
-    // best-effort cleanup
+  } catch (error) {
+    // Best-effort retention cleanup: a failure must not surface to the telemetry
+    // write path, but log so it leaves a trace (CLAUDE.md error-handling
+    // convention — no bare swallow).
+    logger.warn(`os_events retention cleanup failed: ${error}`, error);
   } finally {
     cleanupInProgress = false;
   }

--- a/src/db/osEventRepository.ts
+++ b/src/db/osEventRepository.ts
@@ -14,7 +14,12 @@ export interface RecordOsEventInput {
 }
 
 const RETENTION_MAX_ROWS = 10_000;
+// Amortize the retention scan (#2799): run the count(*) gate at most once per
+// this many inserts instead of on every insert. Worst-case overshoot is bounded
+// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
+const CLEANUP_CHECK_INTERVAL = 256;
 let cleanupInProgress = false;
+let insertsSinceCleanup = 0;
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -72,30 +77,45 @@ export async function getOsEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS
+  maxRows: number = RETENTION_MAX_ROWS,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
 ): Promise<void> {
+  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
+  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
+  // so retention still fires deterministically every N inserts without putting a
+  // scan on the hot path each time.
+  if (++insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  insertsSinceCleanup = 0;
+
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
-    // via an indexed backward walk on idx_os_events_timestamp instead of a
-    // full-table count(*) on every insert. If the probe returns a row the table
-    // is over cap and everything strictly older is pruned — byte-identical to the
-    // previous count-gated path, minus the hot-path scan.
-    const cutoff = await d
+    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
+    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
+    // offset probe, which only runs on the rare insert that pushes over the cap.
+    const count = await d
       .selectFrom("os_events")
-      .select("timestamp")
-      .orderBy("timestamp", "desc")
-      .offset(maxRows)
-      .limit(1)
-      .executeTakeFirst();
+      .select(d.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
 
-    if (cutoff) {
-      await d
-        .deleteFrom("os_events")
-        .where("timestamp", "<", cutoff.timestamp)
-        .execute();
+    if (Number(count.count) > maxRows) {
+      const cutoff = await d
+        .selectFrom("os_events")
+        .select("timestamp")
+        .orderBy("timestamp", "desc")
+        .offset(maxRows)
+        .limit(1)
+        .executeTakeFirst();
+
+      if (cutoff) {
+        await d
+          .deleteFrom("os_events")
+          .where("timestamp", "<", cutoff.timestamp)
+          .execute();
+      }
     }
   } catch (error) {
     // Best-effort retention cleanup: a failure must not surface to the telemetry

--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -17,7 +17,12 @@ export interface RecordStorageEventInput {
 }
 
 const RETENTION_MAX_ROWS = 10_000;
+// Amortize the retention scan (#2799): run the count(*) gate at most once per
+// this many inserts instead of on every insert. Worst-case overshoot is bounded
+// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
+const CLEANUP_CHECK_INTERVAL = 256;
 let cleanupInProgress = false;
+let insertsSinceCleanup = 0;
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -115,30 +120,45 @@ export async function getStorageEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS
+  maxRows: number = RETENTION_MAX_ROWS,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
 ): Promise<void> {
+  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
+  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
+  // so retention still fires deterministically every N inserts without putting a
+  // scan on the hot path each time.
+  if (++insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  insertsSinceCleanup = 0;
+
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
-    // via an indexed backward walk on idx_storage_events_timestamp instead of a
-    // full-table count(*) on every insert. If the probe returns a row the table
-    // is over cap and everything strictly older is pruned — byte-identical to the
-    // previous count-gated path, minus the hot-path scan.
-    const cutoff = await d
+    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
+    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
+    // offset probe, which only runs on the rare insert that pushes over the cap.
+    const count = await d
       .selectFrom("storage_events")
-      .select("timestamp")
-      .orderBy("timestamp", "desc")
-      .offset(maxRows)
-      .limit(1)
-      .executeTakeFirst();
+      .select(d.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
 
-    if (cutoff) {
-      await d
-        .deleteFrom("storage_events")
-        .where("timestamp", "<", cutoff.timestamp)
-        .execute();
+    if (Number(count.count) > maxRows) {
+      const cutoff = await d
+        .selectFrom("storage_events")
+        .select("timestamp")
+        .orderBy("timestamp", "desc")
+        .offset(maxRows)
+        .limit(1)
+        .executeTakeFirst();
+
+      if (cutoff) {
+        await d
+          .deleteFrom("storage_events")
+          .where("timestamp", "<", cutoff.timestamp)
+          .execute();
+      }
     }
   } catch (error) {
     // Best-effort retention cleanup: a failure must not surface to the telemetry

--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -113,31 +113,32 @@ export async function getStorageEvents(
   }));
 }
 
-async function cleanupIfNeeded(db?: Kysely<Database>): Promise<void> {
+export async function cleanupIfNeeded(
+  db?: Kysely<Database>,
+  maxRows: number = RETENTION_MAX_ROWS
+): Promise<void> {
   if (cleanupInProgress) {return;}
   cleanupInProgress = true;
   try {
     const d = getDb(db);
-    const count = await d
+    // Amortized retention (#2799): probe the (maxRows+1)-th newest row directly
+    // via an indexed backward walk on idx_storage_events_timestamp instead of a
+    // full-table count(*) on every insert. If the probe returns a row the table
+    // is over cap and everything strictly older is pruned — byte-identical to the
+    // previous count-gated path, minus the hot-path scan.
+    const cutoff = await d
       .selectFrom("storage_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
+      .select("timestamp")
+      .orderBy("timestamp", "desc")
+      .offset(maxRows)
+      .limit(1)
+      .executeTakeFirst();
 
-    if (Number(count.count) > RETENTION_MAX_ROWS) {
-      const cutoff = await d
-        .selectFrom("storage_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(RETENTION_MAX_ROWS)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("storage_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
+    if (cutoff) {
+      await d
+        .deleteFrom("storage_events")
+        .where("timestamp", "<", cutoff.timestamp)
+        .execute();
     }
   } catch (error) {
     // Best-effort retention cleanup: a failure must not surface to the telemetry

--- a/test/db/eventRetention.test.ts
+++ b/test/db/eventRetention.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import type { Database } from "../../src/db/types";
+import { runMigrations } from "../../src/db/migrator";
+import { logger } from "../../src/utils/logger";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+import { recordNetworkEvent, cleanupIfNeeded as cleanupNetwork } from "../../src/db/networkEventRepository";
+import { recordLogEvent, cleanupIfNeeded as cleanupLog } from "../../src/db/logEventRepository";
+import { recordOsEvent, cleanupIfNeeded as cleanupOs } from "../../src/db/osEventRepository";
+import { recordNavigationEvent, cleanupIfNeeded as cleanupNavigation } from "../../src/db/navigationEventRepository";
+import { recordLayoutEvent, cleanupIfNeeded as cleanupLayout } from "../../src/db/layoutEventRepository";
+import { recordStorageEvent, cleanupIfNeeded as cleanupStorage } from "../../src/db/storageEventRepository";
+
+/**
+ * Retention behavior for the six telemetry event repositories (#2799).
+ *
+ * The per-insert full-table `count(*)` was removed in favor of a single indexed
+ * offset-probe on `idx_<table>_timestamp`. These tests lock in three things:
+ *   1. the retention SQL no longer issues a `count(*)` (the hot-path scan is gone),
+ *   2. retention still trims to the cap and prunes the same rows (output-preserving),
+ *   3. a cleanup failure is logged, not silently swallowed (CLAUDE.md convention).
+ *
+ * `RETENTION_MAX_ROWS` is injectable via `cleanupIfNeeded(db, maxRows)` so the trim
+ * behavior is verified at a low cap in <100ms without inserting 10k real rows.
+ */
+
+/** Builds an in-memory test DB that records every executed SQL string. */
+async function createInstrumentedTestDatabase(): Promise<{ db: Kysely<Database>; sqls: string[] }> {
+  const bunDb = new BunDatabase(":memory:");
+  const sqls: string[] = [];
+  const db = new Kysely<Database>({
+    dialect: new BunSqliteDialect({ database: bunDb }),
+    log: event => {
+      if (event.level === "query") {
+        sqls.push(event.query.sql);
+      }
+    },
+  });
+  await runMigrations(db as Kysely<unknown>);
+  return { db, sqls };
+}
+
+/** Lets detached fire-and-forget cleanups from `recordX` settle before assertions. */
+async function flushPendingCleanups(): Promise<void> {
+  await new Promise<void>(resolve => defaultTimer.setTimeout(() => resolve(), 15));
+}
+
+interface RepoUnderTest {
+  name: string;
+  record: (input: any, db?: Kysely<Database>) => Promise<number>;
+  cleanup: (db?: Kysely<Database>, maxRows?: number) => Promise<void>;
+  make: (timestamp: number) => any;
+}
+
+const REPOS: RepoUnderTest[] = [
+  {
+    name: "network",
+    record: recordNetworkEvent,
+    cleanup: cleanupNetwork,
+    make: ts => ({
+      deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
+      url: "https://x/y", method: "GET", statusCode: 200, durationMs: 1,
+      requestBodySize: 0, responseBodySize: 0, protocol: null, host: null, path: null, error: null,
+    }),
+  },
+  {
+    name: "log",
+    record: recordLogEvent,
+    cleanup: cleanupLog,
+    make: ts => ({
+      deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
+      level: 3, tag: "T", message: "m", filterName: "f",
+    }),
+  },
+  {
+    name: "os",
+    record: recordOsEvent,
+    cleanup: cleanupOs,
+    make: ts => ({
+      deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
+      category: "lifecycle", kind: "resume", details: null,
+    }),
+  },
+  {
+    name: "navigation",
+    record: recordNavigationEvent,
+    cleanup: cleanupNavigation,
+    make: ts => ({
+      deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
+      destination: "Home", source: null, arguments: null, metadata: null,
+    }),
+  },
+  {
+    name: "layout",
+    record: recordLayoutEvent,
+    cleanup: cleanupLayout,
+    make: ts => ({
+      deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
+      subType: "recomposition", composableName: null, composableId: null,
+      recompositionCount: null, durationMs: null, likelyCause: null, detailsJson: null,
+    }),
+  },
+  {
+    name: "storage",
+    record: recordStorageEvent,
+    cleanup: cleanupStorage,
+    make: ts => ({
+      deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "k", value: "v", valueType: "string", changeType: "update",
+    }),
+  },
+];
+
+const TABLE_BY_NAME: Record<string, string> = {
+  network: "network_events",
+  log: "log_events",
+  os: "os_events",
+  navigation: "navigation_events",
+  layout: "layout_events",
+  storage: "storage_events",
+};
+
+describe("event repository retention (#2799)", () => {
+  for (const repo of REPOS) {
+    describe(repo.name, () => {
+      test("cleanup issues no count(*) — only the indexed offset probe", async () => {
+        const { db, sqls } = await createInstrumentedTestDatabase();
+        try {
+          // A few rows via the public record path; then isolate the explicit cleanup SQL.
+          for (let ts = 1; ts <= 3; ts++) {
+            await repo.record(repo.make(ts), db);
+          }
+          await flushPendingCleanups();
+          sqls.length = 0;
+
+          await repo.cleanup(db, 2);
+
+          const joined = sqls.join("\n").toLowerCase();
+          expect(joined.length).toBeGreaterThan(0);
+          expect(joined).not.toContain("count(");
+          expect(joined).toContain("offset");
+        } finally {
+          await db.destroy();
+        }
+      });
+
+      test("retention trims to the cap and prunes the oldest rows (output-preserving)", async () => {
+        const { db } = await createInstrumentedTestDatabase();
+        try {
+          const cap = 5;
+          const total = 12;
+          for (let ts = 1; ts <= total; ts++) {
+            await repo.record(repo.make(ts), db);
+          }
+          await flushPendingCleanups();
+
+          await repo.cleanup(db, cap);
+
+          const rows = await db
+            .selectFrom(TABLE_BY_NAME[repo.name] as any)
+            .select("timestamp")
+            .orderBy("timestamp", "asc")
+            .execute();
+          const timestamps = rows.map((r: any) => Number(r.timestamp));
+
+          // Existing semantics keep cap+1 rows (offset(cap) cutoff, strict-less-than delete).
+          expect(timestamps).toEqual([7, 8, 9, 10, 11, 12]);
+        } finally {
+          await db.destroy();
+        }
+      });
+
+      test("under the cap, cleanup prunes nothing", async () => {
+        const { db } = await createInstrumentedTestDatabase();
+        try {
+          for (let ts = 1; ts <= 3; ts++) {
+            await repo.record(repo.make(ts), db);
+          }
+          await flushPendingCleanups();
+
+          await repo.cleanup(db, 10);
+
+          const rows = await db
+            .selectFrom(TABLE_BY_NAME[repo.name] as any)
+            .select("timestamp")
+            .execute();
+          expect(rows).toHaveLength(3);
+        } finally {
+          await db.destroy();
+        }
+      });
+
+      test("a cleanup failure is logged, not silently swallowed", async () => {
+        const { db } = await createInstrumentedTestDatabase();
+        const warnSpy = spyOn(logger, "warn");
+        try {
+          await db.destroy(); // force every subsequent query to throw
+          await expect(repo.cleanup(db, 3)).resolves.toBeUndefined(); // never propagates
+          expect(warnSpy).toHaveBeenCalled();
+          const logged = warnSpy.mock.calls.map(c => String(c[0])).join("\n");
+          expect(logged).toContain(TABLE_BY_NAME[repo.name]);
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+    });
+  }
+});

--- a/test/db/eventRetention.test.ts
+++ b/test/db/eventRetention.test.ts
@@ -5,7 +5,6 @@ import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import type { Database } from "../../src/db/types";
 import { runMigrations } from "../../src/db/migrator";
 import { logger } from "../../src/utils/logger";
-import { defaultTimer } from "../../src/utils/SystemTimer";
 import { recordNetworkEvent, cleanupIfNeeded as cleanupNetwork } from "../../src/db/networkEventRepository";
 import { recordLogEvent, cleanupIfNeeded as cleanupLog } from "../../src/db/logEventRepository";
 import { recordOsEvent, cleanupIfNeeded as cleanupOs } from "../../src/db/osEventRepository";
@@ -16,17 +15,23 @@ import { recordStorageEvent, cleanupIfNeeded as cleanupStorage } from "../../src
 /**
  * Retention behavior for the six telemetry event repositories (#2799).
  *
- * The per-insert full-table `count(*)` was removed in favor of a single indexed
- * offset-probe on `idx_<table>_timestamp`. These tests lock in three things:
- *   1. the retention SQL no longer issues a `count(*)` (the hot-path scan is gone),
+ * The retention scan is now *amortized*: `cleanupIfNeeded` runs the `count(*)`
+ * gate at most once per `checkInterval` inserts instead of on every insert
+ * (issue Option A). These tests lock in:
+ *   1. amortization — the `count(*)` gate runs at most once per interval; the
+ *      other N-1 calls are synchronous no-ops that touch neither the DB nor the
+ *      re-entrancy guard,
  *   2. retention still trims to the cap and prunes the same rows (output-preserving),
  *   3. a cleanup failure is logged, not silently swallowed (CLAUDE.md convention).
  *
- * `RETENTION_MAX_ROWS` is injectable via `cleanupIfNeeded(db, maxRows)` so the trim
- * behavior is verified at a low cap in <100ms without inserting 10k real rows.
+ * `maxRows` and `checkInterval` are injectable via
+ * `cleanupIfNeeded(db, maxRows, checkInterval)`, so behavior is verified at a low
+ * cap / interval in <100ms without inserting 10k real rows or 256 to force a scan.
+ * `checkInterval: 1` fires the scan on every call regardless of the module
+ * counter's residual value, so behavior tests are deterministic and self-normalizing.
  */
 
-/** Builds an in-memory test DB that records every executed SQL string. */
+/** In-memory test DB that also records every executed SQL string (for the amortization spy). */
 async function createInstrumentedTestDatabase(): Promise<{ db: Kysely<Database>; sqls: string[] }> {
   const bunDb = new BunDatabase(":memory:");
   const sqls: string[] = [];
@@ -42,23 +47,17 @@ async function createInstrumentedTestDatabase(): Promise<{ db: Kysely<Database>;
   return { db, sqls };
 }
 
-/** Lets detached fire-and-forget cleanups from `recordX` settle before assertions. */
-async function flushPendingCleanups(): Promise<void> {
-  await new Promise<void>(resolve => defaultTimer.setTimeout(() => resolve(), 15));
-}
-
 interface RepoUnderTest {
   name: string;
-  record: (input: any, db?: Kysely<Database>) => Promise<number>;
-  cleanup: (db?: Kysely<Database>, maxRows?: number) => Promise<void>;
+  table: string;
+  record: (input: any, db?: Kysely<Database>) => Promise<unknown>;
+  cleanup: (db?: Kysely<Database>, maxRows?: number, checkInterval?: number) => Promise<void>;
   make: (timestamp: number) => any;
 }
 
 const REPOS: RepoUnderTest[] = [
   {
-    name: "network",
-    record: recordNetworkEvent,
-    cleanup: cleanupNetwork,
+    name: "network", table: "network_events", record: recordNetworkEvent, cleanup: cleanupNetwork,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       url: "https://x/y", method: "GET", statusCode: 200, durationMs: 1,
@@ -66,36 +65,28 @@ const REPOS: RepoUnderTest[] = [
     }),
   },
   {
-    name: "log",
-    record: recordLogEvent,
-    cleanup: cleanupLog,
+    name: "log", table: "log_events", record: recordLogEvent, cleanup: cleanupLog,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       level: 3, tag: "T", message: "m", filterName: "f",
     }),
   },
   {
-    name: "os",
-    record: recordOsEvent,
-    cleanup: cleanupOs,
+    name: "os", table: "os_events", record: recordOsEvent, cleanup: cleanupOs,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       category: "lifecycle", kind: "resume", details: null,
     }),
   },
   {
-    name: "navigation",
-    record: recordNavigationEvent,
-    cleanup: cleanupNavigation,
+    name: "navigation", table: "navigation_events", record: recordNavigationEvent, cleanup: cleanupNavigation,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       destination: "Home", source: null, arguments: null, metadata: null,
     }),
   },
   {
-    name: "layout",
-    record: recordLayoutEvent,
-    cleanup: cleanupLayout,
+    name: "layout", table: "layout_events", record: recordLayoutEvent, cleanup: cleanupLayout,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       subType: "recomposition", composableName: null, composableId: null,
@@ -103,9 +94,7 @@ const REPOS: RepoUnderTest[] = [
     }),
   },
   {
-    name: "storage",
-    record: recordStorageEvent,
-    cleanup: cleanupStorage,
+    name: "storage", table: "storage_events", record: recordStorageEvent, cleanup: cleanupStorage,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       fileName: "prefs.xml", key: "k", value: "v", valueType: "string", changeType: "update",
@@ -113,34 +102,29 @@ const REPOS: RepoUnderTest[] = [
   },
 ];
 
-const TABLE_BY_NAME: Record<string, string> = {
-  network: "network_events",
-  log: "log_events",
-  os: "os_events",
-  navigation: "navigation_events",
-  layout: "layout_events",
-  storage: "storage_events",
-};
+const countOccurrences = (sqls: string[], needle: string): number =>
+  sqls.filter(s => s.toLowerCase().includes(needle)).length;
 
 describe("event repository retention (#2799)", () => {
   for (const repo of REPOS) {
     describe(repo.name, () => {
-      test("cleanup issues no count(*) — only the indexed offset probe", async () => {
+      test("amortizes: count(*) gate runs at most once per checkInterval", async () => {
         const { db, sqls } = await createInstrumentedTestDatabase();
         try {
-          // A few rows via the public record path; then isolate the explicit cleanup SQL.
-          for (let ts = 1; ts <= 3; ts++) {
-            await repo.record(repo.make(ts), db);
-          }
-          await flushPendingCleanups();
+          const interval = 5;
+          // Drain any residual counter to a known state; this fires one scan.
+          await repo.cleanup(db, 1000, 1);
           sqls.length = 0;
 
-          await repo.cleanup(db, 2);
+          // The first interval-1 calls must be pure no-ops: no DB query at all.
+          for (let i = 0; i < interval - 1; i++) {
+            await repo.cleanup(db, 1000, interval);
+          }
+          expect(sqls).toHaveLength(0);
 
-          const joined = sqls.join("\n").toLowerCase();
-          expect(joined.length).toBeGreaterThan(0);
-          expect(joined).not.toContain("count(");
-          expect(joined).toContain("offset");
+          // The interval-th call fires exactly one count(*) gate.
+          await repo.cleanup(db, 1000, interval);
+          expect(countOccurrences(sqls, "count(")).toBe(1);
         } finally {
           await db.destroy();
         }
@@ -150,16 +134,14 @@ describe("event repository retention (#2799)", () => {
         const { db } = await createInstrumentedTestDatabase();
         try {
           const cap = 5;
-          const total = 12;
-          for (let ts = 1; ts <= total; ts++) {
+          for (let ts = 1; ts <= 12; ts++) {
             await repo.record(repo.make(ts), db);
           }
-          await flushPendingCleanups();
-
-          await repo.cleanup(db, cap);
+          // checkInterval: 1 forces the scan to run now, regardless of the counter.
+          await repo.cleanup(db, cap, 1);
 
           const rows = await db
-            .selectFrom(TABLE_BY_NAME[repo.name] as any)
+            .selectFrom(repo.table as any)
             .select("timestamp")
             .orderBy("timestamp", "asc")
             .execute();
@@ -178,14 +160,9 @@ describe("event repository retention (#2799)", () => {
           for (let ts = 1; ts <= 3; ts++) {
             await repo.record(repo.make(ts), db);
           }
-          await flushPendingCleanups();
+          await repo.cleanup(db, 10, 1);
 
-          await repo.cleanup(db, 10);
-
-          const rows = await db
-            .selectFrom(TABLE_BY_NAME[repo.name] as any)
-            .select("timestamp")
-            .execute();
+          const rows = await db.selectFrom(repo.table as any).select("timestamp").execute();
           expect(rows).toHaveLength(3);
         } finally {
           await db.destroy();
@@ -197,10 +174,11 @@ describe("event repository retention (#2799)", () => {
         const warnSpy = spyOn(logger, "warn");
         try {
           await db.destroy(); // force every subsequent query to throw
-          await expect(repo.cleanup(db, 3)).resolves.toBeUndefined(); // never propagates
+          // checkInterval: 1 so the scan actually runs (and then throws).
+          await expect(repo.cleanup(db, 3, 1)).resolves.toBeUndefined(); // never propagates
           expect(warnSpy).toHaveBeenCalled();
           const logged = warnSpy.mock.calls.map(c => String(c[0])).join("\n");
-          expect(logged).toContain(TABLE_BY_NAME[repo.name]);
+          expect(logged).toContain(repo.table);
         } finally {
           warnSpy.mockRestore();
         }


### PR DESCRIPTION
## Summary

The six telemetry event repositories (`network / log / os / navigation / layout /
storage EventRepository.ts`) ran a retention `SELECT count(*)` inside
`cleanupIfNeeded` on **every insert** to gate a 10k-row trim. This PR **amortizes**
that scan (issue #2799, Option A): it now runs at most once per
`CLEANUP_CHECK_INTERVAL` (256) inserts via a per-table insert counter, so 255/256
of the fire-and-forget retention calls are pure synchronous no-ops that never touch
the DB or the connection mutex.

Closes #2799.

## Why not "just replace count(\*) with an indexed offset probe"

That was the first approach here (and the reviewer-suggested "cheap indexed walk"),
but an adversarial perf review **benchmarked in bun:sqlite** and disproved the
premise:

| table rows | `count(*)` | `offset(cap).limit(1)` probe | ratio |
|-----------:|-----------:|-----------------------------:|------:|
| 10,001     | **0.58 µs**| **33.2 µs**                  | ~57x  |

`EXPLAIN QUERY PLAN` shows both use the covering `idx_<table>_timestamp`, but
`count(*)` compiles to the **page-granular `Count` opcode** (≈ O(pages)), while the
probe steps **once per index entry** to reach `OFFSET cap` (O(cap)). So swapping in
the probe made the hot path ~57x *slower* per scan, not faster. The `count(*)` is
the cheaper query; the right fix is to run it **less often**, not replace it.

## The change

```ts
const CLEANUP_CHECK_INTERVAL = 256;
let insertsSinceCleanup = 0;

export async function cleanupIfNeeded(db?, maxRows = RETENTION_MAX_ROWS, checkInterval = CLEANUP_CHECK_INTERVAL) {
  if (++insertsSinceCleanup < checkInterval) { return; }   // no DB, no guard — pure no-op
  insertsSinceCleanup = 0;
  if (cleanupInProgress) { return; }
  cleanupInProgress = true;
  try {
    // cheap page-granular count(*) gate; O(cap) offset probe only when actually over cap
    ...unchanged count-gated trim...
  } catch (error) {
    logger.warn(`<table> retention cleanup failed: ${error}`, error);   // was bare catch {}
  } finally { cleanupInProgress = false; }
}
```

- The counter is bumped **synchronously** at the top (before any `await`), so even
  though `recordX` dispatches `cleanupIfNeeded` fire-and-forget, retention still
  fires deterministically every N inserts — and the skipped calls return before
  touching `cleanupInProgress`, so there is no guard race.
- Pruned-row output is **unchanged**: when the gate fires it runs the identical
  count-gated `offset(maxRows)` cutoff + `timestamp < cutoff` delete as before.
- Worst-case overshoot is bounded to `cap + checkInterval` (10,256) rows —
  negligible against the 10k cap, and retention is still eventually enforced.

## Measured effect (M = 1000 inserts, in-memory)

- `count(*)` executions: **1000 → 3** (fires at inserts 256/512/768).
- Per-insert retention cost on the other 997 inserts: a counter increment + compare
  (no query, no mutex-held segment). This is a genuine reduction in queries
  serialized through the single `bun:sqlite` connection — the issue's actual motivation.

## Also in this PR

- **Injectable cap + interval.** `cleanupIfNeeded(db?, maxRows, checkInterval)` is
  exported so tests verify amortization and trim behavior at a low interval/cap in
  <100ms (no 10k rows, no real timers). `recordX` still calls it fire-and-forget
  with the defaults; behavior is unchanged.
- **Logged swallow (CLAUDE.md).** The five repos that still had a bare `} catch {}`
  in `cleanupIfNeeded` now `logger.warn(...)` with a one-line reason, matching the
  already-landed `storageEventRepository`. This overlaps #2894 by construction (the
  rewrite touches the same body); **#2894 can be closed as resolved for these repos.**

## Testing

New `test/db/eventRetention.test.ts` (parametrized over all six repos, in-memory DB,
no real timers, <100ms each):

- **amortization** — `count(*)` runs at most once per `checkInterval`; the other
  N-1 calls issue **zero** SQL (SQL-spy via Kysely `log`).
- **output-preserving trim** — insert 12, cap 5 → retains newest `[7..12]`, prunes oldest.
- **under cap** — prunes nothing.
- **failure logged** — a cleanup against a destroyed DB is caught, logged
  (`logger.warn` spy, asserts table name), and never propagates.

`bun run lint`, `bun run build`, and `bun test test/db/` all green locally. (The
prior offset-probe commit also passed all CI jobs incl. Windows; this rework only
changes the retention gate + tests.)

## Deliberate scope decisions / deferred follow-ups (filed separately)

- Kept the point-fix per-repo rather than Devin's shared batched-ingestion
  `TelemetryRecorder` / `EventRetentionPolicy` — the issue explicitly defers batching
  (a durability/latency change) to its own workstream — filed as #3138.
- The six repos still keep the existing `offset(maxRows)` + timestamp-only delete
  (N+1 steady state), not the canonical `offset(N-1)` + id-tiebreak of the three
  config repos, because #2799 constrains the fix to "must NOT change query results."
  Convergence (which *does* change pruned output) is filed as #3137.
- A shared `cleanupIfNeeded` helper to collapse the six near-identical bodies is
  filed as #3136 (independent of batching).
