### PR TITLE
ci(image): disable JSC Wasm OSR for Bun image runtime smoke (#3189)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1028,7 +1028,15 @@ jobs:
       - name: "Run Bun MCP startup smoke"
         run: bun run test:startup:bun
 
+      # The smoke exercises @jimp/wasm-webp (Emscripten WASM). Bun's JSC Wasm
+      # OSR tier intermittently miscompiles Emscripten modules on Linux x64
+      # (oven-sh/bun#26366), surfacing as "access to a null reference
+      # (evaluating 'cppInvokerFunc.apply(...)')" in the embind glue. Disable
+      # the OSR tier for this step only; semantics are unchanged, JSC falls
+      # back to its other Wasm tiers. See issue #3189.
       - name: "Run Bun image runtime smoke"
+        env:
+          BUN_JSC_useWasmOSR: "0"
         run: bun run test:image:bun
 
       - name: "Run Tests with Coverage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,12 @@ jobs:
       - name: Run Bun MCP startup smoke
         run: bun run test:startup:bun
 
+      # Disable the JSC Wasm OSR tier: it intermittently miscompiles the
+      # @jimp/wasm-webp Emscripten module on Linux x64 (oven-sh/bun#26366),
+      # failing the smoke with an embind null-reference error. See issue #3189.
       - name: Run Bun image runtime smoke
+        env:
+          BUN_JSC_useWasmOSR: "0"
         run: bun run test:image:bun
 
       - name: Create release notes


### PR DESCRIPTION
Closes #3189

## Root cause

The intermittent `Node TypeScript Build and Test (ubuntu-latest)` failure in `bun scripts/ci/image-runtime-smoke.ts`:

```
error: Image processing error: access to a null reference (evaluating 'cppInvokerFunc.apply(null, invokerFuncArgs)')
```

is not a regression in AutoMobile code. `cppInvokerFunc.apply(null, invokerFuncArgs)` is Emscripten **embind** glue, and the only Emscripten WASM module on the smoke path is `@jimp/wasm-webp` (the WebP codec behind `Image...webp().toBuffer()` — the failing `toBuffer` frame at `src/utils/image/ImageTransformer.ts:138` is just the catch-rethrow around `backend.execute`). Bun's JSC **Wasm OSR tier intermittently miscompiles Emscripten modules on Linux x64** — upstream [oven-sh/bun#26366](https://github.com/oven-sh/bun/issues/26366) (open, reported on Linux x64, intermittent after JIT tier-up, documented workaround `JSC_useWasmOSR=0`). This is the same bug class this repo already works around on Windows, where it manifests as a `bun test` segfault (see the gate comment in `test/utils/image/backend/JimpBackend.test.ts:21`).

That explains every observation in #3189: intermittent (JIT tier-up timing), passes on rerun, unrelated to the PR that hit it, and not reproducible on macOS (different JIT backend/arch).

## Fix

Set `BUN_JSC_useWasmOSR: "0"` on the two steps that run `bun run test:image:bun` — the PR ubuntu job (`pull_request.yml`) and the release verify job (`release.yml`, also ubuntu-latest). This disables only the buggy OSR tier; JSC's other Wasm tiers execute the module with identical semantics, so the smoke still validates everything it validated before (PNG/WebP roundtrip, three distinct WebP modes, metadata, perceptual hash).

## Validation

- Downloaded the exact CI-pinned **Bun 1.3.9** and confirmed via `BUN_JSC_dumpOptions=2` that `useWasmOSR` exists (default `true`) and that the step-style env `BUN_JSC_useWasmOSR=0` flips it to `false` **in the child VM spawned by `bun run test:image:bun`** (env inherits through `bun run`): `useWasmOSR=false (default: true)` + `Image runtime smoke passed`.
- Smoke passes with and without the flag on Bun 1.3.9 and 1.3.14, no measurable timing change (~0.2s).
- `actionlint` on both workflows: no findings on changed lines (pre-existing findings elsewhere untouched).
- `bunx turbo run lint build test`: green (no TS changes; typecheck gate not applicable).
- Could not reproduce the crash locally: it is Linux-x64-JIT-specific (macOS arm64 host, no Docker daemon available). Attribution rests on the exact embind error signature + upstream bun#26366 + this repo's existing Windows precedent for the same bug class.

## Caveats / follow-up

- The ubuntu **coverage** step (`bun test`) also executes `@jimp/wasm-webp` (JimpBackend WebP tests run on non-Windows), so the same upstream bug could in principle flake there too. Left out of this PR to keep the change scoped to the observed failure; if it recurs in `bun test`, extend the same env var to that step.
- The long-term removal of this WASM crash surface is the sharp/cwebp backend migration tracked in `docs/design-docs/image-backend.md` (#2974/#3009 series).
- Files touched are CI workflows only — in-lane for ci-image-flake, no source changes.
