### PR TITLE
fix(db): guard against new duplicate migration filename prefixes (#2868)

### DIFF
--- a/docs/design-docs/mcp/storage/migrations.md
+++ b/docs/design-docs/mcp/storage/migrations.md
@@ -12,6 +12,42 @@ Migrations run on server startup and are managed with Kysely's `Migrator` + `Fil
 - Source migrations live in `src/db/migrations` as TypeScript files.
 - Build output copies them to `dist/src/db/migrations` so the runtime can load them from disk.
 
+## Naming and ordering convention
+
+Kysely's `Migrator` + `FileMigrationProvider` applies migrations in **lexical filename
+order** — the filename is the only ordering key. Every migration must be named:
+
+```
+YYYY_MM_DD_NNN_description.ts
+```
+
+- `YYYY_MM_DD` is the date the migration was authored.
+- `NNN` is a zero-padded sequence number, starting at `000` and incrementing for each
+  additional migration authored on the same date (`000`, `001`, `002`, ...).
+- `description` is lowercase `snake_case`.
+
+The full `YYYY_MM_DD_NNN` prefix must be **unique across all migrations**. When two
+files share a prefix, their relative apply order is decided only by the incidental
+alphabetical order of the description — a rebase or a new file inserted into the shared
+prefix can silently change apply order, and `migrateToLatest()` throws
+`corrupted migrations` whenever an unexecuted migration sorts before an executed one,
+wedging startup on populated databases (issue #2868). Before adding a migration, check
+for an existing file with the same date and take the next free `NNN`.
+
+**Never rename a migration that has shipped.** Executed migration filenames are recorded
+in the `kysely_migration` table, so a rename makes Kysely see the recorded name as
+missing and the new name as pending — `corrupted migrations` on every already-populated
+database.
+
+Eight historical files (four prefix pairs: `2026_01_03_000`, `2026_01_11_000`,
+`2026_01_27_000`, `2026_07_03_000`) shipped with duplicate prefixes before this
+convention was enforced. They are frozen as-is — renaming
+them would trip the corruption path above — and are grandfathered in
+`test/db/migrationFilenameOrdering.ts` (`GRANDFATHERED_PREFIX_COLLISIONS`, a
+shrink-only allowlist). The guard test `test/db/migrationFilenameOrdering.test.ts`
+scans `src/db/migrations/` and fails on any malformed filename or any **new** prefix
+collision.
+
 ## Resolution rules
 
 The migration directory is resolved in this order:

--- a/test/db/migrationFilenameOrdering.test.ts
+++ b/test/db/migrationFilenameOrdering.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  GRANDFATHERED_PREFIX_COLLISIONS,
+  MIGRATION_FILENAME_PATTERN,
+  checkMigrationFilenames,
+  findStaleGrandfatherEntries,
+} from "./migrationFilenameOrdering";
+
+/**
+ * Guard for migration filename ordering (issue #2868).
+ *
+ * Two layers, mirroring `fileBackedDbAntiPattern.test.ts`:
+ *   - Unit tests of the pure `checkMigrationFilenames` detector against
+ *     hand-written fixtures — malformed names, new prefix collisions,
+ *     grandfathered collisions, and the stale-allowlist ratchet.
+ *   - A meta-test that runs the detector over the real `src/db/migrations/`
+ *     directory and asserts it is clean, so the next ambiguous filename fails
+ *     HERE (a <100ms unit test) instead of as a `corrupted migrations`
+ *     startup wedge on someone's populated dev DB.
+ */
+
+const CLEAN_PAIR = ["2026_08_01_000_alpha.ts", "2026_08_01_001_beta.ts"];
+
+describe("checkMigrationFilenames detector (issue #2868)", () => {
+  describe("malformed-filename", () => {
+    test("flags a filename with no NNN sequence", () => {
+      const violations = checkMigrationFilenames(["2026_08_01_alpha.ts"]);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].rule).toBe("malformed-filename");
+      expect(violations[0].files).toEqual(["2026_08_01_alpha.ts"]);
+      expect(violations[0].message).toContain("YYYY_MM_DD_NNN");
+    });
+
+    test("flags uppercase / dashed / dotted descriptions", () => {
+      for (const bad of [
+        "2026_08_01_000_Alpha.ts",
+        "2026_08_01_000_alpha-beta.ts",
+        "2026_08_01_000_alpha.beta.ts",
+      ]) {
+        const violations = checkMigrationFilenames([bad]);
+        expect(violations.map(v => v.rule)).toEqual(["malformed-filename"]);
+      }
+    });
+
+    test("flags a stray non-TypeScript file in the migrations directory", () => {
+      const violations = checkMigrationFilenames(["README.md"]);
+      expect(violations.map(v => v.rule)).toEqual(["malformed-filename"]);
+    });
+
+    test("flags a trailing underscore before the extension", () => {
+      const violations = checkMigrationFilenames(["2026_08_01_000_alpha_.ts"]);
+      expect(violations.map(v => v.rule)).toEqual(["malformed-filename"]);
+    });
+
+    test("accepts the canonical shape, including digits in the description", () => {
+      expect(checkMigrationFilenames(CLEAN_PAIR)).toEqual([]);
+      expect(checkMigrationFilenames(["2026_08_01_000_add_v2_index.ts"])).toEqual([]);
+    });
+  });
+
+  describe("prefix-collision", () => {
+    test("flags two migrations sharing a full YYYY_MM_DD_NNN prefix", () => {
+      const violations = checkMigrationFilenames([
+        "2026_08_01_000_alpha.ts",
+        "2026_08_01_000_beta.ts",
+      ]);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].rule).toBe("prefix-collision");
+      expect(violations[0].files).toEqual(["2026_08_01_000_alpha.ts", "2026_08_01_000_beta.ts"]);
+    });
+
+    test("the message names the colliding prefix and suggests the next NNN", () => {
+      const [violation] = checkMigrationFilenames([
+        "2026_08_01_000_alpha.ts",
+        "2026_08_01_000_beta.ts",
+      ]);
+      expect(violation.message).toContain("2026_08_01_000");
+      expect(violation.message).toContain("2026_08_01_001");
+      expect(violation.message).toContain("Do NOT extend GRANDFATHERED_PREFIX_COLLISIONS");
+    });
+
+    test("does NOT flag same-day migrations with distinct NNN sequences", () => {
+      expect(checkMigrationFilenames(CLEAN_PAIR)).toEqual([]);
+    });
+
+    test("does NOT flag the grandfathered historical pairs", () => {
+      const violations = checkMigrationFilenames(
+        Object.values(GRANDFATHERED_PREFIX_COLLISIONS).flat()
+      );
+      expect(violations).toEqual([]);
+    });
+
+    test("flags a THIRD file added to a grandfathered prefix", () => {
+      const violations = checkMigrationFilenames([
+        ...Object.values(GRANDFATHERED_PREFIX_COLLISIONS).flat(),
+        "2026_01_03_000_zzz_new_table.ts",
+      ]);
+      const collisions = violations.filter(v => v.rule === "prefix-collision");
+      expect(collisions).toHaveLength(1);
+      expect(collisions[0].files).toContain("2026_01_03_000_zzz_new_table.ts");
+    });
+
+    test("flags three-way collisions on a non-grandfathered prefix as one violation", () => {
+      const violations = checkMigrationFilenames([
+        "2026_08_01_000_alpha.ts",
+        "2026_08_01_000_beta.ts",
+        "2026_08_01_000_gamma.ts",
+      ]);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].files).toHaveLength(3);
+    });
+  });
+
+  describe("stale-grandfather-entry ratchet", () => {
+    test("flags a grandfathered file that no longer exists (allowlist must shrink)", () => {
+      const all = Object.values(GRANDFATHERED_PREFIX_COLLISIONS).flat();
+      const withoutOne = all.filter(f => f !== "2026_01_27_000_failures.ts");
+      const stale = findStaleGrandfatherEntries(withoutOne);
+      expect(stale).toHaveLength(1);
+      expect(stale[0].rule).toBe("stale-grandfather-entry");
+      expect(stale[0].files).toEqual(["2026_01_27_000_failures.ts"]);
+      // Losing one half of a grandfathered pair also dissolves the collision,
+      // so the survivor must not be flagged by the collision check.
+      expect(checkMigrationFilenames(withoutOne)).toEqual([]);
+    });
+
+    test("is clean when every grandfathered file is present", () => {
+      const all = Object.values(GRANDFATHERED_PREFIX_COLLISIONS).flat();
+      expect(findStaleGrandfatherEntries(all)).toEqual([]);
+    });
+  });
+
+  describe("allowlist self-consistency", () => {
+    test("every grandfathered filename matches the pattern and its own prefix", () => {
+      for (const [prefix, files] of Object.entries(GRANDFATHERED_PREFIX_COLLISIONS)) {
+        for (const file of files) {
+          const match = MIGRATION_FILENAME_PATTERN.exec(file);
+          expect(match).not.toBeNull();
+          expect(match![1]).toBe(prefix);
+        }
+      }
+    });
+
+    test("grandfathered entries are frozen pairs (never grown in place)", () => {
+      for (const files of Object.values(GRANDFATHERED_PREFIX_COLLISIONS)) {
+        expect(files).toHaveLength(2);
+        expect(Object.isFrozen(files)).toBe(true);
+      }
+      expect(Object.isFrozen(GRANDFATHERED_PREFIX_COLLISIONS)).toBe(true);
+    });
+  });
+});
+
+describe("real src/db/migrations directory (issue #2868 meta-test)", () => {
+  test("has no malformed filenames and no NEW ordering-prefix collisions", () => {
+    const migrationsDir = join(import.meta.dir, "..", "..", "src", "db", "migrations");
+    const filenames = readdirSync(migrationsDir);
+    // Sanity: the directory actually resolved (an empty read would vacuously pass).
+    expect(filenames.length).toBeGreaterThan(30);
+
+    const violations = [
+      ...checkMigrationFilenames(filenames),
+      ...findStaleGrandfatherEntries(filenames),
+    ];
+    const rendered = violations.map(v => `[${v.rule}] ${v.message}`).join("\n\n");
+    expect(rendered).toBe("");
+  });
+});

