### PR TITLE
fix(android): resolve control-proxy lintDebug errors (#3181)

### DIFF
--- a/android/control-proxy/src/main/AndroidManifest.xml
+++ b/android/control-proxy/src/main/AndroidManifest.xml
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
   <!-- Package visibility for Android 11+ to access ContentProviders in other apps -->
   <!-- This permission allows the accessibility service to query any installed package -->
   <!-- Required for storage inspection to work with any app that has the AutoMobile SDK -->
-  <!-- Note: This is appropriate for a debugging/development tool like AutoMobile -->
-  <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+  <!-- Note: This is appropriate for a debugging/development tool like AutoMobile. -->
+  <!-- CtrlProxy is sideloaded via adb for device automation and is never distributed -->
+  <!-- through Google Play, so the Play policy behind QueryAllPackagesPermission does -->
+  <!-- not apply. A <queries> allowlist is impossible: target apps are arbitrary. -->
+  <uses-permission
+      android:name="android.permission.QUERY_ALL_PACKAGES"
+      tools:ignore="QueryAllPackagesPermission" />
   <uses-permission android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL" />
 
   <!-- Permissions required for accessibility service -->

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -2340,7 +2340,23 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val endX = x2.toFloat()
       val endY = y2.toFloat()
 
-      if (pressDurationMs > 0) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        // Pre-API-26 GestureDescription has no stroke continuation (the willContinue
+        // StrokeDescription constructor is API 26+), so press/drag/hold cannot be
+        // chained as one continuous touch. Approximate with a single stroke covering
+        // the combined duration. Previously this path threw NoSuchMethodError.
+        val totalDurationMs = maxOf(1L, pressDurationMs + dragDurationMs + holdDurationMs)
+        val dragPath =
+          Path().apply {
+            moveTo(startX, startY)
+            lineTo(endX, endY)
+          }
+        gestureBuilder.addStroke(GestureDescription.StrokeDescription(dragPath, 0, totalDurationMs))
+        Log.d(
+          TAG,
+          "Legacy (<API 26) single-stroke drag: ($startX, $startY) -> ($endX, $endY), duration=${totalDurationMs}ms",
+        )
+      } else if (pressDurationMs > 0) {
         // Phase 1: Press and hold at start position
         // Use zero-length path (moveTo + lineTo same point) for stationary touch
         val pressPath =

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -821,7 +821,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       if (Build.VERSION.SDK_INT >= 30) {
         stateDescription = node.stateDescription?.toString()
       }
-      val hintText: String? = node.hintText?.toString()
+      // AccessibilityNodeInfo.getHintText requires API 26 (minSdk is 24)
+      val hintText: String? = if (Build.VERSION.SDK_INT >= 26) node.hintText?.toString() else null
       val errorMessage: String? = node.error?.toString()
       if (Build.VERSION.SDK_INT >= 28) {
         tooltipText = node.tooltipText?.toString()
@@ -1809,7 +1810,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       if (Build.VERSION.SDK_INT >= 30) {
         stateDescription = focusedNode.stateDescription?.toString()
       }
-      val hintText: String? = focusedNode.hintText?.toString()
+      // AccessibilityNodeInfo.getHintText requires API 26 (minSdk is 24)
+      val hintText: String? =
+        if (Build.VERSION.SDK_INT >= 26) focusedNode.hintText?.toString() else null
       val errorMessage: String? = focusedNode.error?.toString()
       var tooltipText: String? = null
       var paneTitle: String? = null


### PR DESCRIPTION
Closes #3181

## Summary

`./gradlew :control-proxy:lintDebug` failed on main with 8 errors (reproduced in this worktree). This PR fixes all of them:

- **`QueryAllPackagesPermission`** (`AndroidManifest.xml`): added a targeted `tools:ignore` with an inline justification. CtrlProxy is an adb-sideloaded automation runner installed by the daemon from a pinned release — it is never distributed through Google Play, so the Play policy behind this check does not apply, and a `<queries>` allowlist is impossible because the apps under automation are arbitrary.
- **`NewApi`: `AccessibilityNodeInfo.getHintText` (API 26, minSdk 24)** — 2 sites in `ViewHierarchyExtractor.kt`, now guarded with `SDK_INT >= 26` checks matching the file's existing guard style (`>= 28`, `>= 30` on adjacent lines). Returns `null` on API 24/25 instead of throwing `NoSuchMethodError`; the TS layer already treats `hintText` as optional.
- **`NewApi`: 4-arg `StrokeDescription(..., willContinue)` (API 26)** — 5 sites in `CtrlProxy.performDrag`. Added a pre-26 branch that approximates the drag with a single 3-arg stroke (API 24+) over the combined press+drag+hold duration. The existing API 26+ multi-stroke logic is untouched. Note: previously *every* pre-26 drag crashed at runtime (`NoSuchMethodError` — both branches used the 4-arg constructor), so the fallback is a strict improvement.

## Validation

- `./gradlew :control-proxy:lintDebug` (JDK 21): **before** = 8 errors / 46 warnings, FAILED; **after** = 0 errors / 46 warnings, BUILD SUCCESSFUL (no new warnings introduced).
- `./gradlew :control-proxy:testDebugUnitTest`: BUILD SUCCESSFUL (includes the source-scan suites over `CtrlProxy.kt`).
- `scripts/ktfmt/validate_ktfmt.sh` on touched files: clean.
- `turbo run lint build test`: green (Android-only change; TS untouched).

## Caveats

- No unit test for the pre-26 drag fallback: exercising it would need a Robolectric `@Config(sdk = 25)` harness driving a private method on the `AccessibilityService`; the `NewApi` lint gate (the subject of this issue) is the regression backstop.
- Runtime behavior of the runner ships via the pinned release APK, so the API 24/25 fixes reach devices with the next runner release cut; the lint-gate benefit is immediate.
- The 46 remaining lint *warnings* (ScopedStorage, InternalInsetResource, OldTargetApi, etc.) do not fail `lintDebug` and are out of scope per the issue, which called out the 3 error classes as the actionable blockers.