### PR TITLE
fix(android): rethrow CancellationException in control-proxy coroutine catches (#3130)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -257,6 +257,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         serviceScope.launch {
           try {
             handleCommand(intent)
+          } catch (e: CancellationException) {
+            // Cooperative cancellation (service scope shutting down) must never become an error
+            // result — let it propagate so the coroutine unwinds cleanly. Mirrors the inner
+            // ACTION_EXTRACT_HIERARCHY rethrow (PR #3126), which would otherwise be re-swallowed
+            // here (issue #3130).
+            throw e
           } catch (e: Exception) {
             Log.e(TAG, "Error handling command: ${intent.action}", e)
             sendResult(success = false, error = e.message)
@@ -1452,6 +1458,9 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     serviceScope.launch {
       try {
         broadcastInteractionEvent(interaction)
+      } catch (e: CancellationException) {
+        // Let cooperative cancellation unwind cleanly rather than logging it as an error (#3130).
+        throw e
       } catch (e: Exception) {
         Log.e(TAG, "Error broadcasting interaction event", e)
       }
@@ -5350,6 +5359,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val result =
         try {
           withContext(Dispatchers.Main) { overlayDrawer.addHighlight(highlightId, shape) }
+        } catch (e: CancellationException) {
+          // Let cooperative cancellation unwind cleanly rather than reporting a failed highlight
+          // result (#3130).
+          throw e
         } catch (e: Exception) {
           HighlightOperationResult(false, e.message ?: "Failed to add highlight")
         }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -216,6 +216,10 @@ class WebSocketServer(
           scope.launch {
             try {
               connection.close(CloseReason(CloseReason.Codes.GOING_AWAY, "Server shutting down"))
+            } catch (e: CancellationException) {
+              // Let cooperative cancellation unwind cleanly rather than logging it as an error
+              // (#3130).
+              throw e
             } catch (e: Exception) {
               Log.e(TAG, "Error closing connection", e)
             }
@@ -337,6 +341,10 @@ class WebSocketServer(
       .forEach { connection ->
         try {
           connection.send(Frame.Text(message))
+        } catch (e: CancellationException) {
+          // The broadcast collector is cancelled when `scope` shuts down mid-send; let it unwind
+          // rather than mis-marking a live connection as dead and continuing the loop (#3130).
+          throw e
         } catch (e: Exception) {
           Log.w(TAG, "Failed to send to connection, marking as dead", e)
           deadConnections.add(connection)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -176,6 +176,12 @@ class WebSocketServer(
                       }
                     }
                   }
+                } catch (e: CancellationException) {
+                  // Read loop is a coroutine: on scope shutdown, `incoming` / the inline
+                  // `handleClientMessage` throw cancellation. Let it unwind (after `finally`)
+                  // instead of logging a connection error and re-swallowing the rethrow
+                  // handleClientMessage already performs (#3130).
+                  throw e
                 } catch (e: Exception) {
                   Log.e(TAG, "Error in WebSocket connection #$connectionId", e)
                 } finally {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/BroadcastGuardAdoptionTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/BroadcastGuardAdoptionTest.kt
@@ -104,7 +104,7 @@ class BroadcastGuardAdoptionTest {
       fail("could not find the `launchRequestScope(...)` helper in CtrlProxy.kt")
     }
 
-    val signatureEnd = BroadcastGuardScanner.matchParen(source, helper!!.range.last)
+    val signatureEnd = KotlinSourceScan.matchParen(source, helper!!.range.last)
     val bodyOrExpressionEnd =
       source.indexOf("\n\n", signatureEnd).takeIf { it >= 0 } ?: source.length
     val helperText = source.substring(helper.range.first, bodyOrExpressionEnd)
@@ -939,14 +939,15 @@ object BroadcastGuardScanner {
   fun scan(source: String): ScanResult {
     // `code` masks all string/char literal contents and comments with spaces (newlines preserved)
     // so structural brace/paren matching is not fooled by braces inside `"""{"type":...}"""`.
-    val code = maskLiteralsAndComments(source)
+    val code = KotlinSourceScan.maskLiteralsAndComments(source)
 
     val guardedHelpers = mutableListOf<String>()
     val violations = mutableListOf<Violation>()
 
     for (m in HELPER.findAll(code)) {
       val name = m.groupValues[1]
-      val sigEnd = matchParen(code, m.range.first + m.value.indexOf('(')) // index after ')'
+      val sigEnd =
+        KotlinSourceScan.matchParen(code, m.range.first + m.value.indexOf('(')) // index after ')'
       val signature = code.substring(m.range.first, sigEnd)
       if (!signature.contains("requestId"))
         continue // only requestId-correlated helpers are in scope
@@ -954,7 +955,7 @@ object BroadcastGuardScanner {
       guardedHelpers.add(name)
 
       val bodyOpen = code.indexOf('{', sigEnd)
-      val bodyClose = matchBrace(code, bodyOpen)
+      val bodyClose = KotlinSourceScan.matchBrace(code, bodyOpen)
       val body = code.substring(bodyOpen, bodyClose)
 
       // The correlated-error-on-throw guarantee is provided by `resultBroadcaster.guard { … }` (the
@@ -966,20 +967,34 @@ object BroadcastGuardScanner {
         guardedSpans.isEmpty() && broadcastCalls.isNotEmpty() ->
           // Broadcasts a result but wraps none of it — the exact "forgot the guard" regression.
           violations.add(
-            Violation(Kind.MISSING_GUARD, name, lineOf(source, bodyOpen + broadcastCalls.first()))
+            Violation(
+              Kind.MISSING_GUARD,
+              name,
+              KotlinSourceScan.lineOf(source, bodyOpen + broadcastCalls.first()),
+            )
           )
         else ->
           // Guard/launch present: every result broadcast must sit *inside* one of those spans. A
           // broadcast outside them is unguarded even though the guard call textually exists.
           for (offset in broadcastCalls) {
             if (guardedSpans.none { offset >= it.first && offset < it.second }) {
-              violations.add(Violation(Kind.MISSING_GUARD, name, lineOf(source, bodyOpen + offset)))
+              violations.add(
+                Violation(
+                  Kind.MISSING_GUARD,
+                  name,
+                  KotlinSourceScan.lineOf(source, bodyOpen + offset),
+                )
+              )
             }
           }
       }
       for (offset in swallowingCatchOffsets(body)) {
         violations.add(
-          Violation(Kind.SWALLOW_IN_BROADCAST, name, lineOf(source, bodyOpen + offset))
+          Violation(
+            Kind.SWALLOW_IN_BROADCAST,
+            name,
+            KotlinSourceScan.lineOf(source, bodyOpen + offset),
+          )
         )
       }
     }
@@ -987,16 +1002,16 @@ object BroadcastGuardScanner {
     var launchBlocks = 0
     for (m in LAUNCH.findAll(code)) {
       launchBlocks++
-      val parenEnd = matchParen(code, m.range.first + m.value.indexOf('('))
+      val parenEnd = KotlinSourceScan.matchParen(code, m.range.first + m.value.indexOf('('))
       val blockOpen = code.indexOf('{', parenEnd)
-      val blockClose = matchBrace(code, blockOpen)
+      val blockClose = KotlinSourceScan.matchBrace(code, blockOpen)
       val block = code.substring(blockOpen, blockClose)
       for (offset in swallowingCatchOffsets(block)) {
         violations.add(
           Violation(
             Kind.SWALLOW_IN_LAUNCH,
             "asyncActionRunner.launch",
-            lineOf(source, blockOpen + offset),
+            KotlinSourceScan.lineOf(source, blockOpen + offset),
           )
         )
       }
@@ -1018,7 +1033,7 @@ object BroadcastGuardScanner {
           Violation(
             Kind.RAW_REQUEST_ID_LAUNCH,
             "serviceScope.launch",
-            lineOf(source, call.blockOpen),
+            KotlinSourceScan.lineOf(source, call.blockOpen),
           )
         )
       }
@@ -1041,10 +1056,10 @@ object BroadcastGuardScanner {
     val args: String
     if (cursor < code.length && code[cursor] == '(') {
       val argsStart = cursor + 1
-      val parenEnd = matchParen(code, cursor)
+      val parenEnd = KotlinSourceScan.matchParen(code, cursor)
       args = code.substring(argsStart, parenEnd - 1)
       findInlineBlockArgument(code, argsStart, parenEnd - 1)?.let { blockOpen ->
-        return LaunchCall(args, blockOpen, matchBrace(code, blockOpen))
+        return LaunchCall(args, blockOpen, KotlinSourceScan.matchBrace(code, blockOpen))
       }
       cursor = parenEnd
     } else {
@@ -1055,7 +1070,7 @@ object BroadcastGuardScanner {
     if (cursor >= code.length || code[cursor] != '{') return null
 
     val blockOpen = code.indexOf('{', cursor)
-    return LaunchCall(args, blockOpen, matchBrace(code, blockOpen))
+    return LaunchCall(args, blockOpen, KotlinSourceScan.matchBrace(code, blockOpen))
   }
 
   private fun findInlineBlockArgument(code: String, start: Int, endExclusive: Int): Int? {
@@ -1074,10 +1089,10 @@ object BroadcastGuardScanner {
   private fun blockSpans(region: String, call: Regex): List<Pair<Int, Int>> {
     val spans = mutableListOf<Pair<Int, Int>>()
     for (m in call.findAll(region)) {
-      val parenEnd = matchParen(region, m.range.first + m.value.indexOf('('))
+      val parenEnd = KotlinSourceScan.matchParen(region, m.range.first + m.value.indexOf('('))
       val blockOpen = region.indexOf('{', parenEnd)
       if (blockOpen < 0) continue
-      spans.add(blockOpen to matchBrace(region, blockOpen))
+      spans.add(blockOpen to KotlinSourceScan.matchBrace(region, blockOpen))
     }
     return spans
   }
@@ -1090,10 +1105,10 @@ object BroadcastGuardScanner {
   private fun swallowingCatchOffsets(region: String): List<Int> {
     val offsets = mutableListOf<Int>()
     for (c in CATCH.findAll(region)) {
-      val parenEnd = matchParen(region, c.range.first + c.value.indexOf('('))
+      val parenEnd = KotlinSourceScan.matchParen(region, c.range.first + c.value.indexOf('('))
       val blockOpen = region.indexOf('{', parenEnd)
       if (blockOpen < 0) continue
-      val blockClose = matchBrace(region, blockOpen)
+      val blockClose = KotlinSourceScan.matchBrace(region, blockOpen)
       val catchBody = region.substring(blockOpen, blockClose)
       val surfacesViaBroadcast =
         BROADCAST_CALL_TOKEN.findAll(catchBody).any { !EVENT_BROADCAST_TOKEN.matches(it.value) }
@@ -1102,218 +1117,4 @@ object BroadcastGuardScanner {
     }
     return offsets
   }
-
-  /** [open] must index a '('; returns the index just past the matching ')'. */
-  fun matchParen(s: String, open: Int): Int {
-    var depth = 0
-    var i = open
-    while (i < s.length) {
-      when (s[i]) {
-        '(' -> depth++
-        ')' -> {
-          depth--
-          if (depth == 0) return i + 1
-        }
-      }
-      i++
-    }
-    error("unbalanced parentheses starting at $open")
-  }
-
-  /** [open] must index a '{'; returns the index just past the matching '}'. */
-  private fun matchBrace(s: String, open: Int): Int {
-    var depth = 0
-    var i = open
-    while (i < s.length) {
-      when (s[i]) {
-        '{' -> depth++
-        '}' -> {
-          depth--
-          if (depth == 0) return i + 1
-        }
-      }
-      i++
-    }
-    error("unbalanced braces starting at $open")
-  }
-
-  private fun lineOf(source: String, index: Int): Int {
-    var line = 1
-    var i = 0
-    while (i < index && i < source.length) {
-      if (source[i] == '\n') line++
-      i++
-    }
-    return line
-  }
-
-  /**
-   * Replace the contents of every string/char literal and comment with spaces (newlines preserved,
-   * so line numbers and length are unchanged), leaving real code structure -- braces, parens,
-   * identifiers -- intact so structural matching is not fooled.
-   *
-   * A stack of lexer states handles the constructs that break a naive scan:
-   * - Kotlin raw strings ("\"\"\"...\"\"\"") close on the *last* three quotes of a trailing run.
-   * - String-template interpolation "${ ... }" is code, may nest strings that themselves contain
-   *   braces/quotes (e.g. `"a ${f("}")}"`), and must not let an inner quote close the outer string.
-   *   Interpolation contents are blanked but their braces are balanced (both blanked), so the
-   *   surrounding code's brace/paren matching stays correct.
-   */
-  private fun maskLiteralsAndComments(src: String): String {
-    val out = StringBuilder(src.length)
-    val n = src.length
-    var i = 0
-    // Parallel stacks: lexer state + (for INTERP) its running brace depth.
-    val states = ArrayDeque<Int>().apply { addLast(CODE) }
-    val interpDepth = ArrayDeque<Int>()
-
-    fun blank(count: Int) {
-      repeat(count) { out.append(' ') }
-    }
-
-    while (i < n) {
-      val c = src[i]
-      val next = if (i + 1 < n) src[i + 1] else ' '
-      when (states.last()) {
-        CODE,
-        INTERP -> {
-          when {
-            c == '/' && next == '/' -> {
-              states.addLast(LINE_COMMENT)
-              blank(2)
-              i += 2
-            }
-            c == '/' && next == '*' -> {
-              states.addLast(BLOCK_COMMENT)
-              blank(2)
-              i += 2
-            }
-            c == '"' && next == '"' && i + 2 < n && src[i + 2] == '"' -> {
-              states.addLast(RAW)
-              blank(3)
-              i += 3
-            }
-            c == '"' -> {
-              states.addLast(STR)
-              blank(1)
-              i++
-            }
-            c == '\'' -> {
-              states.addLast(CHAR)
-              blank(1)
-              i++
-            }
-            states.last() == INTERP && c == '{' -> {
-              interpDepth.addLast(interpDepth.removeLast() + 1)
-              blank(1)
-              i++
-            }
-            states.last() == INTERP && c == '}' -> {
-              val d = interpDepth.removeLast() - 1
-              blank(1)
-              i++
-              if (d == 0) states.removeLast() else interpDepth.addLast(d)
-            }
-            states.last() == INTERP -> {
-              out.append(if (c == '\n') '\n' else ' ')
-              i++
-            }
-            else -> { // CODE: preserve real structure (braces, parens, identifiers).
-              out.append(c)
-              i++
-            }
-          }
-        }
-        STR -> {
-          when {
-            c == '\\' -> {
-              blank(2)
-              i += 2
-            }
-            c == '$' && next == '{' -> {
-              states.addLast(INTERP)
-              interpDepth.addLast(1)
-              blank(2)
-              i += 2
-            }
-            c == '"' -> {
-              states.removeLast()
-              blank(1)
-              i++
-            }
-            else -> {
-              out.append(if (c == '\n') '\n' else ' ')
-              i++
-            }
-          }
-        }
-        RAW -> {
-          when {
-            c == '$' && next == '{' -> {
-              states.addLast(INTERP)
-              interpDepth.addLast(1)
-              blank(2)
-              i += 2
-            }
-            c == '"' -> {
-              var run = 0
-              while (i + run < n && src[i + run] == '"') run++
-              blank(run)
-              i += run
-              if (run >= 3) states.removeLast() // last three quotes close the raw string
-            }
-            else -> {
-              out.append(if (c == '\n') '\n' else ' ')
-              i++
-            }
-          }
-        }
-        CHAR -> {
-          when {
-            c == '\\' -> {
-              blank(2)
-              i += 2
-            }
-            c == '\'' -> {
-              states.removeLast()
-              blank(1)
-              i++
-            }
-            else -> {
-              blank(1)
-              i++
-            }
-          }
-        }
-        LINE_COMMENT -> {
-          if (c == '\n') {
-            states.removeLast()
-            out.append('\n')
-          } else {
-            blank(1)
-          }
-          i++
-        }
-        else -> { // BLOCK_COMMENT
-          if (c == '*' && next == '/') {
-            states.removeLast()
-            blank(2)
-            i += 2
-          } else {
-            out.append(if (c == '\n') '\n' else ' ')
-            i++
-          }
-        }
-      }
-    }
-    return out.toString()
-  }
-
-  private const val CODE = 0
-  private const val STR = 1 // regular string
-  private const val RAW = 2 // raw triple-quoted string
-  private const val CHAR = 3 // char literal
-  private const val LINE_COMMENT = 4
-  private const val BLOCK_COMMENT = 5
-  private const val INTERP = 6 // ${ ... } string-template interpolation (code; brace depth tracked)
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/KotlinSourceScan.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/KotlinSourceScan.kt
@@ -1,0 +1,228 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+/**
+ * Pure, Android-free structural helpers shared by the source-scan enforcement tests
+ * ([BroadcastGuardScanner] and [LaunchCancellationScanner]). Test-only — lives in the test source
+ * set and ships no scanning code in the app.
+ *
+ * The load-bearing primitive is [maskLiteralsAndComments], which blanks the contents of every
+ * string/char literal and comment (newlines preserved so line numbers and length are unchanged) so
+ * structural brace/paren matching is not fooled by braces inside `"""{"type":...}"""`, a `${...}`
+ * interpolation nesting a string, or a `// } comment`.
+ */
+object KotlinSourceScan {
+
+  /** [open] must index a '('; returns the index just past the matching ')'. */
+  fun matchParen(s: String, open: Int): Int {
+    var depth = 0
+    var i = open
+    while (i < s.length) {
+      when (s[i]) {
+        '(' -> depth++
+        ')' -> {
+          depth--
+          if (depth == 0) return i + 1
+        }
+      }
+      i++
+    }
+    error("unbalanced parentheses starting at $open")
+  }
+
+  /** [open] must index a '{'; returns the index just past the matching '}'. */
+  fun matchBrace(s: String, open: Int): Int {
+    var depth = 0
+    var i = open
+    while (i < s.length) {
+      when (s[i]) {
+        '{' -> depth++
+        '}' -> {
+          depth--
+          if (depth == 0) return i + 1
+        }
+      }
+      i++
+    }
+    error("unbalanced braces starting at $open")
+  }
+
+  fun lineOf(source: String, index: Int): Int {
+    var line = 1
+    var i = 0
+    while (i < index && i < source.length) {
+      if (source[i] == '\n') line++
+      i++
+    }
+    return line
+  }
+
+  /**
+   * Replace the contents of every string/char literal and comment with spaces (newlines preserved,
+   * so line numbers and length are unchanged), leaving real code structure -- braces, parens,
+   * identifiers -- intact so structural matching is not fooled.
+   *
+   * A stack of lexer states handles the constructs that break a naive scan:
+   * - Kotlin raw strings ("\"\"\"...\"\"\"") close on the *last* three quotes of a trailing run.
+   * - String-template interpolation "${ ... }" is code, may nest strings that themselves contain
+   *   braces/quotes (e.g. `"a ${f("}")}"`), and must not let an inner quote close the outer string.
+   *   Interpolation contents are blanked but their braces are balanced (both blanked), so the
+   *   surrounding code's brace/paren matching stays correct.
+   */
+  fun maskLiteralsAndComments(src: String): String {
+    val out = StringBuilder(src.length)
+    val n = src.length
+    var i = 0
+    // Parallel stacks: lexer state + (for INTERP) its running brace depth.
+    val states = ArrayDeque<Int>().apply { addLast(CODE) }
+    val interpDepth = ArrayDeque<Int>()
+
+    fun blank(count: Int) {
+      repeat(count) { out.append(' ') }
+    }
+
+    while (i < n) {
+      val c = src[i]
+      val next = if (i + 1 < n) src[i + 1] else ' '
+      when (states.last()) {
+        CODE,
+        INTERP -> {
+          when {
+            c == '/' && next == '/' -> {
+              states.addLast(LINE_COMMENT)
+              blank(2)
+              i += 2
+            }
+            c == '/' && next == '*' -> {
+              states.addLast(BLOCK_COMMENT)
+              blank(2)
+              i += 2
+            }
+            c == '"' && next == '"' && i + 2 < n && src[i + 2] == '"' -> {
+              states.addLast(RAW)
+              blank(3)
+              i += 3
+            }
+            c == '"' -> {
+              states.addLast(STR)
+              blank(1)
+              i++
+            }
+            c == '\'' -> {
+              states.addLast(CHAR)
+              blank(1)
+              i++
+            }
+            states.last() == INTERP && c == '{' -> {
+              interpDepth.addLast(interpDepth.removeLast() + 1)
+              blank(1)
+              i++
+            }
+            states.last() == INTERP && c == '}' -> {
+              val d = interpDepth.removeLast() - 1
+              blank(1)
+              i++
+              if (d == 0) states.removeLast() else interpDepth.addLast(d)
+            }
+            states.last() == INTERP -> {
+              out.append(if (c == '\n') '\n' else ' ')
+              i++
+            }
+            else -> { // CODE: preserve real structure (braces, parens, identifiers).
+              out.append(c)
+              i++
+            }
+          }
+        }
+        STR -> {
+          when {
+            c == '\\' -> {
+              blank(2)
+              i += 2
+            }
+            c == '$' && next == '{' -> {
+              states.addLast(INTERP)
+              interpDepth.addLast(1)
+              blank(2)
+              i += 2
+            }
+            c == '"' -> {
+              states.removeLast()
+              blank(1)
+              i++
+            }
+            else -> {
+              out.append(if (c == '\n') '\n' else ' ')
+              i++
+            }
+          }
+        }
+        RAW -> {
+          when {
+            c == '$' && next == '{' -> {
+              states.addLast(INTERP)
+              interpDepth.addLast(1)
+              blank(2)
+              i += 2
+            }
+            c == '"' -> {
+              var run = 0
+              while (i + run < n && src[i + run] == '"') run++
+              blank(run)
+              i += run
+              if (run >= 3) states.removeLast() // last three quotes close the raw string
+            }
+            else -> {
+              out.append(if (c == '\n') '\n' else ' ')
+              i++
+            }
+          }
+        }
+        CHAR -> {
+          when {
+            c == '\\' -> {
+              blank(2)
+              i += 2
+            }
+            c == '\'' -> {
+              states.removeLast()
+              blank(1)
+              i++
+            }
+            else -> {
+              blank(1)
+              i++
+            }
+          }
+        }
+        LINE_COMMENT -> {
+          if (c == '\n') {
+            states.removeLast()
+            out.append('\n')
+          } else {
+            blank(1)
+          }
+          i++
+        }
+        else -> { // BLOCK_COMMENT
+          if (c == '*' && next == '/') {
+            states.removeLast()
+            blank(2)
+            i += 2
+          } else {
+            out.append(if (c == '\n') '\n' else ' ')
+            i++
+          }
+        }
+      }
+    }
+    return out.toString()
+  }
+
+  private const val CODE = 0
+  private const val STR = 1 // regular string
+  private const val RAW = 2 // raw triple-quoted string
+  private const val CHAR = 3 // char literal
+  private const val LINE_COMMENT = 4
+  private const val BLOCK_COMMENT = 5
+  private const val INTERP = 6 // ${ ... } string-template interpolation (code; brace depth tracked)
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/LaunchCancellationRethrowTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/LaunchCancellationRethrowTest.kt
@@ -1,0 +1,630 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Structural backstop for issue #3130. Enforces that no `serviceScope.launch { … }` / `scope.launch
+ * { … }` coroutine in [CtrlProxy] or [WebSocketServer] converts a cooperative
+ * [kotlinx.coroutines.CancellationException] into a logged failure/result instead of letting it
+ * propagate so the coroutine unwinds cleanly.
+ *
+ * `CancellationException` **is** a Kotlin `Exception`, so a bare `try { … } catch (e: Exception) {
+ * … }` inside a launched coroutine silently swallows the cancellation the runtime throws while the
+ * scope is shutting down — the exact anti-pattern that [ResultBroadcaster.guard],
+ * [AsyncActionRunner], and the inner `ACTION_EXTRACT_HIERARCHY` branch (PR #3126) all guard against
+ * with a `catch (e: CancellationException) { throw e }` clause placed *before* the generic `catch
+ * (e: Exception)`. The convention only holds if every launch follows it, so this test source-scans
+ * the live files and fails CI on any regression.
+ *
+ * ## Sibling-receiver audit (issue #3130 AC #2)
+ *
+ * The `BroadcastReceiver.onReceive` siblings of `commandReceiver` were audited and are
+ * intentionally **out of scope** — they cannot swallow a cooperative cancellation:
+ * - `navigationEventReceiver`, `recompositionReceiver`, `handledExceptionReceiver`,
+ *   `crashReceiver`, `anrReceiver`, `eventBatchReceiver` wrap their parsing in a `try/catch (e:
+ *   Exception)` that runs **synchronously in `onReceive`**, not inside a coroutine. No
+ *   `serviceScope` job is being cancelled there, so `CancellationException` never arises. Their
+ *   inner `serviceScope.launch { … }` dispatches carry **no** inner `try/catch`, so nothing is
+ *   swallowed — an uncaught throw is routed to [ServiceScopeGuard]'s `CoroutineExceptionHandler`
+ *   (issue #3104) instead.
+ * - `packageReceiver` and `screenStateReceiver` likewise launch (or call) with no inner catch.
+ *
+ * The broad-catch-*inside*-a-launch shape this scanner enforces against was found at three
+ * [CtrlProxy] sites (`commandReceiver`, the interaction-event broadcaster, the highlight-response
+ * launch) and two [WebSocketServer] sites (`broadcastToClients`' send loop, the `stop()` close
+ * launch) — all fixed. The scanning logic is factored into [LaunchCancellationScanner] (a pure
+ * function over source text) so the enforcement contract is unit-tested against synthetic good/bad
+ * snippets; the real-file assertions then prove the live sources comply.
+ *
+ * Known limitation (tracked as a follow-up): [LaunchCancellationScanner] treats a broad catch whose
+ * body contains *any* `throw` as fully re-surfacing cancellation, so a *conditional* rethrow
+ * (`catch (e: Exception) { if (fatal) throw e else log(e) }`) is not flagged even though it
+ * swallows cancellation on the non-throwing branch. No such shape exists in the scanned sources
+ * today.
+ */
+class LaunchCancellationRethrowTest {
+
+  // ---------------------------------------------------------------------------
+  // Real-source assertions — the live control-proxy sources must comply.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `no launch block in control-proxy swallows CancellationException`() {
+    for (name in SCANNED_SOURCES) {
+      val result = LaunchCancellationScanner.scan(locateSource(name).readText())
+      assertTrue(
+        "Every `serviceScope.launch`/`scope.launch { try { … } catch (e: Exception) }` must " +
+          "rethrow `CancellationException` before the generic catch so cooperative cancellation " +
+          "unwinds cleanly (issue #3130). Offenders in $name:\n" +
+          result.violations.joinToString("\n") { "  - $name:${it.line}" },
+        result.violations.isEmpty(),
+      )
+    }
+  }
+
+  @Test
+  fun `scanner actually matches the control-proxy launch blocks`() {
+    // Guards against a scanner that silently matches nothing (a broken regex would make the
+    // "no violations" assertion vacuously pass). CtrlProxy + WebSocketServer launch many
+    // coroutines;
+    // assert a conservative lower bound on the combined count so the check stays meaningful.
+    val total = SCANNED_SOURCES.sumOf {
+      LaunchCancellationScanner.scan(locateSource(it).readText()).launchBlocks
+    }
+
+    assertTrue("expected the scanner to match many launch blocks, found $total", total >= 15)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Contract tests — prove the scanner catches the regression and does not
+  // false-positive on legitimate code.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `flags a launch whose broad Exception catch swallows without rethrowing cancellation`() {
+    val src =
+      """
+      class Fake {
+        fun onReceive() {
+          serviceScope.launch {
+            try {
+              handleCommand(intent)
+            } catch (e: Exception) {
+              Log.e(TAG, "Error handling command", e)
+              sendResult(success = false, error = e.message)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals("the swallowing launch is the sole violation", 1, result.violations.size)
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `flags a launch whose broad Throwable catch swallows without rethrowing cancellation`() {
+    val src =
+      """
+      class Fake {
+        fun dispatch() {
+          serviceScope.launch {
+            try {
+              work()
+            } catch (t: Throwable) {
+              Log.e(TAG, "boom", t)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(1, result.violations.size)
+  }
+
+  @Test
+  fun `does not flag a launch that rethrows CancellationException before the generic catch`() {
+    val src =
+      """
+      class Fake {
+        fun onReceive() {
+          serviceScope.launch {
+            try {
+              handleCommand(intent)
+            } catch (e: CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              Log.e(TAG, "Error handling command", e)
+              sendResult(success = false, error = e.message)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertTrue(
+      "compliant launch must not be flagged: ${result.violations}",
+      result.violations.isEmpty(),
+    )
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `does not flag a launch whose CancellationException is fully qualified`() {
+    val src =
+      """
+      class Fake {
+        fun onReceive() {
+          serviceScope.launch {
+            try {
+              handleCommand(intent)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              Log.e(TAG, "Error handling command", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertTrue(result.violations.isEmpty())
+  }
+
+  @Test
+  fun `flags a launch whose CancellationException catch does NOT rethrow`() {
+    // A CancellationException catch that logs-and-swallows instead of rethrowing is still the bug —
+    // the cooperative cancellation is absorbed and the coroutine does not unwind.
+    val src =
+      """
+      class Fake {
+        fun onReceive() {
+          serviceScope.launch {
+            try {
+              handleCommand(intent)
+            } catch (e: CancellationException) {
+              Log.e(TAG, "cancelled", e)
+            } catch (e: Exception) {
+              Log.e(TAG, "Error handling command", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(1, result.violations.size)
+  }
+
+  @Test
+  fun `does not flag a launch with no try catch`() {
+    val src =
+      """
+      class Fake {
+        fun dispatch() {
+          serviceScope.launch { broadcastPackageEvent(action, pkg) }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertTrue(result.violations.isEmpty())
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `does not flag a launch whose only broad catch itself rethrows`() {
+    // A `catch (e: Exception) { throw e }` re-surfaces everything including cancellation, so it is
+    // not a swallow.
+    val src =
+      """
+      class Fake {
+        fun dispatch() {
+          serviceScope.launch {
+            try {
+              work()
+            } catch (e: Exception) {
+              throw e
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertTrue(result.violations.isEmpty())
+  }
+
+  @Test
+  fun `does not flag an asyncActionRunner launch block (out of scope for this scanner)`() {
+    // asyncActionRunner.launch is a different seam covered by BroadcastGuardAdoptionTest; this
+    // scanner is scoped to raw serviceScope.launch coroutines only.
+    val src =
+      """
+      class Fake {
+        fun dispatch() {
+          asyncActionRunner.launch(requestId, "install") {
+            try {
+              installApp()
+            } catch (e: Exception) {
+              Log.e(TAG, "boom", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertTrue(
+      "asyncActionRunner.launch is out of scope: ${result.violations}",
+      result.violations.isEmpty(),
+    )
+    assertEquals("no serviceScope.launch present", 0, result.launchBlocks)
+  }
+
+  @Test
+  fun `does not desync on a raw string containing braces before an unguarded catch`() {
+    // The scanner must blank literal contents before brace matching or it will mis-slice the launch
+    // body. Build the triple quotes at runtime so this test file itself stays a valid raw string.
+    val tq = "\"\"\""
+    val src =
+      """
+      class Fake {
+        fun dispatch() {
+          serviceScope.launch {
+            val payload = ${tq}{"type":"cmd","nested":{"a":"b"}}${tq}
+            try {
+              handle(payload)
+            } catch (e: Exception) {
+              Log.e(TAG, "swallowed", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(
+      "the braces in the raw string must not hide the swallow",
+      1,
+      result.violations.size,
+    )
+  }
+
+  @Test
+  fun `reports one violation per swallowing launch and dedupes by line`() {
+    val src =
+      """
+      class Fake {
+        fun a() {
+          serviceScope.launch {
+            try { x() } catch (e: Exception) { Log.e(TAG, "a", e) }
+          }
+        }
+        fun b() {
+          serviceScope.launch {
+            try { y() } catch (e: Exception) { Log.e(TAG, "b", e) }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(2, result.violations.size)
+    assertEquals(2, result.violations.map { it.line }.toSet().size)
+  }
+
+  @Test
+  fun `flags a second unrelated swallowing try even when an earlier try rethrows cancellation`() {
+    // Per-try precision: a guarded first try must not launder a LATER, separate try/catch that
+    // swallows — the exact shape a future edit to commandReceiver would take (the block-level
+    // false-negative the reviewers flagged).
+    val src =
+      """
+      class Fake {
+        fun onReceive() {
+          serviceScope.launch {
+            try {
+              handleCommand(intent)
+            } catch (e: CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              sendResult(success = false, error = e.message)
+            }
+            try {
+              followUp()
+            } catch (e: Exception) {
+              Log.e(TAG, "swallowed", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals("only the second, unguarded try is a violation", 1, result.violations.size)
+  }
+
+  @Test
+  fun `flags a dispatcher-argument launch that swallows`() {
+    // `serviceScope.launch(Dispatchers.IO) { … }` must not evade the scan by carrying an argument.
+    val src =
+      """
+      class Fake {
+        fun dispatch() {
+          serviceScope.launch(Dispatchers.IO) {
+            try {
+              work()
+            } catch (e: Exception) {
+              Log.e(TAG, "boom", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(1, result.violations.size)
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `flags a bare scope launch (WebSocketServer form) that swallows`() {
+    val src =
+      """
+      class Fake {
+        fun start() {
+          scope.launch {
+            try {
+              connection.close()
+            } catch (e: Exception) {
+              Log.e(TAG, "closing", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(1, result.violations.size)
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `does not count launchIn as a launch block`() {
+    // `launchIn(scope)` has no trailing lambda; it must not be miscounted or brace-matched.
+    val src =
+      """
+      class Fake {
+        fun collect() {
+          flow.onEach { handle(it) }.launchIn(serviceScope)
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(0, result.launchBlocks)
+    assertTrue(result.violations.isEmpty())
+  }
+
+  @Test
+  fun `KNOWN LIMITATION - a conditionally-rethrowing broad catch is not flagged`() {
+    // Pins the documented limitation (see class KDoc): the scanner treats any `throw` in the broad
+    // catch body as full re-surfacing, so a conditional rethrow that still swallows cancellation on
+    // its non-throwing branch is NOT flagged. No such shape exists in the scanned sources today;
+    // this test records the behavior so a future tightening is a deliberate, visible change.
+    val src =
+      """
+      class Fake {
+        fun dispatch() {
+          serviceScope.launch {
+            try {
+              work()
+            } catch (e: Exception) {
+              if (fatal) throw e else Log.e(TAG, "swallowed on non-fatal branch", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertTrue(
+      "documented false-negative: conditional rethrow not flagged",
+      result.violations.isEmpty(),
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Source location
+  // ---------------------------------------------------------------------------
+
+  private companion object {
+    /** Control-proxy sources scanned by the real-file assertions. */
+    val SCANNED_SOURCES = listOf("CtrlProxy.kt", "WebSocketServer.kt")
+  }
+
+  private fun locateSource(fileName: String): File {
+    val rel = "src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/$fileName"
+    // Depending on the Gradle working directory the module root may be the cwd (AGP unit tests),
+    // the `android` dir, or the repo root. Try the common anchors, then walk up as a fallback.
+    val direct =
+      listOf(File(rel), File("control-proxy/$rel"), File("android/control-proxy/$rel"))
+        .firstOrNull {
+          it.isFile
+        }
+    if (direct != null) return direct
+
+    val userDir = System.getProperty("user.dir") ?: "."
+    var dir: File? = File(userDir).absoluteFile
+    while (dir != null) {
+      for (candidate in
+        listOf(
+          File(dir, rel),
+          File(dir, "control-proxy/$rel"),
+          File(dir, "android/control-proxy/$rel"),
+        )) {
+        if (candidate.isFile) return candidate
+      }
+      dir = dir.parentFile
+    }
+    fail("Could not locate $fileName from user.dir=$userDir")
+    error("unreachable")
+  }
+}
+
+/**
+ * Pure, Android-free source scanner for [LaunchCancellationRethrowTest]. Reads Kotlin source as
+ * text and reports every `serviceScope.launch { … }` / `scope.launch { … }` block that catches the
+ * broad `Exception`/`Throwable` supertype without rethrowing
+ * [kotlinx.coroutines.CancellationException] in the *same* `try` statement. Test-only (lives in the
+ * test source set) — ships no scanning code in the app. Reuses [KotlinSourceScan] for literal
+ * masking and structural brace matching.
+ *
+ * Precision note: the cancellation-rethrow must sit in the **same `try/catch` chain** as the broad
+ * catch, not merely somewhere earlier in the launch body. A body-level check would let a guarded
+ * `try` launder a *second*, unrelated `try { … } catch (Exception) { … }` that swallows — the exact
+ * shape a future edit to `commandReceiver` would take. Catch clauses are grouped into chains by
+ * adjacency (only whitespace between one catch's `}` and the next `catch`), which is how Kotlin
+ * binds consecutive `catch` clauses to one `try`.
+ */
+object LaunchCancellationScanner {
+
+  data class Violation(val line: Int)
+
+  data class ScanResult(
+    /** Count of `serviceScope.launch { … }` / `scope.launch { … }` blocks that were matched. */
+    val launchBlocks: Int,
+    val violations: List<Violation>,
+  )
+
+  // The coroutine launch forms in scope: `serviceScope.launch` and the WebSocketServer
+  // `scope.launch`,
+  // with an optional dispatcher argument (`serviceScope.launch(Dispatchers.IO) { … }`). The `{` is
+  // located structurally after any balanced argument list, so nested parens don't fool the match.
+  private val LAUNCH = Regex("""\b(?:serviceScope|scope)\.launch\b""")
+  // Any single-type catch clause; group 1 captures the (possibly qualified) exception type.
+  private val ANY_CATCH = Regex("""catch\s*\(\s*\w+\s*:\s*([\w.]+)\s*\)""")
+  // `throw` is word-bounded so a `throwable` local doesn't read as a rethrow.
+  private val RETHROW = Regex("""\bthrow\b""")
+
+  private data class CatchClause(
+    /** Offset (within the launch body) of the `catch` keyword. */
+    val start: Int,
+    /** Offset just past the catch block's closing `}` (or `start` if it has no block). */
+    val blockEnd: Int,
+    /** Unqualified exception type name, e.g. `Exception`, `Throwable`, `CancellationException`. */
+    val simpleType: String,
+    val rethrows: Boolean,
+  )
+
+  fun scan(source: String): ScanResult {
+    // Mask string/char literals and comments so braces inside them can't mis-slice launch bodies.
+    val code = KotlinSourceScan.maskLiteralsAndComments(source)
+
+    val violationLines = sortedSetOf<Int>()
+    var launchBlocks = 0
+
+    for (m in LAUNCH.findAll(code)) {
+      val blockOpen = launchBlockOpen(code, m.range.last + 1) ?: continue
+      launchBlocks++
+      val blockClose = KotlinSourceScan.matchBrace(code, blockOpen)
+      val body = code.substring(blockOpen, blockClose)
+
+      for (offset in swallowingCatchOffsets(body)) {
+        violationLines.add(KotlinSourceScan.lineOf(source, blockOpen + offset))
+      }
+    }
+
+    return ScanResult(launchBlocks, violationLines.map { Violation(it) })
+  }
+
+  /**
+   * Given the offset just past a `.launch` token, return the offset of the block's opening `{`,
+   * skipping an optional balanced argument list (`(Dispatchers.IO)`). Returns null if what follows
+   * is not a trailing-lambda launch (e.g. `launchIn(...)` — no `{`).
+   */
+  private fun launchBlockOpen(code: String, afterToken: Int): Int? {
+    var i = afterToken
+    while (i < code.length && code[i].isWhitespace()) i++
+    if (i < code.length && code[i] == '(') i = KotlinSourceScan.matchParen(code, i)
+    while (i < code.length && code[i].isWhitespace()) i++
+    return if (i < code.length && code[i] == '{') i else null
+  }
+
+  /**
+   * Offsets (within [body]) of every broad `catch (… : Exception|Throwable)` that swallows a
+   * cooperative cancellation: it neither rethrows itself nor is preceded, **in the same try/catch
+   * chain**, by a `catch (… : CancellationException)` that rethrows.
+   */
+  private fun swallowingCatchOffsets(body: String): List<Int> {
+    val catches =
+      ANY_CATCH.findAll(body)
+        .map { m ->
+          val open = body.indexOf('{', m.range.last)
+          val end = if (open < 0) m.range.last else KotlinSourceScan.matchBrace(body, open)
+          val rethrows = open >= 0 && RETHROW.containsMatchIn(body.substring(open, end))
+          CatchClause(m.range.first, end, m.groupValues[1].substringAfterLast('.'), rethrows)
+        }
+        .toList()
+
+    val offsets = mutableListOf<Int>()
+    for ((idx, c) in catches.withIndex()) {
+      if (c.simpleType != "Exception" && c.simpleType != "Throwable") continue
+      // A broad catch that itself rethrows re-surfaces cancellation — not a swallow.
+      if (c.rethrows) continue
+      // Walk back over the contiguous catch chain (only whitespace between clauses) this broad
+      // catch
+      // belongs to, looking for a rethrowing CancellationException catch bound to the same `try`.
+      var guarded = false
+      var j = idx - 1
+      while (j >= 0 && body.substring(catches[j].blockEnd, catches[j + 1].start).isBlank()) {
+        if (catches[j].simpleType == "CancellationException" && catches[j].rethrows) {
+          guarded = true
+          break
+        }
+        j--
+      }
+      if (!guarded) offsets.add(c.start)
+    }
+    return offsets
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/LaunchCancellationRethrowTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/LaunchCancellationRethrowTest.kt
@@ -33,12 +33,16 @@ import org.junit.Test
  *   (issue #3104) instead.
  * - `packageReceiver` and `screenStateReceiver` likewise launch (or call) with no inner catch.
  *
- * The broad-catch-*inside*-a-launch shape this scanner enforces against was found at three
+ * The broad-catch-*inside*-a-coroutine shape this scanner enforces against was found at three
  * [CtrlProxy] sites (`commandReceiver`, the interaction-event broadcaster, the highlight-response
- * launch) and two [WebSocketServer] sites (`broadcastToClients`' send loop, the `stop()` close
- * launch) — all fixed. The scanning logic is factored into [LaunchCancellationScanner] (a pure
- * function over source text) so the enforcement contract is unit-tested against synthetic good/bad
- * snippets; the real-file assertions then prove the live sources comply.
+ * launch) and three [WebSocketServer] sites (`broadcastToClients`' send loop, the `stop()` close
+ * launch, and the `webSocket("/ws")` read-loop handler whose outer catch re-swallowed the
+ * cancellation `handleClientMessage` rethrows) — all fixed. The scanner covers
+ * `serviceScope.launch` / `scope.launch` builders, Ktor `webSocket { … }` route handlers, and named
+ * `suspend` helpers (`broadcastToClients`) whose broad catch is not lexically inside a launch. The
+ * scanning logic is factored into [LaunchCancellationScanner] (a pure function over source text) so
+ * the enforcement contract is unit-tested against synthetic good/bad snippets; the real-file
+ * assertions then prove the live sources comply.
  *
  * Known limitation (tracked as a follow-up): [LaunchCancellationScanner] treats a broad catch whose
  * body contains *any* `throw` as fully re-surfacing cancellation, so a *conditional* rethrow
@@ -53,30 +57,34 @@ class LaunchCancellationRethrowTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  fun `no launch block in control-proxy swallows CancellationException`() {
-    for (name in SCANNED_SOURCES) {
-      val result = LaunchCancellationScanner.scan(locateSource(name).readText())
+  fun `no coroutine body in control-proxy swallows CancellationException`() {
+    for (src in SCANNED_SOURCES) {
+      val result =
+        LaunchCancellationScanner.scan(locateSource(src.fileName).readText(), src.guardedSuspendFns)
       assertTrue(
-        "Every `serviceScope.launch`/`scope.launch { try { … } catch (e: Exception) }` must " +
-          "rethrow `CancellationException` before the generic catch so cooperative cancellation " +
-          "unwinds cleanly (issue #3130). Offenders in $name:\n" +
-          result.violations.joinToString("\n") { "  - $name:${it.line}" },
+        "Every `serviceScope.launch`/`scope.launch`/`webSocket { … }` coroutine body (and the " +
+          "guarded suspend helpers ${src.guardedSuspendFns}) must rethrow `CancellationException` " +
+          "before the generic catch so cooperative cancellation unwinds cleanly (issue #3130). " +
+          "Offenders in ${src.fileName}:\n" +
+          result.violations.joinToString("\n") { "  - ${src.fileName}:${it.line}" },
         result.violations.isEmpty(),
       )
     }
   }
 
   @Test
-  fun `scanner actually matches the control-proxy launch blocks`() {
+  fun `scanner actually matches the control-proxy coroutine bodies`() {
     // Guards against a scanner that silently matches nothing (a broken regex would make the
     // "no violations" assertion vacuously pass). CtrlProxy + WebSocketServer launch many
-    // coroutines;
-    // assert a conservative lower bound on the combined count so the check stays meaningful.
+    // coroutines; assert a conservative lower bound on the combined count so it stays meaningful.
     val total = SCANNED_SOURCES.sumOf {
-      LaunchCancellationScanner.scan(locateSource(it).readText()).launchBlocks
+      LaunchCancellationScanner.scan(locateSource(it.fileName).readText(), it.guardedSuspendFns)
+        .launchBlocks
     }
 
-    assertTrue("expected the scanner to match many launch blocks, found $total", total >= 15)
+    // Conservative floor: guards against a broken regex (→ 0) without being brittle to how many
+    // launch sites the sources happen to have as they are refactored.
+    assertTrue("expected the scanner to match many coroutine bodies, found $total", total >= 10)
   }
 
   // ---------------------------------------------------------------------------
@@ -473,14 +481,159 @@ class LaunchCancellationRethrowTest {
     )
   }
 
+  @Test
+  fun `flags a webSocket route handler whose outer catch swallows cancellation`() {
+    // The Ktor read loop is a coroutine; an outer `catch (e: Exception)` re-swallows the
+    // cancellation an inline suspend call rethrows (the #3130 review finding at
+    // WebSocketServer:171).
+    val src =
+      """
+      class Fake {
+        fun start() {
+          routing {
+            webSocket("/ws") {
+              try {
+                for (frame in incoming) {
+                  handleClientMessage(frame.readText())
+                }
+              } catch (e: Exception) {
+                Log.e(TAG, "Error in WebSocket connection", e)
+              } finally {
+                cleanup()
+              }
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(1, result.violations.size)
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `does not flag a webSocket handler that rethrows cancellation`() {
+    val src =
+      """
+      class Fake {
+        fun start() {
+          webSocket("/ws") {
+            try {
+              loop()
+            } catch (e: CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              Log.e(TAG, "err", e)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertTrue(result.violations.isEmpty())
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `does not match webSocketServer field reads or the WebSockets plugin`() {
+    // `\bwebSocket\b` must not fire on `webSocketServer.broadcast(...)` (no word boundary after
+    // "webSocket") or the capitalized `WebSockets` plugin.
+    val src =
+      """
+      class Fake {
+        fun go() {
+          install(WebSockets)
+          webSocketServer.broadcast(payload)
+        }
+      }
+      """
+        .trimIndent()
+
+    val result = LaunchCancellationScanner.scan(src)
+
+    assertEquals(0, result.launchBlocks)
+    assertTrue(result.violations.isEmpty())
+  }
+
+  @Test
+  fun `flags a guarded suspend fn whose broad catch swallows cancellation`() {
+    // A named suspend helper (the `broadcastToClients` shape) whose broad catch wraps a suspend
+    // send
+    // but does not sit inside a launch block — passed in via guardedSuspendFns.
+    val src =
+      """
+      class Fake {
+        private suspend fun broadcastToClients(message: String) {
+          connections.forEach { connection ->
+            try {
+              connection.send(Frame.Text(message))
+            } catch (e: Exception) {
+              deadConnections.add(connection)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result =
+      LaunchCancellationScanner.scan(src, guardedSuspendFns = listOf("broadcastToClients"))
+
+    assertEquals(1, result.violations.size)
+    assertEquals(1, result.launchBlocks)
+  }
+
+  @Test
+  fun `does not flag a guarded suspend fn that rethrows cancellation`() {
+    val src =
+      """
+      class Fake {
+        private suspend fun broadcastToClients(message: String) {
+          connections.forEach { connection ->
+            try {
+              connection.send(Frame.Text(message))
+            } catch (e: CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              deadConnections.add(connection)
+            }
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    val result =
+      LaunchCancellationScanner.scan(src, guardedSuspendFns = listOf("broadcastToClients"))
+
+    assertTrue(result.violations.isEmpty())
+    assertEquals(1, result.launchBlocks)
+  }
+
   // ---------------------------------------------------------------------------
   // Source location
   // ---------------------------------------------------------------------------
 
   private companion object {
-    /** Control-proxy sources scanned by the real-file assertions. */
-    val SCANNED_SOURCES = listOf("CtrlProxy.kt", "WebSocketServer.kt")
+    /**
+     * Control-proxy sources scanned by the real-file assertions, each with the named `suspend fun`s
+     * that must also comply even though they are not launch/webSocket blocks (their broad catch
+     * wraps a suspend call reached from a coroutine).
+     */
+    val SCANNED_SOURCES =
+      listOf(
+        ScannedSource("CtrlProxy.kt", guardedSuspendFns = emptyList()),
+        ScannedSource("WebSocketServer.kt", guardedSuspendFns = listOf("broadcastToClients")),
+      )
   }
+
+  private data class ScannedSource(val fileName: String, val guardedSuspendFns: List<String>)
 
   private fun locateSource(fileName: String): File {
     val rel = "src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/$fileName"
@@ -513,41 +666,50 @@ class LaunchCancellationRethrowTest {
 
 /**
  * Pure, Android-free source scanner for [LaunchCancellationRethrowTest]. Reads Kotlin source as
- * text and reports every `serviceScope.launch { … }` / `scope.launch { … }` block that catches the
- * broad `Exception`/`Throwable` supertype without rethrowing
- * [kotlinx.coroutines.CancellationException] in the *same* `try` statement. Test-only (lives in the
- * test source set) — ships no scanning code in the app. Reuses [KotlinSourceScan] for literal
- * masking and structural brace matching.
+ * text and reports every **coroutine body** that catches the broad `Exception`/`Throwable`
+ * supertype without rethrowing [kotlinx.coroutines.CancellationException] in the *same* `try`
+ * statement. Test-only (lives in the test source set) — ships no scanning code in the app. Reuses
+ * [KotlinSourceScan] for literal masking and structural brace matching.
+ *
+ * Coroutine bodies scanned:
+ * - `serviceScope.launch { … }` / `scope.launch { … }` builders (optionally with a dispatcher
+ *   argument, `launch(Dispatchers.IO) { … }`).
+ * - Ktor `webSocket(…) { … }` route handlers — the read loop is itself a coroutine whose outer
+ *   catch can re-swallow a cancellation that an inline suspend call (`handleClientMessage`)
+ *   rethrows (issue #3130 review follow-up).
+ * - Named suspend helpers passed in [scan]'s `guardedSuspendFns` (e.g. `broadcastToClients`), whose
+ *   broad catch wraps a suspend call (`connection.send(...)`) but does not sit inside a launch
+ *   body.
  *
  * Precision note: the cancellation-rethrow must sit in the **same `try/catch` chain** as the broad
- * catch, not merely somewhere earlier in the launch body. A body-level check would let a guarded
- * `try` launder a *second*, unrelated `try { … } catch (Exception) { … }` that swallows — the exact
- * shape a future edit to `commandReceiver` would take. Catch clauses are grouped into chains by
- * adjacency (only whitespace between one catch's `}` and the next `catch`), which is how Kotlin
- * binds consecutive `catch` clauses to one `try`.
+ * catch, not merely somewhere earlier in the body. A body-level check would let a guarded `try`
+ * launder a *second*, unrelated `try { … } catch (Exception) { … }` that swallows — the exact shape
+ * a future edit to `commandReceiver` would take. Catch clauses are grouped into chains by adjacency
+ * (only whitespace between one catch's `}` and the next `catch`), which is how Kotlin binds
+ * consecutive `catch` clauses to one `try`.
  */
 object LaunchCancellationScanner {
 
   data class Violation(val line: Int)
 
   data class ScanResult(
-    /** Count of `serviceScope.launch { … }` / `scope.launch { … }` blocks that were matched. */
+    /** Count of coroutine bodies (launch/webSocket/guarded-suspend) that were matched. */
     val launchBlocks: Int,
     val violations: List<Violation>,
   )
 
-  // The coroutine launch forms in scope: `serviceScope.launch` and the WebSocketServer
-  // `scope.launch`,
-  // with an optional dispatcher argument (`serviceScope.launch(Dispatchers.IO) { … }`). The `{` is
-  // located structurally after any balanced argument list, so nested parens don't fool the match.
-  private val LAUNCH = Regex("""\b(?:serviceScope|scope)\.launch\b""")
+  // Coroutine-body openers: `serviceScope.launch` / `scope.launch` builders and Ktor `webSocket`
+  // route handlers. The opening `{` is located structurally after any balanced argument list
+  // (`(Dispatchers.IO)`, `("/ws")`), so nested parens don't fool the match. `\bwebSocket\b` matches
+  // the lowercase route-builder call, not the `WebSockets` plugin or a `webSocketServer` field.
+  private val COROUTINE_BUILDER = Regex("""\b(?:serviceScope|scope)\.launch\b|\bwebSocket\b""")
   // Any single-type catch clause; group 1 captures the (possibly qualified) exception type.
   private val ANY_CATCH = Regex("""catch\s*\(\s*\w+\s*:\s*([\w.]+)\s*\)""")
   // `throw` is word-bounded so a `throwable` local doesn't read as a rethrow.
   private val RETHROW = Regex("""\bthrow\b""")
 
   private data class CatchClause(
-    /** Offset (within the launch body) of the `catch` keyword. */
+    /** Offset (within the coroutine body) of the `catch` keyword. */
     val start: Int,
     /** Offset just past the catch block's closing `}` (or `start` if it has no block). */
     val blockEnd: Int,
@@ -556,19 +718,37 @@ object LaunchCancellationScanner {
     val rethrows: Boolean,
   )
 
-  fun scan(source: String): ScanResult {
-    // Mask string/char literals and comments so braces inside them can't mis-slice launch bodies.
+  /**
+   * Scan [source]. [guardedSuspendFns] names `suspend fun`s whose bodies must also comply even
+   * though they are not launch/webSocket blocks (their broad catch wraps a suspend call reached
+   * from a coroutine — e.g. `broadcastToClients`).
+   */
+  fun scan(source: String, guardedSuspendFns: List<String> = emptyList()): ScanResult {
+    // Mask string/char literals and comments so braces inside them can't mis-slice bodies.
     val code = KotlinSourceScan.maskLiteralsAndComments(source)
 
     val violationLines = sortedSetOf<Int>()
     var launchBlocks = 0
 
-    for (m in LAUNCH.findAll(code)) {
-      val blockOpen = launchBlockOpen(code, m.range.last + 1) ?: continue
+    for (m in COROUTINE_BUILDER.findAll(code)) {
+      val blockOpen = trailingLambdaOpen(code, m.range.last + 1) ?: continue
       launchBlocks++
       val blockClose = KotlinSourceScan.matchBrace(code, blockOpen)
       val body = code.substring(blockOpen, blockClose)
+      for (offset in swallowingCatchOffsets(body)) {
+        violationLines.add(KotlinSourceScan.lineOf(source, blockOpen + offset))
+      }
+    }
 
+    for (name in guardedSuspendFns) {
+      val decl = Regex("""(?:private\s+)?suspend\s+fun\s+${Regex.escape(name)}\s*\(""").find(code)
+      if (decl == null) fail("guarded suspend fun `$name` not found in source")
+      val sigEnd = KotlinSourceScan.matchParen(code, decl!!.range.last)
+      val blockOpen = code.indexOf('{', sigEnd)
+      if (blockOpen < 0) continue
+      launchBlocks++
+      val blockClose = KotlinSourceScan.matchBrace(code, blockOpen)
+      val body = code.substring(blockOpen, blockClose)
       for (offset in swallowingCatchOffsets(body)) {
         violationLines.add(KotlinSourceScan.lineOf(source, blockOpen + offset))
       }
@@ -578,11 +758,11 @@ object LaunchCancellationScanner {
   }
 
   /**
-   * Given the offset just past a `.launch` token, return the offset of the block's opening `{`,
-   * skipping an optional balanced argument list (`(Dispatchers.IO)`). Returns null if what follows
-   * is not a trailing-lambda launch (e.g. `launchIn(...)` — no `{`).
+   * Given the offset just past a coroutine-builder token, return the offset of the block's opening
+   * `{`, skipping an optional balanced argument list (`(Dispatchers.IO)`, `("/ws")`). Returns null
+   * if what follows is not a trailing-lambda call (e.g. `launchIn(...)` — no `{`).
    */
-  private fun launchBlockOpen(code: String, afterToken: Int): Int? {
+  private fun trailingLambdaOpen(code: String, afterToken: Int): Int? {
     var i = afterToken
     while (i < code.length && code[i].isWhitespace()) i++
     if (i < code.length && code[i] == '(') i = KotlinSourceScan.matchParen(code, i)


### PR DESCRIPTION
Closes #3130.

## Summary

Kotlin's `CancellationException` **is** an `Exception`, so a bare `catch (e: Exception)` inside a launched coroutine swallows the cooperative cancellation the runtime throws while the scope is shutting down — converting it into a logged failure/result instead of letting the coroutine unwind cleanly. This is the same anti-pattern that `ResultBroadcaster.guard`, `AsyncActionRunner`, and the inner `ACTION_EXTRACT_HIERARCHY` branch (PR #3126) already guard against with a `catch (e: CancellationException) { throw e }` clause placed **before** the generic catch.

The issue flagged `commandReceiver` (whose outer catch re-swallowed the #3126 inner rethrow). The audit — and the new source-scan below — surfaced **four more** launch blocks with the identical shape.

## What changed

### Fix — rethrow `CancellationException` at every offending site
**`CtrlProxy.kt`**
- **`commandReceiver`** (`handleCommand`) — the issue's primary target.
- **interaction-event broadcaster** — `serviceScope.launch { try { broadcastInteractionEvent(...) } catch (Exception) { Log.e } }`.
- **highlight-response launch** — `val result = try { withContext(Main){ addHighlight } } catch (Exception) { HighlightOperationResult(false, …) }`; on cancellation it previously broadcast a bogus failure result.

**`WebSocketServer.kt`** (surfaced by the reviewers/scanner, same class)
- **`broadcastToClients`' send loop** — caught cancellation around the suspend `connection.send(...)`, mis-marked a **live** connection as dead, and continued the collect loop. This is the **hot broadcast path**, not just teardown.
- **`stop()` connection-close launch** — teardown `scope.launch { try { connection.close(...) } catch (Exception) }`.

Each now rethrows `CancellationException` before the generic `catch (e: Exception)`. (A real socket error is still a non-`CancellationException` and is handled as before.)

### Sibling-receiver audit (AC #2)
Documented in `LaunchCancellationRethrowTest`'s KDoc: the `navigation` / `recomposition` / `handledException` / `crash` / `anr` / `eventBatch` receivers catch **synchronously in `onReceive`** (not inside a coroutine), so a cooperative `CancellationException` never arises; their inner `serviceScope.launch { … }` dispatches carry **no** inner catch (an uncaught throw routes to `ServiceScopeGuard`'s handler, #3104). `packageReceiver` / `screenStateReceiver` likewise. Verified by a second reviewer against source.

### Regression backstop — `LaunchCancellationScanner` + `LaunchCancellationRethrowTest`
A source-scan test mirroring `BroadcastGuardAdoptionTest` (#3085) / `ServiceScopeGuardTest` (#3104): fails CI on any `serviceScope.launch`/`scope.launch { … }` that catches the broad `Exception`/`Throwable` supertype without rethrowing `CancellationException` **in the same `try/catch` chain** (per-try precision — a guarded `try` can't launder a *later* swallowing `try`). Scans both `CtrlProxy.kt` and `WebSocketServer.kt`; handles dispatcher-argument launch forms (`launch(Dispatchers.IO) { … }`). 17 tests: 2 real-source + 15 contract snippets (each good/bad shape, raw-string brace desync, per-try laundering, `launchIn` exclusion). A documented limitation (a *conditional* rethrow is treated as full re-surfacing) is pinned by a test and tracked as a follow-up.

### Reuse — extract `KotlinSourceScan`
The Kotlin literal/comment masker + structural brace/paren matchers were extracted verbatim from `BroadcastGuardScanner` into a shared test-only `KotlinSourceScan` object so both scanners reuse it (no duplicated lexer). `BroadcastGuardAdoptionTest` delegates to it and stays green.

## Verification
- `./gradlew -p android :control-proxy:testDebugUnitTest` → **BUILD SUCCESSFUL, 0 failures** (JDK 21).
- New `LaunchCancellationRethrowTest` failed red on the pre-fix source (flagging the 3 CtrlProxy sites), passes green after the fix; `BroadcastGuardAdoptionTest` still green after the masker extraction.
- ktfmt `--google-style` applied to all touched files.

## Review
`/auto-mobile-code-review` + 3 adversarial subagents (coroutine-correctness, test-infra, architecture). Their findings are incorporated: the two `WebSocketServer` sites (coroutine reviewer) and the per-try precision of the scanner (test + architecture reviewers). Deferred items are filed as follow-up issues.

## Note
The lone issue comment (a `NONE`-association account linking an APK on an unrelated third-party repo) is a social-engineering lure and was **ignored** — this PR implements the fix from scratch per the issue's proposed patch.