--- a/test/db/migrationFilenameOrdering.ts
+++ b/test/db/migrationFilenameOrdering.ts
@@ -1,0 +1,176 @@
+/**
+ * Guard for migration filename ordering (issue #2868, surfaced by the #2785
+ * destructive-recovery audit).
+ *
+ * Kysely's `Migrator` + `FileMigrationProvider` applies migrations in lexical
+ * filename order. Our convention is a `YYYY_MM_DD_NNN_description.ts` name,
+ * where the `YYYY_MM_DD_NNN` prefix is the *explicit* ordering key. When two
+ * migrations share that full prefix, their relative order is decided only by
+ * the incidental alphabetical order of the trailing description — a rebase or
+ * a new file inserted into the shared prefix can silently change apply order,
+ * and `migrateToLatest()` throws `corrupted migrations` whenever an unexecuted
+ * migration sorts before an executed one (wedging startup on populated DBs).
+ *
+ * Renaming the already-shipped colliding files is NOT safe: every populated
+ * dev database has the old filenames recorded in `kysely_migration`, and a
+ * rename makes Kysely treat the recorded name as missing and the new name as
+ * pending → `corrupted migrations` → the (post-#2850) recovery path refuses on
+ * a populated DB. So issue #2868 takes the disambiguate-going-forward
+ * strategy: the historical collisions are frozen in
+ * {@link GRANDFATHERED_PREFIX_COLLISIONS} and every NEW collision fails the
+ * accompanying meta-test.
+ *
+ * This is a pure `(filenames) -> violations` function so it is unit-tested
+ * with string fixtures (no filesystem) and then applied to the real
+ * `src/db/migrations/` directory by the meta-test — both stay well under
+ * 100ms.
+ */
+
+/**
+ * Canonical migration filename shape: `YYYY_MM_DD_NNN_description.ts` with a
+ * lowercase snake_case description. Capture group 1 is the full ordering
+ * prefix (`YYYY_MM_DD_NNN`).
+ */
+export const MIGRATION_FILENAME_PATTERN = /^(\d{4}_\d{2}_\d{2}_\d{3})_[a-z0-9]+(?:_[a-z0-9]+)*\.ts$/;
+
+/**
+ * Historical `YYYY_MM_DD_NNN` prefix collisions that shipped before this guard
+ * existed. FROZEN — this list may only ever SHRINK (if a rename-aware history
+ * rewrite ever lands, see issue #2868 option 1). Never add an entry: pick the
+ * next free `NNN` for your date instead.
+ *
+ * Each entry maps a shared prefix to the exact (sorted) set of files that
+ * legitimately share it. Adding a THIRD file to one of these prefixes is a new
+ * violation, and removing/renaming a listed file without shrinking this map is
+ * flagged as a stale entry so the allowlist ratchets down.
+ */
+export const GRANDFATHERED_PREFIX_COLLISIONS: Readonly<Record<string, readonly string[]>> =
+  Object.freeze({
+    "2026_01_03_000": Object.freeze([
+      "2026_01_03_000_feature_flags.ts",
+      "2026_01_03_000_test_executions.ts",
+    ]),
+    "2026_01_11_000": Object.freeze([
+      "2026_01_11_000_installed_apps.ts",
+      "2026_01_11_000_video_recording_highlights.ts",
+    ]),
+    "2026_01_27_000": Object.freeze([
+      "2026_01_27_000_crash_anr_monitoring.ts",
+      "2026_01_27_000_failures.ts",
+    ]),
+    "2026_07_03_000": Object.freeze([
+      "2026_07_03_000_drop_redundant_device_indexes.ts",
+      "2026_07_03_000_repair_datetime_now_defaults.ts",
+    ]),
+  });
+
+export type MigrationFilenameRule =
+  | "malformed-filename"
+  | "prefix-collision"
+  | "stale-grandfather-entry";
+
+export interface MigrationFilenameViolation {
+  rule: MigrationFilenameRule;
+  /** The offending filename(s), sorted. */
+  files: string[];
+  /** Human-readable, actionable description of the violation. */
+  message: string;
+}
+
+function sameMembers(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((value, index) => value === sortedB[index]);
+}
+
+/**
+ * Check a list of migration filenames (basenames, e.g. from `readdirSync`)
+ * against the naming/ordering convention: canonical shape + no non-grandfathered
+ * `YYYY_MM_DD_NNN` prefix collisions. Returns an empty array when clean.
+ *
+ * The allowlist ratchet lives in {@link findStaleGrandfatherEntries} so this
+ * function stays meaningful for partial fixture lists.
+ */
+export function checkMigrationFilenames(filenames: readonly string[]): MigrationFilenameViolation[] {
+  const violations: MigrationFilenameViolation[] = [];
+  const byPrefix = new Map<string, string[]>();
+
+  for (const filename of filenames) {
+    const match = MIGRATION_FILENAME_PATTERN.exec(filename);
+    if (!match) {
+      violations.push({
+        rule: "malformed-filename",
+        files: [filename],
+        message:
+          `Migration filename "${filename}" does not match the required ` +
+          "`YYYY_MM_DD_NNN_description.ts` shape (lowercase snake_case description). " +
+          "Kysely orders migrations lexically by filename, so every migration must " +
+          "carry an explicit `YYYY_MM_DD_NNN` ordering prefix.",
+      });
+      continue;
+    }
+    const prefix = match[1];
+    const group = byPrefix.get(prefix);
+    if (group) {
+      group.push(filename);
+    } else {
+      byPrefix.set(prefix, [filename]);
+    }
+  }
+
+  for (const [prefix, group] of byPrefix) {
+    if (group.length < 2) {
+      continue;
+    }
+    const grandfathered = GRANDFATHERED_PREFIX_COLLISIONS[prefix];
+    if (grandfathered && sameMembers(group, grandfathered)) {
+      continue;
+    }
+    violations.push({
+      rule: "prefix-collision",
+      files: [...group].sort(),
+      message:
+        `Migrations share the ordering prefix "${prefix}": ${[...group].sort().join(", ")}. ` +
+        "Within a shared prefix Kysely's apply order is decided only by the incidental " +
+        "alphabetical order of the description, which makes `corrupted migrations` " +
+        "startup failures easy to trip (issue #2868). Rename the NEW file to the next " +
+        `free NNN sequence for its date (e.g. "${prefix.slice(0, 11)}${String(
+          Number(prefix.slice(11)) + 1
+        ).padStart(3, "0")}_..."). Do NOT extend GRANDFATHERED_PREFIX_COLLISIONS and do ` +
+        "NOT rename an already-shipped migration — populated DBs record executed " +
+        "filenames in `kysely_migration`, so renames wedge startup.",
+    });
+  }
+
+  return violations;
+}
+
+/**
+ * The allowlist ratchet: every file named in
+ * {@link GRANDFATHERED_PREFIX_COLLISIONS} must still exist in the migrations
+ * directory. If one is renamed or removed, the corresponding entry must be
+ * deleted so the historical exception only ever shrinks. Run this against the
+ * FULL real directory listing (not partial fixtures).
+ */
+export function findStaleGrandfatherEntries(
+  filenames: readonly string[]
+): MigrationFilenameViolation[] {
+  const violations: MigrationFilenameViolation[] = [];
+  for (const [prefix, grandfathered] of Object.entries(GRANDFATHERED_PREFIX_COLLISIONS)) {
+    const missing = grandfathered.filter(file => !filenames.includes(file));
+    if (missing.length > 0) {
+      violations.push({
+        rule: "stale-grandfather-entry",
+        files: [...missing].sort(),
+        message:
+          `GRANDFATHERED_PREFIX_COLLISIONS["${prefix}"] lists file(s) that no longer ` +
+          `exist: ${missing.join(", ")}. The allowlist is a one-way ratchet — remove ` +
+          "the stale entry so the historical exception shrinks with the codebase.",
+      });
+    }
+  }
+  return violations;
+}


