### PR TITLE
chore(android): clean up cmdline tools AVD helpers

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -857,7 +857,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const availableAvds = await this.listAvds();
     perf.endOperation("validateAvd");
     if (!availableAvds.find(emu => emu.name === avdName)) {
-      throw new ActionableError(`AVD '${avdName}' not found. Available AVDs: ${availableAvds.join(", ")}`);
+      throw new ActionableError(`AVD '${avdName}' not found. Available AVDs: ${availableAvds.map(emu => emu.name).join(", ")}`);
     }
 
     // Check if already running or starting

--- a/src/utils/android-cmdline-tools/AvdManagerService.ts
+++ b/src/utils/android-cmdline-tools/AvdManagerService.ts
@@ -13,20 +13,7 @@ import {
   DeviceProfile,
   AvdManagerDependencies
 } from "./avdmanager";
-
-/**
- * Interface for AVD Manager operations
- * Enables dependency injection and testing with fakes
- */
-interface AvdManager {
-  acceptLicenses(): Promise<{ success: boolean; message: string }>;
-  listSystemImages(filter?: SystemImageFilter): Promise<SystemImage[]>;
-  installSystemImage(packageName: string, acceptLicense?: boolean): Promise<{ success: boolean; message: string }>;
-  listDeviceImages(): Promise<AvdInfo[]>;
-  createAvd(params: CreateAvdParams): Promise<{ success: boolean; message: string; avdName?: string }>;
-  deleteAvd(name: string): Promise<{ success: boolean; message: string }>;
-  listDevices(): Promise<DeviceProfile[]>;
-}
+import type { AvdManager } from "./interfaces/AvdManager";
 
 /**
  * Service wrapper for AVD Manager operations

--- a/src/utils/android-cmdline-tools/avdmanager.ts
+++ b/src/utils/android-cmdline-tools/avdmanager.ts
@@ -13,7 +13,6 @@ import {
   validateRequiredTools,
   type AndroidToolsLocation
 } from "./detection";
-import { installAndroidTools } from "./install";
 
 // Dependencies interface for dependency injection
 export interface AvdManagerDependencies {
@@ -24,7 +23,6 @@ export interface AvdManagerDependencies {
   getAndroidHomeWithSystemImages: typeof getAndroidHomeWithSystemImages;
   getBestAndroidToolsLocation: typeof getBestAndroidToolsLocation;
   validateRequiredTools: typeof validateRequiredTools;
-  installAndroidTools: typeof installAndroidTools;
 }
 
 // Create default dependencies
@@ -36,7 +34,6 @@ const createDefaultDependencies = (): AvdManagerDependencies => ({
   getAndroidHomeWithSystemImages,
   getBestAndroidToolsLocation,
   validateRequiredTools,
-  installAndroidTools // This function now throws - kept for compatibility with existing code
 });
 
 const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];

--- a/src/utils/android-cmdline-tools/install.ts
+++ b/src/utils/android-cmdline-tools/install.ts
@@ -1,29 +1,3 @@
-import { homedir, platform } from "os";
-import { join } from "path";
-import {
-  type AndroidToolsLocation,
-  type AndroidToolsSource
-} from "./detection";
-
-/**
- * Get default installation path for manual installation
- */
-export function getDefaultInstallPath(): string {
-  const home = homedir();
-  const platformName = platform();
-
-  switch (platformName) {
-    case "darwin":
-      return join(home, "Library/Android/sdk");
-    case "linux":
-      return join(home, "Android/Sdk");
-    case "win32":
-      return join(home, "AppData/Local/Android/Sdk");
-    default:
-      return join(home, "android-sdk");
-  }
-}
-
 /**
  * Android command line tools download information - Updated to latest version
  */
@@ -45,36 +19,3 @@ export const CMDLINE_TOOLS_DOWNLOAD = {
     }
   }
 };
-
-/**
- * Default high-priority tools for AutoMobile MCP - Enhanced
- */
-export const DEFAULT_REQUIRED_TOOLS = [
-  "apkanalyzer",
-  "avdmanager",
-  "sdkmanager"
-];
-
-/**
- * Main installation function
- */
-export async function installAndroidTools(params: InstallAndroidToolsParams = {}): Promise<InstallationResult> {
-  throw new Error("Tool installation functionality has been removed. Please install Android command-line tools manually.");
-}
-
-interface InstallAndroidToolsParams {
-  tools?: string[]; // Specific tools to install, empty defaults to high-priority tools
-  method?: "auto" | "homebrew" | "manual" | "sdk"; // Installation method preference
-  installPath?: string; // Custom installation path for manual installation
-  force?: boolean; // Force reinstallation even if tools exist
-}
-
-interface InstallationResult {
-  success: boolean;
-  installed_tools: string[];
-  failed_tools: string[];
-  installation_path: string;
-  installation_method: AndroidToolsSource;
-  message: string;
-  existing_location?: AndroidToolsLocation;
-}

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -243,4 +243,20 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
       restoreEnv();
     }
   });
