### PR TITLE
refactor(server): add ToolRegistry.callInternal seam for internal tool calls (#3108)

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -4,7 +4,6 @@ import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { ToolRegistry } from "../../server/toolRegistry";
-import { markInternalToolCall } from "../../server/internalToolCall";
 import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
@@ -177,7 +176,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
       // scroll-position and #2758 lastHierarchy fixes). With `result` typed,
       // `result.found` is now a compile error and the `getStructuredField` keys
       // are checked against the payload.
-      const result = asToolEnvelope<SwipeOnToolPayload>(await swipeOnTool.handler(markInternalToolCall(swipeOnArgs)));
+      const result = asToolEnvelope<SwipeOnToolPayload>(await ToolRegistry.callInternal(swipeOnTool, swipeOnArgs));
 
       if (getStructuredField(result, "success") && getStructuredField(result, "found")) {
         logger.info(`[UI_STATE_SETUP] Successfully scrolled to target element`);
@@ -282,8 +281,9 @@ export class DefaultUIStateSetup implements UIStateSetup {
         args.elementId = element.resourceId;
       }
 
-      // Internal setup tap (#3087): no diff/strip, no baseline advance.
-      await tapTool.handler(markInternalToolCall(args));
+      // Internal setup tap (#3087) via the callInternal seam (#3108): no
+      // diff/strip, no baseline advance.
+      await ToolRegistry.callInternal(tapTool, args);
 
       // Small delay for UI to update
       await this.sleep(100);
@@ -377,13 +377,13 @@ export class DefaultUIStateSetup implements UIStateSetup {
           // swipeOn targets a scrollable child and would scroll the sheet's inner
           // list instead of dragging the sheet itself down (SwipeOn.execute). We
           // want the full-screen downward swipe (executeScreenSwipe) that a
-          // dismissal needs. Internal setup swipe (#3087): no diff/strip, no
-          // baseline advance.
-          await swipeTool.handler(markInternalToolCall({
+          // dismissal needs. Internal setup swipe (#3087) via the callInternal
+          // seam (#3108): no diff/strip, no baseline advance.
+          await ToolRegistry.callInternal(swipeTool, {
             direction: "down",
             autoTarget: false,
             platform
-          }));
+          });
           await this.sleep(200);
 
           // Verify dismissal
@@ -482,12 +482,13 @@ export class DefaultUIStateSetup implements UIStateSetup {
 
     for (const text of closeTexts) {
       try {
-        // Internal close-button tap (#3087): no diff/strip, no baseline advance.
-        await tapTool.handler(markInternalToolCall({
+        // Internal close-button tap (#3087) via the callInternal seam (#3108):
+        // no diff/strip, no baseline advance.
+        await ToolRegistry.callInternal(tapTool, {
           action: "tap",
           text,
           platform
-        }));
+        });
         logger.debug(`[UI_STATE_SETUP] Tapped close button: "${text}"`);
         return true;
       } catch (error) {

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -5,7 +5,6 @@ import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { ToolRegistry } from "../../server/toolRegistry";
-import { markInternalToolCall } from "../../server/internalToolCall";
 import {
   NavigationGraphManager,
   ToolCallInteraction,
@@ -307,18 +306,18 @@ export class NavigateTo {
    * Execute a tool call by looking up the tool in the registry.
    */
   private async executeToolCall(interaction: ToolCallInteraction): Promise<void> {
-    const tool = ToolRegistry.getTool(interaction.toolName);
-    if (!tool) {
-      throw new Error(`Tool not found: ${interaction.toolName}`);
-    }
-
     logger.info(`[NAVIGATE_TO] Replaying tool call: ${interaction.toolName}`);
 
-    // Call the tool handler with the original args, marked internal (#3087):
-    // `markInternalToolCall` returns a copy, so the stored edge `interaction.args`
-    // is never mutated. Under `--actions-diff-observe` this replay neither diffs
-    // its observation nor advances the agent-facing diff baseline.
-    await tool.handler(markInternalToolCall(interaction.args as Record<string, unknown>));
+    // Replay through the internal-call seam (#3108): it resolves the tool,
+    // marks the call internal (#3087), and invokes the handler in one step.
+    // `callInternal` copies the args before marking, so the stored edge
+    // `interaction.args` is never mutated. Under `--actions-diff-observe` this
+    // replay neither diffs its observation nor advances the agent-facing diff
+    // baseline. Throws ActionableError if the tool is not registered.
+    await ToolRegistry.callInternal(
+      interaction.toolName,
+      interaction.args as Record<string, unknown>
+    );
   }
 
   /**

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -26,7 +26,7 @@ import { formatToolResultLog } from "./toolResultLog";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
 import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
-import { INTERNAL_NO_DIFF_PARAM } from "./internalToolCall";
+import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
 import { asToolEnvelope, getStructuredField } from "../utils/toolUtils";
 
 // Re-exported for backward compatibility; the implementation now lives in
@@ -815,6 +815,37 @@ class ToolRegistryClass {
       return undefined;
     }
     return tool;
+  }
+
+  // Invoke a tool's wrapped handler on behalf of an internal caller (a
+  // PlanExecutor step or a navigation/setup replay) rather than the agent. In
+  // one call it resolves the tool, marks the args via `markInternalToolCall`,
+  // invokes `.handler()`, and returns the RAW response — callers keep their own
+  // result handling (reading `found`, discarding, racing a timeout).
+  //
+  // This is the single internal-call seam (#3108): marking the call is no longer
+  // a per-site two-step, so a new internal caller cannot forget the
+  // `__internalNoDiff` marker and silently advance the agent-facing diff baseline
+  // (the #3087 bug class). Pass a tool name to also centralize the
+  // resolve-and-null-check (`options.forPlan` selects `getToolForPlan` for tools
+  // hidden from MCP discovery but valid in plans); pass an already-resolved
+  // `RegisteredTool` for sites that must resolve it themselves first (e.g. to run
+  // `tool.schema.parse` before the call). Throws `ActionableError` when a name
+  // does not resolve; callers that degrade gracefully wrap the call in try/catch.
+  async callInternal(
+    tool: string | RegisteredTool,
+    args: Record<string, unknown>,
+    progress?: ProgressCallback,
+    signal?: AbortSignal,
+    options: { forPlan?: boolean } = {}
+  ): Promise<any> {
+    const resolved = typeof tool === "string"
+      ? (options.forPlan ? this.getToolForPlan(tool) : this.getTool(tool))
+      : tool;
+    if (!resolved) {
+      throw new ActionableError(`Tool not found: ${tool}`);
+    }
+    return resolved.handler(markInternalToolCall(args), progress, signal);
   }
 
   // Get a tool for internal plan execution. Some tools are intentionally hidden

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -8,7 +8,6 @@ import {
 } from "../../models/Plan";
 import { logger } from "../logger";
 import { ToolRegistry, type RegisteredTool } from "../../server/toolRegistry";
-import { markInternalToolCall } from "../../server/internalToolCall";
 import { ActionableError } from "../../models";
 import { isDebugModeEnabled } from "../debug";
 import {
@@ -233,16 +232,16 @@ export class DefaultPlanExecutor implements PlanExecutor {
       if (sessionUuid) {
         enhancedParams.sessionUuid = sessionUuid;
       }
-      // Internal failure-recovery observe (#3053): mark internal so it does not
-      // overwrite the agent-facing diff baseline (`observe` always resets it).
-      // This capture is for the plan's failure summary, not shown to the agent.
-      const parsedParams = markInternalToolCall(
-        observeTool.schema.parse(enhancedParams) as Record<string, unknown>
-      );
+      // Internal failure-recovery observe (#3053): the callInternal seam (#3108)
+      // marks it internal so it does not overwrite the agent-facing diff baseline
+      // (`observe` always resets it). This capture is for the plan's failure
+      // summary, not shown to the agent. Parse against the tool schema first, then
+      // pass the resolved tool to the seam so the timeout race stays local.
+      const parsedParams = observeTool.schema.parse(enhancedParams) as Record<string, unknown>;
 
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       const response = await Promise.race([
-        observeTool.handler(parsedParams, undefined, undefined),
+        ToolRegistry.callInternal(observeTool, parsedParams),
         new Promise<never>((_, reject) => {
           timeoutHandle = this.timer.setTimeout(() => {
             reject(new Error("failure observation timed out"));
@@ -369,15 +368,12 @@ export class DefaultPlanExecutor implements PlanExecutor {
         context.sessionUuid,
       );
 
-      // Parse and validate the parameters, then mark this as an internal
-      // tool-to-tool call (#3053) so finalize emits the full observation on the
-      // step envelope - never a diff or a stripped payload - regardless of
-      // `--actions-diff-observe`/`--actions-no-observe`. Marked AFTER schema.parse
-      // (which strips unknown keys) so it reaches the wrapped handler; mirrors
-      // the `__mcpSessionId` internal-param convention.
-      const parsedParams = markInternalToolCall(
-        tool.schema.parse(enhancedParams) as Record<string, unknown>
-      );
+      // Parse and validate the parameters (schema.parse strips unknown keys).
+      // The internal marker (#3053) is applied by the callInternal seam (#3108)
+      // below so finalize emits the full observation on the step envelope - never
+      // a diff or a stripped payload - regardless of
+      // `--actions-diff-observe`/`--actions-no-observe`.
+      const parsedParams = tool.schema.parse(enhancedParams) as Record<string, unknown>;
 
       if (context.deviceId) {
         ScreenshotJobTracker.cancelJob(context.deviceId);
@@ -390,7 +386,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
         logger.info(`${context.logPrefix} Calling ${step.tool} with params: ${paramsPreview}`);
       }
 
-      const response = await tool.handler(parsedParams, undefined, context.signal);
+      const response = await ToolRegistry.callInternal(tool, parsedParams, undefined, context.signal);
       throwIfAborted(context.signal);
 
       const toolResult = this.extractToolResult(response);

--- a/test/server/toolRegistry.callInternal.test.ts
+++ b/test/server/toolRegistry.callInternal.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { ProgressCallback, RegisteredTool, ToolRegistry } from "../../src/server/toolRegistry";
+import { INTERNAL_NO_DIFF_PARAM } from "../../src/server/internalToolCall";
+import { ActionableError } from "../../src/models/ActionableError";
+
+/**
+ * Unit guard for the `ToolRegistry.callInternal` seam (#3108).
+ *
+ * The seam is the single internal-caller entry point: it resolves the tool
+ * (by name via `getTool`/`getToolForPlan`, or from an already-resolved
+ * `RegisteredTool` for sites that must pre-parse), marks the args via
+ * `markInternalToolCall`, and invokes the wrapped `.handler()` in one call,
+ * returning the raw response untouched. It makes marking the internal path the
+ * path of least resistance so a new internal caller cannot forget the
+ * `__internalNoDiff` marker and pollute the agent-facing diff baseline (the
+ * #3087 bug class).
+ */
+describe("ToolRegistry.callInternal (#3108)", () => {
+  const schema = z.object({
+    text: z.string().optional(),
+    platform: z.string().optional(),
+  });
+
+  interface Capture {
+    args: Record<string, unknown>;
+    progress?: ProgressCallback;
+    signal?: AbortSignal;
+  }
+
+  const SENTINEL = { unique: Symbol("raw-response") };
+  let captured: Capture[];
+
+  function registerCapturingTool(name: string, options?: { debugOnly?: boolean }): void {
+    captured = [];
+    ToolRegistry.register(
+      name,
+      `Mock ${name}`,
+      schema,
+      async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
+        captured.push({ args, progress, signal });
+        return SENTINEL;
+      },
+      options
+    );
+  }
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    captured = [];
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  test("AC1: marks args and returns the raw handler response untransformed", async () => {
+    registerCapturingTool("tapOn");
+    const tool = ToolRegistry.getTool("tapOn")!;
+
+    const response = await ToolRegistry.callInternal(tool, { text: "Go" });
+
+    // Raw response passes through by identity — no diff/strip/finalize wrapping.
+    expect(response).toBe(SENTINEL);
+    // The marker reached the handler.
+    expect(captured).toHaveLength(1);
+    expect(captured[0].args[INTERNAL_NO_DIFF_PARAM]).toBe(true);
+    expect(captured[0].args.text).toBe("Go");
+  });
+
+  test("AC1: does not mutate the caller's args object", async () => {
+    registerCapturingTool("tapOn");
+    const tool = ToolRegistry.getTool("tapOn")!;
+    const original: Record<string, unknown> = { text: "Go" };
+
+    await ToolRegistry.callInternal(tool, original);
+
+    expect(original[INTERNAL_NO_DIFF_PARAM]).toBeUndefined();
+    expect(captured[0].args).not.toBe(original);
+  });
+
+  test("AC1: forwards progress and signal to the handler", async () => {
+    registerCapturingTool("tapOn");
+    const tool = ToolRegistry.getTool("tapOn")!;
+    const progress: ProgressCallback = async () => {};
+    const controller = new AbortController();
+
+    await ToolRegistry.callInternal(tool, { text: "Go" }, progress, controller.signal);
+
+    expect(captured[0].progress).toBe(progress);
+    expect(captured[0].signal).toBe(controller.signal);
+  });
+
+  test("AC2: resolves a tool by name via getTool (string form)", async () => {
+    registerCapturingTool("tapOn");
+
+    const response = await ToolRegistry.callInternal("tapOn", { text: "Go" });
+
+    expect(response).toBe(SENTINEL);
+    expect(captured[0].args[INTERNAL_NO_DIFF_PARAM]).toBe(true);
+  });
+
+  test("AC2: forPlan resolves a plan-executable tool that getTool hides", async () => {
+    // A gated (debugOnly) but planExecutable tool: getTool hides it, getToolForPlan
+    // returns it. Only the `forPlan` resolution should reach it.
+    registerCapturingTool("hiddenStep", { debugOnly: true });
+    ((ToolRegistry as any).tools.get("hiddenStep") as RegisteredTool).planExecutable = true;
+
+    // Sanity: getTool hides it, so the default (non-forPlan) resolution must fail.
+    expect(ToolRegistry.getTool("hiddenStep")).toBeUndefined();
+    await expect(ToolRegistry.callInternal("hiddenStep", { text: "Go" })).rejects.toThrow(
+      /Tool not found/
+    );
+
+    // forPlan resolves it via getToolForPlan.
+    const response = await ToolRegistry.callInternal(
+      "hiddenStep",
+      { text: "Go" },
+      undefined,
+      undefined,
+      { forPlan: true }
+    );
+    expect(response).toBe(SENTINEL);
+    expect(captured[0].args[INTERNAL_NO_DIFF_PARAM]).toBe(true);
+  });
+
+  test("AC3: throws ActionableError when the tool name is unresolved", async () => {
+    await expect(ToolRegistry.callInternal("nonexistent", {})).rejects.toBeInstanceOf(ActionableError);
+    await expect(ToolRegistry.callInternal("nonexistent", {})).rejects.toThrow(/Tool not found: nonexistent/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ToolRegistry.callInternal(tool, args, progress?, signal?, { forPlan? })` as the single internal-caller entry point for tool-to-tool calls. In one step it resolves the tool (by name via `getTool`/`getToolForPlan`, or from an already-resolved `RegisteredTool`), marks the args via `markInternalToolCall`, invokes the wrapped `.handler()`, and returns the **raw** response — callers keep their own result handling.

This removes the residual mark-then-call footgun surfaced in PR #3096's architecture review: a **new** internal caller could still forget the `markInternalToolCall` wrap and silently advance the agent-facing diff baseline (the #3087 bug class). The seam makes the marked internal path the path of least resistance.

## Linked Issue

Closes #3108

## Changes

- **New seam** `ToolRegistry.callInternal` in `src/server/toolRegistry.ts`. The `string | RegisteredTool` overload handles the heterogeneous sites the issue's caveat calls out: pass a **name** to also centralize the resolve-and-null-check (`forPlan` selects `getToolForPlan` for tools hidden from MCP discovery but valid in plans); pass an **already-resolved tool** for sites that must resolve it themselves first (e.g. to run `tool.schema.parse` before the call). Throws `ActionableError` when a name does not resolve.
- **Migrated all 7 live internal sites** to the seam, preserving each caller's own resolution / null-check / result handling:
  - `NavigateTo.executeToolCall` (string form)
  - `DefaultUIStateSetup`: `setupScrollPosition` (reads `found`), `tapOnElement`, bottomsheet swipe (has a fallback branch), `tapCloseButton` (tool form)
  - `PlanExecutor`: `captureFailureObservation` (races handler against a 3s timeout), `executeStep` (pre-parses against `tool.schema`, passes `signal`)
- `markInternalToolCall` now lives only inside the seam; its import is dropped from all three migrated files.

## Validation

- [x] `bun test` — full suite green (6651 pass, 2 skip, 0 fail)
- [x] `bun run typecheck` reports no new errors from this change (the 4 flagged errors are pre-existing local `node_modules` `adm-zip`/`ajv` noise in untouched files — identical with these changes stashed; resolve on CI)
- [x] New unit tests use no real DB / no timers; run in <100ms
- [x] No Android/iOS/shell/schema surfaces touched (TS only)

## Acceptance criteria (inferred — the issue is an optional ergonomics nicety)

- [x] **AC1** — single `callInternal` seam marks args + invokes `.handler()`, returning the raw response
- [x] **AC2** — resolves by name via `getTool` and `getToolForPlan` (`forPlan`)
- [x] **AC3** — throws `ActionableError` when the tool is unresolved
- [x] **AC4** — all 7 internal sites route through the seam, each keeping its own result handling
- [x] **AC5** — internal calls stay opted out of diff/baseline (marker still reaches the wrapped handler)

Pinned by new `test/server/toolRegistry.callInternal.test.ts` (AC1–AC3) plus existing regression suites that stay green (AC4/AC5): `toolRegistry.internalNoDiff`, `planExecutorInternalNoDiff`, `navigationInternalNoDiff`, `navigateToInternalNoDiffE2E`, `DefaultUIStateSetup`.

## Follow-ups

None identified.
