### PR TITLE
test(db): consolidate sync temp cleanup

### DIFF
--- a/test/db/backupDatabaseFile.test.ts
+++ b/test/db/backupDatabaseFile.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely, sql } from "kysely";
-import { existsSync, mkdtempSync, readdirSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, readdirSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { backupDatabaseFile } from "../../src/db/database";
 import { ActionableError } from "../../src/models/ActionableError";
+import { removeTempDbDirSync } from "./tempDbDir";
 
 describe("backupDatabaseFile", () => {
   let dir: string;
@@ -24,14 +25,7 @@ describe("backupDatabaseFile", () => {
 
   afterEach(async () => {
     await db.destroy();
-    // Windows releases the sqlite file handle lazily after destroy(), so removing
-    // the temp dir can transiently hit EBUSY — retry, and treat cleanup as
-    // best-effort (a leftover temp dir must not fail the test).
-    try {
-      rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
-    } catch {
-      // best-effort: OS will reclaim the temp dir
-    }
+    removeTempDbDirSync(dir);
   });
 
   test("captures uncheckpointed WAL rows into a timestamped backup file", async () => {

--- a/test/db/tempDbDir.test.ts
+++ b/test/db/tempDbDir.test.ts
@@ -1,10 +1,32 @@
 import { describe, expect, test } from "bun:test";
 import path from "path";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { FakeTimer } from "../fakes/FakeTimer";
-import { removeTempDbDir } from "./tempDbDir";
+import { removeTempDbDir, removeTempDbDirSync } from "./tempDbDir";
+
+function ebusy(code = "EBUSY"): NodeJS.ErrnoException {
+  const error = new Error(`${code}: resource busy`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+class FakeSyncTimer {
+  private readonly sleepHistory: number[] = [];
+
+  sleep(ms: number): void {
+    this.sleepHistory.push(ms);
+  }
+
+  getSleepHistory(): number[] {
+    return [...this.sleepHistory];
+  }
+
+  getSleepCallCount(): number {
+    return this.sleepHistory.length;
+  }
+}
 
 /**
  * Unit tests for the shared bounded temp-dir cleanup helper (issue #2916).
@@ -19,12 +41,6 @@ import { removeTempDbDir } from "./tempDbDir";
  * These run with no real filesystem or wall-clock, so they stay <100ms.
  */
 describe("removeTempDbDir (issue #2916)", () => {
-  function ebusy(code = "EBUSY"): NodeJS.ErrnoException {
-    const error = new Error(`${code}: resource busy`) as NodeJS.ErrnoException;
-    error.code = code;
-    return error;
-  }
-
   test("removes the dir on the first attempt and never sleeps when rm succeeds", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
@@ -148,6 +164,121 @@ describe("removeTempDbDir (issue #2916)", () => {
     await expect(
       removeTempDbDir("/tmp/auto-mobile-x", { rm, timer, maxAttempts: 5, delayMs: 50 })
     ).rejects.toThrow("EACCES");
+    expect(attempts).toBe(1);
+    expect(timer.getSleepCallCount()).toBe(0);
+  });
+});
+
+describe("removeTempDbDirSync (issue #2948)", () => {
+  test("removes the dir on the first attempt and never sleeps when rmSync succeeds", () => {
+    const timer = new FakeSyncTimer();
+    const calls: string[] = [];
+    const rmSync = (dir: string) => {
+      calls.push(dir);
+    };
+
+    removeTempDbDirSync("/tmp/auto-mobile-x", { rmSync, timer });
+
+    expect(calls).toEqual(["/tmp/auto-mobile-x"]);
+    expect(timer.getSleepCallCount()).toBe(0);
+  });
+
+  test("retries a transient EBUSY synchronously, then succeeds", () => {
+    const timer = new FakeSyncTimer();
+    let attempts = 0;
+    const rmSync = () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw ebusy();
+      }
+    };
+
+    removeTempDbDirSync("/tmp/auto-mobile-x", { rmSync, timer, maxAttempts: 5, delayMs: 50 });
+
+    expect(attempts).toBe(3);
+    expect(timer.getSleepHistory()).toEqual([50, 50]);
+  });
+
+  test("gives up WITHOUT throwing after a persistent sync lock, within a bounded sleep budget", () => {
+    const timer = new FakeSyncTimer();
+    let attempts = 0;
+    const rmSync = () => {
+      attempts += 1;
+      throw ebusy();
+    };
+    const gaveUp: Array<{ dir: string; error: unknown }> = [];
+
+    removeTempDbDirSync("/tmp/auto-mobile-locked", {
+      rmSync,
+      timer,
+      maxAttempts: 5,
+      delayMs: 50,
+      onGiveUp: (dir, error) => gaveUp.push({ dir, error }),
+    });
+
+    expect(attempts).toBe(5);
+    const history = timer.getSleepHistory();
+    expect(history.length).toBe(4);
+    expect(history.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(200);
+    expect(gaveUp.length).toBe(1);
+    expect(gaveUp[0].dir).toBe("/tmp/auto-mobile-locked");
+    expect((gaveUp[0].error as NodeJS.ErrnoException).code).toBe("EBUSY");
+  });
+
+  test.each(["EPERM", "ENOTEMPTY"])(
+    "treats %s as a transient sync Windows lock and gives up gracefully",
+    code => {
+      const timer = new FakeSyncTimer();
+      const rmSync = () => {
+        throw ebusy(code);
+      };
+      let gaveUp = false;
+
+      removeTempDbDirSync("/tmp/auto-mobile-x", {
+        rmSync,
+        timer,
+        maxAttempts: 3,
+        delayMs: 10,
+        onGiveUp: () => {
+          gaveUp = true;
+        },
+      });
+
+      expect(gaveUp).toBe(true);
+    }
+  );
+
+  test("removes a real temp dir (and its contents) through the default sync rm/timer", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "auto-mobile-tempdbdir-sync-real-"));
+    writeFileSync(path.join(dir, "auto-mobile.db"), "not-a-real-db");
+    expect(existsSync(dir)).toBe(true);
+
+    removeTempDbDirSync(dir);
+
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("the default sync onGiveUp runs without throwing when a lock never clears", () => {
+    const rmSync = () => {
+      throw ebusy();
+    };
+
+    expect(() =>
+      removeTempDbDirSync("/tmp/auto-mobile-locked", { rmSync, maxAttempts: 2, delayMs: 1 })
+    ).not.toThrow();
+  });
+
+  test("rethrows an unexpected sync non-lock error code without retrying", () => {
+    const timer = new FakeSyncTimer();
+    let attempts = 0;
+    const rmSync = () => {
+      attempts += 1;
+      throw ebusy("EACCES");
+    };
+
+    expect(() =>
+      removeTempDbDirSync("/tmp/auto-mobile-x", { rmSync, timer, maxAttempts: 5, delayMs: 50 })
+    ).toThrow("EACCES");
     expect(attempts).toBe(1);
     expect(timer.getSleepCallCount()).toBe(0);
   });

--- a/test/db/tempDbDir.ts
+++ b/test/db/tempDbDir.ts
@@ -1,3 +1,4 @@
+import { rmSync as fsRmSync } from "node:fs";
 import { rm as fsRm } from "node:fs/promises";
 import type { Timer } from "../../src/utils/SystemTimer";
 import { defaultTimer } from "../../src/utils/SystemTimer";
@@ -52,6 +53,27 @@ export interface RemoveTempDbDirOptions {
   onGiveUp?: (dir: string, error: unknown) => void;
 }
 
+export interface SyncTimer {
+  sleep(ms: number): void;
+}
+
+export interface RemoveTempDbDirSyncOptions {
+  /** Removal primitive. Defaults to `rmSync(dir, { recursive: true, force: true })`. */
+  rmSync?: (dir: string) => void;
+  /** Synchronous backoff sleeper. Defaults to a bounded blocking sleep. */
+  timer?: SyncTimer;
+  /** Total attempts before giving up. Bounded so cleanup can never stall CI. */
+  maxAttempts?: number;
+  /** Delay between attempts, in ms. */
+  delayMs?: number;
+  /**
+   * Invoked once if every attempt loses to a persistent lock. Defaults to a
+   * single `logger.warn` so a leaked dir is visible in CI logs; the unit test
+   * injects a spy instead.
+   */
+  onGiveUp?: (dir: string, error: unknown) => void;
+}
+
 // Windows raises these while a bun:sqlite handle outlives destroy(); they are
 // the only codes we treat as a transient lock and retry. Anything else is a
 // real failure and rethrown.
@@ -60,12 +82,27 @@ const TRANSIENT_LOCK_CODES = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
 const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_DELAY_MS = 50;
 
-function defaultOnGiveUp(dir: string, error: unknown): void {
+const defaultSyncTimer: SyncTimer = {
+  sleep(ms: number): void {
+    if (ms <= 0) {
+      return;
+    }
+    const shared = new Int32Array(new SharedArrayBuffer(4));
+    Atomics.wait(shared, 0, 0, ms);
+  },
+};
+
+function isTransientLockError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return Boolean(code && TRANSIENT_LOCK_CODES.has(code));
+}
+
+function defaultOnGiveUp(helperName: string, dir: string, error: unknown): void {
   const code = (error as NodeJS.ErrnoException | undefined)?.code ?? "unknown";
   // Log-and-continue: the dir is a throwaway temp dir the OS will sweep; a
   // Windows handle livelock is the expected reason and is safe to swallow.
   logger.warn(
-    `removeTempDbDir: gave up removing ${dir} after ${code}; leaving it for OS temp cleanup (issue #2916)`,
+    `${helperName}: gave up removing ${dir} after ${code}; leaving it for OS temp cleanup (issue #2916)`,
     error
   );
 }
@@ -78,7 +115,7 @@ export async function removeTempDbDir(
   const timer = options.timer ?? defaultTimer;
   const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
-  const onGiveUp = options.onGiveUp ?? defaultOnGiveUp;
+  const onGiveUp = options.onGiveUp ?? ((target, error) => defaultOnGiveUp("removeTempDbDir", target, error));
 
   let lastError: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
@@ -86,13 +123,42 @@ export async function removeTempDbDir(
       await rm(dir);
       return;
     } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (!code || !TRANSIENT_LOCK_CODES.has(code)) {
+      if (!isTransientLockError(error)) {
         throw error;
       }
       lastError = error;
       if (attempt < maxAttempts - 1) {
         await timer.sleep(delayMs);
+      }
+    }
+  }
+
+  onGiveUp(dir, lastError);
+}
+
+export function removeTempDbDirSync(
+  dir: string,
+  options: RemoveTempDbDirSyncOptions = {}
+): void {
+  const rmSync = options.rmSync ?? (target => fsRmSync(target, { recursive: true, force: true }));
+  const timer = options.timer ?? defaultSyncTimer;
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
+  const onGiveUp =
+    options.onGiveUp ?? ((target, error) => defaultOnGiveUp("removeTempDbDirSync", target, error));
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      rmSync(dir);
+      return;
+    } catch (error) {
+      if (!isTransientLockError(error)) {
+        throw error;
+      }
+      lastError = error;
+      if (attempt < maxAttempts - 1) {
+        timer.sleep(delayMs);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add `removeTempDbDirSync` as the synchronous sibling to the bounded async temp DB cleanup helper.
- Route `backupDatabaseFile.test.ts` through the shared sync helper instead of hand-rolled `rmSync` retry options.
- Cover sync cleanup success, transient retry, give-up, default cleanup, and unexpected-error behavior with fake-driven tests.

Closes #2948.

## Testing
- `bun test test/db/tempDbDir.test.ts`
- `bun test test/db/backupDatabaseFile.test.ts`
- `bun test test/db/fileBackedDbAntiPattern.test.ts`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

Note: no `.github/PULL_REQUEST_TEMPLATE*` file exists in this repo; this body follows the repo's `skills/gh-pr-workflow/SKILL.md` `## Summary` / `## Testing` shape and was created for `gh pr create --body-file`.