### PR TITLE
fix(server): advertise bounds as number, not integer — iOS coordinates are fractional points (#3206)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -132,34 +132,22 @@
               "type": "object",
               "properties": {
                 "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 }
               },
               "required": [
@@ -3352,34 +3340,22 @@
                         "type": "object",
                         "properties": {
                           "left": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "top": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "right": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "bottom": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "centerX": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "centerY": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           }
                         },
                         "required": [
@@ -3414,34 +3390,22 @@
                         "type": "object",
                         "properties": {
                           "left": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "top": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "right": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "bottom": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "centerX": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           },
                           "centerY": {
-                            "type": "integer",
-                            "minimum": -9007199254740991,
-                            "maximum": 9007199254740991
+                            "type": "number"
                           }
                         },
                         "required": [
@@ -3561,34 +3525,22 @@
                     "type": "object",
                     "properties": {
                       "left": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "top": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "right": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "bottom": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "centerX": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "centerY": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       }
                     },
                     "required": [
@@ -3631,34 +3583,22 @@
                 "type": "object",
                 "properties": {
                   "left": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "top": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "right": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "bottom": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "centerX": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "centerY": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   }
                 },
                 "required": [
@@ -3717,34 +3657,22 @@
               "type": "object",
               "properties": {
                 "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 }
               },
               "required": [
@@ -3919,34 +3847,22 @@
               "type": "object",
               "properties": {
                 "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 }
               },
               "required": [
@@ -4121,34 +4037,22 @@
               "type": "object",
               "properties": {
                 "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 }
               },
               "required": [
@@ -4499,34 +4403,22 @@
               "type": "object",
               "properties": {
                 "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 }
               },
               "required": [
@@ -6482,34 +6374,22 @@
               "type": "object",
               "properties": {
                 "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 }
               },
               "required": [
@@ -6698,34 +6578,22 @@
                     "type": "object",
                     "properties": {
                       "left": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "top": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "right": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "bottom": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "centerX": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       },
                       "centerY": {
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
+                        "type": "number"
                       }
                     },
                     "required": [
@@ -6784,34 +6652,22 @@
                   "type": "object",
                   "properties": {
                     "left": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "top": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "right": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "bottom": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "centerX": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "centerY": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -6986,34 +6842,22 @@
                   "type": "object",
                   "properties": {
                     "left": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "top": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "right": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "bottom": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "centerX": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     },
                     "centerY": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -7220,34 +7064,22 @@
               "type": "object",
               "properties": {
                 "left": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "top": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "right": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "bottom": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerX": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 },
                 "centerY": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
+                  "type": "number"
                 }
               },
               "required": [
@@ -7316,34 +7148,22 @@
                 "type": "object",
                 "properties": {
                   "left": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "top": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "right": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "bottom": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "centerX": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   },
                   "centerY": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
+                    "type": "number"
                   }
                 },
                 "required": [

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -94,6 +94,13 @@ export interface NodeAttributes {
 export interface ViewHierarchyNode {
   $: NodeAttributes;
   node?: ViewHierarchyNode[];
+  /**
+   * Element bounds in the platform's coordinate space: integer pixels on
+   * Android (accessibility-service `Rect`s), XCUITest points on iOS — which are
+   * legitimately fractional (retina point→pixel, sub-point layout). Consumers
+   * and wire schemas must treat these as plain numbers, never assume integers
+   * (issue #3206; see `boundsObjectSchema` in `src/server/toolOutputSchemas.ts`).
+   */
   bounds?: ElementBounds;
   recomposition?: RecompositionNodeInfo;
   recompositionMetrics?: RecompositionMetrics;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -5,13 +5,22 @@ import { z } from "zod";
 const booleanOrString = z.union([z.boolean(), z.literal("true"), z.literal("false")]).optional();
 
 // Default (verbose) bounds shape: the four-key object plus optional centers.
+//
+// Coordinates are plain numbers, NOT `.int()` (issue #3206): Android bounds are
+// integer pixels (accessibility-service `Rect`s), but iOS bounds are XCUITest
+// points — a coordinate space where fractional values (retina point→pixel,
+// sub-point layout) are legitimate. The iOS runner happens to truncate to `Int`
+// today (`ios/control-proxy/.../ElementLocator.swift`), but the TS model layer
+// (`ElementBounds`) is `number` end-to-end and nothing between the model and the
+// wire enforces integrality, so advertising `integer` would make a strict MCP
+// client reject a real observation the moment any producer emits a `.5`.
 const boundsObjectSchema = z.object({
-  left: z.number().int(),
-  top: z.number().int(),
-  right: z.number().int(),
-  bottom: z.number().int(),
-  centerX: z.number().int().optional(),
-  centerY: z.number().int().optional()
+  left: z.number(),
+  top: z.number(),
+  right: z.number(),
+  bottom: z.number(),
+  centerX: z.number().optional(),
+  centerY: z.number().optional()
 });
 
 // Compact bounds shape emitted only when the `--observe-result-compact` output-
@@ -20,7 +29,7 @@ const boundsObjectSchema = z.object({
 // The tuple carries no centers — a consumer derives them as (left+right)/2,
 // (top+bottom)/2. This is a fixed-length 4-tuple so it round-trips losslessly.
 const compactBoundsTupleSchema = z
-  .tuple([z.number().int(), z.number().int(), z.number().int(), z.number().int()])
+  .tuple([z.number(), z.number(), z.number(), z.number()])
   .describe(
     "Compact bounds tuple [left, top, right, bottom]; emitted in place of the " +
       "{left, top, right, bottom} object only when the --observe-result-compact " +
@@ -238,9 +247,9 @@ const viewHierarchyWindowSchema = z.object({
  *
  * The iOS root `Hierarchy.bounds` is deliberately NOT routed through the union:
  * its `left`/`top` are optional (`{left?, top?, right, bottom}`, points), so the
- * element union (which requires all four integer keys, and whose compact tuple
- * cannot express the `[null, null, r, b]` holes `compactObserveBounds` emits for
- * a partial root) would wrongly reject a real iOS observation. It rides
+ * element union (which requires all four keys, and whose compact tuple cannot
+ * express the `[null, null, r, b]` holes `compactObserveBounds` emits for a
+ * partial root) would wrongly reject a real iOS observation. It rides
  * `.passthrough()` on the hierarchy object instead — honest by omission rather
  * than advertising a shape the server never emits for that site. Everything else
  * (`packageName`, `sources`, screen/density metadata, …) also passes through.

--- a/test/fixtures/observe/ios-fractional-bounds.json
+++ b/test/fixtures/observe/ios-fractional-bounds.json
@@ -1,0 +1,108 @@
+{
+  "updatedAt": 1751500000000,
+  "screenSize": {
+    "width": 1179,
+    "height": 2556
+  },
+  "viewHierarchy": {
+    "hierarchy": {
+      "bounds": {
+        "right": 393,
+        "bottom": 851.6666666666666
+      },
+      "node": {
+        "class": "XCUIElementTypeApplication",
+        "view-id": "root",
+        "bounds": {
+          "left": 0,
+          "top": 0,
+          "right": 393,
+          "bottom": 851.6666666666666
+        },
+        "node": [
+          {
+            "class": "XCUIElementTypeNavigationBar",
+            "view-id": "nav-bar",
+            "bounds": {
+              "left": 0,
+              "top": 59.333333333333336,
+              "right": 393,
+              "bottom": 103.66666666666667
+            },
+            "node": [
+              {
+                "class": "XCUIElementTypeStaticText",
+                "text": "Reminders",
+                "view-id": "title",
+                "bounds": {
+                  "left": 20.5,
+                  "top": 68.33333333333333,
+                  "right": 168.5,
+                  "bottom": 94.66666666666667
+                }
+              }
+            ]
+          },
+          {
+            "class": "XCUIElementTypeButton",
+            "text": "New Reminder",
+            "clickable": "true",
+            "enabled": "true",
+            "view-id": "new-reminder",
+            "bounds": {
+              "left": 16.333333333333332,
+              "top": 786.5,
+              "right": 201.66666666666666,
+              "bottom": 823.5
+            }
+          }
+        ]
+      }
+    },
+    "packageName": "com.apple.reminders",
+    "screenScale": 3,
+    "screenWidth": 393,
+    "screenHeight": 852
+  },
+  "elements": {
+    "clickable": [
+      {
+        "class": "XCUIElementTypeButton",
+        "text": "New Reminder",
+        "view-id": "new-reminder",
+        "bounds": {
+          "left": 16.333333333333332,
+          "top": 786.5,
+          "right": 201.66666666666666,
+          "bottom": 823.5
+        }
+      }
+    ],
+    "scrollable": [],
+    "text": [
+      {
+        "class": "XCUIElementTypeStaticText",
+        "text": "Reminders",
+        "view-id": "title",
+        "bounds": {
+          "left": 20.5,
+          "top": 68.33333333333333,
+          "right": 168.5,
+          "bottom": 94.66666666666667
+        }
+      }
+    ],
+    "media": []
+  },
+  "focusedElement": {
+    "text": "New Reminder",
+    "bounds": {
+      "left": 16.333333333333332,
+      "top": 786.5,
+      "right": 201.66666666666666,
+      "bottom": 823.5,
+      "centerX": 109,
+      "centerY": 805
+    }
+  }
+}

--- a/test/fixtures/observe/observeFixture.ts
+++ b/test/fixtures/observe/observeFixture.ts
@@ -35,6 +35,27 @@ export function loadAndroidHomeObserve(): { raw: string; observe: ObserveResult 
 }
 
 /**
+ * iOS observe fixture with fractional point coordinates (issue #3206).
+ *
+ * No real iOS capture exists in-tree, so this is a HAND-BUILT representative —
+ * not a device capture. It mirrors the shape
+ * `CtrlProxyHierarchy.convertToViewHierarchyResult` produces (root
+ * `hierarchy.bounds` with optional left/top in points,
+ * `screenScale`/`screenWidth`/`screenHeight`, XCUIElement class names) and
+ * carries the fractional values the iOS points coordinate space legitimately
+ * produces (thirds from @3x retina, `.5` sub-point layout). It pins that the
+ * advertised output schemas never claim `integer` for a points-based
+ * coordinate. Replace with a real simulator capture when one is taken (needs
+ * hardware; see issue #3206 verification notes).
+ */
+export const IOS_FRACTIONAL_FIXTURE_PATH = join(import.meta.dir, "ios-fractional-bounds.json");
+
+/** Load the iOS fractional-bounds fixture as a parsed `ObserveResult`. */
+export function loadIosFractionalObserve(): ObserveResult {
+  return JSON.parse(readFileSync(IOS_FRACTIONAL_FIXTURE_PATH, "utf8")) as ObserveResult;
+}
+
+/**
  * Real-device before/after observation pairs captured for the `--actions-diff-observe`
  * sign-off (issue #3051; see
  * `docs/design-docs/plat/android/actions-diff-observe-signoff.md`). Each file is a

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src/server/compactBoundsAdvertisement";
 import { flattenTopLevelUnion } from "../../src/server/TopLevelUnionFlattener";
 import { sanitizeObserveResult } from "../../src/features/observe/output/ObserveResultOutput";
-import { loadAndroidHomeObserve } from "../fixtures/observe/observeFixture";
+import { loadAndroidHomeObserve, loadIosFractionalObserve } from "../fixtures/observe/observeFixture";
 import { ToolRegistry, toolHasOutputSchema } from "../../src/server/toolRegistry";
 import { registerObserveTools } from "../../src/server/observeTools";
 import { serverConfig } from "../../src/utils/ServerConfig";
@@ -64,12 +64,24 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
 
   test("accepts an iOS root hierarchy.bounds with optional left/top (points)", () => {
     // Hierarchy.bounds is `{left?, top?, right, bottom}` on iOS — the element
-    // union (all-four-int) would wrongly reject it, so it rides passthrough.
+    // union (all four keys required) would wrongly reject it, so it rides
+    // passthrough.
     const objectRoot = { viewHierarchy: { hierarchy: { bounds: { right: 390, bottom: 844 } } } };
     expect(() => observeResultSchema.parse(objectRoot)).not.toThrow();
     // ...and its compacted `[null, null, r, b]` tuple form is not rejected either.
     const compactedRoot = { viewHierarchy: { hierarchy: { bounds: [null, null, 390, 844] } } };
     expect(() => observeResultSchema.parse(compactedRoot)).not.toThrow();
+  });
+
+  test("accepts the iOS fractional-points fixture, object and compacted forms (#3206)", () => {
+    // iOS bounds are XCUITest points — legitimately fractional. The previous
+    // `z.number().int()` claim made a strict client reject such an observation.
+    const observe = loadIosFractionalObserve();
+    // Sanity: the fixture really does carry fractional coordinates.
+    expect(JSON.stringify(observe)).toContain("786.5");
+    expect(() => observeResultSchema.parse(observe)).not.toThrow();
+    const compacted = sanitizeObserveResult(observe, { dropElements: false, compact: true });
+    expect(() => observeResultSchema.parse(compacted)).not.toThrow();
   });
 
   test("routes elements.media[].bounds through the advertised union (object + tuple)", () => {

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -51,3 +51,37 @@ describe("elementBoundsSchema: object + compact tuple (#2990)", () => {
     expect(json.toLowerCase()).toContain("observe-result-compact");
   });
 });
+
+/**
+ * Fractional-coordinate coverage (issue #3206). iOS bounds are XCUITest points,
+ * which are legitimately fractional (retina point→pixel thirds, `.5` sub-point
+ * layout). The schema previously claimed `z.number().int()`, so a strict MCP
+ * client generating a decoder from the advertised `outputSchema` would have
+ * rejected a real iOS observation carrying a `.5` coordinate.
+ */
+describe("elementBoundsSchema: fractional iOS point coordinates (#3206)", () => {
+  test("accepts fractional object bounds (the issue's repro)", () => {
+    const fractional = { left: 0.5, top: 1.2, right: 100, bottom: 200 };
+    expect(elementBoundsSchema.parse(fractional)).toEqual(fractional);
+  });
+
+  test("accepts fractional centerX/centerY", () => {
+    const withCenters = { left: 20.5, top: 68.5, right: 168.5, bottom: 94.5, centerX: 94.5, centerY: 81.5 };
+    expect(elementBoundsSchema.parse(withCenters)).toEqual(withCenters);
+  });
+
+  test("accepts a fractional compact tuple", () => {
+    const tuple = [16.333333333333332, 786.5, 201.66666666666666, 823.5];
+    expect(elementBoundsSchema.parse(tuple)).toEqual(tuple);
+  });
+
+  test("the advertised JSON schema claims number, not integer, for bounds coordinates", () => {
+    const json = toJSONSchema(elementBoundsSchema) as Record<string, unknown>;
+    expect(JSON.stringify(json)).not.toContain("\"integer\"");
+  });
+
+  test("still rejects non-numeric bounds values", () => {
+    expect(() => elementBoundsSchema.parse({ left: "0.5", top: 1, right: 2, bottom: 3 })).toThrow();
+    expect(() => elementBoundsSchema.parse([0.5, 1, 2, "3"])).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #3206

## Summary

`elementBoundsSchema` advertised bounds coordinates as `z.number().int()`, but iOS bounds are XCUITest **points** — a coordinate space where fractional values (retina point→pixel thirds, `.5` sub-point layout) are legitimate. A strict MCP client generating a decoder from the advertised `outputSchema` would reject a real iOS observation carrying a `.5` coordinate. This affects every tool routing bounds through the shared schema: `tapOn`, `accessibilityFocus`, and `observe`.

Per the issue's decision fork ("guaranteed integer? document; otherwise relax"): the only integrality today is an incidental `Int(frame.origin.x)` truncation in the iOS runner (`ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift:648`) — the TS model layer (`ElementBounds`) is `number` end-to-end and nothing between the model and the wire enforces integers, so the schema is **relaxed** rather than documenting a guarantee that no layer actually owns.

## Changes

- `src/server/toolOutputSchemas.ts`: `boundsObjectSchema` (left/top/right/bottom/centerX/centerY) and `compactBoundsTupleSchema` relaxed from `z.number().int()` to `z.number()`, with a comment explaining why; fixed the now-stale "all four integer keys" comment on the iOS root-bounds exemption.
- `schemas/tool-definitions.json`: regenerated (`bun scripts/generate-tool-definitions.ts`); the diff is exclusively bounds `"integer"` → `"number"` blocks (verified by filtered diff — no other content changed).
- `src/models/ViewHierarchyResult.ts`: documented the per-platform coordinate space on `ViewHierarchyNode.bounds` (Android integer pixels, iOS fractional points).
- `test/fixtures/observe/ios-fractional-bounds.json` + loader: iOS-shaped observe fixture with fractional point coordinates (partial root `hierarchy.bounds`, `screenScale`, XCUIElement class names).
- Tests: the issue's exact repro (`elementBoundsSchema.parse({left:0.5, top:1.2, right:100, bottom:200})`) now passes; fractional tuple/centers accepted; advertised JSON schema asserted to claim `number` (never `integer`); non-numeric values still rejected; the fixture parses in both object and compacted (`sanitizeObserveResult(..., {compact:true})`) forms.

## Validation

- `bun test test/server/toolOutputSchemas.test.ts test/server/observeOutputSchema.test.ts test/server/compactBoundsAdvertisement.test.ts test/fixtures/observe/androidHomeFixture.test.ts` — 39 pass / 0 fail (~294ms)
- `turbo run lint build test` — 3 tasks successful; 6673 pass / 0 fail
- `bun run typecheck` — gate green, no new errors. (It reports some baseline errors "no longer occur", but that delta does not reproduce consistently on clean HEAD locally — environment noise, so the baseline was deliberately NOT ratcheted here.)
- Confirmed `outputSchema` is advertisement-only (`toolRegistry.ts`; `index.ts` parses tool *input* only), so this change has zero server-side runtime effect — it only stops the advertised contract from over-claiming.

## Caveats

- The fixture is a **hand-built representative** (clearly documented in `observeFixture.ts`), not a real capture — no iOS fixture exists in-tree and capturing one needs simulator hardware. Follow-up: replace it with a real `observe` capture from an iOS simulator.
- `screenSizeSchema`/`systemInsetsSchema` keep `.int()` deliberately: iOS screen dimensions are `Math.round`-ed before emission and insets are Android-sourced (zeroed fallback on iOS).
- Only lane-owned files touched (plus the generated `schemas/tool-definitions.json` and test files, which the issue explicitly calls for).
