### PR TITLE
test(db): tripwire so a non-Windows bun:sqlite handle-leak can't hide behind removeTempDbDir's silent give-up (#2949)

### DIFF
--- a/test/db/tempDbDir.test.ts
+++ b/test/db/tempDbDir.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { FakeTimer } from "../fakes/FakeTimer";
-import { removeTempDbDir, removeTempDbDirSync } from "./tempDbDir";
+import {
+  getDefaultGiveUpCount,
+  removeTempDbDir,
+  removeTempDbDirSync,
+  resetDefaultGiveUpCount,
+} from "./tempDbDir";
 
 function ebusy(code = "EBUSY"): NodeJS.ErrnoException {
   const error = new Error(`${code}: resource busy`) as NodeJS.ErrnoException;
@@ -166,6 +171,103 @@ describe("removeTempDbDir (issue #2916)", () => {
     ).rejects.toThrow("EACCES");
     expect(attempts).toBe(1);
     expect(timer.getSleepCallCount()).toBe(0);
+  });
+});
+
+/**
+ * Give-up tripwire (issue #2949).
+ *
+ * The DEFAULT (un-injected) give-up path is expected to fire ONLY on Windows,
+ * where bun:sqlite holds `.db`/`-wal`/`-shm` handles past `Kysely.destroy()`.
+ * macOS/Linux release handles immediately, so `rm` wins on the first attempt and
+ * no give-up should ever fire. The module-level counter makes that observable so
+ * a future cross-platform handle-leak regression surfaces instead of being
+ * swallowed by a silent `logger.warn`. These tests assert:
+ *   1. the DEFAULT give-up increments the counter (async + sync),
+ *   2. an INJECTED `onGiveUp` spy does NOT (unit tests deliberately give up),
+ *   3. on non-`win32`, real happy-path cleanup leaves the counter at 0.
+ */
+describe("removeTempDbDir give-up tripwire (issue #2949)", () => {
+  beforeEach(() => {
+    resetDefaultGiveUpCount();
+  });
+
+  test("the DEFAULT give-up increments the tripwire counter", async () => {
+    const rm = async () => {
+      throw ebusy();
+    };
+
+    await removeTempDbDir("/tmp/auto-mobile-locked", { rm, maxAttempts: 2, delayMs: 1 });
+
+    expect(getDefaultGiveUpCount()).toBe(1);
+  });
+
+  test("the DEFAULT sync give-up increments the tripwire counter", () => {
+    const rmSync = () => {
+      throw ebusy();
+    };
+
+    removeTempDbDirSync("/tmp/auto-mobile-locked", { rmSync, maxAttempts: 2, delayMs: 1 });
+
+    expect(getDefaultGiveUpCount()).toBe(1);
+  });
+
+  test("an INJECTED onGiveUp does NOT increment the tripwire counter", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const rm = async () => {
+      throw ebusy();
+    };
+    let injectedGaveUp = false;
+
+    await removeTempDbDir("/tmp/auto-mobile-locked", {
+      rm,
+      timer,
+      maxAttempts: 2,
+      delayMs: 1,
+      onGiveUp: () => {
+        injectedGaveUp = true;
+      },
+    });
+
+    expect(injectedGaveUp).toBe(true);
+    // Injected spy replaces the default entirely; the tripwire must stay silent
+    // so unit-test give-ups can never trip the non-win32 assertion below.
+    expect(getDefaultGiveUpCount()).toBe(0);
+  });
+
+  test("resetDefaultGiveUpCount zeroes an accumulated count", async () => {
+    const rm = async () => {
+      throw ebusy();
+    };
+    await removeTempDbDir("/tmp/a", { rm, maxAttempts: 1, delayMs: 1 });
+    await removeTempDbDir("/tmp/b", { rm, maxAttempts: 1, delayMs: 1 });
+    expect(getDefaultGiveUpCount()).toBe(2);
+
+    resetDefaultGiveUpCount();
+
+    expect(getDefaultGiveUpCount()).toBe(0);
+  });
+
+  test("real happy-path cleanup never gives up on non-win32", async () => {
+    // The invariant the tripwire protects: on macOS/Linux the default rm wins on
+    // the first attempt, so no give-up ever fires. On Windows the handle-leak is
+    // expected, so we only assert this off-Windows.
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const dir = await mkdtemp(path.join(tmpdir(), "auto-mobile-tempdbdir-tripwire-"));
+    await writeFile(path.join(dir, "auto-mobile.db"), "not-a-real-db");
+
+    await removeTempDbDir(dir);
+    const syncDir = mkdtempSync(path.join(tmpdir(), "auto-mobile-tempdbdir-tripwire-sync-"));
+    writeFileSync(path.join(syncDir, "auto-mobile.db"), "not-a-real-db");
+    removeTempDbDirSync(syncDir);
+
+    expect(existsSync(dir)).toBe(false);
+    expect(existsSync(syncDir)).toBe(false);
+    expect(getDefaultGiveUpCount()).toBe(0);
   });
 });
 

