### PR TITLE
fix(cli): publish daemon dbPath before DB open to end direct-mode over-refusal (#2871)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -233,6 +233,12 @@ export class Daemon {
     logger.info("Starting AutoMobile daemon...");
     this.setupShutdownHandlers();
 
+    // Publish the owned DB path in the PID file BEFORE opening the DB so the
+    // direct-mode DB-ownership guard can tell a same-file collision from an
+    // isolated-path launch during our own multi-second startup window, instead
+    // of failing closed on an unknown path. Issue #2871.
+    await this.writeEarlyOwnerRecord();
+
     await this.initializeDatabase();
 
     // Find an available port
@@ -638,6 +644,57 @@ export class Daemon {
   }
 
   /**
+   * Persist a PID-file record to disk (creating the directory as needed).
+   * Shared by the early owner record and the final complete write.
+   */
+  private async persistPidFileData(pidData: PidFileData): Promise<void> {
+    await mkdir(dirname(PID_FILE_PATH), { recursive: true });
+    await writeFile(PID_FILE_PATH, JSON.stringify(pidData, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    this.pidFileWritten = true;
+  }
+
+  /**
+   * Publish this daemon's owned DB path in the PID file BEFORE the DB is opened.
+   *
+   * `Daemon.start()` opens and migrates the shared SQLite file (via
+   * {@link initializeDatabase}) seconds before the full PID file is written (that
+   * only happens after port selection and device discovery). Between those points
+   * the daemon is live and visible to `ps`, but its `dbPath` is not yet recorded —
+   * so the direct-mode DB-ownership guard (see {@link import("./directModeGuard")})
+   * would see an owner with an unknown path and fail CLOSED, transiently refusing a
+   * concurrent direct-mode launch even when it targets an ISOLATED `AUTOMOBILE_DB_PATH`.
+   *
+   * Recording the resolved `dbPath` (knowable via {@link getDatabasePath} WITHOUT
+   * opening the DB) before {@link initializeDatabase} closes that window: any daemon
+   * that has opened the DB now always exposes a resolvable `dbPath`, so a same-file
+   * launch is still refused while an isolated-path launch is allowed. The remaining
+   * TOCTOU (a daemon opening the DB immediately after the guard's check) is covered
+   * by the migration cross-process lock (#2794). Issue #2871.
+   *
+   * The record is minimal by design (pid, dbPath, socketPath, startedAt, version).
+   * Consumers that gate on daemon readiness — `status()`/`waitForReady()` — key on
+   * the socket file plus `verifyDaemonConnection`, not on the PID file's `port`, so
+   * a partial record written before the socket exists cannot make the daemon look
+   * ready early. {@link writePidFile} overwrites it with the complete record.
+   */
+  private async writeEarlyOwnerRecord(): Promise<void> {
+    const pidData: PidFileData = {
+      pid: process.pid,
+      socketPath: SOCKET_PATH,
+      port: this.port,
+      dbPath: getDatabasePath(),
+      startedAt: this.timer.now(),
+      version: DAEMON_VERSION,
+      options: this.options,
+    };
+    await this.persistPidFileData(pidData);
+    logger.info(`Early daemon owner record written to ${PID_FILE_PATH} (dbPath ${pidData.dbPath})`);
+  }
+
+  /**
    * Write PID file with daemon metadata
    */
   private async writePidFile(): Promise<void> {
@@ -655,12 +712,7 @@ export class Daemon {
       options: this.options,
     };
 
-    await mkdir(dirname(PID_FILE_PATH), { recursive: true });
-    await writeFile(PID_FILE_PATH, JSON.stringify(pidData, null, 2), {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
-    this.pidFileWritten = true;
+    await this.persistPidFileData(pidData);
     logger.info(`PID file written to ${PID_FILE_PATH}`);
   }
 

--- a/src/daemon/directModeGuard.ts
+++ b/src/daemon/directModeGuard.ts
@@ -11,12 +11,17 @@ import type { PidFileData } from "./types";
  * A live daemon process paired with the resolved SQLite file it owns.
  *
  * `dbPath` is `undefined` when we cannot determine which DB file the daemon
- * owns — most importantly a daemon that is still starting up (`Daemon.start()`
- * opens and migrates the DB seconds before it records its `dbPath` in the PID
- * file), or one using a non-default PID file. Such a daemon could be about to
+ * owns — e.g. one using a non-default PID file. Such a daemon could be about to
  * write this very file, so the guard fails CLOSED on it (refuses) rather than
  * silently assuming no collision. A daemon with a KNOWN, different `dbPath`
  * still never matches, so the `AUTOMOBILE_DB_PATH` escape hatch is preserved.
+ *
+ * As of #2871 a daemon that is still starting up is NO LONGER a source of an
+ * unknown path: `Daemon.start()` publishes its resolved `dbPath` in the PID file
+ * (`writeEarlyOwnerRecord`) BEFORE it opens the DB, so any daemon that has opened
+ * the DB always exposes a resolvable `dbPath`. That turns the transient
+ * mid-startup over-refusal (an isolated-path launch refused during the daemon's
+ * multi-second bring-up) into a precise same-file check.
  */
 export interface DaemonDbOwner {
   pid: number;
@@ -122,11 +127,12 @@ export function assertDirectModeDbOwnership(deps: DirectModeGuardDeps): void {
   }
 
   // Fail closed on uncertainty. A live daemon whose owned DB path can't be
-  // determined may be mid-startup — it opens and migrates the DB seconds before
-  // it records `dbPath` (daemon.ts opens at start(), writes the PID file only
-  // after device discovery) — so it could be about to write this same file.
-  // Refuse rather than risk a second writer. The residual TOCTOU (a daemon that
-  // opens the DB immediately after this check) is #2794's owner-lock.
+  // determined (e.g. using a non-default PID file) could be about to write this
+  // same file, so refuse rather than risk a second writer. Note: as of #2871 a
+  // mid-startup daemon publishes its `dbPath` BEFORE opening the DB
+  // (writeEarlyOwnerRecord), so it is no longer surfaced as unknown-path here.
+  // The residual TOCTOU (a daemon that opens the DB immediately after this
+  // check) is covered by the migration cross-process lock (#2794).
   const unverifiable = owners.filter(owner => owner.dbPath === undefined);
   if (unverifiable.length > 0) {
     const pids = unverifiable.map(owner => owner.pid).join(", ");
@@ -209,11 +215,12 @@ export function createDefaultDirectModeGuardDeps(
 
       const unresolved = livePids.filter(pid => !resolvedPids.has(pid));
       if (unresolved.length > 0) {
-        // These live daemons don't match the default PID file — most importantly
-        // one still starting up (its `dbPath` isn't recorded until after device
-        // discovery), or one using a custom AUTOMOBILE_DAEMON_PID_FILE_PATH. We
-        // can't learn which DB file they own, so they're surfaced with an unknown
-        // path; the guard fails CLOSED on them (assertDirectModeDbOwnership).
+        // These live daemons don't match the default PID file — e.g. one using a
+        // custom AUTOMOBILE_DAEMON_PID_FILE_PATH. (A daemon still starting up now
+        // publishes its `dbPath` early via writeEarlyOwnerRecord (#2871), so it
+        // resolves above rather than landing here.) We can't learn which DB file
+        // these own, so they're surfaced with an unknown path; the guard fails
+        // CLOSED on them (assertDirectModeDbOwnership).
         // Trace it so the refusal is diagnosable. Reading every daemon's PID file
         // for a definitive per-file answer is #2794's owner-lock.
         logger.debug(

--- a/test/daemon/directModeGuard.test.ts
+++ b/test/daemon/directModeGuard.test.ts
@@ -258,6 +258,36 @@ describe("createDefaultDirectModeGuardDeps", () => {
     expect(deps.findLiveDaemonDbOwners()).toEqual([]);
   });
 
+  test("mid-startup daemon (early owner record) + isolated path → ALLOWED (#2871)", () => {
+    // #2871: Daemon.start() now publishes its resolved dbPath in the PID file
+    // (writeEarlyOwnerRecord) BEFORE opening the DB. So during the multi-second
+    // startup window the live daemon's dbPath is already resolvable, and a
+    // concurrent direct-mode launch targeting an ISOLATED path is no longer
+    // refused — it correctly resolves to a different-file (escape hatch).
+    const daemonDb = join("/home/tester/.auto-mobile", "auto-mobile.db");
+    const isolatedDb = "/home/tester/bench/isolated.db";
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: { findLiveDaemonProcesses: () => [1000] },
+      // Early record: live pid 1000 already has its dbPath published pre-DB-open.
+      readPidFileData: () => pidData({ pid: 1000, dbPath: daemonDb }),
+      resolveDbPath: () => isolatedDb,
+    });
+    expect(deps.findLiveDaemonDbOwners()).toEqual([{ pid: 1000, dbPath: daemonDb }]);
+    expect(() => assertDirectModeDbOwnership(deps)).not.toThrow();
+  });
+
+  test("mid-startup daemon (early owner record) + SAME path → REFUSED (#2795 preserved)", () => {
+    // The complement: with the early record, a same-file direct-mode launch is
+    // still refused throughout startup — no regression to #2795's core guarantee.
+    const daemonDb = join("/home/tester/.auto-mobile", "auto-mobile.db");
+    const deps = createDefaultDirectModeGuardDeps({
+      manager: { findLiveDaemonProcesses: () => [1000] },
+      readPidFileData: () => pidData({ pid: 1000, dbPath: daemonDb }),
+      resolveDbPath: () => daemonDb,
+    });
+    expect(() => assertDirectModeDbOwnership(deps)).toThrow(ActionableError);
+  });
+
   test("end-to-end: default deps refuse a live default-path daemon (EC1)", () => {
     const dbPath = join("/home/tester/.auto-mobile", "auto-mobile.db");
     const deps = createDefaultDirectModeGuardDeps({


### PR DESCRIPTION
## Summary
Closes #2871.

The direct-mode DB-ownership guard (#2795/PR#2852) fails closed on uncertainty: a live daemon whose owned `dbPath` can't be determined is treated as a potential same-file writer and refuses `--no-proxy`/`--direct`. During the daemon's own multi-second startup window it opens+migrates the DB (`daemon.ts` `initializeDatabase()`) well before it records `dbPath` in the PID file (`writePidFile()`, only after port selection + device discovery). In that window a concurrent direct-mode launch was **transiently over-refused even when it targeted an isolated `AUTOMOBILE_DB_PATH`** (no real collision).

## Fix (publish ownership before DB open)
`Daemon.start()` now calls a new `writeEarlyOwnerRecord()` **before** `initializeDatabase()`. It writes a minimal PID-file record (pid, `dbPath` via `getDatabasePath()` — knowable without opening the DB, socketPath, startedAt, version, options). So any daemon that has opened the DB always exposes a resolvable `dbPath`, and "unknown path" no longer coincides with "DB already open." `writePidFile()` later overwrites it with the complete record. The shared write is factored into `persistPidFileData()`.

Result: a mid-startup daemon + isolated direct-mode path is **allowed** (escape hatch preserved); a same-file direct-mode launch is **still refused** throughout (no regression to #2795).

## Coordination with #2794
#2794 merged as the migration **cross-process lock** (`src/db/migrationLock.ts`), not the `<db>.owner.lock` file the issue anticipated. No owner-lock file exists to reuse, so this early record is the self-contained Option 1 from the issue (minimal early PID record, not a parallel marker file). The residual TOCTOU (a daemon opening the DB immediately after the guard's check) remains covered by #2794's migration lock.

## Consumer-safety verification
`status()`/`waitForReady()` gate on the socket file + `verifyDaemonConnection`, not on the PID file's `port` or the optional `sockets`/`entryScript`/`buildId` fields — a partial early record (written before the socket exists) cannot make the daemon look ready early. Failed-startup cleanup is correct: the early write sets `pidFileWritten=true`, so `getDaemonFileCleanupOptions()` returns `{ expectedPid: process.pid }` and the exit handler removes only our own early PID file.

## Tests
- New `directModeGuard.test.ts` cases: mid-startup daemon (early owner record) + isolated path -> allowed; + same path -> refused (interface + fakes, no real DB/process table, <100ms).
- Startup-ordering direct test (stretch AC) intentionally deferred: exercising `start()` installs real process lifecycle handlers/`chdir`; the guard-level tests prove the behavioral acceptance criteria. Captured as follow-up.

## Validation
- `bun test test/daemon/directModeGuard.test.ts` -> 21 pass
- `bun test test/daemon/` -> 632 pass, 0 fail
- `bun build.ts` -> success; `bun run typecheck` -> no new type errors; eslint clean on changed files
- Review gate: adversarial self-review via auto-mobile-code-review skill (no unresolved findings)

## Caveats
- Stretch AC (extracted startup-ordering interface + direct test) not implemented; see follow-up.
