### PR TITLE
refactor(control-proxy): share gesture dispatch lifecycle

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -2165,6 +2165,58 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   /**
+   * Dispatch a built gesture and centralize the callback/perf lifecycle shared by every gesture
+   * action. The caller owns gesture construction and result broadcasting; this helper owns the
+   * `dispatchGesture` perf operation, callback result conversion, and guaranteed outer perf close.
+   */
+  private fun dispatchGestureWithResult(
+    perfLabel: String,
+    gesture: GestureDescription,
+    requestId: String?,
+    startTimeMs: Long,
+    gestureBuiltTimeMs: Long,
+    beforeCompletedResult: () -> Unit = {},
+    onResult: (GestureDispatchOutcome) -> Unit,
+  ) {
+    val lifecycle =
+      GestureDispatchLifecycle(
+        startTimeMs = startTimeMs,
+        gestureBuiltTimeMs = gestureBuiltTimeMs,
+        nowMs = { System.currentTimeMillis() },
+        startOperation = { perfProvider.startOperation(it) },
+        endOperation = { perfProvider.endOperation(it) },
+        endPerfBlock = { perfProvider.end() },
+      )
+
+    lifecycle.startDispatch()
+    val dispatched =
+      try {
+        dispatchGesture(
+          gesture,
+          object : GestureResultCallback() {
+            override fun onCompleted(gestureDescription: GestureDescription?) {
+              lifecycle.completed(beforeResult = beforeCompletedResult, onResult = onResult)
+            }
+
+            override fun onCancelled(gestureDescription: GestureDescription?) {
+              lifecycle.cancelled(onResult)
+            }
+          },
+          null,
+        )
+      } catch (e: Exception) {
+        Log.e(TAG, "Error dispatching $perfLabel gesture (requestId=$requestId)", e)
+        lifecycle.failed(e, onResult)
+        return
+      }
+
+    if (!dispatched) {
+      Log.e(TAG, "Failed to dispatch $perfLabel gesture (requestId=$requestId)")
+      lifecycle.notDispatched(onResult)
+    }
+  }
+
+  /**
    * Perform a swipe gesture using AccessibilityService's dispatchGesture API. This is significantly
    * faster than ADB's input swipe command.
    */
@@ -2199,55 +2251,27 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val gestureBuiltTime = System.currentTimeMillis()
       Log.d(TAG, "Gesture built in ${gestureBuiltTime - startTime}ms")
 
