### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Keep PRs focused: one feature or fix per PR (see .github/CONTRIBUTING.md).
+Delete sections that do not apply.
+-->
+
+## Summary
+
+<!-- What changed and why, in a short paragraph. -->
+
+## Linked Issue
+
+<!-- Reference the issue this PR addresses. Use "Closes #N" to auto-close on merge. -->
+Closes #
+
+## Bug / Regression Context
+
+<!-- Fill in for bug fixes and regressions; delete for pure features. -->
+- **Prior attempts:** <!-- e.g. an earlier PR that merged but did not fix it -->
+- **Observed symptom:** <!-- what was actually failing -->
+- **Repro steps / conditions:** <!-- the sequence that triggers it -->
+
+## Validation
+
+<!-- Almost everything in CI runs locally; see the scripts/ directory. -->
+- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
+- [ ] `bun run typecheck` reports no new errors (baseline gate)
+- [ ] Android/iOS changes: ran the matching `scripts/` validation
+- [ ] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
+- [ ] Rebased onto latest `main`, conflicts resolved
+
+## Device Verification
+
+<!-- For changes that affect on-device behavior (observe, gestures, hierarchy, tools). Delete if N/A. -->
+- [ ] Verified on a real Android device / iOS simulator via `observe`
+- [ ] Screenshots or before/after attached
+
+## Follow-ups
+
+<!-- Out-of-scope gaps kept separate to keep this PR focused. -->
+- [ ] Follow-up issues filed for gaps not addressed here: #


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md`, codifying the PR workflow this project already follows manually on nearly every change.

The sections are derived from recurring authoring patterns and aligned with `.github/CONTRIBUTING.md`:
- **Linked Issue** — PRs routinely close/reference an issue.
- **Bug / Regression Context** — mirrors how regressions are actually reported (prior attempts, observed symptom, repro conditions).
- **Validation** — the local gate: `scripts/all_fast_validate_checks.sh` + `bun run typecheck` baseline, interfaces/fakes/FakeTimer, rebase on main.
- **Device Verification** — the `observe` on-device check for behavior-affecting changes.
- **Follow-ups** — filing out-of-scope gaps as separate issues to keep PRs focused.

Each section is optional/deletable so it stays lightweight for docs and small fixes.

## Validation
- [x] Docs-only change; no code paths touched.