### PR TITLE
fix(db): barrier-track NavigationGraphManager shutdown write via trackExisting (#2885)

### DIFF
--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -26,6 +26,46 @@ export interface DbWriteBarrier {
   track<T>(work: () => Promise<T>): Promise<T | undefined>;
 
   /**
+   * Count an ALREADY-STARTED best-effort write toward the shutdown drain without
+   * inserting an await hop into the caller's chain (issue #2885). The caller
+   * starts the promise itself and keeps awaiting the *original* promise object, so
+   * the write's start time and its resolution timing relative to anything the
+   * caller interleaves are byte-for-byte identical to a world with no barrier at
+   * all. This lets the fire-and-forget navigation-graph write be drained without
+   * touching the hot-path nav-event↔hierarchy-update ordering that "preserve SDK
+   * screen names" depends on.
+   *
+   * Why not {@link track} here? `await track(() => write())` would work today —
+   * the current post-#3063 ordering test tolerates the one extra microtask tick
+   * `track` adds — but the #2885 author flagged this specific interleaving as
+   * timing-sensitive, and a future regression from that tick would be SILENT (no
+   * test guards it). `trackExisting` takes on *zero* ordering risk instead of a
+   * small-but-untested one, which is the right trade for a best-effort drain
+   * feature. Prefer plain {@link track} everywhere the caller does not already own
+   * the started promise on an ordering-sensitive path — this method is the narrow
+   * exception, not the default.
+   *
+   * Contract / misuse warning: the returned promise NEVER rejects (it resolves the
+   * value on success and `undefined` on rejection) so a fire-and-forget
+   * `void barrier.trackExisting(p)` cannot surface an unhandled rejection. But it
+   * only swallows ITS OWN derived copy — the ORIGINAL `p`'s rejection is still the
+   * caller's to own. Always use the exact idiom
+   * `const p = write(); void barrier.trackExisting(p); await p;` (or otherwise
+   * `.catch` `p`); passing an un-awaited promise
+   * (`void barrier.trackExisting(write())`) leaks an unhandled rejection on the
+   * original. Unlike {@link track}, which owns promise creation, this method
+   * cannot enforce that for you.
+   *
+   * While draining it short-circuits: the write already started and cannot be
+   * skipped, so it is simply not counted (Part 1's dialect reject-on-closed makes
+   * that mid-flight close race safe, issue #2792) and `undefined` is returned.
+   * Consequence: `trackExisting` only meaningfully drains writes registered
+   * *before* {@link beginDrain}; a write registered mid-drain gets best-effort
+   * Part-1 coverage, not a drain guarantee.
+   */
+  trackExisting<T>(work: Promise<T>): Promise<T | undefined>;
+
+  /**
    * Flip the draining flag so subsequent {@link track} calls short-circuit.
    * The flag latches for the instance's lifetime; a fresh cold start comes from
    * a new barrier. `closeDatabase()` clears the *shared* barrier via
@@ -81,19 +121,54 @@ export class InMemoryDbWriteBarrier implements DbWriteBarrier {
       return undefined;
     }
 
+    this.#enter();
+    try {
+      return await work();
+    } finally {
+      this.#leave();
+    }
+  }
+
+  trackExisting<T>(work: Promise<T>): Promise<T | undefined> {
+    if (this.#draining) {
+      // The write already started and cannot be un-started; it is simply not
+      // counted toward the drain (Part 1's reject-on-closed covers the race,
+      // issue #2792). Resolve `undefined` and never reject — safe to `void`.
+      logger.debug("[DbWriteBarrier] Not tracking an in-flight DB write during shutdown drain");
+      return work.then(() => undefined, () => undefined);
+    }
+
+    this.#enter();
+    // Attach the settle handler to the ORIGINAL promise so the caller can keep
+    // awaiting `work` directly with unchanged timing. The derived promise
+    // swallows rejection to `undefined` so a fire-and-forget `void` of it never
+    // surfaces an unhandled rejection — the caller's own await owns `work`'s error.
+    return work.then(
+      value => {
+        this.#leave();
+        return value as T | undefined;
+      },
+      () => {
+        this.#leave();
+        return undefined;
+      }
+    );
+  }
+
+  /** Increment the in-flight count, arming the idle promise on the 0→1 edge. */
+  #enter(): void {
     if (this.#inFlight++ === 0) {
       this.#idle = new Promise<void>(resolve => {
         this.#resolveIdle = resolve;
       });
     }
