### PR TITLE
refactor(ios): ActionableError sweep for DeviceAppManager/OpenURL error family (#3102)

### DIFF
--- a/src/features/action/OpenURL.ts
+++ b/src/features/action/OpenURL.ts
@@ -2,6 +2,7 @@ import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange } from "./BaseVisualChange";
 import { BootedDevice, OpenURLResult } from "../../models";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
+import { toActionableError } from "../../models/ActionableError";
 import { DeviceAppManager, DeviceUrlLauncher } from "../../utils/ios-cmdline-tools/DeviceAppManager";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
@@ -123,7 +124,7 @@ export class OpenURL extends BaseVisualChange {
         return {
           success: false,
           url: trimmedUrl,
-          error: `Failed to launch app: ${error}`
+          error: toActionableError(error, "Failed to launch app").message
         };
       }
     }
@@ -208,7 +209,7 @@ export class OpenURL extends BaseVisualChange {
       return {
         success: false,
         url,
-        error: String(error)
+        error: toActionableError(error, `Failed to open URL on iOS simulator ${this.device.deviceId}`).message
       };
     }
   }
@@ -257,7 +258,7 @@ export class OpenURL extends BaseVisualChange {
       return {
         success: false,
         url,
-        error: String(error)
+        error: toActionableError(error, "Failed to open URL on physical iOS device").message
       };
     }
   }

--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { ExecResult } from "../../models";
+import { ActionableError, toActionableError } from "../../models/ActionableError";
 import { hashAppBundle } from "./AppBundleHasher";
 import { isProcessAlreadyGoneError } from "./iosProcessErrors";
 import { logger } from "../logger";
