### PR TITLE
perf(db): WAL hygiene — journal_size_limit + checkpoint(TRUNCATE) on close (#2802)

### DIFF
--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -14,6 +14,7 @@ import {
 } from "kysely";
 import { CompiledQuery } from "kysely";
 import { ActionableError } from "../models/ActionableError";
+import { logger } from "../utils/logger";
 
 const MAX_CACHED_STATEMENTS = 200;
 
@@ -262,6 +263,17 @@ export class BunSqliteConnectionState {
     this.#closed = true;
     this.#clearStatementCache();
     if (this.#db) {
+      try {
+        // Flush the WAL into the main DB and truncate the `-wal`/`-shm`
+        // sidecars so a clean shutdown leaves a single-file artifact. Stays
+        // synchronous — close() runs inside destroy() and must not introduce
+        // an await point that could reorder with the mutex (issue #2802).
+        this.#db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+      } catch (error) {
+        // Best-effort: a busy/failed checkpoint at shutdown is expected under
+        // load and safe to ignore — db.close() still persists committed data.
+        logger.debug(`WAL checkpoint on close failed: ${error}`);
+      }
       this.#db.close();
       this.#db = null;
     }

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -28,6 +28,15 @@ let bunDatabaseConstructor: BunDatabaseConstructor | null = null;
 
 export const SQLITE_BUSY_TIMEOUT_MS = 5_000;
 
+/**
+ * Runtime cap on the WAL file: after each passive/auto checkpoint SQLite
+ * truncates the WAL back to this bound instead of leaving it allocated at its
+ * high-water mark. This is a steady-state knob only — it is independent of the
+ * one-shot `wal_checkpoint(TRUNCATE)` issued at connection close (which
+ * truncates the WAL to zero unconditionally, ignoring this limit). See #2802.
+ */
+export const SQLITE_WAL_SIZE_LIMIT_BYTES = 4 * 1024 * 1024;
+
 interface SqlitePragmaDatabase {
   exec(sql: string): unknown;
 }
@@ -55,6 +64,10 @@ export function configureSqliteDatabase(sqliteDb: SqlitePragmaDatabase): void {
 
   // Enable WAL mode for better concurrent read performance
   sqliteDb.exec("PRAGMA journal_mode = WAL;");
+
+  // Truncate the WAL back to this bound after each passive/auto checkpoint
+  // instead of leaving it allocated at its high-water mark (issue #2802).
+  sqliteDb.exec(`PRAGMA journal_size_limit = ${SQLITE_WAL_SIZE_LIMIT_BYTES};`);
 
   // WAL + NORMAL avoids an fsync per commit while remaining corruption-safe.
   // The whole DB stores local telemetry, diagnostics, cache, config, and session

--- a/test/db/bunSqliteDialect.test.ts
+++ b/test/db/bunSqliteDialect.test.ts
@@ -156,10 +156,13 @@ class FakeDatabase {
   readonly calls: Array<{ method: "all" | "run"; sql: string; params: unknown[] }> = [];
   readonly preparedStatements: FakeStatement[] = [];
   readonly prepareCalls: string[] = [];
+  /** Ordered exec/close events so close-path ordering is assertable (#2802). */
+  readonly lifecycleEvents: string[] = [];
   rows: unknown[] = [];
   runResult: FakeRunResult = { changes: 0, lastInsertRowid: 0 };
   schemaVersion = 1;
   throwOn?: unknown;
+  throwOnExec?: unknown;
 
   prepare(sql: string): FakeStatement {
     const statement = new FakeStatement(this, sql);
@@ -172,8 +175,15 @@ class FakeDatabase {
     this.calls.push({ method, sql, params });
   }
 
+  exec(sql: string): void {
+    this.lifecycleEvents.push(`exec:${sql}`);
+    if (this.throwOnExec) {
+      throw this.throwOnExec;
+    }
+  }
+
   close(): void {
-    // no-op
+    this.lifecycleEvents.push("close");
   }
 
   get last(): { method: "all" | "run"; sql: string; params: unknown[] } | undefined {
@@ -522,5 +532,58 @@ describe("BunSqliteConnectionState — C6 word-boundary RETURNING detection", ()
     await state.executeQuery(compiled, owner);
 
     expect(db.last?.method).toBe("all");
+  });
+});
+
+describe("BunSqliteConnectionState — WAL checkpoint on close (issue #2802)", () => {
+  test("issues wal_checkpoint(TRUNCATE) before closing the handle", () => {
+    const db = new FakeDatabase();
+    const state = makeState(db);
+
+    state.close();
+
+    expect(db.lifecycleEvents).toEqual([
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
+      "close",
+    ]);
+  });
+
+  test("a failing checkpoint never blocks the close", () => {
+    const db = new FakeDatabase();
+    db.throwOnExec = new Error("database is locked");
+    const state = makeState(db);
+
+    // Best-effort: the checkpoint error must be swallowed, not rethrown.
+    expect(() => state.close()).not.toThrow();
+
+    expect(db.lifecycleEvents).toEqual([
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
+      "close",
+    ]);
+  });
+
+  test("close is idempotent: the checkpoint and close run once", () => {
+    const db = new FakeDatabase();
+    const state = makeState(db);
+
+    state.close();
+    state.close();
+
+    expect(db.lifecycleEvents).toEqual([
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
+      "close",
+    ]);
+  });
+
+  test("does not open a lazily-unopened database just to checkpoint it", () => {
+    let opened = false;
+    const state = new BunSqliteConnectionState(() => {
+      opened = true;
+      return new FakeDatabase() as unknown as never;
+    });
+
+    state.close();
+
+    expect(opened).toBe(false);
   });
 });

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
-import { mkdtempSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, rmSync, statSync } from "fs";
 import { Kysely } from "kysely";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -8,6 +8,7 @@ import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import {
   configureSqliteDatabase,
   SQLITE_BUSY_TIMEOUT_MS,
+  SQLITE_WAL_SIZE_LIMIT_BYTES,
 } from "../../src/db/database";
 
 class FakeSqliteDatabase {
@@ -33,7 +34,7 @@ function createDeferred<T = void>(): Deferred<T> {
 }
 
 describe("configureSqliteDatabase", () => {
-  test("enables WAL, busy timeout, and foreign keys for new connections", () => {
+  test("enables WAL, busy timeout, WAL size limit, and foreign keys for new connections", () => {
     const db = new FakeSqliteDatabase();
 
     configureSqliteDatabase(db);
@@ -41,6 +42,7 @@ describe("configureSqliteDatabase", () => {
     expect(db.statements).toEqual([
       `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`,
       "PRAGMA journal_mode = WAL;",
+      `PRAGMA journal_size_limit = ${SQLITE_WAL_SIZE_LIMIT_BYTES};`,
       "PRAGMA synchronous = NORMAL;",
       "PRAGMA foreign_keys = ON;",
     ]);
@@ -79,6 +81,94 @@ describe("configureSqliteDatabase", () => {
       expect(synchronous?.synchronous).toBe(1);
     } finally {
       sqliteDb.close();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("caps the WAL size via journal_size_limit on Bun SQLite databases", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-sqlite-"));
+    const sqliteDb = new BunDatabase(join(tempDir, "test.db"));
+
+    try {
+      configureSqliteDatabase(sqliteDb);
+
+      const limit = sqliteDb
+        .query<{ journal_size_limit: number }, []>("PRAGMA journal_size_limit;")
+        .get();
+      expect(limit?.journal_size_limit).toBe(SQLITE_WAL_SIZE_LIMIT_BYTES);
+    } finally {
+      sqliteDb.close();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("WAL checkpoint on close (issue #2802)", () => {
+  /** Size of the WAL sidecar, or 0 when SQLite already deleted it. */
+  function walSize(dbPath: string): number {
+    const walPath = `${dbPath}-wal`;
+    return existsSync(walPath) ? statSync(walPath).size : 0;
+  }
+
+  test("wal_checkpoint(TRUNCATE) reports not-busy and truncates the WAL on the single owning connection", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-sqlite-"));
+    const dbPath = join(tempDir, "test.db");
+    const sqliteDb = new BunDatabase(dbPath);
+
+    try {
+      configureSqliteDatabase(sqliteDb);
+      sqliteDb.exec("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL);");
+      for (let i = 0; i < 50; i += 1) {
+        sqliteDb.exec(`INSERT INTO items (name) VALUES ('row-${i}');`);
+      }
+      // The uncheckpointed writes must live in the WAL sidecar.
+      expect(walSize(dbPath)).toBeGreaterThan(0);
+
+      // `.query(...).get()` (not `.exec()`) so the `busy` flag is observable:
+      // a busy checkpoint would silently skip truncation (issue #2802 review).
+      const result = sqliteDb
+        .query<{ busy: number; log: number; checkpointed: number }, []>(
+          "PRAGMA wal_checkpoint(TRUNCATE);"
+        )
+        .get();
+      expect(result?.busy).toBe(0);
+      expect(result?.checkpointed).toBe(result?.log);
+
+      expect(walSize(dbPath)).toBe(0);
+    } finally {
+      sqliteDb.close();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a clean Kysely destroy leaves no WAL sidecar bytes behind", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-sqlite-"));
+    const dbPath = join(tempDir, "test.db");
+    const sqliteDb = new BunDatabase(dbPath);
+    configureSqliteDatabase(sqliteDb);
+
+    const db = new Kysely<{ items: { id: number; name: string } }>({
+      dialect: new BunSqliteDialect({ database: sqliteDb }),
+    });
+
+    try {
+      await db.schema
+        .createTable("items")
+        .addColumn("id", "integer", col => col.primaryKey())
+        .addColumn("name", "text", col => col.notNull())
+        .execute();
+      for (let i = 0; i < 50; i += 1) {
+        await db.insertInto("items").values({ id: i, name: `row-${i}` }).execute();
+      }
+      expect(walSize(dbPath)).toBeGreaterThan(0);
+
+      // This is the same path `closeDatabase()` takes: Kysely destroy() ->
+      // driver destroy() -> BunSqliteConnectionState.close() -> checkpoint.
+      await db.destroy();
+
+      expect(walSize(dbPath)).toBe(0);
+    } finally {
+      await db.destroy();
       rmSync(tempDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Closes #2802

## Summary

WAL hygiene per the issue's acceptance criteria (unblocked by #2792 / PR #2880):

- **`src/db/database.ts`** — `configureSqliteDatabase` now emits `PRAGMA journal_size_limit = 4194304;` (new exported `SQLITE_WAL_SIZE_LIMIT_BYTES`) after `journal_mode = WAL` and before `foreign_keys = ON`, so passive/auto checkpoints truncate the WAL back to the bound instead of leaving it allocated at its high-water mark. Per the review note in the issue, the constant's docs keep this steady-state knob explicitly distinct from the shutdown TRUNCATE.
- **`src/db/bunSqliteDialect.ts`** — `BunSqliteConnectionState.close()` issues a best-effort, synchronous `PRAGMA wal_checkpoint(TRUNCATE);` immediately before `db.close()` (no new await point). Failure is swallowed with `logger.debug` + a why-comment (CLAUDE.md catch strategy 3), exactly as prescribed by the issue.

## Scope note

My lane nominally owns the `src/db/database.ts` close path, but the issue's acceptance criteria explicitly require the checkpoint in `BunSqliteConnectionState.close()` (`src/db/bunSqliteDialect.ts`) — the single choke point that owns the raw handle (`closeDatabase()` only holds the Kysely instance). The dialect edit is minimal (one try/catch + logger import).

## Validation

- `bun test test/db/database.test.ts test/db/bunSqliteDialect.test.ts` — 33 pass
- `bun test test/db/` — 694 pass (incl. `fileBackedDbAntiPattern` guard)
- `turbo run lint build test` — 6674 pass, 0 fail
- `bun run typecheck` — no new type errors (2 pre-existing `src/doctor/checks/ios.ts` baseline errors already vanished on main; left the baseline untouched to avoid ratchet conflicts across parallel wave-1 PRs)

## Tests

- Exact PRAGMA-sequence fake test extended with `journal_size_limit` (acceptance criterion).
- Real file-backed bun:sqlite: `PRAGMA journal_size_limit` returns the configured bound.
- Busy-flag observability per the issue's review: a test runs the checkpoint via `.query(...).get()` and asserts `busy === 0`, `checkpointed === log`, and a 0-byte `-wal`.
- Fake-ordering unit tests (interface + fake, no timers) pin: checkpoint fires **before** close, a throwing checkpoint never blocks close, close is idempotent (one checkpoint, one close), and a lazily-unopened handle is not opened just to checkpoint it.
- End-to-end: Kysely `destroy()` (the exact path `closeDatabase()` takes) leaves 0 WAL sidecar bytes on a file-backed DB after 50 writes.

## Caveats

- **The end-to-end sidecar assertion is not the regression pin.** I verified with a scratch probe that bun:sqlite's bare `db.close()` already triggers SQLite's last-connection auto-checkpoint (WAL left at 0 bytes) in the happy path — so that test passes even without the explicit checkpoint. The fake-ordering test is the pin; the explicit TRUNCATE's value is covering the cases where the close-time automatic checkpoint is silently skipped (e.g. busy), plus making the intent explicit.
- The "no `-wal` under real telemetry load" guarantee rests on #2792's drain-before-close barrier, which already landed (PR #2880).
- No background/periodic checkpoint loop was added (explicit must-not-do in the issue). Daemon startup is untouched (#2871/#3044 chain ships later).
