### PR TITLE
fix(db): upgraded-DB parity for updated_at defaults (#2937)

### DIFF
--- a/src/db/migrations/2026_07_05_000_repair_updated_at_defaults.ts
+++ b/src/db/migrations/2026_07_05_000_repair_updated_at_defaults.ts
@@ -1,0 +1,242 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * #2937 — give eight tables' `updated_at` columns their `(datetime('now'))`
+ * default on already-upgraded databases.
+ *
+ * PR #2922 (issue #2913) reconciled the schema by adding
+ * `.defaultTo(sql`(datetime('now'))`)` to these eight tables' `updated_at`
+ * migration declarations, matching their `created_at` sibling. But editing a
+ * historical migration body does NOT re-run it — Kysely tracks executed
+ * migrations by name, with no content checksum — so the added default lands only
+ * on FRESH/replayed databases. A database that already ran the pre-#2922
+ * migrations keeps the old `updated_at TEXT NOT NULL` column with no default,
+ * and a defaulted insert (one that omits `updated_at`) fails its NOT NULL
+ * constraint there.
+ *
+ * This mirrors the `created_at` situation before #2915, minus the live bug:
+ * `created_at` had a broken string-literal default actively poisoning new rows,
+ * which the {@link file://./2026_07_03_000_repair_datetime_now_defaults.ts}
+ * rebuild repaired. `updated_at` has no such poison — every current writer
+ * supplies it explicitly — so this migration only needs to REBUILD each column's
+ * default; the existing rows already hold real, explicitly-written timestamps and
+ * are copied through untouched (no row repair).
+ *
+ * REBUILD MECHANICS — identical to the #2915 repair: SQLite cannot alter a column
+ * default in place, and bun:sqlite forbids editing `sqlite_master` directly, so
+ * each table is rebuilt via a twin: create a twin whose `updated_at` carries the
+ * corrected default, copy the rows with `INSERT ... SELECT *`, drop the original,
+ * rename the twin back, replay the table's explicit indexes/triggers, and restore
+ * its `sqlite_sequence` AUTOINCREMENT high-water mark (so a rebuilt table cannot
+ * reuse a deleted top id). FK enforcement is toggled OFF around the transaction so
+ * dropping a referenced parent (e.g. `navigation_apps`) cannot cascade-delete its
+ * children.
+ *
+ * TARGETING — the eight tables are enumerated in {@link TABLES_WITH_DEFAULTED_UPDATED_AT}
+ * (exactly the set #2922 edited), and each is rebuilt only when its live
+ * `updated_at` default is absent. Detection reads
+ * `pragma_table_info(...).dflt_value`: `NULL` means the no-default upgraded column
+ * (rebuild it); the corrected default reports as `datetime('now')` and is skipped.
+ * `device_sessions` / `failure_groups` are deliberately NOT listed — their
+ * `updated_at` default has existed on every database since #2915 repaired the
+ * broken literal they originally shipped, so they need no rebuild.
+ *
+ * Safe on a fresh DB and idempotent: a fresh/replayed or already-rebuilt schema
+ * carries the default, so nothing matches and the whole pass is a no-op that never
+ * touches FK state. A second run finds every column already defaulted.
+ */
+
+/**
+ * The eight tables whose `updated_at` default was added by PR #2922 (a migration
+ * edit that does not replay), so an upgraded DB's copy still lacks it. Ordered
+ * arbitrarily; each is independently rebuilt.
+ */
+const TABLES_WITH_DEFAULTED_UPDATED_AT = [
+  "device_configs",
+  "navigation_apps",
+  "prediction_transition_stats",
+  "accessibility_baselines",
+  "feature_flags",
+  "video_recording_configs",
+  "device_snapshot_configs",
+  "appearance_configs",
+] as const;
+
+/** The corrected default expression `updated_at` should carry, as raw SQL. */
+const CORRECTED_DEFAULT = "(datetime('now'))";
+
+interface ColumnInfoRow {
+  name: string;
+  dflt_value: string | null;
+}
+
+interface SqlRow {
+  sql: string | null;
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Fast path: only the tables whose `updated_at` column exists AND has no
+  // default need a rebuild. On a fresh/already-fixed schema this is empty, so we
+  // return WITHOUT touching PRAGMA foreign_keys — leaving the connection's FK
+  // state exactly as the caller set it, as the common case (every existing DB and
+  // test) requires. Only the rare upgraded-DB path below toggles it.
+  const tablesToRebuild: string[] = [];
+  for (const table of TABLES_WITH_DEFAULTED_UPDATED_AT) {
+    if (await updatedAtLacksDefault(db, table)) {
+      tablesToRebuild.push(table);
+    }
+  }
+  if (tablesToRebuild.length === 0) {
+    return;
+  }
+
+  // Rebuilding a table that OTHER tables reference by foreign key requires FK
+  // enforcement OFF: `DROP TABLE` performs an implicit DELETE that would otherwise
+  // fire `ON DELETE CASCADE` and wipe the child rows (deferral only delays the
+  // constraint *check*, not the cascade *action*). `PRAGMA foreign_keys` is a
+  // no-op inside a transaction, so it is toggled on the connection around the
+  // transaction — safe because the migrator does not wrap SQLite migrations in a
+  // transaction and the run is serialized by the migration lock. Restored to ON
+  // afterwards, the state `configureSqliteDatabase` and the rest of the chain
+  // expect on the production connection.
+  await sql`PRAGMA foreign_keys = OFF`.execute(db);
+  try {
+    // One transaction so a mid-rebuild failure cannot leave a half-swapped schema.
+    await db.transaction().execute(async trx => {
+      for (const table of tablesToRebuild) {
+        await rebuildTableWithUpdatedAtDefault(trx, table);
+      }
+    });
+  } finally {
+    await sql`PRAGMA foreign_keys = ON`.execute(db);
+  }
+}
+
+/**
+ * True when `table` exists and its `updated_at` column is present with NO stored
+ * default (the pre-#2922 upgraded-DB shape). A corrected `(datetime('now'))`
+ * default reports its `dflt_value` as `datetime('now')` (non-null) and is skipped;
+ * a missing table or column yields no matching row and is also skipped.
+ *
+ * The table name is inlined as a literal (`sql.lit`) rather than a bound
+ * parameter: a parameterized `pragma_table_info(?)` read was observed to
+ * intermittently return a null `dflt_value` under parallel-file load (a bun:sqlite
+ * quirk, see #2922's test), which here — where null is the very signal that
+ * triggers a rebuild — would spuriously rebuild a fresh table.
+ */
+async function updatedAtLacksDefault(db: Kysely<unknown>, table: string): Promise<boolean> {
+  const columns = await sql<ColumnInfoRow>`
+    SELECT name, dflt_value FROM pragma_table_info(${sql.lit(table)})
+  `.execute(db);
+  const updatedAt = columns.rows.find(column => column.name === "updated_at");
+  return updatedAt !== undefined && updatedAt.dflt_value === null;
+}
+
+/**
+ * Rebuild `table` so its `updated_at` column gains the `(datetime('now'))`
+ * default, preserving data, indexes, and triggers. Only the `updated_at` column's
+ * `DEFAULT` clause changes; the column set and order are untouched, so
+ * `INSERT ... SELECT *` lines the rows up 1:1.
+ */
+async function rebuildTableWithUpdatedAtDefault(
+  trx: Kysely<unknown>,
+  table: string
+): Promise<void> {
+  const createRow = await sql<SqlRow>`
+    SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ${table}
+  `.execute(trx);
+  const createSql = createRow.rows[0]?.sql;
+  if (!createSql) {
+    return;
+  }
+
+  const tempTable = `__rebuild_${table}`;
+  const correctedSql = addUpdatedAtDefault(replaceFirstTableName(createSql, table, tempTable));
+
+  // Capture the table's own indexes and triggers before the drop — auto-indexes
+  // backing PRIMARY KEY / UNIQUE constraints have a NULL `sql` and are recreated
+  // by the CREATE TABLE itself, so only the explicit ones need replaying.
+  const auxiliary = await sql<SqlRow>`
+    SELECT sql FROM sqlite_master
+    WHERE tbl_name = ${table} AND type IN ('index', 'trigger') AND sql IS NOT NULL
+  `.execute(trx);
+
+  // Capture the AUTOINCREMENT high-water mark. `sqlite_sequence` records the
+  // highest rowid EVER used so AUTOINCREMENT never reuses a deleted id; the
+  // copy/drop/rename below would otherwise reset it to `max(current id)` and let a
+  // deleted top id be handed out again. Restored after the rename.
+  const originalSequence = await captureSequence(trx, table);
+
+  await sql.raw(correctedSql).execute(trx);
+  await sql`INSERT INTO ${sql.ref(tempTable)} SELECT * FROM ${sql.ref(table)}`.execute(trx);
+  await sql`DROP TABLE ${sql.ref(table)}`.execute(trx);
+  await sql`ALTER TABLE ${sql.ref(tempTable)} RENAME TO ${sql.ref(table)}`.execute(trx);
+  for (const { sql: auxSql } of auxiliary.rows) {
+    if (auxSql) {
+      await sql.raw(auxSql).execute(trx);
+    }
+  }
+
+  if (originalSequence !== undefined) {
+    await sql`DELETE FROM sqlite_sequence WHERE name = ${table}`.execute(trx);
+    await sql`INSERT INTO sqlite_sequence (name, seq) VALUES (${table}, ${originalSequence})`.execute(
+      trx
+    );
+  }
+}
+
+/**
+ * Read a table's `sqlite_sequence` high-water mark, or `undefined` when the table
+ * is not AUTOINCREMENT / has never been inserted into (no sequence row) or the
+ * `sqlite_sequence` table does not exist (no AUTOINCREMENT table in the DB).
+ */
+async function captureSequence(
+  trx: Kysely<unknown>,
+  table: string
+): Promise<number | undefined> {
+  const hasSequenceTable = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_sequence'
+  `.execute(trx);
+  if (hasSequenceTable.rows.length === 0) {
+    return undefined;
+  }
+  const seqRow = await sql<{ seq: number }>`
+    SELECT seq FROM sqlite_sequence WHERE name = ${table}
+  `.execute(trx);
+  return seqRow.rows[0]?.seq;
+}
+
+/**
+ * Inject `default (datetime('now'))` into the `updated_at` column definition of a
+ * `CREATE TABLE` statement, right after its type keyword. Matches only when the
+ * column has no existing default (the type is immediately followed by `not null`),
+ * so it is a no-op on a schema that already carries the default and never
+ * double-adds. Only the first (and only) `"updated_at"` column definition is
+ * rewritten.
+ */
+function addUpdatedAtDefault(createSql: string): string {
+  return createSql.replace(
+    /("updated_at"\s+\w+)(\s+not\s+null)/i,
+    `$1 default ${CORRECTED_DEFAULT}$2`
+  );
+}
+
+/**
+ * Replace the table name in a `CREATE TABLE` statement, tolerating the double-
+ * quoted (Kysely) and bare forms and arbitrary whitespace after the keyword.
+ * Only the first occurrence — the table being declared — is rewritten; a later
+ * self-reference (e.g. a table-level FK) keeps pointing at the real name so the
+ * copy still works.
+ */
+function replaceFirstTableName(createSql: string, from: string, to: string): string {
+  return createSql.replace(
+    /^(\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?)(?:"([^"]+)"|(\w+))/i,
+    (match, prefix: string, quotedName: string | undefined, bareName: string | undefined) =>
+      (quotedName ?? bareName) === from ? `${prefix}"${to}"` : match
+  );
+}
+
+export async function down(): Promise<void> {
+  // Irreversible repair: the corrected default carries no information worth
+  // reverting, so the down migration is intentionally a no-op.
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -13,7 +13,7 @@ export interface DeviceConfigTable {
   active_mode: string | null;
   config_json: string; // JSON blob for flexible config storage
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Installed apps cache table
@@ -78,7 +78,7 @@ export interface PerformanceAuditResultsTable {
 export interface NavigationAppsTable {
   app_id: string;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 export interface NavigationNodesTable {
@@ -212,7 +212,7 @@ export interface PredictionTransitionStatsTable {
   successes: number;
   total_confidence: number;
   brier_score_sum: number;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
@@ -283,7 +283,7 @@ interface AccessibilityBaselinesTable {
   screen_id: string;
   violations_json: string; // JSON blob of WcagViolation[]
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Memory audit tables
@@ -468,7 +468,7 @@ export interface DeviceSessionsTable {
   heartbeat_timeout_ms: number;
   has_received_heartbeat: number;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Feature flags table
@@ -477,7 +477,7 @@ export interface FeatureFlagsTable {
   enabled: number; // SQLite boolean (0/1)
   config_json: string | null;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 // Device snapshot tables
@@ -498,7 +498,7 @@ export interface DeviceSnapshotsTable {
 export interface DeviceSnapshotConfigsTable {
   key: string;
   config_json: string;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
@@ -526,14 +526,14 @@ export interface VideoRecordingsTable {
 export interface VideoRecordingConfigsTable {
   key: string;
   config_json: string;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
 export interface AppearanceConfigsTable {
   key: string;
   config_json: string;
-  updated_at: string;
+  updated_at: Generated<string>;
   created_at: Generated<string>;
 }
 
@@ -775,7 +775,7 @@ interface FailureGroupsTable {
   stack_trace_json: string | null;
   tool_call_info_json: string | null;
   created_at: Generated<string>;
-  updated_at: string;
+  updated_at: Generated<string>;
 }
 
 interface FailureOccurrencesTable {

--- a/src/features/accessibility/BaselineManager.ts
+++ b/src/features/accessibility/BaselineManager.ts
@@ -2,7 +2,9 @@
  * Manages accessibility violation baselines for suppressing known violations
  */
 
+import { sql, type Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
+import type { Database } from "../../db/types";
 import type { WcagViolation } from "../../models/AccessibilityAudit";
 import { getCutoffDate, DEFAULT_TTL } from "../shared/MetricsUtils";
 
@@ -13,11 +15,28 @@ interface BaselineData {
 }
 
 export class BaselineManager {
+  private readonly injectedDb: Kysely<Database> | null;
+
+  /**
+   * @param db Optional Kysely handle. Resolved LAZILY (per use, via {@link db})
+   * rather than in a field initializer so merely constructing a manager does not
+   * open the real file-backed database. Inject an in-memory DB
+   * (`createTestDatabase`) for tests that exercise the query paths (issue #3067).
+   */
+  constructor(db?: Kysely<Database>) {
+    this.injectedDb = db ?? null;
+  }
+
+  /** The injected DB, or the shared singleton resolved on first use. */
+  private get db(): Kysely<Database> {
+    return this.injectedDb ?? getDatabase();
+  }
+
   /**
    * Get baseline for a screen
    */
   async getBaseline(screenId: string): Promise<BaselineData | null> {
-    const db = getDatabase();
+    const db = this.db;
 
     const result = await db
       .selectFrom("accessibility_baselines")
@@ -40,7 +59,7 @@ export class BaselineManager {
    * Save baseline for a screen
    */
   async saveBaseline(screenId: string, violations: WcagViolation[]): Promise<void> {
-    const db = getDatabase();
+    const db = this.db;
     const now = new Date().toISOString();
 
     // Upsert baseline
@@ -77,7 +96,7 @@ export class BaselineManager {
    * Clear baseline for a screen
    */
   async clearBaseline(screenId: string): Promise<void> {
-    const db = getDatabase();
+    const db = this.db;
 
     await db
       .deleteFrom("accessibility_baselines")
@@ -89,7 +108,7 @@ export class BaselineManager {
    * List all baselines
    */
   async listBaselines(): Promise<BaselineData[]> {
-    const db = getDatabase();
+    const db = this.db;
 
     const results = await db
       .selectFrom("accessibility_baselines")
@@ -107,7 +126,7 @@ export class BaselineManager {
    * Clear all baselines
    */
   async clearAllBaselines(): Promise<void> {
-    const db = getDatabase();
+    const db = this.db;
 
     await db.deleteFrom("accessibility_baselines").execute();
   }
@@ -116,12 +135,21 @@ export class BaselineManager {
    * Clean up old baselines (older than specified days)
    */
   async cleanupOldBaselines(daysOld: number = DEFAULT_TTL.baselineDays): Promise<number> {
-    const db = getDatabase();
+    const db = this.db;
     const cutoffIso = getCutoffDate(daysOld);
 
+    // Normalize BOTH sides through `datetime(...)` before comparing, exactly as
+    // ThresholdManager.cleanupExpiredThresholds does. A raw
+    // string `<` would compare `updated_at` and the ISO cutoff lexically, which
+    // is only sound while every stored value is ISO-8601. Once a defaulted
+    // `updated_at` writer lands (issue #2937), the column can hold SQLite's
+    // `YYYY-MM-DD HH:MM:SS` form (no `T`), and a bare-space sorts before `T` — so
+    // a same-day-but-newer row would sort before the ISO cutoff and be wrongly
+    // deleted. `datetime(...)` renders both forms to one canonical format,
+    // comparing them as actual instants.
     const result = await db
       .deleteFrom("accessibility_baselines")
-      .where("updated_at", "<", cutoffIso)
+      .where(sql`datetime(updated_at)`, "<", sql`datetime(${cutoffIso})`)
       .executeTakeFirst();
 
     return Number(result.numDeletedRows) || 0;

--- a/test/db/repairUpdatedAtDefaultsMigration.test.ts
+++ b/test/db/repairUpdatedAtDefaultsMigration.test.ts
@@ -1,0 +1,412 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "./testDbHelper";
+import {
+  up as repairUp,
+  down as repairDown,
+} from "../../src/db/migrations/2026_07_05_000_repair_updated_at_defaults";
+
+/**
+ * Coverage for the #2937 repair migration. PR #2922 added
+ * `.defaultTo(sql`(datetime('now'))`)` to eight tables' `updated_at` columns, but
+ * editing a historical migration body does NOT re-run it (Kysely tracks
+ * migrations by name), so an already-upgraded database keeps the old
+ * `updated_at TEXT NOT NULL` column with NO default. This migration rebuilds
+ * those columns on upgraded DBs so a future defaulted insert stores a real
+ * timestamp instead of failing the NOT NULL constraint — without touching the
+ * columns' existing (explicitly-written) row values, other tables, indexes,
+ * foreign keys, or AUTOINCREMENT high-water marks.
+ */
+describe("2026_07_05_000_repair_updated_at_defaults migration (#2937)", () => {
+  describe("on an upgraded database with the no-default updated_at columns", () => {
+    let bunDb: BunDatabase;
+    let db: Kysely<unknown>;
+
+    beforeEach(() => {
+      bunDb = new BunDatabase(":memory:");
+      db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    });
+
+    afterEach(async () => {
+      await db.destroy();
+    });
+
+    test("rebuilds the default so a future defaulted insert stores a real timestamp (P1)", async () => {
+      // Reproduce exactly what the pre-#2922 migration left on disk: created_at
+      // carries the corrected default (repaired by #2915 on any upgraded DB), but
+      // updated_at is NOT NULL with no default at all.
+      bunDb.exec(
+        `CREATE TABLE "feature_flags" (` +
+          `"key" text primary key, ` +
+          `"enabled" integer not null default 0, ` +
+          `"created_at" text default (datetime('now')) not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.query(`INSERT INTO feature_flags (key, updated_at) VALUES ('old', '2026-01-01T00:00:00.000Z')`).run();
+
+      // Precondition: omitting updated_at fails the NOT NULL constraint today.
+      expect(() =>
+        bunDb.query(`INSERT INTO feature_flags (key) VALUES ('pre')`).run()
+      ).toThrow();
+
+      await repairUp(db);
+
+      // The pre-existing row keeps its explicit value verbatim.
+      const oldRow = bunDb
+        .query(`SELECT updated_at FROM feature_flags WHERE key='old'`)
+        .get() as { updated_at: string };
+      expect(oldRow.updated_at).toBe("2026-01-01T00:00:00.000Z");
+
+      // A NEW row that omits updated_at now evaluates the corrected default
+      // rather than failing NOT NULL — this is the P1 fix.
+      bunDb.query(`INSERT INTO feature_flags (key) VALUES ('new')`).run();
+      const newRow = bunDb
+        .query(`SELECT updated_at FROM feature_flags WHERE key='new'`)
+        .get() as { updated_at: string };
+      expect(newRow.updated_at).not.toBe("datetime('now')");
+      expect(newRow.updated_at).toBeTruthy();
+      expect(Number.isNaN(Date.parse(newRow.updated_at))).toBe(false);
+
+      // The stored default is the raw evaluated expression, symmetric with created_at.
+      const columns = bunDb
+        .query(`SELECT name, dflt_value FROM pragma_table_info('feature_flags')`)
+        .all() as { name: string; dflt_value: string | null }[];
+      const updatedAt = columns.find(c => c.name === "updated_at");
+      const createdAt = columns.find(c => c.name === "created_at");
+      expect(updatedAt?.dflt_value).toBe("datetime('now')");
+      expect(updatedAt?.dflt_value).toBe(createdAt?.dflt_value);
+    });
+
+    test("rebuilds every enumerated table's updated_at default", async () => {
+      // A minimal reproduction of each of the eight target tables carrying the
+      // no-default updated_at column. After the migration each must accept a
+      // defaulted insert (updated_at omitted) and store a real timestamp.
+      const reproductions: { table: string; create: string; insert: string }[] = [
+        {
+          table: "device_configs",
+          create:
+            `CREATE TABLE "device_configs" ("id" integer primary key autoincrement, ` +
+            `"device_id" text not null, "created_at" text default (datetime('now')) not null, ` +
+            `"updated_at" text not null)`,
+          insert: `INSERT INTO device_configs (device_id) VALUES ('d1')`,
+        },
+        {
+          table: "navigation_apps",
+          create:
+            `CREATE TABLE "navigation_apps" ("app_id" text primary key, ` +
+            `"created_at" text default (datetime('now')) not null, "updated_at" text not null)`,
+          insert: `INSERT INTO navigation_apps (app_id) VALUES ('a1')`,
+        },
+        {
+          table: "prediction_transition_stats",
+          create:
+            `CREATE TABLE "prediction_transition_stats" ("id" integer primary key autoincrement, ` +
+            `"app_id" text not null, "created_at" text default (datetime('now')) not null, ` +
+            `"updated_at" text not null)`,
+          insert: `INSERT INTO prediction_transition_stats (app_id) VALUES ('a1')`,
+        },
+        {
+          table: "accessibility_baselines",
+          create:
+            `CREATE TABLE "accessibility_baselines" ("id" integer primary key autoincrement, ` +
+            `"screen_id" text not null, "violations_json" text not null, ` +
+            `"created_at" text default (datetime('now')) not null, "updated_at" text not null)`,
+          insert: `INSERT INTO accessibility_baselines (screen_id, violations_json) VALUES ('s1', '[]')`,
+        },
+        {
+          table: "feature_flags",
+          create:
+            `CREATE TABLE "feature_flags" ("key" text primary key, ` +
+            `"created_at" text default (datetime('now')) not null, "updated_at" text not null)`,
+          insert: `INSERT INTO feature_flags (key) VALUES ('f1')`,
+        },
+        {
+          table: "video_recording_configs",
+          create:
+            `CREATE TABLE "video_recording_configs" ("key" text primary key, ` +
+            `"config_json" text not null, "created_at" text default (datetime('now')) not null, ` +
+            `"updated_at" text not null)`,
+          insert: `INSERT INTO video_recording_configs (key, config_json) VALUES ('v1', '{}')`,
+        },
+        {
+          table: "device_snapshot_configs",
+          create:
+            `CREATE TABLE "device_snapshot_configs" ("key" text primary key, ` +
+            `"config_json" text not null, "created_at" text default (datetime('now')) not null, ` +
+            `"updated_at" text not null)`,
+          insert: `INSERT INTO device_snapshot_configs (key, config_json) VALUES ('s1', '{}')`,
+        },
+        {
+          table: "appearance_configs",
+          create:
+            `CREATE TABLE "appearance_configs" ("key" text primary key, ` +
+            `"config_json" text not null, "created_at" text default (datetime('now')) not null, ` +
+            `"updated_at" text not null)`,
+          insert: `INSERT INTO appearance_configs (key, config_json) VALUES ('a1', '{}')`,
+        },
+      ];
+
+      for (const { create } of reproductions) {
+        bunDb.exec(create);
+      }
+
+      await repairUp(db);
+
+      for (const { table, insert } of reproductions) {
+        bunDb.query(insert).run();
+        const row = bunDb
+          .query(`SELECT updated_at FROM ${table} ORDER BY rowid DESC LIMIT 1`)
+          .get() as { updated_at: string };
+        expect(Number.isNaN(Date.parse(row.updated_at))).toBe(false);
+      }
+    });
+
+    test("does NOT touch a table that is not in the enumerated set", async () => {
+      // A non-target table with an updated_at column that legitimately has no
+      // default must be left exactly as-is.
+      bunDb.exec(
+        `CREATE TABLE "memory_baselines" (` +
+          `"id" integer primary key, "updated_at" text not null)`
+      );
+
+      await repairUp(db);
+
+      const columns = bunDb
+        .query(`SELECT name, dflt_value FROM pragma_table_info('memory_baselines')`)
+        .all() as { name: string; dflt_value: string | null }[];
+      const updatedAt = columns.find(c => c.name === "updated_at");
+      // Still no default — the migration only rebuilds the enumerated tables.
+      expect(updatedAt?.dflt_value).toBeNull();
+    });
+
+    test("preserves child rows and foreign keys across the rebuild", async () => {
+      bunDb.exec(`PRAGMA foreign_keys = ON`);
+      bunDb.exec(
+        `CREATE TABLE "navigation_apps" (` +
+          `"app_id" text primary key, ` +
+          `"created_at" text default (datetime('now')) not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.exec(
+        `CREATE TABLE "navigation_nodes" (` +
+          `"id" integer primary key, ` +
+          `"app_id" text not null references "navigation_apps" ("app_id") on delete cascade)`
+      );
+      bunDb.query(`INSERT INTO navigation_apps (app_id, updated_at) VALUES ('a', 'u')`).run();
+      bunDb.query(`INSERT INTO navigation_nodes (id, app_id) VALUES (1, 'a')`).run();
+
+      await repairUp(db);
+
+      // Child row preserved (the parent rebuild must not cascade-delete it).
+      const child = bunDb.query(`SELECT app_id FROM navigation_nodes WHERE id=1`).get() as {
+        app_id: string;
+      };
+      expect(child.app_id).toBe("a");
+      // FK still enforced after the rebuild: an orphan child insert must fail.
+      expect(() =>
+        bunDb.query(`INSERT INTO navigation_nodes (id, app_id) VALUES (2, 'missing')`).run()
+      ).toThrow();
+    });
+
+    test("rebuilds a real FK parent AND child that are BOTH in the enumerated set, integrity-checked", async () => {
+      // `prediction_transition_stats` references `navigation_apps` ON DELETE
+      // CASCADE, and BOTH are in the rebuild set — so the migration drops/rebuilds
+      // an FK parent and an FK child within one FK-off transaction. Verify no
+      // cascade wipes the child, both defaults land, FK enforcement is restored,
+      // and `foreign_key_check` reports no violations.
+      bunDb.exec(`PRAGMA foreign_keys = ON`);
+      bunDb.exec(
+        `CREATE TABLE "navigation_apps" (` +
+          `"app_id" text primary key, ` +
+          `"created_at" text default (datetime('now')) not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.exec(
+        `CREATE TABLE "prediction_transition_stats" (` +
+          `"id" integer primary key autoincrement, ` +
+          `"app_id" text not null references "navigation_apps" ("app_id") on delete cascade, ` +
+          `"created_at" text default (datetime('now')) not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.query(`INSERT INTO navigation_apps (app_id, updated_at) VALUES ('a', 'u')`).run();
+      bunDb
+        .query(`INSERT INTO prediction_transition_stats (app_id, updated_at) VALUES ('a', 'u')`)
+        .run();
+
+      await repairUp(db);
+
+      // Child survived the parent rebuild (no cascade).
+      const child = bunDb
+        .query(`SELECT app_id FROM prediction_transition_stats WHERE app_id='a'`)
+        .get() as { app_id: string };
+      expect(child.app_id).toBe("a");
+
+      // Both tables' updated_at defaults are now present.
+      for (const table of ["navigation_apps", "prediction_transition_stats"]) {
+        const col = bunDb
+          .query(`SELECT dflt_value FROM pragma_table_info('${table}') WHERE name='updated_at'`)
+          .get() as { dflt_value: string | null };
+        expect(col.dflt_value).toBe("datetime('now')");
+      }
+
+      // No dangling FK references after the rebuild.
+      const violations = bunDb.query(`PRAGMA foreign_key_check`).all();
+      expect(violations).toHaveLength(0);
+
+      // FK enforcement is restored: an orphan child insert must fail.
+      expect(() =>
+        bunDb
+          .query(`INSERT INTO prediction_transition_stats (app_id, updated_at) VALUES ('missing', 'u')`)
+          .run()
+      ).toThrow();
+    });
+
+    test("preserves the AUTOINCREMENT high-water mark so deleted ids are not reused", async () => {
+      bunDb.exec(
+        `CREATE TABLE "device_configs" (` +
+          `"id" integer primary key autoincrement, ` +
+          `"device_id" text not null, ` +
+          `"created_at" text default (datetime('now')) not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.query(`INSERT INTO device_configs (device_id, updated_at) VALUES ('a', 'u')`).run(); // id 1
+      bunDb.query(`INSERT INTO device_configs (device_id, updated_at) VALUES ('b', 'u')`).run(); // id 2
+      bunDb.query(`DELETE FROM device_configs WHERE id = 2`).run();
+
+      await repairUp(db);
+
+      // Without sqlite_sequence preservation the rebuild resets the counter to
+      // max(current id)=1 and hands out 2 again; the next id must be 3.
+      bunDb.query(`INSERT INTO device_configs (device_id) VALUES ('c')`).run();
+      const next = bunDb.query(`SELECT MAX(id) AS id FROM device_configs`).get() as { id: number };
+      expect(next.id).toBe(3);
+    });
+
+    test("is idempotent — a second pass finds nothing to rebuild", async () => {
+      bunDb.exec(
+        `CREATE TABLE "feature_flags" (` +
+          `"key" text primary key, ` +
+          `"created_at" text default (datetime('now')) not null, ` +
+          `"updated_at" text not null)`
+      );
+      bunDb.query(`INSERT INTO feature_flags (key, updated_at) VALUES ('old', 'u')`).run();
+
+      await repairUp(db);
+      bunDb.query(`INSERT INTO feature_flags (key) VALUES ('new1')`).run();
+      const first = bunDb
+        .query(`SELECT updated_at FROM feature_flags WHERE key='new1'`)
+        .get() as { updated_at: string };
+
+      await repairUp(db);
+      // The default survives a second pass and the pre-existing row is unchanged.
+      const stored = bunDb
+        .query(`SELECT dflt_value FROM pragma_table_info('feature_flags') WHERE name='updated_at'`)
+        .get() as { dflt_value: string | null };
+      expect(stored.dflt_value).toBe("datetime('now')");
+      expect(Number.isNaN(Date.parse(first.updated_at))).toBe(false);
+    });
+  });
+
+  describe("against the real table shapes (derived from the migrated schema)", () => {
+    // The reproductions above are hand-written minimal tables. This block proves
+    // the rebuild also works on the ACTUAL production column set/constraints: it
+    // takes each table's real `CREATE TABLE` from a fully-migrated schema, strips
+    // the `updated_at` default to reconstruct the pre-#2922 upgraded shape, then
+    // runs the migration and asserts the default is restored symmetric with
+    // created_at.
+    const TABLES = [
+      "device_configs",
+      "navigation_apps",
+      "prediction_transition_stats",
+      "accessibility_baselines",
+      "feature_flags",
+      "video_recording_configs",
+      "device_snapshot_configs",
+      "appearance_configs",
+    ];
+
+    test("restores the updated_at default on every enumerated table's real DDL", async () => {
+      // 1. Capture the real fresh CREATE SQL for each table.
+      const fresh = await createTestDatabase();
+      const realCreate: Record<string, string> = {};
+      for (const table of TABLES) {
+        const row = await sql<{ sql: string }>`
+          SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ${table}
+        `.execute(fresh);
+        realCreate[table] = row.rows[0].sql;
+      }
+      await fresh.destroy();
+
+      // 2. Build an upgraded DB: real DDL with the updated_at default removed.
+      const bunDb = new BunDatabase(":memory:");
+      const db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+      for (const table of TABLES) {
+        const stripped = realCreate[table].replace(
+          /("updated_at"\s+\w+)\s+default\s+\(datetime\('now'\)\)(\s+not\s+null)/i,
+          "$1$2"
+        );
+        // Guard: the strip must actually have removed a default (else the test
+        // would silently prove nothing).
+        expect(stripped).not.toBe(realCreate[table]);
+        bunDb.exec(stripped);
+        const before = bunDb
+          .query(`SELECT dflt_value FROM pragma_table_info('${table}') WHERE name='updated_at'`)
+          .get() as { dflt_value: string | null };
+        expect(before.dflt_value).toBeNull();
+      }
+
+      // 3. Run the repair.
+      await repairUp(db);
+
+      // 4. Every updated_at default is restored and symmetric with created_at.
+      for (const table of TABLES) {
+        const updatedAt = bunDb
+          .query(`SELECT dflt_value FROM pragma_table_info('${table}') WHERE name='updated_at'`)
+          .get() as { dflt_value: string | null };
+        const createdAt = bunDb
+          .query(`SELECT dflt_value FROM pragma_table_info('${table}') WHERE name='created_at'`)
+          .get() as { dflt_value: string | null };
+        expect(updatedAt.dflt_value).toBe("datetime('now')");
+        expect(updatedAt.dflt_value).toBe(createdAt.dflt_value);
+      }
+      await db.destroy();
+    });
+  });
+
+  describe("on the current (already-fixed) schema", () => {
+    let db: Kysely<Database>;
+
+    beforeEach(async () => {
+      db = await createTestDatabase();
+    });
+
+    afterEach(async () => {
+      await db.destroy();
+    });
+
+    test("is a no-op: a defaulted updated_at insert already stores a real timestamp", async () => {
+      await repairUp(db as unknown as Kysely<unknown>);
+      // Omit updated_at entirely — the fresh schema already carries the default.
+      const rows = await sql<{ updated_at: string }>`
+        INSERT INTO feature_flags (key) VALUES ('fresh') RETURNING updated_at
+      `.execute(db);
+      expect(Number.isNaN(Date.parse(rows.rows[0]?.updated_at as string))).toBe(false);
+    });
+
+    test("runs as part of the real migration chain (migration is registered)", async () => {
+      const executed = await db
+        .selectFrom("kysely_migration" as never)
+        .select("name" as never)
+        .execute();
+      const names = executed.map((r: { name: string }) => r.name);
+      expect(names).toContain("2026_07_05_000_repair_updated_at_defaults");
+    });
+
+    test("down() is a safe no-op (irreversible repair)", async () => {
+      await expect(repairDown()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/test/db/updatedAtColumnDefaults.test.ts
+++ b/test/db/updatedAtColumnDefaults.test.ts
@@ -13,20 +13,18 @@ import { createTestDatabase } from "./testDbHelper";
  *
  * Each row below inserts ONLY the columns that are required with no default,
  * deliberately OMITTING `updated_at`, so the SQL-level default path is exercised
- * exactly the way a future defaulted writer would hit it. Before the fix these
- * inserts throw a NOT NULL constraint failure; after it they store a real
- * timestamp.
+ * exactly the way a defaulted writer hits it. Before #2922 these inserts threw a
+ * NOT NULL constraint failure; after it they store a real timestamp.
  *
- * NOTE the insert casts (`as never`): the `updated_at` TypeScript type is
- * INTENTIONALLY left required (`string`, not `Generated<string>`) even though
- * the fresh schema now carries a default. An upgraded database — one that
- * already ran the historical migration — keeps the old no-default column, since
- * editing a migration body does not re-run it (Kysely tracks migrations by name).
- * Advertising the column as omittable in TypeScript would let a writer pass local
- * validation yet fail `NOT NULL` for upgraded users. The type may be relaxed once
- * a repair migration rebuilds these columns' defaults on upgraded DBs (unlike
- * `created_at`, whose default #2915 already repaired everywhere). The cast lets
- * this test exercise the SQL default directly, which is what the fix delivers.
+ * The `updated_at` TypeScript type was relaxed to `Generated<string>` by #2937,
+ * once its companion repair migration
+ * (`2026_07_05_000_repair_updated_at_defaults`) rebuilt these columns' defaults on
+ * already-upgraded databases too — so an omitted-`updated_at` insert is now sound
+ * on every database, not just fresh ones (mirroring `created_at`, whose default
+ * #2915 repaired everywhere). The insert casts (`as never`) remain only because
+ * `table` iterates a heterogeneous union of `keyof Database`, which Kysely's
+ * insert builder cannot correlate to a single row shape — not because of the
+ * column type.
  *
  * The source-grep guard that rejects the buggy string-literal form
  * (`defaultTo("datetime('now')")`, the #2895 class) lives in

--- a/test/features/accessibility/BaselineManager.test.ts
+++ b/test/features/accessibility/BaselineManager.test.ts
@@ -1,124 +1,39 @@
 /**
  * Unit tests for BaselineManager
  * Tests baseline CRUD operations and database interactions
+ *
+ * The real `BaselineManager` is exercised directly with an injected in-memory
+ * database (its constructor takes an optional `Kysely<Database>`, resolved lazily
+ * so construction never touches the file-backed singleton — issue #3067). The
+ * database is built from the real migration chain so `saveBaseline` can rely on
+ * the schema's `created_at`/`updated_at` defaults exactly as it does in
+ * production.
  */
 
 import { expect, describe, it, beforeEach, afterEach } from "bun:test";
 import type { WcagViolation } from "../../../src/models/AccessibilityAudit";
-import { createTestDatabase, destroyTestDatabase } from "../../helpers/test-database";
+import { createTestDatabase } from "../../db/testDbHelper";
+import { BaselineManager } from "../../../src/features/accessibility/BaselineManager";
 import type { Kysely } from "kysely";
 import type { Database as DatabaseSchema } from "../../../src/db/types";
 
-// We'll create a test-specific BaselineManager that uses our test database
-let testDb: Kysely<DatabaseSchema>;
-
-// Create a custom BaselineManager class that uses our test database instead of the singleton
-class TestBaselineManager {
-  private db: Kysely<DatabaseSchema>;
-
-  constructor(db: Kysely<DatabaseSchema>) {
-    this.db = db;
-  }
-
-  async getBaseline(screenId: string) {
-    const result = await this.db
-      .selectFrom("accessibility_baselines")
-      .selectAll()
-      .where("screen_id", "=", screenId)
-      .executeTakeFirst();
-
-    if (!result) {
-      return null;
-    }
-
-    return {
-      screenId: result.screen_id,
-      violations: JSON.parse(result.violations_json),
-      updatedAt: result.updated_at,
-    };
-  }
-
-  async saveBaseline(screenId: string, violations: WcagViolation[]) {
-    const now = new Date().toISOString();
-
-    const existing = await this.db
-      .selectFrom("accessibility_baselines")
-      .select("id")
-      .where("screen_id", "=", screenId)
-      .executeTakeFirst();
-
-    if (existing) {
-      await this.db
-        .updateTable("accessibility_baselines")
-        .set({
-          violations_json: JSON.stringify(violations),
-          updated_at: now,
-        })
-        .where("screen_id", "=", screenId)
-        .execute();
-    } else {
-      await this.db
-        .insertInto("accessibility_baselines")
-        .values({
-          screen_id: screenId,
-          violations_json: JSON.stringify(violations),
-          created_at: now,
-          updated_at: now,
-        })
-        .execute();
-    }
-  }
-
-  async clearBaseline(screenId: string) {
-    await this.db
-      .deleteFrom("accessibility_baselines")
-      .where("screen_id", "=", screenId)
-      .execute();
-  }
-
-  async listBaselines() {
-    const results = await this.db
-      .selectFrom("accessibility_baselines")
-      .selectAll()
-      .execute();
-
-    return results.map(row => ({
-      screenId: row.screen_id,
-      violations: JSON.parse(row.violations_json),
-      updatedAt: row.updated_at,
-    }));
-  }
-
-  async clearAllBaselines() {
-    await this.db.deleteFrom("accessibility_baselines").execute();
-  }
-
-  async cleanupOldBaselines(daysOld: number) {
-    const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - daysOld);
-    const cutoffIso = cutoffDate.toISOString();
-
-    const result = await this.db
-      .deleteFrom("accessibility_baselines")
-      .where("updated_at", "<", cutoffIso)
-      .executeTakeFirst();
-
-    return Number(result.numDeletedRows) || 0;
-  }
+/** Render a Date as SQLite's `YYYY-MM-DD HH:MM:SS` (UTC) — the format a
+ * `datetime('now')` column default produces (no `T`, no `Z`, no milliseconds). */
+function toSqliteFormat(date: Date): string {
+  return date.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "");
 }
 
 describe("BaselineManager", function() {
-  let manager: TestBaselineManager;
+  let testDb: Kysely<DatabaseSchema>;
+  let manager: BaselineManager;
 
   beforeEach(async function() {
-    // Create in-memory test database
     testDb = await createTestDatabase();
-    manager = new TestBaselineManager(testDb);
+    manager = new BaselineManager(testDb);
   });
 
   afterEach(async function() {
-    // Destroy test database
-    await destroyTestDatabase(testDb);
+    await testDb.destroy();
   });
 
   describe("CRUD Operations", function() {
@@ -291,6 +206,55 @@ describe("BaselineManager", function() {
 
       expect(deletedCount).toBe(0);
     });
+
+    it("should not delete a SQLite-format row that is newer than the cutoff (#2937)", async function() {
+      // Regression guard for the ISO-vs-`datetime('now')` format trap. Once a
+      // defaulted `updated_at` writer lands, the column can hold SQLite's
+      // `YYYY-MM-DD HH:MM:SS` form. A naive string `<` against the ISO-8601 cutoff
+      // compares the two lexically: at the date/time separator a SQLite space
+      // (0x20) sorts before the ISO `T` (0x54), so a row on the SAME calendar date
+      // as the cutoff but at a LATER time-of-day sorts BEFORE the cutoff and would
+      // be wrongly deleted despite being newer. `datetime(...)` normalization
+      // compares them as real instants.
+      const daysOld = 30;
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - daysOld);
+
+      // Same UTC date as the cutoff, at end-of-day — chronologically newer than
+      // the cutoff instant (tests do not run in the final second of a UTC day),
+      // yet lexically smaller than the ISO cutoff string.
+      const sameDay = cutoff.toISOString().slice(0, 10);
+      const newerSqliteFormat = `${sameDay} 23:59:59`;
+
+      // An unambiguously ancient SQLite-format row that must still be deleted.
+      const ancientSqliteFormat = toSqliteFormat(new Date("2000-01-01T00:00:00Z"));
+
+      await testDb
+        .insertInto("accessibility_baselines")
+        .values({
+          screen_id: "boundary_newer",
+          violations_json: "[]",
+          created_at: newerSqliteFormat,
+          updated_at: newerSqliteFormat,
+        })
+        .execute();
+      await testDb
+        .insertInto("accessibility_baselines")
+        .values({
+          screen_id: "ancient",
+          violations_json: "[]",
+          created_at: ancientSqliteFormat,
+          updated_at: ancientSqliteFormat,
+        })
+        .execute();
+
+      const deletedCount = await manager.cleanupOldBaselines(daysOld);
+
+      // Only the genuinely-ancient row is removed; the newer boundary row lives.
+      expect(deletedCount).toBe(1);
+      expect(await manager.getBaseline("boundary_newer")).not.toBeNull();
+      expect(await manager.getBaseline("ancient")).toBeNull();
+    });
   });
 
   describe("Data Integrity", function() {
@@ -344,8 +308,8 @@ describe("BaselineManager", function() {
       expect(baseline).not.toBeNull();
 
       const updatedAt = new Date(baseline!.updatedAt);
-      expect(updatedAt.getTime()).toBeGreaterThanOrEqual(beforeSave.getTime());
-      expect(updatedAt.getTime()).toBeLessThanOrEqual(new Date().getTime());
+      expect(updatedAt.getTime()).toBeGreaterThanOrEqual(beforeSave.getTime() - 1000);
+      expect(updatedAt.getTime()).toBeLessThanOrEqual(new Date().getTime() + 1000);
     });
   });
 });


### PR DESCRIPTION
## Summary

Completes full upgraded-DB parity of `updated_at` with `created_at`, closing #2937.

PR #2922 added `.defaultTo(sql`(datetime('now'))`)` to eight tables' `updated_at`
migration declarations, but editing a historical migration body does **not** re-run it
(Kysely tracks migrations by name), so an **already-upgraded** database keeps the old
`updated_at TEXT NOT NULL` column with **no default** — where a defaulted insert fails the
`NOT NULL` constraint. This PR lands the deferred follow-up work:

1. **Repair migration** `2026_07_05_000_repair_updated_at_defaults` rebuilds the eight
   tables' `updated_at` column on upgraded DBs so it carries the `(datetime('now'))`
   default. It reuses the proven #2915 table-rebuild pattern:
   - FK enforcement toggled **off** around the transaction (so dropping an FK-parent like
     `navigation_apps` can't cascade-delete children),
   - explicit indexes/triggers replayed, `sqlite_sequence` AUTOINCREMENT high-water mark
     restored (so deleted ids aren't reused),
   - **no row repair** — every existing row already holds an explicit `updated_at` value,
     so rows are copied through untouched.
   - Detection targets exactly the eight enumerated tables and rebuilds one only when its
     live `updated_at` default is absent (`pragma_table_info.dflt_value IS NULL`), read via
     `sql.lit` to dodge the parameterized-pragma null flake. It is idempotent and a **no-op**
     on fresh/already-fixed schemas (never touches FK state). `device_sessions` /
     `failure_groups` are intentionally excluded — their default has existed on every DB
     since #2915 repaired the broken literal they originally shipped.

2. **BaselineManager retention format fix.**
   `BaselineManager.cleanupOldBaselines` compared `updated_at` against an ISO-8601 cutoff
   with a raw string `<`. That is only sound while every stored value is ISO. Once a
   defaulted `updated_at` writer lands, the column can hold SQLite's `YYYY-MM-DD HH:MM:SS`
   form, and at the date/time separator a space (`0x20`) sorts before ISO's `T` (`0x54`) —
   so a same-day-but-newer row sorts *before* the cutoff and is wrongly deleted. Both sides
   are now normalized through `datetime(...)` (as `ThresholdManager`/`MemoryThresholdManager`
   already do). `BaselineManager` also gained an optional injected DB (lazy resolver,
   mirroring `MemoryBaselineManager`) so its tests exercise the **real** class instead of a
   duplicate.

3. **Type relaxation.** `updated_at` is now `Generated<string>` for the eight tables plus
   `device_sessions`/`failure_groups`, honestly encoding that an omitted-`updated_at` insert
   is sound on every database.

## Acceptance criteria

- [x] Repair migration rebuilds the 8 `updated_at` columns' defaults on an upgraded DB
      (`test/db/repairUpdatedAtDefaultsMigration.test.ts`, incl. a case derived from the
      **real** migrated DDL of all 8 tables).
- [x] `BaselineManager` retention comparison is format-normalized and covered by a
      regression test (verified to fail against the old un-normalized query).
- [x] `updated_at` typed `Generated<string>` for the affected tables; `tsc` clean.
- [x] Idempotent + FK/child-row safe + `sqlite_sequence`-preserving (mirrors the #2915
      repair test patterns).

## Testing

- `bun test test/db/ test/features/memory/ test/features/navigation/ test/features/featureFlags/ test/features/performance/` → **1034 pass, 0 fail**
- `bun test test/features/accessibility/BaselineManager.test.ts` → 14 pass (incl. the #2937 regression guard)
- `bun build.ts`, `eslint`, and the `datetime-now-literal` / `debug-tags` validators clean.
- Pre-existing `ContrastChecker.test.ts` image-backend failures are unrelated (fail identically on a clean tree).

## Notes / follow-ups

- `MemoryBaselineManager.cleanupStaleBaselines` has the same latent lexical trap on
  `memory_baselines.last_updated` (inert today — no default, ISO-only writers). Filed as a
  follow-up rather than expanded here to keep this PR scoped to #2937.
- True "touch on every write" `updated_at` semantics would need a trigger, out of scope per
  the issue's semantic note (INSERT defaults are a floor, not an on-update guarantee).

Closes #2937.
