### PR TITLE
feat(ios): setAppPermissions reset on physical iOS devices via CtrlProxy runner

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -135,6 +135,10 @@ public class CommandHandler: CommandHandling {
             case let .launchApp(payload):
                 return try handleLaunchApp(payload, startTime: startTime)
 
+            // App privacy permissions
+            case let .resetPermissions(payload):
+                return try handleResetPermissions(payload, startTime: startTime)
+
             // Device control
             case let .rotate(payload):
                 return try handleRotate(payload, startTime: startTime)
@@ -851,6 +855,27 @@ public class CommandHandler: CommandHandling {
         )
     }
 
+    // MARK: - App Privacy Permissions
+
+    /// Reset privacy authorizations for an app to not-determined. `bundleId` and
+    /// `permissions` are decode-required, so both are present here; an empty
+    /// `permissions` array is still rejected so the client gets an actionable error
+    /// instead of a silent success. An unmapped resource throws from the gesture
+    /// performer and surfaces as a structured error via the `handle(_:)` catch. (#2491)
+    private func handleResetPermissions(_ request: RequestResetPermissions, startTime: Date) throws
+        -> WebSocketResponse
+    {
+        guard !request.permissions.isEmpty else {
+            throw CommandError.missingParameter("permissions")
+        }
+        try gesturePerformer.resetAuthorizations(bundleId: request.bundleId, resources: request.permissions)
+        return WebSocketResponse.success(
+            type: ResponseType.resetPermissionsResult.rawValue,
+            requestId: request.requestId,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
+
     // MARK: - Device Control
 
     private func handleRotate(_ request: RequestRotate, startTime: Date) throws -> RotateResponse {
@@ -1462,6 +1487,8 @@ public class CommandHandler: CommandHandling {
             return ResponseType.actionResult.rawValue
         case RequestType.requestLaunchApp.rawValue:
             return ResponseType.launchAppResult.rawValue
+        case RequestType.requestResetPermissions.rawValue:
+            return ResponseType.resetPermissionsResult.rawValue
         case RequestType.requestRotate.rawValue:
             return ResponseType.rotateResult.rawValue
         case RequestType.requestClipboard.rawValue:

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -186,6 +186,11 @@ public class FakeGesturePerformer: GesturePerforming {
         public let resourceId: String?
     }
 
+    public struct ResetAuthorizationsCall {
+        public let bundleId: String
+        public let resources: [String]
+    }
+
     private var tapHistory: [TapCall] = []
     private var doubleTapHistory: [(x: Double, y: Double)] = []
     private var longPressHistory: [(x: Double, y: Double, duration: TimeInterval)] = []
@@ -213,6 +218,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var appTerminateHistory: [String] = []
     private var clipboardHistory: [(action: String, text: String?)] = []
     private var clipboardContents: String?
+    private var resetAuthorizationsHistory: [ResetAuthorizationsCall] = []
 
     public init() {}
 
@@ -332,6 +338,10 @@ public class FakeGesturePerformer: GesturePerforming {
         clipboardContents = text
     }
 
+    public func getResetAuthorizationsHistory() -> [ResetAuthorizationsCall] {
+        resetAuthorizationsHistory
+    }
+
     public func clearHistory() {
         tapHistory.removeAll()
         doubleTapHistory.removeAll()
@@ -359,6 +369,7 @@ public class FakeGesturePerformer: GesturePerforming {
         appLaunchHistory.removeAll()
         appTerminateHistory.removeAll()
         clipboardHistory.removeAll()
+        resetAuthorizationsHistory.removeAll()
     }
 
     // MARK: - Private Helpers
@@ -594,6 +605,11 @@ public class FakeGesturePerformer: GesturePerforming {
 
     public func updateApplication(bundleId: String) {
         updateApplicationHistory.append(bundleId)
+    }
+
+    public func resetAuthorizations(bundleId: String, resources: [String]) throws {
+        try checkFailure("resetAuthorizations")
+        resetAuthorizationsHistory.append(ResetAuthorizationsCall(bundleId: bundleId, resources: resources))
     }
 }
 

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -1282,6 +1282,44 @@ public class GesturePerformer: GesturePerforming {
             }, fallback: ())
         }
 
+        // MARK: - App Privacy Permissions
+
+        /// Reset each named resource's authorization to not-determined on the target
+        /// app. `resetAuthorizationStatus(for:)` (Xcode 11.4+) works on real devices,
+        /// not just simulators — the whole point of #2491. An AutoMobile permission
+        /// with no `XCUIProtectedResource` equivalent (e.g. `siri`, `motion`) throws
+        /// `invalidParameter` so the caller reports it as a per-permission failure.
+        public func resetAuthorizations(bundleId: String, resources: [String]) throws {
+            try runOnMainThread {
+                let app = XCUIApplication(bundleIdentifier: bundleId)
+                for raw in resources {
+                    guard let resource = Self.protectedResource(for: raw) else {
+                        throw CommandError.invalidParameter("permission", raw)
+                    }
+                    app.resetAuthorizationStatus(for: resource)
+                }
+            }
+        }
+
+        /// Map an AutoMobile permission name to the `XCUIProtectedResource` the
+        /// runner can reset. Names without an XCUITest equivalent return nil (the
+        /// support matrix is advertised honestly — see issue #2491). The mapping is
+        /// authoritative here rather than duplicated on the TS host, since
+        /// `XCUIProtectedResource` only exists in this process.
+        private static func protectedResource(for name: String) -> XCUIProtectedResource? {
+            switch name {
+            case "camera": return .camera
+            case "photos", "photos-add": return .photos
+            case "microphone": return .microphone
+            case "contacts", "contacts-limited": return .contacts
+            case "location", "location-always": return .location
+            case "calendar": return .calendar
+            case "reminders": return .reminders
+            case "media-library": return .mediaLibrary
+            default: return nil
+            }
+        }
+
     #else
         /// Non-iOS stub implementation
         private let elementLocator: ElementLocating
@@ -1434,6 +1472,10 @@ public class GesturePerformer: GesturePerforming {
 
         public func updateApplication(bundleId _: String) {
             // no-op on non-iOS
+        }
+
+        public func resetAuthorizations(bundleId _: String, resources _: [String]) throws {
+            throw GestureError.notSupported("XCUITest only available on iOS")
         }
     #endif
 }

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -1290,6 +1290,10 @@ public class GesturePerformer: GesturePerforming {
         /// with no `XCUIProtectedResource` equivalent (e.g. `siri`, `motion`) throws
         /// `invalidParameter` so the caller reports it as a per-permission failure.
         public func resetAuthorizations(bundleId: String, resources: [String]) throws {
+            // Throws on the first unmapped resource, so a mixed batch applies the
+            // resets before it and then fails as a whole. The TS client sends one
+            // permission per request, so each is isolated and accounted per-permission;
+            // this only matters for a hypothetical multi-resource single request.
             try runOnMainThread {
                 let app = XCUIApplication(bundleIdentifier: bundleId)
                 for raw in resources {

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -137,6 +137,24 @@ public struct RequestLaunchApp: Decodable {
     public var coldBoot: Bool?
 }
 
+// MARK: App privacy permissions
+
+/// Reset privacy authorizations (camera/photos/etc.) for an app back to
+/// not-determined via `XCUIApplication.resetAuthorizationStatus(for:)`. `bundleId`
+/// and `permissions` are decode-required so their absence is rejected at the wire
+/// boundary rather than silently no-op'ing. See issue #2491.
+public struct RequestResetPermissions: Decodable {
+    public var requestId: String?
+    public var bundleId: String
+    public var permissions: [String]
+
+    public init(requestId: String? = nil, bundleId: String, permissions: [String]) {
+        self.requestId = requestId
+        self.bundleId = bundleId
+        self.permissions = permissions
+    }
+}
+
 // MARK: Device control
 
 public struct RequestRotate: Decodable {
@@ -264,6 +282,7 @@ public enum WebSocketRequest: Decodable {
 
     case action(RequestAction)
     case launchApp(RequestLaunchApp)
+    case resetPermissions(RequestResetPermissions)
     case rotate(RequestRotate)
     case clipboard(RequestClipboard)
 
@@ -346,6 +365,8 @@ public enum WebSocketRequest: Decodable {
             self = try .action(RequestAction(from: decoder))
         case .requestLaunchApp:
             self = try .launchApp(RequestLaunchApp(from: decoder))
+        case .requestResetPermissions:
+            self = try .resetPermissions(RequestResetPermissions(from: decoder))
         case .requestRotate:
             self = try .rotate(RequestRotate(from: decoder))
         case .requestClipboard:
@@ -409,6 +430,7 @@ public enum WebSocketRequest: Decodable {
         case .recentApps: return .requestRecentApps
         case .action: return .requestAction
         case .launchApp: return .requestLaunchApp
+        case .resetPermissions: return .requestResetPermissions
         case .rotate: return .requestRotate
         case .clipboard: return .requestClipboard
         case .getCurrentFocus: return .getCurrentFocus
@@ -464,6 +486,7 @@ public enum WebSocketRequest: Decodable {
         case let .pressButton(payload): return payload.requestId
         case let .action(payload): return payload.requestId
         case let .launchApp(payload): return payload.requestId
+        case let .resetPermissions(payload): return payload.requestId
         case let .rotate(payload): return payload.requestId
         case let .clipboard(payload): return payload.requestId
         case let .addHighlight(payload): return payload.requestId
@@ -1372,6 +1395,9 @@ public enum RequestType: String, CaseIterable {
     case requestAction = "request_action"
     case requestLaunchApp = "request_launch_app"
 
+    /// App privacy permissions
+    case requestResetPermissions = "request_reset_permissions"
+
     /// Device control
     case requestRotate = "request_rotate"
 
@@ -1426,6 +1452,7 @@ public enum ResponseType: String {
     case recentAppsResult = "recent_apps_result"
     case actionResult = "action_result"
     case launchAppResult = "launch_app_result"
+    case resetPermissionsResult = "reset_permissions_result"
     case rotateResult = "rotate_result"
     case clipboardResult = "clipboard_result"
     case currentFocusResult = "current_focus_result"

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -191,6 +191,15 @@ public protocol GesturePerforming {
 
     /// Update the internal application reference for gesture operations.
     func updateApplication(bundleId: String)
+
+    // MARK: - App Privacy Permissions
+
+    /// Reset privacy authorizations for the given app back to the not-determined
+    /// ("ask next time") state via `XCUIApplication.resetAuthorizationStatus(for:)`.
+    /// Each entry in `resources` is an AutoMobile permission name mapped to an
+    /// `XCUIProtectedResource`; an unmapped name throws so the caller can surface a
+    /// per-permission failure. Works on physical devices, not just simulators. (#2491)
+    func resetAuthorizations(bundleId: String, resources: [String]) throws
 }
 
 // MARK: - StorageInspecting Protocol

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1420,6 +1420,45 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertTrue(errorResponse.error?.contains("App not installed") ?? false)
     }
 
+    // MARK: - Reset Permissions Tests
+
+    func testResetPermissionsForwardsResourcesToGesturePerformer() {
+        let request = WebSocketRequest.resetPermissions(RequestResetPermissions(
+            requestId: "reset-1",
+            bundleId: "com.example.app",
+            permissions: ["camera", "photos"]
+        ))
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(response.type, "reset_permissions_result")
+        XCTAssertEqual(response.requestId, "reset-1")
+        XCTAssertEqual(response.success, true)
+        let history = fakeGesturePerformer.getResetAuthorizationsHistory()
+        XCTAssertEqual(history.count, 1)
+        XCTAssertEqual(history.first?.bundleId, "com.example.app")
+        XCTAssertEqual(history.first?.resources, ["camera", "photos"])
+    }
+
+    func testResetPermissionsSurfacesRunnerErrorAsStructuredFailure() {
+        fakeGesturePerformer.setFailure(
+            for: "resetAuthorizations",
+            error: CommandError.invalidParameter("permission", "siri")
+        )
+
+        let request = WebSocketRequest.resetPermissions(RequestResetPermissions(
+            requestId: "reset-err",
+            bundleId: "com.example.app",
+            permissions: ["siri"]
+        ))
+
+        guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+
+        XCTAssertEqual(response.type, "reset_permissions_result")
+        XCTAssertEqual(response.success, false)
+        XCTAssertTrue(response.error?.contains("siri") ?? false, "error should name the unmapped resource")
+    }
+
     // MARK: - Unknown Command Tests
 
     /// An unrecognized command `type` is now rejected at the decode boundary

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -159,6 +159,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             .listTables: "{}",
             .getTableData: "{}",
             .getTableStructure: "{}",
+            .requestResetPermissions: #"{"bundleId":"com.example.app","permissions":["camera"]}"#,
         ]
 
         for requestType in RequestType.allCases {
@@ -494,6 +495,20 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         XCTAssertEqual(history.first?.text, "payload")
     }
 
+    // MARK: - Reset permissions
+
+    func testResetPermissionsDecodeDispatchForwardsResources() {
+        let response = dispatch(
+            #"{"type":"request_reset_permissions","requestId":"rp-1","bundleId":"com.example.app","permissions":["camera","photos"]}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(response?.type, "reset_permissions_result")
+        XCTAssertEqual(response?.requestId, "rp-1")
+        let history = fakeGesturePerformer.getResetAuthorizationsHistory()
+        XCTAssertEqual(history.first?.bundleId, "com.example.app")
+        XCTAssertEqual(history.first?.resources, ["camera", "photos"])
+    }
+
     // MARK: - Hierarchy / screenshot
 
     func testHierarchyDecodeDispatchForwardsDisableAllFiltering() throws {
@@ -717,6 +732,8 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             (#"{"type":"set_preference","requestId":"x","value":"v","valueType":"STRING"}"#, "key"),
             (#"{"type":"remove_preference","requestId":"x"}"#, "key"),
             (#"{"type":"set_network_mock_rules","requestId":"x"}"#, "rules"),
+            (#"{"type":"request_reset_permissions","requestId":"x","permissions":["camera"]}"#, "bundleId"),
+            (#"{"type":"request_reset_permissions","requestId":"x","bundleId":"com.example.app"}"#, "permissions"),
         ]
         for (json, missingKey) in cases {
             XCTAssertThrowsError(try decodeWebSocketRequest(json), "expected \(json) to be rejected") { error in

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3994,7 +3994,7 @@
   },
   {
     "name": "setAppPermissions",
-    "description": "Grant, revoke, reset, or configure app permissions",
+    "description": "Grant, revoke, reset, or configure app permissions on Android devices, iOS simulators (grant/revoke/reset), and iOS physical devices (reset only)",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -4003,7 +4003,7 @@
           "type": "string"
         },
         "action": {
-          "description": "Permission action; defaults to grant",
+          "description": "Permission action; defaults to grant. Android supports grant; iOS simulators support grant/revoke/reset; iOS physical devices support reset only.",
           "type": "string",
           "enum": [
             "grant",

--- a/src/features/action/AppPermissions.ts
+++ b/src/features/action/AppPermissions.ts
@@ -12,6 +12,12 @@ import {
   type IosSimulatorPrivacyClient,
   type TccPermissionReader
 } from "./IosSimulatorPermissions";
+import {
+  CtrlProxyIosPhysicalPrivacyClient,
+  IosPhysicalPermissions,
+  type IosPhysicalPrivacyClient
+} from "./IosPhysicalPermissions";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 
 export type AppPermissionAction = IosSimulatorPermissionAction;
 
@@ -73,6 +79,7 @@ export interface AppPermissionsDependencies {
   adbFactory?: AdbClientFactory;
   simctl?: IosSimulatorPrivacyClient | null;
   tccReader?: TccPermissionReader | null;
+  iosPhysicalClient?: IosPhysicalPrivacyClient | null;
 }
 
 function parseAndroidRuntimePermissions(output: string): Map<string, AppPermissionStateResult> {
@@ -109,11 +116,14 @@ export class AppPermissions {
 
   private tccReader: TccPermissionReader | null;
 
+  private iosPhysicalClient: IosPhysicalPrivacyClient | null;
+
   constructor(device: BootedDevice, dependencies: AppPermissionsDependencies = {}) {
     this.device = device;
     this.adbFactory = dependencies.adbFactory ?? defaultAdbClientFactory;
     this.simctl = dependencies.simctl ?? null;
     this.tccReader = dependencies.tccReader ?? null;
+    this.iosPhysicalClient = dependencies.iosPhysicalClient ?? null;
   }
 
   async setPermissions(appId: string, input: SetAppPermissionsInput): Promise<SetAppPermissionsResult> {
@@ -156,6 +166,13 @@ export class AppPermissions {
         error,
       };
     }
+
+    // Physical iOS devices cannot use simctl privacy; route reset through the
+    // CtrlProxy XCUITest runner (grant/revoke surface a clear "reset only" failure).
+    if (!isIosSimulatorUdid(this.device.deviceId)) {
+      return this.setIosPhysicalPermissions(appId, action, permissions);
+    }
+
     const iosPermissions = new IosSimulatorPermissions(this.device, this.simctl, this.tccReader);
     const result = await iosPermissions.setPermissions(action, appId, permissions);
 
@@ -169,6 +186,35 @@ export class AppPermissions {
       failedCount: result.failedCount,
       operations: result.results.map(permissionResult => ({
         operationId: `ios_simctl_privacy:${action}:${permissionResult.permission}`,
+        success: permissionResult.success,
+        changedCount: permissionResult.success ? 1 : 0,
+        failedCount: permissionResult.success ? 0 : 1,
+        result: permissionResult,
+        ...(permissionResult.error ? { error: permissionResult.error } : {}),
+      })),
+      ...(result.error ? { error: result.error } : {}),
+    };
+  }
+
+  private async setIosPhysicalPermissions(
+    appId: string,
+    action: AppPermissionAction,
+    permissions: string[]
+  ): Promise<SetAppPermissionsResult> {
+    const client = this.iosPhysicalClient ?? new CtrlProxyIosPhysicalPrivacyClient(this.device);
+    const iosPermissions = new IosPhysicalPermissions(this.device, client);
+    const result = await iosPermissions.setPermissions(action, appId, permissions);
+
+    return {
+      success: result.success,
+      appId: result.appId,
+      deviceId: result.deviceId,
+      platform: result.platform,
+      action,
+      changedCount: result.changedCount,
+      failedCount: result.failedCount,
+      operations: result.results.map(permissionResult => ({
+        operationId: `ios_xcuitest_reset:${action}:${permissionResult.permission}`,
         success: permissionResult.success,
         changedCount: permissionResult.success ? 1 : 0,
         failedCount: permissionResult.success ? 0 : 1,

--- a/src/features/action/IosPhysicalPermissions.ts
+++ b/src/features/action/IosPhysicalPermissions.ts
@@ -1,0 +1,139 @@
+import type { BootedDevice } from "../../models";
+import { IOSCtrlProxyClient } from "../observe/ios/IOSCtrlProxyClient";
+import {
+  normalizePermissions,
+  type IosSimulatorPermissionAction,
+  type IosSimulatorPermissionCommandResult,
+  type IosSimulatorPermissionMutationResult,
+} from "./IosSimulatorPermissions";
+
+/**
+ * Reset privacy authorizations on a *physical* iOS device through the CtrlProxy
+ * XCUITest runner. The concrete client sends one `request_reset_permissions` per
+ * permission so accounting stays per-permission and partial failures are reported
+ * honestly (issue #2491).
+ */
+export interface IosPhysicalPrivacyClient {
+  resetAuthorizations(
+    appId: string,
+    permissions: string[]
+  ): Promise<IosSimulatorPermissionCommandResult[]>;
+}
+
+/**
+ * Physical-iOS counterpart to {@link IosSimulatorPermissions}. Only the `reset`
+ * action is possible on real hardware — there is no public API to set TCC to
+ * allowed/denied — so `grant`/`revoke` return an explicit structured failure
+ * naming the limitation rather than the old blanket simulator error. The result
+ * shape mirrors the simulator path so `AppPermissions` maps both identically.
+ */
+export class IosPhysicalPermissions {
+  constructor(
+    private readonly device: BootedDevice,
+    private readonly client: IosPhysicalPrivacyClient
+  ) {}
+
+  async setPermissions(
+    action: IosSimulatorPermissionAction,
+    appId: string,
+    permissions: string[]
+  ): Promise<IosSimulatorPermissionMutationResult> {
+    const normalizedAppId = appId.trim();
+    const normalizedPermissions = normalizePermissions(permissions);
+
+    if (action !== "reset") {
+      return this.mutationFailure(
+        action,
+        normalizedAppId,
+        `iOS physical devices only support action=reset; '${action}' requires a simulator ` +
+          "(no public TCC mutation API exists for real hardware)"
+      );
+    }
+
+    if (!normalizedAppId) {
+      return this.mutationFailure(action, normalizedAppId, "appId must be a non-empty iOS bundle identifier");
+    }
+
+    if (normalizedPermissions.length === 0) {
+      return {
+        success: true,
+        appId: normalizedAppId,
+        deviceId: this.device.deviceId,
+        platform: "ios",
+        action,
+        changedCount: 0,
+        failedCount: 0,
+        results: [],
+      };
+    }
+
+    const results = await this.client.resetAuthorizations(normalizedAppId, normalizedPermissions);
+    const failedCount = results.filter(result => !result.success).length;
+
+    return {
+      success: failedCount === 0,
+      appId: normalizedAppId,
+      deviceId: this.device.deviceId,
+      platform: "ios",
+      action,
+      changedCount: results.length - failedCount,
+      failedCount,
+      results,
+      ...(failedCount > 0 ? { error: `One or more iOS physical permissions failed to ${action}` } : {}),
+    };
+  }
+
+  private mutationFailure(
+    action: IosSimulatorPermissionAction,
+    appId: string,
+    error: string
+  ): IosSimulatorPermissionMutationResult {
+    return {
+      success: false,
+      appId,
+      deviceId: this.device.deviceId,
+      platform: "ios",
+      action,
+      changedCount: 0,
+      failedCount: 0,
+      results: [],
+      error,
+    };
+  }
+}
+
+/**
+ * Production {@link IosPhysicalPrivacyClient} backed by the CtrlProxy runner
+ * WebSocket (port 8765). Sends one reset request per permission and adapts each
+ * runner response into a per-permission result. When the runner is unreachable the
+ * shared not-connected path yields a clear, actionable error on every permission.
+ */
+export class CtrlProxyIosPhysicalPrivacyClient implements IosPhysicalPrivacyClient {
+  constructor(
+    private readonly device: BootedDevice,
+    private readonly getClient: () => IOSCtrlProxyClient = () => IOSCtrlProxyClient.getInstance(this.device)
+  ) {}
+
+  async resetAuthorizations(
+    appId: string,
+    permissions: string[]
+  ): Promise<IosSimulatorPermissionCommandResult[]> {
+    const client = this.getClient();
+    return Promise.all(
+      permissions.map(async permission => {
+        try {
+          const response = await client.requestResetPermissions(appId, [permission]);
+          return response.success
+            ? { permission, success: true }
+            : { permission, success: false, error: response.error ?? "Failed to reset permission" };
+        } catch (error) {
+          return {
+            permission,
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      })
+    );
+  }
+}

--- a/src/features/action/IosPhysicalPermissions.ts
+++ b/src/features/action/IosPhysicalPermissions.ts
@@ -1,4 +1,5 @@
 import type { BootedDevice } from "../../models";
+import { logger } from "../../utils/logger";
 import { IOSCtrlProxyClient } from "../observe/ios/IOSCtrlProxyClient";
 import {
   normalizePermissions,
@@ -127,11 +128,12 @@ export class CtrlProxyIosPhysicalPrivacyClient implements IosPhysicalPrivacyClie
             ? { permission, success: true }
             : { permission, success: false, error: response.error ?? "Failed to reset permission" };
         } catch (error) {
-          return {
-            permission,
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-          };
+          // Best-effort per-permission path: log the unexpected failure (so there is
+          // a trace even though the message is also surfaced in the result) and
+          // report it as a typed failure rather than aborting the whole batch.
+          const message = error instanceof Error ? error.message : String(error);
+          logger.warn(`[IosPhysicalPermissions] reset of '${permission}' failed: ${message}`, error);
+          return { permission, success: false, error: message };
         }
       })
     );

--- a/src/features/observe/ios/CtrlProxyPermissions.ts
+++ b/src/features/observe/ios/CtrlProxyPermissions.ts
@@ -1,0 +1,50 @@
+/**
+ * CtrlProxy iOS Permissions - Delegate for app privacy permission operations.
+ *
+ * Handles resetting iOS privacy authorizations (camera/photos/etc.) on physical
+ * devices via the CtrlProxy XCUITest runner, which calls
+ * `XCUIApplication.resetAuthorizationStatus(for:)`. See issue #2491.
+ */
+
+import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
+import type { DelegateContext, CtrlProxyResetPermissionsResult } from "./types";
+import { sendCommand } from "../DeviceServiceUtils";
+
+/**
+ * Delegate class for app privacy permission operations.
+ */
+export class CtrlProxyPermissions {
+  private readonly context: DelegateContext;
+
+  constructor(context: DelegateContext) {
+    this.context = context;
+  }
+
+  /**
+   * Reset the given privacy resources for an app back to not-determined.
+   *
+   * The runner maps each AutoMobile permission name to an `XCUIProtectedResource`
+   * and resets it; an unmapped resource (e.g. `siri`) comes back as a structured
+   * failure. When the runner is unreachable the shared not-connected path surfaces a
+   * clear, actionable message rather than an opaque socket timeout.
+   */
+  async requestResetPermissions(
+    bundleId: string,
+    permissions: string[],
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<CtrlProxyResetPermissionsResult> {
+    return sendCommand<CtrlProxyResetPermissionsResult>(this.context, {
+      idPrefix: "resetPermissions",
+      responseType: "reset_permissions_result",
+      messageType: "request_reset_permissions",
+      params: { bundleId, permissions },
+      timeoutMs,
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedMessage:
+        "iOS permission reset requires the CtrlProxy runner to be active on the device (port 8765)",
+      errorLabel: "Reset permissions",
+    });
+  }
+}

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -109,6 +109,7 @@ import { CtrlProxyVoiceOver } from "./CtrlProxyVoiceOver";
 import { CtrlProxyKeyboard } from "./CtrlProxyKeyboard";
 import { CtrlProxyHighlights } from "./CtrlProxyHighlights";
 import { CtrlProxyDatabase } from "./CtrlProxyDatabase";
+import { CtrlProxyPermissions } from "./CtrlProxyPermissions";
 import { decodeCtrlProxyMessage } from "./decodeCtrlProxyMessage";
 import { DefaultIosSdkEventIngestor, type IosSdkEventIngestor } from "./IosSdkEventIngestor";
 
@@ -135,6 +136,7 @@ import type {
   CtrlProxyRecentAppsResult,
   CtrlProxyRotateResult,
   CtrlProxyLaunchAppResult,
+  CtrlProxyResetPermissionsResult,
   CtrlProxyPerfTiming,
   CtrlProxyPerformanceSnapshot,
   CtrlProxyCachedHierarchy,
@@ -258,6 +260,10 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     bundleId: string, timeoutMs?: number, perf?: PerformanceTracker, coldBoot?: boolean
   ): Promise<CtrlProxyLaunchAppResult>;
 
+  requestResetPermissions(
+    bundleId: string, permissions: string[], timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<CtrlProxyResetPermissionsResult>;
+
   requestScreenshot(
     timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyScreenshotResult>;
@@ -356,6 +362,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private _keyboard: CtrlProxyKeyboard | null = null;
   private _highlights: CtrlProxyHighlights | null = null;
   private _database: CtrlProxyDatabase | null = null;
+  private _permissions: CtrlProxyPermissions | null = null;
 
   // Logging tag for base class
   protected readonly logTag = "IOSCtrlProxyClient";
@@ -739,6 +746,13 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       this._database = new CtrlProxyDatabase(this.createDelegateContext());
     }
     return this._database;
+  }
+
+  private get permissions(): CtrlProxyPermissions {
+    if (!this._permissions) {
+      this._permissions = new CtrlProxyPermissions(this.createDelegateContext());
+    }
+    return this._permissions;
   }
 
   // ===========================================================================
@@ -1259,6 +1273,16 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     bundleId: string, timeoutMs: number = 10000, perf?: PerformanceTracker, coldBoot: boolean = false
   ): Promise<CtrlProxyLaunchAppResult> {
     return this.navigation.requestLaunchApp(bundleId, timeoutMs, perf, coldBoot);
+  }
+
+  // ===========================================================================
+  // Delegated Public Methods - App Privacy Permissions
+  // ===========================================================================
+
+  async requestResetPermissions(
+    bundleId: string, permissions: string[], timeoutMs: number = 5000, perf?: PerformanceTracker
+  ): Promise<CtrlProxyResetPermissionsResult> {
+    return this.permissions.requestResetPermissions(bundleId, permissions, timeoutMs, perf);
   }
 
   // ===========================================================================

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -48,6 +48,9 @@ export const IOS_KNOWN_REQUEST_TYPES = [
   "request_action",
   "request_launch_app",
 
+  // App privacy permissions
+  "request_reset_permissions",
+
   // Device control
   "request_rotate",
 

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -88,6 +88,7 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
     case "press_back_result":
     case "recent_apps_result":
     case "launch_app_result":
+    case "reset_permissions_result":
       result = {
         success: message.success ?? true,
         totalTimeMs: message.totalTimeMs ?? 0,

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -189,6 +189,9 @@ export interface CtrlProxyRotateResult extends BaseResult {
 /** Launch app result from CtrlProxy iOS */
 export type CtrlProxyLaunchAppResult = BaseResult;
 
+/** Reset-privacy-permissions result from CtrlProxy iOS (physical devices, issue #2491) */
+export type CtrlProxyResetPermissionsResult = BaseResult;
+
 /** Recent apps result from CtrlProxy iOS */
 export type CtrlProxyRecentAppsResult = BaseResult;
 

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -69,7 +69,10 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
     appId: z.string(),
     action: appPermissionActionSchema
       .optional()
-      .describe("Permission action; defaults to grant"),
+      .describe(
+        "Permission action; defaults to grant. Android supports grant; iOS simulators " +
+        "support grant/revoke/reset; iOS physical devices support reset only."
+      ),
     permissions: z
       .array(z.string().min(1))
       .optional()
@@ -330,7 +333,8 @@ export function registerAppTools(
 
   ToolRegistry.registerDeviceAware(
     "setAppPermissions",
-    "Grant, revoke, reset, or configure app permissions",
+    "Grant, revoke, reset, or configure app permissions on Android devices, iOS simulators " +
+    "(grant/revoke/reset), and iOS physical devices (reset only)",
     setAppPermissionsSchema,
     setAppPermissionsHandler
   );

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -3,7 +3,11 @@ import { AppPermissions } from "../../../src/features/action/AppPermissions";
 import type { BootedDevice } from "../../../src/models";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
-import type { TccPermissionReader } from "../../../src/features/action/IosSimulatorPermissions";
+import type {
+  IosSimulatorPermissionCommandResult,
+  TccPermissionReader,
+} from "../../../src/features/action/IosSimulatorPermissions";
+import type { IosPhysicalPrivacyClient } from "../../../src/features/action/IosPhysicalPermissions";
 
 const androidDevice: BootedDevice = {
   name: "Pixel",
@@ -16,6 +20,24 @@ const iosSimulator: BootedDevice = {
   platform: "ios",
   deviceId: "12345678-1234-1234-1234-123456789ABC",
 };
+
+const iosPhysical: BootedDevice = {
+  name: "iPhone (physical)",
+  platform: "ios",
+  deviceId: "00008110-001234567890ABCD",
+};
+
+class RecordingPhysicalPrivacyClient implements IosPhysicalPrivacyClient {
+  public calls: Array<{ appId: string; permissions: string[] }> = [];
+
+  async resetAuthorizations(
+    appId: string,
+    permissions: string[]
+  ): Promise<IosSimulatorPermissionCommandResult[]> {
+    this.calls.push({ appId, permissions });
+    return permissions.map(permission => ({ permission, success: true }));
+  }
+}
 
 describe("AppPermissions", () => {
   test("sets Android runtime permissions and Android-specific options through one action", async () => {
@@ -125,5 +147,41 @@ describe("AppPermissions", () => {
         },
       },
     ]);
+  });
+
+  test("routes reset on a physical iOS device through the CtrlProxy runner", async () => {
+    const iosPhysicalClient = new RecordingPhysicalPrivacyClient();
+    const permissions = new AppPermissions(iosPhysical, { iosPhysicalClient });
+
+    const result = await permissions.setPermissions("com.example.app", {
+      action: "reset",
+      permissions: ["camera", "photos"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.platform).toBe("ios");
+    expect(result.changedCount).toBe(2);
+    expect(result.operations.map(operation => operation.operationId)).toEqual([
+      "ios_xcuitest_reset:reset:camera",
+      "ios_xcuitest_reset:reset:photos",
+    ]);
+    expect(iosPhysicalClient.calls).toEqual([
+      { appId: "com.example.app", permissions: ["camera", "photos"] },
+    ]);
+  });
+
+  test("rejects grant on a physical iOS device with a reset-only failure", async () => {
+    const iosPhysicalClient = new RecordingPhysicalPrivacyClient();
+    const permissions = new AppPermissions(iosPhysical, { iosPhysicalClient });
+
+    const result = await permissions.setPermissions("com.example.app", {
+      action: "grant",
+      permissions: ["camera"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.action).toBe("grant");
+    expect(result.error).toContain("reset");
+    expect(iosPhysicalClient.calls).toEqual([]);
   });
 });

--- a/test/features/action/IosPhysicalPermissions.test.ts
+++ b/test/features/action/IosPhysicalPermissions.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import {
+  IosPhysicalPermissions,
+  type IosPhysicalPrivacyClient,
+} from "../../../src/features/action/IosPhysicalPermissions";
+import type { BootedDevice } from "../../../src/models";
+import type { IosSimulatorPermissionCommandResult } from "../../../src/features/action/IosSimulatorPermissions";
+
+const physicalDevice: BootedDevice = {
+  name: "iPhone (physical)",
+  platform: "ios",
+  deviceId: "00008110-001234567890ABCD",
+};
+
+/**
+ * Recording fake for the CtrlProxy-backed reset client. Returns per-permission
+ * results the caller pre-seeds, so a test can force partial failure without a device.
+ */
+class FakePhysicalPrivacyClient implements IosPhysicalPrivacyClient {
+  public calls: Array<{ appId: string; permissions: string[] }> = [];
+  private resultByPermission = new Map<string, IosSimulatorPermissionCommandResult>();
+
+  setResult(permission: string, result: IosSimulatorPermissionCommandResult): void {
+    this.resultByPermission.set(permission, result);
+  }
+
+  async resetAuthorizations(
+    appId: string,
+    permissions: string[]
+  ): Promise<IosSimulatorPermissionCommandResult[]> {
+    this.calls.push({ appId, permissions });
+    return permissions.map(
+      permission =>
+        this.resultByPermission.get(permission) ?? { permission, success: true }
+    );
+  }
+}
+
+describe("IosPhysicalPermissions", () => {
+  test("reset delegates to the client and reports per-permission success", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("reset", "com.example.app", ["camera", "photos"]);
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("reset");
+    expect(result.appId).toBe("com.example.app");
+    expect(result.deviceId).toBe(physicalDevice.deviceId);
+    expect(result.platform).toBe("ios");
+    expect(result.changedCount).toBe(2);
+    expect(result.failedCount).toBe(0);
+    expect(result.results.map(r => r.permission)).toEqual(["camera", "photos"]);
+    expect(client.calls).toEqual([{ appId: "com.example.app", permissions: ["camera", "photos"] }]);
+  });
+
+  test("reset aggregates partial failure (e.g. unmapped resource) honestly", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    client.setResult("siri", {
+      permission: "siri",
+      success: false,
+      error: "Invalid value 'siri' for parameter 'permission'",
+    });
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("reset", "com.example.app", ["camera", "siri"]);
+
+    expect(result.success).toBe(false);
+    expect(result.changedCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+    expect(result.error).toContain("reset");
+    const failed = result.results.find(r => r.permission === "siri");
+    expect(failed?.success).toBe(false);
+    expect(failed?.error).toContain("siri");
+  });
+
+  test("empty permission list is a no-op success and never calls the client", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("reset", "com.example.app", []);
+
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(0);
+    expect(result.results).toEqual([]);
+    expect(client.calls).toEqual([]);
+  });
+
+  test("grant is rejected with a clear reset-only message and no client call", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("grant", "com.example.app", ["camera"]);
+
+    expect(result.success).toBe(false);
+    expect(result.action).toBe("grant");
+    expect(result.changedCount).toBe(0);
+    expect(result.results).toEqual([]);
+    expect(result.error).toContain("reset");
+    expect(result.error?.toLowerCase()).toContain("physical");
+    expect(client.calls).toEqual([]);
+  });
+
+  test("revoke is rejected with a clear reset-only message and no client call", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("revoke", "com.example.app", ["camera"]);
+
+    expect(result.success).toBe(false);
+    expect(result.action).toBe("revoke");
+    expect(result.error).toContain("reset");
+    expect(client.calls).toEqual([]);
+  });
+
+  test("empty appId is rejected before any client call", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("reset", "   ", ["camera"]);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.toLowerCase()).toContain("bundle identifier");
+    expect(client.calls).toEqual([]);
+  });
+});

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -76,6 +76,7 @@ const SWIFT_REQUEST_TYPES = [
   "list_tables",
   "get_table_data",
   "get_table_structure",
+  "request_reset_permissions",
 ];
 
 /**

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -52,6 +52,7 @@ describe("decodeCtrlProxyMessage", () => {
     "press_back_result",
     "recent_apps_result",
     "launch_app_result",
+    "reset_permissions_result",
     "multi_finger_swipe_result",
   ];
 


### PR DESCRIPTION
## Summary

Implements the `reset` action of `setAppPermissions` on **physical iOS devices** by routing through the CtrlProxy XCUITest runner (`XCUIApplication.resetAuthorizationStatus(for:)`), which works on real hardware where `simctl privacy` does not. `grant`/`revoke` now return an explicit, structured "reset only" failure on physical devices instead of the old blanket `iOS permission changes via simctl privacy are only supported on simulators` error. The simulator path is unchanged. Closes #2491.

### Why

Real-device automation (camera capture, Bluetooth/local-network, Face ID, motion) is exactly where deterministic permission setup matters, yet iOS users got full functionality on simulators and **zero** on hardware. `resetAuthorizationStatus(for:)` (Xcode 11.4+) is the only Apple-supported way to change authorization on a real device — it can re-arm the system prompt (not-determined) but cannot set allowed/denied, so `grant`/`revoke` remain infeasible and are reported as such.

### Changes

**Wire protocol (new command `request_reset_permissions` → `reset_permissions_result`)**
- `Models.swift` — new `RequestResetPermissions` payload (`bundleId`, `permissions[]`, both decode-required), `WebSocketRequest.resetPermissions` case, `RequestType`/`ResponseType` entries.
- `CommandHandler.swift` — dispatch + `handleResetPermissions` (rejects an empty `permissions` array) + `responseType(for:)` arm.
- `Protocols.swift` / `GesturePerformer.swift` — `resetAuthorizations(bundleId:resources:)` on `GesturePerforming`; iOS impl maps AutoMobile permission names → `XCUIProtectedResource` and calls `resetAuthorizationStatus(for:)`; non-iOS stub throws.
- The **mapping is authoritative on the runner** (single source of truth — `XCUIProtectedResource` only exists there). Unmapped names (`siri`, `motion`, …) throw `invalidParameter` and surface as per-permission failures.

**TS host**
- New `IosPhysicalPermissions` (+ `IosPhysicalPrivacyClient` interface and `CtrlProxyIosPhysicalPrivacyClient` concrete client). Reset-only; result shape mirrors `IosSimulatorPermissions` so `AppPermissions` maps both identically. The concrete client sends **one request per permission** for honest per-permission accounting and partial-failure reporting.
- `AppPermissions.setIosPermissions` branches on `!isIosSimulatorUdid(...)` → physical path; operations use the `ios_xcuitest_reset:` operationId prefix (distinct from `ios_simctl_privacy:`).
- New `CtrlProxyPermissions` delegate + `IOSCtrlProxyClient.requestResetPermissions`; a clear "runner must be active on port 8765" message on the not-connected path.
- `decodeCtrlProxyMessage` gains an explicit `reset_permissions_result` case grouped with the other base-result types (convention parity).
- `ctrlProxyRequestTypes.ts` known-set + advertised tool text (registration + `action` schema describe) updated to be honest: physical iOS supports `reset` only.

## Testing

- New `test/features/action/IosPhysicalPermissions.test.ts` — reset delegates + per-permission accounting, partial failure, empty-list no-op, grant/revoke rejection, empty-appId rejection (interface + fake, no device).
- `test/features/action/AppPermissions.test.ts` — physical reset routes through an injected client (`ios_xcuitest_reset:reset:*` ops); physical grant → reset-only failure.
- `ctrlProxyWireParity.test.ts` + `decodeCtrlProxyMessage.test.ts` — new command in the Swift↔TS parity set and the base-result decode group.
- Swift `TypedRequestDecodeTests` (decode/dispatch, allCases fixture, missing-field rejection for `bundleId`/`permissions`) and `CommandHandlerTests` (forwarding + runner-error → structured failure).
- `bun test` on affected suites: 68 pass / 0 fail. `./scripts/ios/swift-test.sh`: control-proxy green. `turbo run lint build`: clean. SwiftFormat/ESLint clean on changed files. Pre-existing image-backend failures (`@jimp/wasm-webp` not installed in this worktree) are unrelated.

## Delivery note

Physical devices run the **pinned downloaded** CtrlProxy runner, so the runner's `connected` handshake gates `request_reset_permissions` by `supportedCommands`. Until the iOS runner release is re-cut (the standard periodic `chore: bump versions` process — feature PRs deliberately don't touch `release.ts` checksums), a physical device with an older runner degrades gracefully to the "runner out of sync, rebuild/redeploy" error. Use `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` to test against this branch's runner locally.

### Known caveats (advertised honestly, per the issue)
- `grant`/`revoke` are infeasible on real hardware (no public TCC-mutation API) → structured "reset only" failure.
- `resetAuthorizationStatus(for:)` covers a subset of the `kTCCService*` names the simulator path maps (`siri`, `motion`, etc. have no `XCUIProtectedResource`) → per-permission failure.
- `getAppPermissions` (query) on physical devices still returns the simulator-only failure — out of scope here; follow-up filed.

Closes #2491
