### PR TITLE
fix(observe): clear hierarchy request owners after uncorrelated observe completions (#3190)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -3,6 +3,8 @@ package dev.jasonpearson.automobile.ctrlproxy
 import android.util.Log
 import dev.jasonpearson.automobile.ctrlproxy.perf.PerfProvider
 import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.RequestHierarchy
+import dev.jasonpearson.automobile.protocol.RequestHierarchyIfStale
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.WebSocketMessageHandler
 import dev.jasonpearson.automobile.protocol.WebSocketRequest as ProtocolRequest
@@ -393,6 +395,20 @@ class WebSocketServer(
     sendToClient(connection, message)
   }
 
+  /**
+   * True when [request]'s normal completion echoes its `requestId` back over the wire so the owner
+   * mapping recorded for it can later be cleared. Hierarchy requests are uncorrelated on success
+   * (no requestId reaches the action layer or the `hierarchy_update` frame, and the stale-skip path
+   * emits nothing), so recording them would leak until disconnect — see [handleClientMessage]
+   * and #3190.
+   */
+  private fun recordsRequestOwner(request: ProtocolRequest): Boolean =
+    when (request) {
+      is RequestHierarchy,
+      is RequestHierarchyIfStale -> false
+      else -> true
+    }
+
   private fun forgetRequestConnectionForRawMessage(message: String) {
     forgetRequestConnection(extractRequestId(message))
   }
@@ -459,8 +475,20 @@ class WebSocketServer(
       }
 
     Log.d(TAG, "Received ${request::class.simpleName} (requestId: ${request.requestId})")
-    request.requestId?.let { requestId ->
-      synchronized(connections) { requestConnections[requestId] = connection }
+    // Only record owner mappings for request types whose normal completion carries the same
+    // requestId back over the wire (raw or typed responses that clear the entry via
+    // `forgetRequestConnection`). Hierarchy requests are the exception: the action layer never
+    // receives their requestId, the success `hierarchy_update` frame has no requestId, and the
+    // stale-skip path emits no frame at all — so a recorded owner would never be cleared until the
+    // WebSocket disconnects, recreating the long-lived-session leak and leaving a stale id
+    // available
+    // for later same-id error misrouting (#3190, follow-up to #3159). Their correlated error path
+    // (a handler throw) still targets the originating connection directly via `sendErrorResponse`,
+    // not this map, so skipping the record preserves PR #3159's targeted delivery.
+    if (recordsRequestOwner(request)) {
+      request.requestId?.let { requestId ->
+        synchronized(connections) { requestConnections[requestId] = connection }
+      }
     }
     // Dispatch inline on the WebSocket read loop (already a coroutine) rather than launching into
     // `scope`, so commands execute in wire order: a synchronous command such as

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -1203,4 +1203,115 @@ class WebSocketServerIntegrationTest {
       asyncServer.stop()
     }
   }
+
+  @Test
+  fun `uncorrelated hierarchy success does not leave stale request owner`() = runBlocking {
+    // Issue #3190 (follow-up to #3159): a request_hierarchy carrying a requestId completes with an
+    // uncorrelated success — the action broadcasts a `hierarchy_update` frame that has NO requestId
+    // (production: CtrlProxy.kt broadcasts via HierarchyDebouncer without threading the requestId
+    // through). Because that frame cannot clear an owner entry, the server must NOT record one in
+    // the first place. This test proves a later same-id ErrorResponse is broadcast to ALL clients
+    // rather than being misrouted only to the original requester's connection.
+    lateinit var hierarchyServer: WebSocketServer
+    hierarchyServer =
+      WebSocketServer(
+        port = 0,
+        scope = testScope,
+        messageHandler =
+          CtrlProxyMessageHandler(
+            object : NoOpCtrlProxyActions() {
+              override fun requestHierarchy(disableAllFiltering: Boolean) {
+                // Mirror production: success broadcasts a hierarchy_update with no requestId.
+                testScope.launch {
+                  hierarchyServer.broadcast("""{"type":"hierarchy_update","hierarchy":{}}""")
+                }
+              }
+            }
+          ),
+      )
+    hierarchyServer.start()
+    try {
+      val ownerMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val bystanderMessages = java.util.Collections.synchronizedList(mutableListOf<String>())
+      val ownerReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReady = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendOwnerMessage = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val ownerReceivedUpdate = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val bystanderReceivedUpdate = kotlinx.coroutines.CompletableDeferred<Unit>()
+      val sendLateError = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+      val ownerClient = HttpClient(CIO) { install(WebSockets) }
+      val bystanderClient = HttpClient(CIO) { install(WebSockets) }
+      ownerClient.use { owner ->
+        bystanderClient.use { bystander ->
+          val ownerJob = launch {
+            owner.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = hierarchyServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              ownerReady.complete(Unit)
+              sendOwnerMessage.await()
+              send(Frame.Text("""{"type":"request_hierarchy","requestId":"req-hierarchy"}"""))
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+              ownerReceivedUpdate.complete(Unit)
+              sendLateError.await()
+              ownerMessages.add((withTimeout(1000) { incoming.receive() } as Frame.Text).readText())
+            }
+          }
+
+          val bystanderJob = launch {
+            bystander.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = hierarchyServer.getActualPort() ?: error("Server not running"),
+              path = "/ws",
+            ) {
+              incoming.receive() // Connection message
+              bystanderReady.complete(Unit)
+              sendOwnerMessage.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+              bystanderReceivedUpdate.complete(Unit)
+              sendLateError.await()
+              bystanderMessages.add(
+                (withTimeout(1000) { incoming.receive() } as Frame.Text).readText()
+              )
+            }
+          }
+
+          ownerReady.await()
+          bystanderReady.await()
+          sendOwnerMessage.complete(Unit)
+          ownerReceivedUpdate.await()
+          bystanderReceivedUpdate.await()
+          hierarchyServer.broadcast(
+            ErrorResponse(requestId = "req-hierarchy", error = "late correlated failure")
+          )
+          sendLateError.complete(Unit)
+          ownerJob.join()
+          bystanderJob.join()
+
+          assertEquals("""{"type":"hierarchy_update","hierarchy":{}}""", ownerMessages[0])
+          assertEquals("""{"type":"hierarchy_update","hierarchy":{}}""", bystanderMessages[0])
+          val ownerError = json.parseToJsonElement(ownerMessages[1]).jsonObject
+          val bystanderError = json.parseToJsonElement(bystanderMessages[1]).jsonObject
+          assertEquals("error", ownerError["type"]?.jsonPrimitive?.content)
+          assertEquals("req-hierarchy", ownerError["requestId"]?.jsonPrimitive?.content)
+          assertEquals(
+            "an uncorrelated hierarchy success must not record owner mapping, so a later same-id " +
+              "error broadcasts to all clients instead of being targeted to the original requester",
+            "error",
+            bystanderError["type"]?.jsonPrimitive?.content,
+          )
+          assertEquals("req-hierarchy", bystanderError["requestId"]?.jsonPrimitive?.content)
+        }
+      }
+    } finally {
+      hierarchyServer.stop()
+    }
+  }
 }


