### PR TITLE
refactor(ios): merge CtrlProxyVoiceOverActionResult into CtrlProxyActionResult

### DIFF
--- a/src/features/observe/ios/CtrlProxyVoiceOver.ts
+++ b/src/features/observe/ios/CtrlProxyVoiceOver.ts
@@ -7,7 +7,7 @@
  */
 
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
-import type { DelegateContext, CtrlProxyVoiceOverResult, CtrlProxyVoiceOverActionResult, CtrlProxyActionResult } from "./types";
+import type { DelegateContext, CtrlProxyVoiceOverResult, CtrlProxyActionResult } from "./types";
 import { sendCommand } from "../DeviceServiceUtils";
 
 /**
@@ -85,7 +85,8 @@ export class CtrlProxyVoiceOver {
    * dedicated `request_voiceover_action` command, which never existed in the Swift
    * `RequestType` and so failed to decode on-device — always falling back to a
    * coordinate tap (issue #2857). The runner replies `action_result`, which decodes
-   * into the same shape as `CtrlProxyVoiceOverActionResult`.
+   * into a `CtrlProxyActionResult` — the same shape `requestAction` returns (the
+   * two were merged in #2956).
    *
    * @param label - The accessibility label of the target element
    * @param action - The action to perform: "activate" or "long_press"
@@ -98,8 +99,8 @@ export class CtrlProxyVoiceOver {
     action: "activate" | "long_press",
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
-  ): Promise<CtrlProxyVoiceOverActionResult> {
-    return sendCommand<CtrlProxyVoiceOverActionResult>(this.context, {
+  ): Promise<CtrlProxyActionResult> {
+    return sendCommand<CtrlProxyActionResult>(this.context, {
       idPrefix: "voiceover_action",
       responseType: "action",
       messageType: "request_action",
@@ -108,6 +109,9 @@ export class CtrlProxyVoiceOver {
       perf,
       cancelScreenshotBackoff: false,
       notConnectedError: () => ({ success: false, error: "Not connected to CtrlProxy" }),
+      // Parity with requestVoiceOverState: request_action is a real command, so this
+      // is defense-in-depth against an older runner that predates it (#2956).
+      unsupportedCommandError: (_messageType, error) => ({ success: false, totalTimeMs: 0, error }),
       timeoutError: () => ({ success: false, error: "Timeout waiting for action_result" }),
     });
   }

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -141,7 +141,6 @@ import type {
   CtrlProxyPerformanceSnapshot,
   CtrlProxyCachedHierarchy,
   CtrlProxyVoiceOverResult,
-  CtrlProxyVoiceOverActionResult,
   CtrlProxyActionResult,
   CtrlProxyClipboardResult,
   CtrlProxyHighlightResult,
@@ -278,7 +277,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
 
   requestVoiceOverActivate(
     label: string, action: "activate" | "long_press", timeoutMs?: number, perf?: PerformanceTracker
-  ): Promise<CtrlProxyVoiceOverActionResult>;
+  ): Promise<CtrlProxyActionResult>;
 
   requestAction(
     action: string,
@@ -1329,7 +1328,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     action: "activate" | "long_press",
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
-  ): Promise<CtrlProxyVoiceOverActionResult> {
+  ): Promise<CtrlProxyActionResult> {
     return this.voiceOver.requestVoiceOverActivate(label, action, timeoutMs, perf);
   }
 

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -220,14 +220,6 @@ export interface CtrlProxyVoiceOverResult {
   error?: string;
 }
 
-/** VoiceOver action result from CtrlProxy iOS */
-export interface CtrlProxyVoiceOverActionResult {
-  success: boolean;
-  action?: string;
-  totalTimeMs?: number;
-  error?: string;
-}
-
 /** Highlight result from CtrlProxy iOS */
 export type CtrlProxyHighlightResult = HighlightOperationResult;
 

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -311,8 +311,6 @@ export function registerObserveTools() {
     "Get screen view hierarchy",
     observeSchema,
     observeHandler,
-    false,
-    false,
     { outputSchema: observeResultSchema }
   );
 

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -23,7 +23,6 @@ import {
 } from "../../src/features/observe/ios";
 import type {
   CtrlProxyVoiceOverResult,
-  CtrlProxyVoiceOverActionResult,
   CtrlProxyActionResult,
 } from "../../src/features/observe/ios/types";
 import type { SetTextOptions } from "../../src/features/observe/DeviceService";