-      perfProvider.startOperation("dispatchGesture")
-      // Dispatch the gesture
-      val dispatched =
-        dispatchGesture(
-          gesture,
-          object : GestureResultCallback() {
-            override fun onCompleted(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end() // end performSwipe block
-              val completedTime = System.currentTimeMillis()
-              val totalTime = completedTime - startTime
-              val gestureTime = completedTime - gestureBuiltTime
-              Log.d(TAG, "Swipe completed: gesture=${gestureTime}ms, total=${totalTime}ms")
-
-              // Broadcast success result
-              serviceScope.launch {
-                broadcastSwipeResult(requestId, true, null, totalTime, gestureTime)
-              }
-            }
-
-            override fun onCancelled(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end() // end performSwipe block
-              val cancelledTime = System.currentTimeMillis()
-              val totalTime = cancelledTime - startTime
-              Log.w(TAG, "Swipe cancelled after ${totalTime}ms")
-
-              // Broadcast cancelled result
-              serviceScope.launch {
-                broadcastSwipeResult(requestId, false, "Gesture was cancelled", totalTime, null)
-              }
-            }
-          },
-          null,
-        )
-
-      if (!dispatched) {
-        perfProvider.endOperation("dispatchGesture")
-        perfProvider.end() // end performSwipe block
-        val failTime = System.currentTimeMillis()
-        Log.e(TAG, "Failed to dispatch swipe gesture")
-        serviceScope.launch {
-          broadcastSwipeResult(
-            requestId,
-            false,
-            "Failed to dispatch gesture",
-            failTime - startTime,
-            null,
+      dispatchGestureWithResult("performSwipe", gesture, requestId, startTime, gestureBuiltTime) {
+        outcome ->
+        if (outcome.completed) {
+          Log.d(
+            TAG,
+            "Swipe completed: gesture=${outcome.gestureTimeMs}ms, total=${outcome.totalTimeMs}ms",
           )
+          serviceScope.launch {
+            broadcastSwipeResult(
+              requestId,
+              true,
+              null,
+              outcome.totalTimeMs,
+              outcome.gestureTimeMs,
+            )
+          }
+        } else {
+          Log.w(TAG, "Swipe failed after ${outcome.totalTimeMs}ms: ${outcome.error}")
+          serviceScope.launch {
+            broadcastSwipeResult(requestId, false, outcome.error, outcome.totalTimeMs, null)
+          }
         }
       }
     } catch (e: Exception) {
@@ -2399,52 +2423,27 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val gestureBuiltTime = System.currentTimeMillis()
       Log.d(TAG, "Drag gesture built in ${gestureBuiltTime - startTime}ms")
 
-      perfProvider.startOperation("dispatchGesture")
-      val dispatched =
-        dispatchGesture(
-          gesture,
-          object : GestureResultCallback() {
-            override fun onCompleted(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end() // end performDrag block
-              val completedTime = System.currentTimeMillis()
-              val totalTime = completedTime - startTime
-              val gestureTime = completedTime - gestureBuiltTime
-              Log.d(TAG, "Drag completed: gesture=${gestureTime}ms, total=${totalTime}ms")
-
-              serviceScope.launch {
-                broadcastDragResult(requestId, true, null, totalTime, gestureTime)
-              }
-            }
-
-            override fun onCancelled(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end() // end performDrag block
-              val cancelledTime = System.currentTimeMillis()
-              val totalTime = cancelledTime - startTime
-              Log.w(TAG, "Drag cancelled after ${totalTime}ms")
-
-              serviceScope.launch {
-                broadcastDragResult(requestId, false, "Gesture was cancelled", totalTime, null)
-              }
-            }
-          },
-          null,
-        )
-
-      if (!dispatched) {
-        perfProvider.endOperation("dispatchGesture")
-        perfProvider.end() // end performDrag block
-        val failTime = System.currentTimeMillis()
-        Log.e(TAG, "Failed to dispatch drag gesture")
-        serviceScope.launch {
-          broadcastDragResult(
-            requestId,
-            false,
-            "Failed to dispatch gesture",
-            failTime - startTime,
-            null,
+      dispatchGestureWithResult("performDrag", gesture, requestId, startTime, gestureBuiltTime) {
+        outcome ->
+        if (outcome.completed) {
+          Log.d(
+            TAG,
+            "Drag completed: gesture=${outcome.gestureTimeMs}ms, total=${outcome.totalTimeMs}ms",
           )
+          serviceScope.launch {
+            broadcastDragResult(
+              requestId,
+              true,
+              null,
+              outcome.totalTimeMs,
+              outcome.gestureTimeMs,
+            )
+          }
+        } else {
+          Log.w(TAG, "Drag failed after ${outcome.totalTimeMs}ms: ${outcome.error}")
+          serviceScope.launch {
+            broadcastDragResult(requestId, false, outcome.error, outcome.totalTimeMs, null)
+          }
         }
       }
     } catch (e: Exception) {
@@ -2486,73 +2485,38 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val gestureBuiltTime = System.currentTimeMillis()
       Log.d(TAG, "Tap gesture built in ${gestureBuiltTime - startTime}ms")
 
-      perfProvider.startOperation("dispatchGesture")
-      // Dispatch the gesture
-      val dispatched =
-        dispatchGesture(
-          gesture,
-          object : GestureResultCallback() {
-            override fun onCompleted(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-
-              // Wait for UI to settle after tap, then extract fresh hierarchy
-              val freshHierarchy =
-                hierarchyDebouncer.extractAfterQuiescence(
-                  quiescenceMs = 50L,
-                  maxWaitMs = 500L,
-                  pollIntervalMs = 10L,
-                )
-              if (freshHierarchy != null) {
-                kotlinx.coroutines.runBlocking {
-                  broadcastHierarchyUpdate(freshHierarchy, sync = true)
-                }
-              }
-
-              perfProvider.end() // end performTapCoordinates block
-              val completedTime = System.currentTimeMillis()
-              val totalTime = completedTime - startTime
-              val gestureTime = completedTime - gestureBuiltTime
-              Log.d(TAG, "Tap completed: gesture=${gestureTime}ms, total=${totalTime}ms")
-
-              // Broadcast success result
-              serviceScope.launch {
-                broadcastTapCoordinatesResult(requestId, true, null, totalTime)
-              }
-            }
-
-            override fun onCancelled(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end() // end performTapCoordinates block
-              val cancelledTime = System.currentTimeMillis()
-              val totalTime = cancelledTime - startTime
-              Log.w(TAG, "Tap cancelled after ${totalTime}ms")
-
-              // Broadcast cancelled result
-              serviceScope.launch {
-                broadcastTapCoordinatesResult(
-                  requestId,
-                  false,
-                  "Gesture was cancelled",
-                  totalTime,
-                )
-              }
-            }
-          },
-          null,
-        )
-
-      if (!dispatched) {
-        perfProvider.endOperation("dispatchGesture")
-        perfProvider.end() // end performTapCoordinates block
-        val failTime = System.currentTimeMillis()
-        Log.e(TAG, "Failed to dispatch tap gesture")
-        serviceScope.launch {
-          broadcastTapCoordinatesResult(
-            requestId,
-            false,
-            "Failed to dispatch gesture",
-            failTime - startTime,
+      dispatchGestureWithResult(
+        "performTapCoordinates",
+        gesture,
+        requestId,
+        startTime,
+        gestureBuiltTime,
+        beforeCompletedResult = {
+          // Wait for UI to settle after tap, then extract fresh hierarchy.
+          val freshHierarchy =
+            hierarchyDebouncer.extractAfterQuiescence(
+              quiescenceMs = 50L,
+              maxWaitMs = 500L,
+              pollIntervalMs = 10L,
+            )
+          if (freshHierarchy != null) {
+            kotlinx.coroutines.runBlocking { broadcastHierarchyUpdate(freshHierarchy, sync = true) }
+          }
+        },
+      ) { outcome ->
+        if (outcome.completed) {
+          Log.d(
+            TAG,
+            "Tap completed: gesture=${outcome.gestureTimeMs}ms, total=${outcome.totalTimeMs}ms",
           )
+          serviceScope.launch {
+            broadcastTapCoordinatesResult(requestId, true, null, outcome.totalTimeMs)
+          }
+        } else {
+          Log.w(TAG, "Tap failed after ${outcome.totalTimeMs}ms: ${outcome.error}")
+          serviceScope.launch {
+            broadcastTapCoordinatesResult(requestId, false, outcome.error, outcome.totalTimeMs)
+          }
         }
       }
     } catch (e: Exception) {
@@ -2619,58 +2583,32 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val gestureBuiltTime = System.currentTimeMillis()
       Log.d(TAG, "Two-finger gesture built in ${gestureBuiltTime - startTime}ms")
 
-      perfProvider.startOperation("dispatchGesture")
-      // Dispatch the gesture
-      val dispatched =
-        dispatchGesture(
-          gesture,
-          object : GestureResultCallback() {
-            override fun onCompleted(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end() // end performTwoFingerSwipe block
-              val completedTime = System.currentTimeMillis()
-              val totalTime = completedTime - startTime
-              val gestureTime = completedTime - gestureBuiltTime
-              Log.d(
-                TAG,
-                "Two-finger swipe completed: gesture=${gestureTime}ms, total=${totalTime}ms",
-              )
-
-              // Broadcast success result
-              serviceScope.launch {
-                broadcastSwipeResult(requestId, true, null, totalTime, gestureTime)
-              }
-            }
-
-            override fun onCancelled(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end() // end performTwoFingerSwipe block
-              val cancelledTime = System.currentTimeMillis()
-              val totalTime = cancelledTime - startTime
-              Log.w(TAG, "Two-finger swipe cancelled after ${totalTime}ms")
-
-              // Broadcast cancelled result
-              serviceScope.launch {
-                broadcastSwipeResult(requestId, false, "Gesture was cancelled", totalTime, null)
-              }
-            }
-          },
-          null,
-        )
-
-      if (!dispatched) {
-        perfProvider.endOperation("dispatchGesture")
-        perfProvider.end() // end performTwoFingerSwipe block
-        val failTime = System.currentTimeMillis()
-        Log.e(TAG, "Failed to dispatch two-finger swipe gesture")
-        serviceScope.launch {
-          broadcastSwipeResult(
-            requestId,
-            false,
-            "Failed to dispatch gesture",
-            failTime - startTime,
-            null,
+      dispatchGestureWithResult(
+        "performTwoFingerSwipe",
+        gesture,
+        requestId,
+        startTime,
+        gestureBuiltTime,
+      ) { outcome ->
+        if (outcome.completed) {
+          Log.d(
+            TAG,
+            "Two-finger swipe completed: gesture=${outcome.gestureTimeMs}ms, total=${outcome.totalTimeMs}ms",
           )
+          serviceScope.launch {
+            broadcastSwipeResult(
+              requestId,
+              true,
+              null,
+              outcome.totalTimeMs,
+              outcome.gestureTimeMs,
+            )
+          }
+        } else {
+          Log.w(TAG, "Two-finger swipe failed after ${outcome.totalTimeMs}ms: ${outcome.error}")
+          serviceScope.launch {
+            broadcastSwipeResult(requestId, false, outcome.error, outcome.totalTimeMs, null)
+          }
         }
       }
     } catch (e: Exception) {
@@ -2728,58 +2666,27 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val gestureBuiltTime = System.currentTimeMillis()
       Log.d(TAG, "Pinch gesture built in ${gestureBuiltTime - startTime}ms")
 
-      perfProvider.startOperation("dispatchGesture")
-      val dispatched =
-        dispatchGesture(
-          gesture,
-          object : GestureResultCallback() {
-            override fun onCompleted(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end()
-              val completedTime = System.currentTimeMillis()
-              val totalTime = completedTime - startTime
-              val gestureTime = completedTime - gestureBuiltTime
-              Log.d(TAG, "Pinch completed: gesture=${gestureTime}ms, total=${totalTime}ms")
-
-              serviceScope.launch {
-                broadcastPinchResult(requestId, true, null, totalTime, gestureTime)
-              }
-            }
-
-            override fun onCancelled(gestureDescription: GestureDescription?) {
-              perfProvider.endOperation("dispatchGesture")
-              perfProvider.end()
-              val cancelledTime = System.currentTimeMillis()
-              val totalTime = cancelledTime - startTime
-              Log.w(TAG, "Pinch cancelled after ${totalTime}ms")
-
-              serviceScope.launch {
-                broadcastPinchResult(
-                  requestId,
-                  false,
-                  "Gesture was cancelled",
-                  totalTime,
-                  null,
-                )
-              }
-            }
-          },
-          null,
-        )
-
-      if (!dispatched) {
-        perfProvider.endOperation("dispatchGesture")
-        perfProvider.end()
-        val failTime = System.currentTimeMillis()
-        Log.e(TAG, "Failed to dispatch pinch gesture")
-        serviceScope.launch {
-          broadcastPinchResult(
-            requestId,
-            false,
-            "Failed to dispatch gesture",
-            failTime - startTime,
-            null,
+      dispatchGestureWithResult("performPinch", gesture, requestId, startTime, gestureBuiltTime) {
+        outcome ->
+        if (outcome.completed) {
+          Log.d(
+            TAG,
+            "Pinch completed: gesture=${outcome.gestureTimeMs}ms, total=${outcome.totalTimeMs}ms",
           )
+          serviceScope.launch {
+            broadcastPinchResult(
+              requestId,
+              true,
+              null,
+              outcome.totalTimeMs,
+              outcome.gestureTimeMs,
+            )
+          }
+        } else {
+          Log.w(TAG, "Pinch failed after ${outcome.totalTimeMs}ms: ${outcome.error}")
+          serviceScope.launch {
+            broadcastPinchResult(requestId, false, outcome.error, outcome.totalTimeMs, null)
+          }
         }
       }
     } catch (e: Exception) {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/GestureDispatchLifecycle.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/GestureDispatchLifecycle.kt
@@ -1,0 +1,110 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+/**
+ * Result produced by the shared AccessibilityService gesture dispatch lifecycle.
+ *
+ * [gestureTimeMs] is only present for completed gestures because cancellation, rejected dispatch,
+ * and exceptions do not have a completed platform gesture duration.
+ */
+internal data class GestureDispatchOutcome(
+  val completed: Boolean,
+  val totalTimeMs: Long,
+  val gestureTimeMs: Long?,
+  val error: String?,
+)
+
+/**
+ * Owns the perf bookkeeping that used to be hand-copied across each gesture callback.
+ *
+ * Android callback construction stays in [CtrlProxy], but every terminal branch routes through this
+ * helper so the outer perf block is closed even when result handling throws.
+ */
+internal class GestureDispatchLifecycle(
+  private val startTimeMs: Long,
+  private val gestureBuiltTimeMs: Long,
+  private val nowMs: () -> Long,
+  private val startOperation: (String) -> Unit,
+  private val endOperation: (String) -> Unit,
+  private val endPerfBlock: () -> Unit,
+) {
+  fun startDispatch() {
+    startOperation(DISPATCH_GESTURE_OPERATION)
+  }
+
+  fun completed(
+    beforeResult: () -> Unit = {},
+    onResult: (GestureDispatchOutcome) -> Unit,
+  ) {
+    val outcome: GestureDispatchOutcome
+    try {
+      endOperation(DISPATCH_GESTURE_OPERATION)
+      beforeResult()
+      val completedTime = nowMs()
+      outcome =
+        GestureDispatchOutcome(
+          completed = true,
+          totalTimeMs = completedTime - startTimeMs,
+          gestureTimeMs = completedTime - gestureBuiltTimeMs,
+          error = null,
+        )
+    } finally {
+      endPerfBlock()
+    }
+    onResult(outcome)
+  }
+
+  fun cancelled(onResult: (GestureDispatchOutcome) -> Unit) {
+    val cancelledTime = nowMs()
+    finish(
+      GestureDispatchOutcome(
+        completed = false,
+        totalTimeMs = cancelledTime - startTimeMs,
+        gestureTimeMs = null,
+        error = "Gesture was cancelled",
+      ),
+      onResult,
+    )
+  }
+
+  fun notDispatched(onResult: (GestureDispatchOutcome) -> Unit) {
+    val failedTime = nowMs()
+    finish(
+      GestureDispatchOutcome(
+        completed = false,
+        totalTimeMs = failedTime - startTimeMs,
+        gestureTimeMs = null,
+        error = "Failed to dispatch gesture",
+      ),
+      onResult,
+    )
+  }
+
+  fun failed(error: Exception, onResult: (GestureDispatchOutcome) -> Unit) {
+    val failedTime = nowMs()
+    finish(
+      GestureDispatchOutcome(
+        completed = false,
+        totalTimeMs = failedTime - startTimeMs,
+        gestureTimeMs = null,
+        error = error.message,
+      ),
+      onResult,
+    )
+  }
+
+  private fun finish(
+    outcome: GestureDispatchOutcome,
+    onResult: (GestureDispatchOutcome) -> Unit,
+  ) {
+    try {
+      endOperation(DISPATCH_GESTURE_OPERATION)
+    } finally {
+      endPerfBlock()
+    }
+    onResult(outcome)
+  }
+
+  companion object {
+    private const val DISPATCH_GESTURE_OPERATION = "dispatchGesture"
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/GestureDispatchLifecycleTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/GestureDispatchLifecycleTest.kt
@@ -1,0 +1,152 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Fast, Android-free tests for the shared gesture dispatch perf/result lifecycle introduced for
+ * issue #2817. The AccessibilityService callback wiring stays in [CtrlProxy], while this helper
+ * pins the branch behavior that used to be hand-copied across five gesture methods.
+ */
+class GestureDispatchLifecycleTest {
+
+  @Test
+  fun `completed result includes gesture timing and closes perf in order`() {
+    val events = mutableListOf<String>()
+    val clock = MutableClock(100L)
+    val lifecycle = createLifecycle(events, clock)
+    val outcomes = mutableListOf<GestureDispatchOutcome>()
+
+    lifecycle.startDispatch()
+    clock.now = 180L
+    lifecycle.completed { outcome ->
+      events.add("result:${outcome.completed}")
+      outcomes.add(outcome)
+    }
+
+    assertEquals(
+      listOf("start:dispatchGesture", "endOperation:dispatchGesture", "end", "result:true"),
+      events,
+    )
+    assertEquals(
+      GestureDispatchOutcome(
+        completed = true,
+        totalTimeMs = 80L,
+        gestureTimeMs = 30L,
+        error = null,
+      ),
+      outcomes.single(),
+    )
+  }
+
+  @Test
+  fun `cancelled result reports cancellation and closes perf`() {
+    val events = mutableListOf<String>()
+    val clock = MutableClock(200L)
+    val lifecycle = createLifecycle(events, clock)
+    val outcomes = mutableListOf<GestureDispatchOutcome>()
+
+    lifecycle.startDispatch()
+    clock.now = 260L
+    lifecycle.cancelled { outcomes.add(it) }
+
+    assertEquals(listOf("start:dispatchGesture", "endOperation:dispatchGesture", "end"), events)
+    assertEquals(false, outcomes.single().completed)
+    assertEquals(60L, outcomes.single().totalTimeMs)
+    assertNull(outcomes.single().gestureTimeMs)
+    assertEquals("Gesture was cancelled", outcomes.single().error)
+  }
+
+  @Test
+  fun `completed result captures time after pre-result work`() {
+    val events = mutableListOf<String>()
+    val clock = MutableClock(100L)
+    val lifecycle = createLifecycle(events, clock)
+    val outcomes = mutableListOf<GestureDispatchOutcome>()
+
+    lifecycle.startDispatch()
+    clock.now = 180L
+    lifecycle.completed(
+      beforeResult = {
+        events.add("beforeResult")
+        clock.now = 210L
+      },
+      onResult = { outcomes.add(it) },
+    )
+
+    assertEquals(
+      listOf("start:dispatchGesture", "endOperation:dispatchGesture", "beforeResult", "end"),
+      events,
+    )
+    assertEquals(110L, outcomes.single().totalTimeMs)
+    assertEquals(60L, outcomes.single().gestureTimeMs)
+  }
+
+  @Test
+  fun `not dispatched result reports dispatch failure and closes perf`() {
+    val events = mutableListOf<String>()
+    val clock = MutableClock(300L)
+    val lifecycle = createLifecycle(events, clock)
+    val outcomes = mutableListOf<GestureDispatchOutcome>()
+
+    lifecycle.startDispatch()
+    clock.now = 315L
+    lifecycle.notDispatched { outcomes.add(it) }
+
+    assertEquals(listOf("start:dispatchGesture", "endOperation:dispatchGesture", "end"), events)
+    assertEquals(false, outcomes.single().completed)
+    assertEquals(15L, outcomes.single().totalTimeMs)
+    assertEquals("Failed to dispatch gesture", outcomes.single().error)
+  }
+
+  @Test
+  fun `exception result reports exception message and closes perf`() {
+    val events = mutableListOf<String>()
+    val clock = MutableClock(400L)
+    val lifecycle = createLifecycle(events, clock)
+    val outcomes = mutableListOf<GestureDispatchOutcome>()
+
+    lifecycle.startDispatch()
+    clock.now = 425L
+    lifecycle.failed(IllegalStateException("dispatch exploded")) { outcomes.add(it) }
+
+    assertEquals(listOf("start:dispatchGesture", "endOperation:dispatchGesture", "end"), events)
+    assertFalse(outcomes.single().completed)
+    assertEquals(25L, outcomes.single().totalTimeMs)
+    assertNull(outcomes.single().gestureTimeMs)
+    assertEquals("dispatch exploded", outcomes.single().error)
+  }
+
+  @Test
+  fun `result exception still closes root perf block`() {
+    val events = mutableListOf<String>()
+    val lifecycle = createLifecycle(events, MutableClock(500L))
+
+    lifecycle.startDispatch()
+    val thrown =
+      assertThrows(RuntimeException::class.java) {
+        lifecycle.completed { throw RuntimeException("result failed") }
+      }
+
+    assertEquals("result failed", thrown.message)
+    assertEquals(listOf("start:dispatchGesture", "endOperation:dispatchGesture", "end"), events)
+  }
+
+  private fun createLifecycle(
+    events: MutableList<String>,
+    clock: MutableClock,
+  ): GestureDispatchLifecycle =
+    GestureDispatchLifecycle(
+      startTimeMs = clock.now,
+      gestureBuiltTimeMs = clock.now + 50L,
+      nowMs = { clock.now },
+      startOperation = { events.add("start:$it") },
+      endOperation = { events.add("endOperation:$it") },
+      endPerfBlock = { events.add("end") },
+    )
+
+  private class MutableClock(var now: Long)
+}


### PR DESCRIPTION
## Summary

- Extract shared `GestureDispatchLifecycle` handling for Android gesture callbacks and perf cleanup.
- Route swipe, drag, tap, two-finger swipe, and pinch through one `dispatchGestureWithResult` helper.
- Preserve tap-only quiescence/hierarchy refresh before tap result timing is captured.

## Tests

- `./gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.GestureDispatchLifecycleTest`
- `./gradlew :control-proxy:testDebugUnitTest`
- `./gradlew :control-proxy:assembleDebug`
- `INSTALL_KTFMT_WHEN_MISSING=true ONLY_TOUCHED_FILES=true scripts/ktfmt/validate_ktfmt.sh`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Notes

- Closes #2817.
- I checked for a repo PR template and did not find `.github/PULL_REQUEST_TEMPLATE*`; this body uses the repo's standard summary/tests shape.
- `./gradlew :control-proxy:lintDebug` currently fails on pre-existing lint errors, including `QUERY_ALL_PACKAGES`, `ViewHierarchyExtractor.hintText` API checks, and existing drag `StrokeDescription(..., willContinue)` API checks in `CtrlProxy.kt`.
