### PR TITLE
refactor(ios): extract ProcessSupervisor

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -13,6 +13,7 @@ import { DeviceAppManager } from "./ios-cmdline-tools/DeviceAppManager";
 import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
 import { isRunningInDocker } from "./dockerEnv";
 import { exponentialBackoff } from "./Backoff";
+import { DefaultProcessSupervisor, type ProcessSupervisor } from "./ProcessSupervisor";
 import { createConnection } from "node:net";
 import {
   getHostControlHost,
@@ -204,13 +205,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private xcTestProcessId: number | null = null;
   private xcTestProcess: ChildProcess | null = null;
 
-  // Process monitoring
-  private processMonitorInterval: ReturnType<typeof setInterval> | null = null;
-
-  // Auto-restart state
-  private autoRestartEnabled: boolean = true;
-  private restartAttempts: number = 0;
-  private restartTimeout: ReturnType<Timer["setTimeout"]> | null = null;
+  // Process supervision
+  private readonly processSupervisor: ProcessSupervisor;
+  private readonly iproxySupervisor: ProcessSupervisor;
+  private isProcessSupervisorRestarting = false;
   private static readonly MAX_RESTART_ATTEMPTS = 5;
   private static readonly RESTART_BASE_DELAY_MS = 2000;
   private static readonly RESTART_MAX_DELAY_MS = 30000;
@@ -221,9 +219,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private iproxyProcessId: number | null = null;
   private iproxyProcess: ChildProcess | null = null;
   private iproxyDevicePort: number | null = null;
-  private iproxyMonitorInterval: ReturnType<typeof setInterval> | null = null;
-  private iproxyRestartTimeout: ReturnType<Timer["setTimeout"]> | null = null;
-  private iproxyRestartAttempts: number = 0;
   private isStopping: boolean = false;
 
   // Mutex to prevent concurrent start() calls from spawning multiple processes
@@ -277,6 +272,54 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       stop: params => stopCtrlProxyIOS(params),
       status: params => getCtrlProxyIOSStatus(params)
     };
