### PR TITLE
[codex] Add ship-issue workflow command

### DIFF
--- a/commands/ship-issue.md
+++ b/commands/ship-issue.md
@@ -1,0 +1,168 @@
+# Ship Issue
+
+Implement an AutoMobile GitHub issue end to end with explicit checkpoints, TDD, validation, review, PR creation, CI follow-through, and conservative follow-up handling.
+
+## Instructions
+
+Use this command when the user wants to implement a GitHub issue in the AutoMobile repository and carry it through to a production-ready PR.
+
+Parse the first user-provided argument as the GitHub issue number. If no issue number is provided, ask for one before doing any work.
+
+Keep all work in the current isolated worktree. Do not modify the central clone at `~/kaeawc/auto-mobile`.
+
+## Phase 1: Issue Intake
+
+Read the issue and all relevant context before editing code:
+
+```bash
+gh issue view <issue-number> --comments
+```
+
+Also inspect linked issues, linked PRs, repo notes, design docs, and nearby code when they materially affect scope.
+
+Before implementation, report a concise plan that includes:
+
+- desired outcome from the issue
+- explicit acceptance criteria
+- inferred acceptance criteria
+- non-goals and risky ambiguities
+- likely implementation surfaces
+- TDD plan
+- validation plan
+
+Checkpoint: do not edit code until this intake summary and plan are complete.
+
+If the issue is ambiguous enough that different implementations would satisfy different user-visible outcomes, ask a focused question before changing code. Otherwise make conservative assumptions and proceed.
+
+## Phase 2: Test-First Implementation
+
+Drive the work through tests.
+
+1. Write focused failing tests for the acceptance criteria first.
+2. Prefer interfaces, fakes, and `FakeTimer` to keep unit tests fast and non-flaky.
+3. Keep tests behavior-oriented and narrow enough to identify regressions quickly.
+4. Confirm the targeted tests fail for the expected reason before implementing when practical.
+5. Implement the smallest repo-consistent change that passes the tests.
+6. Add regression tests for edge cases discovered during implementation.
+
+Use existing repo helpers and patterns before adding new abstractions. Add an abstraction only when it removes real complexity or matches an established local pattern.
+
+Checkpoint: do not call implementation complete until each acceptance criterion has a matching test or a documented reason it cannot be tested locally.
+
+## Phase 3: Generated Artifacts and Docs
+
+If the change touches MCP tools, schemas, generated definitions, docs, scripts, or platform surfaces, update the corresponding generated artifacts and documentation through the repo's existing paths.
+
+Do not hand-edit generated files when a generator exists. Regenerate them and review the diff.
+
+## Phase 4: Local Validation
+
+Validate in this order:
+
+1. Focused tests for touched behavior.
+2. `bun test --bail`
+3. `bun run build`
+4. `bun run lint`
+5. `git diff --check`
+
+For shell scripts under `scripts/`, also run the relevant BATS tests and `shellcheck`.
+
+For Android work, run tasks through `android/gradlew` from the `android/` directory. For iOS work, use the repo's existing Swift/Xcode validation path.
+
+If validation fails, reproduce with the narrowest failing command, fix it, then rerun the focused command before rerunning the broader validation set.
+
+Checkpoint: do not create or update the PR until local validation is green, or until the remaining failure is explicitly documented as unrelated and already present on the base branch.
+
+## Phase 5: Review Checkpoint
+
+After implementation and local validation pass, run `/auto-mobile-code-review` on the current diff and address all actionable findings.
+
+Then perform three focused review passes:
+
+1. Correctness, edge cases, failure modes, and user-visible regressions.
+2. Architecture, reuse of existing helpers, maintainability, and API shape.
+3. Test coverage, generated artifacts, docs, validation gaps, and false-negative risks.
+
+Treat actionable findings as incomplete work. Add tests before fixes when the finding exposes untested behavior.
+
+Checkpoint: do not move to PR creation while actionable local review findings remain open.
+
+## Phase 6: PR Creation
+
+Find and use the repo's actual PR template if one exists. Do not assume it is at `.github/PULL_REQUEST_TEMPLATE.md`.
+
+Create or update the PR with `gh` and `--body-file` so newlines are preserved. The PR body must include:
+
+- summary of the user-visible change
+- tests and validation actually run
+- issue closure reference
+- any known limitations or intentionally deferred work
+
+If no PR template exists, say so in the PR body and use a clear fallback structure.
+
+Checkpoint: after creating or updating the PR, record the PR URL and head branch before inspecting PR feedback and CI.
+
+## Phase 7: PR Feedback and CI
+
+After the PR exists, inspect all relevant PR state:
+
+- PR comments
+- inline review comments
+- unresolved review threads
+- requested changes
+- failing or pending CI checks
+
+Address only actionable feedback. Ignore outdated comments only after confirming they no longer apply to the current head.
+
+For failing CI:
+
+1. Inspect the failing job and logs.
+2. Identify the smallest likely local reproduction.
+3. Fix the failure with focused tests when applicable.
+4. Rerun focused validation, then the full validation set.
+5. Push the fix and re-check CI.
+
+## Phase 8: Automerge Gate
+
+Enable automerge only when all of these are true:
+
+- local validation is green
+- CI is green
+- required approvals are present
+- there are no unresolved actionable review threads
+- there are no known implementation gaps from the issue's acceptance criteria
+
+If any condition is not met, report the blocker and leave automerge disabled.
+
+## Phase 9: Deferred Work
+
+Before finishing, look for deferred work, TODOs, skipped review feedback, known limitations, and follow-up ideas.
+
+Do not create speculative issues. Create follow-up GitHub issues only when the work is clearly out of scope for the current PR, non-duplicative, and supported by enough context for another agent to pick it up.
+
+Each follow-up issue should include:
+
+- what remains to be done
+- why it was deferred
+- links to the original issue and PR
+- relevant files, tests, logs, or review comments
+- concrete acceptance criteria
+
+## Final Response
+
+Summarize:
+
+- issue implemented
+- PR URL
+- validation run and result
+- review and CI status
+- automerge status or blocker
+- follow-up issues created, if any
+
+If work is incomplete, state the exact next checkpoint and blocker.
+
+## Usage
+
+```text
+/ship-issue 3089
+```


### PR DESCRIPTION
## Summary
- add a repo-local `/ship-issue` slash command for issue-driven AutoMobile implementation work
- bake in checkpoints for issue intake, TDD, validation, local review, PR creation, CI follow-through, automerge gating, and follow-up issue hygiene

## Validation
- Not run: Markdown command-only change.

## Notes
- No PR template was found in `.github/` or other conventional repository template locations, so this PR uses a fallback structure.
