### PR TITLE
fix ios dnd readback detection

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -317,10 +317,13 @@ per-package resilience of iOS app-data restore.
 <kbd>✅ Implemented</kbd> <kbd>📱 Simulator (iOS ≤17) Only</kbd>
 
 The `setDeviceState` / `getDeviceState` MCP tools control Do Not Disturb. On iOS,
-DND is **simulator-only and binary** (on/off) — this is a hard platform
-limitation, not a missing wiring detail. **On iOS 18+ simulators it is not
-available at all** (see below): DND moved to the private `donotdisturbd` Focus
-daemon, so both read and write report `capability: "unsupported"`.
+DND is **simulator-only and binary** (on/off) when the legacy notification path
+can prove it works — this is a hard platform limitation, not a missing wiring
+detail. Known **iOS 18+ simulators skip the legacy write probe and report
+`capability: "unsupported"`** (see below): DND moved to the private
+`donotdisturbd` Focus daemon. Unknown or older simulator runtimes attempt the
+legacy path, but write success is behavior-based and requires an independent
+fresh-process readback.
 
 ### How it works (iOS ≤17 simulators)
 
@@ -332,38 +335,49 @@ daemon, so both read and write report `capability: "unsupported"`.
      no process has registered the key.
    - `notifyutil -s com.apple.donotdisturb.enabled <0|1>` sets the value while
      the registration is alive.
-   - `notifyutil -g com.apple.donotdisturb.enabled` verifies the registered
-     state in the same invocation.
+   - `notifyutil -g com.apple.donotdisturb.enabled` reads the registered state in
+     the same invocation.
    - `notifyutil -p com.apple.donotdisturb.enabled` posts it so observers react.
+   - After a short settle, a separate fresh-process
+     `notifyutil -g com.apple.donotdisturb.enabled` verifies that the value
+     persisted. Only this independent readback can make the write
+     `verified: true`.
 2. **Honest capability reporting** — every result carries a machine-readable
    `capability` field so callers can branch instead of string-matching warnings:
-   - `binary` — iOS ≤17 simulator: on/off only.
-   - `unsupported` — physical device, or **iOS 18+ simulator**: DND cannot be
-     read or set at all.
+   - `binary` — simulator legacy path verified: on/off only.
+   - `unsupported` — physical device, known **iOS 18+ simulator**, or a legacy
+     write whose independent readback reverted instead of persisting.
    - (`full` is reserved for Android, where all four `zen_mode` tiers are
      distinct, persisted, and verified.)
 3. **No silent downgrade** — a `priority` or `alarms` request applies plain DND
    and reports it honestly: `requestedMode: "priority"|"alarms"`,
    `appliedMode: "none"`, a structured `warning`, and `verified: false` (so
    `success` is `false`). The tool never claims a tier it cannot deliver.
-4. **Best effort** — results are `bestEffort: true`. The setter verifies inside
-   the registered invocation; the readback is advisory, not authoritative.
+4. **Best effort with behavior verification** — results are `bestEffort: true`.
+   The registered set invocation is not authoritative by itself; the setter only
+   reports success when the independent readback observes the requested binary
+   state.
 
 ### Limitations
 
-- **iOS 18+ simulators: unsupported.** iOS 18 moved Do Not Disturb / Focus to the
+- **Known iOS 18+ simulators: unsupported fast-path.** iOS 18 moved Do Not Disturb / Focus to the
   private **`donotdisturbd`** daemon (a Core Data store + Focus-assertion model).
   That daemon owns the legacy `com.apple.donotdisturb.enabled` notification and
   immediately resets it to its authoritative value — verified empirically, a
   `notifyutil -s` write reads back `0` from a fresh process even sub-second later
   (an unmanaged notify key set the same way persists). So the legacy key neither
   reflects nor controls the real Focus state: writes cannot verify and reads are a
