### PR TITLE
feat(commands): add /ship-issue issue-to-merge command with STOP-gate checkpoints

### DIFF
--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -1,0 +1,117 @@
+---
+description: Drive one GitHub issue to a merged PR via TDD, with a plan-approval gate, a pre-PR local validation gate, triaged review, and conservative follow-up capture.
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Task, WebFetch, Skill
+argument-hint: [issue number]
+---
+
+Take GitHub issue **#$ARGUMENTS** from reading to a merged PR. Do all work in the
+current isolated git worktree — never commit, push, or reset the central clone at
+`~/kaeawc/auto-mobile`. Work through the phases below in order. Two phases are
+hard **STOP** gates: do not cross them without the stated condition being met.
+
+## Phase 0 — Understand the issue
+
+1. `gh issue view $ARGUMENTS --comments` and read the full body, every comment,
+   and any linked issues/PRs.
+2. Extract the issue's **acceptance criteria** verbatim. If the issue has none,
+   write the criteria you infer and mark them as inferred — you will confirm them
+   at the plan gate.
+3. Note related prior work referenced in the issue so you reuse existing repo
+   helpers and conventions instead of reinventing them.
+
+## Phase 1 — Plan  🚦 STOP GATE (plan approval)
+
+1. Produce a plan that maps **each acceptance criterion → the change that
+   satisfies it → the test that pins it**. Every criterion must be traceable to a
+   test; if one can't be, say so.
+2. State the risk class of the change (see Phase 6). Call out anything touching DB
+   lifecycle/migrations, the runner protocol, or public tool schemas.
+3. **STOP and present the plan + acceptance criteria to the user for approval.**
+   Do not write any implementation or test code until the user approves or
+   redirects. A wrong reading of the issue caught here is free; caught after a PR
+   it is not.
+
+## Phase 2 — TDD (red first)
+
+1. Write tests that encode the approved acceptance criteria — derived from the
+   issue, not invented to match a preferred implementation.
+2. Run them and **confirm they fail for the right reason** (red). A test that
+   passes before the change is not pinning anything — fix it.
+3. Honor repo test rules: interface + fake + FakeTimer, unit tests < 100ms, never
+   resolve the real file-backed `getDatabase()` (see CLAUDE.md).
+
+## Phase 3 — Implement (green)
+
+1. Implement the minimum to make the new tests pass and satisfy the plan.
+2. Continue until every acceptance criterion's test is green and the plan is fully
+   realized. Do not expand scope beyond the issue — capture extras as follow-ups
+   (Phase 8), don't build them.
+
+## Phase 4 — Pre-PR local validation  🚦 STOP GATE (must be green)
+
+Do **not** open a PR until all of these pass locally. Fixing here is far cheaper
+than a CI round-trip.
+
+1. `turbo run lint build test` (or `bun test` for a fast full pass) — the **whole**
+   suite, to catch regressions, not just the new tests.
+2. `bun run typecheck` — the new-error gate. If you fixed type errors, run
+   `bun run typecheck:update` and commit the smaller baseline.
+3. `/validate` for any shell/Swift/Docker/schema surfaces you touched.
+4. Re-confirm each acceptance-criterion test is green.
+
+If anything here is red, fix it before proceeding. Do not open a PR on red.
+
+## Phase 5 — PR
+
+1. Verify worktree isolation before committing: `git diff --name-only main...HEAD`
+   must contain only your intended paths. Concurrent sessions share the checkout
+   and can move refs — commit/push/PR only from this worktree.
+2. Create the PR using the repo PR template if one exists
+   (`.github/PULL_REQUEST_TEMPLATE.md` or `.github/pull_request_template.md`);
+   otherwise use clear Summary / Changes / Testing / Acceptance-criteria sections.
+   Link the PR to issue #$ARGUMENTS (`Closes #$ARGUMENTS`).
+3. Do **not** enable auto-merge yet.
+
+## Phase 6 — Review (triage, not obey)
+
+1. Run `/auto-mobile-code-review` on the PR.
+2. Spawn **three review subagents as orthogonal lenses** (not personalities),
+   each given the diff and the acceptance criteria:
+   - **Regression / behavioral compatibility** — what existing behavior could this
+     break?
+   - **Test adequacy** — do the tests actually pin each acceptance criterion, and
+     do they fail without the change?
+   - **API-contract / interface surface** — tool schemas, public interfaces, and
+     the Interface+Fake seams.
+3. Read all PR review comments, inline comments, and any failing CI
+   (delegate to `/check-ci`).
+4. **Triage every finding** — do not blanket "address all." For each one:
+   reproduce/verify it against the diff and the acceptance criteria, then:
+   - **Fix** confirmed issues.
+   - **Reject** false positives / session-or-env artifacts with a one-line reason.
+   - **Defer** valid-but-out-of-scope items to a follow-up (Phase 8).
+   Do not grow scope to satisfy a suggestion — file a follow-up instead.
+
+## Phase 7 — Merge (conditional)
+
+1. Make **all** review edits and push them **first**. Only after the final commit
+   is pushed and CI is green do you touch auto-merge — enabling it earlier can
+   merge+delete the PR before your follow-up commit lands.
+2. Gate auto-merge on risk class:
+   - **Low-risk** (self-contained, well-covered, no DB/migration/runner/schema
+     surface): enable auto-merge.
+   - **Higher-risk** (DB lifecycle, migrations, runner protocol, public tool
+     schemas, or anything you flagged in Phase 1): **STOP** — summarize state and
+     hand off to the user for the merge decision.
+
+## Phase 8 — Follow-ups (conservative)
+
+1. Collect deferred items and any review feedback intentionally not addressed.
+2. For each, **search existing open issues first** (`gh issue list --search ...`);
+   only file if it isn't already tracked.
+3. File one issue per discrete unit, each linking back to this PR and issue
+   #$ARGUMENTS with enough context to be picked up cold. Prefer a single grouped
+   issue over several near-duplicates. For minor observations, a note in the PR may
+   be lighter than a new issue.
+4. End with a short summary: what merged (or awaits merge), which criteria are
+   satisfied, what was deferred and where it's tracked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,4 +125,5 @@ not visible even though they are present in the shade.
 - pr-analysis: Perform a deep read-only PR review covering code, tests, CI, and risk. Path: `skills/pr-analysis/SKILL.md`.
 - push-my-prs: Iterate over open authored PRs, address feedback, and keep them moving. Path: `skills/push-my-prs/SKILL.md`.
 - research: Conduct cited research with saved sources and synthesis summaries. Path: `skills/research/SKILL.md`.