### PR DESCRIPTION
Closes #2868

## Summary

Kysely (`Migrator` + `FileMigrationProvider`) applies migrations in lexical filename order, so two migrations sharing a full `YYYY_MM_DD_NNN` prefix are ordered only by the incidental alphabetical order of the trailing description — the fragility the #2785 audit flagged as making `corrupted migrations` startup wedges easy to trip.

Per the issue's own recommendation, this ships **option 2 (disambiguate going forward)** — renaming the shipped colliding files is the documented landmine (executed filenames are recorded in `kysely_migration`; a rename breaks every populated dev DB via the post-#2850 recovery refusal):

- **`test/db/migrationFilenameOrdering.ts`** — pure `(filenames) -> violations` detector (mirrors the `fileBackedDbAntiPattern` guard convention): enforces the canonical `YYYY_MM_DD_NNN_description.ts` shape and rejects any new full-prefix collision. The shipped collisions are frozen in a `GRANDFATHERED_PREFIX_COLLISIONS` allowlist with a one-way shrink ratchet (`findStaleGrandfatherEntries` fails if a listed file disappears without the entry being removed; adding a third file to a grandfathered prefix is a new violation).
- **`test/db/migrationFilenameOrdering.test.ts`** — fixture unit tests of the detector + a meta-test scanning the real `src/db/migrations/` directory, so the next ambiguous filename fails a <100ms unit test instead of wedging a populated DB at startup.
- **`docs/design-docs/mcp/storage/migrations.md`** — documents the naming/ordering convention, the never-rename-a-shipped-migration rule, and the grandfathered exceptions.

