### PR TITLE
refactor(db): extract telemetry event tables

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -8,6 +8,7 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
+import { copyDatabaseRuntimeFiles } from "./scripts/build/copy-db-runtime-files";
 
 // Clean dist directory
 const distPath = join(import.meta.dir, "dist");
@@ -73,16 +74,8 @@ if (existsSync(sourcemapPath)) {
   }
 }
 
-// Copy migrations for runtime usage (FileMigrationProvider reads from disk)
-const migrationsSource = join(import.meta.dir, "src", "db", "migrations");
-const migrationsDest = join(import.meta.dir, "dist", "src", "db", "migrations");
-if (existsSync(migrationsSource)) {
-  mkdirSync(migrationsDest, { recursive: true });
-  cpSync(migrationsSource, migrationsDest, { recursive: true });
-  console.log("✓ Copied database migrations");
-} else {
-  console.warn(`Database migrations not found at ${migrationsSource}`);
-}
+// Copy raw DB runtime files for FileMigrationProvider usage.
+copyDatabaseRuntimeFiles({ projectRoot: import.meta.dir });
 
 // Copy schemas for runtime validation (PlanSchemaValidator reads from disk)
 const schemasSource = join(import.meta.dir, "schemas");

--- a/scripts/build/copy-db-runtime-files.ts
+++ b/scripts/build/copy-db-runtime-files.ts
@@ -1,0 +1,40 @@
+import { cpSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+
+const DB_RUNTIME_FILES = ["eventTables.ts"] as const;
+
+export interface CopyDatabaseRuntimeFilesOptions {
+  projectRoot: string;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+export function copyDatabaseRuntimeFiles({
+  projectRoot,
+  log = console.log,
+  warn = console.warn,
+}: CopyDatabaseRuntimeFilesOptions): void {
+  const dbSource = join(projectRoot, "src", "db");
+  const dbDest = join(projectRoot, "dist", "src", "db");
+  const migrationsSource = join(dbSource, "migrations");
+  const migrationsDest = join(dbDest, "migrations");
+
+  if (existsSync(migrationsSource)) {
+    mkdirSync(migrationsDest, { recursive: true });
+    cpSync(migrationsSource, migrationsDest, { recursive: true });
+    log("✓ Copied database migrations");
+  } else {
+    warn(`Database migrations not found at ${migrationsSource}`);
+  }
+
+  mkdirSync(dbDest, { recursive: true });
+  for (const file of DB_RUNTIME_FILES) {
+    const source = join(dbSource, file);
+    if (!existsSync(source)) {
+      warn(`Database runtime file not found at ${source}`);
+      continue;
+    }
+    cpSync(source, join(dbDest, file));
+  }
+  log("✓ Copied database runtime files");
+}

--- a/src/db/eventTables.ts
+++ b/src/db/eventTables.ts
@@ -1,0 +1,8 @@
+export const EVENT_TABLES = [
+  "network_events",
+  "log_events",
+  "os_events",
+  "navigation_events",
+  "storage_events",
+  "layout_events",
+] as const;

--- a/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
+++ b/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
@@ -1,4 +1,15 @@
 import type { Kysely } from "kysely";
+import { EVENT_TABLES } from "../eventTables";
+
+async function tableExists(db: Kysely<unknown>, tableName: string): Promise<boolean> {
+  const result = await db
+    .selectFrom("sqlite_master" as never)
+    .select("name")
+    .where("type", "=", "table")
+    .where("name", "=", tableName)
+    .execute();
+  return result.length > 0;
+}
 
 /**
  * Composite (device_id, timestamp) indexes for the telemetry event tables (#2788).
@@ -29,17 +40,11 @@ import type { Kysely } from "kysely";
  *     `idx_<table>_device` indexes to cut per-insert write amplification is
  *     deferred to a follow-up so the change is reviewed on its own (see #2788).
  */
-const TABLES = [
-  "network_events",
-  "log_events",
-  "os_events",
-  "navigation_events",
-  "storage_events",
-  "layout_events",
-] as const;
-
 export async function up(db: Kysely<unknown>): Promise<void> {
-  for (const table of TABLES) {
+  for (const table of EVENT_TABLES) {
+    if (!(await tableExists(db, table))) {
+      continue;
+    }
     // .ifNotExists() so the migration survives #2785's destructive-recovery
     // replay (drop-all then replay every migration on an empty DB).
     await db.schema
@@ -52,7 +57,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  for (const table of TABLES) {
+  for (const table of EVENT_TABLES) {
     // .ifExists() so a partial-up followed by down (recovery machinery can
     // invoke migrations in unusual orders) does not throw.
     await db.schema.dropIndex(`idx_${table}_device_timestamp`).ifExists().execute();

--- a/src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts
+++ b/src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts
@@ -1,4 +1,15 @@
 import type { Kysely } from "kysely";
+import { EVENT_TABLES } from "../eventTables";
+
+async function tableExists(db: Kysely<unknown>, tableName: string): Promise<boolean> {
+  const result = await db
+    .selectFrom("sqlite_master" as never)
+    .select("name")
+    .where("type", "=", "table")
+    .where("name", "=", tableName)
+    .execute();
+  return result.length > 0;
+}
 
 /**
  * Drop the now-redundant single-column `idx_<table>_device` indexes on the six
@@ -33,17 +44,8 @@ import type { Kysely } from "kysely";
  * `2026_07_02_000_event_composite_indexes.ts`, so the composite that subsumes
  * each device index is guaranteed present when its device index is dropped.
  */
-const TABLES = [
-  "network_events",
-  "log_events",
-  "os_events",
-  "navigation_events",
-  "storage_events",
-  "layout_events",
-] as const;
-
 export async function up(db: Kysely<unknown>): Promise<void> {
-  for (const table of TABLES) {
+  for (const table of EVENT_TABLES) {
     // .ifExists() so replay on a DB that never had the standalone device index
     // (or a partial recovery order) does not throw.
     await db.schema.dropIndex(`idx_${table}_device`).ifExists().execute();
@@ -51,7 +53,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  for (const table of TABLES) {
+  for (const table of EVENT_TABLES) {
+    if (!(await tableExists(db, table))) {
+      continue;
+    }
     // Recreate the single-column device index exactly as the base migrations
     // defined it. .ifNotExists() so a down after a partial-up is idempotent.
     await db.schema

--- a/test/db/dropRedundantDeviceIndexes.test.ts
+++ b/test/db/dropRedundantDeviceIndexes.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely, sql } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { EVENT_TABLES } from "../../src/db/eventTables";
 import { runMigrations } from "../../src/db/migrator";
 import { up as telemetryUp } from "../../src/db/migrations/2026_03_15_000_telemetry_events";
 import { up as navigationUp } from "../../src/db/migrations/2026_03_18_000_navigation_events";
@@ -28,17 +29,8 @@ import {
  * the composite with no filesort, the standalone `timestamp` and category indexes
  * are left intact, and the migration is reversible / idempotent / replay-safe.
  */
-const TABLES = [
-  "network_events",
-  "log_events",
-  "os_events",
-  "navigation_events",
-  "storage_events",
-  "layout_events",
-] as const;
-
 /** Category/content indexes that must survive the drop (different query shapes). */
-const CATEGORY_INDEX: Partial<Record<(typeof TABLES)[number], string>> = {
+const CATEGORY_INDEX: Partial<Record<(typeof EVENT_TABLES)[number], string>> = {
   network_events: "idx_network_events_host",
   log_events: "idx_log_events_tag",
   os_events: "idx_os_events_category",
@@ -102,14 +94,14 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
 
   test("up drops the six redundant idx_<table>_device indexes", async () => {
     // Precondition: the device indexes exist before the drop.
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device`)).toBe(true);
     }
 
     await dropUp(db);
 
     // sqlite_master no longer lists any of the six device indexes.
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device`)).toBe(false);
     }
   });
@@ -117,7 +109,7 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("up leaves the composite, timestamp, and category indexes intact", async () => {
     await dropUp(db);
 
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const list = await indexList(db, table);
       // Composite survives — it is what subsumes the dropped device index.
       expect(list).toContain(`idx_${table}_device_timestamp`);
@@ -136,7 +128,7 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("device_id=? ORDER BY timestamp DESC LIMIT n still uses the composite, no filesort", async () => {
     await dropUp(db);
 
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const plan = queryPlan(
         bunDb,
         `SELECT * FROM ${table} WHERE device_id = 'dev-1' ORDER BY timestamp DESC LIMIT 100`
@@ -152,7 +144,7 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("bare device_id=? (no ORDER BY) still uses the composite left-prefix", async () => {
     await dropUp(db);
 
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const plan = queryPlan(
         bunDb,
         `SELECT * FROM ${table} WHERE device_id = 'dev-1'`
@@ -164,7 +156,7 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("COUNT(*) WHERE device_id=? is served by the composite (covering scan)", async () => {
     await dropUp(db);
 
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const plan = queryPlan(
         bunDb,
         `SELECT COUNT(*) FROM ${table} WHERE device_id = 'dev-1'`
@@ -193,7 +185,7 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("retention cutoff (ORDER BY timestamp DESC, no device filter) still uses the timestamp index", async () => {
     await dropUp(db);
 
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const plan = queryPlan(
         bunDb,
         `SELECT timestamp FROM ${table} ORDER BY timestamp DESC LIMIT 1 OFFSET 10000`
@@ -231,7 +223,7 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("up is idempotent (safe to re-run, as destructive-recovery replay would)", async () => {
     await dropUp(db);
     await expect(dropUp(db)).resolves.toBeUndefined();
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device`)).toBe(false);
     }
   });
@@ -239,7 +231,7 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("down recreates the six single-column device indexes", async () => {
     await dropUp(db);
     await dropDown(db);
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const name = `idx_${table}_device`;
       expect(await indexExists(db, name)).toBe(true);
       expect(await indexColumns(db, name)).toEqual(["device_id"]);
@@ -249,13 +241,32 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration", () => {
   test("down is idempotent — a partial-up followed by down does not throw", async () => {
     // Never dropped: down() must recreate cleanly even though indexes already exist.
     await expect(dropDown(db)).resolves.toBeUndefined();
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device`)).toBe(true);
     }
     // And after a full up, a double down is still safe.
     await dropUp(db);
     await dropDown(db);
     await expect(dropDown(db)).resolves.toBeUndefined();
+  });
+
+  test("down skips canonical tables that are not present yet during replay", async () => {
+    const partialBunDb = new BunDatabase(":memory:");
+    const partialDb = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: partialBunDb }),
+    });
+    try {
+      await telemetryUp(partialDb);
+      await navigationUp(partialDb);
+      await storageUp(partialDb);
+
+      await expect(dropDown(partialDb)).resolves.toBeUndefined();
+      expect(await indexExists(partialDb, "idx_storage_events_device")).toBe(true);
+      expect(await indexExists(partialDb, "idx_layout_events_device")).toBe(false);
+    } finally {
+      await partialDb.destroy();
+      partialBunDb.close();
+    }
   });
 });
 
@@ -277,13 +288,13 @@ describe("2026_07_03_000_drop_redundant_device_indexes migration — full replay
   });
 
   test("the six device indexes are gone after a fresh full migration chain", async () => {
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device`)).toBe(false);
     }
   });
 
   test("the composite and timestamp indexes survive the full chain", async () => {
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(true);
       expect(await indexExists(db, `idx_${table}_timestamp`)).toBe(true);
     }

--- a/test/db/eventCompositeIndexes.test.ts
+++ b/test/db/eventCompositeIndexes.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely, sql } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { EVENT_TABLES } from "../../src/db/eventTables";
 import { runMigrations } from "../../src/db/migrator";
 import { up as telemetryUp } from "../../src/db/migrations/2026_03_15_000_telemetry_events";
 import { up as navigationUp } from "../../src/db/migrations/2026_03_18_000_navigation_events";
@@ -24,15 +25,6 @@ import {
  * planner actually uses it, the filesort disappears, results are unchanged, and
  * the migration is idempotent / reversible / replay-safe.
  */
-const TABLES = [
-  "network_events",
-  "log_events",
-  "os_events",
-  "navigation_events",
-  "storage_events",
-  "layout_events",
-] as const;
-
 /**
  * Build the six event tables via their original migrations (no composite index
  * yet). The later `alterTable` migrations (…_002_storage_events_previous_value,
@@ -92,13 +84,13 @@ describe("2026_07_02_000_event_composite_indexes migration", () => {
   });
 
   test("up creates a composite (device_id, timestamp) index on all six tables", async () => {
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(false);
     }
 
     await compositeUp(db);
 
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const name = `idx_${table}_device_timestamp`;
       expect(await indexExists(db, name)).toBe(true);
       // Columns are ordered (device_id, timestamp) ascending — mirrors precedent.
@@ -108,14 +100,14 @@ describe("2026_07_02_000_event_composite_indexes migration", () => {
 
   test("planner uses the composite index and drops the temp B-tree filesort", async () => {
     // Before: device filter picks the single-column device index, forcing a sort.
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const before = queryPlan(bunDb, table).join("\n");
       expect(before).toContain("USE TEMP B-TREE FOR ORDER BY");
     }
 
     await compositeUp(db);
 
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       const after = queryPlan(bunDb, table).join("\n");
       const indexName = `idx_${table}_device_timestamp`;
       // The composite index now satisfies both the equality filter and the order.
@@ -154,15 +146,34 @@ describe("2026_07_02_000_event_composite_indexes migration", () => {
   test("up is idempotent (safe to re-run, as destructive-recovery replay would)", async () => {
     await compositeUp(db);
     await expect(compositeUp(db)).resolves.toBeUndefined();
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(true);
+    }
+  });
+
+  test("up skips canonical tables that are not present yet during replay", async () => {
+    const partialBunDb = new BunDatabase(":memory:");
+    const partialDb = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: partialBunDb }),
+    });
+    try {
+      await telemetryUp(partialDb);
+      await navigationUp(partialDb);
+      await storageUp(partialDb);
+
+      await expect(compositeUp(partialDb)).resolves.toBeUndefined();
+      expect(await indexExists(partialDb, "idx_storage_events_device_timestamp")).toBe(true);
+      expect(await indexExists(partialDb, "idx_layout_events_device_timestamp")).toBe(false);
+    } finally {
+      await partialDb.destroy();
+      partialBunDb.close();
     }
   });
 
   test("down drops all six composite indexes", async () => {
     await compositeUp(db);
     await compositeDown(db);
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(false);
     }
   });
@@ -202,7 +213,7 @@ describe("2026_07_02_000_event_composite_indexes migration — full replay", () 
   });
 
   test("the composite indexes exist after a fresh full migration chain", async () => {
-    for (const table of TABLES) {
+    for (const table of EVENT_TABLES) {
       expect(await indexExists(db, `idx_${table}_device_timestamp`)).toBe(true);
     }
   });

--- a/test/db/telemetryEventIndexInventory.test.ts
+++ b/test/db/telemetryEventIndexInventory.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely, sql } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { EVENT_TABLES } from "../../src/db/eventTables";
 import { runMigrations } from "../../src/db/migrator";
 
 /**
@@ -84,7 +85,11 @@ const CANONICAL_INDEXES: Record<string, Record<string, string[]>> = {
   },
 };
 
-const TABLES = Object.keys(CANONICAL_INDEXES);
+const TABLES = [...EVENT_TABLES];
+
+test("EVENT_TABLES is the canonical table list used by the telemetry index guard", () => {
+  expect([...TABLES].sort()).toEqual(Object.keys(CANONICAL_INDEXES).sort());
+});
 
 /**
  * Explicit-index inventory of a table: name → ordered columns, ignoring the

--- a/test/scripts/copyDbRuntimeFiles.test.ts
+++ b/test/scripts/copyDbRuntimeFiles.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { copyDatabaseRuntimeFiles } from "../../scripts/build/copy-db-runtime-files";
+
+describe("copyDatabaseRuntimeFiles", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function makeProjectRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "auto-mobile-db-runtime-"));
+    roots.push(root);
+    mkdirSync(join(root, "src", "db", "migrations"), { recursive: true });
+    writeFileSync(
+      join(root, "src", "db", "migrations", "2026_07_02_000_event_composite_indexes.ts"),
+      'import { EVENT_TABLES } from "../eventTables";\nexport async function up() {}\n'
+    );
+    writeFileSync(
+      join(root, "src", "db", "eventTables.ts"),
+      'export const EVENT_TABLES = ["network_events"] as const;\n'
+    );
+    return root;
+  }
+
+  test("copies raw migrations and their sibling runtime dependencies into dist", () => {
+    const root = makeProjectRoot();
+    const logs: string[] = [];
+
+    copyDatabaseRuntimeFiles({ projectRoot: root, log: message => logs.push(message) });
+
+    const migration = join(
+      root,
+      "dist",
+      "src",
+      "db",
+      "migrations",
+      "2026_07_02_000_event_composite_indexes.ts"
+    );
+    const runtimeFile = join(root, "dist", "src", "db", "eventTables.ts");
+
+    expect(existsSync(migration)).toBe(true);
+    expect(readFileSync(migration, "utf8")).toContain('../eventTables"');
+    expect(readFileSync(runtimeFile, "utf8")).toContain("EVENT_TABLES");
+    expect(logs).toContain("✓ Copied database migrations");
+    expect(logs).toContain("✓ Copied database runtime files");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract a canonical `EVENT_TABLES` list for the six telemetry event tables.
- Update the composite-index and redundant-device-index migrations plus sibling tests to consume the shared list.
- Keep dated migrations replay-safe if a future event table is added before its create-table migration runs.
- Copy DB runtime files needed by raw packaged migrations into `dist/src/db` during build.

Note: I checked for a repo PR template and found no `.github/PULL_REQUEST_TEMPLATE*` file; only issue templates and `.github/workflows/pull_request.yml` are present.

## Validation

- `bun test test/scripts/copyDbRuntimeFiles.test.ts test/db/eventCompositeIndexes.test.ts test/db/dropRedundantDeviceIndexes.test.ts test/db/telemetryEventIndexInventory.test.ts`
- `bun test test/db/`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Review

- Ran AutoMobile-style final review against the diff.
- Ran three independent subagent reviews:
  - TypeScript/API maintainer: found packaged raw migrations would import `../eventTables` without the file being copied to `dist`; fixed with `copyDatabaseRuntimeFiles` and a build-copy test.
  - Database migration historian: found dated migrations importing a live table list could break future full replay before future tables exist; fixed with table-existence guards and replay-safety tests.
  - Test/guard skeptic: found order-sensitive table-list assertion; fixed with sorted membership comparison.

Closes #2943.
