### PR TITLE
fix(android): correlate the ADB-broadcast fallback hierarchy request into waitForFreshData (#3089)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -46,6 +46,7 @@ import dev.jasonpearson.automobile.protocol.BroadcastEventResponse
 import dev.jasonpearson.automobile.protocol.CrashData
 import dev.jasonpearson.automobile.protocol.CrashEvent
 import dev.jasonpearson.automobile.protocol.DeviceInfo
+import dev.jasonpearson.automobile.protocol.ErrorResponse
 import dev.jasonpearson.automobile.protocol.HandledExceptionData
 import dev.jasonpearson.automobile.protocol.HandledExceptionEvent
 import dev.jasonpearson.automobile.protocol.LifecycleEventData
@@ -79,6 +80,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
 import kotlin.coroutines.resume
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -1871,29 +1873,46 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       ACTION_EXTRACT_HIERARCHY -> {
         val uuid = intent.getStringExtra("uuid")
         if (uuid.isNullOrBlank()) {
+          // No uuid to correlate a WebSocket error frame to, so only the legacy ADB result is sent.
           sendResult(success = false, error = "UUID parameter is required")
           return
         }
 
-        val textFilter = intent.getStringExtra("text")
-        val disableAllFiltering = intent.getBooleanExtra("disableAllFiltering", false)
-        val hierarchy = extractHierarchy(textFilter, disableAllFiltering)
-        if (hierarchy != null) {
-          val filename = "hierarchy_$uuid.json"
-          writeHierarchyToFile(hierarchy, filename)
+        // The daemon's ADB-broadcast hierarchy fallback awaits this uuid over the WebSocket in
+        // waitForFreshData. On extraction failure we send a correlated error frame keyed by the
+        // uuid so that wait fails fast rather than hanging to timeout, closing the last member of
+        // the #3032/#3061 hang class (issue #3089). The legacy ADB result broadcast is retained.
+        try {
+          val textFilter = intent.getStringExtra("text")
+          val disableAllFiltering = intent.getBooleanExtra("disableAllFiltering", false)
+          val hierarchy = extractHierarchy(textFilter, disableAllFiltering)
+          if (hierarchy != null) {
+            val filename = "hierarchy_$uuid.json"
+            writeHierarchyToFile(hierarchy, filename)
 
-          // Broadcast to WebSocket clients
-          broadcastHierarchyUpdate(hierarchy)
+            // Broadcast to WebSocket clients
+            broadcastHierarchyUpdate(hierarchy)
 
-          val message =
-            if (textFilter != null) {
-              "Hierarchy extracted with text filter: '$textFilter', saved as $filename"
-            } else {
-              "Hierarchy extracted successfully, saved as $filename"
-            }
-          sendResult(success = true, data = message)
-        } else {
-          sendResult(success = false, error = "Failed to extract hierarchy")
+            val message =
+              if (textFilter != null) {
+                "Hierarchy extracted with text filter: '$textFilter', saved as $filename"
+              } else {
+                "Hierarchy extracted successfully, saved as $filename"
+              }
+            sendResult(success = true, data = message)
+          } else {
+            sendResult(success = false, error = "Failed to extract hierarchy")
+            broadcastHierarchyExtractError(uuid, "Failed to extract hierarchy")
+          }
+        } catch (e: CancellationException) {
+          // Cooperative cancellation (service scope shutting down) must never be converted into an
+          // error frame — let it propagate so the coroutine unwinds cleanly.
+          throw e
+        } catch (e: Exception) {
+          val cause = e.message ?: e::class.simpleName ?: "unknown error"
+          Log.e(TAG, "Error extracting hierarchy for uuid=$uuid", e)
+          sendResult(success = false, error = cause)
+          broadcastHierarchyExtractError(uuid, "Hierarchy extraction failed: $cause")
         }
       }
     }
@@ -1940,6 +1959,28 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         error?.let { putExtra("error", it) }
       }
     sendBroadcast(resultIntent)
