### PR TITLE
fix(ios): emit real UserDefaults change telemetry via before/after diff

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -475,6 +475,31 @@ public struct SdkStorageChangedEvent: SdkEvent {
         self.changeType = changeType
         self.sequenceNumber = sequenceNumber
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case eventType, timestamp, suiteName, key, newValue, previousValue, valueType, changeType, sequenceNumber
+    }
+
+    // Custom decode so events persisted by an older SDK build (before
+    // `changeType`/`previousValue` existed) still load — `EventPersistence
+    // .loadPending()` decodes `SdkStorageChangedEvent`, and Swift's synthesized
+    // `Decodable` would reject the missing keys and silently drop the event.
+    // Legacy payloads default `changeType` to "modify" (the prior implicit
+    // behavior) and leave `previousValue` nil.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let type = try container.decodeIfPresent(SdkEventType.self, forKey: .eventType) {
+            eventType = type
+        }
+        timestamp = try container.decode(Int64.self, forKey: .timestamp)
+        suiteName = try container.decodeIfPresent(String.self, forKey: .suiteName)
+        key = try container.decodeIfPresent(String.self, forKey: .key)
+        newValue = try container.decodeIfPresent(String.self, forKey: .newValue)
+        previousValue = try container.decodeIfPresent(String.self, forKey: .previousValue)
+        valueType = try container.decode(String.self, forKey: .valueType)
+        changeType = try container.decodeIfPresent(String.self, forKey: .changeType) ?? "modify"
+        sequenceNumber = try container.decode(Int64.self, forKey: .sequenceNumber)
+    }
 }
 
 /// Batch of events for efficient transmission.

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -440,11 +440,18 @@ public struct SdkInteractionEvent: SdkEvent {
 }
 
 /// A UserDefaults change event with suite, key, and value metadata.
