### PR TITLE
refactor(ios): extract IOSCtrlProxyManager port-health and host-port collaborators (#3218)

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -14,7 +14,11 @@ import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
 import { isRunningInDocker } from "./dockerEnv";
 import { exponentialBackoff } from "./Backoff";
 import { DefaultProcessSupervisor, type ProcessSupervisor } from "./ProcessSupervisor";
-import { createConnection } from "node:net";
+import {
+  TcpHostPortAvailabilityChecker,
+  type HostPortAvailabilityChecker
+} from "./ios/IOSHostPortAvailabilityChecker";
+import { IOSCtrlProxyHealthClient, isValidCtrlProxyPort } from "./ios/IOSCtrlProxyHealthClient";
 import {
   getHostControlHost,
   getCtrlProxyIOSStatus,
@@ -108,37 +112,9 @@ interface ListeningProcess {
   ppid?: number;
 }
 
-export interface HostPortAvailabilityChecker {
-  isAvailable(host: string, port: number): Promise<boolean>;
-}
-
-class TcpHostPortAvailabilityChecker implements HostPortAvailabilityChecker {
-  private static readonly CONNECT_TIMEOUT_MS = 1000;
-
-  public isAvailable(host: string, port: number): Promise<boolean> {
-    return new Promise(resolve => {
-      const socket = createConnection({ host, port });
-      let settled = false;
-
-      const finish = (available: boolean) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        socket.destroy();
-        resolve(available);
-      };
-
-      socket.setTimeout(TcpHostPortAvailabilityChecker.CONNECT_TIMEOUT_MS);
-      socket.once("connect", () => finish(false));
-      socket.once("timeout", () => finish(false));
-      socket.once("error", error => {
-        const code = (error as NodeJS.ErrnoException).code;
-        finish(code === "ECONNREFUSED");
-      });
-    });
-  }
-}
+// Re-exported from the extracted collaborator (issue #3218) so existing
+// consumers/tests keep importing it from this facade module.
+export type { HostPortAvailabilityChecker };
 
 class HostControlServicePortUnavailableError extends Error {
   constructor(host: string, port: number) {
@@ -171,6 +147,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private readonly appInspector: DeviceAppManager;
   private readonly hostControl: HostControlCtrlProxyIOSRunner;
   private readonly hostPortAvailabilityChecker: HostPortAvailabilityChecker;
+  private readonly healthClient: IOSCtrlProxyHealthClient;
   private hostControlAvailability: Promise<boolean> | null = null;
 
   // Singleton instances per device
@@ -272,6 +249,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       stop: params => stopCtrlProxyIOS(params),
       status: params => getCtrlProxyIOSStatus(params)
     };
+    this.healthClient = new IOSCtrlProxyHealthClient(this.processExecutor, this.timer, {
+      useHostControl: () => this.useHostControl(),
+      getHost: () => this.hostControl.getHost(),
+      deviceId: this.device.deviceId,
+    });
     this.processSupervisor = new DefaultProcessSupervisor({
       name: "iOS CtrlProxy XCTest runner",
       timer: this.timer,
@@ -1602,11 +1584,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return null;
   }
 
-  /** Single source of truth for "is this a usable TCP port number". */
-  private static isValidPort(value: unknown): value is number {
-    return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535;
-  }
-
   private parseCtrlProxyPortFromProcessArgs(args: string): number | null {
     const match = args.match(/(?:^|\s)(?:SIMCTL_CHILD_)?CTRL_PROXY_IOS_PORT=(\d+)(?:\s|$)/);
     if (!match) {
@@ -1614,7 +1591,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     const port = Number.parseInt(match[1], 10);
-    return IOSCtrlProxyManager.isValidPort(port) ? port : null;
+    return isValidCtrlProxyPort(port) ? port : null;
   }
 
   private async ensureServicePortReadyForLaunch(): Promise<void> {
@@ -2130,12 +2107,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async checkHealthEndpoint(): Promise<boolean> {
-    return this.checkHealthEndpointOnPort(this.servicePort);
-  }
-
-  private async checkHealthEndpointOnPort(port: number): Promise<boolean> {
-    const body = await this.readHealthEndpointBodyOnPort(port);
-    return body !== null && (body.includes("ok") || body.includes("healthy"));
+    return this.healthClient.checkHealthEndpointOnPort(this.servicePort);
   }
 
   /**
@@ -2162,7 +2134,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   public async getReportedRunnerPort(): Promise<number | null> {
     const candidatePorts = new Set([this.servicePort, IOSCtrlProxyManager.DEFAULT_PORT]);
     for (const port of candidatePorts) {
-      const reportedPort = await this.readReportedPortFromHealth(port);
+      const reportedPort = await this.healthClient.readReportedPortFromHealth(port);
       if (reportedPort !== null) {
         return reportedPort;
       }
@@ -2170,68 +2142,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return null;
   }
 
-  private async readReportedPortFromHealth(port: number): Promise<number | null> {
-    const body = await this.readHealthEndpointBodyOnPort(port);
-    if (body === null) {
-      return null;
-    }
-    try {
-      const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown; port?: unknown };
-      if (health.status !== "ok") {
-        return null;
-      }
-      // Require a positive device match: a runner answering this port that does
-      // not identify as our device is some other runner and must not be adopted.
-      // A new runner reporting a port always reports its device id; a runner that
-      // omits it is too old to report a port anyway (caught below), so this loses
-      // no genuine coverage while closing the cross-device false-adoption hole.
-      if (health.deviceId !== this.device.deviceId) {
-        return null;
-      }
-      return IOSCtrlProxyManager.isValidPort(health.port) ? health.port : null;
-    } catch {
-      return null;
-    }
-  }
-
   private async checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean> {
-    const body = await this.readHealthEndpointBodyOnPort(port);
-    if (body === null) {
-      return false;
-    }
-
-    try {
-      const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown };
-      return health.status === "ok" && health.deviceId === deviceId;
-    } catch {
-      return false;
-    }
-  }
-
-  private async readHealthEndpointBodyOnPort(port: number): Promise<string | null> {
-    try {
-      const host = this.useHostControl() ? this.hostControl.getHost() : "localhost";
-      if (this.useHostControl()) {
-        const controller = new AbortController();
-        const timeoutId = this.timer.setTimeout(() => controller.abort(), 2000);
-        try {
-          const response = await fetch(`http://${host}:${port}/health`, {
-            signal: controller.signal
-          });
-          return await response.text();
-        } finally {
-          this.timer.clearTimeout(timeoutId);
-        }
-      }
-
-      // Use curl to check the health endpoint locally
-      const { stdout } = await this.processExecutor.exec(
-        `curl -s --max-time 2 http://${host}:${port}/health`
-      );
-      return stdout;
-    } catch {
-      return null;
-    }
+    return this.healthClient.checkHealthEndpointOnPortForDevice(port, deviceId);
   }
 
   private getIproxyStartTimeoutMs(): number {

--- a/src/utils/ios/IOSCtrlProxyHealthClient.ts
+++ b/src/utils/ios/IOSCtrlProxyHealthClient.ts
@@ -1,0 +1,129 @@
+import type { ProcessExecutor } from "../ProcessExecutor";
+import type { Timer } from "../SystemTimer";
+
+/**
+ * Single source of truth for "is this a usable TCP port number".
+ * Shared by the health client and {@link IOSCtrlProxyManager}.
+ */
+export function isValidCtrlProxyPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 65535;
+}
+
+/**
+ * Host/transport context the health client needs to reach a runner. Supplied by
+ * {@link IOSCtrlProxyManager} so the client stays agnostic of host-control gating
+ * and device identity.
+ */
+export interface CtrlProxyHealthContext {
+  /** true when reaching the runner through the host-control daemon (Docker). */
+  useHostControl(): boolean;
+  /** Host to probe when {@link useHostControl} is true. */
+  getHost(): string;
+  /** The device this manager owns; used to reject cross-device runners. */
+  readonly deviceId: string;
+}
+
+/**
+ * Reads and interprets the CtrlProxy iOS runner `/health` endpoint.
+ *
+ * Extracted from {@link IOSCtrlProxyManager} (issue #3218) so runner-readiness /
+ * health-poll decisions live in one focused, injectable collaborator. Behavior is
+ * unchanged: local probes go through `curl` on the injected {@link ProcessExecutor}
+ * and host-control probes use `fetch` with a timer-driven abort, exactly as before.
+ */
+export class IOSCtrlProxyHealthClient {
+  private static readonly FETCH_TIMEOUT_MS = 2000;
+
+  public constructor(
+    private readonly processExecutor: ProcessExecutor,
+    private readonly timer: Timer,
+    private readonly context: CtrlProxyHealthContext
+  ) {}
+
+  /**
+   * Loose liveness check: the runner answered `/health` with an "ok"/"healthy"
+   * body. Does not require device identity — used to gate spawn/restart on any
+   * responding runner on the port.
+   */
+  public async checkHealthEndpointOnPort(port: number): Promise<boolean> {
+    const body = await this.readHealthEndpointBodyOnPort(port);
+    return body !== null && (body.includes("ok") || body.includes("healthy"));
+  }
+
+  /**
+   * Strict liveness check: the runner answered `/health` with `status === "ok"`
+   * AND identifies as `deviceId`. Rejects a sibling simulator's runner or the
+   * Android runner answering the same/default port.
+   */
+  public async checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean> {
+    const body = await this.readHealthEndpointBodyOnPort(port);
+    if (body === null) {
+      return false;
+    }
+
+    try {
+      const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown };
+      return health.status === "ok" && health.deviceId === deviceId;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * The port the runner self-reports in its `/health` payload, or null. Only
+   * accepted when `status === "ok"` and the reported `deviceId` matches this
+   * manager's device, so a cross-device runner is never adopted.
+   */
+  public async readReportedPortFromHealth(port: number): Promise<number | null> {
+    const body = await this.readHealthEndpointBodyOnPort(port);
+    if (body === null) {
+      return null;
+    }
+    try {
+      const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown; port?: unknown };
+      if (health.status !== "ok") {
+        return null;
+      }
+      if (health.deviceId !== this.context.deviceId) {
+        return null;
+      }
+      return isValidCtrlProxyPort(health.port) ? health.port : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Raw `/health` body, or null when the runner does not answer. Local probes use
+   * `curl` (bounded by `--max-time`); host-control probes use `fetch` bounded by a
+   * timer-driven `AbortController`.
+   */
+  public async readHealthEndpointBodyOnPort(port: number): Promise<string | null> {
+    try {
+      const host = this.context.useHostControl() ? this.context.getHost() : "localhost";
+      if (this.context.useHostControl()) {
+        const controller = new AbortController();
+        const timeoutId = this.timer.setTimeout(
+          () => controller.abort(),
+          IOSCtrlProxyHealthClient.FETCH_TIMEOUT_MS
+        );
+        try {
+          const response = await fetch(`http://${host}:${port}/health`, {
+            signal: controller.signal
+          });
+          return await response.text();
+        } finally {
+          this.timer.clearTimeout(timeoutId);
+        }
+      }
+
+      // Use curl to check the health endpoint locally
+      const { stdout } = await this.processExecutor.exec(
+        `curl -s --max-time 2 http://${host}:${port}/health`
+      );
+      return stdout;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/utils/ios/IOSHostPortAvailabilityChecker.ts
+++ b/src/utils/ios/IOSHostPortAvailabilityChecker.ts
@@ -1,0 +1,47 @@
+import { createConnection } from "node:net";
+
+/**
+ * Decides whether a TCP host:port is free to bind for a CtrlProxy iOS runner.
+ *
+ * Extracted from {@link IOSCtrlProxyManager} (issue #3218) so host-port
+ * availability decisions live in one focused, injectable collaborator instead of
+ * inline in the manager. The manager re-exports this interface for backward
+ * compatibility with existing consumers/tests.
+ */
+export interface HostPortAvailabilityChecker {
+  isAvailable(host: string, port: number): Promise<boolean>;
+}
+
+/**
+ * Real {@link HostPortAvailabilityChecker} backed by a short-lived TCP connect
+ * probe. A port is treated as available only when the connect is actively
+ * refused (`ECONNREFUSED`); a successful connect or a timeout means something is
+ * (or may be) listening, so the port is treated as unavailable.
+ */
+export class TcpHostPortAvailabilityChecker implements HostPortAvailabilityChecker {
+  private static readonly CONNECT_TIMEOUT_MS = 1000;
+
+  public isAvailable(host: string, port: number): Promise<boolean> {
+    return new Promise(resolve => {
+      const socket = createConnection({ host, port });
+      let settled = false;
+
+      const finish = (available: boolean) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        socket.destroy();
+        resolve(available);
+      };
+
+      socket.setTimeout(TcpHostPortAvailabilityChecker.CONNECT_TIMEOUT_MS);
+      socket.once("connect", () => finish(false));
+      socket.once("timeout", () => finish(false));
+      socket.once("error", error => {
+        const code = (error as NodeJS.ErrnoException).code;
+        finish(code === "ECONNREFUSED");
+      });
+    });
+  }
+}

--- a/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyHealthClient.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  IOSCtrlProxyHealthClient,
+  isValidCtrlProxyPort,
+  type CtrlProxyHealthContext
+} from "../../../src/utils/ios/IOSCtrlProxyHealthClient";
+import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import type { ExecResult } from "../../../src/models";
+
+function execResult(stdout: string): ExecResult {
+  return {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (searchString: string) => stdout.includes(searchString),
+  };
+}
+
+const DEVICE_ID = "SIM-DEVICE-1";
+
+function localContext(): CtrlProxyHealthContext {
+  return {
+    useHostControl: () => false,
+    getHost: () => "unused.local",
+    deviceId: DEVICE_ID,
+  };
+}
+
+function makeClient(
+  handler: (command: string) => ExecResult,
+  context: CtrlProxyHealthContext = localContext()
+): { client: IOSCtrlProxyHealthClient; executor: FakeProcessExecutor } {
+  const executor = new FakeProcessExecutor();
+  executor.setCommandHandler("curl", handler);
+  const client = new IOSCtrlProxyHealthClient(executor, new FakeTimer(), context);
+  return { client, executor };
+}
+
+describe("isValidCtrlProxyPort", function() {
+  test("accepts an in-range integer port", function() {
+    expect(isValidCtrlProxyPort(8765)).toBe(true);
+    expect(isValidCtrlProxyPort(1)).toBe(true);
+    expect(isValidCtrlProxyPort(65535)).toBe(true);
+  });
+
+  test("rejects out-of-range, non-integer, and non-number values", function() {
+    expect(isValidCtrlProxyPort(0)).toBe(false);
+    expect(isValidCtrlProxyPort(65536)).toBe(false);
+    expect(isValidCtrlProxyPort(80.5)).toBe(false);
+    expect(isValidCtrlProxyPort("8765")).toBe(false);
+    expect(isValidCtrlProxyPort(undefined)).toBe(false);
+  });
+});
+
+describe("IOSCtrlProxyHealthClient (local curl transport)", function() {
+  test("checkHealthEndpointOnPort is true for an 'ok'/'healthy' body", async function() {
+    const { client } = makeClient(() => execResult("{\"status\":\"ok\"}"));
+    expect(await client.checkHealthEndpointOnPort(8765)).toBe(true);
+  });
+
+  test("checkHealthEndpointOnPort is false when the runner does not answer", async function() {
+    const { client } = makeClient(() => { throw new Error("connection refused"); });
+    expect(await client.checkHealthEndpointOnPort(8765)).toBe(false);
+  });
+
+  test("checkHealthEndpointOnPortForDevice requires a matching device id", async function() {
+    const matching = makeClient(() =>
+      execResult(`{"status":"ok","deviceId":"${DEVICE_ID}"}`));
+    expect(await matching.client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(true);
+
+    const foreign = makeClient(() =>
+      execResult("{\"status\":\"ok\",\"deviceId\":\"OTHER\"}"));
+    expect(await foreign.client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(false);
+  });
+
+  test("checkHealthEndpointOnPortForDevice rejects a non-JSON (Android 'OK') body", async function() {
+    const { client } = makeClient(() => execResult("OK"));
+    expect(await client.checkHealthEndpointOnPortForDevice(8765, DEVICE_ID)).toBe(false);
+  });
+
+  test("readReportedPortFromHealth returns the self-reported port for our device", async function() {
+    const { client } = makeClient(() =>
+      execResult(`{"status":"ok","deviceId":"${DEVICE_ID}","port":9100}`));
+    expect(await client.readReportedPortFromHealth(8765)).toBe(9100);
+  });
+
+  test("readReportedPortFromHealth rejects a runner for a different device", async function() {
+    const { client } = makeClient(() =>
+      execResult("{\"status\":\"ok\",\"deviceId\":\"OTHER\",\"port\":9100}"));
+    expect(await client.readReportedPortFromHealth(8765)).toBeNull();
+  });
+
+  test("readReportedPortFromHealth rejects a non-ok status or invalid port", async function() {
+    const notOk = makeClient(() =>
+      execResult(`{"status":"starting","deviceId":"${DEVICE_ID}","port":9100}`));
+    expect(await notOk.client.readReportedPortFromHealth(8765)).toBeNull();
+
+    const badPort = makeClient(() =>
+      execResult(`{"status":"ok","deviceId":"${DEVICE_ID}","port":70000}`));
+    expect(await badPort.client.readReportedPortFromHealth(8765)).toBeNull();
+  });
+
+  test("probes localhost on the requested port via curl", async function() {
+    const commands: string[] = [];
+    const { client } = makeClient(command => {
+      commands.push(command);
+      return execResult("{\"status\":\"ok\"}");
+    });
+    await client.checkHealthEndpointOnPort(9999);
+    expect(commands.some(c => c.includes("http://localhost:9999/health"))).toBe(true);
+  });
+});

--- a/test/utils/ios/IOSHostPortAvailabilityChecker.test.ts
+++ b/test/utils/ios/IOSHostPortAvailabilityChecker.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:net";
+import { TcpHostPortAvailabilityChecker } from "../../../src/utils/ios/IOSHostPortAvailabilityChecker";
+
+/**
+ * These tests exercise the real TCP-connect probe against loopback. They avoid
+ * timers entirely: a listening server resolves the connect immediately, and a
+ * closed port is refused immediately, so both settle well under the unit budget.
+ */
+describe("TcpHostPortAvailabilityChecker", function() {
+  let server: Server | null = null;
+
+  afterEach(async function() {
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = null;
+    }
+  });
+
+  async function listenOnEphemeralPort(): Promise<number> {
+    server = createServer();
+    return new Promise<number>((resolve, reject) => {
+      server!.once("error", reject);
+      server!.listen(0, "127.0.0.1", () => {
+        const address = server!.address();
+        if (address && typeof address === "object") {
+          resolve(address.port);
+        } else {
+          reject(new Error("failed to bind ephemeral port"));
+        }
+      });
+    });
+  }
+
+  test("reports a bound port as NOT available (connect succeeds)", async function() {
+    const port = await listenOnEphemeralPort();
+    const checker = new TcpHostPortAvailabilityChecker();
+    expect(await checker.isAvailable("127.0.0.1", port)).toBe(false);
+  });
+
+  test("reports a closed port as available (connect refused)", async function() {
+    // Bind then immediately release, so the port is almost certainly free and refuses.
+    const port = await listenOnEphemeralPort();
+    await new Promise<void>(resolve => server!.close(() => resolve()));
+    server = null;
+
+    const checker = new TcpHostPortAvailabilityChecker();
+    expect(await checker.isAvailable("127.0.0.1", port)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #2770 (ProcessSupervisor extraction). Extracts two focused, injectable collaborators out of the `IOSCtrlProxyManager` facade for the remaining non-supervision lifecycle concerns called out in #3218:

- **`src/utils/ios/IOSHostPortAvailabilityChecker.ts`** — host-port availability decisions. Moves the `HostPortAvailabilityChecker` interface + `TcpHostPortAvailabilityChecker` (TCP-connect probe) out of the manager. The interface is re-exported from `IOSCtrlProxyManager` so existing consumers/tests keep their import path.
- **`src/utils/ios/IOSCtrlProxyHealthClient.ts`** — health polling / runner readiness. Owns `/health` reading + interpretation (`checkHealthEndpointOnPort`, `checkHealthEndpointOnPortForDevice`, `readReportedPortFromHealth`, `readHealthEndpointBodyOnPort`) plus the shared `isValidCtrlProxyPort` predicate (was the manager's `isValidPort` static). The manager now delegates to it via a small `CtrlProxyHealthContext` seam (`useHostControl`/`getHost`/`deviceId`).

The manager stays the public facade; it instantiates and delegates to both collaborators. No behavior change: local probes still use `curl --max-time 2`, host-control probes still use `fetch` with a timer-driven `AbortController` (2s), and cross-device / non-JSON (Android `OK`) / invalid-port rejection are all preserved.

## Scope

Only touches `src/utils/IOSCtrlProxyManager.ts` (lane-owned) plus the two new collaborator modules and their tests. No files outside the `ios-ctrlproxy-collaborators` lane were modified. Host-control gating and port allocation/adoption logic were intentionally left in the manager for a later pass (they are deeply coupled to `PortManager`/service-port mutation and the stale-child protections from #3213); this PR takes the two lowest-coupling collaborators the issue lists.

## Validation

- `bun test test/utils/IOSCtrlProxyManager.test.ts` — 94 pass, 0 fail (existing coverage green)
- `bun test test/utils/ios/` — 12 pass (new focused collaborator tests: interface + FakeProcessExecutor + FakeTimer; loopback socket for the Tcp checker; all <100ms)
- `bun test` (full) — 6761 pass, 2 skip, 0 fail
- `bun run build` — success
- `turbo run lint` — clean
- `bun run typecheck` — no new type errors (280 baseline)
- `git diff --check` — clean

## Caveats

- The `#2834`/`#3213` stale-child protections (own-runner identity guards, hung-runner recovery) remain in the manager and are unchanged — the extracted health client is a pure read/parse collaborator, so those flows keep their existing FakeTimer/FakeProcessExecutor regression tests.

Closes #3218