+  }
 
-    try {
-      return await work();
-    } finally {
-      if (--this.#inFlight === 0) {
-        this.#resolveIdle?.();
-        this.#resolveIdle = undefined;
-      }
+  /** Decrement the in-flight count, resolving the idle promise on the 1→0 edge. */
+  #leave(): void {
+    if (--this.#inFlight === 0) {
+      this.#resolveIdle?.();
+      this.#resolveIdle = undefined;
     }
   }
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2361,13 +2361,16 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           }
 
           logger.info(`[CTRL_PROXY] Navigation event: ${event.destination} (app: ${event.applicationId})`);
-          // Not routed through the DB-write barrier on purpose: this write
-          // interleaves with hierarchy_update processing to preserve SDK screen
-          // names, and adding a drain await hop would perturb that ordering on
-          // the hot path. A shutdown race here is already made safe by the
-          // dialect's reject-on-closed handling (issue #2792), so the row is
-          // dropped cleanly rather than stranding.
-          await this.getNavigationGraphManager().recordNavigationEvent(event);
+          // Barrier-tracked via trackExisting so graceful shutdown drains this
+          // fire-and-forget write, WITHOUT wrapping it in track(): the caller keeps
+          // awaiting the original promise, so the nav-event↔hierarchy-update
+          // interleaving that "preserve SDK screen names" depends on is unchanged
+          // (issue #2885). If the write is still in flight when the drain window
+          // closes, Part 1's dialect reject-on-closed drops the row cleanly
+          // (issue #2792).
+          const navWrite = this.getNavigationGraphManager().recordNavigationEvent(event);
+          void getDbWriteBarrier().trackExisting(navWrite);
+          await navWrite;
 
           if (event.applicationId && event.destination && serverConfig.isNavigationScreenshotsEnabled()) {
             NavigationScreenshotManager.getInstance()

--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -18,6 +18,7 @@ import type { FailureRecorderService } from "../../failures/interfaces/FailureRe
 import { logger } from "../../../utils/logger";
 import { serverConfig } from "../../../utils/ServerConfig";
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
+import { getDbWriteBarrier } from "../../../db/dbWriteBarrier";
 import type { NavigationEvent } from "../../../utils/interfaces/NavigationGraph";
 import type { ViewHierarchyResult } from "../../../models";
 import type { SdkEvent, SdkEventIngestor } from "../interfaces/SdkEventIngestor";
@@ -150,11 +151,17 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
             const navMeta = (p.metadata as Record<string, string>) ?? null;
             let screenshotUri: string | null = null;
             if (applicationId && destination) {
-              await this.getNavigationGraphManager().recordNavigationEvent({
+              // Barrier-tracked via trackExisting so graceful shutdown drains this
+              // fire-and-forget write without a track() await hop perturbing the
+              // nav-event↔hierarchy-update ordering (issue #2885); a mid-flight
+              // shutdown race is dropped cleanly by Part 1 (issue #2792).
+              const navWrite = this.getNavigationGraphManager().recordNavigationEvent({
                 applicationId, destination, source: navSource,
                 arguments: navArgs ?? {}, metadata: navMeta ?? {},
                 triggeringInteraction: null,
               } as NavigationEvent);
+              void getDbWriteBarrier().trackExisting(navWrite);
+              await navWrite;
 
               if (this.navigationScreenshotsEnabled()) {
                 try {

--- a/test/db/dbWriteBarrier.test.ts
+++ b/test/db/dbWriteBarrier.test.ts
@@ -101,4 +101,86 @@ describe("InMemoryDbWriteBarrier", () => {
     await expect(p).rejects.toThrow("boom");
     expect(barrier.inFlightCount()).toBe(0);
   });
+
+  describe("trackExisting (issue #2885)", () => {
+    it("counts an already-started promise and clears on settle (E1)", async () => {
+      const d = deferred<number>();
+      const started = d.promise; // the write is already in flight
+      void barrier.trackExisting(started);
+      expect(barrier.inFlightCount()).toBe(1);
+      d.resolve(1);
+      await started;
+      // Let the barrier's settle handler run.
+      await Promise.resolve();
+      expect(barrier.inFlightCount()).toBe(0);
+    });
+
+    it("drain waits for a trackExisting promise then resolves true (E2)", async () => {
+      const d = deferred<void>();
+      void barrier.trackExisting(d.promise);
+      expect(barrier.inFlightCount()).toBe(1);
+
+      const drainPromise = barrier.drain(1000);
+      expect(timer.getPendingTimeoutCount()).toBe(1);
+
+      d.resolve();
+      await d.promise;
+
+      expect(await drainPromise).toBe(true);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    it("a wedged trackExisting promise times out at the bound (E2)", async () => {
+      const wedged = deferred<void>();
+      void barrier.trackExisting(wedged.promise);
+      expect(barrier.inFlightCount()).toBe(1);
+
+      const drainPromise = barrier.drain(1000);
+      timer.advanceTime(1000);
+      expect(await drainPromise).toBe(false);
+    });
+
+    it("decrements the counter when the underlying promise rejects (E3)", async () => {
+      const d = deferred<void>();
+      const started = d.promise;
+      const tracked = barrier.trackExisting(started);
+      expect(barrier.inFlightCount()).toBe(1);
+      d.reject(new Error("boom"));
+      // The derived promise never rejects (E4) — it swallows to undefined.
+      expect(await tracked).toBeUndefined();
+      // The original promise still carries the rejection for the caller.
+      await expect(started).rejects.toThrow("boom");
+      expect(barrier.inFlightCount()).toBe(0);
+    });
+
+    it("returned promise resolves undefined on reject — safe to void (E4)", async () => {
+      const d = deferred<void>();
+      const started = d.promise;
+      // Original owner handles the rejection (mirrors the WS handler's `await`).
+      const ownerHandled = started.catch(() => "handled");
+      // Fire-and-forget registration must not surface an unhandled rejection.
+      void barrier.trackExisting(started);
+      d.reject(new Error("boom"));
+      expect(await ownerHandled).toBe("handled");
+      // Give the microtask queue a beat; no unhandled rejection should escape.
+      await Promise.resolve();
+      expect(barrier.inFlightCount()).toBe(0);
+    });
+
+    it("passes the resolved value through when not draining", async () => {
+      const tracked = barrier.trackExisting(Promise.resolve(42));
+      expect(await tracked).toBe(42);
+    });
+
+    it("short-circuits without counting while draining (E5)", async () => {
+      barrier.beginDrain();
+      const d = deferred<void>();
+      const started = d.promise;
+      const tracked = barrier.trackExisting(started);
+      // Not counted — the write already started; Part-1 covers the close race.
+      expect(barrier.inFlightCount()).toBe(0);
+      d.resolve();
+      expect(await tracked).toBeUndefined();
+    });
+  });
 });

--- a/test/fakes/FakeDbWriteBarrier.ts
+++ b/test/fakes/FakeDbWriteBarrier.ts
@@ -5,8 +5,9 @@ import type { DbWriteBarrier } from "../../src/db/dbWriteBarrier";
  *
  * Records enough to assert both halves of the shutdown-drain contract without a
  * real timer or DB: `trackCalls`/`ranCount` count attempts vs. writes that
- * actually ran, and `ran` marks each executed write. While `draining`, tracked
- * work short-circuits (resolves `undefined`) exactly like
+ * actually ran, and `ran` marks each executed write. `trackExistingCalls`/
+ * `trackedExisting` mirror that for {@link trackExisting} (issue #2885). While
+ * `draining`, tracked work short-circuits (resolves `undefined`) exactly like
  * {@link InMemoryDbWriteBarrier}, but with no in-flight/idle bookkeeping.
  */
 export class FakeDbWriteBarrier implements DbWriteBarrier {
@@ -14,6 +15,8 @@ export class FakeDbWriteBarrier implements DbWriteBarrier {
   trackCalls = 0;
   ranCount = 0;
   ran: string[] = [];
+  trackExistingCalls = 0;
+  trackedExisting: string[] = [];
 
   isDraining(): boolean {
     return this.draining;
@@ -40,5 +43,15 @@ export class FakeDbWriteBarrier implements DbWriteBarrier {
     this.ranCount += 1;
     this.ran.push("ran");
     return work();
+  }
+
+  trackExisting<T>(work: Promise<T>): Promise<T | undefined> {
+    this.trackExistingCalls += 1;
+    if (this.draining) {
+      // Not counted while draining (issue #2885); never rejects, safe to `void`.
+      return work.then(() => undefined, () => undefined);
+    }
+    this.trackedExisting.push("tracked");
+    return work.then(value => value as T | undefined, () => undefined);
   }
 }

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { getDbWriteBarrier, resetDbWriteBarrier } from "../../../src/db/dbWriteBarrier";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
@@ -594,6 +595,78 @@ describe("AndroidCtrlProxyClient", function() {
       } finally {
         await testClient.close();
         await navHarness.dispose();
+      }
+    });
+
+    test("routes the navigation-graph write through the DB-write barrier for shutdown drain (#2885)", async function() {
+      NavigationGraphManager.resetInstance();
+      resetDbWriteBarrier();
+      // The Android handler resolves getDbWriteBarrier() per write (#2912), so a
+      // spy on the freshly-reset shared barrier observes the nav write's
+      // registration. trackExisting (not track) proves the write is drain-covered
+      // without a track() await hop that would perturb the ordering the preceding
+      // test guards.
+      const barrier = getDbWriteBarrier();
+      const trackExistingSpy = spyOn(barrier, "trackExisting");
+      const navHarness = await installInMemoryNavManager();
+      const navManager = navHarness.manager;
+
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        testTimer
+      );
+
+      try {
+        const resultPromise = testClient.getLatestHierarchy(true, 2000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "navigation_event",
+          event: {
+            destination: "SdkHome",
+            source: "SdkStart",
+            arguments: {},
+            metadata: {},
+            timestamp: testTimer.now(),
+            sequenceNumber: 1,
+            applicationId: "com.example.sdk",
+          }
+        }));
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: {
+            updatedAt: testTimer.now(),
+            packageName: "com.example.sdk",
+            hierarchy: {
+              "text": "SDK Home",
+              "resource-id": "com.example.sdk:id/home",
+            }
+          }
+        }));
+
+        await resultPromise;
+        for (let i = 0; i < 10; i++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+          await testTimer.advanceTimersByTimeAsync(1);
+        }
+
+        expect(trackExistingSpy).toHaveBeenCalledTimes(1);
+        // Ordering still preserved: the write committed the SDK screen name.
+        expect(navManager.getCurrentScreen()).toBe("SdkHome");
+      } finally {
+        trackExistingSpy.mockRestore();
+        await testClient.close();
+        await navHarness.dispose();
+        resetDbWriteBarrier();
       }
     });
   });


