### PR TITLE
test-infra: arm unit-test DB guard by default under bun-test context (#3140)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,11 +1,13 @@
 [test]
-# LOAD-BEARING: this preload arms the unit-test real-DB guard by setting
-# AUTOMOBILE_UNIT_TEST_DB_GUARD=1 (see test/setup/unitTestDbGuard.ts and
-# assertUnitTestDbAccessAllowed in src/db/database.ts). Removing this line — or
-# running `bun test` in a way that doesn't read this bunfig — SILENTLY disables
-# the guard, letting a real-DB race (the #3063 class) flake unguarded while the
-# suite reports a false green. test/db/unitTestDbGuardPreloadArmed.test.ts is the
-# tripwire that fails loudly if this preload ever stops running (issue #3083).
+# BELT-AND-SUSPENDERS: this preload force-arms the unit-test real-DB guard by
+# setting AUTOMOBILE_UNIT_TEST_DB_GUARD=1 (see test/setup/unitTestDbGuard.ts and
+# assertUnitTestDbAccessAllowed in src/db/database.ts). As of #3140 the guard also
+# arms BY DEFAULT under a bun-test context (NODE_ENV=test), so skipping this
+# preload no longer silently disables it. This flag is retained to cover the one
+# gap arm-by-default leaves: `NODE_ENV=production bun test` slips past the context
+# check (bun won't override an explicit NODE_ENV) and relies on this flag.
+# test/db/unitTestDbGuardPreloadArmed.test.ts is the tripwire that fails loudly if
+# this fallback preload ever stops running (issues #3083 / #3140).
 preload = ["./test/setup/unitTestDbGuard.ts"]
 coverageReporter = ["text", "lcov"]
 coverageDir = "./coverage"

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -105,11 +105,44 @@ export function resolveDatabasePathFromEnvironment(
 }
 
 /**
- * Env var, set only by the bun test preload (`test/setup/unitTestDbGuard.ts`),
- * that arms {@link assertUnitTestDbAccessAllowed}. It is never set in production,
- * so the guard is inert outside `bun test`.
+ * Explicit force-arm env var for {@link assertUnitTestDbAccessAllowed}.
+ *
+ * As of #3140 the guard arms BY DEFAULT under a bun-test context (see
+ * {@link isBunTestContext}), so this flag is no longer the *sole* arming path and
+ * the guard can no longer silently fail open if the bun test preload
+ * (`test/setup/unitTestDbGuard.ts`) is skipped. It is retained as an OR'd
+ * belt-and-suspenders fallback for the one gap arm-by-default leaves open: bun
+ * does NOT override an explicitly-set `NODE_ENV`, so `NODE_ENV=production bun
+ * test` would slip past the {@link isBunTestContext} check — the preload's flag
+ * keeps that run guarded. It is never set in production, so it does not widen the
+ * guard's production footprint beyond {@link isBunTestContext}.
  */
 export const UNIT_TEST_DB_GUARD_ENV = "AUTOMOBILE_UNIT_TEST_DB_GUARD";
+
+/**
+ * True when this process is a Bun test runner context. `bun test` sets
+ * `NODE_ENV=test` automatically when it is not already set, and nothing in
+ * production (the daemon runs under `bun run`/a compiled binary) sets it, so this
+ * is the arm-by-default signal for the real-DB guard (#3140). It is deliberately
+ * env-based — not a `bun:test`/`Bun.jest` runtime probe — because `Bun.jest` is a
+ * function under any Bun runtime (including a plain `bun run`), so it does not
+ * distinguish a test run from production.
+ */
+function isBunTestContext(env: NodeJS.ProcessEnv): boolean {
+  return env.NODE_ENV === "test";
+}
+
+/**
+ * Whether the real-DB guard is armed for this process. Armed when EITHER the
+ * arm-by-default bun-test context holds ({@link isBunTestContext}) OR the explicit
+ * force-arm flag is set ({@link UNIT_TEST_DB_GUARD_ENV}). The OR is what removes
+ * the single-point-of-failure preload dependency: a runner that never loaded the
+ * preload still arms via `NODE_ENV=test`, while an explicit flag still arms a
+ * `NODE_ENV`-overridden bun test run (#3140).
+ */
+function isUnitTestDbGuardArmed(env: NodeJS.ProcessEnv): boolean {
+  return isBunTestContext(env) || env[UNIT_TEST_DB_GUARD_ENV] === "1";
+}
 
 // The four env vars that redirect the database off the default `~/.auto-mobile`
 // location. A test that sets any of these has explicitly opted into a real
@@ -141,13 +174,14 @@ function hasExplicitDbPathOverride(env: NodeJS.ProcessEnv): boolean {
  * exact call site that reached for the real DB, forcing the test to inject an
  * in-memory DB instead — the durable fix for the whole class (issue #3067).
  *
- * The guard is armed only under the bun test preload ({@link UNIT_TEST_DB_GUARD_ENV})
- * and deliberately fires ONLY on the default path: a test that sets
- * AUTOMOBILE_DB_PATH / AUTOMOBILE_DB_DIR (the DB-lifecycle tests that must
- * exercise real file behavior) or `:memory:` has explicitly opted in and passes.
+ * The guard is armed by default under a bun-test context and deliberately fires
+ * ONLY on the default path: a test that sets AUTOMOBILE_DB_PATH /
+ * AUTOMOBILE_DB_DIR (the DB-lifecycle tests that must exercise real file
+ * behavior) or `:memory:` has explicitly opted in and passes. See
+ * {@link isUnitTestDbGuardArmed} for the arm-by-default / force-arm signals.
  */
 function assertUnitTestDbAccessAllowed(env: NodeJS.ProcessEnv, resolvedPath: string): void {
-  if (env[UNIT_TEST_DB_GUARD_ENV] !== "1") {
+  if (!isUnitTestDbGuardArmed(env)) {
     return;
   }
   if (isInMemoryDatabasePath(resolvedPath) || hasExplicitDbPathOverride(env)) {

--- a/test/db/unitTestDbGuard.test.ts
+++ b/test/db/unitTestDbGuard.test.ts
@@ -148,6 +148,18 @@ describe("unit-test real-DB guard (issues #3067 / #3140)", () => {
 
       expect(db.getDatabasePath()).toBe(DEFAULT_DB_PATH);
     });
+
+    test("NODE_ENV is matched by exact equality — an empty string is NOT a bun-test context", async () => {
+      // Pins `isBunTestContext`'s strict `=== "test"` so a future loosening to a
+      // substring/prefix match (which "" would satisfy under some sloppy checks)
+      // trips here rather than arming the guard in production.
+      setEnv("NODE_ENV", "");
+      setEnv(UNIT_TEST_DB_GUARD_ENV, undefined);
+      clearOverrides();
+      const db = await importFreshDatabaseModule();
+
+      expect(db.getDatabasePath()).toBe(DEFAULT_DB_PATH);
+    });
   });
 
   describe("shared opt-out surface (issue #3067)", () => {

--- a/test/db/unitTestDbGuard.test.ts
+++ b/test/db/unitTestDbGuard.test.ts
@@ -7,17 +7,23 @@ import { ActionableError } from "../../src/models/ActionableError";
 import { importFreshDatabaseModule } from "./freshDatabaseModule";
 
 /**
- * Unit tests for the real-DB guard (issue #3067).
+ * Unit tests for the real-DB guard (issues #3067 / #3140).
  *
- * The guard is armed process-wide by the bun test preload
- * (`test/setup/unitTestDbGuard.ts`), so `process.env[UNIT_TEST_DB_GUARD_ENV]`
- * is already "1" here. These tests import a FRESH copy of `src/db/database.ts`
- * per case (its resolved-path cache is a module global) and drive it purely via
- * env: no real DB is ever opened because every resolve either throws or targets
- * an explicit override.
+ * As of #3140 the guard is ARMED BY DEFAULT under a bun-test context
+ * (`NODE_ENV === "test"`, which `bun test` sets automatically) rather than only
+ * when the preload has set {@link UNIT_TEST_DB_GUARD_ENV}. The explicit env flag
+ * is retained as an OR'd belt-and-suspenders force-arm for the rare
+ * `NODE_ENV=production bun test` case (bun does not override an explicitly-set
+ * NODE_ENV). These tests import a FRESH copy of `src/db/database.ts` per case
+ * (its resolved-path cache is a module global) and drive it purely via env: no
+ * real DB is ever opened because every resolve either throws or targets an
+ * explicit override.
  */
-describe("unit-test real-DB guard (issue #3067)", () => {
+describe("unit-test real-DB guard (issues #3067 / #3140)", () => {
+  const DEFAULT_DB_PATH = path.join(os.homedir(), ".auto-mobile", "auto-mobile.db");
+
   const trackedKeys = [
+    "NODE_ENV",
     UNIT_TEST_DB_GUARD_ENV,
     IN_MEMORY_DB_OPT_IN_ENV,
     "AUTOMOBILE_DB_PATH",
@@ -45,6 +51,17 @@ describe("unit-test real-DB guard (issue #3067)", () => {
     setEnv(IN_MEMORY_DB_OPT_IN_ENV, undefined);
   }
 
+  /**
+   * Put the process into a genuine bun-test context (armed by default) with NO
+   * explicit force-arm flag, so a resolve exercises the #3140 arm-by-default path
+   * rather than the legacy env-flag path.
+   */
+  function armViaBunTestContext(): void {
+    setEnv("NODE_ENV", "test");
+    setEnv(UNIT_TEST_DB_GUARD_ENV, undefined);
+    clearOverrides();
+  }
+
   afterEach(() => {
     for (const key of trackedKeys) {
       setEnv(key, saved.get(key));
@@ -58,84 +75,150 @@ describe("unit-test real-DB guard (issue #3067)", () => {
   // the repo bans as a randomness source) and keeps the raw cache-busted import in
   // exactly one place (enforced by fileBackedDbAntiPattern.test.ts, issue #3081).
 
-  test("getDatabasePath() throws an ActionableError on the default real path when armed", async () => {
-    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
-    clearOverrides();
-    const db = await importFreshDatabaseModule();
+  describe("arm-by-default under a bun-test context (issue #3140)", () => {
+    test("throws on the default real path when NODE_ENV=test even with the force-arm flag UNSET", async () => {
+      // The core #3140 behavior: no preload / no explicit flag, yet `bun test`'s
+      // ambient NODE_ENV=test arms the guard on its own.
+      armViaBunTestContext();
+      const db = await importFreshDatabaseModule();
 
-    let thrown: unknown;
-    try {
-      db.getDatabasePath();
-    } catch (error) {
-      thrown = error;
-    }
+      let thrown: unknown;
+      try {
+        db.getDatabasePath();
+      } catch (error) {
+        thrown = error;
+      }
 
-    expect(thrown).toBeInstanceOf(ActionableError);
-    const message = (thrown as Error).message;
-    // Names the real path and the required remediation so the failure is actionable.
-    expect(message).toContain(path.join(os.homedir(), ".auto-mobile", "auto-mobile.db"));
-    expect(message).toContain("createTestDatabase");
+      expect(thrown).toBeInstanceOf(ActionableError);
+      const message = (thrown as Error).message;
+      expect(message).toContain(DEFAULT_DB_PATH);
+      expect(message).toContain("createTestDatabase");
+    });
+
+    test("bun-test context still respects the opt-outs (AUTOMOBILE_DB_DIR override)", async () => {
+      armViaBunTestContext();
+      const tempDir = path.join(os.tmpdir(), "auto-mobile-guard-3140-armdefault");
+      setEnv("AUTOMOBILE_DB_DIR", tempDir);
+      const db = await importFreshDatabaseModule();
+
+      expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
+    });
+
+    test("bun-test context still respects the `:memory:` opt-out", async () => {
+      armViaBunTestContext();
+      setEnv("AUTOMOBILE_DB_PATH", ":memory:");
+      setEnv(IN_MEMORY_DB_OPT_IN_ENV, "1");
+      const db = await importFreshDatabaseModule();
+
+      expect(db.getDatabasePath()).toBe(":memory:");
+    });
   });
 
-  test("allows the `:memory:` sentinel without throwing", async () => {
-    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
-    clearOverrides();
-    setEnv("AUTOMOBILE_DB_PATH", ":memory:");
-    // `:memory:` via the real singleton also needs the #3065 production opt-in,
-    // which the guard's own `:memory:` opt-out branch relies on being present.
-    setEnv(IN_MEMORY_DB_OPT_IN_ENV, "1");
-    const db = await importFreshDatabaseModule();
+  describe("explicit force-arm flag (belt-and-suspenders, issue #3140)", () => {
+    test("arms even when NODE_ENV is not a bun-test value (e.g. NODE_ENV=production bun test)", async () => {
+      // bun does NOT override an explicitly-set NODE_ENV, so `NODE_ENV=production
+      // bun test` would slip past the arm-by-default path; the preload's flag is
+      // the retained fallback that keeps such a run guarded.
+      setEnv("NODE_ENV", "production");
+      setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+      clearOverrides();
+      const db = await importFreshDatabaseModule();
 
-    expect(db.getDatabasePath()).toBe(":memory:");
+      expect(() => db.getDatabasePath()).toThrow(ActionableError);
+    });
   });
 
-  test("allows an explicit AUTOMOBILE_DB_DIR override without throwing", async () => {
-    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
-    clearOverrides();
-    const tempDir = path.join(os.tmpdir(), "auto-mobile-guard-test");
-    setEnv("AUTOMOBILE_DB_DIR", tempDir);
-    const db = await importFreshDatabaseModule();
+  describe("production safety: inert when neither arming signal is present (issue #3140)", () => {
+    test("resolves the default real path with no throw when NODE_ENV is non-test and the flag is unset", async () => {
+      // Simulates the real daemon: no bun-test context, no force-arm flag.
+      setEnv("NODE_ENV", "production");
+      setEnv(UNIT_TEST_DB_GUARD_ENV, undefined);
+      clearOverrides();
+      const db = await importFreshDatabaseModule();
 
-    expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
+      expect(db.getDatabasePath()).toBe(DEFAULT_DB_PATH);
+    });
+
+    test("resolves the default real path with no throw when NODE_ENV is unset and the flag is unset", async () => {
+      // A directly-launched daemon under `bun run` has no NODE_ENV at all.
+      setEnv("NODE_ENV", undefined);
+      setEnv(UNIT_TEST_DB_GUARD_ENV, undefined);
+      clearOverrides();
+      const db = await importFreshDatabaseModule();
+
+      expect(db.getDatabasePath()).toBe(DEFAULT_DB_PATH);
+    });
   });
 
-  test("allows the legacy AUTO_MOBILE_DB_DIR alias override without throwing", async () => {
-    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
-    clearOverrides();
-    const tempDir = path.join(os.tmpdir(), "auto-mobile-guard-test-legacy");
-    setEnv("AUTO_MOBILE_DB_DIR", tempDir);
-    const db = await importFreshDatabaseModule();
+  describe("shared opt-out surface (issue #3067)", () => {
+    test("getDatabasePath() throws an ActionableError on the default real path when armed", async () => {
+      setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+      clearOverrides();
+      const db = await importFreshDatabaseModule();
 
-    expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
-  });
+      let thrown: unknown;
+      try {
+        db.getDatabasePath();
+      } catch (error) {
+        thrown = error;
+      }
 
-  test("an empty-string override is NOT an override — still throws on the default path", async () => {
-    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
-    clearOverrides();
-    setEnv("AUTOMOBILE_DB_DIR", "");
-    const db = await importFreshDatabaseModule();
+      expect(thrown).toBeInstanceOf(ActionableError);
+      const message = (thrown as Error).message;
+      // Names the real path and the required remediation so the failure is actionable.
+      expect(message).toContain(DEFAULT_DB_PATH);
+      expect(message).toContain("createTestDatabase");
+    });
 
-    expect(() => db.getDatabasePath()).toThrow(ActionableError);
-  });
+    test("allows the `:memory:` sentinel without throwing", async () => {
+      setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+      clearOverrides();
+      setEnv("AUTOMOBILE_DB_PATH", ":memory:");
+      // `:memory:` via the real singleton also needs the #3065 production opt-in,
+      // which the guard's own `:memory:` opt-out branch relies on being present.
+      setEnv(IN_MEMORY_DB_OPT_IN_ENV, "1");
+      const db = await importFreshDatabaseModule();
 
-  test("allows an explicit AUTOMOBILE_DB_PATH override without throwing", async () => {
-    setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
-    clearOverrides();
-    const dbPath = path.join(os.tmpdir(), "auto-mobile-guard-test", "explicit.db");
-    setEnv("AUTOMOBILE_DB_PATH", dbPath);
-    const db = await importFreshDatabaseModule();
+      expect(db.getDatabasePath()).toBe(":memory:");
+    });
 
-    expect(db.getDatabasePath()).toBe(dbPath);
-  });
+    test("allows an explicit AUTOMOBILE_DB_DIR override without throwing", async () => {
+      setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+      clearOverrides();
+      const tempDir = path.join(os.tmpdir(), "auto-mobile-guard-test");
+      setEnv("AUTOMOBILE_DB_DIR", tempDir);
+      const db = await importFreshDatabaseModule();
 
-  test("is inert (no throw) when the guard flag is not set — production safety", async () => {
-    setEnv(UNIT_TEST_DB_GUARD_ENV, undefined);
-    clearOverrides();
-    const db = await importFreshDatabaseModule();
+      expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
+    });
 
-    // Resolves the default real path silently, exactly like production.
-    expect(db.getDatabasePath()).toBe(
-      path.join(os.homedir(), ".auto-mobile", "auto-mobile.db")
-    );
+    test("allows the legacy AUTO_MOBILE_DB_DIR alias override without throwing", async () => {
+      setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+      clearOverrides();
+      const tempDir = path.join(os.tmpdir(), "auto-mobile-guard-test-legacy");
+      setEnv("AUTO_MOBILE_DB_DIR", tempDir);
+      const db = await importFreshDatabaseModule();
+
+      expect(db.getDatabasePath()).toBe(path.join(tempDir, "auto-mobile.db"));
+    });
+
+    test("an empty-string override is NOT an override — still throws on the default path", async () => {
+      setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+      clearOverrides();
+      setEnv("AUTOMOBILE_DB_DIR", "");
+      const db = await importFreshDatabaseModule();
+
+      expect(() => db.getDatabasePath()).toThrow(ActionableError);
+    });
+
+    test("allows an explicit AUTOMOBILE_DB_PATH override without throwing", async () => {
+      setEnv(UNIT_TEST_DB_GUARD_ENV, "1");
+      clearOverrides();
+      const dbPath = path.join(os.tmpdir(), "auto-mobile-guard-test", "explicit.db");
+      setEnv("AUTOMOBILE_DB_PATH", dbPath);
+      const db = await importFreshDatabaseModule();
+
+      expect(db.getDatabasePath()).toBe(dbPath);
+    });
   });
 });

--- a/test/db/unitTestDbGuardPreloadArmed.test.ts
+++ b/test/db/unitTestDbGuardPreloadArmed.test.ts
@@ -9,26 +9,28 @@ import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
 const bunfigPreload: string[] = (bunfigConfig as { test?: { preload?: string[] } }).test?.preload ?? [];
 
 /**
- * Positive "the arming machinery is intact" tripwire for the real-DB guard
- * (issue #3083, follow-up to #3067 / PR #3082).
+ * Positive "the belt-and-suspenders arming machinery is intact" tripwire for the
+ * real-DB guard (issue #3083, follow-up to #3067 / PR #3082; kept valid through
+ * the #3140 inversion).
  *
- * The guard in `src/db/database.ts` (`assertUnitTestDbAccessAllowed`) only fires
- * when `process.env[UNIT_TEST_DB_GUARD_ENV] === "1"`, and that flag is set solely
- * by the bun test preload `test/setup/unitTestDbGuard.ts` (wired via
- * `bunfig.toml` `[test].preload`). If the preload never runs — a `bun test
- * --config other.toml`, a future CI job that doesn't pick up `bunfig.toml`, or an
- * accidentally-deleted `[test].preload` line — the guard silently disables itself
- * and the suite can report a false green while a real-DB race (the #3063 class)
- * flakes unguarded. The guard "fails open".
+ * As of #3140 the guard in `src/db/database.ts` (`assertUnitTestDbAccessAllowed`)
+ * arms BY DEFAULT under a bun-test context (`NODE_ENV === "test"`), so it can no
+ * longer silently fail open when the preload is skipped — that was the whole
+ * fragility #3083 detected. The bun test preload `test/setup/unitTestDbGuard.ts`
+ * (wired via `bunfig.toml` `[test].preload`) now sets `UNIT_TEST_DB_GUARD_ENV` as
+ * an OR'd belt-and-suspenders force-arm, retained to cover the one gap
+ * arm-by-default leaves open: bun does NOT override an explicitly-set `NODE_ENV`,
+ * so `NODE_ENV=production bun test` slips past the context check and relies on
+ * this flag to stay guarded. This tripwire keeps that fallback path honest.
  *
- * These two assertions turn that silent failure LOUD:
+ * These two assertions turn a silently-broken fallback LOUD:
  *   1. Ambient-env: the preload actually ran in THIS test process. This test does
  *      NOT set the flag itself (that would be vacuous) — it reads the ambient
  *      value, so it goes red if the preload was skipped for ANY reason.
  *   2. Wiring: `bunfig.toml` still lists the preload, so removing the line trips a
  *      targeted failure that names the exact cause.
  */
-describe("unit-test DB guard preload is armed (issue #3083)", () => {
+describe("unit-test DB guard preload is armed (issues #3083 / #3140)", () => {
   test("the bun test preload ran: UNIT_TEST_DB_GUARD_ENV is set to \"1\" in this process", () => {
     // Read the AMBIENT value — deliberately not set here, so this fails loudly if
     // the preload (test/setup/unitTestDbGuard.ts) did not run for this process.

--- a/test/setup/unitTestDbGuard.ts
+++ b/test/setup/unitTestDbGuard.ts
@@ -1,16 +1,23 @@
 import { UNIT_TEST_DB_GUARD_ENV } from "../../src/db/database";
 
 /**
- * Bun test preload (wired via `bunfig.toml` `[test].preload`) that arms the
+ * Bun test preload (wired via `bunfig.toml` `[test].preload`) that force-arms the
  * unit-test database guard for the whole suite.
  *
- * Setting {@link UNIT_TEST_DB_GUARD_ENV} makes `getDatabase()` throw when a test
- * resolves the DEFAULT, real file-backed DB (`~/.auto-mobile/auto-mobile.db`)
- * instead of injecting an in-memory DB via `createTestDatabase` — the durable
- * fix for the real-DB-race flake class (issues #3063 / #3067). Tests that must
- * exercise real file behavior opt out by setting AUTOMOBILE_DB_DIR to a temp dir
- * or AUTOMOBILE_DB_PATH=':memory:' explicitly (see the guard in
- * `src/db/database.ts`).
+ * As of #3140 the guard arms BY DEFAULT under a bun-test context
+ * (`NODE_ENV === "test"`), so this preload is NO LONGER the sole arming path and
+ * the guard can no longer silently fail open when the preload is skipped. Setting
+ * {@link UNIT_TEST_DB_GUARD_ENV} is retained as a belt-and-suspenders force-arm
+ * for the one gap arm-by-default leaves open: bun does NOT override an
+ * explicitly-set `NODE_ENV`, so `NODE_ENV=production bun test` slips past the
+ * context check and relies on this flag to stay guarded.
+ *
+ * When armed, `getDatabase()` throws when a test resolves the DEFAULT, real
+ * file-backed DB (`~/.auto-mobile/auto-mobile.db`) instead of injecting an
+ * in-memory DB via `createTestDatabase` — the durable fix for the real-DB-race
+ * flake class (issues #3063 / #3067). Tests that must exercise real file behavior
+ * opt out by setting AUTOMOBILE_DB_DIR to a temp dir or AUTOMOBILE_DB_PATH=':memory:'
+ * explicitly (see the guard in `src/db/database.ts`).
  *
  * A preload runs once per test process before any test file is imported, so the
  * flag is set before the first lazy `resolveDbPath()`.


### PR DESCRIPTION
## Summary

Follow-up to #3083 / PR #3117. Inverts the unit-test real-DB guard from **preload-opt-in** to **arm-by-default under a bun-test context**, closing the "guard fails open when the preload is skipped" fragility (#3083 finding 4).

Previously `assertUnitTestDbAccessAllowed` (`src/db/database.ts`) early-returned inert unless `AUTOMOBILE_UNIT_TEST_DB_GUARD=1`, a flag set **solely** by the `bunfig.toml` `[test].preload`. Any `bun test` path that didn't read that bunfig (a `--config other.toml`, a future CI job, an accidentally-deleted preload line) silently lost the guard — a single point of failure.

## What changed

- **Arm-by-default:** the guard now fires whenever the process is a bun-test context (`NODE_ENV === "test"`, which `bun test` sets automatically) **OR** the explicit force-arm flag is set. New pure helpers `isBunTestContext(env)` and `isUnitTestDbGuardArmed(env)` express this.
- **Explicit flag retained as belt-and-suspenders:** `AUTOMOBILE_UNIT_TEST_DB_GUARD=1` (set by the preload) is kept as an OR'd fallback for the one gap arm-by-default leaves open — bun does **not** override an explicitly-set `NODE_ENV`, so `NODE_ENV=production bun test` slips past the context check and relies on this flag to stay guarded.
- **Opt-outs unchanged:** the four `AUTOMOBILE_DB_PATH`/`DIR` overrides and `:memory:` + `AUTOMOBILE_ALLOW_IN_MEMORY_DB` opt-in still short-circuit the guard.
- **Docs updated** on the guard, the preload, and the `bunfig.toml` comment; the #3117 tripwire remains valid (now guarding the retained fallback path) with refreshed prose.

## Why `NODE_ENV`, not a runtime probe

`Bun.jest` is a function under **any** Bun runtime (including a plain `bun run`), so it does not distinguish a test run from production. `NODE_ENV` is the only reliable env-level discriminator: `bun test` sets it to `test`, `bun run`/the compiled daemon leave it unset, and nothing in the repo sets it otherwise (verified by grep). The guard still fires **only** on the default `~/.auto-mobile` path, so production and explicit-override paths are untouched.

## Acceptance criteria (from #3140)

- [x] Guard fires on the default `~/.auto-mobile` path under `bun test` **without** relying on the preload having run — new test sets `NODE_ENV=test` with the flag UNSET and asserts the throw.
- [x] Production (non-test `NODE_ENV`, flag unset) resolves the real DB with no throw — two new tests (`NODE_ENV=production` and unset).
- [x] Existing opt-outs (temp `AUTOMOBILE_DB_DIR`, `AUTOMOBILE_DB_PATH`, `:memory:` + opt-in) still pass.
- [x] The #3117 tripwire remains valid (kept; now covers the belt-and-suspenders fallback).

## Testing

- `bun test test/db/unitTestDbGuard.test.ts test/db/unitTestDbGuardPreloadArmed.test.ts test/db/fileBackedDbAntiPattern.test.ts` → 40 pass.
- Full suite: `bun test` → 6451 pass, 2 skip, 0 fail.
- `turbo run lint build` → clean.

Closes #3140
