### PR TITLE
feat(server): debug-log intentional structuredContent omission (#2962)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,7 +13,7 @@ import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanEx
 
 // Import the tool registry
 import { ToolRegistry, toolHasOutputSchema } from "./toolRegistry";
-import { stripToolResultStructuredContent } from "./stripToolResultStructuredContent";
+import { stripToolResultStructuredContent, structuredContentOmissionReason, responseCarriesStructuredContent } from "./stripToolResultStructuredContent";
 
 // Import the resource registry
 import { ResourceRegistry } from "./resourceRegistry";
@@ -347,7 +347,20 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       // #2899). Applied here — not inside a tool handler — so internal handler
       // callers keep reading `structuredContent`, and so plain-registered tools
       // are covered.
-      return stripToolResultStructuredContent(result, toolHasOutputSchema(tool));
+      // Field-debuggability trace (issue #2962): when the wire boundary actually
+      // drops a `structuredContent` tree, emit one debug line naming the tool and
+      // WHY, so a client that reads both paths can tell an intentional omission
+      // from an accidental miss. The reason is resolved once here and passed into
+      // the strip (single source of truth), and the trace is gated on the same
+      // "a field is actually present" condition as the strip, so it never
+      // over-reports on non-envelope responses. Debug level → dropped at the
+      // default INFO level, so no per-call noise beyond the guard. Aligns with the
+      // "log-and-continue with a why" convention.
+      const omissionReason = structuredContentOmissionReason(toolHasOutputSchema(tool));
+      if (omissionReason !== null && responseCarriesStructuredContent(result)) {
+        logger.debug(`[MCP] Omitted structuredContent for tool "${name}" (reason: ${omissionReason})`);
+      }
+      return stripToolResultStructuredContent(result, omissionReason);
     } finally {
       executionTracker.endExecution(execution.id);
     }

--- a/src/server/stripToolResultStructuredContent.ts
+++ b/src/server/stripToolResultStructuredContent.ts
@@ -1,24 +1,70 @@
 import { serverConfig } from "../utils/ServerConfig";
 
 /**
+ * Why `structuredContent` is intentionally omitted for a tool result:
+ * - `"no-schema"` — the tool declares no `outputSchema`, so `structuredContent`
+ *   is dropped unconditionally (#2759).
+ * - `"flag"` — a schema tool stripped because the
+ *   `--tool-results-no-structured-content` flag is on (#2899).
+ */
+export type StructuredContentOmissionReason = "no-schema" | "flag";
+
+/**
+ * Single source of truth for the wire-boundary omission decision (issue #2962).
+ * Returns the reason `structuredContent` is intentionally omitted, or `null` when
+ * it is retained (a schema tool with the flag off). Both the strip
+ * (`stripToolResultStructuredContent`) and the `index.ts` debug trace consume this
+ * one decision, so a stripped-vs-accidentally-missing `structuredContent` is
+ * distinguishable in the field.
+ *
+ * `"no-schema"` takes precedence over `"flag"`: a no-schema tool is stripped
+ * unconditionally regardless of the flag, so its omission reason is always
+ * `"no-schema"`. Equivalent to the pre-#2962 `!hasOutputSchema || flag` gate.
+ *
+ * @param hasOutputSchema Whether the tool declares an `outputSchema`.
+ * @param flagEnabled     The `--tool-results-no-structured-content` flag state;
+ *                        defaults to the live `serverConfig` value.
+ */
+export function structuredContentOmissionReason(
+  hasOutputSchema: boolean,
+  flagEnabled: boolean = serverConfig.isToolResultsNoStructuredContentEnabled()
+): StructuredContentOmissionReason | null {
+  if (!hasOutputSchema) {
+    return "no-schema";
+  }
+  if (flagEnabled) {
+    return "flag";
+  }
+  return null;
+}
+
+/**
+ * True when `response` is an MCP tool-call envelope that actually carries a
+ * `structuredContent` tree — i.e. stripping it would remove something.
+ * Non-envelope, primitive, `null`, and already-`structuredContent`-free responses
+ * are false. Shared by the strip and the `index.ts` debug trace so the trace only
+ * fires when a field was really dropped (not merely because the policy would).
+ */
+export function responseCarriesStructuredContent(response: unknown): boolean {
+  return (
+    response !== null &&
+    typeof response === "object" &&
+    "structuredContent" in (response as Record<string, unknown>)
+  );
+}
+
+/**
  * Wire-boundary policy for the duplicated `structuredContent` tree on MCP
  * tool-result envelopes. Handlers pre-serialize the payload into
  * `content[0].text` alongside `structuredContent` (see
  * `createStructuredToolResponse`), so the two are byte-identical duplicates —
  * dropping `structuredContent` halves the wire payload with no information loss.
  *
- * `structuredContent` is dropped when EITHER (issue #2899 + #2759):
- * - the tool declares no `outputSchema` — per MCP (2025-06-18) `structuredContent`
- *   is only meaningful for a tool that advertises an `outputSchema`, so it is
- *   pure duplication for no-schema tools (`observe`, the largest payload, is one)
- *   and is dropped **unconditionally**; or
- * - the `--tool-results-no-structured-content` flag is set — which also drops it
- *   for schema tools (and `getToolDefinitions` drops their `outputSchema`
- *   advertisement under the same flag, so the server never advertises structured
- *   output it will not return).
- *
- * Equivalently, `structuredContent` is kept only for a schema tool while the flag
- * is off.
+ * The omission decision is pre-resolved by `structuredContentOmissionReason` and
+ * passed in as `reason` (issue #2962), rather than re-derived here, so the strip
+ * and the `index.ts` debug trace share a single evaluation of the policy:
+ * - any reason (`"no-schema"` #2759, `"flag"` #2899) → drop `structuredContent`;
+ * - `null` → retain it (a schema tool with the flag off).
  *
  * This is applied at the MCP CallTool serialization boundary, NOT inside a tool's
  * handler, and that placement is deliberate:
@@ -34,18 +80,15 @@ import { serverConfig } from "../utils/ServerConfig";
  * Non-envelope, primitive, and already-`structuredContent`-free responses pass
  * through unchanged — a safe no-op.
  *
- * @param response        The MCP tool-call envelope (or anything envelope-shaped).
- * @param hasOutputSchema Whether the tool declares an `outputSchema`
- *                        (`toolHasOutputSchema(tool)` at the call site).
+ * @param response The MCP tool-call envelope (or anything envelope-shaped).
+ * @param reason   The pre-resolved omission reason from
+ *                 `structuredContentOmissionReason(...)`; `null` retains the field.
  */
