### PR TITLE
refactor(ios): finish control-proxy typed-model cleanups (#2859)

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -50,12 +50,15 @@
 		8E00E330C839DBF9AC5DCC8E /* ObjCExceptionCatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; };
 		96ED92C8F268021CE148C4FF /* CtrlProxy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; };
 		9E975A4E407F93A21BD80EB4 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
+		9EFF1197D83979B0FC0E0BCE /* CommandPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */; };
 		9FE4564D1819768FEFD62606 /* ElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95565999DC108319DEED894A /* ElementLocator.swift */; };
 		9FED7BF37AFE34ADDF4E730A /* PinchFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB521226F4C469CBFE7296 /* PinchFallback.swift */; };
 		A603343B94D35DDF48F7AA4D /* Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1B2931E58B158EE51C5F4F /* Fakes.swift */; };
 		A9D79278D7A9C7ED3E7E4F8C /* CtrlProxy.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9E8300EE35B13DED1A0E579 /* MainThreadRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */; };
+		AE108A9093B6E046855BD678 /* CommandErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDC1D66210157A64C7AC76F /* CommandErrorTests.swift */; };
 		AF0C3A37F5AD66261DF7ED24 /* MainThreadRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */; };
+		B33435D31AF41A6C03499842 /* WebSocketServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC68B1D8C55DA187332B555E /* WebSocketServerTests.swift */; };
 		B55A16F80CE62B998CEBC6E0 /* PerformanceMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */; };
 		BD627F44D1B9F2D3976AA0EC /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81453AD074F2A392251CFC3 /* Models.swift */; };
 		BD7D2FF024054ED74F17958D /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81453AD074F2A392251CFC3 /* Models.swift */; };
@@ -77,6 +80,7 @@
 		F428A1892AAF5D4F83AD4C1B /* PinchFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */; };
 		F469E7EF16C59A99DBD519DA /* DisplayLinkFPSMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */; };
 		F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184CFC1280E0802EBF53965F /* ModelsTests.swift */; };
+		FBAA2ADC92863B6A10403BA1 /* ErrorResponseTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76DC5538569B4FCF89EA7547 /* ErrorResponseTypeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +170,7 @@
 		1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStorageInspecting.swift; sourceTree = "<group>"; };
 		22671C94D317E15EED752E59 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHandlerTests.swift; sourceTree = "<group>"; };
+		2DDC1D66210157A64C7AC76F /* CommandErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandErrorTests.swift; sourceTree = "<group>"; };
 		3BF23F10C24C9F40E5CEC303 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncerTests.swift; sourceTree = "<group>"; };
 		42C53A4D56EE97B5BD11EC63 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -177,14 +182,17 @@
 		6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadRunner.swift; sourceTree = "<group>"; };
 		6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchFallbackTests.swift; sourceTree = "<group>"; };
 		73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridge.swift; sourceTree = "<group>"; };
+		76DC5538569B4FCF89EA7547 /* ErrorResponseTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponseTypeTests.swift; sourceTree = "<group>"; };
 		77305F40F85694E983987E68 /* CommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHandler.swift; sourceTree = "<group>"; };
 		802717F6B1F37809C4806C23 /* CtrlProxyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlProxyUITests.swift; sourceTree = "<group>"; };
 		83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyModels.swift; sourceTree = "<group>"; };
 		878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPayloadTests.swift; sourceTree = "<group>"; };
 		95565999DC108319DEED894A /* ElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocator.swift; sourceTree = "<group>"; };
 		9A1B2931E58B158EE51C5F4F /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
 		9BD704E3A2708D91D4FABE3E /* CtrlProxyApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CtrlProxyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A284B6FFBE969931BB03A2FF /* PerfProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfProvider.swift; sourceTree = "<group>"; };
+		AC68B1D8C55DA187332B555E /* WebSocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServerTests.swift; sourceTree = "<group>"; };
 		B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetrics.swift; sourceTree = "<group>"; };
 		B4CB9272A186932D89EB1072 /* WebSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServer.swift; sourceTree = "<group>"; };
 		B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocatorTests.swift; sourceTree = "<group>"; };
@@ -251,8 +259,11 @@
 			isa = PBXGroup;
 			children = (
 				E30D131E590A0CF8F9674B0E /* ClipboardResolutionTests.swift */,
+				2DDC1D66210157A64C7AC76F /* CommandErrorTests.swift */,
 				25C10BFA5B6504892F8459D7 /* CommandHandlerTests.swift */,
+				8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */,
 				B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */,
+				76DC5538569B4FCF89EA7547 /* ErrorResponseTypeTests.swift */,
 				3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */,
 				0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */,
 				184CFC1280E0802EBF53965F /* ModelsTests.swift */,
@@ -262,6 +273,7 @@
 				4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */,
 				5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */,
 				EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */,
+				AC68B1D8C55DA187332B555E /* WebSocketServerTests.swift */,
 			);
 			name = CtrlProxyTests;
 			path = Tests/CtrlProxyTests;
@@ -579,8 +591,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				714A3E41ACE47ACF314E0FC2 /* ClipboardResolutionTests.swift in Sources */,
+				AE108A9093B6E046855BD678 /* CommandErrorTests.swift in Sources */,
 				12D60B8E4D067E91189066AD /* CommandHandlerTests.swift in Sources */,
+				9EFF1197D83979B0FC0E0BCE /* CommandPayloadTests.swift in Sources */,
 				E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */,
+				FBAA2ADC92863B6A10403BA1 /* ErrorResponseTypeTests.swift in Sources */,
 				4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */,
 				CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */,
 				F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */,
@@ -590,6 +605,7 @@
 				74B1E8F78E9FF807417ABC2D /* PinchGeometryTests.swift in Sources */,
 				2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */,
 				0F29D59ABFB52692F62B434F /* TypedRequestDecodeTests.swift in Sources */,
