### PR TITLE
chore(db): converge telemetry-event retention onto canonical offset(N-1)+id-tiebreak idiom (#3137)

### DIFF
--- a/src/db/eventRetention.ts
+++ b/src/db/eventRetention.ts
@@ -42,18 +42,33 @@ export async function pruneEventTableByCount(
       .executeTakeFirstOrThrow();
 
     if (Number(count.count) > maxRows) {
-      const cutoff = await resolvedDb
+      // Canonical retention idiom (#3137): pick the Nth-newest row as the
+      // threshold (offset maxRows - 1) and delete everything strictly older,
+      // breaking cutoff-timestamp ties on the monotonic `id`. This trims to
+      // *exactly* maxRows rows and deterministically prunes same-timestamp rows,
+      // unlike the prior `offset(maxRows)` + `timestamp < cutoff` form, which
+      // retained maxRows + 1 rows and could never remove rows equal to the
+      // cutoff timestamp (a burst of same-millisecond events at the cutoff could
+      // retain more than maxRows).
+      const threshold = await resolvedDb
         .selectFrom(table)
-        .select("timestamp")
+        .select(["id", "timestamp"])
         .orderBy("timestamp", "desc")
-        .offset(maxRows)
+        .orderBy("id", "desc")
         .limit(1)
+        .offset(maxRows - 1)
         .executeTakeFirst();
 
-      if (cutoff) {
+      if (threshold) {
         await resolvedDb
           .deleteFrom(table)
-          .where("timestamp", "<", cutoff.timestamp)
+          .where(eb => eb.or([
+            eb("timestamp", "<", threshold.timestamp),
+            eb.and([
+              eb("timestamp", "=", threshold.timestamp),
+              eb("id", "<", threshold.id),
+            ]),
+          ]))
           .execute();
       }
     }

--- a/test/db/eventRetention.test.ts
+++ b/test/db/eventRetention.test.ts
@@ -169,7 +169,7 @@ describe("event repository retention (#2799)", () => {
         }
       });
 
-      test("retention trims to the cap and prunes the oldest rows (output-preserving)", async () => {
+      test("retention trims to exactly the cap and prunes the oldest rows (#3137)", async () => {
         const { db } = await createInstrumentedTestDatabase();
         try {
           const cap = 5;
@@ -186,8 +186,44 @@ describe("event repository retention (#2799)", () => {
             .execute();
           const timestamps = rows.map((r: any) => Number(r.timestamp));
 
-          // Existing semantics keep cap+1 rows (offset(cap) cutoff, strict-less-than delete).
-          expect(timestamps).toEqual([7, 8, 9, 10, 11, 12]);
+          // Canonical idiom (#3137): trims to *exactly* cap rows — the cap newest.
+          // (The prior offset(cap) + strict-less-than form kept cap+1: [7..12].)
+          expect(timestamps).toEqual([8, 9, 10, 11, 12]);
+        } finally {
+          await db.destroy();
+        }
+      });
+
+      test("same-timestamp rows at the cutoff are broken by id (#3137)", async () => {
+        const { db } = await createInstrumentedTestDatabase();
+        try {
+          const cap = 3;
+          // Five rows all sharing timestamp 100. The prior `timestamp < cutoff`
+          // form could never delete any of them (all equal to the cutoff),
+          // retaining all five. The id-tiebreak form trims to exactly cap by
+          // deleting the lowest-id rows at the tied timestamp.
+          for (let i = 0; i < 5; i++) {
+            await repo.record(repo.make(100), db);
+          }
+          // Not every repo's record() returns the id, so read them from the DB.
+          const beforeRows = await db
+            .selectFrom(repo.table as any)
+            .select("id")
+            .orderBy("id", "asc")
+            .execute();
+          const ids = beforeRows.map((r: any) => Number(r.id));
+
+          await cleanupRepo(repo, db, createRetentionState(), cap, 1);
+
+          const rows = await db
+            .selectFrom(repo.table as any)
+            .select("id")
+            .orderBy("id", "asc")
+            .execute();
+          const remaining = rows.map((r: any) => Number(r.id));
+
+          // Exactly the cap highest ids survive; the two oldest (lowest id) are pruned.
+          expect(remaining).toEqual(ids.slice(-cap));
         } finally {
           await db.destroy();
         }


### PR DESCRIPTION
Closes #3137

## Summary
Converges the six telemetry event repositories (network, log, os, navigation, storage, layout) onto the canonical `offset(maxRows - 1)` + compound `id`-tiebreak delete idiom already used by the three config retention repos (`performanceAuditRepository`/`testExecutionRepository`/`failureAnalyticsRepository`).

Because all six telemetry repos delegate retention to the shared `pruneEventTableByCount` helper (added in #3136), the convergence is a single-point change in `src/db/eventRetention.ts` — no per-repo edits required.

### Before
```ts
.orderBy("timestamp", "desc").offset(maxRows).limit(1)   // cutoff
// delete WHERE timestamp < cutoff.timestamp
```
Kept `maxRows + 1` rows in steady state and could never remove rows equal to the cutoff timestamp (a burst of same-millisecond events at the cutoff could retain more than `maxRows`).

### After (canonical)
```ts
.orderBy("timestamp", "desc").orderBy("id", "desc").limit(1).offset(maxRows - 1)  // threshold
// delete WHERE timestamp < threshold.timestamp OR (timestamp = threshold.timestamp AND id < threshold.id)
```
Trims to **exactly** `maxRows` and breaks cutoff-timestamp ties deterministically on the monotonic `id`.

## Deliberate semantics change
Per the issue and #2799's constraint ("must NOT change query results"), this is an **intentional pruned-output change**: retention now trims to N instead of N+1, and prunes same-timestamp rows the prior form retained. Recorded on-purpose here rather than riding #3124.

## Tests
- Updated the "trims to the cap" behavior test across all six repos to assert exact trim-to-N (`[8,9,10,11,12]` for cap=5, previously `[7..12]`).
- Added a same-timestamp id-tiebreak test: five rows sharing one timestamp trim to exactly the cap highest ids (the prior `timestamp < cutoff` form could delete none of them).

## Validation
- `bun test test/db/eventRetention.test.ts` — 31 pass
- `bun test test/db/` — 716 pass
- `bunx turbo run lint build` — pass
- `bun run typecheck` — no new type errors

## Caveats
- Scope is strictly the shared helper + its test; no files outside the db-retention lane touched.
- No `maxRows === 0` guard added — consistent with the three canonical config repos and `RETENTION_MAX_ROWS = 10000`.