### PR TITLE
fix(db): normalize MemoryBaselineManager retention comparison via datetime() (#3157)

### DIFF
--- a/src/features/memory/MemoryBaselineManager.ts
+++ b/src/features/memory/MemoryBaselineManager.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
 import { Database, MemoryBaseline, NewMemoryBaseline, MemoryBaselineUpdate } from "../../db/types";
 import { logger } from "../../utils/logger";
@@ -187,14 +187,26 @@ export class MemoryBaselineManager {
     try {
       const cutoffDate = getCutoffDate(daysOld);
 
+      // Normalize BOTH sides through `datetime(...)` before comparing, exactly
+      // as BaselineManager.cleanupOldBaselines (#2937) and
+      // ThresholdManager.cleanupExpiredThresholds do. A raw string `<` compares
+      // `last_updated` and the ISO-8601 cutoff lexically, which is only sound
+      // while every stored value is ISO. If a defaulted `last_updated` writer
+      // ever lands, the column can hold SQLite's `YYYY-MM-DD HH:MM:SS` form
+      // (no `T`), and a bare space sorts before `T` — so a same-day-but-newer
+      // row would sort before the ISO cutoff and be wrongly deleted (#3157).
+      // `executeTakeFirst().numDeletedRows` is the actual deleted-row count;
+      // `execute()` returns a single DeleteResult per statement, so its
+      // `.length` is always 1 and would log "Cleaned up 1" even for no-ops.
       const deleted = await this.db
         .deleteFrom("memory_baselines")
-        .where("last_updated", "<", cutoffDate)
-        .execute();
+        .where(sql`datetime(last_updated)`, "<", sql`datetime(${cutoffDate})`)
+        .executeTakeFirst();
 
-      if (deleted.length > 0) {
+      const deletedCount = Number(deleted.numDeletedRows) || 0;
+      if (deletedCount > 0) {
         logger.info(
-          `[MemoryBaselineManager] Cleaned up ${deleted.length} stale baselines older than ${daysOld} days`
+          `[MemoryBaselineManager] Cleaned up ${deletedCount} stale baselines older than ${daysOld} days`
         );
       }
     } catch (error) {

--- a/test/features/memory/MemoryBaselineManager.test.ts
+++ b/test/features/memory/MemoryBaselineManager.test.ts
@@ -1,7 +1,15 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
 import { MemoryBaselineManager } from "../../../src/features/memory/MemoryBaselineManager";
-import type { MemoryBaseline } from "../../../src/db/types";
+import type { Database as DatabaseSchema, MemoryBaseline, NewMemoryBaseline } from "../../../src/db/types";
 import type { MemoryMetrics } from "../../../src/features/memory/MemoryMetricsCollector";
+import { createTestDatabase } from "../../db/testDbHelper";
+
+/** Render a Date as SQLite's `YYYY-MM-DD HH:MM:SS` (UTC) — the format a
+ * `datetime('now')` column default produces (no `T`, no `Z`, no milliseconds). */
+function toSqliteFormat(date: Date): string {
+  return date.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "");
+}
 
 describe("MemoryBaselineManager - Unit Tests", function() {
   let manager: MemoryBaselineManager;
@@ -218,6 +226,94 @@ describe("MemoryBaselineManager - Unit Tests", function() {
 
       // Unreachable objects multiplier should be 0 when null
       expect(result.unreachableObjectsMultiplier).toBe(0);
+    });
+  });
+
+  describe("cleanupStaleBaselines", function() {
+    let testDb: Kysely<DatabaseSchema>;
+    let dbManager: MemoryBaselineManager;
+
+    beforeEach(async function() {
+      testDb = await createTestDatabase();
+      dbManager = new MemoryBaselineManager(testDb);
+    });
+
+    afterEach(async function() {
+      await testDb.destroy();
+    });
+
+    function baselineRow(toolName: string, lastUpdated: string): NewMemoryBaseline {
+      return {
+        device_id: "test-device",
+        package_name: "com.example.app",
+        tool_name: toolName,
+        java_heap_baseline_mb: 50,
+        native_heap_baseline_mb: 30,
+        gc_count_baseline: 5,
+        gc_duration_baseline_ms: 100,
+        unreachable_objects_baseline: 100,
+        sample_count: 1,
+        last_updated: lastUpdated,
+      };
+    }
+
+    async function remainingToolNames(): Promise<string[]> {
+      const rows = await testDb
+        .selectFrom("memory_baselines")
+        .select("tool_name")
+        .execute();
+      return rows.map(row => row.tool_name).sort();
+    }
+
+    test("should delete only ISO rows older than the cutoff", async function() {
+      const daysOld = 30;
+      const ancientIso = new Date("2000-01-01T00:00:00Z").toISOString();
+      const recentIso = new Date().toISOString();
+
+      await testDb
+        .insertInto("memory_baselines")
+        .values([baselineRow("ancient", ancientIso), baselineRow("recent", recentIso)])
+        .execute();
+
+      await dbManager.cleanupStaleBaselines(daysOld);
+
+      expect(await remainingToolNames()).toEqual(["recent"]);
+    });
+
+    test("should not delete a SQLite-format row that is newer than the cutoff (#3157)", async function() {
+      // Regression guard for the ISO-vs-`datetime('now')` format trap (#2937's
+      // sibling). If a defaulted `last_updated` writer ever lands, the column can
+      // hold SQLite's `YYYY-MM-DD HH:MM:SS` form. A naive string `<` against the
+      // ISO-8601 cutoff compares the two lexically: at the date/time separator a
+      // SQLite space (0x20) sorts before the ISO `T` (0x54), so a row on the SAME
+      // calendar date as the cutoff but at a LATER time-of-day sorts BEFORE the
+      // cutoff and would be wrongly deleted despite being newer. `datetime(...)`
+      // normalization compares them as real instants.
+      const daysOld = 30;
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - daysOld);
+
+      // Same UTC date as the cutoff, at end-of-day — chronologically newer than
+      // the cutoff instant (tests do not run in the final second of a UTC day),
+      // yet lexically smaller than the ISO cutoff string.
+      const sameDay = cutoff.toISOString().slice(0, 10);
+      const newerSqliteFormat = `${sameDay} 23:59:59`;
+
+      // An unambiguously ancient SQLite-format row that must still be deleted.
+      const ancientSqliteFormat = toSqliteFormat(new Date("2000-01-01T00:00:00Z"));
+
+      await testDb
+        .insertInto("memory_baselines")
+        .values([
+          baselineRow("boundary_newer", newerSqliteFormat),
+          baselineRow("ancient", ancientSqliteFormat),
+        ])
+        .execute();
+
+      await dbManager.cleanupStaleBaselines(daysOld);
+
+      // Only the genuinely-ancient row is removed; the newer boundary row lives.
+      expect(await remainingToolNames()).toEqual(["boundary_newer"]);
     });
   });
 });