+- ship-issue: Drive one issue to a merged PR via TDD, with a plan-approval STOP gate, a pre-PR local-validation STOP gate, triaged review, and conservative follow-up capture. Path: `skills/ship-issue/SKILL.md`.
 - auto-mobile-code-review: AutoMobile-specific code review of a PR or current diff — verify findings in code, reproduce before asserting, distinguish bugs from daemon-session/env artifacts, reuse repo helpers/conventions, and catch regressions/false-negatives. Path: `skills/auto-mobile-code-review/SKILL.md`.

--- a/skills/ship-issue/SKILL.md
+++ b/skills/ship-issue/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ship-issue
+description: "Drive one GitHub issue to a merged PR via TDD, with a plan-approval STOP gate, a pre-PR local-validation STOP gate, triaged (not blanket) review, and conservative follow-up capture. Use when asked to implement/ship/close out a specific issue end to end."
+---
+
+# Ship Issue
+
+Take a single GitHub issue from reading to a merged PR. All work stays in the
+current isolated git worktree — never commit, push, or reset the central clone.
+Two phases are hard STOP gates; do not cross them without the stated condition.
+
+## Workflow
+
+0. **Understand** — `gh issue view <n> --comments`; read the body, all comments,
+   and linked issues/PRs. Extract acceptance criteria verbatim (mark inferred
+   ones). Note prior work so you reuse repo helpers.
+1. **Plan — STOP GATE.** Map each acceptance criterion → change → the test that
+   pins it. State the risk class. Present the plan + criteria and wait for user
+   approval before writing any code.
+2. **TDD (red).** Write tests encoding the approved criteria, run them, and
+   confirm they fail for the right reason. Honor repo test rules (interface +
+   fake + FakeTimer, <100ms units, never resolve the real file-backed
+   `getDatabase()`).
+3. **Implement (green).** Minimum change to pass the tests and realize the plan;
+   no scope creep — extras become follow-ups.
+4. **Pre-PR validation — STOP GATE.** Before any PR: `turbo run lint build test`
+   (whole suite, for regressions), `bun run typecheck` (new-error gate; run
+   `typecheck:update` if you fixed errors), `validate` for touched
+   shell/Swift/Docker/schema surfaces, and re-confirm every criterion test is
+   green. Never open a PR on red.
+5. **PR.** Verify isolation with `git diff --name-only main...HEAD` (intended paths
+   only). Create the PR with the repo template if present, linking `Closes #<n>`.
+   Do not enable auto-merge yet.
+6. **Review (triage).** Run `auto-mobile-code-review`; spawn three review lenses
+   (regression, test adequacy, API/interface contract) given the diff + criteria;
+   read all PR/inline comments and failing CI (`check-ci`). Triage each finding —
+   fix confirmed, reject artifacts with a reason, defer out-of-scope. Never blanket
+   "address all"; never grow scope to satisfy a suggestion.
+7. **Merge (conditional).** Push all review edits first; only then, on green CI,
+   touch auto-merge. Auto-merge only low-risk changes; for DB/migration/runner/
+   schema surfaces, STOP and hand the merge decision to the user.
+8. **Follow-ups (conservative).** Search existing open issues before filing; one
+   issue per discrete unit, linked back to the PR and issue, enough context to act
+   cold. Prefer grouping over near-duplicates. End with a status summary.
+
+## Related skills
+
+- `check-ci` — PR CI triage and local repro.
+- `auto-mobile-code-review` — the AutoMobile-specific review pass.
+- `push-pr` — commit/push/create-PR/auto-merge mechanics.


