### PR TITLE
refactor(session): remove dead observe screenshot cache chain (#3221)

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -32,8 +32,8 @@ export interface KeepScreenAwakeRestorer {
  *
  * Every field is a typed top-level slot — the canonical source of truth for its
  * concern (issue #2917). Write each through its dedicated setter
- * (`setLastHierarchy`, `setLastScreenshot`, `setKeepScreenAwake`,
- * `setDeviceLabels`, …) so a writer/reader type drift is caught at compile time.
+ * (`setLastHierarchy`, `setKeepScreenAwake`, `setDeviceLabels`, …) so a
+ * writer/reader type drift is caught at compile time.
  *
  * There is deliberately NO `customData?: Record<string, any>` escape hatch
  * (issue #2973): it previously held well-known, fixed-type keyed state
@@ -43,8 +43,7 @@ export interface KeepScreenAwakeRestorer {
  */
 export interface SessionCacheData {
   lastHierarchy?: ViewHierarchyResult; // Last observed view hierarchy (full, untrimmed)
-  lastScreenshot?: string;     // Base64 encoded last screenshot
-  lastObserveTime?: number;    // Timestamp of last hierarchy observation (hierarchy only, not screenshot)
+  lastObserveTime?: number;    // Timestamp of last hierarchy observation
   lastRenderedObservation?: ObserveResult; // Last observation emitted to the agent (sanitized), the #2761 diff baseline
   keepScreenAwake?: KeepScreenAwakeState; // Keep-awake state applied at session setup, restored on release
   deviceLabels?: DeviceLabelMap; // Device-label → session map for multi-device (`device:`-labelled) sessions
@@ -358,14 +357,6 @@ export class SessionManager {
       lastHierarchy: hierarchy,
       lastObserveTime: this.timer.now(),
     });
-  }
-
-  /**
-   * Cache the most recent base64-encoded screenshot for a session in the typed
-   * top-level `lastScreenshot` slot (canonical source of truth per #2917).
-   */
-  setLastScreenshot(sessionId: string, screenshot: string): void {
-    this.updateSessionCache(sessionId, { lastScreenshot: screenshot });
   }
 
   /**

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -229,26 +229,19 @@ export interface ObserveResult {
 
 /**
  * The payload the `observe` tool packs into its MCP `structuredContent` envelope.
- * Equals {@link ObserveResult} (which already carries the `awaitedElement` /
- * `awaitDuration` / `awaitTimeout` wait fields the handler spreads) plus the
- * optional base64 `screenshot` slot the toolRegistry `setLastScreenshot` read
- * consumes.
+ * Equals {@link ObserveResult}, which already carries the `awaitedElement` /
+ * `awaitDuration` / `awaitTimeout` wait fields the handler spreads.
  *
- * WARNING — the `screenshot` chain is currently DEAD: production `observe` does
- * NOT emit `screenshot` (its envelope is built from an `ObserveResult`, which has
- * no such field), so `setLastScreenshot` never fires and the `lastScreenshot`
- * session slot has no reader. This field only gives the *pre-existing* dead read
- * a typed home so it compiles against a real key instead of a stringly-typed
- * guess — no behavior change. Resolving the dead chain (remove it, or make
- * `observe` actually emit a screenshot with a real consumer) is tracked in
- * **#3221**; do not assume screenshot caching works.
+ * The alias is kept (rather than using `ObserveResult` directly) to name the
+ * envelope payload at the tool boundary: it annotates the
+ * `StructuredToolResponse<ObserveToolPayload>` the handler returns and types the
+ * toolRegistry lastHierarchy read site so an envelope-top-level
+ * `response.viewHierarchy` read is a **compile error** (issue #2932;
+ * envelope-vs-`structuredContent` dead-read class, issue #2907).
  *
- * Used to annotate the `StructuredToolResponse<ObserveToolPayload>` the handler
- * returns and to type the toolRegistry lastHierarchy/lastScreenshot read sites
- * so an envelope-top-level `response.viewHierarchy` read is a **compile error**
- * (issue #2932; envelope-vs-`structuredContent` dead-read class, issue #2907).
+ * There is deliberately no `screenshot` field: production `observe` never
+ * emitted one and the session `lastScreenshot` cache slot it fed had no reader,
+ * so the dead chain was removed (issue #3221). If observe ever attaches a
+ * screenshot payload, add the field back together with a real consumer.
  */
-export interface ObserveToolPayload extends ObserveResult {
-  /** Optional base64 screenshot; the toolRegistry cache read is dead today — see #3221. */
-  screenshot?: string;
-}
+export type ObserveToolPayload = ObserveResult;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -588,10 +588,11 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
       if (observeHierarchy) {
         sessionManager.setLastHierarchy(sessionUuid, observeHierarchy);
       }
-      const observeScreenshot = name === "observe" ? getStructuredField(observeEnvelope, "screenshot") : undefined;
-      if (observeScreenshot) {
-        sessionManager.setLastScreenshot(sessionUuid, observeScreenshot);
-      }
+      // NOTE: there is deliberately no `screenshot` read here. Production
+      // `observe` never emitted a `screenshot` payload field and the session
+      // `lastScreenshot` slot had no reader, so the whole cache chain was dead
+      // and was removed (issue #3221). If observe ever attaches a screenshot,
+      // reintroduce the write together with a real consumer.
     }
 
     const baselineStore: ObservationBaselineStore | undefined =

--- a/test/daemon/integration/parallelExecution.test.ts
+++ b/test/daemon/integration/parallelExecution.test.ts
@@ -188,12 +188,12 @@ describe("Parallel Execution Across Multiple Devices", function() {
       const hierarchy2: ViewHierarchyResult = { hierarchy: { node: { "$": {}, "view-id": "session-2" } } };
       sessionManager.updateSessionCache(session1Id, {
         lastHierarchy: hierarchy1,
-        lastScreenshot: "screenshot-session-1",
+        deviceLabels: { A: session1Id },
       });
 
       sessionManager.updateSessionCache(session2Id, {
         lastHierarchy: hierarchy2,
-        lastScreenshot: "screenshot-session-2",
+        deviceLabels: { A: session2Id },
       });
 
       // Verify each session has its own cache
@@ -201,13 +201,13 @@ describe("Parallel Execution Across Multiple Devices", function() {
       const cache2 = sessionManager.getSessionCache(session2Id);
 
       expect(cache1?.lastHierarchy).toEqual(hierarchy1);
-      expect(cache1?.lastScreenshot).toBe("screenshot-session-1");
+      expect(cache1?.deviceLabels).toEqual({ A: session1Id });
       expect(cache2?.lastHierarchy).toEqual(hierarchy2);
-      expect(cache2?.lastScreenshot).toBe("screenshot-session-2");
+      expect(cache2?.deviceLabels).toEqual({ A: session2Id });
 
       // Verify caches are different
       expect(cache1?.lastHierarchy).not.toBe(cache2?.lastHierarchy);
-      expect(cache1?.lastScreenshot).not.toBe(cache2?.lastScreenshot);
+      expect(cache1?.deviceLabels).not.toEqual(cache2?.deviceLabels);
     });
 
     test("should ensure device assignment persistence across session operations", async function() {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -159,11 +159,11 @@ describe("SessionManager", () => {
       const hierarchy = makeHierarchy("root");
       sessionManager.updateSessionCache("session-1", {
         lastHierarchy: hierarchy,
-        lastScreenshot: "base64-data",
+        lastObserveTime: 987654,
       });
       const cache = sessionManager.getSessionCache("session-1");
       expect(cache?.lastHierarchy).toEqual(hierarchy);
-      expect(cache?.lastScreenshot).toBe("base64-data");
+      expect(cache?.lastObserveTime).toBe(987654);
     });
 
     test("setLastHierarchy stores a ViewHierarchyResult in the typed top-level slot and stamps lastObserveTime (#2917)", async () => {
@@ -180,16 +180,6 @@ describe("SessionManager", () => {
       expect(session.cacheData.lastObserveTime).toBe(123456);
       // The dormant-decoy key never leaks into an untyped bag — the `customData`
       // escape hatch no longer exists at all (#2917/#2973).
-      expect((session.cacheData as Record<string, unknown>).customData).toBeUndefined();
-    });
-
-    test("setLastScreenshot stores the base64 string in the typed top-level slot (#2917)", async () => {
-      await sessionManager.createSession("session-1", "emulator-5554", "android");
-
-      sessionManager.setLastScreenshot("session-1", "base64-screenshot");
-
-      const session = sessionManager.getSession("session-1")!;
-      expect(session.cacheData.lastScreenshot).toBe("base64-screenshot");
       expect((session.cacheData as Record<string, unknown>).customData).toBeUndefined();
     });
 
@@ -216,19 +206,19 @@ describe("SessionManager", () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");
       sessionManager.updateSessionCache("session-1", {
         lastHierarchy: makeHierarchy("root"),
-        lastScreenshot: "base64-data",
+        lastObserveTime: 987654,
       });
       sessionManager.clearSessionCache("session-1", "lastHierarchy");
       const cache = sessionManager.getSessionCache("session-1");
       expect(cache?.lastHierarchy).toBeUndefined();
-      expect(cache?.lastScreenshot).toBe("base64-data");
+      expect(cache?.lastObserveTime).toBe(987654);
     });
 
     test("should clear all cache when no key specified", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");
       sessionManager.updateSessionCache("session-1", {
         lastHierarchy: makeHierarchy("root"),
-        lastScreenshot: "base64-data",
+        lastObserveTime: 987654,
         deviceLabels: { A: "session-1" },
       });
       sessionManager.clearSessionCache("session-1");

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -95,10 +95,12 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     sessionUuid: z.string().optional(),
   });
 
-  test("populates lastHierarchy + lastScreenshot from structuredContent and sanitizes the returned response", async () => {
+  test("populates lastHierarchy from structuredContent and sanitizes the returned response", async () => {
     const sessionId = await setupAutolockedSession();
 
     const observeResult = makeObserveResult();
+    // Inject a rogue `screenshot` field: the dead lastScreenshot cache chain was
+    // removed (#3221), so even a payload that carries one must NOT be cached.
     (observeResult as any).screenshot = "base64-screenshot-data";
     ToolRegistry.registerDeviceAware(
       "observe",
@@ -122,8 +124,9 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     expect(cachedHierarchy.hierarchy.node.clickable).toBe("false");
     // Observe timestamp is stamped alongside the hierarchy.
     expect(typeof cacheData.lastObserveTime).toBe("number");
-    // Screenshot cache repair (symmetric structuredContent read).
-    expect(cacheData.lastScreenshot).toBe("base64-screenshot-data");
+    // The dead screenshot cache chain is removed (#3221): no lastScreenshot slot
+    // is written even when the payload carries a `screenshot` field.
+    expect((cacheData as Record<string, unknown>).lastScreenshot).toBeUndefined();
     // The dormant-decoy keys never leak into an untyped bag — the `customData`
     // escape hatch no longer exists at all (#2917/#2973).
     expect((cacheData as Record<string, unknown>).customData).toBeUndefined();


### PR DESCRIPTION
Closes #3221

## Summary

Removes the doubly-dead observe screenshot cache chain (issue #3221, option 1 — remove, as the issue prefers): production `observe` never emitted a `screenshot` payload field, so `setLastScreenshot` never fired, and the session `lastScreenshot` slot had zero readers.

- **`src/server/toolRegistry.ts`** — drop the `getStructuredField(observeEnvelope, "screenshot")` read + `setLastScreenshot` call in `DefaultAfterToolCallHandler`; a NOTE comment marks the deliberate absence.
- **`src/daemon/sessionManager.ts`** — remove `SessionManager.setLastScreenshot` and the `SessionCacheData.lastScreenshot` slot; setter list in the doc comment updated.
- **`src/models/ObserveResult.ts`** — `ObserveToolPayload` loses its `screenshot` field and becomes a documented `type` alias of `ObserveResult` (the alias is kept to name the envelope payload at the tool boundary per #2932/#3222; no `implements`/declaration-merge consumers exist).
- **Tests** — `test/server/toolRegistry.lastHierarchyCache.test.ts` still injects a rogue `screenshot` field but now asserts it is **NOT** cached (regression guard against reintroducing the dead read); the `setLastScreenshot` unit test is removed; `test/daemon/sessionManager.test.ts` and `test/daemon/integration/parallelExecution.test.ts` cache-shape tests re-pointed at live typed slots (`lastObserveTime`, `deviceLabels`) so `updateSessionCache`/`clearSessionCache`/session-isolation coverage is unchanged.

## Validation

- `bun test test/server/toolRegistry.lastHierarchyCache.test.ts test/daemon/sessionManager.test.ts test/daemon/integration/parallelExecution.test.ts test/server/internalToolPayloads.test.ts` — 59 pass / 0 fail (~434ms)
- `turbo run lint build test` — 3/3 successful, 6666 tests pass / 0 fail
- `bun run typecheck` — gate green, no new errors
- `grep -rn "lastScreenshot|setLastScreenshot" src/ test/` — only explanatory comments remain

## Caveats

- The typecheck gate reports "2 baseline error(s) no longer occur" (in `src/doctor/checks/ios.ts`) — verified via stash that this **pre-exists this branch** (drift from #3220 landing without a ratchet). Deliberately NOT ratcheted here to avoid `scripts/typecheck-baseline.txt` merge conflicts with parallel wave-1 lanes; follow-up ratchet suggested.
- No files outside the session-cache lane were touched beyond the three source files that formed the dead chain.