### PR TITLE
fix(cache): remove dormant lastActionTime write

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -18,10 +18,10 @@ import type { ObserveResult } from "../models/ObserveResult";
  * `setLastHierarchy` / `setLastScreenshot` setters.
  *
  * `customData` still holds other keyed tool state accessed via well-known
- * constants (keep-awake `KeepScreenAwakeState`, the device-label map, the
- * ad-hoc `lastActionTime`). Those remain untyped and are candidates for the
- * same typed-slot treatment — the `Record<string, any>` shape is an escape
- * hatch that can reintroduce the #2917 decoy bug for any future key.
+ * constants (keep-awake `KeepScreenAwakeState`, the device-label map). Those
+ * remain untyped and are candidates for the same typed-slot treatment — the
+ * `Record<string, any>` shape is an escape hatch that can reintroduce the
+ * #2917 decoy bug for any future key.
  */
 export interface SessionCacheData {
   lastHierarchy?: ViewHierarchyResult; // Last observed view hierarchy (full, untrimmed)

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -15,7 +15,7 @@ import { IOSCtrlProxyClient } from "../features/observe/ios";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { logger } from "../utils/logger";
 import { DaemonState } from "../daemon/daemonState";
-import { createToolExecutionContext, updateSessionCache } from "./ToolExecutionContext";
+import { createToolExecutionContext } from "./ToolExecutionContext";
 import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
 import { ToolCallRepository } from "../db/toolCallRepository";
 import { getDeviceLabelMap, releaseDeviceLabelSessions } from "./deviceLabelMapping";
@@ -454,11 +454,6 @@ class ToolRegistryClass {
           // Update session cache if sessionUuid provided
           if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
             const sessionManager = DaemonState.getInstance().getSessionManager();
-            const devicePool = DaemonState.getInstance().getDevicePool();
-            const context = await createToolExecutionContext(sessionUuid, sessionManager, devicePool, {
-              keepScreenAwake,
-              platform: platform === "android" || platform === "ios" ? platform : undefined
-            });
 
             // Cache observation data for certain tools to reduce API calls.
             // Handlers pre-serialize into an MCP envelope, so the ObserveResult
@@ -476,15 +471,6 @@ class ToolRegistryClass {
             const observeScreenshot = name === "observe" ? getStructuredField<string>(response, "screenshot") : undefined;
             if (observeScreenshot) {
               sessionManager.setLastScreenshot(sessionUuid, observeScreenshot);
-            }
-
-            // Update last action timestamp for interaction tools. Unlike the
-            // observe hierarchy/screenshot above, `lastActionTime` is ad-hoc
-            // interaction bookkeeping with no typed slot or consumer, so it
-            // intentionally stays on the generic `customData` path (see #2917
-            // follow-up to type or remove it).
-            if (["tapOn", "swipeOn", "pinchOn", "dragAndDrop", "scroll", "inputText", "clearText", "pressButton"].includes(name)) {
-              await updateSessionCache(context, "lastActionTime", this.timer.now());
             }
           }
 

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -142,7 +142,7 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
   });
 
   test("sanitizes a tapOn action response's .observation end-to-end through the chokepoint", async () => {
-    await setupAutolockedSession();
+    const sessionId = await setupAutolockedSession();
 
     const observation = makeObserveResult();
     ToolRegistry.registerDeviceAware(
@@ -171,5 +171,8 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     const parsed = JSON.parse(response.content[0].text);
     expect(parsed.observation.viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
     expect(response.content[0].text).toBe(stringifyToolResponse(response.structuredContent));
+
+    const cacheData = daemonSessionManager!.getSession(sessionId)!.cacheData;
+    expect(cacheData.customData?.lastActionTime).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Remove the dormant untyped `lastActionTime` session-cache write from `toolRegistry`.
- Keep session-cache writes in this block on the typed observe-cache setters.
- Update the session-cache documentation so it no longer lists `lastActionTime` as supported custom data.

Fixes #2972

## Testing
- `bun test test/server/toolRegistry.lastHierarchyCache.test.ts`
- `bun test test/server/toolRegistry.lastHierarchyCache.test.ts test/daemon/sessionManager.test.ts`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Notes
- I searched for a repo PR template with `rg --files -g 'PULL_REQUEST_TEMPLATE*' -g '.github/**'` and found none, so this body uses the repo's existing Summary/Testing convention.
