### PR TITLE
feat(ios): physical-aware failure for getAppPermissions on physical devices

### DIFF
--- a/src/features/action/AppPermissions.ts
+++ b/src/features/action/AppPermissions.ts
@@ -317,6 +317,20 @@ export class AppPermissions {
   }
 
   private async getIosPermissions(appId: string, input: GetAppPermissionsInput): Promise<GetAppPermissionsResult> {
+    // Physical iOS devices expose no readable TCC store, so permission state
+    // cannot be queried; mirror the set path's simulator/physical split and
+    // surface a physical-aware failure instead of the simulator-only message.
+    if (!isIosSimulatorUdid(this.device.deviceId)) {
+      return {
+        success: false,
+        appId: appId.trim(),
+        deviceId: this.device.deviceId,
+        platform: "ios",
+        permissions: [],
+        error: "iOS permission state queries are not available on physical devices (no readable TCC store); use setAppPermissions with action=reset to re-arm the system prompt",
+      };
+    }
+
     const iosPermissions = new IosSimulatorPermissions(this.device, this.simctl, this.tccReader);
     const result = await iosPermissions.getPermissions(appId, normalizePermissions(input.permissions));
 

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -209,6 +209,28 @@ describe("AppPermissions", () => {
     ]);
   });
 
+  test("returns a physical-aware failure for getPermissions on a physical iOS device", async () => {
+    const tccReader: TccPermissionReader = {
+      readPermissions: async () => {
+        throw new Error("TCC reader must not be used for physical iOS devices");
+      },
+    };
+    const permissions = new AppPermissions(iosPhysical, { tccReader });
+
+    const result = await permissions.getPermissions("com.example.app", {
+      permissions: ["camera"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.platform).toBe("ios");
+    expect(result.appId).toBe("com.example.app");
+    expect(result.deviceId).toBe(iosPhysical.deviceId);
+    expect(result.permissions).toEqual([]);
+    expect(result.error).toBe(
+      "iOS permission state queries are not available on physical devices (no readable TCC store); use setAppPermissions with action=reset to re-arm the system prompt"
+    );
+  });
+
   test("rejects grant on a physical iOS device with a reset-only failure", async () => {
     const iosPhysicalClient = new RecordingPhysicalPrivacyClient();
     const permissions = new AppPermissions(iosPhysical, { iosPhysicalClient });


### PR DESCRIPTION
Closes #3135

## Summary

`getAppPermissions` on a physical iOS device previously fell through to `IosSimulatorPermissions.getPermissions`, which returned `success:false` with the misleading message "iOS permission queries are only supported on simulators". This PR adds a physical-device branch in `AppPermissions.getIosPermissions` (mirroring the `set` path's `!isIosSimulatorUdid` split from #2491/PR #3127) that returns a physical-aware structured failure:

> iOS permission state queries are not available on physical devices (no readable TCC store); use setAppPermissions with action=reset to re-arm the system prompt

Message-clarity only — no functional change. The physical path already returned a clean structured failure (no wrong TCC read); check ordering is preserved (the old flow also hit the simulator guard before the empty-appId guard for physical devices).

## Changes

- `src/features/action/AppPermissions.ts` — physical-device short-circuit in `getIosPermissions`, owned at the same layer as the set path's split
- `test/features/action/AppPermissions.test.ts` — new test pinning the physical-aware message; fake `TccPermissionReader` throws if touched

## Validation

- `bun test test/features/action/AppPermissions.test.ts test/features/action/GrantIosSimulatorPermissions.test.ts test/features/action/IosPhysicalPermissions.test.ts` — 23 pass
- `turbo run lint build test` — 6668 pass / 0 fail
- `bun run typecheck` — gate passes, no new errors (local hint about 2 vanished baseline errors is known node_modules env noise, not from this change; baseline untouched)

## Caveats

- Direct constructors of `IosSimulatorPermissions` still get its own simulator-only guard message — intentional; the issue proposed owning the physical-aware message at the `AppPermissions` layer.
- Chain follow-ups #3188 / #3134 are NOT implemented here per wave sequencing.