+///
+/// Wire-contract note: the TS ingestor (`IosSdkEventIngestor`) maps
+/// `suiteName` → `fileName` and `newValue` → `value` to match Android's
+/// storage telemetry wire format (Android emits `fileName`/`value`). Don't
+/// assume iOS uses Android's field names.
 public struct SdkStorageChangedEvent: SdkEvent {
     public private(set) var eventType: SdkEventType = .storageChanged
     public let timestamp: Int64
+    /// The UserDefaults suite; maps to `fileName` in the TS ingestor.
     public let suiteName: String?
     public let key: String?
+    /// The value after the change (nil for a removal); maps to `value` in TS.
     public let newValue: String?
     /// The value BEFORE the change (nil if there was no prior value). Emitted so the
     /// TS telemetry ingest can skip its per-insert previous-value lookup (#3000).

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -450,6 +450,10 @@ public struct SdkStorageChangedEvent: SdkEvent {
     /// TS telemetry ingest can skip its per-insert previous-value lookup (#3000).
     public let previousValue: String?
     public let valueType: String
+    /// The kind of change this event records: "add", "modify", or "remove".
+    /// Mirrors Android's storage `changeType` so the desktop telemetry consumer
+    /// can render added/removed values instead of always treating iOS as "modify".
+    public let changeType: String
     public let sequenceNumber: Int64
 
     public init(
@@ -459,6 +463,7 @@ public struct SdkStorageChangedEvent: SdkEvent {
         newValue: String?,
         previousValue: String? = nil,
         valueType: String,
+        changeType: String = "modify",
         sequenceNumber: Int64
     ) {
         self.timestamp = timestamp
@@ -467,6 +472,7 @@ public struct SdkStorageChangedEvent: SdkEvent {
         self.newValue = newValue
         self.previousValue = previousValue
         self.valueType = valueType
+        self.changeType = changeType
         self.sequenceNumber = sequenceNumber
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -16,6 +16,12 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     private var sequenceCounter: Int64 = 0
     private var kvoObserver: NSObjectProtocol?
 
+    /// Last-observed key→value snapshot per suite, keyed by ``suiteKey(_:)``.
+    /// `UserDefaults.didChangeNotification` does not identify which key changed,
+    /// so we diff the current suite contents against this snapshot to recover the
+    /// real changed key, value, type, and add/modify/remove change kind.
+    private var lastSnapshots: [String: [String: KeyValuePair]] = [:]
+
     func initialize(buffer: SdkEventBuffer? = nil) {
         lock.lock()
         defer { lock.unlock() }
@@ -77,12 +83,17 @@ public final class UserDefaultsInspector: @unchecked Sendable {
             object: defaults,
             queue: nil
         ) { [weak self] _ in
-            self?.notifyChangeListeners(suiteName: suiteName, key: nil)
+            self?.handleDidChange(suiteName: suiteName)
         }
 
         lock.lock()
         kvoObserver = observer
         lock.unlock()
+
+        // Seed the baseline snapshot with the suite's current contents so the
+        // first change diffs against real state — otherwise every pre-existing
+        // key would be reported as a spurious "add" on the next notification.
+        captureBaseline(suiteName: suiteName)
     }
 
     /// Stop listening for changes.
@@ -95,28 +106,123 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         lock.unlock()
     }
 
-    private func notifyChangeListeners(suiteName: String?, key: String?) {
+    /// Record the current contents of a suite as the baseline for future diffs.
+    /// Internal (not private) so tests can seed a snapshot without registering a
+    /// live `NotificationCenter` observer.
+    func captureBaseline(suiteName: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let driver = _driver else { return }
+        lastSnapshots[Self.suiteKey(suiteName)] = Self.snapshotDict(driver.getValues(suiteName: suiteName))
+    }
+
+    /// Handle a `UserDefaults.didChangeNotification` by diffing the suite's
+    /// current contents against the last snapshot and emitting one
+    /// `SdkStorageChangedEvent` per changed key. Internal so tests can drive it
+    /// deterministically without relying on the KVO callback firing.
+    func handleDidChange(suiteName: String?) {
         guard AutoMobileSDK.shared.isEnabled, isEnabled else { return }
 
         lock.lock()
-        sequenceCounter += 1
-        let seq = sequenceCounter
-        let currentListeners = changeListeners
+        guard let driver = _driver else {
+            lock.unlock()
+            return
+        }
         let currentBuffer = buffer
+        let currentListeners = changeListeners
+        let suiteKey = Self.suiteKey(suiteName)
+        let previous = lastSnapshots[suiteKey] ?? [:]
+
+        // Snapshot + diff + sequence allocation are done under the lock so
+        // overlapping notifications can't diff against the same stale snapshot
+        // and double-emit. The driver read is in-memory (fake) or a fast
+        // UserDefaults read (real), so holding the lock briefly is acceptable.
+        let current = Self.snapshotDict(driver.getValues(suiteName: suiteName))
+        lastSnapshots[suiteKey] = current
+
+        let changes = Self.diff(previous: previous, current: current)
+        var events: [SdkStorageChangedEvent] = []
+        events.reserveCapacity(changes.count)
+        for change in changes {
+            sequenceCounter += 1
+            events.append(SdkStorageChangedEvent(
+                suiteName: suiteName,
+                key: change.key,
+                newValue: change.newValue,
+                valueType: change.valueType,
+                changeType: change.changeType,
+                sequenceNumber: sequenceCounter
+            ))
+        }
         lock.unlock()
 
-        for listener in currentListeners {
-            listener.onPreferenceChanged(suiteName: suiteName, key: key)
+        for event in events {
+            for listener in currentListeners {
+                listener.onPreferenceChanged(suiteName: suiteName, key: event.key)
+            }
+            currentBuffer?.add(event)
+        }
+    }
+
+    // MARK: - Diff Helpers
+
+    /// A single detected change: the key, its new value/type (nil/type of the
+    /// removed value for a removal), and the add/modify/remove kind.
+    private struct StorageChange {
+        let key: String
+        let newValue: String?
+        let valueType: String
+        let changeType: String
+    }
+
+    /// Stable key used to bucket snapshots per suite. `nil` (the standard
+    /// suite) can't collide with a real suite name because the sentinel starts
+    /// with a NUL, which is not valid in a suite name.
+    private static func suiteKey(_ suiteName: String?) -> String {
+        suiteName ?? "\u{0}__standard__"
+    }
+
+    private static func snapshotDict(_ pairs: [KeyValuePair]) -> [String: KeyValuePair] {
+        var dict: [String: KeyValuePair] = [:]
+        dict.reserveCapacity(pairs.count)
+        for pair in pairs {
+            dict[pair.key] = pair
+        }
+        return dict
+    }
+
+    /// Diff two key→value snapshots into per-key changes, sorted by key so
+    /// sequence numbers and emission order are deterministic.
+    private static func diff(
+        previous: [String: KeyValuePair],
+        current: [String: KeyValuePair]
+    ) -> [StorageChange] {
+        var changes: [StorageChange] = []
+
+        for (key, pair) in current {
+            if let prior = previous[key] {
+                if prior.value != pair.value {
+                    changes.append(StorageChange(
+                        key: key, newValue: pair.value,
+                        valueType: pair.type.rawValue, changeType: "modify"
+                    ))
+                }
+            } else {
+                changes.append(StorageChange(
+                    key: key, newValue: pair.value,
+                    valueType: pair.type.rawValue, changeType: "add"
+                ))
+            }
         }
 
-        let event = SdkStorageChangedEvent(
-            suiteName: suiteName,
-            key: key,
-            newValue: nil,
-            valueType: "unknown",
-            sequenceNumber: seq
-        )
-        currentBuffer?.add(event)
+        for (key, prior) in previous where current[key] == nil {
+            changes.append(StorageChange(
+                key: key, newValue: nil,
+                valueType: prior.type.rawValue, changeType: "remove"
+            ))
+        }
+
+        return changes.sorted { $0.key < $1.key }
     }
 
     // MARK: - Testing Support
@@ -135,6 +241,7 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         buffer = nil
         changeListeners.removeAll()
         sequenceCounter = 0
+        lastSnapshots.removeAll()
         lock.unlock()
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -69,6 +69,16 @@ public final class UserDefaultsInspector: @unchecked Sendable {
 
     /// Start listening for changes on a specific UserDefaults suite.
     /// Safe to call multiple times — previous observer is unregistered first.
+    ///
+    /// Uses `NotificationCenter` + snapshot-diffing rather than per-key KVO or
+    /// setter swizzling: `UserDefaults.didChangeNotification` doesn't name the
+    /// changed key, per-key KVO on `UserDefaults` is fragile, and swizzling is
+    /// too invasive for a debug-only SDK.
+    ///
+    /// Note: for the standard suite (`suiteName == nil`) the driver reads
+    /// `UserDefaults.standard.dictionaryRepresentation()`, which includes
+    /// `NSGlobalDomain` system keys — prefer an app-group suite to avoid
+    /// system-pref churn in the telemetry (see follow-up on noise filtering).
     public func startListening(suiteName: String? = nil) {
         guard isEnabled else { return }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -131,7 +131,12 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     /// `SdkStorageChangedEvent` per changed key. Internal so tests can drive it
     /// deterministically without relying on the KVO callback firing.
     func handleDidChange(suiteName: String?) {
-        guard AutoMobileSDK.shared.isEnabled, isEnabled else { return }
+        // Read the enabled state up front (both getters lock, and NSLock isn't
+        // recursive). When disabled we still refresh the baseline below but skip
+        // emitting — otherwise changes made during a disabled window would leak
+        // out on the first notification after re-enable, diffed against a stale
+        // pre-disable snapshot.
+        let enabled = AutoMobileSDK.shared.isEnabled && isEnabled
 
         lock.lock()
         guard let driver = _driver else {
@@ -149,6 +154,12 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         // UserDefaults read (real), so holding the lock briefly is acceptable.
         let current = Self.snapshotDict(driver.getValues(suiteName: suiteName))
         lastSnapshots[suiteKey] = current
+
+        guard enabled else {
+            // Baseline advanced silently so the disabled window is not replayed.
+            lock.unlock()
+            return
+        }
 
         let changes = Self.diff(previous: previous, current: current)
         var events: [SdkStorageChangedEvent] = []
@@ -211,7 +222,10 @@ public final class UserDefaultsInspector: @unchecked Sendable {
 
         for (key, pair) in current {
             if let prior = previous[key] {
-                if prior.value != pair.value {
+                // Compare type as well as value: a real type change with the same
+                // string representation (e.g. Int 1 -> String "1") is still a
+                // modification the telemetry surfaces via valueType.
+                if prior.value != pair.value || prior.type != pair.type {
                     changes.append(StorageChange(
                         key: key, newValue: pair.value,
                         valueType: pair.type.rawValue, changeType: "modify"

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -88,6 +88,15 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         let defaults = suiteName.map { UserDefaults(suiteName: $0) } ?? UserDefaults.standard
         guard let defaults = suiteName != nil ? defaults : UserDefaults.standard else { return }
 
+        // Seed the baseline BEFORE registering the observer. If a write on
+        // another thread raced observer installation, the notification could
+        // enter `handleDidChange` with no snapshot yet and diff against `[:]`,
+        // reporting every pre-existing key as a spurious "add". Seeding first
+        // closes that window; a write in the (now inverted) gap between seeding
+        // and registration is simply picked up as a normal change on the next
+        // notification rather than a burst of phantom adds.
+        captureBaseline(suiteName: suiteName)
+
         let observer = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: defaults,
@@ -99,11 +108,6 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         lock.lock()
         kvoObserver = observer
         lock.unlock()
-
-        // Seed the baseline snapshot with the suite's current contents so the
-        // first change diffs against real state — otherwise every pre-existing
-        // key would be reported as a spurious "add" on the next notification.
-        captureBaseline(suiteName: suiteName)
     }
 
     /// Stop listening for changes.

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -170,6 +170,7 @@ public final class UserDefaultsInspector: @unchecked Sendable {
                 suiteName: suiteName,
                 key: change.key,
                 newValue: change.newValue,
+                previousValue: change.previousValue,
                 valueType: change.valueType,
                 changeType: change.changeType,
                 sequenceNumber: sequenceCounter
@@ -188,10 +189,12 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     // MARK: - Diff Helpers
 
     /// A single detected change: the key, its new value/type (nil/type of the
-    /// removed value for a removal), and the add/modify/remove kind.
+    /// removed value for a removal), the prior value (nil for an add), and the
+    /// add/modify/remove kind.
     private struct StorageChange {
         let key: String
         let newValue: String?
+        let previousValue: String?
         let valueType: String
         let changeType: String
     }
@@ -227,13 +230,13 @@ public final class UserDefaultsInspector: @unchecked Sendable {
                 // modification the telemetry surfaces via valueType.
                 if prior.value != pair.value || prior.type != pair.type {
                     changes.append(StorageChange(
-                        key: key, newValue: pair.value,
+                        key: key, newValue: pair.value, previousValue: prior.value,
                         valueType: pair.type.rawValue, changeType: "modify"
                     ))
                 }
             } else {
                 changes.append(StorageChange(
-                    key: key, newValue: pair.value,
+                    key: key, newValue: pair.value, previousValue: nil,
                     valueType: pair.type.rawValue, changeType: "add"
                 ))
             }
@@ -241,7 +244,7 @@ public final class UserDefaultsInspector: @unchecked Sendable {
 
         for (key, prior) in previous where current[key] == nil {
             changes.append(StorageChange(
-                key: key, newValue: nil,
+                key: key, newValue: nil, previousValue: prior.value,
                 valueType: prior.type.rawValue, changeType: "remove"
             ))
         }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
@@ -42,6 +42,46 @@ final class EventPersistenceTests: XCTestCase {
         }
     }
 
+    func testPersistAndLoadStorageChangedEvent() {
+        let event = SdkStorageChangedEvent(
+            timestamp: 1000, suiteName: "defaults", key: "theme",
+            newValue: "dark", valueType: "string", changeType: "add", sequenceNumber: 7
+        )
+        let batchId = persistence.persist([event])
+        XCTAssertNotNil(batchId)
+
+        let pending = persistence.loadPending()
+        XCTAssertEqual(pending.count, 1)
+        guard let loaded = pending[0].events.first as? SdkStorageChangedEvent else {
+            return XCTFail("Expected SdkStorageChangedEvent")
+        }
+        XCTAssertEqual(loaded.eventType, .storageChanged)
+        XCTAssertEqual(loaded.key, "theme")
+        XCTAssertEqual(loaded.newValue, "dark")
+        XCTAssertEqual(loaded.valueType, "string")
+        XCTAssertEqual(loaded.changeType, "add")
+        XCTAssertEqual(loaded.sequenceNumber, 7)
+    }
+
+    /// A storage event persisted by an SDK build predating `changeType` must
+    /// still decode (defaulting to "modify") instead of being silently dropped
+    /// by `loadPending`'s `try?`.
+    func testStorageChangedDecodesLegacyPayloadWithoutChangeType() throws {
+        let legacyJson = Data("""
+        {"eventType":"storage_changed","timestamp":1000,"suiteName":"defaults",\
+        "key":"k","newValue":"v","valueType":"string","sequenceNumber":3}
+        """.utf8)
+
+        let event = try JSONDecoder().decode(SdkStorageChangedEvent.self, from: legacyJson)
+
+        XCTAssertEqual(event.eventType, .storageChanged)
+        XCTAssertEqual(event.key, "k")
+        XCTAssertEqual(event.newValue, "v")
+        XCTAssertEqual(event.valueType, "string")
+        XCTAssertEqual(event.changeType, "modify")
+        XCTAssertEqual(event.sequenceNumber, 3)
+    }
+
     func testPersistAndLoadNavigationEvent() {
         let event = SdkNavigationEvent(
             timestamp: 1000,

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -217,6 +217,41 @@ final class UserDefaultsInspectorTests: XCTestCase {
         inspector.stopListening()
     }
 
+    func testDiffEmitsModifyWhenOnlyTypeChanges() {
+        // Same string representation ("1"), but Int -> String is a real change.
+        let harness = makeDiffHarness(seed: [(key: "flag", value: "1", type: .int)])
+
+        harness.driver.setValue(suiteName: nil, key: "flag", value: "1", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events()
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].key, "flag")
+        XCTAssertEqual(events[0].changeType, "modify")
+        XCTAssertEqual(events[0].valueType, "string")
+    }
+
+    func testChangesDuringDisabledWindowAreNotReplayedAfterReEnable() {
+        let harness = makeDiffHarness(seed: [(key: "a", value: "1", type: .string)])
+
+        // A write happens while disabled — it must not be captured, and it must
+        // not be replayed on the next notification after re-enabling.
+        AutoMobileSDK.shared.setEnabled(false)
+        harness.driver.setValue(suiteName: nil, key: "a", value: "2", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+        XCTAssertTrue(harness.events().isEmpty)
+
+        AutoMobileSDK.shared.setEnabled(true)
+        // An unrelated later change: only this one should be reported, not the
+        // "a: 1 -> 2" that happened during the disabled window.
+        harness.driver.setValue(suiteName: nil, key: "b", value: "x", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events()
+        XCTAssertEqual(events.compactMap { $0.key }, ["b"])
+        XCTAssertEqual(events.first?.changeType, "add")
+    }
+
     /// Baselines are bucketed per suite, so a change in one suite must not be
     /// attributed to (or suppressed by) another suite's snapshot.
     func testDiffTracksSeparateBaselinesPerSuite() {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -130,8 +130,27 @@ final class UserDefaultsInspectorTests: XCTestCase {
         let event = events[0]
         XCTAssertEqual(event.key, "session")
         XCTAssertNil(event.newValue)
+        XCTAssertEqual(event.previousValue, "abc")
         XCTAssertEqual(event.valueType, "string")
         XCTAssertEqual(event.changeType, "remove")
+    }
+
+    func testDiffThreadsPreviousValueForModifyAndNilForAdd() {
+        let harness = makeDiffHarness(seed: [(key: "count", value: "1", type: .int)])
+
+        harness.driver.setValue(suiteName: nil, key: "count", value: "2", type: .int)
+        harness.driver.setValue(suiteName: nil, key: "fresh", value: "new", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events().sorted { ($0.key ?? "") < ($1.key ?? "") }
+        // "count" modified: prior value threaded so the ingest can skip its lookup.
+        XCTAssertEqual(events[0].key, "count")
+        XCTAssertEqual(events[0].changeType, "modify")
+        XCTAssertEqual(events[0].previousValue, "1")
+        // "fresh" added: no prior value.
+        XCTAssertEqual(events[1].key, "fresh")
+        XCTAssertEqual(events[1].changeType, "add")
+        XCTAssertNil(events[1].previousValue)
     }
 
     func testDiffEmitsNothingWhenNoValueChanged() {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -182,6 +182,79 @@ final class UserDefaultsInspectorTests: XCTestCase {
         XCTAssertTrue(harness.events().isEmpty)
         AutoMobileSDK.shared.setEnabled(true)
     }
+
+    /// Exercises the real production wiring: `startListening` registers the
+    /// `NotificationCenter` observer and seeds the baseline, and posting the
+    /// actual `UserDefaults.didChangeNotification` drives the diff. The observer
+    /// uses `queue: nil`, so delivery is synchronous — no async waiting needed.
+    func testStartListeningObserverEmitsOnDidChangeNotification() {
+        AutoMobileSDK.shared.setEnabled(true)
+        let fakeDriver = FakeUserDefaultsDriver()
+        fakeDriver.setValue(suiteName: nil, key: "existing", value: "old", type: .string)
+
+        let captured = CapturedEvents()
+        let buffer = SdkEventBuffer { events in
+            captured.append(events.compactMap { $0 as? SdkStorageChangedEvent })
+        }
+        buffer.start()
+        diffBuffer = buffer
+
+        let inspector = UserDefaultsInspector.shared
+        inspector.initialize(buffer: buffer)
+        inspector.setDriver(fakeDriver)
+        inspector.setEnabled(true)
+        inspector.startListening(suiteName: nil)
+
+        // App writes a new key, then the OS posts the change notification.
+        fakeDriver.setValue(suiteName: nil, key: "fresh", value: "new", type: .string)
+        NotificationCenter.default.post(name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
+
+        buffer.flush()
+        let events = captured.all
+        XCTAssertEqual(events.compactMap { $0.key }, ["fresh"])
+        XCTAssertEqual(events.first?.changeType, "add")
+
+        inspector.stopListening()
+    }
+
+    /// Baselines are bucketed per suite, so a change in one suite must not be
+    /// attributed to (or suppressed by) another suite's snapshot.
+    func testDiffTracksSeparateBaselinesPerSuite() {
+        AutoMobileSDK.shared.setEnabled(true)
+        let fakeDriver = FakeUserDefaultsDriver()
+        fakeDriver.setValue(suiteName: nil, key: "k1", value: "v1", type: .string)
+        fakeDriver.setValue(suiteName: "group.app", key: "k2", value: "v2", type: .string)
+
+        let captured = CapturedEvents()
+        let buffer = SdkEventBuffer { events in
+            captured.append(events.compactMap { $0 as? SdkStorageChangedEvent })
+        }
+        buffer.start()
+        diffBuffer = buffer
+
+        let inspector = UserDefaultsInspector.shared
+        inspector.initialize(buffer: buffer)
+        inspector.setDriver(fakeDriver)
+        inspector.setEnabled(true)
+        inspector.captureBaseline(suiteName: nil)
+        inspector.captureBaseline(suiteName: "group.app")
+
+        fakeDriver.setValue(suiteName: nil, key: "k1", value: "v1b", type: .string)
+        fakeDriver.setValue(suiteName: "group.app", key: "k2", value: "v2b", type: .string)
+
+        inspector.handleDidChange(suiteName: nil)
+        inspector.handleDidChange(suiteName: "group.app")
+
+        buffer.flush()
+        let events = captured.all.sorted { ($0.suiteName ?? "") < ($1.suiteName ?? "") }
+        XCTAssertEqual(events.count, 2)
+        XCTAssertNil(events[0].suiteName)
+        XCTAssertEqual(events[0].key, "k1")
+        XCTAssertEqual(events[0].changeType, "modify")
+        XCTAssertEqual(events[1].suiteName, "group.app")
+        XCTAssertEqual(events[1].key, "k2")
+        XCTAssertEqual(events[1].changeType, "modify")
+    }
 }
 
 /// Thread-safe collector for events delivered on the buffer's flush queue.

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -3,8 +3,15 @@ import SQLite3
 import XCTest
 
 final class UserDefaultsInspectorTests: XCTestCase {
+    private var diffBuffer: SdkEventBuffer?
+
     override func tearDown() {
         UserDefaultsInspector.shared.reset()
+        diffBuffer?.shutdown()
+        diffBuffer = nil
+        // Diff tests toggle the global SDK flag; restore its default so later
+        // suites aren't left with the SDK disabled.
+        AutoMobileSDK.shared.setEnabled(true)
         super.tearDown()
     }
 
@@ -46,6 +53,152 @@ final class UserDefaultsInspectorTests: XCTestCase {
 
         fakeDriver.clear(suiteName: nil)
         XCTAssertTrue(fakeDriver.getValues(suiteName: nil).isEmpty)
+    }
+
+    // MARK: - Change Diffing
+
+    /// Wire up an enabled inspector over a fake driver and a real callback-backed
+    /// buffer, seed the baseline snapshot, and return the pieces a diff test needs.
+    private func makeDiffHarness(
+        seed: [(key: String, value: String, type: KeyValueType)] = []
+    ) -> (driver: FakeUserDefaultsDriver, buffer: SdkEventBuffer, events: () -> [SdkStorageChangedEvent]) {
+        AutoMobileSDK.shared.setEnabled(true)
+
+        let fakeDriver = FakeUserDefaultsDriver()
+        for entry in seed {
+            fakeDriver.setValue(suiteName: nil, key: entry.key, value: entry.value, type: entry.type)
+        }
+
+        let captured = CapturedEvents()
+        let buffer = SdkEventBuffer { events in
+            captured.append(events.compactMap { $0 as? SdkStorageChangedEvent })
+        }
+        buffer.start()
+        diffBuffer = buffer
+
+        let inspector = UserDefaultsInspector.shared
+        inspector.initialize(buffer: buffer)
+        inspector.setDriver(fakeDriver)
+        inspector.setEnabled(true)
+        // Seed the baseline so pre-existing keys aren't reported as spurious adds.
+        inspector.captureBaseline(suiteName: nil)
+
+        return (fakeDriver, buffer, {
+            buffer.flush()
+            return captured.all
+        })
+    }
+
+    func testDiffEmitsAddForNewKey() {
+        let harness = makeDiffHarness()
+
+        harness.driver.setValue(suiteName: nil, key: "theme", value: "dark", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events()
+        XCTAssertEqual(events.count, 1)
+        let event = events[0]
+        XCTAssertEqual(event.key, "theme")
+        XCTAssertEqual(event.newValue, "dark")
+        XCTAssertEqual(event.valueType, "string")
+        XCTAssertEqual(event.changeType, "add")
+    }
+
+    func testDiffEmitsModifyForChangedValue() {
+        let harness = makeDiffHarness(seed: [(key: "count", value: "1", type: .int)])
+
+        harness.driver.setValue(suiteName: nil, key: "count", value: "2", type: .int)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events()
+        XCTAssertEqual(events.count, 1)
+        let event = events[0]
+        XCTAssertEqual(event.key, "count")
+        XCTAssertEqual(event.newValue, "2")
+        XCTAssertEqual(event.valueType, "int")
+        XCTAssertEqual(event.changeType, "modify")
+    }
+
+    func testDiffEmitsRemoveForDeletedKey() {
+        let harness = makeDiffHarness(seed: [(key: "session", value: "abc", type: .string)])
+
+        harness.driver.removeValue(suiteName: nil, key: "session")
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events()
+        XCTAssertEqual(events.count, 1)
+        let event = events[0]
+        XCTAssertEqual(event.key, "session")
+        XCTAssertNil(event.newValue)
+        XCTAssertEqual(event.valueType, "string")
+        XCTAssertEqual(event.changeType, "remove")
+    }
+
+    func testDiffEmitsNothingWhenNoValueChanged() {
+        let harness = makeDiffHarness(seed: [(key: "stable", value: "x", type: .string)])
+
+        // Re-set the same value: didChangeNotification can fire without any
+        // observable value change, and that must not emit an event.
+        harness.driver.setValue(suiteName: nil, key: "stable", value: "x", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        XCTAssertTrue(harness.events().isEmpty)
+    }
+
+    func testDiffEmitsMultipleChangesWithMonotonicSequence() {
+        let harness = makeDiffHarness(seed: [(key: "keep", value: "1", type: .int)])
+
+        harness.driver.setValue(suiteName: nil, key: "alpha", value: "a", type: .string)
+        harness.driver.setValue(suiteName: nil, key: "keep", value: "2", type: .int)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events().sorted { ($0.key ?? "") < ($1.key ?? "") }
+        XCTAssertEqual(events.compactMap { $0.key }, ["alpha", "keep"])
+        XCTAssertEqual(events.map { $0.changeType }, ["add", "modify"])
+        // Distinct, monotonically-increasing sequence numbers per emitted event.
+        XCTAssertEqual(Set(events.map { $0.sequenceNumber }).count, 2)
+        XCTAssertLessThan(events[0].sequenceNumber, events[1].sequenceNumber)
+    }
+
+    func testDiffDoesNotEmitPreExistingKeysOnFirstChange() {
+        // Baseline already contains "existing"; only the newly-added key changes.
+        let harness = makeDiffHarness(seed: [(key: "existing", value: "old", type: .string)])
+
+        harness.driver.setValue(suiteName: nil, key: "fresh", value: "new", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events()
+        XCTAssertEqual(events.compactMap { $0.key }, ["fresh"])
+        XCTAssertEqual(events.first?.changeType, "add")
+    }
+
+    func testDiffEmitsNothingWhenSdkDisabled() {
+        let harness = makeDiffHarness()
+        AutoMobileSDK.shared.setEnabled(false)
+
+        harness.driver.setValue(suiteName: nil, key: "theme", value: "dark", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        XCTAssertTrue(harness.events().isEmpty)
+        AutoMobileSDK.shared.setEnabled(true)
+    }
+}
+
+/// Thread-safe collector for events delivered on the buffer's flush queue.
+private final class CapturedEvents: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [SdkStorageChangedEvent] = []
+
+    var all: [SdkStorageChangedEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+
+    func append(_ newEvents: [SdkStorageChangedEvent]) {
+        lock.lock()
+        defer { lock.unlock() }
+        events.append(contentsOf: newEvents)
     }
 }
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -236,6 +236,38 @@ final class UserDefaultsInspectorTests: XCTestCase {
         inspector.stopListening()
     }
 
+    /// `startListening` must seed the baseline before it starts observing, so the
+    /// first notification diffs against the suite's existing contents rather than
+    /// an empty snapshot (which would report every pre-existing key as an "add").
+    func testStartListeningSeedsBaselineSoPreexistingKeysAreNotEmitted() {
+        AutoMobileSDK.shared.setEnabled(true)
+        let fakeDriver = FakeUserDefaultsDriver()
+        fakeDriver.setValue(suiteName: nil, key: "a", value: "1", type: .string)
+        fakeDriver.setValue(suiteName: nil, key: "b", value: "2", type: .string)
+
+        let captured = CapturedEvents()
+        let buffer = SdkEventBuffer { events in
+            captured.append(events.compactMap { $0 as? SdkStorageChangedEvent })
+        }
+        buffer.start()
+        diffBuffer = buffer
+
+        let inspector = UserDefaultsInspector.shared
+        inspector.initialize(buffer: buffer)
+        inspector.setDriver(fakeDriver)
+        inspector.setEnabled(true)
+        inspector.startListening(suiteName: nil)
+
+        // A notification with no change since startListening must emit nothing —
+        // the pre-existing keys were captured into the baseline before observing.
+        NotificationCenter.default.post(name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
+
+        buffer.flush()
+        XCTAssertTrue(captured.all.isEmpty)
+
+        inspector.stopListening()
+    }
+
     func testDiffEmitsModifyWhenOnlyTypeChanges() {
         // Same string representation ("1"), but Int -> String is a real change.
         let harness = makeDiffHarness(seed: [(key: "flag", value: "1", type: .int)])

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -225,8 +225,10 @@ public struct SdkStorageChangedEvent: SdkEvent
   public let newValue: String?
   public let previousValue: String?
   public let valueType: String
+  public let changeType: String
   public let sequenceNumber: Int64
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), suiteName: String?, key: String?, newValue: String?, previousValue: String? = nil, valueType: String, sequenceNumber: Int64 )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), suiteName: String?, key: String?, newValue: String?, previousValue: String? = nil, valueType: String, changeType: String = "modify", sequenceNumber: Int64 )
+  public init(from decoder: Decoder) throws
 public struct SdkEventBatch: Codable, Sendable
   public let bundleId: String?
   public let events: [SdkEventEnvelope]
@@ -349,6 +351,7 @@ public final class AutoMobileNetwork: @unchecked Sendable
   public func protocolClass() -> AnyClass
   public func recordRequest(_ record: NetworkRequestRecord)
   public func recordRequest( url: String, method: String, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil, statusCode: Int? = nil, responseHeaders: [String: String]? = nil, responseBodySize: Int? = nil, durationMs: Double? = nil, error: String? = nil, requestBody: String? = nil, responseBody: String? = nil, contentType: String? = nil )
+  public func recordFromTask( _ task: URLSessionTask, startTime: Date, receivedData: Data?, error: Error? )
   public func recordWebSocketFrame( url: String, direction: WebSocketFrameDirection, frameType: WebSocketFrameType, payloadSize: Int? = nil )
 public class AutoMobileURLProtocol: URLProtocol
   public override class func canInit(with request: URLRequest) -> Bool
@@ -391,6 +394,48 @@ public final class AutoMobileOsEvents: @unchecked Sendable
   public static let shared = AutoMobileOsEvents()
   public var isEnabled: Bool
   public func setEnabled(_ enabled: Bool)
+
+// Public/AutoMobileAPI.swift
+public protocol AutoMobileAPI: AnyObject, Sendable
+
+// Public/AutoMobileCrashesAPI.swift
+public protocol AutoMobileCrashesAPI: AnyObject, Sendable
+public final class DefaultAutoMobileCrashesAPI: AutoMobileCrashesAPI, @unchecked Sendable
+  public init()
+  public func enableSignalHandlers()
+  public func setCurrentScreenProvider(_ provider: (@Sendable () -> String?)?)
+
+// Public/AutoMobileNetworkAPI.swift
+public protocol AutoMobileNetworkAPI: AnyObject, Sendable
+public final class DefaultAutoMobileNetworkAPI: AutoMobileNetworkAPI, @unchecked Sendable
+  public init()
+  public func recordRequest(_ record: NetworkRequestRecord)
+  public func setCaptureHeaders(_ enabled: Bool)
+  public func setCaptureBodies(_ enabled: Bool)
+
+// Public/DefaultAutoMobileAPI.swift
+public final class DefaultAutoMobileAPI: AutoMobileAPI, @unchecked Sendable
+  public init()
+  public func initialize()
+  public func initialize(configuration: AutoMobileConfiguration)
+  public func shutdown()
+  public var isEnabled: Bool
+  public func setEnabled(_ enabled: Bool)
+  public var isInitialized: Bool
+  public func addNavigationListener(_ listener: NavigationListener)
+  public func addNavigationListener(_ block: @escaping @Sendable (NavigationEvent) -> Void) -> NavigationListener
+  public func removeNavigationListener(_ listener: NavigationListener)
+  public func clearNavigationListeners()
+  public func notifyNavigationEvent(_ event: NavigationEvent)
+  public var listenerCount: Int
+  public func currentSessionId() -> String?
+  public func addBreadcrumb(message: String, category: BreadcrumbCategory, metadata: [String: String])
+  public func setUserId(_ userId: String?)
+  public func setTag(_ key: String, value: String)
+  public func removeTag(_ key: String)
+  public var configuration: AutoMobileConfiguration?
+  public var bundleId: String?
+  public var dropReport: [DropReason: Int]
 
 // Storage/DatabaseInspector.swift
 public final class DatabaseInspector: @unchecked Sendable
@@ -497,12 +542,16 @@ public struct SdkViewNode: Codable, Sendable
   public let alpha: Float
   public let backgroundColor: String?
   public let cornerRadius: Float
+  public let borderColor: String?
+  public let borderWidth: Float
+  public let isLayerNode: Bool
   public let isHidden: Bool
   public let isUserInteractionEnabled: Bool
   public let hasTapTarget: Bool
   public let isOccluded: Bool
   public let children: [SdkViewNode]?
-  public init( className: String, bounds: SdkBounds, accessibilityLabel: String? = nil, accessibilityIdentifier: String? = nil, isAccessibilityElement: Bool = false, accessibilityElementsHidden: Bool = false, accessibilityTraits: [String] = [], accessibilityCustomActions: [String] = [], gestureRecognizers: [SdkGestureInfo] = [], alpha: Float = 1.0, backgroundColor: String? = nil, cornerRadius: Float = 0, isHidden: Bool = false, isUserInteractionEnabled: Bool = true, hasTapTarget: Bool = false, isOccluded: Bool = false, children: [SdkViewNode]? = nil )
+  public init( className: String, bounds: SdkBounds, accessibilityLabel: String? = nil, accessibilityIdentifier: String? = nil, isAccessibilityElement: Bool = false, accessibilityElementsHidden: Bool = false, accessibilityTraits: [String] = [], accessibilityCustomActions: [String] = [], gestureRecognizers: [SdkGestureInfo] = [], alpha: Float = 1.0, backgroundColor: String? = nil, cornerRadius: Float = 0, borderColor: String? = nil, borderWidth: Float = 0, isLayerNode: Bool = false, isHidden: Bool = false, isUserInteractionEnabled: Bool = true, hasTapTarget: Bool = false, isOccluded: Bool = false, children: [SdkViewNode]? = nil )
+  public init(from decoder: Decoder) throws
 public struct SdkBounds: Codable, Sendable, Hashable
   public let left: Int
   public let top: Int
@@ -526,45 +575,3 @@ public final class ViewHierarchyTracker: @unchecked Sendable
 public enum ViewHierarchyWalker
   public static func walk(bundleId: String? = nil) -> SdkViewHierarchy
   public static func computeHash(_ hierarchy: SdkViewHierarchy) -> Int
-
-// Public/AutoMobileAPI.swift
-public protocol AutoMobileAPI: AnyObject, Sendable
-  func initialize()
-  func initialize(configuration: AutoMobileConfiguration)
-  func shutdown()
-  var isEnabled: Bool { get }
-  func setEnabled(_ enabled: Bool)
-  var isInitialized: Bool { get }
-  func addNavigationListener(_ listener: NavigationListener)
-  @discardableResult func addNavigationListener(_ block: @escaping @Sendable (NavigationEvent) -> Void) -> NavigationListener
-  func removeNavigationListener(_ listener: NavigationListener)
-  func clearNavigationListeners()
-  func notifyNavigationEvent(_ event: NavigationEvent)
-  var listenerCount: Int { get }
-  func currentSessionId() -> String?
-  func addBreadcrumb(message: String, category: BreadcrumbCategory, metadata: [String: String])
-  func setUserId(_ userId: String?)
-  func setTag(_ key: String, value: String)
-  func removeTag(_ key: String)
-  var configuration: AutoMobileConfiguration? { get }
-  var bundleId: String? { get }
-  var dropReport: [DropReason: Int] { get }
-
-// Public/DefaultAutoMobileAPI.swift
-public final class DefaultAutoMobileAPI: AutoMobileAPI, @unchecked Sendable
-  public init()
-
-// Public/AutoMobileNetworkAPI.swift
-public protocol AutoMobileNetworkAPI: AnyObject, Sendable
-  func recordRequest(_ record: NetworkRequestRecord)
-  func setCaptureHeaders(_ enabled: Bool)
-  func setCaptureBodies(_ enabled: Bool)
-public final class DefaultAutoMobileNetworkAPI: AutoMobileNetworkAPI, @unchecked Sendable
-  public init()
-
-// Public/AutoMobileCrashesAPI.swift
-public protocol AutoMobileCrashesAPI: AnyObject, Sendable
-  func enableSignalHandlers()
-  func setCurrentScreenProvider(_ provider: (@Sendable () -> String?)?)
-public final class DefaultAutoMobileCrashesAPI: AutoMobileCrashesAPI, @unchecked Sendable
-  public init()

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -31,6 +31,12 @@ src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argu
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2769: No overload matches this call.
+src/db/migrations/2026_07_02_000_event_composite_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
+src/db/migrations/2026_07_02_000_event_composite_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
+src/db/migrations/2026_07_02_000_event_composite_indexes.ts: error TS2769: No overload matches this call.
+src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
+src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
+src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts: error TS2769: No overload matches this call.
 src/db/migrator.ts: error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
 src/db/migrator.ts: error TS2307: Cannot find module 'kysely/migration' or its corresponding type declarations.
 src/db/migrator.ts: error TS2307: Cannot find module 'kysely/migration' or its corresponding type declarations.
@@ -236,7 +242,6 @@ src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2345: Argument of type '
 src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2420: Class 'NoOpIOSCtrlProxyManager' incorrectly implements interface 'CtrlProxyIosManager'.
 src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2739: Type '{ fps: number; frameTimeMs: number; jankFrames: number; droppedFrames: number; memoryUsageMb: number; cpuUsagePercent: number; touchLatencyMs: number | null; timeToInteractiveMs: number | null; screenName: string | null; isResponsive: boolean; }' is missing the following properties from type 'PerformanceStreamData': recompositionCount, recompositionRate
 src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2741: Property 'resetSetupState' is missing in type 'NoOpIOSCtrlProxyManager' but required in type 'CtrlProxyIosManager'.
-src/features/observe/ios/IosSdkEventIngestor.ts: error TS2353: Object literal may only specify known properties, and 'operation' does not exist in type '{ timestamp: number; applicationId: string | null; fileName: string; key: string | null; value: string | null; valueType: string | null; changeType: string; previousValue?: string | null | undefined; }'.
 src/features/observe/ios/index.ts: error TS2300: Duplicate identifier 'CtrlProxyHierarchy'.
 src/features/observe/ios/index.ts: error TS2300: Duplicate identifier 'CtrlProxyHierarchy'.
 src/features/performance/PerformanceAudit.ts: error TS2551: Property 'refreshRateHz' does not exist on type 'DeviceCapabilities'. Did you mean 'refreshRate'?

--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -248,7 +248,7 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
               details: { durationMs: String((p.durationMs as number) ?? 0) },
             });
             break;
-          case "storage_changed":
+          case "storage_changed": {
             // The iOS SDK's SdkStorageChangedEvent serializes as suiteName/key/newValue/
             // valueType/changeType/sequenceNumber (ios/auto-mobile-sdk/.../SdkEvent.swift).
             // It carries no `value` and no `operation`; the recorder REQUIRES valueType +
@@ -256,20 +256,30 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
             // valueType through, and use the SDK-diffed changeType (add/modify/remove).
             // Older SDK builds emitted no change kind — fall back to `operation` then
             // "modify" for wire compatibility.
+            const changeType = (p.changeType as string) ?? (p.operation as string) ?? "modify";
+            // Resolve the prior value:
+            //  - "add" ⇒ the key had no prior value by definition. Assert null
+            //    EXPLICITLY: Swift's synthesized Encodable omits nil optionals, so the
+            //    SDK's `previousValue: nil` for adds never reaches the wire, and without
+            //    this the repository's auto-lookup could attribute a stale earlier row
+            //    (e.g. a key removed while offline then re-added) as the previous value.
+            //  - otherwise ⇒ thread the runner-supplied prior value when present, else
+            //    omit so the repository's `previousValue !== undefined` guard falls
+            //    through to the auto-lookup (#3000). An explicit null is honored verbatim.
+            const previousValue: string | null | undefined = changeType === "add"
+              ? null
+              : ("previousValue" in p ? (p.previousValue as string | null) : undefined);
             await recorder.recordStorageEvent({
               timestamp: ts, applicationId,
               fileName: (p.suiteName as string) ?? "",
               key: (p.key as string) ?? null,
               value: (p.newValue as string) ?? (p.value as string) ?? null,
               valueType: (p.valueType as string) ?? null,
-              changeType: (p.changeType as string) ?? (p.operation as string) ?? "modify",
-              // Thread the runner-supplied prior value ONLY when the payload carries
-              // it, so the repository's `previousValue !== undefined` guard falls
-              // through to the auto-lookup for legacy runners that omit it (#3000).
-              // An explicit null ("no prior value") is honored verbatim.
-              ...("previousValue" in p ? { previousValue: (p.previousValue as string | null) } : {}),
+              changeType,
+              ...(previousValue !== undefined ? { previousValue } : {}),
             });
             break;
+          }
           default:
           // Record unknown types as log events
             await recorder.recordLogEvent({

--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -250,19 +250,19 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
             break;
           case "storage_changed":
             // The iOS SDK's SdkStorageChangedEvent serializes as suiteName/key/newValue/
-            // valueType/sequenceNumber (ios/auto-mobile-sdk/.../SdkEvent.swift). It carries
-            // no `value` and no `operation`, and the recorder REQUIRES valueType + changeType
-            // (issue #3001). Map: suiteName→fileName, newValue→value, pass valueType through,
-            // and derive changeType. KVO can't distinguish set vs remove so the SDK emits no
-            // operation — default to "modify" (matching the Android call site) while honoring
-            // an explicit `operation` if a future SDK build adds one.
+            // valueType/changeType/sequenceNumber (ios/auto-mobile-sdk/.../SdkEvent.swift).
+            // It carries no `value` and no `operation`; the recorder REQUIRES valueType +
+            // changeType (issue #3001). Map: suiteName→fileName, newValue→value, pass
+            // valueType through, and use the SDK-diffed changeType (add/modify/remove).
+            // Older SDK builds emitted no change kind — fall back to `operation` then
+            // "modify" for wire compatibility.
             await recorder.recordStorageEvent({
               timestamp: ts, applicationId,
               fileName: (p.suiteName as string) ?? "",
               key: (p.key as string) ?? null,
               value: (p.newValue as string) ?? (p.value as string) ?? null,
               valueType: (p.valueType as string) ?? null,
-              changeType: (p.operation as string) ?? "modify",
+              changeType: (p.changeType as string) ?? (p.operation as string) ?? "modify",
               // Thread the runner-supplied prior value ONLY when the payload carries
               // it, so the repository's `previousValue !== undefined` guard falls
               // through to the auto-lookup for legacy runners that omit it (#3000).

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -238,6 +238,27 @@ describe("DefaultIosSdkEventIngestor", () => {
     });
   });
 
+  test("storage_changed forces previousValue: null for adds (defeats the repo auto-lookup)", async () => {
+    // An "add" has no prior value by definition. Swift's Encodable omits the nil
+    // previousValue, so the ingestor must assert null explicitly — otherwise the
+    // repository would auto-look-up a stale earlier row for the same suite/key.
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "defaults", key: "k", newValue: "v", valueType: "string", changeType: "add",
+    }), "com.app");
+    // Present AND null (not undefined), so recordStorageEvent skips its lookup.
+    expect(recorder.storage[0].event).toHaveProperty("previousValue", null);
+  });
+
+  test("storage_changed does NOT force previousValue for modify (auto-lookup preserved)", async () => {
+    // A modify without a runner-supplied previousValue must omit it so the
+    // repository's `!== undefined` guard falls through to the auto-lookup (#3000).
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "defaults", key: "k", newValue: "v2", valueType: "string", changeType: "modify",
+    }), "com.app");
+    expect(recorder.storage[0].event.previousValue).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(recorder.storage[0].event, "previousValue")).toBe(false);
+  });
+
   test("storage_changed reads changeType remove, and defaults to modify when the wire omits it", async () => {
     await ingestor.recordSdkEvent(event("storage_changed", {
       suiteName: "defaults", key: "gone", newValue: null, valueType: "string", changeType: "remove",

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -227,6 +227,31 @@ describe("DefaultIosSdkEventIngestor", () => {
     expect(Object.prototype.hasOwnProperty.call(recorder.storage[0].event, "previousValue")).toBe(false);
   });
 
+  test("storage_changed reads the SDK-diffed changeType (add) from the payload", async () => {
+    // The snapshot-diff SDK build emits a real add/modify/remove changeType; it
+    // must be read directly (not defaulted to "modify").
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "defaults", key: "k", newValue: "v", valueType: "string", changeType: "add",
+    }), "com.app");
+    expect(recorder.storage[0].event).toMatchObject({
+      fileName: "defaults", key: "k", value: "v", valueType: "string", changeType: "add",
+    });
+  });
+
+  test("storage_changed reads changeType remove, and defaults to modify when the wire omits it", async () => {
+    await ingestor.recordSdkEvent(event("storage_changed", {
+      suiteName: "defaults", key: "gone", newValue: null, valueType: "string", changeType: "remove",
+    }), "com.app");
+    expect(recorder.storage[0].event).toMatchObject({
+      fileName: "defaults", key: "gone", value: null, valueType: "string", changeType: "remove",
+    });
+
+    await ingestor.recordSdkEvent(event("storage_changed", { suiteName: "defaults", key: "k" }), "com.app");
+    expect(recorder.storage[1].event).toMatchObject({
+      fileName: "defaults", key: "k", value: null, valueType: null, changeType: "modify",
+    });
+  });
+
   test("unknown event types fall back to a log event", async () => {
     await ingestor.recordSdkEvent(event("totally_new_type", { foo: "bar" }), "com.app");
     expect(recorder.logs[0].event).toMatchObject({ tag: "UnknownEvent", filterName: "custom" });


### PR DESCRIPTION
## Problem

Every iOS `storage_changed` telemetry row landed as `key=NULL, value=NULL, value_type="unknown", change_type="modify"`. `UserDefaultsInspector.notifyChangeListeners` was the only emitter and hardcoded `newValue: nil, valueType: "unknown"`, passing `key: nil` — the KVO observer fires on `UserDefaults.didChangeNotification`, which doesn't identify *which* key changed.

While fixing this I found the iOS TS ingestor (`IosSdkEventIngestor.ts`) was also broken: it read `p.value`/`p.operation` (fields the Swift event never emitted) and passed a non-existent `operation` field to `recordStorageEvent` — a real `tsc` error masked because Bun skips typechecking.

## Fix

- **`UserDefaultsInspector`** now snapshots the suite's key/value dictionary and diffs current vs. baseline on each notification, emitting one `SdkStorageChangedEvent` per changed key with the real `key`, `newValue`, `valueType`, and a proper `add`/`modify`/`remove` `changeType`. `startListening` seeds a baseline so pre-existing keys aren't reported as spurious adds; snapshot + diff + sequence allocation run under the lock so overlapping notifications can't double-emit; changes are sorted by key for deterministic sequence numbers. Listeners now fire with the real changed key.
- **`SdkStorageChangedEvent`** gains a non-optional `changeType: String` (default `"modify"`), mirroring Android's wire field, so the desktop telemetry consumer's add/remove rendering (`TelemetryDetailPanel.kt`) fires for iOS instead of only ever seeing `"modify"`.
- **iOS TS ingestor** now reads the real payload fields (`newValue`/`valueType`/`changeType`) and maps them into `recordStorageEvent`, fixing the latent type error and letting `change_type` reflect the SDK's real diff.

## Tests

- 8 new Swift tests (add/modify/remove, no-op re-set, multi-change monotonic sequences, baseline suppression, SDK-disabled gate). Full Swift suite: 221 passed.
- Updated + expanded the TS ingestor test (the old one asserted the broken `value`/`operation` shape). 18 passed.
- eslint clean, `bun build.ts` OK, storage-event repo tests green.

Note: iOS still doesn't send `previousValue` on the wire, but the repository auto-looks-up the prior row by key, which is what the desktop before/after rendering already relies on.