+    this.processSupervisor = new DefaultProcessSupervisor({
+      name: "iOS CtrlProxy XCTest runner",
+      timer: this.timer,
+      monitorIntervalMs: 30000,
+      maxRestartAttempts: IOSCtrlProxyManager.MAX_RESTART_ATTEMPTS,
+      restartBackoff: exponentialBackoff({
+        initialDelayMs: IOSCtrlProxyManager.RESTART_BASE_DELAY_MS,
+        maxDelayMs: IOSCtrlProxyManager.RESTART_MAX_DELAY_MS
+      }),
+      restart: async () => {
+        this.isProcessSupervisorRestarting = true;
+        try {
+          await this.start();
+        } finally {
+          this.isProcessSupervisorRestarting = false;
+        }
+      },
+      isAlive: () => this.isSupervisedCtrlProxyProcessAlive(),
+      onExit: () => {
+        this.xcTestProcessId = null;
+        this.xcTestProcess = null;
+        this.clearCaches();
+      },
+      onRestartSuccess: () => {
+        logger.info("[IOSCtrlProxy] Auto-restart successful");
+      },
+      onRestartFailure: error => {
+        logger.warn(`[IOSCtrlProxy] Auto-restart failed: ${error instanceof Error ? error.message : String(error)}`);
+      },
+    });
+    this.iproxySupervisor = new DefaultProcessSupervisor({
+      name: "iOS iproxy tunnel",
+      timer: this.timer,
+      monitorIntervalMs: IOSCtrlProxyManager.IPROXY_MONITOR_INTERVAL_MS,
+      restartBackoff: exponentialBackoff({
+        initialDelayMs: IOSCtrlProxyManager.IPROXY_RESTART_BASE_DELAY_MS,
+        maxDelayMs: IOSCtrlProxyManager.IPROXY_RESTART_MAX_DELAY_MS
+      }),
+      restart: () => this.restartIproxyTunnel(),
+      isAlive: () => this.isSupervisedIproxyTunnelAlive(),
+      onExit: () => {
+        this.iproxyProcessId = null;
+        this.iproxyProcess = null;
+      },
+      onRestartFailure: error => {
+        logger.warn(`[IOSCtrlProxy] Failed to restart iproxy: ${error instanceof Error ? error.message : String(error)}`);
+      },
+    });
   }
 
   /**
@@ -613,10 +656,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         }
         if (!restartedAliveProcess) {
           perf.endOperation("iproxyTunnel");
-          this.startIproxyMonitoring();
+          await this.iproxySupervisor.start();
         }
       }
       if (!restartedAliveProcess) {
+        await this.startProcessSupervision();
         return;
       }
     }
@@ -627,6 +671,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       perf.endOperation("runningCheck");
       if (alreadyRunning) {
         logger.info("[IOSCtrlProxy] Service is already running");
+        await this.startProcessSupervision();
         return;
       }
 
@@ -700,6 +745,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         perf.endOperation("healthPolling");
         logger.info("[IOSCtrlProxy] HTTP health endpoint is ready");
         this.clearCaches();
+        await this.startProcessSupervision();
 
         // Wait additional time for WebSocket server to be ready
         // The HTTP server can respond before WebSocket is fully initialized
@@ -709,7 +755,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         perf.endOperation("websocketInit");
 
         if (!this.isSimulator()) {
-          this.startIproxyMonitoring();
+          await this.iproxySupervisor.start();
         }
         return;
       }
@@ -736,6 +782,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         this.clearCaches();
         // Mirror the normal success path's WebSocket-init settle (#2834 review — MINOR-3).
         await this.timer.sleep(500);
+        await this.startProcessSupervision();
         return;
       }
       // Otherwise it is genuinely hung. Merely un-tracking it is NOT enough: the process
@@ -792,7 +839,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `(exited/PID-reused); un-tracking without terminating`
           );
         }
-        this.stopProcessMonitoring();
         this.xcTestProcessId = null;
         this.xcTestProcess = null;
         // Host-control mode has no local child-exit event to clear these as a side
@@ -800,6 +846,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         // cachedRunning/cachedAvailability can serve a stale positive to the next
         // setup() for up to STATUS_CACHE_TTL (#2834 review).
         this.clearCaches();
+        this.processSupervisor.stop();
+        await this.processSupervisor.start();
       } finally {
         // Do NOT leave isStopping latched across the throw below (#2834 review — MINOR-2):
         // a caller that does not retry start() would otherwise wedge the manager in
@@ -828,12 +876,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     logger.info("[IOSCtrlProxy] Stopping CtrlProxy");
     this.isStopping = true;
 
-    // Cancel any pending restart
-    if (this.restartTimeout) {
-      this.timer.clearTimeout(this.restartTimeout);
-      this.restartTimeout = null;
-    }
-    this.restartAttempts = 0;
+    this.processSupervisor.stop();
 
     if (this.useHostControl()) {
       try {
@@ -850,16 +893,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
       this.xcTestProcessId = null;
       this.xcTestProcess = null;
-      this.stopProcessMonitoring();
       this.clearCaches();
       PortManager.release(this.device.deviceId);
       this.isStopping = false;
       logger.info("[IOSCtrlProxy] Service stopped");
       return;
     }
-
-    // Stop process monitoring first
-    this.stopProcessMonitoring();
 
     // Stop iproxy tunnel if running
     await this.stopIproxyTunnel({ clearDevicePort: true });
@@ -1259,9 +1298,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       this.xcTestProcess = child;
       logger.info(`[IOSCtrlProxy] Started xcodebuild test with PID ${child.pid}`);
 
-      // Start process monitoring
-      this.startProcessMonitoring();
-
       // Capture output for debugging
       this.captureProcessOutput(child);
     }
@@ -1304,107 +1340,38 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
-   * Start process health monitoring
-   */
-  private startProcessMonitoring(): void {
-    // Clear any existing monitor
-    this.stopProcessMonitoring();
-
-    // Check every 30 seconds
-    this.processMonitorInterval = this.timer.setInterval(async () => {
-      try {
-        const isHealthy = await this.checkHealthEndpoint();
-
-        if (!isHealthy && this.xcTestProcessId) {
-          // Check if process is still running
-          const processRunning = await this.isProcessRunning(this.xcTestProcessId);
-          if (!processRunning) {
-            logger.warn("[IOSCtrlProxy] XCTest process crashed, health endpoint not responding");
-            // Don't auto-restart here - let the next setup() call handle it
-            this.handleProcessExit();
-          }
-        }
-      } catch {
-        // Ignore monitoring errors
-      }
-    }, 30000);
-  }
-
-  /**
-   * Stop process monitoring
-   */
-  private stopProcessMonitoring(): void {
-    if (this.processMonitorInterval) {
-      this.timer.clearInterval(this.processMonitorInterval);
-      this.processMonitorInterval = null;
-    }
-  }
-
-  /**
    * Handle process exit
    */
   private handleProcessExit(): void {
-    this.xcTestProcessId = null;
-    this.xcTestProcess = null;
-    this.stopProcessMonitoring();
-    this.clearCaches();
+    this.processSupervisor.processExited();
+  }
 