--- a/test/db/tempDbDir.ts
+++ b/test/db/tempDbDir.ts
@@ -97,7 +97,32 @@ function isTransientLockError(error: unknown): boolean {
   return Boolean(code && TRANSIENT_LOCK_CODES.has(code));
 }
 
+/**
+ * Tripwire counter (issue #2949): every DEFAULT give-up — the un-injected path
+ * that fires in real file-backed tests — bumps this. The give-up path is only
+ * expected to fire on Windows (bun:sqlite holds `.db`/`-wal`/`-shm` handles past
+ * `Kysely.destroy()` there). macOS/Linux release handles immediately, so `rm`
+ * should win on the first attempt and this stays `0`. `test/db` asserts it is
+ * `0` on non-`win32` so a future cross-platform handle-leak regression surfaces
+ * instead of being swallowed by a silent `logger.warn`.
+ *
+ * Only the DEFAULT give-up increments it: unit tests that deliberately drive a
+ * give-up inject their own `onGiveUp` spy and must NOT perturb this counter.
+ */
+let defaultGiveUpCount = 0;
+
+/** Total number of default give-ups since the last {@link resetDefaultGiveUpCount}. */
+export function getDefaultGiveUpCount(): number {
+  return defaultGiveUpCount;
+}
+
+/** Reset the tripwire counter (call in a suite `beforeAll`/`afterAll`). */
+export function resetDefaultGiveUpCount(): void {
+  defaultGiveUpCount = 0;
+}
+
 function defaultOnGiveUp(helperName: string, dir: string, error: unknown): void {
+  defaultGiveUpCount += 1;
   const code = (error as NodeJS.ErrnoException | undefined)?.code ?? "unknown";
   // Log-and-continue: the dir is a throwaway temp dir the OS will sweep; a
   // Windows handle livelock is the expected reason and is safe to swallow.


### PR DESCRIPTION
Closes #2949

## Summary
Follow-up from #2916 / PR #2923. `removeTempDbDir`/`removeTempDbDirSync` retry the transient Windows lock codes (EBUSY/EPERM/ENOTEMPTY) a bounded number of times and then **silently give up** (logged at `logger.warn`), leaving the throwaway temp dir for the OS sweeper. That give-up path is expected to fire **only on Windows**; macOS/Linux release bun:sqlite handles immediately so `rm` wins on the first attempt. Nothing asserted that, so a future cross-platform handle-leak regression would be swallowed.

This adds a lightweight, opt-in **give-up tripwire**:
- A module-level counter incremented **only** by the DEFAULT (un-injected) give-up path (`defaultOnGiveUp`). Unit tests that inject their own `onGiveUp` spy deliberately give up and must NOT perturb it, so the counter stays clean.
- `getDefaultGiveUpCount()` / `resetDefaultGiveUpCount()` exports so any file-backed `test/db` suite can assert it is `0`.
- A test that drives the **real** default `rm`/`rmSync` happy path on non-`win32` and asserts the counter is `0` — the actual regression tripwire. On Windows it early-returns (the handle-leak is expected there).

Matches issue option 1 (a module-level give-up counter) and its 'keep it cheap and non-flaky, no global mutable state that leaks across files without reset' constraint: the counter is scoped/reset per suite via the exported reset helper rather than an unmanaged global `afterAll`.

## Scope
Test-only, confined to owned scope `test/db/tempDbDir.ts` + its test. No production code touched.

## Validation
- `bun test test/db/tempDbDir.test.ts` — 21 pass, 0 fail (~111ms)
- `bun test test/db/` — 715 pass, 0 fail
- `bunx turbo run build` — success
- `bun run typecheck` — no new type errors
- `eslint` on both files — clean

## Caveats
Kept the tripwire in-file rather than a global `test/db` `afterAll` to avoid a shared mutable counter asserted across parallel test files. Any future real file-backed suite can adopt it via the exported accessor + reset.