### PR TITLE
fix(daemon): forward and broadcast tools/resources list_changed across proxy and multi-session daemon (#3223)

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -4,11 +4,12 @@ import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { logger } from "../utils/logger";
 import { ActionableError } from "../models";
-import { DaemonRequest, DaemonResponse } from "./types";
+import { DaemonRequest, DaemonResponse, DaemonNotification, isDaemonNotification } from "./types";
 import {
   SOCKET_PATH,
   CONNECTION_TIMEOUT_MS,
   DAEMON_VERSION,
+  DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD,
 } from "./constants";
 import { type BuildIdentity, getCurrentBuildIdentity } from "./buildIdentity";
 import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
@@ -84,6 +85,7 @@ export class DaemonClient {
   }> = new Map();
   private buffer: string = "";
   private connected: boolean = false;
+  private notificationHandlers: Set<(notification: DaemonNotification) => void> = new Set();
   private recoveryOptions: DaemonClientRecoveryOptions;
   private readonly clientIdentity: { version: string; build: BuildIdentity } | null;
 
@@ -315,13 +317,54 @@ export class DaemonClient {
     for (const line of lines) {
       if (line.trim()) {
         try {
-          const response: DaemonResponse = JSON.parse(line);
-          this.handleResponse(response);
+          const frame: unknown = JSON.parse(line);
+          if (isDaemonNotification(frame)) {
+            this.handleNotification(frame);
+          } else {
+            this.handleResponse(frame as DaemonResponse);
+          }
         } catch (error) {
           logger.error(`Error parsing daemon response: ${error}`);
         }
       }
     }
+  }
+
+  /**
+   * Dispatch a daemon-pushed notification frame (issue #3223) to registered
+   * handlers. Best-effort: a throwing handler is logged and never tears down
+   * the socket or blocks sibling handlers.
+   */
+  private handleNotification(notification: DaemonNotification): void {
+    for (const handler of this.notificationHandlers) {
+      try {
+        handler(notification);
+      } catch (error) {
+        logger.warn(`Daemon notification handler failed for ${notification.method}: ${error}`);
+      }
+    }
+  }
+
+  /**
+   * Register a handler for daemon-pushed notifications. Frames only arrive
+   * after {@link subscribeToNotifications} opts this connection in.
+   * Returns an unsubscribe function.
+   */
+  onNotification(handler: (notification: DaemonNotification) => void): () => void {
+    this.notificationHandlers.add(handler);
+    return () => {
+      this.notificationHandlers.delete(handler);
+    };
+  }
+
+  /**
+   * Opt this connection in to server-pushed notifications (tools/resources
+   * list_changed forwarding, issue #3223). Connects first if needed. Callers
+   * own the failure strategy — a daemon that predates the subscription method
+   * returns an error response, which surfaces here as a rejection.
+   */
+  async subscribeToNotifications(): Promise<void> {
+    await this.callDaemonMethod(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD, {});
   }
 
   /**
@@ -485,6 +528,7 @@ export class DaemonClient {
       this.timer.clearTimeout(timeout);
     }
     this.pendingRequests.clear();
+    this.notificationHandlers.clear();
   }
 }
 
@@ -494,6 +538,13 @@ export interface DaemonClientLike {
   callTool(toolName: string, params: Record<string, any>): Promise<any>;
   readResource(uri: string): Promise<any>;
   callDaemonMethod(method: string, params: Record<string, any>): Promise<any>;
+  /**
+   * Optional daemon-push capability (issue #3223). Clients that cannot surface
+   * server-pushed frames omit both members and the proxy skips notification
+   * wiring entirely — so a client must implement both or neither.
+   */
+  onNotification?(handler: (notification: DaemonNotification) => void): () => void;
+  subscribeToNotifications?(): Promise<void>;
 }
 
 export type DaemonClientFactory = () => DaemonClientLike;

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -130,6 +130,14 @@ export const READINESS_PROBE_BACKOFF_MS = 150;
 export const MCP_STREAMABLE_PATH = "/auto-mobile/streamable";
 
 /**
+ * Control-socket method a client sends to opt in to server-pushed
+ * `DaemonNotification` frames (tools/resources list_changed forwarding,
+ * issue #3223). Opt-in keeps the push invisible to Kotlin/Swift/legacy
+ * clients that only understand request/response frames.
+ */
+export const DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD = "daemon/subscribe-notifications";
+
+/**
  * Whether the daemon enforces the inbound version/build-identity handshake
  * (#2744). Enabled by default; set `AUTOMOBILE_DAEMON_DISABLE_HANDSHAKE=1`
  * (or `AUTO_MOBILE_DAEMON_DISABLE_HANDSHAKE=1`) as an escape hatch if a

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -2,7 +2,8 @@ import { DaemonClient, DaemonUnavailableError, type DaemonClientLike, type Daemo
 import { DaemonManager, type DaemonManagerLike } from "./manager";
 import { logger } from "../utils/logger";
 import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "./constants";
-import type { DaemonOptions } from "./types";
+import type { DaemonNotification, DaemonOptions } from "./types";
+import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
 import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
@@ -250,6 +251,14 @@ export class DaemonMcpProxy {
   private cachedResources: ProxiedResourceDefinition[] | null = null;
   private cachedResourceTemplates: ProxiedResourceTemplate[] | null = null;
 
+  // Listeners for daemon-forwarded list-changed notifications (issue #3223),
+  // fired after the matching cache is invalidated so a re-fetch is never stale.
+  private readonly listChangedListeners = new Set<(kind: ListChangedKind) => void>();
+  // Releases this proxy's handler on the current client. Needed because a
+  // clientFactory may return a shared/reused client (test fakes do); without it
+  // every reconnect would stack another handler on that client.
+  private notificationUnsubscribe: (() => void) | null = null;
+
   constructor(config: DaemonMcpProxyConfig = {}) {
     this.config = {
       autoStartDaemon: true,
@@ -313,9 +322,73 @@ export class DaemonMcpProxy {
 
     // Create and connect client
     this.client = this.clientFactory();
-    await this.client.connect();
+    const client = this.client;
+    // Wire daemon-pushed list-changed forwarding (issue #3223) when the client
+    // supports it. The handler is registered BEFORE connect so no early frame
+    // is dropped; the opt-in subscription request goes out after connect.
+    const supportsNotifications =
+      typeof client.onNotification === "function" &&
+      typeof client.subscribeToNotifications === "function";
+    if (supportsNotifications) {
+      this.notificationUnsubscribe?.();
+      this.notificationUnsubscribe = client.onNotification!(
+        notification => this.handleDaemonNotification(notification)
+      );
+    }
+    await client.connect();
     this.connected = true;
     logger.info("[DaemonMcpProxy] Connected to daemon");
+
+    if (supportsNotifications) {
+      try {
+        await client.subscribeToNotifications!();
+      } catch (error) {
+        // Best-effort: without the subscription the proxy degrades to the old
+        // cached behavior instead of failing the connection. Unexpected against
+        // a same-version daemon (the handshake gate pins versions), so warn.
+        logger.warn(`[DaemonMcpProxy] Failed to subscribe to daemon notifications: ${error}`);
+      }
+    }
+  }
+
+  /**
+   * Register a listener for daemon-forwarded list-changed notifications
+   * (issue #3223). The proxy invalidates the matching cache before firing, so
+   * listeners re-fetching `listTools()`/`listResources()` always see fresh
+   * definitions. Returns an unsubscribe function.
+   */
+  onListChanged(listener: (kind: ListChangedKind) => void): () => void {
+    this.listChangedListeners.add(listener);
+    return () => {
+      this.listChangedListeners.delete(listener);
+    };
+  }
+
+  private handleDaemonNotification(notification: DaemonNotification): void {
+    const kind = listChangedKindForMethod(notification.method);
+    if (kind === undefined) {
+      // Unknown pushed methods are expected as the daemon grows new
+      // notification families; ignoring keeps old proxies forward-compatible.
+      logger.debug(`[DaemonMcpProxy] Ignoring unknown daemon notification: ${notification.method}`);
+      return;
+    }
+
+    if (kind === "tools") {
+      this.cachedTools = null;
+    } else {
+      this.cachedResources = null;
+      this.cachedResourceTemplates = null;
+    }
+
+    for (const listener of this.listChangedListeners) {
+      try {
+        listener(kind);
+      } catch (error) {
+        // Best-effort re-emit: a dead/mid-teardown client transport must not
+        // break cache invalidation or sibling listeners.
+        logger.warn(`[DaemonMcpProxy] list_changed listener failed for ${kind}: ${error}`);
+      }
+    }
   }
 
   /**
@@ -612,6 +685,8 @@ export class DaemonMcpProxy {
     const staleClient = this.client;
     this.connected = false;
     this.client = null;
+    this.notificationUnsubscribe?.();
+    this.notificationUnsubscribe = null;
     this.invalidateCache();
 
     if (!staleClient) {
@@ -758,6 +833,8 @@ export class DaemonMcpProxy {
       await this.client.close();
       this.client = null;
     }
+    this.notificationUnsubscribe?.();
+    this.notificationUnsubscribe = null;
     this.connected = false;
     this.invalidateCache();
     logger.debug("[DaemonMcpProxy] Disconnected from daemon");

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -11,11 +11,22 @@ import { logger } from "../utils/logger";
 import { resolveMcpRequestTimeoutMs, MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import {
+  DaemonNotification,
   DaemonRequest,
   DaemonResponse,
   SessionContext,
 } from "./types";
-import { SOCKET_PATH, DAEMON_HANDSHAKE_ENABLED, DAEMON_VERSION } from "./constants";
+import {
+  SOCKET_PATH,
+  DAEMON_HANDSHAKE_ENABLED,
+  DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD,
+  DAEMON_VERSION,
+} from "./constants";
+import {
+  ListChangedBroadcaster,
+  LIST_CHANGED_NOTIFICATION_METHODS,
+  type ListChangedKind,
+} from "../server/listChangedBroadcast";
 import {
   evaluateClientHandshake,
   extractClientHandshake,
@@ -84,6 +95,11 @@ export class UnixSocketServer {
   private server: NetServer | null = null;
   private socketFileIdentity: SocketFileIdentity | null = null;
   private sessions: Map<string, SessionContext> = new Map();
+  /** Live client sockets by session ID, for server-pushed notification frames (issue #3223). */
+  private clientSockets: Map<string, Socket> = new Map();
+  /** Socket sessions that opted in to server-pushed notifications. */
+  private notificationSubscribers: Set<string> = new Set();
+  private listChangedUnsubscribe: (() => void) | null = null;
   private socketPath: string;
   private mcpEndpoint: string;
   private daemonState: DaemonStateAccess;
