### PR TITLE
chore(db): share event retention cleanup

### DIFF
--- a/src/db/eventRetention.ts
+++ b/src/db/eventRetention.ts
@@ -1,0 +1,65 @@
+import type { Kysely } from "kysely";
+import type { Database } from "./types";
+import type { EVENT_TABLES } from "./eventTables";
+import { getDatabase } from "./database";
+import { logger } from "../utils/logger";
+
+export const RETENTION_MAX_ROWS = 10_000;
+
+// Amortize the retention scan (#2799): run the count(*) gate at most once per
+// this many inserts instead of on every insert. Worst-case overshoot is bounded
+// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
+export const CLEANUP_CHECK_INTERVAL = 256;
+
+export type EventTableName = typeof EVENT_TABLES[number];
+
+export interface EventRetentionState {
+  cleanupInProgress: boolean;
+  insertsSinceCleanup: number;
+}
+
+export async function pruneEventTableByCount(
+  db: Kysely<Database> | undefined,
+  table: EventTableName,
+  state: EventRetentionState,
+  maxRows: number = RETENTION_MAX_ROWS,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
+): Promise<void> {
+  // The counter is bumped synchronously on every call, so retention still fires
+  // deterministically every N inserts without putting a scan on the hot path.
+  if (++state.insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  state.insertsSinceCleanup = 0;
+
+  if (state.cleanupInProgress) {return;}
+  state.cleanupInProgress = true;
+  try {
+    const resolvedDb = db ?? (getDatabase() as unknown as Kysely<Database>);
+    const count = await resolvedDb
+      .selectFrom(table)
+      .select(resolvedDb.fn.countAll().as("count"))
+      .executeTakeFirstOrThrow();
+
+    if (Number(count.count) > maxRows) {
+      const cutoff = await resolvedDb
+        .selectFrom(table)
+        .select("timestamp")
+        .orderBy("timestamp", "desc")
+        .offset(maxRows)
+        .limit(1)
+        .executeTakeFirst();
+
+      if (cutoff) {
+        await resolvedDb
+          .deleteFrom(table)
+          .where("timestamp", "<", cutoff.timestamp)
+          .execute();
+      }
+    }
+  } catch (error) {
+    logger.warn(`${table} retention cleanup failed: ${error}`, error);
+  } finally {
+    state.cleanupInProgress = false;
+  }
+}

--- a/src/db/layoutEventRepository.ts
+++ b/src/db/layoutEventRepository.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
-import { logger } from "../utils/logger";
+import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
 
 export interface RecordLayoutEventInput {
   deviceId: string | null;
@@ -18,13 +18,7 @@ export interface RecordLayoutEventInput {
   screenName?: string | null;
 }
 
-const RETENTION_MAX_ROWS = 10_000;
-// Amortize the retention scan (#2799): run the count(*) gate at most once per
-// this many inserts instead of on every insert. Worst-case overshoot is bounded
-// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
-const CLEANUP_CHECK_INTERVAL = 256;
-let cleanupInProgress = false;
-let insertsSinceCleanup = 0;
+const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -89,52 +83,8 @@ export async function getLayoutEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS,
-  checkInterval: number = CLEANUP_CHECK_INTERVAL
+  maxRows?: number,
+  checkInterval?: number
 ): Promise<void> {
-  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
-  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
-  // so retention still fires deterministically every N inserts without putting a
-  // scan on the hot path each time.
-  if (++insertsSinceCleanup < checkInterval) {
-    return;
-  }
-  insertsSinceCleanup = 0;
-
-  if (cleanupInProgress) {return;}
-  cleanupInProgress = true;
-  try {
-    const d = getDb(db);
-    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
-    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
-    // offset probe, which only runs on the rare insert that pushes over the cap.
-    const count = await d
-      .selectFrom("layout_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
-
-    if (Number(count.count) > maxRows) {
-      const cutoff = await d
-        .selectFrom("layout_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(maxRows)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("layout_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
-    }
-  } catch (error) {
-    // Best-effort retention cleanup: a failure must not surface to the telemetry
-    // write path, but log so it leaves a trace (CLAUDE.md error-handling
-    // convention — no bare swallow).
-    logger.warn(`layout_events retention cleanup failed: ${error}`, error);
-  } finally {
-    cleanupInProgress = false;
-  }
+  await pruneEventTableByCount(db, "layout_events", retentionState, maxRows, checkInterval);
 }

--- a/src/db/logEventRepository.ts
+++ b/src/db/logEventRepository.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
-import { logger } from "../utils/logger";
+import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
 
 export interface RecordLogEventInput {
   deviceId: string | null;
@@ -14,13 +14,7 @@ export interface RecordLogEventInput {
   filterName: string;
 }
 
-const RETENTION_MAX_ROWS = 10_000;
-// Amortize the retention scan (#2799): run the count(*) gate at most once per
-// this many inserts instead of on every insert. Worst-case overshoot is bounded
-// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
-const CLEANUP_CHECK_INTERVAL = 256;
-let cleanupInProgress = false;
-let insertsSinceCleanup = 0;
+const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -80,52 +74,8 @@ export async function getLogEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS,
-  checkInterval: number = CLEANUP_CHECK_INTERVAL
+  maxRows?: number,
+  checkInterval?: number
 ): Promise<void> {
-  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
-  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
-  // so retention still fires deterministically every N inserts without putting a
-  // scan on the hot path each time.
-  if (++insertsSinceCleanup < checkInterval) {
-    return;
-  }
-  insertsSinceCleanup = 0;
-
-  if (cleanupInProgress) {return;}
-  cleanupInProgress = true;
-  try {
-    const d = getDb(db);
-    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
-    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
-    // offset probe, which only runs on the rare insert that pushes over the cap.
-    const count = await d
-      .selectFrom("log_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
-
-    if (Number(count.count) > maxRows) {
-      const cutoff = await d
-        .selectFrom("log_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(maxRows)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("log_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
-    }
-  } catch (error) {
-    // Best-effort retention cleanup: a failure must not surface to the telemetry
-    // write path, but log so it leaves a trace (CLAUDE.md error-handling
-    // convention — no bare swallow).
-    logger.warn(`log_events retention cleanup failed: ${error}`, error);
-  } finally {
-    cleanupInProgress = false;
-  }
+  await pruneEventTableByCount(db, "log_events", retentionState, maxRows, checkInterval);
 }

--- a/src/db/navigationEventRepository.ts
+++ b/src/db/navigationEventRepository.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
-import { logger } from "../utils/logger";
+import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
 
 export interface RecordNavigationEventInput {
   deviceId: string | null;
@@ -14,13 +14,7 @@ export interface RecordNavigationEventInput {
   metadata: Record<string, string> | null;
 }
 
-const RETENTION_MAX_ROWS = 10_000;
-// Amortize the retention scan (#2799): run the count(*) gate at most once per
-// this many inserts instead of on every insert. Worst-case overshoot is bounded
-// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
-const CLEANUP_CHECK_INTERVAL = 256;
-let cleanupInProgress = false;
-let insertsSinceCleanup = 0;
+const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -77,52 +71,8 @@ export async function getNavigationEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS,
-  checkInterval: number = CLEANUP_CHECK_INTERVAL
+  maxRows?: number,
+  checkInterval?: number
 ): Promise<void> {
-  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
-  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
-  // so retention still fires deterministically every N inserts without putting a
-  // scan on the hot path each time.
-  if (++insertsSinceCleanup < checkInterval) {
-    return;
-  }
-  insertsSinceCleanup = 0;
-
-  if (cleanupInProgress) {return;}
-  cleanupInProgress = true;
-  try {
-    const d = getDb(db);
-    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
-    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
-    // offset probe, which only runs on the rare insert that pushes over the cap.
-    const count = await d
-      .selectFrom("navigation_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
-
-    if (Number(count.count) > maxRows) {
-      const cutoff = await d
-        .selectFrom("navigation_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(maxRows)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("navigation_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
-    }
-  } catch (error) {
-    // Best-effort retention cleanup: a failure must not surface to the telemetry
-    // write path, but log so it leaves a trace (CLAUDE.md error-handling
-    // convention — no bare swallow).
-    logger.warn(`navigation_events retention cleanup failed: ${error}`, error);
-  } finally {
-    cleanupInProgress = false;
-  }
+  await pruneEventTableByCount(db, "navigation_events", retentionState, maxRows, checkInterval);
 }

--- a/src/db/networkEventRepository.ts
+++ b/src/db/networkEventRepository.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
-import { logger } from "../utils/logger";
+import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
 import { truncateBodyText } from "../utils/truncateBodyText";
 
 export interface RecordNetworkEventInput {
@@ -26,13 +26,7 @@ export interface RecordNetworkEventInput {
   contentType?: string | null;
 }
 
-const RETENTION_MAX_ROWS = 10_000;
-// Amortize the retention scan (#2799): run the count(*) gate at most once per
-// this many inserts instead of on every insert. Worst-case overshoot is bounded
-// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
-const CLEANUP_CHECK_INTERVAL = 256;
-let cleanupInProgress = false;
-let insertsSinceCleanup = 0;
+const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -174,52 +168,8 @@ export async function getNetworkEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS,
-  checkInterval: number = CLEANUP_CHECK_INTERVAL
+  maxRows?: number,
+  checkInterval?: number
 ): Promise<void> {
-  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
-  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
-  // so retention still fires deterministically every N inserts without putting a
-  // scan on the hot path each time.
-  if (++insertsSinceCleanup < checkInterval) {
-    return;
-  }
-  insertsSinceCleanup = 0;
-
-  if (cleanupInProgress) {return;}
-  cleanupInProgress = true;
-  try {
-    const d = getDb(db);
-    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
-    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
-    // offset probe, which only runs on the rare insert that pushes over the cap.
-    const count = await d
-      .selectFrom("network_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
-
-    if (Number(count.count) > maxRows) {
-      const cutoff = await d
-        .selectFrom("network_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(maxRows)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("network_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
-    }
-  } catch (error) {
-    // Best-effort retention cleanup: a failure must not surface to the telemetry
-    // write path, but log so it leaves a trace (CLAUDE.md error-handling
-    // convention — no bare swallow).
-    logger.warn(`network_events retention cleanup failed: ${error}`, error);
-  } finally {
-    cleanupInProgress = false;
-  }
+  await pruneEventTableByCount(db, "network_events", retentionState, maxRows, checkInterval);
 }

--- a/src/db/osEventRepository.ts
+++ b/src/db/osEventRepository.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
-import { logger } from "../utils/logger";
+import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
 
 export interface RecordOsEventInput {
   deviceId: string | null;
@@ -13,13 +13,7 @@ export interface RecordOsEventInput {
   details: Record<string, string> | null;
 }
 
-const RETENTION_MAX_ROWS = 10_000;
-// Amortize the retention scan (#2799): run the count(*) gate at most once per
-// this many inserts instead of on every insert. Worst-case overshoot is bounded
-// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
-const CLEANUP_CHECK_INTERVAL = 256;
-let cleanupInProgress = false;
-let insertsSinceCleanup = 0;
+const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -77,52 +71,8 @@ export async function getOsEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS,
-  checkInterval: number = CLEANUP_CHECK_INTERVAL
+  maxRows?: number,
+  checkInterval?: number
 ): Promise<void> {
-  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
-  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
-  // so retention still fires deterministically every N inserts without putting a
-  // scan on the hot path each time.
-  if (++insertsSinceCleanup < checkInterval) {
-    return;
-  }
-  insertsSinceCleanup = 0;
-
-  if (cleanupInProgress) {return;}
-  cleanupInProgress = true;
-  try {
-    const d = getDb(db);
-    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
-    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
-    // offset probe, which only runs on the rare insert that pushes over the cap.
-    const count = await d
-      .selectFrom("os_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
-
-    if (Number(count.count) > maxRows) {
-      const cutoff = await d
-        .selectFrom("os_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(maxRows)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("os_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
-    }
-  } catch (error) {
-    // Best-effort retention cleanup: a failure must not surface to the telemetry
-    // write path, but log so it leaves a trace (CLAUDE.md error-handling
-    // convention — no bare swallow).
-    logger.warn(`os_events retention cleanup failed: ${error}`, error);
-  } finally {
-    cleanupInProgress = false;
-  }
+  await pruneEventTableByCount(db, "os_events", retentionState, maxRows, checkInterval);
 }

--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
 import { getDatabase } from "./database";
+import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
 import { logger } from "../utils/logger";
 
 export interface RecordStorageEventInput {
@@ -16,13 +17,7 @@ export interface RecordStorageEventInput {
   previousValue?: string | null;
 }
 
-const RETENTION_MAX_ROWS = 10_000;
-// Amortize the retention scan (#2799): run the count(*) gate at most once per
-// this many inserts instead of on every insert. Worst-case overshoot is bounded
-// (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against the 10k cap.
-const CLEANUP_CHECK_INTERVAL = 256;
-let cleanupInProgress = false;
-let insertsSinceCleanup = 0;
+const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
   return db ?? (getDatabase() as unknown as Kysely<Database>);
@@ -120,52 +115,8 @@ export async function getStorageEvents(
 
 export async function cleanupIfNeeded(
   db?: Kysely<Database>,
-  maxRows: number = RETENTION_MAX_ROWS,
-  checkInterval: number = CLEANUP_CHECK_INTERVAL
+  maxRows?: number,
+  checkInterval?: number
 ): Promise<void> {
-  // Amortize (#2799): only scan once per checkInterval inserts. The counter is
-  // bumped synchronously on every call (recordX dispatches this fire-and-forget),
-  // so retention still fires deterministically every N inserts without putting a
-  // scan on the hot path each time.
-  if (++insertsSinceCleanup < checkInterval) {
-    return;
-  }
-  insertsSinceCleanup = 0;
-
-  if (cleanupInProgress) {return;}
-  cleanupInProgress = true;
-  try {
-    const d = getDb(db);
-    // count(*) is the cheap gate: SQLite compiles it to the page-granular Count
-    // opcode (~0.6µs on a 10k-row covering index), far cheaper than the O(cap)
-    // offset probe, which only runs on the rare insert that pushes over the cap.
-    const count = await d
-      .selectFrom("storage_events")
-      .select(d.fn.countAll().as("count"))
-      .executeTakeFirstOrThrow();
-
-    if (Number(count.count) > maxRows) {
-      const cutoff = await d
-        .selectFrom("storage_events")
-        .select("timestamp")
-        .orderBy("timestamp", "desc")
-        .offset(maxRows)
-        .limit(1)
-        .executeTakeFirst();
-
-      if (cutoff) {
-        await d
-          .deleteFrom("storage_events")
-          .where("timestamp", "<", cutoff.timestamp)
-          .execute();
-      }
-    }
-  } catch (error) {
-    // Best-effort retention cleanup: a failure must not surface to the telemetry
-    // write path, but log so it leaves a trace (CLAUDE.md error-handling
-    // convention — no bare swallow).
-    logger.warn(`storage_events retention cleanup failed: ${error}`, error);
-  } finally {
-    cleanupInProgress = false;
-  }
+  await pruneEventTableByCount(db, "storage_events", retentionState, maxRows, checkInterval);
 }

--- a/test/db/eventRetention.test.ts
+++ b/test/db/eventRetention.test.ts
@@ -5,18 +5,19 @@ import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import type { Database } from "../../src/db/types";
 import { runMigrations } from "../../src/db/migrator";
 import { logger } from "../../src/utils/logger";
+import { pruneEventTableByCount, type EventRetentionState, type EventTableName } from "../../src/db/eventRetention";
 import { recordNetworkEvent, cleanupIfNeeded as cleanupNetwork } from "../../src/db/networkEventRepository";
 import { recordLogEvent, cleanupIfNeeded as cleanupLog } from "../../src/db/logEventRepository";
-import { recordOsEvent, cleanupIfNeeded as cleanupOs } from "../../src/db/osEventRepository";
-import { recordNavigationEvent, cleanupIfNeeded as cleanupNavigation } from "../../src/db/navigationEventRepository";
-import { recordLayoutEvent, cleanupIfNeeded as cleanupLayout } from "../../src/db/layoutEventRepository";
-import { recordStorageEvent, cleanupIfNeeded as cleanupStorage } from "../../src/db/storageEventRepository";
+import { recordOsEvent } from "../../src/db/osEventRepository";
+import { recordNavigationEvent } from "../../src/db/navigationEventRepository";
+import { recordLayoutEvent } from "../../src/db/layoutEventRepository";
+import { recordStorageEvent } from "../../src/db/storageEventRepository";
 
 /**
  * Retention behavior for the six telemetry event repositories (#2799).
  *
- * The retention scan is now *amortized*: `cleanupIfNeeded` runs the `count(*)`
- * gate at most once per `checkInterval` inserts instead of on every insert
+ * The retention scan is now *amortized*: `pruneEventTableByCount` runs the
+ * `count(*)` gate at most once per `checkInterval` inserts instead of on every insert
  * (issue Option A). These tests lock in:
  *   1. amortization — the `count(*)` gate runs at most once per interval; the
  *      other N-1 calls are synchronous no-ops that touch neither the DB nor the
@@ -24,9 +25,8 @@ import { recordStorageEvent, cleanupIfNeeded as cleanupStorage } from "../../src
  *   2. retention still trims to the cap and prunes the same rows (output-preserving),
  *   3. a cleanup failure is logged, not silently swallowed (CLAUDE.md convention).
  *
- * `maxRows` and `checkInterval` are injectable via
- * `cleanupIfNeeded(db, maxRows, checkInterval)`, so behavior is verified at a low
- * cap / interval in <100ms without inserting 10k real rows or 256 to force a scan.
+ * `maxRows` and `checkInterval` are injectable, so behavior is verified at a low
+ * cap / interval without inserting 10k real rows or 256 to force a scan.
  * `checkInterval: 1` fires the scan on every call regardless of the module
  * counter's residual value, so behavior tests are deterministic and self-normalizing.
  */
@@ -49,15 +49,14 @@ async function createInstrumentedTestDatabase(): Promise<{ db: Kysely<Database>;
 
 interface RepoUnderTest {
   name: string;
-  table: string;
+  table: EventTableName;
   record: (input: any, db?: Kysely<Database>) => Promise<unknown>;
-  cleanup: (db?: Kysely<Database>, maxRows?: number, checkInterval?: number) => Promise<void>;
   make: (timestamp: number) => any;
 }
 
 const REPOS: RepoUnderTest[] = [
   {
-    name: "network", table: "network_events", record: recordNetworkEvent, cleanup: cleanupNetwork,
+    name: "network", table: "network_events", record: recordNetworkEvent,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       url: "https://x/y", method: "GET", statusCode: 200, durationMs: 1,
@@ -65,28 +64,28 @@ const REPOS: RepoUnderTest[] = [
     }),
   },
   {
-    name: "log", table: "log_events", record: recordLogEvent, cleanup: cleanupLog,
+    name: "log", table: "log_events", record: recordLogEvent,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       level: 3, tag: "T", message: "m", filterName: "f",
     }),
   },
   {
-    name: "os", table: "os_events", record: recordOsEvent, cleanup: cleanupOs,
+    name: "os", table: "os_events", record: recordOsEvent,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       category: "lifecycle", kind: "resume", details: null,
     }),
   },
   {
-    name: "navigation", table: "navigation_events", record: recordNavigationEvent, cleanup: cleanupNavigation,
+    name: "navigation", table: "navigation_events", record: recordNavigationEvent,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       destination: "Home", source: null, arguments: null, metadata: null,
     }),
   },
   {
-    name: "layout", table: "layout_events", record: recordLayoutEvent, cleanup: cleanupLayout,
+    name: "layout", table: "layout_events", record: recordLayoutEvent,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       subType: "recomposition", composableName: null, composableId: null,
@@ -94,7 +93,7 @@ const REPOS: RepoUnderTest[] = [
     }),
   },
   {
-    name: "storage", table: "storage_events", record: recordStorageEvent, cleanup: cleanupStorage,
+    name: "storage", table: "storage_events", record: recordStorageEvent,
     make: ts => ({
       deviceId: "d1", timestamp: ts, applicationId: null, sessionId: null,
       fileName: "prefs.xml", key: "k", value: "v", valueType: "string", changeType: "update",
@@ -105,25 +104,65 @@ const REPOS: RepoUnderTest[] = [
 const countOccurrences = (sqls: string[], needle: string): number =>
   sqls.filter(s => s.toLowerCase().includes(needle)).length;
 
+function createRetentionState(): EventRetentionState {
+  return { cleanupInProgress: false, insertsSinceCleanup: 0 };
+}
+
+async function cleanupRepo(
+  repo: RepoUnderTest,
+  db: Kysely<Database>,
+  state: EventRetentionState,
+  maxRows: number,
+  checkInterval: number
+): Promise<void> {
+  await pruneEventTableByCount(db, repo.table, state, maxRows, checkInterval);
+}
+
 describe("event repository retention (#2799)", () => {
+  test("repository cleanup wrappers keep independent state and target their own table", async () => {
+    const { db, sqls } = await createInstrumentedTestDatabase();
+    try {
+      const interval = 2;
+      await cleanupNetwork(db, 1000, 1);
+      await cleanupLog(db, 1000, 1);
+      sqls.length = 0;
+
+      await cleanupNetwork(db, 1000, interval);
+      await cleanupLog(db, 1000, interval);
+      expect(sqls).toHaveLength(0);
+
+      await cleanupNetwork(db, 1000, interval);
+      expect(countOccurrences(sqls, "from \"network_events\"")).toBe(1);
+      expect(countOccurrences(sqls, "from \"log_events\"")).toBe(0);
+
+      sqls.length = 0;
+      await cleanupLog(db, 1000, interval);
+      expect(countOccurrences(sqls, "from \"network_events\"")).toBe(0);
+      expect(countOccurrences(sqls, "from \"log_events\"")).toBe(1);
+    } finally {
+      await db.destroy();
+    }
+  });
+
   for (const repo of REPOS) {
     describe(repo.name, () => {
       test("amortizes: count(*) gate runs at most once per checkInterval", async () => {
         const { db, sqls } = await createInstrumentedTestDatabase();
         try {
           const interval = 5;
+          const state = createRetentionState();
           // Drain any residual counter to a known state; this fires one scan.
-          await repo.cleanup(db, 1000, 1);
+          await cleanupRepo(repo, db, state, 1000, 1);
           sqls.length = 0;
 
           // The first interval-1 calls must be pure no-ops: no DB query at all.
           for (let i = 0; i < interval - 1; i++) {
-            await repo.cleanup(db, 1000, interval);
+            await cleanupRepo(repo, db, state, 1000, interval);
           }
           expect(sqls).toHaveLength(0);
 
           // The interval-th call fires exactly one count(*) gate.
-          await repo.cleanup(db, 1000, interval);
+          await cleanupRepo(repo, db, state, 1000, interval);
           expect(countOccurrences(sqls, "count(")).toBe(1);
         } finally {
           await db.destroy();
@@ -138,7 +177,7 @@ describe("event repository retention (#2799)", () => {
             await repo.record(repo.make(ts), db);
           }
           // checkInterval: 1 forces the scan to run now, regardless of the counter.
-          await repo.cleanup(db, cap, 1);
+          await cleanupRepo(repo, db, createRetentionState(), cap, 1);
 
           const rows = await db
             .selectFrom(repo.table as any)
@@ -160,7 +199,7 @@ describe("event repository retention (#2799)", () => {
           for (let ts = 1; ts <= 3; ts++) {
             await repo.record(repo.make(ts), db);
           }
-          await repo.cleanup(db, 10, 1);
+          await cleanupRepo(repo, db, createRetentionState(), 10, 1);
 
           const rows = await db.selectFrom(repo.table as any).select("timestamp").execute();
           expect(rows).toHaveLength(3);
@@ -175,7 +214,7 @@ describe("event repository retention (#2799)", () => {
         try {
           await db.destroy(); // force every subsequent query to throw
           // checkInterval: 1 so the scan actually runs (and then throws).
-          await expect(repo.cleanup(db, 3, 1)).resolves.toBeUndefined(); // never propagates
+          await expect(cleanupRepo(repo, db, createRetentionState(), 3, 1)).resolves.toBeUndefined(); // never propagates
           expect(warnSpy).toHaveBeenCalled();
           const logged = warnSpy.mock.calls.map(c => String(c[0])).join("\n");
           expect(logged).toContain(repo.table);


### PR DESCRIPTION
## Summary

Extracts the duplicated telemetry event retention cleanup into one shared helper. The six event repositories now keep only their per-table retention state and delegate count-based pruning to `pruneEventTableByCount`, so the retention policy has one implementation while preserving the existing repository call shape.

## Linked Issue

Closes #3136

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalent covered by `bun run lint` + `bun test --bail`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A
- [x] New code uses existing fast unit-test style; no timers added
- [ ] Rebased onto latest `main`, conflicts resolved

Additional validation run:

- [x] `bun test test/db/eventRetention.test.ts`
- [x] `bun run build`
- [x] `bun run turbo:validate`
- [x] `git diff --check`

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