+
+  test("lists available AVD names when requested AVD does not exist", async () => {
+    const execAsync = async (command: string): Promise<ExecResult> => {
+      if (command.includes("-list-avds")) {
+        return createExecResult("Pixel_9_Pro\nMedium_Phone_API_35\n");
+      }
+      return createExecResult("");
+    };
+
+    const client = new AndroidEmulatorClient(execAsync, null, fakeTimer, fakeFactory);
+    skipEmulatorPathDetection(client);
+
+    await expect(client.startEmulator("Missing_Device")).rejects.toThrow(
+      "AVD 'Missing_Device' not found. Available AVDs: Pixel_9_Pro, Medium_Phone_API_35"
+    );
+  });
 });

--- a/test/utils/android-cmdline-tools/avdmanager.test.ts
+++ b/test/utils/android-cmdline-tools/avdmanager.test.ts
@@ -15,7 +15,6 @@ describe("AVDManager", function() {
     // Clear module cache first
     delete require.cache[require.resolve("../../../src/utils/android-cmdline-tools/avdmanager")];
     delete require.cache[require.resolve("../../../src/utils/android-cmdline-tools/detection")];
-    delete require.cache[require.resolve("../../../src/utils/android-cmdline-tools/install")];
 
     // Now require the modules
     avdmanager = require("../../../src/utils/android-cmdline-tools/avdmanager");
@@ -98,14 +97,6 @@ describe("AVDManager", function() {
       getAndroidHomeWithSystemImages: () => null,
       getBestAndroidToolsLocation: () => mockLocation,
       validateRequiredTools: () => ({ valid: true, missing: [] }),
-      installAndroidTools: async () => ({
-        success: true,
-        installed_tools: ["avdmanager", "sdkmanager"],
-        failed_tools: [],
-        installation_path: "/mock/path",
-        installation_method: "manual",
-        message: "Success"
-      }),
       ...overrides
     };
   }
@@ -683,7 +674,7 @@ id: pixel_4
   });
 
   describe("Error Handling", () => {
-    test("should handle tools installation failure", async () => {
+    test("should report manual install guidance when command-line tools are unavailable", async () => {
       const mockDeps = createDependencies();
 
       mockDeps.detectAndroidCommandLineTools = async () => [];
@@ -695,7 +686,7 @@ id: pixel_4
       expect(result.message).toContain("Tool installation functionality has been removed");
     });
 
-    test("should handle missing tools after installation", async () => {
+    test("should report manual install guidance when required tools are missing", async () => {
       const mockDeps = createDependencies();
 
       mockDeps.detectAndroidCommandLineTools = async () => [];

--- a/test/utils/android-cmdline-tools/install.test.ts
+++ b/test/utils/android-cmdline-tools/install.test.ts
@@ -1,21 +1,9 @@
 import { expect, describe, test } from "bun:test";
 import {
-  DEFAULT_REQUIRED_TOOLS,
   CMDLINE_TOOLS_DOWNLOAD,
-  getDefaultInstallPath
 } from "../../../src/utils/android-cmdline-tools/install";
 
 describe("Android Command Line Tools - Installation", () => {
-  describe("DEFAULT_REQUIRED_TOOLS", () => {
-    test("should contain essential Android tools", () => {
-      expect(DEFAULT_REQUIRED_TOOLS).toEqual([
-        "apkanalyzer",
-        "avdmanager",
-        "sdkmanager"
-      ]);
-    });
-  });
-
   describe("CMDLINE_TOOLS_DOWNLOAD", () => {
     test("should have correct download information", () => {
       expect(CMDLINE_TOOLS_DOWNLOAD.version).toBe("13114758");
@@ -34,14 +22,6 @@ describe("Android Command Line Tools - Installation", () => {
         expect(typeof platform.checksum).toBe("string");
         expect(platform.checksum.length).toBe(64); // SHA-256 hex
       });
-    });
-  });
-
-  describe("getDefaultInstallPath", () => {
-    test("should return a valid path string", () => {
-      const result = getDefaultInstallPath();
-      expect(typeof result).toBe("string");
-      expect(result).not.toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Closes #2769.
- Remove the dead `installAndroidTools` throw-stub and its unused AVD dependency wiring.
- Make `AvdManagerService` implement the canonical exported `AvdManager` interface instead of a duplicate local interface.
- Fix the missing-AVD error so available devices render by name instead of `[object Object]`.

## Evaluation Criteria
- No production or test fake dependency remains for `installAndroidTools`.
- `AvdManagerService` compiles against `src/utils/android-cmdline-tools/interfaces/AvdManager.ts`.
- `startEmulator()` reports available AVD names when a requested AVD does not exist.
- Existing Android cmdline-tools behavior remains covered by fast fake-based tests.

## Testing
- `bun test test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts test/utils/android-cmdline-tools/install.test.ts test/utils/android-cmdline-tools/avdmanager.test.ts`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Notes
- I checked for a repo PR template file and did not find `.github/PULL_REQUEST_TEMPLATE.md`; this body follows the repo PR guidance in `.github/CONTRIBUTING.md`.