@@ -458,13 +459,13 @@ export class DeviceAppManager implements DeviceUrlLauncher {
   async launchWithPayloadUrl(deviceUdid: string, bundleId: string, url: string): Promise<void> {
     const precondition = this.getLaunchPrecondition();
     if (!precondition.ok && precondition.reason === "host-control") {
-      throw new Error(
+      throw new ActionableError(
         "Opening a URL on a physical iOS device is not supported under host control: " +
         "the host-control bridge exposes no devicectl launch-with-URL primitive."
       );
     }
     if (!precondition.ok && precondition.reason === "non-darwin") {
-      throw new Error("Opening URLs on a physical iOS device requires macOS");
+      throw new ActionableError("Opening URLs on a physical iOS device requires macOS");
     }
     const command = [
       "xcrun", "devicectl", "device", "process", "launch",
@@ -473,7 +474,11 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       "--terminate-existing",
       quoteShell(bundleId)
     ].join(" ");
-    await this.deps.exec(command);
+    try {
+      await this.deps.exec(command);
+    } catch (error) {
+      throw toActionableError(error, `Failed to open URL on physical iOS device ${bundleId}`);
+    }
   }
 
   public async getInstalledAppBundleHash(deviceUdid: string, bundleId: string, isSimulator = false): Promise<string | null> {
@@ -522,7 +527,7 @@ export class DeviceAppManager implements DeviceUrlLauncher {
    */
   public async clearAppDataViaReinstall(deviceUdid: string, bundleId: string): Promise<void> {
     if (this.isHostControlMode()) {
-      throw new Error(
+      throw new ActionableError(
         `Clearing app data via uninstall+reinstall is not supported under host control for ${bundleId}: ` +
         "the host-control bridge cannot copy the installed bundle off-device to reinstall it."
       );
@@ -534,7 +539,7 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       return true;
     });
     if (!done) {
-      throw new Error(`Could not resolve installed bundle for ${bundleId} to reinstall`);
+      throw new ActionableError(`Could not resolve installed bundle for ${bundleId} to reinstall`);
     }
   }
 
@@ -634,7 +639,9 @@ export class DeviceAppManager implements DeviceUrlLauncher {
 
       const result = await this.deps.hostControl.uninstallApp(deviceUdid, bundleId);
       if (!result.success) {
-        throw new Error(result.error || "Host control devicectl uninstall failed");
+        throw new ActionableError(
+          `Failed to uninstall ${bundleId} on physical device via host control: ${result.error || "unknown error"}`
+        );
       }
       return;
     }
@@ -652,7 +659,11 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       quoteShell(bundleId),
       "--quiet"
     ].join(" ");
-    await this.deps.exec(command);
+    try {
+      await this.deps.exec(command);
+    } catch (error) {
+      throw toActionableError(error, `Failed to uninstall ${bundleId} on physical iOS device`);
+    }
   }
 
   public async installApp(deviceUdid: string, artifactPath: string): Promise<void> {
@@ -660,18 +671,20 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       const available = await this.deps.hostControl.isAvailable();
       if (!available) {
         this.deps.logger.warn("[DeviceAppManager] Host control not available for devicectl install");
-        throw new Error("Host control not available for physical device app installation");
+        throw new ActionableError("Host control not available for physical device app installation");
       }
 
       const result = await this.deps.hostControl.installApp(deviceUdid, artifactPath);
       if (!result.success) {
-        throw new Error(result.error || "Host control devicectl install failed");
+        throw new ActionableError(
+          `Failed to install app on physical device via host control: ${result.error || "unknown error"}`
+        );
       }
       return;
     }
 
     if (this.deps.platform() !== "darwin") {
-      throw new Error("Physical device app installation requires macOS");
+      throw new ActionableError("Physical device app installation requires macOS");
     }
     const command = [
       "xcrun",
@@ -683,7 +696,11 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       quoteShell(artifactPath),
       "--quiet"
     ].join(" ");
-    await this.deps.exec(command);
+    try {
+      await this.deps.exec(command);
+    } catch (error) {
+      throw toActionableError(error, "Failed to install app on physical iOS device");
+    }
   }
 
   /**
@@ -776,14 +793,14 @@ export class DeviceAppManager implements DeviceUrlLauncher {
    */
   public async terminateApp(deviceUdid: string, bundleId: string): Promise<{ wasInstalled: boolean; wasRunning: boolean }> {
     if (this.isHostControlMode()) {
-      throw new Error(
+      throw new ActionableError(
         `Terminating an app on a physical device is not supported under host control for ${bundleId}: ` +
         "the host-control bridge exposes install/uninstall but no devicectl process-management primitive."
       );
     }
 
     if (this.deps.platform() !== "darwin") {
-      throw new Error("Physical iOS device app termination requires macOS");
+      throw new ActionableError("Physical iOS device app termination requires macOS");
     }
 
     const bundlePath = await this.resolveInstalledBundlePathOnDevice(deviceUdid, bundleId);
@@ -818,7 +835,14 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       // already-exited case; any other failure (device locked, not connected)
       // still propagates. Log at debug since this is an expected non-error.
       if (!isDevicectlProcessGoneError(message)) {
-        throw error;
+        // Wrap in an ActionableError that carries the full exec diagnostic —
+        // devicectl writes its actionable failure text (e.g. "device is locked")
+        // to stderr, which getExecErrorText folds into `message`. A bare rethrow
+        // of `error` keeps stderr only on a non-enumerable field the MCP client
+        // never sees; a plain String(error) drops it entirely.
+        throw new ActionableError(
+          `Failed to terminate ${bundleId} (PID ${pid}) on physical iOS device: ${message}`
+        );
       }
       this.deps.logger.debug(
         `[DeviceAppManager] terminate PID ${pid} for ${bundleId} raced an exit; treating as terminated: ${message}`

--- a/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
@@ -6,6 +6,7 @@ import { DeviceAppManager, findProcessIdentifier, findRunningProcessPid, isDevic
 import { isProcessAlreadyGoneError } from "../../../src/utils/ios-cmdline-tools/iosProcessErrors";
 import { hashAppBundle } from "../../../src/utils/ios-cmdline-tools/AppBundleHasher";
 import { FakeHostControlDeviceAppManager } from "../../fakes/FakeHostControlDeviceAppManager";
+import { ActionableError } from "../../../src/models/ActionableError";
 
 const bundleId = "dev.jasonpearson.automobile.ctrlproxy";
 
@@ -956,6 +957,7 @@ describe("DeviceAppManager terminate (devicectl)", () => {
     const inspector = createInspector({ platform: "linux", exec });
 
     await expect(inspector.terminateApp("device-udid", bundleId)).rejects.toThrow(/macOS/);
+    await expect(inspector.terminateApp("device-udid", bundleId)).rejects.toBeInstanceOf(ActionableError);
     expect(commands).toEqual([]);
   });
 
@@ -1028,13 +1030,17 @@ describe("DeviceAppManager terminate (devicectl)", () => {
     });
 
     const inspector = createInspector({ exec });
-    // The original devicectl error propagates unchanged (its diagnostic lives on
-    // stderr); we only assert it is not swallowed, then confirm the stderr text.
+    // The failure is not swallowed: it surfaces as an ActionableError whose
+    // message folds in the stderr diagnostic (devicectl writes "device is locked"
+    // to stderr, which getExecErrorText captures), so the MCP client sees the
+    // actionable text rather than a bare non-enumerable stderr field.
     const thrown = await inspector.terminateApp("device-udid", bundleId).then(
       () => { throw new Error("expected terminateApp to reject"); },
       (error: unknown) => error
     );
-    expect((thrown as { stderr?: string }).stderr).toMatch(/locked/i);
+    expect(thrown).toBeInstanceOf(ActionableError);
+    expect((thrown as Error).message).toMatch(/locked/i);
+    expect((thrown as Error).message).toContain(bundleId);
     expect(commands.some(c => c.includes("device process terminate"))).toBe(true);
   });
 });

--- a/test/utils/ios-cmdline-tools/DeviceAppManagerUrlLaunch.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManagerUrlLaunch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { DeviceAppManager } from "../../../src/utils/ios-cmdline-tools/DeviceAppManager";
+import { ActionableError } from "../../../src/models/ActionableError";
 import type { ExecResult } from "../../../src/models";
 
 const execResult = (stdout = ""): ExecResult => ({
@@ -109,30 +110,41 @@ describe("DeviceAppManager.launchWithPayloadUrl", () => {
     expect(commands[0]).toContain("--payload-url 'https://x/'\\''; rm -rf /'");
   });
 
-  test("throws an explicit macOS error on a non-darwin host", async () => {
+  test("throws an explicit macOS ActionableError on a non-darwin host", async () => {
     const { inspector, commands } = makeInspector({ platform: () => "linux" });
     await expect(
       inspector.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
     ).rejects.toThrow(/macOS/);
+    await expect(
+      inspector.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
+    ).rejects.toBeInstanceOf(ActionableError);
     expect(commands).toHaveLength(0);
   });
 
-  test("throws an explicit host-control error under Docker host control", async () => {
+  test("throws an explicit host-control ActionableError under Docker host control", async () => {
     const { inspector, commands } = makeInspector({
       hostControl: { shouldUseHostControl: () => true, isRunningInDocker: () => true },
     });
     await expect(
       inspector.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
     ).rejects.toThrow(/host control/i);
+    await expect(
+      inspector.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
+    ).rejects.toBeInstanceOf(ActionableError);
     expect(commands).toHaveLength(0);
   });
 
-  test("propagates an underlying devicectl exec failure", async () => {
+  test("wraps an underlying devicectl exec failure in an ActionableError with context", async () => {
     const { inspector } = makeInspector({
       exec: async () => { throw new Error("device locked"); },
     });
-    await expect(
-      inspector.launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
-    ).rejects.toThrow(/device locked/);
+    const thrown = await inspector
+      .launchWithPayloadUrl("udid", "com.apple.mobilesafari", "https://example.com")
+      .then(() => { throw new Error("expected reject"); }, (e: unknown) => e);
+    expect(thrown).toBeInstanceOf(ActionableError);
+    // Underlying diagnostic preserved …
+    expect((thrown as Error).message).toContain("device locked");
+    // … plus actionable context (which app/what failed).
+    expect((thrown as Error).message).toContain("com.apple.mobilesafari");
   });
 });


### PR DESCRIPTION
Closes #3102

## Summary
Applies CLAUDE.md's Error Handling Convention (strategy 1) to the iOS physical-device launch/terminate/install/open-URL error family, consolidated into `DeviceAppManager` by #3116.

- `DeviceAppManager`: every client-facing `throw new Error(...)` at the devicectl/host-control boundaries is now `ActionableError` (launchWithPayloadUrl host-control/non-darwin, clearAppDataViaReinstall, uninstall/install host-control + macOS gates, terminateApp host-control/non-darwin).
- Underlying `devicectl` exec failures in `launchWithPayloadUrl`, `installApp`, `uninstallApp`, and `terminateApp` are now wrapped with actionable context via `toActionableError` / an `ActionableError` that folds in the full exec diagnostic (devicectl writes its actionable failure text to stderr, which `getExecErrorText` captures — a bare rethrow kept it only on a non-enumerable field the MCP client never sees).
- `OpenURL`: the three `{ success:false, error: String(error) }` sites (package-launch, simulator, physical-device) now carry actionable context via `toActionableError(error, context).message`. The `{ success, error }` return contract is unchanged.

## Validation
- `bun test` targeted (DeviceAppManager, DeviceAppManagerUrlLaunch, OpenURL, TerminateApp): 79 pass / 0 fail
- `bun run lint`, `bun run build`, `bun run typecheck` (no new tsc errors) all green
- Existing tests updated: the terminateApp "device locked" test now asserts an `ActionableError` whose message folds in the stderr diagnostic (previously asserted a raw `.stderr` field); URL-launch and terminate gate tests strengthened to assert `ActionableError`.

## Caveats
- The `Unsupported platform` default in `OpenURL.execute` remains a plain `Error` — it is an unreachable programming invariant (non-android/ios), out of scope for this iOS result-error sweep.
- `launchApp`'s `{ success:false, error }` already used `getErrorMessage` (message-only, no "Error:" prefix), so it was left as-is.
- No files outside the owned scope were modified.