### PR TITLE
fix(ios): faithfully encode Data/Date/collection UserDefaults telemetry (#3194)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -429,14 +429,16 @@ final class DefaultUserDefaultsDriver: UserDefaultsDriver, @unchecked Sendable {
     func getValues(suiteName: String?) -> [KeyValuePair] {
         guard let defaults = resolveDefaults(suiteName: suiteName) else { return [] }
         return defaults.dictionaryRepresentation().map { key, value in
-            KeyValuePair(key: key, value: "\(value)", type: typeOf(value))
+            let type = typeOf(value)
+            return KeyValuePair(key: key, value: Self.encode(value, as: type), type: type)
         }.sorted { $0.key < $1.key }
     }
 
     func getValue(suiteName: String?, key: String) -> KeyValuePair? {
         guard let defaults = resolveDefaults(suiteName: suiteName) else { return nil }
         guard let value = defaults.object(forKey: key) else { return nil }
-        return KeyValuePair(key: key, value: "\(value)", type: typeOf(value))
+        let type = typeOf(value)
+        return KeyValuePair(key: key, value: Self.encode(value, as: type), type: type)
     }
 
     func setValue(suiteName: String?, key: String, value: Any?, type: KeyValueType) {
@@ -460,6 +462,55 @@ final class DefaultUserDefaultsDriver: UserDefaultsDriver, @unchecked Sendable {
             defaults.removeObject(forKey: key)
         }
         #endif
+    }
+
+    /// ISO-8601 formatter with fractional seconds, so `Date` values round-trip
+    /// to sub-second precision. `.withInternetDateTime` alone truncates to whole
+    /// seconds; adding `.withFractionalSeconds` preserves the stored instant.
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// Encode a UserDefaults value into a recoverable string for telemetry.
+    ///
+    /// Scalars (`string`/`int`/`double`/`bool`) keep their historic Swift
+    /// interpolation. Complex types use a documented, round-trippable encoding
+    /// so a downstream consumer can decode by `valueType`:
+    /// - `date` → ISO-8601 with fractional seconds
+    /// - `data` → base64
+    /// - `array` / `dictionary` → JSON via `JSONSerialization`
+    ///
+    /// `array`/`dictionary` fall back to interpolation only when the collection
+    /// holds non-JSON-native leaves (e.g. a nested `Data`/`Date`), which
+    /// `JSONSerialization` cannot represent; the historic lossy form is strictly
+    /// better than dropping the value.
+    static func encode(_ value: Any, as type: KeyValueType) -> String {
+        switch type {
+        case .date:
+            if let date = value as? Date {
+                return iso8601.string(from: date)
+            }
+            return "\(value)"
+        case .data:
+            if let data = value as? Data {
+                return data.base64EncodedString()
+            }
+            return "\(value)"
+        case .array, .dictionary:
+            // `.sortedKeys` makes dictionary encoding deterministic: the snapshot
+            // diff compares encoded strings, and an unchanged dictionary re-read
+            // with unstable key order would otherwise surface as a phantom modify.
+            if JSONSerialization.isValidJSONObject(value),
+               let json = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+               let string = String(data: json, encoding: .utf8) {
+                return string
+            }
+            return "\(value)"
+        case .string, .int, .double, .bool, .unknown:
+            return "\(value)"
+        }
     }
 
     private func typeOf(_ value: Any) -> KeyValueType {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -820,3 +820,71 @@ private final class LockedErrors: @unchecked Sendable {
         messages.append(message)
     }
 }
+
+// MARK: - Value Encoding Fidelity (#3194)
+
+/// Round-trip coverage for `DefaultUserDefaultsDriver.encode`, which replaced the
+/// lossy `"\(value)"` stringification for `Data`/`Date`/array/dictionary with a
+/// recoverable encoding a downstream consumer can decode by `valueType`.
+final class UserDefaultsValueEncodingTests: XCTestCase {
+    func testEncodesDateAsRoundTrippableISO8601() {
+        let date = Date(timeIntervalSince1970: 1_751_724_600.25)
+        let encoded = DefaultUserDefaultsDriver.encode(date, as: .date)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let decoded = formatter.date(from: encoded)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded!.timeIntervalSince1970, date.timeIntervalSince1970, accuracy: 0.001)
+        // Not the debug description ("… +0000").
+        XCTAssertFalse(encoded.contains("+0000"))
+    }
+
+    func testEncodesDataAsRoundTrippableBase64() {
+        let data = Data([0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56, 0x78])
+        let encoded = DefaultUserDefaultsDriver.encode(data, as: .data)
+
+        XCTAssertEqual(Data(base64Encoded: encoded), data)
+        // Not the debug hex-dump form ("<deadbeef …>").
+        XCTAssertFalse(encoded.hasPrefix("<"))
+    }
+
+    func testEncodesArrayAsRoundTrippableJSON() throws {
+        let array: [Any] = ["a", 1, true]
+        let encoded = DefaultUserDefaultsDriver.encode(array, as: .array)
+
+        let decoded = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(encoded.utf8)) as? [Any]
+        )
+        XCTAssertEqual(decoded.count, 3)
+        XCTAssertEqual(decoded[0] as? String, "a")
+        XCTAssertEqual(decoded[1] as? Int, 1)
+        XCTAssertEqual(decoded[2] as? Bool, true)
+    }
+
+    func testEncodesDictionaryAsRoundTrippableJSON() throws {
+        let dict: [String: Any] = ["name": "widget", "count": 3]
+        let encoded = DefaultUserDefaultsDriver.encode(dict, as: .dictionary)
+
+        let decoded = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(encoded.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(decoded["name"] as? String, "widget")
+        XCTAssertEqual(decoded["count"] as? Int, 3)
+    }
+
+    func testScalarEncodingIsUnchanged() {
+        XCTAssertEqual(DefaultUserDefaultsDriver.encode("dark", as: .string), "dark")
+        XCTAssertEqual(DefaultUserDefaultsDriver.encode(42, as: .int), "42")
+        XCTAssertEqual(DefaultUserDefaultsDriver.encode(true, as: .bool), "true")
+    }
+
+    func testNonJsonNativeCollectionFallsBackToInterpolation() {
+        // An array holding a nested Data leaf is not JSON-serializable; the
+        // encoder must fall back to interpolation rather than drop the value.
+        let array: [Any] = [Data([0x01])]
+        let encoded = DefaultUserDefaultsDriver.encode(array, as: .array)
+        XCTAssertFalse(encoded.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #3194

## Problem
`DefaultUserDefaultsDriver.getValues`/`getValue` rendered every value with Swift interpolation `"\(value)"`. Fine for scalars, but for `Date`/`Data`/`array`/`dictionary` it produced debug-only, non-round-trippable text carried in the `newValue` storage_changed telemetry field (e.g. `Date` -> `"2026-07-05 14:30:00 +0000"`, `Data` -> hex dump, collections -> lossy `description`).

## Fix
Added `DefaultUserDefaultsDriver.encode(_:as:)` used by both read paths. Encoding is keyed on the already-computed `valueType` so a consumer can decode by type:
- `date` -> ISO-8601 with fractional seconds (`ISO8601DateFormatter`, sub-second round-trip)
- `data` -> base64
- `array`/`dictionary` -> JSON via `JSONSerialization` with `.sortedKeys` (deterministic so the snapshot diff doesn't emit phantom `modify` events from unstable key order)
- scalars (`string`/`int`/`double`/`bool`) and `unknown` keep the historic interpolation

Non-JSON-native collections (e.g. an array with a nested `Data` leaf) fall back to interpolation rather than dropping the value.

## Validation
- `swift build` (auto-mobile-sdk): Build complete
- New `UserDefaultsValueEncodingTests`: 6 round-trip tests (Date/Data/array/dictionary + scalar-unchanged + non-JSON fallback), all pass
- Existing `UserDefaultsInspectorTests`: 23 pass (no diff regressions)
- swiftformat local (0.61.1) diverges from CI-pinned 0.54.6; kept additions consistent with existing file style and did NOT reformat the whole file (per known version-mismatch gotcha)

## Caveats
- SPM package (`ios/auto-mobile-sdk`), no `.pbxproj` / xcodegen involved; this is the app-embedded SDK, not `ios/control-proxy`, so no runner release re-cut is required.
- The TS iOS ingestor (`src/features/observe/ios/IosSdkEventIngestor.ts:276`) passes `newValue` through as an opaque string, so this is backward-compatible — it only improves fidelity, no consumer decodes by type yet.
- No files outside lane scope touched.