### PR TITLE
fix(ios): correct storage_changed recorder mapping (valueType/changeType) (#3001)

### DIFF
--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -242,10 +242,20 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
             });
             break;
           case "storage_changed":
+            // The iOS SDK's SdkStorageChangedEvent serializes as suiteName/key/newValue/
+            // valueType/sequenceNumber (ios/auto-mobile-sdk/.../SdkEvent.swift). It carries
+            // no `value` and no `operation`, and the recorder REQUIRES valueType + changeType
+            // (issue #3001). Map: suiteName→fileName, newValue→value, pass valueType through,
+            // and derive changeType. KVO can't distinguish set vs remove so the SDK emits no
+            // operation — default to "modify" (matching the Android call site) while honoring
+            // an explicit `operation` if a future SDK build adds one.
             await recorder.recordStorageEvent({
               timestamp: ts, applicationId,
-              fileName: (p.suiteName as string) ?? "", key: (p.key as string) ?? "",
-              value: (p.value as string) ?? "", operation: (p.operation as string) ?? "write",
+              fileName: (p.suiteName as string) ?? "",
+              key: (p.key as string) ?? null,
+              value: (p.newValue as string) ?? (p.value as string) ?? null,
+              valueType: (p.valueType as string) ?? null,
+              changeType: (p.operation as string) ?? "modify",
             });
             break;
           default:

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -141,11 +141,65 @@ describe("DefaultIosSdkEventIngestor", () => {
     expect((recorder.logs[0].event as { message: string }).message).toContain("sku");
   });
 