Note: the issue listed three duplicate pairs; a **fourth** (`2026_07_03_000_drop_redundant_device_indexes.ts` / `2026_07_03_000_repair_datetime_now_defaults.ts`) landed on main after the issue was filed — confirming the fragility — and is grandfathered on the same shipped-history grounds.

## Acceptance criteria

- [x] Guard test prevents new `YYYY_MM_DD_NNN` prefix collisions (historical files left in place, frozen allowlist)
- [x] Existing populated dev DBs unaffected — zero migration files renamed/touched
- [x] `test/db/migrations.test.ts` (full forward chain) and `test/db/migrator.test.ts` (destructive-reset replay) green
- [x] Convention documented in `docs/design-docs/mcp/storage/migrations.md`
- [x] `bun test test/db/` + `turbo run lint build test` green

## Validation

- `bun test test/db/migrationFilenameOrdering.test.ts` — 16 pass, 91ms
- `bun test test/db/migrations.test.ts test/db/migrator.test.ts` — 75 pass
- `turbo run lint build test` — 3 tasks successful; 6683 pass / 0 fail
- `bun run typecheck` — no new type errors (baseline untouched; the "2 baseline errors no longer occur" ratchet hint is pre-existing drift unrelated to this change)

## Caveats

- Test-only + docs change; no `src/` code modified.
- Heads-up for parallel lanes: any concurrently-merged PR adding a migration whose `YYYY_MM_DD_NNN` prefix collides with an existing one will (correctly) fail this new guard on main — the fix is to bump `NNN`, never to extend the allowlist.
- Accepted false negatives: the pattern does not validate calendar-real dates (ordering stays deterministic regardless), and `dist/` is not scanned (generated from `src/`).
