### PR TITLE
test(db): use bounded temp DB cleanup in synchronous pragma readback test (#3160)

### DIFF
--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
 import { existsSync, mkdtempSync, rmSync, statSync } from "fs";
+import { mkdtemp } from "fs/promises";
 import { Kysely } from "kysely";
 import { join } from "path";
 import { tmpdir } from "os";
+import { removeTempDbDir } from "./tempDbDir";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import {
   configureSqliteDatabase,
@@ -63,8 +65,13 @@ describe("configureSqliteDatabase", () => {
     }
   });
 
-  test("sets synchronous NORMAL after enabling WAL on Bun SQLite databases", () => {
-    const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-sqlite-"));
+  test("sets synchronous NORMAL after enabling WAL on Bun SQLite databases", async () => {
+    // WAL mode needs a real file (an in-memory DB reports journal_mode
+    // "memory"), so this test uses a temp dir. Cleanup goes through the shared
+    // bounded helper: bun:sqlite can briefly hold the `.db`/`-wal`/`-shm`
+    // handles past close() on Windows, so a raw `rmSync` flakes with
+    // EBUSY/EPERM/ENOTEMPTY (issues #2916/#3160).
+    const tempDir = await mkdtemp(join(tmpdir(), "auto-mobile-sqlite-"));
     const sqliteDb = new BunDatabase(join(tempDir, "test.db"));
 
     try {
@@ -81,7 +88,7 @@ describe("configureSqliteDatabase", () => {
       expect(synchronous?.synchronous).toBe(1);
     } finally {
       sqliteDb.close();
-      rmSync(tempDir, { recursive: true, force: true });
+      await removeTempDbDir(tempDir);
     }
   });
 


### PR DESCRIPTION
Closes #3160

## Summary

Follow-up to PR #3146 (Codex review comment): the live `PRAGMA synchronous` readback test in `test/db/database.test.ts` cleaned up its file-backed temp SQLite dir with a raw `rmSync`, which flakes on Windows CI with `EBUSY`/`EPERM`/`ENOTEMPTY` when bun:sqlite briefly holds the `.db`/`-wal`/`-shm` handles past `close()` (the documented #2916 flake class).

Narrowest patch per the issue:
- `mkdtempSync`/`rmSync` from `fs` replaced with `mkdtemp` from `fs/promises` plus the shared bounded `removeTempDbDir` helper (`test/db/tempDbDir.ts`).
- The test is now async and calls `await removeTempDbDir(tempDir)` in `finally`.
- Still verifies `PRAGMA journal_mode;` returns `wal` and `PRAGMA synchronous;` returns `1` — assertions unchanged.

The full `withFileBackedDb` harness was not used because this test does not exercise the migration lifecycle or fresh-module imports — it only needs a real file so WAL can be enabled.

## Validation

- `bun test test/db/database.test.ts test/db/fileBackedDbAntiPattern.test.ts` — 34 pass, 0 fail (anti-pattern guard remains green)
- Full `bun test` — 6669 pass / 0 fail
- `bun run lint` clean; `bun run typecheck` — no new type errors