### PR TITLE
test(ios): de-flake IOSCtrlProxyManager health-poll timeout tests

### DIFF
--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -236,6 +236,7 @@ function createFakeBuilder(xctestrunPath = "/tmp/CtrlProxy.xctestrun") {
 describe("IOSCtrlProxyManager", function() {
   let testDevice: BootedDevice;
   let fakeTimer: FakeTimer;
+  let prevHealthMaxAttempts: string | undefined;
 
   beforeEach(function() {
     fakeTimer = new FakeTimer();
@@ -247,6 +248,20 @@ describe("IOSCtrlProxyManager", function() {
       name: "iPhone 16 Simulator"
     };
 
+    // Cap the health-poll budget suite-wide. The timeout-path tests
+    // (`enableAutoAdvance()` + `start()` rejects "failed to start within timeout")
+    // run the FULL health-poll loop, and each iteration's `timer.sleep(500)`
+    // resolves via a real `setImmediate` under auto-advance — so the loop costs
+    // one real event-loop tick per attempt. At the default 60 attempts that is 60
+    // real ticks whose wall-clock scales with event-loop load, which intermittently
+    // blew past bun's 5000ms per-test timeout in the full suite (a real macOS-CI
+    // flake, e.g. "ignores xcodebuild CtrlProxy processes for other simulators").
+    // A tiny budget proves the same timeout/spawn behavior deterministically and
+    // fast. Tests that need a specific budget still override this locally
+    // (`withHealthBudget` / the resolver parsing test) and restore to this value.
+    prevHealthMaxAttempts = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+    process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = "3";
+
     // Reset singleton instances
     IOSCtrlProxyManager.resetInstances();
     PortManager.reset();
@@ -254,6 +269,11 @@ describe("IOSCtrlProxyManager", function() {
   });
 
   afterEach(function() {
+    if (prevHealthMaxAttempts === undefined) {
+      delete process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+    } else {
+      process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS = prevHealthMaxAttempts;
+    }
     IOSCtrlProxyManager.resetInstances();
     PortManager.reset();
     PortManager.setPortAvailabilityCheckerForTesting(null);


### PR DESCRIPTION
## Summary
De-flakes the `IOSCtrlProxyManager` test suite, which intermittently failed on macOS CI (e.g. blocked PR #3132's auto-merge):

```
(fail) IOSCtrlProxyManager > ... > start() ignores xcodebuild CtrlProxy processes for other simulators [5305.53ms]
  ^ this test timed out after 5000ms.
```

## Root cause
The timeout-path tests use `fakeTimer.enableAutoAdvance()` and assert `start()` rejects with *"failed to start within timeout"*, so they run the **full** health-poll loop (`src/utils/IOSCtrlProxyManager.ts`, default `DEFAULT_HEALTH_POLL_MAX_ATTEMPTS = 60`). Under auto-advance, each iteration's `timer.sleep(500)` is scheduled via a **real `setImmediate`** (`test/fakes/FakeTimer.ts:258`), so the loop costs **one real event-loop tick per attempt** — 60 real ticks whose wall-clock scales with event-loop load. In the full ~6400-test suite on a loaded macOS runner this occasionally exceeds bun's 5000ms per-test timeout. The same test passes in **115ms in isolation** — the tell-tale sign of a load-sensitive real-timer flake, not a logic bug.

This is not a shell-out (the process executor is faked); it's the real-`setImmediate` scheduling of the per-attempt sleep multiplied by the full 60-attempt budget.

## Fix
Cap `AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS=3` in the suite's `beforeEach` (restored in `afterEach`). Every timeout test proves the identical timeout/spawn behavior in a few deterministic ticks instead of 60 load-sensitive ones. Tests that need a specific budget (`withHealthBudget`, the resolver-parsing test) still override locally and restore to this value.

## Verification
- `bun test test/utils/IOSCtrlProxyManager.test.ts` → **90 pass / 0 fail in ~140ms** (previously the one flaky test alone could take 5305ms).
- No test asserts on the health-poll attempt count, so the cap changes timing only, not coverage.
- `eslint` clean on the changed file.

Follow-up context: found while landing #3132 (the flake blocked its merge; #3132 has since merged after a rerun).