@@ -116,7 +115,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
   private swipeResult: CtrlProxySwipeResult | null = null;
   private recentAppsResult: CtrlProxyRecentAppsResult | null = null;
   private voiceOverState: boolean = false;
-  private voiceOverActivateResult: CtrlProxyVoiceOverActionResult | null = null;
+  private voiceOverActivateResult: CtrlProxyActionResult | null = null;
   private multiFingerSwipeResult: CtrlProxySwipeResult | null = null;
   private actionResult: CtrlProxyActionResult | null = null;
   private clipboardResult: CtrlProxyClipboardResult | null = null;
@@ -247,7 +246,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
   /**
    * Configure VoiceOver activate result (null = default success)
    */
-  setVoiceOverActivateResult(result: CtrlProxyVoiceOverActionResult | null): void {
+  setVoiceOverActivateResult(result: CtrlProxyActionResult | null): void {
     this.voiceOverActivateResult = result;
   }
 
@@ -954,7 +953,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     action: "activate" | "long_press",
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
-  ): Promise<CtrlProxyVoiceOverActionResult> {
+  ): Promise<CtrlProxyActionResult> {
     await this.applyDelay("voiceOverActivate");
     this.checkFailure("voiceOverActivate");
 

--- a/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
+++ b/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
@@ -274,11 +274,14 @@ describe("CtrlProxyVoiceOver", function() {
       expect(_roundTrip).toBeDefined();
     });
 
-    // Regression guard for #2956: keeping `requestVoiceOverActivate` as a
-    // convenience wrapper means it gains the `unsupportedCommandError` handler
-    // its sibling `requestVoiceOverState` has. When the connected device does not
-    // advertise `request_action`, the call must resolve to a graceful failure
-    // (never send on the wire, never hang) rather than time out.
+    // Regression guard for #2956: when the connected device does not advertise
+    // `request_action`, `requestVoiceOverActivate` must resolve to a graceful
+    // failure (never send on the wire, never hang) rather than time out. Note
+    // this contract is satisfied by `sendCommand`'s default unsupported-command
+    // fallback too — the wrapper's own `unsupportedCommandError` handler (added
+    // here for parity with `requestVoiceOverState`) produces the byte-identical
+    // shape, so this test pins the observable behavior, not the handler's
+    // presence specifically.
     test("resolves gracefully when the device does not support request_action", async function() {
       const { factory, getSocket } = createCapturingFactory(fakeTimer);
       const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);

--- a/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
+++ b/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { IOSCtrlProxyClient } from "../../../../src/features/observe/ios";
+import type { CtrlProxyActionResult, IOSCtrlProxy } from "../../../../src/features/observe/ios";
 import type { BootedDevice } from "../../../../src/models";
 import {
   FakeWebSocket,
@@ -248,6 +249,60 @@ describe("CtrlProxyVoiceOver", function() {
 
         const result = await resultPromise;
         expect(result.success).toBe(true);
+      } finally {
+        await client.close();
+      }
+    });
+
+    // Regression guard for #2956: `requestVoiceOverActivate` and `requestAction`
+    // are filled from the same `action_result` decode path, so they must share a
+    // single return type. If someone re-introduces a divergent
+    // `CtrlProxyVoiceOverActionResult`, these mutual assignments stop compiling
+    // and the typecheck gate fails.
+    test("returns the same CtrlProxyActionResult type as requestAction (compile-time guard)", function() {
+      type ActivateResult = Awaited<ReturnType<IOSCtrlProxy["requestVoiceOverActivate"]>>;
+      type ActionResult = Awaited<ReturnType<IOSCtrlProxy["requestAction"]>>;
+
+      // Both directions must hold → the two shapes are identical.
+      const fromAction: ActivateResult = {} as ActionResult;
+      const fromActivate: ActionResult = {} as ActivateResult;
+      // And both are exactly CtrlProxyActionResult.
+      const canonical: CtrlProxyActionResult = fromActivate;
+      const _roundTrip: ActivateResult = canonical;
+
+      expect(fromAction).toBeDefined();
+      expect(_roundTrip).toBeDefined();
+    });
+
+    // Regression guard for #2956: keeping `requestVoiceOverActivate` as a
+    // convenience wrapper means it gains the `unsupportedCommandError` handler
+    // its sibling `requestVoiceOverState` has. When the connected device does not
+    // advertise `request_action`, the call must resolve to a graceful failure
+    // (never send on the wire, never hang) rather than time out.
+    test("resolves gracefully when the device does not support request_action", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        // Device advertises a command set that excludes request_action.
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          id: 1,
+          supportedCommands: ["request_recent_apps"],
+        }));
+
+        const result = await client.requestVoiceOverActivate("Submit", "activate");
+
+        expect(result.success).toBe(false);
+        expect(result.totalTimeMs).toBe(0);
+        expect(result.error).toContain("request_action");
+        // Unsupported commands short-circuit before hitting the wire.
+        expect(socket!.sentMessages).toHaveLength(0);
       } finally {
         await client.close();
       }