-  confident falsehood. The simulator's iOS major version is detected (from device
-  metadata or `simctl list devices <udid> --json`) and, on 18+, both
-  `getDeviceState` and `setDeviceState` return `capability: "unsupported"` with a
-  precise error rather than trusting the dead key. Apple exposes no public API to
-  read or set Focus/DND. Use an iOS 17 or earlier simulator, or set it manually /
-  via a Shortcuts automation.
+  confident falsehood. When the simulator's iOS major version is known from device
+  metadata or `simctl list devices <udid> --json`, iOS 18+ is treated as an
+  unsupported fast-path to avoid a known-dead probe. When the version is unknown
+  or expected to support the legacy path, `setDeviceState` still probes behavior:
+  if the fresh-process readback reverts, the result is `capability:
+  "unsupported"` instead of a false success. On unknown runtimes, an off request
+  reading back disabled is not enough to prove capability, because reclaimed
+  runtimes also settle to `0`; positive enable persistence is the useful proof.
+  Apple exposes no public API to read or set Focus/DND. Use an iOS 17 or earlier
+  simulator with verified legacy behavior, or set it manually / via a Shortcuts
+  automation.
 - **Simulator only.** Physical iOS devices return `supported: false`,
   `capability: "unsupported"`, and a specific error: iOS exposes **no public
   API** to enable/disable Focus or Do Not Disturb (only the read-only Focus

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -5,6 +5,8 @@ import { isIosSimulatorDevice } from "../action/IosSimulatorPermissions";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
 import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
 import { logger } from "../../utils/logger";
+import type { Timer } from "../../utils/SystemTimer";
+import { defaultTimer } from "../../utils/SystemTimer";
 import {
   IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
   iosNotifyutilGetCommand,
@@ -71,9 +73,11 @@ interface IosSimulatorClient {
 export interface DeviceStateDependencies {
   adbFactory?: AdbClientFactory;
   simctl?: IosSimulatorClient | null;
+  timer?: Timer;
 }
 
 const IOS_DND_NOTIFICATION = "com.apple.donotdisturb.enabled";
+const IOS_DND_INDEPENDENT_READBACK_SETTLE_MS = 500;
 
 /**
  * Physical iOS devices expose no public API to enable/disable Focus or Do Not
@@ -87,7 +91,7 @@ const IOS_PHYSICAL_DND_UNSUPPORTED_ERROR =
   + "enable/disable Focus or Do Not Disturb (only the read-only Focus Filter API). "
   + "Use an iOS Simulator for DND automation, or trigger DND manually / via a Shortcuts automation on device.";
 
-/** iOS major version at/after which the legacy binary-DND notification is dead. */
+/** Last iOS major version where the legacy binary-DND notification is expected to work. */
 const IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR = 17;
 
 /**
@@ -99,8 +103,9 @@ const IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR = 17;
  * while an unmanaged notify key (e.g. BiometricKit's) set the same way persists.
  * So the legacy key neither reflects nor controls the real Focus state — a write
  * cannot verify and a read is a confident falsehood (always `0`). Apple ships no
- * public API to read or set Focus/DND, so on iOS 18+ simulators both the read and
- * write paths honestly report unsupported instead of trusting the dead key.
+ * public API to read or set Focus/DND. The version check is only a fast-path:
+ * legacy writes that are attempted must still prove persistence with an
+ * independent fresh-process readback before reporting success.
  */
 const IOS18_SIM_DND_UNSUPPORTED_ERROR =
   "Do Not Disturb cannot be reliably read or set on an iOS 18+ simulator: iOS 18 moved Do Not "
@@ -184,30 +189,37 @@ function iosDndStateFromNotifyutilOutput(raw: string): DoNotDisturbState {
   };
 }
 
+function iosDndUnsupportedReadbackResult(
+  state: DoNotDisturbState,
+  requestedMode: DoNotDisturbMode,
+  requestedEnabled: boolean,
+  reason: string
+): DoNotDisturbState {
+  const observed = state.enabled === undefined ? "unknown" : (state.enabled ? "enabled" : "disabled");
+  const requested = requestedEnabled ? "enabled" : "disabled";
+  return {
+    ...state,
+    supported: false,
+    capability: "unsupported",
+    requestedMode,
+    verified: false,
+    bestEffort: true,
+    error: `iOS simulator Do Not Disturb write did not persist: independent notifyutil readback observed ${observed} after requesting ${requested}. ${reason}`,
+  };
+}
+
 /**
- * Builds the honest warning for an iOS simulator DND write. The two failure
- * axes are independent and must both be surfaced:
- * - `downgraded`: a `priority`/`alarms` tier was requested but only plain binary
- *   DND is available.
- * - `!stateMatches`: the binary `notifyutil -g` readback did not confirm the
- *   requested enabled state — so we cannot even assert plain DND was applied.
+ * Builds the honest warning for an iOS simulator DND write when the binary
+ * state verified, but the requested priority/alarms tier cannot be represented.
  */
 function iosDndSetWarning(
   requestedMode: DoNotDisturbMode,
-  downgraded: boolean,
-  stateMatches: boolean
+  downgraded: boolean
 ): string | undefined {
-  const readbackFailed =
-    "the binary DND toggle did not verify: notifyutil did not read back the requested state.";
   if (downgraded) {
     const tier = `iOS DND is binary on the simulator; requested "${requestedMode}" has no per-mode/priority/alarms `
       + "fidelity (no public Focus API)";
-    return stateMatches
-      ? `${tier}, so it was applied as plain DND.`
-      : `${tier}, and ${readbackFailed}`;
-  }
-  if (!stateMatches) {
-    return `iOS simulator Do Not Disturb notification was posted, but ${readbackFailed}`;
+    return `${tier}, so it was applied as plain DND.`;
   }
   return undefined;
 }
@@ -226,10 +238,13 @@ export class DeviceState {
 
   private simctl: IosSimulatorClient | null;
 
+  private timer: Timer;
+
   constructor(device: BootedDevice, dependencies: DeviceStateDependencies = {}) {
     this.device = device;
     this.adbFactory = dependencies.adbFactory ?? defaultAdbClientFactory;
     this.simctl = dependencies.simctl ?? null;
+    this.timer = dependencies.timer ?? defaultTimer;
   }
 
   async getState(): Promise<DeviceStateResult> {
@@ -424,13 +439,11 @@ export class DeviceState {
 
     const simctl = this.simctl ?? new SimCtlClient(this.device);
 
-    // iOS 18+ simulators: the legacy binary-DND notification is dead (DND moved to
-    // donotdisturbd, which owns the key and immediately resets it to its
-    // authoritative value — so a posted toggle is overwritten and can never
-    // verify). Report unsupported and issue no misleading notifyutil write,
-    // mirroring the physical-device early return. iOS <18 (and unknown) keep the
-    // legacy best-effort path below.
+    // Known iOS 18+ simulators skip the legacy probe as a fast-path optimization:
+    // the key is owned/reset by donotdisturbd there. Unknown and older runtimes
+    // still attempt the legacy path, then prove behavior with a fresh readback.
     const iosMajor = await this.resolveSimulatorIosMajorVersion(simctl);
+    const versionKnown = iosMajor !== null;
     if (iosMajor !== null && iosMajor > IOS_DND_LEGACY_NOTIFICATION_LAST_SUPPORTED_MAJOR) {
       return {
         supported: false,
@@ -441,7 +454,7 @@ export class DeviceState {
       };
     }
 
-    // Simulator (iOS <18): the only lever is the binary `com.apple.donotdisturb.enabled`
+    // Simulator legacy path: the only lever is the binary `com.apple.donotdisturb.enabled`
     // Darwin notification. `notifyutil -s` is a no-op unless the key has a
     // registration, so set/read/post must happen in one registered invocation.
     // There is no per-mode (priority/alarms) Darwin notification analogous to
@@ -458,14 +471,46 @@ export class DeviceState {
         iosNotifyutilRegisteredSetCommand(this.device.deviceId, IOS_DND_NOTIFICATION, value),
         IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS
       );
-      const state = iosDndStateFromNotifyutilOutput(writeResult.stdout ?? "");
+      const writeStderr = writeResult.stderr?.trim();
+      if (writeStderr) {
+        return {
+          supported: true,
+          capability: "binary",
+          requestedMode,
+          method: "ios_simulator_notifyutil",
+          bestEffort: true,
+          error: `notifyutil failed: ${writeStderr}`,
+        };
+      }
+
+      await this.timer.sleep(IOS_DND_INDEPENDENT_READBACK_SETTLE_MS);
+      const readbackResult = await simctl.executeCommand(
+        iosNotifyutilGetCommand(this.device.deviceId, IOS_DND_NOTIFICATION)
+      );
+      const state = iosDndStateFromNotifyutilOutput(readbackResult.stdout ?? "");
       const stateMatches = state.enabled === requestedEnabled;
+      if (!stateMatches) {
+        return iosDndUnsupportedReadbackResult(
+          state,
+          requestedMode,
+          requestedEnabled,
+          "The runtime may reset the legacy com.apple.donotdisturb.enabled notification via donotdisturbd."
+        );
+      }
+      if (!requestedEnabled && !versionKnown) {
+        return iosDndUnsupportedReadbackResult(
+          state,
+          requestedMode,
+          requestedEnabled,
+          "The simulator iOS version is unknown, and an off request reading back disabled does not prove the legacy DND notification can enable DND."
+        );
+      }
       // For priority/alarms we applied *a* DND state but NOT the requested tier,
       // so verified is intentionally false: setState() will then report
       // success:false, surfacing the unfulfillable request instead of hiding it.
       const verified = stateMatches && !downgraded;
 
-      const warning = iosDndSetWarning(requestedMode, downgraded, stateMatches);
+      const warning = iosDndSetWarning(requestedMode, downgraded);
 
       // Only assert an applied mode when the binary readback confirmed the
       // requested enabled state. If it did not, we cannot claim plain DND was

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -3,6 +3,7 @@ import type { BootedDevice } from "../../../src/models";
 import { DeviceState } from "../../../src/features/utility/DeviceState";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 const androidDevice: BootedDevice = {
   name: "Pixel",
@@ -27,6 +28,20 @@ const ios18Simulator: BootedDevice = {
   iosVersion: "18.6",
 };
 
+const IOS_SIMULATOR_DND_GET_COMMAND =
+  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled";
+const IOS_SIMULATOR_DND_SET_ON_COMMAND =
+  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled";
+const IOS_SIMULATOR_DND_SET_OFF_COMMAND =
+  "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled";
+const IOS_DND_INDEPENDENT_READBACK_SETTLE_MS = 500;
+
+function autoAdvanceTimer(): FakeTimer {
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  return timer;
+}
+
 describe("DeviceState", () => {
   test("reads Android Do Not Disturb from zen_mode", async () => {
     const adbFactory = new FakeAdbClientFactory();
@@ -49,7 +64,7 @@ describe("DeviceState", () => {
   test("reads iOS <18 simulator Do Not Disturb from the legacy notifyutil key", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -g com.apple.donotdisturb.enabled",
+      IOS_SIMULATOR_DND_GET_COMMAND,
       "com.apple.donotdisturb.enabled 1\n"
     );
 
@@ -105,12 +120,17 @@ describe("DeviceState", () => {
 
   test("sets iOS <18 simulator Do Not Disturb on with notifyutil best-effort commands", async () => {
     const simctl = new FakeSimCtlClient();
+    const timer = autoAdvanceTimer();
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      IOS_SIMULATOR_DND_SET_ON_COMMAND,
+      "com.apple.donotdisturb.enabled 1\n"
+    );
+    simctl.setCommandResult(
+      IOS_SIMULATOR_DND_GET_COMMAND,
       "com.apple.donotdisturb.enabled 1\n"
     );
 
-    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
     const result = await deviceState.setState({
       doNotDisturb: { enabled: true },
     });
@@ -127,22 +147,74 @@ describe("DeviceState", () => {
       verified: true,
     });
     expect(result.doNotDisturb?.warning).toBeUndefined();
+    expect(timer.getSleepHistory()).toEqual([IOS_DND_INDEPENDENT_READBACK_SETTLE_MS]);
     expect(simctl.getMethodCalls("executeCommand")).toEqual([
       {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+        command: IOS_SIMULATOR_DND_SET_ON_COMMAND,
         timeoutMs: 5000,
+      },
+      {
+        command: IOS_SIMULATOR_DND_GET_COMMAND,
+        timeoutMs: undefined,
+      },
+    ]);
+  });
+
+  test("reports unsupported when an independent iOS simulator DND readback reverts", async () => {
+    const simctl = new FakeSimCtlClient();
+    const timer = autoAdvanceTimer();
+    simctl.setCommandResult(
+      IOS_SIMULATOR_DND_SET_ON_COMMAND,
+      "com.apple.donotdisturb.enabled 1\n"
+    );
+    simctl.setCommandResult(
+      IOS_SIMULATOR_DND_GET_COMMAND,
+      "com.apple.donotdisturb.enabled 0\n"
+    );
+
+    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: true },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      enabled: false,
+      mode: "off",
+      requestedMode: "none",
+      verified: false,
+      bestEffort: true,
+    });
+    expect(result.error).toContain("independent notifyutil readback");
+    expect(result.error).toContain("donotdisturbd");
+    expect(timer.getSleepHistory()).toEqual([IOS_DND_INDEPENDENT_READBACK_SETTLE_MS]);
+    expect(simctl.getMethodCalls("executeCommand")).toEqual([
+      {
+        command: IOS_SIMULATOR_DND_SET_ON_COMMAND,
+        timeoutMs: 5000,
+      },
+      {
+        command: IOS_SIMULATOR_DND_GET_COMMAND,
+        timeoutMs: undefined,
       },
     ]);
   });
 
   test("sets iOS <18 simulator Do Not Disturb off with notifyutil best-effort commands", async () => {
     const simctl = new FakeSimCtlClient();
+    const timer = autoAdvanceTimer();
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      IOS_SIMULATOR_DND_SET_OFF_COMMAND,
+      "com.apple.donotdisturb.enabled 0\n"
+    );
+    simctl.setCommandResult(
+      IOS_SIMULATOR_DND_GET_COMMAND,
       "com.apple.donotdisturb.enabled 0\n"
     );
 
-    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
     const result = await deviceState.setState({
       doNotDisturb: { enabled: false },
     });
@@ -161,20 +233,29 @@ describe("DeviceState", () => {
     expect(result.doNotDisturb?.warning).toBeUndefined();
     expect(simctl.getMethodCalls("executeCommand")).toEqual([
       {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+        command: IOS_SIMULATOR_DND_SET_OFF_COMMAND,
         timeoutMs: 5000,
+      },
+      {
+        command: IOS_SIMULATOR_DND_GET_COMMAND,
+        timeoutMs: undefined,
       },
     ]);
   });
 
   test("sets iOS simulator Do Not Disturb with a temporary notifyutil registration", async () => {
     const simctl = new FakeSimCtlClient();
+    const timer = autoAdvanceTimer();
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      IOS_SIMULATOR_DND_SET_ON_COMMAND,
       "com.apple.donotdisturb.enabled 1\ncom.apple.donotdisturb.enabled\n"
     );
+    simctl.setCommandResult(
+      IOS_SIMULATOR_DND_GET_COMMAND,
+      "com.apple.donotdisturb.enabled 1\n"
+    );
 
-    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
     const result = await deviceState.setState({
       doNotDisturb: { enabled: true },
     });
@@ -191,13 +272,18 @@ describe("DeviceState", () => {
 
   test("reports honest downgrade for iOS simulator priority/alarms (no silent tier claim)", async () => {
     const simctl = new FakeSimCtlClient();
+    const timer = autoAdvanceTimer();
     // notifyutil reads back enabled, but the requested *tier* cannot be applied.
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      IOS_SIMULATOR_DND_SET_ON_COMMAND,
+      "com.apple.donotdisturb.enabled 1\n"
+    );
+    simctl.setCommandResult(
+      IOS_SIMULATOR_DND_GET_COMMAND,
       "com.apple.donotdisturb.enabled 1\n"
     );
 
-    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
     const result = await deviceState.setState({
       doNotDisturb: { mode: "priority" },
     });
@@ -219,30 +305,41 @@ describe("DeviceState", () => {
     // We still posted the binary toggle (a DND state was applied, just not the tier).
     expect(simctl.getMethodCalls("executeCommand")).toEqual([
       {
-        command: "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+        command: IOS_SIMULATOR_DND_SET_ON_COMMAND,
         timeoutMs: 5000,
+      },
+      {
+        command: IOS_SIMULATOR_DND_GET_COMMAND,
+        timeoutMs: undefined,
       },
     ]);
   });
 
-  test("surfaces both the downgrade and a failed binary readback for iOS priority/alarms", async () => {
+  test("reports unsupported when priority/alarms DND fails independent binary readback", async () => {
     const simctl = new FakeSimCtlClient();
-    // notifyutil reads back DISABLED even though we requested an enabled tier:
+    const timer = autoAdvanceTimer();
+    // Fresh notifyutil reads back DISABLED even though we requested an enabled tier:
     // the binary toggle itself did not verify, on top of the tier downgrade.
     simctl.setCommandResult(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      IOS_SIMULATOR_DND_SET_ON_COMMAND,
+      "com.apple.donotdisturb.enabled 1\n"
+    );
+    simctl.setCommandResult(
+      IOS_SIMULATOR_DND_GET_COMMAND,
       "com.apple.donotdisturb.enabled 0\n"
     );
 
-    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const deviceState = new DeviceState(iosSimulator, { simctl, timer });
     const result = await deviceState.setState({
       doNotDisturb: { mode: "alarms" },
     });
 
     expect(result.success).toBe(false);
     expect(result.doNotDisturb).toMatchObject({
-      supported: true,
-      capability: "binary",
+      supported: false,
+      capability: "unsupported",
+      enabled: false,
+      mode: "off",
       requestedMode: "alarms",
       verified: false,
       bestEffort: true,
@@ -251,20 +348,18 @@ describe("DeviceState", () => {
     // mode; the reported mode reflects what the readback observed (off).
     expect(result.doNotDisturb?.appliedMode).toBeUndefined();
     expect(result.doNotDisturb?.mode).toBe("off");
-    // The warning must NOT claim plain DND was applied — the readback failed.
-    expect(result.doNotDisturb?.warning).toContain("alarms");
-    expect(result.doNotDisturb?.warning).toContain("did not read back");
-    expect(result.doNotDisturb?.warning).not.toContain("applied as plain DND");
+    expect(result.doNotDisturb?.error).toContain("independent notifyutil readback");
+    expect(result.doNotDisturb?.warning).toBeUndefined();
   });
 
   test("surfaces simctl errors without throwing out of setState", async () => {
     const simctl = new FakeSimCtlClient();
     simctl.setCommandError(
-      "spawn 12345678-1234-1234-1234-123456789ABC notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      IOS_SIMULATOR_DND_SET_ON_COMMAND,
       new Error("simctl spawn failed")
     );
 
-    const deviceState = new DeviceState(iosSimulator, { simctl });
+    const deviceState = new DeviceState(iosSimulator, { simctl, timer: autoAdvanceTimer() });
     const result = await deviceState.setState({
       doNotDisturb: { enabled: true },
     });
@@ -426,8 +521,12 @@ describe("DeviceState", () => {
       "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 1 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
       "com.apple.donotdisturb.enabled 1\n"
     );
+    simctl.setCommandResult(
+      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -g com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 1\n"
+    );
 
-    const deviceState = new DeviceState(bareSimulator, { simctl });
+    const deviceState = new DeviceState(bareSimulator, { simctl, timer: autoAdvanceTimer() });
     const result = await deviceState.setState({
       doNotDisturb: { enabled: true },
     });
@@ -441,6 +540,40 @@ describe("DeviceState", () => {
     });
     const commands = simctl.getMethodCalls("executeCommand").map(c => c.command as string);
     expect(commands.some(c => c.includes("notifyutil"))).toBe(true);
+  });
+
+  test("does not claim unknown-runtime iOS DND off is verified when readback is already disabled", async () => {
+    const bareSimulator: BootedDevice = {
+      name: "iPhone",
+      platform: "ios",
+      deviceId: "AAAAAAAA-1111-2222-3333-444444444444",
+    };
+    const simctl = new FakeSimCtlClient();
+    simctl.setCommandResult(
+      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -1 com.apple.donotdisturb.enabled -s com.apple.donotdisturb.enabled 0 -g com.apple.donotdisturb.enabled -p com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 0\n"
+    );
+    simctl.setCommandResult(
+      "spawn AAAAAAAA-1111-2222-3333-444444444444 notifyutil -g com.apple.donotdisturb.enabled",
+      "com.apple.donotdisturb.enabled 0\n"
+    );
+
+    const deviceState = new DeviceState(bareSimulator, { simctl, timer: autoAdvanceTimer() });
+    const result = await deviceState.setState({
+      doNotDisturb: { enabled: false },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.doNotDisturb).toMatchObject({
+      supported: false,
+      capability: "unsupported",
+      enabled: false,
+      mode: "off",
+      requestedMode: "off",
+      verified: false,
+      bestEffort: true,
+    });
+    expect(result.error).toContain("does not prove");
   });
 
   test("reports physical iOS as unsupported with a precise no-public-API error", async () => {


### PR DESCRIPTION
## Summary

- verify iOS simulator DND legacy writes with an independent fresh-process `notifyutil -g` readback after a short settle
- keep known iOS 18+ simulator runtimes on the unsupported fast path while treating reverted or unverifiable legacy probes as unsupported
- update iOS simctl DND docs and cover persisted, reverted, version fast-path, unknown-off, Android, and physical iOS behavior

## Testing

- `bun test test/features/utility/DeviceState.test.ts`
- `bun run lint`
- `bun run build`
- `git diff --check`
- `bun test --bail`

## Review

- `/auto-mobile-code-review` local diff review completed
- three read-only subagent reviews completed; the iOS behavior finding was fixed with regression coverage

## Notes

- Repo PR template: no conventional `.github/PULL_REQUEST_TEMPLATE*` file was present, so this uses the repo-standard summary/testing/risk structure.
- Real iOS <=17 simulator validation was not available in this run.

Closes #2861