### PR DESCRIPTION
Closes #3190

## Problem

Follow-up to #3159. `WebSocketServer.handleClientMessage` records every decoded request with a `requestId` into `requestConnections`, relying on a later raw/typed response carrying the same `requestId` to clear it. Hierarchy requests are **uncorrelated on success**:

- `RequestHierarchy` / `RequestHierarchyIfStale` dispatch without threading `requestId` into the action layer (`CtrlProxyMessageHandler.kt:90-91`; `CtrlProxy.kt:1000-1004` take no `requestId`).
- The success frame is a `hierarchy_update` with **no** `requestId`, and `handleMessage` returns `null` (no synchronous response to clear the entry).
- The stale-skip path emits **no** frame at all.

So a hierarchy `requestId` stays in `requestConnections` until the WebSocket disconnects — recreating the long-lived-session owner leak and leaving a stale id available for later same-id `ErrorResponse` misrouting.

## Fix (issue direction 1: don't record uncorrelatable owners)

`WebSocketServer.kt`: gate the owner-map insert behind a new `recordsRequestOwner(request)` predicate that returns `false` for `RequestHierarchy` / `RequestHierarchyIfStale`. These types can never be correlated by any completion frame, so not recording them is the only path that can't leak.

Targeted `ErrorResponse` delivery from #3159 is preserved: a hierarchy handler-throw uses `sendErrorResponse(connection, ...)` with the **direct** originating connection, not the `requestConnections` map, and no async hierarchy error ever carries a `requestId` to look up anyway.

## Test

New regression test `uncorrelated hierarchy success does not leave stale request owner` (`WebSocketServerIntegrationTest.kt`), mirroring the #3159 owner-clear tests: an owner client sends `request_hierarchy` with a `requestId`, the fake action broadcasts a `hierarchy_update` with no `requestId` (production shape), then a later same-id `ErrorResponse` must reach **both** clients (broadcast, not targeted) — proving no stale ownership.

## Validation

- `./gradlew :control-proxy:testDebugUnitTest --tests "*WebSocketServer*"` — BUILD SUCCESSFUL (22 integration cases incl. the new one).
- Negative check: reverting the guard (`if (true)`) makes the new test **fail**, confirming it catches the leak.
- ktfmt (0.64, --google-style) applied + clean on both files.
- `bun run typecheck` — no new tsc errors (Kotlin-only change).

## Caveats

- Test uses real network I/O via `runBlocking` (not a <100ms unit test) — consistent with the existing `WebSocketServerIntegrationTest` convention documented at the top of that file.
- The test covers `RequestHierarchy`; `RequestHierarchyIfStale` shares the identical `recordsRequestOwner` branch, so the type-level guard covers the stale-skip path too.