### PR TITLE
refactor(doctor): fold ios.ts createExecResult clone into canonical

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -19,6 +19,7 @@ import { IOSCtrlProxyClient, IOS_RUNNER_FEATURE_COMMANDS } from "../../features/
 import { ObserveElementsBuilder } from "../../features/observe/ObserveElementsBuilder";
 import type { CtrlProxyHierarchy } from "../../features/observe/ios/types";
 import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
+import { createExecResult } from "../../utils/execResult";
 
 // Re-exported so doctor consumers (and tests) can reference the feature command
 // set without reaching into the runner client module.
@@ -344,20 +345,6 @@ export function createIosObserveRoundTripInspector(
   };
 }
 
-const createExecResult = (stdout: string, stderr: string): ExecResult => ({
-  stdout,
-  stderr,
-  toString() {
-    return this.stdout;
-  },
-  trim() {
-    return this.stdout.trim();
-  },
-  includes(searchString: string) {
-    return this.stdout.includes(searchString);
-  }
-});
-
 const createIosDoctorDependencies = (): IosDoctorDependencies => ({
   platform: () => process.platform,
   execFile: async (file, args) => {
@@ -365,9 +352,7 @@ const createIosDoctorDependencies = (): IosDoctorDependencies => ({
       timeout: DOCTOR_EXEC_TIMEOUT_MS,
       killSignal: "SIGKILL",
     });
-    const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
-    const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
-    return createExecResult(stdout, stderr);
+    return createExecResult(result.stdout, result.stderr);
   },
   fileExists: existsSync,
   readDir: async path => fs.readdir(path),

--- a/test/doctor/iosExecResultConsolidation.test.ts
+++ b/test/doctor/iosExecResultConsolidation.test.ts
@@ -19,7 +19,10 @@ describe("ios doctor createExecResult consolidation (#3200)", () => {
   });
 
   it("declares no local createExecResult factory", () => {
-    expect(source).not.toMatch(/\bconst\s+createExecResult\s*=/);
+    // Catch every local (re)declaration form, not just `const` — a `let`, `var`,
+    // or `function createExecResult` would otherwise slip the guard.
+    expect(source).not.toMatch(/\b(?:const|let|var)\s+createExecResult\s*=/);
+    expect(source).not.toMatch(/\bfunction\s+createExecResult\s*\(/);
   });
 
   it("does not re-inline Buffer→string coercion for exec stdout/stderr", () => {

--- a/test/doctor/iosExecResultConsolidation.test.ts
+++ b/test/doctor/iosExecResultConsolidation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Guard for issue #3200: src/doctor/checks/ios.ts must not re-implement the
+// canonical `createExecResult` (src/utils/execResult.ts) nor re-inline the
+// Buffer→string coercion the canonical factory now owns (as of #3197). One
+// canonical primitive per concern (CLAUDE.md).
+describe("ios doctor createExecResult consolidation (#3200)", () => {
+  const source = readFileSync(
+    join(import.meta.dir, "../../src/doctor/checks/ios.ts"),
+    "utf8"
+  );
+
+  it("imports the canonical createExecResult from utils/execResult", () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bcreateExecResult\b[^}]*\}\s*from\s*["'][^"']*utils\/execResult["']/
+    );
+  });
+
+  it("declares no local createExecResult factory", () => {
+    expect(source).not.toMatch(/\bconst\s+createExecResult\s*=/);
+  });
+
+  it("does not re-inline Buffer→string coercion for exec stdout/stderr", () => {
+    expect(source).not.toMatch(/typeof\s+result\.(stdout|stderr)\s*===\s*["']string["']/);
+  });
+});


### PR DESCRIPTION
## Summary

Folds the local `createExecResult` clone in `src/doctor/checks/ios.ts` into the
canonical `src/utils/execResult.ts::createExecResult`. The local factory was a
dead-ringer duplicate of the canonical one, and the inline `typeof … .toString()`
Buffer→string coercion at the exec seam is now redundant because the canonical
factory accepts `string | Buffer` and coerces internally (as of #3197). One
canonical primitive per concern (CLAUDE.md). Pure consolidation, no behavior
change.

## Linked Issue

Closes #3200

## Changes

- Delete the module-private `createExecResult` (was `ios.ts:347-359`) and the
  inline stdout/stderr coercion (was `ios.ts:368-369`).
- `import { createExecResult } from "../../utils/execResult"` and call it with
  the raw `result.stdout`/`result.stderr`, letting the factory coerce.
- `ExecResult` type import retained (still used by the `IosDoctorDependencies`
  interface).
- Add `test/doctor/iosExecResultConsolidation.test.ts` — a source-scan guard
  pinning that `ios.ts` imports the canonical factory and carries no local clone
  or inline coercion.

## Validation

- [x] `bun run lint` clean, `bun test` full suite green (6648 pass / 0 fail)
- [x] `bun run typecheck` reports no new errors from this diff (the 4 local
  `adm-zip`/`ajv` `node_modules` errors pre-exist identically without this
  change — verified via `git stash`)
- [x] New guard test fails red before the change (no import, local clone + inline
  coercion present) and passes green after
- [x] Existing `test/doctor/ios.test.ts` (69 tests) stays green — AC2

## Acceptance Criteria

- [x] `src/doctor/checks/ios.ts` has no local `ExecResult` factory or inline
  Buffer coercion; it uses `src/utils/execResult.ts::createExecResult`.
- [x] No behavior change: existing `doctor` iOS-check tests stay green.