### PR DESCRIPTION
## Summary

Follow-up to #2792 that closes the last enumerated gap from the #2880 review: the fire-and-forget `NavigationGraphManager.recordNavigationEvent` write issued from the Android/iOS CtrlProxy WS handlers is now covered by the graceful-shutdown DB-write barrier — **without** changing the hot-path `navigation_event`↔`hierarchy_update` interleaving that the "preserve SDK screen names" logic depends on.

Closes #2885.

## The gap

`recordNavigationEvent` is dispatched fire-and-forget from `void this.handleMessage(...)` in both WS clients, so it is exactly the "queued behind the connection when close fires" class #2792 targets. It was left untracked in #2880 because wrapping it in the existing `track(() => work())` inserts an await hop that perturbs the ordering the SDK-screen-name preservation depends on.

## Approach — a `trackExisting(promise)` barrier primitive (issue option 1)

Added `DbWriteBarrier.trackExisting<T>(work: Promise<T>)`, which counts an **already-started** best-effort write toward the shutdown drain without inserting itself into the caller's awaited chain:

```ts
const navWrite = mgr.recordNavigationEvent(event);
void getDbWriteBarrier().trackExisting(navWrite); // drain-registration only
await navWrite;                                    // identical timing to the pre-change await
```

Because the caller keeps awaiting the **original** promise object, the write's start time and resolution timing relative to concurrently-processed WS messages are byte-for-byte identical to a world with no barrier — verified empirically. The `#enter`/`#leave` in-flight bookkeeping is factored out of `track()` and shared. The returned promise never rejects (resolves `undefined` on rejection) so the fire-and-forget `void` is unhandled-rejection-safe; the caller's own `await` owns the original promise's rejection. While draining, an already-started write is not counted (it cannot be un-started) and relies on #2792's dialect reject-on-closed for the mid-flight close race — the documented Part-1 coverage.