@@ -134,6 +150,14 @@ export class UnixSocketServer {
       this.handleConnection(socket);
     });
 
+    // Fan list-changed events out to subscribed socket clients (issue #3223).
+    // Subscribed here (not in the daemon) so a socket-server recreation during
+    // recovery re-wires itself; close() unsubscribes symmetrically.
+    this.listChangedUnsubscribe?.();
+    this.listChangedUnsubscribe = ListChangedBroadcaster.subscribe(kind => {
+      this.broadcastListChanged(kind);
+    });
+
     return new Promise((resolve, reject) => {
       this.server!.listen(this.socketPath, () => {
         this.socketFileIdentity = this.readSocketFileIdentity();
@@ -161,6 +185,7 @@ export class UnixSocketServer {
     };
 
     this.sessions.set(sessionId, session);
+    this.clientSockets.set(sessionId, socket);
     logger.info(`New client connection: ${sessionId}`);
 
     let buffer = "";
@@ -189,7 +214,7 @@ export class UnixSocketServer {
           const request: DaemonRequest = JSON.parse(line);
           requestId = request.id;
           const response = await this.handleRequest(sessionId, request);
-          this.writeResponse(socket, sessionId, response);
+          this.writeFrame(socket, sessionId, response);
         } catch (error) {
           logger.error(`Error processing request ${requestId} from ${sessionId}:`, error);
           const errorResponse: DaemonResponse = {
@@ -198,7 +223,7 @@ export class UnixSocketServer {
             success: false,
             error: error instanceof Error ? error.message : String(error),
           };
-          this.writeResponse(socket, sessionId, errorResponse);
+          this.writeFrame(socket, sessionId, errorResponse);
         }
       }
     });
@@ -206,23 +231,46 @@ export class UnixSocketServer {
     socket.on("close", () => {
       logger.info(`Client disconnected: ${sessionId}`);
       this.sessions.delete(sessionId);
+      this.clientSockets.delete(sessionId);
+      this.notificationSubscribers.delete(sessionId);
     });
 
     socket.on("error", error => {
       logger.error(`Socket error for ${sessionId}:`, error);
       this.sessions.delete(sessionId);
+      this.clientSockets.delete(sessionId);
+      this.notificationSubscribers.delete(sessionId);
       if (!socket.destroyed) {
         socket.destroy();
       }
     });
   }
 
-  private writeResponse(socket: Socket, sessionId: string, response: DaemonResponse): void {
+  /**
+   * Push a list-changed notification frame to every subscribed client socket
+   * (issue #3223). Best-effort per socket: a dead/mid-teardown socket is
+   * skipped or destroyed by the write helper, never thrown.
+   */
+  private broadcastListChanged(kind: ListChangedKind): void {
+    const notification: DaemonNotification = {
+      type: "daemon_notification",
+      method: LIST_CHANGED_NOTIFICATION_METHODS[kind],
+    };
+    for (const sessionId of this.notificationSubscribers) {
+      const socket = this.clientSockets.get(sessionId);
+      if (!socket) {
+        continue;
+      }
+      this.writeFrame(socket, sessionId, notification);
+    }
+  }
+
+  private writeFrame(socket: Socket, sessionId: string, frame: DaemonResponse | DaemonNotification): void {
     if (socket.destroyed) {
       return;
     }
     try {
-      const ok = socket.write(JSON.stringify(response) + "\n");
+      const ok = socket.write(JSON.stringify(frame) + "\n");
       if (!ok) {
         logger.debug(
           `Daemon RPC socket ${sessionId} backpressured; awaiting drain (idle timeout still armed)`
@@ -256,6 +304,18 @@ export class UnixSocketServer {
     const handshakeError = this.rejectOnHandshakeMismatch(request);
     if (handshakeError) {
       return handshakeError;
+    }
+
+    // Notification opt-in is per-socket-session state owned here, not by the
+    // daemon request handlers — answer immediately without queueing (issue #3223).
+    if (request.method === DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD) {
+      this.notificationSubscribers.add(sessionId);
+      return {
+        id: request.id,
+        type: "mcp_response",
+        success: true,
+        result: { subscribed: true },
+      };
     }
 
     // Enqueue request to maintain order
@@ -950,6 +1010,10 @@ export class UnixSocketServer {
   async close(): Promise<void> {
     logger.info("Closing Unix socket server...");
 
+    // Stop receiving list-changed events (mirrors the subscribe in start()).
+    this.listChangedUnsubscribe?.();
+    this.listChangedUnsubscribe = null;
+
     // Close MCP clients
     const clients = Array.from(this.mcpClients.entries());
     this.mcpClients.clear();
@@ -969,6 +1033,8 @@ export class UnixSocketServer {
 
     // Clear sessions
     this.sessions.clear();
+    this.clientSockets.clear();
+    this.notificationSubscribers.clear();
 
     const ownsSocketPath = this.isOwnedSocketFile();
 

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -44,6 +44,29 @@ export interface DaemonResponse {
 }
 
 /**
+ * Server-pushed notification frame sent from daemon to a subscribed CLI client
+ * over the control socket (issue #3223). Unlike {@link DaemonResponse} it has no
+ * `id` — it does not correlate to a request. Clients discriminate on `type`.
+ * Only sent to sessions that opted in via `daemon/subscribe-notifications`, so
+ * legacy/Kotlin/Swift clients never see an unexpected frame shape.
+ */
+export interface DaemonNotification {
+  type: "daemon_notification";
+  /** MCP notification method, e.g. "notifications/tools/list_changed". */
+  method: string;
+}
+
+/** Discriminates a daemon socket frame as a server-pushed notification. */
+export function isDaemonNotification(frame: unknown): frame is DaemonNotification {
+  return (
+    typeof frame === "object" &&
+    frame !== null &&
+    (frame as { type?: unknown }).type === "daemon_notification" &&
+    typeof (frame as { method?: unknown }).method === "string"
+  );
+}
+
+/**
  * Known Unix-domain sockets exposed by the daemon.
  */
 export type DaemonSocketName =

--- a/src/features/featureFlags/ToolListChangedNotifier.ts
+++ b/src/features/featureFlags/ToolListChangedNotifier.ts
@@ -5,9 +5,10 @@
  * into {@link FeatureFlagService} so the notification stays fakeable in unit
  * tests and the feature-flag layer keeps no hard dependency on the MCP server /
  * `ToolRegistry`. The production wiring (in `createMcpServer`) delegates to
- * `ToolRegistry.notifyToolListChanged()`, which owns the server reference and the
- * best-effort emit — mirroring how `ResourceRegistry` emits `resources/list_changed`.
- * See issue #2963.
+ * `ToolRegistry.notifyToolListChanged()`, which owns the live-server set and the
+ * best-effort fan-out (all daemon sessions plus the Unix-socket push to proxy
+ * clients, issue #3223) — mirroring how `ResourceRegistry` emits
+ * `resources/list_changed`. See issue #2963.
  *
  * Contract: implementations are best-effort and MUST NOT throw — a failed
  * notification must never break the flag toggle that triggered it.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -238,15 +238,16 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   // Emit notifications/tools/list_changed when a runtime feature-flag toggle
   // changes tool definitions (outputSchema advertisement or tool availability),
   // so caching clients re-fetch tools/list (issue #2963). The emit itself lives on
-  // ToolRegistry (which now holds the server), mirroring ResourceRegistry's
-  // resources/list_changed; this only routes the feature-flag singleton to it.
-  // Wired here because the singleton is constructed before the server exists.
+  // ToolRegistry (which tracks every live session's server), mirroring
+  // ResourceRegistry's resources/list_changed; this only routes the feature-flag
+  // singleton to it. Wired here because the singleton is constructed before the
+  // server exists.
   //
-  // NOTE: in the default proxy topology (external client -> proxy -> daemon) this
-  // notification is not yet forwarded/honored by DaemonMcpProxy (it serves cached
-  // tools and does not invalidate on tools/list_changed) — a pre-existing,
-  // cross-cutting proxy limitation shared with resources/list_changed, tracked as
-  // a follow-up. Direct-mode clients receive and honor it.
+  // In the default proxy topology (external client -> proxy -> daemon) the
+  // notification also reaches proxy-mode clients (issue #3223): ToolRegistry
+  // fans out to all live daemon sessions AND emits on the ListChangedBroadcaster,
+  // which the daemon's Unix socket server pushes to subscribed DaemonMcpProxy
+  // clients; each proxy invalidates its tool cache and re-emits to its client.
   FeatureFlagService.getInstance().setToolListChangedNotifier({
     notifyToolListChanged: () => ToolRegistry.notifyToolListChanged(),
   });

--- a/src/server/listChangedBroadcast.ts
+++ b/src/server/listChangedBroadcast.ts
@@ -1,0 +1,74 @@
+import { logger } from "../utils/logger";
+
+/**
+ * The two MCP list-changed notification families AutoMobile emits at runtime
+ * (issue #3223, follow-up to #2963). "tools" covers tool-definition changes
+ * (outputSchema advertisement / availability after a feature-flag toggle);
+ * "resources" covers resource registration changes.
+ */
+export type ListChangedKind = "tools" | "resources";
+
+/**
+ * MCP wire method for each list-changed kind. Shared by the daemon socket
+ * broadcast (kind -> method) and the proxy's inbound dispatch (method -> kind)
+ * so the two ends can never drift.
+ */
+export const LIST_CHANGED_NOTIFICATION_METHODS: Record<ListChangedKind, string> = {
+  tools: "notifications/tools/list_changed",
+  resources: "notifications/resources/list_changed",
+};
+
+/** Reverse lookup for {@link LIST_CHANGED_NOTIFICATION_METHODS}; undefined for unknown methods. */
+export function listChangedKindForMethod(method: string): ListChangedKind | undefined {
+  for (const [kind, wireMethod] of Object.entries(LIST_CHANGED_NOTIFICATION_METHODS)) {
+    if (wireMethod === method) {
+      return kind as ListChangedKind;
+    }
+  }
+  return undefined;
+}
+
+export interface ListChangedListener {
+  (kind: ListChangedKind): void;
+}
+
+/**
+ * Process-wide fan-out for list-changed events, decoupled from any single MCP
+ * server/transport (issue #3223). `ToolRegistry.notifyToolListChanged` and
+ * `ResourceRegistry.notifyResourceListChanged` emit here in addition to their
+ * per-session MCP notifications, and transport owners that are NOT MCP servers
+ * (the daemon's Unix socket server, which pushes frames to connected
+ * `DaemonMcpProxy` clients) subscribe. Emission is best-effort: a throwing
+ * listener is logged and never breaks the runtime change that triggered it.
+ */
+class ListChangedBroadcasterClass {
+  private readonly listeners = new Set<ListChangedListener>();
+
+  /** Register a listener; returns an unsubscribe function. */
+  subscribe(listener: ListChangedListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  emit(kind: ListChangedKind): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(kind);
+      } catch (error) {
+        // Best-effort fan-out: one broken sink must not block the others or the
+        // flag toggle / resource change that triggered the emit.
+        logger.warn(`[ListChangedBroadcaster] listener failed for ${kind} list_changed: ${error}`);
+      }
+    }
+  }
+
+  /** Test-only: drop all listeners so suites sharing the singleton stay hermetic. */
+  clearForTesting(): void {
+    this.listeners.clear();
+  }
+}
+
+// Singleton: one process-wide broadcast channel, mirroring ToolRegistry/ResourceRegistry.
+export const ListChangedBroadcaster = new ListChangedBroadcasterClass();

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -53,6 +53,25 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
     },
   });
 
+  // Forward daemon-emitted list-changed notifications to the external client
+  // (issue #3223): the proxy has already invalidated its matching cache, so a
+  // client re-fetch after this notification returns fresh definitions. The
+  // McpServer send helpers are no-ops until a transport connects, and the
+  // try/catch keeps a mid-teardown transport from breaking the forward path.
+  proxy.onListChanged(kind => {
+    try {
+      if (kind === "tools") {
+        server.sendToolListChanged();
+      } else {
+        server.sendResourceListChanged();
+      }
+    } catch (error) {
+      // Best-effort: a failed client notification must never break the proxy
+      // connection; the client just keeps its stale list until the next fetch.
+      logger.warn(`[ProxyServer] Failed to forward ${kind} list_changed notification: ${error}`);
+    }
+  });
+
   // Register ping handler as per MCP specification
   const PingRequestSchema = require("@modelcontextprotocol/sdk/types.js").PingRequestSchema;
   server.server.setRequestHandler(PingRequestSchema, async () => {

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Resource, ResourceTemplate, ReadResourceRequestSchema, ListResourcesRequestSchema, ListResourceTemplatesRequestSchema, SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "../utils/logger";
+import { ListChangedBroadcaster } from "./listChangedBroadcast";
 
 // Interface for resource content handlers
 interface ResourceHandler {
@@ -42,7 +43,12 @@ interface RegisteredResourceTemplate {
 class ResourceRegistryClass {
   private resources: Map<string, RegisteredResource> = new Map();
   private templates: Map<string, RegisteredResourceTemplate> = new Map();
-  private server: McpServer | null = null;
+  // Every live MCP server this registry has been registered with. In daemon
+  // mode `registerWithServer` runs once per HTTP session, so notifications must
+  // fan out to ALL live sessions — a single retained server would be
+  // last-writer-wins (issue #3223). Entries are pruned via the underlying
+  // server's onclose hook when a session's transport closes.
+  private servers: Set<McpServer> = new Set();
   private subscriptions: Set<string> = new Set();
 
   // Register a new resource
@@ -159,9 +165,26 @@ class ResourceRegistryClass {
     }));
   }
 
+  // Track a server for notification fan-out and prune it when its session's
+  // transport closes. The underlying Protocol preserves a pre-set `onclose`
+  // (both the transport's and the server's), so chaining here cannot clobber
+  // other lifecycle hooks (e.g. ToolRegistry's identical prune hook).
+  private trackServer(server: McpServer): void {
+    if (this.servers.has(server)) {
+      return;
+    }
+    this.servers.add(server);
+    const underlying = server.server;
+    const existingOnClose = underlying.onclose;
+    underlying.onclose = () => {
+      this.servers.delete(server);
+      existingOnClose?.();
+    };
+  }
+
   // Register all resources with an MCP server
   registerWithServer(server: McpServer): void {
-    this.server = server;
+    this.trackServer(server);
 
     // Set handler for listing resources
     server.server.setRequestHandler(ListResourcesRequestSchema, async () => {
@@ -255,10 +278,6 @@ class ResourceRegistryClass {
 
   // Send resource update notification (only if client is subscribed)
   async notifyResourceUpdated(uri: string): Promise<void> {
-    if (!this.server) {
-      return;
-    }
-
     if (!this.subscriptions.has(uri)) {
       return;
     }
@@ -269,17 +288,21 @@ class ResourceRegistryClass {
       return;
     }
 
-    try {
-      // Send notification to clients that resource has changed
-      await this.server.server.notification({
-        method: "notifications/resources/updated",
-        params: {
-          uri: resource ? resource.uri : uri
-        }
-      });
-    } catch (error) {
-      // Silently ignore notification errors (e.g., when transport is not connected during tests)
-      logger.debug(`[ResourceRegistry] Failed to notify resource update for ${uri}: ${error}`);
+    // Subscriptions are tracked registry-wide, so every live session's server
+    // gets the update (issue #3223) — best-effort per server.
+    for (const server of this.servers) {
+      try {
+        // Send notification to clients that resource has changed
+        await server.server.notification({
+          method: "notifications/resources/updated",
+          params: {
+            uri: resource ? resource.uri : uri
+          }
+        });
+      } catch (error) {
+        // Silently ignore notification errors (e.g., when transport is not connected during tests)
+        logger.debug(`[ResourceRegistry] Failed to notify resource update for ${uri}: ${error}`);
+      }
     }
   }
 
@@ -290,20 +313,30 @@ class ResourceRegistryClass {
     }
   }
 
-  // Send notification that the resource list has changed
+  // Send notification that the resource list has changed. Fans out to every
+  // live session's server (issue #3223), and the ListChangedBroadcaster carries
+  // the event to non-MCP transports — the daemon's Unix socket server pushes it
+  // to connected DaemonMcpProxy clients, which invalidate their resource caches
+  // and re-emit to their own external clients.
   async notifyResourceListChanged(): Promise<void> {
-    if (!this.server) {
-      return;
+    for (const server of this.servers) {
+      try {
+        await server.server.notification({
+          method: "notifications/resources/list_changed",
+          params: {}
+        });
+      } catch (error) {
+        // Best-effort: a failed notification must never break the resource
+        // change that triggered it, nor block sibling sessions.
+        logger.warn(`[ResourceRegistry] Failed to notify resource list change: ${error}`);
+      }
     }
+    ListChangedBroadcaster.emit("resources");
+  }
 
-    try {
-      await this.server.server.notification({
-        method: "notifications/resources/list_changed",
-        params: {}
-      });
-    } catch (error) {
-      logger.warn(`[ResourceRegistry] Failed to notify resource list change: ${error}`);
-    }
+  // Test-only: drop tracked servers so suites sharing the singleton stay hermetic.
+  clearServersForTesting(): void {
+    this.servers.clear();
   }
 
   // Clear all registered resources, templates, and subscriptions (for testing)

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -27,6 +27,7 @@ import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
 import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
+import { ListChangedBroadcaster } from "./listChangedBroadcast";
 import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
 import {
   InternalToolName,
@@ -647,7 +648,12 @@ class DefaultPlanLifecycleManager implements PlanLifecycleManager {
 // The registry that holds all tools
 class ToolRegistryClass {
   private tools: Map<string, RegisteredTool> = new Map();
-  private server: McpServer | null = null;
+  // Every live MCP server this registry has been registered with. In daemon
+  // mode `registerWithServer` runs once per HTTP session, so notifications must
+  // fan out to ALL live sessions — a single retained server would be
+  // last-writer-wins (issue #3223). Entries are pruned via the underlying
+  // server's onclose hook when a session's transport closes.
+  private servers: Set<McpServer> = new Set();
   private deviceSessionManager: DeviceSessionManager;
   private cleanupService: AppCleanupService;
   private toolCallRepository: ToolCallRepository;
@@ -902,9 +908,10 @@ class ToolRegistryClass {
   // Register all tools with an MCP server
   registerWithServer(server: McpServer): void {
     // Retained so runtime changes that alter tool definitions can emit
-    // notifications/tools/list_changed (issue #2963), mirroring how
-    // ResourceRegistry retains the server for resources/list_changed.
-    this.server = server;
+    // notifications/tools/list_changed (issue #2963) to EVERY live session, not
+    // just the most recently created one (issue #3223), mirroring how
+    // ResourceRegistry retains its servers for resources/list_changed.
+    this.trackServer(server);
 
     this.tools.forEach(tool => {
       if (!this.isToolAvailable(tool)) {
@@ -948,6 +955,28 @@ class ToolRegistryClass {
     });
   }
 
+  // Track a server for list-changed fan-out and prune it when its session's
+  // transport closes. The underlying Protocol preserves a pre-set `onclose`
+  // (both the transport's and the server's), so chaining here cannot clobber
+  // other lifecycle hooks — and vice versa.
+  private trackServer(server: McpServer): void {
+    if (this.servers.has(server)) {
+      return;
+    }
+    this.servers.add(server);
+    const underlying = server.server;
+    const existingOnClose = underlying.onclose;
+    underlying.onclose = () => {
+      this.servers.delete(server);
+      existingOnClose?.();
+    };
+  }
+
+  // Test-only: drop tracked servers so suites sharing the singleton stay hermetic.
+  clearServersForTesting(): void {
+    this.servers.clear();
+  }
+
   // Emit notifications/tools/list_changed so caching clients re-fetch tools/list
   // after a runtime change that alters tool definitions — outputSchema
   // advertisement (getToolDefinitions) or tool availability (isToolAvailable).
@@ -956,23 +985,24 @@ class ToolRegistryClass {
   // sendToolListChanged() is itself a guarded no-op until a client connects, so
   // this is safe to call before any transport attaches.
   //
-  // Last-writer-wins: registerWithServer runs per HTTP session in daemon mode, so
-  // this.server points at the most-recently-created session — only that session
-  // is notified. This matches ResourceRegistry's single `server` field; a
-  // cross-cutting multi-session broadcaster is tracked as a follow-up.
+  // Fan-out (issue #3223): every live session's server is notified (not just the
+  // most recently created one), and the ListChangedBroadcaster carries the event
+  // to non-MCP transports — the daemon's Unix socket server pushes it to
+  // connected DaemonMcpProxy clients, which invalidate their tool cache and
+  // re-emit to their own external clients.
   notifyToolListChanged(): void {
-    if (!this.server) {
-      return;
+    for (const server of this.servers) {
+      try {
+        server.sendToolListChanged();
+      } catch (error) {
+        // Best-effort: a failed notification must never break the flag toggle
+        // that triggered it, nor block sibling sessions. Unexpected for a
+        // connected client (transport mid-teardown is the only expected case),
+        // so warn — matching notifyResourceListChanged.
+        logger.warn(`[ToolRegistry] Failed to notify tool list change: ${error}`);
+      }
     }
-
-    try {
-      this.server.sendToolListChanged();
-    } catch (error) {
-      // Best-effort: a failed notification must never break the flag toggle that
-      // triggered it. Unexpected for a connected client (transport mid-teardown
-      // is the only expected case), so warn — matching notifyResourceListChanged.
-      logger.warn(`[ToolRegistry] Failed to notify tool list change: ${error}`);
-    }
+    ListChangedBroadcaster.emit("tools");
   }
 
   // Get tools in MCP format

--- a/test/daemon/daemonClientNotifications.test.ts
+++ b/test/daemon/daemonClientNotifications.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { DaemonClient } from "../../src/daemon/client";
+import { isDaemonNotification, type DaemonNotification } from "../../src/daemon/types";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+// Issue #3223: the daemon control socket carries server-pushed notification
+// frames alongside request/response frames. These tests drive the private
+// line-parsing path directly (no real socket) so they stay fast and hermetic.
+
+function feed(client: DaemonClient, frames: unknown[]): void {
+  const payload = frames.map(frame => JSON.stringify(frame)).join("\n") + "\n";
+  (client as unknown as { handleData(data: Buffer): void }).handleData(Buffer.from(payload));
+}
+
+describe("isDaemonNotification", () => {
+  test("accepts a well-formed notification frame", () => {
+    expect(isDaemonNotification({ type: "daemon_notification", method: "notifications/tools/list_changed" })).toBe(true);
+  });
+
+  test("rejects responses, null, and malformed frames", () => {
+    expect(isDaemonNotification({ id: "1", type: "mcp_response", success: true })).toBe(false);
+    expect(isDaemonNotification(null)).toBe(false);
+    expect(isDaemonNotification("daemon_notification")).toBe(false);
+    expect(isDaemonNotification({ type: "daemon_notification" })).toBe(false);
+    expect(isDaemonNotification({ type: "daemon_notification", method: 42 })).toBe(false);
+  });
+});
+
+describe("DaemonClient notification frames", () => {
+  test("routes notification frames to registered handlers", () => {
+    const client = new DaemonClient("/tmp/never-connected.sock", 1000, new FakeTimer());
+    const received: DaemonNotification[] = [];
+    client.onNotification(notification => {
+      received.push(notification);
+    });
+
+    feed(client, [{ type: "daemon_notification", method: "notifications/tools/list_changed" }]);
+
+    expect(received).toEqual([
+      { type: "daemon_notification", method: "notifications/tools/list_changed" },
+    ]);
+  });
+
+  test("notification frames interleaved with responses do not disturb response handling", () => {
+    const client = new DaemonClient("/tmp/never-connected.sock", 1000, new FakeTimer());
+    const received: string[] = [];
+    client.onNotification(notification => {
+      received.push(notification.method);
+    });
+
+    // A response for an unknown request id only logs; a notification dispatches.
+    feed(client, [
+      { id: "unknown-id", type: "mcp_response", success: true, result: {} },
+      { type: "daemon_notification", method: "notifications/resources/list_changed" },
+    ]);
+
+    expect(received).toEqual(["notifications/resources/list_changed"]);
+  });
+
+  test("a throwing handler does not block sibling handlers", () => {
+    const client = new DaemonClient("/tmp/never-connected.sock", 1000, new FakeTimer());
+    const received: string[] = [];
+    client.onNotification(() => {
+      throw new Error("handler boom");
+    });
+    client.onNotification(notification => {
+      received.push(notification.method);
+    });
+
+    expect(() =>
+      feed(client, [{ type: "daemon_notification", method: "notifications/tools/list_changed" }])
+    ).not.toThrow();
+    expect(received).toEqual(["notifications/tools/list_changed"]);
+  });
+
+  test("onNotification returns an unsubscribe function", () => {
+    const client = new DaemonClient("/tmp/never-connected.sock", 1000, new FakeTimer());
+    const received: string[] = [];
+    const unsubscribe = client.onNotification(notification => {
+      received.push(notification.method);
+    });
+
+    unsubscribe();
+    feed(client, [{ type: "daemon_notification", method: "notifications/tools/list_changed" }]);
+
+    expect(received).toEqual([]);
+  });
+});

--- a/test/daemon/daemonMcpProxyListChanged.test.ts
+++ b/test/daemon/daemonMcpProxyListChanged.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, test, spyOn } from "bun:test";
+import { DaemonMcpProxy } from "../../src/daemon/daemonMcpProxy";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION, DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD } from "../../src/daemon/constants";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+
+// Issue #3223: the proxy must honor daemon-pushed list-changed notifications —
+// invalidate the matching cache and re-emit to its own listeners — so proxy-mode
+// clients observe flag-driven tool/resource changes without a daemon restart.
+
+const TOOLS_V1 = { tools: [{ name: "toolA", inputSchema: {} }] };
+const RESOURCES_V1 = { resources: [{ uri: "automobile:one", name: "one" }] };
+const TEMPLATES_V1 = { resourceTemplates: [{ uriTemplate: "automobile:{x}", name: "x" }] };
+
+function runningManager(): FakeDaemonManager {
+  const manager = new FakeDaemonManager();
+  manager.statusResult = {
+    running: true,
+    pid: 1234,
+    port: 3000,
+    socketPath: "/tmp/test.sock",
+    version: DAEMON_VERSION,
+  };
+  return manager;
+}
+
+function createProxy(fakeClient: FakeDaemonClient): DaemonMcpProxy {
+  return new DaemonMcpProxy({
+    clientFactory: () => fakeClient,
+    daemonManager: runningManager(),
+    autoStartDaemon: false,
+  });
+}
+
+function createFakeClient(): FakeDaemonClient {
+  return new FakeDaemonClient({
+    daemonMethodResults: new Map<string, any>([
+      ["tools/list", TOOLS_V1],
+      ["resources/list", RESOURCES_V1],
+      ["resources/list-templates", TEMPLATES_V1],
+    ]),
+  });
+}
+
+let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
+
+function mockDaemonAvailable(): void {
+  isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+}
+
+afterEach(() => {
+  isAvailableSpy?.mockRestore();
+  isAvailableSpy = null;
+});
+
+describe("DaemonMcpProxy list-changed forwarding", () => {
+  test("subscribes to daemon notifications on connect", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+
+    await proxy.listTools();
+
+    expect(fakeClient.subscribeToNotificationsCalls).toBe(1);
+  });
+
+  test("subscription failure is best-effort: connect still succeeds", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    fakeClient.shouldFailSubscribe = true;
+    const proxy = createProxy(fakeClient);
+
+    const tools = await proxy.listTools();
+
+    expect(tools).toEqual(TOOLS_V1.tools as any);
+    expect(proxy.isConnected()).toBe(true);
+  });
+
+  test("tools/list_changed invalidates the tool cache and re-fetches", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+
+    await proxy.listTools();
+    // Second call is served from cache: no extra tools/list round-trip.
+    await proxy.listTools();
+    const listCallsBefore = fakeClient.callDaemonMethodCalls
+      .filter(call => call.method === "tools/list").length;
+    expect(listCallsBefore).toBe(1);
+
+    fakeClient.emitNotification("notifications/tools/list_changed");
+    await proxy.listTools();
+
+    const listCallsAfter = fakeClient.callDaemonMethodCalls
+      .filter(call => call.method === "tools/list").length;
+    expect(listCallsAfter).toBe(2);
+  });
+
+  test("tools/list_changed leaves resource caches intact", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+
+    await proxy.listResources();
+    fakeClient.emitNotification("notifications/tools/list_changed");
+    await proxy.listResources();
+
+    const resourceListCalls = fakeClient.callDaemonMethodCalls
+      .filter(call => call.method === "resources/list").length;
+    expect(resourceListCalls).toBe(1);
+  });
+
+  test("resources/list_changed invalidates resources AND templates caches", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+
+    await proxy.listResources();
+    await proxy.listResourceTemplates();
+    fakeClient.emitNotification("notifications/resources/list_changed");
+    await proxy.listResources();
+    await proxy.listResourceTemplates();
+
+    const resourceListCalls = fakeClient.callDaemonMethodCalls
+      .filter(call => call.method === "resources/list").length;
+    const templateListCalls = fakeClient.callDaemonMethodCalls
+      .filter(call => call.method === "resources/list-templates").length;
+    expect(resourceListCalls).toBe(2);
+    expect(templateListCalls).toBe(2);
+  });
+
+  test("re-emits list-changed to registered listeners with the right kind", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+    const kinds: string[] = [];
+    proxy.onListChanged(kind => {
+      kinds.push(kind);
+    });
+
+    await proxy.listTools();
+    fakeClient.emitNotification("notifications/tools/list_changed");
+    fakeClient.emitNotification("notifications/resources/list_changed");
+
+    expect(kinds).toEqual(["tools", "resources"]);
+  });
+
+  test("a throwing listener does not break cache invalidation or siblings", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+    const kinds: string[] = [];
+    proxy.onListChanged(() => {
+      throw new Error("listener boom");
+    });
+    proxy.onListChanged(kind => {
+      kinds.push(kind);
+    });
+
+    await proxy.listTools();
+    expect(() => fakeClient.emitNotification("notifications/tools/list_changed")).not.toThrow();
+    await proxy.listTools();
+
+    expect(kinds).toEqual(["tools"]);
+    const listCalls = fakeClient.callDaemonMethodCalls
+      .filter(call => call.method === "tools/list").length;
+    expect(listCalls).toBe(2);
+  });
+
+  test("unknown pushed notification methods are ignored", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+    const kinds: string[] = [];
+    proxy.onListChanged(kind => {
+      kinds.push(kind);
+    });
+
+    await proxy.listTools();
+    fakeClient.emitNotification("notifications/some/future_thing");
+    await proxy.listTools();
+
+    expect(kinds).toEqual([]);
+    const listCalls = fakeClient.callDaemonMethodCalls
+      .filter(call => call.method === "tools/list").length;
+    expect(listCalls).toBe(1);
+  });
+
+  test("unsubscribed onListChanged listener stops receiving events", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+    const kinds: string[] = [];
+    const unsubscribe = proxy.onListChanged(kind => {
+      kinds.push(kind);
+    });
+
+    await proxy.listTools();
+    unsubscribe();
+    fakeClient.emitNotification("notifications/tools/list_changed");
+
+    expect(kinds).toEqual([]);
+  });
+
+  test("reconnect with a reused client does not stack duplicate handlers", async () => {
+    mockDaemonAvailable();
+    const fakeClient = createFakeClient();
+    const proxy = createProxy(fakeClient);
+    const kinds: string[] = [];
+    proxy.onListChanged(kind => {
+      kinds.push(kind);
+    });
+
+    await proxy.listTools();
+    // Simulate the stale-session recovery path: reset then reconnect. The
+    // factory returns the SAME fake client, so a leaked handler would double
+    // every subsequent notification.
+    await (proxy as unknown as { resetConnection(): Promise<void> }).resetConnection();
+    await proxy.listTools();
+
+    fakeClient.emitNotification("notifications/tools/list_changed");
+
+    expect(kinds).toEqual(["tools"]);
+    expect(fakeClient.subscribeToNotificationsCalls).toBe(2);
+  });
+
+  test("clients without notification support skip subscription entirely", async () => {
+    mockDaemonAvailable();
+    // Legacy-shaped client: only the five required DaemonClientLike members.
+    const calls: string[] = [];
+    const legacyClient = {
+      connect: async () => {},
+      close: async () => {},
+      callTool: async () => ({}),
+      readResource: async () => ({}),
+      callDaemonMethod: async (method: string) => {
+        calls.push(method);
+        return { tools: [] };
+      },
+    };
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => legacyClient,
+      daemonManager: runningManager(),
+      autoStartDaemon: false,
+    });
+
+    await proxy.listTools();
+
+    expect(calls).toEqual(["tools/list"]);
+    expect(calls).not.toContain(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+  });
+});

--- a/test/daemon/socketServerNotifications.test.ts
+++ b/test/daemon/socketServerNotifications.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
+import { DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD } from "../../src/daemon/constants";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+import type { DaemonResponse } from "../../src/daemon/types";
+
+// Issue #3223: the daemon's Unix socket server pushes list-changed notification
+// frames to clients that opted in via daemon/subscribe-notifications, and only
+// to those clients — legacy request/response clients never see pushed frames.
+
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+/** Persistent test client that collects every newline-delimited frame it receives. */
+class FrameCollectingClient {
+  readonly frames: any[] = [];
+  private socket = new Socket();
+  private buffer = "";
+  private frameWaiters: Array<() => void> = [];
+
+  connect(socketPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket.connect(socketPath, resolve);
+      this.socket.on("error", reject);
+      this.socket.on("data", data => {
+        this.buffer += data.toString();
+        const lines = this.buffer.split("\n");
+        this.buffer = lines.pop() || "";
+        for (const line of lines) {
+          if (line.trim()) {
+            this.frames.push(JSON.parse(line));
+          }
+        }
+        const waiters = this.frameWaiters;
+        this.frameWaiters = [];
+        waiters.forEach(waiter => waiter());
+      });
+    });
+  }
+
+  send(method: string, params: Record<string, unknown> = {}): void {
+    this.socket.write(JSON.stringify({ id: randomUUID(), type: "daemon_request", method, params }) + "\n");
+  }
+
+  /** Resolves once at least `count` frames have arrived (bounded by the bun test timeout). */
+  async waitForFrames(count: number): Promise<void> {
+    while (this.frames.length < count) {
+      await new Promise<void>(resolve => {
+        this.frameWaiters.push(resolve);
+      });
+    }
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}
+
+describe("UnixSocketServer notification broadcast", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  const clients: FrameCollectingClient[] = [];
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `test-notify-${randomUUID()}.sock`);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      new FakeTimer()
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    clients.splice(0).forEach(client => client.close());
+    await server.close();
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+  });
+
+  async function connectedClient(): Promise<FrameCollectingClient> {
+    const client = new FrameCollectingClient();
+    clients.push(client);
+    await client.connect(socketPath);
+    return client;
+  }
+
+  test("subscription request is acknowledged", async () => {
+    const client = await connectedClient();
+    client.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await client.waitForFrames(1);
+
+    const response = client.frames[0] as DaemonResponse;
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({ subscribed: true });
+  });
+
+  test("broadcasts list-changed frames to subscribed clients only", async () => {
+    const subscriber = await connectedClient();
+    const bystander = await connectedClient();
+
+    subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await subscriber.waitForFrames(1);
+
+    // Emitted by ToolRegistry.notifyToolListChanged in production; the socket
+    // server subscribes to the broadcaster in start().
+    ListChangedBroadcaster.emit("tools");
+    await subscriber.waitForFrames(2);
+
+    expect(subscriber.frames[1]).toEqual({
+      type: "daemon_notification",
+      method: "notifications/tools/list_changed",
+    });
+    // A short settle window: any stray frame for the bystander would have been
+    // written in the same synchronous broadcast as the subscriber's frame.
+    await new Promise(resolve => defaultTimer.setTimeout(resolve, 25));
+    expect(bystander.frames).toEqual([]);
+  });
+
+  test("broadcasts resources list-changed with the resources method", async () => {
+    const subscriber = await connectedClient();
+    subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await subscriber.waitForFrames(1);
+
+    ListChangedBroadcaster.emit("resources");
+    await subscriber.waitForFrames(2);
+
+    expect(subscriber.frames[1]).toEqual({
+      type: "daemon_notification",
+      method: "notifications/resources/list_changed",
+    });
+  });
+
+  test("close() unsubscribes from the broadcaster (no write to dead sockets)", async () => {
+    const subscriber = await connectedClient();
+    subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await subscriber.waitForFrames(1);
+
+    // net.Server.close waits for live connections, so drop the client first.
+    subscriber.close();
+    await server.close();
+
+    // The broadcaster subscription is released on close, so emitting after
+    // close must not throw and must not attempt any socket writes.
+    expect((server as unknown as { listChangedUnsubscribe: unknown }).listChangedUnsubscribe).toBeNull();
+    expect(() => ListChangedBroadcaster.emit("tools")).not.toThrow();
+    expect(subscriber.frames).toHaveLength(1);
+  });
+});

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -1,5 +1,6 @@
 import type { DaemonClientLike } from "../../src/daemon/client";
 import { DaemonUnavailableError } from "../../src/daemon/client";
+import type { DaemonNotification } from "../../src/daemon/types";
 
 export interface FakeDaemonClientOptions {
   toolResult?: any;
@@ -15,7 +16,10 @@ export class FakeDaemonClient implements DaemonClientLike {
   private toolResult: any;
   private resourceResult: any;
   private daemonMethodResults: Map<string, any>;
+  private readonly notificationHandlers = new Set<(notification: DaemonNotification) => void>();
+  subscribeToNotificationsCalls = 0;
   shouldFailConnect = false;
+  shouldFailSubscribe = false;
 
   constructor(options: FakeDaemonClientOptions = {}) {
     this.toolResult = options.toolResult ?? { content: [{ type: "text", text: "success" }] };
@@ -51,5 +55,26 @@ export class FakeDaemonClient implements DaemonClientLike {
 
   isConnected(): boolean {
     return this.connected;
+  }
+
+  onNotification(handler: (notification: DaemonNotification) => void): () => void {
+    this.notificationHandlers.add(handler);
+    return () => {
+      this.notificationHandlers.delete(handler);
+    };
+  }
+
+  async subscribeToNotifications(): Promise<void> {
+    this.subscribeToNotificationsCalls += 1;
+    if (this.shouldFailSubscribe) {
+      throw new Error("Unsupported daemon method: daemon/subscribe-notifications");
+    }
+  }
+
+  /** Test hook: simulate a daemon-pushed notification frame. */
+  emitNotification(method: string): void {
+    for (const handler of this.notificationHandlers) {
+      handler({ type: "daemon_notification", method });
+    }
   }
 }

--- a/test/server/listChangedBroadcast.test.ts
+++ b/test/server/listChangedBroadcast.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ListChangedBroadcaster,
+  LIST_CHANGED_NOTIFICATION_METHODS,
+  listChangedKindForMethod,
+} from "../../src/server/listChangedBroadcast";
+
+describe("listChangedKindForMethod", () => {
+  test("round-trips both kinds through the shared method map", () => {
+    expect(listChangedKindForMethod(LIST_CHANGED_NOTIFICATION_METHODS.tools)).toBe("tools");
+    expect(listChangedKindForMethod(LIST_CHANGED_NOTIFICATION_METHODS.resources)).toBe("resources");
+  });
+
+  test("returns undefined for unknown methods", () => {
+    expect(listChangedKindForMethod("notifications/prompts/list_changed")).toBeUndefined();
+    expect(listChangedKindForMethod("")).toBeUndefined();
+  });
+});
+
+describe("ListChangedBroadcaster", () => {
+  test("emit reaches all subscribers; unsubscribe stops delivery", () => {
+    const first: string[] = [];
+    const second: string[] = [];
+    const unsubscribeFirst = ListChangedBroadcaster.subscribe(kind => {
+      first.push(kind);
+    });
+    const unsubscribeSecond = ListChangedBroadcaster.subscribe(kind => {
+      second.push(kind);
+    });
+
+    try {
+      ListChangedBroadcaster.emit("tools");
+      unsubscribeFirst();
+      ListChangedBroadcaster.emit("resources");
+
+      expect(first).toEqual(["tools"]);
+      expect(second).toEqual(["tools", "resources"]);
+    } finally {
+      unsubscribeFirst();
+      unsubscribeSecond();
+    }
+  });
+
+  test("a throwing listener does not block sibling listeners", () => {
+    const received: string[] = [];
+    const unsubscribeThrowing = ListChangedBroadcaster.subscribe(() => {
+      throw new Error("listener boom");
+    });
+    const unsubscribeHealthy = ListChangedBroadcaster.subscribe(kind => {
+      received.push(kind);
+    });
+
+    try {
+      expect(() => ListChangedBroadcaster.emit("tools")).not.toThrow();
+      expect(received).toEqual(["tools"]);
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeHealthy();
+    }
+  });
+});

--- a/test/server/proxyServerListChanged.test.ts
+++ b/test/server/proxyServerListChanged.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test, spyOn } from "bun:test";
+import { createProxyMcpServer } from "../../src/server/proxyServer";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+
+// Issue #3223: the proxy MCP server re-emits daemon-forwarded list-changed
+// notifications to its own (external) client.
+
+let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
+
+afterEach(() => {
+  isAvailableSpy?.mockRestore();
+  isAvailableSpy = null;
+});
+
+function createHarness() {
+  isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+  const fakeClient = new FakeDaemonClient({
+    daemonMethodResults: new Map<string, any>([
+      ["tools/list", { tools: [] }],
+    ]),
+  });
+  const fakeManager = new FakeDaemonManager();
+  fakeManager.statusResult = {
+    running: true,
+    pid: 1234,
+    port: 3000,
+    socketPath: "/tmp/test.sock",
+    version: DAEMON_VERSION,
+  };
+  const { server, proxy } = createProxyMcpServer({
+    proxyConfig: {
+      clientFactory: () => fakeClient,
+      daemonManager: fakeManager,
+      autoStartDaemon: false,
+    },
+  });
+  return { server, proxy, fakeClient };
+}
+
+describe("createProxyMcpServer list-changed forwarding", () => {
+  test("daemon tools/list_changed is re-emitted as sendToolListChanged", async () => {
+    const { server, proxy, fakeClient } = createHarness();
+    const sendToolsSpy = spyOn(server, "sendToolListChanged").mockImplementation(() => {});
+    const sendResourcesSpy = spyOn(server, "sendResourceListChanged").mockImplementation(() => {});
+
+    await proxy.listTools();
+    fakeClient.emitNotification("notifications/tools/list_changed");
+
+    expect(sendToolsSpy).toHaveBeenCalledTimes(1);
+    expect(sendResourcesSpy).not.toHaveBeenCalled();
+  });
+
+  test("daemon resources/list_changed is re-emitted as sendResourceListChanged", async () => {
+    const { server, proxy, fakeClient } = createHarness();
+    const sendToolsSpy = spyOn(server, "sendToolListChanged").mockImplementation(() => {});
+    const sendResourcesSpy = spyOn(server, "sendResourceListChanged").mockImplementation(() => {});
+
+    await proxy.listTools();
+    fakeClient.emitNotification("notifications/resources/list_changed");
+
+    expect(sendResourcesSpy).toHaveBeenCalledTimes(1);
+    expect(sendToolsSpy).not.toHaveBeenCalled();
+  });
+
+  test("a throwing send is swallowed (dead transport never breaks the proxy)", async () => {
+    const { server, proxy, fakeClient } = createHarness();
+    spyOn(server, "sendToolListChanged").mockImplementation(() => {
+      throw new Error("transport torn down");
+    });
+
+    await proxy.listTools();
+
+    expect(() => fakeClient.emitNotification("notifications/tools/list_changed")).not.toThrow();
+  });
+
+  test("without a connected transport the real send helpers are safe no-ops", async () => {
+    const { proxy, fakeClient } = createHarness();
+
+    await proxy.listTools();
+
+    // No transport is connected in this test, so the SDK's isConnected() guard
+    // makes the un-mocked send helpers no-ops — the emit must not throw.
+    expect(() => fakeClient.emitNotification("notifications/tools/list_changed")).not.toThrow();
+  });
+});

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
+
+// Minimal MCP-server stand-in for ResourceRegistry: registerWithServer installs
+// request handlers on `server.server` and tracks the wrapper for notification
+// fan-out; notifyResourceListChanged sends via `server.server.notification`.
+class FakeUnderlyingServer {
+  notifications: Array<{ method: string; params?: unknown }> = [];
+  handlersBySchema = new Map<unknown, (request: unknown) => Promise<unknown>>();
+  shouldThrow = false;
+  onclose?: () => void;
+  setRequestHandler(schema: unknown, handler: (request: unknown) => Promise<unknown>): void {
+    this.handlersBySchema.set(schema, handler);
+  }
+  async notification(payload: { method: string; params?: unknown }): Promise<void> {
+    if (this.shouldThrow) {
+      throw new Error("Not connected");
+    }
+    this.notifications.push(payload);
+  }
+}
+
+class FakeMcpServer {
+  server = new FakeUnderlyingServer();
+}
+
+function methodsSent(server: FakeMcpServer): string[] {
+  return server.server.notifications.map(n => n.method);
+}
+
+describe("ResourceRegistry list-changed fan-out (issue #3223)", () => {
+  beforeEach(() => {
+    // The registry singleton is shared across suites; drop servers registered
+    // by other tests so counts here are hermetic.
+    ResourceRegistry.clearServersForTesting();
+  });
+
+  test("notifyResourceListChanged reaches every registered server", async () => {
+    const first = new FakeMcpServer();
+    const second = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(first as unknown as McpServer);
+    ResourceRegistry.registerWithServer(second as unknown as McpServer);
+
+    await ResourceRegistry.notifyResourceListChanged();
+
+    expect(methodsSent(first)).toEqual(["notifications/resources/list_changed"]);
+    expect(methodsSent(second)).toEqual(["notifications/resources/list_changed"]);
+  });
+
+  test("one failing server does not block sibling sessions and never throws", async () => {
+    const failing = new FakeMcpServer();
+    failing.server.shouldThrow = true;
+    const healthy = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(failing as unknown as McpServer);
+    ResourceRegistry.registerWithServer(healthy as unknown as McpServer);
+
+    await ResourceRegistry.notifyResourceListChanged();
+
+    expect(methodsSent(healthy)).toEqual(["notifications/resources/list_changed"]);
+  });
+
+  test("prunes a server when its underlying transport closes", async () => {
+    const closing = new FakeMcpServer();
+    const surviving = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(closing as unknown as McpServer);
+    ResourceRegistry.registerWithServer(surviving as unknown as McpServer);
+
+    closing.server.onclose?.();
+    await ResourceRegistry.notifyResourceListChanged();
+
+    expect(methodsSent(closing)).toEqual([]);
+    expect(methodsSent(surviving)).toEqual(["notifications/resources/list_changed"]);
+  });
+
+  test("emits on the ListChangedBroadcaster even with zero servers", async () => {
+    const kinds: string[] = [];
+    const unsubscribe = ListChangedBroadcaster.subscribe(kind => {
+      kinds.push(kind);
+    });
+    try {
+      await ResourceRegistry.notifyResourceListChanged();
+      expect(kinds).toEqual(["resources"]);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  test("notifyResourceUpdated reaches every registered server for a subscribed URI", async () => {
+    const first = new FakeMcpServer();
+    const second = new FakeMcpServer();
+    ResourceRegistry.registerWithServer(first as unknown as McpServer);
+    ResourceRegistry.registerWithServer(second as unknown as McpServer);
+    ResourceRegistry.register(
+      "automobile:test/updated-resource",
+      "test",
+      "test resource",
+      "text/plain",
+      async () => ({ uri: "automobile:test/updated-resource", text: "x" })
+    );
+    // Subscribe the same way a client would: through the registered handler.
+    const subscribeHandler = first.server.handlersBySchema.get(SubscribeRequestSchema);
+    expect(subscribeHandler).toBeDefined();
+    await subscribeHandler!({ params: { uri: "automobile:test/updated-resource" } });
+
+    try {
+      await ResourceRegistry.notifyResourceUpdated("automobile:test/updated-resource");
+
+      expect(methodsSent(first)).toEqual(["notifications/resources/updated"]);
+      expect(methodsSent(second)).toEqual(["notifications/resources/updated"]);
+    } finally {
+      ResourceRegistry.unregister("automobile:test/updated-resource");
+      const unsubscribeHandler = first.server.handlersBySchema.get(UnsubscribeRequestSchema);
+      await unsubscribeHandler?.({ params: { uri: "automobile:test/updated-resource" } });
+    }
+  });
+});

--- a/test/server/toolRegistry.registerWithServer.test.ts
+++ b/test/server/toolRegistry.registerWithServer.test.ts
@@ -18,6 +18,8 @@ interface RegisteredMcpTool {
 
 class FakeMcpServer {
   registeredTools: RegisteredMcpTool[] = [];
+  // Underlying Protocol stand-in — registerWithServer chains `onclose` here.
+  server: { onclose?: () => void } = {};
 
   registerTool(name: string, config: any, handler: any): void {
     this.registeredTools.push({ name, config, handler });

--- a/test/server/toolRegistryNotifyToolListChanged.test.ts
+++ b/test/server/toolRegistryNotifyToolListChanged.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
 
 // Minimal MCP-server stand-in: registerWithServer only calls registerTool (no-op
-// here) and stores the server; notifyToolListChanged calls sendToolListChanged.
+// here), tracks the server, and hooks the underlying Protocol onclose for
+// pruning; notifyToolListChanged calls sendToolListChanged on every live server.
 class FakeMcpServer {
   calls = 0;
   shouldThrow = false;
+  // Underlying Protocol stand-in — registerWithServer chains `onclose` here.
+  server: { onclose?: () => void } = {};
   registerTool(): void {
     // no-op — we only care about the notify path
   }
@@ -19,6 +23,12 @@ class FakeMcpServer {
 }
 
 describe("ToolRegistry.notifyToolListChanged", () => {
+  beforeEach(() => {
+    // The registry singleton is shared across suites; drop servers registered
+    // by other tests so counts here are hermetic.
+    ToolRegistry.clearServersForTesting();
+  });
+
   test("delegates to server.sendToolListChanged() after registerWithServer", () => {
     const server = new FakeMcpServer();
     ToolRegistry.registerWithServer(server as unknown as McpServer);
@@ -35,5 +45,78 @@ describe("ToolRegistry.notifyToolListChanged", () => {
 
     expect(() => ToolRegistry.notifyToolListChanged()).not.toThrow();
     expect(server.calls).toBe(1);
+  });
+
+  test("fans out to every registered server, not just the last one (issue #3223)", () => {
+    const first = new FakeMcpServer();
+    const second = new FakeMcpServer();
+    ToolRegistry.registerWithServer(first as unknown as McpServer);
+    ToolRegistry.registerWithServer(second as unknown as McpServer);
+
+    ToolRegistry.notifyToolListChanged();
+
+    expect(first.calls).toBe(1);
+    expect(second.calls).toBe(1);
+  });
+
+  test("one throwing server does not block sibling sessions", () => {
+    const throwing = new FakeMcpServer();
+    throwing.shouldThrow = true;
+    const healthy = new FakeMcpServer();
+    ToolRegistry.registerWithServer(throwing as unknown as McpServer);
+    ToolRegistry.registerWithServer(healthy as unknown as McpServer);
+
+    expect(() => ToolRegistry.notifyToolListChanged()).not.toThrow();
+    expect(healthy.calls).toBe(1);
+  });
+
+  test("prunes a server when its underlying transport closes", () => {
+    const closing = new FakeMcpServer();
+    const surviving = new FakeMcpServer();
+    ToolRegistry.registerWithServer(closing as unknown as McpServer);
+    ToolRegistry.registerWithServer(surviving as unknown as McpServer);
+
+    // Simulate the session teardown the SDK performs on transport close.
+    closing.server.onclose?.();
+    ToolRegistry.notifyToolListChanged();
+
+    expect(closing.calls).toBe(0);
+    expect(surviving.calls).toBe(1);
+  });
+
+  test("onclose prune chains a pre-existing onclose hook instead of clobbering it", () => {
+    const server = new FakeMcpServer();
+    let priorHookCalls = 0;
+    server.server.onclose = () => {
+      priorHookCalls += 1;
+    };
+    ToolRegistry.registerWithServer(server as unknown as McpServer);
+
+    server.server.onclose?.();
+
+    expect(priorHookCalls).toBe(1);
+  });
+
+  test("re-registering the same server does not double-notify", () => {
+    const server = new FakeMcpServer();
+    ToolRegistry.registerWithServer(server as unknown as McpServer);
+    ToolRegistry.registerWithServer(server as unknown as McpServer);
+
+    ToolRegistry.notifyToolListChanged();
+
+    expect(server.calls).toBe(1);
+  });
+
+  test("emits on the ListChangedBroadcaster even with zero servers", () => {
+    const kinds: string[] = [];
+    const unsubscribe = ListChangedBroadcaster.subscribe(kind => {
+      kinds.push(kind);
+    });
+    try {
+      ToolRegistry.notifyToolListChanged();
+      expect(kinds).toEqual(["tools"]);
+    } finally {
+      unsubscribe();
+    }
   });
 });


### PR DESCRIPTION
Closes #3223

## Summary

Follow-up to #2963 / #3212: `tools/list_changed` and `resources/list_changed` now reach **proxy-mode** clients and **all** concurrent daemon sessions, instead of dying at the proxy boundary / notifying only the most-recently-created session.

One cross-cutting mechanism covering both notification families:

- **Multi-session fan-out:** `ToolRegistry` / `ResourceRegistry` now track every live session's `McpServer` in a `Set` (pruned via a chained `Protocol.onclose` hook — the SDK preserves pre-set hooks, verified at `protocol.js:224-227`) instead of a last-writer-wins single field. `notifyToolListChanged()` / `notifyResourceListChanged()` / `notifyResourceUpdated()` iterate all live servers, best-effort per server.
- **`ListChangedBroadcaster`** (new `src/server/listChangedBroadcast.ts`): process-wide fan-out decoupled from any MCP server, plus the shared kind<->wire-method map so both ends can never drift.
- **Daemon socket push:** `UnixSocketServer` subscribes to the broadcaster in `start()` (unsubscribes in `close()`, so recovery-recreation re-wires itself) and pushes a `daemon_notification` frame to socket sessions that opted in via the new `daemon/subscribe-notifications` method. **Opt-in** keeps pushed frames invisible to Kotlin/Swift/legacy request-response clients.
- **Proxy forwarding:** `DaemonClient` discriminates pushed frames (`isDaemonNotification`) and exposes `onNotification` + `subscribeToNotifications` (optional members on `DaemonClientLike`, so narrow clients/fakes opt out cleanly). `DaemonMcpProxy` wires the handler before `connect()`, subscribes after (best-effort — an old daemon's "Unsupported daemon method" degrades to the previous cached behavior with a warn), invalidates the matching cache (`tools` vs `resources`+templates) and re-emits via `onListChanged`. `createProxyMcpServer` forwards to the external client via the SDK's `isConnected()`-guarded send helpers.

### Acceptance criteria

- Proxy-mode flag toggle → external client receives `tools/list_changed`, and the next `tools/list` re-fetches from the daemon (cache invalidated) → updated `outputSchema`, no daemon restart.
- Multiple concurrent daemon sessions all receive the notification (fan-out + onclose prune, covered by tests).
- `resources/list_changed` (and `resources/updated`) ride the same paths.
- No storm: `FeatureFlagService` still emits only on an actual value change; best-effort emission everywhere — a dead/mid-teardown transport or throwing listener is logged and never throws (verified the streamable transport silently drops notifications with no SSE stream, so no unhandled-rejection from fanout either).

## Validation

- `bunx turbo run lint build test` — green (6709 tests / 525 files)
- `bun run typecheck` — green (no new errors; the "2 baseline errors no longer occur" hint is pre-existing on main from an unrelated merge, left un-ratcheted to avoid cross-PR baseline conflicts)
- New tests: broadcaster unit tests; ToolRegistry/ResourceRegistry multi-server fan-out + onclose-prune + chained-hook tests; DaemonClient frame-routing tests; DaemonMcpProxy cache-invalidation/re-emit/subscription tests (incl. reconnect handler-dedup regression); proxyServer forwarding tests; UnixSocketServer subscription + broadcast-to-subscribers-only tests over a real tmpdir Unix socket

## Caveats

- Wire-protocol addition is backward/forward compatible: notifications are only pushed to opted-in socket sessions; an old daemon answers the subscription with an error the proxy logs and survives; the version/build handshake makes mixed-version pairs transient anyway.
- Self-review fix included: on reconnect the proxy releases its previous notification handler before re-registering, so a `clientFactory` returning a shared client cannot stack duplicate handlers.
- Out-of-scope files touched: none beyond the notification path (`src/server/index.ts` comment update only). No overlap with #3221's session-cache code.
