### PR TITLE
refactor(gestures): protected SharedGestureDelegate.coord() so Android two-finger swipe reuses shared rounding (#3049)

### DIFF
--- a/src/features/observe/android/CtrlProxyGestures.ts
+++ b/src/features/observe/android/CtrlProxyGestures.ts
@@ -40,19 +40,19 @@ export class CtrlProxyGestures extends SharedGestureDelegate {
     timeoutMs: number = 5000,
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<A11ySwipeResult> {
-    // The two-finger path hard-rounds coordinates here (matching the delegate's roundCoordinates
-    // rounding) so TalkBack two-finger swipes land on whole pixels. Intentional and not to be
-    // regressed — the runner accepts fractional coordinates (#2927), but this path deliberately
-    // sends integers. See the constructor note.
+    // Coordinates go through the shared `coord()` policy (roundCoordinates: true for Android) so
+    // TalkBack two-finger swipes land on whole pixels, exactly like the sibling swipe/tap/drag/
+    // pinch gestures (#3049). Intentional and not to be regressed — the runner accepts fractional
+    // coordinates (#2927), but this path deliberately sends integers. See the constructor note.
     return sendCommand<A11ySwipeResult>(this.context, {
       idPrefix: "two_finger_swipe",
       responseType: "swipe",
       messageType: "request_two_finger_swipe",
       params: {
-        x1: Math.round(x1),
-        y1: Math.round(y1),
-        x2: Math.round(x2),
-        y2: Math.round(y2),
+        x1: this.coord(x1),
+        y1: this.coord(y1),
+        x2: this.coord(x2),
+        y2: this.coord(y2),
         duration,
         offset,
       },

--- a/src/features/observe/shared/SharedGestureDelegate.ts
+++ b/src/features/observe/shared/SharedGestureDelegate.ts
@@ -25,7 +25,14 @@ export class SharedGestureDelegate {
     this.config = config;
   }
 
-  private coord(v: number): number {
+  /**
+   * Applies the platform coordinate policy (Android rounds to integers, iOS passes exact values).
+   *
+   * `protected` so platform-specific gesture overrides (e.g. the Android-only two-finger swipe)
+   * reuse this single rounding source instead of re-inlining `Math.round`, making it structurally
+   * impossible for a platform override to diverge from the sibling gestures' policy (#3049).
+   */
+  protected coord(v: number): number {
     return this.config.roundCoordinates ? Math.round(v) : v;
   }
 

--- a/test/features/observe/android/CtrlProxyGestures.test.ts
+++ b/test/features/observe/android/CtrlProxyGestures.test.ts
@@ -35,11 +35,14 @@ function createFakeContext(overrides?: Partial<DelegateContext>): {
   return { context, sent, timer, requestManager };
 }
 
-/** Let the async ensureConnected chain flush so the request is registered + sent. */
+/**
+ * Let the async ensureConnected/sendCommand chain flush so the request is registered + sent.
+ * A single setImmediate hop is a settle signal for the purely microtask-based chain: the event
+ * loop drains the entire pending microtask queue (however many awaits sendCommand grows) before
+ * running the immediate callback, so this stays robust against await-count changes (#3049).
+ */
 async function flush(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+  await new Promise<void>(resolve => setImmediate(resolve));
 }
 
 describe("CtrlProxyGestures.requestTwoFingerSwipe (#2988)", () => {
@@ -112,6 +115,35 @@ describe("CtrlProxyGestures.requestTwoFingerSwipe (#2988)", () => {
     // Resolve so the promise settles (avoid a dangling pending request).
     requestManager.resolve<A11ySwipeResult>(sentMsg.requestId as string, { success: true, totalTimeMs: 1 });
     await promise;
+  });
+
+  it("rounds coordinates identically to the shared base gesture path (#3049)", async () => {
+    // The two-finger override must reuse SharedGestureDelegate.coord() — the single Android
+    // rounding source — so its wire coordinates can never diverge from the sibling gestures.
+    const { context, sent, requestManager } = createFakeContext();
+    const gestures = new CtrlProxyGestures(context);
+    const coords = [10.5, 20.49, -3.5, 40.999] as const;
+
+    const swipePromise = gestures.requestSwipe(...coords, 300, 5000);
+    await flush();
+    const swipeMsg = JSON.parse(sent[sent.length - 1]);
+
+    const twoFingerPromise = gestures.requestTwoFingerSwipe(...coords, 300, 100, 5000);
+    await flush();
+    const twoFingerMsg = JSON.parse(sent[sent.length - 1]);
+
+    expect(twoFingerMsg.type).toBe("request_two_finger_swipe");
+    expect(swipeMsg.type).toBe("request_swipe");
+    for (const key of ["x1", "y1", "x2", "y2"] as const) {
+      expect(twoFingerMsg[key]).toBe(swipeMsg[key]);
+      expect(Number.isInteger(twoFingerMsg[key])).toBe(true);
+    }
+
+    // Resolve both so no pending request dangles.
+    requestManager.resolve(swipeMsg.requestId as string, { success: true, totalTimeMs: 1 });
+    requestManager.resolve(twoFingerMsg.requestId as string, { success: true, totalTimeMs: 1 });
+    await Promise.all([swipePromise, twoFingerPromise]);
+    expect(requestManager.getPendingCount()).toBe(0);
   });
 
   it("still times out when the runner never replies", async () => {


### PR DESCRIPTION
Closes #3049

## Summary

Makes `SharedGestureDelegate.coord()` `protected` (was `private`) so platform-specific gesture overrides reuse the single coordinate-rounding-policy source, and switches the Android-only `requestTwoFingerSwipe` override from inline `Math.round(...)` to `this.coord(...)`.

- **Behavior-identical:** Android constructs the delegate with `roundCoordinates: true`, so `coord(v)` is exactly `Math.round(v)`. The two-finger path still calls `sendCommand` directly, so rounding is applied exactly once (no double-rounding).
- **Structurally impossible to diverge:** a future Android-only gesture override can now share the sibling swipe/tap/drag/pinch rounding policy instead of re-inlining it. New parity test pins that the two-finger wire coordinates round identically to `requestSwipe` and stay integers — this is now the backstop against ever regressing `roundCoordinates: true` (previously guarded only by duplicated code + comments).
- **Bundled (as the issue's "Also noted" suggests):** the test helper `flush()` in `test/features/observe/android/CtrlProxyGestures.test.ts` was a brittle fixed count of `await Promise.resolve()`; it is now a single `setImmediate` settle-signal, which drains the entire microtask chain regardless of how many awaits `sendCommand` grows.

iOS `CtrlProxyGestures.requestMultiFingerSwipe` is deliberately untouched — `coord()` is the identity there (`roundCoordinates: false`) and the issue scopes this to the Android-only override.

## Files

- `src/features/observe/shared/SharedGestureDelegate.ts` — `coord()` private -> protected + doc comment
- `src/features/observe/android/CtrlProxyGestures.ts` — override uses `this.coord()`; comment updated
- `test/features/observe/android/CtrlProxyGestures.test.ts` — new rounding-parity test; `flush()` settle-signal

## Validation

- `bun test test/features/observe/android/CtrlProxyGestures.test.ts` — 6 pass, 0 fail (~105 ms whole file, deterministic across 3 runs)
- Related suites (`SharedGestureDelegate.test.ts`, iOS `CtrlProxyGestures.test.ts`, `ctrlProxyWireParity.test.ts`, `ctrlProxyProtocol.test.ts`) — 58 pass, 0 fail
- `turbo run lint build test` — all green (6668 pass / 0 fail)
- `bun run typecheck` — no new errors. Note: the gate reports 2 pre-existing baseline errors no longer occur on main; verified via before/after `tsc` diff that they are unrelated to this change, so the baseline ratchet is left to whichever change fixed them (avoids cross-PR conflicts).

## Caveats

- No Kotlin/Swift changes; no runner re-cut needed (TS-only, wire payload unchanged).
