### PR TITLE
perf(db): truncate request/response bodies in the getNetworkEvents list projection (#2801)

### DIFF
--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -21,8 +21,8 @@ import { truncateBodyText } from "../utils/truncateBodyText";
  * (#2801). Network bodies are already capped upstream in the repository
  * `mapRow`; this bounds the remaining plain-text columns at the backfill
  * boundary so the DB read contract for those repos is unchanged. Only opaque
- * text is listed — structured JSON columns (os `details_json`, failure blobs)
- * would be corrupted by a blind slice and are tracked as a follow-up.
+ * text is listed — structured JSON columns (os `details`, layout `detailsJson`,
+ * failure blobs) would be corrupted by a blind slice and are tracked in #3182.
  */
 const BOUNDED_BACKFILL_TEXT_FIELDS: Record<string, readonly string[]> = {
   log: ["message"],

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -13,6 +13,47 @@ import { getDatabase } from "../db/database";
 import type { Database } from "../db/types";
 import type { Kysely } from "kysely";
 import { TELEMETRY_PUSH_SOCKET_CONFIG } from "./daemonFiles";
+import { truncateBodyText } from "../utils/truncateBodyText";
+
+/**
+ * Opaque plain-text fields that the backfill fans out (limit=100) and that can
+ * balloon a single subscribe by megabytes the dashboard already caps at 10KB
+ * (#2801). Network bodies are already capped upstream in the repository
+ * `mapRow`; this bounds the remaining plain-text columns at the backfill
+ * boundary so the DB read contract for those repos is unchanged. Only opaque
+ * text is listed — structured JSON columns (os `details_json`, failure blobs)
+ * would be corrupted by a blind slice and are tracked as a follow-up.
+ */
+const BOUNDED_BACKFILL_TEXT_FIELDS: Record<string, readonly string[]> = {
+  log: ["message"],
+  storage: ["value", "previousValue"],
+};
+
+/**
+ * Cap known large plain-text fields on a backfilled telemetry event to
+ * BODY_TRUNCATION_LIMIT, returning a shallow copy when anything changed so the
+ * caller's source rows are not mutated. Surrogate-safe (see truncateBodyText).
+ */
+export function boundBackfillEventText(event: TelemetryEvent): TelemetryEvent {
+  const fields = BOUNDED_BACKFILL_TEXT_FIELDS[event.category];
+  if (!fields || event.data === null || typeof event.data !== "object") {
+    return event;
+  }
+  const data = event.data as Record<string, unknown>;
+  let bounded: Record<string, unknown> | null = null;
+  for (const field of fields) {
+    const value = data[field];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const capped = truncateBodyText(value);
+    if (capped !== value) {
+      bounded = bounded ?? { ...data };
+      bounded[field] = capped;
+    }
+  }
+  return bounded ? { ...event, data: bounded as TelemetryEvent["data"] } : event;
+}
 
 interface TelemetryFilter {
   category: string | null; // "network", "log", "os", "navigation", "crash", "anr", "nonfatal", "storage", "layout", or null for all
@@ -215,7 +256,9 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     events.sort((a, b) => a.timestamp - b.timestamp);
 
     for (const event of events) {
-      const msg = this.createPushMessage(event);
+      // Single boundary cap for large plain-text fields (#2801): network bodies
+      // are already capped in the repository mapRow; this bounds log/storage.
+      const msg = this.createPushMessage(boundBackfillEventText(event));
       this.sendJson(socket, msg);
     }
 

--- a/src/db/networkEventRepository.ts
+++ b/src/db/networkEventRepository.ts
@@ -2,6 +2,7 @@ import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
 import { logger } from "../utils/logger";
+import { truncateBodyText } from "../utils/truncateBodyText";
 
 export interface RecordNetworkEventInput {
   deviceId: string | null;
@@ -86,8 +87,6 @@ export interface NetworkEventQuery {
   minStatusCode?: number;
 }
 
-const BODY_TRUNCATION_LIMIT = 10_240; // 10KB
-
 function mapRow(r: any): NetworkEventWithId {
   return {
     id: r.id,
@@ -107,8 +106,13 @@ function mapRow(r: any): NetworkEventWithId {
     error: r.error,
     requestHeaders: r.request_headers_json ? JSON.parse(r.request_headers_json) : null,
     responseHeaders: r.response_headers_json ? JSON.parse(r.response_headers_json) : null,
-    requestBody: r.request_body ?? null,
-    responseBody: r.response_body ?? null,
+    // Truncate bodies to 10KB here so both getNetworkEventById and the
+    // getNetworkEvents list projection (fanned out 100-at-a-time by the
+    // telemetry backfill) share one cap — the dashboard renders at most this
+    // many bytes anyway (#2801). Original sizes are preserved in
+    // request_body_size / response_body_size for truncation-flag callers.
+    requestBody: truncateBodyText(r.request_body ?? null),
+    responseBody: truncateBodyText(r.response_body ?? null),
     contentType: r.content_type ?? null,
   };
 }
@@ -127,17 +131,9 @@ export async function getNetworkEventById(
     return null;
   }
 
-  const event = mapRow(row);
-
-  // Truncate bodies to 10KB
-  if (event.requestBody && event.requestBody.length > BODY_TRUNCATION_LIMIT) {
-    event.requestBody = event.requestBody.slice(0, BODY_TRUNCATION_LIMIT);
-  }
-  if (event.responseBody && event.responseBody.length > BODY_TRUNCATION_LIMIT) {
-    event.responseBody = event.responseBody.slice(0, BODY_TRUNCATION_LIMIT);
-  }
-
-  return event;
+  // mapRow already caps bodies at BODY_TRUNCATION_LIMIT (surrogate-safe), so
+  // there is exactly one truncation site shared with getNetworkEvents (#2801).
+  return mapRow(row);
 }
 
 export async function getNetworkEvents(

--- a/src/server/networkResources.ts
+++ b/src/server/networkResources.ts
@@ -6,8 +6,7 @@ import {
   type NetworkEventWithId,
 } from "../db/networkEventRepository";
 import { NetworkState } from "./NetworkState";
-
-const BODY_TRUNCATION_LIMIT = 10_240; // 10KB
+import { BODY_TRUNCATION_LIMIT } from "../utils/truncateBodyText";
 
 const NETWORK_RESOURCE_URIS = {
   REQUEST: "automobile:network/request/{requestId}",

--- a/src/utils/truncateBodyText.ts
+++ b/src/utils/truncateBodyText.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical body/text truncation for telemetry read paths (#2801).
+ *
+ * The network detail view (`getNetworkEventById`) has capped request/response
+ * bodies at 10&nbsp;KB since #1624, but the list projection (`getNetworkEvents`)
+ * and the telemetry backfill never did — so a burst of large payloads could
+ * inflate a single backfill by megabytes the dashboard already caps to 10&nbsp;KB.
+ * Centralize the cap here so every read path shares one primitive rather than
+ * re-omitting it per repository ("one canonical primitive per concern").
+ */
+
+/** Maximum retained body length, in UTF-16 code units (10&nbsp;KB). */
+export const BODY_TRUNCATION_LIMIT = 10_240;
+
+/**
+ * Truncate `text` to at most `limit` UTF-16 code units without splitting a
+ * surrogate pair. A naive `text.slice(0, limit)` can leave a lone high
+ * surrogate when a pair (e.g. an emoji or astral-plane character) straddles the
+ * boundary, which serializes to mojibake (`�`) on the wire — the latent bug
+ * in the historical `getNetworkEventById` slice. Byte semantics are otherwise
+ * identical: an ASCII body over the limit is still capped to exactly `limit`.
+ */
+export function truncateBodyText(
+  text: string | null,
+  limit: number = BODY_TRUNCATION_LIMIT
+): string | null {
+  if (text === null || text.length <= limit) {
+    return text;
+  }
+  let end = limit;
+  // If the last retained code unit is a high surrogate, its low-surrogate mate
+  // sits just past the boundary; drop it so we never emit a lone surrogate.
+  const lastCode = text.charCodeAt(end - 1);
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    end -= 1;
+  }
+  return text.slice(0, end);
+}

--- a/src/utils/truncateBodyText.ts
+++ b/src/utils/truncateBodyText.ts
@@ -13,11 +13,13 @@
 export const BODY_TRUNCATION_LIMIT = 10_240;
 
 /**
- * Truncate `text` to at most `limit` UTF-16 code units without splitting a
- * surrogate pair. A naive `text.slice(0, limit)` can leave a lone high
+ * Truncate `text` to at most `limit` UTF-16 code units without leaving a lone
+ * surrogate at the cut. A naive `text.slice(0, limit)` can leave a lone high
  * surrogate when a pair (e.g. an emoji or astral-plane character) straddles the
  * boundary, which serializes to mojibake (`�`) on the wire — the latent bug
- * in the historical `getNetworkEventById` slice. Byte semantics are otherwise
+ * in the historical `getNetworkEventById` slice. This also drops a trailing
+ * lone low surrogate (already-malformed input) so the boundary is never a lone
+ * surrogate regardless of input well-formedness. Byte semantics are otherwise
  * identical: an ASCII body over the limit is still capped to exactly `limit`.
  */
 export function truncateBodyText(
@@ -28,11 +30,19 @@ export function truncateBodyText(
     return text;
   }
   let end = limit;
-  // If the last retained code unit is a high surrogate, its low-surrogate mate
-  // sits just past the boundary; drop it so we never emit a lone surrogate.
   const lastCode = text.charCodeAt(end - 1);
   if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    // Trailing high surrogate: its low-surrogate mate sits just past the
+    // boundary, so keeping it would emit a lone surrogate — drop it.
     end -= 1;
+  } else if (lastCode >= 0xdc00 && lastCode <= 0xdfff) {
+    // Trailing low surrogate: keep it only when the preceding unit is its high
+    // mate (a complete pair ending exactly at the cut); otherwise it is a lone
+    // low surrogate (malformed input) and is dropped.
+    const prevCode = end >= 2 ? text.charCodeAt(end - 2) : 0;
+    if (prevCode < 0xd800 || prevCode > 0xdbff) {
+      end -= 1;
+    }
   }
   return text.slice(0, end);
 }

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { Socket } from "node:net";
-import { TelemetryPushSocketServer } from "../../src/daemon/telemetryPushSocketServer";
+import {
+  TelemetryPushSocketServer,
+  boundBackfillEventText,
+} from "../../src/daemon/telemetryPushSocketServer";
 import type { TelemetryEvent } from "../../src/features/telemetry/TelemetryRecorder";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
@@ -58,6 +61,69 @@ class TestableTelemetryPushSocketServer extends TelemetryPushSocketServer {
     (this as any).checkKeepalive();
   }
 }
+
+describe("boundBackfillEventText", () => {
+  it("caps a large log message at 10KB", () => {
+    const event: TelemetryEvent = {
+      category: "log",
+      timestamp: 1,
+      deviceId: null,
+      data: { level: 4, tag: "t", message: "m".repeat(50_000) },
+    };
+    const bounded = boundBackfillEventText(event);
+    expect((bounded.data as { message: string }).message.length).toBe(10_240);
+  });
+
+  it("caps large storage value and previousValue at 10KB", () => {
+    const event: TelemetryEvent = {
+      category: "storage",
+      timestamp: 1,
+      deviceId: null,
+      data: {
+        key: "k",
+        value: "v".repeat(30_000),
+        previousValue: "p".repeat(30_000),
+        valueType: "string",
+      },
+    };
+    const bounded = boundBackfillEventText(event);
+    const data = bounded.data as { value: string; previousValue: string };
+    expect(data.value.length).toBe(10_240);
+    expect(data.previousValue.length).toBe(10_240);
+  });
+
+  it("leaves small fields and unrelated categories untouched", () => {
+    const event: TelemetryEvent = {
+      category: "log",
+      timestamp: 1,
+      deviceId: null,
+      data: { level: 4, tag: "t", message: "small" },
+    };
+    const bounded = boundBackfillEventText(event);
+    expect((bounded.data as { message: string }).message).toBe("small");
+
+    const os: TelemetryEvent = {
+      category: "os",
+      timestamp: 1,
+      deviceId: null,
+      data: { category: "lifecycle", kind: "foreground", details: null },
+    };
+    expect(boundBackfillEventText(os)).toEqual(os);
+  });
+
+  it("does not split a surrogate pair in a bounded field", () => {
+    const event: TelemetryEvent = {
+      category: "log",
+      timestamp: 1,
+      deviceId: null,
+      data: { level: 4, tag: "t", message: "m".repeat(10_239) + "😀" + "n".repeat(50) },
+    };
+    const bounded = boundBackfillEventText(event);
+    const msg = (bounded.data as { message: string }).message;
+    expect(msg.length).toBe(10_239);
+    expect(msg.isWellFormed()).toBe(true);
+  });
+});
 
 describe("TelemetryPushSocketServer", () => {
   let server: TestableTelemetryPushSocketServer;

--- a/test/db/networkEventRepository.test.ts
+++ b/test/db/networkEventRepository.test.ts
@@ -154,8 +154,9 @@ describe("networkEventRepository extended queries", () => {
     expect(events).toHaveLength(100);
     const serializedBytes = JSON.stringify(events).length;
     const rawBytes = 100 * 100_000;
-    // Capped payload is far under the raw size and near the 100 x 10KB target.
-    expect(serializedBytes).toBeLessThan(rawBytes / 5);
+    // Capped payload is ~1MB (100 x 10KB) vs ~10MB raw — assert the ~10x win
+    // with margin for the non-body JSON scaffolding per row.
+    expect(serializedBytes).toBeLessThan(rawBytes / 8);
     expect(events.every(e => e.responseBody!.length === 10_240)).toBe(true);
   });
 

--- a/test/db/networkEventRepository.test.ts
+++ b/test/db/networkEventRepository.test.ts
@@ -81,6 +81,84 @@ describe("networkEventRepository extended queries", () => {
     expect(event!.responseBody!.length).toBe(10_240);
   });
 
+  test("getNetworkEvents truncates bodies over 10KB", async () => {
+    const largeRequest = "q".repeat(15_000);
+    const largeResponse = "r".repeat(20_000);
+    await recordNetworkEvent(
+      makeInput({
+        requestBody: largeRequest,
+        responseBody: largeResponse,
+        requestBodySize: 15_000,
+        responseBodySize: 20_000,
+      }),
+      db
+    );
+
+    const events = await getNetworkEvents({}, db);
+    expect(events).toHaveLength(1);
+    expect(events[0].requestBody!.length).toBe(10_240);
+    expect(events[0].responseBody!.length).toBe(10_240);
+  });
+
+  test("getNetworkEvents leaves sub-10KB bodies unchanged and null bodies null", async () => {
+    const small = '{"ok":true}';
+    await recordNetworkEvent(
+      makeInput({ requestBody: small, responseBody: null }),
+      db
+    );
+
+    const events = await getNetworkEvents({}, db);
+    expect(events[0].requestBody).toBe(small);
+    expect(events[0].responseBody).toBeNull();
+  });
+
+  test("getNetworkEvents and getNetworkEventById agree on the truncated body", async () => {
+    const largeBody = "z".repeat(50_000);
+    const id = await recordNetworkEvent(
+      makeInput({ responseBody: largeBody, responseBodySize: 50_000 }),
+      db
+    );
+
+    const single = await getNetworkEventById(id, db);
+    const listed = (await getNetworkEvents({}, db)).find(e => e.id === id);
+    expect(listed).toBeDefined();
+    expect(listed!.responseBody).toBe(single!.responseBody!);
+    expect(listed!.responseBody!.length).toBe(10_240);
+  });
+
+  test("getNetworkEvents truncation does not split a surrogate pair", async () => {
+    // Place a 😀 (surrogate pair) so its high surrogate lands at the 10_240th
+    // code unit — a naive slice would leave a lone surrogate (mojibake).
+    const body = "x".repeat(10_239) + "😀" + "y".repeat(5_000);
+    const id = await recordNetworkEvent(
+      makeInput({ responseBody: body, responseBodySize: body.length }),
+      db
+    );
+
+    const listed = (await getNetworkEvents({}, db)).find(e => e.id === id);
+    expect(listed!.responseBody!.length).toBe(10_239);
+    expect(listed!.responseBody!.isWellFormed()).toBe(true);
+  });
+
+  test("backfill payload shrinks ~10x once list bodies are capped", async () => {
+    // 100 rows each carrying a 100KB body: the serialized list should drop from
+    // ~10MB (raw) to ~1MB (100 x 10KB) — the win the issue measures.
+    const bigBody = "b".repeat(100_000);
+    for (let i = 0; i < 100; i++) {
+      await recordNetworkEvent(
+        makeInput({ timestamp: 1000 + i, responseBody: bigBody, responseBodySize: 100_000 }),
+        db
+      );
+    }
+    const events = await getNetworkEvents({ limit: 100 }, db);
+    expect(events).toHaveLength(100);
+    const serializedBytes = JSON.stringify(events).length;
+    const rawBytes = 100 * 100_000;
+    // Capped payload is far under the raw size and near the 100 x 10KB target.
+    expect(serializedBytes).toBeLessThan(rawBytes / 5);
+    expect(events.every(e => e.responseBody!.length === 10_240)).toBe(true);
+  });
+
   test("getNetworkEvents returns id on each event", async () => {
     await recordNetworkEvent(makeInput({ timestamp: 100 }), db);
     await recordNetworkEvent(makeInput({ timestamp: 200 }), db);

--- a/test/utils/truncateBodyText.test.ts
+++ b/test/utils/truncateBodyText.test.ts
@@ -46,6 +46,20 @@ describe("truncateBodyText", () => {
     expect(body.slice(0, BODY_TRUNCATION_LIMIT).isWellFormed()).toBe(false);
   });
 
+  test("drops a lone low surrogate at the boundary (already-malformed input)", () => {
+    // Orphan low surrogate (no preceding high mate) landing at the cut: a naive
+    // slice would keep it, leaving the result ill-formed.
+    const body = "x".repeat(BODY_TRUNCATION_LIMIT - 1) + "\uDE00" + "y".repeat(50);
+    const result = truncateBodyText(body)!;
+    expect(result.length).toBe(BODY_TRUNCATION_LIMIT - 1);
+    expect(result.isWellFormed()).toBe(true);
+  });
+
+  test("limit of 0 or 1 never emits a partial surrogate", () => {
+    expect(truncateBodyText("😀tail", 1)).toBe("");
+    expect(truncateBodyText("😀tail", 1)!.isWellFormed()).toBe(true);
+  });
+
   test("keeps a whole surrogate pair when the low surrogate is the last kept unit", () => {
     // Pair sits so the LOW surrogate lands at index LIMIT-1 → the whole pair is
     // within the kept range and must be preserved intact.

--- a/test/utils/truncateBodyText.test.ts
+++ b/test/utils/truncateBodyText.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BODY_TRUNCATION_LIMIT,
+  truncateBodyText,
+} from "../../src/utils/truncateBodyText";
+
+describe("truncateBodyText", () => {
+  test("null stays null", () => {
+    expect(truncateBodyText(null)).toBeNull();
+  });
+
+  test("body shorter than the limit is returned unchanged", () => {
+    const body = "x".repeat(100);
+    expect(truncateBodyText(body)).toBe(body);
+  });
+
+  test("body exactly at the limit is returned unchanged", () => {
+    const body = "x".repeat(BODY_TRUNCATION_LIMIT);
+    const result = truncateBodyText(body);
+    expect(result).toBe(body);
+    expect(result!.length).toBe(BODY_TRUNCATION_LIMIT);
+  });
+
+  test("ASCII body over the limit is capped to exactly the limit", () => {
+    const body = "x".repeat(20_000);
+    expect(truncateBodyText(body)!.length).toBe(BODY_TRUNCATION_LIMIT);
+  });
+
+  test("respects a custom limit argument", () => {
+    expect(truncateBodyText("abcdef", 3)).toBe("abc");
+    expect(truncateBodyText("ab", 3)).toBe("ab");
+  });
+
+  test("does not emit a lone surrogate when a pair straddles the boundary", () => {
+    // Fill the first LIMIT-1 code units with ASCII, then place a surrogate pair
+    // (😀 = U+1F600 = "😀") so its HIGH surrogate lands at index
+    // LIMIT-1 and its LOW surrogate at index LIMIT — exactly the mid-pair split.
+    const body = "x".repeat(BODY_TRUNCATION_LIMIT - 1) + "😀" + "y".repeat(50);
+    const result = truncateBodyText(body)!;
+
+    // The dangling high surrogate is dropped rather than split.
+    expect(result.length).toBe(BODY_TRUNCATION_LIMIT - 1);
+    // No lone surrogate remains: the string is well-formed UTF-16.
+    expect(result.isWellFormed()).toBe(true);
+    // Sanity: a naive slice WOULD have left a lone high surrogate.
+    expect(body.slice(0, BODY_TRUNCATION_LIMIT).isWellFormed()).toBe(false);
+  });
+
+  test("keeps a whole surrogate pair when the low surrogate is the last kept unit", () => {
+    // Pair sits so the LOW surrogate lands at index LIMIT-1 → the whole pair is
+    // within the kept range and must be preserved intact.
+    const body = "x".repeat(BODY_TRUNCATION_LIMIT - 2) + "😀" + "y".repeat(50);
+    const result = truncateBodyText(body)!;
+    expect(result.length).toBe(BODY_TRUNCATION_LIMIT);
+    expect(result.isWellFormed()).toBe(true);
+    expect(result.endsWith("😀")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2801.

`getNetworkEvents` (the list projection) returned **untruncated** `request_body`/`response_body` strings, while its sibling `getNetworkEventById` capped each body at `BODY_TRUNCATION_LIMIT` (10 KB). The telemetry push backfill fans out up to 100 network rows per subscribe over a Unix socket on every subscribe, so a burst of large-payload requests could inflate a single backfill by megabytes of body text the dashboard already caps to 10 KB when rendering.

## What changed

- **New canonical primitive** `src/utils/truncateBodyText.ts` — exports `BODY_TRUNCATION_LIMIT` and a **surrogate-safe** `truncateBodyText()`. A naive `.slice(0, LIMIT)` on UTF-16 code units can leave a lone high surrogate when an emoji/astral-plane character straddles the boundary (the latent mojibake bug in the old `getNetworkEventById` slice); the helper drops a trailing high surrogate so the result is always well-formed. ASCII bodies still cap to exactly 10_240, so byte semantics are unchanged. Dedupes the two previously-copied `BODY_TRUNCATION_LIMIT` constants.
- **`src/db/networkEventRepository.ts`** — apply `truncateBodyText` inside the shared `mapRow`, so **both** `getNetworkEvents` and `getNetworkEventById` return capped bodies from one truncation site. Removed the now-redundant slice block in `getNetworkEventById`. Original sizes remain in `request_body_size`/`response_body_size`, so the detail view's `*Truncated` flags are unaffected.
- **`src/server/networkResources.ts`** — import the shared `BODY_TRUNCATION_LIMIT` (unify the duplicate).
- **`src/daemon/telemetryPushSocketServer.ts`** — single **backfill-boundary cap** (`boundBackfillEventText`) for the remaining opaque plain-text fields fanned out by the same `limit = 100` backfill: log `message` and storage `value`/`previousValue`. Network bodies are already capped upstream (idempotent). Applied once before `sendJson`.

### Why truncate network at the repo, not the boundary
Grepped every `getNetworkEvents` caller: `eventToSummary` omits bodies; `eventToDetail` is fed only by the already-capped `getNetworkEventById`; `buildNetworkGraph` ignores bodies; stats/bucketing use only scalars. No caller needs raw bodies, so capping in `mapRow` is safe and satisfies the issue's read-back acceptance criterion.

### Deferred (follow-up issue)
Structured-JSON columns fanned out by the same backfill — os `details`, layout `detailsJson`, and failure `stack_trace_json`/`tool_call_info_json`/`tool_args_json` — are **not** capped here because a blind string slice would corrupt the JSON. Tracked as a follow-up for JSON-aware/size-guarded handling.

## Tests

- `test/utils/truncateBodyText.test.ts` — null/short/exact/over-limit, custom limit, surrogate-pair straddle (both boundary orientations), well-formedness.
- `test/db/networkEventRepository.test.ts` — `getNetworkEvents` truncation (req + resp), sub-10KB/null passthrough, **list-vs-detail agree-invariant**, surrogate-safety, and a **~10× payload-shrink measurement** (100×100 KB bodies → serialized bytes < raw/5, each body == 10_240).
- `test/daemon/telemetryPushSocketServer.test.ts` — `boundBackfillEventText` caps log `message`, storage `value`/`previousValue`; leaves small fields and unrelated categories untouched; surrogate-safe.

## Validation
- `bun test test/utils test/db test/daemon test/server` green (2000+ tests).
- `turbo run lint build` green.

## Acceptance criteria (from #2801)
- [x] `getNetworkEvents` caps req/resp bodies at 10_240 (read-back test).
- [x] Large text at the backfill boundary bounded for network + log + storage; os/layout/failure JSON blobs explicitly deferred to a named follow-up.
- [x] UTF-8/surrogate-safe truncation (fixes latent lone-surrogate bug) + test.
- [x] Grepped `getNetworkEvents` callers; none need raw bodies → safe to cap in `mapRow`.
- [x] List and detail paths **agree** on the truncated body (invariant test).
- [x] `getNetworkEventById` behavior unchanged; existing truncation test stays green.
- [x] Non-body fields and ≤10 KB bodies byte-identical.
- [x] Measurement: ~10 MB → ~1 MB for 100×100 KB.
- [x] `bun test` + `turbo run lint build test` green.
