### PR TITLE
test(ios): field-name wire-parity backstop for control-proxy request payloads (#2954)

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		141E5CD4FAF4509F538E736C /* OSLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA97A6C3A1240A055D9876C /* OSLogReader.swift */; };
 		158C6F3B528C02BE92AA6132 /* HierarchyMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */; };
 		1BF8D64D9A034BEC375AEE8B /* ObjCExceptionCatcher.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1E92C9DDBA24968595494BA3 /* RequestSnapshotWireParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A158ADBA8E3301E9FF181598 /* RequestSnapshotWireParityTests.swift */; };
 		1F968B5EDB744057F51321EF /* ElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95565999DC108319DEED894A /* ElementLocator.swift */; };
 		261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */; };
 		2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */; };
@@ -191,6 +192,7 @@
 		95565999DC108319DEED894A /* ElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocator.swift; sourceTree = "<group>"; };
 		9A1B2931E58B158EE51C5F4F /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
 		9BD704E3A2708D91D4FABE3E /* CtrlProxyApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CtrlProxyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A158ADBA8E3301E9FF181598 /* RequestSnapshotWireParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestSnapshotWireParityTests.swift; sourceTree = "<group>"; };
 		A284B6FFBE969931BB03A2FF /* PerfProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfProvider.swift; sourceTree = "<group>"; };
 		AC68B1D8C55DA187332B555E /* WebSocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServerTests.swift; sourceTree = "<group>"; };
 		B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetrics.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */,
 				6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */,
 				4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */,
+				A158ADBA8E3301E9FF181598 /* RequestSnapshotWireParityTests.swift */,
 				5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */,
 				EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */,
 				AC68B1D8C55DA187332B555E /* WebSocketServerTests.swift */,
@@ -603,6 +606,7 @@
 				0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */,
 				F428A1892AAF5D4F83AD4C1B /* PinchFallbackTests.swift in Sources */,
 				74B1E8F78E9FF807417ABC2D /* PinchGeometryTests.swift in Sources */,
+				1E92C9DDBA24968595494BA3 /* RequestSnapshotWireParityTests.swift in Sources */,
 				2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */,
 				0F29D59ABFB52692F62B434F /* TypedRequestDecodeTests.swift in Sources */,
 				B33435D31AF41A6C03499842 /* WebSocketServerTests.swift in Sources */,