The interface doc is explicit that `trackExisting` is the narrow exception, not the default: prefer plain `track()` unless the caller already owns the started promise on an ordering-sensitive path, and it warns about the one misuse mode (passing an un-awaited promise).

## Changes

- `src/db/dbWriteBarrier.ts` — `trackExisting` on the interface + `InMemoryDbWriteBarrier`; shared `#enter`/`#leave` helpers.
- `src/features/observe/android/AndroidCtrlProxyClient.ts`, `src/features/observe/ios/IosSdkEventIngestor.ts` — route the nav-graph write through `trackExisting`; replace the "not routed on purpose" comment with the new rationale.
- `test/fakes/FakeDbWriteBarrier.ts` — parity implementation + counters.
- `test/db/dbWriteBarrier.test.ts` — 7 new `trackExisting` unit tests (counting, drain-waits, drain-timeout, decrement-on-reject, non-rejecting derived promise, value pass-through, draining short-circuit).
- `test/features/observe/CtrlProxyClient.test.ts` — E6 regression guard: an Android `navigation_event` routes through the barrier (spy asserts `trackExisting` called once) and still preserves the SDK screen name.

## Acceptance criteria

- [x] The navigation-graph shutdown write is barrier-tracked (drained on shutdown; skipped-but-Part-1-covered if registered mid-drain).
- [x] `CtrlProxyClient.test.ts` "preserve SDK screen names" passes unchanged (ordering preserved).
- [x] The `trackExisting` primitive has unit coverage in `test/db/dbWriteBarrier.test.ts`.

## Testing

- `bun test test/db/dbWriteBarrier.test.ts test/features/observe/CtrlProxyClient.test.ts` → 52 pass.
- `bun test test/db/ test/features/navigation/ test/fakes/` → 1035 pass.
- `bun test test/features/observe/ios/IosSdkEventIngestor.test.ts` → 17 pass.
- `turbo run lint build` clean; `tsc --noEmit` clean (only a pre-existing unrelated deprecation warning).

## Deferred (unchanged from #2885)

The two lower-priority follow-ups the issue named remain out of scope: a one-line comment noting the barrier covers only fire-and-forget writes on `SessionManager`'s awaited writes, and same-process daemon-restart reset of writer singletons. Tracked separately.

## Review

Reviewed via the AutoMobile code-review skill plus three adversarial subagent passes (async-correctness, issue-closure/test-quality, architectural-direction). The architectural pass flagged that the original "wrapping in `track()` reproducibly breaks the test" premise no longer reproduces on the post-#3063 test; the code comments and interface doc were corrected to the accurate rationale (zero ordering risk vs `track()`'s small-but-untested one-microtask perturbation on a flagged-sensitive path) and hardened with a misuse warning.
