### PR TITLE
feat(ios): auto-start UserDefaults change listening + filter NSGlobalDomain noise

### DIFF
--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -289,6 +289,17 @@ Debug-time `UserDefaults` inspection (iOS equivalent of Android's `SharedPrefere
 - Write/clear operations are `#if DEBUG` guarded
 - Change listeners via `UserDefaults.didChangeNotification`
 - Emits `SdkStorageChangedEvent` with sequence numbers on changes
+- **Production trigger (decision, #3193):** `setEnabled(true)` auto-starts standard-suite
+  change listening (chosen over an Android-style desktop command handler and over a
+  separate host opt-in step), so `initialize` + `setEnabled(true)` is the complete
+  integration. If `setEnabled(true)` runs before `initialize`, the auto-start is
+  deferred to `initialize` so the diff baseline is seeded from a real driver read.
+  Hosts can still call `startListening(suiteName:)` for a specific app-group suite;
+  a later `setEnabled(true)` never replaces an already-registered observer.
+- **System-key noise filter:** `dictionaryRepresentation()` merges `NSGlobalDomain`
+  into every suite's search list, so diff snapshots drop keys with the well-known
+  system prefixes `com.apple.`, `NS`, and `Apple` — OS-churned prefs never emit
+  `storage_changed` events. Inspection reads via `getDriver()` are unfiltered.
 
 ### DatabaseInspector / SQLiteDatabaseDriver
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -24,9 +24,16 @@ public final class UserDefaultsInspector: @unchecked Sendable {
 
     func initialize(buffer: SdkEventBuffer? = nil) {
         lock.lock()
-        defer { lock.unlock() }
         _driver = DefaultUserDefaultsDriver()
         self.buffer = buffer
+        let shouldAutoStart = _isEnabled && kvoObserver == nil
+        lock.unlock()
+        // If the host enabled inspection before AutoMobileSDK.initialize ran,
+        // start listening now that a driver exists — see setEnabled(_:) for the
+        // auto-start decision (#3193).
+        if shouldAutoStart {
+            startListening(suiteName: nil)
+        }
     }
 
     /// Whether inspection is enabled.
@@ -37,10 +44,30 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     }
 
     /// Enable or disable inspection.
+    ///
+    /// Enabling auto-starts change listening on the standard suite (decision for
+    /// #3193: auto-start over a desktop command handler or a separate host
+    /// opt-in step, so `storage_changed` telemetry flows with the single
+    /// `setEnabled(true)` call hosts already make). System-managed
+    /// `NSGlobalDomain` keys are filtered out of the diff, see
+    /// ``isSystemKey(_:)``. Hosts that want a specific app-group suite instead
+    /// can call ``startListening(suiteName:)`` first — an already-registered
+    /// observer is never replaced here.
+    ///
+    /// Disabling keeps the observer registered: ``handleDidChange(suiteName:)``
+    /// silently advances the baseline while disabled, so changes made during a
+    /// disabled window are not replayed on re-enable.
     public func setEnabled(_ enabled: Bool) {
         lock.lock()
         _isEnabled = enabled
+        let shouldAutoStart = enabled && _driver != nil && kvoObserver == nil
         lock.unlock()
+        // Auto-start only when a driver exists (initialize ran); otherwise
+        // initialize(buffer:) starts listening once the driver is available,
+        // ensuring the baseline is seeded from a real driver read.
+        if shouldAutoStart {
+            startListening(suiteName: nil)
+        }
     }
 
     /// Get the driver for direct access.
@@ -75,10 +102,11 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     /// changed key, per-key KVO on `UserDefaults` is fragile, and swizzling is
     /// too invasive for a debug-only SDK.
     ///
-    /// Note: for the standard suite (`suiteName == nil`) the driver reads
-    /// `UserDefaults.standard.dictionaryRepresentation()`, which includes
-    /// `NSGlobalDomain` system keys — prefer an app-group suite to avoid
-    /// system-pref churn in the telemetry (see follow-up on noise filtering).
+    /// Note: `dictionaryRepresentation()` merges `NSGlobalDomain` system keys
+    /// (AppleLanguages, keyboard/accessibility toggles, …) into every suite's
+    /// search list, so diff snapshots filter well-known system key prefixes —
+    /// see ``isSystemKey(_:)`` — instead of emitting spurious `storage_changed`
+    /// events for keys the app never touched.
     public func startListening(suiteName: String? = nil) {
         guard isEnabled else { return }
 
@@ -118,6 +146,14 @@ public final class UserDefaultsInspector: @unchecked Sendable {
             kvoObserver = nil
         }
         lock.unlock()
+    }
+
+    /// Whether a change observer is currently registered. Internal so tests can
+    /// assert the auto-start wiring without poking at the observer handle.
+    var isListening: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return kvoObserver != nil
     }
 
     /// Record the current contents of a suite as the baseline for future diffs.
@@ -210,10 +246,28 @@ public final class UserDefaultsInspector: @unchecked Sendable {
         suiteName ?? "\u{0}__standard__"
     }
 
+    /// Prefixes of system-managed defaults keys. `dictionaryRepresentation()`
+    /// merges `NSGlobalDomain` (system prefs: `AppleLanguages`, `AppleLocale`,
+    /// keyboard/accessibility toggles, `NSLinguisticData…`, `com.apple.*`, …)
+    /// into every `UserDefaults` search list, and the OS churns those keys
+    /// without the app touching them. Best-effort by prefix — an app-authored
+    /// key starting with one of these (unconventional) would be filtered too.
+    private static let systemKeyPrefixes = ["com.apple.", "NS", "Apple"]
+
+    /// Whether a defaults key is system-managed noise that must be excluded
+    /// from change telemetry. Internal so tests can pin the prefix set.
+    static func isSystemKey(_ key: String) -> Bool {
+        systemKeyPrefixes.contains { key.hasPrefix($0) }
+    }
+
+    /// Build a diff snapshot, dropping system-managed keys (see
+    /// ``isSystemKey(_:)``). Filtering both the baseline and the current
+    /// snapshot means system keys can never appear as an add, modify, or
+    /// remove. Inspection reads via ``getDriver()`` are unaffected.
     private static func snapshotDict(_ pairs: [KeyValuePair]) -> [String: KeyValuePair] {
         var dict: [String: KeyValuePair] = [:]
         dict.reserveCapacity(pairs.count)
-        for pair in pairs {
+        for pair in pairs where !isSystemKey(pair.key) {
             dict[pair.key] = pair
         }
         return dict

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -80,6 +80,11 @@ final class UserDefaultsInspectorTests: XCTestCase {
         inspector.initialize(buffer: buffer)
         inspector.setDriver(fakeDriver)
         inspector.setEnabled(true)
+        // setEnabled(true) auto-starts a real NotificationCenter observer on the
+        // standard suite. These tests drive handleDidChange directly, so drop the
+        // observer to keep unrelated real-standard-defaults churn in the test
+        // process from racing extra handleDidChange calls into the capture.
+        inspector.stopListening()
         // Seed the baseline so pre-existing keys aren't reported as spurious adds.
         inspector.captureBaseline(suiteName: nil)
 
@@ -266,6 +271,150 @@ final class UserDefaultsInspectorTests: XCTestCase {
         XCTAssertTrue(captured.all.isEmpty)
 
         inspector.stopListening()
+    }
+
+    // MARK: - Auto-start (production trigger, #3193)
+
+    /// The production trigger: `setEnabled(true)` alone must start standard-suite
+    /// listening — no separate `startListening` integration step — so a host that
+    /// only calls `initialize` + `setEnabled(true)` (e.g. PlaygroundApp) produces
+    /// `storage_changed` events end-to-end.
+    func testSetEnabledAutoStartsStandardSuiteListening() {
+        AutoMobileSDK.shared.setEnabled(true)
+        let fakeDriver = FakeUserDefaultsDriver()
+        fakeDriver.setValue(suiteName: nil, key: "existing", value: "old", type: .string)
+
+        let captured = CapturedEvents()
+        let buffer = SdkEventBuffer { events in
+            captured.append(events.compactMap { $0 as? SdkStorageChangedEvent })
+        }
+        buffer.start()
+        diffBuffer = buffer
+
+        let inspector = UserDefaultsInspector.shared
+        inspector.initialize(buffer: buffer)
+        inspector.setDriver(fakeDriver)
+        XCTAssertFalse(inspector.isListening)
+
+        inspector.setEnabled(true)
+        XCTAssertTrue(inspector.isListening)
+
+        // App writes a new key, then the OS posts the change notification.
+        fakeDriver.setValue(suiteName: nil, key: "fresh", value: "new", type: .string)
+        NotificationCenter.default.post(name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
+
+        buffer.flush()
+        let events = captured.all
+        // Baseline was seeded at auto-start, so "existing" is not replayed.
+        XCTAssertEqual(events.compactMap { $0.key }, ["fresh"])
+        XCTAssertEqual(events.first?.changeType, "add")
+
+        inspector.stopListening()
+    }
+
+    /// The reverse init order: `setEnabled(true)` before `initialize` cannot
+    /// start listening (no driver to seed the baseline from — diffing against an
+    /// empty snapshot would replay every pre-existing key as an "add"), so
+    /// `initialize` must pick up the deferred auto-start.
+    func testInitializeAutoStartsWhenEnabledBeforeInitialize() {
+        let inspector = UserDefaultsInspector.shared
+        // Hermetic: clear any driver/observer state left by earlier suites so
+        // the pre-initialize assertions below are order-independent.
+        inspector.reset()
+
+        inspector.setEnabled(true)
+        XCTAssertFalse(inspector.isListening)
+
+        inspector.initialize()
+        XCTAssertTrue(inspector.isListening)
+
+        inspector.stopListening()
+    }
+
+    /// A host that explicitly listens on an app-group suite must keep that
+    /// choice: a later `setEnabled(true)` never replaces an already-registered
+    /// observer with the standard-suite one.
+    func testSetEnabledDoesNotReplaceExplicitSuiteListener() {
+        AutoMobileSDK.shared.setEnabled(true)
+        let fakeDriver = FakeUserDefaultsDriver()
+
+        let captured = CapturedEvents()
+        let buffer = SdkEventBuffer { events in
+            captured.append(events.compactMap { $0 as? SdkStorageChangedEvent })
+        }
+        buffer.start()
+        diffBuffer = buffer
+
+        let inspector = UserDefaultsInspector.shared
+        inspector.initialize(buffer: buffer)
+        inspector.setDriver(fakeDriver)
+        inspector.setEnabled(true)
+
+        // Host opts into a specific app-group suite, then re-enables.
+        inspector.startListening(suiteName: "group.app")
+        inspector.setEnabled(true)
+        XCTAssertTrue(inspector.isListening)
+
+        // A standard-suite change + notification must NOT be observed — the
+        // registered observer targets the app-group suite's defaults object,
+        // and no standard-suite observer was re-registered by setEnabled.
+        fakeDriver.setValue(suiteName: nil, key: "fresh", value: "new", type: .string)
+        NotificationCenter.default.post(name: UserDefaults.didChangeNotification, object: UserDefaults.standard)
+
+        buffer.flush()
+        XCTAssertTrue(captured.all.isEmpty)
+
+        inspector.stopListening()
+    }
+
+    // MARK: - System-key noise filter (#3193)
+
+    func testIsSystemKeyMatchesKnownPrefixesOnly() {
+        XCTAssertTrue(UserDefaultsInspector.isSystemKey("com.apple.keyboard.preferences"))
+        XCTAssertTrue(UserDefaultsInspector.isSystemKey("AppleLanguages"))
+        XCTAssertTrue(UserDefaultsInspector.isSystemKey("AppleLocale"))
+        XCTAssertTrue(UserDefaultsInspector.isSystemKey("NSLinguisticDataAssetsRequested"))
+
+        XCTAssertFalse(UserDefaultsInspector.isSystemKey("theme"))
+        XCTAssertFalse(UserDefaultsInspector.isSystemKey("com.example.flag"))
+        // Prefix match is case-sensitive: app-style lowercase keys pass through.
+        XCTAssertFalse(UserDefaultsInspector.isSystemKey("apple_pie"))
+        XCTAssertFalse(UserDefaultsInspector.isSystemKey("nsFlag"))
+    }
+
+    /// `NSGlobalDomain` churn (system keys changing without the app touching
+    /// them) must not emit `storage_changed` events; app keys still do.
+    func testDiffIgnoresSystemKeyChanges() {
+        let harness = makeDiffHarness(seed: [
+            (key: "AppleLanguages", value: "(en)", type: .array),
+            (key: "com.apple.metal.deviceStats", value: "1", type: .int),
+        ])
+
+        // System keys modify, remove, and add alongside a single app-key change.
+        harness.driver.setValue(suiteName: nil, key: "AppleLanguages", value: "(fr)", type: .array)
+        harness.driver.removeValue(suiteName: nil, key: "com.apple.metal.deviceStats")
+        harness.driver.setValue(suiteName: nil, key: "NSLanguages", value: "(fr)", type: .array)
+        harness.driver.setValue(suiteName: nil, key: "theme", value: "dark", type: .string)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: nil)
+
+        let events = harness.events()
+        XCTAssertEqual(events.compactMap { $0.key }, ["theme"])
+        XCTAssertEqual(events.first?.changeType, "add")
+    }
+
+    /// `dictionaryRepresentation()` merges `NSGlobalDomain` into every suite's
+    /// search list — named suites included — so the filter applies there too.
+    func testDiffIgnoresSystemKeysInNamedSuites() {
+        let harness = makeDiffHarness()
+        UserDefaultsInspector.shared.captureBaseline(suiteName: "group.app")
+
+        harness.driver.setValue(suiteName: "group.app", key: "AppleLocale", value: "en_US", type: .string)
+        harness.driver.setValue(suiteName: "group.app", key: "count", value: "1", type: .int)
+        UserDefaultsInspector.shared.handleDidChange(suiteName: "group.app")
+
+        let events = harness.events()
+        XCTAssertEqual(events.compactMap { $0.key }, ["count"])
+        XCTAssertEqual(events.first?.suiteName, "group.app")
     }
 
     func testDiffEmitsModifyWhenOnlyTypeChanges() {


### PR DESCRIPTION
Closes #3193

## Summary

`UserDefaultsInspector.startListening` — the only thing that registers the `UserDefaults.didChangeNotification` observer and seeds the diff baseline — had no production caller, so the `storage_changed` diff engine improved in #3186 never ran in a real app. This PR wires the production trigger and filters the standard-suite `NSGlobalDomain` noise that made auto-listening unsafe.

### Decision on trigger mechanism (issue option 2: auto-start)

- **`setEnabled(true)` auto-starts standard-suite listening.** Chosen over an Android-style desktop command handler (iOS has no per-suite subscribe route, and the desktop only ingests pushed SDK events via `IosSdkEventIngestor.ts`) and over a separate documented host opt-in step. With this, the integration hosts already have — `AutoMobileSDK.initialize()` + `UserDefaultsInspector.shared.setEnabled(true)` (exactly what `ios/Playground/Sources/PlaygroundApp.swift` does) — produces non-empty `storage_changed` rows end-to-end.
- **Reverse init order is handled:** `setEnabled(true)` before `initialize` defers the auto-start to `initialize`, so the diff baseline is always seeded from a real driver read (never diffed against an empty snapshot → no phantom "add" burst).
- **Host opt-in is preserved:** an explicit `startListening(suiteName:)` observer is never replaced by a later `setEnabled(true)` (`kvoObserver == nil` check).
- Decision recorded in `docs/design-docs/plat/ios/auto-mobile-sdk.md` and in the `setEnabled` doc comment.

### NSGlobalDomain noise filter

`dictionaryRepresentation()` merges `NSGlobalDomain` (AppleLanguages, AppleLocale, keyboard/accessibility toggles, ...) into every suite's search list, so diff snapshots now drop keys with the well-known system prefixes `com.apple.`, `NS`, `Apple` (the prefixes proposed in the issue). Filtering both baseline and current snapshot means system keys can never surface as add/modify/remove. Inspection reads via `getDriver()` are unfiltered.

## Tests

- `testSetEnabledAutoStartsStandardSuiteListening` — enable-only integration emits events via a real posted `didChangeNotification`, baseline not replayed
- `testInitializeAutoStartsWhenEnabledBeforeInitialize` — deferred auto-start on the reverse init order
- `testSetEnabledDoesNotReplaceExplicitSuiteListener` — host app-group opt-in survives re-enable
- `testIsSystemKeyMatchesKnownPrefixesOnly`, `testDiffIgnoresSystemKeyChanges`, `testDiffIgnoresSystemKeysInNamedSuites` — noise filter (incl. named suites, since `NSGlobalDomain` merges into every search list)
- Diff-test harness now drops the auto-started observer so direct `handleDidChange` tests can't race real standard-defaults churn

## Validation

- `swift test` in `ios/auto-mobile-sdk`: all suites pass (UserDefaultsInspectorTests 23/23, whole package green)
- `scripts/ios/api-dump.sh --check`: public API surface unchanged (new members are internal)
- `swiftlint` on changed files: no new violations (remaining warnings pre-date this PR, in the SQLite concurrency tests)
- `bunx turbo run lint build test`: 6667 pass / 0 fail; `bun run typecheck`: no new errors (did not ratchet the baseline — no TS touched here)

## Caveats

- Changes are in `ios/auto-mobile-sdk` (host-embedded SPM package), **not** `ios/control-proxy` — no runner release re-cut needed; hosts get this when they build against the updated SDK (Playground builds from source).
- Pre-existing (not introduced here): two racing `startListening` calls can leak one observer since `kvoObserver` is registered outside the lock; auto-start call sites are serial app-startup paths.
- Intentional false-negative: app-authored keys starting with `NS`/`Apple`/`com.apple.` (unconventional) are filtered from telemetry; documented in code and docs.
