### PR TITLE
test(db): guard MIGRATION_RUNTIME_DEPENDENCIES against migration import drift (#2867)

### DIFF
--- a/test/db/migrationRuntimeDependencies.test.ts
+++ b/test/db/migrationRuntimeDependencies.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { MIGRATION_RUNTIME_DEPENDENCIES } from "../../src/db/migrationDependencyIntegrity";
+import {
+  barePackageName,
+  extractValueImportPackages,
+  findMigrationDependencyDrift,
+} from "./migrationRuntimeDependencies";
+
+/**
+ * Guard for {@link MIGRATION_RUNTIME_DEPENDENCIES} drift (issue #2867).
+ *
+ * Two layers, mirroring `migrationFilenameOrdering.test.ts`:
+ *   - Unit tests of the pure extractor / drift-detector against hand-written
+ *     source fixtures — value vs type-only imports, inline `type` members,
+ *     scoped/subpath specifiers, relative imports.
+ *   - A meta-test that scans the real `src/db/migrations/` directory and
+ *     asserts every runtime value import is present in the allowlist, so a new
+ *     migration importing an un-listed package fails HERE (a <100ms unit test)
+ *     instead of silently losing the recoverable incomplete-extraction message
+ *     for that dependency (issue #2833 symptom).
+ */
+
+describe("barePackageName", () => {
+  test("returns the package name unchanged for a bare specifier", () => {
+    expect(barePackageName("kysely")).toBe("kysely");
+  });
+
+  test("strips a subpath from an unscoped package", () => {
+    expect(barePackageName("kysely/helpers/postgres")).toBe("kysely");
+  });
+
+  test("keeps the scope for a scoped package", () => {
+    expect(barePackageName("@scope/pkg")).toBe("@scope/pkg");
+    expect(barePackageName("@scope/pkg/sub")).toBe("@scope/pkg");
+  });
+
+  test("returns null for relative and absolute specifiers (not packages)", () => {
+    expect(barePackageName("../eventTables")).toBeNull();
+    expect(barePackageName("./foo")).toBeNull();
+    expect(barePackageName("/abs/path")).toBeNull();
+  });
+});
+
+describe("extractValueImportPackages", () => {
+  test("captures a plain value import", () => {
+    expect(extractValueImportPackages('import { sql } from "kysely";')).toEqual(["kysely"]);
+  });
+
+  test("captures a value import with multiple members", () => {
+    expect(extractValueImportPackages('import { Kysely, sql } from "kysely";')).toEqual(["kysely"]);
+  });
+
+  test("captures the value member of a mixed inline-type import", () => {
+    // `{ type Kysely, sql }` — `sql` is a runtime value, so `kysely` counts.
+    expect(extractValueImportPackages('import { type Kysely, sql } from "kysely";')).toEqual([
+      "kysely",
+    ]);
+  });
+
+  test("ignores a whole-clause `import type`", () => {
+    expect(extractValueImportPackages('import type { Kysely } from "kysely";')).toEqual([]);
+  });
+
+  test("ignores a named import whose members are all inline `type`", () => {
+    expect(extractValueImportPackages('import { type Kysely } from "kysely";')).toEqual([]);
+    expect(extractValueImportPackages('import { type A, type B } from "kysely";')).toEqual([]);
+  });
+
+  test("ignores relative imports (not packages)", () => {
+    expect(extractValueImportPackages('import { EVENT_TABLES } from "../eventTables";')).toEqual([]);
+  });
+
+  test("de-duplicates and sorts across multiple imports", () => {
+    const source = [
+      'import type { Kysely } from "kysely";',
+      'import { sql } from "kysely";',
+      'import { z } from "zod";',
+      'import { EVENT_TABLES } from "../eventTables";',
+    ].join("\n");
+    expect(extractValueImportPackages(source)).toEqual(["kysely", "zod"]);
+  });
+
+  test("reduces a scoped/subpath specifier to its package name", () => {
+    expect(extractValueImportPackages('import { x } from "@scope/pkg/sub";')).toEqual([
+      "@scope/pkg",
+    ]);
+  });
+
+  test("handles single-quoted specifiers and leading indentation", () => {
+    expect(extractValueImportPackages("  import { sql } from 'kysely';")).toEqual(["kysely"]);
+  });
+});
+
+describe("findMigrationDependencyDrift detector (issue #2867)", () => {
+  test("is clean when every value import is in the allowlist", () => {
+    const sources = new Map([
+      ["m1.ts", 'import { sql } from "kysely";'],
+      ["m2.ts", 'import type { Kysely } from "kysely";'],
+    ]);
+    expect(findMigrationDependencyDrift(sources, ["kysely"])).toEqual([]);
+  });
+
+  test("flags a value import from a package missing from the allowlist", () => {
+    const sources = new Map([["m1.ts", 'import { z } from "zod";']]);
+    const violations = findMigrationDependencyDrift(sources, ["kysely"]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].package).toBe("zod");
+    expect(violations[0].files).toEqual(["m1.ts"]);
+    expect(violations[0].message).toContain("MIGRATION_RUNTIME_DEPENDENCIES");
+    expect(violations[0].message).toContain("zod");
+  });
+
+  test("does NOT flag a type-only import of an un-listed package", () => {
+    const sources = new Map([["m1.ts", 'import type { Foo } from "some-types-pkg";']]);
+    expect(findMigrationDependencyDrift(sources, ["kysely"])).toEqual([]);
+  });
+
+  test("aggregates every file importing the same missing package, sorted", () => {
+    const sources = new Map([
+      ["b.ts", 'import { z } from "zod";'],
+      ["a.ts", 'import { schema } from "zod";'],
+    ]);
+    const violations = findMigrationDependencyDrift(sources, ["kysely"]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].files).toEqual(["a.ts", "b.ts"]);
+  });
+
+  test("reports one violation per distinct missing package, sorted by name", () => {
+    const sources = new Map([
+      ["m1.ts", 'import { z } from "zod";\nimport { produce } from "immer";'],
+    ]);
+    const violations = findMigrationDependencyDrift(sources, ["kysely"]);
+    expect(violations.map(v => v.package)).toEqual(["immer", "zod"]);
+  });
+});
+
+describe("real src/db/migrations directory (issue #2867 meta-test)", () => {
+  test("every runtime value import is declared in MIGRATION_RUNTIME_DEPENDENCIES", () => {
+    const migrationsDir = join(import.meta.dir, "..", "..", "src", "db", "migrations");
+    const filenames = readdirSync(migrationsDir).filter(name => name.endsWith(".ts"));
+    // Sanity: the directory actually resolved (an empty read would vacuously pass).
+    expect(filenames.length).toBeGreaterThan(30);
+
+    const sources = new Map(
+      filenames.map(name => [name, readFileSync(join(migrationsDir, name), "utf8")])
+    );
+
+    // Sanity: the scan finds the known `kysely` value import somewhere, proving
+    // the extractor is actually seeing real import lines (not vacuously empty).
+    const allImported = new Set<string>();
+    for (const source of sources.values()) {
+      for (const pkg of extractValueImportPackages(source)) {
+        allImported.add(pkg);
+      }
+    }
+    expect(allImported.has("kysely")).toBe(true);
+
+    const violations = findMigrationDependencyDrift(sources, MIGRATION_RUNTIME_DEPENDENCIES);
+    const rendered = violations.map(v => v.message).join("\n\n");
+    expect(rendered).toBe("");
+  });
+
+  test("the allowlist has no unused entries (every listed dep is actually imported)", () => {
+    const migrationsDir = join(import.meta.dir, "..", "..", "src", "db", "migrations");
+    const filenames = readdirSync(migrationsDir).filter(name => name.endsWith(".ts"));
+    const imported = new Set<string>();
+    for (const name of filenames) {
+      for (const pkg of extractValueImportPackages(readFileSync(join(migrationsDir, name), "utf8"))) {
+        imported.add(pkg);
+      }
+    }
+    const unused = MIGRATION_RUNTIME_DEPENDENCIES.filter(dep => !imported.has(dep));
+    expect(unused).toEqual([]);
+  });
+});

