### PR TITLE
refactor(ios): share device launch preconditions

### DIFF
--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -29,6 +29,10 @@ interface DeviceAppManagerDependencies {
   };
 }
 
+type LaunchPreconditionResult =
+  | { ok: true }
+  | { ok: false; reason: "host-control" | "non-darwin" };
+
 const defaultDependencies: DeviceAppManagerDependencies = {
   platform: () => process.platform,
   exec: async command => {
@@ -392,11 +396,21 @@ export class DeviceAppManager implements DeviceUrlLauncher {
    * host-control bridge rather than driving a local `devicectl`. The bridge
    * exposes install/uninstall but no process-launch/URL primitives, so the
    * launch-family methods return an explicit "not supported under host control"
-   * posture instead of shelling out. Single source for the gate expression that
-   * every devicectl entry point shares.
+   * posture instead of shelling out. Single source for the host-control gate
+   * expression that devicectl entry points share.
    */
   private isHostControlMode(): boolean {
     return this.deps.hostControl.shouldUseHostControl() && this.deps.hostControl.isRunningInDocker();
+  }
+
+  private getLaunchPrecondition(): LaunchPreconditionResult {
+    if (this.isHostControlMode()) {
+      return { ok: false, reason: "host-control" };
+    }
+    if (this.deps.platform() !== "darwin") {
+      return { ok: false, reason: "non-darwin" };
+    }
+    return { ok: true };
   }
 
   /**
@@ -442,13 +456,14 @@ export class DeviceAppManager implements DeviceUrlLauncher {
    * because it carries no PID-capture/JSON-output plumbing.
    */
   async launchWithPayloadUrl(deviceUdid: string, bundleId: string, url: string): Promise<void> {
-    if (this.isHostControlMode()) {
+    const precondition = this.getLaunchPrecondition();
+    if (!precondition.ok && precondition.reason === "host-control") {
       throw new Error(
         "Opening a URL on a physical iOS device is not supported under host control: " +
         "the host-control bridge exposes no devicectl launch-with-URL primitive."
       );
     }
-    if (this.deps.platform() !== "darwin") {
+    if (!precondition.ok && precondition.reason === "non-darwin") {
       throw new Error("Opening URLs on a physical iOS device requires macOS");
     }
     const command = [
@@ -694,7 +709,8 @@ export class DeviceAppManager implements DeviceUrlLauncher {
     bundleId: string,
     options: { terminateExisting?: boolean } = {}
   ): Promise<{ success: boolean; pid?: number; error?: string }> {
-    if (this.isHostControlMode()) {
+    const precondition = this.getLaunchPrecondition();
+    if (!precondition.ok && precondition.reason === "host-control") {
       return {
         success: false,
         error: `Launching apps on a physical device is not supported under host control for ${bundleId}: ` +
@@ -702,7 +718,7 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       };
     }
 
-    if (this.deps.platform() !== "darwin") {
+    if (!precondition.ok && precondition.reason === "non-darwin") {
       return { success: false, error: "Physical device app launch requires macOS" };
     }
 

--- a/test/utils/ios-cmdline-tools/DeviceAppManagerLaunchPreconditions.drift.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManagerLaunchPreconditions.drift.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DEVICE_APP_MANAGER = "src/utils/ios-cmdline-tools/DeviceAppManager.ts";
+
+function readSource(): string {
+  return readFileSync(join(process.cwd(), DEVICE_APP_MANAGER), "utf8");
+}
+
+function extractMethodBody(source: string, methodName: string): string {
+  const marker = methodName === "launchApp"
+    ? "public async launchApp("
+    : `async ${methodName}(`;
+  const signatureIndex = source.indexOf(marker);
+  if (signatureIndex === -1) {
+    throw new Error(`Method ${methodName} not found in ${DEVICE_APP_MANAGER}`);
+  }
+
+  let cursor = source.indexOf("(", signatureIndex);
+  let parenDepth = 0;
+  for (; cursor < source.length; cursor++) {
+    if (source[cursor] === "(") {
+      parenDepth++;
+    } else if (source[cursor] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) {
+        cursor++;
+        break;
+      }
+    }
+  }
+
+  const bodyStartMatch = /\{\r?\n/.exec(source.slice(cursor));
+  if (!bodyStartMatch) {
+    throw new Error(`Method ${methodName} body not found in ${DEVICE_APP_MANAGER}`);
+  }
+  const openBrace = cursor + bodyStartMatch.index;
+  let braceDepth = 0;
+  for (let index = openBrace; index < source.length; index++) {
+    if (source[index] === "{") {
+      braceDepth++;
+    } else if (source[index] === "}") {
+      braceDepth--;
+      if (braceDepth === 0) {
+        return source.slice(openBrace, index + 1);
+      }
+    }
+  }
+
+  throw new Error(`Unbalanced braces scanning ${methodName}`);
+}
+
+describe("DeviceAppManager launch precondition drift guard (issue #3123)", () => {
+  const source = readSource();
+
+  test("launchApp and launchWithPayloadUrl share one launch precondition helper", () => {
+    for (const methodName of ["launchApp", "launchWithPayloadUrl"]) {
+      const body = extractMethodBody(source, methodName);
+      expect(
+        body,
+        `${methodName} must use getLaunchPrecondition so host-control and non-darwin guards cannot drift.`
+      ).toContain("this.getLaunchPrecondition()");
+    }
+  });
+
+  test("launch entry points do not duplicate host-control or platform guard reads", () => {
+    for (const methodName of ["launchApp", "launchWithPayloadUrl"]) {
+      const body = extractMethodBody(source, methodName);
+      expect(body, `${methodName} must not read the host-control gate directly.`)
+        .not.toContain("this.isHostControlMode()");
+      expect(body, `${methodName} must not read the platform gate directly.`)
+        .not.toContain("this.deps.platform()");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Shares the physical iOS launch precondition preamble between `DeviceAppManager.launchApp` and `launchWithPayloadUrl` with a small discriminated helper. Each caller still preserves its existing contract: `launchApp` returns `{ success: false, error }`, while `launchWithPayloadUrl` throws.

Adds a focused drift-guard test so future changes cannot update the host-control or non-darwin launch guard in one path without touching the other.

## Linked Issue

Closes #3123

## Bug / Regression Context

- **Prior attempts:** PR #3116 folded the open-URL primitive into `DeviceAppManager`, but kept the launch preamble duplicated because the two methods have different return contracts.
- **Observed symptom:** `launchApp` and `launchWithPayloadUrl` both guarded the same devicectl launch preconditions independently, creating a drift risk for future host-control or platform changes.
- **Repro steps / conditions:** Source-level drift risk only; behavior remains byte-identical.

## Validation

- [x] `bun test test/utils/ios-cmdline-tools/DeviceAppManagerLaunchPreconditions.drift.test.ts test/utils/ios-cmdline-tools/DeviceAppManager.test.ts test/utils/ios-cmdline-tools/DeviceAppManagerUrlLaunch.test.ts`
- [x] `bunx turbo run lint build test`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] New code uses existing dependency seams; new unit drift guard runs in under 100ms.

## Device Verification

N/A: this is a behavior-preserving TypeScript refactor covered by existing command/error tests.

## Follow-ups

None.
