### PR TITLE
refactor(server): extract tool registry pipeline

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -236,7 +236,6 @@ src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2345: Argument of type '
 src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2420: Class 'NoOpIOSCtrlProxyManager' incorrectly implements interface 'CtrlProxyIosManager'.
 src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2739: Type '{ fps: number; frameTimeMs: number; jankFrames: number; droppedFrames: number; memoryUsageMb: number; cpuUsagePercent: number; touchLatencyMs: number | null; timeToInteractiveMs: number | null; screenName: string | null; isResponsive: boolean; }' is missing the following properties from type 'PerformanceStreamData': recompositionCount, recompositionRate
 src/features/observe/ios/IOSCtrlProxyClient.ts: error TS2741: Property 'resetSetupState' is missing in type 'NoOpIOSCtrlProxyManager' but required in type 'CtrlProxyIosManager'.
-src/features/observe/ios/IosSdkEventIngestor.ts: error TS2353: Object literal may only specify known properties, and 'operation' does not exist in type '{ timestamp: number; applicationId: string | null; fileName: string; key: string | null; value: string | null; valueType: string | null; changeType: string; previousValue?: string | null | undefined; }'.
 src/features/observe/ios/index.ts: error TS2300: Duplicate identifier 'CtrlProxyHierarchy'.
 src/features/observe/ios/index.ts: error TS2300: Duplicate identifier 'CtrlProxyHierarchy'.
 src/features/performance/PerformanceAudit.ts: error TS2551: Property 'refreshRateHz' does not exist on type 'DeviceCapabilities'. Did you mean 'refreshRate'?

--- a/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
+++ b/src/db/migrations/2026_07_02_000_event_composite_indexes.ts
@@ -1,14 +1,11 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 import { EVENT_TABLES } from "../eventTables";
 
 async function tableExists(db: Kysely<unknown>, tableName: string): Promise<boolean> {
-  const result = await db
-    .selectFrom("sqlite_master" as never)
-    .select("name")
-    .where("type", "=", "table")
-    .where("name", "=", tableName)
-    .execute();
-  return result.length > 0;
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${tableName}
+  `.execute(db);
+  return result.rows.length > 0;
 }
 
 /**
@@ -50,8 +47,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     await db.schema
       .createIndex(`idx_${table}_device_timestamp`)
       .ifNotExists()
-      .on(table)
-      .columns(["device_id", "timestamp"])
+      .on(table as never)
+      .columns(["device_id", "timestamp"] as never[])
       .execute();
   }
 }

--- a/src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts
+++ b/src/db/migrations/2026_07_03_000_drop_redundant_device_indexes.ts
@@ -1,14 +1,11 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 import { EVENT_TABLES } from "../eventTables";
 
 async function tableExists(db: Kysely<unknown>, tableName: string): Promise<boolean> {
-  const result = await db
-    .selectFrom("sqlite_master" as never)
-    .select("name")
-    .where("type", "=", "table")
-    .where("name", "=", tableName)
-    .execute();
-  return result.length > 0;
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${tableName}
+  `.execute(db);
+  return result.rows.length > 0;
 }
 
 /**
@@ -62,8 +59,8 @@ export async function down(db: Kysely<unknown>): Promise<void> {
     await db.schema
       .createIndex(`idx_${table}_device`)
       .ifNotExists()
-      .on(table)
-      .column("device_id")
+      .on(table as never)
+      .column("device_id" as never)
       .execute();
   }
 }

--- a/src/server/accessibilityFocusTools.ts
+++ b/src/server/accessibilityFocusTools.ts
@@ -71,13 +71,5 @@ export function registerAccessibilityFocusTools() {
   // to focus an arbitrary node. Re-evaluate whether it should be removed, kept as
   // an internal debug primitive, or implemented through human-representative
   // TalkBack navigation gestures instead.
-  ToolRegistry.registerDeviceAware(
-    "accessibilityFocus",
-    "Set or clear Android TalkBack focus by resourceId, text, or contentDesc.",
-    accessibilityFocusSchema,
-    handler,
-    false,
-    true,
-    { outputSchema: accessibilityFocusResultSchema }
-  );
+  ToolRegistry.registerDeviceAware("accessibilityFocus", "Set or clear Android TalkBack focus by resourceId, text, or contentDesc.", accessibilityFocusSchema, handler, { debugOnly: true, outputSchema: accessibilityFocusResultSchema });
 }

--- a/src/server/accessibilityTools.ts
+++ b/src/server/accessibilityTools.ts
@@ -99,13 +99,5 @@ export function registerAccessibilityTools() {
     throw new ActionableError(`Unsupported platform: ${device.platform}`);
   };
 
-  ToolRegistry.registerDeviceAware(
-    "accessibility",
-    "Check or control accessibility services. On Android: omit talkback to check TalkBack state, or pass talkback: true/false to enable/disable it. On iOS: omit voiceover to check VoiceOver state, or pass voiceover: true/false to enable/disable it (Simulator only). Always returns fresh state from the device.",
-    accessibilitySchema,
-    accessibilityHandler,
-    false,
-    false,
-    { outputSchema: accessibilityStateSchema }
-  );
+  ToolRegistry.registerDeviceAware("accessibility", "Check or control accessibility services. On Android: omit talkback to check TalkBack state, or pass talkback: true/false to enable/disable it. On iOS: omit voiceover to check VoiceOver state, or pass voiceover: true/false to enable/disable it (Simulator only). Always returns fresh state from the device.", accessibilitySchema, accessibilityHandler, { outputSchema: accessibilityStateSchema });
 }

--- a/src/server/biometricTools.ts
+++ b/src/server/biometricTools.ts
@@ -67,11 +67,5 @@ export function registerBiometricTools() {
   };
 
   // Register the tool
-  ToolRegistry.registerDeviceAware(
-    "biometricAuth",
-    "Simulate biometric auth: Android emulator/SDK hook or iOS Simulator.",
-    biometricAuthSchema,
-    biometricAuthHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("biometricAuth", "Simulate biometric auth: Android emulator/SDK hook or iOS Simulator.", biometricAuthSchema, biometricAuthHandler, { supportsProgress: true });
 }

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -216,13 +216,7 @@ const criticalSectionHandler = async (
  * Register the criticalSection tool.
  */
 export function registerCriticalSectionTools(): void {
-  ToolRegistry.registerDeviceAware(
-    "criticalSection",
-    "Synchronize multiple devices at a barrier, then run steps serially.",
-    criticalSectionSchema,
-    criticalSectionHandler,
-    false // Does not support progress notifications
-  );
+  ToolRegistry.registerDeviceAware("criticalSection", "Synchronize multiple devices at a barrier, then run steps serially.", criticalSectionSchema, criticalSectionHandler);
 
   logger.info("Critical section tools registered");
 }

--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -175,15 +175,7 @@ export function registerDatabaseTools() {
   };
 
   // Register the sqlQuery tool
