### PR TITLE
fix(observe): capture-layer stable node identity for id-less scroll rows (#3228)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1017,9 +1017,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
    * Generate a deterministic UUID from a hierarchy path string. Uses SHA-256 to hash the path and
    * formats the first 16 bytes as a UUID string.
    *
-   * NOTE (#3228): this id is *positional* — a list scroll shifts child indices, so a moved row
-   * gets a different UUID and the row now occupying its old slot inherits the departed row's.
-   * The daemon's TS ingest (`StableNodeIdentity.assignStableViewIds`) therefore rewrites every
+   * NOTE (#3228): this id is *positional* — a list scroll shifts child indices, so a moved row gets
+   * a different UUID and the row now occupying its old slot inherits the departed row's. The
+   * daemon's TS ingest (`StableNodeIdentity.assignStableViewIds`) therefore rewrites every
    * UUID-shaped viewId into a content-derived stable id before the hierarchy reaches consumers.
    * Keep the UUID shape here (8-4-4-4-12 lowercase hex): it is the marker the ingest matches;
    * emitting a different shape would make ids pass through unrewritten.

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1016,6 +1016,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   /**
    * Generate a deterministic UUID from a hierarchy path string. Uses SHA-256 to hash the path and
    * formats the first 16 bytes as a UUID string.
+   *
+   * NOTE (#3228): this id is *positional* — a list scroll shifts child indices, so a moved row
+   * gets a different UUID and the row now occupying its old slot inherits the departed row's.
+   * The daemon's TS ingest (`StableNodeIdentity.assignStableViewIds`) therefore rewrites every
+   * UUID-shaped viewId into a content-derived stable id before the hierarchy reaches consumers.
+   * Keep the UUID shape here (8-4-4-4-12 lowercase hex): it is the marker the ingest matches;
+   * emitting a different shape would make ids pass through unrewritten.
    */
   private fun generateDeterministicUuid(path: String): String {
     val bytes = java.security.MessageDigest.getInstance("SHA-256").digest(path.toByteArray())

--- a/docs/design-docs/plat/android/actions-diff-observe-signoff.md
+++ b/docs/design-docs/plat/android/actions-diff-observe-signoff.md
@@ -208,7 +208,14 @@ above:
 
 - Capture-layer: emit real stable node identity so scroll diffs collapse the
   id-less/text-less cascade (the residual opacity in §4) — the genuine fix
-  #3107 pointed at, orthogonal to the diff format.
+  #3107 pointed at, orthogonal to the diff format. **Landed as #3228**: the TS
+  ingest (`assignStableViewIds`, `src/features/observe/android/StableNodeIdentity.ts`)
+  rewrites the runner's path-derived UUID `view-id`s into content-derived
+  stable ids (Merkle hash of stable subtree content, ordinal-suffixed for
+  content-identical duplicates), and `view-id` joined `extras` in
+  `DIFF_IGNORED_ATTRS`. On this scroll pair the opaque residuals drop 28 → 4,
+  churn 56 → 40, and the diff share falls to ~26% bytes / ~59% tokens (pinned
+  by `test/features/observe/output/stableIdentityScrollDiff.test.ts`).
 - Capture-layer: surface Compose toggle state (`checked`/`selected`/
   `stateDescription`) in the extracted hierarchy so state toggles diff as
   `changed` on real Compose apps (**#3139**).

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -24,6 +24,7 @@ import type {
 } from "./types";
 import { generateSecureId } from "./types";
 import { ctrlProxyRequests, serializeCtrlProxyRequest } from "./ctrlProxyProtocol";
+import { assignStableViewIds } from "./StableNodeIdentity";
 
 /** Cooldown after a WebSocket timeout before retrying fresh-data waits.
  *  Keep short: a long cooldown (e.g. 5s) turns a single slow response into
@@ -486,10 +487,20 @@ export class CtrlProxyHierarchy {
       // Convert the accessibility node format
       const convertedHierarchy = this.convertAccessibilityNode(hierarchyToConvert);
 
+      // Capture-layer stable node identity (issue #3228): rewrite the runner's
+      // positional (path-derived UUID) view-ids into content-derived stable ids
+      // so id-less rows keep their identity across a scroll and the diff
+      // layer's content-identity re-pair can collapse scroll churn.
+      assignStableViewIds(convertedHierarchy);
+
       // Convert accessibility-focused element if present
       const accessibilityFocusedElement = accessibilityHierarchy["accessibility-focused-element"]
         ? this.convertAccessibilityNode(accessibilityHierarchy["accessibility-focused-element"])
         : undefined;
+      // Same rewrite for the focus mirror so its view-id matches the hierarchy
+      // node's (the mirror is the same node content, so the content hash
+      // agrees; only a content-identical duplicate's ordinal suffix can differ).
+      assignStableViewIds(accessibilityFocusedElement);
 
       const result: ViewHierarchyResult = {
         "hierarchy": convertedHierarchy,

--- a/src/features/observe/android/StableNodeIdentity.ts
+++ b/src/features/observe/android/StableNodeIdentity.ts
@@ -1,0 +1,144 @@
+import { createHash } from "crypto";
+
+/**
+ * Capture-layer stable node identity for id-less Android nodes (issue #3228).
+ *
+ * The Android CtrlProxy runner (`ViewHierarchyExtractor.kt`) fills `view-id`
+ * with the `resource-id` when one exists, and otherwise with a deterministic
+ * UUID derived from the node's *tree path* (ancestor child indices +
+ * resource-ids). That path is positional: a list scroll shifts every row's
+ * child index, so a moved row gets a *different* UUID — and, worse, the row
+ * that now occupies the old slot gets the *same* UUID as the departed one.
+ * The diff layer's content-identity re-pair (`contentIdentityKey` in
+ * `ObserveResultOutput.ts`) therefore can never re-pair id-less/text-less rows
+ * across a scroll: their only candidate id churns with position. That is the
+ * residual "opaque remove+add cascade" quantified in
+ * `docs/design-docs/plat/android/actions-diff-observe-signoff.md` §4.
+ *
+ * This module rewrites those *generated* (UUID-shaped) `view-id`s at TS
+ * ingest into a **content-derived** stable id: a Merkle-style SHA-256 over the
+ * node's own stable content fields plus its children's content hashes —
+ * deliberately excluding everything a scroll or interaction perturbs (bounds,
+ * sibling position, `extras`, focus/checked/occlusion state). The same row
+ * therefore keeps the same id before and after a scroll, and two rows with
+ * different content can never share one.
+ *
+ * Content-identical duplicates (repeated spacer rows, empty Compose click
+ * surfaces) share a hash by construction, so the k-th duplicate (document
+ * order) gets an ordinal `-k` suffix. That keeps `view-id` unique within a
+ * capture (a property the path UUIDs provided) and lets the diff layer's
+ * uniqueness-on-both-sides guard re-pair duplicates in encounter order — the
+ * same best-effort heuristic `diffObserveResult` already applies to identical
+ * same-path siblings. Distinct rows still cannot false-merge: an ordinal only
+ * ever disambiguates nodes whose *entire* stable subtree content is identical.
+ *
+ * Rewriting at ingest (rather than in the Kotlin extractor) means it applies
+ * to every already-released runner — the runner APK is a pinned release, so a
+ * Kotlin-side change would not reach devices until the next re-cut. If the
+ * extractor later emits content-derived ids natively they just won't match
+ * the UUID shape and will pass through untouched.
+ */
+
+/**
+ * Shape of the runner's *generated* `view-id` (see
+ * `ViewHierarchyExtractor.generateDeterministicUuid`): the first 16 bytes of a
+ * SHA-256 formatted as a lowercase hex UUID. A real Android `resource-id`
+ * (`package:id/name`) can never match. Only ids matching this shape are
+ * rewritten, so resource-id-backed `view-id`s and any future non-UUID formats
+ * pass through untouched (which also makes the rewrite idempotent — the
+ * emitted `s-…` ids do not match).
+ */
+export const GENERATED_VIEW_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Prefix marking a content-derived stable id emitted by this module. */
+export const STABLE_VIEW_ID_PREFIX = "s-";
+
+/**
+ * Node fields that participate in the content hash: the stable, position-free
+ * description of what the node *is*. Everything else is deliberately excluded:
+ * `bounds` and sibling order shift on scroll; `focused` / `checked` /
+ * `selected` / `enabled` flip on interaction (a toggle should surface as a
+ * `changed` delta, not an identity change); `extras` and
+ * `occlusionState`/`occludedBy` churn nondeterministically between captures
+ * (#3051).
+ */
+const CONTENT_FIELDS: readonly string[] = [
+  "className",
+  "resource-id",
+  "content-desc",
+  "text",
+  "test-tag",
+];
+
+/** Normalize the `node` child slot (absent / single object / array) to an array. */
+function toChildArray(node: Record<string, unknown>): Record<string, unknown>[] {
+  const children = node["node"];
+  if (!children) {
+    return [];
+  }
+  const arr = Array.isArray(children) ? children : [children];
+  return arr.filter((c): c is Record<string, unknown> => !!c && typeof c === "object");
+}
+
+/**
+ * Rewrite every generated (UUID-shaped) `view-id` under `root` — in place —
+ * into a content-derived stable id: `s-<hash16>` for the first node with a
+ * given content hash in document order, `s-<hash16>-<k>` for the k-th
+ * content-identical duplicate. Nodes whose `view-id` is absent or not
+ * UUID-shaped (resource-id-backed ids, already-stable ids) are left untouched,
+ * so the pass is a no-op on non-CtrlProxy hierarchies and idempotent on its
+ * own output. Accepts the converted hierarchy root (or any node-like object);
+ * a non-object input is ignored.
+ */
+export function assignStableViewIds(root: unknown): void {
+  if (!root || typeof root !== "object") {
+    return;
+  }
+  if (Array.isArray(root)) {
+    // A multi-root capture: each root is an independent tree, but duplicates
+    // are still suffixed per tree here (roots are processed independently) —
+    // acceptable because the Android converter emits a single root object.
+    for (const item of root) {
+      assignStableViewIds(item);
+    }
+    return;
+  }
+  const rootNode = root as Record<string, unknown>;
+
+  // Pass 1 (bottom-up): Merkle content hash per node — own stable fields plus
+  // the *hashes* of the children, so cost stays O(n) instead of concatenating
+  // whole subtrees at every level.
+  const contentHash = new Map<Record<string, unknown>, string>();
+  const compute = (node: Record<string, unknown>): string => {
+    const childHashes = toChildArray(node).map(compute);
+    // JSON-encoding the field array keeps values from straddling separator
+    // boundaries (text can contain any delimiter we might pick by hand).
+    const canonical = JSON.stringify([
+      ...CONTENT_FIELDS.map(field => node[field] ?? ""),
+      childHashes,
+    ]);
+    const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+    contentHash.set(node, hash);
+    return hash;
+  };
+  compute(rootNode);
+
+  // Pass 2 (pre-order): assign ids, suffixing content-identical duplicates by
+  // document-order occurrence so ids stay unique within the capture.
+  const occurrences = new Map<string, number>();
+  const assign = (node: Record<string, unknown>): void => {
+    const viewId = node["view-id"];
+    if (typeof viewId === "string" && GENERATED_VIEW_ID_PATTERN.test(viewId)) {
+      const hash = contentHash.get(node)!;
+      const seen = (occurrences.get(hash) ?? 0) + 1;
+      occurrences.set(hash, seen);
+      node["view-id"] =
+        seen === 1 ? `${STABLE_VIEW_ID_PREFIX}${hash}` : `${STABLE_VIEW_ID_PREFIX}${hash}-${seen}`;
+    }
+    for (const child of toChildArray(node)) {
+      assign(child);
+    }
+  };
+  assign(rootNode);
+}

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -589,8 +589,21 @@ function elementValuesEqual(a: unknown, b: unknown): boolean {
  * consumer can reconstruct it without the baseline, and `extras` is never part of
  * the node identity key — so this changes only what a matched node / mirror
  * *reports*, never how nodes are paired.
+ *
+ * `view-id` (issue #3228): post-trim, a `view-id` is always a *synthetic*
+ * identity — either the capture layer's content-derived stable id
+ * (`assignStableViewIds`, an SHA-256 over the node's stable subtree content) or
+ * a legacy path-derived UUID; a resource-id-backed `view-id` duplicates
+ * `resource-id` and is dropped by `trimHierarchyNodes`. Its value exists to
+ * *pair* nodes (`contentIdentityKey` still reads it), but its own churn is
+ * never an actionable UI delta: a content-derived id changes exactly when some
+ * descendant's content changed — which the child's own diff entry already
+ * reports — so surfacing it on every id-less ancestor of an edited node would
+ * re-flood localized diffs the way `extras` once did. Excluded from the
+ * *changed* comparison only; pairing and `added`/`removed` reconstruction are
+ * unaffected.
  */
-export const DIFF_IGNORED_ATTRS: ReadonlySet<string> = new Set(["extras"]);
+export const DIFF_IGNORED_ATTRS: ReadonlySet<string> = new Set(["extras", "view-id"]);
 
 /** Per-attribute diff of two attribute maps (union of keys). */
 function diffAttributes(
@@ -622,6 +635,11 @@ function diffAttributes(
  * index (the fields a scroll/insert perturbs) so a node keeps this key when it
  * only moves. Returns `null` when the node carries no stable identity at all (all
  * four empty) — an empty key is not identity and must never be used to re-pair.
+ *
+ * For id-less/text-less Android nodes the `view-id` slot is the capture layer's
+ * content-derived stable id (`assignStableViewIds`, issue #3228) — stable across
+ * a scroll and ordinal-suffixed for content-identical duplicates — which is what
+ * lets this key re-pair rows the other three fields cannot describe.
  */
 function contentIdentityKey(attrs: Record<string, unknown>): string | null {
   const resourceId = String(attrs["resource-id"] ?? "");

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -785,6 +785,41 @@ describe("AndroidCtrlProxyClient", function() {
       expect(result.hierarchy.error).toContain("Accessibility hierarchy missing from accessibility service");
     });
 
+    test("rewrites the runner's path-derived UUID view-ids into stable content ids at ingest (#3228)", function() {
+      // The runner emits a positional UUID for id-less nodes; two captures of the
+      // same row at different scroll offsets carry DIFFERENT UUIDs. Ingest must
+      // rewrite them into content-derived ids so the row keeps one identity.
+      const capture = (uuid: string, top: number) => ({
+        updatedAt: 1750934583218,
+        packageName: "com.test.app",
+        hierarchy: {
+          "resource-id": "com.test.app:id/root",
+          "view-id": "com.test.app:id/root",
+          "node": [
+            {
+              "view-id": uuid,
+              "content-desc": "Basic long press card",
+              "bounds": { left: 42, top, right: 1038, bottom: top + 231 }
+            }
+          ]
+        }
+      });
+
+      const before = accessibilityServiceClient.convertToViewHierarchyResult(
+        capture("791e44df-05d9-5e5a-3ea7-c898eedcb939", 1404)
+      );
+      const after = accessibilityServiceClient.convertToViewHierarchyResult(
+        capture("8eb00289-ddfa-18de-7fc7-480b4d13d8cf", 1079)
+      );
+
+      const beforeId = (before.hierarchy.node as any)["view-id"];
+      const afterId = (after.hierarchy.node as any)["view-id"];
+      expect(beforeId).toStartWith("s-");
+      expect(afterId).toBe(beforeId);
+      // Resource-id-backed view-ids pass through untouched.
+      expect(before.hierarchy["view-id"]).toBe("com.test.app:id/root");
+    });
+
   });
 
   describe("getAccessibilityHierarchy", function() {

--- a/test/features/observe/android/stableNodeIdentity.test.ts
+++ b/test/features/observe/android/stableNodeIdentity.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assignStableViewIds,
+  GENERATED_VIEW_ID_PATTERN,
+  STABLE_VIEW_ID_PREFIX,
+} from "../../../../src/features/observe/android/StableNodeIdentity";
+
+/**
+ * Capture-layer stable node identity (issue #3228): the ingest pass that
+ * rewrites the Android runner's positional (path-derived UUID) `view-id`s into
+ * content-derived stable ids, so id-less rows keep their identity across a
+ * scroll and `diffObserveResult`'s content-identity re-pair can collapse the
+ * scroll cascade. Fixture-level acceptance (the #3132 scroll pair) is pinned
+ * separately in `test/features/observe/output/stableIdentityScrollDiff.test.ts`.
+ */
+
+/** A fresh path-derived UUID the runner would emit for an id-less node. */
+function generatedUuid(seed: string): string {
+  // Any UUID-shaped lowercase hex string; vary by seed for uniqueness.
+  const hex = (seed.split("").reduce((a, c) => (a * 31 + c.charCodeAt(0)) >>> 0, 7) >>> 0)
+    .toString(16)
+    .padStart(8, "0");
+  return `${hex}-0000-4000-8000-00000000000${seed.length % 10}`;
+}
+
+function node(attrs: Record<string, unknown>, children?: Record<string, unknown>[]): Record<string, unknown> {
+  const n: Record<string, unknown> = { ...attrs };
+  if (children && children.length > 0) {
+    n.node = children.length === 1 ? children[0] : children;
+  }
+  return n;
+}
+
+describe("assignStableViewIds (#3228)", () => {
+  test("rewrites a generated UUID view-id into a prefixed content hash", () => {
+    const root = node({ "view-id": generatedUuid("row"), "content-desc": "Basic long press card", "bounds": { left: 0, top: 100, right: 500, bottom: 200 } });
+    assignStableViewIds(root);
+    const id = root["view-id"] as string;
+    expect(id.startsWith(STABLE_VIEW_ID_PREFIX)).toBe(true);
+    expect(GENERATED_VIEW_ID_PATTERN.test(id)).toBe(false);
+  });
+
+  test("leaves resource-id-backed and non-UUID view-ids untouched", () => {
+    const withResourceId = node({ "view-id": "com.example:id/button", "resource-id": "com.example:id/button" });
+    const withCustom = node({ "view-id": "custom-id-shape" });
+    const withoutViewId = node({ text: "no view-id at all" });
+    for (const n of [withResourceId, withCustom, withoutViewId]) {
+      const before = { ...n };
+      assignStableViewIds(n);
+      expect(n).toEqual(before);
+    }
+  });
+
+  test("same content at a different position/state yields the SAME id (scroll survival)", () => {
+    // The same row captured before and after a ~250px scroll: bounds moved, the
+    // path-derived UUID changed, volatile extras/occlusion churned — but the
+    // stable content is identical, so the assigned id must match.
+    const before = node(
+      { "view-id": generatedUuid("a"), "bounds": { left: 42, top: 983, right: 1038, bottom: 1089 }, "extras": { traversalIndex: 7 }, "occlusionState": "partial" },
+      [node({ "view-id": generatedUuid("b"), "text": "Item 42", "bounds": { left: 60, top: 990, right: 900, bottom: 1080 } })]
+    );
+    const after = node(
+      { "view-id": generatedUuid("c"), "bounds": { left: 42, top: 658, right: 1038, bottom: 764 }, "extras": { traversalIndex: 3 } },
+      [node({ "view-id": generatedUuid("d"), "text": "Item 42", "bounds": { left: 60, top: 665, right: 900, bottom: 755 } })]
+    );
+    assignStableViewIds(before);
+    assignStableViewIds(after);
+    expect(before["view-id"]).toEqual(after["view-id"]);
+    expect((before.node as Record<string, unknown>)["view-id"]).toEqual(
+      (after.node as Record<string, unknown>)["view-id"]
+    );
+  });
+
+  test("different descendant content yields DIFFERENT ids (distinct rows never share)", () => {
+    const rowA = node({ "view-id": generatedUuid("a") }, [node({ "view-id": generatedUuid("a1"), "text": "Item 1" })]);
+    const rowB = node({ "view-id": generatedUuid("b") }, [node({ "view-id": generatedUuid("b1"), "text": "Item 2" })]);
+    assignStableViewIds(rowA);
+    assignStableViewIds(rowB);
+    expect(rowA["view-id"]).not.toEqual(rowB["view-id"]);
+  });
+
+  test("interaction-state flips (checked/focused) do not change identity", () => {
+    const off = node({ "view-id": generatedUuid("t"), "content-desc": "Wifi toggle", "checked": "false" });
+    const on = node({ "view-id": generatedUuid("t"), "content-desc": "Wifi toggle", "checked": "true", "focused": "true" });
+    assignStableViewIds(off);
+    assignStableViewIds(on);
+    expect(off["view-id"]).toEqual(on["view-id"]);
+  });
+
+  test("content-identical duplicates get document-order ordinal suffixes (ids stay unique per capture)", () => {
+    const spacer = () => node({ "view-id": generatedUuid("s"), "bounds": {} });
+    const root = node({ "view-id": generatedUuid("root"), "resource-id": "" }, [spacer(), spacer(), spacer()]);
+    assignStableViewIds(root);
+    const children = root.node as Record<string, unknown>[];
+    const ids = children.map(c => c["view-id"] as string);
+    expect(new Set(ids).size).toBe(3);
+    expect(ids[0].startsWith(STABLE_VIEW_ID_PREFIX)).toBe(true);
+    expect(ids[1]).toBe(`${ids[0]}-2`);
+    expect(ids[2]).toBe(`${ids[0]}-3`);
+  });
+
+  test("is idempotent — a second pass changes nothing", () => {
+    const root = node({ "view-id": generatedUuid("r") }, [
+      node({ "view-id": generatedUuid("x"), "text": "A" }),
+      node({ "view-id": generatedUuid("y"), "text": "A" }), // duplicate content
+    ]);
+    assignStableViewIds(root);
+    const snapshot = JSON.parse(JSON.stringify(root));
+    assignStableViewIds(root);
+    expect(root).toEqual(snapshot);
+  });
+
+  test("handles single-object and array child slots plus non-object input", () => {
+    const single = node({ "view-id": generatedUuid("p") }, [node({ "view-id": generatedUuid("c"), "text": "only" })]);
+    expect(Array.isArray(single.node)).toBe(false); // single child is an object, not an array
+    assignStableViewIds(single);
+    expect(((single.node as Record<string, unknown>)["view-id"] as string).startsWith(STABLE_VIEW_ID_PREFIX)).toBe(true);
+    // Non-objects are ignored without throwing.
+    assignStableViewIds(undefined);
+    assignStableViewIds(null);
+    assignStableViewIds("not a node");
+  });
+
+  test("a node's own text participates in identity (a text edit is a new identity, matching nodeKey semantics)", () => {
+    const empty = node({ "view-id": generatedUuid("e"), "text": "" });
+    const typed = node({ "view-id": generatedUuid("e"), "text": "SignOff3051" });
+    assignStableViewIds(empty);
+    assignStableViewIds(typed);
+    expect(empty["view-id"]).not.toEqual(typed["view-id"]);
+  });
+});

--- a/test/features/observe/output/stableIdentityScrollDiff.test.ts
+++ b/test/features/observe/output/stableIdentityScrollDiff.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import {
+  diffObserveResult,
+  type ObserveDiff,
+  type ObserveDiffNode,
+} from "../../../../src/features/observe/output/ObserveResultOutput";
+import { assignStableViewIds } from "../../../../src/features/observe/android/StableNodeIdentity";
+import { loadDiffFixture, measureValue } from "../../../fixtures/observe/observeFixture";
+import type { ObserveResult } from "../../../../src/models/ObserveResult";
+
+/**
+ * Acceptance for capture-layer stable node identity (issue #3228) on the real
+ * #3132 scroll captures (`test/fixtures/observe/diff/scroll-before|after`).
+ *
+ * The fixtures were captured before #3228, so their id-less nodes still carry
+ * the runner's path-derived UUID `view-id`s. Applying `assignStableViewIds` to
+ * a deep clone reproduces exactly what the ingest layer
+ * (`CtrlProxyHierarchy.convertToViewHierarchyResult`) now emits for the same
+ * runner payload — both sides of a production diff pass through that ingest,
+ * so rewriting both fixtures is the faithful simulation.
+ *
+ * Baseline numbers (sign-off doc §4, re-measured here): churn 56 with ~28
+ * opaque (id-less *and* text-less) residual entries; diff/full share 28.7%
+ * bytes / 64% tokens with the production formatter.
+ */
+
+function withStableIds(obs: ObserveResult): ObserveResult {
+  const copy = JSON.parse(JSON.stringify(obs)) as ObserveResult;
+  const roots = copy.viewHierarchy?.hierarchy?.node;
+  for (const root of Array.isArray(roots) ? roots : roots ? [roots] : []) {
+    assignStableViewIds(root);
+  }
+  return copy;
+}
+
+/** Opaque = no `resource-id` and no `text` — the #3107 residual class. */
+function opaqueResiduals(diff: ObserveDiff): ObserveDiffNode[] {
+  return [...diff.added, ...diff.removed].filter(
+    n => !n.attributes["resource-id"] && !n.attributes["text"]
+  );
+}
+
+function churn(diff: ObserveDiff): number {
+  return diff.added.length + diff.removed.length + diff.changed.length;
+}
+
+describe("capture-layer stable identity on the real scroll pair (#3228)", () => {
+  const rawBefore = loadDiffFixture("scroll-before");
+  const rawAfter = loadDiffFixture("scroll-after");
+  const before = withStableIds(rawBefore);
+  const after = withStableIds(rawAfter);
+  const legacyDiff = diffObserveResult(rawBefore, rawAfter);
+  const stableDiff = diffObserveResult(before, after);
+
+  test("AC#1 — the same id-less row carries the same view-id before and after the scroll", () => {
+    // "Basic long press card" is an id-less/text-less row (content-desc only)
+    // that persists across the ~250px scroll. Pre-#3228 its path-derived UUID
+    // differed between captures; the content-derived id must now match.
+    const findCard = (obs: ObserveResult): Record<string, unknown> | undefined => {
+      let found: Record<string, unknown> | undefined;
+      const walk = (node: unknown): void => {
+        if (!node || typeof node !== "object") {return;}
+        if (Array.isArray(node)) {
+          node.forEach(walk);
+          return;
+        }
+        const rec = node as Record<string, unknown>;
+        if (rec["content-desc"] === "Basic long press card" && !rec["resource-id"]) {
+          found = found ?? rec;
+        }
+        const kids = rec["node"];
+        for (const child of Array.isArray(kids) ? kids : kids ? [kids] : []) {walk(child);}
+      };
+      walk(obs.viewHierarchy?.hierarchy?.node);
+      return found;
+    };
+    const cardBefore = findCard(before);
+    const cardAfter = findCard(after);
+    expect(cardBefore).toBeDefined();
+    expect(cardAfter).toBeDefined();
+    // Same row, moved: identical stable id despite different bounds…
+    expect(cardBefore!["view-id"]).toEqual(cardAfter!["view-id"]);
+    expect(cardBefore!["bounds"]).not.toEqual(cardAfter!["bounds"]);
+    // …and the pre-#3228 capture genuinely had differing ids here (the bug).
+    expect(findCard(rawBefore)!["view-id"]).not.toEqual(findCard(rawAfter)!["view-id"]);
+  });
+
+  test("AC#2 — opaque residual entries drop materially below the ~28 baseline", () => {
+    // Guard the baseline first so a fixture refresh can't silently hollow this out.
+    expect(opaqueResiduals(legacyDiff).length).toBeGreaterThanOrEqual(20);
+    // Rewritten: only genuinely-entered/left content remains (measured: 4).
+    expect(opaqueResiduals(stableDiff).length).toBeLessThanOrEqual(8);
+    expect(churn(stableDiff)).toBeLessThan(churn(legacyDiff));
+  });
+
+  test("AC#2 — scroll diff byte/token share falls below the sign-off's 28.7% / 64%", () => {
+    const full = measureValue(after);
+    const diff = measureValue(stableDiff);
+    expect(diff.bytes / full.bytes).toBeLessThan(0.287);
+    expect(diff.tokens / full.tokens).toBeLessThan(0.64);
+    // And strictly better than the legacy (path-UUID) diff of the same pair.
+    const legacy = measureValue(legacyDiff);
+    expect(diff.bytes).toBeLessThan(legacy.bytes);
+    expect(diff.tokens).toBeLessThan(legacy.tokens);
+  });
+
+  test("AC#3 — no false-merge: re-paired entries never report content changes", () => {
+    // A re-pair (fromKey present) joins nodes with identical stable content by
+    // construction, so a text/content-desc/className delta on one would mean
+    // two *distinct* rows collapsed. None may exist.
+    const rePaired = stableDiff.changed.filter(c => c.fromKey !== undefined);
+    expect(rePaired.length).toBeGreaterThan(0);
+    for (const c of rePaired) {
+      expect("text" in c.changes).toBe(false);
+      expect("content-desc" in c.changes).toBe(false);
+      expect("className" in c.changes).toBe(false);
+    }
+  });
+
+  test("view-id churn is never reported as a `changed` delta (DIFF_IGNORED_ATTRS)", () => {
+    // The synthetic id exists to pair nodes; its own movement between hash
+    // values is not an actionable UI delta (mirrors the `extras` exclusion).
+    expect(stableDiff.changed.some(c => "view-id" in c.changes)).toBe(false);
+    expect(legacyDiff.changed.some(c => "view-id" in c.changes)).toBe(false);
+  });
+
+  test("localized (text-entry) pair is not regressed by the rewrite", () => {
+    const textBefore = withStableIds(loadDiffFixture("text-input-empty"));
+    const textAfter = withStableIds(loadDiffFixture("text-input-typed"));
+    const diff = diffObserveResult(textBefore, textAfter);
+    // Same compact envelope the sign-off measured (added=1, removed=3, changed=2):
+    // ancestors of the edited field change their content hash, but that churn is
+    // excluded from `changed`, so the diff stays a handful of entries.
+    expect(churn(diff)).toBeLessThanOrEqual(6);
+    const full = measureValue(textAfter);
+    const d = measureValue(diff);
+    expect(d.bytes).toBeLessThan(full.bytes * 0.1);
+  });
+});


### PR DESCRIPTION
Closes #3228

## Summary

Capture-layer stable node identity for id-less scroll rows — the genuine scroll-opacity fix #3107 / PR #3227 pointed at.

The Android runner fills `view-id` for id-less nodes with a deterministic UUID derived from the node's **tree path** (`ViewHierarchyExtractor.generateDeterministicUuid`). That id is positional: a ~250px scroll shifts child indices, so a moved row gets a *different* UUID (and the row now occupying its old slot inherits the departed row's), which is exactly why `contentIdentityKey` could never re-pair the ~28 opaque (id-less *and* text-less) residual entries on the #3132 scroll pair.

**Fix — TS hierarchy ingest** (`assignStableViewIds`, new `src/features/observe/android/StableNodeIdentity.ts`, wired in `CtrlProxyHierarchy.convertToViewHierarchyResult`):

- Rewrites every *generated* (UUID-shaped) `view-id` into a content-derived stable id: Merkle SHA-256 over the node's stable content fields (`className`, `resource-id`, `content-desc`, `text`, `test-tag`) plus child hashes — excluding bounds, sibling position, `extras`, occlusion and interaction state. Same row ⇒ same id across a scroll; distinct rows can never share one.
- Content-identical duplicates (repeated spacers, empty Compose click surfaces) get a document-order ordinal suffix (`s-<hash>-2`), keeping `view-id` unique per capture and letting the diff's uniqueness-on-both-sides guard re-pair duplicates in encounter order — the same best-effort heuristic `diffObserveResult` already applies to identical same-path siblings. A re-pair can only ever join nodes whose *entire* stable subtree content is identical, so distinct rows still cannot false-merge (pinned by test).
- Resource-id-backed `view-id`s and any non-UUID shapes pass through untouched (idempotent; no-op on non-CtrlProxy hierarchies).
- **Diff layer** (allowed consumer per the lane notes): `view-id` joins `extras` in `DIFF_IGNORED_ATTRS`. Post-trim a `view-id` is always synthetic; a content-derived id churns exactly when a descendant's already-reported content changed, so surfacing it would re-flood localized diffs the way `extras` once did (#3051). Pairing (`contentIdentityKey`) and `added`/`removed` reconstruction are unaffected.

Rewriting at TS ingest (rather than in the Kotlin extractor) applies to every already-released runner — the runner APK is a pinned release, so a Kotlin change would be undeliverable until the next re-cut. `ViewHierarchyExtractor.kt` gets a comment-only note documenting the contract (keep the UUID shape: it is the marker the ingest matches). #3139 (Compose toggle state) is deliberately NOT implemented here per the chain plan.

## Acceptance criteria, measured on the real #3132 fixtures

Pinned by `test/features/observe/output/stableIdentityScrollDiff.test.ts` (fixtures pre-date #3228, so the test applies the ingest rewrite to clones — exactly what production ingest now emits):

| Metric (scroll pair, production formatter) | before | after |
|---|---|---|
| Opaque (`bounds+index`-only) residual entries | 28 | **4** |
| Total churn (added+removed+changed) | 56 | **40** |
| Diff / full share — bytes | 30.8% (doc: 28.7%) | **26.2%** |
| Diff / full share — tokens | 74.7% (doc: 64%) | **59.0%** |
| Localized text-entry pair | churn 6, 1.8% bytes | unchanged (6, 1.7%) |

- AC#1: same id-less row ("Basic long press card") carries the same `view-id` before/after the scroll; the raw fixtures' path UUIDs demonstrably differ.
- AC#3: no re-paired (`fromKey`) entry reports a `text`/`content-desc`/`className` delta — no false merges.

## Validation

- `bun test test/features/observe/` — 881 pass
- `bunx turbo run lint build test` — lint+build pass; one unrelated flake (`TakeScreenshot` timer test) passes in isolation
- `bun run typecheck` — no new errors (2 *pre-existing* stale baseline entries in `src/doctor/checks/ios.ts` exist on clean main; left un-ratcheted to avoid cross-lane baseline conflicts)
- Kotlin change is comment-only (no ktfmt-affecting lines >100 cols); no gradle run needed

## Out-of-scope changes (flagged per lane rules)

- `src/features/observe/output/ObserveResultOutput.ts`: `DIFF_IGNORED_ATTRS` + two doc comments — the sanctioned diff-layer consumption of the new id ("the diff layer may consume the new stable id").
- `docs/design-docs/plat/android/actions-diff-observe-signoff.md`: follow-ups section updated to record this landing.

## Caveats / follow-ups

- iOS has the identical positional-UUID pattern (`ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift:666`); the same normalizer could be applied at iOS ingest (`IOSCtrlProxyClient` / iOS `CtrlProxyHierarchy`). Out of this lane.
- The focus-mirror element is rewritten too; for a focused node with content-identical duplicates its ordinal suffix can differ from the hierarchy node's (display-only; the diff compare excludes `view-id`).
- Ordinal suffixes pair content-identical nodes in encounter order across captures — observationally indistinguishable by construction, and consistent with the diff's existing same-path-duplicate heuristic.