### PR DESCRIPTION
## Summary

Adds a parameterized `/ship-issue` slash command (and matching Codex skill) that drives a single GitHub issue from reading to a merged PR via TDD. This codifies a previously ad-hoc clipboard prompt into a reviewable, version-controlled workflow, with safety checkpoints added.

## Why

The prior approach was one long headless run (plan → implement → PR → auto-merge) with no human checkpoint and unconditional instructions ("address all feedback," "automerge," "file issues"). That invites wrong-issue-reading caught only after a PR, review-bot over-fitting, scope creep, and the known auto-merge-before-second-push race. This command keeps the good bones (TDD, worktree isolation, review loop, deferred-work capture) and adds gates + triage.

## What changed

- `.claude/commands/ship-issue.md` — Claude slash command, invoked as `/ship-issue <issue-number>` (`$ARGUMENTS`).
- `skills/ship-issue/SKILL.md` — matching Codex skill (name matches dir; description quoted per validator).
- `AGENTS.md` — registers the skill under Workflow Skills.

## Checkpoints baked in

- **Plan-approval STOP gate** before any code — each acceptance criterion traced to the test that pins it.
- **Pre-PR local-validation STOP gate** — full `turbo run lint build test` + `bun run typecheck` baseline, so regressions are caught before a CI round-trip; no PR on red.
- **Triaged review** (fix / reject-with-reason / defer) instead of blanket "address all findings."
- **Three review subagents as orthogonal lenses** (regression, test adequacy, API/interface contract) instead of personalities.
- **Conditional, correctly-sequenced auto-merge** — push edits first; auto-merge low-risk only; DB/migration/runner/schema changes hand off to a human. Guards the auto-merge-before-second-push race.
- **Worktree-isolation verification** (`git diff --name-only main...HEAD`) and conservative, deduped follow-up filing.

## Testing

- `bash scripts/validate_codex_skills.sh` → passes (16 skills validated).