-  ToolRegistry.registerDeviceAware(
-    "sqlQuery",
-    "Execute SQL on app SQLite database.",
-    sqlQuerySchema,
-    sqlQueryHandler,
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+  ToolRegistry.registerDeviceAware("sqlQuery", "Execute SQL on app SQLite database.", sqlQuerySchema, sqlQueryHandler, { embeddedSdkOnly: true });
 }
 
 /**

--- a/src/server/debugTools.ts
+++ b/src/server/debugTools.ts
@@ -114,21 +114,7 @@ export function registerDebugTools() {
   };
 
   // Register tools with the tool registry
-  ToolRegistry.registerDeviceAware(
-    "debugSearch",
-    "Debug element search operations. Shows all matching elements, which one would be selected, and near-misses that almost matched. Use this to understand why an element isn't being found or why the wrong element is being selected.",
-    debugSearchSchema,
-    debugSearchHandler,
-    false,
-    true
-  );
+  ToolRegistry.registerDeviceAware("debugSearch", "Debug element search operations. Shows all matching elements, which one would be selected, and near-misses that almost matched. Use this to understand why an element isn't being found or why the wrong element is being selected.", debugSearchSchema, debugSearchHandler, { debugOnly: true });
 
-  ToolRegistry.registerDeviceAware(
-    "bugReport",
-    "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, logcat, window info, and screenshot. The report is saved to a file for sharing with AutoMobile developers.",
-    bugReportSchema,
-    bugReportHandler,
-    false,
-    true
-  );
+  ToolRegistry.registerDeviceAware("bugReport", "Generate a comprehensive bug report for debugging AutoMobile interactions. Captures screen state, view hierarchy, logcat, window info, and screenshot. The report is saved to a file for sharing with AutoMobile developers.", bugReportSchema, bugReportHandler, { debugOnly: true });
 }

--- a/src/server/deepLinkTools.ts
+++ b/src/server/deepLinkTools.ts
@@ -43,11 +43,5 @@ export function registerDeepLinkTools() {
   };
 
   // Register with the tool registry
-  ToolRegistry.registerDeviceAware(
-    "getDeepLinks",
-    "Query app deep links",
-    getDeepLinksSchema,
-    getDeepLinksHandler,
-    false // Does not support progress notifications
-  );
+  ToolRegistry.registerDeviceAware("getDeepLinks", "Query app deep links", getDeepLinksSchema, getDeepLinksHandler);
 }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -540,13 +540,7 @@ export function registerDeviceTools() {
     listDevicesHandler
   );
 
-  ToolRegistry.register(
-    "startDevice",
-    "Start device",
-    startDeviceSchema,
-    startDeviceHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.register("startDevice", "Start device", startDeviceSchema, startDeviceHandler, { supportsProgress: true });
 
   ToolRegistry.register(
     "killDevice",

--- a/src/server/formTools.ts
+++ b/src/server/formTools.ts
@@ -66,52 +66,44 @@ const setUIStateResultSchema = z.object({
  */
 export function registerFormTools(): void {
   // setUIState tool
-  ToolRegistry.registerDeviceAware(
-    "setUIState",
-    "Set multiple form fields by desired state.",
-    addDeviceTargetingToSchema(setUIStateSchema),
-    async (
-      device: BootedDevice,
-      args: z.infer<typeof setUIStateSchema>,
-      progress?: ProgressCallback,
-      signal?: AbortSignal
-    ) => {
-      const adb = device.platform === "android" ? defaultAdbClientFactory.create(device) : null;
-      const setUIState = new SetUIState(device, adb);
+  ToolRegistry.registerDeviceAware("setUIState", "Set multiple form fields by desired state.", addDeviceTargetingToSchema(setUIStateSchema), async (
+    device: BootedDevice,
+    args: z.infer<typeof setUIStateSchema>,
+    progress?: ProgressCallback,
+    signal?: AbortSignal
+  ) => {
+    const adb = device.platform === "android" ? defaultAdbClientFactory.create(device) : null;
+    const setUIState = new SetUIState(device, adb);
 
-      const result = await setUIState.execute(
-        {
-          fields: args.fields.map(f => ({
-            selector: {
-              text: f.selector.text,
-              elementId: f.selector.elementId
-            },
-            value: f.value,
-            selected: f.selected
-          })),
-          scrollDirection: args.scrollDirection
-        },
-        progress,
-        signal
-      );
-
-      return createStructuredToolResponse({
-        success: result.success,
-        fields: result.fields.map(f => ({
-          selector: f.selector,
-          success: f.success,
-          attempts: f.attempts,
-          verified: f.verified,
-          error: f.error,
-          fieldType: f.fieldType,
-          skipped: f.skipped
+    const result = await setUIState.execute(
+      {
+        fields: args.fields.map(f => ({
+          selector: {
+            text: f.selector.text,
+            elementId: f.selector.elementId
+          },
+          value: f.value,
+          selected: f.selected
         })),
-        totalAttempts: result.totalAttempts,
-        error: result.error
-      });
-    },
-    true, // supportsProgress
-    true, // debugOnly
-    { outputSchema: setUIStateResultSchema, planExecutable: true }
-  );
+        scrollDirection: args.scrollDirection
+      },
+      progress,
+      signal
+    );
+
+    return createStructuredToolResponse({
+      success: result.success,
+      fields: result.fields.map(f => ({
+        selector: f.selector,
+        success: f.success,
+        attempts: f.attempts,
+        verified: f.verified,
+        error: f.error,
+        fieldType: f.fieldType,
+        skipped: f.skipped
+      })),
+      totalAttempts: result.totalAttempts,
+      error: result.error
+    });
+  }, { supportsProgress: true, debugOnly: true, outputSchema: setUIStateResultSchema, planExecutable: true });
 }

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -378,12 +378,5 @@ export function registerHighlightTools(dependencies: HighlightToolDependencies =
     }
   };
 
-  ToolRegistry.registerDeviceAware(
-    "highlight",
-    "Draw a visual highlight around a UI element.",
-    highlightSchema,
-    highlightHandler,
-    false,
-    false
-  );
+  ToolRegistry.registerDeviceAware("highlight", "Draw a visual highlight around a UI element.", highlightSchema, highlightHandler);
 }

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -942,151 +942,41 @@ export function registerInteractionTools() {
   };
 
   // Register with the tool registry
-  ToolRegistry.registerDeviceAware(
-    "clearText",
-    "Clear text from focused input",
-    clearTextSchema,
-    clearTextHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("clearText", "Clear text from focused input", clearTextSchema, clearTextHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "selectAllText",
-    "Select all text in focused input",
-    selectAllTextSchema,
-    selectAllTextHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("selectAllText", "Select all text in focused input", selectAllTextSchema, selectAllTextHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "pressButton",
-    "Press device or navigation button",
-    pressButtonSchema,
-    pressButtonHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("pressButton", "Press device or navigation button", pressButtonSchema, pressButtonHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "systemTray",
-    "System tray actions for notifications (open/close/find/tap/dismiss/clearAll)",
-    systemTraySchema,
-    systemTrayHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("systemTray", "System tray actions for notifications (open/close/find/tap/dismiss/clearAll)", systemTraySchema, systemTrayHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "inputText",
-    "Input text. The optional mode field is Android-only and ignored on iOS.",
-    inputTextSchema,
-    inputTextHandler,
-    false // Does not support progress notifications
-  );
+  ToolRegistry.registerDeviceAware("inputText", "Input text. The optional mode field is Android-only and ignored on iOS.", inputTextSchema, inputTextHandler);
 
-  ToolRegistry.registerDeviceAware(
-    "openLink",
-    "Open URL in browser",
-    openLinkSchema,
-    openLinkHandler,
-    false // Does not support progress notifications
-  );
+  ToolRegistry.registerDeviceAware("openLink", "Open URL in browser", openLinkSchema, openLinkHandler);
 
-  ToolRegistry.registerDeviceAware(
-    "tapOn",
-    "Tap an element by text/content-desc or resource-id; use sibling for adjacent controls.",
-    tapOnSchema,
-    tapOnHandler,
-    true,
-    false,
-    { outputSchema: tapOnResultSchema }
-  );
+  ToolRegistry.registerDeviceAware("tapOn", "Tap an element by text/content-desc or resource-id; use sibling for adjacent controls.", tapOnSchema, tapOnHandler, { supportsProgress: true, outputSchema: tapOnResultSchema });
 
-  ToolRegistry.registerDeviceAware(
-    "tapAny",
-    "Tap any clickable element; scope with container or scrollableContainer.",
-    tapAnySchema,
-    tapAnyHandler,
-    true
-  );
+  ToolRegistry.registerDeviceAware("tapAny", "Tap any clickable element; scope with container or scrollableContainer.", tapAnySchema, tapAnyHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "dragAndDrop",
-    "Drag and drop element",
-    dragAndDropSchema,
-    dragAndDropHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("dragAndDrop", "Drag and drop element", dragAndDropSchema, dragAndDropHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "swipeOn",
-    "Swipe/scroll on screen or elements",
-    swipeOnSchema,
-    swipeOnHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("swipeOn", "Swipe/scroll on screen or elements", swipeOnSchema, swipeOnHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "pinchOn",
-    "Pinch to zoom",
-    pinchOnSchema,
-    pinchOnHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("pinchOn", "Pinch to zoom", pinchOnSchema, pinchOnHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "shake",
-    "Shake device; iOS Simulator only.",
-    shakeSchema,
-    shakeHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("shake", "Shake device; iOS Simulator only.", shakeSchema, shakeHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "imeAction",
-    "Perform IME action",
-    imeActionSchema,
-    imeActionHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("imeAction", "Perform IME action", imeActionSchema, imeActionHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "keyboard",
-    "Open, close, or detect the on-screen keyboard",
-    keyboardSchema,
-    keyboardHandler,
-    false // Does not support progress notifications
-  );
+  ToolRegistry.registerDeviceAware("keyboard", "Open, close, or detect the on-screen keyboard", keyboardSchema, keyboardHandler);
 
-  ToolRegistry.registerDeviceAware(
-    "recentApps",
-    "Open recent apps",
-    recentAppsSchema,
-    recentAppsHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("recentApps", "Open recent apps", recentAppsSchema, recentAppsHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware(
-    "homeScreen",
-    "Go to home screen",
-    homeScreenSchema,
-    homeScreenHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("homeScreen", "Go to home screen", homeScreenSchema, homeScreenHandler, { supportsProgress: true });
 
   // Register the new rotate tool
-  ToolRegistry.registerDeviceAware(
-    "rotate",
-    "Rotate device orientation",
-    rotateSchema,
-    rotateHandler,
-    true // Supports progress notifications
-  );
+  ToolRegistry.registerDeviceAware("rotate", "Rotate device orientation", rotateSchema, rotateHandler, { supportsProgress: true });
 
   // Register the clipboard tool
-  ToolRegistry.registerDeviceAware(
-    "clipboard",
-    "Clipboard operations (copy/paste/clear/get)",
-    clipboardSchema,
-    clipboardHandler,
-    false // Does not support progress notifications
-  );
+  ToolRegistry.registerDeviceAware("clipboard", "Clipboard operations (copy/paste/clear/get)", clipboardSchema, clipboardHandler);
 }

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -116,23 +116,9 @@ export function registerNavigationTools() {
   };
 
   // Register with the tool registry
-  ToolRegistry.registerDeviceAware(
-    "navigateTo",
-    "Navigate to screen using navigation graph",
-    navigateToSchema,
-    navigateToHandler,
-    true, // supports progress
-    true // debugOnly - navigation graph not production-ready
-  );
+  ToolRegistry.registerDeviceAware("navigateTo", "Navigate to screen using navigation graph", navigateToSchema, navigateToHandler, { supportsProgress: true, debugOnly: true });
 
-  ToolRegistry.registerDeviceAware(
-    "getNavigationGraph",
-    "Get navigation graph for debugging",
-    getNavigationGraphSchema,
-    getNavigationGraphHandler,
-    false,
-    true
-  );
+  ToolRegistry.registerDeviceAware("getNavigationGraph", "Get navigation graph for debugging", getNavigationGraphSchema, getNavigationGraphHandler, { debugOnly: true });
 
   // Explore handler
   const exploreHandler = async (
@@ -171,12 +157,5 @@ export function registerNavigationTools() {
     }
   };
 
-  ToolRegistry.registerDeviceAware(
-    "explore",
-    "Automatically explore app to build navigation graph",
-    exploreSchema,
-    exploreHandler,
-    true, // supports progress
-    true // debugOnly - navigation graph not production-ready
-  );
+  ToolRegistry.registerDeviceAware("explore", "Automatically explore app to build navigation graph", exploreSchema, exploreHandler, { supportsProgress: true, debugOnly: true });
 }

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -155,172 +155,140 @@ export function registerNetworkTools(): void {
   const state = NetworkState.getInstance();
 
   // --- network ---
-  ToolRegistry.registerDeviceAware(
-    "network",
-    "Control network capture and error simulation.",
-    networkSchema,
-    async (device, args: NetworkArgs) => {
-      if (args.capture !== undefined) {
-        state.setCapture(args.capture);
-      }
+  ToolRegistry.registerDeviceAware("network", "Control network capture and error simulation.", networkSchema, async (device, args: NetworkArgs) => {
+    if (args.capture !== undefined) {
+      state.setCapture(args.capture);
+    }
 
-      if (args.simulateErrors !== undefined) {
-        if (device.platform !== "android") {
-          throw new ActionableError(
-            "Network error simulation is only supported on Android devices."
-          );
+    if (args.simulateErrors !== undefined) {
+      if (device.platform !== "android") {
+        throw new ActionableError(
+          "Network error simulation is only supported on Android devices."
+        );
+      }
+      if (args.simulateErrors.cancel) {
+        state.cancelSimulation();
+      } else {
+        if (!args.simulateErrors.durationSeconds) {
+          throw new ActionableError("durationSeconds is required unless cancel is true");
         }
-        if (args.simulateErrors.cancel) {
-          state.cancelSimulation();
-        } else {
-          if (!args.simulateErrors.durationSeconds) {
-            throw new ActionableError("durationSeconds is required unless cancel is true");
-          }
-          const errorType: SimulatedErrorType =
-            args.simulateErrors.errorType ?? "http500";
-          state.startSimulation(
-            errorType,
-            args.simulateErrors.durationSeconds,
-            args.simulateErrors.limit ?? null
-          );
-        }
-        syncErrorSimulationToDevice(device, state);
+        const errorType: SimulatedErrorType =
+                args.simulateErrors.errorType ?? "http500";
+        state.startSimulation(
+          errorType,
+          args.simulateErrors.durationSeconds,
+          args.simulateErrors.limit ?? null
+        );
       }
+      syncErrorSimulationToDevice(device, state);
+    }
 
-      if (args.notifFilter !== undefined) {
-        state.setNotifFilter(args.notifFilter);
-      }
-      if (args.notifDebounceMs !== undefined) {
-        state.setNotifDebounceMs(args.notifDebounceMs);
-      }
-      if (args.slowThresholdMs !== undefined) {
-        state.setSlowThresholdMs(args.slowThresholdMs);
-      }
+    if (args.notifFilter !== undefined) {
+      state.setNotifFilter(args.notifFilter);
+    }
+    if (args.notifDebounceMs !== undefined) {
+      state.setNotifDebounceMs(args.notifDebounceMs);
+    }
+    if (args.slowThresholdMs !== undefined) {
+      state.setSlowThresholdMs(args.slowThresholdMs);
+    }
 
-      return createJSONToolResponse(state.getSnapshot());
-    },
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+    return createJSONToolResponse(state.getSnapshot());
+  }, { embeddedSdkOnly: true });
 
   // --- mockNetwork ---
-  ToolRegistry.registerDeviceAware(
-    "mockNetwork",
-    "Add mock network response rule.",
-    mockNetworkSchema,
-    async (device, args: MockNetworkArgs) => {
-      if (!serverConfig.isNetworkMockableEnabled()) {
-        throw new ActionableError(
-          "Network mocking is disabled. Start the server with --network-mockable to enable."
-        );
-      }
-      if (device.platform !== "android" && device.platform !== "ios") {
-        throw new ActionableError(
-          "Network mocking is only supported on Android and iOS devices."
-        );
-      }
+  ToolRegistry.registerDeviceAware("mockNetwork", "Add mock network response rule.", mockNetworkSchema, async (device, args: MockNetworkArgs) => {
+    if (!serverConfig.isNetworkMockableEnabled()) {
+      throw new ActionableError(
+        "Network mocking is disabled. Start the server with --network-mockable to enable."
+      );
+    }
+    if (device.platform !== "android" && device.platform !== "ios") {
+      throw new ActionableError(
+        "Network mocking is only supported on Android and iOS devices."
+      );
+    }
 
-      // Validate regex patterns before creating the mock rule
-      try {
-        new RegExp(args.host);
-      } catch {
-        throw new ActionableError(`Invalid host regex: ${args.host}`);
-      }
-      try {
-        new RegExp(args.path);
-      } catch {
-        throw new ActionableError(`Invalid path regex: ${args.path}`);
-      }
+    // Validate regex patterns before creating the mock rule
+    try {
+      new RegExp(args.host);
+    } catch {
+      throw new ActionableError(`Invalid host regex: ${args.host}`);
+    }
+    try {
+      new RegExp(args.path);
+    } catch {
+      throw new ActionableError(`Invalid path regex: ${args.path}`);
+    }
 
-      const mock = state.addMock({
-        host: args.host,
-        path: args.path,
-        method: args.method ?? "*",
-        limit: args.limit ?? null,
-        remaining: args.limit ?? null,
-        statusCode: args.statusCode ?? 200,
-        responseHeaders: args.responseHeaders ?? {},
-        responseBody: args.responseBody ?? "",
-        contentType: args.contentType ?? "application/json",
-      });
+    const mock = state.addMock({
+      host: args.host,
+      path: args.path,
+      method: args.method ?? "*",
+      limit: args.limit ?? null,
+      remaining: args.limit ?? null,
+      statusCode: args.statusCode ?? 200,
+      responseHeaders: args.responseHeaders ?? {},
+      responseBody: args.responseBody ?? "",
+      contentType: args.contentType ?? "application/json",
+    });
 
-      syncMockRulesToDevice(device, state);
+    syncMockRulesToDevice(device, state);
 
-      return createJSONToolResponse({
-        mockId: mock.mockId,
-        mocked: state.getMockSummary(),
-      });
-    },
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+    return createJSONToolResponse({
+      mockId: mock.mockId,
+      mocked: state.getMockSummary(),
+    });
+  }, { embeddedSdkOnly: true });
 
   // --- clearMockNetwork ---
-  ToolRegistry.registerDeviceAware(
-    "clearMockNetwork",
-    "Clear mock network response rules.",
-    clearMockNetworkSchema,
-    async (device, args: ClearMockNetworkArgs) => {
-      if (!serverConfig.isNetworkMockableEnabled()) {
-        throw new ActionableError(
-          "Network mocking is disabled. Start the server with --network-mockable to enable."
-        );
-      }
-      if (device.platform !== "android" && device.platform !== "ios") {
-        throw new ActionableError(
-          "Network mocking is only supported on Android and iOS devices."
-        );
-      }
+  ToolRegistry.registerDeviceAware("clearMockNetwork", "Clear mock network response rules.", clearMockNetworkSchema, async (device, args: ClearMockNetworkArgs) => {
+    if (!serverConfig.isNetworkMockableEnabled()) {
+      throw new ActionableError(
+        "Network mocking is disabled. Start the server with --network-mockable to enable."
+      );
+    }
+    if (device.platform !== "android" && device.platform !== "ios") {
+      throw new ActionableError(
+        "Network mocking is only supported on Android and iOS devices."
+      );
+    }
 
-      let cleared: number;
-      if (args.mockId) {
-        cleared = state.removeMock(args.mockId) ? 1 : 0;
-        if (cleared === 0) {
-          throw new ActionableError(`Mock '${args.mockId}' not found`);
-        }
-      } else {
-        cleared = state.clearAllMocks();
+    let cleared: number;
+    if (args.mockId) {
+      cleared = state.removeMock(args.mockId) ? 1 : 0;
+      if (cleared === 0) {
+        throw new ActionableError(`Mock '${args.mockId}' not found`);
       }
+    } else {
+      cleared = state.clearAllMocks();
+    }
 
-      syncMockRulesToDevice(device, state);
+    syncMockRulesToDevice(device, state);
 
-      return createJSONToolResponse({
-        cleared,
-        remaining: state.getMockSummary(),
-      });
-    },
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+    return createJSONToolResponse({
+      cleared,
+      remaining: state.getMockSummary(),
+    });
+  }, { embeddedSdkOnly: true });
 
   // --- getNetworkGraph ---
-  ToolRegistry.registerDeviceAware(
-    "getNetworkGraph",
-    "Get aggregate captured network graph.",
-    getNetworkGraphSchema,
-    async (device, args: GetNetworkGraphArgs) => {
-      const sinceTimestamp = args.sinceSeconds
-        ? defaultTimer.now() - args.sinceSeconds * 1000
-        : undefined;
+  ToolRegistry.registerDeviceAware("getNetworkGraph", "Get aggregate captured network graph.", getNetworkGraphSchema, async (device, args: GetNetworkGraphArgs) => {
+    const sinceTimestamp = args.sinceSeconds
+      ? defaultTimer.now() - args.sinceSeconds * 1000
+      : undefined;
 
-      const events = await getNetworkEvents({
-        deviceId: device.deviceId,
-        sinceTimestamp,
-        method: args.method,
-        limit: 10_000,
-      });
+    const events = await getNetworkEvents({
+      deviceId: device.deviceId,
+      sinceTimestamp,
+      method: args.method,
+      limit: 10_000,
+    });
 
-      const graph = buildNetworkGraph(events, {
-        minRequests: args.minRequests,
-      });
+    const graph = buildNetworkGraph(events, {
+      minRequests: args.minRequests,
+    });
 
-      return createJSONToolResponse(graph);
-    },
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+    return createJSONToolResponse(graph);
+  }, { embeddedSdkOnly: true });
 }

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -306,12 +306,5 @@ export function registerObserveTools() {
     observeHandler
   );
 
-  ToolRegistry.registerDeviceAware(
-    "identifyInteractions",
-    "Suggest likely interactions",
-    identifyInteractionsSchema,
-    identifyInteractionsHandler,
-    false,
-    true
-  );
+  ToolRegistry.registerDeviceAware("identifyInteractions", "Suggest likely interactions", identifyInteractionsSchema, identifyInteractionsHandler, { debugOnly: true });
 }

--- a/src/server/planTools.ts
+++ b/src/server/planTools.ts
@@ -289,44 +289,12 @@ const recordStepsTool = async (params: { action: "begin" | "end" | "status"; pla
 
 // Register plan tools for daemon-backed MCP servers and CLI usage.
 export const registerPlanTools = () => {
-  ToolRegistry.registerDeviceAware(
-    "executePlan",
-    "Execute YAML plan steps; stops on first failed step.",
-    executePlanSchema,
-    executePlanTool,
-    true,
-    false,
-    { outputSchema: executePlanResultSchema }
-  );
+  ToolRegistry.registerDeviceAware("executePlan", "Execute YAML plan steps; stops on first failed step.", executePlanSchema, executePlanTool, { supportsProgress: true, outputSchema: executePlanResultSchema });
 
-  ToolRegistry.registerDeviceAware(
-    "startTestRecording",
-    "Start recording user interactions for exportPlan.",
-    startTestRecordingSchema,
-    startTestRecordingTool,
-    false,
-    false,
-    { outputSchema: startTestRecordingResultSchema }
-  );
+  ToolRegistry.registerDeviceAware("startTestRecording", "Start recording user interactions for exportPlan.", startTestRecordingSchema, startTestRecordingTool, { outputSchema: startTestRecordingResultSchema });
 
-  ToolRegistry.register(
-    "exportPlan",
-    "Stop active recording and export a YAML plan.",
-    exportPlanSchema,
-    exportPlanTool,
-    false,
-    false,
-    exportPlanResultSchema
-  );
+  ToolRegistry.register("exportPlan", "Stop active recording and export a YAML plan.", exportPlanSchema, exportPlanTool, { outputSchema: exportPlanResultSchema });
 
   // MCP call recording — begin/end gated by "mcp-recording" feature flag; status always available.
-  ToolRegistry.register(
-    "recordSteps",
-    "Record MCP tool calls to YAML. begin/end require mcp-recording; status always works.",
-    recordStepsSchema,
-    recordStepsTool,
-    false,
-    false,
-    recordStepsResultSchema
-  );
+  ToolRegistry.register("recordSteps", "Record MCP tool calls to YAML. begin/end require mcp-recording; status always works.", recordStepsSchema, recordStepsTool, { outputSchema: recordStepsResultSchema });
 };

--- a/src/server/storageTools.ts
+++ b/src/server/storageTools.ts
@@ -265,33 +265,9 @@ export function registerStorageTools(): void {
     }
   };
 
-  ToolRegistry.registerDeviceAware(
-    "setKeyValue",
-    "Set app key-value storage entry.",
-    setKeyValueSchema,
-    setKeyValueHandler,
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+  ToolRegistry.registerDeviceAware("setKeyValue", "Set app key-value storage entry.", setKeyValueSchema, setKeyValueHandler, { embeddedSdkOnly: true });
 
-  ToolRegistry.registerDeviceAware(
-    "removeKeyValue",
-    "Remove app key-value storage entry.",
-    removeKeyValueSchema,
-    removeKeyValueHandler,
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+  ToolRegistry.registerDeviceAware("removeKeyValue", "Remove app key-value storage entry.", removeKeyValueSchema, removeKeyValueHandler, { embeddedSdkOnly: true });
 
-  ToolRegistry.registerDeviceAware(
-    "clearKeyValueFile",
-    "Clear app key-value storage file.",
-    clearKeyValueFileSchema,
-    clearKeyValueFileHandler,
-    false,
-    false,
-    { embeddedSdkOnly: true }
-  );
+  ToolRegistry.registerDeviceAware("clearKeyValueFile", "Clear app key-value storage file.", clearKeyValueFileSchema, clearKeyValueFileHandler, { embeddedSdkOnly: true });
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -49,10 +49,15 @@ interface DeviceAwareToolHandler<T = any> {
   (device: BootedDevice, args: T, progress?: ProgressCallback, signal?: AbortSignal): Promise<any>;
 }
 
-interface DeviceAwareToolOptions<T = any> {
+interface ToolRegistrationOptions {
+  supportsProgress?: boolean;
+  debugOnly?: boolean;
+  outputSchema?: any;
+}
+
+interface DeviceAwareToolOptions<T = any> extends ToolRegistrationOptions {
   shouldEnsureDevice?: (args: T) => boolean;
   nonDeviceHandler?: ToolHandler<T>;
-  outputSchema?: any;
   embeddedSdkOnly?: boolean;
   planExecutable?: boolean;
 }
@@ -88,488 +93,245 @@ export function toolHasOutputSchema(tool: Pick<RegisteredTool, "outputSchema">):
   return tool.outputSchema !== undefined && tool.outputSchema !== null;
 }
 
-// The registry that holds all tools
-class ToolRegistryClass {
-  private tools: Map<string, RegisteredTool> = new Map();
-  private deviceSessionManager: DeviceSessionManager;
-  private cleanupService: AppCleanupService;
-  private toolCallRepository: ToolCallRepository;
-  private timer: Timer;
+interface ExecutionTargetInput {
+  name: string;
+  args: any;
+  options: DeviceAwareToolOptions;
+  deviceSessionManager: DeviceSessionManager;
+}
 
-  constructor(timer: Timer = defaultTimer) {
-    this.deviceSessionManager = DeviceSessionManager.getInstance();
-    this.cleanupService = new DefaultAppCleanupService();
-    this.toolCallRepository = new ToolCallRepository();
-    this.timer = timer;
-  }
+interface ExecutionTargetContext {
+  args: any;
+  baseSessionUuid: string | undefined;
+  device: BootedDevice | undefined;
+  internalCall: boolean;
+  sessionUuid: string | undefined;
+  shouldResolveDevice: boolean;
+}
 
-  private getToolAvailabilityGateReasons(tool: RegisteredTool): string[] {
-    const reasons: string[] = [];
-    if (tool.debugOnly && !isDebugModeEnabled()) {
-      reasons.push("--debug is disabled");
-    }
-    if (tool.embeddedSdkOnly && !serverConfig.isEmbeddedSdkEnabled()) {
-      reasons.push("embedded SDK mode is disabled");
-    }
-    return reasons;
-  }
+interface ExecutionTargetResolver {
+  resolveExecutionTarget(input: ExecutionTargetInput): Promise<ExecutionTargetContext>;
+}
 
-  private isToolAvailable(tool: RegisteredTool): boolean {
-    return this.getToolAvailabilityGateReasons(tool).length === 0;
-  }
+interface AuditRunnerInput {
+  name: string;
+  args: any;
+  device: BootedDevice;
+  handler: DeviceAwareToolHandler;
+  progress?: ProgressCallback;
+  signal?: AbortSignal;
+}
 
-  // Register a new tool
-  register(
-    name: string,
-    description: string,
-    schema: any,
-    handler: ToolHandler,
-    supportsProgress: boolean = false,
-    debugOnly: boolean = false,
-    outputSchema?: any
-  ): void {
-    this.tools.set(name, {
-      name,
-      description,
-      schema,
-      handler,
-      supportsProgress,
-      requiresDevice: false,
-      debugOnly,
-      embeddedSdkOnly: false,
-      outputSchema
-    });
-  }
+interface AuditRunner {
+  run(input: AuditRunnerInput): Promise<any>;
+}
 
-  // Helper: Get foreground app package name
-  private async getForegroundPackageName(device: BootedDevice): Promise<string | null> {
-    try {
-      const adb = defaultAdbClientFactory.create(device);
-      const { stdout } = await adb.executeCommand(
-        "shell dumpsys window | grep mCurrentFocus"
-      );
+interface NavigationToolCallRecorder {
+  record(name: string, args: any, device: BootedDevice | undefined, sessionUuid: string | undefined): void;
+}
 
-      // Parse: "mCurrentFocus=Window{... u0 com.example.app/com.example.Activity}"
-      const match = stdout.match(/\s+(\S+)\/\S+\}/);
-      return match ? match[1] : null;
-    } catch (error) {
-      logger.warn(`[ToolRegistry] Failed to get foreground package name: ${error}`);
-      return null;
-    }
-  }
+interface AfterToolCallInput {
+  name: string;
+  args: any;
+  device: BootedDevice | undefined;
+  internalCall: boolean;
+  response: any;
+  sessionUuid: string | undefined;
+  shouldResolveDevice: boolean;
+  signal?: AbortSignal;
+  timer: Timer;
+  toolStartMs: number;
+}
 
-  // Register a device-aware tool
-  registerDeviceAware(
-    name: string,
-    description: string,
-    schema: any,
-    handler: DeviceAwareToolHandler,
-    supportsProgress: boolean = false,
-    debugOnly: boolean = false,
-    options: DeviceAwareToolOptions = {}
-  ): void {
-    // Create a wrapper that handles device ID injection
-    const wrappedHandler: ToolHandler = async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
-      const shouldResolveDevice = options.shouldEnsureDevice
-        ? options.shouldEnsureDevice(args)
-        : true;
+interface AfterToolCallResult {
+  durationMs: number;
+  finalizedResponse: any;
+}
 
-      // Extract internal routing params from args.
-      // If you add new injected params here, also update INTERNAL_PARAMS in
-      // src/features/record/McpCallRecorder.ts so they are stripped from recordings.
-      let providedDeviceId = args.deviceId;
-      const baseSessionUuid = args.sessionUuid;
-      const deviceLabel = typeof args.device === "string" ? args.device : undefined;
-      const declaredDeviceLabels = Array.isArray(args.devices) ? args.devices : undefined;
-      const mcpSessionId = typeof args.__mcpSessionId === "string" ? args.__mcpSessionId : undefined;
-      // Internal tool-to-tool marker (#3053 / #3087): internal callers (PlanExecutor
-      // steps, navigation/setup replays) set this via `markInternalToolCall` so a
-      // plan/navigation step's finalized envelope is never diffed/stripped and never
-      // advances the agent-facing diff baseline (a future internal
-      // `.observation.viewHierarchy` reader stays correct).
-      const internalCall = args[INTERNAL_NO_DIFF_PARAM] === true;
-      let sessionUuid = baseSessionUuid;
-      const keepScreenAwake = typeof args.keepScreenAwake === "boolean" ? args.keepScreenAwake : undefined;
+interface AfterToolCallHandler {
+  handle(input: AfterToolCallInput): Promise<AfterToolCallResult>;
+}
 
-      if (deviceLabel && shouldResolveDevice) {
-        if (!DaemonState.getInstance().isInitialized()) {
-          throw new ActionableError("Device labels require an active daemon session.");
-        }
-        if (!baseSessionUuid) {
-          throw new ActionableError(`Device label '${deviceLabel}' requires sessionUuid to be provided.`);
-        }
+interface PlanLifecycleInput {
+  name: string;
+  args: any;
+  baseSessionUuid: string | undefined;
+  cleanupService: AppCleanupService;
+  device: BootedDevice | undefined;
+  sessionUuid: string | undefined;
+  shouldResolveDevice: boolean;
+}
 
-        const deviceLabelMap = getDeviceLabelMap(baseSessionUuid);
-        if (deviceLabelMap) {
-          const mappedSession = deviceLabelMap[deviceLabel];
-          if (!mappedSession) {
-            const available = Object.keys(deviceLabelMap);
-            const suffix = available.length > 0 ? ` Available labels: ${available.join(", ")}` : "";
-            throw new ActionableError(`Unknown device label '${deviceLabel}'.${suffix}`);
-          }
-          sessionUuid = mappedSession;
-        } else if (name === "executePlan" && declaredDeviceLabels?.includes(deviceLabel)) {
-          sessionUuid = baseSessionUuid;
-        } else {
-          throw new ActionableError(
-            `Device label '${deviceLabel}' is not allocated. Provide a devices list to executePlan before using device labels.`
-          );
-        }
+interface PlanLifecycleManager {
+  afterExecution(input: PlanLifecycleInput): Promise<void>;
+}
 
-        if (providedDeviceId) {
-          logger.warn(`[ToolRegistry] Ignoring deviceId because device label '${deviceLabel}' was provided.`);
-          providedDeviceId = undefined;
-        }
+interface ToolRegistryPipelineOverrides {
+  executionTargetResolver?: ExecutionTargetResolver;
+  auditRunner?: AuditRunner;
+  afterToolCall?: AfterToolCallHandler;
+  planLifecycleManager?: PlanLifecycleManager;
+}
+
+class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
+  async resolveExecutionTarget(input: ExecutionTargetInput): Promise<ExecutionTargetContext> {
+    const { name, args, options, deviceSessionManager } = input;
+    const shouldResolveDevice = options.shouldEnsureDevice
+      ? options.shouldEnsureDevice(args)
+      : true;
+
+    // Extract internal routing params from args.
+    // If you add new injected params here, also update INTERNAL_PARAMS in
+    // src/features/record/McpCallRecorder.ts so they are stripped from recordings.
+    let providedDeviceId = args.deviceId;
+    const baseSessionUuid = args.sessionUuid;
+    const deviceLabel = typeof args.device === "string" ? args.device : undefined;
+    const declaredDeviceLabels = Array.isArray(args.devices) ? args.devices : undefined;
+    const mcpSessionId = typeof args.__mcpSessionId === "string" ? args.__mcpSessionId : undefined;
+    // Internal tool-to-tool marker (#3053 / #3087): internal callers (PlanExecutor
+    // steps, navigation/setup replays) set this via `markInternalToolCall` so a
+    // plan/navigation step's finalized envelope is never diffed/stripped and never
+    // advances the agent-facing diff baseline (a future internal
+    // `.observation.viewHierarchy` reader stays correct).
+    const internalCall = args[INTERNAL_NO_DIFF_PARAM] === true;
+    let sessionUuid = baseSessionUuid;
+    const keepScreenAwake = typeof args.keepScreenAwake === "boolean" ? args.keepScreenAwake : undefined;
+
+    if (deviceLabel && shouldResolveDevice) {
+      if (!DaemonState.getInstance().isInitialized()) {
+        throw new ActionableError("Device labels require an active daemon session.");
+      }
+      if (!baseSessionUuid) {
+        throw new ActionableError(`Device label '${deviceLabel}' requires sessionUuid to be provided.`);
       }
 
-      const toolStartMs = this.timer.now();
-      const toolCallTimestamp = new Date().toISOString();
-      let toolDurationMs: number | undefined;
+      const deviceLabelMap = getDeviceLabelMap(baseSessionUuid);
+      if (deviceLabelMap) {
+        const mappedSession = deviceLabelMap[deviceLabel];
+        if (!mappedSession) {
+          const available = Object.keys(deviceLabelMap);
+          const suffix = available.length > 0 ? ` Available labels: ${available.join(", ")}` : "";
+          throw new ActionableError(`Unknown device label '${deviceLabel}'.${suffix}`);
+        }
+        sessionUuid = mappedSession;
+      } else if (name === "executePlan" && declaredDeviceLabels?.includes(deviceLabel)) {
+        sessionUuid = baseSessionUuid;
+      } else {
+        throw new ActionableError(
+          `Device label '${deviceLabel}' is not allocated. Provide a devices list to executePlan before using device labels.`
+        );
+      }
 
+      if (providedDeviceId) {
+        logger.warn(`[ToolRegistry] Ignoring deviceId because device label '${deviceLabel}' was provided.`);
+        providedDeviceId = undefined;
+      }
+    }
+
+    // Extract platform from args, default to "either" for backward compatibility
+    let platform: SomePlatform = args.platform || "either";
+
+    if (shouldResolveDevice) {
+      const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId);
+      if (implicitSessionUuid) {
+        sessionUuid = implicitSessionUuid;
+        args.sessionUuid = implicitSessionUuid;
+        logger.info(`[ToolRegistry] Resolved implicit autolock session for MCP session ${mcpSessionId}: ${implicitSessionUuid}`);
+      }
+      await this.enforceSessionUuidForMultipleIos(platform, sessionUuid, providedDeviceId, deviceSessionManager);
+      await this.enforceSessionUuidForAutolock(platform, sessionUuid, providedDeviceId, deviceSessionManager);
+    }
+
+    logger.info(`[ToolRegistry] Tool ${name} called, sessionUuid=${sessionUuid}, daemonInitialized=${DaemonState.getInstance().isInitialized()}`);
+
+    // If session UUID provided, resolve device from session
+    if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
+      logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
+      const sessionManager = DaemonState.getInstance().getSessionManager();
+      const devicePool = DaemonState.getInstance().getDevicePool();
+      const context = await createToolExecutionContext(sessionUuid, sessionManager, devicePool, {
+        keepScreenAwake,
+        platform: platform === "android" || platform === "ios" ? platform : undefined
+      });
+      if (context.deviceId && !providedDeviceId) {
+        providedDeviceId = context.deviceId;
+        logger.info(`[ToolRegistry] Resolved device from session: ${providedDeviceId}`);
+      }
+      if (platform === "either" && context.devicePlatform) {
+        platform = context.devicePlatform;
+      }
+    } else if (sessionUuid) {
+      logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
+    }
+
+    let device: BootedDevice | undefined;
+    if (shouldResolveDevice) {
+      if (sessionUuid && DaemonState.getInstance().isInitialized() && providedDeviceId) {
+        // Daemon session path: device already resolved via createToolExecutionContext.
+        // Construct BootedDevice directly to avoid mutating global DeviceSessionManager state.
+        const resolvedPlatform = (platform === "android" || platform === "ios") ? platform : "android";
+        const pooledDevice = DaemonState.getInstance().getDevicePool().getDevice(providedDeviceId);
+        device = {
+          deviceId: providedDeviceId,
+          name: pooledDevice?.name ?? providedDeviceId,
+          platform: pooledDevice?.platform ?? resolvedPlatform,
+          iosVersion: pooledDevice?.iosVersion,
+        };
+        logger.info(`[ToolRegistry] ${name}: Using session-resolved device ${device.deviceId}`);
+      } else {
+        // Legacy single-agent path or no session: use DeviceSessionManager (may set global state)
+        logger.info(`[ToolRegistry] ${name}: Resolving device for platform=${platform}, providedDeviceId=${providedDeviceId}`);
+        device = await deviceSessionManager.ensureDeviceReady(
+          platform,
+          providedDeviceId,
+          { skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled() }
+        );
+        logger.info(`[ToolRegistry] ${name}: Using device ${device.deviceId}`);
+      }
+    } else {
+      logger.info(`[ToolRegistry] ${name}: Skipping device resolution.`);
+    }
+
+    // Enforce autolock: a locked device may only be driven by the session that locked it.
+    if (device && isDevicePoolAutolockEnabled() && DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().getDevicePool().assertAutolockAccess(device.deviceId, sessionUuid);
+    }
+
+    // Bind session to device's CtrlProxyClient for multi-agent NavigationGraphManager isolation
+    if (device && sessionUuid) {
       try {
-        // Extract platform from args, default to "either" for backward compatibility
-        let platform: SomePlatform = args.platform || "either";
-
-        if (shouldResolveDevice) {
-          const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId);
-          if (implicitSessionUuid) {
-            sessionUuid = implicitSessionUuid;
-            args.sessionUuid = implicitSessionUuid;
-            logger.info(`[ToolRegistry] Resolved implicit autolock session for MCP session ${mcpSessionId}: ${implicitSessionUuid}`);
-          }
-          await this.enforceSessionUuidForMultipleIos(platform, sessionUuid, providedDeviceId);
-          await this.enforceSessionUuidForAutolock(platform, sessionUuid, providedDeviceId);
+        if (device.platform === "android") {
+          AndroidCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
+        } else if (device.platform === "ios") {
+          IOSCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
         }
-
-        logger.info(`[ToolRegistry] Tool ${name} called, sessionUuid=${sessionUuid}, daemonInitialized=${DaemonState.getInstance().isInitialized()}`);
-
-        // If session UUID provided, resolve device from session
-        if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
-          logger.info(`[ToolRegistry] Entering session-based device assignment for ${sessionUuid}`);
-          const sessionManager = DaemonState.getInstance().getSessionManager();
-          const devicePool = DaemonState.getInstance().getDevicePool();
-          const context = await createToolExecutionContext(sessionUuid, sessionManager, devicePool, {
-            keepScreenAwake,
-            platform: platform === "android" || platform === "ios" ? platform : undefined
-          });
-          if (context.deviceId && !providedDeviceId) {
-            providedDeviceId = context.deviceId;
-            logger.info(`[ToolRegistry] Resolved device from session: ${providedDeviceId}`);
-          }
-          if (platform === "either" && context.devicePlatform) {
-            platform = context.devicePlatform;
-          }
-        } else if (sessionUuid) {
-          logger.warn(`[ToolRegistry] SessionUuid provided but DaemonState not initialized!`);
-        }
-
-        let device: BootedDevice | undefined;
-        if (shouldResolveDevice) {
-          if (sessionUuid && DaemonState.getInstance().isInitialized() && providedDeviceId) {
-            // Daemon session path: device already resolved via createToolExecutionContext.
-            // Construct BootedDevice directly to avoid mutating global DeviceSessionManager state.
-            const resolvedPlatform = (platform === "android" || platform === "ios") ? platform : "android";
-            const pooledDevice = DaemonState.getInstance().getDevicePool().getDevice(providedDeviceId);
-            device = {
-              deviceId: providedDeviceId,
-              name: pooledDevice?.name ?? providedDeviceId,
-              platform: pooledDevice?.platform ?? resolvedPlatform,
-              iosVersion: pooledDevice?.iosVersion,
-            };
-            logger.info(`[ToolRegistry] ${name}: Using session-resolved device ${device.deviceId}`);
-          } else {
-            // Legacy single-agent path or no session: use DeviceSessionManager (may set global state)
-            logger.info(`[ToolRegistry] ${name}: Resolving device for platform=${platform}, providedDeviceId=${providedDeviceId}`);
-            device = await this.deviceSessionManager.ensureDeviceReady(
-              platform,
-              providedDeviceId,
-              { skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled() }
-            );
-            logger.info(`[ToolRegistry] ${name}: Using device ${device.deviceId}`);
-          }
-        } else {
-          logger.info(`[ToolRegistry] ${name}: Skipping device resolution.`);
-        }
-
-        // Enforce autolock: a locked device may only be driven by the session that locked it.
-        if (device && isDevicePoolAutolockEnabled() && DaemonState.getInstance().isInitialized()) {
-          DaemonState.getInstance().getDevicePool().assertAutolockAccess(device.deviceId, sessionUuid);
-        }
-
-        // Bind session to device's CtrlProxyClient for multi-agent NavigationGraphManager isolation
-        if (device && sessionUuid) {
-          try {
-            if (device.platform === "android") {
-              AndroidCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
-            } else if (device.platform === "ios") {
-              IOSCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
-            }
-          } catch {
-            // CtrlProxy may not be initialized yet — binding is best-effort
-          }
-        }
-
-        try {
-          // Record tool call for navigation graph correlation
-          // Only record UI interaction tools that may cause navigation
-          // Excludes app lifecycle tools (launchApp, terminateApp, homeScreen, etc.)
-          // as they don't represent replayable in-app navigation paths
-          const navigationRelevantTools = [
-            "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
-            "pressButton", "inputText", "clearText", "imeAction"
-          ];
-          if (navigationRelevantTools.includes(name)) {
-            // Extract UI state from the most recent cached observation
-            const cachedResult = device
-              ? RealObserveScreen.getRecentCachedResultForDevice(device.deviceId)
-              : RealObserveScreen.getRecentCachedResult();
-            const uiState = new UIStateExtractor().extractFromObservation(cachedResult);
-            const navManager = sessionUuid
-              ? NavigationGraphManager.getInstanceForSession(sessionUuid)
-              : NavigationGraphManager.getInstance();
-            navManager.recordToolCall(name, args, uiState);
-          }
-
-          let response: any | undefined;
-          if (!shouldResolveDevice) {
-            if (!options.nonDeviceHandler) {
-              throw new ActionableError(`Tool ${name} requires a device.`);
-            }
-            response = await options.nonDeviceHandler(args, progress, signal);
-          } else if (device !== undefined) {
-            // Check if memory performance audit mode is enabled
-            const memPerfAuditEnabled = serverConfig.isMemPerfAuditEnabled();
-
-            if (memPerfAuditEnabled && device.platform === "android") {
-              // Get the foreground app package name
-              const packageName = await this.getForegroundPackageName(device);
-
-              if (packageName) {
-                logger.info(`[ToolRegistry] Running memory audit for ${packageName} during ${name}`);
-
-                // Create memory audit instance
-                const memoryAudit = new MemoryAudit(device);
-                const perf = createGlobalPerformanceTracker();
-
-                // Run the handler within memory audit
-                const auditResult = await memoryAudit.runAudit(
-                  packageName,
-                  name,
-                  args,
-                  async () => {
-                    response = await handler(device, args, progress, signal);
-                  },
-                  perf
-                );
-
-                // If audit failed, throw error with diagnostics
-                if (!auditResult.passed) {
-                  const errorMsg = `Memory audit FAILED for ${packageName} during ${name}\n\n${auditResult.diagnostics}`;
-                  logger.error(`[ToolRegistry] ${errorMsg}`);
-                  throw new ActionableError(errorMsg);
-                }
-
-                logger.info(`[ToolRegistry] Memory audit PASSED for ${packageName} during ${name}`);
-              } else {
-                logger.warn(`[ToolRegistry] Could not determine foreground app, skipping memory audit for ${name}`);
-                response = await handler(device, args, progress, signal);
-              }
-            } else {
-              // Memory audit not enabled or not Android platform, execute normally
-              response = await handler(device, args, progress, signal);
-            }
-          }
-
-          // Unwrap MCP response envelope to get the inner result for success/error checks.
-          // Tools may return { content: [{ type: "text", text: '{"success":false,...}' }] }
-          // instead of a plain { success, error } object.
-          let unwrapped = response;
-          if (
-            response && typeof response === "object" &&
-            !("success" in response) &&
-            Array.isArray(response.content) && response.content.length > 0
-          ) {
-            const first = response.content[0];
-            if (first?.type === "text" && typeof first.text === "string") {
-              try {
-                const parsed = JSON.parse(first.text);
-                if (parsed && typeof parsed === "object" && "success" in parsed) {
-                  unwrapped = parsed;
-                }
-              } catch { /* not JSON — use original response */ }
-            }
-          }
-
-          const toolSuccess = unwrapped && typeof unwrapped === "object" && "success" in unwrapped
-            ? unwrapped.success !== false
-            : true;
-          const toolError = unwrapped && typeof unwrapped === "object" && "error" in unwrapped
-            ? String(unwrapped.error || "")
-            : null;
-          if (unwrapped && typeof unwrapped === "object" && "success" in unwrapped) {
-            // If the caller's request already timed out (signal aborted), the late
-            // result contradicts the timeout they received — surface it as a warning
-            // rather than a bare success=true. See issue #2723.
-            const resultLog = formatToolResultLog({
-              toolName: name,
-              success: unwrapped.success !== false,
-              error: unwrapped.error,
-              callerTimedOut: signal?.aborted ?? false,
-            });
-            logger[resultLog.level](resultLog.message);
-          }
-
-          // Emit tool call telemetry
-          toolDurationMs = this.timer.now() - toolStartMs;
-          TelemetryRecorder.getInstance().recordToolCallEvent({
-            timestamp: toolStartMs,
-            toolName: name,
-            durationMs: toolDurationMs,
-            success: toolSuccess,
-            error: toolError,
-            args: typeof args === "object" ? args : null,
-          });
-
-          // Record successful tool call for MCP recording (test plan generation)
-          if (toolSuccess) {
-            getMcpRecorder()?.record(name, args);
-          }
-
-          // After swipeOn executes with lookFor, update the tool call with scroll position.
-          // Handlers pre-serialize into an MCP envelope, so `found` lives under
-          // `structuredContent` — `createStructuredToolResponse` only hoists
-          // `success`/`error` to the envelope top level. The former `response?.found`
-          // read was always undefined, so this block was dead and scroll-position
-          // tracking never fired (issue #2897; same class as the #2758 lastHierarchy fix).
-          if (name === "swipeOn" && args.lookFor && getStructuredField<boolean>(response, "success") && getStructuredField<boolean>(response, "found")) {
-            const scrollPosition = UIStateExtractor.createScrollPosition(args);
-            if (scrollPosition) {
-              const scrollNavManager = sessionUuid
-                ? NavigationGraphManager.getInstanceForSession(sessionUuid)
-                : NavigationGraphManager.getInstance();
-              scrollNavManager.updateScrollPosition(scrollPosition);
-            }
-          }
-
-          // Update session cache if sessionUuid provided
-          if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
-            const sessionManager = DaemonState.getInstance().getSessionManager();
-
-            // Cache observation data for certain tools to reduce API calls.
-            // Handlers pre-serialize into an MCP envelope, so the ObserveResult
-            // lives under `structuredContent`, not on `response` directly (the
-            // former read of `response.viewHierarchy` was always undefined, so
-            // `lastHierarchy` never populated — the #2761 diff baseline needs it).
-            // Route through the typed setters so the canonical top-level slots
-            // are the source of truth rather than the untyped `customData` bag
-            // (issue #2917). Runs before finalizeToolResponse, so the cache keeps
-            // the full, untrimmed hierarchy while the wire copy is sanitized.
-            const observeHierarchy = name === "observe" ? getStructuredField<ViewHierarchyResult>(response, "viewHierarchy") : undefined;
-            if (observeHierarchy) {
-              sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);
-            }
-            const observeScreenshot = name === "observe" ? getStructuredField<string>(response, "screenshot") : undefined;
-            if (observeScreenshot) {
-              sessionManager.setLastScreenshot(sessionUuid, observeScreenshot);
-            }
-          }
-
-          // Back the #2761 diff baseline with the session cache when a session
-          // and daemon are present (legacy single-agent path stays diff-free and
-          // emits the full observation). The closures read/write the typed
-          // `lastRenderedObservation` slot; finalize only invokes them when
-          // `--actions-diff-observe` is on, so this is inert by default.
-          const baselineStore: ObservationBaselineStore | undefined =
-            sessionUuid && DaemonState.getInstance().isInitialized()
-              ? {
-                // Read via the side-effect-free reader so a diffed action records
-                // session activity once (from the baseline `set`), not twice (#3053).
-                get: uuid => DaemonState.getInstance().getSessionManager().getLastRenderedObservation(uuid),
-                set: (uuid, observation) => DaemonState.getInstance().getSessionManager().setLastRenderedObservation(uuid, observation),
-              }
-              : undefined;
-          return finalizeToolResponse(response, { name, sessionUuid, baselineStore, internal: internalCall });
-        } catch (error) {
-          if (error instanceof ActionableError) {
-            throw error;
-          }
-          const deviceContext = device ? ` on device ${device.deviceId}` : "";
-          throw new ActionableError(`Failed to execute tool ${name}${deviceContext}: ${error}`);
-        } finally {
-          if (device && name === "executePlan" && args?.cleanupAppId) {
-            await this.cleanupService.cleanup(device, {
-              appId: args.cleanupAppId,
-              clearAppData: args.cleanupClearAppData,
-            });
-          }
-
-          // Auto-release session after executePlan completes
-          // This frees the device immediately for parallel test execution
-          if (shouldResolveDevice && sessionUuid && name === "executePlan" && DaemonState.getInstance().isInitialized()) {
-            try {
-              const sessionManager = DaemonState.getInstance().getSessionManager();
-              const devicePool = DaemonState.getInstance().getDevicePool();
-              const releaseSessionUuid = baseSessionUuid ?? sessionUuid;
-              if (releaseSessionUuid) {
-                await releaseDeviceLabelSessions(releaseSessionUuid);
-              }
-
-              const session = releaseSessionUuid ? sessionManager.getSession(releaseSessionUuid) : null;
-              if (session) {
-                const deviceId = session.assignedDevice;
-                sessionManager.releaseSession(session.sessionId);
-                await devicePool.releaseDevice(deviceId);
-                // Clean up session-scoped navigation state and observe cache
-                NavigationGraphManager.releaseSession(releaseSessionUuid);
-                RealObserveScreen.clearCache(deviceId);
-                logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);
-              }
-            } catch (releaseError) {
-              // Don't fail the tool if session release fails
-              // Session will be cleaned up by timeout mechanism
-              logger.warn(`Failed to auto-release session ${sessionUuid}: ${releaseError}`);
-            }
-          }
-        }
-      } finally {
-        await this.toolCallRepository.recordToolCall({
-          toolName: name,
-          timestamp: toolCallTimestamp,
-          sessionUuid,
-          durationMs: toolDurationMs ?? this.timer.now() - toolStartMs,
-        });
+      } catch (error) {
+        logger.debug(`[ToolRegistry] Best-effort CtrlProxy session bind skipped for ${name}: ${error}`);
       }
-    };
+    }
 
-    this.tools.set(name, {
-      name,
-      description,
-      schema,
-      handler: wrappedHandler,
-      supportsProgress,
-      requiresDevice: true,
-      deviceAwareHandler: handler,
-      debugOnly,
-      embeddedSdkOnly: options.embeddedSdkOnly ?? false,
-      planExecutable: options.planExecutable ?? false,
-      outputSchema: options.outputSchema
-    });
+    return {
+      args,
+      baseSessionUuid,
+      device,
+      internalCall,
+      sessionUuid,
+      shouldResolveDevice,
+    };
   }
 
   private async enforceSessionUuidForMultipleIos(
     platform: SomePlatform,
     sessionUuid: string | undefined,
-    providedDeviceId: string | undefined
+    providedDeviceId: string | undefined,
+    deviceSessionManager: DeviceSessionManager
   ): Promise<void> {
     if (sessionUuid || providedDeviceId) {
       return;
     }
 
-    // Check if an iOS device was set via setActiveDevice and platform is explicitly ios
-    // Only skip the guard when platform === "ios" because ensureDeviceReady only honors
-    // the current device when the requested platform matches currentPlatform
-    const currentDevice = this.deviceSessionManager.getCurrentDevice();
-    const currentPlatform = this.deviceSessionManager.getCurrentPlatform();
+    const currentDevice = deviceSessionManager.getCurrentDevice();
+    const currentPlatform = deviceSessionManager.getCurrentPlatform();
     if (currentDevice && currentPlatform === "ios" && platform === "ios") {
       return;
     }
@@ -578,7 +340,7 @@ class ToolRegistryClass {
       return;
     }
 
-    const connectedPlatforms = await this.deviceSessionManager.detectConnectedPlatforms();
+    const connectedPlatforms = await deviceSessionManager.detectConnectedPlatforms();
     const iosDevices = connectedPlatforms.filter(device => device.platform === "ios");
     if (iosDevices.length <= 1) {
       return;
@@ -625,20 +387,11 @@ class ToolRegistryClass {
     return session?.assignedDevice === providedDeviceId ? sessionId : undefined;
   }
 
-  /**
-   * When device pool autolock is enabled, a tool call that does not name a target
-   * (no sessionUuid and no deviceId) must not be routed to an arbitrary device if
-   * more than one candidate exists — that would defeat the per-session device
-   * ownership autolock provides. Resolve the MCP session's autolock session when
-   * available; otherwise require the sessionUuid returned by startDevice.
-   *
-   * No-op when autolock is disabled, when a target is already specified, when a
-   * device was pinned via setActiveDevice, or when only one candidate exists.
-   */
   private async enforceSessionUuidForAutolock(
     platform: SomePlatform,
     sessionUuid: string | undefined,
-    providedDeviceId: string | undefined
+    providedDeviceId: string | undefined,
+    deviceSessionManager: DeviceSessionManager
   ): Promise<void> {
     if (!isDevicePoolAutolockEnabled()) {
       return;
@@ -647,14 +400,13 @@ class ToolRegistryClass {
       return;
     }
 
-    // A device pinned via setActiveDevice is an unambiguous target.
-    const currentDevice = this.deviceSessionManager.getCurrentDevice();
-    const currentPlatform = this.deviceSessionManager.getCurrentPlatform();
+    const currentDevice = deviceSessionManager.getCurrentDevice();
+    const currentPlatform = deviceSessionManager.getCurrentPlatform();
     if (currentDevice && (platform === "either" || platform === currentPlatform)) {
       return;
     }
 
-    const connectedPlatforms = await this.deviceSessionManager.detectConnectedPlatforms();
+    const connectedPlatforms = await deviceSessionManager.detectConnectedPlatforms();
     const candidates = platform === "either"
       ? connectedPlatforms
       : connectedPlatforms.filter(device => device.platform === platform);
@@ -667,6 +419,374 @@ class ToolRegistryClass {
       "Device pool autolock is enabled and multiple devices are available. " +
       "Call startDevice first from this MCP session, or provide the sessionId returned by 'startDevice' (or a deviceId) to target a specific device."
     );
+  }
+}
+
+class DefaultAuditRunner implements AuditRunner {
+  async run(input: AuditRunnerInput): Promise<any> {
+    const { name, args, device, handler, progress, signal } = input;
+    if (!serverConfig.isMemPerfAuditEnabled() || device.platform !== "android") {
+      return handler(device, args, progress, signal);
+    }
+
+    const packageName = await this.getForegroundPackageName(device);
+    if (!packageName) {
+      logger.warn(`[ToolRegistry] Could not determine foreground app, skipping memory audit for ${name}`);
+      return handler(device, args, progress, signal);
+    }
+
+    logger.info(`[ToolRegistry] Running memory audit for ${packageName} during ${name}`);
+    const memoryAudit = new MemoryAudit(device);
+    const perf = createGlobalPerformanceTracker();
+    let response: any | undefined;
+
+    const auditResult = await memoryAudit.runAudit(
+      packageName,
+      name,
+      args,
+      async () => {
+        response = await handler(device, args, progress, signal);
+      },
+      perf
+    );
+
+    if (!auditResult.passed) {
+      const errorMsg = `Memory audit FAILED for ${packageName} during ${name}\n\n${auditResult.diagnostics}`;
+      logger.error(`[ToolRegistry] ${errorMsg}`);
+      throw new ActionableError(errorMsg);
+    }
+
+    logger.info(`[ToolRegistry] Memory audit PASSED for ${packageName} during ${name}`);
+    return response;
+  }
+
+  private async getForegroundPackageName(device: BootedDevice): Promise<string | null> {
+    try {
+      const adb = defaultAdbClientFactory.create(device);
+      const { stdout } = await adb.executeCommand(
+        "shell dumpsys window | grep mCurrentFocus"
+      );
+
+      const match = stdout.match(/\s+(\S+)\/\S+\}/);
+      return match ? match[1] : null;
+    } catch (error) {
+      logger.warn(`[ToolRegistry] Failed to get foreground package name: ${error}`);
+      return null;
+    }
+  }
+}
+
+class DefaultNavigationToolCallRecorder implements NavigationToolCallRecorder {
+  record(name: string, args: any, device: BootedDevice | undefined, sessionUuid: string | undefined): void {
+    // Record tool call for navigation graph correlation before the handler mutates UI state.
+    // Only record UI interaction tools that may cause navigation. Excludes app lifecycle
+    // tools (launchApp, terminateApp, homeScreen, etc.) because they don't represent
+    // replayable in-app navigation paths.
+    const navigationRelevantTools = [
+      "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
+      "pressButton", "inputText", "clearText", "imeAction"
+    ];
+    if (!navigationRelevantTools.includes(name)) {
+      return;
+    }
+
+    const cachedResult = device
+      ? RealObserveScreen.getRecentCachedResultForDevice(device.deviceId)
+      : RealObserveScreen.getRecentCachedResult();
+    const uiState = new UIStateExtractor().extractFromObservation(cachedResult);
+    const navManager = sessionUuid
+      ? NavigationGraphManager.getInstanceForSession(sessionUuid)
+      : NavigationGraphManager.getInstance();
+    navManager.recordToolCall(name, args, uiState);
+  }
+}
+
+class DefaultAfterToolCallHandler implements AfterToolCallHandler {
+  async handle(input: AfterToolCallInput): Promise<AfterToolCallResult> {
+    const { name, args, internalCall, response, sessionUuid, shouldResolveDevice, signal, timer, toolStartMs } = input;
+
+    // Unwrap MCP response envelope to get the inner result for success/error checks.
+    // Tools may return { content: [{ type: "text", text: '{"success":false,...}' }] }
+    // instead of a plain { success, error } object.
+    let unwrapped = response;
+    if (
+      response && typeof response === "object" &&
+      !("success" in response) &&
+      Array.isArray(response.content) && response.content.length > 0
+    ) {
+      const first = response.content[0];
+      if (first?.type === "text" && typeof first.text === "string") {
+        try {
+          const parsed = JSON.parse(first.text);
+          if (parsed && typeof parsed === "object" && "success" in parsed) {
+            unwrapped = parsed;
+          }
+        } catch { /* not JSON — use original response */ }
+      }
+    }
+
+    const toolSuccess = unwrapped && typeof unwrapped === "object" && "success" in unwrapped
+      ? unwrapped.success !== false
+      : true;
+    const toolError = unwrapped && typeof unwrapped === "object" && "error" in unwrapped
+      ? String(unwrapped.error || "")
+      : null;
+    if (unwrapped && typeof unwrapped === "object" && "success" in unwrapped) {
+      const resultLog = formatToolResultLog({
+        toolName: name,
+        success: unwrapped.success !== false,
+        error: unwrapped.error,
+        callerTimedOut: signal?.aborted ?? false,
+      });
+      logger[resultLog.level](resultLog.message);
+    }
+
+    const durationMs = timer.now() - toolStartMs;
+    TelemetryRecorder.getInstance().recordToolCallEvent({
+      timestamp: toolStartMs,
+      toolName: name,
+      durationMs,
+      success: toolSuccess,
+      error: toolError,
+      args: typeof args === "object" ? args : null,
+    });
+
+    if (toolSuccess) {
+      getMcpRecorder()?.record(name, args);
+    }
+
+    if (name === "swipeOn" && args.lookFor && getStructuredField<boolean>(response, "success") && getStructuredField<boolean>(response, "found")) {
+      const scrollPosition = UIStateExtractor.createScrollPosition(args);
+      if (scrollPosition) {
+        const scrollNavManager = sessionUuid
+          ? NavigationGraphManager.getInstanceForSession(sessionUuid)
+          : NavigationGraphManager.getInstance();
+        scrollNavManager.updateScrollPosition(scrollPosition);
+      }
+    }
+
+    if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
+      const sessionManager = DaemonState.getInstance().getSessionManager();
+      const observeHierarchy = name === "observe" ? getStructuredField<ViewHierarchyResult>(response, "viewHierarchy") : undefined;
+      if (observeHierarchy) {
+        sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);
+      }
+      const observeScreenshot = name === "observe" ? getStructuredField<string>(response, "screenshot") : undefined;
+      if (observeScreenshot) {
+        sessionManager.setLastScreenshot(sessionUuid, observeScreenshot);
+      }
+    }
+
+    const baselineStore: ObservationBaselineStore | undefined =
+      sessionUuid && DaemonState.getInstance().isInitialized()
+        ? {
+          get: uuid => DaemonState.getInstance().getSessionManager().getLastRenderedObservation(uuid),
+          set: (uuid, observation) => DaemonState.getInstance().getSessionManager().setLastRenderedObservation(uuid, observation),
+        }
+        : undefined;
+
+    return {
+      durationMs,
+      finalizedResponse: finalizeToolResponse(response, { name, sessionUuid, baselineStore, internal: internalCall }),
+    };
+  }
+}
+
+class DefaultPlanLifecycleManager implements PlanLifecycleManager {
+  async afterExecution(input: PlanLifecycleInput): Promise<void> {
+    const { name, args, baseSessionUuid, cleanupService, device, sessionUuid, shouldResolveDevice } = input;
+    if (device && name === "executePlan" && args?.cleanupAppId) {
+      await cleanupService.cleanup(device, {
+        appId: args.cleanupAppId,
+        clearAppData: args.cleanupClearAppData,
+      });
+    }
+
+    if (shouldResolveDevice && sessionUuid && name === "executePlan" && DaemonState.getInstance().isInitialized()) {
+      try {
+        const sessionManager = DaemonState.getInstance().getSessionManager();
+        const devicePool = DaemonState.getInstance().getDevicePool();
+        const releaseSessionUuid = baseSessionUuid ?? sessionUuid;
+        if (releaseSessionUuid) {
+          await releaseDeviceLabelSessions(releaseSessionUuid);
+        }
+
+        const session = releaseSessionUuid ? sessionManager.getSession(releaseSessionUuid) : null;
+        if (session) {
+          const deviceId = session.assignedDevice;
+          sessionManager.releaseSession(session.sessionId);
+          await devicePool.releaseDevice(deviceId);
+          NavigationGraphManager.releaseSession(releaseSessionUuid);
+          RealObserveScreen.clearCache(deviceId);
+          logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);
+        }
+      } catch (releaseError) {
+        logger.warn(`Failed to auto-release session ${sessionUuid}: ${releaseError}`);
+      }
+    }
+  }
+}
+
+// The registry that holds all tools
+class ToolRegistryClass {
+  private tools: Map<string, RegisteredTool> = new Map();
+  private deviceSessionManager: DeviceSessionManager;
+  private cleanupService: AppCleanupService;
+  private toolCallRepository: ToolCallRepository;
+  private timer: Timer;
+  private executionTargetResolver: ExecutionTargetResolver;
+  private auditRunner: AuditRunner;
+  private navigationToolCallRecorder: NavigationToolCallRecorder;
+  private afterToolCall: AfterToolCallHandler;
+  private planLifecycleManager: PlanLifecycleManager;
+
+  constructor(timer: Timer = defaultTimer) {
+    this.deviceSessionManager = DeviceSessionManager.getInstance();
+    this.cleanupService = new DefaultAppCleanupService();
+    this.toolCallRepository = new ToolCallRepository();
+    this.timer = timer;
+    this.executionTargetResolver = new DefaultExecutionTargetResolver();
+    this.auditRunner = new DefaultAuditRunner();
+    this.navigationToolCallRecorder = new DefaultNavigationToolCallRecorder();
+    this.afterToolCall = new DefaultAfterToolCallHandler();
+    this.planLifecycleManager = new DefaultPlanLifecycleManager();
+  }
+
+  private getToolAvailabilityGateReasons(tool: RegisteredTool): string[] {
+    const reasons: string[] = [];
+    if (tool.debugOnly && !isDebugModeEnabled()) {
+      reasons.push("--debug is disabled");
+    }
+    if (tool.embeddedSdkOnly && !serverConfig.isEmbeddedSdkEnabled()) {
+      reasons.push("embedded SDK mode is disabled");
+    }
+    return reasons;
+  }
+
+  private isToolAvailable(tool: RegisteredTool): boolean {
+    return this.getToolAvailabilityGateReasons(tool).length === 0;
+  }
+
+  // Register a new tool
+  register(
+    name: string,
+    description: string,
+    schema: any,
+    handler: ToolHandler,
+    options: ToolRegistrationOptions = {}
+  ): void {
+    this.tools.set(name, {
+      name,
+      description,
+      schema,
+      handler,
+      supportsProgress: options.supportsProgress ?? false,
+      requiresDevice: false,
+      debugOnly: options.debugOnly ?? false,
+      embeddedSdkOnly: false,
+      outputSchema: options.outputSchema
+    });
+  }
+
+  // Register a device-aware tool
+  registerDeviceAware(
+    name: string,
+    description: string,
+    schema: any,
+    handler: DeviceAwareToolHandler,
+    options: DeviceAwareToolOptions = {}
+  ): void {
+    // Create a wrapper that handles device ID injection
+    const wrappedHandler: ToolHandler = async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
+      const toolStartMs = this.timer.now();
+      const toolCallTimestamp = new Date().toISOString();
+      let toolDurationMs: number | undefined;
+      let target: ExecutionTargetContext | undefined;
+      let sessionUuid = args.sessionUuid;
+
+      try {
+        target = await this.executionTargetResolver.resolveExecutionTarget({
+          name,
+          args,
+          options,
+          deviceSessionManager: this.deviceSessionManager,
+        });
+        sessionUuid = target.sessionUuid;
+        try {
+          let response: any | undefined;
+          if (!target.shouldResolveDevice) {
+            if (!options.nonDeviceHandler) {
+              throw new ActionableError(`Tool ${name} requires a device.`);
+            }
+            response = await options.nonDeviceHandler(args, progress, signal);
+          } else if (target.device !== undefined) {
+            this.navigationToolCallRecorder.record(name, args, target.device, target.sessionUuid);
+            response = await this.auditRunner.run({
+              name,
+              args,
+              device: target.device,
+              handler,
+              progress,
+              signal,
+            });
+          }
+
+          const afterToolCallResult = await this.afterToolCall.handle({
+            name,
+            args,
+            device: target.device,
+            internalCall: target.internalCall,
+            response,
+            sessionUuid: target.sessionUuid,
+            shouldResolveDevice: target.shouldResolveDevice,
+            signal,
+            timer: this.timer,
+            toolStartMs,
+          });
+          toolDurationMs = afterToolCallResult.durationMs;
+          return afterToolCallResult.finalizedResponse;
+        } catch (error) {
+          if (error instanceof ActionableError) {
+            throw error;
+          }
+          const deviceContext = target.device ? ` on device ${target.device.deviceId}` : "";
+          throw new ActionableError(`Failed to execute tool ${name}${deviceContext}: ${error}`);
+        } finally {
+          if (target) {
+            await this.planLifecycleManager.afterExecution({
+              name,
+              args,
+              baseSessionUuid: target.baseSessionUuid,
+              cleanupService: this.cleanupService,
+              device: target.device,
+              sessionUuid: target.sessionUuid,
+              shouldResolveDevice: target.shouldResolveDevice,
+            });
+          }
+        }
+      } finally {
+        await this.toolCallRepository.recordToolCall({
+          toolName: name,
+          timestamp: toolCallTimestamp,
+          sessionUuid,
+          durationMs: toolDurationMs ?? this.timer.now() - toolStartMs,
+        });
+      }
+    };
+
+    this.tools.set(name, {
+      name,
+      description,
+      schema,
+      handler: wrappedHandler,
+      supportsProgress: options.supportsProgress ?? false,
+      requiresDevice: true,
+      deviceAwareHandler: handler,
+      debugOnly: options.debugOnly ?? false,
+      embeddedSdkOnly: options.embeddedSdkOnly ?? false,
+      planExecutable: options.planExecutable ?? false,
+      outputSchema: options.outputSchema
+    });
   }
 
   // Get all registered tools
@@ -795,6 +915,37 @@ class ToolRegistryClass {
   // Allow tests to inject a cleanup implementation
   setCleanupService(cleanupService: AppCleanupService): void {
     this.cleanupService = cleanupService;
+  }
+
+  // Allow focused unit tests to replace pipeline collaborators without relying
+  // on private field names. Production uses the defaults wired in the constructor.
+  setPipelineOverridesForTesting(overrides: ToolRegistryPipelineOverrides): () => void {
+    const previous = {
+      executionTargetResolver: this.executionTargetResolver,
+      auditRunner: this.auditRunner,
+      afterToolCall: this.afterToolCall,
+      planLifecycleManager: this.planLifecycleManager,
+    };
+
+    if (overrides.executionTargetResolver) {
+      this.executionTargetResolver = overrides.executionTargetResolver;
+    }
+    if (overrides.auditRunner) {
+      this.auditRunner = overrides.auditRunner;
+    }
+    if (overrides.afterToolCall) {
+      this.afterToolCall = overrides.afterToolCall;
+    }
+    if (overrides.planLifecycleManager) {
+      this.planLifecycleManager = overrides.planLifecycleManager;
+    }
+
+    return () => {
+      this.executionTargetResolver = previous.executionTargetResolver;
+      this.auditRunner = previous.auditRunner;
+      this.afterToolCall = previous.afterToolCall;
+      this.planLifecycleManager = previous.planLifecycleManager;
+    };
   }
 
   // Clear all registered tools (for testing)

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -317,16 +317,6 @@ export function registerVideoRecordingTools(): void {
     );
   };
 
-  ToolRegistry.registerDeviceAware(
-    "videoRecording",
-    "Start or stop device video recording.",
-    videoRecordingSchema,
-    videoRecordingHandler,
-    false,
-    false,
-    {
-      shouldEnsureDevice: args => !(args.action === "stop" && args.recordingId),
-      nonDeviceHandler: videoRecordingNonDeviceHandler,
-    }
-  );
+  ToolRegistry.registerDeviceAware("videoRecording", "Start or stop device video recording.", videoRecordingSchema, videoRecordingHandler, { shouldEnsureDevice: args => !(args.action === "stop" && args.recordingId),
+    nonDeviceHandler: videoRecordingNonDeviceHandler, });
 }

--- a/src/utils/server/ToolRegistry.ts
+++ b/src/utils/server/ToolRegistry.ts
@@ -12,6 +12,10 @@ export interface RegisteredTool {
   requiresDevice?: boolean;
 }
 
+export interface ToolRegistrationOptions {
+  supportsProgress?: boolean;
+}
+
 /**
  * Interface for tool registry
  */
@@ -35,7 +39,7 @@ export interface ToolRegistry {
    * @param description - Description of the tool
    * @param schema - The schema for tool parameters
    * @param handler - The handler function for the tool
-   * @param supportsProgress - Whether the tool supports progress callbacks
+   * @param options - Tool registration options
    * @returns void
    */
   registerTool(
@@ -43,7 +47,7 @@ export interface ToolRegistry {
     description: string,
     schema: any,
     handler: (args: any) => Promise<any>,
-    supportsProgress?: boolean
+    options?: ToolRegistrationOptions
   ): void;
 }
 
@@ -80,8 +84,8 @@ export class DefaultToolRegistry implements ToolRegistry {
     description: string,
     schema: any,
     handler: (args: any) => Promise<any>,
-    supportsProgress?: boolean
+    options?: ToolRegistrationOptions
   ): void {
-    ToolRegistryImpl.register(name, description, schema, handler, supportsProgress);
+    ToolRegistryImpl.register(name, description, schema, handler, options);
   }
 }

--- a/test/fakes/FakeToolRegistry.ts
+++ b/test/fakes/FakeToolRegistry.ts
@@ -2,7 +2,7 @@
  * Fake implementation of ToolRegistry for testing
  * Allows registering and retrieving tools in memory
  */
-import { ToolRegistry, RegisteredTool } from "../../src/utils/server/ToolRegistry";
+import { ToolRegistry, RegisteredTool, ToolRegistrationOptions } from "../../src/utils/server/ToolRegistry";
 
 export class FakeToolRegistry implements ToolRegistry {
   private tools: Map<string, RegisteredTool> = new Map();
@@ -13,21 +13,21 @@ export class FakeToolRegistry implements ToolRegistry {
    * @param description - Description of the tool
    * @param schema - The schema for tool parameters
    * @param handler - The handler function for the tool
-   * @param supportsProgress - Whether the tool supports progress callbacks
+   * @param options - Tool registration options
    */
   registerTool(
     name: string,
     description: string,
     schema: any,
     handler: (args: any) => Promise<any>,
-    supportsProgress: boolean = false
+    options: ToolRegistrationOptions = {}
   ): void {
     this.tools.set(name, {
       name,
       description,
       schema,
       handler,
-      supportsProgress,
+      supportsProgress: options.supportsProgress ?? false,
       requiresDevice: false
     });
   }

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -222,21 +222,13 @@ describe("criticalSection tool", () => {
 
     const executionLog: string[] = [];
     const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
-    ToolRegistry.registerDeviceAware(
-      "mockPlanExecutableHiddenStep",
-      "Mock hidden plan-executable step",
-      z.object({
-        device: z.string(),
-        value: z.string(),
-      }),
-      async (_device, params: { device: string; value: string }) => {
-        executionLog.push(`${params.device}:${params.value}`);
-        return { success: true };
-      },
-      false,
-      true,
-      { planExecutable: true }
-    );
+    ToolRegistry.registerDeviceAware("mockPlanExecutableHiddenStep", "Mock hidden plan-executable step", z.object({
+      device: z.string(),
+      value: z.string(),
+    }), async (_device, params: { device: string; value: string }) => {
+      executionLog.push(`${params.device}:${params.value}`);
+      return { success: true };
+    }, { debugOnly: true, planExecutable: true });
 
     expect(ToolRegistry.getTool("mockPlanExecutableHiddenStep")).toBeUndefined();
     expect(ToolRegistry.getToolForPlan("mockPlanExecutableHiddenStep")).toBeDefined();
@@ -285,14 +277,7 @@ describe("criticalSection tool", () => {
       name: "Test Device Hidden Debug Tool",
     };
 
-    ToolRegistry.registerDeviceAware(
-      "mockDebugOnlyHiddenStep",
-      "Mock debug-only hidden step",
-      z.object({ device: z.string() }),
-      async () => ({ success: true }),
-      false,
-      true
-    );
+    ToolRegistry.registerDeviceAware("mockDebugOnlyHiddenStep", "Mock debug-only hidden step", z.object({ device: z.string() }), async () => ({ success: true }), { debugOnly: true });
 
     expect(ToolRegistry.getTool("mockDebugOnlyHiddenStep")).toBeUndefined();
     expect(ToolRegistry.getToolForPlan("mockDebugOnlyHiddenStep")).toBeUndefined();
@@ -325,21 +310,13 @@ describe("criticalSection tool", () => {
 
     const executionLog: string[] = [];
     const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
-    ToolRegistry.registerDeviceAware(
-      "mockEmbeddedPlanExecutableStep",
-      "Mock embedded plan-executable step",
-      z.object({
-        device: z.string(),
-        value: z.string(),
-      }),
-      async (_device, params: { device: string; value: string }) => {
-        executionLog.push(`${params.device}:${params.value}`);
-        return { success: true };
-      },
-      false,
-      false,
-      { embeddedSdkOnly: true, planExecutable: true }
-    );
+    ToolRegistry.registerDeviceAware("mockEmbeddedPlanExecutableStep", "Mock embedded plan-executable step", z.object({
+      device: z.string(),
+      value: z.string(),
+    }), async (_device, params: { device: string; value: string }) => {
+      executionLog.push(`${params.device}:${params.value}`);
+      return { success: true };
+    }, { embeddedSdkOnly: true, planExecutable: true });
 
     expect(ToolRegistry.getTool("mockEmbeddedPlanExecutableStep")).toBeUndefined();
     expect(ToolRegistry.getToolForPlan("mockEmbeddedPlanExecutableStep")).toBeDefined();

--- a/test/server/stripToolResultWireBoundary.test.ts
+++ b/test/server/stripToolResultWireBoundary.test.ts
@@ -20,15 +20,7 @@ describe("CallTool wire boundary strips structuredContent (issue #2899)", () => 
   const TOOL = "__strip_probe_2899__";
 
   beforeAll(async () => {
-    ToolRegistry.register(
-      TOOL,
-      "probe tool for structuredContent strip",
-      z.object({}).passthrough(),
-      async () => createStructuredToolResponse({ success: true, marker: "probe" }),
-      false,
-      false,
-      z.object({ success: z.boolean(), marker: z.string() })
-    );
+    ToolRegistry.register(TOOL, "probe tool for structuredContent strip", z.object({}).passthrough(), async () => createStructuredToolResponse({ success: true, marker: "probe" }), { outputSchema: z.object({ success: z.boolean(), marker: z.string() }) });
     fixture = new McpTestFixture();
     await fixture.setup();
   });

--- a/test/server/toolRegistry.duration.test.ts
+++ b/test/server/toolRegistry.duration.test.ts
@@ -30,23 +30,13 @@ describe("ToolRegistry tool call duration recording", () => {
   });
 
   test("records elapsed duration for a completed tool call", async () => {
-    ToolRegistry.registerDeviceAware(
-      "durationProbe",
-      "Measures tool call duration",
-      z.object({
-        sessionUuid: z.string().optional(),
-      }),
-      async () => ({ success: true }),
-      false,
-      false,
-      {
-        shouldEnsureDevice: () => false,
-        nonDeviceHandler: async () => {
-          timer.advanceTime(37);
-          return { success: true };
-        },
-      }
-    );
+    ToolRegistry.registerDeviceAware("durationProbe", "Measures tool call duration", z.object({
+      sessionUuid: z.string().optional(),
+    }), async () => ({ success: true }), { shouldEnsureDevice: () => false,
+      nonDeviceHandler: async () => {
+        timer.advanceTime(37);
+        return { success: true };
+      }, });
 
     const tool = ToolRegistry.getTool("durationProbe");
     expect(tool).toBeDefined();
@@ -64,21 +54,11 @@ describe("ToolRegistry tool call duration recording", () => {
   });
 
   test("records elapsed duration when a tool call throws", async () => {
-    ToolRegistry.registerDeviceAware(
-      "durationFailureProbe",
-      "Measures failed tool call duration",
-      z.object({}),
-      async () => ({ success: true }),
-      false,
-      false,
-      {
-        shouldEnsureDevice: () => false,
-        nonDeviceHandler: async () => {
-          timer.advanceTime(19);
-          throw new Error("probe failed");
-        },
-      }
-    );
+    ToolRegistry.registerDeviceAware("durationFailureProbe", "Measures failed tool call duration", z.object({}), async () => ({ success: true }), { shouldEnsureDevice: () => false,
+      nonDeviceHandler: async () => {
+        timer.advanceTime(19);
+        throw new Error("probe failed");
+      }, });
 
     const tool = ToolRegistry.getTool("durationFailureProbe");
     expect(tool).toBeDefined();
@@ -106,21 +86,11 @@ describe("ToolRegistry tool call duration recording", () => {
       },
     };
 
-    ToolRegistry.registerDeviceAware(
-      "durationAwaitProbe",
-      "Waits for duration recording",
-      z.object({}),
-      async () => ({ success: true }),
-      false,
-      false,
-      {
-        shouldEnsureDevice: () => false,
-        nonDeviceHandler: async () => {
-          timer.advanceTime(11);
-          return { success: true };
-        },
-      }
-    );
+    ToolRegistry.registerDeviceAware("durationAwaitProbe", "Waits for duration recording", z.object({}), async () => ({ success: true }), { shouldEnsureDevice: () => false,
+      nonDeviceHandler: async () => {
+        timer.advanceTime(11);
+        return { success: true };
+      }, });
 
     const tool = ToolRegistry.getTool("durationAwaitProbe");
     expect(tool).toBeDefined();
@@ -131,8 +101,9 @@ describe("ToolRegistry tool call duration recording", () => {
       return result;
     });
 
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let i = 0; i < 10 && !recordStarted; i++) {
+      await Promise.resolve();
+    }
 
     expect(recordStarted).toBe(true);
     expect(records).toEqual([

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import type { BootedDevice } from "../../src/models";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { logger } from "../../src/utils/logger";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+
+describe("ToolRegistry device-aware pipeline", () => {
+  const device: BootedDevice = {
+    name: "Pixel",
+    deviceId: "emulator-5554",
+    platform: "android",
+  };
+
+  let restorePipelineOverrides: (() => void) | undefined;
+  let originalToolCallRepository: unknown;
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    originalToolCallRepository = (ToolRegistry as any).toolCallRepository;
+  });
+
+  afterEach(() => {
+    restorePipelineOverrides?.();
+    restorePipelineOverrides = undefined;
+    (ToolRegistry as any).toolCallRepository = originalToolCallRepository;
+    ToolRegistry.clearTools();
+  });
+
+  test("stores registerDeviceAware flags from the options bag", () => {
+    ToolRegistry.registerDeviceAware(
+      "optionsProbe",
+      "Options probe",
+      z.object({}),
+      async () => ({ success: true }),
+      {
+        supportsProgress: true,
+        debugOnly: true,
+        embeddedSdkOnly: true,
+        planExecutable: true,
+        outputSchema: z.object({ success: z.boolean() }),
+      }
+    );
+
+    const tool = ToolRegistry.getAllTools({ includeUnavailable: true })[0];
+    expect(tool.supportsProgress).toBe(true);
+    expect(tool.debugOnly).toBe(true);
+    expect(tool.embeddedSdkOnly).toBe(true);
+    expect(tool.planExecutable).toBe(true);
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  test("stores register flags from the options bag", () => {
+    ToolRegistry.register(
+      "plainOptionsProbe",
+      "Plain options probe",
+      z.object({}),
+      async () => ({ success: true }),
+      {
+        supportsProgress: true,
+        debugOnly: true,
+        outputSchema: z.object({ success: z.boolean() }),
+      }
+    );
+
+    const tool = ToolRegistry.getAllTools({ includeUnavailable: true })[0];
+    expect(tool.requiresDevice).toBe(false);
+    expect(tool.supportsProgress).toBe(true);
+    expect(tool.debugOnly).toBe(true);
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  test("wrapped handler delegates to fakeable pipeline collaborators in order", async () => {
+    const events: string[] = [];
+    const args = { sessionUuid: "session-1", platform: "android" };
+
+    restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        async resolveExecutionTarget(input: any) {
+          events.push("resolve");
+          expect(input.name).toBe("pipelineProbe");
+          expect(input.args).toBe(args);
+          return {
+            args: input.args,
+            baseSessionUuid: "session-1",
+            device,
+            internalCall: false,
+            sessionUuid: "session-1",
+            shouldResolveDevice: true,
+          };
+        },
+      },
+      auditRunner: {
+        async run(input: any) {
+          events.push("audit");
+          return input.handler(input.device, input.args, input.progress, input.signal);
+        },
+      },
+      afterToolCall: {
+        async handle(input: any) {
+          events.push("after");
+          expect(input.name).toBe("pipelineProbe");
+          expect(input.response).toEqual({ success: true });
+          return {
+            durationMs: 7,
+            finalizedResponse: { success: true, finalized: true },
+          };
+        },
+      },
+      planLifecycleManager: {
+        async afterExecution() {
+          events.push("planLifecycle");
+        },
+      },
+    });
+    (ToolRegistry as any).toolCallRepository = {
+      async recordToolCall(record: any) {
+        events.push("record");
+        expect(record.toolName).toBe("pipelineProbe");
+        expect(record.sessionUuid).toBe("session-1");
+        expect(record.durationMs).toBe(7);
+      },
+    };
+
+    ToolRegistry.registerDeviceAware(
+      "pipelineProbe",
+      "Pipeline probe",
+      z.object({}),
+      async () => {
+        events.push("handler");
+        return { success: true };
+      },
+      { supportsProgress: true }
+    );
+
+    const tool = ToolRegistry.getTool("pipelineProbe")!;
+    const response = await tool.handler(args);
+
+    expect(response).toEqual({ success: true, finalized: true });
+    expect(events).toEqual(["resolve", "audit", "handler", "after", "planLifecycle", "record"]);
+  });
+
+  test("logs and continues when best-effort CtrlProxy session bind fails", async () => {
+    const fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    fakeDeviceSessionManager.setConnectedDevices([device]);
+    const originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+    const originalGetInstance = (AndroidCtrlProxyClient as any).getInstance;
+    const originalDebug = logger.debug;
+    const debugMessages: string[] = [];
+
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+    (ToolRegistry as any).toolCallRepository = {
+      async recordToolCall(): Promise<void> {},
+    };
+    (AndroidCtrlProxyClient as any).getInstance = () => ({
+      bindSession() {
+        throw new Error("bind unavailable");
+      },
+    });
+    logger.debug = (message: string) => {
+      debugMessages.push(message);
+    };
+
+    try {
+      ToolRegistry.registerDeviceAware(
+        "bindFailureProbe",
+        "Bind failure probe",
+        z.object({}),
+        async () => ({ success: true })
+      );
+
+      const tool = ToolRegistry.getTool("bindFailureProbe")!;
+      await expect(tool.handler({ platform: "android", sessionUuid: "session-1" })).resolves.toEqual({ success: true });
+      expect(debugMessages).toEqual([
+        expect.stringContaining("[ToolRegistry] Best-effort CtrlProxy session bind skipped for bindFailureProbe: Error: bind unavailable"),
+      ]);
+    } finally {
+      (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+      (AndroidCtrlProxyClient as any).getInstance = originalGetInstance;
+      logger.debug = originalDebug;
+    }
+  });
+});

--- a/test/server/toolRegistry.postTimeoutLog.test.ts
+++ b/test/server/toolRegistry.postTimeoutLog.test.ts
@@ -19,18 +19,8 @@ describe("ToolRegistry post-timeout result logging", () => {
   });
 
   function registerProbe(): void {
-    ToolRegistry.registerDeviceAware(
-      "postTimeoutProbe",
-      "Resolves with success regardless of caller state",
-      z.object({}),
-      async () => ({ success: true }),
-      false,
-      false,
-      {
-        shouldEnsureDevice: () => false,
-        nonDeviceHandler: async () => ({ success: true }),
-      }
-    );
+    ToolRegistry.registerDeviceAware("postTimeoutProbe", "Resolves with success regardless of caller state", z.object({}), async () => ({ success: true }), { shouldEnsureDevice: () => false,
+      nonDeviceHandler: async () => ({ success: true }), });
   }
 
   test("warns (not infos) when the caller's request already timed out", async () => {

--- a/test/server/toolRegistry.registerWithServer.test.ts
+++ b/test/server/toolRegistry.registerWithServer.test.ts
@@ -45,17 +45,11 @@ describe("ToolRegistry.registerWithServer", () => {
     let receivedProgress: ProgressCallback | undefined;
     let receivedSignal: AbortSignal | undefined;
 
-    ToolRegistry.register(
-      "progressTool",
-      "A tool that supports progress",
-      z.object({ input: z.string() }),
-      async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
-        receivedProgress = progress;
-        receivedSignal = signal;
-        return { content: [{ type: "text", text: "done" }] };
-      },
-      true // supportsProgress
-    );
+    ToolRegistry.register("progressTool", "A tool that supports progress", z.object({ input: z.string() }), async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
+      receivedProgress = progress;
+      receivedSignal = signal;
+      return { content: [{ type: "text", text: "done" }] };
+    }, { supportsProgress: true });
 
     ToolRegistry.registerWithServer(fakeMcpServer as any);
 
@@ -81,16 +75,10 @@ describe("ToolRegistry.registerWithServer", () => {
     let capturedProgress: ProgressCallback | undefined;
     const sentNotifications: any[] = [];
 
-    ToolRegistry.register(
-      "notifyTool",
-      "A tool that sends progress",
-      z.object({}),
-      async (_args: any, progress?: ProgressCallback) => {
-        capturedProgress = progress;
-        return { content: [{ type: "text", text: "ok" }] };
-      },
-      true // supportsProgress
-    );
+    ToolRegistry.register("notifyTool", "A tool that sends progress", z.object({}), async (_args: any, progress?: ProgressCallback) => {
+      capturedProgress = progress;
+      return { content: [{ type: "text", text: "ok" }] };
+    }, { supportsProgress: true });
 
     ToolRegistry.registerWithServer(fakeMcpServer as any);
 
@@ -126,16 +114,10 @@ describe("ToolRegistry.registerWithServer", () => {
     let capturedProgress: ProgressCallback | undefined;
     const sentNotifications: any[] = [];
 
-    ToolRegistry.register(
-      "noTokenTool",
-      "Tool without client-provided progress token",
-      z.object({}),
-      async (_args: any, progress?: ProgressCallback) => {
-        capturedProgress = progress;
-        return { content: [{ type: "text", text: "ok" }] };
-      },
-      true
-    );
+    ToolRegistry.register("noTokenTool", "Tool without client-provided progress token", z.object({}), async (_args: any, progress?: ProgressCallback) => {
+      capturedProgress = progress;
+      return { content: [{ type: "text", text: "ok" }] };
+    }, { supportsProgress: true });
 
     ToolRegistry.registerWithServer(fakeMcpServer as any);
 
@@ -167,17 +149,11 @@ describe("ToolRegistry.registerWithServer", () => {
     let receivedProgress: ProgressCallback | undefined = undefined;
     let receivedSignal: AbortSignal | undefined = undefined;
 
-    ToolRegistry.register(
-      "simpleTool",
-      "A simple tool without progress",
-      z.object({ value: z.number() }),
-      async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
-        receivedProgress = progress;
-        receivedSignal = signal;
-        return { content: [{ type: "text", text: String(args.value) }] };
-      },
-      false // supportsProgress = false
-    );
+    ToolRegistry.register("simpleTool", "A simple tool without progress", z.object({ value: z.number() }), async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
+      receivedProgress = progress;
+      receivedSignal = signal;
+      return { content: [{ type: "text", text: String(args.value) }] };
+    });
 
     ToolRegistry.registerWithServer(fakeMcpServer as any);
 
@@ -201,15 +177,7 @@ describe("ToolRegistry.registerWithServer", () => {
   test("keeps output schemas internal instead of advertising them through MCP registration", () => {
     const outputSchema = z.object({ ok: z.boolean() });
 
-    ToolRegistry.register(
-      "schemaTool",
-      "Tool with a structured result contract",
-      z.object({}),
-      async () => ({ content: [{ type: "text", text: "ok" }] }),
-      false,
-      false,
-      outputSchema
-    );
+    ToolRegistry.register("schemaTool", "Tool with a structured result contract", z.object({}), async () => ({ content: [{ type: "text", text: "ok" }] }), { outputSchema: outputSchema });
 
     ToolRegistry.registerWithServer(fakeMcpServer as any);
 
@@ -222,16 +190,10 @@ describe("ToolRegistry.registerWithServer", () => {
   test("progress callback does not throw when sendNotification fails", async () => {
     let capturedProgress: ProgressCallback | undefined;
 
-    ToolRegistry.register(
-      "failNotifyTool",
-      "Tool where notification sending fails",
-      z.object({}),
-      async (_args: any, progress?: ProgressCallback) => {
-        capturedProgress = progress;
-        return { content: [{ type: "text", text: "ok" }] };
-      },
-      true
-    );
+    ToolRegistry.register("failNotifyTool", "Tool where notification sending fails", z.object({}), async (_args: any, progress?: ProgressCallback) => {
+      capturedProgress = progress;
+      return { content: [{ type: "text", text: "ok" }] };
+    }, { supportsProgress: true });
 
     ToolRegistry.registerWithServer(fakeMcpServer as any);
 

--- a/test/server/tools/structuredContentGating.test.ts
+++ b/test/server/tools/structuredContentGating.test.ts
@@ -59,15 +59,7 @@ describe("structuredContent gating (issue #2759)", () => {
       z.object({}),
       async () => createStructuredToolResponse(bigPayload())
     );
-    ToolRegistry.register(
-      SCHEMA_TOOL,
-      "throwaway tool with outputSchema",
-      z.object({}),
-      async () => createStructuredToolResponse({ success: true, value: "hello" }),
-      false,
-      false,
-      schemaResult
-    );
+    ToolRegistry.register(SCHEMA_TOOL, "throwaway tool with outputSchema", z.object({}), async () => createStructuredToolResponse({ success: true, value: "hello" }), { outputSchema: schemaResult });
 
     fixture = new McpTestFixture();
     await fixture.setup();

--- a/test/utils/serverToolRegistryAdapter.test.ts
+++ b/test/utils/serverToolRegistryAdapter.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DefaultToolRegistry } from "../../src/utils/server/ToolRegistry";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+describe("DefaultToolRegistry adapter", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  test("forwards registerTool options to the server ToolRegistry", () => {
+    const adapter = new DefaultToolRegistry();
+
+    adapter.registerTool(
+      "adapterProgressProbe",
+      "Adapter progress probe",
+      {},
+      async () => ({ success: true }),
+      { supportsProgress: true }
+    );
+
+    expect(ToolRegistry.getTool("adapterProgressProbe")?.supportsProgress).toBe(true);
+    expect(adapter.getTool("adapterProgressProbe")?.supportsProgress).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2804.

- Extracts `ToolRegistry.registerDeviceAware` dispatch into fakeable collaborators for execution target resolution, memory audit wrapping, navigation recording, post-call handling, and executePlan lifecycle cleanup/release.
- Replaces positional boolean registration flags with named options for `register()` and `registerDeviceAware()`.
- Migrates server tool registrations and tests to the options-bag API.
- Adds debug logging when best-effort CtrlProxy session binding fails and continues.

## Evaluation Criteria

- `wrappedHandler` is thin orchestration over testable collaborators.
- `supportsProgress` and `debugOnly` are named options instead of positional boolean traps.
- Existing session/autolock routing, memory audit, telemetry, MCP recording, observe cache, scroll-position, finalization, and executePlan cleanup behavior remains covered.
- CtrlProxy bind failure is logged at debug level without failing the tool call.

## Validation

- `bun test --bail` (6535 pass, 2 skip)
- `bun run build`
- `bun run lint`
- `git diff --check origin/main..HEAD`

## Review

- Ran `/auto-mobile-code-review` workflow against the current diff after fetching latest `origin/main`; no confirmed bugs found.
