### PR TITLE
feat(types): type-checker-enforced ToolHandler envelope boundary (#2932)

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -9,7 +9,7 @@ import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
 import { RealObserveScreen } from "../observe/ObserveScreen";
-import { getStructuredField, StructuredToolResponse } from "../../utils/toolUtils";
+import { asToolEnvelope, getStructuredField } from "../../utils/toolUtils";
 import { SwipeOnToolPayload } from "../../models";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
 import { defaultTimer, Timer } from "../../utils/SystemTimer";
@@ -168,15 +168,16 @@ export class DefaultUIStateSetup implements UIStateSetup {
       // sees the full (unstripped) result.
       // Typed envelope (issue #2932): `swipeOnTool.handler` is declared
       // `Promise<any>` at the registry boundary, so narrow to the concrete
-      // `SwipeOnToolPayload` envelope here. `found` lives under
-      // `structuredContent` (createStructuredToolResponse hoists only
-      // `success`/`error`); a raw `result?.found` off the envelope was always
-      // undefined, leaving this success branch dead so setup logged the "could
-      // not find" warning even on a successful scroll (issue #2897; same class
-      // as the toolRegistry scroll-position and #2758 lastHierarchy fixes). With
-      // `result` typed, `result.found` is now a compile error and the
-      // `getStructuredField` keys are checked against the payload.
-      const result: StructuredToolResponse<SwipeOnToolPayload> = await swipeOnTool.handler(markInternalToolCall(swipeOnArgs));
+      // `SwipeOnToolPayload` envelope via `asToolEnvelope` (it names the
+      // unchecked `any`→typed crossing). `found` lives under `structuredContent`
+      // (createStructuredToolResponse hoists only `success`/`error`); a raw
+      // `result?.found` off the envelope was always undefined, leaving this
+      // success branch dead so setup logged the "could not find" warning even on
+      // a successful scroll (issue #2897; same class as the toolRegistry
+      // scroll-position and #2758 lastHierarchy fixes). With `result` typed,
+      // `result.found` is now a compile error and the `getStructuredField` keys
+      // are checked against the payload.
+      const result = asToolEnvelope<SwipeOnToolPayload>(await swipeOnTool.handler(markInternalToolCall(swipeOnArgs)));
 
       if (getStructuredField(result, "success") && getStructuredField(result, "found")) {
         logger.info(`[UI_STATE_SETUP] Successfully scrolled to target element`);

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -9,7 +9,8 @@ import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
 import { RealObserveScreen } from "../observe/ObserveScreen";
-import { getStructuredField } from "../../utils/toolUtils";
+import { getStructuredField, StructuredToolResponse } from "../../utils/toolUtils";
+import { SwipeOnToolPayload } from "../../models";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
 import { defaultTimer, Timer } from "../../utils/SystemTimer";
 
@@ -165,15 +166,19 @@ export class DefaultUIStateSetup implements UIStateSetup {
       // `--actions-diff-observe` this setup scroll neither diffs its observation
       // nor advances the agent-facing diff baseline — the `found` read below still
       // sees the full (unstripped) result.
-      const result = await swipeOnTool.handler(markInternalToolCall(swipeOnArgs));
+      // Typed envelope (issue #2932): `swipeOnTool.handler` is declared
+      // `Promise<any>` at the registry boundary, so narrow to the concrete
+      // `SwipeOnToolPayload` envelope here. `found` lives under
+      // `structuredContent` (createStructuredToolResponse hoists only
+      // `success`/`error`); a raw `result?.found` off the envelope was always
+      // undefined, leaving this success branch dead so setup logged the "could
+      // not find" warning even on a successful scroll (issue #2897; same class
+      // as the toolRegistry scroll-position and #2758 lastHierarchy fixes). With
+      // `result` typed, `result.found` is now a compile error and the
+      // `getStructuredField` keys are checked against the payload.
+      const result: StructuredToolResponse<SwipeOnToolPayload> = await swipeOnTool.handler(markInternalToolCall(swipeOnArgs));
 
-      // `swipeOn` pre-serializes into an MCP envelope via createStructuredToolResponse,
-      // which hoists only `success`/`error` to the top level — `found` lives under
-      // `structuredContent`. Reading `result?.found` off the envelope was always
-      // undefined, so this success branch was dead and setup always logged the
-      // "could not find" warning even on a successful scroll (issue #2897; same class
-      // as the toolRegistry scroll-position and #2758 lastHierarchy fixes).
-      if (getStructuredField<boolean>(result, "success") && getStructuredField<boolean>(result, "found")) {
+      if (getStructuredField(result, "success") && getStructuredField(result, "found")) {
         logger.info(`[UI_STATE_SETUP] Successfully scrolled to target element`);
         return `swipeOn(lookFor: ${JSON.stringify(scrollPosition.targetElement)})`;
       } else {

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -226,3 +226,25 @@ export interface ObserveResult {
    */
   rawViewHierarchy?: RawViewHierarchyResult;
 }
+
+/**
+ * The payload the `observe` tool packs into its MCP `structuredContent` envelope.
+ * Equals {@link ObserveResult} (which already carries the `awaitedElement` /
+ * `awaitDuration` / `awaitTimeout` wait fields the handler spreads) plus the
+ * optional base64 `screenshot` slot the session cache-repair path reads (#2917).
+ *
+ * NOTE: production `observe` does not currently emit `screenshot`, so the
+ * toolRegistry `setLastScreenshot` read is presently dead (tracked as a
+ * follow-up). The field keeps that typed read site honest — the read compiles
+ * against a real payload key instead of a stringly-typed guess — without any
+ * behavior change.
+ *
+ * Used to annotate the `StructuredToolResponse<ObserveToolPayload>` the handler
+ * returns and to type the toolRegistry lastHierarchy/lastScreenshot read sites
+ * so an envelope-top-level `response.viewHierarchy` read is a **compile error**
+ * (issue #2932; envelope-vs-`structuredContent` dead-read class, issue #2907).
+ */
+export interface ObserveToolPayload extends ObserveResult {
+  /** Optional base64 screenshot read into the session cache (#2917/#2932). */
+  screenshot?: string;
+}

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -231,13 +231,17 @@ export interface ObserveResult {
  * The payload the `observe` tool packs into its MCP `structuredContent` envelope.
  * Equals {@link ObserveResult} (which already carries the `awaitedElement` /
  * `awaitDuration` / `awaitTimeout` wait fields the handler spreads) plus the
- * optional base64 `screenshot` slot the session cache-repair path reads (#2917).
+ * optional base64 `screenshot` slot the toolRegistry `setLastScreenshot` read
+ * consumes.
  *
- * NOTE: production `observe` does not currently emit `screenshot`, so the
- * toolRegistry `setLastScreenshot` read is presently dead (tracked as a
- * follow-up). The field keeps that typed read site honest — the read compiles
- * against a real payload key instead of a stringly-typed guess — without any
- * behavior change.
+ * WARNING — the `screenshot` chain is currently DEAD: production `observe` does
+ * NOT emit `screenshot` (its envelope is built from an `ObserveResult`, which has
+ * no such field), so `setLastScreenshot` never fires and the `lastScreenshot`
+ * session slot has no reader. This field only gives the *pre-existing* dead read
+ * a typed home so it compiles against a real key instead of a stringly-typed
+ * guess — no behavior change. Resolving the dead chain (remove it, or make
+ * `observe` actually emit a screenshot with a real consumer) is tracked in
+ * **#3221**; do not assume screenshot caching works.
  *
  * Used to annotate the `StructuredToolResponse<ObserveToolPayload>` the handler
  * returns and to type the toolRegistry lastHierarchy/lastScreenshot read sites
@@ -245,6 +249,6 @@ export interface ObserveResult {
  * (issue #2932; envelope-vs-`structuredContent` dead-read class, issue #2907).
  */
 export interface ObserveToolPayload extends ObserveResult {
-  /** Optional base64 screenshot read into the session cache (#2917/#2932). */
+  /** Optional base64 screenshot; the toolRegistry cache read is dead today — see #3221. */
   screenshot?: string;
 }

--- a/src/models/SwipeOnResult.ts
+++ b/src/models/SwipeOnResult.ts
@@ -47,3 +47,21 @@ export interface ScrollableCandidate {
   contentDesc?: string;
   className?: string;
 }
+
+/**
+ * The payload the `swipeOn` tool packs into its MCP `structuredContent` envelope:
+ * the {@link SwipeOnResult} the command produces plus the human-readable
+ * `message` the handler attaches.
+ *
+ * This is the single source of truth used to (a) annotate the
+ * `StructuredToolResponse<SwipeOnToolPayload>` the handler returns and (b) type
+ * the internal read sites (the toolRegistry scroll-position update and
+ * `DefaultUIStateSetup` scroll setup). With the envelope typed, a `found`/
+ * `success` read is compiler-checked against this payload and an
+ * envelope-top-level `response.found` read is a **compile error** rather than a
+ * silent `undefined` (issue #2932; envelope-vs-`structuredContent` dead-read
+ * class, issue #2907).
+ */
+export interface SwipeOnToolPayload extends SwipeOnResult {
+  message: string;
+}

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -21,9 +21,10 @@ import {
   ActionableError,
   BootedDevice,
   ClipboardResult,
+  SwipeOnToolPayload,
 } from "../models";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
-import { createJSONToolResponse, createStructuredToolResponse } from "../utils/toolUtils";
+import { createJSONToolResponse, createStructuredToolResponse, StructuredToolResponse } from "../utils/toolUtils";
 import { resolveSwipeDirection } from "../utils/swipeOnUtils";
 import { RecompositionTracker } from "../features/performance/RecompositionTracker";
 import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
@@ -749,7 +750,7 @@ export function registerInteractionTools() {
   };
 
   // Swipe on handler
-  const swipeOnHandler = async (device: BootedDevice, args: SwipeOnArgs, progress?: ProgressCallback) => {
+  const swipeOnHandler = async (device: BootedDevice, args: SwipeOnArgs, progress?: ProgressCallback): Promise<StructuredToolResponse<SwipeOnToolPayload>> => {
     RecompositionTracker.getInstance().recordInteraction();
     const swipeOn = new SwipeOn(device);
     const resolvedDirection = resolveSwipeDirection({ direction: args.direction, gestureType: args.gestureType });

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -4,8 +4,8 @@ import { ResourceRegistry } from "./resourceRegistry";
 import { RESOURCE_URIS } from "./observationResources";
 import { ActionableError } from "../models/ActionableError";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
-import { createJSONToolResponse, createStructuredToolResponse, throwIfAborted } from "../utils/toolUtils";
-import { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../models";
+import { createJSONToolResponse, createStructuredToolResponse, throwIfAborted, StructuredToolResponse } from "../utils/toolUtils";
+import { BootedDevice, Element, ObserveResult, ObserveToolPayload, ViewHierarchyResult } from "../models";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
@@ -202,7 +202,7 @@ const waitForObservation = async (
 // Register tools (this will be called when this file is imported)
 export function registerObserveTools() {
   // Observe handler
-  const observeHandler = async (device: BootedDevice, args: ObserveArgs, _progress?: unknown, signal?: AbortSignal) => {
+  const observeHandler = async (device: BootedDevice, args: ObserveArgs, _progress?: unknown, signal?: AbortSignal): Promise<StructuredToolResponse<ObserveToolPayload>> => {
     try {
       const observeScreen = new RealObserveScreen(device);
       const waitFor = args.waitFor;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -27,7 +27,7 @@ import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
 import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM } from "./internalToolCall";
-import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
+import { asToolEnvelope, getStructuredField } from "../utils/toolUtils";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -555,12 +555,13 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
     }
 
     // Typed envelope views (issue #2932): the heterogeneous pipeline hands back
-    // `any`, so narrow to the concrete tool payload before reading. Reading a
+    // `any`, so narrow to the concrete tool payload via `asToolEnvelope` before
+    // reading (it names the unchecked `any`→typed crossing). Reading a
     // non-hoisted field off the envelope top level (`swipeEnvelope.found`) is now
     // a compile error, and `getStructuredField`'s key is checked against the
     // payload — the stringly-typed dead-read footgun is gone.
     if (name === "swipeOn" && args.lookFor) {
-      const swipeEnvelope: StructuredToolResponse<SwipeOnToolPayload> = response;
+      const swipeEnvelope = asToolEnvelope<SwipeOnToolPayload>(response);
       if (getStructuredField(swipeEnvelope, "success") && getStructuredField(swipeEnvelope, "found")) {
         const scrollPosition = UIStateExtractor.createScrollPosition(args);
         if (scrollPosition) {
@@ -574,7 +575,7 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
 
     if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
       const sessionManager = DaemonState.getInstance().getSessionManager();
-      const observeEnvelope: StructuredToolResponse<ObserveToolPayload> = response;
+      const observeEnvelope = asToolEnvelope<ObserveToolPayload>(response);
       const observeHierarchy = name === "observe" ? getStructuredField(observeEnvelope, "viewHierarchy") : undefined;
       if (observeHierarchy) {
         sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,8 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toJSONSchema } from "zod";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
-import { ActionableError, BootedDevice, SomePlatform } from "../models";
-import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
+import { ActionableError, BootedDevice, ObserveToolPayload, SomePlatform, SwipeOnToolPayload } from "../models";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { UIStateExtractor } from "../features/navigation/UIStateExtractor";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
@@ -28,7 +27,7 @@ import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
 import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM } from "./internalToolCall";
-import { getStructuredField } from "../utils/toolUtils";
+import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -555,23 +554,32 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
       getMcpRecorder()?.record(name, args);
     }
 
-    if (name === "swipeOn" && args.lookFor && getStructuredField<boolean>(response, "success") && getStructuredField<boolean>(response, "found")) {
-      const scrollPosition = UIStateExtractor.createScrollPosition(args);
-      if (scrollPosition) {
-        const scrollNavManager = sessionUuid
-          ? NavigationGraphManager.getInstanceForSession(sessionUuid)
-          : NavigationGraphManager.getInstance();
-        scrollNavManager.updateScrollPosition(scrollPosition);
+    // Typed envelope views (issue #2932): the heterogeneous pipeline hands back
+    // `any`, so narrow to the concrete tool payload before reading. Reading a
+    // non-hoisted field off the envelope top level (`swipeEnvelope.found`) is now
+    // a compile error, and `getStructuredField`'s key is checked against the
+    // payload — the stringly-typed dead-read footgun is gone.
+    if (name === "swipeOn" && args.lookFor) {
+      const swipeEnvelope: StructuredToolResponse<SwipeOnToolPayload> = response;
+      if (getStructuredField(swipeEnvelope, "success") && getStructuredField(swipeEnvelope, "found")) {
+        const scrollPosition = UIStateExtractor.createScrollPosition(args);
+        if (scrollPosition) {
+          const scrollNavManager = sessionUuid
+            ? NavigationGraphManager.getInstanceForSession(sessionUuid)
+            : NavigationGraphManager.getInstance();
+          scrollNavManager.updateScrollPosition(scrollPosition);
+        }
       }
     }
 
     if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
       const sessionManager = DaemonState.getInstance().getSessionManager();
-      const observeHierarchy = name === "observe" ? getStructuredField<ViewHierarchyResult>(response, "viewHierarchy") : undefined;
+      const observeEnvelope: StructuredToolResponse<ObserveToolPayload> = response;
+      const observeHierarchy = name === "observe" ? getStructuredField(observeEnvelope, "viewHierarchy") : undefined;
       if (observeHierarchy) {
         sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);
       }
-      const observeScreenshot = name === "observe" ? getStructuredField<string>(response, "screenshot") : undefined;
+      const observeScreenshot = name === "observe" ? getStructuredField(observeEnvelope, "screenshot") : undefined;
       if (observeScreenshot) {
         sessionManager.setLastScreenshot(sessionUuid, observeScreenshot);
       }

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -165,35 +165,38 @@ export const getStructuredPayload = <T = Record<string, unknown>>(
 
 /**
  * The typed seam for reading a single payload field off an MCP tool-call
- * envelope (issue #2907). Payload fields live under `structuredContent`, not on
- * the envelope top level — a raw `response.found` read is always `undefined`
- * and produces a silently-dead branch. Route every payload-field read through
- * this accessor so the read targets `structuredContent`, not the envelope.
+ * envelope (issues #2907 / #2932). Payload fields live under `structuredContent`,
+ * not on the envelope top level — a raw `response.found` read is always
+ * `undefined` and produces a silently-dead branch. Route every payload-field
+ * read through this accessor so the read targets `structuredContent`, not the
+ * envelope.
  *
- * This is a *structural* guard: it guarantees you read from `structuredContent`
- * and not the envelope top level, and only an own key resolves. It does NOT
- * validate that `key` exists on the payload or that the value matches `T` — the
- * caller asserts `T`, so a wrong `key` or `T` still yields a silent `undefined`
- * / mistyped value. Making those a compile error requires a fully typed handler
- * boundary (see follow-up); this accessor closes the envelope-vs-payload half.
+ * Fully typed against a concrete payload `TPayload`: because `response` is a
+ * `StructuredToolResponse<TPayload>`, the `key` is constrained to
+ * `keyof TPayload` (a typo like `"founded"` is a **compile error**) and the
+ * return type is `TPayload[K]` (a wrong `T` assertion is gone — the value type
+ * is inferred). This closes the stringly-typed hole the earlier loose
+ * `getStructuredField<T>(response, "key")` left open (issue #2932): both the
+ * envelope-vs-payload half AND the typo/wrong-type half are now compiler-caught.
  *
- * Accepts a loosely-typed envelope (handlers hand back `any`), safely narrows,
- * and returns `undefined` for null/undefined responses, a missing or
- * non-object `structuredContent`, or an absent (or non-own) field.
+ * Still a *structural* guard at runtime: only an own key resolves, so an
+ * inherited prototype key never leaks through. Returns `undefined` for
+ * null/undefined responses, a missing or non-object `structuredContent`, or an
+ * absent (own) field.
  *
- * @param response The tool-call envelope (or anything envelope-shaped).
- * @param key The payload field to read from `structuredContent`.
+ * @param response The typed tool-call envelope.
+ * @param key The payload field to read from `structuredContent` (keyof TPayload).
  */
-export const getStructuredField = <T = unknown>(
-  response: { structuredContent?: unknown } | null | undefined,
-  key: string
-): T | undefined => {
+export const getStructuredField = <TPayload, K extends keyof TPayload & string>(
+  response: StructuredToolResponse<TPayload> | null | undefined,
+  key: K
+): TPayload[K] | undefined => {
   const structuredContent = response?.structuredContent;
   if (structuredContent && typeof structuredContent === "object") {
     if (!Object.hasOwn(structuredContent, key)) {
       return undefined;
     }
-    return (structuredContent as Record<string, unknown>)[key] as T | undefined;
+    return (structuredContent as TPayload)[key];
   }
   return undefined;
 };

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -184,6 +184,12 @@ export const getStructuredPayload = <T = Record<string, unknown>>(
  * null/undefined responses, a missing or non-object `structuredContent`, or an
  * absent (own) field.
  *
+ * Requires a fully-typed `StructuredToolResponse<TPayload>`, not a bare
+ * envelope-shaped literal — narrow an `any`-boundary value through
+ * {@link asToolEnvelope} first. Caveat: keep `TPayload` a *closed* type; if it
+ * carries a string index signature, `keyof TPayload` widens to include `string`
+ * and the typo-protection silently evaporates.
+ *
  * @param response The typed tool-call envelope.
  * @param key The payload field to read from `structuredContent` (keyof TPayload).
  */
@@ -200,6 +206,24 @@ export const getStructuredField = <TPayload, K extends keyof TPayload & string>(
   }
   return undefined;
 };
+
+/**
+ * Names the single unchecked narrowing at the heterogeneous `ToolHandler`
+ * boundary (issue #2932): the registry stores handlers as `Promise<any>`, so a
+ * consumer that knows which tool it invoked asserts the concrete envelope shape
+ * here. This is deliberately an UNCHECKED cast (no runtime validation) — its
+ * value is that the `any`→typed crossing is explicit and greppable, and that a
+ * runtime shape assertion (or the removal that a genericized registry allows)
+ * has one home. Prefer this over a bare `const e: StructuredToolResponse<T> =
+ * anyValue`, which reads as if the compiler had checked the shape.
+ *
+ * Once read through the returned typed envelope, an envelope-top-level
+ * `e.found` read is a compile error and {@link getStructuredField} keys are
+ * checked against `T`. Removing this cast entirely requires threading the
+ * payload generic through the registry — tracked as a follow-up to #2932.
+ */
+export const asToolEnvelope = <T>(response: unknown): StructuredToolResponse<T> =>
+  response as StructuredToolResponse<T>;
 
 export const throwIfAborted = (signal?: AbortSignal): void => {
   if (signal?.aborted) {

--- a/test/utils/toolUtilsStructuredField.test.ts
+++ b/test/utils/toolUtilsStructuredField.test.ts
@@ -3,70 +3,103 @@ import {
   createStructuredToolResponse,
   getStructuredField,
   getStructuredPayload,
+  StructuredToolResponse,
 } from "../../src/utils/toolUtils";
 
 /**
- * Typed seam for the envelope-vs-`structuredContent` dead-read bug class (issue
- * #2907). `createStructuredToolResponse` hoists ONLY `success`/`error` to the
- * envelope top level; every other payload field lives under `structuredContent`.
- * A raw `response.found` read silently yields `undefined`. `getStructuredField`
- * is the single accessor every payload-field read must route through.
+ * Typed seam for the envelope-vs-`structuredContent` dead-read bug class (issues
+ * #2907 / #2932). `createStructuredToolResponse` hoists ONLY `success`/`error`
+ * to the envelope top level; every other payload field lives under
+ * `structuredContent`, so a raw `response.found` read silently yields
+ * `undefined`.
+ *
+ * `getStructuredField` is now fully typed against a concrete payload: the `key`
+ * is constrained to `keyof TPayload` and the return type is `TPayload[K]`. That
+ * makes BOTH the envelope-top-level read AND a key typo / wrong `<T>` a **compile
+ * error** (issue #2932) — the compile-time half is asserted by the typecheck
+ * gate over the migrated src read sites (toolRegistry, DefaultUIStateSetup); the
+ * runtime behavior below asserts the accessor is otherwise unchanged.
  */
-describe("getStructuredField", () => {
+
+/** Minimal concrete payload standing in for a real tool payload. */
+interface SamplePayload {
+  success: boolean;
+  found?: boolean;
+  viewHierarchy?: { hierarchy: { node: object } };
+  awaitTimeout?: boolean;
+}
+
+// A loose view of the accessor, used ONLY to exercise the runtime own-key guard
+// with keys the type system now (correctly) forbids passing directly.
+const looseField = getStructuredField as unknown as (
+  response: unknown,
+  key: string
+) => unknown;
+
+describe("getStructuredField (typed)", () => {
   test("returns a payload field that lives under structuredContent", () => {
-    const response = createStructuredToolResponse({ success: true, found: true });
-    expect(getStructuredField<boolean>(response, "found")).toBe(true);
+    const response = createStructuredToolResponse<SamplePayload>({ success: true, found: true });
+    const found: boolean | undefined = getStructuredField(response, "found");
+    expect(found).toBe(true);
   });
 
   test("returns a nested object field by reference", () => {
     const hierarchy = { hierarchy: { node: {} } };
-    const response = createStructuredToolResponse({ success: true, viewHierarchy: hierarchy });
+    const response = createStructuredToolResponse<SamplePayload>({ success: true, viewHierarchy: hierarchy });
     expect(getStructuredField(response, "viewHierarchy")).toBe(hierarchy);
   });
 
   test("returns undefined for a field absent from the payload", () => {
-    const response = createStructuredToolResponse({ success: true });
+    const response = createStructuredToolResponse<SamplePayload>({ success: true });
     expect(getStructuredField(response, "found")).toBeUndefined();
   });
 
   test("ignores a field that exists only at the envelope top level, not in structuredContent", () => {
     // Hand-built envelope where `found` sits at the top level but NOT in the
     // payload — the accessor must read only `structuredContent` and not leak it.
-    const envelope = { content: [], structuredContent: { success: true }, found: true };
-    expect(getStructuredField<boolean>(envelope, "found")).toBeUndefined();
+    const envelope: StructuredToolResponse<SamplePayload> = {
+      content: [],
+      structuredContent: { success: true },
+    };
+    (envelope as Record<string, unknown>).found = true;
+    expect(getStructuredField(envelope, "found")).toBeUndefined();
   });
 
   test("returns undefined for null / undefined responses", () => {
-    expect(getStructuredField(null, "found")).toBeUndefined();
-    expect(getStructuredField(undefined, "found")).toBeUndefined();
+    expect(getStructuredField<SamplePayload, "found">(null, "found")).toBeUndefined();
+    expect(getStructuredField<SamplePayload, "found">(undefined, "found")).toBeUndefined();
   });
 
   test("returns undefined when structuredContent is missing or not an object", () => {
-    expect(getStructuredField({ content: [] }, "found")).toBeUndefined();
-    expect(getStructuredField({ structuredContent: "not-an-object" }, "found")).toBeUndefined();
-    expect(getStructuredField({ structuredContent: null }, "found")).toBeUndefined();
+    expect(looseField({ content: [] }, "found")).toBeUndefined();
+    expect(looseField({ structuredContent: "not-an-object" }, "found")).toBeUndefined();
+    expect(looseField({ structuredContent: null }, "found")).toBeUndefined();
   });
 
   test("reading the same field off the envelope top level is undefined (the foot-gun)", () => {
-    const response = createStructuredToolResponse({ success: true, found: true });
-    // Raw top-level read — the mistake this accessor exists to prevent.
+    const response = createStructuredToolResponse<SamplePayload>({ success: true, found: true });
+    // Raw top-level read — the mistake this accessor exists to prevent. At the
+    // migrated src read sites this line is now a COMPILE error; here we cast to
+    // reproduce the historical runtime foot-gun.
     expect((response as Record<string, unknown>).found).toBeUndefined();
     // Accessor gets the real value.
-    expect(getStructuredField<boolean>(response, "found")).toBe(true);
+    expect(getStructuredField(response, "found")).toBe(true);
   });
 
   test("does not resolve inherited (non-own) keys like prototype methods", () => {
-    const response = createStructuredToolResponse({ success: true });
-    // `toString`/`constructor` exist on Object.prototype but are not payload
-    // fields — an own-key guard must keep them from leaking through.
-    expect(getStructuredField(response, "toString")).toBeUndefined();
-    expect(getStructuredField(response, "constructor")).toBeUndefined();
-    expect(getStructuredField(response, "__proto__")).toBeUndefined();
+    const response = createStructuredToolResponse<SamplePayload>({ success: true });
+    // `toString`/`constructor`/`__proto__` exist on Object.prototype but are not
+    // payload fields. The keyof constraint now makes passing them a compile error,
+    // so the own-key runtime guard is defense-in-depth — exercised via the loose
+    // view to prove it still holds.
+    expect(looseField(response, "toString")).toBeUndefined();
+    expect(looseField(response, "constructor")).toBeUndefined();
+    expect(looseField(response, "__proto__")).toBeUndefined();
   });
 
   test("resolves an own key whose value is falsy (found: false)", () => {
-    const response = createStructuredToolResponse({ success: true, found: false });
-    expect(getStructuredField<boolean>(response, "found")).toBe(false);
+    const response = createStructuredToolResponse<SamplePayload>({ success: true, found: false });
+    expect(getStructuredField(response, "found")).toBe(false);
   });
 });
 

--- a/test/utils/toolUtilsStructuredField.test.ts
+++ b/test/utils/toolUtilsStructuredField.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  asToolEnvelope,
   createStructuredToolResponse,
   getStructuredField,
   getStructuredPayload,
@@ -100,6 +101,25 @@ describe("getStructuredField (typed)", () => {
   test("resolves an own key whose value is falsy (found: false)", () => {
     const response = createStructuredToolResponse<SamplePayload>({ success: true, found: false });
     expect(getStructuredField(response, "found")).toBe(false);
+  });
+});
+
+describe("asToolEnvelope", () => {
+  test("is an identity narrowing — returns the same reference, no runtime validation", () => {
+    // It only names the unchecked any->typed crossing at the registry boundary;
+    // it must NOT copy, wrap, or validate the value.
+    const response = createStructuredToolResponse<SamplePayload>({ success: true, found: true });
+    const narrowed = asToolEnvelope<SamplePayload>(response as unknown);
+    expect(narrowed).toBe(response);
+    expect(getStructuredField(narrowed, "found")).toBe(true);
+  });
+
+  test("passes non-envelope values straight through (unchecked)", () => {
+    // No runtime shape assertion today — a garbage value is returned as-is, and
+    // the downstream getStructuredField guard still yields undefined.
+    const garbage = asToolEnvelope<SamplePayload>(42 as unknown);
+    expect(garbage as unknown).toBe(42);
+    expect(getStructuredField(garbage, "found")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #2932.

Delivers the **type-checker-enforced** arm of the envelope-vs-`structuredContent`
dead-read fix (the by-convention arm shipped in #2921 / issue #2907). Payload
fields live only under `structuredContent`; `createStructuredToolResponse` hoists
only `success`/`error` to the envelope top level, so a raw `response.found` read
silently yields `undefined`. Before this PR the compiler couldn't catch that: the
handler boundary erased the payload type back to `any` and `getStructuredField`
was stringly-typed (a `"founded"` typo relocated the same silent-`undefined` bug
from `.found` to `"found"`).

- **Typed payload interfaces** — `SwipeOnToolPayload` ([SwipeOnResult.ts](src/models/SwipeOnResult.ts)) and `ObserveToolPayload` ([ObserveResult.ts](src/models/ObserveResult.ts)) are the single source of truth for the two tool payloads read back internally.
- **`getStructuredField` is now fully typed** ([toolUtils.ts](src/utils/toolUtils.ts)): `<TPayload, K extends keyof TPayload & string>` over `StructuredToolResponse<TPayload>`. The `key` is constrained to `keyof TPayload` (a typo is a compile error) and the return type is `TPayload[K]` (a wrong `<T>` assertion is impossible). The own-key runtime guard is unchanged (defense-in-depth against prototype keys).
- **Producers annotated** — `swipeOnHandler` / `observeHandler` now declare `Promise<StructuredToolResponse<…Payload>>`, tying each payload type to its actual producer (drift breaks at the source).
- **Read sites migrated** — the toolRegistry scroll-position + lastHierarchy/lastScreenshot reads ([toolRegistry.ts](src/server/toolRegistry.ts)) and `DefaultUIStateSetup` scroll setup ([DefaultUIStateSetup.ts](src/features/navigation/DefaultUIStateSetup.ts)) narrow the `any` the heterogeneous registry hands back to the concrete typed envelope. `response.found` off the envelope top level is now a **compile error** at these sites.

Pure type tightening — no runtime behavior change. The shared `ToolHandler` /
`DeviceAwareToolHandler` registry map stays `Promise<any>` (it is intentionally
heterogeneous); the realized durability lives at the typed producers + typed read
sites + typed accessor, exactly the gap the three adversarial reviewers of #2921
converged on.

## Evaluation Criteria

- Reading a non-hoisted field off a tool-call envelope top level (`response.found`) is a **compile error** at the migrated read sites. Proven with a temporary probe: `result.found` → `TS2339: Property 'found' does not exist on type 'StructuredToolResponse<SwipeOnToolPayload>'`.
- `getStructuredField`'s `key`/return type are checked against the payload. Proven: `getStructuredField(result, "founded")` → `TS2345` (key not assignable to `keyof SwipeOnToolPayload`).
- No behavior change: the runtime read path (own-key read from `structuredContent`) is byte-identical; the full suite is green.

## Validation

- `bun test` (6590 pass, 2 skip, 0 fail)
- `bun run build`
- `bun run lint`
- `bun run typecheck` — no new type errors introduced. (Locally the gate reports 4 pre-existing `adm-zip`/`ajv` baseline entries as "new" because a git-worktree resolves `node_modules` to the primary clone's absolute path, which the baseline's repo-root strip can't normalize; these are untouched by this diff and normalize cleanly in CI's non-worktree checkout.)
- `git diff --check origin/main..HEAD`

## Review

- Ran `/auto-mobile-code-review` against the current diff after `git fetch origin main` and rebasing; verified behavior-equivalence of the restructured swipeOn block and that the remaining `result.found` reads elsewhere are direct domain-object reads, not envelope dead-reads.

## Follow-ups

- The `observe` payload's `screenshot` slot is read into the session cache (`setLastScreenshot`) but production `observe` never emits `screenshot`, so that write is presently dead (and `lastScreenshot` has no reader). Surfaced by the typed boundary; tracked as **#3221** rather than expanded here to keep this PR a pure no-behavior-change type tightening.
- The shared registry `ToolHandler` return type remains `Promise<any>`; a fully generic tool registry could thread the payload type end-to-end and remove the localized `any→typed` narrowing (`asToolEnvelope`) at each read site — tracked as **#3222**.
