### PR TITLE
perf(db): set SQLite synchronous normal under WAL

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -57,6 +57,8 @@ export function configureSqliteDatabase(sqliteDb: SqlitePragmaDatabase): void {
   sqliteDb.exec("PRAGMA journal_mode = WAL;");
 
   // WAL + NORMAL avoids an fsync per commit while remaining corruption-safe.
+  // The whole DB stores local telemetry, diagnostics, cache, config, and session
+  // state where losing the last commit on OS/power loss is acceptable.
   sqliteDb.exec("PRAGMA synchronous = NORMAL;");
 
   // Enable foreign key enforcement for cascade deletes

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -56,6 +56,9 @@ export function configureSqliteDatabase(sqliteDb: SqlitePragmaDatabase): void {
   // Enable WAL mode for better concurrent read performance
   sqliteDb.exec("PRAGMA journal_mode = WAL;");
 
+  // WAL + NORMAL avoids an fsync per commit while remaining corruption-safe.
+  sqliteDb.exec("PRAGMA synchronous = NORMAL;");
+
   // Enable foreign key enforcement for cascade deletes
   sqliteDb.exec("PRAGMA foreign_keys = ON;");
 }

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "fs";
 import { Kysely } from "kysely";
+import { join } from "path";
+import { tmpdir } from "os";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import {
   configureSqliteDatabase,
@@ -38,6 +41,7 @@ describe("configureSqliteDatabase", () => {
     expect(db.statements).toEqual([
       `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`,
       "PRAGMA journal_mode = WAL;",
+      "PRAGMA synchronous = NORMAL;",
       "PRAGMA foreign_keys = ON;",
     ]);
   });
@@ -54,6 +58,28 @@ describe("configureSqliteDatabase", () => {
       expect(result?.timeout).toBe(5_000);
     } finally {
       sqliteDb.close();
+    }
+  });
+
+  test("sets synchronous NORMAL after enabling WAL on Bun SQLite databases", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-sqlite-"));
+    const sqliteDb = new BunDatabase(join(tempDir, "test.db"));
+
+    try {
+      configureSqliteDatabase(sqliteDb);
+
+      const journalMode = sqliteDb
+        .query<{ journal_mode: string }, []>("PRAGMA journal_mode;")
+        .get();
+      expect(journalMode?.journal_mode).toBe("wal");
+
+      const synchronous = sqliteDb
+        .query<{ synchronous: number }, []>("PRAGMA synchronous;")
+        .get();
+      expect(synchronous?.synchronous).toBe(1);
+    } finally {
+      sqliteDb.close();
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
- Set `PRAGMA synchronous = NORMAL;` immediately after enabling WAL in `configureSqliteDatabase`.
- Update the fake pragma-order assertion to pin `busy_timeout`, `journal_mode = WAL`, `synchronous = NORMAL`, then `foreign_keys`.
- Add a live file-backed `bun:sqlite` readback test confirming WAL mode and `PRAGMA synchronous;` returns `1`.

## Durability / performance note
- Under WAL, `NORMAL` remains corruption-safe and removes the per-commit fsync from the telemetry write stream.
- The tradeoff is limited to possible loss of the most recent committed transactions on OS crash or power loss before checkpoint; application crashes remain safe.
- This pragma is applied per connection to the whole AutoMobile DB. That includes telemetry/diagnostics plus persistent config and state rows such as appearance config, device snapshot config, video recording config, installed-app cache, and device-session metadata.
- Losing the last committed config/cache/session row during an OS crash or power loss is acceptable for this local automation diagnostics DB: users can reapply config, caches can be refreshed, sessions can be recreated, and the database remains uncorrupted. This is preferable to blocking every single-row telemetry insert on fsync.

## Testing
- `bun test test/db/database.test.ts`
- `bun run turbo:validate`

## Review
- Ran `/auto-mobile-code-review`-style local review against latest `origin/main`; no confirmed code findings.
- Independent database review flagged that the PR note should explicitly name whole-DB config/state durability tradeoffs; this body now documents that scope.

Closes #2787