### PR TITLE
fix(ios): ignore stale iproxy child events

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1407,14 +1407,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
-   * Check if the tracked CtrlProxy process is alive AND still the real CtrlProxy.
-   * Used by startInternal() to skip spawning when the process is merely slow.
-   *
-   * We require both a PID liveness check AND a health endpoint response so that
-   * a stale xcTestProcessId that has been PID-reused by a different process does
-   * not produce a false "alive" result and cause setup() to silently skip restart.
-   */
-  /**
    * Whether the runner process WE spawned is alive at the OS level, regardless of
    * whether its health endpoint is up yet. Unlike {@link isCtrlProxyProcessAlive}
    * this does NOT require a health response, so a runner still initializing counts
@@ -1484,6 +1476,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return IOSCtrlProxyManager.DEFAULT_HEALTH_POLL_MAX_ATTEMPTS;
   }
 
+  /**
+   * Check if the tracked CtrlProxy process is alive AND still the real CtrlProxy.
+   * Used by startInternal() to skip spawning when the process is merely slow.
+   *
+   * We require both a PID liveness check AND a health endpoint response so that
+   * a stale xcTestProcessId that has been PID-reused by a different process does
+   * not produce a false "alive" result and cause setup() to silently skip restart.
+   */
   private async isCtrlProxyProcessAlive(): Promise<boolean> {
     if (!this.xcTestProcessId) {
       return false;
@@ -1943,7 +1943,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   /**
    * Check if the tracked iproxy process is alive.
-   * Used by startIproxyMonitoring() so it only restarts the tunnel when the
+   * Used by the iproxy supervisor so it only restarts the tunnel when the
    * process actually died, not when CtrlProxy is temporarily slow.
    */
   private async isIproxyProcessAlive(): Promise<boolean> {
@@ -2319,6 +2319,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.captureIproxyOutput(child);
 
     child.on("exit", () => {
+      if (this.iproxyProcess !== child) {
+        return;
+      }
       if (!this.isStopping) {
         logger.warn("[IOSCtrlProxy] iproxy exited unexpectedly");
         this.iproxySupervisor.processExited();
@@ -2326,6 +2329,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     });
 
     child.on("error", error => {
+      if (this.iproxyProcess !== child) {
+        return;
+      }
       if (!this.isStopping) {
         logger.warn(`[IOSCtrlProxy] iproxy error: ${error.message}`);
         this.iproxySupervisor.processExited();

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -596,6 +596,43 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses().length).toBe(2);
     });
 
+    test("ignores stale local iproxy exit or error after a newer tunnel is tracked", async function() {
+      for (const staleEvent of ["exit", "error"] as const) {
+        const eventTimer = new FakeTimer();
+        const eventExecutor = new FakeProcessExecutor();
+        eventExecutor.setCommandResponse("idevice_id -l", createExecResult(`${physicalDevice.deviceId}\n`, ""));
+        eventExecutor.setCommandResponse("curl -s", createExecResult("", ""));
+        const oldProcess = new FakeChildProcess();
+        oldProcess.pid = 1111;
+        const newProcess = new FakeChildProcess();
+        newProcess.pid = 2222;
+        eventExecutor.setNextSpawnProcess(oldProcess);
+        const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+          physicalDevice,
+          eventTimer,
+          undefined,
+          eventExecutor
+        );
+
+        await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+        await (manager as unknown as { stopIproxyTunnel: () => Promise<void> }).stopIproxyTunnel();
+        eventExecutor.setNextSpawnProcess(newProcess);
+        await (manager as unknown as { startIproxyTunnel: () => Promise<void> }).startIproxyTunnel();
+
+        if (staleEvent === "exit") {
+          oldProcess.emit("exit", 0, null);
+        } else {
+          oldProcess.emit("error", new Error("old tunnel failed after replacement"));
+        }
+        for (let i = 0; i < 5; i++) {await Promise.resolve();}
+
+        expect((manager as unknown as { iproxyProcessId: number | null }).iproxyProcessId).toBe(2222);
+        expect((manager as unknown as { iproxyProcess: FakeChildProcess | null }).iproxyProcess).toBe(newProcess);
+        expect(eventTimer.getPendingTimeoutCount()).toBe(0);
+        expect(eventExecutor.getSpawnedProcesses().length).toBe(2);
+      }
+    });
+
     test("host-control iproxy skips ports that are busy on the host", async function() {
       const { runner, iproxyStarts } = createHostControlRunner();
       const checker = new FakeHostPortAvailabilityChecker(new Set([8765]));


### PR DESCRIPTION
## Summary

- Fix a stale local `iproxy` child-process race found during the issue #2770 ProcessSupervisor review pass.
- Ignore late `exit`/`error` events from an older local `iproxy` process after a newer tunnel has already been tracked.
- Move stale JSDoc to the method it describes and update the old iproxy monitor wording.

## Context

Follow-up to #2770. The ProcessSupervisor extraction is already present on `main`; this PR addresses a lifecycle parity gap found while reviewing the current implementation.

No repo PR template file was present under `.github`.

## Validation

- `bun test test/utils/IOSCtrlProxyManager.test.ts --grep "ignores stale local iproxy"`
- `bun test test/utils/ProcessSupervisor.test.ts test/utils/IOSCtrlProxyManager.test.ts`
- `bun run build`
- `bun run lint`
- `bun test --bail`
- `git diff --check`
