### PR TITLE
Strip observe debug perf telemetry from output

### DIFF
--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -22,7 +22,7 @@ All collected data is assembled into an object containing (fields may be omitted
 - `wakefulness` and `backStack`: Android-specific state
 - `displayedTimeMetrics` (Android launchApp "Displayed" startup timings), `performanceAudit`, and `accessibilityAudit`: present when the relevant modes are enabled
 - `perfTiming`: collected internally for debug/perf capture diagnostics but stripped from the sanitized MCP tool output to reduce payload size
-- `gfxMetrics`: emitted in sanitized output for action UI-stability summaries; frame timing fields may be trimmed when `performanceAudit.metrics` already carries the computed performance summary
+- `gfxMetrics`: emitted in sanitized output for action UI-stability summaries; frame timing fields may be trimmed when `performanceAudit.metrics` already carries non-null computed replacements
 - `error`: error messages encountered during observation
 
 The observation gracefully handles various error conditions:

--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -20,7 +20,9 @@ All collected data is assembled into an object containing (fields may be omitted
 - `focusedElement`: currently focused UI element (if any)
 - `intentChooserDetected`: whether a system intent chooser is visible
 - `wakefulness` and `backStack`: Android-specific state
-- `perfTiming`, `displayedTimeMetrics` (Android launchApp "Displayed" startup timings), `performanceAudit`, and `accessibilityAudit`: present when the relevant modes are enabled
+- `displayedTimeMetrics` (Android launchApp "Displayed" startup timings), `performanceAudit`, and `accessibilityAudit`: present when the relevant modes are enabled
+- `perfTiming`: collected internally for debug/perf capture diagnostics but stripped from the sanitized MCP tool output to reduce payload size
+- `gfxMetrics`: emitted in sanitized output for action UI-stability summaries; frame timing fields may be trimmed when `performanceAudit.metrics` already carries the computed performance summary
 - `error`: error messages encountered during observation
 
 The observation gracefully handles various error conditions:

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -31,12 +31,6 @@ src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argu
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2769: No overload matches this call.
-src/db/migrations/2026_07_02_000_event_composite_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
-src/db/migrations/2026_07_02_000_event_composite_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
-src/db/migrations/2026_07_02_000_event_composite_indexes.ts: error TS2769: No overload matches this call.
-src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
-src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
-src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts: error TS2769: No overload matches this call.
 src/db/migrator.ts: error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
 src/db/migrator.ts: error TS2307: Cannot find module 'kysely/migration' or its corresponding type declarations.
 src/db/migrator.ts: error TS2307: Cannot find module 'kysely/migration' or its corresponding type declarations.

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -118,23 +118,39 @@ export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveCo
  * Reduce top-level debug-perf telemetry that is useful while measuring capture
  * internals but mostly duplicates richer summaries. `perfTiming` is raw capture
  * timing, so it is dropped. `gfxMetrics` also carries action UI-stability
- * fields, so only frame timing fields covered by `performanceAudit.metrics` are
- * removed, and only when an audit summary exists.
+ * fields, so only frame timing fields with non-null replacements in
+ * `performanceAudit.metrics` are removed.
  */
 function reduceTopLevelDebugPerfTelemetry(out: ObserveResult): void {
   delete out.perfTiming;
 
-  if (!out.performanceAudit || !out.gfxMetrics) {
+  const auditMetrics = out.performanceAudit?.metrics;
+  const gfxMetrics = out.gfxMetrics;
+  if (!auditMetrics || !gfxMetrics) {
     return;
   }
 
-  delete out.gfxMetrics.percentile50thMs;
-  delete out.gfxMetrics.percentile90thMs;
-  delete out.gfxMetrics.percentile95thMs;
-  delete out.gfxMetrics.percentile99thMs;
-  delete out.gfxMetrics.missedVsyncCount;
-  delete out.gfxMetrics.slowUiThreadCount;
-  delete out.gfxMetrics.frameDeadlineMissedCount;
+  if (auditMetrics.p50Ms !== null && auditMetrics.p50Ms !== undefined) {
+    delete gfxMetrics.percentile50thMs;
+  }
+  if (auditMetrics.p90Ms !== null && auditMetrics.p90Ms !== undefined) {
+    delete gfxMetrics.percentile90thMs;
+  }
+  if (auditMetrics.p95Ms !== null && auditMetrics.p95Ms !== undefined) {
+    delete gfxMetrics.percentile95thMs;
+  }
+  if (auditMetrics.p99Ms !== null && auditMetrics.p99Ms !== undefined) {
+    delete gfxMetrics.percentile99thMs;
+  }
+  if (auditMetrics.missedVsyncCount !== null && auditMetrics.missedVsyncCount !== undefined) {
+    delete gfxMetrics.missedVsyncCount;
+  }
+  if (auditMetrics.slowUiThreadCount !== null && auditMetrics.slowUiThreadCount !== undefined) {
+    delete gfxMetrics.slowUiThreadCount;
+  }
+  if (auditMetrics.frameDeadlineMissedCount !== null && auditMetrics.frameDeadlineMissedCount !== undefined) {
+    delete gfxMetrics.frameDeadlineMissedCount;
+  }
 }
 
 /**

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -125,10 +125,11 @@ function reduceTopLevelDebugPerfTelemetry(out: ObserveResult): void {
   delete out.perfTiming;
 
   const auditMetrics = out.performanceAudit?.metrics;
-  const gfxMetrics = out.gfxMetrics;
-  if (!auditMetrics || !gfxMetrics) {
+  if (!auditMetrics || !out.gfxMetrics) {
     return;
   }
+
+  const gfxMetrics = out.gfxMetrics as Partial<NonNullable<ObserveResult["gfxMetrics"]>>;
 
   if (auditMetrics.p50Ms !== null && auditMetrics.p50Ms !== undefined) {
     delete gfxMetrics.percentile50thMs;

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -82,9 +82,10 @@ export type CompactBounds = [number, number, number, number];
 
 /**
  * Return an output-only copy of `obs` shrunk for serialization. Applies, in
- * order: perf-audit strip (always), per-node trim (default on), bounds compaction
- * (gated by `cfg.compact`), and elements-drop (gated by `cfg.dropElements`). The
- * input is never mutated.
+ * order: perf-audit strip (always), top-level debug-perf telemetry strip
+ * (always), per-node trim (default on), bounds compaction (gated by
+ * `cfg.compact`), and elements-drop (gated by `cfg.dropElements`). The input is
+ * never mutated.
  */
 export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveConfig): ObserveResult {
   // Deep-clone boundary: mutate only the copy that goes to the wire. The
@@ -94,6 +95,7 @@ export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveCo
   const out = JSON.parse(JSON.stringify(obs)) as ObserveResult;
 
   stripPerformanceAudit(out);
+  stripTopLevelDebugPerfTelemetry(out);
 
   if (cfg.trimNodes !== false) {
     for (const root of toNodeArray(out.viewHierarchy?.hierarchy?.node)) {
@@ -110,6 +112,17 @@ export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveCo
   }
 
   return out;
+}
+
+/**
+ * Drop top-level debug-perf telemetry that is useful while measuring capture
+ * internals but not for agent decisions. `performanceAudit` keeps the computed
+ * summary metrics; these fields duplicate timing/raw graphics detail and are
+ * only removed from the output copy.
+ */
+function stripTopLevelDebugPerfTelemetry(out: ObserveResult): void {
+  delete out.perfTiming;
+  delete out.gfxMetrics;
 }
 
 /**

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -82,7 +82,7 @@ export type CompactBounds = [number, number, number, number];
 
 /**
  * Return an output-only copy of `obs` shrunk for serialization. Applies, in
- * order: perf-audit strip (always), top-level debug-perf telemetry strip
+ * order: perf-audit strip (always), top-level debug-perf telemetry reduction
  * (always), per-node trim (default on), bounds compaction (gated by
  * `cfg.compact`), and elements-drop (gated by `cfg.dropElements`). The input is
  * never mutated.
@@ -95,7 +95,7 @@ export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveCo
   const out = JSON.parse(JSON.stringify(obs)) as ObserveResult;
 
   stripPerformanceAudit(out);
-  stripTopLevelDebugPerfTelemetry(out);
+  reduceTopLevelDebugPerfTelemetry(out);
 
   if (cfg.trimNodes !== false) {
     for (const root of toNodeArray(out.viewHierarchy?.hierarchy?.node)) {
@@ -115,14 +115,26 @@ export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveCo
 }
 
 /**
- * Drop top-level debug-perf telemetry that is useful while measuring capture
- * internals but not for agent decisions. `performanceAudit` keeps the computed
- * summary metrics; these fields duplicate timing/raw graphics detail and are
- * only removed from the output copy.
+ * Reduce top-level debug-perf telemetry that is useful while measuring capture
+ * internals but mostly duplicates richer summaries. `perfTiming` is raw capture
+ * timing, so it is dropped. `gfxMetrics` also carries action UI-stability
+ * fields, so only frame timing fields covered by `performanceAudit.metrics` are
+ * removed, and only when an audit summary exists.
  */
-function stripTopLevelDebugPerfTelemetry(out: ObserveResult): void {
+function reduceTopLevelDebugPerfTelemetry(out: ObserveResult): void {
   delete out.perfTiming;
-  delete out.gfxMetrics;
+
+  if (!out.performanceAudit || !out.gfxMetrics) {
+    return;
+  }
+
+  delete out.gfxMetrics.percentile50thMs;
+  delete out.gfxMetrics.percentile90thMs;
+  delete out.gfxMetrics.percentile95thMs;
+  delete out.gfxMetrics.percentile99thMs;
+  delete out.gfxMetrics.missedVsyncCount;
+  delete out.gfxMetrics.slowUiThreadCount;
+  delete out.gfxMetrics.frameDeadlineMissedCount;
 }
 
 /**

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -137,14 +137,14 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     } else if (isObserveResult(payload.observation)) {
       const sanitized = sanitizeObserveResult(payload.observation as ObserveResult, cfg);
       let observationOut: unknown = sanitized;
-      if (canDiff) {
+      if (canDiff && hasRenderableHierarchy(sanitized)) {
         // Emit a diff vs the baseline when it exists and the screen is unchanged;
         // otherwise fall back to the full observation (cross-screen diffs are
         // meaningless, and there is nothing to diff on the first action). Either
         // way, update the baseline to this observation so the next action diffs
         // against current state.
         const baseline = ctx.baselineStore!.get(ctx.sessionUuid!);
-        if (baseline && isSameObservationScreen(baseline, sanitized)) {
+        if (baseline && hasRenderableHierarchy(baseline) && isSameObservationScreen(baseline, sanitized)) {
           observationOut = diffObserveResult(baseline, sanitized);
         }
         ctx.baselineStore!.set(ctx.sessionUuid!, sanitized);
@@ -200,4 +200,8 @@ function isObserveResult(value: unknown): value is ObserveResult {
 
   const record = value as Record<string, unknown>;
   return OBSERVE_RESULT_MARKERS.some(key => key in record);
+}
+
+function hasRenderableHierarchy(observation: ObserveResult): boolean {
+  return !!observation.viewHierarchy?.hierarchy;
 }

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -173,14 +173,31 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
 
 /**
  * A value is treated as an `ObserveResult` for sanitization purposes when it is
- * an object carrying a `viewHierarchy`. This is intentionally lax: sanitize is a
- * safe no-op on a result with no hierarchy/elements/perf, but requiring the
- * marker field avoids cloning arbitrary success payloads for nothing.
+ * an object carrying observe-specific fields. Hierarchy collection can fail
+ * while the rest of observe still completes, so `viewHierarchy` is only one
+ * marker; debug-perf fields on hierarchy-less observations must still be
+ * stripped at the wire boundary.
  */
+const OBSERVE_RESULT_MARKERS: ReadonlyArray<string> = [
+  "updatedAt",
+  "screenSize",
+  "systemInsets",
+  "viewHierarchy",
+  "rawViewHierarchy",
+  "elements",
+  "perfTiming",
+  "perfTimingTruncated",
+  "gfxMetrics",
+  "performanceAudit",
+  "accessibilityAudit",
+  "freshness",
+];
+
 function isObserveResult(value: unknown): value is ObserveResult {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    "viewHierarchy" in (value as Record<string, unknown>)
-  );
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return OBSERVE_RESULT_MARKERS.some(key => key in record);
 }

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -311,8 +311,6 @@ export function registerObserveTools() {
     "Get screen view hierarchy",
     observeSchema,
     observeHandler,
-    false,
-    false,
     { outputSchema: observeResultSchema }
   );
 

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -149,6 +149,82 @@ describe("sanitizeObserveResult", () => {
     });
   });
 
+  describe("top-level debug-perf telemetry strip (always)", () => {
+    test("drops perfTiming from the output copy while leaving the input untouched", () => {
+      const { observe } = loadAndroidHomeObserve();
+      expect(observe.perfTiming).toBeDefined();
+      const before = JSON.stringify(observe.perfTiming);
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.perfTiming).toBeUndefined();
+      expect(JSON.stringify(observe.perfTiming)).toBe(before);
+    });
+
+    test("measurably shrinks bytes and tokens by dropping fixture perfTiming", () => {
+      const { observe } = loadAndroidHomeObserve();
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      const withPerfTiming = { ...out, perfTiming: observe.perfTiming };
+
+      expect(measureValue(out).bytes).toBeLessThan(measureValue(withPerfTiming).bytes);
+      expect(measureValue(out).tokens).toBeLessThan(measureValue(withPerfTiming).tokens);
+    });
+
+    test("drops redundant gfxMetrics without mutating performanceAudit metrics", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.gfxMetrics = {
+        p50Ms: 12,
+        p90Ms: 18,
+        p95Ms: 22,
+        p99Ms: 30,
+        jankCount: 2,
+        missedVsyncCount: 1,
+        slowUiThreadCount: 1,
+        frameDeadlineMissedCount: 0,
+        gfxinfoRaw: "raw gfxinfo dump that overlaps performanceAudit.metrics",
+      } as any;
+      const auditMetricsBefore = JSON.stringify(observe.performanceAudit?.metrics);
+      const gfxMetricsBefore = JSON.stringify(observe.gfxMetrics);
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.gfxMetrics).toBeUndefined();
+      expect(JSON.stringify(observe.gfxMetrics)).toBe(gfxMetricsBefore);
+      expect(JSON.stringify(observe.performanceAudit?.metrics)).toBe(auditMetricsBefore);
+    });
+
+    test("measurably shrinks bytes and tokens by dropping synthetic gfxMetrics", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.gfxMetrics = {
+        p50Ms: 12,
+        p90Ms: 18,
+        p95Ms: 22,
+        p99Ms: 30,
+        jankCount: 2,
+        missedVsyncCount: 1,
+        slowUiThreadCount: 1,
+        frameDeadlineMissedCount: 0,
+        gfxinfoRaw: "Frame timing raw dump\n".repeat(100),
+      } as any;
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      const withGfxMetrics = { ...out, gfxMetrics: observe.gfxMetrics };
+
+      expect(measureValue(out).bytes).toBeLessThan(measureValue(withGfxMetrics).bytes);
+      expect(measureValue(out).tokens).toBeLessThan(measureValue(withGfxMetrics).tokens);
+    });
+
+    test("preserves the perfTimingTruncated signal", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.perfTimingTruncated = true;
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.perfTiming).toBeUndefined();
+      expect(out.perfTimingTruncated).toBe(true);
+    });
+  });
+
   describe("per-node trim (default on)", () => {
     test("drops view-id when it equals resource-id", () => {
       const { observe } = loadAndroidHomeObserve();

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -149,7 +149,7 @@ describe("sanitizeObserveResult", () => {
     });
   });
 
-  describe("top-level debug-perf telemetry strip (always)", () => {
+  describe("top-level debug-perf telemetry reduction (always)", () => {
     test("drops perfTiming from the output copy while leaving the input untouched", () => {
       const { observe } = loadAndroidHomeObserve();
       expect(observe.perfTiming).toBeDefined();
@@ -170,48 +170,81 @@ describe("sanitizeObserveResult", () => {
       expect(measureValue(out).tokens).toBeLessThan(measureValue(withPerfTiming).tokens);
     });
 
-    test("drops redundant gfxMetrics without mutating performanceAudit metrics", () => {
+    test("preserves action UI-stability gfxMetrics when no performanceAudit exists", () => {
       const { observe } = loadAndroidHomeObserve();
+      delete observe.performanceAudit;
       observe.gfxMetrics = {
-        p50Ms: 12,
-        p90Ms: 18,
-        p95Ms: 22,
-        p99Ms: 30,
-        jankCount: 2,
+        packageName: "com.example.app",
+        percentile50thMs: 12,
+        percentile90thMs: 18,
+        percentile95thMs: 22,
+        percentile99thMs: 30,
         missedVsyncCount: 1,
         slowUiThreadCount: 1,
         frameDeadlineMissedCount: 0,
-        gfxinfoRaw: "raw gfxinfo dump that overlaps performanceAudit.metrics",
-      } as any;
+        pollCount: 7,
+        stabilityWaitMs: 350,
+        isStable: true,
+      };
+      const gfxMetricsBefore = JSON.stringify(observe.gfxMetrics);
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.gfxMetrics).toEqual(observe.gfxMetrics);
+      expect(JSON.stringify(observe.gfxMetrics)).toBe(gfxMetricsBefore);
+    });
+
+    test("trims redundant gfxMetrics frame fields when performanceAudit metrics are present", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.gfxMetrics = {
+        packageName: "com.example.app",
+        percentile50thMs: 12,
+        percentile90thMs: 18,
+        percentile95thMs: 22,
+        percentile99thMs: 30,
+        missedVsyncCount: 1,
+        slowUiThreadCount: 1,
+        frameDeadlineMissedCount: 0,
+        pollCount: 7,
+        stabilityWaitMs: 350,
+        isStable: true,
+      };
       const auditMetricsBefore = JSON.stringify(observe.performanceAudit?.metrics);
       const gfxMetricsBefore = JSON.stringify(observe.gfxMetrics);
 
       const out = sanitizeObserveResult(observe, DROP_NONE);
 
-      expect(out.gfxMetrics).toBeUndefined();
+      expect(out.gfxMetrics).toEqual({
+        packageName: "com.example.app",
+        pollCount: 7,
+        stabilityWaitMs: 350,
+        isStable: true,
+      });
       expect(JSON.stringify(observe.gfxMetrics)).toBe(gfxMetricsBefore);
       expect(JSON.stringify(observe.performanceAudit?.metrics)).toBe(auditMetricsBefore);
     });
 
-    test("measurably shrinks bytes and tokens by dropping synthetic gfxMetrics", () => {
+    test("measurably shrinks bytes and tokens by trimming redundant gfxMetrics frame fields", () => {
       const { observe } = loadAndroidHomeObserve();
       observe.gfxMetrics = {
-        p50Ms: 12,
-        p90Ms: 18,
-        p95Ms: 22,
-        p99Ms: 30,
-        jankCount: 2,
+        packageName: "com.example.app",
+        percentile50thMs: 12,
+        percentile90thMs: 18,
+        percentile95thMs: 22,
+        percentile99thMs: 30,
         missedVsyncCount: 1,
         slowUiThreadCount: 1,
         frameDeadlineMissedCount: 0,
-        gfxinfoRaw: "Frame timing raw dump\n".repeat(100),
-      } as any;
+        pollCount: 7,
+        stabilityWaitMs: 350,
+        isStable: true,
+      };
 
       const out = sanitizeObserveResult(observe, DROP_NONE);
-      const withGfxMetrics = { ...out, gfxMetrics: observe.gfxMetrics };
+      const withFullGfxMetrics = { ...out, gfxMetrics: observe.gfxMetrics };
 
-      expect(measureValue(out).bytes).toBeLessThan(measureValue(withGfxMetrics).bytes);
-      expect(measureValue(out).tokens).toBeLessThan(measureValue(withGfxMetrics).tokens);
+      expect(measureValue(out).bytes).toBeLessThan(measureValue(withFullGfxMetrics).bytes);
+      expect(measureValue(out).tokens).toBeLessThan(measureValue(withFullGfxMetrics).tokens);
     });
 
     test("preserves the perfTimingTruncated signal", () => {

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -224,6 +224,34 @@ describe("sanitizeObserveResult", () => {
       expect(JSON.stringify(observe.performanceAudit?.metrics)).toBe(auditMetricsBefore);
     });
 
+    test("preserves gfxMetrics frame fields when audit replacements are null", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.performanceAudit!.metrics.p50Ms = null;
+      observe.performanceAudit!.metrics.p90Ms = null;
+      observe.performanceAudit!.metrics.p95Ms = null;
+      observe.performanceAudit!.metrics.p99Ms = null;
+      observe.performanceAudit!.metrics.missedVsyncCount = null;
+      observe.performanceAudit!.metrics.slowUiThreadCount = null;
+      observe.performanceAudit!.metrics.frameDeadlineMissedCount = null;
+      observe.gfxMetrics = {
+        packageName: "com.example.app",
+        percentile50thMs: 12,
+        percentile90thMs: 18,
+        percentile95thMs: 22,
+        percentile99thMs: 30,
+        missedVsyncCount: 1,
+        slowUiThreadCount: 1,
+        frameDeadlineMissedCount: 0,
+        pollCount: 7,
+        stabilityWaitMs: 350,
+        isStable: true,
+      };
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.gfxMetrics).toEqual(observe.gfxMetrics);
+    });
+
     test("measurably shrinks bytes and tokens by trimming redundant gfxMetrics frame fields", () => {
       const { observe } = loadAndroidHomeObserve();
       observe.gfxMetrics = {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -173,11 +173,38 @@ describe("finalizeToolResponse", () => {
     expect(finalizeToolResponse("plain", { name: "observe" })).toBe("plain");
   });
 
-  test("EC5: observe payload without a viewHierarchy is a safe no-op", () => {
-    const payload: any = { updatedAt: 1, screenSize: { width: 1, height: 1 }, systemInsets: {} };
+  test("observe payload without a viewHierarchy still strips perfTiming", () => {
+    const payload: any = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: {},
+      perfTiming: [{ name: "observe", durationMs: 12 }],
+      perfTimingTruncated: true,
+    };
     const response = createStructuredToolResponse(payload);
+
     const finalized = finalizeToolResponse(response, { name: "observe" });
-    expect(finalized.structuredContent).toEqual(payload);
+
+    expect((finalized.structuredContent as any).perfTiming).toBeUndefined();
+    expect((finalized.structuredContent as any).perfTimingTruncated).toBe(true);
+    expect(payload.perfTiming).toBeDefined();
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+  });
+
+  test("action observation without a viewHierarchy still strips perfTiming", () => {
+    const observation: any = {
+      updatedAt: 1,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: {},
+      perfTiming: [{ name: "tapOn", durationMs: 12 }],
+    };
+    const response = createStructuredToolResponse({ success: true, observation });
+
+    const finalized = finalizeToolResponse(response, { name: "tapOn" });
+
+    expect((finalized.structuredContent as any).observation.perfTiming).toBeUndefined();
+    expect(observation.perfTiming).toBeDefined();
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
   });
 
   test("strips the performance-audit raw dumps and truncates diagnostics at the GFXINFO marker", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -513,6 +513,43 @@ describe("finalizeToolResponse", () => {
       expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
     });
 
+    test("hierarchy-less action observations emit full sanitized payloads, not empty diffs", () => {
+      const { store, map } = makeStore();
+      const baseline = sameScreenObserve();
+      finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
+
+      const hierarchyLess = (durationMs: number): ObserveResult => ({
+        updatedAt: durationMs,
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        freshness: { isFresh: true },
+        errors: [{ phase: "viewHierarchy", message: "service unavailable" } as any],
+        perfTiming: [{ name: "observe", durationMs }],
+      });
+
+      const first = finalizeToolResponse(
+        createStructuredToolResponse({ success: false, observation: hierarchyLess(12) }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+      const second = finalizeToolResponse(
+        createStructuredToolResponse({ success: false, observation: hierarchyLess(13) }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const firstObs = (first.structuredContent as any).observation;
+      const secondObs = (second.structuredContent as any).observation;
+      expect(firstObs.isDiff).toBeUndefined();
+      expect(secondObs.isDiff).toBeUndefined();
+      expect(firstObs.errors[0].message).toBe("service unavailable");
+      expect(secondObs.errors[0].message).toBe("service unavailable");
+      expect(firstObs.perfTiming).toBeUndefined();
+      expect(secondObs.perfTiming).toBeUndefined();
+      expect(map.get("s1")).toBeDefined();
+      expect(map.get("s1")!.viewHierarchy).toBeDefined();
+      expect(first.content[0].text).toBe(stringifyToolResponse(first.structuredContent));
+      expect(second.content[0].text).toBe(stringifyToolResponse(second.structuredContent));
+    });
+
     test("a non-observe action updates the baseline to its own observation (next diff is against current state)", () => {
       const { store, map } = makeStore();
       finalizeToolResponse(createStructuredToolResponse(sameScreenObserve()), { name: "observe", sessionUuid: "s1", baselineStore: store });


### PR DESCRIPTION
## What is the problem being solved?

Closes #2878.

`sanitizeObserveResult` already strips heavy nested `performanceAudit` raw dumps for output-size reduction, but debug-perf captures still emitted top-level `perfTiming` and `gfxMetrics` on the MCP output copy. Those fields are capture telemetry rather than agent decision inputs, and `gfxMetrics` overlaps the retained computed `performanceAudit.metrics` summary.

## What concepts or ideas do we need to explore to solve it?

- Drop top-level `perfTiming` from the sanitized output copy after the existing deep-clone boundary.
- Preserve action UI-stability `gfxMetrics` when no `performanceAudit` exists.
- Trim only the redundant `gfxMetrics` frame timing fields when `performanceAudit.metrics` already carries non-null computed replacements.
- Preserve the in-memory `ObserveResult`, `performanceAudit` computed summaries, and the `perfTimingTruncated` signal.
- Extend the existing pure-function fixture tests to prove byte and token reductions with the production formatter.

## Validation

- `bun test test/features/observe/output/ObserveResultOutput.test.ts`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

Note: this repo does not currently have a dedicated `.github/PULL_REQUEST_TEMPLATE.md`; the body uses the available `.github/feature_request.md` structure plus implementation and validation details.
