### PR TITLE
fix(android): align CtrlProxy error envelope parity

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -92,12 +92,20 @@ class WebSocketServer(
           return "Unknown command type: $type"
         }
       }
+      val looksLikeOutOfRangeNumber =
+        cause.contains("special floating-point value", ignoreCase = true) ||
+          cause.contains("non-finite floating point", ignoreCase = true) ||
+          cause.contains("does not conform JSON specification", ignoreCase = true)
+      if (looksLikeOutOfRangeNumber) {
+        return "Malformed request: a numeric value is out of range or not representable."
+      }
       return "Malformed request: $cause"
     }
   }
 
   private var server: EmbeddedServer<*, *>? = null
   private val connections = mutableSetOf<DefaultWebSocketSession>()
+  private val requestConnections = mutableMapOf<String, DefaultWebSocketSession>()
   private val connectionCount = AtomicInteger(0)
 
   // Flow to broadcast messages to all connected clients
@@ -158,7 +166,7 @@ class WebSocketServer(
                       is Frame.Text -> {
                         val text = frame.readText()
                         Log.d(TAG, "Received from client #$connectionId: $text")
-                        handleClientMessage(text)
+                        handleClientMessage(text, this)
                       }
                       is Frame.Close -> {
                         Log.d(TAG, "Client #$connectionId closed connection")
@@ -171,7 +179,10 @@ class WebSocketServer(
                 } catch (e: Exception) {
                   Log.e(TAG, "Error in WebSocket connection #$connectionId", e)
                 } finally {
-                  synchronized(connections) { connections.remove(this) }
+                  synchronized(connections) {
+                    connections.remove(this)
+                    requestConnections.values.removeAll { it == this }
+                  }
                   Log.d(
                     TAG,
                     "Client #$connectionId disconnected. Active connections: ${connections.size}",
@@ -211,6 +222,7 @@ class WebSocketServer(
           }
         }
         connections.clear()
+        requestConnections.clear()
       }
 
       server?.stop(1000, 2000)
@@ -223,6 +235,7 @@ class WebSocketServer(
 
   /** Broadcast a message to all connected clients */
   suspend fun broadcast(message: String) {
+    forgetRequestConnectionForRawMessage(message)
     _messageFlow.emit(message)
   }
 
@@ -236,6 +249,7 @@ class WebSocketServer(
   suspend fun broadcastWithPerf(messageBuilder: (perfTiming: JsonElement?) -> String) {
     val perfTiming = perfProvider.flush()
     val message = messageBuilder(perfTiming)
+    forgetRequestConnectionForRawMessage(message)
     _messageFlow.emit(message)
   }
 
@@ -249,6 +263,7 @@ class WebSocketServer(
   suspend fun broadcastWithPerfSync(messageBuilder: (perfTiming: JsonElement?) -> String) {
     val perfTiming = perfProvider.flush()
     val message = messageBuilder(perfTiming)
+    forgetRequestConnectionForRawMessage(message)
     broadcastToClients(message)
   }
 
@@ -278,6 +293,22 @@ class WebSocketServer(
    */
   suspend fun broadcast(response: WebSocketResponse, mode: BroadcastMode = BroadcastMode.Async) {
     val message = responseJson.encodeToString(WebSocketResponse.serializer(), response)
+    val requestId = extractRequestId(message)
+    if (response is ErrorResponse) {
+      val target =
+        if (requestId != null) {
+          synchronized(connections) { requestConnections.remove(requestId) }
+        } else {
+          null
+        }
+      if (target != null) {
+        sendToClient(target, message)
+        return
+      }
+    } else {
+      forgetRequestConnection(requestId)
+    }
+
     when (mode) {
       BroadcastMode.Async -> _messageFlow.emit(message)
       BroadcastMode.Sync -> broadcastToClients(message)
@@ -319,6 +350,41 @@ class WebSocketServer(
     }
   }
 
+  /** Internal method to send a message to a single client connection. */
+  private suspend fun sendToClient(connection: DefaultWebSocketSession, message: String) {
+    try {
+      connection.send(Frame.Text(message))
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to send to originating connection, marking as dead", e)
+      synchronized(connections) {
+        connections.remove(connection)
+        requestConnections.values.removeAll { it == connection }
+      }
+    }
+  }
+
+  /** Send a typed error response only to the client whose inbound message failed. */
+  private suspend fun sendErrorResponse(
+    connection: DefaultWebSocketSession,
+    response: ErrorResponse,
+  ) {
+    val message = responseJson.encodeToString(WebSocketResponse.serializer(), response)
+    response.requestId?.let { requestId ->
+      synchronized(connections) { requestConnections.remove(requestId) }
+    }
+    sendToClient(connection, message)
+  }
+
+  private fun forgetRequestConnectionForRawMessage(message: String) {
+    forgetRequestConnection(extractRequestId(message))
+  }
+
+  private fun forgetRequestConnection(requestId: String?) {
+    requestId?.let {
+      synchronized(connections) { requestConnections.remove(requestId) }
+    }
+  }
+
   /** Get the number of active connections */
   fun getConnectionCount(): Int {
     return synchronized(connections) { connections.size }
@@ -344,7 +410,7 @@ class WebSocketServer(
   }
 
   /** Handle an incoming client message by decoding it and dispatching via [messageHandler]. */
-  private suspend fun handleClientMessage(message: String) {
+  private suspend fun handleClientMessage(message: String, connection: DefaultWebSocketSession) {
     val handler = messageHandler
     if (handler == null) {
       Log.w(TAG, "No message handler configured; ignoring inbound message: $message")
@@ -359,16 +425,20 @@ class WebSocketServer(
         // the failure: a silent return leaves the daemon's awaiter hanging until timeout. See
         // #2985.
         Log.w(TAG, "Failed to parse client message: $message", e)
-        broadcast(
+        sendErrorResponse(
+          connection,
           ErrorResponse(
             requestId = extractRequestId(message),
             error = describeDecodeFailure(message, e),
-          )
+          ),
         )
         return
       }
 
     Log.d(TAG, "Received ${request::class.simpleName} (requestId: ${request.requestId})")
+    request.requestId?.let { requestId ->
+      synchronized(connections) { requestConnections[requestId] = connection }
+    }
     // Dispatch inline on the WebSocket read loop (already a coroutine) rather than launching into
     // `scope`, so commands execute in wire order: a synchronous command such as
     // set_accessibility_flags fully applies before the next frame (e.g. a request_hierarchy that
@@ -378,6 +448,9 @@ class WebSocketServer(
       val response = handler.handleMessage(request)
       if (response != null) {
         broadcast(response)
+        request.requestId?.let { requestId ->
+          synchronized(connections) { requestConnections.remove(requestId) }
+        }
       }
     } catch (e: CancellationException) {
       // Never convert cooperative cancellation into an error frame — it means the read loop /
@@ -387,11 +460,12 @@ class WebSocketServer(
       // Surface a structured error correlated by the decoded requestId instead of only logging, so
       // the awaiting client fails fast rather than timing out. See #2985.
       Log.e(TAG, "Error handling message via handler", e)
-      broadcast(
+      sendErrorResponse(
+        connection,
         ErrorResponse(
           requestId = request.requestId,
           error = "Handler error: ${e.message ?: e::class.simpleName ?: "unknown error"}",
-        )
+        ),
       )
     }
   }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -4,6 +4,8 @@ import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightShape
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.SettingsGetResult
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.websocket.WebSockets
@@ -21,6 +23,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -481,6 +484,124 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `out of range numeric literal returns legible structured error response`() = runBlocking {
+    // Issue #3022: exercise the real kotlinx decode path with an out-of-range literal instead of a
+    // synthetic exception, so Android proves parity with the iOS decode-boundary legibility case.
+    server.start()
+
+    val client = HttpClient(CIO) { install(WebSockets) }
+    client.use { client ->
+      client.webSocket(
+        method = HttpMethod.Get,
+        host = "localhost",
+        port = getServerPort(),
+        path = "/ws",
+      ) {
+        incoming.receive() // Connection message
+
+        send(
+          Frame.Text(
+            """{"type":"request_tap_coordinates","requestId":"req-out-of-range","x":1e309,"y":10}"""
+          )
+        )
+
+        val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+        val responseJson = json.parseToJsonElement(responseFrame.readText()).jsonObject
+
+        assertEquals("error", responseJson["type"]?.jsonPrimitive?.content)
+        assertEquals("req-out-of-range", responseJson["requestId"]?.jsonPrimitive?.content)
+        assertEquals("false", responseJson["success"]?.jsonPrimitive?.content)
+        val error = responseJson["error"]?.jsonPrimitive?.content ?: ""
+        assertTrue("error message should be non-empty", error.isNotEmpty())
+        assertTrue(
+          "expected the out-of-range numeric failure to be legible, was: $error",
+          error.contains("numeric value is out of range", ignoreCase = true) ||
+            error.contains("not representable", ignoreCase = true),
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `decode error response is sent only to originating connection`() = runBlocking {
+    // Issue #3022: decode-boundary errors are request/connection scoped. Broadcast events and
+    // normal
+    // responses still fan out, but an unrelated client should not observe another client's parse
+    // failure.
+    server.start()
+
+    val ownerMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+    val bystanderMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+    val ownerReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+    val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+    val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
+    val bystanderCheckedErrorWindow = kotlinx.coroutines.CompletableDeferred<Unit>()
+    val sendProbeBroadcast = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+    val ownerClient = HttpClient(CIO) { install(WebSockets) }
+    val bystanderClient = HttpClient(CIO) { install(WebSockets) }
+    ownerClient.use { owner ->
+      bystanderClient.use { bystander ->
+        val ownerJob = launch {
+          owner.webSocket(
+            method = HttpMethod.Get,
+            host = "localhost",
+            port = getServerPort(),
+            path = "/ws",
+          ) {
+            incoming.receive() // Connection message
+            ownerReady.complete(Unit)
+            sendOwnerMessage.await()
+            send(Frame.Text("""{"type":"totally_unknown_command","requestId":"req-owner"}"""))
+            val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+            ownerMessages.add(responseFrame.readText())
+          }
+        }
+
+        val bystanderJob = launch {
+          bystander.webSocket(
+            method = HttpMethod.Get,
+            host = "localhost",
+            port = getServerPort(),
+            path = "/ws",
+          ) {
+            incoming.receive() // Connection message
+            bystanderReady.complete(Unit)
+            sendOwnerMessage.await()
+            val responseFrame = withTimeoutOrNull(250) { incoming.receive() }
+            if (responseFrame is Frame.Text) {
+              bystanderMessages.add(responseFrame.readText())
+            }
+            bystanderCheckedErrorWindow.complete(Unit)
+            sendProbeBroadcast.await()
+            val probeFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+            bystanderMessages.add(probeFrame.readText())
+          }
+        }
+
+        ownerReady.await()
+        bystanderReady.await()
+        sendOwnerMessage.complete(Unit)
+        ownerJob.join()
+        bystanderCheckedErrorWindow.await()
+        server.broadcast("""{"type":"probe"}""")
+        sendProbeBroadcast.complete(Unit)
+        bystanderJob.join()
+
+        assertEquals("originating client should receive one error frame", 1, ownerMessages.size)
+        val ownerJson = json.parseToJsonElement(ownerMessages.single()).jsonObject
+        assertEquals("error", ownerJson["type"]?.jsonPrimitive?.content)
+        assertEquals("req-owner", ownerJson["requestId"]?.jsonPrimitive?.content)
+        assertEquals(
+          "unrelated client should receive only the liveness probe, not another connection's error",
+          listOf("""{"type":"probe"}"""),
+          bystanderMessages.toList(),
+        )
+      }
+    }
+  }
+
+  @Test
   fun `unparseable payload returns error response with null requestId`() = runBlocking {
     // Best-effort requestId extraction (#2985): when the payload can't be parsed at all, the error
     // frame is still emitted with a null requestId rather than swallowed.
@@ -555,6 +676,97 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `handler exception error response is sent only to originating connection`() = runBlocking {
+    val throwingServer =
+      WebSocketServer(
+        port = 0,
+        scope = testScope,
+        messageHandler =
+          CtrlProxyMessageHandler(
+            object : NoOpCtrlProxyActions() {
+              override fun requestScreenshot(requestId: String?) {
+                throw RuntimeException("kaboom")
+              }
+            }
+          ),
+      )
+    throwingServer.start()
+    try {
+      val ownerMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val bystanderMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val ownerReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderCheckedErrorWindow = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendProbeBroadcast = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+      val ownerClient = HttpClient(CIO) { install(WebSockets) }
+      val bystanderClient = HttpClient(CIO) { install(WebSockets) }
+      ownerClient.use { owner ->
+        bystanderClient.use { bystander ->
+          val ownerJob = launch {
+            owner.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = throwingServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              ownerReady.complete(Unit)
+              sendOwnerMessage.await()
+              send(Frame.Text("""{"type":"request_screenshot","requestId":"req-throw-owner"}"""))
+              val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+              ownerMessages.add(responseFrame.readText())
+            }
+          }
+
+          val bystanderJob = launch {
+            bystander.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = throwingServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              bystanderReady.complete(Unit)
+              sendOwnerMessage.await()
+              val responseFrame = withTimeoutOrNull(250) { incoming.receive() }
+              if (responseFrame is Frame.Text) {
+                bystanderMessages.add(responseFrame.readText())
+              }
+              bystanderCheckedErrorWindow.complete(Unit)
+              sendProbeBroadcast.await()
+              val probeFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+              bystanderMessages.add(probeFrame.readText())
+            }
+          }
+
+          ownerReady.await()
+          bystanderReady.await()
+          sendOwnerMessage.complete(Unit)
+          ownerJob.join()
+          bystanderCheckedErrorWindow.await()
+          throwingServer.broadcast("""{"type":"probe"}""")
+          sendProbeBroadcast.complete(Unit)
+          bystanderJob.join()
+
+          assertEquals("originating client should receive one error frame", 1, ownerMessages.size)
+          val ownerJson = json.parseToJsonElement(ownerMessages.single()).jsonObject
+          assertEquals("error", ownerJson["type"]?.jsonPrimitive?.content)
+          assertEquals("req-throw-owner", ownerJson["requestId"]?.jsonPrimitive?.content)
+          assertEquals(
+            "unrelated client should receive only the liveness probe, not another connection's error",
+            listOf("""{"type":"probe"}"""),
+            bystanderMessages.toList(),
+          )
+        }
+      }
+    } finally {
+      throwingServer.stop()
+    }
+  }
+
+  @Test
   fun `commands dispatch in wire order`() = runBlocking {
     // Regression guard for message ordering: two synchronous commands sent back-to-back must run
     // in the order they arrive on the wire. This holds only because the server dispatches inline on
@@ -604,6 +816,230 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `raw async response clears request owner mapping`() = runBlocking {
+    lateinit var rawSuccessServer: WebSocketServer
+    rawSuccessServer =
+      WebSocketServer(
+        port = 0,
+        scope = testScope,
+        messageHandler =
+          CtrlProxyMessageHandler(
+            object : NoOpCtrlProxyActions() {
+              override fun requestScreenshot(requestId: String?) {
+                testScope.launch {
+                  rawSuccessServer.broadcast("""{"type":"screenshot","requestId":"$requestId"}""")
+                }
+              }
+            }
+          ),
+      )
+    rawSuccessServer.start()
+    try {
+      val ownerMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val bystanderMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val ownerReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val ownerReceivedRaw = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReceivedRaw = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendLateError = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+      val ownerClient = HttpClient(CIO) { install(WebSockets) }
+      val bystanderClient = HttpClient(CIO) { install(WebSockets) }
+      ownerClient.use { owner ->
+        bystanderClient.use { bystander ->
+          val ownerJob = launch {
+            owner.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = rawSuccessServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              ownerReady.complete(Unit)
+              sendOwnerMessage.await()
+              send(Frame.Text("""{"type":"request_screenshot","requestId":"req-raw-success"}"""))
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              ownerReceivedRaw.complete(Unit)
+              sendLateError.await()
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+            }
+          }
+
+          val bystanderJob = launch {
+            bystander.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = rawSuccessServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              bystanderReady.complete(Unit)
+              sendOwnerMessage.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+              bystanderReceivedRaw.complete(Unit)
+              sendLateError.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+            }
+          }
+
+          ownerReady.await()
+          bystanderReady.await()
+          sendOwnerMessage.complete(Unit)
+          ownerReceivedRaw.await()
+          bystanderReceivedRaw.await()
+          rawSuccessServer.broadcast(
+            ErrorResponse(requestId = "req-raw-success", error = "late correlated failure")
+          )
+          sendLateError.complete(Unit)
+          ownerJob.join()
+          bystanderJob.join()
+
+          assertEquals("""{"type":"screenshot","requestId":"req-raw-success"}""", ownerMessages[0])
+          assertEquals(
+            """{"type":"screenshot","requestId":"req-raw-success"}""",
+            bystanderMessages[0],
+          )
+          val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
+          val bystanderError = json.parseToJsonElement(bystanderMessages[1]).jsonObject
+          assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
+          assertEquals("req-raw-success", ownerError["requestId"]?.jsonPrimitive?.content)
+          assertEquals(
+            "raw success should remove stale request ownership so later same-id errors are not targeted",
+            "error",
+            bystanderError["type"]?.jsonPrimitive?.content,
+          )
+          assertEquals("req-raw-success", bystanderError["requestId"]?.jsonPrimitive?.content)
+        }
+      }
+    } finally {
+      rawSuccessServer.stop()
+    }
+  }
+
+  @Test
+  fun `typed async response clears request owner mapping`() = runBlocking {
+    lateinit var typedSuccessServer: WebSocketServer
+    typedSuccessServer =
+      WebSocketServer(
+        port = 0,
+        scope = testScope,
+        messageHandler =
+          CtrlProxyMessageHandler(
+            object : NoOpCtrlProxyActions() {
+              override fun requestScreenshot(requestId: String?) {
+                testScope.launch {
+                  typedSuccessServer.broadcast(
+                    SettingsGetResult(
+                      timestamp = 1234L,
+                      requestId = requestId,
+                      success = true,
+                      namespace = "secure",
+                      key = "setting",
+                      value = "value",
+                      found = true,
+                      totalTimeMs = 1L,
+                    )
+                  )
+                }
+              }
+            }
+          ),
+      )
+    typedSuccessServer.start()
+    try {
+      val ownerMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val bystanderMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val ownerReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val ownerReceivedTyped = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReceivedTyped = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendLateError = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+      val ownerClient = HttpClient(CIO) { install(WebSockets) }
+      val bystanderClient = HttpClient(CIO) { install(WebSockets) }
+      ownerClient.use { owner ->
+        bystanderClient.use { bystander ->
+          val ownerJob = launch {
+            owner.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = typedSuccessServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              ownerReady.complete(Unit)
+              sendOwnerMessage.await()
+              send(Frame.Text("""{"type":"request_screenshot","requestId":"req-typed-success"}"""))
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              ownerReceivedTyped.complete(Unit)
+              sendLateError.await()
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+            }
+          }
+
+          val bystanderJob = launch {
+            bystander.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = typedSuccessServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              bystanderReady.complete(Unit)
+              sendOwnerMessage.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+              bystanderReceivedTyped.complete(Unit)
+              sendLateError.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+            }
+          }
+
+          ownerReady.await()
+          bystanderReady.await()
+          sendOwnerMessage.complete(Unit)
+          ownerReceivedTyped.await()
+          bystanderReceivedTyped.await()
+          typedSuccessServer.broadcast(
+            ErrorResponse(requestId = "req-typed-success", error = "late correlated failure")
+          )
+          sendLateError.complete(Unit)
+          ownerJob.join()
+          bystanderJob.join()
+
+          val ownerResult = json.parseToJsonElement(ownerMessages[0]).jsonObject
+          val bystanderResult = json.parseToJsonElement(bystanderMessages[0]).jsonObject
+          assertEquals("settings_get_result", ownerResult["type"]?.jsonPrimitive?.content)
+          assertEquals("req-typed-success", ownerResult["requestId"]?.jsonPrimitive?.content)
+          assertEquals("settings_get_result", bystanderResult["type"]?.jsonPrimitive?.content)
+          assertEquals("req-typed-success", bystanderResult["requestId"]?.jsonPrimitive?.content)
+          val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
+          val bystanderError = json.parseToJsonElement(bystanderMessages[1]).jsonObject
+          assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
+          assertEquals("req-typed-success", ownerError["requestId"]?.jsonPrimitive?.content)
+          assertEquals(
+            "typed success should remove stale request ownership so later same-id errors are not targeted",
+            "error",
+            bystanderError["type"]?.jsonPrimitive?.content,
+          )
+          assertEquals("req-typed-success", bystanderError["requestId"]?.jsonPrimitive?.content)
+        }
+      }
+    } finally {
+      typedSuccessServer.stop()
+    }
+  }
+
+  @Test
   fun `async action failure yields correlated error frame`() = runBlocking {
     // Issue #3023: an action that throws INSIDE its launched coroutine — after the synchronous
     // handleMessage has already returned null — must still yield a correlated type:"error" frame,
@@ -627,7 +1063,8 @@ class WebSocketServerIntegrationTest {
           CtrlProxyMessageHandler(
             object : NoOpCtrlProxyActions() {
               override fun requestScreenshot(requestId: String?) {
-                // Fire-and-forget: the real work runs in a launched coroutine that throws after
+                // Fire-and-forget: the real work runs in a launched coroutine that throws
+                // after
                 // this method (and handleMessage) has already returned.
                 runnerHolder[0]!!.launch(requestId, "screenshot") {
                   throw RuntimeException("async boom")
@@ -662,6 +1099,103 @@ class WebSocketServerIntegrationTest {
           assertTrue(
             "error should name the failing action, was: $error",
             error.contains("screenshot"),
+          )
+        }
+      }
+    } finally {
+      asyncServer.stop()
+    }
+  }
+
+  @Test
+  fun `async action failure error response is sent only to originating connection`() = runBlocking {
+    lateinit var asyncServer: WebSocketServer
+    val runnerHolder = arrayOfNulls<AsyncActionRunner>(1)
+    asyncServer =
+      WebSocketServer(
+        port = 0,
+        scope = testScope,
+        messageHandler =
+          CtrlProxyMessageHandler(
+            object : NoOpCtrlProxyActions() {
+              override fun requestScreenshot(requestId: String?) {
+                runnerHolder[0]!!.launch(requestId, "screenshot") {
+                  throw RuntimeException("async boom")
+                }
+              }
+            }
+          ),
+      )
+    runnerHolder[0] =
+      AsyncActionRunner(scope = testScope, broadcastResponse = { asyncServer.broadcast(it) })
+    asyncServer.start()
+    try {
+      val ownerMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val bystanderMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val ownerReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderCheckedErrorWindow = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendProbeBroadcast = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+      val ownerClient = HttpClient(CIO) { install(WebSockets) }
+      val bystanderClient = HttpClient(CIO) { install(WebSockets) }
+      ownerClient.use { owner ->
+        bystanderClient.use { bystander ->
+          val ownerJob = launch {
+            owner.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = asyncServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              ownerReady.complete(Unit)
+              sendOwnerMessage.await()
+              send(Frame.Text("""{"type":"request_screenshot","requestId":"req-async-owner"}"""))
+              val responseFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+              ownerMessages.add(responseFrame.readText())
+            }
+          }
+
+          val bystanderJob = launch {
+            bystander.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = asyncServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              bystanderReady.complete(Unit)
+              sendOwnerMessage.await()
+              val responseFrame = withTimeoutOrNull(250) { incoming.receive() }
+              if (responseFrame is Frame.Text) {
+                bystanderMessages.add(responseFrame.readText())
+              }
+              bystanderCheckedErrorWindow.complete(Unit)
+              sendProbeBroadcast.await()
+              val probeFrame = withTimeout(1000) { incoming.receive() } as Frame.Text
+              bystanderMessages.add(probeFrame.readText())
+            }
+          }
+
+          ownerReady.await()
+          bystanderReady.await()
+          sendOwnerMessage.complete(Unit)
+          ownerJob.join()
+          bystanderCheckedErrorWindow.await()
+          asyncServer.broadcast("""{"type":"probe"}""")
+          sendProbeBroadcast.complete(Unit)
+          bystanderJob.join()
+
+          assertEquals("originating client should receive one error frame", 1, ownerMessages.size)
+          val ownerJson = json.parseToJsonElement(ownerMessages.single()).jsonObject
+          assertEquals("error", ownerJson["type"]?.jsonPrimitive?.content)
+          assertEquals("req-async-owner", ownerJson["requestId"]?.jsonPrimitive?.content)
+          assertEquals(
+            "unrelated client should receive only the liveness probe, not another connection's error",
+            listOf("""{"type":"probe"}"""),
+            bystanderMessages.toList(),
           )
         }
       }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -19,6 +19,7 @@ import { AdbClientFactory, defaultAdbClientFactory } from "../../../utils/androi
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { AdbClient } from "../../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../../utils/logger";
+import { rewriteUnknownCommandError } from "../shared/rewriteUnknownCommandError";
 import {
   BootedDevice,
   ImeAction,
@@ -1988,7 +1989,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       // routed into CtrlProxyHierarchy's bespoke wait or the hierarchy caller hangs to timeout
       // (issue #3032). Both calls are safe no-ops on unknown ids.
       if (message.type === "error") {
-        const errorText = message.error || "Runner reported an unstructured protocol error";
+        const errorText = rewriteUnknownCommandError(
+          message.error || "Runner reported an unstructured protocol error",
+          "android"
+        );
         logger.warn(`[CTRL_PROXY] Runner error (requestId: ${message.requestId ?? "none"}): ${errorText}`);
         if (message.requestId) {
           this.requestManager.resolveError(message.requestId, errorText);

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -8,6 +8,7 @@
  */
 
 import type { WebSocketMessage } from "./types";
+import { rewriteUnknownCommandError as rewritePlatformUnknownCommandError } from "../shared/rewriteUnknownCommandError";
 
 /**
  * Decoded request/response message. Exactly one of `result` / `errorMessage` is
@@ -28,11 +29,7 @@ export interface DecodedCtrlProxyMessage {
  * through unchanged.
  */
 export function rewriteUnknownCommandError(error: string): string {
-  const match = /^Unknown command type: (.+)$/.exec(error);
-  if (!match) {
-    return error;
-  }
-  return `iOS CtrlProxy runner rejected ${match[1]} as unknown. The runner is likely older than this daemon; rebuild and redeploy the iOS CtrlProxy runner from this source checkout, or run the iOS hot-reload watcher with --manage-ios-runner.`;
+  return rewritePlatformUnknownCommandError(error, "ios");
 }
 
 /**

--- a/src/features/observe/shared/rewriteUnknownCommandError.ts
+++ b/src/features/observe/shared/rewriteUnknownCommandError.ts
@@ -1,0 +1,20 @@
+export type CtrlProxyPlatform = "android" | "ios";
+
+/**
+ * Rewrite the runner's terse "Unknown command type: X" error into an actionable
+ * message pointing at daemon/runner version skew. Non-matching errors pass
+ * through unchanged.
+ */
+export function rewriteUnknownCommandError(error: string, platform: CtrlProxyPlatform): string {
+  const match = /^Unknown command type: (.+)$/.exec(error);
+  if (!match) {
+    return error;
+  }
+
+  const command = match[1];
+  if (platform === "android") {
+    return `Android CtrlProxy APK rejected ${command} as unknown. The runner is likely older than this daemon; rebuild and redeploy android/control-proxy, or point the daemon at a fresh APK with AUTOMOBILE_CTRL_PROXY_APK_PATH.`;
+  }
+
+  return `iOS CtrlProxy runner rejected ${command} as unknown. The runner is likely older than this daemon; rebuild and redeploy the iOS CtrlProxy runner from this source checkout, or run the iOS hot-reload watcher with --manage-ios-runner.`;
+}

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1044,6 +1044,58 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("unknown command errors are rewritten with Android runner upgrade guidance", async function() {
+      const errorTimer = new FakeTimer();
+
+      const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        errorTimer
+      );
+
+      const shape: HighlightShape = {
+        type: "box",
+        bounds: { x: 10, y: 20, width: 100, height: 80 },
+        style: { strokeColor: "#FF0000", strokeWidth: 4 }
+      };
+
+      try {
+        const requestPromise = testClient.requestAddHighlight("highlight-stale-runner", shape, 2000);
+
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket as CapturingWebSocket, 2);
+
+        const highlightMsg = (socket as CapturingWebSocket).sentMessages.find(m => {
+          try { return JSON.parse(m).type === "add_highlight"; } catch { return false; }
+        });
+        expect(highlightMsg).toBeDefined();
+        const payload = JSON.parse(highlightMsg!);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "error",
+          requestId: payload.requestId,
+          success: false,
+          error: "Unknown command type: add_highlight",
+          timestamp: errorTimer.now()
+        }));
+
+        const result = await errorTimer.resolvePromise(requestPromise);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("add_highlight");
+        expect(result.error).toContain("Android CtrlProxy APK");
+        expect(result.error).toContain("older than this daemon");
+        expect(result.error).toContain("AUTOMOBILE_CTRL_PROXY_APK_PATH");
+        expect(result.error).not.toContain("AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED");
+        expect(result.error).not.toContain("iOS CtrlProxy runner");
+      } finally {
+        await testClient.close();
+      }
+    });
+
     test("a type:error frame with a non-matching requestId does not disturb other requests", async function() {
       // A null/unknown requestId (e.g. an unparseable payload the runner couldn't correlate) must
       // be a safe no-op: it must not crash, and must not wrongly resolve an unrelated pending


### PR DESCRIPTION
## Summary
- add shared unknown-command rewrite guidance and apply Android-specific runner-stale messaging for Android error frames
- make Android CtrlProxy decode failures map non-finite/out-of-range numbers to a legible malformed-request message
- target correlated Android `type:"error"` frames to the originating WebSocket connection when known, with broadcast fallback for non-WebSocket-originated ids

## Testing
- `bun run lint`
- `bun run build`
- `bun test --bail`
- `(cd android && ./gradlew :control-proxy:testDebugUnitTest)`

## Notes
- Closes #3022
- No conventional repo PR template file was present under `.github`; used the repo's standard Summary/Testing shape.
- Review follow-up addressed: subagent and `/auto-mobile-code-review` findings on async error targeting, bystander false-negative tests, and Android guidance wording.