### PR TITLE
feat(ios): support all privacy reset on physical devices

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -62,6 +62,35 @@ public class GesturePerformer: GesturePerforming {
         }
     }
 
+    static let allResettablePrivacyResourceNames = [
+        "camera",
+        "photos",
+        "microphone",
+        "contacts",
+        "location",
+        "calendar",
+        "reminders",
+        "media-library",
+    ]
+
+    private static let resettablePrivacyResourceAliases = Set(
+        allResettablePrivacyResourceNames + [
+            "photos-add",
+            "contacts-limited",
+            "location-always",
+        ]
+    )
+
+    static func expandedPrivacyResourceNames(for name: String) -> [String]? {
+        if name == "all" {
+            return allResettablePrivacyResourceNames
+        }
+        if resettablePrivacyResourceAliases.contains(name) {
+            return [name]
+        }
+        return nil
+    }
+
     #if canImport(XCTest) && os(iOS)
         private weak var application: XCUIApplication?
         /// Strong reference to keep the application alive when set via updateApplication.
@@ -1289,6 +1318,8 @@ public class GesturePerformer: GesturePerforming {
         /// not just simulators — the whole point of #2491. An AutoMobile permission
         /// with no `XCUIProtectedResource` equivalent (e.g. `siri`, `motion`) throws
         /// `invalidParameter` so the caller reports it as a per-permission failure.
+        /// The aggregate `all` keyword expands to every unique resettable
+        /// `XCUIProtectedResource` value before calling XCTest.
         public func resetAuthorizations(bundleId: String, resources: [String]) throws {
             // Throws on the first unmapped resource, so a mixed batch applies the
             // resets before it and then fails as a whole. The TS client sends one
@@ -1297,10 +1328,12 @@ public class GesturePerformer: GesturePerforming {
             try runOnMainThread {
                 let app = XCUIApplication(bundleIdentifier: bundleId)
                 for raw in resources {
-                    guard let resource = Self.protectedResource(for: raw) else {
+                    guard let resettableResources = Self.protectedResources(for: raw) else {
                         throw CommandError.invalidParameter("permission", raw)
                     }
-                    app.resetAuthorizationStatus(for: resource)
+                    for resource in resettableResources {
+                        app.resetAuthorizationStatus(for: resource)
+                    }
                 }
             }
         }
@@ -1310,6 +1343,20 @@ public class GesturePerformer: GesturePerforming {
         /// support matrix is advertised honestly — see issue #2491). The mapping is
         /// authoritative here rather than duplicated on the TS host, since
         /// `XCUIProtectedResource` only exists in this process.
+        private static func protectedResources(for name: String) -> [XCUIProtectedResource]? {
+            guard let names = expandedPrivacyResourceNames(for: name) else {
+                return nil
+            }
+            var resources: [XCUIProtectedResource] = []
+            for name in names {
+                guard let resource = protectedResource(for: name) else {
+                    return nil
+                }
+                resources.append(resource)
+            }
+            return resources
+        }
+
         private static func protectedResource(for name: String) -> XCUIProtectedResource? {
             switch name {
             case "camera": return .camera

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -81,6 +81,15 @@ public class GesturePerformer: GesturePerforming {
         ]
     )
 
+    static func canonicalPrivacyResourceName(for name: String) -> String {
+        switch name {
+        case "photos-add": return "photos"
+        case "contacts-limited": return "contacts"
+        case "location-always": return "location"
+        default: return name
+        }
+    }
+
     static func expandedPrivacyResourceNames(for name: String) -> [String]? {
         if name == "all" {
             return allResettablePrivacyResourceNames
@@ -1327,11 +1336,20 @@ public class GesturePerformer: GesturePerforming {
             // this only matters for a hypothetical multi-resource single request.
             try runOnMainThread {
                 let app = XCUIApplication(bundleIdentifier: bundleId)
+                var resetResourceNames = Set<String>()
                 for raw in resources {
-                    guard let resettableResources = Self.protectedResources(for: raw) else {
+                    guard let resettableResourceNames = Self.expandedPrivacyResourceNames(for: raw) else {
                         throw CommandError.invalidParameter("permission", raw)
                     }
-                    for resource in resettableResources {
+                    for resettableResourceName in resettableResourceNames {
+                        let canonicalResourceName = Self.canonicalPrivacyResourceName(for: resettableResourceName)
+                        if resetResourceNames.contains(canonicalResourceName) {
+                            continue
+                        }
+                        guard let resource = Self.protectedResource(for: resettableResourceName) else {
+                            throw CommandError.invalidParameter("permission", resettableResourceName)
+                        }
+                        resetResourceNames.insert(canonicalResourceName)
                         app.resetAuthorizationStatus(for: resource)
                     }
                 }
@@ -1343,20 +1361,6 @@ public class GesturePerformer: GesturePerforming {
         /// support matrix is advertised honestly — see issue #2491). The mapping is
         /// authoritative here rather than duplicated on the TS host, since
         /// `XCUIProtectedResource` only exists in this process.
-        private static func protectedResources(for name: String) -> [XCUIProtectedResource]? {
-            guard let names = expandedPrivacyResourceNames(for: name) else {
-                return nil
-            }
-            var resources: [XCUIProtectedResource] = []
-            for name in names {
-                guard let resource = protectedResource(for: name) else {
-                    return nil
-                }
-                resources.append(resource)
-            }
-            return resources
-        }
-
         private static func protectedResource(for name: String) -> XCUIProtectedResource? {
             switch name {
             case "camera": return .camera

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -142,7 +142,8 @@ public struct RequestLaunchApp: Decodable {
 /// Reset privacy authorizations (camera/photos/etc.) for an app back to
 /// not-determined via `XCUIApplication.resetAuthorizationStatus(for:)`. `bundleId`
 /// and `permissions` are decode-required so their absence is rejected at the wire
-/// boundary rather than silently no-op'ing. See issue #2491.
+/// boundary rather than silently no-op'ing. `permissions=["all"]` expands on the
+/// runner to every resettable resource. See issues #2491 and #3133.
 public struct RequestResetPermissions: Decodable {
     public var requestId: String?
     public var bundleId: String

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -197,8 +197,9 @@ public protocol GesturePerforming {
     /// Reset privacy authorizations for the given app back to the not-determined
     /// ("ask next time") state via `XCUIApplication.resetAuthorizationStatus(for:)`.
     /// Each entry in `resources` is an AutoMobile permission name mapped to an
-    /// `XCUIProtectedResource`; an unmapped name throws so the caller can surface a
-    /// per-permission failure. Works on physical devices, not just simulators. (#2491)
+    /// `XCUIProtectedResource`; `all` expands to every resettable resource, while
+    /// an unmapped name throws so the caller can surface a per-permission failure.
+    /// Works on physical devices, not just simulators. (#2491/#3133)
     func resetAuthorizations(bundleId: String, resources: [String]) throws
 }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1422,6 +1422,24 @@ final class CommandHandlerTests: XCTestCase {
 
     // MARK: - Reset Permissions Tests
 
+    func testResetPermissionsAllExpandsToEveryResettablePrivacyResource() {
+        XCTAssertEqual(
+            GesturePerformer.expandedPrivacyResourceNames(for: "all"),
+            [
+                "camera",
+                "photos",
+                "microphone",
+                "contacts",
+                "location",
+                "calendar",
+                "reminders",
+                "media-library",
+            ]
+        )
+        XCTAssertEqual(GesturePerformer.expandedPrivacyResourceNames(for: "photos-add"), ["photos-add"])
+        XCTAssertNil(GesturePerformer.expandedPrivacyResourceNames(for: "siri"))
+    }
+
     func testResetPermissionsForwardsResourcesToGesturePerformer() {
         let request = WebSocketRequest.resetPermissions(RequestResetPermissions(
             requestId: "reset-1",

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1437,6 +1437,9 @@ final class CommandHandlerTests: XCTestCase {
             ]
         )
         XCTAssertEqual(GesturePerformer.expandedPrivacyResourceNames(for: "photos-add"), ["photos-add"])
+        XCTAssertEqual(GesturePerformer.canonicalPrivacyResourceName(for: "photos-add"), "photos")
+        XCTAssertEqual(GesturePerformer.canonicalPrivacyResourceName(for: "contacts-limited"), "contacts")
+        XCTAssertEqual(GesturePerformer.canonicalPrivacyResourceName(for: "location-always"), "location")
         XCTAssertNil(GesturePerformer.expandedPrivacyResourceNames(for: "siri"))
     }
 

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -457,7 +457,7 @@
               },
               "permissions": {
                 "type": "array",
-                "description": "Runtime permissions or simulator privacy services to change",
+                "description": "Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'",
                 "minItems": 1,
                 "items": {
                   "type": "string",
@@ -1182,7 +1182,7 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "Runtime permissions or simulator privacy services to change"
+          "description": "Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'"
         },
         "userId": {
           "type": "integer",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3994,7 +3994,7 @@
   },
   {
     "name": "setAppPermissions",
-    "description": "Grant, revoke, reset, or configure app permissions on Android devices, iOS simulators (grant/revoke/reset), and iOS physical devices (reset only)",
+    "description": "Grant, revoke, reset, or configure app permissions on Android devices, iOS simulators (grant/revoke/reset), and iOS physical devices (reset only, permissions=['all'] supported)",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -4003,7 +4003,7 @@
           "type": "string"
         },
         "action": {
-          "description": "Permission action; defaults to grant. Android supports grant; iOS simulators support grant/revoke/reset; iOS physical devices support reset only.",
+          "description": "Permission action; defaults to grant. Android supports grant; iOS simulators support grant/revoke/reset; iOS physical devices support reset only, including permissions=['all'].",
           "type": "string",
           "enum": [
             "grant",
@@ -4012,7 +4012,7 @@
           ]
         },
         "permissions": {
-          "description": "Runtime permissions or simulator privacy services to change",
+          "description": "Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'",
           "type": "array",
           "items": {
             "type": "string",

--- a/src/features/action/IosPhysicalPermissions.ts
+++ b/src/features/action/IosPhysicalPermissions.ts
@@ -8,6 +8,38 @@ import {
   type IosSimulatorPermissionMutationResult,
 } from "./IosSimulatorPermissions";
 
+const IOS_PHYSICAL_RESET_ALL_PERMISSIONS = [
+  "camera",
+  "photos",
+  "microphone",
+  "contacts",
+  "location",
+  "calendar",
+  "reminders",
+  "media-library",
+];
+
+function expandIosPhysicalResetPermissions(permissions: string[]): string[] {
+  const expanded: string[] = [];
+  const seen = new Set<string>();
+
+  for (const permission of permissions) {
+    const permissionsToAdd = permission === "all"
+      ? IOS_PHYSICAL_RESET_ALL_PERMISSIONS
+      : [permission];
+
+    for (const expandedPermission of permissionsToAdd) {
+      if (seen.has(expandedPermission)) {
+        continue;
+      }
+      seen.add(expandedPermission);
+      expanded.push(expandedPermission);
+    }
+  }
+
+  return expanded;
+}
+
 /**
  * Reset privacy authorizations on a *physical* iOS device through the CtrlProxy
  * XCUITest runner. The concrete client sends one `request_reset_permissions` per
@@ -55,7 +87,9 @@ export class IosPhysicalPermissions {
       return this.mutationFailure(action, normalizedAppId, "appId must be a non-empty iOS bundle identifier");
     }
 
-    if (normalizedPermissions.length === 0) {
+    const permissionsToReset = expandIosPhysicalResetPermissions(normalizedPermissions);
+
+    if (permissionsToReset.length === 0) {
       return {
         success: true,
         appId: normalizedAppId,
@@ -68,7 +102,7 @@ export class IosPhysicalPermissions {
       };
     }
 
-    const results = await this.client.resetAuthorizations(normalizedAppId, normalizedPermissions);
+    const results = await this.client.resetAuthorizations(normalizedAppId, permissionsToReset);
     const failedCount = results.filter(result => !result.success).length;
 
     return {

--- a/src/features/action/IosPhysicalPermissions.ts
+++ b/src/features/action/IosPhysicalPermissions.ts
@@ -19,6 +19,16 @@ const IOS_PHYSICAL_RESET_ALL_PERMISSIONS = [
   "media-library",
 ];
 
+const IOS_PHYSICAL_RESET_CANONICAL_PERMISSION = new Map<string, string>([
+  ["photos-add", "photos"],
+  ["contacts-limited", "contacts"],
+  ["location-always", "location"],
+]);
+
+function canonicalIosPhysicalResetPermission(permission: string): string {
+  return IOS_PHYSICAL_RESET_CANONICAL_PERMISSION.get(permission) ?? permission;
+}
+
 function expandIosPhysicalResetPermissions(permissions: string[]): string[] {
   const expanded: string[] = [];
   const seen = new Set<string>();
@@ -29,10 +39,11 @@ function expandIosPhysicalResetPermissions(permissions: string[]): string[] {
       : [permission];
 
     for (const expandedPermission of permissionsToAdd) {
-      if (seen.has(expandedPermission)) {
+      const canonicalPermission = canonicalIosPhysicalResetPermission(expandedPermission);
+      if (seen.has(canonicalPermission)) {
         continue;
       }
-      seen.add(expandedPermission);
+      seen.add(canonicalPermission);
       expanded.push(expandedPermission);
     }
   }

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -71,12 +71,12 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
       .optional()
       .describe(
         "Permission action; defaults to grant. Android supports grant; iOS simulators " +
-        "support grant/revoke/reset; iOS physical devices support reset only."
+        "support grant/revoke/reset; iOS physical devices support reset only, including permissions=['all']."
       ),
     permissions: z
       .array(z.string().min(1))
       .optional()
-      .describe("Runtime permissions or simulator privacy services to change"),
+      .describe("Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'"),
     userId: z
       .number()
       .int()
@@ -334,7 +334,7 @@ export function registerAppTools(
   ToolRegistry.registerDeviceAware(
     "setAppPermissions",
     "Grant, revoke, reset, or configure app permissions on Android devices, iOS simulators " +
-    "(grant/revoke/reset), and iOS physical devices (reset only)",
+    "(grant/revoke/reset), and iOS physical devices (reset only, permissions=['all'] supported)",
     setAppPermissionsSchema,
     setAppPermissionsHandler
   );

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -176,7 +176,7 @@ describe("AppPermissions", () => {
 
     const result = await permissions.setPermissions("com.example.app", {
       action: "reset",
-      permissions: ["all"],
+      permissions: ["all", "photos-add", "contacts-limited", "location-always"],
     });
 
     expect(result.success).toBe(true);

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -170,6 +170,45 @@ describe("AppPermissions", () => {
     ]);
   });
 
+  test("reports physical iOS all reset as per-resource operations", async () => {
+    const iosPhysicalClient = new RecordingPhysicalPrivacyClient();
+    const permissions = new AppPermissions(iosPhysical, { iosPhysicalClient });
+
+    const result = await permissions.setPermissions("com.example.app", {
+      action: "reset",
+      permissions: ["all"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(8);
+    expect(result.failedCount).toBe(0);
+    expect(result.operations.map(operation => operation.operationId)).toEqual([
+      "ios_xcuitest_reset:reset:camera",
+      "ios_xcuitest_reset:reset:photos",
+      "ios_xcuitest_reset:reset:microphone",
+      "ios_xcuitest_reset:reset:contacts",
+      "ios_xcuitest_reset:reset:location",
+      "ios_xcuitest_reset:reset:calendar",
+      "ios_xcuitest_reset:reset:reminders",
+      "ios_xcuitest_reset:reset:media-library",
+    ]);
+    expect(iosPhysicalClient.calls).toEqual([
+      {
+        appId: "com.example.app",
+        permissions: [
+          "camera",
+          "photos",
+          "microphone",
+          "contacts",
+          "location",
+          "calendar",
+          "reminders",
+          "media-library",
+        ],
+      },
+    ]);
+  });
+
   test("rejects grant on a physical iOS device with a reset-only failure", async () => {
     const iosPhysicalClient = new RecordingPhysicalPrivacyClient();
     const permissions = new AppPermissions(iosPhysical, { iosPhysicalClient });

--- a/test/features/action/IosPhysicalPermissions.test.ts
+++ b/test/features/action/IosPhysicalPermissions.test.ts
@@ -64,9 +64,17 @@ describe("IosPhysicalPermissions", () => {
     const client = new FakePhysicalPrivacyClient();
     const permissions = new IosPhysicalPermissions(physicalDevice, client);
 
-    const result = await permissions.setPermissions("reset", "com.example.app", ["camera", "all", "photos"]);
+    const result = await permissions.setPermissions("reset", "com.example.app", [
+      "camera",
+      "all",
+      "photos",
+      "photos-add",
+      "contacts-limited",
+      "location-always",
+    ]);
 
     expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(8);
     expect(result.results.map(r => r.permission)).toEqual([
       "camera",
       "photos",
@@ -92,6 +100,18 @@ describe("IosPhysicalPermissions", () => {
         ],
       },
     ]);
+  });
+
+  test("reset preserves the first requested alias when deduplicating aliases", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("reset", "com.example.app", ["photos-add", "photos"]);
+
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(1);
+    expect(result.results.map(r => r.permission)).toEqual(["photos-add"]);
+    expect(client.calls).toEqual([{ appId: "com.example.app", permissions: ["photos-add"] }]);
   });
 
   test("reset delegates to the client and reports per-permission success", async () => {

--- a/test/features/action/IosPhysicalPermissions.test.ts
+++ b/test/features/action/IosPhysicalPermissions.test.ts
@@ -37,6 +37,63 @@ class FakePhysicalPrivacyClient implements IosPhysicalPrivacyClient {
 }
 
 describe("IosPhysicalPermissions", () => {
+  test("reset expands all to every physical iOS resettable resource", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("reset", "com.example.app", [" all "]);
+
+    const expanded = [
+      "camera",
+      "photos",
+      "microphone",
+      "contacts",
+      "location",
+      "calendar",
+      "reminders",
+      "media-library",
+    ];
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(expanded.length);
+    expect(result.failedCount).toBe(0);
+    expect(result.results.map(r => r.permission)).toEqual(expanded);
+    expect(client.calls).toEqual([{ appId: "com.example.app", permissions: expanded }]);
+  });
+
+  test("reset deduplicates explicit resources already covered by all", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const result = await permissions.setPermissions("reset", "com.example.app", ["camera", "all", "photos"]);
+
+    expect(result.success).toBe(true);
+    expect(result.results.map(r => r.permission)).toEqual([
+      "camera",
+      "photos",
+      "microphone",
+      "contacts",
+      "location",
+      "calendar",
+      "reminders",
+      "media-library",
+    ]);
+    expect(client.calls).toEqual([
+      {
+        appId: "com.example.app",
+        permissions: [
+          "camera",
+          "photos",
+          "microphone",
+          "contacts",
+          "location",
+          "calendar",
+          "reminders",
+          "media-library",
+        ],
+      },
+    ]);
+  });
+
   test("reset delegates to the client and reports per-permission success", async () => {
     const client = new FakePhysicalPrivacyClient();
     const permissions = new IosPhysicalPermissions(physicalDevice, client);


### PR DESCRIPTION
## Summary

- expand physical iOS `setAppPermissions action=reset permissions=["all"]` into every resettable privacy resource
- keep per-resource accounting in TS while also accepting `all` directly in the Swift CtrlProxy runner
- update advertised permission-reset text in tool and plan schemas

## Test Plan

- `bun test test/features/action/IosPhysicalPermissions.test.ts test/features/action/AppPermissions.test.ts`
- `(cd ios/control-proxy && swift test --filter CommandHandlerTests/testResetPermissionsAllExpandsToEveryResettablePrivacyResource)`
- `bun test --bail`
- `bun run build`
- `bash scripts/ios/swift-test.sh`
- `bun run lint`
- `git diff --check`

## Review

- Ran `/auto-mobile-code-review`; no remaining actionable findings after adding alias/invalid-name coverage for the Swift expansion helper.
- Subagent review found alias accounting edge cases; addressed by canonicalizing iOS physical aliases in TS and direct Swift runner batches.

## Delivery Notes

- The public `setAppPermissions` tool path expands `all` in TypeScript before sending per-permission runner requests, so it works with the existing physical-device runner.
- The direct Swift runner `request_reset_permissions permissions=["all"]` support is included in source and will apply when the next iOS CtrlProxy runner artifact is shipped or when using a local runner override.

## Template

- No repository PR template was present in this worktree under `.github/`; the only `pull_request_template.md` files found were in Swift dependency checkouts under `.build`, so this body follows the repo's standard Summary/Test Plan shape.

Closes #3133
