### PR TITLE
perf(telemetry): emit prior storage value from CtrlProxy runners to skip recordStorageEvent lookup (#3000)

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -1259,21 +1259,26 @@ public interface dev.jasonpearson.automobile.sdk.storage.OnPreferenceChangeListe
 Compiled from "KeyValueModels.kt"
 public final class dev.jasonpearson.automobile.sdk.storage.PreferenceChange {
   public static final int $stable;
-  public dev.jasonpearson.automobile.sdk.storage.PreferenceChange(java.lang.String, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, long, long);
+  public dev.jasonpearson.automobile.sdk.storage.PreferenceChange(java.lang.String, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, long, long, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType);
+  public dev.jasonpearson.automobile.sdk.storage.PreferenceChange(java.lang.String, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, long, long, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public final java.lang.String getFileName();
   public final java.lang.String getKey();
   public final java.lang.Object getNewValue();
   public final dev.jasonpearson.automobile.sdk.storage.KeyValueType getType();
   public final long getTimestamp();
   public final long getSequenceNumber();
+  public final java.lang.Object getPreviousValue();
+  public final dev.jasonpearson.automobile.sdk.storage.KeyValueType getPreviousValueType();
   public final java.lang.String component1();
   public final java.lang.String component2();
   public final java.lang.Object component3();
   public final dev.jasonpearson.automobile.sdk.storage.KeyValueType component4();
   public final long component5();
   public final long component6();
-  public final dev.jasonpearson.automobile.sdk.storage.PreferenceChange copy(java.lang.String, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, long, long);
-  public static dev.jasonpearson.automobile.sdk.storage.PreferenceChange copy$default(dev.jasonpearson.automobile.sdk.storage.PreferenceChange, java.lang.String, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, long, long, int, java.lang.Object);
+  public final java.lang.Object component7();
+  public final dev.jasonpearson.automobile.sdk.storage.KeyValueType component8();
+  public final dev.jasonpearson.automobile.sdk.storage.PreferenceChange copy(java.lang.String, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, long, long, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType);
+  public static dev.jasonpearson.automobile.sdk.storage.PreferenceChange copy$default(dev.jasonpearson.automobile.sdk.storage.PreferenceChange, java.lang.String, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, long, long, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.KeyValueType, int, java.lang.Object);
   public java.lang.String toString();
   public int hashCode();
   public boolean equals(java.lang.Object);

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -371,6 +371,12 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
         type = change.type.name,
         timestamp = change.timestamp,
         sequenceNumber = change.sequenceNumber,
+        // Serialize the prior value with ITS OWN type (not change.type) so a removed
+        // or type-changed STRING/STRING_SET prior value still serializes correctly —
+        // change.type is UNKNOWN when the new value is null (#3000). A newly-added key
+        // has no prior value, so serializeValue(null, …) yields null.
+        previousValue = serializeValue(change.previousValue, change.previousValueType),
+        previousValueType = change.previousValueType.name,
       )
     }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/KeyValueModels.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/KeyValueModels.kt
@@ -60,4 +60,16 @@ data class PreferenceChange(
   val timestamp: Long,
   /** Monotonically increasing sequence number for ordering changes. */
   val sequenceNumber: Long,
+  /**
+   * The value BEFORE this change, or null if there was no prior value. Captured from a per-file
+   * snapshot the driver maintains, so downstream telemetry can skip re-reading the prior value
+   * (#3000).
+   */
+  val previousValue: Any? = null,
+  /**
+   * The type of [previousValue], which may differ from [type] on a remove (new value null) or a
+   * type-changing write. Serialized/quoted by its OWN type downstream so the prior value stays
+   * valid JSON on the wire even when [type] is UNKNOWN (#3000).
+   */
+  val previousValueType: KeyValueType = KeyValueType.UNKNOWN,
 )

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.net.Uri
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicLong
 
@@ -33,6 +34,15 @@ internal class SharedPreferencesDriverImpl(
 
   /** Per-file change queues for push-based notifications. */
   private val changeQueues = mutableMapOf<String, CopyOnWriteArrayList<PreferenceChange>>()
+
+  /**
+   * Per-file snapshot of the last-known values, keyed by preference key. Seeded on [startListening]
+   * and updated after each change so the change listener — which fires only AFTER the value is
+   * already committed — can report the value that was present BEFORE the change (#3000). Backed by
+   * [ConcurrentHashMap] because the SharedPreferences listener may fire off arbitrary threads; it
+   * cannot store null, so an absent key naturally means "no prior value".
+   */
+  private val valueSnapshots = mutableMapOf<String, ConcurrentHashMap<String, Any?>>()
 
   /** Monotonically increasing sequence counter for ordering changes. */
   private val sequenceCounter = AtomicLong(0)
@@ -94,6 +104,13 @@ internal class SharedPreferencesDriverImpl(
     changeQueues.getOrPut(fileName) { CopyOnWriteArrayList() }
 
     val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+
+    // Seed the previous-value snapshot with the file's current contents so the first
+    // change for a key reports its true prior value rather than null (#3000).
+    val snapshot = ConcurrentHashMap<String, Any?>()
+    prefs.all.forEach { (k, v) -> if (v != null) snapshot[k] = v }
+    valueSnapshots[fileName] = snapshot
+
     val sharedPrefsListener =
       SharedPreferences.OnSharedPreferenceChangeListener { sharedPrefs, key ->
         // Capture the new value
@@ -102,9 +119,33 @@ internal class SharedPreferencesDriverImpl(
         val timestamp = System.currentTimeMillis()
         val sequence = sequenceCounter.incrementAndGet()
 
+        // Derive the prior value from the snapshot taken before this change. A
+        // null key means the whole file was cleared (API 30+), so there is no
+        // single prior value to report (#3000). Capture its own type so it stays
+        // valid JSON on the wire even when the new value's type is UNKNOWN.
+        val previousValue = if (key != null) snapshot[key] else null
+        val previousValueType = detectType(previousValue)
+
         // Queue the change
-        val change = PreferenceChange(fileName, key, newValue, type, timestamp, sequence)
+        val change =
+          PreferenceChange(
+            fileName,
+            key,
+            newValue,
+            type,
+            timestamp,
+            sequence,
+            previousValue,
+            previousValueType,
+          )
         changeQueues[fileName]?.add(change)
+
+        // Advance the snapshot to reflect the new state for the next change.
+        if (key != null) {
+          if (newValue != null) snapshot[key] = newValue else snapshot.remove(key)
+        } else {
+          snapshot.clear()
+        }
 
         // Notify registered listeners
         listeners.forEach { it.onPreferenceChanged(fileName, key) }
@@ -130,6 +171,7 @@ internal class SharedPreferencesDriverImpl(
       prefs.unregisterOnSharedPreferenceChangeListener(listener)
     }
     changeQueues.remove(fileName)
+    valueSnapshots.remove(fileName)
   }
 
   /** Stops listening on all preferences files. */

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesPreviousValueTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesPreviousValueTest.kt
@@ -1,0 +1,144 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import android.content.Context
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Verifies that [SharedPreferencesDriverImpl] captures the value that was present BEFORE a change
+ * and reports it as [PreferenceChange.previousValue] (#3000). The SharedPreferences change listener
+ * fires only after the write is committed, so the driver must derive the prior value from a
+ * per-file snapshot it maintains — these tests pin that behavior across add / modify / remove /
+ * re-listen.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SharedPreferencesPreviousValueTest {
+
+  private lateinit var context: Context
+  private val fileName = "prefs_prev_value"
+
+  @Before
+  fun setup() {
+    context = RuntimeEnvironment.getApplication()
+    // Start each test from a clean file so seeded snapshots are deterministic.
+    context.getSharedPreferences(fileName, Context.MODE_PRIVATE).edit().clear().commit()
+  }
+
+  private fun latestChangeFor(driver: SharedPreferencesDriverImpl, key: String): PreferenceChange? =
+    driver.getQueuedChanges(fileName, 0L).lastOrNull { it.key == key }
+
+  @Test
+  fun `newly added key has null previous value`() {
+    val driver = SharedPreferencesDriverImpl(context)
+    driver.startListening(fileName)
+
+    context
+      .getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      .edit()
+      .putString("k", "v1")
+      .commit()
+
+    val change = latestChangeFor(driver, "k")
+    assertEquals("v1", change?.newValue)
+    assertNull(change?.previousValue, "A newly added key must report no prior value")
+  }
+
+  @Test
+  fun `modifying an existing key reports the prior value`() {
+    // Seed a value BEFORE listening so the snapshot is primed from disk.
+    context
+      .getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      .edit()
+      .putString("k", "old")
+      .commit()
+
+    val driver = SharedPreferencesDriverImpl(context)
+    driver.startListening(fileName)
+
+    context
+      .getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      .edit()
+      .putString("k", "new")
+      .commit()
+
+    val change = latestChangeFor(driver, "k")
+    assertEquals("new", change?.newValue)
+    assertEquals("old", change?.previousValue)
+  }
+
+  @Test
+  fun `successive modifications each report the immediately prior value`() {
+    context.getSharedPreferences(fileName, Context.MODE_PRIVATE).edit().putInt("count", 1).commit()
+
+    val driver = SharedPreferencesDriverImpl(context)
+    driver.startListening(fileName)
+
+    val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+    prefs.edit().putInt("count", 2).commit()
+    prefs.edit().putInt("count", 3).commit()
+
+    val changes = driver.getQueuedChanges(fileName, 0L).filter { it.key == "count" }
+    assertEquals(2, changes.size)
+    assertEquals(1, changes[0].previousValue)
+    assertEquals(2, changes[0].newValue)
+    assertEquals(2, changes[1].previousValue)
+    assertEquals(3, changes[1].newValue)
+  }
+
+  @Test
+  fun `removing a key reports the prior value and a null new value`() {
+    context
+      .getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      .edit()
+      .putString("k", "present")
+      .commit()
+
+    val driver = SharedPreferencesDriverImpl(context)
+    driver.startListening(fileName)
+
+    context.getSharedPreferences(fileName, Context.MODE_PRIVATE).edit().remove("k").commit()
+
+    val change = latestChangeFor(driver, "k")
+    assertNull(change?.newValue)
+    assertEquals("present", change?.previousValue)
+    // The new value is null (type UNKNOWN), but the prior value keeps its own STRING
+    // type so downstream serialization/quoting stays correct (#3000).
+    assertEquals(KeyValueType.UNKNOWN, change?.type)
+    assertEquals(KeyValueType.STRING, change?.previousValueType)
+  }
+
+  @Test
+  fun `stopListening then relistening reseeds the snapshot from disk`() {
+    context
+      .getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      .edit()
+      .putString("k", "v1")
+      .commit()
+
+    val driver = SharedPreferencesDriverImpl(context)
+    driver.startListening(fileName)
+    context
+      .getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      .edit()
+      .putString("k", "v2")
+      .commit()
+    driver.stopListening(fileName)
+
+    // A fresh listener must re-seed from the on-disk state (v2), not carry stale data.
+    driver.startListening(fileName)
+    context
+      .getSharedPreferences(fileName, Context.MODE_PRIVATE)
+      .edit()
+      .putString("k", "v3")
+      .commit()
+
+    val change = latestChangeFor(driver, "k")
+    assertEquals("v3", change?.newValue)
+    assertEquals("v2", change?.previousValue)
+  }
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -5945,29 +5945,16 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     try {
-      val message = buildString {
-        append("""{"type":"storage_changed","timestamp":${System.currentTimeMillis()}""")
-        append(""","packageName":${jsonCompact.encodeToString(event.packageName)}""")
-        append(""","fileName":${jsonCompact.encodeToString(event.fileName)}""")
-        if (event.key != null) {
-          append(""","key":${jsonCompact.encodeToString(event.key)}""")
-        } else {
-          append(""","key":null""")
-        }
-        if (event.value != null) {
-          // STRING values need JSON encoding (quotes + escaping), other types are already valid
-          // JSON
-          val jsonValue =
-            if (event.type == "STRING") jsonCompact.encodeToString(event.value) else event.value
-          append(""","value":$jsonValue""")
-        } else {
-          append(""","value":null""")
-        }
-        append(""","valueType":${jsonCompact.encodeToString(event.type)}""")
-        append(""","eventTimestamp":${event.timestamp}""")
-        append(""","sequenceNumber":${event.sequenceNumber}""")
-        append("}")
-      }
+      // Build the wire payload via the extracted, unit-tested encoder. It emits the
+      // prior value so the TS telemetry ingest can skip its per-insert previous-value
+      // lookup (#3000), quoting it by its OWN type so a removed/type-changed STRING
+      // stays valid JSON. An absent prior value is emitted as JSON null.
+      val message =
+        dev.jasonpearson.automobile.ctrlproxy.storage.buildStorageChangedMessage(
+          event,
+          System.currentTimeMillis(),
+          jsonCompact,
+        )
       webSocketServer.broadcast(message)
       Log.d(TAG, "Broadcasted storage change to ${webSocketServer.getConnectionCount()} clients")
     } catch (e: Exception) {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoder.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoder.kt
@@ -1,0 +1,50 @@
+package dev.jasonpearson.automobile.ctrlproxy.storage
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Builds the `storage_changed` WebSocket payload for a [PreferenceChangeEvent].
+ *
+ * Extracted from CtrlProxy so the JSON shaping — in particular the type-aware quoting of
+ * `value`/`previousValue` — can be unit-tested for validity across add / modify / remove /
+ * type-change cases (#3000).
+ *
+ * STRING values need JSON quoting + escaping; all other types (numbers, booleans, STRING_SET
+ * arrays produced by the SDK) are already valid JSON fragments. Crucially, `previousValue` is
+ * quoted by its OWN [PreferenceChangeEvent.previousValueType], not by the new value's [type]: on a
+ * remove (new value null) or a type-changing write the new type is UNKNOWN, so quoting the prior
+ * value by it would emit an unquoted STRING and break the entire message's JSON.
+ */
+internal fun buildStorageChangedMessage(
+  event: PreferenceChangeEvent,
+  messageTimestampMs: Long,
+  json: Json,
+): String = buildString {
+  append("""{"type":"storage_changed","timestamp":$messageTimestampMs""")
+  append(""","packageName":${json.encodeToString(event.packageName)}""")
+  append(""","fileName":${json.encodeToString(event.fileName)}""")
+  if (event.key != null) {
+    append(""","key":${json.encodeToString(event.key)}""")
+  } else {
+    append(""","key":null""")
+  }
+  append(""","value":${encodeTypedValue(event.value, event.type, json)}""")
+  append(""","valueType":${json.encodeToString(event.type)}""")
+  append(
+    ""","previousValue":${encodeTypedValue(event.previousValue, event.previousValueType, json)}"""
+  )
+  append(""","eventTimestamp":${event.timestamp}""")
+  append(""","sequenceNumber":${event.sequenceNumber}""")
+  append("}")
+}
+
+/**
+ * Encodes a JSON value fragment for a preference value. Returns the literal `null` for a null
+ * value, a JSON-quoted+escaped string for STRING, and the already-valid-JSON [value] verbatim for
+ * every other type (numbers, booleans, and SDK-produced STRING_SET arrays).
+ */
+private fun encodeTypedValue(value: String?, type: String?, json: Json): String {
+  if (value == null) return "null"
+  return if (type == "STRING") json.encodeToString(value) else value
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoder.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoder.kt
@@ -10,11 +10,11 @@ import kotlinx.serialization.json.Json
  * `value`/`previousValue` — can be unit-tested for validity across add / modify / remove /
  * type-change cases (#3000).
  *
- * STRING values need JSON quoting + escaping; all other types (numbers, booleans, STRING_SET
- * arrays produced by the SDK) are already valid JSON fragments. Crucially, `previousValue` is
- * quoted by its OWN [PreferenceChangeEvent.previousValueType], not by the new value's [type]: on a
- * remove (new value null) or a type-changing write the new type is UNKNOWN, so quoting the prior
- * value by it would emit an unquoted STRING and break the entire message's JSON.
+ * STRING values need JSON quoting + escaping; all other types (numbers, booleans, STRING_SET arrays
+ * produced by the SDK) are already valid JSON fragments. Crucially, `previousValue` is quoted by
+ * its OWN [PreferenceChangeEvent.previousValueType], not by the new value's [type]: on a remove
+ * (new value null) or a type-changing write the new type is UNKNOWN, so quoting the prior value by
+ * it would emit an unquoted STRING and break the entire message's JSON.
  */
 internal fun buildStorageChangedMessage(
   event: PreferenceChangeEvent,
@@ -31,9 +31,19 @@ internal fun buildStorageChangedMessage(
   }
   append(""","value":${encodeTypedValue(event.value, event.type, json)}""")
   append(""","valueType":${json.encodeToString(event.type)}""")
-  append(
-    ""","previousValue":${encodeTypedValue(event.previousValue, event.previousValueType, json)}"""
-  )
+  // Emit `previousValue` ONLY when the SDK actually supplied a prior-value type — i.e.
+  // it captured the change and knows the prior value (a genuine "no prior value" add
+  // still carries previousValueType = UNKNOWN, so it is emitted as null). A legacy SDK
+  // that predates #3000 omits previousValueType (it decodes to null through the protocol
+  // and StorageSubscriptionManager), so we omit `previousValue` entirely. That leaves the
+  // field absent on the wire, so the TS ingest's `previousValue !== undefined` guard falls
+  // through to the DB auto-lookup instead of recording a spurious null for a legacy-SDK
+  // change that lands after an existing row.
+  if (event.previousValueType != null) {
+    append(
+      ""","previousValue":${encodeTypedValue(event.previousValue, event.previousValueType, json)}"""
+    )
+  }
   append(""","eventTimestamp":${event.timestamp}""")
   append(""","sequenceNumber":${event.sequenceNumber}""")
   append("}")

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageModels.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageModels.kt
@@ -62,4 +62,16 @@ data class PreferenceChangeEvent(
   val timestamp: Long,
   /** Monotonically increasing sequence number for ordering changes. */
   val sequenceNumber: Long,
+  /**
+   * JSON-encoded value BEFORE the change (null if there was no prior value). Threaded from the SDK
+   * so the TS telemetry ingest can skip its per-insert previous-value lookup (#3000). Defaults to
+   * null for older SDKs.
+   */
+  val previousValue: String? = null,
+  /**
+   * Type name of [previousValue], which may differ from [type] on a remove or type-changing write.
+   * The wire encoder quotes [previousValue] by THIS type so it stays valid JSON even when [type] is
+   * UNKNOWN (#3000). Null for older SDKs / no prior value.
+   */
+  val previousValueType: String? = null,
 )

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
@@ -565,6 +565,8 @@ class StorageSubscriptionManager(private val context: Context) {
                   type = change.type,
                   timestamp = change.timestamp,
                   sequenceNumber = change.sequenceNumber,
+                  previousValue = change.previousValue,
+                  previousValueType = change.previousValueType,
                 )
 
               _changeEvents.tryEmit(event)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoderTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoderTest.kt
@@ -1,0 +1,97 @@
+package dev.jasonpearson.automobile.ctrlproxy.storage
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Validates the `storage_changed` wire payload built by [buildStorageChangedMessage] (#3000). The
+ * critical guard is that `previousValue` is quoted by its OWN type: a removed or type-changed STRING
+ * prior value must stay valid JSON even when the new value's type is UNKNOWN — otherwise the whole
+ * message fails JSON.parse on the TS side and the telemetry event is dropped.
+ */
+class StorageChangeWireEncoderTest {
+
+  private val json = Json { prettyPrint = false }
+
+  private fun encodeAndParse(event: PreferenceChangeEvent): JsonObject {
+    val wire = buildStorageChangedMessage(event, messageTimestampMs = 111L, json = json)
+    // Must be valid JSON — parse or throw.
+    return json.parseToJsonElement(wire) as JsonObject
+  }
+
+  private fun baseEvent(
+    value: String?,
+    type: String,
+    previousValue: String?,
+    previousValueType: String?,
+  ) =
+    PreferenceChangeEvent(
+      packageName = "com.example",
+      fileName = "prefs.xml",
+      key = "theme",
+      value = value,
+      type = type,
+      timestamp = 222L,
+      sequenceNumber = 3L,
+      previousValue = previousValue,
+      previousValueType = previousValueType,
+    )
+
+  @Test
+  fun `modify string quotes both value and previous value`() {
+    val obj = encodeAndParse(baseEvent("dark", "STRING", "light", "STRING"))
+    assertEquals("dark", obj["value"]!!.jsonPrimitive.content)
+    assertEquals("light", obj["previousValue"]!!.jsonPrimitive.content)
+    assertEquals("storage_changed", obj["type"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `removing a string key keeps previousValue valid JSON even though new type is UNKNOWN`() {
+    // The regression this guards: new value null -> type UNKNOWN, but the prior value
+    // is a STRING and MUST still be quoted (by previousValueType), not emitted raw.
+    val obj = encodeAndParse(baseEvent(null, "UNKNOWN", "was-here", "STRING"))
+    assertTrue(obj["value"] is JsonNull)
+    assertEquals("was-here", obj["previousValue"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `type-changing write quotes previous value by its own prior type`() {
+    // STRING -> INT: new type INT (unquoted number), prior STRING must stay quoted.
+    val obj = encodeAndParse(baseEvent("42", "INT", "hello", "STRING"))
+    // Unquoted number stays a JSON number; prior STRING stays quoted.
+    assertEquals("42", obj["value"]!!.jsonPrimitive.content)
+    assertTrue(!obj["value"]!!.jsonPrimitive.isString)
+    assertEquals("hello", obj["previousValue"]!!.jsonPrimitive.content)
+    assertTrue(obj["previousValue"]!!.jsonPrimitive.isString)
+  }
+
+  @Test
+  fun `newly added key emits previousValue null`() {
+    val obj = encodeAndParse(baseEvent("first", "STRING", null, "UNKNOWN"))
+    assertEquals("first", obj["value"]!!.jsonPrimitive.content)
+    assertTrue(obj["previousValue"] is JsonNull)
+  }
+
+  @Test
+  fun `string with quotes and backslashes is escaped in previousValue`() {
+    // Ensures JSON escaping (not just wrapping) — a raw append would corrupt this.
+    val nasty = "a\"b\\c"
+    val obj = encodeAndParse(baseEvent("new", "STRING", nasty, "STRING"))
+    assertEquals(nasty, obj["previousValue"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `string set previous value is emitted as a valid JSON array`() {
+    // The SDK serializes STRING_SET to a JSON array string; it must pass through raw
+    // (not re-quoted) and remain valid JSON.
+    val obj = encodeAndParse(baseEvent("""["x"]""", "STRING_SET", """["a","b"]""", "STRING_SET"))
+    // previousValue parses as an array element, not a string — assert it is not a primitive string.
+    assertTrue(obj["previousValue"] !is JsonPrimitive || !obj["previousValue"]!!.jsonPrimitive.isString)
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoderTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageChangeWireEncoderTest.kt
@@ -11,9 +11,9 @@ import org.junit.Test
 
 /**
  * Validates the `storage_changed` wire payload built by [buildStorageChangedMessage] (#3000). The
- * critical guard is that `previousValue` is quoted by its OWN type: a removed or type-changed STRING
- * prior value must stay valid JSON even when the new value's type is UNKNOWN — otherwise the whole
- * message fails JSON.parse on the TS side and the telemetry event is dropped.
+ * critical guard is that `previousValue` is quoted by its OWN type: a removed or type-changed
+ * STRING prior value must stay valid JSON even when the new value's type is UNKNOWN — otherwise the
+ * whole message fails JSON.parse on the TS side and the telemetry event is dropped.
  */
 class StorageChangeWireEncoderTest {
 
@@ -79,6 +79,21 @@ class StorageChangeWireEncoderTest {
   }
 
   @Test
+  fun `legacy SDK without previousValueType omits the previousValue field entirely`() {
+    // A target app embedding an older SDK does not supply previousValue/previousValueType;
+    // they decode to null through the protocol and StorageSubscriptionManager. The encoder
+    // must OMIT `previousValue` (not emit null) so the TS ingest's `!== undefined` guard falls
+    // through to the DB auto-lookup instead of recording a spurious null for a change that
+    // lands after an existing row (#3000, Codex review on PR #3170).
+    val obj = encodeAndParse(baseEvent("dark", "STRING", null, null))
+    assertEquals("dark", obj["value"]!!.jsonPrimitive.content)
+    assertTrue(
+      "previousValue must be absent, not JSON null, for a legacy SDK",
+      !obj.containsKey("previousValue"),
+    )
+  }
+
+  @Test
   fun `string with quotes and backslashes is escaped in previousValue`() {
     // Ensures JSON escaping (not just wrapping) — a raw append would corrupt this.
     val nasty = "a\"b\\c"
@@ -92,6 +107,8 @@ class StorageChangeWireEncoderTest {
     // (not re-quoted) and remain valid JSON.
     val obj = encodeAndParse(baseEvent("""["x"]""", "STRING_SET", """["a","b"]""", "STRING_SET"))
     // previousValue parses as an array element, not a string — assert it is not a primitive string.
-    assertTrue(obj["previousValue"] !is JsonPrimitive || !obj["previousValue"]!!.jsonPrimitive.isString)
+    assertTrue(
+      obj["previousValue"] !is JsonPrimitive || !obj["previousValue"]!!.jsonPrimitive.isString
+    )
   }
 }

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/StorageProtocol.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/StorageProtocol.kt
@@ -223,6 +223,19 @@ data class StorageChangeEvent(
   val timestamp: Long,
   /** Monotonically increasing sequence number for ordering changes. */
   val sequenceNumber: Long,
+  /**
+   * JSON-encoded value BEFORE the change (null if there was no prior value). The SDK captures this
+   * from a per-file snapshot so the TS telemetry ingest can skip its per-insert previous-value
+   * lookup (#3000). Defaults to null so payloads from older SDKs that omit the field still
+   * deserialize.
+   */
+  val previousValue: String? = null,
+  /**
+   * Type name of [previousValue] (STRING, INT, …), which may differ from [type] on a remove or
+   * type-changing write. Consumers quote [previousValue] by THIS type so it stays valid JSON on the
+   * wire even when [type] is UNKNOWN (#3000). Null for older SDKs / no prior value.
+   */
+  val previousValueType: String? = null,
 )
 
 // =============================================================================

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/StorageProtocolTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/StorageProtocolTest.kt
@@ -204,6 +204,8 @@ class StorageProtocolTest {
               type = "INT",
               timestamp = 1234567890L,
               sequenceNumber = 1L,
+              previousValue = "41",
+              previousValueType = "INT",
             ),
             StorageChangeEvent(
               fileName = "prefs",
@@ -224,7 +226,30 @@ class StorageProtocolTest {
     assertEquals("prefs", deserialized.fileName)
     assertEquals(2, deserialized.changes.size)
     assertEquals("counter", deserialized.changes[0].key)
+    // The runner-supplied prior value and its own type round-trip (#3000).
+    assertEquals("41", deserialized.changes[0].previousValue)
+    assertEquals("INT", deserialized.changes[0].previousValueType)
     assertNull(deserialized.changes[1].key)
+    // Absent prior value defaults to null (value and type).
+    assertNull(deserialized.changes[1].previousValue)
+    assertNull(deserialized.changes[1].previousValueType)
+  }
+
+  @Test
+  fun `Changes response decodes previousValue when omitted (backward compat)`() {
+    // A payload emitted by an older SDK that predates previousValue must still
+    // deserialize, defaulting the field to null (#3000).
+    val legacyJson =
+      """{"type":"changes","fileName":"prefs","changes":[""" +
+        """{"fileName":"prefs","key":"k","value":"v","type":"STRING",""" +
+        """"timestamp":1,"sequenceNumber":1}]}"""
+
+    val deserialized = StorageProtocolSerializer.responseFromJson(legacyJson)
+
+    assertNotNull(deserialized)
+    assertIs<StorageResponse.Changes>(deserialized)
+    assertEquals(1, deserialized.changes.size)
+    assertNull(deserialized.changes[0].previousValue)
   }
 
   @Test

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -446,6 +446,9 @@ public struct SdkStorageChangedEvent: SdkEvent {
     public let suiteName: String?
     public let key: String?
     public let newValue: String?
+    /// The value BEFORE the change (nil if there was no prior value). Emitted so the
+    /// TS telemetry ingest can skip its per-insert previous-value lookup (#3000).
+    public let previousValue: String?
     public let valueType: String
     public let sequenceNumber: Int64
 
@@ -454,6 +457,7 @@ public struct SdkStorageChangedEvent: SdkEvent {
         suiteName: String?,
         key: String?,
         newValue: String?,
+        previousValue: String? = nil,
         valueType: String,
         sequenceNumber: Int64
     ) {
@@ -461,6 +465,7 @@ public struct SdkStorageChangedEvent: SdkEvent {
         self.suiteName = suiteName
         self.key = key
         self.newValue = newValue
+        self.previousValue = previousValue
         self.valueType = valueType
         self.sequenceNumber = sequenceNumber
     }

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -223,9 +223,10 @@ public struct SdkStorageChangedEvent: SdkEvent
   public let suiteName: String?
   public let key: String?
   public let newValue: String?
+  public let previousValue: String?
   public let valueType: String
   public let sequenceNumber: Int64
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), suiteName: String?, key: String?, newValue: String?, valueType: String, sequenceNumber: Int64 )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), suiteName: String?, key: String?, newValue: String?, previousValue: String? = nil, valueType: String, sequenceNumber: Int64 )
 public struct SdkEventBatch: Codable, Sendable
   public let bundleId: String?
   public let events: [SdkEventEnvelope]

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -574,6 +574,48 @@ interface WsStorageChangedMessage extends WsMessageBase {
   valueType?: KeyValueType;
   sequenceNumber?: number;
   changeType?: string;
+  // Prior value for this key, emitted by runners that capture it on-device
+  // (#3000). Absent on legacy runners; an explicit null means "no prior value".
+  previousValue?: string | null;
+}
+
+/** Telemetry `recordStorageEvent` input shape built from a `storage_changed` wire message. */
+export interface StorageTelemetryInput {
+  timestamp: number;
+  applicationId: string | null;
+  fileName: string;
+  key: string | null;
+  value: string | null;
+  valueType: KeyValueType;
+  changeType: string;
+  previousValue?: string | null;
+}
+
+/**
+ * Build the telemetry `recordStorageEvent` input from a `storage_changed` wire
+ * message. The runner-supplied `previousValue` is threaded through ONLY when the
+ * wire message carries it (`!== undefined`), so the repository's
+ * `previousValue !== undefined` guard falls through to the per-insert auto-lookup
+ * for legacy runners that omit it (#3000). An explicit null ("no prior value")
+ * is honored verbatim and also skips the lookup.
+ */
+export function storageTelemetryInputFromWire(
+  message: WsStorageChangedMessage,
+  resolvedTimestamp: number
+): StorageTelemetryInput {
+  const input: StorageTelemetryInput = {
+    timestamp: resolvedTimestamp,
+    applicationId: message.packageName ?? null,
+    fileName: message.fileName ?? "",
+    key: message.key ?? null,
+    value: message.value ?? null,
+    valueType: message.valueType ?? "STRING",
+    changeType: message.changeType ?? "modify",
+  };
+  if (message.previousValue !== undefined) {
+    input.previousValue = message.previousValue;
+  }
+  return input;
 }
 
 /**
@@ -2567,15 +2609,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         // Record to telemetry timeline
         const recorder = TelemetryRecorder.getInstance();
         recorder.setContext(this.device.deviceId, null);
-        recorder.recordStorageEvent({
-          timestamp: storageEvent.timestamp,
-          applicationId: message.packageName ?? null,
-          fileName: storageEvent.fileName,
-          key: storageEvent.key,
-          value: storageEvent.value,
-          valueType: storageEvent.valueType,
-          changeType: message.changeType ?? "modify",
-        });
+        recorder.recordStorageEvent(storageTelemetryInputFromWire(message, storageEvent.timestamp));
       }
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error handling WebSocket message: ${error}`);

--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -263,6 +263,11 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
               value: (p.newValue as string) ?? (p.value as string) ?? null,
               valueType: (p.valueType as string) ?? null,
               changeType: (p.operation as string) ?? "modify",
+              // Thread the runner-supplied prior value ONLY when the payload carries
+              // it, so the repository's `previousValue !== undefined` guard falls
+              // through to the auto-lookup for legacy runners that omit it (#3000).
+              // An explicit null ("no prior value") is honored verbatim.
+              ...("previousValue" in p ? { previousValue: (p.previousValue as string | null) } : {}),
             });
             break;
           default:

--- a/test/db/storageEventRepository.test.ts
+++ b/test/db/storageEventRepository.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, afterEach, describe, expect, test } from "bun:test";
-import type { Kysely } from "kysely";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import type { Database } from "../../src/db/types";
+import { runMigrations } from "../../src/db/migrator";
 import { createTestDatabase } from "./testDbHelper";
 import { recordStorageEvent, getStorageEvents } from "../../src/db/storageEventRepository";
 
@@ -143,6 +146,81 @@ describe("StorageEventRepository", () => {
     }, db);
     const events = await getStorageEvents({}, db);
     expect(events[0].previousValue).toBeNull();
+  });
+
+  describe("previous-value lookup query count (acceptance #3000)", () => {
+    // A Kysely wired with a `log` sink that counts SELECT statements issued
+    // against `storage_events`. This is the "query-counting fake" the issue
+    // acceptance asks for: with a runner-supplied previousValue the hot path
+    // must issue ZERO such SELECTs.
+    const buildCountingDb = (): { db: Kysely<Database>; selectCount: () => number } => {
+      let selects = 0;
+      const bunDb = new BunDatabase(":memory:");
+      const kysely = new Kysely<Database>({
+        dialect: new BunSqliteDialect({ database: bunDb }),
+        log: event => {
+          if (event.level === "query") {
+            const sql = event.query.sql.toLowerCase();
+            // Match ONLY the previous-value lookup shape (`select "value" from
+            // "storage_events" …`), not the retention gate's `count(*)`/`timestamp`
+            // probes — so the assertion can't be confounded if retention ever fires
+            // (it won't at this fixture size, but keep the filter precise).
+            if (sql.startsWith('select "value"') && sql.includes("storage_events")) {
+              selects += 1;
+            }
+          }
+        },
+      });
+      return { db: kysely, selectCount: () => selects };
+    };
+
+    test("issues NO select on the hot path when previousValue is supplied", async () => {
+      const { db: counting, selectCount } = buildCountingDb();
+      await runMigrations(counting as Kysely<unknown>);
+      try {
+        // A competing prior row exists that the auto-lookup WOULD read.
+        await recordStorageEvent({
+          deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+          fileName: "prefs.xml", key: "theme", value: "light", valueType: null, changeType: "add",
+        }, counting);
+        const baseline = selectCount();
+
+        await recordStorageEvent({
+          deviceId: "d1", timestamp: 2000, applicationId: null, sessionId: null,
+          fileName: "prefs.xml", key: "theme", value: "dark", valueType: null, changeType: "modify",
+          previousValue: "runner-supplied",
+        }, counting);
+
+        // No new SELECT against storage_events was issued for the supplied insert.
+        expect(selectCount()).toBe(baseline);
+        const events = await getStorageEvents({ deviceId: "d1", limit: 10 }, counting);
+        expect(events[0].previousValue).toBe("runner-supplied");
+      } finally {
+        await counting.destroy();
+      }
+    });
+
+    test("issues a select on the hot path when previousValue is omitted (auto-lookup)", async () => {
+      const { db: counting, selectCount } = buildCountingDb();
+      await runMigrations(counting as Kysely<unknown>);
+      try {
+        await recordStorageEvent({
+          deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+          fileName: "prefs.xml", key: "theme", value: "light", valueType: null, changeType: "add",
+        }, counting);
+        const baseline = selectCount();
+
+        await recordStorageEvent({
+          deviceId: "d1", timestamp: 2000, applicationId: null, sessionId: null,
+          fileName: "prefs.xml", key: "theme", value: "dark", valueType: null, changeType: "modify",
+        }, counting);
+
+        // The omitted-field path performs the previous-value lookup.
+        expect(selectCount()).toBeGreaterThan(baseline);
+      } finally {
+        await counting.destroy();
+      }
+    });
   });
 
   test("getStorageEvents filters by deviceId", async () => {

--- a/test/features/observe/android/storageChangedWireToDb.test.ts
+++ b/test/features/observe/android/storageChangedWireToDb.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../../../src/db/types";
+import { createTestDatabase } from "../../../db/testDbHelper";
+import { recordStorageEvent, getStorageEvents } from "../../../../src/db/storageEventRepository";
+import { storageTelemetryInputFromWire } from "../../../../src/features/observe/android/AndroidCtrlProxyClient";
+
+/**
+ * End-to-end guard for the Android `storage_changed` path (#3000): a realistic wire
+ * payload — shaped exactly as the runner's `buildStorageChangedMessage`
+ * (StorageChangeWireEncoder.kt) emits it — is parsed, mapped by
+ * `storageTelemetryInputFromWire`, and persisted via `recordStorageEvent`. This pins
+ * the cross-language field contract: if the Kotlin encoder key drifted from
+ * `WsStorageChangedMessage.previousValue`, the parsed object would lack the field and
+ * the runner-supplied value would NOT win over the competing prior row below.
+ */
+describe("Android storage_changed wire → ingest → DB (#3000)", () => {
+  let db: Kysely<Database>;
+  beforeEach(async () => { db = await createTestDatabase(); });
+  afterEach(async () => { await db.destroy(); });
+
+  // Mirrors the exact JSON the runner emits for a STRING modify (see
+  // StorageChangeWireEncoder.kt): note `previousValue` quoted, `eventTimestamp`
+  // separate from the envelope `timestamp`.
+  const modifyWire = JSON.stringify({
+    type: "storage_changed",
+    timestamp: 999,
+    packageName: "com.example",
+    fileName: "prefs.xml",
+    key: "theme",
+    value: "dark",
+    valueType: "STRING",
+    previousValue: "light",
+    eventTimestamp: 2000,
+    sequenceNumber: 3,
+  });
+
+  test("runner-supplied previousValue is stored verbatim, beating a competing prior row", async () => {
+    // A stale telemetry row the auto-lookup WOULD have found.
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "STALE", valueType: "STRING", changeType: "add",
+    }, db);
+
+    const message = JSON.parse(modifyWire);
+    const input = storageTelemetryInputFromWire(message, message.eventTimestamp ?? message.timestamp);
+    // The ingest sets device context on the recorder; here we record directly with a deviceId.
+    await recordStorageEvent({ deviceId: "d1", sessionId: null, ...input }, db);
+
+    const events = await getStorageEvents({ deviceId: "d1", limit: 10 }, db);
+    expect(events[0].value).toBe("dark");
+    // Runner value wins over the "STALE" the auto-lookup would have found → proves the
+    // wire field reached the DB and the lookup was skipped.
+    expect(events[0].previousValue).toBe("light");
+  });
+
+  test("removed STRING key: prior value survives the wire as valid JSON and is stored", async () => {
+    // On a remove the runner emits value:null, valueType:UNKNOWN, but previousValue is
+    // still the (quoted) prior STRING — the regression the wire encoder guards.
+    const removeWire = JSON.stringify({
+      type: "storage_changed",
+      timestamp: 999,
+      packageName: "com.example",
+      fileName: "prefs.xml",
+      key: "token",
+      value: null,
+      valueType: "UNKNOWN",
+      previousValue: "secret",
+      eventTimestamp: 2100,
+      sequenceNumber: 4,
+    });
+
+    const message = JSON.parse(removeWire);
+    const input = storageTelemetryInputFromWire(message, message.eventTimestamp ?? message.timestamp);
+    await recordStorageEvent({ deviceId: "d1", sessionId: null, ...input }, db);
+
+    const events = await getStorageEvents({ deviceId: "d1", limit: 10 }, db);
+    expect(events[0].value).toBeNull();
+    expect(events[0].previousValue).toBe("secret");
+  });
+
+  test("legacy runner (no previousValue field) falls through to the DB auto-lookup", async () => {
+    await recordStorageEvent({
+      deviceId: "d1", timestamp: 1000, applicationId: null, sessionId: null,
+      fileName: "prefs.xml", key: "theme", value: "from-lookup", valueType: "STRING", changeType: "add",
+    }, db);
+
+    // No previousValue key at all — the pre-#3000 wire shape.
+    const legacyWire = JSON.stringify({
+      type: "storage_changed", timestamp: 999, packageName: "com.example",
+      fileName: "prefs.xml", key: "theme", value: "new", valueType: "STRING",
+      eventTimestamp: 3000, sequenceNumber: 5,
+    });
+    const message = JSON.parse(legacyWire);
+    const input = storageTelemetryInputFromWire(message, message.eventTimestamp ?? message.timestamp);
+    // Field must be absent so the repository performs the auto-lookup.
+    expect("previousValue" in input).toBe(false);
+    await recordStorageEvent({ deviceId: "d1", sessionId: null, ...input }, db);
+
+    const events = await getStorageEvents({ deviceId: "d1", limit: 10 }, db);
+    expect(events[0].previousValue).toBe("from-lookup");
+  });
+});

--- a/test/features/observe/android/storageTelemetryInputFromWire.test.ts
+++ b/test/features/observe/android/storageTelemetryInputFromWire.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { storageTelemetryInputFromWire } from "../../../../src/features/observe/android/AndroidCtrlProxyClient";
+
+/**
+ * Unit tests for the pure wire → telemetry mapping used by the Android
+ * `storage_changed` push handler. These pin the #3000 contract: a runner-supplied
+ * `previousValue` is threaded through so the repository skips its per-insert
+ * previous-value lookup, while legacy runners that omit it fall through to the
+ * auto-lookup (field must be absent, not an explicit undefined/null).
+ */
+describe("storageTelemetryInputFromWire (Android #3000)", () => {
+  const base = { type: "storage_changed" as const };
+
+  test("maps the core wire fields with defaults", () => {
+    const input = storageTelemetryInputFromWire({
+      ...base, packageName: "com.example", fileName: "prefs.xml", key: "theme",
+      value: "dark", valueType: "STRING", changeType: "modify",
+    }, 1234);
+    expect(input).toEqual({
+      timestamp: 1234,
+      applicationId: "com.example",
+      fileName: "prefs.xml",
+      key: "theme",
+      value: "dark",
+      valueType: "STRING",
+      changeType: "modify",
+    });
+  });
+
+  test("threads a runner-supplied previousValue through", () => {
+    const input = storageTelemetryInputFromWire({
+      ...base, fileName: "prefs.xml", key: "theme", value: "dark", previousValue: "light",
+    }, 1000);
+    expect(input.previousValue).toBe("light");
+  });
+
+  test("honors an explicit previousValue: null verbatim (skips lookup)", () => {
+    const input = storageTelemetryInputFromWire({
+      ...base, fileName: "prefs.xml", key: "theme", value: "dark", previousValue: null,
+    }, 1000);
+    expect(input).toHaveProperty("previousValue", null);
+  });
+
+  test("omits previousValue entirely when the runner does not emit it (auto-lookup)", () => {
+    const input = storageTelemetryInputFromWire({
+      ...base, fileName: "prefs.xml", key: "theme", value: "dark",
+    }, 1000);
+    // Field must be absent so the repository's `!== undefined` guard triggers the
+    // auto-lookup for legacy runners.
+    expect("previousValue" in input).toBe(false);
+    expect(input.previousValue).toBeUndefined();
+  });
+
+  test("defaults packageName/fileName/valueType/changeType/key/value for sparse messages", () => {
+    const input = storageTelemetryInputFromWire({ ...base }, 42);
+    expect(input).toEqual({
+      timestamp: 42,
+      applicationId: null,
+      fileName: "",
+      key: null,
+      value: null,
+      valueType: "STRING",
+      changeType: "modify",
+    });
+  });
+});

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -202,6 +202,31 @@ describe("DefaultIosSdkEventIngestor", () => {
     expect(recorder.storage[0].event.changeType).toBe("delete");
   });
 
+  test("storage_changed threads a runner-supplied previousValue through (#3000)", async () => {
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "defaults", key: "k", value: "new", previousValue: "old", operation: "write",
+    }), "com.app");
+    expect(recorder.storage[0].event).toMatchObject({ key: "k", value: "new", previousValue: "old" });
+  });
+
+  test("storage_changed threads an explicit previousValue: null through (#3000)", async () => {
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "defaults", key: "k", value: "new", previousValue: null, operation: "write",
+    }), "com.app");
+    // Explicit null asserts "no prior value" — must be preserved verbatim, not dropped.
+    expect(recorder.storage[0].event).toHaveProperty("previousValue", null);
+  });
+
+  test("storage_changed omits previousValue when the runner does not emit it (auto-lookup preserved)", async () => {
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "defaults", key: "k", value: "new", operation: "write",
+    }), "com.app");
+    // Field must be absent (undefined) so the repository's `!== undefined` guard
+    // falls through to the auto-lookup for legacy runners.
+    expect(recorder.storage[0].event.previousValue).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(recorder.storage[0].event, "previousValue")).toBe(false);
+  });
+
   test("unknown event types fall back to a log event", async () => {
     await ingestor.recordSdkEvent(event("totally_new_type", { foo: "bar" }), "com.app");
     expect(recorder.logs[0].event).toMatchObject({ tag: "UnknownEvent", filterName: "custom" });


### PR DESCRIPTION
## What

Activates the dormant `previousValue` skip path added in #2999 by having the **Android CtrlProxy runner capture and emit the prior SharedPreferences value** in `storage_changed` push payloads, then threading it through both TS ingest sites so the repository's per-insert previous-value `SELECT` is skipped.

Advances #3000 (Android runner + full TS ingest for both platforms). The iOS **UserDefaults old-value capture** is genuinely follow-up-sized (the iOS SDK inspector is currently a stub that emits `newValue: nil`), so #3000 stays open and the iOS work is tracked in #3174.

## Why

#2999 threaded an optional `previousValue` through `TelemetryRecorder.recordStorageEvent` → `RecordStorageEventInput`; when a caller supplies it, the repository skips the per-insert lookup (and closes the mutex-released read-then-insert stale-read window). **No runner emitted it on the wire**, so every storage telemetry insert still paid for the lookup. This wires a source to emit it.

The guard is `input.previousValue !== undefined` (not `?? null`), so:
- **legacy runners** that omit the field → `undefined` → auto-lookup preserved (back-compat),
- **updated runners** → skip the lookup,
- an explicit **`null`** ("no prior value") → honored verbatim, still skips.

**Semantic note:** for updated runners the stored `previous_value` now reflects the **on-device value at change time** (from the SDK's per-file snapshot), rather than the last-recorded `storage_events` row that the auto-lookup returned. This is strictly more correct (ground-truth device state) and closes the mutex-released read-then-insert stale-read window, but consumers of `previous_value` should know its meaning shifted from "last recorded value" to "prior on-device value."

## How

**Android chain (source of the wire value):**
- `SharedPreferencesDriverImpl` maintains a per-file value **snapshot**, seeded on `startListening` from `prefs.all`, so the change listener — which fires only *after* the write commits — can report the value present *before* the change. `PreferenceChange` carries `previousValue` **and** `previousValueType`.
- `previousValueType` is threaded because on a **remove** (new value null ⇒ type UNKNOWN) or a **type-changing write**, the prior value must be serialized/quoted by its **own** type. Quoting it by the new type would emit an unquoted STRING and break the whole message's JSON. `SharedPreferencesInspectorProvider` serializes with `change.previousValueType`.
- Protocol `StorageChangeEvent` + control-proxy `PreferenceChangeEvent` gain `previousValue` / `previousValueType` (default null ⇒ older SDKs still deserialize).
- The wire JSON build was extracted into a unit-tested `buildStorageChangedMessage` (`StorageChangeWireEncoder.kt`) that quotes `value`/`previousValue` each by its own type.

**TS ingest:**
- `WsStorageChangedMessage.previousValue`; a pure, unit-tested `storageTelemetryInputFromWire` helper threads it **only when present**.
- `IosSdkEventIngestor` threads `payload.previousValue` only when present.

**iOS:** `SdkStorageChangedEvent.previousValue` added for struct/protocol symmetry (UserDefaults old-value capture is deferred — see follow-up).

## Not in scope (follow-ups filed)

- **iOS UserDefaults old-value capture** — the iOS SDK's `notifyChangeListeners` currently emits `newValue: nil` (never captures new *or* old value); real capture is a separate effort. The TS/struct plumbing here is ready for it.
- **release.ts checksum re-cut** — this is a runner protocol change; the pinned release runner + checksum registry (`src/constants/release.ts`) are auto-generated and re-cut by periodic version-bump PRs, so an updated runner reaches default installs only after that.
- Pre-existing iOS `recordStorageEvent` type mismatch (`operation`/missing `valueType`,`changeType`) tracked in #3001.

## Testing

- **`test/db/storageEventRepository.test.ts`** — new **query-counting** proof: a runner-supplied `previousValue` issues **zero** `SELECT` against `storage_events` on the hot path (the acceptance criterion), while an omitted field still performs the lookup.
- **`test/features/observe/android/storageTelemetryInputFromWire.test.ts`** — wire→telemetry mapping: present threads, explicit null honored, omitted field absent (auto-lookup).
- **`test/features/observe/android/storageChangedWireToDb.test.ts`** — end-to-end guard: a realistic wire payload (shaped as `buildStorageChangedMessage` emits) is parsed → mapped → persisted; pins the Kotlin-encoder ↔ TS-wire field contract for modify / remove / legacy-no-field.
- **`test/features/observe/ios/IosSdkEventIngestor.test.ts`** — iOS ingest threads present/null, omits when absent.
- **`StorageProtocolTest.kt`** — `previousValue`/`previousValueType` round-trip + backward-compat decode of a payload omitting them.
- **`StorageChangeWireEncoderTest.kt`** — the wire payload is valid JSON across add/modify/**remove**/type-change; the removed-STRING case (prior value quoted by its own type) is the regression guard.
- **`SharedPreferencesPreviousValueTest.kt`** (Robolectric) — snapshot capture across add/modify/remove/successive-writes/re-listen, asserting `previousValueType`.
- `bun test` (TS storage/telemetry/observe + db) green; `:protocol:test`, `:auto-mobile-sdk:testDebugUnitTest`, `:control-proxy:testDebugUnitTest` green; iOS `swift build` green; ktfmt clean.

## Reviewed

Ran `/auto-mobile-code-review` plus three independent adversarial reviewers (DB-correctness, Android-runner-regression, architecture/completeness). Substantive findings addressed:
- **Wire JSON regression** (code-review): `previousValue` was quoted by the **new** value's type, so removing/type-changing a STRING pref emitted invalid JSON and dropped the entire `storage_changed` message on the TS side. Fixed by threading `previousValueType`; the `StorageChangeWireEncoder` unit test reproduces the broken case.
- **Stale Android API dump** (Android reviewer): the public `PreferenceChange` data class changed but `android/auto-mobile-sdk/api/auto-mobile-sdk.api` wasn't regenerated (iOS's was) → `:auto-mobile-sdk:apiCheck` would fail. Regenerated (minimal `PreferenceChange`-only hunk).
- **Query-count test robustness** (DB reviewer): narrowed the SELECT filter to the exact lookup shape so it can't be confounded by the retention `count(*)`/`offset` probes.
- **Missing end-to-end coverage** (architecture reviewer): added `storageChangedWireToDb.test.ts` to pin the cross-language field contract.
- **iOS scope** (architecture reviewer): confirmed iOS capture is genuinely follow-up-sized; this PR does not auto-close #3000; iOS capture is tracked in #3174.