-export function stripToolResultStructuredContent<T>(response: T, hasOutputSchema: boolean): T {
-  const shouldStrip = !hasOutputSchema || serverConfig.isToolResultsNoStructuredContentEnabled();
-  if (
-    shouldStrip &&
-    response !== null &&
-    typeof response === "object" &&
-    "structuredContent" in (response as Record<string, unknown>)
-  ) {
+export function stripToolResultStructuredContent<T>(
+  response: T,
+  reason: StructuredContentOmissionReason | null
+): T {
+  if (reason !== null && responseCarriesStructuredContent(response)) {
     delete (response as Record<string, unknown>).structuredContent;
   }
   return response;

--- a/test/server/stripToolResultStructuredContent.test.ts
+++ b/test/server/stripToolResultStructuredContent.test.ts
@@ -1,24 +1,112 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { stripToolResultStructuredContent } from "../../src/server/stripToolResultStructuredContent";
+import {
+  responseCarriesStructuredContent,
+  stripToolResultStructuredContent,
+  structuredContentOmissionReason,
+} from "../../src/server/stripToolResultStructuredContent";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 
 /**
  * Wire-boundary strip for the duplicated `structuredContent` tree.
  * `content[0].text` and `structuredContent` are byte-identical duplicates, so
- * dropping the latter halves the wire payload with no data loss. It is dropped
- * for no-schema tools unconditionally (issue #2759) and for schema tools when
- * the `--tool-results-no-structured-content` flag is set (issue #2899).
+ * dropping the latter halves the wire payload with no data loss. The strip is a
+ * pure mechanism: the omission decision is resolved by
+ * `structuredContentOmissionReason` (tested separately) and passed in as `reason`
+ * (issue #2962) — any reason drops the field, `null` retains it.
  *
- * Decision matrix (second arg = the tool's `hasOutputSchema`):
- *   hasOutputSchema | flag  | keep structuredContent?
- *   ----------------|-------|------------------------
- *   false           | off   | NO  (#2759 no-schema unconditional)
- *   false           | on    | NO
- *   true            | off   | YES (#2899 schema tool, spec-conforming)
- *   true            | on    | NO  (#2899 flag drops it too)
+ *   reason         | drops structuredContent?
+ *   ---------------|-------------------------
+ *   "no-schema"    | YES (#2759 no-schema unconditional)
+ *   "flag"         | YES (#2899 flag on a schema tool)
+ *   null           | NO  (schema tool, flag off — spec-conforming)
  */
 describe("stripToolResultStructuredContent", () => {
+  test("EC-A: drops structuredContent for a 'flag' reason (schema tool, gate on), keeps content text", () => {
+    const payload = { success: true, message: "done", nested: { a: 1 } };
+    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload), "flag");
+
+    expect("structuredContent" in response).toBe(false);
+    expect(response.content[0].type).toBe("text");
+    // Full payload is still recoverable from the retained text — no data loss.
+    expect(JSON.parse(response.content[0].text)).toEqual(payload);
+  });
+
+  test("EC-B: preserves structuredContent for a null reason (schema tool, gate off)", () => {
+    const response = stripToolResultStructuredContent(createStructuredToolResponse({ success: true }), null);
+    expect(response.structuredContent).toEqual({ success: true });
+  });
+
+  test("EC-2759: drops structuredContent for a 'no-schema' reason, keeping the text block", () => {
+    const payload = { success: true, viewHierarchy: { node: [] } };
+    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload), "no-schema");
+    expect("structuredContent" in response).toBe(false);
+    // Text block is preserved — the model-facing surface is intact.
+    expect(JSON.parse(response.content[0].text)).toEqual(payload);
+  });
+
+  test("EC-D: strips regardless of payload shape (covers plain-registered tools)", () => {
+    // e.g. exportPlan/recordSteps: declare an outputSchema, bypass finalizeToolResponse.
+    const response = stripToolResultStructuredContent(
+      createStructuredToolResponse({ success: true, plan: "steps:\n  - tapOn: {}" }),
+      "flag"
+    );
+    expect("structuredContent" in response).toBe(false);
+    expect(JSON.parse(response.content[0].text).plan).toBe("steps:\n  - tapOn: {}");
+  });
+
+  test("EC-E: response without structuredContent is an unchanged no-op even with a reason", () => {
+    const imageResponse: any = { content: [{ type: "image", data: "b64", mimeType: "image/png" }] };
+    const result = stripToolResultStructuredContent(imageResponse, "no-schema");
+    expect(result).toBe(imageResponse);
+    expect("structuredContent" in result).toBe(false);
+  });
+
+  test("null / primitive responses pass through untouched", () => {
+    expect(stripToolResultStructuredContent(null, "no-schema")).toBeNull();
+    expect(stripToolResultStructuredContent(undefined, "no-schema")).toBeUndefined();
+    expect(stripToolResultStructuredContent("plain", "no-schema")).toBe("plain");
+    expect(stripToolResultStructuredContent(42, "no-schema")).toBe(42);
+  });
+});
+
+/**
+ * `responseCarriesStructuredContent` gates BOTH the strip's delete and the
+ * `index.ts` debug trace, so the trace only fires when a field is actually
+ * dropped (never merely because the policy would). It must recognize an envelope
+ * carrying the field and reject everything else.
+ */
+describe("responseCarriesStructuredContent", () => {
+  test("true only when an envelope actually carries structuredContent", () => {
+    expect(responseCarriesStructuredContent(createStructuredToolResponse({ success: true }))).toBe(true);
+    expect(responseCarriesStructuredContent({ structuredContent: { a: 1 } })).toBe(true);
+  });
+
+  test("false for envelopes without the field, primitives, and null/undefined", () => {
+    expect(responseCarriesStructuredContent({ content: [{ type: "text", text: "hi" }] })).toBe(false);
+    expect(responseCarriesStructuredContent({})).toBe(false);
+    expect(responseCarriesStructuredContent(null)).toBe(false);
+    expect(responseCarriesStructuredContent(undefined)).toBe(false);
+    expect(responseCarriesStructuredContent("plain")).toBe(false);
+    expect(responseCarriesStructuredContent(42)).toBe(false);
+  });
+});
+
+/**
+ * `structuredContentOmissionReason` is the single source of truth for the
+ * omission decision (issue #2962): the wire strip derives `shouldStrip` from it,
+ * and `index.ts` uses it to emit the debug trace. It must classify WHY the field
+ * is omitted so the debug line can name the reason.
+ *
+ * Matrix (hasOutputSchema x flag):
+ *   hasOutputSchema | flag  | reason
+ *   ----------------|-------|-----------
+ *   false           | off   | "no-schema"   (#2759 unconditional, precedes flag)
+ *   false           | on    | "no-schema"   (still no-schema, not "flag")
+ *   true            | off   | null          (retained — no omission)
+ *   true            | on    | "flag"        (#2899)
+ */
+describe("structuredContentOmissionReason", () => {
   let original: boolean;
 
   beforeEach(() => {
@@ -29,62 +117,51 @@ describe("stripToolResultStructuredContent", () => {
     serverConfig.setToolResultsNoStructuredContentEnabled(original);
   });
 
-  test("EC-A: drops structuredContent for a schema tool when the gate is enabled, keeps content text", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(true);
-    const payload = { success: true, message: "done", nested: { a: 1 } };
-    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload), true);
+  describe("explicit flag argument (pure, no serverConfig dependency)", () => {
+    test("no-schema + flag off → 'no-schema'", () => {
+      expect(structuredContentOmissionReason(false, false)).toBe("no-schema");
+    });
 
-    expect("structuredContent" in response).toBe(false);
-    expect(response.content[0].type).toBe("text");
-    // Full payload is still recoverable from the retained text — no data loss.
-    expect(JSON.parse(response.content[0].text)).toEqual(payload);
+    test("no-schema + flag on → 'no-schema' (unconditional strip precedes the flag)", () => {
+      expect(structuredContentOmissionReason(false, true)).toBe("no-schema");
+    });
+
+    test("schema + flag off → null (structuredContent is retained)", () => {
+      expect(structuredContentOmissionReason(true, false)).toBeNull();
+    });
+
+    test("schema + flag on → 'flag'", () => {
+      expect(structuredContentOmissionReason(true, true)).toBe("flag");
+    });
   });
 
-  test("EC-B: preserves structuredContent for a schema tool when the gate is disabled", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(false);
-    const response = stripToolResultStructuredContent(createStructuredToolResponse({ success: true }), true);
-    expect(response.structuredContent).toEqual({ success: true });
+  describe("defaults to the live serverConfig flag when omitted", () => {
+    test("schema tool follows the flag: null when off, 'flag' when on", () => {
+      serverConfig.setToolResultsNoStructuredContentEnabled(false);
+      expect(structuredContentOmissionReason(true)).toBeNull();
+      serverConfig.setToolResultsNoStructuredContentEnabled(true);
+      expect(structuredContentOmissionReason(true)).toBe("flag");
+    });
+
+    test("no-schema tool is 'no-schema' regardless of the live flag", () => {
+      serverConfig.setToolResultsNoStructuredContentEnabled(false);
+      expect(structuredContentOmissionReason(false)).toBe("no-schema");
+      serverConfig.setToolResultsNoStructuredContentEnabled(true);
+      expect(structuredContentOmissionReason(false)).toBe("no-schema");
+    });
   });
 
-  test("EC-2759a: drops structuredContent for a no-schema tool even when the gate is disabled", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(false);
-    const payload = { success: true, viewHierarchy: { node: [] } };
-    const response = stripToolResultStructuredContent(createStructuredToolResponse(payload), false);
-    expect("structuredContent" in response).toBe(false);
-    // Text block is preserved — the model-facing surface is intact.
-    expect(JSON.parse(response.content[0].text)).toEqual(payload);
-  });
-
-  test("EC-2759b: drops structuredContent for a no-schema tool when the gate is enabled", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(true);
-    const response = stripToolResultStructuredContent(createStructuredToolResponse({ success: true }), false);
-    expect("structuredContent" in response).toBe(false);
-  });
-
-  test("EC-D: strips regardless of payload shape (covers plain-registered tools)", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(true);
-    // e.g. exportPlan/recordSteps: declare an outputSchema, bypass finalizeToolResponse.
-    const response = stripToolResultStructuredContent(
-      createStructuredToolResponse({ success: true, plan: "steps:\n  - tapOn: {}" }),
-      true
-    );
-    expect("structuredContent" in response).toBe(false);
-    expect(JSON.parse(response.content[0].text).plan).toBe("steps:\n  - tapOn: {}");
-  });
-
-  test("EC-E: response without structuredContent is an unchanged no-op", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(true);
-    const imageResponse: any = { content: [{ type: "image", data: "b64", mimeType: "image/png" }] };
-    const result = stripToolResultStructuredContent(imageResponse, false);
-    expect(result).toBe(imageResponse);
-    expect("structuredContent" in result).toBe(false);
-  });
-
-  test("null / primitive responses pass through untouched", () => {
-    serverConfig.setToolResultsNoStructuredContentEnabled(true);
-    expect(stripToolResultStructuredContent(null, false)).toBeNull();
-    expect(stripToolResultStructuredContent(undefined, false)).toBeUndefined();
-    expect(stripToolResultStructuredContent("plain", false)).toBe("plain");
-    expect(stripToolResultStructuredContent(42, false)).toBe(42);
+  test("drives the strip end-to-end: reason === null iff structuredContent kept across the full matrix", () => {
+    for (const hasSchema of [true, false]) {
+      for (const flag of [true, false]) {
+        const reason = structuredContentOmissionReason(hasSchema, flag);
+        const response = stripToolResultStructuredContent(
+          createStructuredToolResponse({ success: true }),
+          reason
+        );
+        const kept = "structuredContent" in response;
+        expect(kept).toBe(reason === null);
+      }
+    }
   });
 });

