### PR TITLE
fix(ios): guard non-finite pinch rotationDegrees and multi-finger offset in CtrlProxy (#2991)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -357,7 +357,10 @@ public class CommandHandler: CommandHandling {
     /// arrive over the wire today. This guard is defense-in-depth for the
     /// non-wire path — a caller constructing a request directly, or a computed
     /// coordinate (division, `hypot`, normalized offset) that yields a non-finite
-    /// `Double`. Throwing `CommandError.invalidParameter` makes `handle`'s catch
+    /// `Double`. Non-coordinate gesture inputs that feed the path math (pinch
+    /// `rotationDegrees`, multi-finger `offset` spacing) get the same guard
+    /// (#2991, mirroring Android #2964). Throwing
+    /// `CommandError.invalidParameter` makes `handle`'s catch
     /// return a clean, actionable per-command error response (see #2909's thesis
     /// that the runner must never surface an opaque failure for unusual input)
     /// rather than the silent no-op XCUITest would produce.
@@ -414,6 +417,10 @@ public class CommandHandler: CommandHandling {
         let fingerCount = request.fingerCount ?? 2
         let duration = request.duration ?? 300
         let fingerSpacing = request.offset ?? 25
+        // Android leaves `offset` unguarded because it is an `Int` (cannot be
+        // non-finite). On iOS `offset` is a `Double?` feeding the per-finger
+        // spacing geometry, so the same defense-in-depth guard applies (#2991).
+        try requireFinite(fingerSpacing, field: "offset")
 
         try gesturePerformer.multiFingerSwipe(
             startX: request.x1,
@@ -461,6 +468,12 @@ public class CommandHandler: CommandHandling {
         try requireFinite(request.centerY, field: "centerY")
         try requireFinite(request.distanceStart, field: "distanceStart")
         try requireFinite(request.distanceEnd, field: "distanceEnd")
+        // `rotationDegrees` is a `Float?` (not a coordinate) but still flows into
+        // the gesture-path math (degrees → radians → cos/sin), so a computed
+        // non-finite rotation is guarded too — mirroring Android #2964 / PR #2984
+        // (#2991). `Double(Float.nan/±infinity)` stays non-finite, so widening
+        // before the check loses nothing.
+        try requireFinite(Double(request.rotationDegrees ?? 0), field: "rotationDegrees")
         let path = try gesturePerformer.pinch(
             centerX: request.centerX,
             centerY: request.centerY,

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -836,6 +836,103 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         XCTAssertTrue(fakeGesturePerformer.getPinchHistory().isEmpty, "pinch must not reach the engine")
     }
 
+    /// `rotationDegrees` is a `Float?`, not a coordinate, but it flows into the
+    /// pinch gesture-path math (degrees → radians → cos/sin), so a computed
+    /// non-finite rotation is rejected at the handler boundary too — the iOS
+    /// mirror of Android #2964 / PR #2984 (#2991). Covers all three non-finite
+    /// `Float` values.
+    func testNonFinitePinchRotationIsRejected() {
+        for bad in [Float.infinity, -Float.infinity, Float.nan] {
+            let response = commandHandler.handle(.pinch(RequestPinch(
+                requestId: "pinch-rot",
+                centerX: 100,
+                centerY: 200,
+                distanceStart: 40,
+                distanceEnd: 80,
+                rotationDegrees: bad
+            ))) as? WebSocketResponse
+            assertRejectedNonFinite(response, type: "pinch_result", field: "rotationDegrees")
+            XCTAssertTrue(
+                fakeGesturePerformer.getPinchHistory().isEmpty,
+                "pinch with rotationDegrees=\(bad) must not reach the engine"
+            )
+        }
+    }
+
+    /// Finite rotations — the default (`nil` → 0), zero, negative, and fractional
+    /// degrees — pass the guard unchanged and are forwarded to the engine.
+    func testFinitePinchRotationStillDispatches() {
+        let cases: [(rotation: Float?, forwarded: Double)] = [
+            (nil, 0),
+            (0, 0),
+            (-90, -90),
+            (22.5, 22.5),
+        ]
+        for (rotation, forwarded) in cases {
+            fakeGesturePerformer.clearHistory()
+            let response = commandHandler.handle(.pinch(RequestPinch(
+                requestId: "pinch-ok",
+                centerX: 100,
+                centerY: 200,
+                distanceStart: 40,
+                distanceEnd: 80,
+                rotationDegrees: rotation
+            ))) as? WebSocketResponse
+            XCTAssertEqual(response?.success, true, "finite rotation \(String(describing: rotation)) must succeed")
+            let history = fakeGesturePerformer.getPinchHistory()
+            XCTAssertEqual(history.count, 1)
+            XCTAssertEqual(history.first?.rotationDegrees, forwarded)
+        }
+    }
+
+    /// iOS `offset` (multi-finger spacing) is a `Double?` — unlike Android's
+    /// `Int`, which cannot be non-finite and is deliberately unguarded there — so
+    /// a computed non-finite spacing gets the same defense-in-depth guard (#2991).
+    func testNonFiniteMultiFingerSwipeOffsetIsRejected() {
+        for bad in [Double.infinity, -.infinity, .nan] {
+            let response = commandHandler.handle(.multiFingerSwipe(RequestMultiFingerSwipe(
+                requestId: "mfs-offset",
+                x1: 10,
+                y1: 20,
+                x2: 30,
+                y2: 40,
+                fingerCount: 3,
+                offset: bad
+            ))) as? WebSocketResponse
+            assertRejectedNonFinite(response, type: "multi_finger_swipe_result", field: "offset")
+            XCTAssertTrue(
+                fakeGesturePerformer.getMultiFingerSwipeHistory().isEmpty,
+                "multi-finger swipe with offset=\(bad) must not reach the engine"
+            )
+        }
+    }
+
+    /// Finite offsets — the default (`nil` → 25), fractional, and zero — pass the
+    /// guard and are forwarded as the finger spacing.
+    func testFiniteMultiFingerSwipeOffsetStillDispatches() {
+        let cases: [(offset: Double?, forwarded: Double)] = [
+            (nil, 25),
+            (0, 0),
+            (12.5, 12.5),
+        ]
+        for (offset, forwarded) in cases {
+            fakeGesturePerformer.clearHistory()
+            let response = commandHandler.handle(.multiFingerSwipe(RequestMultiFingerSwipe(
+                requestId: "mfs-ok",
+                x1: 10,
+                y1: 20,
+                x2: 30,
+                y2: 40,
+                fingerCount: 3,
+                offset: offset
+            ))) as? WebSocketResponse
+            XCTAssertEqual(response?.success, true, "finite offset \(String(describing: offset)) must succeed")
+            let history = fakeGesturePerformer.getMultiFingerSwipeHistory()
+            XCTAssertEqual(history.count, 1)
+            XCTAssertEqual(history.first?.fingerSpacing, forwarded)
+        }
+    }
+
     /// The two-finger alias routes through the same multi-finger handler, so it
     /// gets the same guard.
     func testNonFiniteTwoFingerSwipeCoordinateIsRejected() {


### PR DESCRIPTION
Closes #2991

## Summary

iOS parity with Android #2964 / PR #2984: guard non-finite (`NaN`/`±Infinity`) pinch `rotationDegrees` at the CtrlProxy `CommandHandler` boundary.

- `handlePinch`: `try requireFinite(Double(request.rotationDegrees ?? 0), field: "rotationDegrees")` alongside the existing `centerX`/`centerY`/`distanceStart`/`distanceEnd` guards. `rotationDegrees` is a `Float?` (not a coordinate) but flows into the gesture-path math (degrees → radians → cos/sin); a non-finite value now returns a clean `pinch_result` `success:false` actionable error naming the field instead of dispatching.
- `handleMultiFingerSwipe`: **offset/fingerSpacing decision (AC3)** — Android deliberately leaves `offset` unguarded because it is an `Int` (cannot be non-finite). On iOS `offset` is a `Double?` feeding the per-finger spacing geometry, so a computed non-finite spacing *can* occur on the in-process construction path; it gets the same guard (documented in code, symmetric to the Android rationale). Covers the `request_two_finger_swipe` alias too (shared handler).
- Reuses the existing `requireFinite(_:field:)` helper — no new mechanism. Updated its doc comment to note the non-coordinate fields it now covers.

Defense-in-depth only: Apple `JSONDecoder` rejects overflow literals (`1e309`) at pre-parse, so a non-finite value cannot arrive over the wire (same finding as PR #2957 / #2984). The guard protects the in-process typed-initializer / computed-value path.

## Tests (TypedRequestDecodeTests conventions)

- `testNonFinitePinchRotationIsRejected` — +Inf/-Inf/NaN rotation → `pinch_result` failure naming `rotationDegrees`, nothing dispatched (all coordinate fields finite, so the new guard line is independently load-bearing).
- `testFinitePinchRotationStillDispatches` — default (`nil`→0), 0, negative, fractional rotations forwarded unchanged.
- `testNonFiniteMultiFingerSwipeOffsetIsRejected` / `testFiniteMultiFingerSwipeOffsetStillDispatches` — same pattern for `offset` (default `nil`→25 pinned).

## Validation

- `swift test` (ios/control-proxy): **369 tests, 0 failures** (83 in the TypedRequestDecode suite).
- `bunx turbo run lint build test`: green (no TS changes; cache hit).
- `bun run typecheck`: gate passes, no new errors.
- No files added/removed → no `xcodegen`/pbxproj regen needed.
- No added line exceeds the 120-col SwiftFormat max; style matches surrounding code (pinned-SwiftFormat hazard avoided by keeping the diff minimal).

## Caveats

- **Runtime delivery rides the next iOS runner release re-cut** (`RELEASE_CHECKSUM_REGISTRY` in `src/constants/release.ts`) — the daemon downloads a pinned release runner, so this guard reaches devices when the release is next cut (same as #2984's note). Test with `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` locally in the meantime.
- No files outside `ios/control-proxy` touched.