--- a/ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift
@@ -1,0 +1,282 @@
+@testable import CtrlProxy
+import XCTest
+
+/// Field-name wire-parity backstop for the TS client ↔ Swift runner (issue #2954,
+/// checklist item 3 of #2857).
+///
+/// The command-name tripwire (`test/features/observe/ios/ctrlProxyWireParity.test.ts`)
+/// catches a renamed `type` discriminator but not a renamed field *inside* a command
+/// payload. This suite is the Swift half of a two-sided guard around the shared JSON
+/// snapshot fixture `test/fixtures/ios-ctrlproxy-request-snapshots.json`:
+///
+///   1. (TS) `ctrlProxyRequestSnapshots.test.ts` captures every snapshot live from the
+///      real TS builders and asserts deep equality with the fixture, so the fixture
+///      cannot drift from what the client actually sends.
+///   2. (here) Every snapshot is decoded through the real `WebSocketRequest` wire path
+///      and every wire field must land on a same-named property of the typed payload
+///      struct with the same value — via `Mirror`, so new fixture entries are covered
+///      automatically with no per-command test arm.
+///
+/// A one-sided payload-field rename therefore fails a test on whichever side moved:
+/// TS rename → TS capture test fails → fixture update → this suite fails until
+/// `Models.swift` matches; Swift rename → this suite fails immediately.
+///
+/// Assumption (holds for every request payload in `Models.swift`): payload structs use
+/// synthesized `Decodable` with no custom `CodingKeys`, so a property's Mirror label IS
+/// its wire key. A payload that introduces custom `CodingKeys` breaks that equivalence
+/// and fails here loudly — update the normalization (not the fixture) in that case.
+final class RequestSnapshotWireParityTests: XCTestCase {
+    private struct Snapshot {
+        let name: String
+        let wire: [String: Any]
+    }
+
+    private enum FixtureError: Error {
+        case malformed(String)
+    }
+
+    /// The canonical fixture lives at the repo root so the TS and Swift suites read the
+    /// same bytes. `#filePath` is `<repo>/ios/control-proxy/Tests/CtrlProxyTests/<file>`,
+    /// so five `deleteLastPathComponent()` calls reach the repo root. A missing fixture
+    /// fails loudly (never skips): silently skipping would defeat the tripwire.
+    private static func fixtureURL() -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 {
+            url.deleteLastPathComponent()
+        }
+        return url
+            .appendingPathComponent("test")
+            .appendingPathComponent("fixtures")
+            .appendingPathComponent("ios-ctrlproxy-request-snapshots.json")
+    }
+
+    private static func loadSnapshots() throws -> [Snapshot] {
+        let data = try Data(contentsOf: fixtureURL())
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entries = root["snapshots"] as? [[String: Any]]
+        else {
+            throw FixtureError.malformed("fixture root must be { snapshots: [...] }")
+        }
+        return try entries.map { entry in
+            guard let name = entry["name"] as? String,
+                  let wire = entry["wire"] as? [String: Any]
+            else {
+                throw FixtureError.malformed("snapshot entries must carry `name` and `wire`")
+            }
+            return Snapshot(name: name, wire: wire)
+        }
+    }
+
+    // MARK: - Mirror-based payload normalization
+
+    /// Convert a decoded payload value into a JSON-comparable form: optionals unwrap
+    /// (nil → NSNull), numbers/strings pass through, structs become dictionaries keyed
+    /// by property name, collections and dictionaries recurse.
+    private func jsonNormalized(_ value: Any) -> Any {
+        let mirror = Mirror(reflecting: value)
+        if mirror.displayStyle == .optional {
+            guard let child = mirror.children.first else {
+                return NSNull()
+            }
+            return jsonNormalized(child.value)
+        }
+        // Int/Int64/Double/Float/Bool all bridge to NSNumber; String stays String.
+        if let number = value as? NSNumber {
+            return number
+        }
+        if let string = value as? String {
+            return string
+        }
+        switch mirror.displayStyle {
+        case .collection:
+            return mirror.children.map { jsonNormalized($0.value) }
+        case .dictionary:
+            var dict = [String: Any]()
+            for child in mirror.children {
+                let pair = Mirror(reflecting: child.value).children.map(\.value)
+                if pair.count == 2, let key = pair[0] as? String {
+                    dict[key] = jsonNormalized(pair[1])
+                }
+            }
+            return dict
+        case .struct, .class:
+            var dict = [String: Any]()
+            for child in mirror.children {
+                if let label = child.label {
+                    dict[label] = jsonNormalized(child.value)
+                }
+            }
+            return dict
+        default:
+            return value
+        }
+    }
+
+    /// Assert every wire field lands on a same-named payload property with an equal
+    /// value, recursively. Payload-only keys must be NSNull (an optional the wire did
+    /// not carry) — a non-nil payload-only value means the struct decoded something
+    /// the fixture doesn't document, which is its own kind of drift.
+    private func assertWireSubset(
+        wire: [String: Any],
+        payload: [String: Any],
+        context: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for (key, expected) in wire {
+            guard let actual = payload[key] else {
+                XCTFail(
+                    "\(context): wire field `\(key)` has no matching Swift property — " +
+                        "TS/Swift payload field-name drift (see Models.swift)",
+                    file: file,
+                    line: line
+                )
+                continue
+            }
+            assertValueEqual(expected: expected, actual: actual, context: "\(context).\(key)", file: file, line: line)
+        }
+        for (key, value) in payload where wire[key] == nil {
+            XCTAssertTrue(
+                value is NSNull,
+                "\(context): Swift property `\(key)` decoded \(value) from a wire payload that does not carry it",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func assertValueEqual(
+        expected: Any,
+        actual: Any,
+        context: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        if let expectedDict = expected as? [String: Any] {
+            guard let actualDict = actual as? [String: Any] else {
+                XCTFail("\(context): wire has an object, payload decoded \(actual)", file: file, line: line)
+                return
+            }
+            assertWireSubset(wire: expectedDict, payload: actualDict, context: context, file: file, line: line)
+            return
+        }
+        if let expectedArray = expected as? [Any] {
+            guard let actualArray = actual as? [Any] else {
+                XCTFail("\(context): wire has an array, payload decoded \(actual)", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(actualArray.count, expectedArray.count, context, file: file, line: line)
+            for (index, pair) in zip(expectedArray, actualArray).enumerated() {
+                assertValueEqual(expected: pair.0, actual: pair.1, context: "\(context)[\(index)]", file: file, line: line)
+            }
+            return
+        }
+        // Scalars: NSNumber/NSString/NSNull equality (NSNumber compares across widths,
+        // so a wire integer equals a decoded Double of the same value).
+        XCTAssertTrue(
+            (actual as AnyObject).isEqual(expected),
+            "\(context): decoded \(actual) != wire \(expected)",
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: - Tests
+
+    func testFixtureCoversTheAcceptanceCriticalCommands() throws {
+        let snapshots = try Self.loadSnapshots()
+        XCTAssertGreaterThanOrEqual(snapshots.count, 30, "fixture unexpectedly small — was it truncated?")
+        XCTAssertEqual(
+            Set(snapshots.map(\.name)).count,
+            snapshots.count,
+            "snapshot names must be unique"
+        )
+
+        let coveredTypes = Set(snapshots.compactMap { $0.wire["type"] as? String })
+        let required: Set<String> = [
+            "request_action",
+            "request_set_text",
+            "request_ime_action",
+            "request_hierarchy",
+            "request_hierarchy_if_stale",
+            "list_preference_files",
+            "get_preferences",
+            "get_preference",
+            "set_preference",
+            "remove_preference",
+            "clear_preferences",
+            "execute_sql",
+            "list_databases",
+            "list_tables",
+            "get_table_data",
+            "get_table_structure",
+        ]
+        XCTAssertEqual(required.subtracting(coveredTypes), [], "acceptance-critical commands missing from fixture")
+    }
+
+    /// Every snapshot must decode through the real wire path into the payload struct
+    /// matching its discriminator, with every wire field landing on a same-named
+    /// property carrying the same value.
+    func testEverySnapshotDecodesWithFieldNameParity() throws {
+        for snapshot in try Self.loadSnapshots() {
+            let wireData = try JSONSerialization.data(withJSONObject: snapshot.wire)
+            guard let wireJson = String(data: wireData, encoding: .utf8) else {
+                XCTFail("\(snapshot.name): could not re-serialize wire object")
+                continue
+            }
+
+            let request: WebSocketRequest
+            do {
+                request = try decodeWebSocketRequest(wireJson)
+            } catch {
+                XCTFail("\(snapshot.name): failed to decode through WebSocketRequest: \(error)")
+                continue
+            }
+
+            guard let type = snapshot.wire["type"] as? String else {
+                XCTFail("\(snapshot.name): snapshot has no `type` discriminator")
+                continue
+            }
+            XCTAssertEqual(request.typeString, type, snapshot.name)
+
+            guard let payloadFields = jsonNormalized(request.payload) as? [String: Any] else {
+                XCTFail("\(snapshot.name): payload did not normalize to an object")
+                continue
+            }
+            // `type` is the envelope discriminator, not a payload property.
+            var payloadWire = snapshot.wire
+            payloadWire.removeValue(forKey: "type")
+            assertWireSubset(
+                wire: payloadWire,
+                payload: payloadFields,
+                context: "\(snapshot.name) (\(Swift.type(of: request.payload)))"
+            )
+        }
+    }
+
+    /// Meta-guard: prove the parity check actually bites by feeding it a snapshot with
+    /// a renamed field. If this stops failing, the guard has gone vacuous.
+    func testARenamedWireFieldIsDetected() throws {
+        let wire: [String: Any] = [
+            "type": "request_set_text",
+            "requestId": "fixture-request-id",
+            "text": "hello",
+            // The real field is `resourceId`; simulate a one-sided TS rename.
+            "identifier": "login_username_field",
+        ]
+        let request = try decodeWebSocketRequest(
+            String(data: JSONSerialization.data(withJSONObject: wire), encoding: .utf8)!
+        )
+        guard let payloadFields = jsonNormalized(request.payload) as? [String: Any] else {
+            XCTFail("payload did not normalize to an object")
+            return
+        }
+        XCTAssertNil(
+            payloadFields["identifier"],
+            "RequestSetText unexpectedly grew an `identifier` property — update this meta-guard"
+        )
+        // The decoded struct dropped the renamed field entirely and left the real
+        // optional at nil — exactly the silent runtime failure the suite exists to catch.
+        XCTAssertTrue(payloadFields["resourceId"] is NSNull)
+    }
+}

--- a/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
+++ b/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Field-name wire-parity backstop for the iOS control-proxy TS client ↔ Swift runner
+ * (issue #2954, checklist item 3 of #2857).
+ *
+ * The command-name tripwire (`ctrlProxyWireParity.test.ts`) catches a dropped/renamed
+ * `type` discriminator but NOT a renamed field *inside* a command payload: renaming
+ * `disableAllFiltering` on the TS side compiles cleanly and only fails at runtime
+ * on-device, when the Swift payload struct (`Models.swift`) decodes the wrong field.
+ *
+ * This suite is one half of a two-sided guard around a shared JSON snapshot fixture,
+ * `test/fixtures/ios-ctrlproxy-request-snapshots.json`:
+ *
+ *   1. (here) Every snapshot is captured LIVE from the real TS builder — the delegate
+ *      method is invoked against a fake `DelegateContext` and the exact JSON written to
+ *      the WebSocket is compared with the committed fixture. A TS-side field rename
+ *      diverges from the fixture and fails here, forcing a fixture update.
+ *   2. (Swift) `RequestSnapshotWireParityTests.swift` decodes each snapshot through the
+ *      real `WebSocketRequest` wire path and asserts every fixture field lands on a
+ *      same-named property of the typed payload struct with the same value. A fixture
+ *      update that the Swift structs can't decode — or a Swift-side field rename —
+ *      fails there.
+ *
+ * Together, a one-sided rename of any covered payload field fails a test on whichever
+ * side moved.
+ *
+ * To regenerate the fixture after an INTENTIONAL wire change:
+ *   AUTOMOBILE_UPDATE_IOS_WIRE_SNAPSHOTS=1 bun test test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
+ * then re-run the Swift suite (`cd ios/control-proxy && swift test`) — an intentional
+ * change must update Models.swift (or the Swift test) in the same commit.
+ *
+ * `set_network_mock_rules` is the one semi-transcribed entry: it is emitted by the
+ * private `IOSCtrlProxyClient.syncNetworkMockRulesToDevice()` (not a delegate we can
+ * drive in isolation), so its envelope is transcribed while the `rules` payload — where
+ * all the field names live — is built by the production `buildNetworkMockRules`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { CtrlProxyClipboard } from "../../../../src/features/observe/ios/CtrlProxyClipboard";
+import { CtrlProxyDatabase } from "../../../../src/features/observe/ios/CtrlProxyDatabase";
+import { CtrlProxyGestures } from "../../../../src/features/observe/ios/CtrlProxyGestures";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/ios/CtrlProxyHierarchy";
+import { CtrlProxyHighlights } from "../../../../src/features/observe/ios/CtrlProxyHighlights";
+import { CtrlProxyKeyboard } from "../../../../src/features/observe/ios/CtrlProxyKeyboard";
+import { CtrlProxyNavigation } from "../../../../src/features/observe/ios/CtrlProxyNavigation";
+import { CtrlProxyPermissions } from "../../../../src/features/observe/ios/CtrlProxyPermissions";
+import { CtrlProxyScreenshot } from "../../../../src/features/observe/ios/CtrlProxyScreenshot";
+import { CtrlProxyStorage } from "../../../../src/features/observe/ios/CtrlProxyStorage";
+import { CtrlProxyText } from "../../../../src/features/observe/ios/CtrlProxyText";
+import { CtrlProxyVoiceOver } from "../../../../src/features/observe/ios/CtrlProxyVoiceOver";
+import { IOS_KNOWN_REQUEST_TYPE_SET } from "../../../../src/features/observe/ios/ctrlProxyRequestTypes";
+import type { HierarchyDelegateContext } from "../../../../src/features/observe/ios/types";
+import { buildNetworkMockRules } from "../../../../src/server/networkMockRules";
+import { NetworkState } from "../../../../src/server/NetworkState";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+const FIXTURE_PATH = resolve(import.meta.dir, "../../../fixtures/ios-ctrlproxy-request-snapshots.json");
+
+/**
+ * `requestId` values are generated per call (`RequestManager.generateId`), so captured
+ * ids are normalized to this placeholder before comparison. The KEY name itself is
+ * still guarded: a rename of the `requestId` wire key leaves the captured object with
+ * a different key than the fixture and fails the deep-equality assertion.
+ */
+const FIXTURE_REQUEST_ID = "fixture-request-id";
+
+interface FixtureFile {
+  $comment: string[];
+  snapshots: { name: string; builder: string; wire: Record<string, unknown> }[];
+}
+
+interface Harness {
+  context: HierarchyDelegateContext;
+  requestManager: RequestManager;
+  sent: string[];
+}
+
+function createHarness(): Harness {
+  const timer = new FakeTimer();
+  timer.enableAutoAdvance();
+  const sent: string[] = [];
+  const requestManager = new RequestManager(timer);
+  const context: HierarchyDelegateContext = {
+    getWebSocket: () => ({
+      send: (data: string) => { sent.push(data); },
+      readyState: 1,
+    } as any),
+    requestManager,
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => {},
+    // Hierarchy-specific members (unused by the other delegates).
+    cacheFreshTtlMs: 0,
+    getCachedHierarchy: () => null,
+    setCachedHierarchy: () => {},
+  };
+  return { context, requestManager, sent };
+}
+
+interface SnapshotSpec {
+  /** Unique snapshot key; usually the wire `type`, suffixed when a command has variants. */
+  name: string;
+  /** The production builder captured, for the fixture's documentation field. */
+  builder: string;
+  invoke: (h: Harness) => Promise<unknown>;
+  /**
+   * Response the fake resolves the request with. Several builders (storage, database)
+   * throw unless the response reports success, so those specs provide a matching shape.
+   */
+  resolveWith?: unknown;
+}
+
+/**
+ * One spec per (command × payload shape) the iOS TS client can put on the wire.
+ * Argument values are chosen so every payload field is present and distinctive
+ * (fractional coordinates prove the iOS no-rounding path; no two coordinate
+ * fields share a value, so a swapped field is caught by value, not just name).
+ */
+const SNAPSHOT_SPECS: SnapshotSpec[] = [
+  {
+    name: "request_hierarchy",
+    builder: "CtrlProxyHierarchy.requestHierarchySync (disableAllFiltering=true)",
+    invoke: h => new CtrlProxyHierarchy(h.context).requestHierarchySync(undefined, true),
+    resolveWith: {},
+  },
+  {
+    name: "request_hierarchy_if_stale",
+    builder: "CtrlProxyHierarchy.requestHierarchySync (disableAllFiltering=false)",
+    invoke: h => new CtrlProxyHierarchy(h.context).requestHierarchySync(undefined, false),
+    resolveWith: {},
+  },
+  {
+    name: "request_screenshot",
+    builder: "CtrlProxyScreenshot.requestScreenshot",
+    invoke: h => new CtrlProxyScreenshot(h.context).requestScreenshot(),
+  },
+  {
+    name: "request_tap_coordinates",
+    builder: "SharedGestureDelegate.requestTapCoordinates (via CtrlProxyGestures, roundCoordinates=false)",
+    invoke: h => new CtrlProxyGestures(h.context).requestTapCoordinates(120.5, 240.25, 35),
+  },
+  {
+    name: "request_swipe",
+    builder: "SharedGestureDelegate.requestSwipe (via CtrlProxyGestures)",
+    invoke: h => new CtrlProxyGestures(h.context).requestSwipe(10.5, 20.25, 300.75, 401.5, 275),
+  },
+  {
+    name: "request_drag",
+    builder: "SharedGestureDelegate.requestDrag (via CtrlProxyGestures)",
+    invoke: h => new CtrlProxyGestures(h.context).requestDrag(11.5, 22.25, 33.75, 44.5, 350, 900, 150, 5000),
+  },
+  {
+    name: "request_pinch",
+    builder: "SharedGestureDelegate.requestPinch (via CtrlProxyGestures)",
+    invoke: h => new CtrlProxyGestures(h.context).requestPinch(160.5, 320.25, 80.5, 200.75, 45.5, 275),
+  },
+  {
+    name: "request_multi_finger_swipe",
+    builder: "CtrlProxyGestures.requestMultiFingerSwipe",
+    invoke: h => new CtrlProxyGestures(h.context)
+      .requestMultiFingerSwipe(15.5, 25.25, 35.75, 46.5, 3, 450, 5000, undefined, 24.5),
+  },
+  {
+    name: "request_set_text",
+    builder: "SharedTextDelegate.requestSetText (via CtrlProxyText)",
+    invoke: h => new CtrlProxyText(h.context).requestSetText("hello world", { resourceId: "login_username_field" }),
+  },
+  {
+    name: "request_clear_text",
+    builder: "CtrlProxyText.requestClearText",
+    invoke: h => new CtrlProxyText(h.context).requestClearText("login_username_field"),
+  },
+  {
+    name: "request_ime_action",
+    builder: "SharedTextDelegate.requestImeAction (via CtrlProxyText)",
+    invoke: h => new CtrlProxyText(h.context).requestImeAction("done"),
+  },
+  {
+    name: "request_select_all",
+    builder: "SharedTextDelegate.requestSelectAll (via CtrlProxyText)",
+    invoke: h => new CtrlProxyText(h.context).requestSelectAll(),
+  },
+  {
+    name: "request_keyboard",
+    builder: "CtrlProxyKeyboard.requestKeyboard",
+    invoke: h => new CtrlProxyKeyboard(h.context).requestKeyboard("open"),
+  },
+  {
+    name: "request_press_button",
+    builder: "CtrlProxyNavigation.requestPressButton",
+    invoke: h => new CtrlProxyNavigation(h.context).requestPressButton("volume_up"),
+  },
+  {
+    name: "request_press_home",
+    builder: "CtrlProxyNavigation.requestPressHome",
+    invoke: h => new CtrlProxyNavigation(h.context).requestPressHome(),
+  },
+  {
+    name: "request_press_back",
+    builder: "CtrlProxyNavigation.requestPressBack",
+    invoke: h => new CtrlProxyNavigation(h.context).requestPressBack(),
+  },
+  {
+    name: "request_shake",
+    builder: "CtrlProxyNavigation.requestShake",
+    invoke: h => new CtrlProxyNavigation(h.context).requestShake(),
+  },
+  {
+    name: "request_recent_apps",
+    builder: "CtrlProxyNavigation.requestRecentApps",
+    invoke: h => new CtrlProxyNavigation(h.context).requestRecentApps(),
+  },
+  {
+    name: "request_action",
+    builder: "CtrlProxyVoiceOver.requestAction (resourceId + label lookup)",
+    invoke: h => new CtrlProxyVoiceOver(h.context).requestAction("scroll_forward", "primary_table", "Primary Table"),
+  },
+  {
+    name: "request_action_voiceover_activate",
+    builder: "CtrlProxyVoiceOver.requestVoiceOverActivate (label-only lookup)",
+    invoke: h => new CtrlProxyVoiceOver(h.context).requestVoiceOverActivate("Submit", "activate"),
+  },
+  {
+    name: "request_action_null_lookup",
+    builder: "CtrlProxyVoiceOver.requestAction (explicit-null resourceId/label)",
+    invoke: h => new CtrlProxyVoiceOver(h.context).requestAction("scroll_backward"),
+  },
+  {
+    name: "request_launch_app",
+    builder: "CtrlProxyNavigation.requestLaunchApp",
+    invoke: h => new CtrlProxyNavigation(h.context).requestLaunchApp("com.example.app", 10000, undefined, true),
+  },
+  {
+    name: "request_rotate",
+    builder: "CtrlProxyNavigation.requestRotate",
+    invoke: h => new CtrlProxyNavigation(h.context).requestRotate("landscape"),
+  },
+  {
+    name: "request_clipboard",
+    builder: "CtrlProxyClipboard.requestClipboard",
+    invoke: h => new CtrlProxyClipboard(h.context).requestClipboard("copy", "clipboard text"),
+  },
+  {
+    name: "add_highlight_box",
+    builder: "CtrlProxyHighlights.requestAddHighlight (box shape; bounds are rounded by the builder)",
+    invoke: h => new CtrlProxyHighlights(h.context).requestAddHighlight("hl-1", {
+      type: "box",
+      bounds: { x: 10.4, y: 20.6, width: 100.2, height: 50.5, sourceWidth: 390, sourceHeight: 844 },
+      style: {
+        strokeColor: "#FF0000",
+        strokeWidth: 3.5,
+        dashPattern: [4, 2],
+        smoothing: "bezier",
+        tension: 0.5,
+        capStyle: "round",
+        joinStyle: "miter",
+      },
+    }),
+  },
+  {
+    name: "add_highlight_path",
+    builder: "CtrlProxyHighlights.requestAddHighlight (path shape with points)",
+    invoke: h => new CtrlProxyHighlights(h.context).requestAddHighlight("hl-2", {
+      type: "path",
+      points: [{ x: 1.5, y: 2.5 }, { x: 3.5, y: 4.5 }],
+      bounds: { x: 1, y: 2, width: 10, height: 12 },
+    }),
+  },
+  {
+    name: "request_reset_permissions",
+    builder: "CtrlProxyPermissions.requestResetPermissions",
+    invoke: h => new CtrlProxyPermissions(h.context).requestResetPermissions("com.example.app", ["camera", "photos"]),
+  },
+  {
+    name: "get_voiceover_state",
+    builder: "CtrlProxyVoiceOver.requestVoiceOverState",
+    invoke: h => new CtrlProxyVoiceOver(h.context).requestVoiceOverState(),
+  },
+  {
+    name: "list_preference_files",
+    builder: "CtrlProxyStorage.listPreferenceFiles",
+    invoke: h => new CtrlProxyStorage(h.context).listPreferenceFiles("unused"),
+    resolveWith: { success: true, files: [] },
+  },
+  {
+    name: "get_preferences",
+    builder: "CtrlProxyStorage.getPreferenceEntries",
+    invoke: h => new CtrlProxyStorage(h.context).getPreferenceEntries("unused", "Standard"),
+    resolveWith: { success: true, entries: [] },
+  },
+  {
+    name: "get_preference",
+    builder: "CtrlProxyStorage.getPreference",
+    invoke: h => new CtrlProxyStorage(h.context).getPreference("unused", "Standard", "launch_count"),
+    resolveWith: { success: true, found: false },
+  },
+  {
+    name: "set_preference",
+    builder: "CtrlProxyStorage.setPreference",
+    invoke: h => new CtrlProxyStorage(h.context).setPreference("unused", "Standard", "launch_count", "42", "INT"),
+    resolveWith: { success: true },
+  },
+  {
+    name: "remove_preference",
+    builder: "CtrlProxyStorage.removePreference",
+    invoke: h => new CtrlProxyStorage(h.context).removePreference("unused", "Standard", "launch_count"),
+    resolveWith: { success: true },
+  },
+  {
+    name: "clear_preferences",
+    builder: "CtrlProxyStorage.clearPreferenceStore",
+    invoke: h => new CtrlProxyStorage(h.context).clearPreferenceStore("unused", "Standard"),
+    resolveWith: { success: true },
+  },
+  {
+    name: "execute_sql",
+    builder: "CtrlProxyDatabase.executeSQL",
+    invoke: h => new CtrlProxyDatabase(h.context).executeSQL("com.example.app", "/Documents/app.sqlite", "SELECT * FROM users"),
+    resolveWith: { success: true, totalTimeMs: 1, queryType: "query", columns: [], rows: [] },
+  },
+  {
+    name: "list_databases",
+    builder: "CtrlProxyDatabase.listDatabases",
+    invoke: h => new CtrlProxyDatabase(h.context).listDatabases("com.example.app"),
+    resolveWith: { success: true, totalTimeMs: 1, databases: [] },
+  },
+  {
+    name: "list_tables",
+    builder: "CtrlProxyDatabase.listTables",
+    invoke: h => new CtrlProxyDatabase(h.context).listTables("com.example.app", "/Documents/app.sqlite"),
+    resolveWith: { success: true, totalTimeMs: 1, tables: [] },
+  },
+  {
+    name: "get_table_data",
+    builder: "CtrlProxyDatabase.getTableData",
+    invoke: h => new CtrlProxyDatabase(h.context).getTableData("com.example.app", "/Documents/app.sqlite", "users", 25, 10),
+    resolveWith: { success: true, totalTimeMs: 1, columns: [], rows: [], total: 0 },
+  },
+  {
+    name: "get_table_structure",
+    builder: "CtrlProxyDatabase.getTableStructure",
+    invoke: h => new CtrlProxyDatabase(h.context).getTableStructure("com.example.app", "/Documents/app.sqlite", "users"),
+    resolveWith: { success: true, totalTimeMs: 1, columns: [] },
+  },
+];
+
+/**
+ * Semi-transcribed snapshot for `set_network_mock_rules` (see module doc). The `rules`
+ * array — the payload's entire field surface — is produced by the production
+ * `buildNetworkMockRules`, mirroring `IOSCtrlProxyClient.syncNetworkMockRulesToDevice()`:
+ *   this.sendMessage(JSON.stringify({ type: "set_network_mock_rules", rules }));
+ */
+function buildNetworkMockRulesSnapshot(): Record<string, unknown> {
+  const state = new NetworkState({
+    timer: new FakeTimer(),
+    notifier: { notifyResourceUpdated: () => {} },
+  });
+  state.addMock({
+    host: "api.example.com",
+    path: "/v1/users",
+    method: "GET",
+    limit: 3,
+    remaining: 3,
+    statusCode: 200,
+    responseHeaders: { "X-Mocked": "true" },
+    responseBody: "{\"users\":[]}",
+    contentType: "application/json",
+  });
+  const rules = buildNetworkMockRules(state);
+  // Round-trip through JSON.stringify exactly like the emit site, so the captured
+  // object reflects on-the-wire serialization (dropped undefineds, etc.).
+  return JSON.parse(JSON.stringify({ type: "set_network_mock_rules", rules }));
+}
+
+/** Run a spec against a fresh harness and return the exact JSON object put on the wire. */
+async function captureWire(spec: SnapshotSpec): Promise<Record<string, unknown>> {
+  const h = createHarness();
+  const promise = spec.invoke(h);
+  // Let ensureConnected/register microtasks run until the message is sent.
+  for (let i = 0; i < 20 && h.sent.length === 0; i++) {
+    await Promise.resolve();
+  }
+  expect(h.sent.length).toBe(1);
+  const wire = JSON.parse(h.sent[0]) as Record<string, unknown>;
+  h.requestManager.resolve(wire.requestId as string, spec.resolveWith ?? { success: true, totalTimeMs: 1 });
+  await promise;
+  return wire;
+}
+
+/** Normalize the generated requestId to the fixture placeholder (key name still guarded). */
+function normalizeRequestId(wire: Record<string, unknown>): Record<string, unknown> {
+  expect(typeof wire.requestId).toBe("string");
+  expect((wire.requestId as string).length).toBeGreaterThan(0);
+  return { ...wire, requestId: FIXTURE_REQUEST_ID };
+}
+
+async function captureAllSnapshots(): Promise<Map<string, Record<string, unknown>>> {
+  const captured = new Map<string, Record<string, unknown>>();
+  for (const spec of SNAPSHOT_SPECS) {
+    captured.set(spec.name, normalizeRequestId(await captureWire(spec)));
+  }
+  // Sent without a requestId (fire-and-forget sync on reconnect) — not normalized.
+  captured.set("set_network_mock_rules", buildNetworkMockRulesSnapshot());
+  return captured;
+}
+
+function builderDoc(name: string): string {
+  return SNAPSHOT_SPECS.find(s => s.name === name)?.builder
+    ?? "IOSCtrlProxyClient.syncNetworkMockRulesToDevice (envelope transcribed; rules built by buildNetworkMockRules)";
+}
+
+function loadFixture(): FixtureFile {
+  return JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as FixtureFile;
+}
+
+describe("iOS control-proxy — request snapshot fixture matches live TS builders", () => {
+  test("every fixture snapshot equals the JSON the TS builder puts on the wire", async () => {
+    const captured = await captureAllSnapshots();
+
+    if (process.env.AUTOMOBILE_UPDATE_IOS_WIRE_SNAPSHOTS === "1") {
+      const current = loadFixture();
+      const updated: FixtureFile = {
+        $comment: current.$comment,
+        snapshots: [...captured.entries()].map(([name, wire]) => ({
+          name,
+          builder: builderDoc(name),
+          wire,
+        })),
+      };
+      writeFileSync(FIXTURE_PATH, `${JSON.stringify(updated, null, 2)}\n`);
+    }
+
+    const fixture = loadFixture();
+    // Same snapshot set on both sides — a spec added here without a fixture entry (or a
+    // stale fixture entry with no live spec) fails before any per-field comparison.
+    expect([...captured.keys()].sort()).toEqual(fixture.snapshots.map(s => s.name).sort());
+
+    for (const snapshot of fixture.snapshots) {
+      // Full deep equality: a renamed, added, dropped, or re-valued field in any TS
+      // builder diverges from the committed fixture here.
+      expect(captured.get(snapshot.name)).toEqual(snapshot.wire);
+    }
+  });
+
+  test("fixture snapshot names are unique", () => {
+    const names = loadFixture().snapshots.map(s => s.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every fixture wire type is a known RequestType rawValue", () => {
+    for (const snapshot of loadFixture().snapshots) {
+      expect(IOS_KNOWN_REQUEST_TYPE_SET.has(snapshot.wire.type as string)).toBe(true);
+    }
+  });
+
+  test("the acceptance-critical commands are covered", () => {
+    const covered = new Set(loadFixture().snapshots.map(s => s.wire.type as string));
+    const required = [
+      "request_action",
+      "request_set_text",
+      "request_ime_action",
+      "request_hierarchy",
+      "request_hierarchy_if_stale",
+      // storage
+      "list_preference_files",
+      "get_preferences",
+      "get_preference",
+      "set_preference",
+      "remove_preference",
+      "clear_preferences",
+      // database
+      "execute_sql",
+      "list_databases",
+      "list_tables",
+      "get_table_data",
+      "get_table_structure",
+    ];
+    expect(required.filter(t => !covered.has(t))).toEqual([]);
+  });
+});

--- a/test/fixtures/ios-ctrlproxy-request-snapshots.json
+++ b/test/fixtures/ios-ctrlproxy-request-snapshots.json
@@ -1,0 +1,474 @@
+{
+  "$comment": [
+    "iOS control-proxy request wire snapshots (issue #2954). One JSON snapshot per command x payload shape",
+    "the TS client can put on the WebSocket wire to the Swift CtrlProxy runner.",
+    "Guarded from BOTH sides:",
+    "  - test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts captures each snapshot LIVE from the",
+    "    real TS builder and asserts deep equality with this file (requestId normalized to a placeholder).",
+    "  - ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift decodes each snapshot",
+    "    through the real WebSocketRequest wire path and asserts every field lands on a same-named property",
+    "    of the typed Swift payload struct with the same value.",
+    "Do not edit by hand. Regenerate with:",
+    "  AUTOMOBILE_UPDATE_IOS_WIRE_SNAPSHOTS=1 bun test test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts",
+    "then re-run the Swift suite (cd ios/control-proxy && swift test)."
+  ],
+  "snapshots": [
+    {
+      "name": "request_hierarchy",
+      "builder": "CtrlProxyHierarchy.requestHierarchySync (disableAllFiltering=true)",
+      "wire": {
+        "type": "request_hierarchy",
+        "requestId": "fixture-request-id",
+        "disableAllFiltering": true
+      }
+    },
+    {
+      "name": "request_hierarchy_if_stale",
+      "builder": "CtrlProxyHierarchy.requestHierarchySync (disableAllFiltering=false)",
+      "wire": {
+        "type": "request_hierarchy_if_stale",
+        "requestId": "fixture-request-id",
+        "disableAllFiltering": false
+      }
+    },
+    {
+      "name": "request_screenshot",
+      "builder": "CtrlProxyScreenshot.requestScreenshot",
+      "wire": {
+        "type": "request_screenshot",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "request_tap_coordinates",
+      "builder": "SharedGestureDelegate.requestTapCoordinates (via CtrlProxyGestures, roundCoordinates=false)",
+      "wire": {
+        "type": "request_tap_coordinates",
+        "requestId": "fixture-request-id",
+        "x": 120.5,
+        "y": 240.25,
+        "duration": 35
+      }
+    },
+    {
+      "name": "request_swipe",
+      "builder": "SharedGestureDelegate.requestSwipe (via CtrlProxyGestures)",
+      "wire": {
+        "type": "request_swipe",
+        "requestId": "fixture-request-id",
+        "x1": 10.5,
+        "y1": 20.25,
+        "x2": 300.75,
+        "y2": 401.5,
+        "duration": 275
+      }
+    },
+    {
+      "name": "request_drag",
+      "builder": "SharedGestureDelegate.requestDrag (via CtrlProxyGestures)",
+      "wire": {
+        "type": "request_drag",
+        "requestId": "fixture-request-id",
+        "x1": 11.5,
+        "y1": 22.25,
+        "x2": 33.75,
+        "y2": 44.5,
+        "pressDurationMs": 350,
+        "dragDurationMs": 900,
+        "holdDurationMs": 150
+      }
+    },
+    {
+      "name": "request_pinch",
+      "builder": "SharedGestureDelegate.requestPinch (via CtrlProxyGestures)",
+      "wire": {
+        "type": "request_pinch",
+        "requestId": "fixture-request-id",
+        "centerX": 160.5,
+        "centerY": 320.25,
+        "distanceStart": 80.5,
+        "distanceEnd": 200.75,
+        "rotationDegrees": 45.5,
+        "duration": 275
+      }
+    },
+    {
+      "name": "request_multi_finger_swipe",
+      "builder": "CtrlProxyGestures.requestMultiFingerSwipe",
+      "wire": {
+        "type": "request_multi_finger_swipe",
+        "requestId": "fixture-request-id",
+        "x1": 15.5,
+        "y1": 25.25,
+        "x2": 35.75,
+        "y2": 46.5,
+        "fingerCount": 3,
+        "duration": 450,
+        "offset": 24.5
+      }
+    },
+    {
+      "name": "request_set_text",
+      "builder": "SharedTextDelegate.requestSetText (via CtrlProxyText)",
+      "wire": {
+        "type": "request_set_text",
+        "requestId": "fixture-request-id",
+        "text": "hello world",
+        "resourceId": "login_username_field"
+      }
+    },
+    {
+      "name": "request_clear_text",
+      "builder": "CtrlProxyText.requestClearText",
+      "wire": {
+        "type": "request_clear_text",
+        "requestId": "fixture-request-id",
+        "resourceId": "login_username_field"
+      }
+    },
+    {
+      "name": "request_ime_action",
+      "builder": "SharedTextDelegate.requestImeAction (via CtrlProxyText)",
+      "wire": {
+        "type": "request_ime_action",
+        "requestId": "fixture-request-id",
+        "action": "done"
+      }
+    },
+    {
+      "name": "request_select_all",
+      "builder": "SharedTextDelegate.requestSelectAll (via CtrlProxyText)",
+      "wire": {
+        "type": "request_select_all",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "request_keyboard",
+      "builder": "CtrlProxyKeyboard.requestKeyboard",
+      "wire": {
+        "type": "request_keyboard",
+        "requestId": "fixture-request-id",
+        "action": "open"
+      }
+    },
+    {
+      "name": "request_press_button",
+      "builder": "CtrlProxyNavigation.requestPressButton",
+      "wire": {
+        "type": "request_press_button",
+        "requestId": "fixture-request-id",
+        "action": "volume_up"
+      }
+    },
+    {
+      "name": "request_press_home",
+      "builder": "CtrlProxyNavigation.requestPressHome",
+      "wire": {
+        "type": "request_press_home",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "request_press_back",
+      "builder": "CtrlProxyNavigation.requestPressBack",
+      "wire": {
+        "type": "request_press_back",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "request_shake",
+      "builder": "CtrlProxyNavigation.requestShake",
+      "wire": {
+        "type": "request_shake",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "request_recent_apps",
+      "builder": "CtrlProxyNavigation.requestRecentApps",
+      "wire": {
+        "type": "request_recent_apps",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "request_action",
+      "builder": "CtrlProxyVoiceOver.requestAction (resourceId + label lookup)",
+      "wire": {
+        "type": "request_action",
+        "requestId": "fixture-request-id",
+        "action": "scroll_forward",
+        "resourceId": "primary_table",
+        "label": "Primary Table"
+      }
+    },
+    {
+      "name": "request_action_voiceover_activate",
+      "builder": "CtrlProxyVoiceOver.requestVoiceOverActivate (label-only lookup)",
+      "wire": {
+        "type": "request_action",
+        "requestId": "fixture-request-id",
+        "label": "Submit",
+        "action": "activate"
+      }
+    },
+    {
+      "name": "request_action_null_lookup",
+      "builder": "CtrlProxyVoiceOver.requestAction (explicit-null resourceId/label)",
+      "wire": {
+        "type": "request_action",
+        "requestId": "fixture-request-id",
+        "action": "scroll_backward",
+        "resourceId": null,
+        "label": null
+      }
+    },
+    {
+      "name": "request_launch_app",
+      "builder": "CtrlProxyNavigation.requestLaunchApp",
+      "wire": {
+        "type": "request_launch_app",
+        "requestId": "fixture-request-id",
+        "bundleId": "com.example.app",
+        "coldBoot": true
+      }
+    },
+    {
+      "name": "request_rotate",
+      "builder": "CtrlProxyNavigation.requestRotate",
+      "wire": {
+        "type": "request_rotate",
+        "requestId": "fixture-request-id",
+        "orientation": "landscape"
+      }
+    },
+    {
+      "name": "request_clipboard",
+      "builder": "CtrlProxyClipboard.requestClipboard",
+      "wire": {
+        "type": "request_clipboard",
+        "requestId": "fixture-request-id",
+        "action": "copy",
+        "text": "clipboard text"
+      }
+    },
+    {
+      "name": "add_highlight_box",
+      "builder": "CtrlProxyHighlights.requestAddHighlight (box shape; bounds are rounded by the builder)",
+      "wire": {
+        "type": "add_highlight",
+        "requestId": "fixture-request-id",
+        "id": "hl-1",
+        "shape": {
+          "type": "box",
+          "bounds": {
+            "x": 10,
+            "y": 21,
+            "width": 100,
+            "height": 51,
+            "sourceWidth": 390,
+            "sourceHeight": 844
+          },
+          "style": {
+            "strokeColor": "#FF0000",
+            "strokeWidth": 3.5,
+            "dashPattern": [
+              4,
+              2
+            ],
+            "smoothing": "bezier",
+            "tension": 0.5,
+            "capStyle": "round",
+            "joinStyle": "miter"
+          }
+        }
+      }
+    },
+    {
+      "name": "add_highlight_path",
+      "builder": "CtrlProxyHighlights.requestAddHighlight (path shape with points)",
+      "wire": {
+        "type": "add_highlight",
+        "requestId": "fixture-request-id",
+        "id": "hl-2",
+        "shape": {
+          "type": "path",
+          "points": [
+            {
+              "x": 1.5,
+              "y": 2.5
+            },
+            {
+              "x": 3.5,
+              "y": 4.5
+            }
+          ],
+          "bounds": {
+            "x": 1,
+            "y": 2,
+            "width": 10,
+            "height": 12
+          }
+        }
+      }
+    },
+    {
+      "name": "request_reset_permissions",
+      "builder": "CtrlProxyPermissions.requestResetPermissions",
+      "wire": {
+        "type": "request_reset_permissions",
+        "requestId": "fixture-request-id",
+        "bundleId": "com.example.app",
+        "permissions": [
+          "camera",
+          "photos"
+        ]
+      }
+    },
+    {
+      "name": "get_voiceover_state",
+      "builder": "CtrlProxyVoiceOver.requestVoiceOverState",
+      "wire": {
+        "type": "get_voiceover_state",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "list_preference_files",
+      "builder": "CtrlProxyStorage.listPreferenceFiles",
+      "wire": {
+        "type": "list_preference_files",
+        "requestId": "fixture-request-id"
+      }
+    },
+    {
+      "name": "get_preferences",
+      "builder": "CtrlProxyStorage.getPreferenceEntries",
+      "wire": {
+        "type": "get_preferences",
+        "requestId": "fixture-request-id",
+        "fileName": "Standard"
+      }
+    },
+    {
+      "name": "get_preference",
+      "builder": "CtrlProxyStorage.getPreference",
+      "wire": {
+        "type": "get_preference",
+        "requestId": "fixture-request-id",
+        "fileName": "Standard",
+        "key": "launch_count"
+      }
+    },
+    {
+      "name": "set_preference",
+      "builder": "CtrlProxyStorage.setPreference",
+      "wire": {
+        "type": "set_preference",
+        "requestId": "fixture-request-id",
+        "fileName": "Standard",
+        "key": "launch_count",
+        "value": "42",
+        "valueType": "INT"
+      }
+    },
+    {
+      "name": "remove_preference",
+      "builder": "CtrlProxyStorage.removePreference",
+      "wire": {
+        "type": "remove_preference",
+        "requestId": "fixture-request-id",
+        "fileName": "Standard",
+        "key": "launch_count"
+      }
+    },
+    {
+      "name": "clear_preferences",
+      "builder": "CtrlProxyStorage.clearPreferenceStore",
+      "wire": {
+        "type": "clear_preferences",
+        "requestId": "fixture-request-id",
+        "fileName": "Standard"
+      }
+    },
+    {
+      "name": "execute_sql",
+      "builder": "CtrlProxyDatabase.executeSQL",
+      "wire": {
+        "type": "execute_sql",
+        "requestId": "fixture-request-id",
+        "appId": "com.example.app",
+        "databasePath": "/Documents/app.sqlite",
+        "query": "SELECT * FROM users"
+      }
+    },
+    {
+      "name": "list_databases",
+      "builder": "CtrlProxyDatabase.listDatabases",
+      "wire": {
+        "type": "list_databases",
+        "requestId": "fixture-request-id",
+        "appId": "com.example.app"
+      }
+    },
+    {
+      "name": "list_tables",
+      "builder": "CtrlProxyDatabase.listTables",
+      "wire": {
+        "type": "list_tables",
+        "requestId": "fixture-request-id",
+        "appId": "com.example.app",
+        "databasePath": "/Documents/app.sqlite"
+      }
+    },
+    {
+      "name": "get_table_data",
+      "builder": "CtrlProxyDatabase.getTableData",
+      "wire": {
+        "type": "get_table_data",
+        "requestId": "fixture-request-id",
+        "appId": "com.example.app",
+        "databasePath": "/Documents/app.sqlite",
+        "table": "users",
+        "limit": 25,
+        "offset": 10
+      }
+    },
+    {
+      "name": "get_table_structure",
+      "builder": "CtrlProxyDatabase.getTableStructure",
+      "wire": {
+        "type": "get_table_structure",
+        "requestId": "fixture-request-id",
+        "appId": "com.example.app",
+        "databasePath": "/Documents/app.sqlite",
+        "table": "users"
+      }
+    },
+    {
+      "name": "set_network_mock_rules",
+      "builder": "IOSCtrlProxyClient.syncNetworkMockRulesToDevice (envelope transcribed; rules built by buildNetworkMockRules)",
+      "wire": {
+        "type": "set_network_mock_rules",
+        "rules": [
+          {
+            "mockId": "mock-1",
+            "host": "api.example.com",
+            "path": "/v1/users",
+            "method": "GET",
+            "limit": 3,
+            "remaining": 3,
+            "statusCode": 200,
+            "responseHeaders": {
+              "X-Mocked": "true"
+            },
+            "responseBody": "{\"users\":[]}",
+            "contentType": "application/json"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #2954

## Summary

Field-name wire-parity backstop for the iOS control-proxy (checklist item 3 of #2857, deferred from PR #2950). The existing command-name tripwire catches a renamed `type` discriminator but not a renamed field *inside* a command payload — e.g. `disableAllFiltering` → `disableFiltering` compiled cleanly and only failed at runtime on-device.

Implements **option 1** from the issue (fixture + Swift decode test), as a two-sided guard around a shared JSON snapshot fixture:

- **`test/fixtures/ios-ctrlproxy-request-snapshots.json`** — 38 snapshots, one per reached command × payload shape (all acceptance-critical commands: `request_action` ×3 variants incl. explicit-null lookup, `request_set_text`, `request_ime_action`, `request_hierarchy`/`_if_stale`, all storage + database commands, plus gestures, text, navigation, clipboard, highlights (box+path), permissions, network-mock rules).
- **`test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts`** — captures every snapshot **live** from the real TS builders (fake `DelegateContext` + `FakeTimer`, mirroring the existing `CtrlProxyGestures.test.ts` harness) and asserts deep equality with the fixture, so the fixture cannot drift from what the client actually sends. `requestId` is normalized to a placeholder (the key name itself is still guarded). Regeneration: `AUTOMOBILE_UPDATE_IOS_WIRE_SNAPSHOTS=1 bun test <file>`.
- **`ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift`** — decodes each snapshot through the real `WebSocketRequest` wire path and asserts every wire field lands on a **same-named property** of the typed payload struct with the same value (Mirror-based, so new fixture entries are covered with no per-command test arm; payload-only extras must be nil optionals). Fixture read via `#filePath` repo-root navigation; a missing fixture fails loudly rather than skipping. Includes a meta-guard test proving the check detects a renamed field.

**Acceptance verified by reproduction:** tampering the fixture (`disableAllFiltering` → `disableFiltering`) fails BOTH the TS capture test and the Swift decode test; a TS-side builder rename diverges from the fixture and fails the TS test directly.

## Caveats

- `set_network_mock_rules` is the one semi-transcribed entry: it is emitted by the private `IOSCtrlProxyClient.syncNetworkMockRulesToDevice()`, so the envelope is transcribed while the `rules` payload — the entire field surface — is built by the production `buildNetworkMockRules`. Documented in the test.
- Option 2 (centralized iOS request builder à la Android's `serializeCtrlProxyProtocol`) was not taken; the AST-scan follow-up #2955 ships separately.
- `ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj` regenerated via `xcodegen generate` for the new Swift test file (4-line additive diff) — possible contention with parallel iOS lanes.
- Swift payload structs currently use synthesized `Decodable` with no custom `CodingKeys` (verified); the Mirror label ↔ wire key assumption is documented and fails loudly if violated.

## Validation

- `bun test test/features/observe/ios/` — 177 pass (capture test itself: 3.8 ms)
- `cd ios/control-proxy && swift test -Xswiftc -warnings-as-errors` — 368 pass
- `turbo run lint build test` — 6671 pass, lint/build clean
- `bun run typecheck` — no new errors (baseline untouched)
- Negative test: fixture field rename fails both suites (reverted)
