### PR TITLE
perf(db): batch dashboard read queries

### DIFF
--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -11,6 +11,7 @@ import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { type DbWriteBarrier, getDbWriteBarrier } from "./dbWriteBarrier";
+import { appendToBucket, chunkBySqliteParameterLimit } from "./sqliteBatch";
 import type {
   FailureType,
   FailureSeverity,
@@ -28,6 +29,57 @@ import type {
 
 const RETENTION_MAX_ROWS = 10_000;
 let cleanupInProgress = false;
+
+interface FailureScreenCountRow {
+  screenName: string;
+  failureCount: number;
+}
+
+interface VisitScreenCountRow {
+  screenName: string;
+  visitCount: number;
+}
+
+export function mergeScreenBreakdownRows(
+  failureScreens: readonly FailureScreenCountRow[],
+  visitedScreens: readonly VisitScreenCountRow[]
+): ScreenBreakdown[] {
+  const visitMap = new Map(visitedScreens.map(screen => [screen.screenName, screen.visitCount]));
+  const totalVisits = visitedScreens.reduce((sum, screen) => sum + screen.visitCount, 0);
+
+  const result: ScreenBreakdown[] = [];
+  const processedScreens = new Set<string>();
+
+  for (const row of failureScreens) {
+    const visitCount = visitMap.get(row.screenName) ?? 0;
+    result.push({
+      screenName: row.screenName,
+      visitCount,
+      failureCount: row.failureCount,
+      visitPercentage: totalVisits > 0 ? (visitCount / totalVisits) * 100 : 0,
+    });
+    processedScreens.add(row.screenName);
+  }
+
+  const visitOnlyScreens = visitedScreens
+    .filter(screen => !processedScreens.has(screen.screenName))
+    .sort((a, b) => b.visitCount - a.visitCount || a.screenName.localeCompare(b.screenName))
+    .slice(0, 5);
+
+  for (const screen of visitOnlyScreens) {
+    result.push({
+      screenName: screen.screenName,
+      visitCount: screen.visitCount,
+      failureCount: 0,
+      visitPercentage: totalVisits > 0 ? (screen.visitCount / totalVisits) * 100 : 0,
+    });
+  }
+
+  return result
+    .map((screen, index) => ({ screen, index }))
+    .sort((a, b) => b.screen.visitCount - a.screen.visitCount || a.index - b.index)
+    .map(({ screen }) => screen);
+}
 
 // Types for recording failures
 
@@ -337,26 +389,30 @@ export class FailureAnalyticsRepository {
       .offset(offset)
       .execute();
 
-    const result: FailureGroup[] = [];
+    const groupIds = groups.map(group => group.id);
+    if (groupIds.length === 0) {
+      return [];
+    }
 
-    for (const group of groups) {
-      const [
-        deviceBreakdown,
-        versionBreakdown,
-        screenBreakdown,
-        affectedTests,
-        recentCaptures,
-        sampleOccurrences,
-      ] = await Promise.all([
-        this.getDeviceBreakdown(group.id),
-        this.getVersionBreakdown(group.id),
-        this.getScreenBreakdown(group.id),
-        this.getAffectedTests(group.id),
-        this.getRecentCaptures(group.id, 5),
-        this.getSampleOccurrences(group.id, 6),
-      ]);
+    const [
+      deviceBreakdowns,
+      versionBreakdowns,
+      screenBreakdowns,
+      affectedTestsByGroup,
+      recentCapturesByGroup,
+      sampleOccurrencesByGroup,
+    ] = await Promise.all([
+      this.getDeviceBreakdowns(groupIds),
+      this.getVersionBreakdowns(groupIds),
+      this.getScreenBreakdowns(groupIds),
+      this.getAffectedTestsByGroup(groupIds),
+      this.getRecentCapturesByGroup(groupIds, 5),
+      this.getSampleOccurrencesByGroup(groupIds, 6),
+    ]);
 
-      result.push({
+    return groups.map(group => {
+      const screenBreakdown = screenBreakdowns.get(group.id) ?? [];
+      return {
         id: group.id,
         type: group.type as FailureType,
         signature: group.signature,
@@ -367,8 +423,8 @@ export class FailureAnalyticsRepository {
         totalCount: group.total_count,
         uniqueSessions: group.unique_sessions,
         severity: group.severity as FailureSeverity,
-        deviceBreakdown,
-        versionBreakdown,
+        deviceBreakdown: deviceBreakdowns.get(group.id) ?? [],
+        versionBreakdown: versionBreakdowns.get(group.id) ?? [],
         screenBreakdown,
         failureScreens: this.computeFailureScreens(screenBreakdown),
         stackTraceElements: group.stack_trace_json
@@ -377,13 +433,11 @@ export class FailureAnalyticsRepository {
         toolCallInfo: group.tool_call_info_json
           ? (JSON.parse(group.tool_call_info_json) as AggregatedToolCallInfo)
           : null,
-        affectedTests,
-        recentCaptures,
-        sampleOccurrences,
-      });
-    }
-
-    return result;
+        affectedTests: affectedTestsByGroup.get(group.id) ?? {},
+        recentCaptures: recentCapturesByGroup.get(group.id) ?? [],
+        sampleOccurrences: sampleOccurrencesByGroup.get(group.id) ?? [],
+      };
+    });
   }
 
   /**
@@ -578,203 +632,388 @@ export class FailureAnalyticsRepository {
 
   // Private helper methods
 
-  private async getDeviceBreakdown(groupId: string): Promise<DeviceBreakdown[]> {
+  private async getDeviceBreakdowns(groupIds: string[]): Promise<Map<string, DeviceBreakdown[]>> {
     const db = this.getDb();
+    const buckets = new Map<string, Array<{
+      deviceModel: string;
+      os: string;
+      count: number;
+    }>>();
 
-    const rows = await db
-      .selectFrom("failure_occurrences")
-      .select(["device_model", "os"])
-      .select(eb => eb.fn.count<number>("id").as("count"))
-      .where("group_id", "=", groupId)
-      .groupBy(["device_model", "os"])
-      .orderBy("count", "desc")
-      .limit(10)
-      .execute();
+    for (const chunk of chunkBySqliteParameterLimit(groupIds)) {
+      const rows = await sql<{
+        groupId: string;
+        deviceModel: string;
+        os: string;
+        occurrenceCount: number;
+      }>`
+        SELECT groupId, deviceModel, os, occurrenceCount
+        FROM (
+          SELECT
+            group_id AS groupId,
+            device_model AS deviceModel,
+            os,
+            COUNT(id) AS occurrenceCount,
+            ROW_NUMBER() OVER (
+              PARTITION BY group_id
+              ORDER BY COUNT(id) DESC, device_model ASC, os ASC
+            ) AS rn
+          FROM failure_occurrences
+          WHERE group_id IN (${sql.join(chunk)})
+          GROUP BY group_id, device_model, os
+        )
+        WHERE rn <= 10
+        ORDER BY groupId ASC, occurrenceCount DESC, deviceModel ASC, os ASC
+      `.execute(db);
 
-    const total = rows.reduce((sum, r) => sum + Number(r.count), 0);
-
-    return rows.map(row => ({
-      deviceModel: row.device_model,
-      os: row.os,
-      count: Number(row.count),
-      percentage: total > 0 ? (Number(row.count) / total) * 100 : 0,
-    }));
-  }
-
-  private async getVersionBreakdown(groupId: string): Promise<VersionBreakdown[]> {
-    const db = this.getDb();
-
-    const rows = await db
-      .selectFrom("failure_occurrences")
-      .select("app_version")
-      .select(eb => eb.fn.count<number>("id").as("count"))
-      .where("group_id", "=", groupId)
-      .groupBy("app_version")
-      .orderBy("count", "desc")
-      .limit(10)
-      .execute();
-
-    const total = rows.reduce((sum, r) => sum + Number(r.count), 0);
-
-    return rows.map(row => ({
-      version: row.app_version,
-      count: Number(row.count),
-      percentage: total > 0 ? (Number(row.count) / total) * 100 : 0,
-    }));
-  }
-
-  private async getScreenBreakdown(groupId: string): Promise<ScreenBreakdown[]> {
-    const db = this.getDb();
-
-    // Get failure counts per screen
-    const failureScreens = await db
-      .selectFrom("failure_occurrences")
-      .select("screen_at_failure")
-      .select(eb => eb.fn.count<number>("id").as("failure_count"))
-      .where("group_id", "=", groupId)
-      .where("screen_at_failure", "is not", null)
-      .groupBy("screen_at_failure")
-      .execute();
-
-    // Get visit counts from screens visited
-    const visitedScreens = await db
-      .selectFrom("failure_occurrence_screens")
-      .innerJoin(
-        "failure_occurrences",
-        "failure_occurrence_screens.occurrence_id",
-        "failure_occurrences.id"
-      )
-      .select("screen_name")
-      .select(eb => eb.fn.count<number>("failure_occurrence_screens.id").as("visit_count"))
-      .where("failure_occurrences.group_id", "=", groupId)
-      .groupBy("screen_name")
-      .execute();
-
-    const visitMap = new Map(visitedScreens.map(s => [s.screen_name, Number(s.visit_count)]));
-    const totalVisits = Array.from(visitMap.values()).reduce((sum, c) => sum + c, 0);
-
-    const result: ScreenBreakdown[] = [];
-    const processedScreens = new Set<string>();
-
-    // Add screens where failures occurred
-    for (const row of failureScreens) {
-      const screenName = row.screen_at_failure!;
-      const visitCount = visitMap.get(screenName) ?? 0;
-      result.push({
-        screenName,
-        visitCount,
-        failureCount: Number(row.failure_count),
-        visitPercentage: totalVisits > 0 ? (visitCount / totalVisits) * 100 : 0,
-      });
-      processedScreens.add(screenName);
-    }
-
-    // Add visited screens without failures (limit to top 5)
-    let addedVisitOnly = 0;
-    for (const screen of visitedScreens) {
-      if (!processedScreens.has(screen.screen_name) && addedVisitOnly < 5) {
-        result.push({
-          screenName: screen.screen_name,
-          visitCount: Number(screen.visit_count),
-          failureCount: 0,
-          visitPercentage: totalVisits > 0 ? (Number(screen.visit_count) / totalVisits) * 100 : 0,
+      for (const row of rows.rows) {
+        appendToBucket(buckets, row.groupId, {
+          deviceModel: row.deviceModel,
+          os: row.os,
+          count: Number(row.occurrenceCount),
         });
-        addedVisitOnly++;
       }
     }
 
-    return result.sort((a, b) => b.visitCount - a.visitCount);
-  }
-
-  private async getAffectedTests(groupId: string): Promise<Record<string, number>> {
-    const db = this.getDb();
-
-    const rows = await db
-      .selectFrom("failure_occurrences")
-      .select("test_name")
-      .select(eb => eb.fn.count<number>("id").as("count"))
-      .where("group_id", "=", groupId)
-      .where("test_name", "is not", null)
-      .groupBy("test_name")
-      .execute();
-
-    const result: Record<string, number> = {};
-    for (const row of rows) {
-      if (row.test_name) {
-        result[row.test_name] = Number(row.count);
-      }
+    const result = new Map<string, DeviceBreakdown[]>();
+    for (const [groupId, rows] of buckets) {
+      const sorted = rows
+        .sort((a, b) => b.count - a.count || a.deviceModel.localeCompare(b.deviceModel) || a.os.localeCompare(b.os))
+        .slice(0, 10);
+      const total = sorted.reduce((sum, row) => sum + row.count, 0);
+      result.set(groupId, sorted.map(row => ({
+        deviceModel: row.deviceModel,
+        os: row.os,
+        count: row.count,
+        percentage: total > 0 ? (row.count / total) * 100 : 0,
+      })));
     }
     return result;
   }
 
-  private async getRecentCaptures(groupId: string, limit: number): Promise<FailureCapture[]> {
+  private async getVersionBreakdowns(groupIds: string[]): Promise<Map<string, VersionBreakdown[]>> {
     const db = this.getDb();
+    const buckets = new Map<string, Array<{ version: string; count: number }>>();
 
-    const rows = await db
-      .selectFrom("failure_captures")
-      .innerJoin("failure_occurrences", "failure_captures.occurrence_id", "failure_occurrences.id")
-      .select([
-        "failure_captures.id",
-        "failure_captures.type",
-        "failure_captures.path",
-        "failure_captures.timestamp",
-        "failure_captures.device_model",
-      ])
-      .where("failure_occurrences.group_id", "=", groupId)
-      .orderBy("failure_captures.timestamp", "desc")
-      .limit(limit)
-      .execute();
+    for (const chunk of chunkBySqliteParameterLimit(groupIds)) {
+      const rows = await sql<{
+        groupId: string;
+        version: string;
+        occurrenceCount: number;
+      }>`
+        SELECT groupId, version, occurrenceCount
+        FROM (
+          SELECT
+            group_id AS groupId,
+            app_version AS version,
+            COUNT(id) AS occurrenceCount,
+            ROW_NUMBER() OVER (
+              PARTITION BY group_id
+              ORDER BY COUNT(id) DESC, app_version ASC
+            ) AS rn
+          FROM failure_occurrences
+          WHERE group_id IN (${sql.join(chunk)})
+          GROUP BY group_id, app_version
+        )
+        WHERE rn <= 10
+        ORDER BY groupId ASC, occurrenceCount DESC, version ASC
+      `.execute(db);
 
-    return rows.map(row => ({
-      id: row.id,
-      type: row.type as "screenshot" | "video",
-      path: row.path,
-      timestamp: row.timestamp,
-      deviceModel: row.device_model,
-    }));
+      for (const row of rows.rows) {
+        appendToBucket(buckets, row.groupId, {
+          version: row.version,
+          count: Number(row.occurrenceCount),
+        });
+      }
+    }
+
+    const result = new Map<string, VersionBreakdown[]>();
+    for (const [groupId, rows] of buckets) {
+      const sorted = rows
+        .sort((a, b) => b.count - a.count || a.version.localeCompare(b.version))
+        .slice(0, 10);
+      const total = sorted.reduce((sum, row) => sum + row.count, 0);
+      result.set(groupId, sorted.map(row => ({
+        version: row.version,
+        count: row.count,
+        percentage: total > 0 ? (row.count / total) * 100 : 0,
+      })));
+    }
+    return result;
   }
 
-  private async getSampleOccurrences(groupId: string, limit: number): Promise<FailureOccurrence[]> {
+  private async getScreenBreakdowns(groupIds: string[]): Promise<Map<string, ScreenBreakdown[]>> {
     const db = this.getDb();
+    const failureScreensByGroup = new Map<string, FailureScreenCountRow[]>();
+    const visitedScreensByGroup = new Map<string, VisitScreenCountRow[]>();
 
-    const rows = await db
-      .selectFrom("failure_occurrences")
-      .selectAll()
-      .where("group_id", "=", groupId)
-      .orderBy("timestamp", "desc")
-      .limit(limit)
-      .execute();
+    for (const chunk of chunkBySqliteParameterLimit(groupIds)) {
+      const failureRows = await sql<{
+        groupId: string;
+        screenName: string;
+        failureCount: number;
+      }>`
+        SELECT
+          group_id AS groupId,
+          screen_at_failure AS screenName,
+          COUNT(id) AS failureCount
+        FROM failure_occurrences
+        WHERE group_id IN (${sql.join(chunk)})
+          AND screen_at_failure IS NOT NULL
+        GROUP BY group_id, screen_at_failure
+        ORDER BY group_id ASC, screen_at_failure ASC
+      `.execute(db);
 
-    const result: FailureOccurrence[] = [];
+      const visitRows = await sql<{
+        groupId: string;
+        screenName: string;
+        visitCount: number;
+      }>`
+        SELECT
+          failure_occurrences.group_id AS groupId,
+          failure_occurrence_screens.screen_name AS screenName,
+          COUNT(failure_occurrence_screens.id) AS visitCount
+        FROM failure_occurrence_screens
+        INNER JOIN failure_occurrences
+          ON failure_occurrence_screens.occurrence_id = failure_occurrences.id
+        WHERE failure_occurrences.group_id IN (${sql.join(chunk)})
+        GROUP BY failure_occurrences.group_id, failure_occurrence_screens.screen_name
+        ORDER BY failure_occurrences.group_id ASC, failure_occurrence_screens.screen_name ASC
+      `.execute(db);
 
-    for (const row of rows) {
-      // Get screens visited
-      const screens = await db
-        .selectFrom("failure_occurrence_screens")
-        .select("screen_name")
-        .where("occurrence_id", "=", row.id)
-        .orderBy("visit_order", "asc")
-        .execute();
+      for (const row of failureRows.rows) {
+        appendToBucket(failureScreensByGroup, row.groupId, {
+          screenName: row.screenName,
+          failureCount: Number(row.failureCount),
+        });
+      }
+      for (const row of visitRows.rows) {
+        appendToBucket(visitedScreensByGroup, row.groupId, {
+          screenName: row.screenName,
+          visitCount: Number(row.visitCount),
+        });
+      }
+    }
 
-      // Get capture if any
-      const capture = await db
-        .selectFrom("failure_captures")
-        .select(["path", "type"])
-        .where("occurrence_id", "=", row.id)
-        .executeTakeFirst();
+    const result = new Map<string, ScreenBreakdown[]>();
+    for (const groupId of groupIds) {
+      result.set(
+        groupId,
+        mergeScreenBreakdownRows(
+          failureScreensByGroup.get(groupId) ?? [],
+          visitedScreensByGroup.get(groupId) ?? []
+        )
+      );
+    }
+    return result;
+  }
 
-      result.push({
+  private async getAffectedTestsByGroup(groupIds: string[]): Promise<Map<string, Record<string, number>>> {
+    const db = this.getDb();
+    const result = new Map<string, Record<string, number>>();
+
+    for (const chunk of chunkBySqliteParameterLimit(groupIds)) {
+      const rows = await sql<{
+        groupId: string;
+        testName: string;
+        occurrenceCount: number;
+      }>`
+        SELECT
+          group_id AS groupId,
+          test_name AS testName,
+          COUNT(id) AS occurrenceCount
+        FROM failure_occurrences
+        WHERE group_id IN (${sql.join(chunk)})
+          AND test_name IS NOT NULL
+        GROUP BY group_id, test_name
+        ORDER BY group_id ASC, test_name ASC
+      `.execute(db);
+
+      for (const row of rows.rows) {
+        const tests = result.get(row.groupId) ?? {};
+        tests[row.testName] = Number(row.occurrenceCount);
+        result.set(row.groupId, tests);
+      }
+    }
+
+    return result;
+  }
+
+  private async getRecentCapturesByGroup(
+    groupIds: string[],
+    limit: number
+  ): Promise<Map<string, FailureCapture[]>> {
+    const db = this.getDb();
+    const result = new Map<string, FailureCapture[]>();
+
+    for (const chunk of chunkBySqliteParameterLimit(groupIds, 1)) {
+      const rows = await sql<{
+        groupId: string;
+        id: string;
+        type: "screenshot" | "video";
+        path: string;
+        timestamp: number;
+        deviceModel: string;
+      }>`
+        SELECT groupId, id, type, path, timestamp, deviceModel
+        FROM (
+          SELECT
+            failure_occurrences.group_id AS groupId,
+            failure_captures.id,
+            failure_captures.type,
+            failure_captures.path,
+            failure_captures.timestamp,
+            failure_captures.device_model AS deviceModel,
+            ROW_NUMBER() OVER (
+              PARTITION BY failure_occurrences.group_id
+              ORDER BY failure_captures.timestamp DESC, failure_captures.id ASC
+            ) AS rn
+          FROM failure_captures
+          INNER JOIN failure_occurrences
+            ON failure_captures.occurrence_id = failure_occurrences.id
+          WHERE failure_occurrences.group_id IN (${sql.join(chunk)})
+        )
+        WHERE rn <= ${limit}
+        ORDER BY groupId ASC, timestamp DESC, id ASC
+      `.execute(db);
+
+      for (const row of rows.rows) {
+        appendToBucket(result, row.groupId, {
+          id: row.id,
+          type: row.type,
+          path: row.path,
+          timestamp: row.timestamp,
+          deviceModel: row.deviceModel,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  private async getSampleOccurrencesByGroup(
+    groupIds: string[],
+    limit: number
+  ): Promise<Map<string, FailureOccurrence[]>> {
+    const db = this.getDb();
+    const occurrenceRows: Array<{
+      id: string;
+      groupId: string;
+      timestamp: number;
+      deviceModel: string;
+      os: string;
+      appVersion: string;
+      sessionId: string;
+      screenAtFailure: string | null;
+      testName: string | null;
+    }> = [];
+
+    for (const chunk of chunkBySqliteParameterLimit(groupIds, 1)) {
+      const rows = await sql<{
+        id: string;
+        groupId: string;
+        timestamp: number;
+        deviceModel: string;
+        os: string;
+        appVersion: string;
+        sessionId: string;
+        screenAtFailure: string | null;
+        testName: string | null;
+      }>`
+        SELECT
+          id,
+          groupId,
+          timestamp,
+          deviceModel,
+          os,
+          appVersion,
+          sessionId,
+          screenAtFailure,
+          testName
+        FROM (
+          SELECT
+            id,
+            group_id AS groupId,
+            timestamp,
+            device_model AS deviceModel,
+            os,
+            app_version AS appVersion,
+            session_id AS sessionId,
+            screen_at_failure AS screenAtFailure,
+            test_name AS testName,
+            ROW_NUMBER() OVER (
+              PARTITION BY group_id
+              ORDER BY timestamp DESC, id ASC
+            ) AS rn
+          FROM failure_occurrences
+          WHERE group_id IN (${sql.join(chunk)})
+        )
+        WHERE rn <= ${limit}
+        ORDER BY groupId ASC, timestamp DESC, id ASC
+      `.execute(db);
+
+      occurrenceRows.push(...rows.rows);
+    }
+
+    const occurrenceIds = occurrenceRows.map(row => row.id);
+    const screensByOccurrence = new Map<string, string[]>();
+    const captureByOccurrence = new Map<string, { path: string; type: "screenshot" | "video" }>();
+
+    for (const chunk of chunkBySqliteParameterLimit(occurrenceIds)) {
+      const screenRows = await sql<{
+        occurrenceId: string;
+        screenName: string;
+      }>`
+        SELECT
+          occurrence_id AS occurrenceId,
+          screen_name AS screenName
+        FROM failure_occurrence_screens
+        WHERE occurrence_id IN (${sql.join(chunk)})
+        ORDER BY occurrence_id ASC, visit_order ASC
+      `.execute(db);
+
+      const captureRows = await sql<{
+        occurrenceId: string;
+        path: string;
+        type: "screenshot" | "video";
+      }>`
+        SELECT
+          occurrence_id AS occurrenceId,
+          path,
+          type
+        FROM failure_captures
+        WHERE occurrence_id IN (${sql.join(chunk)})
+        ORDER BY occurrence_id ASC, timestamp DESC, id ASC
+      `.execute(db);
+
+      for (const row of screenRows.rows) {
+        appendToBucket(screensByOccurrence, row.occurrenceId, row.screenName);
+      }
+      for (const row of captureRows.rows) {
+        if (!captureByOccurrence.has(row.occurrenceId)) {
+          captureByOccurrence.set(row.occurrenceId, {
+            path: row.path,
+            type: row.type,
+          });
+        }
+      }
+    }
+
+    const result = new Map<string, FailureOccurrence[]>();
+    for (const row of occurrenceRows) {
+      const capture = captureByOccurrence.get(row.id);
+      appendToBucket(result, row.groupId, {
         id: row.id,
         timestamp: row.timestamp,
-        deviceModel: row.device_model,
+        deviceModel: row.deviceModel,
         os: row.os,
-        appVersion: row.app_version,
-        sessionId: row.session_id,
-        screenAtFailure: row.screen_at_failure,
-        screensVisited: screens.map(s => s.screen_name),
-        testName: row.test_name,
+        appVersion: row.appVersion,
+        sessionId: row.sessionId,
+        screenAtFailure: row.screenAtFailure,
+        screensVisited: screensByOccurrence.get(row.id) ?? [],
+        testName: row.testName,
         capturePath: capture?.path ?? null,
-        captureType: capture ? (capture.type as "screenshot" | "video") : null,
+        captureType: capture?.type ?? null,
       });
     }
 

--- a/src/db/sqliteBatch.ts
+++ b/src/db/sqliteBatch.ts
@@ -1,0 +1,30 @@
+export const SQLITE_MAX_BOUND_PARAMETERS = 999;
+
+export function chunkBySqliteParameterLimit<T>(
+  values: readonly T[],
+  fixedParameterCount = 0,
+  maxBoundParameters = SQLITE_MAX_BOUND_PARAMETERS
+): T[][] {
+  const chunkSize = maxBoundParameters - fixedParameterCount;
+  if (chunkSize < 1) {
+    throw new Error(
+      `SQLite batch query has ${fixedParameterCount} fixed parameters, exceeding ` +
+      `${maxBoundParameters} available bound parameters`
+    );
+  }
+
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
+export function appendToBucket<K, V>(buckets: Map<K, V[]>, key: K, value: V): void {
+  const bucket = buckets.get(key);
+  if (bucket) {
+    bucket.push(value);
+    return;
+  }
+  buckets.set(key, [value]);
+}

--- a/src/db/testExecutionRepository.ts
+++ b/src/db/testExecutionRepository.ts
@@ -5,6 +5,7 @@ import type { Database, NewTestExecution, NewTestExecutionStep, NewTestExecution
 import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
+import { appendToBucket, chunkBySqliteParameterLimit } from "./sqliteBatch";
 
 const TEST_EXECUTION_RETENTION_MAX_ROWS = 10_000;
 export const TEST_EXECUTION_RETENTION_MAX_DAYS = 90;
@@ -243,12 +244,29 @@ export class TestExecutionRepository {
 
     const executions = await query.execute();
 
-    // Fetch steps and screens for each execution
-    const runs: TestRun[] = [];
-    for (const exec of executions) {
+    const executionIds = executions.map(exec => exec.id);
+    if (executionIds.length === 0) {
+      return [];
+    }
+
+    const stepsByExecutionId = new Map<number, Array<{
+      id: number;
+      stepIndex: number;
+      action: string;
+      target: string | null;
+      status: "completed" | "failed" | "skipped";
+      durationMs: number;
+      screenName: string | null;
+      screenshotPath: string | null;
+      errorMessage: string | null;
+    }>>();
+    const screensByExecutionId = new Map<number, string[]>();
+
+    for (const chunk of chunkBySqliteParameterLimit(executionIds)) {
       const steps = await db
         .selectFrom("test_execution_steps")
         .select([
+          "execution_id as executionId",
           "id",
           "step_index as stepIndex",
           "action",
@@ -259,18 +277,42 @@ export class TestExecutionRepository {
           "screenshot_path as screenshotPath",
           "error_message as errorMessage",
         ])
-        .where("execution_id", "=", exec.id)
+        .where("execution_id", "in", chunk)
+        .orderBy("execution_id", "asc")
         .orderBy("step_index", "asc")
         .execute();
 
       const screens = await db
         .selectFrom("test_execution_screens")
-        .select(["screen_name as screenName"])
-        .where("execution_id", "=", exec.id)
+        .select(["execution_id as executionId", "screen_name as screenName"])
+        .where("execution_id", "in", chunk)
+        .orderBy("execution_id", "asc")
         .orderBy("visit_order", "asc")
         .execute();
 
-      runs.push({
+      for (const step of steps) {
+        appendToBucket(stepsByExecutionId, step.executionId, {
+          id: step.id,
+          stepIndex: step.stepIndex,
+          action: step.action,
+          target: step.target,
+          status: step.status as "completed" | "failed" | "skipped",
+          durationMs: step.durationMs,
+          screenName: step.screenName,
+          screenshotPath: step.screenshotPath,
+          errorMessage: step.errorMessage,
+        });
+      }
+
+      for (const screen of screens) {
+        appendToBucket(screensByExecutionId, screen.executionId, screen.screenName);
+      }
+    }
+
+    return executions.map(exec => {
+      const steps = stepsByExecutionId.get(exec.id) ?? [];
+      const screensVisited = screensByExecutionId.get(exec.id) ?? [];
+      return {
         id: exec.id,
         testClass: exec.testClass,
         testMethod: exec.testMethod,
@@ -283,22 +325,10 @@ export class TestExecutionRepository {
         errorMessage: exec.errorMessage,
         videoPath: exec.videoPath,
         snapshotPath: exec.snapshotPath,
-        steps: steps.map(s => ({
-          id: s.id,
-          stepIndex: s.stepIndex,
-          action: s.action,
-          target: s.target,
-          status: s.status as "completed" | "failed" | "skipped",
-          durationMs: s.durationMs,
-          screenName: s.screenName,
-          screenshotPath: s.screenshotPath,
-          errorMessage: s.errorMessage,
-        })),
-        screensVisited: screens.map(s => s.screenName),
-      });
-    }
-
-    return runs;
+        steps,
+        screensVisited,
+      };
+    });
   }
 
   private async cleanupRetention(): Promise<void> {

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
 import type { Kysely } from "kysely";
+import { Kysely as KyselyRuntime } from "kysely";
 import type { Database } from "../../src/db/types";
-import { FailureAnalyticsRepository } from "../../src/db/failureAnalyticsRepository";
+import {
+  FailureAnalyticsRepository,
+  mergeScreenBreakdownRows,
+} from "../../src/db/failureAnalyticsRepository";
 import type { RecordFailureInput } from "../../src/db/failureAnalyticsRepository";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { runMigrations } from "../../src/db/migrator";
 import { createTestDatabase } from "./testDbHelper";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
@@ -242,6 +249,160 @@ describe("FailureAnalyticsRepository", () => {
       expect(group.deviceBreakdown[0].deviceModel).toBe("Pixel 7");
       expect(group.versionBreakdown).toHaveLength(1);
       expect(group.versionBreakdown[0].version).toBe("1.0.0");
+    });
+
+    test("fetches aggregated group details with a bounded query count and preserves per-group top-N", async () => {
+      const instrumented = await createInstrumentedTestDatabase();
+      const instrumentedRepo = new FailureAnalyticsRepository(timer, instrumented.db, () => new FakeDbWriteBarrier());
+      try {
+        await seedFailureGroup(instrumented.db, {
+          id: "group-high-volume",
+          signature: "high-volume",
+          title: "High volume",
+          lastOccurrence: 2000,
+          totalCount: 8,
+        });
+        await seedFailureGroup(instrumented.db, {
+          id: "group-quiet",
+          signature: "quiet",
+          title: "Quiet group",
+          lastOccurrence: 1500,
+          totalCount: 1,
+        });
+
+        for (let i = 0; i < 8; i++) {
+          await seedFailureOccurrence(instrumented.db, {
+            id: `high-occ-${i}`,
+            groupId: "group-high-volume",
+            timestamp: 1000 + i,
+            deviceModel: i % 2 === 0 ? "Pixel A" : "Pixel B",
+            appVersion: `1.0.${i % 2}`,
+            screenAtFailure: i % 2 === 0 ? "Home" : "Settings",
+            screensVisited: ["Launch", "Home", `Step${i}`],
+            capturePath: `/captures/high-${i}.png`,
+          });
+        }
+        await seedFailureOccurrence(instrumented.db, {
+          id: "quiet-occ-0",
+          groupId: "group-quiet",
+          timestamp: 1400,
+          deviceModel: "Pixel Quiet",
+          appVersion: "2.0.0",
+          screenAtFailure: "QuietScreen",
+          screensVisited: ["QuietScreen"],
+          capturePath: "/captures/quiet.png",
+        });
+
+        instrumented.resetQueryCount();
+        const groups = await instrumentedRepo.getFailureGroups({ limit: 2 });
+
+        expect(groups.map(group => group.id)).toEqual(["group-high-volume", "group-quiet"]);
+        expect(instrumented.queryCount()).toBeLessThanOrEqual(10);
+
+        const highVolume = groups[0];
+        expect(highVolume.sampleOccurrences.map(occ => occ.id)).toEqual([
+          "high-occ-7",
+          "high-occ-6",
+          "high-occ-5",
+          "high-occ-4",
+          "high-occ-3",
+          "high-occ-2",
+        ]);
+        expect(highVolume.recentCaptures.map(capture => capture.path)).toEqual([
+          "/captures/high-7.png",
+          "/captures/high-6.png",
+          "/captures/high-5.png",
+          "/captures/high-4.png",
+          "/captures/high-3.png",
+        ]);
+        expect(highVolume.deviceBreakdown.map(row => row.deviceModel)).toEqual(["Pixel A", "Pixel B"]);
+
+        const quiet = groups[1];
+        expect(quiet.sampleOccurrences.map(occ => occ.id)).toEqual(["quiet-occ-0"]);
+        expect(quiet.recentCaptures.map(capture => capture.path)).toEqual(["/captures/quiet.png"]);
+      } finally {
+        await instrumented.db.destroy();
+      }
+    });
+
+    test("chunks more than SQLite's conservative bound-parameter limit without dropping groups", async () => {
+      const instrumented = await createInstrumentedTestDatabase();
+      const instrumentedRepo = new FailureAnalyticsRepository(timer, instrumented.db, () => new FakeDbWriteBarrier());
+      try {
+        for (let i = 0; i < 1005; i++) {
+          await seedFailureGroup(instrumented.db, {
+            id: `chunk-group-${i.toString().padStart(4, "0")}`,
+            signature: `chunk-sig-${i}`,
+            title: `Chunk group ${i}`,
+            lastOccurrence: 5000 - i,
+            totalCount: [997, 998, 999, 1000].includes(i) ? 1 : 0,
+          });
+        }
+        for (const i of [997, 998, 999, 1000]) {
+          await seedFailureOccurrence(instrumented.db, {
+            id: `chunk-occ-${i}`,
+            groupId: `chunk-group-${i.toString().padStart(4, "0")}`,
+            timestamp: 5000 - i,
+            deviceModel: `Pixel ${i}`,
+            appVersion: `9.${i}.0`,
+            screenAtFailure: `Screen ${i}`,
+            screensVisited: [`Launch ${i}`, `Screen ${i}`],
+            capturePath: `/captures/chunk-${i}.png`,
+          });
+        }
+
+        instrumented.resetQueryCount();
+        const groups = await instrumentedRepo.getFailureGroups({ limit: 1005 });
+
+        expect(groups).toHaveLength(1005);
+        expect(groups[0].id).toBe("chunk-group-0000");
+        expect(groups[1004].id).toBe("chunk-group-1004");
+        for (const i of [997, 998, 999, 1000]) {
+          const group = groups.find(item => item.id === `chunk-group-${i.toString().padStart(4, "0")}`);
+          expect(group?.deviceBreakdown[0]).toMatchObject({ deviceModel: `Pixel ${i}`, count: 1 });
+          expect(group?.versionBreakdown[0]).toMatchObject({ version: `9.${i}.0`, count: 1 });
+          expect(group?.screenBreakdown.map(screen => screen.screenName)).toEqual([`Screen ${i}`, `Launch ${i}`]);
+          expect(group?.recentCaptures[0].path).toBe(`/captures/chunk-${i}.png`);
+          expect(group?.sampleOccurrences[0]).toMatchObject({
+            id: `chunk-occ-${i}`,
+            screensVisited: [`Launch ${i}`, `Screen ${i}`],
+            capturePath: `/captures/chunk-${i}.png`,
+          });
+        }
+      } finally {
+        await instrumented.db.destroy();
+      }
+    });
+  });
+
+  describe("mergeScreenBreakdownRows", () => {
+    test("preserves failure rows, caps visit-only additions, and handles overlap", () => {
+      const rows = mergeScreenBreakdownRows(
+        [
+          { screenName: "Checkout", failureCount: 2 },
+          { screenName: "Settings", failureCount: 1 },
+        ],
+        [
+          { screenName: "Checkout", visitCount: 10 },
+          { screenName: "A", visitCount: 1 },
+          { screenName: "B", visitCount: 9 },
+          { screenName: "C", visitCount: 8 },
+          { screenName: "D", visitCount: 7 },
+          { screenName: "E", visitCount: 6 },
+          { screenName: "F", visitCount: 5 },
+          { screenName: "Settings", visitCount: 3 },
+        ]
+      );
+
+      expect(rows.map(row => row.screenName)).toEqual(["Checkout", "B", "C", "D", "E", "F", "Settings"]);
+      expect(rows.find(row => row.screenName === "Checkout")).toEqual({
+        screenName: "Checkout",
+        visitCount: 10,
+        failureCount: 2,
+        visitPercentage: (10 / 49) * 100,
+      });
+      expect(rows.some(row => row.screenName === "A")).toBe(false);
+      expect(rows.find(row => row.screenName === "Settings")?.failureCount).toBe(1);
     });
   });
 
@@ -552,3 +713,113 @@ describe("FailureAnalyticsRepository", () => {
     });
   });
 });
+
+async function createInstrumentedTestDatabase(): Promise<{
+  db: Kysely<Database>;
+  queryCount: () => number;
+  resetQueryCount: () => void;
+}> {
+  const bunDb = new BunDatabase(":memory:");
+  let count = 0;
+  const db = new KyselyRuntime<Database>({
+    dialect: new BunSqliteDialect({
+      database: bunDb,
+      beforeQuery: async () => {
+        count++;
+      },
+    }),
+  });
+  await runMigrations(db as Kysely<unknown>);
+  return {
+    db,
+    queryCount: () => count,
+    resetQueryCount: () => {
+      count = 0;
+    },
+  };
+}
+
+async function seedFailureGroup(
+  db: Kysely<Database>,
+  input: {
+    id: string;
+    signature: string;
+    title: string;
+    lastOccurrence: number;
+    totalCount: number;
+  }
+): Promise<void> {
+  await db
+    .insertInto("failure_groups")
+    .values({
+      id: input.id,
+      type: "crash",
+      signature: input.signature,
+      title: input.title,
+      message: input.title,
+      severity: "high",
+      first_occurrence: input.lastOccurrence,
+      last_occurrence: input.lastOccurrence,
+      total_count: input.totalCount,
+      unique_sessions: input.totalCount,
+      stack_trace_json: null,
+      tool_call_info_json: null,
+      updated_at: new Date(input.lastOccurrence).toISOString(),
+    })
+    .execute();
+}
+
+async function seedFailureOccurrence(
+  db: Kysely<Database>,
+  input: {
+    id: string;
+    groupId: string;
+    timestamp: number;
+    deviceModel: string;
+    appVersion: string;
+    screenAtFailure: string;
+    screensVisited: string[];
+    capturePath: string;
+  }
+): Promise<void> {
+  await db
+    .insertInto("failure_occurrences")
+    .values({
+      id: input.id,
+      group_id: input.groupId,
+      timestamp: input.timestamp,
+      device_id: null,
+      device_model: input.deviceModel,
+      os: "Android 14",
+      app_version: input.appVersion,
+      session_id: `session-${input.id}`,
+      screen_at_failure: input.screenAtFailure,
+      test_name: `test-${input.groupId}`,
+      test_execution_id: null,
+      error_code: null,
+      duration_ms: null,
+      tool_args_json: null,
+    })
+    .execute();
+
+  await db
+    .insertInto("failure_occurrence_screens")
+    .values(input.screensVisited.map((screenName, index) => ({
+      occurrence_id: input.id,
+      screen_name: screenName,
+      visit_order: index,
+    })))
+    .execute();
+
+  await db
+    .insertInto("failure_captures")
+    .values({
+      id: `capture-${input.id}`,
+      occurrence_id: input.id,
+      type: "screenshot",
+      path: input.capturePath,
+      timestamp: input.timestamp,
+      device_model: input.deviceModel,
+    })
+    .execute();
+}

--- a/test/db/testExecutionRepository.test.ts
+++ b/test/db/testExecutionRepository.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
 import type { Kysely } from "kysely";
+import { Kysely as KyselyRuntime } from "kysely";
 import type { Database } from "../../src/db/types";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { SQLITE_MAX_BOUND_PARAMETERS } from "../../src/db/sqliteBatch";
 import {
   TestExecutionRepository,
   type TestExecutionRecord,
   type TestStepRecord,
 } from "../../src/db/testExecutionRepository";
+import { runMigrations } from "../../src/db/migrator";
 import { createTestDatabase } from "./testDbHelper";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -179,6 +184,66 @@ describe("TestExecutionRepository", () => {
       expect(runs[0].startTime).toBe(1000);
       expect(runs[1].startTime).toBe(2000);
       expect(runs[2].startTime).toBe(3000);
+    });
+
+    test("fetches executions, steps, and screens with exactly three queries", async () => {
+      const instrumented = await createInstrumentedTestDatabase();
+      const instrumentedRepo = new TestExecutionRepository(timer, instrumented.db);
+      try {
+        for (let i = 0; i < 5; i++) {
+          await instrumentedRepo.recordExecution(
+            makeExecution({
+              testClass: `Class${i}`,
+              testMethod: `method${i}`,
+              timestamp: 1000 + i,
+              steps: [
+                makeStep({ stepIndex: 0, action: "tapOn", target: `button-${i}` }),
+                makeStep({ stepIndex: 1, action: "inputText", target: `field-${i}` }),
+              ],
+              screensVisited: [
+                { screenName: `Screen${i}A`, timestamp: 1000 + i },
+                { screenName: `Screen${i}B`, timestamp: 2000 + i },
+              ],
+            })
+          );
+        }
+
+        instrumented.resetQueryCount();
+        const runs = await instrumentedRepo.getTestRuns({ limit: 5 });
+
+        expect(runs).toHaveLength(5);
+        expect(runs[0].steps.map(step => step.stepIndex)).toEqual([0, 1]);
+        expect(runs[0].screensVisited).toEqual(["Screen4A", "Screen4B"]);
+        expect(instrumented.queryCount()).toBe(3);
+      } finally {
+        await instrumented.db.destroy();
+      }
+    });
+
+    test("chunks more than SQLite's conservative bound-parameter limit without mixing steps or screens", async () => {
+      const instrumented = await createInstrumentedTestDatabase();
+      const instrumentedRepo = new TestExecutionRepository(timer, instrumented.db);
+      const executionCount = SQLITE_MAX_BOUND_PARAMETERS + 6;
+      try {
+        await seedTestExecutions(instrumented.db, executionCount);
+
+        instrumented.resetQueryCount();
+        const runs = await instrumentedRepo.getTestRuns({ limit: executionCount });
+
+        expect(runs).toHaveLength(executionCount);
+        expect(instrumented.queryCount()).toBe(1 + 2 * Math.ceil(executionCount / SQLITE_MAX_BOUND_PARAMETERS));
+        for (const id of [SQLITE_MAX_BOUND_PARAMETERS - 1, SQLITE_MAX_BOUND_PARAMETERS, SQLITE_MAX_BOUND_PARAMETERS + 1]) {
+          const run = runs.find(item => item.id === id);
+          expect(run?.steps).toHaveLength(1);
+          expect(run?.steps[0]).toMatchObject({
+            action: `action-${id}`,
+            target: `target-${id}`,
+          });
+          expect(run?.screensVisited).toEqual([`Screen ${id}`]);
+        }
+      } finally {
+        await instrumented.db.destroy();
+      }
     });
   });
 
@@ -450,3 +515,96 @@ describe("TestExecutionRepository", () => {
     });
   });
 });
+
+async function createInstrumentedTestDatabase(): Promise<{
+  db: Kysely<Database>;
+  queryCount: () => number;
+  resetQueryCount: () => void;
+}> {
+  const bunDb = new BunDatabase(":memory:");
+  let count = 0;
+  const db = new KyselyRuntime<Database>({
+    dialect: new BunSqliteDialect({
+      database: bunDb,
+      beforeQuery: async () => {
+        count++;
+      },
+    }),
+  });
+  await runMigrations(db as Kysely<unknown>);
+  return {
+    db,
+    queryCount: () => count,
+    resetQueryCount: () => {
+      count = 0;
+    },
+  };
+}
+
+async function seedTestExecutions(db: Kysely<Database>, count: number): Promise<void> {
+  const ids = Array.from({ length: count }, (_unused, index) => index + 1);
+  for (const chunk of chunkArray(ids, 200)) {
+    await db
+      .insertInto("test_executions")
+      .values(chunk.map(id => ({
+        id,
+        test_class: `Class${id}`,
+        test_method: `method${id}`,
+        duration_ms: id,
+        status: "passed" as const,
+        timestamp: id,
+        device_id: null,
+        device_name: null,
+        device_platform: "android" as const,
+        device_type: "emulator" as const,
+        app_version: null,
+        git_commit: null,
+        target_sdk: null,
+        jdk_version: null,
+        jvm_target: null,
+        gradle_version: null,
+        is_ci: null,
+        session_uuid: null,
+        error_message: null,
+        video_path: null,
+        snapshot_path: null,
+      })))
+      .execute();
+
+    await db
+      .insertInto("test_execution_steps")
+      .values(chunk.map(id => ({
+        id,
+        execution_id: id,
+        step_index: 0,
+        action: `action-${id}`,
+        target: `target-${id}`,
+        status: "completed" as const,
+        duration_ms: id,
+        screen_name: `Screen ${id}`,
+        screenshot_path: null,
+        error_message: null,
+        details_json: null,
+      })))
+      .execute();
+
+    await db
+      .insertInto("test_execution_screens")
+      .values(chunk.map(id => ({
+        id,
+        execution_id: id,
+        screen_name: `Screen ${id}`,
+        visit_order: 0,
+        timestamp: id,
+      })))
+      .execute();
+  }
+}
+
+function chunkArray<T>(values: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
+}


### PR DESCRIPTION
## Summary
- Batch `getFailureGroups` detail reads by page group ids instead of running serialized per-group N+1 helper queries.
- Batch `getTestRuns` steps/screens by execution ids so a normal page uses 3 queries total.
- Add parameter-aware SQLite `IN (...)` chunking plus regression tests for query count, per-group top-N, quiet groups, screen merge behavior, and chunk overflow.

## Notes
- No `.github/PULL_REQUEST_TEMPLATE*` file exists in this repo; only issue templates are present, so this follows the repo's summary/testing PR body convention.
- Closes #2800.

## Testing
- `bun test test/db/testExecutionRepository.test.ts test/db/failureAnalyticsRepository.test.ts`
- `bun test --bail`
- `bun run lint`
- `bun run build`
- `git diff --check`
- `bun run turbo:validate`

## Review
- Ran `/auto-mobile-code-review` locally against the committed diff. No actionable findings.