-    // Schedule auto-restart if enabled and not stopping intentionally
-    if (this.autoRestartEnabled && !this.isStopping) {
-      this.scheduleAutoRestart();
+  private async startProcessSupervision(): Promise<void> {
+    if (!this.isProcessSupervisorRestarting) {
+      await this.processSupervisor.start();
     }
   }
 
-  /**
-   * Schedule automatic restart with exponential backoff
-   */
-  private scheduleAutoRestart(): void {
-    if (this.restartTimeout || this.isStopping) {
-      return;
+  private async isSupervisedCtrlProxyProcessAlive(): Promise<boolean> {
+    const isHealthy = await this.checkHealthEndpoint();
+    if (isHealthy || !this.xcTestProcessId) {
+      return true;
     }
 
-    if (this.restartAttempts >= IOSCtrlProxyManager.MAX_RESTART_ATTEMPTS) {
-      logger.warn(`[IOSCtrlProxy] Max restart attempts (${IOSCtrlProxyManager.MAX_RESTART_ATTEMPTS}) reached, giving up`);
-      this.restartAttempts = 0;
-      return;
+    const processRunning = this.useHostControl()
+      ? await this.isOwnRunnerProcessAlive()
+      : await this.isProcessRunning(this.xcTestProcessId);
+    if (!processRunning) {
+      logger.warn("[IOSCtrlProxy] XCTest process crashed, health endpoint not responding");
     }
-
-    this.restartAttempts++;
-    const delay = exponentialBackoff({
-      initialDelayMs: IOSCtrlProxyManager.RESTART_BASE_DELAY_MS,
-      maxDelayMs: IOSCtrlProxyManager.RESTART_MAX_DELAY_MS
-    }).delayForAttempt(this.restartAttempts);
-
-    logger.info(`[IOSCtrlProxy] Scheduling auto-restart in ${delay}ms (attempt ${this.restartAttempts}/${IOSCtrlProxyManager.MAX_RESTART_ATTEMPTS})`);
-
-    this.restartTimeout = this.timer.setTimeout(() => {
-      this.restartTimeout = null;
-
-      // Don't restart if we're stopping
-      if (this.isStopping) {
-        return;
-      }
-
-      logger.info("[IOSCtrlProxy] Attempting automatic restart...");
-      void this.start().then(() => {
-        logger.info("[IOSCtrlProxy] Auto-restart successful");
-        this.restartAttempts = 0; // Reset on success
-      }).catch(error => {
-        logger.warn(`[IOSCtrlProxy] Auto-restart failed: ${error instanceof Error ? error.message : String(error)}`);
-        // handleProcessExit will be called again, triggering another restart attempt
-      });
-    }, delay);
+    return processRunning;
   }
 
   /**
    * Enable or disable auto-restart
    */
   public setAutoRestart(enabled: boolean): void {
-    this.autoRestartEnabled = enabled;
-    if (!enabled && this.restartTimeout) {
-      this.timer.clearTimeout(this.restartTimeout);
-      this.restartTimeout = null;
-    }
+    this.processSupervisor.setAutoRestart(enabled);
     logger.info(`[IOSCtrlProxy] Auto-restart ${enabled ? "enabled" : "disabled"}`);
   }
 
@@ -1412,7 +1379,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Check if auto-restart is enabled
    */
   public isAutoRestartEnabled(): boolean {
-    return this.autoRestartEnabled;
+    return this.processSupervisor.isAutoRestartEnabled();
   }
 
   /**
@@ -1421,15 +1388,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   public async forceRestart(): Promise<void> {
     logger.info("[IOSCtrlProxy] Force restart requested");
 
-    // Clear any pending restart
-    if (this.restartTimeout) {
-      this.timer.clearTimeout(this.restartTimeout);
-      this.restartTimeout = null;
-    }
-
     // Stop and restart
     await this.stop();
-    this.restartAttempts = 0; // Reset attempts for forced restart
     await this.start();
   }
 
@@ -2124,9 +2084,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       this.xcTestProcess = child;
       logger.info(`[IOSCtrlProxy] Started xcodebuild test with PID ${child.pid}`);
 
-      // Start process monitoring
-      this.startProcessMonitoring();
-
       // Capture output for debugging
       this.captureProcessOutput(child);
     }
@@ -2294,6 +2251,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private async startIproxyTunnel(options: {
     allowServicePortReallocation?: boolean;
     devicePort?: number;
+    supervise?: boolean;
   } = {}): Promise<void> {
     if (this.isSimulator()) {
       return;
@@ -2303,12 +2261,15 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (this.iproxyProcessId) {
         const status = await this.hostControl.getIproxyStatus({ pid: this.iproxyProcessId });
         if (status.success && status.data?.running) {
+          if (options.supervise !== false) {
+            await this.iproxySupervisor.start();
+          }
           return;
         }
       }
 
       const fixedDevicePort = options.devicePort ?? this.iproxyDevicePort;
-      await this.stopIproxyTunnel();
+      await this.stopIproxyTunnel({ stopSupervisor: options.supervise !== false });
       await this.ensureHostControlServicePortAvailable({
         allowReallocation: options.allowServicePortReallocation ?? true,
       });
@@ -2327,14 +2288,20 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       this.iproxyProcess = null;
       this.iproxyDevicePort = devicePort;
       await this.waitForIproxyStartup();
+      if (options.supervise !== false) {
+        await this.iproxySupervisor.start();
+      }
       return;
     }
 
     if (this.iproxyProcessId && await this.isProcessRunning(this.iproxyProcessId)) {
+      if (options.supervise !== false) {
+        await this.iproxySupervisor.start();
+      }
       return;
     }
 
-    await this.stopIproxyTunnel();
+    await this.stopIproxyTunnel({ stopSupervisor: options.supervise !== false });
 
     logger.info(`[IOSCtrlProxy] Starting iproxy tunnel (localhost:${this.servicePort} -> device:${this.servicePort})`);
     const child = this.processExecutor.spawn(
@@ -2354,30 +2321,26 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     child.on("exit", () => {
       if (!this.isStopping) {
         logger.warn("[IOSCtrlProxy] iproxy exited unexpectedly");
-        this.iproxyProcessId = null;
-        this.iproxyProcess = null;
-        this.scheduleIproxyRestart();
+        this.iproxySupervisor.processExited();
       }
     });
 
     child.on("error", error => {
       if (!this.isStopping) {
         logger.warn(`[IOSCtrlProxy] iproxy error: ${error.message}`);
-        this.iproxyProcessId = null;
-        this.iproxyProcess = null;
-        this.scheduleIproxyRestart();
+        this.iproxySupervisor.processExited();
       }
     });
 
     await this.waitForIproxyStartup();
+    if (options.supervise !== false) {
+      await this.iproxySupervisor.start();
+    }
   }
 
-  private async stopIproxyTunnel(options: { clearDevicePort?: boolean } = {}): Promise<void> {
-    this.stopIproxyMonitoring();
-
-    if (this.iproxyRestartTimeout) {
-      this.timer.clearTimeout(this.iproxyRestartTimeout);
-      this.iproxyRestartTimeout = null;
+  private async stopIproxyTunnel(options: { clearDevicePort?: boolean; stopSupervisor?: boolean } = {}): Promise<void> {
+    if (options.stopSupervisor !== false) {
+      this.iproxySupervisor.stop();
     }
 
     if (this.useHostControl()) {
@@ -2406,7 +2369,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (options.clearDevicePort) {
       this.iproxyDevicePort = null;
     }
-    this.iproxyRestartAttempts = 0;
   }
 
   private async waitForIproxyStartup(): Promise<void> {
@@ -2430,76 +2392,47 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     throw new Error(`iproxy failed to stay running within ${timeoutMs}ms`);
   }
 
-  private scheduleIproxyRestart(): void {
-    if (this.iproxyRestartTimeout || this.isStopping) {
-      return;
-    }
-
-    this.iproxyRestartAttempts++;
-    const delay = exponentialBackoff({
-      initialDelayMs: IOSCtrlProxyManager.IPROXY_RESTART_BASE_DELAY_MS,
-      maxDelayMs: IOSCtrlProxyManager.IPROXY_RESTART_MAX_DELAY_MS
-    }).delayForAttempt(this.iproxyRestartAttempts);
-
-    this.iproxyRestartTimeout = this.timer.setTimeout(() => {
-      this.iproxyRestartTimeout = null;
-      void this.startIproxyTunnel({
+  private async restartIproxyTunnel(): Promise<void> {
+    try {
+      await this.startIproxyTunnel({
         allowServicePortReallocation: false,
         devicePort: this.iproxyDevicePort ?? undefined,
-      }).then(() => {
-        this.startIproxyMonitoring();
-      }).catch(error => {
-        if (error instanceof HostControlServicePortUnavailableError) {
-          logger.warn(
-            "[IOSCtrlProxy] Existing CtrlProxy process uses a host port that is no longer available during iproxy restart; restarting"
-          );
-          void this.restartDeviceProcessAfterHostPortCollision().then(() => {
-            this.startIproxyMonitoring();
-          }).catch(restartError => {
-            logger.warn(`[IOSCtrlProxy] Failed to restart CtrlProxy after iproxy port collision: ${restartError instanceof Error ? restartError.message : String(restartError)}`);
-          });
-          return;
-        }
-        logger.warn(`[IOSCtrlProxy] Failed to restart iproxy: ${error instanceof Error ? error.message : String(error)}`);
+        supervise: false,
       });
-    }, delay);
-  }
-
-  private startIproxyMonitoring(): void {
-    if (this.iproxyMonitorInterval || this.isSimulator()) {
-      return;
-    }
-
-    this.iproxyMonitorInterval = this.timer.setInterval(async () => {
-      try {
-        const isConnected = await this.isDeviceDetected();
-        if (!isConnected) {
-          logger.warn(`[IOSCtrlProxy] Device ${this.device.deviceId} not detected, stopping iproxy monitoring`);
-          await this.stopIproxyTunnel({ clearDevicePort: true });
-          return;
-        }
-
-        // Check iproxy process liveness — not CtrlProxy health. A temporarily slow
-        // CtrlProxy would fail a health check even though the tunnel is fine; restarting
-        // the tunnel in that case is harmful. CtrlProxy's own health is covered by the
-        // separate 30 s process monitor.
-        const iproxyAlive = await this.isIproxyProcessAlive();
-        if (!iproxyAlive) {
-          logger.warn("[IOSCtrlProxy] iproxy process is no longer running, scheduling restart");
-          await this.stopIproxyTunnel();
-          this.scheduleIproxyRestart();
-        }
-      } catch (error) {
-        logger.warn(`[IOSCtrlProxy] iproxy monitor error: ${error instanceof Error ? error.message : String(error)}`);
+    } catch (error) {
+      if (!(error instanceof HostControlServicePortUnavailableError)) {
+        throw error;
       }
-    }, IOSCtrlProxyManager.IPROXY_MONITOR_INTERVAL_MS);
+      logger.warn(
+        "[IOSCtrlProxy] Existing CtrlProxy process uses a host port that is no longer available during iproxy restart; restarting"
+      );
+      await this.restartDeviceProcessAfterHostPortCollision();
+      await this.processSupervisor.start();
+    }
   }
 
-  private stopIproxyMonitoring(): void {
-    if (this.iproxyMonitorInterval) {
-      this.timer.clearInterval(this.iproxyMonitorInterval);
-      this.iproxyMonitorInterval = null;
+  private async isSupervisedIproxyTunnelAlive(): Promise<boolean> {
+    if (this.isSimulator()) {
+      return true;
     }
+
+    const isConnected = await this.isDeviceDetected();
+    if (!isConnected) {
+      logger.warn(`[IOSCtrlProxy] Device ${this.device.deviceId} not detected, stopping iproxy monitoring`);
+      await this.stopIproxyTunnel({ clearDevicePort: true });
+      return true;
+    }
+
+    // Check iproxy process liveness — not CtrlProxy health. A temporarily slow
+    // CtrlProxy would fail a health check even though the tunnel is fine; restarting
+    // the tunnel in that case is harmful. CtrlProxy's own health is covered by the
+    // separate process supervisor.
+    const iproxyAlive = await this.isIproxyProcessAlive();
+    if (!iproxyAlive) {
+      logger.warn("[IOSCtrlProxy] iproxy process is no longer running, scheduling restart");
+      await this.stopIproxyTunnel({ stopSupervisor: false });
+    }
+    return iproxyAlive;
   }
 
   private async isDeviceDetected(): Promise<boolean> {

--- a/src/utils/ProcessSupervisor.ts
+++ b/src/utils/ProcessSupervisor.ts
@@ -1,0 +1,155 @@
+import { type BackoffPolicy } from "./Backoff";
+import { type Timer } from "./SystemTimer";
+import { logger } from "./logger";
+
+export interface ProcessSupervisor {
+  start(): Promise<void>;
+  stop(): void;
+  processExited(): void;
+  isAlive(): Promise<boolean>;
+  setAutoRestart(enabled: boolean): void;
+  isAutoRestartEnabled(): boolean;
+}
+
+export interface ProcessSupervisorOptions {
+  readonly name: string;
+  readonly timer: Timer;
+  readonly monitorIntervalMs: number;
+  readonly restartBackoff: BackoffPolicy;
+  readonly restart: () => Promise<void>;
+  readonly isAlive: () => Promise<boolean>;
+  readonly onExit?: () => void | Promise<void>;
+  readonly onRestartSuccess?: () => void | Promise<void>;
+  readonly onRestartFailure?: (error: unknown) => void | Promise<void>;
+  readonly maxRestartAttempts?: number;
+}
+
+export class DefaultProcessSupervisor implements ProcessSupervisor {
+  private monitorInterval: ReturnType<Timer["setInterval"]> | null = null;
+  private restartTimeout: ReturnType<Timer["setTimeout"]> | null = null;
+  private restartAttempts = 0;
+  private isStopping = false;
+  private autoRestartEnabled = true;
+
+  public constructor(private readonly options: ProcessSupervisorOptions) {}
+
+  public async start(): Promise<void> {
+    this.isStopping = false;
+    this.startMonitoring();
+  }
+
+  public stop(): void {
+    this.isStopping = true;
+    this.stopMonitoring();
+    this.clearRestartTimeout();
+    this.restartAttempts = 0;
+  }
+
+  public processExited(): void {
+    void this.handleProcessExit();
+  }
+
+  private async handleProcessExit(): Promise<void> {
+    this.stopMonitoring();
+    await this.options.onExit?.();
+
+    if (this.autoRestartEnabled && !this.isStopping) {
+      this.scheduleRestart();
+    }
+  }
+
+  public isAlive(): Promise<boolean> {
+    return this.options.isAlive();
+  }
+
+  public setAutoRestart(enabled: boolean): void {
+    this.autoRestartEnabled = enabled;
+    if (!enabled) {
+      this.clearRestartTimeout();
+    }
+  }
+
+  public isAutoRestartEnabled(): boolean {
+    return this.autoRestartEnabled;
+  }
+
+  private startMonitoring(): void {
+    this.stopMonitoring();
+    this.monitorInterval = this.options.timer.setInterval(() => {
+      void this.checkLiveness();
+    }, this.options.monitorIntervalMs);
+  }
+
+  private stopMonitoring(): void {
+    if (this.monitorInterval) {
+      this.options.timer.clearInterval(this.monitorInterval);
+      this.monitorInterval = null;
+    }
+  }
+
+  private async checkLiveness(): Promise<void> {
+    try {
+      if (!await this.options.isAlive()) {
+        logger.warn(`[ProcessSupervisor] ${this.options.name} is no longer alive`);
+        this.processExited();
+      }
+    } catch (error) {
+      logger.warn(
+        `[ProcessSupervisor] ${this.options.name} liveness check failed: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  private scheduleRestart(): void {
+    if (this.restartTimeout || this.isStopping || !this.autoRestartEnabled) {
+      return;
+    }
+
+    const maxAttempts = this.options.maxRestartAttempts;
+    if (maxAttempts !== undefined && this.restartAttempts >= maxAttempts) {
+      logger.warn(`[ProcessSupervisor] ${this.options.name} max restart attempts (${maxAttempts}) reached`);
+      this.restartAttempts = 0;
+      return;
+    }
+
+    this.restartAttempts++;
+    const attempt = this.restartAttempts;
+    const delay = this.options.restartBackoff.delayForAttempt(attempt);
+    logger.info(`[ProcessSupervisor] Scheduling ${this.options.name} restart in ${delay}ms (attempt ${attempt})`);
+
+    this.restartTimeout = this.options.timer.setTimeout(() => {
+      this.restartTimeout = null;
+      if (this.isStopping) {
+        return;
+      }
+      void this.restart(attempt);
+    }, delay);
+  }
+
+  private async restart(attempt: number): Promise<void> {
+    try {
+      await this.options.restart();
+      if (this.isStopping) {
+        return;
+      }
+      this.restartAttempts = 0;
+      await this.options.onRestartSuccess?.();
+      this.startMonitoring();
+    } catch (error) {
+      await this.options.onRestartFailure?.(error);
+      logger.warn(
+        `[ProcessSupervisor] ${this.options.name} restart attempt ${attempt} failed: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+      );
+      this.scheduleRestart();
+    }
+  }
+
+  private clearRestartTimeout(): void {
+    if (this.restartTimeout) {
+      this.options.timer.clearTimeout(this.restartTimeout);
+      this.restartTimeout = null;
+    }
+  }
+}

--- a/test/fakes/FakeProcessSupervisor.ts
+++ b/test/fakes/FakeProcessSupervisor.ts
@@ -1,0 +1,35 @@
+import { type ProcessSupervisor } from "../../src/utils/ProcessSupervisor";
+
+export class FakeProcessSupervisor implements ProcessSupervisor {
+  public startCalls = 0;
+  public stopCalls = 0;
+  public processExitedCalls = 0;
+  public setAutoRestartCalls: boolean[] = [];
+  public alive = true;
+  private autoRestartEnabled = true;
+
+  public async start(): Promise<void> {
+    this.startCalls++;
+  }
+
+  public stop(): void {
+    this.stopCalls++;
+  }
+
+  public processExited(): void {
+    this.processExitedCalls++;
+  }
+
+  public async isAlive(): Promise<boolean> {
+    return this.alive;
+  }
+
+  public setAutoRestart(enabled: boolean): void {
+    this.setAutoRestartCalls.push(enabled);
+    this.autoRestartEnabled = enabled;
+  }
+
+  public isAutoRestartEnabled(): boolean {
+    return this.autoRestartEnabled;
+  }
+}

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -70,6 +70,7 @@ function createHostControlRunner(options: {
   const starts: { deviceId: string; port: number; xctestrunPath?: string }[] = [];
   const stops: { deviceId?: string; pid?: number }[] = [];
   const iproxyStarts: { deviceId: string; localPort: number; devicePort?: number }[] = [];
+  const iproxyStops: { pid?: number }[] = [];
   const runningCtrlProxyProcesses = new Map<number, { pid: number; port: number; deviceId?: string }>();
   for (const pid of options.runningCtrlProxyPids ?? []) {
     runningCtrlProxyProcesses.set(pid, { pid, port: 8765 });
@@ -85,6 +86,7 @@ function createHostControlRunner(options: {
     starts,
     stops,
     iproxyStarts,
+    iproxyStops,
     runner: {
       shouldUseHostControl: () => true,
       isRunningInDocker: () => true,
@@ -100,6 +102,7 @@ function createHostControlRunner(options: {
         return { success: true, data: { pid } };
       },
       stopIproxy: async (params: { pid?: number }) => {
+        iproxyStops.push(params);
         if (params.pid) {
           runningIproxyPids.delete(params.pid);
         }
@@ -586,6 +589,7 @@ describe("IOSCtrlProxyManager", function() {
       await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
 
       fakeProcess.emit("exit", 1, null);
+      await Promise.resolve();
       fakeTimer.advanceTime(1000);
       await Promise.resolve();
 
@@ -753,7 +757,6 @@ describe("IOSCtrlProxyManager", function() {
       await (manager as unknown as { startOnDevice: () => Promise<void> }).startOnDevice();
       (manager as unknown as { iproxyProcessId: null }).iproxyProcessId = null;
 
-      (manager as unknown as { startIproxyMonitoring: () => void }).startIproxyMonitoring();
       fakeTimer.advanceTime(5000);
       for (let i = 0; i < 10; i++) {
         await Promise.resolve();
@@ -801,7 +804,6 @@ describe("IOSCtrlProxyManager", function() {
         { deviceId: physicalDevice.deviceId, localPort: 8767, devicePort: 8765 },
       ]);
 
-      (manager as unknown as { startIproxyMonitoring: () => void }).startIproxyMonitoring();
       fakeTimer.advanceTime(5000);
       for (let i = 0; i < 10; i++) {
         await Promise.resolve();
@@ -924,6 +926,43 @@ describe("IOSCtrlProxyManager", function() {
       expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
       // The auto-restart suppression latch is not left set across the throw (MINOR-2).
       expect((manager as unknown as { isStopping: boolean }).isStopping).toBe(false);
+    });
+
+    test("start() re-arms supervision after hung-runner cleanup so the next pre-health exit restarts", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
+      const runnerProcs = [ownRunnerProcess(12345)];
+      installListeningProcessFakes(fakeExecutor, runnerProcs);
+
+      await withHealthBudget("1", async () => {
+        fakeTimer.enableAutoAdvance();
+        await expect(manager.start()).rejects.toThrow(/failed to start within timeout/);
+      });
+
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
+      expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBeNull();
+
+      const failedPreHealthProcess = new FakeChildProcess();
+      failedPreHealthProcess.pid = 22222;
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = failedPreHealthProcess.pid;
+      (manager as unknown as { xcTestProcess: FakeChildProcess }).xcTestProcess = failedPreHealthProcess;
+      fakeExecutor.setCommandHandler("curl -s", () => createExecResult(
+        fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "",
+        ""
+      ));
+
+      (manager as unknown as { handleProcessExit: () => void }).handleProcessExit();
+      fakeTimer.advanceTime(1000);
+      for (let i = 0; i < 5; i++) {await new Promise(resolve => setImmediate(resolve));}
+
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
     });
 
     test("start() does NOT terminate the tracked PID if it was recycled during the wait (#2834)", async function() {
@@ -1297,7 +1336,7 @@ describe("IOSCtrlProxyManager", function() {
       (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 1234;
 
       fakeTimer.enableAutoAdvance();
-      (manager as unknown as { scheduleIproxyRestart: () => void }).scheduleIproxyRestart();
+      (manager as unknown as { iproxySupervisor: { processExited: () => void } }).iproxySupervisor.processExited();
       for (let i = 0; i < 10; i++) {
         await new Promise(resolve => setImmediate(resolve));
       }
@@ -1317,7 +1356,7 @@ describe("IOSCtrlProxyManager", function() {
       ]);
     });
 
-    test("startProcessMonitoring uses the injected timer so tests can control it", function() {
+    test("xctest process supervisor uses the injected timer so tests can control it", async function() {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice,
         fakeTimer,
@@ -1327,7 +1366,7 @@ describe("IOSCtrlProxyManager", function() {
 
       expect(fakeTimer.getPendingIntervals().length).toBe(0);
 
-      (manager as unknown as { startProcessMonitoring: () => void }).startProcessMonitoring();
+      await (manager as unknown as { processSupervisor: { start: () => Promise<void> } }).processSupervisor.start();
 
       expect(fakeTimer.getPendingIntervals().length).toBe(1);
       expect(fakeTimer.getPendingIntervals()[0]).toBe(30000);
@@ -1351,8 +1390,6 @@ describe("IOSCtrlProxyManager", function() {
         // Health endpoint fails (would have triggered restart in old code)
         fakeExecutor.setCommandResponse("curl -s", createExecResult("", ""));
         // kill -0 succeeds by default → iproxy process alive
-
-        (manager as unknown as { startIproxyMonitoring: () => void }).startIproxyMonitoring();
 
         // Fire one monitor interval
         fakeTimer.advanceTime(5000);
@@ -1378,15 +1415,13 @@ describe("IOSCtrlProxyManager", function() {
 
         fakeExecutor.setNextSpawnProcess(fakeProcess2);
 
-        (manager as unknown as { startIproxyMonitoring: () => void }).startIproxyMonitoring();
-
         // Fire monitor — sees no tracked process → schedules restart
         fakeTimer.advanceTime(5000);
-        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+        for (let i = 0; i < 5; i++) {await new Promise(resolve => setImmediate(resolve));}
 
         // Fire restart timer (first attempt = 1000 ms base delay)
         fakeTimer.advanceTime(1000);
-        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+        for (let i = 0; i < 5; i++) {await new Promise(resolve => setImmediate(resolve));}
 
         expect(fakeExecutor.getSpawnedProcesses().length).toBe(2);
       });
@@ -1403,15 +1438,77 @@ describe("IOSCtrlProxyManager", function() {
 
         // Process exit triggers scheduleIproxyRestart
         fakeProcess1.emit("exit", 1, null);
+        await Promise.resolve();
 
         fakeExecutor.setNextSpawnProcess(fakeProcess2);
 
         // Fire restart timer (1000 ms base delay for first attempt)
         fakeTimer.advanceTime(1000);
-        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+        for (let i = 0; i < 5; i++) {await new Promise(resolve => setImmediate(resolve));}
 
         // After restart, startIproxyMonitoring() should have been called → new interval pending
         expect(fakeTimer.getPendingIntervals().length).toBe(1);
+      });
+
+      test("keeps retrying when a scheduled iproxy restart attempt fails before the tunnel is supervised", async function() {
+        const fakeProcess1 = new FakeChildProcess();
+        const fakeProcess2 = new FakeChildProcess();
+        fakeProcess2.pid = undefined as unknown as number;
+        fakeExecutor.setNextSpawnProcess(fakeProcess1);
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          physicalDevice, fakeTimer, undefined, fakeExecutor
+        );
+
+        await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+
+        fakeProcess1.emit("exit", 1, null);
+        await Promise.resolve();
+        expect(fakeTimer.getPendingTimeouts()).toEqual([1000]);
+
+        fakeExecutor.setNextSpawnProcess(fakeProcess2);
+        fakeTimer.advanceTime(1000);
+        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+
+        expect(fakeExecutor.getSpawnedProcesses().length).toBe(2);
+        expect(fakeTimer.getPendingTimeouts()).toEqual([2000]);
+      });
+
+      test("stops a stale host-control iproxy before clearing its tracked pid", async function() {
+        const { runner, iproxyStarts, iproxyStops } = createHostControlRunner();
+        runner.runIdeviceId = async () => ({
+          success: true,
+          data: { stdout: `${physicalDevice.deviceId}\n` },
+        });
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          physicalDevice,
+          fakeTimer,
+          undefined,
+          fakeExecutor,
+          undefined,
+          undefined,
+          runner,
+          new FakeHostPortAvailabilityChecker()
+        );
+
+        await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+        runner.getIproxyStatus = async (params: { pid?: number }) => ({
+          success: true,
+          data: { running: false, pid: params.pid },
+        });
+
+        fakeTimer.advanceTime(5000);
+        for (let i = 0; i < 5; i++) {await new Promise(resolve => setImmediate(resolve));}
+
+        expect(iproxyStops).toEqual([{ pid: 4321 }]);
+        expect(fakeTimer.getPendingTimeouts()).toEqual([1000]);
+
+        fakeTimer.advanceTime(1000);
+        for (let i = 0; i < 5; i++) {await new Promise(resolve => setImmediate(resolve));}
+
+        expect(iproxyStarts).toEqual([
+          { deviceId: physicalDevice.deviceId, localPort: 8765, devicePort: 8765 },
+          { deviceId: physicalDevice.deviceId, localPort: 8765, devicePort: 8765 },
+        ]);
       });
     });
   });

--- a/test/utils/ProcessSupervisor.test.ts
+++ b/test/utils/ProcessSupervisor.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+import { DefaultProcessSupervisor } from "../../src/utils/ProcessSupervisor";
+import { sequenceBackoff } from "../../src/utils/Backoff";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeProcessSupervisor } from "../fakes/FakeProcessSupervisor";
+
+const flushMicrotasks = async (count: number = 5): Promise<void> => {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve();
+  }
+};
+
+describe("DefaultProcessSupervisor", function() {
+  test("monitors liveness and restarts when the process dies", async function() {
+    const timer = new FakeTimer();
+    let alive = true;
+    let exits = 0;
+    let restarts = 0;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100]),
+      restart: async () => {
+        restarts++;
+        alive = true;
+      },
+      isAlive: async () => alive,
+      onExit: () => {
+        exits++;
+      },
+    });
+
+    await supervisor.start();
+    alive = false;
+
+    timer.advanceTime(250);
+    await flushMicrotasks();
+
+    expect(exits).toBe(1);
+    expect(timer.getPendingTimeouts()).toEqual([100]);
+
+    timer.advanceTime(100);
+    await flushMicrotasks();
+
+    expect(restarts).toBe(1);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+    expect(timer.getPendingIntervals()).toEqual([250]);
+  });
+
+  test("uses the injected Backoff policy for retry progression", async function() {
+    const timer = new FakeTimer();
+    const attemptedAt: number[] = [];
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 1000,
+      maxRestartAttempts: 3,
+      restartBackoff: sequenceBackoff([100, 200, 400]),
+      restart: async () => {
+        attemptedAt.push(timer.now());
+        throw new Error("still down");
+      },
+      isAlive: async () => false,
+    });
+
+    supervisor.processExited();
+    await flushMicrotasks();
+    expect(timer.getPendingTimeouts()).toEqual([100]);
+
+    timer.advanceTime(100);
+    await flushMicrotasks();
+    expect(attemptedAt).toEqual([100]);
+    expect(timer.getPendingTimeouts()).toEqual([200]);
+
+    timer.advanceTime(200);
+    await flushMicrotasks();
+    expect(attemptedAt).toEqual([100, 300]);
+    expect(timer.getPendingTimeouts()).toEqual([400]);
+  });
+
+  test("stop clears monitor and restart timers and suppresses future restarts", async function() {
+    const timer = new FakeTimer();
+    let restarts = 0;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100]),
+      restart: async () => {
+        restarts++;
+      },
+      isAlive: async () => false,
+    });
+
+    await supervisor.start();
+    supervisor.processExited();
+    await flushMicrotasks();
+    expect(timer.getPendingIntervalCount()).toBe(0);
+    expect(timer.getPendingTimeouts()).toEqual([100]);
+
+    supervisor.stop();
+
+    expect(timer.getPendingIntervalCount()).toBe(0);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+
+    timer.advanceTime(100);
+    await flushMicrotasks();
+
+    expect(restarts).toBe(0);
+    supervisor.processExited();
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("waits for async exit cleanup before scheduling restart", async function() {
+    const timer = new FakeTimer();
+    let finishExit!: () => void;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100]),
+      restart: async () => {},
+      isAlive: async () => false,
+      onExit: async () => {
+        await new Promise<void>(resolve => {
+          finishExit = resolve;
+        });
+      },
+    });
+
+    supervisor.processExited();
+    await flushMicrotasks();
+
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+
+    finishExit();
+    await flushMicrotasks();
+
+    expect(timer.getPendingTimeouts()).toEqual([100]);
+  });
+
+  test("does not resume monitoring when stopped while restart is in flight", async function() {
+    const timer = new FakeTimer();
+    let finishRestart!: () => void;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100]),
+      restart: async () => {
+        await new Promise<void>(resolve => {
+          finishRestart = resolve;
+        });
+      },
+      isAlive: async () => false,
+    });
+
+    supervisor.processExited();
+    await flushMicrotasks();
+    timer.advanceTime(100);
+    await flushMicrotasks();
+
+    supervisor.stop();
+    finishRestart();
+    await flushMicrotasks();
+
+    expect(timer.getPendingIntervalCount()).toBe(0);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("does not schedule another retry when auto-restart is disabled during an in-flight restart", async function() {
+    const timer = new FakeTimer();
+    let failRestart!: () => void;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100, 200]),
+      restart: async () => {
+        await new Promise<void>(resolve => {
+          failRestart = resolve;
+        });
+        throw new Error("restart failed");
+      },
+      isAlive: async () => false,
+    });
+
+    supervisor.processExited();
+    await flushMicrotasks();
+    timer.advanceTime(100);
+    await flushMicrotasks();
+
+    supervisor.setAutoRestart(false);
+    failRestart();
+    await flushMicrotasks();
+
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("reports liveness through the injected liveness check", async function() {
+    const timer = new FakeTimer();
+    let alive = true;
+    const supervisor = new DefaultProcessSupervisor({
+      name: "test-process",
+      timer,
+      monitorIntervalMs: 250,
+      restartBackoff: sequenceBackoff([100]),
+      restart: async () => {},
+      isAlive: async () => alive,
+    });
+
+    await expect(supervisor.isAlive()).resolves.toBe(true);
+    alive = false;
+    await expect(supervisor.isAlive()).resolves.toBe(false);
+  });
+});
+
+describe("FakeProcessSupervisor", function() {
+  test("records calls for consumers without timers or real restarts", async function() {
+    const supervisor = new FakeProcessSupervisor();
+
+    await supervisor.start();
+    supervisor.processExited();
+    supervisor.stop();
+
+    expect(supervisor.startCalls).toBe(1);
+    expect(supervisor.processExitedCalls).toBe(1);
+    expect(supervisor.stopCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `DefaultProcessSupervisor` as a reusable Timer/Backoff-based supervisor for monitor intervals, restart timers, attempts, and liveness checks.
- Wire `IOSCtrlProxyManager` to instantiate one supervisor for the XCTest runner and one for the iproxy tunnel while keeping the public `CtrlProxyIosManager` facade unchanged.
- Add fast FakeTimer tests for restart-on-death, backoff progression, stopping behavior, liveness, async cleanup ordering, and stopped-during-restart races.

Closes #2770

## Testing

- `bun test test/utils/ProcessSupervisor.test.ts test/utils/IOSCtrlProxyManager.test.ts`
- `bun test --bail` (6547 pass, 2 skip)
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `git diff --check`