--- a/test/db/migrationRuntimeDependencies.ts
+++ b/test/db/migrationRuntimeDependencies.ts
@@ -1,0 +1,152 @@
+/**
+ * Guard for {@link MIGRATION_RUNTIME_DEPENDENCIES} drift (issue #2867,
+ * follow-up to #2833 / PR #2851).
+ *
+ * The incomplete-extraction recovery in `migrationDependencyIntegrity.ts` only
+ * reframes a `Cannot find package '<x>'` failure into the recoverable
+ * `AUTOMOBILE_INCOMPLETE_EXTRACTION` error when `<x>` is in the hardcoded
+ * `MIGRATION_RUNTIME_DEPENDENCIES` allowlist. That scoping is deliberate — it
+ * keeps a genuine code-level bad import (a typo, an unpublished dep) from being
+ * mislabeled "incomplete extraction, re-extract". But it means the allowlist
+ * must stay in sync with the *runtime value imports* in `src/db/migrations/*.ts`:
+ * a new runtime import from a package not in the list silently loses the
+ * actionable recovery message for that dependency.
+ *
+ * This is a pure `(source) -> package names` extractor so it is unit-tested
+ * with string fixtures (no filesystem) and then applied to the real migrations
+ * directory by the meta-test — both stay well under 100ms.
+ *
+ * Scope: the migration files use only single-line named imports
+ * (`import { ... } from "<spec>"`, optionally `import type` or with inline
+ * `type` members). The extractor handles that surface deliberately — a future
+ * migration using a default/namespace/side-effect import would need the parser
+ * extended, and the accompanying test documents the covered forms.
+ */
+
+/**
+ * Matches a single-line ES named import and captures the brace body (group 1)
+ * and the module specifier (group 2). `import type { ... }` is captured too so
+ * the type-only case can be distinguished from a value import by inspecting the
+ * matched text (see {@link extractValueImportPackages}).
+ */
+const NAMED_IMPORT_PATTERN = /^\s*import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*["']([^"']+)["']/;
+
+/** True for `import type { ... }` — a whole-clause type-only import. */
+const TYPE_ONLY_IMPORT_PATTERN = /^\s*import\s+type\s+\{/;
+
+/**
+ * Reduce a module specifier to its bare package name:
+ *   - `kysely`            -> `kysely`
+ *   - `kysely/helpers`    -> `kysely`
+ *   - `@scope/pkg`        -> `@scope/pkg`
+ *   - `@scope/pkg/sub`    -> `@scope/pkg`
+ * Relative specifiers (`./x`, `../x`) and absolute paths are NOT packages and
+ * return null so they are excluded from the allowlist comparison.
+ */
+export function barePackageName(specifier: string): string | null {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) {
+    return null;
+  }
+  const parts = specifier.split("/");
+  if (specifier.startsWith("@")) {
+    // Scoped: `@scope/name` — keep the first two segments.
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : specifier;
+  }
+  return parts[0];
+}
+
+/**
+ * True when a named-import brace body contains at least one VALUE binding —
+ * i.e. a member NOT prefixed with an inline `type`. `{ type Kysely, sql }`
+ * yields true (`sql` is a value); `{ type Kysely }` / `{ type A, type B }`
+ * yields false (all members are type-only).
+ */
+function hasValueMember(braceBody: string): boolean {
+  return braceBody
+    .split(",")
+    .map(member => member.trim())
+    .filter(member => member.length > 0)
+    .some(member => !/^type\s+/.test(member));
+}
+
+/**
+ * Extract the distinct bare package names of the *runtime value* imports in a
+ * migration source file. Excludes whole-clause `import type` imports, named
+ * imports whose members are all inline-`type`, and relative-path imports.
+ * Returns a sorted, de-duplicated list.
+ */
+export function extractValueImportPackages(source: string): string[] {
+  const packages = new Set<string>();
+  for (const line of source.split("\n")) {
+    const match = NAMED_IMPORT_PATTERN.exec(line);
+    if (!match) {
+      continue;
+    }
+    if (TYPE_ONLY_IMPORT_PATTERN.test(line)) {
+      continue;
+    }
+    const [, braceBody, specifier] = match;
+    if (!hasValueMember(braceBody)) {
+      continue;
+    }
+    const name = barePackageName(specifier);
+    if (name !== null) {
+      packages.add(name);
+    }
+  }
+  return [...packages].sort();
+}
+
+export interface MigrationDependencyDriftViolation {
+  /** Package imported for its value at runtime but absent from the allowlist. */
+  package: string;
+  /** Migration filenames that import it, sorted. */
+  files: string[];
+  /** Human-readable, actionable description of the violation. */
+  message: string;
+}
+
+/**
+ * Compare the value-import packages found across a set of migration sources
+ * against the declared allowlist. Returns a violation per package that a
+ * migration imports at runtime but the allowlist omits. Clean -> empty array.
+ *
+ * `sources` maps a migration filename to its file contents; `allowlist` is the
+ * declared {@link MIGRATION_RUNTIME_DEPENDENCIES}.
+ */
+export function findMigrationDependencyDrift(
+  sources: ReadonlyMap<string, string>,
+  allowlist: readonly string[]
+): MigrationDependencyDriftViolation[] {
+  const allowed = new Set(allowlist);
+  const filesByPackage = new Map<string, string[]>();
+
+  for (const [filename, source] of sources) {
+    for (const pkg of extractValueImportPackages(source)) {
+      if (allowed.has(pkg)) {
+        continue;
+      }
+      const files = filesByPackage.get(pkg);
+      if (files) {
+        files.push(filename);
+      } else {
+        filesByPackage.set(pkg, [filename]);
+      }
+    }
+  }
+
+  return [...filesByPackage.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([pkg, files]) => ({
+      package: pkg,
+      files: [...files].sort(),
+      message:
+        `Migration file(s) ${[...files].sort().join(", ")} do a runtime value import ` +
+        `from "${pkg}", but "${pkg}" is not in MIGRATION_RUNTIME_DEPENDENCIES ` +
+        "(src/db/migrationDependencyIntegrity.ts). A half-linked `bunx` extraction " +
+        `missing "${pkg}" would fall through to the generic, non-actionable migration ` +
+        "crash instead of the recoverable AUTOMOBILE_INCOMPLETE_EXTRACTION message " +
+        "(issue #2833). Add it to the allowlist, OR — if this import is only used for " +
+        "its types — change it to `import type { ... }` (or inline `type` members).",
+    }));
+}