+  }
+
+  /**
+   * Emit a correlated WebSocket `type:"error"` frame for a failed `EXTRACT_HIERARCHY` broadcast,
+   * keyed by the broadcast's `sync_` [requestId] uuid.
+   *
+   * The daemon's ADB-broadcast hierarchy fallback awaits that uuid in `waitForFreshData` over this
+   * same WebSocket (the response channel the success-path `hierarchy_update` push also travels on).
+   * Before issue #3089 a broadcast-handler failure only sent an ADB [ACTION_OPERATION_RESULT]
+   * result that the daemon's wait could not correlate, so it degraded to a full timeout. Emitting
+   * this frame closes that last member of the #3032/#3061 `waitForFreshData` hang class, mirroring
+   * the WebSocket `req_`/`stale_` paths and the #2985 decode/handler error envelope.
+   *
+   * Routed through [ResultBroadcaster.guard] so a throw while *sending* this frame degrades to the
+   * daemon's timeout rather than escaping the receiver coroutine (issue #3045 / #3085).
+   */
+  private suspend fun broadcastHierarchyExtractError(requestId: String?, error: String) {
+    resultBroadcaster.guard(requestId, "hierarchy_extract_error") {
+      if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
+        webSocketServer.broadcast(ErrorResponse(requestId = requestId, error = error))
+      }
+    }
   }
 
   /**

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -419,9 +419,13 @@ export class CtrlProxyHierarchy {
 
       // Wait for WebSocket push, correlated with whichever request id we actually sent: the `req_`
       // id when the WebSocket send succeeded (issue #3032), or the ADB-broadcast `sync_` uuid when we
-      // fell back (issue #3089). Either way a runner type:"error" frame carrying that id unblocks the
-      // wait fast instead of hanging to timeout. A fast fail still returns null, so the caller keeps
-      // its stale-cache fallback (see getAccessibilityHierarchy) — nothing is discarded here.
+      // fell back (issue #3089). A runner type:"error" frame carrying that id unblocks the wait fast
+      // instead of hanging to timeout. Note the broadcast fallback only reaches this correlation when
+      // the WebSocket is still readable (a transient send failure / flap) — when the socket is fully
+      // down the daemon receives neither the push nor the error frame and still degrades to timeout,
+      // so this closes the flapping subset of the hang class, not the socket-down subset. A fast fail
+      // still returns null, so the caller keeps its stale-cache fallback (see
+      // getAccessibilityHierarchy) — nothing is discarded here.
       const correlationRequestId = hierarchyRequestId ?? broadcastRequestId ?? undefined;
       const freshData = await perf.track("waitForPush", () =>
         this.waitForFreshData(effectiveTimeoutMs, startTime, false, signal, correlationRequestId)
@@ -695,12 +699,14 @@ export class CtrlProxyHierarchy {
           // request_hierarchy_if_stale should fail the enclosing wait fast rather than hang to the
           // timeout below (issue #3061).
           //
-          // Gate on `requestId`: only correlate the stale nudge when the enclosing wait is itself a
-          // fast-fail wait (i.e. a primary WebSocket request_hierarchy is outstanding, as in
-          // requestHierarchySync). The getLatestHierarchy path and the sync ADB-broadcast fallback
-          // pass no requestId — their timeout is intended to gracefully degrade to the stale cache,
-          // so a rejected stale nudge there would discard that cache and return null. Leaving those
-          // best-effort nudges uncorrelated preserves their documented timeout behavior.
+          // Gate on `requestId`: only correlate the stale nudge when the enclosing wait carries a
+          // correlation id at all. Two callers pass one and want a fast fail: the primary WebSocket
+          // request_hierarchy path (issue #3032) and, since issue #3089, the sync ADB-broadcast
+          // fallback (which now threads its `sync_` uuid). A fast fail there returns null, and
+          // requestHierarchySync's caller keeps its stale cache regardless, so nothing is discarded.
+          // getLatestHierarchy is the lone path that passes NO requestId — its timeout is meant to
+          // gracefully degrade to the stale cache, and a rejected stale nudge there WOULD discard it
+          // and return null, so it is deliberately left uncorrelated.
           if (staleId && requestId) {
             staleRequestId = staleId;
             registerRejector(staleId, "Hierarchy stale nudge");

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -396,10 +396,16 @@ export class CtrlProxyHierarchy {
         return this.sendHierarchyRequest(disableAllFiltering);
       });
 
-      // Fall back to ADB broadcast if WebSocket failed
+      // Fall back to ADB broadcast if WebSocket failed. The broadcast mints its own `sync_` uuid and
+      // passes it to the runner via `--es uuid`; we thread that SAME uuid into the wait below so a
+      // runner type:"error" frame echoing it fails fast, mirroring the `req_`/`stale_` WebSocket
+      // paths (issue #3089). Kept null when the WebSocket send succeeded (that path correlates on
+      // its own `req_` id).
+      let broadcastRequestId: string | null = null;
       if (hierarchyRequestId === null) {
         logger.debug("[CTRL_PROXY] Falling back to ADB broadcast");
         const uuid = `sync_${this.context.timer.now()}_${generateSecureId()}`;
+        broadcastRequestId = uuid;
         await perf.track("sendBroadcast", async () => {
           await this.context.adb.executeCommand(
             `shell "am broadcast -a dev.jasonpearson.automobile.EXTRACT_HIERARCHY --es uuid ${uuid} --ez disableAllFiltering ${disableAllFiltering}"`,
@@ -411,12 +417,14 @@ export class CtrlProxyHierarchy {
         });
       }
 
-      // Wait for WebSocket push. When we sent over WebSocket, correlate the wait with the request id
-      // so a runner error frame unblocks it fast instead of hanging to timeout (issue #3032). The
-      // ADB-broadcast fallback has no WebSocket requestId to correlate, so it retains timeout-only
-      // behavior.
+      // Wait for WebSocket push, correlated with whichever request id we actually sent: the `req_`
+      // id when the WebSocket send succeeded (issue #3032), or the ADB-broadcast `sync_` uuid when we
+      // fell back (issue #3089). Either way a runner type:"error" frame carrying that id unblocks the
+      // wait fast instead of hanging to timeout. A fast fail still returns null, so the caller keeps
+      // its stale-cache fallback (see getAccessibilityHierarchy) — nothing is discarded here.
+      const correlationRequestId = hierarchyRequestId ?? broadcastRequestId ?? undefined;
       const freshData = await perf.track("waitForPush", () =>
-        this.waitForFreshData(effectiveTimeoutMs, startTime, false, signal, hierarchyRequestId ?? undefined)
+        this.waitForFreshData(effectiveTimeoutMs, startTime, false, signal, correlationRequestId)
       );
 
       if (freshData) {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1672,6 +1672,266 @@ describe("AndroidCtrlProxyClient", function() {
     });
   });
 
+  describe("hierarchy ADB-broadcast fallback error frame correlation (issue #3089)", function() {
+    // Last member of the #3032/#3061 waitForFreshData hang class. When the WebSocket
+    // request_hierarchy send fails, requestHierarchySync falls back to an
+    // `am broadcast ... EXTRACT_HIERARCHY --es uuid sync_<ts>_<id>` and then waits for a push.
+    // Before #3089 that fallback wait registered NO rejector (it passed no requestId into
+    // waitForFreshData), so a runner type:"error" frame echoing the broadcast uuid no-op'd and the
+    // caller hung to the full timeout. These tests drive that fallback and assert the sync_ uuid now
+    // correlates a runner error into a fast fail, while staying a safe no-op for uncorrelated ids and
+    // for the getLatestHierarchy stale-cache path (which still registers no requestId).
+
+    // A capturing socket that stays OPEN but throws when asked to SEND a request_hierarchy (or the
+    // stale nudge) frame, forcing requestHierarchySync down its ADB-broadcast fallback branch. It
+    // stays OPEN so the test can still deliver a simulated type:"error" frame back over the same
+    // socket — modeling a WebSocket that momentarily could not accept a send but is still readable.
+    class HierarchySendFailingWebSocket extends CapturingWebSocket {
+      send(data: any): void {
+        const str = data.toString();
+        this.sentMessages.push(str);
+        let parsed: any = null;
+        try { parsed = JSON.parse(str); } catch { parsed = null; }
+        if (parsed && (parsed.type === "request_hierarchy" || parsed.type === "request_hierarchy_if_stale")) {
+          throw new Error("Simulated WebSocket send failure (forces ADB-broadcast fallback)");
+        }
+        // Any other frame: accept silently (base FakeWebSocket.send only checks OPEN and no-ops).
+      }
+    }
+
+    const createSendFailingFactory = (timer?: FakeTimer): {
+      factory: (url: string) => HierarchySendFailingWebSocket;
+      getSocket: () => HierarchySendFailingWebSocket | null;
+    } => {
+      let socket: HierarchySendFailingWebSocket | null = null;
+      return {
+        factory: (url: string) => {
+          socket = new HierarchySendFailingWebSocket(url, "none", 0, timer);
+          return socket;
+        },
+        getSocket: () => socket
+      };
+    };
+
+    // Poll the fake ADB command history until the EXTRACT_HIERARCHY broadcast fallback fires, then
+    // return its `sync_` uuid. The fallback runs a few microtask turns after the request_hierarchy
+    // send throws, so retry across setImmediate flushes rather than assuming a fixed ordering.
+    const waitForBroadcastUuid = async (adb: FakeAdbExecutor): Promise<string | undefined> => {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const cmd = adb.getExecutedCommands().find(c => c.includes("EXTRACT_HIERARCHY"));
+        if (cmd) {
+          const match = cmd.match(/--es uuid (sync_[^\s"]+)/);
+          if (match) {
+            return match[1];
+          }
+        }
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      return undefined;
+    };
+
+    test("a type:error frame echoing the broadcast sync_ uuid fails requestHierarchySync fast", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createSendFailingFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        // 10s hierarchy sync timeout — the whole point is to NOT wait for it.
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+
+        const socket = await waitForSocket(getSocket) as HierarchySendFailingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        // request_hierarchy send throws -> ADB-broadcast fallback mints and broadcasts the sync_ uuid.
+        const uuid = await waitForBroadcastUuid(fakeAdb);
+        expect(uuid).toBeDefined();
+        expect(String(uuid).startsWith("sync_")).toBe(true);
+        // Let waitForFreshData run so it registers the fast-fail rejector for the sync_ uuid.
+        await flushPromises();
+
+        // Runner reports a correlated handler failure echoing the broadcast uuid (issue #3089: the
+        // EXTRACT_HIERARCHY handler emits a type:"error" frame keyed by the broadcast uuid on failure).
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: uuid,
+          success: false,
+          error: "Failed to extract hierarchy",
+          timestamp: errorTimer.now()
+        }));
+
+        // Fail fast: no timer advance toward the 10s timeout. Only flush microtasks/setImmediate.
+        await flushPromises();
+        const result = await syncPromise;
+
+        expect(result).toBeNull();
+        // Prove we did not sit through the timeout: virtually no fake time elapsed.
+        expect(errorTimer.getCurrentTime()).toBeLessThan(10000);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a broadcast-fallback runner error populates diagnostics.runnerError (parity with #3062)", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createSendFailingFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const diagnostics: HierarchySyncDiagnostics = {};
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000, diagnostics);
+
+        const socket = await waitForSocket(getSocket) as HierarchySendFailingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        const uuid = await waitForBroadcastUuid(fakeAdb);
+        expect(uuid).toBeDefined();
+        await flushPromises();
+
+        const runnerText = "Failed to extract hierarchy";
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: uuid,
+          success: false,
+          error: runnerText,
+          timestamp: errorTimer.now()
+        }));
+
+        await flushPromises();
+        const result = await syncPromise;
+
+        // Contract unchanged: still null so existing callers keep their stale-cache fallback.
+        expect(result).toBeNull();
+        // The runner text is surfaced to the caller, distinct from a plain timeout null.
+        expect(diagnostics.runnerError).toBe(runnerText);
+        expect(errorTimer.getCurrentTime()).toBeLessThan(10000);
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("an uncorrelated error id during the broadcast fallback is a safe no-op; the push still resolves", async function() {
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createSendFailingFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        testClient.invalidateCache();
+        const syncPromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+
+        const socket = await waitForSocket(getSocket) as HierarchySendFailingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        const uuid = await waitForBroadcastUuid(fakeAdb);
+        expect(uuid).toBeDefined();
+        await flushPromises();
+
+        // Error frame for an uncorrelated id — must be a safe no-op for the broadcast-fallback wait.
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: "some-unrelated-id",
+          success: false,
+          error: "Malformed request: the payload is not valid JSON",
+          timestamp: errorTimer.now()
+        }));
+
+        // The real hierarchy push for our request still arrives and resolves the sync normally.
+        socket.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: errorTimer.now(),
+          data: {
+            updatedAt: errorTimer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Recovered after uncorrelated broadcast error" }
+          }
+        }));
+
+        const result = await errorTimer.resolvePromise(syncPromise);
+
+        expect(result).not.toBeNull();
+        expect(result!.hierarchy.hierarchy.text).toBe("Recovered after uncorrelated broadcast error");
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("a sync_-prefixed error frame does NOT disturb the getLatestHierarchy stale-cache path", async function() {
+      // getLatestHierarchy never mints a broadcast sync_ uuid and enters waitForFreshData with NO
+      // requestId — its timeout is meant to gracefully fall through to the stale cache. This locks in
+      // that the #3089 correlation is scoped to requestHierarchySync: a sync_-shaped error frame is an
+      // uncorrelated no-op here and must NOT reject the wait to null (which would discard the cache).
+      const errorTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      try {
+        // Prime the connection + cache via a sync that a push resolves quickly.
+        const primePromise = testClient.requestHierarchySync(undefined, false, undefined, 10000);
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+        socket.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: errorTimer.now(),
+          data: {
+            updatedAt: errorTimer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Stale cache preserved" }
+          }
+        }));
+        await errorTimer.resolvePromise(primePromise);
+
+        // Let time pass so the cached data is stale relative to the next wait's start.
+        errorTimer.advanceTime(500);
+
+        const latestPromise = testClient.getLatestHierarchy(true, 3000);
+
+        // Inject a sync_-shaped error frame — no rejector is registered for it on this path.
+        await flushPromises();
+        socket.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: `sync_${errorTimer.now()}_deadbeef`,
+          success: false,
+          error: "Failed to extract hierarchy",
+          timestamp: errorTimer.now()
+        }));
+
+        // The wait falls through to its timeout and returns the STALE CACHE (not null).
+        const result = await errorTimer.resolvePromise(latestPromise);
+        expect(result.hierarchy).not.toBeNull();
+        expect(result.hierarchy!.hierarchy.text).toBe("Stale cache preserved");
+        expect(result.fresh).toBe(false);
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("bindSession", function() {
     afterEach(function() {
       NavigationGraphManager.resetInstance();


### PR DESCRIPTION
Closes #3089.

Follow-up to #3032 (PR #3060) and #3061 (PR #3070). This closes the **last member** of the `waitForFreshData` "hang class" — a runner `type:"error"` frame that no-ops while the hierarchy caller blocks in `waitForFreshData`, degrading to the full timeout — on the remaining uncorrelated path: the ADB-broadcast fallback.

## Feasibility (issue step 2 — resolved: FEASIBLE)

Both #3060 and #3070 documented the broadcast fallback as "inherent-for-now" on the premise that the broadcast transport may carry no correlatable channel back. It does: the `EXTRACT_HIERARCHY` broadcast arrives over ADB, but the runner's handler runs with `webSocketServer` available and already pushes the success-path `hierarchy_update` over that **same WebSocket**. So a failure can be reported back over WebSocket, correlated by the broadcast's `sync_` uuid — exactly like the `req_`/`stale_` paths. This is option (A), not the won't-fix documentation option.

## Coverage scope (review clarification)

The correlated error frame reaches the daemon only when the WebSocket is still **readable** at the moment the fallback runs — i.e. the transient-send-failure / WS-flapping case (socket OPEN but `ws.send()` threw). When the socket is **fully down**, the daemon receives neither the `hierarchy_update` push nor the error frame, so that subset still degrades to the existing timeout. This PR therefore closes the **flapping subset** of the hang class on the broadcast path; the socket-down subset is inherently timeout-bound (there is no channel back). The change is harmless in the socket-down case (an undelivered frame simply never arrives) and safe against an un-re-cut older runner.

## What changed

### TS — thread the `sync_` uuid into the wait (`src/features/observe/android/CtrlProxyHierarchy.ts`)
When the WebSocket `request_hierarchy` send fails, `requestHierarchySync` falls back to `am broadcast ... EXTRACT_HIERARCHY --es uuid sync_<ts>_<id>`. That uuid was minted for the runner but never threaded into `waitForFreshData`, so `pendingHierarchyRejectors` registered no rejector for it. Now the fallback's `sync_` uuid is passed as the wait's correlation `requestId`, so a runner `type:"error"` frame echoing it rejects the wait fast — the same mechanism as `req_` (#3032) and `stale_` (#3061).

A fast fail still returns `null`, so the caller (`getAccessibilityHierarchy`) keeps its stale-cache fallback — **nothing is discarded**, honoring the PR #3070 scope note. `getLatestHierarchy` is untouched and still enters `waitForFreshData` with no `requestId`, so its timeout→stale-cache behavior is preserved.

### Runner — emit a correlated error frame on extraction failure (`android/control-proxy/.../CtrlProxy.kt`)
`handleCommand`'s `ACTION_EXTRACT_HIERARCHY` branch now, on a null-hierarchy result **or** a throw (uuid in scope), emits a correlated `ErrorResponse(requestId = uuid)` over the WebSocket via a new `broadcastHierarchyExtractError` helper — in addition to the legacy ADB `ACTION_OPERATION_RESULT` (kept for non-WebSocket consumers). The helper is routed through `resultBroadcaster.guard` so a throw while *sending* the frame degrades to the daemon's timeout rather than escaping the receiver coroutine (#3045 / #3085 compliance — auto-enforced by `BroadcastGuardAdoptionTest`). `CancellationException` is rethrown, never converted to an error frame.

## Verification

- **New TS tests** (`test/features/observe/CtrlProxyClient.test.ts`, new #3089 describe block, 4 tests) driving the WebSocket-send-failure → ADB-broadcast fallback path (a capturing socket that stays OPEN but throws on `request_hierarchy` sends):
  - a `type:"error"` frame echoing the broadcast `sync_` uuid fails `requestHierarchySync` **fast** (no timeout);
  - the correlated error populates `diagnostics.runnerError` (parity with #3062);
  - an uncorrelated id during the fallback is a safe no-op and the real push still resolves;
  - a `sync_`-shaped error frame does **not** disturb the `getLatestHierarchy` stale-cache path (locks in that the correlation is scoped to `requestHierarchySync`).
  - Confirmed TDD red first (the two fast-fail tests hung before the impl), green after.
- Full `test/features/observe/` suite: **824 pass**.
- `:control-proxy:testDebugUnitTest` (incl. `BroadcastGuardAdoptionTest`, `ResultBroadcasterTest`): **BUILD SUCCESSFUL** — the new guarded helper is recognized and compliant.
- `turbo run lint build` clean; ktfmt applied.

## Delivery note

Per the runner-release convention, the Android `control-proxy` change lands in source here but the delivered runner is **not** re-cut in this feature PR — the daemon downloads a pinned release runner, and `RELEASE_CHECKSUM_REGISTRY` is bumped only by the periodic `chore: bump versions` PRs. The TS-side correlation is inert-but-safe against an older runner (an error frame that never arrives just falls through to the existing timeout); the end-to-end fast-fail activates once the runner is re-cut.

