### PR TITLE
Hoist Reminders retry default

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
@@ -2,6 +2,18 @@ import XCTest
 @testable import XCTestRunner
 
 class RemindersIntegrationBase: AutoMobileTestCase {
+    var defaultRetryCount: Int {
+        return 1
+    }
+
+    override var retryCount: Int {
+        let environment = AutoMobileEnvironment()
+        if let explicit = environment.intValue(["AUTOMOBILE_TEST_RETRY_COUNT", "RETRY_COUNT"]) {
+            return explicit
+        }
+        return defaultRetryCount
+    }
+
     override var planBundle: Bundle? {
         return Bundle.module
     }
@@ -46,24 +58,8 @@ final class RemindersLaunchPlanTests: RemindersIntegrationBase {
             ?? "launch-reminders-app.yaml"
     }
 
-    // #2998: cold Reminders bring-up on a CI simulator intermittently pushes the plan's
-    // `observe waitFor "Reminders"` past its 20s bound, timing out during app launch rather than in
-    // any code under test. The observe timeout surfaces as a retryable `.executionFailed`, so a single
-    // retry re-runs the whole launch→observe→terminate plan and absorbs the transient flake, while a
-    // genuine observe regression times out on every attempt and still fails (the launch plan keeps its
-    // bounded waitFor — see RemindersPlanContentTests). Mirrors the sibling add-flow retry (#2811). An
-    // explicit AUTOMOBILE_TEST_RETRY_COUNT always wins; the retry is tracked for removal once the
-    // iOS-observe bring-up flake is fixed (#2910/#2926/#2952).
-    override var retryCount: Int {
-        // Honor an explicit override — including 0 to disable retries — and default to 1 only when
-        // no override is set. (super.retryCount can't distinguish an explicit 0 from the unset
-        // default, so read the env directly.)
-        let environment = AutoMobileEnvironment()
-        if let explicit = environment.intValue(["AUTOMOBILE_TEST_RETRY_COUNT", "RETRY_COUNT"]) {
-            return explicit
-        }
-        return 1
-    }
+    // #2998: inherits the shared one-retry default to absorb transient cold Reminders bring-up
+    // observe timeouts; tracked for removal once #2910/#2926/#2952 fix the underlying flake.
 
     func testLaunchRemindersPlan() throws {
         PerfTimer.log("testLaunchRemindersPlan START - planPath: \(planPath)")
@@ -79,22 +75,8 @@ final class RemindersAddPlanTests: RemindersIntegrationBase {
             ?? "add-reminder.yaml"
     }
 
-    // #2811: this exercises the system Reminders app, whose exact control labels and layout timing
-    // vary across iOS versions. `add-reminder.yaml`'s waitFor guards remove the common races and its
-    // optional "Not Now" step dismisses the intermittent iCloud alert, but a single retry still
-    // absorbs the residual "fails once, passes on a plain re-run" flake this issue documents. An
-    // explicit AUTOMOBILE_TEST_RETRY_COUNT always wins; a genuine break still fails on every attempt.
-    // The retry is tracked for removal once the guards are proven sufficient — see issue #2855.
-    override var retryCount: Int {
-        // Honor an explicit override — including 0 to disable retries — and default to 1 only when
-        // no override is set. (super.retryCount can't distinguish an explicit 0 from the unset
-        // default, so read the env directly.)
-        let environment = AutoMobileEnvironment()
-        if let explicit = environment.intValue(["AUTOMOBILE_TEST_RETRY_COUNT", "RETRY_COUNT"]) {
-            return explicit
-        }
-        return 1
-    }
+    // #2811: inherits the shared one-retry default to absorb residual cross-iOS Reminders UI flakes;
+    // tracked for removal once the add-flow guards are proven sufficient in #2855.
 
     func testAddReminderPlan() throws {
         PerfTimer.log("testAddReminderPlan START - planPath: \(planPath)")

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -144,6 +144,29 @@ final class RemindersPlanContentTests: XCTestCase {
         )
     }
 
+    /// The retry policy is shared by `RemindersIntegrationBase`; subclasses keep only their
+    /// issue-specific rationale comments instead of duplicating the env/default implementation.
+    func testRemindersRetryCountIsSharedByBaseClass() throws {
+        let source = try loadRemindersIntegrationTestSource()
+
+        XCTAssertTrue(
+            classBody(named: "RemindersIntegrationBase", in: source).contains("override var retryCount"),
+            "RemindersIntegrationBase must own the shared retryCount override"
+        )
+        XCTAssertTrue(
+            classBody(named: "RemindersIntegrationBase", in: source).contains("var defaultRetryCount"),
+            "RemindersIntegrationBase must expose the shared defaultRetryCount hook"
+        )
+        XCTAssertFalse(
+            classBody(named: "RemindersLaunchPlanTests", in: source).contains("override var retryCount"),
+            "RemindersLaunchPlanTests should inherit the shared retryCount behavior"
+        )
+        XCTAssertFalse(
+            classBody(named: "RemindersAddPlanTests", in: source).contains("override var retryCount"),
+            "RemindersAddPlanTests should inherit the shared retryCount behavior"
+        )
+    }
+
     /// Regression guard preserving acceptance criterion 2 (#2998): the retry only masks a *transient*
     /// bring-up flake, so the launch plan must keep its bounded `observe`/`waitFor` guard — a genuinely
     /// broken observe still times out on every attempt and fails, instead of hanging or silently
@@ -333,4 +356,38 @@ private enum PlanStepSequence {
         let value = trimmed.dropFirst("- tool:".count).trimmingCharacters(in: .whitespaces)
         return value.isEmpty ? nil : value
     }
+}
+
+private func loadRemindersIntegrationTestSource() throws -> String {
+    let currentFile = URL(fileURLWithPath: #filePath)
+    let sourceURL = currentFile.deletingLastPathComponent()
+        .appendingPathComponent("RemindersIntegrationTests.swift")
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+}
+
+private func classBody(named className: String, in source: String) -> String {
+    guard let declarationRange = source.range(of: "class \(className)")
+        ?? source.range(of: "final class \(className)")
+    else {
+        return ""
+    }
+    guard let openingBrace = source[declarationRange.upperBound...].firstIndex(of: "{") else {
+        return ""
+    }
+
+    var depth = 0
+    var index = openingBrace
+    while index < source.endIndex {
+        let character = source[index]
+        if character == "{" {
+            depth += 1
+        } else if character == "}" {
+            depth -= 1
+            if depth == 0 {
+                return String(source[source.index(after: openingBrace)..<index])
+            }
+        }
+        index = source.index(after: index)
+    }
+    return ""
 }


### PR DESCRIPTION
## Summary
- hoist the Reminders integration retry override into `RemindersIntegrationBase`
- add a shared `defaultRetryCount` hook that defaults to 1 while preserving explicit retry env overrides, including 0
- add a no-simulator regression test proving the base owns the retry behavior and subclasses no longer duplicate override bodies

## Validation
- `swift test --filter RemindersPlanContentTests`
- `swift test`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Notes
- Closes #3027
- Repo PR template check: no conventional `.github/PULL_REQUEST_TEMPLATE.md` or `pull_request_template.md` file exists in this repo; only issue templates/workflows were found under `.github/`.
- `/auto-mobile-code-review` pass completed locally; three independent subagent review passes reported no findings.
