### PR TITLE
fix(observe/android): short-circuit verifyServiceReady retries on deterministic runner error (#3097)

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -809,6 +809,16 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
 }
 
 /**
+ * verifyServiceReady stops retrying once the SAME correlated runner error text has been observed
+ * on this many CONSECUTIVE verification attempts (issue #3097). A runner handler failure that
+ * reproduces byte-identically after a retry delay is deterministic in practice — retrying to
+ * exhaustion just burns the remaining `maxAttempts * (timeout + delay)` budget. Kept at 2 (not 1)
+ * so a single handler error during service bring-up — where transient failures are expected —
+ * always gets one retry before the loop concludes the failure is deterministic.
+ */
+const VERIFY_READY_IDENTICAL_RUNNER_ERROR_LIMIT = 2;
+
+/**
  * Client for interacting with the AutoMobile Accessibility Service via WebSocket.
  * Uses singleton pattern per device to maintain persistent WebSocket connection.
  */
@@ -1795,6 +1805,18 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     // failure, rather than collapsing every attempt into an anonymous "no hierarchy" (a runner
     // error and a plain timeout previously both surfaced identically here).
     let lastRunnerError: string | undefined;
+    // Consecutive attempts that failed with byte-identical correlated runner error text
+    // (issue #3097). A handler failure that reproduces verbatim after a retry delay is treated
+    // as deterministic — the service will not become ready by retrying — so the loop stops
+    // instead of burning the remaining attempts. Two safety valves protect the startup path
+    // this method exists to verify (where a handler error CAN be transient during bring-up):
+    // the first runner error always gets one retry, and a plain timeout in between resets the
+    // streak (mixed signals are not evidence of determinism). Classifying specific runner
+    // messages (allow/deny lists, structured codes) is deliberately avoided here: codes belong
+    // in the runner's wire contract, and TS string-matching individual messages would be
+    // fragile against runner text changes.
+    let identicalRunnerErrorStreak = 0;
+    let shortCircuited = false;
     const result = await this.retryExecutor.execute(
       async attempt => {
         logger.debug(`[CTRL_PROXY] Verifying service ready (attempt ${attempt}/${maxAttempts})`);
@@ -1808,7 +1830,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         }
 
         if (diagnostics.runnerError) {
+          identicalRunnerErrorStreak = diagnostics.runnerError === lastRunnerError
+            ? identicalRunnerErrorStreak + 1
+            : 1;
           lastRunnerError = diagnostics.runnerError;
+        } else {
+          // A plain timeout breaks the deterministic-failure streak but keeps lastRunnerError,
+          // so the terminal warn still attributes the most recent runner error.
+          identicalRunnerErrorStreak = 0;
         }
         const runnerErrorSuffix = diagnostics.runnerError
           ? `: runner error: ${diagnostics.runnerError}`
@@ -1818,6 +1847,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       {
         maxAttempts,
         delays: delayMs,
+        shouldRetry: () => {
+          if (identicalRunnerErrorStreak >= VERIFY_READY_IDENTICAL_RUNNER_ERROR_LIMIT) {
+            shortCircuited = true;
+            return false;
+          }
+          return true;
+        },
         onRetry: (error, attempt) => {
           logger.debug(`[CTRL_PROXY] Verification attempt ${attempt} failed: ${error.message}`);
           logger.debug(`[CTRL_PROXY] Waiting ${delayMs}ms before next verification attempt`);
@@ -1827,7 +1863,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
     if (!result.success) {
       const runnerErrorSuffix = lastRunnerError ? ` (last runner error: ${lastRunnerError})` : "";
-      logger.warn(`[CTRL_PROXY] Service not ready after ${maxAttempts} verification attempts${runnerErrorSuffix}`);
+      const attemptsSummary = shortCircuited
+        ? `${result.attempts}/${maxAttempts} verification attempts (short-circuited: identical runner error on ${VERIFY_READY_IDENTICAL_RUNNER_ERROR_LIMIT} consecutive attempts)`
+        : `${maxAttempts} verification attempts`;
+      logger.warn(`[CTRL_PROXY] Service not ready after ${attemptsSummary}${runnerErrorSuffix}`);
       return false;
     }
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -18,6 +18,7 @@ import type { DeviceConnectionLostNotifier } from "../../../src/features/observe
 import { PortManager } from "../../../src/utils/PortManager";
 import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
 import type { HierarchySyncDiagnostics } from "../../../src/features/observe/android/types";
+import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
 import { logger } from "../../../src/utils/logger";
 
 describe("AndroidCtrlProxyClient", function() {
@@ -1792,6 +1793,255 @@ describe("AndroidCtrlProxyClient", function() {
         expect(terminalWarn).toContain(runnerText);
       } finally {
         logger.warn = originalWarn;
+        await testClient.close();
+      }
+    });
+  });
+
+  describe("verifyServiceReady deterministic runner-error short-circuit (issue #3097)", function() {
+    // Follow-up to #3062. That surfaced the runner's structured error text to verifyServiceReady
+    // via diagnostics, but the method still retried to exhaustion even when every attempt failed
+    // with the SAME deterministic runner handler error. #3097 short-circuits the retry loop once
+    // byte-identical runner error text repeats on 2 consecutive attempts, while still granting one
+    // retry after the FIRST error (bring-up failures can be transient) and resetting the streak
+    // when a plain timeout intervenes (mixed signals are not evidence of determinism).
+
+    const sentHierarchyRequests = (socket: CapturingWebSocket): any[] =>
+      socket.sentMessages
+        .map(m => {
+          try { return JSON.parse(m); } catch { return null; }
+        })
+        .filter(m => m && m.type === "request_hierarchy");
+
+    // Advance fake time in small steps (firing retry-delay sleeps and wait intervals) until the
+    // Nth request_hierarchy frame has been sent — i.e. until the retry loop reaches attempt N.
+    const advanceUntilHierarchyRequests = async (
+      socket: CapturingWebSocket,
+      timer: FakeTimer,
+      minCount: number,
+      stepMs: number = 250
+    ): Promise<any[]> => {
+      for (let i = 0; i < 40; i++) {
+        const msgs = sentHierarchyRequests(socket);
+        if (msgs.length >= minCount) {
+          return msgs;
+        }
+        timer.advanceTime(stepMs);
+        await flushPromises();
+      }
+      return sentHierarchyRequests(socket);
+    };
+
+    const simulateRunnerError = (
+      socket: CapturingWebSocket,
+      timer: FakeTimer,
+      requestId: string,
+      errorText: string
+    ): void => {
+      socket.simulateMessage(JSON.stringify({
+        type: "error",
+        requestId,
+        success: false,
+        error: errorText,
+        timestamp: timer.now()
+      }));
+    };
+
+    const createShortCircuitTestClient = (): {
+      testClient: AndroidCtrlProxyClient;
+      getSocket: () => CapturingWebSocket | null;
+      timer: FakeTimer;
+    } => {
+      const timer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(timer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        timer,
+        undefined,
+        // Retry delays must run on the SAME fake timer so the test controls them.
+        new DefaultRetryExecutor(timer)
+      );
+      return { testClient, getSocket, timer };
+    };
+
+    const captureWarns = (): { warnMessages: string[]; restore: () => void } => {
+      const warnMessages: string[] = [];
+      const originalWarn = logger.warn;
+      logger.warn = (message: string) => {
+        warnMessages.push(message);
+      };
+      return { warnMessages, restore: () => { logger.warn = originalWarn; } };
+    };
+
+    test("identical runner error on 2 consecutive attempts short-circuits the remaining retries", async function() {
+      const { testClient, getSocket, timer } = createShortCircuitTestClient();
+      const { warnMessages, restore } = captureWarns();
+
+      try {
+        testClient.invalidateCache();
+        const verifyPromise = testClient.verifyServiceReady(5, 500, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        const runnerText = "request_hierarchy handler failed: view hierarchy extraction threw";
+
+        // Attempt 1: correlated runner error.
+        let msgs = await advanceUntilHierarchyRequests(socket, timer, 1);
+        expect(msgs.length).toBe(1);
+        simulateRunnerError(socket, timer, msgs[0].requestId, runnerText);
+        await flushPromises();
+
+        // Attempt 2: byte-identical runner error -> streak of 2 -> stop.
+        msgs = await advanceUntilHierarchyRequests(socket, timer, 2);
+        expect(msgs.length).toBe(2);
+        simulateRunnerError(socket, timer, msgs[1].requestId, runnerText);
+
+        const ready = await timer.resolvePromise(verifyPromise);
+
+        expect(ready).toBe(false);
+        // Short-circuited after 2 attempts: attempts 3-5 never sent a request.
+        expect(sentHierarchyRequests(socket).length).toBe(2);
+        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
+        expect(terminalWarn).toBeDefined();
+        expect(terminalWarn).toContain("short-circuited");
+        expect(terminalWarn).toContain("2/5 verification attempts");
+        expect(terminalWarn).toContain(runnerText);
+      } finally {
+        restore();
+        await testClient.close();
+      }
+    });
+
+    test("a transient runner error on the first attempt still recovers on the retry", async function() {
+      // The regression guard for the startup path this method exists to verify: ONE handler
+      // error during bring-up must not conclude "deterministic" — the retry still runs and a
+      // successful push flips the verification to ready.
+      const { testClient, getSocket, timer } = createShortCircuitTestClient();
+      const { warnMessages, restore } = captureWarns();
+
+      try {
+        testClient.invalidateCache();
+        const verifyPromise = testClient.verifyServiceReady(5, 500, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        // Attempt 1: correlated runner error (transient bring-up failure).
+        let msgs = await advanceUntilHierarchyRequests(socket, timer, 1);
+        expect(msgs.length).toBe(1);
+        simulateRunnerError(socket, timer, msgs[0].requestId, "request_hierarchy handler failed: service still starting");
+        await flushPromises();
+
+        // Attempt 2: the service came up; deliver a fresh hierarchy push.
+        msgs = await advanceUntilHierarchyRequests(socket, timer, 2);
+        expect(msgs.length).toBe(2);
+        socket.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: timer.now(),
+          data: {
+            updatedAt: timer.now(),
+            packageName: "com.example.app",
+            hierarchy: { text: "Service recovered" }
+          }
+        }));
+
+        const ready = await timer.resolvePromise(verifyPromise);
+
+        expect(ready).toBe(true);
+        expect(warnMessages.find(m => m.includes("Service not ready"))).toBeUndefined();
+      } finally {
+        restore();
+        await testClient.close();
+      }
+    });
+
+    test("differing runner error texts never short-circuit (full retry budget)", async function() {
+      const { testClient, getSocket, timer } = createShortCircuitTestClient();
+      const { warnMessages, restore } = captureWarns();
+
+      try {
+        testClient.invalidateCache();
+        const verifyPromise = testClient.verifyServiceReady(3, 500, 10000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          const msgs = await advanceUntilHierarchyRequests(socket, timer, attempt);
+          expect(msgs.length).toBe(attempt);
+          simulateRunnerError(socket, timer, msgs[attempt - 1].requestId, `handler failed: distinct cause ${attempt}`);
+          await flushPromises();
+        }
+
+        const ready = await timer.resolvePromise(verifyPromise);
+
+        expect(ready).toBe(false);
+        // All 3 attempts ran: varying error text is not treated as deterministic.
+        expect(sentHierarchyRequests(socket).length).toBe(3);
+        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
+        expect(terminalWarn).toBeDefined();
+        expect(terminalWarn).not.toContain("short-circuited");
+        expect(terminalWarn).toContain("after 3 verification attempts");
+        expect(terminalWarn).toContain("distinct cause 3");
+      } finally {
+        restore();
+        await testClient.close();
+      }
+    });
+
+    test("a plain timeout between identical runner errors resets the streak", async function() {
+      // error X -> timeout -> error X -> error X with maxAttempts=5: the timeout on attempt 2
+      // breaks the streak, so the short-circuit lands after attempt 4 (streak rebuilt on 3+4),
+      // not after attempt 3 (which a no-reset implementation would produce).
+      const { testClient, getSocket, timer } = createShortCircuitTestClient();
+      const { warnMessages, restore } = captureWarns();
+
+      try {
+        testClient.invalidateCache();
+        // timeoutMs=1000 keeps the timed-out attempt below the 2000ms stale-nudge threshold.
+        const verifyPromise = testClient.verifyServiceReady(5, 500, 1000);
+
+        const socket = await waitForSocket(getSocket) as CapturingWebSocket;
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+
+        const runnerText = "request_hierarchy handler failed: view hierarchy extraction threw";
+
+        // Attempt 1: runner error X.
+        let msgs = await advanceUntilHierarchyRequests(socket, timer, 1);
+        expect(msgs.length).toBe(1);
+        simulateRunnerError(socket, timer, msgs[0].requestId, runnerText);
+        await flushPromises();
+
+        // Attempt 2: never answered -> plain timeout (advanceUntil... drives past the 1000ms
+        // window while waiting for attempt 3's request). Streak resets.
+        // Attempts 3 and 4: runner error X again -> streak rebuilt to 2 -> stop before attempt 5.
+        msgs = await advanceUntilHierarchyRequests(socket, timer, 3);
+        expect(msgs.length).toBe(3);
+        simulateRunnerError(socket, timer, msgs[2].requestId, runnerText);
+        await flushPromises();
+
+        msgs = await advanceUntilHierarchyRequests(socket, timer, 4);
+        expect(msgs.length).toBe(4);
+        simulateRunnerError(socket, timer, msgs[3].requestId, runnerText);
+
+        const ready = await timer.resolvePromise(verifyPromise);
+
+        expect(ready).toBe(false);
+        // 4 attempts, not 3 (timeout reset the streak) and not 5 (short-circuit stopped attempt 5).
+        expect(sentHierarchyRequests(socket).length).toBe(4);
+        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
+        expect(terminalWarn).toBeDefined();
+        expect(terminalWarn).toContain("short-circuited");
+        expect(terminalWarn).toContain("4/5 verification attempts");
+      } finally {
+        restore();
         await testClient.close();
       }
     });


### PR DESCRIPTION
Closes #3097

## Summary

Follow-up to #3062 / PR #3092. `verifyServiceReady` now **short-circuits its retry loop** when the correlated runner error text (surfaced via the #3062 `HierarchySyncDiagnostics` out-parameter) repeats **byte-identically on 2 consecutive attempts** — a handler failure that reproduces verbatim after a retry delay is deterministic in practice, so retrying to exhaustion just burns the remaining `maxAttempts * (timeout + delay)` budget.

### Design decisions (the issue's open questions)

- **"Same error N times => stop" heuristic (N=2), not message classification.** The issue offered either an allow/deny classification of runner messages or a repeat-count heuristic. TS string-matching individual runner messages would be fragile against runner text changes, and a structured error *code* belongs in the runner's wire contract (`android/control-proxy` — out of this lane's scope; can be layered on later without changing this seam).
- **Two safety valves protect the startup path this method exists to verify** (where handler errors CAN be transient during bring-up):
  1. the **first** runner error always gets one retry — only an identical repeat concludes "deterministic";
  2. a **plain timeout resets the streak** (mixed signals are not evidence of determinism), while still keeping `lastRunnerError` for the terminal warn's attribution.
- **Implemented via the existing `RetryExecutor.shouldRetry` seam** (`src/utils/retry/RetryExecutor.ts`) — no new retry primitive, no signature change to `verifyServiceReady`, iOS client untouched.
- The terminal `Service not ready` warn now reports `2/5 verification attempts (short-circuited: ...)` when it stopped early, so logs/telemetry stay legible.
- **Not done (YAGNI, per the issue's "possibly"):** the `getAccessibilityHierarchy` sync path is unchanged — it has no retry loop of this shape, and no caller needs the distinction yet.

### Behavior at existing call sites

- `DeviceSessionManager.ts:509` (`verifyServiceReady(2, 200, 2000)`): **unchanged** — with `maxAttempts=2` the streak can only reach 2 on the final attempt, where `shouldRetry` is never consulted.
- `DeviceSessionManager.ts:605` (`(5, 500, 3000)`): deterministic runner failures now stop after 2 attempts instead of 5; the caller already degrades gracefully (warn + UIAutomator fallback).

### Named false-negative (deliberate trade-off)

A service that emits the *identical* handler error twice in a row during bring-up and would have recovered on attempt >= 3 now yields `false` early. Both Android call sites treat `false` as fall-through to recovery (status check/restart) or a warn + fallback, so the cost is a spurious recovery pass — bounded and visible in the short-circuit warn.

## Validation

- `bun test test/features/observe/CtrlProxyClient.test.ts` — 43 pass / 0 fail (4 new tests, all FakeTimer-driven, no real timers).
- **Mutation check**: ran the 4 new tests against the *old* implementation — the 2 behavior-defining tests fail; the 2 regression guards (transient error recovers on retry; differing texts never short-circuit) pass on both, as designed.
- `turbo run lint build test` — 3/3 successful (6671 tests pass).
- `bun run typecheck` — no new type errors. (Gate reports 2 stale baseline errors, but they are also stale on unmodified `main` in this environment — pre-existing env noise, so the baseline was deliberately not ratcheted here.)

## Caveats

- Scope: only `src/features/observe/android/AndroidCtrlProxyClient.ts` + its test file. No files outside the lane touched.
- Runner-side structured error codes (better classification) remain a possible follow-up in the runner wire contract.