-  test("storage_changed routes to recordStorageEvent (fileName from suiteName)", async () => {
+  test("storage_changed maps the real iOS SDK wire shape to the recorder contract", async () => {
+    // The iOS SDK emits SdkStorageChangedEvent → JSON keys suiteName/key/newValue/valueType/
+    // sequenceNumber (see ios/auto-mobile-sdk/.../SdkEvent.swift). It carries no `operation`
+    // and no `value` field. The recorder REQUIRES valueType + changeType (issue #3001).
     await ingestor.recordSdkEvent(event("storage_changed", {
-      suiteName: "defaults", key: "k", value: "v", operation: "write",
+      suiteName: "defaults", key: "k", newValue: "v", valueType: "string", sequenceNumber: 7,
     }), "com.app");
-    expect(recorder.storage[0].event).toMatchObject({ fileName: "defaults", key: "k", value: "v" });
+    const stored = recorder.storage[0].event;
+    expect(stored).toMatchObject({
+      applicationId: "com.app",
+      fileName: "defaults",
+      key: "k",
+      value: "v",
+      valueType: "string",
+      changeType: "modify",
+      timestamp: 1000,
+    });
+    // Required-by-contract fields must be present (not undefined/NULL on the wire).
+    expect(stored.valueType).toBe("string");
+    expect(stored.changeType).toBe("modify");
+    // The undeclared `operation` field must not leak into the recorder input.
+    expect("operation" in stored).toBe(false);
+  });
+
+  test("storage_changed sources value from newValue, not a `value` field", async () => {
+    // Regression guard: the old call site read p.value (which the wire never sends),
+    // so the recorded value was always dropped. It must read newValue.
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "s", key: "k", newValue: "the-real-value", valueType: "string", sequenceNumber: 1,
+    }), "com.app");
+    expect(recorder.storage[0].event.value).toBe("the-real-value");
+  });
+
+  test("storage_changed defaults valueType/value/changeType when the wire omits them", async () => {
+    // KVO-driven emissions carry newValue: null and valueType: "unknown"; a fully-sparse
+    // payload must still satisfy the required recorder fields with safe defaults.
+    await ingestor.recordSdkEvent(event("storage_changed", { suiteName: "s", key: "k" }), null);
+    const stored = recorder.storage[0].event;
+    expect(stored).toMatchObject({ fileName: "s", key: "k", value: null, valueType: null, changeType: "modify" });
+  });
+
+  test("storage_changed passes the wire valueType through unchanged (real KVO shape)", async () => {
+    // The KVO emit path sends valueType: "unknown" with newValue: null; that literal must
+    // reach the recorder untouched (the ?? null fallback only applies when it is absent).
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "s", key: "k", newValue: null, valueType: "unknown", sequenceNumber: 3,
+    }), "com.app");
+    const stored = recorder.storage[0].event;
+    expect(stored.valueType).toBe("unknown");
+    expect(stored.value).toBeNull();
+    expect(stored.changeType).toBe("modify");
+  });
+
+  test("storage_changed honors an explicit operation as the changeType (forward-compat)", async () => {
+    // If a future SDK build adds an `operation` discriminator, map it to changeType.
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "s", key: "k", newValue: null, valueType: "unknown", operation: "delete",
+    }), "com.app");
+    expect(recorder.storage[0].event.changeType).toBe("delete");
   });
 
   test("unknown event types fall back to a log event", async () => {


### PR DESCRIPTION
## Summary

Fixes #3001. The iOS `storage_changed` SDK-telemetry call site in
`src/features/observe/ios/IosSdkEventIngestor.ts` passed an **undeclared
`operation`** field and **omitted the required `valueType` and `changeType`**
fields, violating `TelemetryRecorder.recordStorageEvent`'s input type. Bun's
bundler skips type-checking, so this strict-TS error (`TS2353`) never failed the
build — at runtime iOS storage rows were persisted with `value_type` /
`change_type` = NULL and the intended change semantics dropped on the floor.

Tracing the **real iOS SDK wire format** (`SdkStorageChangedEvent` in
`ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift`) surfaced a
second latent bug: the payload serializes as
`suiteName` / `key` / `newValue` / `valueType` / `sequenceNumber` — there is **no
`value` and no `operation`**. The old call site read `p.value` (a key the wire
never sends), so the recorded value was **always empty**.

## Mapping (decided)

| recorder field | source |
| --- | --- |
| `fileName` | `suiteName ?? ""` |
| `key` | `key ?? null` |
| `value` | `newValue ?? value ?? null` (was reading the nonexistent `value`) |
| `valueType` | `valueType ?? null` (wire carries it; passed through) |
| `changeType` | `operation ?? "modify"` |

`changeType` defaults to `"modify"` — matching the Android call site
(`AndroidCtrlProxyClient.ts:2570`), since KVO cannot distinguish set vs remove so
the SDK emits no operation. An explicit `operation` is honored for forward-compat.

## Tests

Rewrote the `storage_changed` ingestor tests to lock the recorder contract:
required `valueType`/`changeType` present, no `operation` leak into recorder
input, `value` sourced from `newValue`, `valueType` passthrough of the real
`"unknown"` KVO value, and sensible defaults on a sparse payload. 21/21 pass.

## Deferred (follow-ups filed)

- **`tsc --noEmit` gate (issue #3001 bullet 3):** a repo-wide gate is infeasible
  today — `tsc --noEmit` reports ~542 pre-existing errors (incl. the known
  TS2300 `CtrlProxyHierarchy` collision and TS2305 missing exports). Filed a
  follow-up for a scoped/baseline (changed-files, fail-on-new) typecheck gate.
- **iOS SDK never captures real values:** `UserDefaultsInspector.swift` hardcodes
  `newValue: nil`, `valueType: "unknown"`, `key: nil`. This fix is a necessary
  prerequisite (stops silently dropping fields) but iOS storage rows stay
  near-empty until the SDK snapshots the changed key/value/type. Follow-up filed.
- **Cross-platform `value_type` normalization:** Android emits `"STRING"`
  (uppercase), iOS `"string"`/`"unknown"` — DB queries on `value_type` are
  case-inconsistent. Follow-up filed.

## Validation

- `bunx turbo run lint build` — green
- `bun test` (ingestor + TelemetryRecorder + storageEventRepository) — 61 pass
- Self code-review + 3 independent persona reviews (regression / completeness /
  architecture) — all "ship it", no blocking findings.