--- a/test/server/stripToolResultWireBoundary.test.ts
+++ b/test/server/stripToolResultWireBoundary.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test";
 import { z } from "zod";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import { logger } from "../../src/utils/logger";
 
 /**
  * End-to-end proof that the `--tool-results-no-structured-content` strip runs at
@@ -57,5 +58,134 @@ describe("CallTool wire boundary strips structuredContent (issue #2899)", () => 
     expect(res.structuredContent).toBeUndefined();
     // No data lost: the full payload is still recoverable from content[0].text.
     expect(JSON.parse(res.content[0].text).marker).toBe("probe");
+  });
+});
+
+/**
+ * Field-debuggability trace (issue #2962): when the wire boundary intentionally
+ * omits `structuredContent`, it emits exactly one `logger.debug` line naming the
+ * tool and the omission reason (no-schema vs flag). Debug level only — never
+ * info/warn — so there is no default (INFO) noise. A retained call (schema tool,
+ * flag off) emits no omission trace.
+ */
+describe("CallTool wire boundary debug-logs structuredContent omission (issue #2962)", () => {
+  let fixture: McpTestFixture;
+  // Deliberately NOT containing "omit"/"structuredContent" so a probe name can
+  // never coincidentally satisfy the omission-line matcher below.
+  const SCHEMA_TOOL = "__strip_log_schema_2962__";
+  const NOSCHEMA_TOOL = "__strip_log_noschema_2962__";
+  const PLAIN_TOOL = "__strip_log_plain_2962__";
+
+  // Match ONLY the exact omission trace emitted at the strip site (index.ts),
+  // anchored to the real message format, and return the captured reason. This is
+  // precise on purpose: it must not be satisfied by any other debug line the
+  // handler path emits, nor by the tool name happening to contain a keyword.
+  const omissionReasons = (calls: unknown[][], tool: string): string[] =>
+    calls
+      .map(args => new RegExp(`^\\[MCP\\] Omitted structuredContent for tool "${tool}" \\(reason: (no-schema|flag)\\)$`).exec(String(args[0] ?? "")))
+      .filter((m): m is RegExpExecArray => m !== null)
+      .map(m => m[1]);
+
+  beforeAll(async () => {
+    ToolRegistry.register(
+      SCHEMA_TOOL,
+      "probe tool for omission debug log (schema)",
+      z.object({}).passthrough(),
+      async () => createStructuredToolResponse({ success: true, marker: "probe" }),
+      { outputSchema: z.object({ success: z.boolean(), marker: z.string() }) }
+    );
+    ToolRegistry.register(
+      NOSCHEMA_TOOL,
+      "probe tool for omission debug log (no schema)",
+      z.object({}).passthrough(),
+      async () => createStructuredToolResponse({ success: true, marker: "probe" })
+    );
+    // A no-schema tool whose handler returns a response that never carried a
+    // `structuredContent` tree (e.g. an image/plain-text result). The omission
+    // policy still applies, but nothing is actually dropped — so no trace fires.
+    ToolRegistry.register(
+      PLAIN_TOOL,
+      "probe tool with no structuredContent to drop",
+      z.object({}).passthrough(),
+      async () => ({ content: [{ type: "text", text: "no structuredContent here" }] })
+    );
+    fixture = new McpTestFixture();
+    await fixture.setup();
+  });
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.teardown();
+    }
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(SCHEMA_TOOL);
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(NOSCHEMA_TOOL);
+    (ToolRegistry as unknown as { tools: Map<string, unknown> }).tools.delete(PLAIN_TOOL);
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+  });
+
+  afterEach(() => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+  });
+
+  test("no-schema tool: one debug line naming the tool and the 'no-schema' reason", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      const { client } = fixture.getContext();
+      await client.callTool({ name: NOSCHEMA_TOOL, arguments: {} });
+
+      // Exactly one omission trace, and it names the 'no-schema' reason.
+      expect(omissionReasons(debugSpy.mock.calls, NOSCHEMA_TOOL)).toEqual(["no-schema"]);
+      // No default noise: the omission is never surfaced at info/warn.
+      expect(omissionReasons(infoSpy.mock.calls, NOSCHEMA_TOOL)).toEqual([]);
+      expect(omissionReasons(warnSpy.mock.calls, NOSCHEMA_TOOL)).toEqual([]);
+    } finally {
+      debugSpy.mockRestore();
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("schema tool, flag on: one debug line naming the tool and the 'flag' reason", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
+    try {
+      const { client } = fixture.getContext();
+      await client.callTool({ name: SCHEMA_TOOL, arguments: {} });
+
+      expect(omissionReasons(debugSpy.mock.calls, SCHEMA_TOOL)).toEqual(["flag"]);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  test("schema tool, flag off: no omission trace (structuredContent is retained)", async () => {
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
+    try {
+      const { client } = fixture.getContext();
+      await client.callTool({ name: SCHEMA_TOOL, arguments: {} });
+
+      expect(omissionReasons(debugSpy.mock.calls, SCHEMA_TOOL)).toEqual([]);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  test("no-schema tool with no structuredContent to drop: no trace (nothing was actually omitted)", async () => {
+    // Policy would omit (no schema), but the handler never produced a
+    // `structuredContent` tree — so the trace must NOT fire on the mere policy.
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
+    try {
+      const { client } = fixture.getContext();
+      await client.callTool({ name: PLAIN_TOOL, arguments: {} });
+
+      expect(omissionReasons(debugSpy.mock.calls, PLAIN_TOOL)).toEqual([]);
+    } finally {
+      debugSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Problem

Follow-up from #2759 / PR #2958. When a client consumes both the text and `structuredContent` paths, it should be able to distinguish an **intentional** `structuredContent` omission from an **accidental missing** one. PR #2958 gates `structuredContent` at the MCP CallTool wire boundary (`src/server/index.ts`) — but there was no server-side trace of *when* or *why* the strip fired, which hurts field/server-side debuggability.

## Fix

- **New `structuredContentOmissionReason(hasOutputSchema, flagEnabled?)`** in `src/server/stripToolResultStructuredContent.ts` is the single source of truth for the omission decision, returning the reason the field is omitted:
  - `"no-schema"` — no `outputSchema`, stripped unconditionally (#2759). Takes precedence over the flag.
  - `"flag"` — schema tool stripped because `--tool-results-no-structured-content` is on (#2899).
  - `null` — retained (schema tool, flag off).
  `stripToolResultStructuredContent` now derives its `shouldStrip` from this helper, so the strip and the trace can never disagree.
- **`src/server/index.ts`** emits one `logger.debug` line at the strip site naming the tool and the reason when the omission fires. Debug level → dropped at the default INFO level, so no per-call noise beyond the reason guard. Aligns with the "log-and-continue with a why" convention (CLAUDE.md error-handling §3).

## Tests

- `stripToolResultStructuredContent.test.ts`: full `structuredContentOmissionReason` matrix (explicit-flag-arg + live-`serverConfig` paths) and a consistency check that `reason === null` iff `structuredContent` is kept. Existing strip tests remain green (behavior unchanged).
- `stripToolResultWireBoundary.test.ts`: drives the real CallTool boundary and spies `logger.debug`/`info`/`warn` — no-schema tool emits exactly one `no-schema` trace (and none at info/warn), schema-tool+flag-on emits one `flag` trace, schema-tool+flag-off emits none. Matcher is an anchored regex on the exact message so a format regression fails the test.
- 19 tests pass across the two files. eslint clean, `bun build.ts` OK.

## Acceptance (from #2962)

- [x] With debug logging enabled, a stripped tool call emits one debug line naming the tool and the omission reason.
- [x] No log at default (INFO) level; no per-call overhead beyond the guard.

Closes #2962
