### PR TITLE
Fix Compose hidden-region sparse text heuristic

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -531,7 +531,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       return false
     }
 
-    if (countTextBearingNodes(node) > 0) {
+    if (hasTextContent(node)) {
       return false
     }
 
@@ -543,10 +543,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     return childCoverage <= MAX_VISIBLE_CHILD_COVERAGE
   }
 
-  private fun countTextBearingNodes(node: UIElementInfo): Int {
-    val hasText = !node.text.isNullOrBlank() || !node.contentDesc.isNullOrBlank()
-    return (if (hasText) 1 else 0) +
-      extractChildrenFromNode(node.node).sumOf { countTextBearingNodes(it) }
+  private fun hasTextContent(node: UIElementInfo): Boolean {
+    return !node.text.isNullOrBlank() || !node.contentDesc.isNullOrBlank()
   }
 
   private fun isInteractive(node: UIElementInfo): Boolean {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -984,7 +984,7 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
-  fun `detectContentHiddenRegions ignores large Compose descendants with text content`() {
+  fun `detectContentHiddenRegions reports large Compose descendants with sparse child text content`() {
     val textChild =
       elementWithBounds(
         bounds = bounds(32, 500, 400, 560),
@@ -995,6 +995,98 @@ class ViewHierarchyExtractorTest {
         bounds = bounds(0, 368, 1440, 2752),
         actions = listOf("accessibility_focus"),
         children = listOf(textChild),
+      )
+    val composeRoot =
+      elementWithBounds(
+        className = "androidx.compose.ui.platform.ComposeView",
+        bounds = bounds(0, 0, 1440, 3000),
+        children = listOf(contentRegion),
+      )
+
+    val regions = extractor.detectContentHiddenRegionsForTest(composeRoot, 1440, 3000)
+
+    assertEquals(1, regions.size)
+    assertEquals(bounds(0, 368, 1440, 2752), regions[0].bounds)
+  }
+
+  @Test
+  fun `detectContentHiddenRegions reports large Compose descendants with sparse child content description`() {
+    val iconButton =
+      elementWithBounds(
+        bounds = bounds(32, 500, 112, 580),
+        contentDesc = "Open navigation drawer",
+      )
+    val contentRegion =
+      elementWithBounds(
+        bounds = bounds(0, 368, 1440, 2752),
+        actions = listOf("accessibility_focus"),
+        children = listOf(iconButton),
+      )
+    val composeRoot =
+      elementWithBounds(
+        className = "androidx.compose.ui.platform.ComposeView",
+        bounds = bounds(0, 0, 1440, 3000),
+        children = listOf(contentRegion),
+      )
+
+    val regions = extractor.detectContentHiddenRegionsForTest(composeRoot, 1440, 3000)
+
+    assertEquals(1, regions.size)
+    assertEquals(bounds(0, 368, 1440, 2752), regions[0].bounds)
+  }
+
+  @Test
+  fun `detectContentHiddenRegions ignores large Compose descendants with substantial child text coverage`() {
+    val visibleContent =
+      elementWithBounds(
+        bounds = bounds(0, 368, 1440, 1200),
+        text = "Visible conversation content",
+      )
+    val contentRegion =
+      elementWithBounds(
+        bounds = bounds(0, 368, 1440, 2752),
+        actions = listOf("accessibility_focus"),
+        children = listOf(visibleContent),
+      )
+    val composeRoot =
+      elementWithBounds(
+        className = "androidx.compose.ui.platform.ComposeView",
+        bounds = bounds(0, 0, 1440, 3000),
+        children = listOf(contentRegion),
+      )
+
+    val regions = extractor.detectContentHiddenRegionsForTest(composeRoot, 1440, 3000)
+
+    assertTrue(regions.isEmpty())
+  }
+
+  @Test
+  fun `detectContentHiddenRegions ignores large Compose descendants with text on candidate boundary`() {
+    val contentRegion =
+      elementWithBounds(
+        bounds = bounds(0, 368, 1440, 2752),
+        text = "Conversation list",
+        actions = listOf("accessibility_focus"),
+      )
+    val composeRoot =
+      elementWithBounds(
+        className = "androidx.compose.ui.platform.ComposeView",
+        bounds = bounds(0, 0, 1440, 3000),
+        children = listOf(contentRegion),
+      )
+
+    val regions = extractor.detectContentHiddenRegionsForTest(composeRoot, 1440, 3000)
+
+    assertTrue(regions.isEmpty())
+  }
+
+  @Test
+  fun `detectContentHiddenRegions ignores large Compose descendants with content description on candidate boundary`() {
+    val contentRegion =
+      elementWithBounds(
+        bounds = bounds(0, 368, 1440, 2752),
+        contentDesc = "Conversation list",
+        actions = listOf("accessibility_focus"),
       )
     val composeRoot =
       elementWithBounds(
@@ -1072,6 +1164,7 @@ class ViewHierarchyExtractorTest {
     bounds: ElementBounds? = null,
     className: String? = null,
     text: String? = null,
+    contentDesc: String? = null,
     actions: List<String>? = null,
     children: List<UIElementInfo> = emptyList(),
   ): UIElementInfo {
@@ -1086,6 +1179,7 @@ class ViewHierarchyExtractorTest {
       bounds = bounds,
       className = className,
       text = text,
+      contentDesc = contentDesc,
       actions = actions,
       node = node,
     )


### PR DESCRIPTION
## Summary
- Relax Compose interop hidden-region text handling so sparse text/content-desc descendants do not suppress a likely hidden boundary.
- Keep candidate boundary text/content-desc as a hard reject and continue relying on direct child coverage as the false-positive guard.
- Add focused regression tests for sparse descendant labels, candidate-boundary labels, and substantial visible child coverage.

Fixes #2634

## Testing
- `(cd android && ./gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest)`
- `(cd android && ./gradlew :control-proxy:testDebugUnitTest)`
- `bun test --bail`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Notes
- I did not find a conventional `.github/PULL_REQUEST_TEMPLATE.md` or `.github/pull_request_template.md` file in this repo, so this uses the repo's existing Summary/Testing/Notes structure.
- This implements the low-complexity Option 1 direction from #2634. Real-world sample collection can continue separately if more tuning is needed.