### PR DESCRIPTION
Closes #2867.

## Summary

Adds a fast, self-verifying guard so `MIGRATION_RUNTIME_DEPENDENCIES` (src/db/migrationDependencyIntegrity.ts) cannot silently drift out of sync with the runtime *value* imports in `src/db/migrations/*.ts`. Today the only such import is `kysely`; if a future migration adds `import { X } from "some-dep"` without updating the allowlist, a half-linked `bunx` extraction missing `some-dep` degrades silently to the generic, non-actionable migration crash instead of the recoverable `AUTOMOBILE_INCOMPLETE_EXTRACTION` message (the #2833 symptom, re-introduced for the new dependency).

Follows the established two-layer `migrationFilenameOrdering.test.ts` pattern:

- `test/db/migrationRuntimeDependencies.ts` — pure `(source) -> package names` extractor + `(sources, allowlist) -> violations` drift detector. No filesystem, no DB, no timers.
- `test/db/migrationRuntimeDependencies.test.ts` — unit tests over hand-written source fixtures (value vs `import type`, inline `type` members, scoped/subpath specifiers, relative imports) plus a meta-test that scans the real migrations directory and asserts every runtime value import is declared. Also a reverse ratchet asserting the allowlist has no unused entries.

## Acceptance criteria

- [x] A test under `test/db/` fails when a migration imports a runtime package not in `MIGRATION_RUNTIME_DEPENDENCIES` (`findMigrationDependencyDrift`).
- [x] `import type { ... } from "kysely"` (and inline-`type`-only members) does not trigger a failure.
- [x] The current tree (only `kysely`) passes.

## Validation

- `bun test test/db/migrationRuntimeDependencies.test.ts test/db/migrationDependencyIntegrity.test.ts` — 36 pass, 0 fail (160ms).
- `bunx turbo run lint build` — pass.
- `bun run typecheck` — no new type errors.
- Adversarial probes (renamed `as` value members, comment lines, empty braces, bare scopes) verified.

## Caveats

- Extractor scope is single-line named imports (the entire migration surface today). A future default/namespace/side-effect import would need the parser extended; the meta-test's `kysely`-found sanity assertion guards against a vacuous pass. Documented in the module header.
- Test-only change; no production code touched, no cross-lane files modified.