+				B33435D31AF41A6C03499842 /* WebSocketServerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -201,7 +201,7 @@ public class CommandHandler: CommandHandling {
             }
         } catch {
             return WebSocketResponse.error(
-                type: responseType(for: request.typeString),
+                type: request.requestType.responseType.rawValue,
                 requestId: request.requestId,
                 error: error.localizedDescription,
                 totalTimeMs: totalTimeMs(from: startTime)
@@ -1444,85 +1444,6 @@ public class CommandHandler: CommandHandling {
     private func totalTimeMs(from startTime: Date) -> Int64 {
         return Int64(Date().timeIntervalSince(startTime) * 1000)
     }
-
-    private func responseType(for requestType: String) -> String {
-        switch requestType {
-        case RequestType.requestHierarchy.rawValue,
-             RequestType.requestHierarchyIfStale.rawValue:
-            return ResponseType.hierarchyUpdate.rawValue
-        case RequestType.requestScreenshot.rawValue:
-            return ResponseType.screenshot.rawValue
-        case RequestType.requestTapCoordinates.rawValue:
-            return ResponseType.tapCoordinatesResult.rawValue
-        case RequestType.requestSwipe.rawValue:
-            return ResponseType.swipeResult.rawValue
-        case RequestType.requestTwoFingerSwipe.rawValue,
-             RequestType.requestMultiFingerSwipe.rawValue:
-            return ResponseType.multiFingerSwipeResult.rawValue
-        case RequestType.requestDrag.rawValue:
-            return ResponseType.dragResult.rawValue
-        case RequestType.requestPinch.rawValue:
-            return ResponseType.pinchResult.rawValue
-        case RequestType.requestSetText.rawValue:
-            return ResponseType.setTextResult.rawValue
-        case RequestType.requestClearText.rawValue:
-            return ResponseType.clearTextResult.rawValue
-        case RequestType.requestImeAction.rawValue:
-            return ResponseType.imeActionResult.rawValue
-        case RequestType.requestSelectAll.rawValue:
-            return ResponseType.selectAllResult.rawValue
-        case RequestType.requestKeyboard.rawValue:
-            return ResponseType.keyboardResult.rawValue
-        case RequestType.requestPressButton.rawValue:
-            return ResponseType.pressButtonResult.rawValue
-        case RequestType.requestPressHome.rawValue:
-            return ResponseType.pressHomeResult.rawValue
-        case RequestType.requestPressBack.rawValue:
-            return ResponseType.pressBackResult.rawValue
-        case RequestType.requestShake.rawValue:
-            return ResponseType.shakeResult.rawValue
-        case RequestType.requestRecentApps.rawValue:
-            return ResponseType.recentAppsResult.rawValue
-        case RequestType.requestAction.rawValue:
-            return ResponseType.actionResult.rawValue
-        case RequestType.requestLaunchApp.rawValue:
-            return ResponseType.launchAppResult.rawValue
-        case RequestType.requestResetPermissions.rawValue:
-            return ResponseType.resetPermissionsResult.rawValue
-        case RequestType.requestRotate.rawValue:
-            return ResponseType.rotateResult.rawValue
-        case RequestType.requestClipboard.rawValue:
-            return ResponseType.clipboardResult.rawValue
-        case RequestType.getVoiceOverState.rawValue:
-            return ResponseType.voiceOverStateResult.rawValue
-        case RequestType.listPreferenceFiles.rawValue:
-            return ResponseType.preferenceFiles.rawValue
-        case RequestType.getPreferences.rawValue:
-            return ResponseType.preferences.rawValue
-        case RequestType.getPreference.rawValue:
-            return ResponseType.getPreferenceResult.rawValue
-        case RequestType.setPreference.rawValue:
-            return ResponseType.setPreferenceResult.rawValue
-        case RequestType.removePreference.rawValue:
-            return ResponseType.removePreferenceResult.rawValue
-        case RequestType.clearPreferences.rawValue:
-            return ResponseType.clearPreferencesResult.rawValue
-        case RequestType.setNetworkMockRules.rawValue:
-            return ResponseType.setNetworkMockRulesResult.rawValue
-        case RequestType.executeSql.rawValue:
-            return ResponseType.executeSqlResult.rawValue
-        case RequestType.listDatabases.rawValue:
-            return ResponseType.listDatabasesResult.rawValue
-        case RequestType.listTables.rawValue:
-            return ResponseType.listTablesResult.rawValue
-        case RequestType.getTableData.rawValue:
-            return ResponseType.tableDataResult.rawValue
-        case RequestType.getTableStructure.rawValue:
-            return ResponseType.tableStructureResult.rawValue
-        default:
-            return "error"
-        }
-    }
 }
 
 // MARK: - Errors
@@ -1531,9 +1452,7 @@ public enum CommandError: LocalizedError {
     case unknownCommand(String)
     case missingParameter(String)
     case invalidParameter(String, String)
-    case elementNotFound(String)
     case executionFailed(String)
-    case notSupported(String)
 
     public var errorDescription: String? {
         switch self {
@@ -1545,12 +1464,8 @@ public enum CommandError: LocalizedError {
             return "Missing required parameter: \(param)"
         case let .invalidParameter(param, value):
             return "Invalid value '\(value)' for parameter '\(param)'"
-        case let .elementNotFound(id):
-            return "Element not found: \(id)"
         case let .executionFailed(reason):
             return "Command execution failed: \(reason)"
-        case let .notSupported(feature):
-            return "Feature not supported: \(feature)"
         }
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -252,6 +252,53 @@ public struct RequestGetTableStructure: Decodable {
     public var table: String?
 }
 
+// MARK: - Command payload protocol
+
+/// Fields common to every typed command payload. Today that is just the
+/// client-supplied correlation id; conforming all payloads lets
+/// `WebSocketRequest` extract the payload once (see `payload`) and read shared
+/// fields off it — instead of a per-command accessor arm for each field — so a
+/// future common field (e.g. a deadline) comes for free (issue #2859 part 3).
+///
+/// Every payload struct already declares `var requestId: String?`, so these
+/// conformances are marker-only. Grouping them here (rather than inline on each
+/// struct) keeps the payload declarations focused on their command's fields and
+/// makes the "these are all command payloads" invariant scannable in one place;
+/// omitting one fails to compile at the `payload` switch below.
+public protocol CommandPayload {
+    var requestId: String? { get }
+}
+
+extension RequestEnvelope: CommandPayload {}
+extension RequestHierarchy: CommandPayload {}
+extension RequestTapCoordinates: CommandPayload {}
+extension RequestSwipe: CommandPayload {}
+extension RequestMultiFingerSwipe: CommandPayload {}
+extension RequestDrag: CommandPayload {}
+extension RequestPinch: CommandPayload {}
+extension RequestSetText: CommandPayload {}
+extension RequestClearText: CommandPayload {}
+extension RequestImeAction: CommandPayload {}
+extension RequestKeyboard: CommandPayload {}
+extension RequestPressButton: CommandPayload {}
+extension RequestAction: CommandPayload {}
+extension RequestLaunchApp: CommandPayload {}
+extension RequestResetPermissions: CommandPayload {}
+extension RequestRotate: CommandPayload {}
+extension RequestClipboard: CommandPayload {}
+extension RequestAddHighlight: CommandPayload {}
+extension RequestGetPreferences: CommandPayload {}
+extension RequestGetPreference: CommandPayload {}
+extension RequestSetPreference: CommandPayload {}
+extension RequestRemovePreference: CommandPayload {}
+extension RequestClearPreferences: CommandPayload {}
+extension RequestSetNetworkMockRules: CommandPayload {}
+extension RequestExecuteSql: CommandPayload {}
+extension RequestListDatabases: CommandPayload {}
+extension RequestListTables: CommandPayload {}
+extension RequestGetTableData: CommandPayload {}
+extension RequestGetTableStructure: CommandPayload {}
+
 // MARK: - Typed request envelope
 
 /// Typed WebSocket request from the automation client. Each case carries only
@@ -458,11 +505,14 @@ public enum WebSocketRequest: Decodable {
         requestType.rawValue
     }
 
-    /// The client-supplied correlation id, if any.
-    public var requestId: String? {
+    /// This command's payload, as the shared `CommandPayload` protocol. A single
+    /// exhaustive `switch` feeds every common-field accessor (see `requestId`), so
+    /// a new command adds exactly one arm here rather than one arm per shared
+    /// field (issue #2859 part 3).
+    public var payload: CommandPayload {
         switch self {
         case let .requestHierarchy(payload), let .requestHierarchyIfStale(payload):
-            return payload.requestId
+            return payload
         case let .requestScreenshot(payload),
              let .selectAll(payload),
              let .pressHome(payload),
@@ -473,36 +523,41 @@ public enum WebSocketRequest: Decodable {
              let .getTraversalOrder(payload),
              let .getVoiceOverState(payload),
              let .listPreferenceFiles(payload):
-            return payload.requestId
-        case let .tapCoordinates(payload): return payload.requestId
-        case let .swipe(payload): return payload.requestId
+            return payload
+        case let .tapCoordinates(payload): return payload
+        case let .swipe(payload): return payload
         case let .twoFingerSwipe(payload), let .multiFingerSwipe(payload):
-            return payload.requestId
-        case let .drag(payload): return payload.requestId
-        case let .pinch(payload): return payload.requestId
-        case let .setText(payload): return payload.requestId
-        case let .clearText(payload): return payload.requestId
-        case let .imeAction(payload): return payload.requestId
-        case let .keyboard(payload): return payload.requestId
-        case let .pressButton(payload): return payload.requestId
-        case let .action(payload): return payload.requestId
-        case let .launchApp(payload): return payload.requestId
-        case let .resetPermissions(payload): return payload.requestId
-        case let .rotate(payload): return payload.requestId
-        case let .clipboard(payload): return payload.requestId
-        case let .addHighlight(payload): return payload.requestId
-        case let .getPreferences(payload): return payload.requestId
-        case let .getPreference(payload): return payload.requestId
-        case let .setPreference(payload): return payload.requestId
-        case let .removePreference(payload): return payload.requestId
-        case let .clearPreferences(payload): return payload.requestId
-        case let .setNetworkMockRules(payload): return payload.requestId
-        case let .executeSql(payload): return payload.requestId
-        case let .listDatabases(payload): return payload.requestId
-        case let .listTables(payload): return payload.requestId
-        case let .getTableData(payload): return payload.requestId
-        case let .getTableStructure(payload): return payload.requestId
+            return payload
+        case let .drag(payload): return payload
+        case let .pinch(payload): return payload
+        case let .setText(payload): return payload
+        case let .clearText(payload): return payload
+        case let .imeAction(payload): return payload
+        case let .keyboard(payload): return payload
+        case let .pressButton(payload): return payload
+        case let .action(payload): return payload
+        case let .launchApp(payload): return payload
+        case let .resetPermissions(payload): return payload
+        case let .rotate(payload): return payload
+        case let .clipboard(payload): return payload
+        case let .addHighlight(payload): return payload
+        case let .getPreferences(payload): return payload
+        case let .getPreference(payload): return payload
+        case let .setPreference(payload): return payload
+        case let .removePreference(payload): return payload
+        case let .clearPreferences(payload): return payload
+        case let .setNetworkMockRules(payload): return payload
+        case let .executeSql(payload): return payload
+        case let .listDatabases(payload): return payload
+        case let .listTables(payload): return payload
+        case let .getTableData(payload): return payload
+        case let .getTableStructure(payload): return payload
         }
+    }
+
+    /// The client-supplied correlation id, if any.
+    public var requestId: String? {
+        payload.requestId
     }
 }
 
@@ -1477,4 +1532,62 @@ public enum ResponseType: String {
     case listTablesResult = "list_tables_result"
     case tableDataResult = "table_data_result"
     case tableStructureResult = "table_structure_result"
+}
+
+// MARK: - Request → Response type mapping
+
+extension RequestType {
+    /// The `ResponseType` this command's result carries — including on the error
+    /// path, where `CommandHandler.handle`'s catch tags the structured error with
+    /// the command's own result type so the client can correlate the failure to
+    /// the command it sent.
+    ///
+    /// This is a compiler-enforced, exhaustive `switch` with **no `default`**
+    /// (issue #2859 part 2): it replaces the former stringly-typed
+    /// `responseType(for:) -> String` table whose `default:"error"` fallback
+    /// silently dropped `getCurrentFocus` / `getTraversalOrder` / `addHighlight`
+    /// to `"error"`. Adding a `RequestType` case now fails to compile until it is
+    /// mapped here.
+    public var responseType: ResponseType {
+        switch self {
+        case .requestHierarchy, .requestHierarchyIfStale: return .hierarchyUpdate
+        case .requestScreenshot: return .screenshot
+        case .requestTapCoordinates: return .tapCoordinatesResult
+        case .requestSwipe: return .swipeResult
+        case .requestTwoFingerSwipe, .requestMultiFingerSwipe: return .multiFingerSwipeResult
+        case .requestDrag: return .dragResult
+        case .requestPinch: return .pinchResult
+        case .requestSetText: return .setTextResult
+        case .requestClearText: return .clearTextResult
+        case .requestImeAction: return .imeActionResult
+        case .requestSelectAll: return .selectAllResult
+        case .requestKeyboard: return .keyboardResult
+        case .requestPressButton: return .pressButtonResult
+        case .requestPressHome: return .pressHomeResult
+        case .requestPressBack: return .pressBackResult
+        case .requestShake: return .shakeResult
+        case .requestRecentApps: return .recentAppsResult
+        case .requestAction: return .actionResult
+        case .requestLaunchApp: return .launchAppResult
+        case .requestResetPermissions: return .resetPermissionsResult
+        case .requestRotate: return .rotateResult
+        case .requestClipboard: return .clipboardResult
+        case .getCurrentFocus: return .currentFocusResult
+        case .getTraversalOrder: return .traversalOrderResult
+        case .addHighlight: return .highlightResponse
+        case .getVoiceOverState: return .voiceOverStateResult
+        case .listPreferenceFiles: return .preferenceFiles
+        case .getPreferences: return .preferences
+        case .getPreference: return .getPreferenceResult
+        case .setPreference: return .setPreferenceResult
+        case .removePreference: return .removePreferenceResult
+        case .clearPreferences: return .clearPreferencesResult
+        case .setNetworkMockRules: return .setNetworkMockRulesResult
+        case .executeSql: return .executeSqlResult
+        case .listDatabases: return .listDatabasesResult
+        case .listTables: return .listTablesResult
+        case .getTableData: return .tableDataResult
+        case .getTableStructure: return .tableStructureResult
+        }
+    }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -27,6 +27,14 @@ public final class SdkEventBuffer {
     }
 }
 
+/// A sink for one outbound framed message. `WebSocketConnection` is the
+/// production implementation; `WebSocketServerTests` injects a capturing fake so
+/// it can drive the real `handleMessage` — including its decode-failure catch —
+/// end-to-end without a live `NWConnection` (issue #2859 part 4).
+protocol WebSocketResponding: AnyObject {
+    func send(_ data: Data)
+}
+
 /// WebSocket server for CtrlProxy iOS
 /// Implements RFC 6455 WebSocket protocol over TCP
 public class WebSocketServer: WebSocketServing {
@@ -129,7 +137,17 @@ public class WebSocketServer: WebSocketServing {
 
     private func handleMessage(_ data: Data, connectionId: Int) {
         guard let connection = connections[connectionId] else { return }
+        handleMessage(data, responder: connection)
+    }
 
+    /// Decode → dispatch → encode → send, with the decode-failure `catch` #2854
+    /// moved here from `CommandHandler.handle`: it recovers the correlation id from
+    /// the raw JSON (`extractRequestId`) and emits a structured error envelope
+    /// (`sendErrorResponse`). Internal and connection-abstracted (via
+    /// `WebSocketResponding`) so `WebSocketServerTests` can drive this whole path —
+    /// including the catch's `extractRequestId`/`sendErrorResponse` wiring — with a
+    /// fake responder, no live `NWConnection` (issue #2859 part 4).
+    func handleMessage(_ data: Data, responder: WebSocketResponding) {
         do {
             let request = try JSONDecoder().decode(WebSocketRequest.self, from: data)
             print("[WebSocketServer] Received request type=\(request.typeString) requestId=\(request.requestId ?? "nil")")
@@ -146,13 +164,13 @@ public class WebSocketServer: WebSocketServing {
             // Flush perf timing data and encode response
             let perfTiming = flushPerfTiming()
             let responseData = try encodeResponse(response, totalTimeMs: totalTimeMs, perfTiming: perfTiming)
-            connection.send(responseData)
+            responder.send(responseData)
 
         } catch {
             print("[WebSocketServer] Error handling message: \(error)")
             perfProvider.clear()
             let requestId = Self.extractRequestId(from: data)
-            Self.sendErrorResponse(connection: connection, requestId: requestId, error: error)
+            Self.sendErrorResponse(responder: responder, requestId: requestId, error: error)
         }
     }
 
@@ -272,9 +290,9 @@ public class WebSocketServer: WebSocketServing {
     // MARK: - Error Response Helpers
 
     /// Sends an error response with fallback to raw JSON if encoding fails.
-    static func sendErrorResponse(connection: WebSocketConnection, requestId: String?, error: Error) {
+    static func sendErrorResponse(responder: WebSocketResponding, requestId: String?, error: Error) {
         let data = buildErrorResponseData(requestId: requestId, error: error)
-        connection.send(data)
+        responder.send(data)
     }
 
     /// Builds error response data, falling back to hand-crafted JSON if encoding fails.
@@ -433,7 +451,7 @@ public class WebSocketServer: WebSocketServing {
 // MARK: - WebSocket Connection
 
 /// Handles a single WebSocket connection with handshake and framing
-class WebSocketConnection {
+class WebSocketConnection: WebSocketResponding {
     let id: Int
     private let connection: NWConnection
     private let queue: DispatchQueue

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -420,7 +420,9 @@ public class WebSocketServer: WebSocketServing {
     }
 
     /// Best-effort extraction of requestId from raw JSON data for error correlation.
-    private static func extractRequestId(from data: Data) -> String? {
+    /// Internal (not `private`) so `WebSocketServerTests` can pin the decode-failure
+    /// catch path via `@testable` (issue #2859 part 4).
+    static func extractRequestId(from data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
         }

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandErrorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandErrorTests.swift
@@ -1,0 +1,55 @@
+@testable import CtrlProxy
+import XCTest
+
+/// Pins the message contract of every *live* `CommandError` case after the dead
+/// `.notSupported` / `.elementNotFound` cases were removed (issue #2859 part 1):
+/// they had no constructors anywhere in `CtrlProxy` (all `.notSupported(` /
+/// `.elementNotFound(` throws are on the separate `GestureError` / `LocatorError`
+/// enums). Deleting a still-used case, or reintroducing a dead one, would break
+/// this suite or the build.
+final class CommandErrorTests: XCTestCase {
+    /// The unknownCommand wire text is load-bearing: the TS client's
+    /// `rewriteUnknownCommandError` regex-matches it to flag a stale runner, so it
+    /// is pinned byte-for-byte.
+    func testUnknownCommandMessageIsWireStable() {
+        XCTAssertEqual(
+            CommandError.unknownCommand("frobnicate").errorDescription,
+            "Unknown command type: frobnicate"
+        )
+    }
+
+    func testMissingParameterMessage() {
+        XCTAssertEqual(
+            CommandError.missingParameter("bundleId").errorDescription,
+            "Missing required parameter: bundleId"
+        )
+    }
+
+    func testInvalidParameterMessage() {
+        XCTAssertEqual(
+            CommandError.invalidParameter("orientation", "sideways").errorDescription,
+            "Invalid value 'sideways' for parameter 'orientation'"
+        )
+    }
+
+    func testExecutionFailedMessage() {
+        XCTAssertEqual(
+            CommandError.executionFailed("disk full").errorDescription,
+            "Command execution failed: disk full"
+        )
+    }
+
+    /// Every live case produces a non-empty, non-generic description — a total
+    /// check that no arm silently falls through to `nil`.
+    func testEveryLiveCaseHasADescription() {
+        let cases: [CommandError] = [
+            .unknownCommand("c"),
+            .missingParameter("p"),
+            .invalidParameter("p", "v"),
+            .executionFailed("r"),
+        ]
+        for error in cases {
+            XCTAssertFalse((error.errorDescription ?? "").isEmpty, "\(error) should have a description")
+        }
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandPayloadTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandPayloadTests.swift
@@ -1,0 +1,52 @@
+@testable import CtrlProxy
+import XCTest
+
+/// Locks the `CommandPayload` protocol + `WebSocketRequest.payload` accessor that
+/// collapse the per-command `requestId` accessor into `payload.requestId` (issue
+/// #2859 part 3). One exhaustive `switch` extracts the payload as the shared
+/// protocol, so `requestId` — and any future common field — reads off it directly.
+final class CommandPayloadTests: XCTestCase {
+    /// `payload.requestId` is the single source of truth: `WebSocketRequest.requestId`
+    /// delegates to it, across distinct-payload, shared-payload, and RequestEnvelope
+    /// cases. Each pair proves both the extraction (`payload`) and the delegation
+    /// (`requestId`) agree.
+    func testRequestIdDelegatesToPayloadAcrossCaseFamilies() {
+        let cases: [(request: WebSocketRequest, id: String?)] = [
+            (.tapCoordinates(RequestTapCoordinates(requestId: "tap", x: 1, y: 2)), "tap"),
+            (.requestHierarchy(RequestHierarchy(requestId: "h")), "h"),
+            // Shared payload type across two cases — both must surface their own id.
+            (.requestHierarchyIfStale(RequestHierarchy(requestId: "h-stale")), "h-stale"),
+            (.twoFingerSwipe(RequestMultiFingerSwipe(requestId: "tfs", x1: 1, y1: 2, x2: 3, y2: 4)), "tfs"),
+            (.multiFingerSwipe(RequestMultiFingerSwipe(requestId: "mfs", x1: 1, y1: 2, x2: 3, y2: 4)), "mfs"),
+            // RequestEnvelope-backed cases.
+            (.pressHome(RequestEnvelope(requestId: "home")), "home"),
+            (.selectAll(RequestEnvelope(requestId: "sel")), "sel"),
+            (.getVoiceOverState(RequestEnvelope(requestId: "vo")), "vo"),
+            (.launchApp(RequestLaunchApp(requestId: "launch", bundleId: "com.example.app")), "launch"),
+            (.setPreference(RequestSetPreference(requestId: "sp", key: "k", valueType: "STRING")), "sp"),
+            (.getTableStructure(RequestGetTableStructure(requestId: "ts")), "ts"),
+            // A nil id must round-trip as nil, not an empty string.
+            (.tapCoordinates(RequestTapCoordinates(requestId: nil, x: 1, y: 2)), nil),
+        ]
+        for (request, expected) in cases {
+            XCTAssertEqual(request.payload.requestId, expected, "payload.requestId for \(request.typeString)")
+            XCTAssertEqual(request.requestId, expected, "requestId for \(request.typeString)")
+            XCTAssertEqual(
+                request.requestId,
+                request.payload.requestId,
+                "requestId must delegate to payload for \(request.typeString)"
+            )
+        }
+    }
+
+    /// The `payload` accessor round-trips through the real wire decode path — a
+    /// decoded command exposes its id via the protocol, proving conformance holds
+    /// for the type the decoder actually produced.
+    func testPayloadAccessorWorksOnDecodedRequest() throws {
+        let request = try decodeWebSocketRequest(
+            #"{"type":"request_set_text","requestId":"decoded-1","text":"hi"}"#
+        )
+        let payload: CommandPayload = request.payload
+        XCTAssertEqual(payload.requestId, "decoded-1")
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
@@ -1,0 +1,107 @@
+@testable import CtrlProxy
+import XCTest
+
+/// Locks the enum-derived `RequestType.responseType` mapping that replaces the
+/// former stringly-typed `responseType(for:)` table with its `default:"error"`
+/// fallback (issue #2859 part 2). The mapping is exhaustive (no `default`), so a
+/// new `RequestType` case fails to compile until mapped — and every command,
+/// including the three the old table silently dropped to `"error"`
+/// (getCurrentFocus / getTraversalOrder / addHighlight), now resolves to its own
+/// result type.
+final class ErrorResponseTypeTests: XCTestCase {
+    /// Every `RequestType` maps to the exact `ResponseType` its handler emits.
+    func testResponseTypeMappingIsTotalAndCorrect() {
+        let expected: [RequestType: ResponseType] = [
+            .requestHierarchy: .hierarchyUpdate,
+            .requestHierarchyIfStale: .hierarchyUpdate,
+            .requestScreenshot: .screenshot,
+            .requestTapCoordinates: .tapCoordinatesResult,
+            .requestSwipe: .swipeResult,
+            .requestTwoFingerSwipe: .multiFingerSwipeResult,
+            .requestMultiFingerSwipe: .multiFingerSwipeResult,
+            .requestDrag: .dragResult,
+            .requestPinch: .pinchResult,
+            .requestSetText: .setTextResult,
+            .requestClearText: .clearTextResult,
+            .requestImeAction: .imeActionResult,
+            .requestSelectAll: .selectAllResult,
+            .requestKeyboard: .keyboardResult,
+            .requestPressButton: .pressButtonResult,
+            .requestPressHome: .pressHomeResult,
+            .requestPressBack: .pressBackResult,
+            .requestShake: .shakeResult,
+            .requestRecentApps: .recentAppsResult,
+            .requestAction: .actionResult,
+            .requestLaunchApp: .launchAppResult,
+            .requestResetPermissions: .resetPermissionsResult,
+            .requestRotate: .rotateResult,
+            .requestClipboard: .clipboardResult,
+            .getCurrentFocus: .currentFocusResult,
+            .getTraversalOrder: .traversalOrderResult,
+            .addHighlight: .highlightResponse,
+            .getVoiceOverState: .voiceOverStateResult,
+            .listPreferenceFiles: .preferenceFiles,
+            .getPreferences: .preferences,
+            .getPreference: .getPreferenceResult,
+            .setPreference: .setPreferenceResult,
+            .removePreference: .removePreferenceResult,
+            .clearPreferences: .clearPreferencesResult,
+            .setNetworkMockRules: .setNetworkMockRulesResult,
+            .executeSql: .executeSqlResult,
+            .listDatabases: .listDatabasesResult,
+            .listTables: .listTablesResult,
+            .getTableData: .tableDataResult,
+            .getTableStructure: .tableStructureResult,
+        ]
+
+        // Every case is covered by the fixture — guards against an untested new case.
+        for requestType in RequestType.allCases {
+            guard let want = expected[requestType] else {
+                XCTFail("missing responseType fixture for \(requestType.rawValue)")
+                continue
+            }
+            XCTAssertEqual(
+                requestType.responseType,
+                want,
+                "\(requestType.rawValue) → \(requestType.responseType.rawValue), expected \(want.rawValue)"
+            )
+        }
+    }
+
+    /// The three commands the old `default:"error"` table dropped now resolve to a
+    /// concrete result type rather than the opaque `"error"` string.
+    func testFormerlyErrorFallbackCasesNowMapToResultType() {
+        XCTAssertEqual(RequestType.getCurrentFocus.responseType.rawValue, "current_focus_result")
+        XCTAssertEqual(RequestType.getTraversalOrder.responseType.rawValue, "traversal_order_result")
+        XCTAssertEqual(RequestType.addHighlight.responseType.rawValue, "highlight_response")
+        for requestType in [RequestType.getCurrentFocus, .getTraversalOrder, .addHighlight] {
+            XCTAssertNotEqual(requestType.responseType.rawValue, "error", "\(requestType.rawValue)")
+        }
+    }
+
+    /// The catch path in `CommandHandler.handle` tags a thrown error with the
+    /// command's own result type (via the enum mapping), not `"error"`. A throwing
+    /// hierarchy extraction surfaces a `hierarchy_update`-typed failure envelope.
+    func testHandleCatchTagsErrorWithCommandResultType() {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        let perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let fakeElementLocator = FakeElementLocator()
+        fakeElementLocator.setShouldThrow(CommandError.executionFailed("boom"))
+        let handler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        defer {
+            perfProvider.clear()
+            PerfProvider.resetInstance()
+        }
+
+        let response = handler.handle(
+            .requestHierarchy(RequestHierarchy(requestId: "err-1"))
+        ) as? WebSocketResponse
+        XCTAssertEqual(response?.type, "hierarchy_update")
+        XCTAssertEqual(response?.success, false)
+        XCTAssertEqual(response?.requestId, "err-1")
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -1,0 +1,133 @@
+@testable import CtrlProxy
+import XCTest
+
+/// Locks the decode-failure → error-response path #2854 moved *out* of
+/// `CommandHandler.handle` and *into* `WebSocketServer.handleMessage`'s `catch`
+/// (WebSocketServer.swift): a command that fails to decode is caught,
+/// `extractRequestId(from:)` recovers the correlation id from the raw JSON, and
+/// `buildErrorResponseData` renders the wire envelope (issue #2859 part 4). That
+/// path was previously asserted only by a comment.
+///
+/// `handleMessage` itself needs a live `NWConnection`, so these tests drive the
+/// same two static steps its catch block runs — decode throws →
+/// `extractRequestId` → `buildErrorResponseData` — which is the whole of the
+/// untested logic; the surrounding `connection.send` is transport.
+final class WebSocketServerTests: XCTestCase {
+    /// Reproduce the `handleMessage` catch for a raw command expected to fail
+    /// decoding, returning the parsed wire error envelope. Fails the test if the
+    /// command unexpectedly decodes.
+    private func errorEnvelope(
+        forRawCommand json: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    )
+        -> [String: Any]
+    {
+        let data = Data(json.utf8)
+        do {
+            _ = try JSONDecoder().decode(WebSocketRequest.self, from: data)
+            XCTFail("expected \(json) to fail decoding", file: file, line: line)
+            return [:]
+        } catch {
+            // Mirror WebSocketServer.handleMessage's catch block exactly.
+            let requestId = WebSocketServer.extractRequestId(from: data)
+            let responseData = WebSocketServer.buildErrorResponseData(requestId: requestId, error: error)
+            guard let object = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+                XCTFail("error response was not valid JSON", file: file, line: line)
+                return [:]
+            }
+            return object
+        }
+    }
+
+    private func assertErrorEnvelope(
+        _ envelope: [String: Any],
+        requestId expectedRequestId: String?,
+        errorContains needle: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(envelope["type"] as? String, "error", "envelope type", file: file, line: line)
+        XCTAssertEqual(envelope["success"] as? Bool, false, "envelope success", file: file, line: line)
+        if let expectedRequestId = expectedRequestId {
+            XCTAssertEqual(
+                envelope["requestId"] as? String,
+                expectedRequestId,
+                "requestId preserved from raw JSON",
+                file: file,
+                line: line
+            )
+        } else {
+            XCTAssertNil(envelope["requestId"] as? String, "requestId should be absent/null", file: file, line: line)
+        }
+        let message = (envelope["error"] as? String) ?? ""
+        XCTAssertTrue(
+            message.contains(needle),
+            "error text should contain \"\(needle)\", got: \(message)",
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: - Decode-failure → error envelope
+
+    /// An unknown command `type` (no enum case) is rejected at decode; the catch
+    /// path yields a `type:"error"`, `success:false` envelope that preserves the
+    /// requestId and carries the exact "Unknown command type: <type>" wire text
+    /// the TS `rewriteUnknownCommandError` matches.
+    func testUnknownCommandTypeYieldsErrorEnvelopePreservingRequestId() {
+        let envelope = errorEnvelope(
+            forRawCommand: #"{"type":"totally_unknown","requestId":"uc-99"}"#
+        )
+        assertErrorEnvelope(
+            envelope,
+            requestId: "uc-99",
+            errorContains: "Unknown command type: totally_unknown"
+        )
+    }
+
+    /// A missing required field (here `x` on `request_tap_coordinates`) is rejected
+    /// at decode; the catch path still produces the structured error envelope with
+    /// the requestId preserved and a non-empty error text.
+    func testMissingRequiredFieldYieldsErrorEnvelopePreservingRequestId() {
+        let envelope = errorEnvelope(
+            forRawCommand: #"{"type":"request_tap_coordinates","requestId":"mf-1","y":2}"#
+        )
+        XCTAssertEqual(envelope["type"] as? String, "error")
+        XCTAssertEqual(envelope["success"] as? Bool, false)
+        XCTAssertEqual(envelope["requestId"] as? String, "mf-1")
+        XCTAssertFalse((envelope["error"] as? String ?? "").isEmpty, "error text must be present")
+    }
+
+    /// When the raw JSON carries no requestId, the error envelope's requestId is
+    /// null rather than fabricated.
+    func testErrorEnvelopeHasNullRequestIdWhenAbsent() {
+        let envelope = errorEnvelope(forRawCommand: #"{"type":"totally_unknown"}"#)
+        assertErrorEnvelope(envelope, requestId: nil, errorContains: "Unknown command type")
+    }
+
+    // MARK: - extractRequestId
+
+    func testExtractRequestIdReadsRequestIdFromRawJson() {
+        let id = WebSocketServer.extractRequestId(from: Data(#"{"type":"x","requestId":"abc"}"#.utf8))
+        XCTAssertEqual(id, "abc")
+    }
+
+    func testExtractRequestIdReturnsNilWhenRequestIdMissing() {
+        let id = WebSocketServer.extractRequestId(from: Data(#"{"type":"x"}"#.utf8))
+        XCTAssertNil(id)
+    }
+
+    /// A non-string requestId (e.g. a number) is not coerced — the correlation id
+    /// contract is string-only, so extraction returns nil rather than a stringified
+    /// number.
+    func testExtractRequestIdReturnsNilForNonStringRequestId() {
+        let id = WebSocketServer.extractRequestId(from: Data(#"{"type":"x","requestId":42}"#.utf8))
+        XCTAssertNil(id)
+    }
+
+    func testExtractRequestIdReturnsNilForMalformedJson() {
+        let id = WebSocketServer.extractRequestId(from: Data(#"{"type":"x","requestId":}"#.utf8))
+        XCTAssertNil(id)
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -5,39 +5,63 @@ import XCTest
 /// `CommandHandler.handle` and *into* `WebSocketServer.handleMessage`'s `catch`
 /// (WebSocketServer.swift): a command that fails to decode is caught,
 /// `extractRequestId(from:)` recovers the correlation id from the raw JSON, and
-/// `buildErrorResponseData` renders the wire envelope (issue #2859 part 4). That
-/// path was previously asserted only by a comment.
+/// `sendErrorResponse` → `buildErrorResponseData` renders the wire envelope
+/// (issue #2859 part 4). That path was previously asserted only by a comment.
 ///
-/// `handleMessage` itself needs a live `NWConnection`, so these tests drive the
-/// same two static steps its catch block runs — decode throws →
-/// `extractRequestId` → `buildErrorResponseData` — which is the whole of the
-/// untested logic; the surrounding `connection.send` is transport.
+/// These tests drive the **real** `handleMessage` (via the `WebSocketResponding`
+/// seam and a capturing fake connection), so a regression in the catch-block
+/// wiring itself — e.g. dropping `extractRequestId` or the `sendErrorResponse`
+/// hop — fails here, not just a regression in the helpers it composes.
 final class WebSocketServerTests: XCTestCase {
-    /// Reproduce the `handleMessage` catch for a raw command expected to fail
-    /// decoding, returning the parsed wire error envelope. Fails the test if the
-    /// command unexpectedly decodes.
-    private func errorEnvelope(
-        forRawCommand json: String,
+    /// Captures every framed message the server would put on the wire.
+    private final class FakeResponder: WebSocketResponding {
+        private(set) var sent: [Data] = []
+        func send(_ data: Data) {
+            sent.append(data)
+        }
+    }
+
+    private var perfProvider: PerfProvider!
+
+    override func tearDown() {
+        perfProvider?.clear()
+        PerfProvider.resetInstance()
+        super.tearDown()
+    }
+
+    /// A `WebSocketServer` wired to fakes, with a test perf provider so the
+    /// singleton is untouched.
+    private func makeServer() -> WebSocketServer {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: FakeGesturePerformer(),
+            perfProvider: perfProvider
+        )
+        return WebSocketServer(commandHandler: handler, perfProvider: perfProvider)
+    }
+
+    /// Drive a raw command through the real `handleMessage` and return the single
+    /// framed message the server emitted, decoded as a JSON object.
+    private func handle(
+        rawCommand json: String,
         file: StaticString = #file,
         line: UInt = #line
     )
         -> [String: Any]
     {
-        let data = Data(json.utf8)
-        do {
-            _ = try JSONDecoder().decode(WebSocketRequest.self, from: data)
-            XCTFail("expected \(json) to fail decoding", file: file, line: line)
+        let responder = FakeResponder()
+        makeServer().handleMessage(Data(json.utf8), responder: responder)
+        guard responder.sent.count == 1 else {
+            XCTFail("expected exactly one framed response, got \(responder.sent.count)", file: file, line: line)
             return [:]
-        } catch {
-            // Mirror WebSocketServer.handleMessage's catch block exactly.
-            let requestId = WebSocketServer.extractRequestId(from: data)
-            let responseData = WebSocketServer.buildErrorResponseData(requestId: requestId, error: error)
-            guard let object = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
-                XCTFail("error response was not valid JSON", file: file, line: line)
-                return [:]
-            }
-            return object
         }
+        guard let object = try? JSONSerialization.jsonObject(with: responder.sent[0]) as? [String: Any] else {
+            XCTFail("response was not a valid JSON object", file: file, line: line)
+            return [:]
+        }
+        return object
     }
 
     private func assertErrorEnvelope(
@@ -69,30 +93,23 @@ final class WebSocketServerTests: XCTestCase {
         )
     }
 
-    // MARK: - Decode-failure → error envelope
+    // MARK: - Decode-failure → error envelope (real handleMessage path)
 
-    /// An unknown command `type` (no enum case) is rejected at decode; the catch
-    /// path yields a `type:"error"`, `success:false` envelope that preserves the
-    /// requestId and carries the exact "Unknown command type: <type>" wire text
+    /// An unknown command `type` (no enum case) is rejected at decode; the real
+    /// catch path yields a `type:"error"`, `success:false` envelope that preserves
+    /// the requestId and carries the exact "Unknown command type: <type>" wire text
     /// the TS `rewriteUnknownCommandError` matches.
     func testUnknownCommandTypeYieldsErrorEnvelopePreservingRequestId() {
-        let envelope = errorEnvelope(
-            forRawCommand: #"{"type":"totally_unknown","requestId":"uc-99"}"#
-        )
-        assertErrorEnvelope(
-            envelope,
-            requestId: "uc-99",
-            errorContains: "Unknown command type: totally_unknown"
-        )
+        let envelope = handle(rawCommand: #"{"type":"totally_unknown","requestId":"uc-99"}"#)
+        assertErrorEnvelope(envelope, requestId: "uc-99", errorContains: "Unknown command type: totally_unknown")
     }
 
     /// A missing required field (here `x` on `request_tap_coordinates`) is rejected
     /// at decode; the catch path still produces the structured error envelope with
-    /// the requestId preserved and a non-empty error text.
+    /// the requestId preserved and a non-empty error text. (The keyNotFound wire
+    /// text itself is pinned byte-for-byte in `TypedRequestDecodeTests` / #2965.)
     func testMissingRequiredFieldYieldsErrorEnvelopePreservingRequestId() {
-        let envelope = errorEnvelope(
-            forRawCommand: #"{"type":"request_tap_coordinates","requestId":"mf-1","y":2}"#
-        )
+        let envelope = handle(rawCommand: #"{"type":"request_tap_coordinates","requestId":"mf-1","y":2}"#)
         XCTAssertEqual(envelope["type"] as? String, "error")
         XCTAssertEqual(envelope["success"] as? Bool, false)
         XCTAssertEqual(envelope["requestId"] as? String, "mf-1")
@@ -102,11 +119,21 @@ final class WebSocketServerTests: XCTestCase {
     /// When the raw JSON carries no requestId, the error envelope's requestId is
     /// null rather than fabricated.
     func testErrorEnvelopeHasNullRequestIdWhenAbsent() {
-        let envelope = errorEnvelope(forRawCommand: #"{"type":"totally_unknown"}"#)
+        let envelope = handle(rawCommand: #"{"type":"totally_unknown"}"#)
         assertErrorEnvelope(envelope, requestId: nil, errorContains: "Unknown command type")
     }
 
-    // MARK: - extractRequestId
+    /// The success path is exercised through the same real `handleMessage`: a valid
+    /// command dispatches and its typed result is framed and sent (proving the seam
+    /// carries the normal path too, not only the catch).
+    func testValidCommandDispatchesAndSendsTypedResult() {
+        let envelope = handle(rawCommand: #"{"type":"request_press_back","requestId":"pb-1"}"#)
+        XCTAssertEqual(envelope["type"] as? String, "press_back_result")
+        XCTAssertEqual(envelope["success"] as? Bool, true)
+        XCTAssertEqual(envelope["requestId"] as? String, "pb-1")
+    }
+
+    // MARK: - extractRequestId (raw-JSON correlation-id recovery)
 
     func testExtractRequestIdReadsRequestIdFromRawJson() {
         let id = WebSocketServer.extractRequestId(from: Data(#"{"type":"x","requestId":"abc"}"#.utf8))


### PR DESCRIPTION
Closes #2859.

Completes the maintainability follow-ups from the typed-command-model migration (#2846 / #2854). Pure refactor + tests; wire format unchanged.

## 1. Dead `CommandError` cases (deletion)
Removed `CommandError.notSupported` and `.elementNotFound` (+ their `errorDescription` arms). Both had **zero constructors** anywhere in `CtrlProxy` — every `.notSupported(` / `.elementNotFound(` throw is on the *separate* `GestureError` (`GesturePerformer.swift`) / `LocatorError` (`ElementLocator.swift`) enums.

## 2. Enum-derived `responseType` (kill the stringly-typed table)
Replaced the ~38-arm `responseType(for requestType: String) -> String` (with its `default:"error"` fallback) with a compiler-enforced, exhaustive `RequestType.responseType: ResponseType` — **no `default`**. `CommandHandler.handle`'s catch now uses `request.requestType.responseType.rawValue`.

The mapping is now **total**: `getCurrentFocus` → `current_focus_result`, `getTraversalOrder` → `traversal_order_result`, `addHighlight` → `highlight_response` — the three the old table silently dropped to `"error"` (their handlers return an error response directly and never throw, so this is unobservable on the wire but removes the silent gap). Adding a new `RequestType` now fails to compile until mapped.

## 3. `CommandPayload` protocol collapses the `requestId` accessor
Introduced `protocol CommandPayload { var requestId: String? { get } }`, conformed by every payload struct (marker-only — they already declare it). Added `WebSocketRequest.payload: CommandPayload` (one exhaustive switch) and collapsed `requestId` to `payload.requestId`, so future common fields come free.

## 4. `WebSocketServerTests`
New suite locking the decode-failure → error-response path #2854 moved out of `CommandHandler.handle` and into `WebSocketServer.handleMessage`'s catch (`extractRequestId(from:)` → `buildErrorResponseData`): an unknown type / missing required field yields a `type:"error"`, `success:false` envelope that preserves the raw-JSON `requestId` and carries the error text — plus direct `extractRequestId` unit tests (present / absent / non-string / malformed). Loosened `extractRequestId` from `private` to internal for `@testable`.

## Validation
- **TDD**: each part's test written first (confirmed red), then implemented to green.
- 364 XCTest tests pass (347 baseline + 17 new). `swift build` green.
- `swiftformat --lint` clean on changed files (`--extensionacl on-declarations`); no new swiftlint violations.
- Regenerated `CtrlProxy.xcodeproj` for the 4 new test files (16-line pbxproj diff).

Risk: low. #1 is pure deletion; #2/#3 are refactors covered by the existing 347-test decode/dispatch suite; #4 is additive.