### PR TITLE
feat(server): thread StructuredToolResponse<TPayload> through the tool registry (#3222)

### DIFF
--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -8,8 +8,7 @@ import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
 import { RealObserveScreen } from "../observe/ObserveScreen";
-import { asToolEnvelope, getStructuredField } from "../../utils/toolUtils";
-import { SwipeOnToolPayload } from "../../models";
+import { getStructuredField } from "../../utils/toolUtils";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
 import { defaultTimer, Timer } from "../../utils/SystemTimer";
 
@@ -124,7 +123,8 @@ export class DefaultUIStateSetup implements UIStateSetup {
     );
 
     try {
-      // Get the swipeOn tool from the registry
+      // Resolve swipeOn first so a missing tool degrades gracefully (return null)
+      // rather than throwing out of the `callInternalTyped` seam below.
       const swipeOnTool = ToolRegistry.getTool("swipeOn");
       if (!swipeOnTool) {
         logger.warn(`[UI_STATE_SETUP] swipeOn tool not found, skipping scroll setup`);
@@ -161,22 +161,23 @@ export class DefaultUIStateSetup implements UIStateSetup {
         swipeOnArgs.speed = scrollPosition.speed;
       }
 
-      // Execute swipeOn with lookFor. Marked internal (#3087) so that under
-      // `--actions-diff-observe` this setup scroll neither diffs its observation
-      // nor advances the agent-facing diff baseline — the `found` read below still
-      // sees the full (unstripped) result.
-      // Typed envelope (issue #2932): `swipeOnTool.handler` is declared
-      // `Promise<any>` at the registry boundary, so narrow to the concrete
-      // `SwipeOnToolPayload` envelope via `asToolEnvelope` (it names the
-      // unchecked `any`→typed crossing). `found` lives under `structuredContent`
+      // Execute swipeOn with lookFor via the internal-call seam (#3108), which
+      // marks the call internal (#3087) so that under `--actions-diff-observe`
+      // this setup scroll neither diffs its observation nor advances the
+      // agent-facing diff baseline — the `found` read below still sees the full
+      // (unstripped) result.
+      // Typed envelope (issues #2932 / #3222): `callInternalTyped` threads the
+      // concrete `SwipeOnToolPayload` type through the registry seam and validates
+      // the shape at runtime, so `result` is `StructuredToolResponse<…> | undefined`
+      // with no unchecked cast. `found` lives under `structuredContent`
       // (createStructuredToolResponse hoists only `success`/`error`); a raw
-      // `result?.found` off the envelope was always undefined, leaving this
-      // success branch dead so setup logged the "could not find" warning even on
-      // a successful scroll (issue #2897; same class as the toolRegistry
+      // `result?.found` off the envelope was always undefined, leaving this success
+      // branch dead so setup logged the "could not find" warning even on a
+      // successful scroll (issue #2897; same class as the toolRegistry
       // scroll-position and #2758 lastHierarchy fixes). With `result` typed,
-      // `result.found` is now a compile error and the `getStructuredField` keys
-      // are checked against the payload.
-      const result = asToolEnvelope<SwipeOnToolPayload>(await ToolRegistry.callInternal(swipeOnTool, swipeOnArgs));
+      // `result.found` is a compile error and the `getStructuredField` keys are
+      // checked against the payload.
+      const result = await ToolRegistry.callInternalTyped("swipeOn", swipeOnArgs);
 
       if (getStructuredField(result, "success") && getStructuredField(result, "found")) {
         logger.info(`[UI_STATE_SETUP] Successfully scrolled to target element`);

--- a/src/server/internalToolPayloads.ts
+++ b/src/server/internalToolPayloads.ts
@@ -1,0 +1,58 @@
+import { ObserveToolPayload, SwipeOnToolPayload } from "../models";
+import { StructuredToolResponse } from "../utils/toolUtils";
+
+/**
+ * Single source of truth mapping each internally-consumed tool name to its
+ * concrete `structuredContent` payload type (issue #3222, follow-up to #2932 /
+ * PR #3217).
+ *
+ * The registry stores every handler as `Promise<any>`; a fully generic registry
+ * that threads a payload generic through all ~130 register sites is explicitly
+ * out of scope. This map is the sanctioned smaller step: for the handful of
+ * tools whose envelope is read *internally* (not just returned to the MCP
+ * client), it lets `ToolRegistry.callInternalTyped(name, …)` resolve to the
+ * concrete-payload envelope and lets `narrowInternalToolEnvelope` name the one
+ * `any`→typed crossing at the in-flight pipeline read sites — so both replace
+ * the earlier unchecked envelope cast.
+ *
+ * Keep each payload a *closed* type (no string index signature): `getStructuredField`
+ * relies on `keyof TPayload` staying narrow to catch field typos at compile time.
+ */
+export interface InternalToolPayloads {
+  swipeOn: SwipeOnToolPayload;
+  observe: ObserveToolPayload;
+}
+
+/** A tool name whose envelope is read internally and mapped to a payload type. */
+export type InternalToolName = keyof InternalToolPayloads;
+
+/**
+ * Runtime-validated narrowing of an in-flight pipeline response to the concrete
+ * envelope for tool `name` (issue #3222). It backs both internal read paths:
+ * the `DefaultAfterToolCallHandler` sites (which read the heterogeneous pipeline
+ * result `any` directly, where no typed lookup is available) and
+ * `ToolRegistry.callInternalTyped` (which narrows the `callInternal` result).
+ * End-to-end typing without any runtime check would require the full generic
+ * registry that is out of scope.
+ *
+ * Unlike the old identity cast, this validates the shape: a null/undefined,
+ * non-object, or `structuredContent`-less value returns `undefined` rather than
+ * a mistyped envelope. That preserves the read sites' existing behavior —
+ * `getStructuredField` already yields `undefined` for those cases — while giving
+ * the `any`→typed crossing a single checked home. The `name` argument selects
+ * the payload type via {@link InternalToolPayloads}; it is intentionally unused
+ * at runtime (the payloads share the envelope shape).
+ */
+export const narrowInternalToolEnvelope = <K extends InternalToolName>(
+  _name: K,
+  response: unknown
+): StructuredToolResponse<InternalToolPayloads[K]> | undefined => {
+  if (!response || typeof response !== "object") {
+    return undefined;
+  }
+  const structuredContent = (response as { structuredContent?: unknown }).structuredContent;
+  if (!structuredContent || typeof structuredContent !== "object") {
+    return undefined;
+  }
+  return response as StructuredToolResponse<InternalToolPayloads[K]>;
+};

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toJSONSchema } from "zod";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
-import { ActionableError, BootedDevice, ObserveToolPayload, SomePlatform, SwipeOnToolPayload } from "../models";
+import { ActionableError, BootedDevice, SomePlatform } from "../models";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { UIStateExtractor } from "../features/navigation/UIStateExtractor";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
@@ -27,7 +27,12 @@ import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
 import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
-import { asToolEnvelope, getStructuredField } from "../utils/toolUtils";
+import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
+import {
+  InternalToolName,
+  InternalToolPayloads,
+  narrowInternalToolEnvelope,
+} from "./internalToolPayloads";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -554,14 +559,17 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
       getMcpRecorder()?.record(name, args);
     }
 
-    // Typed envelope views (issue #2932): the heterogeneous pipeline hands back
-    // `any`, so narrow to the concrete tool payload via `asToolEnvelope` before
-    // reading (it names the unchecked `any`→typed crossing). Reading a
-    // non-hoisted field off the envelope top level (`swipeEnvelope.found`) is now
-    // a compile error, and `getStructuredField`'s key is checked against the
+    // Typed envelope views (issues #2932 / #3222): the heterogeneous pipeline
+    // hands back `any`, so narrow to the concrete tool payload via
+    // `narrowInternalToolEnvelope` before reading. Unlike a raw unchecked cast,
+    // this validates the envelope shape at runtime (a bad shape
+    // yields `undefined`, matching `getStructuredField`'s existing behavior) and
+    // keys the payload type off the tool name via `InternalToolPayloads`. Reading
+    // a non-hoisted field off the envelope top level (`swipeEnvelope.found`) is a
+    // compile error, and `getStructuredField`'s key is checked against the
     // payload — the stringly-typed dead-read footgun is gone.
     if (name === "swipeOn" && args.lookFor) {
-      const swipeEnvelope = asToolEnvelope<SwipeOnToolPayload>(response);
+      const swipeEnvelope = narrowInternalToolEnvelope("swipeOn", response);
       if (getStructuredField(swipeEnvelope, "success") && getStructuredField(swipeEnvelope, "found")) {
         const scrollPosition = UIStateExtractor.createScrollPosition(args);
         if (scrollPosition) {
@@ -575,7 +583,7 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
 
     if (shouldResolveDevice && sessionUuid && DaemonState.getInstance().isInitialized()) {
       const sessionManager = DaemonState.getInstance().getSessionManager();
-      const observeEnvelope = asToolEnvelope<ObserveToolPayload>(response);
+      const observeEnvelope = narrowInternalToolEnvelope("observe", response);
       const observeHierarchy = name === "observe" ? getStructuredField(observeEnvelope, "viewHierarchy") : undefined;
       if (observeHierarchy) {
         sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);
@@ -848,6 +856,29 @@ class ToolRegistryClass {
     return resolved.handler(markInternalToolCall(args), progress, signal);
   }
 
+  // Typed variant of `callInternal` for the handful of internally-consumed tools
+  // whose envelope a caller then reads (issue #3222). Threads the concrete
+  // payload type from `InternalToolPayloads` through the registry seam so
+  // `callInternalTyped("swipeOn", …)` resolves to
+  // `StructuredToolResponse<SwipeOnToolPayload> | undefined` instead of the
+  // untyped `Promise<any>` — reading a non-hoisted field off the envelope top
+  // level is a compile error and `getStructuredField` keys are checked against
+  // the payload. It delegates to `callInternal` (so the #3108 `markInternalToolCall`
+  // guarantee is preserved) and validates the shape at runtime via
+  // `narrowInternalToolEnvelope` — there is NO unchecked `any`→typed cast. A
+  // response that is not envelope-shaped narrows to `undefined`, which the read
+  // sites already handle (`getStructuredField(undefined, …)` is `undefined`).
+  async callInternalTyped<K extends InternalToolName>(
+    name: K,
+    args: Record<string, unknown>,
+    progress?: ProgressCallback,
+    signal?: AbortSignal,
+    options: { forPlan?: boolean } = {}
+  ): Promise<StructuredToolResponse<InternalToolPayloads[K]> | undefined> {
+    const response = await this.callInternal(name, args, progress, signal, options);
+    return narrowInternalToolEnvelope(name, response);
+  }
+
   // Get a tool for internal plan execution. Some tools are intentionally hidden
   // from MCP navigation surfaces but remain valid in recorded/replayed plans.
   getToolForPlan(name: string): RegisteredTool | undefined {
@@ -1043,3 +1074,30 @@ class ToolRegistryClass {
 
 // Export a singleton instance
 export const ToolRegistry = new ToolRegistryClass();
+
+// --- Compile-time enforcement of AC1 (issue #3222) ---
+// AC1 is a *type* guarantee: `callInternalTyped(name, …)` must thread the concrete
+// payload type from `InternalToolPayloads` through the registry seam rather than
+// collapse back to the untyped `Promise<any>` of `callInternal`. The runtime tests
+// in `test/server/internalToolPayloads.test.ts` cannot pin this — bun's test runner
+// does not typecheck, and the `bun run typecheck` gate compiles only `src`
+// (`tsconfig.json` include), so an assertion in `test/` is never checked and would
+// pass even against an `any` regression. These type-only aliases live in `src` (and
+// beside the method they guard, to avoid a type-resolution cycle) so the gate DOES
+// fail if the seam regresses; they erase at build time (zero runtime cost).
+type _IsAny<T> = 0 extends 1 & T ? true : false;
+type _AssertTrue<T extends true> = T;
+type _ResolvedTypedEnvelope = NonNullable<Awaited<ReturnType<typeof ToolRegistry.callInternalTyped>>>;
+// The aliases are referenced only by the compiler (their constraint check IS the
+// guard); they are intentionally unused at runtime, hence the disable.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Fails to compile if the resolved envelope widens to `any` (the seam stopped
+// threading the payload type)...
+type _Ac1ResultIsNotAny = _AssertTrue<_IsAny<_ResolvedTypedEnvelope> extends true ? false : true>;
+// ...or if it is no longer the concrete `StructuredToolResponse<…Payload>` envelope.
+type _Ac1ResultIsConcreteEnvelope = _AssertTrue<
+  _ResolvedTypedEnvelope extends StructuredToolResponse<InternalToolPayloads[InternalToolName]>
+    ? true
+    : false
+>;
+/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -185,8 +185,10 @@ export const getStructuredPayload = <T = Record<string, unknown>>(
  * absent (own) field.
  *
  * Requires a fully-typed `StructuredToolResponse<TPayload>`, not a bare
- * envelope-shaped literal — narrow an `any`-boundary value through
- * {@link asToolEnvelope} first. Caveat: keep `TPayload` a *closed* type; if it
+ * envelope-shaped literal — narrow an `any`-boundary value at the registry
+ * boundary first (e.g. `ToolRegistry.getInternalTool` or
+ * `narrowInternalToolEnvelope`, issue #3222). Caveat: keep `TPayload` a *closed*
+ * type; if it
  * carries a string index signature, `keyof TPayload` widens to include `string`
  * and the typo-protection silently evaporates.
  *
@@ -206,24 +208,6 @@ export const getStructuredField = <TPayload, K extends keyof TPayload & string>(
   }
   return undefined;
 };
-
-/**
- * Names the single unchecked narrowing at the heterogeneous `ToolHandler`
- * boundary (issue #2932): the registry stores handlers as `Promise<any>`, so a
- * consumer that knows which tool it invoked asserts the concrete envelope shape
- * here. This is deliberately an UNCHECKED cast (no runtime validation) — its
- * value is that the `any`→typed crossing is explicit and greppable, and that a
- * runtime shape assertion (or the removal that a genericized registry allows)
- * has one home. Prefer this over a bare `const e: StructuredToolResponse<T> =
- * anyValue`, which reads as if the compiler had checked the shape.
- *
- * Once read through the returned typed envelope, an envelope-top-level
- * `e.found` read is a compile error and {@link getStructuredField} keys are
- * checked against `T`. Removing this cast entirely requires threading the
- * payload generic through the registry — tracked as a follow-up to #2932.
- */
-export const asToolEnvelope = <T>(response: unknown): StructuredToolResponse<T> =>
-  response as StructuredToolResponse<T>;
 
 export const throwIfAborted = (signal?: AbortSignal): void => {
   if (signal?.aborted) {

--- a/test/server/internalToolPayloads.test.ts
+++ b/test/server/internalToolPayloads.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import {
+  InternalToolPayloads,
+  narrowInternalToolEnvelope,
+} from "../../src/server/internalToolPayloads";
+import {
+  createStructuredToolResponse,
+  getStructuredField,
+  StructuredToolResponse,
+} from "../../src/utils/toolUtils";
+import { ObserveToolPayload, SwipeOnToolPayload } from "../../src/models";
+import { INTERNAL_NO_DIFF_PARAM } from "../../src/server/internalToolCall";
+
+/**
+ * Issue #3222 (follow-up to #2932 / PR #3217): thread the concrete payload type
+ * through the tool-registry boundary for the internally-consumed tools
+ * (`swipeOn`, `observe`) so the envelope-vs-`structuredContent` guarantee is
+ * enforced by a typed boundary, not by a local `asToolEnvelope` unchecked cast.
+ *
+ * Two acceptance criteria:
+ *  - AC1: `callInternalTyped("observe")`/`callInternalTyped("swipeOn")` resolve to
+ *    the concrete `StructuredToolResponse<…Payload>` envelope (the internal-lookup
+ *    seam threads the payload type through the registry). Composes with the
+ *    `callInternal` seam (#3108) rather than duplicating it.
+ *  - AC2: the `asToolEnvelope<T>()` unchecked casts at the internal read sites are
+ *    eliminated — the in-flight-pipeline sites use a runtime-validated
+ *    `narrowInternalToolEnvelope`, `callInternalTyped` narrows the same way, and
+ *    `asToolEnvelope` is gone from `src/`.
+ */
+
+describe("narrowInternalToolEnvelope (AC2 runtime-validated narrowing)", () => {
+  test("narrows a valid swipeOn envelope so getStructuredField reads the payload", () => {
+    const response: unknown = createStructuredToolResponse<SwipeOnToolPayload>({
+      success: true,
+      found: true,
+      message: "Swiped up and found element",
+    } as SwipeOnToolPayload);
+
+    const envelope = narrowInternalToolEnvelope("swipeOn", response);
+    expect(envelope).toBe(response as StructuredToolResponse<SwipeOnToolPayload>);
+    expect(getStructuredField(envelope, "found")).toBe(true);
+    expect(getStructuredField(envelope, "success")).toBe(true);
+  });
+
+  test("narrows a valid observe envelope keyed to the observe payload type", () => {
+    const hierarchy = { hierarchy: { node: {} } };
+    const response: unknown = createStructuredToolResponse<ObserveToolPayload>({
+      viewHierarchy: hierarchy,
+    } as unknown as ObserveToolPayload);
+
+    const envelope = narrowInternalToolEnvelope("observe", response);
+    expect(getStructuredField(envelope, "viewHierarchy")).toBe(hierarchy as never);
+  });
+
+  test("returns undefined for null / undefined responses", () => {
+    expect(narrowInternalToolEnvelope("swipeOn", null)).toBeUndefined();
+    expect(narrowInternalToolEnvelope("swipeOn", undefined)).toBeUndefined();
+  });
+
+  test("returns undefined for a non-object response", () => {
+    expect(narrowInternalToolEnvelope("observe", 42)).toBeUndefined();
+    expect(narrowInternalToolEnvelope("observe", "text")).toBeUndefined();
+  });
+
+  test("returns undefined when structuredContent is missing or not an object", () => {
+    expect(narrowInternalToolEnvelope("swipeOn", { content: [] })).toBeUndefined();
+    expect(
+      narrowInternalToolEnvelope("swipeOn", { structuredContent: "not-an-object" })
+    ).toBeUndefined();
+    expect(narrowInternalToolEnvelope("swipeOn", { structuredContent: null })).toBeUndefined();
+  });
+});
+
+describe("ToolRegistry.callInternalTyped (AC1 typed seam)", () => {
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  function registerSwipeOn(found: boolean): void {
+    ToolRegistry.register(
+      "swipeOn",
+      "swipeOn",
+      {},
+      async () =>
+        createStructuredToolResponse<SwipeOnToolPayload>({
+          success: true,
+          found,
+          message: found ? "Swiped up and found element" : "Swiped up",
+        } as SwipeOnToolPayload)
+    );
+  }
+
+  test("resolves to the concrete envelope whose payload reads via getStructuredField", async () => {
+    registerSwipeOn(true);
+    // `result` is StructuredToolResponse<SwipeOnToolPayload> | undefined — no cast.
+    const result = await ToolRegistry.callInternalTyped("swipeOn", { direction: "up", lookFor: { text: "x" } });
+    expect(getStructuredField(result, "found")).toBe(true);
+    expect(getStructuredField(result, "success")).toBe(true);
+  });
+
+  test("delegates through callInternal so the args are marked internal (#3108)", async () => {
+    let seenArgs: Record<string, unknown> | undefined;
+    ToolRegistry.register(
+      "swipeOn",
+      "swipeOn",
+      {},
+      async (args: any) => {
+        seenArgs = args;
+        return createStructuredToolResponse<SwipeOnToolPayload>({
+          success: true,
+          found: true,
+          message: "ok",
+        } as SwipeOnToolPayload);
+      }
+    );
+    await ToolRegistry.callInternalTyped("swipeOn", { direction: "up" });
+    // callInternal applies markInternalToolCall → the internal-no-diff marker is present.
+    expect(seenArgs?.[INTERNAL_NO_DIFF_PARAM]).toBe(true);
+  });
+
+  test("throws when the tool is unregistered (callInternal contract)", async () => {
+    ToolRegistry.clearTools();
+    await expect(ToolRegistry.callInternalTyped("swipeOn", {})).rejects.toThrow();
+  });
+
+  test("narrows a non-envelope handler response to undefined", async () => {
+    ToolRegistry.register("swipeOn", "swipeOn", {}, async () => 42 as unknown);
+    const result = await ToolRegistry.callInternalTyped("swipeOn", { direction: "up" });
+    expect(result).toBeUndefined();
+    expect(getStructuredField(result, "found")).toBeUndefined();
+  });
+
+  /**
+   * AC1 is fundamentally a *type-level* guarantee. It is CI-pinned by the
+   * type-only `AssertTrue` guards in `src/server/internalToolPayloads.ts` — NOT
+   * by this test: the `bun run typecheck` gate compiles only `src`
+   * (`tsconfig.json` include), so a type assertion here would never be checked
+   * and would pass even against an `any` regression. This runtime block instead
+   * asserts the value flow and that the payload map is keyed by tool name.
+   */
+  test("resolved envelope is typed; map is keyed by tool name", async () => {
+    registerSwipeOn(false);
+    const typed: StructuredToolResponse<SwipeOnToolPayload> | undefined =
+      await ToolRegistry.callInternalTyped("swipeOn", { direction: "up" });
+    expect(getStructuredField(typed, "found")).toBe(false);
+
+    // The map is keyed by tool name → payload type.
+    type SwipeMapped = InternalToolPayloads["swipeOn"];
+    type ObserveMapped = InternalToolPayloads["observe"];
+    const _swipe: SwipeMapped = { success: true, found: true, message: "" } as SwipeOnToolPayload;
+    const _observe: ObserveMapped = {} as ObserveToolPayload;
+    expect(_swipe).toBeDefined();
+    expect(_observe).toBeDefined();
+  });
+});
+
+describe("asToolEnvelope is eliminated from src (AC2 source scan)", () => {
+  function collectTsFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        out.push(...collectTsFiles(full));
+      } else if (entry.name.endsWith(".ts")) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  test("no src/ file references asToolEnvelope", () => {
+    const srcDir = join(import.meta.dir, "..", "..", "src");
+    const offenders = collectTsFiles(srcDir).filter(file =>
+      readFileSync(file, "utf8").includes("asToolEnvelope")
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/utils/toolUtilsStructuredField.test.ts
+++ b/test/utils/toolUtilsStructuredField.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-  asToolEnvelope,
   createStructuredToolResponse,
   getStructuredField,
   getStructuredPayload,
@@ -101,25 +100,6 @@ describe("getStructuredField (typed)", () => {
   test("resolves an own key whose value is falsy (found: false)", () => {
     const response = createStructuredToolResponse<SamplePayload>({ success: true, found: false });
     expect(getStructuredField(response, "found")).toBe(false);
-  });
-});
-
-describe("asToolEnvelope", () => {
-  test("is an identity narrowing — returns the same reference, no runtime validation", () => {
-    // It only names the unchecked any->typed crossing at the registry boundary;
-    // it must NOT copy, wrap, or validate the value.
-    const response = createStructuredToolResponse<SamplePayload>({ success: true, found: true });
-    const narrowed = asToolEnvelope<SamplePayload>(response as unknown);
-    expect(narrowed).toBe(response);
-    expect(getStructuredField(narrowed, "found")).toBe(true);
-  });
-
-  test("passes non-envelope values straight through (unchecked)", () => {
-    // No runtime shape assertion today — a garbage value is returned as-is, and
-    // the downstream getStructuredField guard still yields undefined.
-    const garbage = asToolEnvelope<SamplePayload>(42 as unknown);
-    expect(garbage as unknown).toBe(42);
-    expect(getStructuredField(garbage, "found")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #2932 / PR #3217, **composed with the `callInternal` seam (#3108)** that
landed on main during this work. That PR typed the envelope *producers* and the *read*
helper, but the shared registry boundary was still `any`, so the internal read sites
bridged the gap with `asToolEnvelope<T>()` — an explicit **unchecked** cast never
cross-checked against the producer's annotation.

This threads the concrete payload type through the registry for the **internally-consumed**
tools (`swipeOn`, `observe`) — the sanctioned smaller step (a fully generic registry over
~130 register sites is explicitly out of scope).

## Linked Issue

Closes #3222

## Changes

- **New `src/server/internalToolPayloads.ts`** — `InternalToolPayloads` name→payload map
  (single source of truth) + `narrowInternalToolEnvelope(name, response)`, a
  **runtime-validated** narrowing (bad shape → `undefined`, matching `getStructuredField`).
- **`ToolRegistry.callInternalTyped<K>(name, args)`** — a typed variant of `callInternal`
  (#3108): it **delegates to `callInternal`** (so the `markInternalToolCall` guarantee is
  preserved) and narrows the result to `StructuredToolResponse<…Payload> | undefined`.
  **No unchecked cast anywhere.**
- **Rewired the 3 read sites** — the two `DefaultAfterToolCallHandler` sites (in-flight
  pipeline `any`) use `narrowInternalToolEnvelope`; `DefaultUIStateSetup` scroll setup uses
  `callInternalTyped`.
- **Removed the unused `asToolEnvelope` helper + its test** — the unchecked-cast footgun.
- **Type-only AC1 guard** in `toolRegistry.ts` fails the `bun run typecheck` gate if
  `callInternalTyped`'s return widens to `any` (the gate compiles only `src`, so a pin in
  `test/` would be invisible — verified the guard fires on an `any` regression).

## Acceptance criteria

- ✅ **AC1** — `callInternalTyped("observe"|"swipeOn")` resolves to the concrete
  `StructuredToolResponse<…Payload>` envelope (the internal-lookup seam threads the payload
  type through the registry). Pinned by the runtime tests + the CI-visible compile-time guard.
- ✅ **AC2** — the `asToolEnvelope<T>()` unchecked casts at the internal read sites are
  eliminated (all three now runtime-validated), enforced by a source-scan test (identifier
  gone from `src/`) plus the existing scroll-position / lastHierarchy / DefaultUIStateSetup
  suites staying green (behavior preserved).

## Validation

- [x] `bun test` — 6660 pass, 0 fail
- [x] `bun run lint` clean
- [x] `bun run typecheck` — no new errors from these files (the 4 flagged are pre-existing
  local `node_modules` adm-zip/ajv noise, absent in CI's clean install)
- [x] Rebased onto latest `main`; composes with `callInternal` (#3108) rather than duplicating it

## Follow-ups

- The full generic registry across ~130 register sites remains the #2932 core; this is the
  named-tool typed-seam first step. No new follow-up filed.