### PR DESCRIPTION
Closes #3157

## Summary

Hardens `MemoryBaselineManager.cleanupStaleBaselines` against the ISO-vs-`datetime('now')` lexical-comparison trap that #2937 fixed for `BaselineManager.cleanupOldBaselines`. The retention filter now normalizes BOTH sides through SQLite `datetime(...)`:

```ts
.where(sql`datetime(last_updated)`, "<", sql`datetime(${cutoffDate})`)
```

This is a defensive follow-up (the bug is latent today — `memory_baselines.last_updated` has no column default and both writers store ISO), but it becomes live the moment a defaulted `last_updated` writer lands, exactly as happened for the eight `updated_at` tables in #2913/#2922.

Also fixed in passing (same method, adjacent lines): the "Cleaned up N stale baselines" log used `deleted.length` from Kysely's delete `.execute()`, which always returns a single `DeleteResult` — so it fired spuriously ("Cleaned up 1") even when zero rows were deleted. Now uses `executeTakeFirst().numDeletedRows`, matching `BaselineManager.cleanupOldBaselines`. Verified empirically: `execute()` on an empty table returns `length: 1, numDeletedRows: 0`.

## Tests

- New `cleanupStaleBaselines` suite in `test/features/memory/MemoryBaselineManager.test.ts` with an injected in-memory DB (`createTestDatabase()`, real migration chain — never touches the file-backed singleton).
- Regression test mirrors the #2937 test: a SQLite-format `YYYY-MM-DD 23:59:59` row on the cutoff's calendar date (chronologically newer, lexically smaller than the ISO cutoff) must survive; an ancient SQLite-format row must be deleted. **Verified it fails against the un-normalized query** (both rows were deleted) before applying the fix.
- Plus a plain ISO retention test pinning the normal path (also proves `datetime()` parses the ISO-with-milliseconds-and-`Z` cutoff rather than NULLing it out).

## Validation

- `bun test test/features/memory/` — 25 pass
- `turbo run lint build test` — 3 successful; full suite 6669 pass / 0 fail
- `bun run typecheck` — no new type errors (2 baseline errors "no longer occur" is known local env noise; baseline not ratcheted from this machine)

## Caveats

- `datetime()` truncates sub-second precision, shifting the retention boundary by <1s on a 30-day TTL — same accepted trade as #2937.
- Rows whose `last_updated` can't be parsed by `datetime()` are retained rather than deleted — same behavior as the #2937 fix.