### PR DESCRIPTION
## Summary
Collapses the byte-identical `CtrlProxyVoiceOverActionResult` into
`CtrlProxyActionResult`. Since #2857 / PR #2950 consolidated the phantom
`request_voiceover_action` command onto the real `request_action`, both types are
filled from the same `action_result` decode path — keeping two names for one shape
was pure redundancy. Closes #2956.

## Changes
- Remove `CtrlProxyVoiceOverActionResult` from `src/features/observe/ios/types.ts`.
- Route `CtrlProxyVoiceOver.requestVoiceOverActivate`, the `IOSCtrlProxy` interface
  method + its `IOSCtrlProxyClient` impl, and `FakeIOSCtrlProxy` through
  `CtrlProxyActionResult`.
- Keep `requestVoiceOverActivate` as a documented convenience wrapper (narrow
  `activate|long_press` typing, distinct `voiceover_action` idPrefix,
  self-documenting sole caller in `TapOnElement`). Per the issue it gains the
  `unsupportedCommandError` handler its sibling `requestVoiceOverState` has —
  defense-in-depth against an older runner, since `request_action` is real today.

## Why no `TapOnElement.ts` change
The sole call site reads only `.success`/`.error`, both present in the retained
shape, and uses type inference (no direct reference to the removed name).

## Tests
- Compile-time type-identity guard: `requestVoiceOverActivate` and `requestAction`
  must share one return type; re-introducing a divergent type fails the typecheck
  gate.
- Behavioral guard: an unsupported `request_action` resolves to a graceful
  `{ success:false, totalTimeMs:0 }` without hitting the wire or hanging.

## Validation
- `bun test test/features/observe/ios test/features/action` → 896 pass, 0 fail.
- `bun run build.ts` clean; eslint clean on changed files.
- Typecheck gate: **no new errors** attributable to this change (10 pre-existing
  dependency/environment-drift errors confirmed present on a clean tree too).

No behavior change intended.
---

### Rebase + folded-in unblock (main was red)
Rebased onto latest `main` (was 16 commits behind). Two things surfaced:
- **Migration typecheck errors** (`2026_07_02/03_*`) that blocked the first CI run
  are already tolerated in the current `main` baseline — the rebase picks that up,
  no change needed.
- **`main` itself was red** on the required `Node TypeScript Build and Test
  (ubuntu-latest)` typecheck gate: `observeTools.ts` still called
  `registerDeviceAware` with the pre-#3201 7-arg positional signature (#3025 and
  #3201 landed concurrently). Fixed in a dedicated commit — dropped the two default
  `false` booleans, kept the options object. Behavior-preserving (795 server tests
  pass); unblocks this PR and main-wide. Happy to split into its own PR if preferred.