### PR TITLE
refactor(daemon): promote well-known customData keys to typed SessionCacheData slots (#2973)

### DIFF
--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -1,10 +1,11 @@
 import { DaemonRequest } from "./types";
-import { Session } from "./sessionManager";
+import { DeviceLabelMap, Session } from "./sessionManager";
 
 export interface DaemonStateAccess {
   isInitialized(): boolean;
   getSessionManager(): {
     getSession(sessionId: string): Session | null;
+    getDeviceLabels(sessionId: string): DeviceLabelMap | undefined;
     releaseSession(sessionId: string): Promise<string | null>;
   };
   getDevicePool(): {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -15,6 +15,16 @@ import type { ObserveResult } from "../models/ObserveResult";
 export type DeviceLabelMap = Record<string, string>;
 
 /**
+ * Narrow seam for restoring keep-awake state on session release. Production uses
+ * `KeepScreenAwakeManager`; tests inject a fake to assert (without a real device)
+ * that `releaseSession` reads the typed `keepScreenAwake` slot and passes its full
+ * payload to `restore` — the behavioral half of the #2973 typed-slot round trip.
+ */
+export interface KeepScreenAwakeRestorer {
+  restore(state: KeepScreenAwakeState): Promise<void>;
+}
+
+/**
  * Session Cache Data
  *
  * Stores data that can be reused across multiple tool calls
@@ -93,6 +103,7 @@ export class SessionManager {
   private releaseCallbacks: SessionReleaseCallback[] = [];
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
+  private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
 
   // Session timeout: 30 minutes
   private readonly SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -109,10 +120,15 @@ export class SessionManager {
     // same-process DB reopen (resetDbWriteBarrier swaps in a fresh barrier) is
     // seen instead of a pinned drained instance (issue #2912).
     getBarrier: () => DbWriteBarrier = getDbWriteBarrier,
+    // Seam for keep-awake restore (issue #2973): defaults to the real manager;
+    // tests inject a fake to assert the typed slot's payload reaches `restore`.
+    keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer =
+    device => new KeepScreenAwakeManager(device),
   ) {
     this.timer = timer;
     this.deviceSessionRepository = deviceSessionRepository;
     this.getBarrier = getBarrier;
+    this.keepScreenAwakeRestorerFactory = keepScreenAwakeRestorerFactory;
     // Start periodic cleanup of expired sessions
     this.startCleanupTimer();
   }
@@ -542,7 +558,7 @@ export class SessionManager {
       platform: session.platform,
       deviceId: session.assignedDevice
     };
-    const manager = new KeepScreenAwakeManager(device);
+    const manager = this.keepScreenAwakeRestorerFactory(device);
     await manager.restore(state);
   }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -1,11 +1,18 @@
 import { defaultTimer, Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { BootedDevice, Platform } from "../models";
-import { KeepScreenAwakeManager, KEEP_SCREEN_AWAKE_STATE_KEY, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
+import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
 import { DeviceSessionRepository } from "../db/deviceSessionRepository";
 import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
 import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import type { ObserveResult } from "../models/ObserveResult";
+
+/**
+ * Device-label → session-UUID map. `buildDeviceLabelMap` assigns each configured
+ * label its own session (the primary label reuses the base session UUID), so a
+ * `device: "B"` tool argument can be routed to the correct label session.
+ */
+export type DeviceLabelMap = Record<string, string>;
 
 /**
  * Session Cache Data
@@ -13,22 +20,24 @@ import type { ObserveResult } from "../models/ObserveResult";
  * Stores data that can be reused across multiple tool calls
  * within the same test session, reducing redundant API calls.
  *
- * The observe cache lives in the typed top-level slots below — they are the
- * canonical source of truth (issue #2917). Write them through the dedicated
- * `setLastHierarchy` / `setLastScreenshot` setters.
+ * Every field is a typed top-level slot — the canonical source of truth for its
+ * concern (issue #2917). Write each through its dedicated setter
+ * (`setLastHierarchy`, `setLastScreenshot`, `setKeepScreenAwake`,
+ * `setDeviceLabels`, …) so a writer/reader type drift is caught at compile time.
  *
- * `customData` still holds other keyed tool state accessed via well-known
- * constants (keep-awake `KeepScreenAwakeState`, the device-label map). Those
- * remain untyped and are candidates for the same typed-slot treatment — the
- * `Record<string, any>` shape is an escape hatch that can reintroduce the
- * #2917 decoy bug for any future key.
+ * There is deliberately NO `customData?: Record<string, any>` escape hatch
+ * (issue #2973): it previously held well-known, fixed-type keyed state
+ * (keep-awake, device-label map) fished out with unchecked `as` casts, which
+ * could silently reintroduce the #2917 decoy bug for any key. Any new
+ * cross-tool session state gets its own typed slot here, not an untyped bag.
  */
 export interface SessionCacheData {
   lastHierarchy?: ViewHierarchyResult; // Last observed view hierarchy (full, untrimmed)
   lastScreenshot?: string;     // Base64 encoded last screenshot
   lastObserveTime?: number;    // Timestamp of last hierarchy observation (hierarchy only, not screenshot)
   lastRenderedObservation?: ObserveResult; // Last observation emitted to the agent (sanitized), the #2761 diff baseline
-  customData?: Record<string, any>; // Custom data set by tools
+  keepScreenAwake?: KeepScreenAwakeState; // Keep-awake state applied at session setup, restored on release
+  deviceLabels?: DeviceLabelMap; // Device-label → session map for multi-device (`device:`-labelled) sessions
 }
 
 /**
@@ -376,6 +385,46 @@ export class SessionManager {
   }
 
   /**
+   * Cache the keep-awake state applied for a session in the typed top-level
+   * `keepScreenAwake` slot (issue #2973). `ToolExecutionContext` writes it once at
+   * session setup; `restoreKeepScreenAwake` reads the same slot on release. Both
+   * go through this typed slot rather than an untyped `customData` cast, so a
+   * writer/reader type drift is a compile error (the #2917 bug class).
+   */
+  setKeepScreenAwake(sessionId: string, state: KeepScreenAwakeState): void {
+    this.updateSessionCache(sessionId, { keepScreenAwake: state });
+  }
+
+  /**
+   * Read the keep-awake state without recording session activity (mirrors
+   * `getLastRenderedObservation`, issue #3053): this is a best-effort setup/restore
+   * read, not a tool interaction, so it must not fire a session-activity write.
+   * Returns `undefined` for an unknown/expired session or before setup ran.
+   */
+  getKeepScreenAwake(sessionId: string): KeepScreenAwakeState | undefined {
+    return this.getSession(sessionId)?.cacheData.keepScreenAwake;
+  }
+
+  /**
+   * Cache the device-label → session map for a multi-device session in the typed
+   * top-level `deviceLabels` slot (issue #2973). Written by `registerDeviceLabelMap`
+   * and read on the `device:`-label routing hot path (`resolveDeviceLabelSession`).
+   */
+  setDeviceLabels(sessionId: string, labels: DeviceLabelMap): void {
+    this.updateSessionCache(sessionId, { deviceLabels: labels });
+  }
+
+  /**
+   * Read the device-label map without recording session activity (issue #3053):
+   * label routing reads this on every `device:`-labelled request, so it must not
+   * fire a session-activity write per read. Returns `undefined` for an
+   * unknown/expired session or a session with no registered labels.
+   */
+  getDeviceLabels(sessionId: string): DeviceLabelMap | undefined {
+    return this.getSession(sessionId)?.cacheData.deviceLabels;
+  }
+
+  /**
    * Get session cache data
    */
   getSessionCache(sessionId: string): SessionCacheData | null {
@@ -483,7 +532,7 @@ export class SessionManager {
     if (session.platform !== "android") {
       return;
     }
-    const state = session.cacheData.customData?.[KEEP_SCREEN_AWAKE_STATE_KEY] as KeepScreenAwakeState | undefined;
+    const state = session.cacheData.keepScreenAwake;
     if (!state || !state.applied) {
       return;
     }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -46,7 +46,6 @@ import type { KeyValueType } from "../features/storage/storageTypes";
 /** Must exceed the longest per-request MCP timeout (executePlan = 10 min), else long tool calls get killed mid-flight. */
 const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 60 * 1000;
 const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
-const DEVICE_LABEL_CACHE_KEY = "deviceLabelMap";
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -529,12 +528,11 @@ export class UnixSocketServer {
     try {
       const labelMap = this.daemonState
         .getSessionManager()
-        .getSession(baseSessionUuid)
-        ?.cacheData.customData?.[DEVICE_LABEL_CACHE_KEY];
-      if (!labelMap || typeof labelMap !== "object" || Array.isArray(labelMap)) {
+        .getDeviceLabels(baseSessionUuid);
+      if (!labelMap) {
         return baseSessionUuid;
       }
-      const mappedSession = (labelMap as Record<string, unknown>)[deviceLabel];
+      const mappedSession = labelMap[deviceLabel];
       return typeof mappedSession === "string" && mappedSession.length > 0
         ? mappedSession
         : baseSessionUuid;

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -5,7 +5,7 @@ import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { logger } from "../utils/logger";
-import { KeepScreenAwakeManager, KEEP_SCREEN_AWAKE_STATE_KEY, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
+import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { createPerformanceTracker, type TimingData } from "../utils/PerformanceTracker";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
@@ -196,7 +196,7 @@ async function ensureKeepScreenAwake(
   if (session.platform !== "android") {
     return;
   }
-  const existingState = session.cacheData.customData?.[KEEP_SCREEN_AWAKE_STATE_KEY] as KeepScreenAwakeState | undefined;
+  const existingState = session.cacheData.keepScreenAwake;
   if (existingState) {
     return;
   }
@@ -217,37 +217,5 @@ async function ensureKeepScreenAwake(
     state = { applied: false, skipReason: "failed" };
   }
 
-  const customData = {
-    ...(session.cacheData.customData ?? {}),
-    [KEEP_SCREEN_AWAKE_STATE_KEY]: state
-  };
-  sessionManager.updateSessionCache(session.sessionId, { customData });
-}
-
-/**
- * Update session cache after tool execution
- *
- * Tools can use this to cache results (hierarchy, screenshot, etc.)
- * for reuse across tool calls within the same session.
- */
-export async function updateSessionCache(
-  context: ToolExecutionContext,
-  cacheKey: string,
-  cacheValue: any
-): Promise<void> {
-  if (!context.sessionId || !context.sessionManager) {
-    return;
-  }
-
-  const session = context.sessionManager.getSession(context.sessionId);
-  if (!session) {
-    return;
-  }
-
-  if (!session.cacheData.customData) {
-    session.cacheData.customData = {};
-  }
-
-  session.cacheData.customData[cacheKey] = cacheValue;
-  context.sessionManager.updateSessionCache(context.sessionId, session.cacheData);
+  sessionManager.setKeepScreenAwake(session.sessionId, state);
 }

--- a/src/server/deviceLabelMapping.ts
+++ b/src/server/deviceLabelMapping.ts
@@ -1,12 +1,9 @@
 import { DaemonState } from "../daemon/daemonState";
 import { ActionableError } from "../models";
-import { createToolExecutionContext, updateSessionCache } from "./ToolExecutionContext";
+import { createToolExecutionContext } from "./ToolExecutionContext";
 import type { SessionOptions } from "./ToolExecutionContext";
+import type { DeviceLabelMap } from "../daemon/sessionManager";
 import { logger } from "../utils/logger";
-
-type DeviceLabelMap = Record<string, string>;
-
-const DEVICE_LABEL_CACHE_KEY = "deviceLabelMap";
 
 const buildDeviceLabelList = (labels: string[]): string[] => {
   const seen = new Set<string>();
@@ -56,17 +53,7 @@ export const getDeviceLabelMap = (baseSessionUuid: string): DeviceLabelMap | nul
   }
 
   const sessionManager = DaemonState.getInstance().getSessionManager();
-  const session = sessionManager.getSession(baseSessionUuid);
-  if (!session) {
-    return null;
-  }
-
-  const map = session.cacheData.customData?.[DEVICE_LABEL_CACHE_KEY];
-  if (!map || typeof map !== "object" || Array.isArray(map)) {
-    return null;
-  }
-
-  return map as DeviceLabelMap;
+  return sessionManager.getDeviceLabels(baseSessionUuid) ?? null;
 };
 
 export const registerDeviceLabelMap = async (
@@ -87,8 +74,10 @@ export const registerDeviceLabelMap = async (
     return deviceLabelMap;
   }
 
-  const baseContext = await createToolExecutionContext(baseSessionUuid, sessionManager, devicePool, sessionOptions);
-  await updateSessionCache(baseContext, DEVICE_LABEL_CACHE_KEY, deviceLabelMap);
+  // Ensure the base session is set up (accessibility/keep-awake side effects),
+  // then store the label map in its typed `deviceLabels` slot (issue #2973).
+  await createToolExecutionContext(baseSessionUuid, sessionManager, devicePool, sessionOptions);
+  sessionManager.setDeviceLabels(baseSessionUuid, deviceLabelMap);
 
   const assignedSessions = new Set(Object.values(deviceLabelMap));
   assignedSessions.delete(baseSessionUuid);

--- a/src/utils/KeepScreenAwakeManager.ts
+++ b/src/utils/KeepScreenAwakeManager.ts
@@ -4,8 +4,6 @@ import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor
 import { logger } from "./logger";
 import { AndroidCtrlProxyClient } from "../features/observe/android/AndroidCtrlProxyClient";
 
-export const KEEP_SCREEN_AWAKE_STATE_KEY = "keepScreenAwakeState";
-
 export type KeepScreenAwakeState = {
   applied: boolean;
   method?: "svc" | "settings";

--- a/test/daemon/sessionCacheNoEscapeHatch.test.ts
+++ b/test/daemon/sessionCacheNoEscapeHatch.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Guard against re-introducing the untyped `customData` escape hatch (issue #2973,
+ * follow-up to #2917).
+ *
+ * PR #2929 promoted the observe cache to typed slots but left
+ * `customData?: Record<string, any>` — which still held well-known, fixed-type
+ * keyed state (keep-awake, device-label map) fished out with unchecked `as` casts.
+ * A writer/reader type drift on any such key is invisible at compile time: the
+ * exact #2917 decoy bug.
+ *
+ * This is a source-scan meta-test (repo convention, cf. #3081/#3085): it fails
+ * HERE, in a <100ms unit test, if someone reintroduces the bag or an unchecked
+ * cast out of it — instead of shipping a latent type-drift bug.
+ */
+describe("SessionCacheData has no untyped escape hatch (issue #2973)", () => {
+  const read = (rel: string): string => readFileSync(join(process.cwd(), rel), "utf8");
+
+  const SESSION_MANAGER = "src/daemon/sessionManager.ts";
+  // Files that previously read/wrote well-known keys through `customData`.
+  const FORMER_CUSTOMDATA_CONSUMERS = [
+    SESSION_MANAGER,
+    "src/server/ToolExecutionContext.ts",
+    "src/server/deviceLabelMapping.ts",
+    "src/daemon/socketServer.ts",
+  ];
+
+  // Extract the `interface SessionCacheData { ... }` body from the source.
+  function sessionCacheDataBody(): string {
+    const source = read(SESSION_MANAGER);
+    const match = source.match(/interface SessionCacheData\s*\{([\s\S]*?)\n\}/);
+    expect(match).not.toBeNull();
+    return match![1];
+  }
+
+  test("EC1: SessionCacheData exposes typed keepScreenAwake + deviceLabels slots", () => {
+    const body = sessionCacheDataBody();
+    expect(body).toMatch(/keepScreenAwake\?\s*:\s*KeepScreenAwakeState/);
+    expect(body).toMatch(/deviceLabels\?\s*:\s*DeviceLabelMap/);
+  });
+
+  test("EC2: SessionCacheData has no customData / Record<string, any> escape hatch", () => {
+    const body = sessionCacheDataBody();
+    expect(body).not.toContain("customData");
+    expect(body).not.toMatch(/Record<\s*string\s*,\s*any\s*>/);
+  });
+
+  test("EC7: no consumer reads a well-known key out of customData via an unchecked cast", () => {
+    for (const rel of FORMER_CUSTOMDATA_CONSUMERS) {
+      const source = read(rel);
+      // The `.customData` member access is gone entirely — the bag no longer exists.
+      expect(source, `${rel} must not access .customData`).not.toMatch(/\.customData\b/);
+      // And the specific unchecked casts the issue called out are gone.
+      expect(source, `${rel} must not cast to KeepScreenAwakeState out of the bag`)
+        .not.toMatch(/as\s+KeepScreenAwakeState\s*\|\s*undefined/);
+    }
+  });
+});

--- a/test/daemon/sessionCacheNoEscapeHatch.test.ts
+++ b/test/daemon/sessionCacheNoEscapeHatch.test.ts
@@ -28,10 +28,15 @@ describe("SessionCacheData has no untyped escape hatch (issue #2973)", () => {
     "src/daemon/socketServer.ts",
   ];
 
-  // Extract the `interface SessionCacheData { ... }` body from the source.
+  // Extract the `SessionCacheData` declaration body from the source. Matches both
+  // `interface SessionCacheData { … }` and a `type SessionCacheData = { … }` alias
+  // (so a future refactor doesn't silently disable the guard), and anchors the
+  // close on a column-0 `}` (`^\}` multiline) rather than any `\n}` — nested
+  // object slots keep their `}` indented, so the non-greedy body still ends at the
+  // real declaration close.
   function sessionCacheDataBody(): string {
     const source = read(SESSION_MANAGER);
-    const match = source.match(/interface SessionCacheData\s*\{([\s\S]*?)\n\}/);
+    const match = source.match(/(?:interface|type)\s+SessionCacheData\b[^{]*\{([\s\S]*?)^\}/m);
     expect(match).not.toBeNull();
     return match![1];
   }

--- a/test/daemon/sessionCacheTypedSlots.test.ts
+++ b/test/daemon/sessionCacheTypedSlots.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { SessionManager, type DeviceLabelMap } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
+import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
+
+/**
+ * Typed `SessionCacheData` slots for the well-known keys that used to live in the
+ * untyped `customData?: Record<string, any>` bag (issue #2973, follow-up to #2917).
+ *
+ * `keepScreenAwake` (KeepScreenAwakeState) and `deviceLabels` (a label→session map)
+ * are fixed-type keyed state; promoting them to typed top-level slots with
+ * dedicated set/get helpers removes the unchecked `as` casts that let a
+ * writer/reader type drift slip past the compiler — the exact #2917 bug class.
+ */
+describe("SessionCacheData typed slots (issue #2973)", () => {
+  let sessionManager: SessionManager;
+  let fakeTimer: FakeTimer;
+
+  // Minimal repo double capturing the fire-and-forget activity writes so the
+  // default file-backed DeviceSessionRepository is never resolved (unit guard).
+  function makeRepo(): { repo: any; activity: string[] } {
+    const activity: string[] = [];
+    const repo = {
+      async upsertActiveSession(): Promise<void> {},
+      async recordActivity(sessionId: string): Promise<void> { activity.push(sessionId); },
+      async markReleased(): Promise<void> {},
+      async markStaleActiveSessionsExpired(): Promise<void> {},
+    };
+    return { repo, activity };
+  }
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+    sessionManager = new SessionManager(fakeTimer);
+  });
+
+  afterEach(() => {
+    sessionManager.stopCleanupTimer();
+  });
+
+  describe("keepScreenAwake slot", () => {
+    const state: KeepScreenAwakeState = {
+      applied: true,
+      method: "settings",
+      appliedSettings: { stayOnWhilePluggedIn: true, screenOffTimeout: true },
+    };
+
+    test("EC3: set/getKeepScreenAwake round-trips the typed state", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android");
+      sessionManager.setKeepScreenAwake("s1", state);
+
+      expect(sessionManager.getKeepScreenAwake("s1")).toEqual(state);
+    });
+
+    test("EC1: the state is stored in the typed top-level slot, not customData", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android");
+      sessionManager.setKeepScreenAwake("s1", state);
+
+      const cache = sessionManager.getSessionCache("s1")!;
+      expect(cache.keepScreenAwake).toEqual(state);
+      expect((cache as Record<string, unknown>).customData).toBeUndefined();
+    });
+
+    test("getKeepScreenAwake returns undefined for an unknown session", () => {
+      expect(sessionManager.getKeepScreenAwake("missing")).toBeUndefined();
+    });
+
+    test("getKeepScreenAwake returns undefined before any state is set", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android");
+      expect(sessionManager.getKeepScreenAwake("s1")).toBeUndefined();
+    });
+
+    test("EC4: getKeepScreenAwake records NO session activity, unlike getSessionCache", async () => {
+      const { repo, activity } = makeRepo();
+      const barrier = new FakeDbWriteBarrier();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+        mgr.setKeepScreenAwake("s1", state);
+        await Promise.resolve();
+        const activityAfterSet = activity.length;
+
+        mgr.getKeepScreenAwake("s1");
+        await Promise.resolve();
+        expect(activity.length).toBe(activityAfterSet);
+
+        // Contrast: getSessionCache DOES record activity (the behavior we avoid).
+        mgr.getSessionCache("s1");
+        await Promise.resolve();
+        expect(activity.length).toBe(activityAfterSet + 1);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+
+    test("EC5: releaseSession reads the typed slot for keep-awake restore", async () => {
+      const { repo } = makeRepo();
+      const barrier = new FakeDbWriteBarrier();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+        // applied:false → restore is a documented no-op, so it reads the slot,
+        // sees it, and returns without touching a real device.
+        mgr.setKeepScreenAwake("s1", { applied: false, skipReason: "disabled" });
+
+        const deviceId = await mgr.releaseSession("s1");
+        expect(deviceId).toBe("emulator-5554");
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+  });
+
+  describe("deviceLabels slot", () => {
+    const labels: DeviceLabelMap = { A: "s1", B: "s1:B" };
+
+    test("EC3: set/getDeviceLabels round-trips the typed map", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android");
+      sessionManager.setDeviceLabels("s1", labels);
+
+      expect(sessionManager.getDeviceLabels("s1")).toEqual(labels);
+    });
+
+    test("EC1: the map is stored in the typed top-level slot, not customData", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android");
+      sessionManager.setDeviceLabels("s1", labels);
+
+      const cache = sessionManager.getSessionCache("s1")!;
+      expect(cache.deviceLabels).toEqual(labels);
+      expect((cache as Record<string, unknown>).customData).toBeUndefined();
+    });
+
+    test("getDeviceLabels returns undefined for an unknown session", () => {
+      expect(sessionManager.getDeviceLabels("missing")).toBeUndefined();
+    });
+
+    test("EC4: getDeviceLabels records NO session activity, unlike getSessionCache", async () => {
+      const { repo, activity } = makeRepo();
+      const barrier = new FakeDbWriteBarrier();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+        mgr.setDeviceLabels("s1", labels);
+        await Promise.resolve();
+        const activityAfterSet = activity.length;
+
+        mgr.getDeviceLabels("s1");
+        await Promise.resolve();
+        expect(activity.length).toBe(activityAfterSet);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+  });
+
+  test("the two typed slots are independent (no shared bag to clobber)", async () => {
+    await sessionManager.createSession("s1", "emulator-5554", "android");
+    sessionManager.setKeepScreenAwake("s1", { applied: false, skipReason: "disabled" });
+    sessionManager.setDeviceLabels("s1", { A: "s1" });
+
+    expect(sessionManager.getKeepScreenAwake("s1")).toEqual({ applied: false, skipReason: "disabled" });
+    expect(sessionManager.getDeviceLabels("s1")).toEqual({ A: "s1" });
+  });
+});

--- a/test/daemon/sessionCacheTypedSlots.test.ts
+++ b/test/daemon/sessionCacheTypedSlots.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { SessionManager, type DeviceLabelMap } from "../../src/daemon/sessionManager";
+import { SessionManager, type DeviceLabelMap, type KeepScreenAwakeRestorer } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
+
+/**
+ * Capturing fake restorer: records every state handed to `restore`, so a test can
+ * assert the reader (`restoreKeepScreenAwake`) read the typed slot's FULL payload —
+ * not just its `.applied` flag — and passed it through on session release.
+ */
+class SpyKeepScreenAwakeRestorer implements KeepScreenAwakeRestorer {
+  readonly restored: KeepScreenAwakeState[] = [];
+  async restore(state: KeepScreenAwakeState): Promise<void> {
+    this.restored.push(state);
+  }
+}
 
 /**
  * Typed `SessionCacheData` slots for the well-known keys that used to live in the
@@ -94,18 +106,59 @@ describe("SessionCacheData typed slots (issue #2973)", () => {
       }
     });
 
-    test("EC5: releaseSession reads the typed slot for keep-awake restore", async () => {
+    test("EC5: releaseSession passes the FULL typed-slot payload to restore (writer/reader round trip)", async () => {
+      // The #2917 bug class is writer/reader drift. This proves the reader
+      // (restoreKeepScreenAwake) reads the whole typed payload from the slot the
+      // setter wrote — not just `.applied` — and hands it to the restorer, with no
+      // real device. Injected restorer stands in for KeepScreenAwakeManager.
       const { repo } = makeRepo();
       const barrier = new FakeDbWriteBarrier();
-      const mgr = new SessionManager(fakeTimer, repo, () => barrier);
+      const spy = new SpyKeepScreenAwakeRestorer();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier, () => spy);
       try {
         await mgr.createSession("s1", "emulator-5554", "android");
-        // applied:false → restore is a documented no-op, so it reads the slot,
-        // sees it, and returns without touching a real device.
-        mgr.setKeepScreenAwake("s1", { applied: false, skipReason: "disabled" });
+        const applied: KeepScreenAwakeState = {
+          applied: true,
+          method: "settings",
+          originalScreenOffTimeout: "60000",
+          appliedSettings: { stayOnWhilePluggedIn: true, screenOffTimeout: true },
+        };
+        mgr.setKeepScreenAwake("s1", applied);
 
         const deviceId = await mgr.releaseSession("s1");
         expect(deviceId).toBe("emulator-5554");
+        // Exact object read back from the slot and forwarded to restore.
+        expect(spy.restored).toEqual([applied]);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+
+    test("EC5: releaseSession does NOT restore when the slot's state is applied:false", async () => {
+      const { repo } = makeRepo();
+      const barrier = new FakeDbWriteBarrier();
+      const spy = new SpyKeepScreenAwakeRestorer();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier, () => spy);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+        mgr.setKeepScreenAwake("s1", { applied: false, skipReason: "disabled" });
+
+        await mgr.releaseSession("s1");
+        expect(spy.restored).toEqual([]);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+
+    test("EC5: releaseSession does NOT restore when no keep-awake state was set", async () => {
+      const { repo } = makeRepo();
+      const barrier = new FakeDbWriteBarrier();
+      const spy = new SpyKeepScreenAwakeRestorer();
+      const mgr = new SessionManager(fakeTimer, repo, () => barrier, () => spy);
+      try {
+        await mgr.createSession("s1", "emulator-5554", "android");
+        await mgr.releaseSession("s1");
+        expect(spy.restored).toEqual([]);
       } finally {
         mgr.stopCleanupTimer();
       }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -178,8 +178,9 @@ describe("SessionManager", () => {
       expect(session.cacheData.lastHierarchy).toEqual(hierarchy);
       expect(session.cacheData.lastHierarchy?.hierarchy.node?.["view-id"]).toBe("com.example:id/root");
       expect(session.cacheData.lastObserveTime).toBe(123456);
-      // The dormant-decoy key must not reappear under customData.
-      expect(session.cacheData.customData?.lastHierarchy).toBeUndefined();
+      // The dormant-decoy key never leaks into an untyped bag — the `customData`
+      // escape hatch no longer exists at all (#2917/#2973).
+      expect((session.cacheData as Record<string, unknown>).customData).toBeUndefined();
     });
 
     test("setLastScreenshot stores the base64 string in the typed top-level slot (#2917)", async () => {
@@ -189,7 +190,7 @@ describe("SessionManager", () => {
 
       const session = sessionManager.getSession("session-1")!;
       expect(session.cacheData.lastScreenshot).toBe("base64-screenshot");
-      expect(session.cacheData.customData?.lastScreenshot).toBeUndefined();
+      expect((session.cacheData as Record<string, unknown>).customData).toBeUndefined();
     });
 
     test("setLastHierarchy on a missing session is a no-op (no throw)", () => {
@@ -200,14 +201,14 @@ describe("SessionManager", () => {
     test("should get session cache without modifying other fields", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");
       sessionManager.updateSessionCache("session-1", {
-        customData: { key: "value" },
+        deviceLabels: { A: "session-1" },
       });
       const session1 = sessionManager.getSession("session-1");
       const initialLastUsed = session1?.lastUsedAt ?? 0;
       fakeTimer.advanceTime(10);
       const cache = sessionManager.getSessionCache("session-1");
       const session2 = sessionManager.getSession("session-1");
-      expect(cache?.customData).toEqual({ key: "value" });
+      expect(cache?.deviceLabels).toEqual({ A: "session-1" });
       expect((session2?.lastUsedAt ?? 0)).toBe(initialLastUsed + 10);
     });
 
@@ -228,7 +229,7 @@ describe("SessionManager", () => {
       sessionManager.updateSessionCache("session-1", {
         lastHierarchy: makeHierarchy("root"),
         lastScreenshot: "base64-data",
-        customData: { key: "value" },
+        deviceLabels: { A: "session-1" },
       });
       sessionManager.clearSessionCache("session-1");
       const cache = sessionManager.getSessionCache("session-1");

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonRequest, DaemonResponse } from "../../src/daemon/types";
-import type { Session } from "../../src/daemon/sessionManager";
+import type { DeviceLabelMap, Session } from "../../src/daemon/sessionManager";
 
 interface FakeMcpClient {
   callTool: (...args: unknown[]) => Promise<unknown>;
@@ -22,7 +22,7 @@ interface FakeMcpClient {
 function createFakeSession(
   sessionId: string,
   assignedDevice: string,
-  customData: Record<string, unknown> = {}
+  deviceLabels?: DeviceLabelMap
 ): Session {
   return {
     sessionId,
@@ -31,7 +31,7 @@ function createFakeSession(
     createdAt: 0,
     lastUsedAt: 0,
     expiresAt: 60_000,
-    cacheData: { customData },
+    cacheData: { deviceLabels },
     lastHeartbeat: 0,
     sessionTimeoutMs: 60_000,
     heartbeatTimeoutMs: 10_000,
@@ -42,7 +42,7 @@ function createFakeSession(
 
 function createFakeDaemonState(
   sessionDevices: Map<string, string>,
-  sessionCustomData: Map<string, Record<string, unknown>>,
+  sessionDeviceLabels: Map<string, DeviceLabelMap>,
   mcpAutolockSessions: Map<string, string>
 ) {
   return {
@@ -50,8 +50,9 @@ function createFakeDaemonState(
     getSessionManager: () => ({
       getSession: (sessionId: string) => {
         const assignedDevice = sessionDevices.get(sessionId);
-        return assignedDevice ? createFakeSession(sessionId, assignedDevice, sessionCustomData.get(sessionId) ?? {}) : null;
+        return assignedDevice ? createFakeSession(sessionId, assignedDevice, sessionDeviceLabels.get(sessionId)) : null;
       },
+      getDeviceLabels: (sessionId: string) => sessionDeviceLabels.get(sessionId),
       releaseSession: async () => null,
     }),
     getDevicePool: () => ({
@@ -170,7 +171,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
   let server: UnixSocketServer;
   let fakeTimer: FakeTimer;
   let sessionDevices: Map<string, string>;
-  let sessionCustomData: Map<string, Record<string, unknown>>;
+  let sessionDeviceLabels: Map<string, DeviceLabelMap>;
   let mcpAutolockSessions: Map<string, string>;
 
   beforeEach(async () => {
@@ -178,12 +179,12 @@ describe("UnixSocketServer MCP forward serialization", () => {
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     sessionDevices = new Map();
-    sessionCustomData = new Map();
+    sessionDeviceLabels = new Map();
     mcpAutolockSessions = new Map();
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
-      createFakeDaemonState(sessionDevices, sessionCustomData, mcpAutolockSessions),
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
       fakeTimer,
     );
     await server.start();
@@ -305,12 +306,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
   test("device-label tools/call serializes with explicit calls for the mapped device", async () => {
     sessionDevices.set("session-a", "device-1");
     sessionDevices.set("session-a:B", "device-2");
-    sessionCustomData.set("session-a", {
-      deviceLabelMap: {
-        A: "session-a",
-        B: "session-a:B",
-      },
-    });
+    sessionDeviceLabels.set("session-a", { A: "session-a", B: "session-a:B" });
     let inFlight = 0;
     let maxInFlight = 0;
 
@@ -348,12 +344,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
   test("device-label tools/call ignores a stale deviceId when choosing the forward key", async () => {
     sessionDevices.set("session-a", "device-1");
     sessionDevices.set("session-a:B", "device-2");
-    sessionCustomData.set("session-a", {
-      deviceLabelMap: {
-        A: "session-a",
-        B: "session-a:B",
-      },
-    });
+    sessionDeviceLabels.set("session-a", { A: "session-a", B: "session-a:B" });
     let inFlight = 0;
     let maxInFlight = 0;
 

--- a/test/daemon/socketServerScopeKey.test.ts
+++ b/test/daemon/socketServerScopeKey.test.ts
@@ -4,12 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
-import type { Session } from "../../src/daemon/sessionManager";
+import type { DeviceLabelMap, Session } from "../../src/daemon/sessionManager";
 
 function createFakeSession(
   sessionId: string,
   assignedDevice: string,
-  customData: Record<string, unknown> = {}
+  deviceLabels?: DeviceLabelMap
 ): Session {
   return {
     sessionId,
@@ -18,7 +18,7 @@ function createFakeSession(
     createdAt: 0,
     lastUsedAt: 0,
     expiresAt: 60_000,
-    cacheData: { customData },
+    cacheData: { deviceLabels },
     lastHeartbeat: 0,
     sessionTimeoutMs: 60_000,
     heartbeatTimeoutMs: 10_000,
@@ -29,7 +29,7 @@ function createFakeSession(
 
 function createFakeDaemonState(
   sessionDevices: Map<string, string>,
-  sessionCustomData: Map<string, Record<string, unknown>>,
+  sessionDeviceLabels: Map<string, DeviceLabelMap>,
   mcpAutolockSessions: Map<string, string>
 ) {
   return {
@@ -38,9 +38,10 @@ function createFakeDaemonState(
       getSession: (sessionId: string) => {
         const assignedDevice = sessionDevices.get(sessionId);
         return assignedDevice
-          ? createFakeSession(sessionId, assignedDevice, sessionCustomData.get(sessionId) ?? {})
+          ? createFakeSession(sessionId, assignedDevice, sessionDeviceLabels.get(sessionId))
           : null;
       },
+      getDeviceLabels: (sessionId: string) => sessionDeviceLabels.get(sessionId),
       releaseSession: async () => null,
     }),
     getDevicePool: () => ({
@@ -56,23 +57,21 @@ function createFakeDaemonState(
 
 function createServer() {
   const sessionDevices = new Map<string, string>();
-  const sessionCustomData = new Map<string, Record<string, unknown>>();
+  const sessionDeviceLabels = new Map<string, DeviceLabelMap>();
   const mcpAutolockSessions = new Map<string, string>();
 
   // session-a is bound to device-1
   sessionDevices.set("session-a", "device-1");
   // device label "B" on session-a maps to session-a:B, bound to device-2
   sessionDevices.set("session-a:B", "device-2");
-  sessionCustomData.set("session-a", {
-    deviceLabelMap: { A: "session-a", B: "session-a:B" },
-  });
+  sessionDeviceLabels.set("session-a", { A: "session-a", B: "session-a:B" });
   // mcp-bound has an autolock session resolving to session-a (device-1)
   mcpAutolockSessions.set("mcp-bound", "session-a");
 
   const server = new UnixSocketServer(
     join(tmpdir(), `scope-${randomUUID()}.sock`),
     "http://localhost:0/mcp",
-    createFakeDaemonState(sessionDevices, sessionCustomData, mcpAutolockSessions),
+    createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
     new FakeTimer(),
   );
   return server;

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -76,6 +76,27 @@ describe("ToolExecutionContext", () => {
     expect(passed.platform).toBe("android");
   });
 
+  test("writes the keep-awake state to the typed keepScreenAwake slot on setup (#2973)", async () => {
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => ({ success: true, message: "ok" }),
+      } as any);
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    // keepScreenAwake:false → apply() short-circuits to an applied:false state,
+    // which ensureKeepScreenAwake must persist to the typed slot (not customData).
+    await createToolExecutionContext("session-1", sessionManager, devicePool, sessionOptions);
+
+    const state = sessionManager.getKeepScreenAwake("session-1");
+    expect(state).toBeDefined();
+    expect(state!.applied).toBe(false);
+    expect((sessionManager.getSessionCache("session-1") as Record<string, unknown>).customData).toBeUndefined();
+  });
+
   test("should not run accessibility setup for existing sessions", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/deviceLabelMapping.test.ts
+++ b/test/server/deviceLabelMapping.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { BootedDevice } from "../../src/models";
+import { buildDeviceLabelMap, getDeviceLabelMap } from "../../src/server/deviceLabelMapping";
+
+/**
+ * Behavioral coverage for the device-label map's read/write path through the REAL
+ * SessionManager typed `deviceLabels` slot (issue #2973). The socketServer routing
+ * tests inject a fake `getDeviceLabels`, so they prove socketServer *calls* the
+ * helper but never exercise the real typed-slot read — this suite closes that gap.
+ */
+describe("deviceLabelMapping ↔ SessionManager.deviceLabels slot (issue #2973)", () => {
+  const androidA: BootedDevice = { name: "Pixel A", deviceId: "emulator-5554", platform: "android" };
+  let sessionManager: SessionManager;
+
+  beforeEach(async () => {
+    const timer = new FakeTimer();
+    sessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidA]);
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([androidA]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+  });
+
+  afterEach(() => {
+    DaemonState.getInstance().reset();
+    sessionManager.stopCleanupTimer();
+  });
+
+  test("getDeviceLabelMap round-trips a map written via the typed setDeviceLabels slot", async () => {
+    await sessionManager.createSession("base", "emulator-5554", "android");
+    const map = buildDeviceLabelMap(["A", "B"], "base");
+    sessionManager.setDeviceLabels("base", map);
+
+    // getDeviceLabelMap reads through the real getDeviceLabels delegation, not a fake.
+    expect(getDeviceLabelMap("base")).toEqual(map);
+    expect(getDeviceLabelMap("base")).toEqual({ A: "base", B: "base:B" });
+  });
+
+  test("getDeviceLabelMap returns null for a session with no registered labels", async () => {
+    await sessionManager.createSession("base", "emulator-5554", "android");
+    expect(getDeviceLabelMap("base")).toBeNull();
+  });
+
+  test("getDeviceLabelMap returns null for an unknown session", () => {
+    expect(getDeviceLabelMap("nope")).toBeNull();
+  });
+
+  test("getDeviceLabelMap returns null when the daemon is not initialized", () => {
+    DaemonState.getInstance().reset();
+    expect(getDeviceLabelMap("base")).toBeNull();
+  });
+});

--- a/test/server/toolRegistry.internalNoDiff.test.ts
+++ b/test/server/toolRegistry.internalNoDiff.test.ts
@@ -8,7 +8,6 @@ import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
-import { KEEP_SCREEN_AWAKE_STATE_KEY } from "../../src/utils/KeepScreenAwakeManager";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
@@ -63,14 +62,9 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     const sessionId = (await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1"))!;
 
-    const session = daemonSessionManager.getSession(sessionId)!;
-    daemonSessionManager.updateSessionCache(sessionId, {
-      ...session.cacheData,
-      customData: {
-        ...(session.cacheData.customData ?? {}),
-        [KEEP_SCREEN_AWAKE_STATE_KEY]: { applied: false, skipReason: "test" },
-      },
-    });
+    // Seed the typed keep-awake slot so ensureKeepScreenAwake short-circuits
+    // instead of touching a device during setup (issue #2973).
+    daemonSessionManager.setKeepScreenAwake(sessionId, { applied: false, skipReason: "disabled" });
     return sessionId;
   }
 

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -8,7 +8,6 @@ import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
-import { KEEP_SCREEN_AWAKE_STATE_KEY } from "../../src/utils/KeepScreenAwakeManager";
 import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
@@ -64,14 +63,9 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     const sessionId = (await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1"))!;
 
-    const session = daemonSessionManager.getSession(sessionId)!;
-    daemonSessionManager.updateSessionCache(sessionId, {
-      ...session.cacheData,
-      customData: {
-        ...(session.cacheData.customData ?? {}),
-        [KEEP_SCREEN_AWAKE_STATE_KEY]: { applied: false, skipReason: "test" },
-      },
-    });
+    // Seed the typed keep-awake slot so ensureKeepScreenAwake short-circuits
+    // instead of touching a device during setup (issue #2973).
+    daemonSessionManager.setKeepScreenAwake(sessionId, { applied: false, skipReason: "disabled" });
     return sessionId;
   }
 
@@ -130,9 +124,9 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     expect(typeof cacheData.lastObserveTime).toBe("number");
     // Screenshot cache repair (symmetric structuredContent read).
     expect(cacheData.lastScreenshot).toBe("base64-screenshot-data");
-    // The dormant-decoy keys must NOT be written under customData anymore (#2917).
-    expect(cacheData.customData?.lastHierarchy).toBeUndefined();
-    expect(cacheData.customData?.lastScreenshot).toBeUndefined();
+    // The dormant-decoy keys never leak into an untyped bag — the `customData`
+    // escape hatch no longer exists at all (#2917/#2973).
+    expect((cacheData as Record<string, unknown>).customData).toBeUndefined();
 
     // Returned wire response is sanitized at the chokepoint.
     const returnedRoot = (response.structuredContent as ObserveResult).viewHierarchy!.hierarchy.node as any;
@@ -173,6 +167,6 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     expect(response.content[0].text).toBe(stringifyToolResponse(response.structuredContent));
 
     const cacheData = daemonSessionManager!.getSession(sessionId)!.cacheData;
-    expect(cacheData.customData?.lastActionTime).toBeUndefined();
+    expect((cacheData as Record<string, unknown>).customData).toBeUndefined();
   });
 });

--- a/test/server/toolRegistry.scrollPositionUpdate.test.ts
+++ b/test/server/toolRegistry.scrollPositionUpdate.test.ts
@@ -8,7 +8,6 @@ import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
-import { KEEP_SCREEN_AWAKE_STATE_KEY } from "../../src/utils/KeepScreenAwakeManager";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
@@ -49,14 +48,9 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     const sessionId = (await pool.autolockDevice(androidA.deviceId, "android", "mcp-session-1"))!;
 
-    const session = daemonSessionManager.getSession(sessionId)!;
-    daemonSessionManager.updateSessionCache(sessionId, {
-      ...session.cacheData,
-      customData: {
-        ...(session.cacheData.customData ?? {}),
-        [KEEP_SCREEN_AWAKE_STATE_KEY]: { applied: false, skipReason: "test" },
-      },
-    });
+    // Seed the typed keep-awake slot so ensureKeepScreenAwake short-circuits
+    // instead of touching a device during setup (issue #2973).
+    daemonSessionManager.setKeepScreenAwake(sessionId, { applied: false, skipReason: "disabled" });
     return sessionId;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #2917 / PR #2929. That PR promoted the observe-cache fields to typed
`SessionCacheData` slots, but the `customData?: Record<string, any>` escape hatch
remained — and it still held **well-known, fixed-type keyed state** (keep-awake
`KeepScreenAwakeState`, the device-label map) accessed via unchecked `as` casts.
A writer/reader type drift on any such key was invisible at compile time: the exact
#2917 decoy bug class.

This PR promotes those two keys to typed top-level slots with dedicated helpers and
removes the `customData` bag entirely (they were its only consumers).

- Add `keepScreenAwake?: KeepScreenAwakeState` and `deviceLabels?: DeviceLabelMap`
  to `SessionCacheData`; **remove `customData`** (Acceptance #2 — the escape hatch is
  fully eliminated, not just narrowed).
- Add dedicated `set/getKeepScreenAwake` and `set/getDeviceLabels` helpers on
  `SessionManager`. Getters route through `getSession` so they record **no session
  activity**, mirroring the side-effect-free `getLastRenderedObservation` reader (#3053).
- Rewire every consumer to the typed slots/helpers, dropping the `as` casts:
  `ensureKeepScreenAwake` / `restoreKeepScreenAwake`, `registerDeviceLabelMap` /
  `getDeviceLabelMap`, and `socketServer.resolveDeviceLabelSession` (the narrow
  `DaemonStateAccess` interface gains `getDeviceLabels`).
- Remove the now-orphaned generic `updateSessionCache(context, key, value)` free
  function and the `KEEP_SCREEN_AWAKE_STATE_KEY` constant.

### Acceptance (from the issue)
- ✅ No well-known session-cache key is accessed via an unchecked `as` cast out of
  `customData`; each has a typed slot + helper.
- ✅ `SessionCacheData` has no remaining `Record<string, any>` escape hatch.

Closes #2973.

## Tests

- `test/daemon/sessionCacheTypedSlots.test.ts` — new: round-trip for both slots,
  getters record no session activity (contrast `getSessionCache`), and the
  `releaseSession` keep-awake-restore read path.
- `test/daemon/sessionCacheNoEscapeHatch.test.ts` — new source-scan guard: fails if
  the `customData` bag or an unchecked `as KeepScreenAwakeState | undefined` cast is
  reintroduced in any former consumer.
- `test/server/ToolExecutionContext.test.ts` — new: `ensureKeepScreenAwake` writes the
  typed `keepScreenAwake` slot (not `customData`) on setup.
- Migrated existing seeding/decoy tests (`sessionManager`, `socketServer*`,
  `toolRegistry.*`) off `customData` to the typed slots.
- `NODE_ENV=test bun test test/daemon/ test/server/` → all green (608 daemon, 878
  daemon+server pass, 0 fail).
- `bunx turbo run lint build` → clean. `bun run typecheck` → no NEW errors from this
  diff (the remaining adm-zip/ajv baseline errors are pre-existing, in untouched files).

## Review

- Ran `/auto-mobile-code-review` against the rebased branch; no actionable findings.
  Verified the removed runtime validation in `resolveDeviceLabelSession` is safe —
  `Session.cacheData` is in-memory only (never hydrated from the DB), so the typed
  slot is the only write path; empty/absent map still falls back to the base session.
