### PR TITLE
feat(ios): reset every resettable XCUIProtectedResource on physical iOS (#3188)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -62,6 +62,14 @@ public class GesturePerformer: GesturePerforming {
         }
     }
 
+    /// Every AutoMobile permission name that maps to a resettable iOS
+    /// `XCUIProtectedResource` (Xcode 26.3 header). The `all` keyword expands to
+    /// this list; the TS host list in `IosPhysicalPermissions.ts`
+    /// (`IOS_PHYSICAL_RESET_ALL_PERMISSIONS`) must stay in lock-step so the public
+    /// tool path and the direct runner path reset the identical set.
+    /// `local-network` is iOS 15.4+ only; below that OS version
+    /// `protectedResource(for:)` returns nil so it fails honestly per-permission
+    /// rather than being silently skipped.
     static let allResettablePrivacyResourceNames = [
         "camera",
         "photos",
@@ -71,6 +79,13 @@ public class GesturePerformer: GesturePerforming {
         "calendar",
         "reminders",
         "media-library",
+        "homekit",
+        "focus",
+        "local-network",
+        "bluetooth",
+        "keyboard-network",
+        "health",
+        "user-tracking",
     ]
 
     private static let resettablePrivacyResourceAliases = Set(
@@ -1371,6 +1386,21 @@ public class GesturePerformer: GesturePerforming {
             case "calendar": return .calendar
             case "reminders": return .reminders
             case "media-library": return .mediaLibrary
+            case "homekit": return .homeKit
+            case "focus": return .focus
+            case "bluetooth": return .bluetooth
+            case "keyboard-network": return .keyboardNetwork
+            case "health": return .health
+            case "user-tracking": return .userTracking
+            case "local-network":
+                // `XCUIProtectedResourceLocalNetwork` is iOS 15.4+ only. Below that
+                // OS version there is no resettable equivalent, so return nil and let
+                // the caller surface an honest per-permission failure instead of
+                // silently skipping it.
+                if #available(iOS 15.4, *) {
+                    return .localNetwork
+                }
+                return nil
             default: return nil
             }
         }

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1434,8 +1434,24 @@ final class CommandHandlerTests: XCTestCase {
                 "calendar",
                 "reminders",
                 "media-library",
+                "homekit",
+                "focus",
+                "local-network",
+                "bluetooth",
+                "keyboard-network",
+                "health",
+                "user-tracking",
             ]
         )
+        // Each newly added XCUIProtectedResource name is a recognized (aliasable)
+        // reset resource, so it expands to itself rather than returning nil.
+        for name in ["homekit", "focus", "local-network", "bluetooth", "keyboard-network", "health", "user-tracking"] {
+            XCTAssertEqual(
+                GesturePerformer.expandedPrivacyResourceNames(for: name),
+                [name],
+                "\(name) should be a recognized resettable resource"
+            )
+        }
         XCTAssertEqual(GesturePerformer.expandedPrivacyResourceNames(for: "photos-add"), ["photos-add"])
         XCTAssertEqual(GesturePerformer.canonicalPrivacyResourceName(for: "photos-add"), "photos")
         XCTAssertEqual(GesturePerformer.canonicalPrivacyResourceName(for: "contacts-limited"), "contacts")

--- a/src/features/action/IosPhysicalPermissions.ts
+++ b/src/features/action/IosPhysicalPermissions.ts
@@ -8,6 +8,14 @@ import {
   type IosSimulatorPermissionMutationResult,
 } from "./IosSimulatorPermissions";
 
+// Every AutoMobile permission name that maps to a resettable iOS
+// `XCUIProtectedResource` (Xcode 26.3 header). Keep in lock-step with the
+// authoritative Swift list in
+// `ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift`
+// (`allResettablePrivacyResourceNames`); the direct Swift runner `all`
+// expansion must reset the same set. `local-network` maps to
+// `XCUIProtectedResourceLocalNetwork` which is iOS 15.4+, so the runner
+// reports it as an honest per-permission failure on older OS versions.
 const IOS_PHYSICAL_RESET_ALL_PERMISSIONS = [
   "camera",
   "photos",
@@ -17,6 +25,13 @@ const IOS_PHYSICAL_RESET_ALL_PERMISSIONS = [
   "calendar",
   "reminders",
   "media-library",
+  "homekit",
+  "focus",
+  "local-network",
+  "bluetooth",
+  "keyboard-network",
+  "health",
+  "user-tracking",
 ];
 
 const IOS_PHYSICAL_RESET_CANONICAL_PERMISSION = new Map<string, string>([

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -179,32 +179,33 @@ describe("AppPermissions", () => {
       permissions: ["all", "photos-add", "contacts-limited", "location-always"],
     });
 
+    const expandedResources = [
+      "camera",
+      "photos",
+      "microphone",
+      "contacts",
+      "location",
+      "calendar",
+      "reminders",
+      "media-library",
+      "homekit",
+      "focus",
+      "local-network",
+      "bluetooth",
+      "keyboard-network",
+      "health",
+      "user-tracking",
+    ];
     expect(result.success).toBe(true);
-    expect(result.changedCount).toBe(8);
+    expect(result.changedCount).toBe(expandedResources.length);
     expect(result.failedCount).toBe(0);
-    expect(result.operations.map(operation => operation.operationId)).toEqual([
-      "ios_xcuitest_reset:reset:camera",
-      "ios_xcuitest_reset:reset:photos",
-      "ios_xcuitest_reset:reset:microphone",
-      "ios_xcuitest_reset:reset:contacts",
-      "ios_xcuitest_reset:reset:location",
-      "ios_xcuitest_reset:reset:calendar",
-      "ios_xcuitest_reset:reset:reminders",
-      "ios_xcuitest_reset:reset:media-library",
-    ]);
+    expect(result.operations.map(operation => operation.operationId)).toEqual(
+      expandedResources.map(resource => `ios_xcuitest_reset:reset:${resource}`)
+    );
     expect(iosPhysicalClient.calls).toEqual([
       {
         appId: "com.example.app",
-        permissions: [
-          "camera",
-          "photos",
-          "microphone",
-          "contacts",
-          "location",
-          "calendar",
-          "reminders",
-          "media-library",
-        ],
+        permissions: expandedResources,
       },
     ]);
   });

--- a/test/features/action/IosPhysicalPermissions.test.ts
+++ b/test/features/action/IosPhysicalPermissions.test.ts
@@ -52,6 +52,13 @@ describe("IosPhysicalPermissions", () => {
       "calendar",
       "reminders",
       "media-library",
+      "homekit",
+      "focus",
+      "local-network",
+      "bluetooth",
+      "keyboard-network",
+      "health",
+      "user-tracking",
     ];
     expect(result.success).toBe(true);
     expect(result.changedCount).toBe(expanded.length);
@@ -73,9 +80,7 @@ describe("IosPhysicalPermissions", () => {
       "location-always",
     ]);
 
-    expect(result.success).toBe(true);
-    expect(result.changedCount).toBe(8);
-    expect(result.results.map(r => r.permission)).toEqual([
+    const expanded = [
       "camera",
       "photos",
       "microphone",
@@ -84,20 +89,21 @@ describe("IosPhysicalPermissions", () => {
       "calendar",
       "reminders",
       "media-library",
-    ]);
+      "homekit",
+      "focus",
+      "local-network",
+      "bluetooth",
+      "keyboard-network",
+      "health",
+      "user-tracking",
+    ];
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(expanded.length);
+    expect(result.results.map(r => r.permission)).toEqual(expanded);
     expect(client.calls).toEqual([
       {
         appId: "com.example.app",
-        permissions: [
-          "camera",
-          "photos",
-          "microphone",
-          "contacts",
-          "location",
-          "calendar",
-          "reminders",
-          "media-library",
-        ],
+        permissions: expanded,
       },
     ]);
   });
@@ -129,6 +135,27 @@ describe("IosPhysicalPermissions", () => {
     expect(result.failedCount).toBe(0);
     expect(result.results.map(r => r.permission)).toEqual(["camera", "photos"]);
     expect(client.calls).toEqual([{ appId: "com.example.app", permissions: ["camera", "photos"] }]);
+  });
+
+  test("reset supports the newly added XCUIProtectedResource names explicitly", async () => {
+    const client = new FakePhysicalPrivacyClient();
+    const permissions = new IosPhysicalPermissions(physicalDevice, client);
+
+    const newlySupported = [
+      "homekit",
+      "focus",
+      "local-network",
+      "bluetooth",
+      "keyboard-network",
+      "health",
+      "user-tracking",
+    ];
+    const result = await permissions.setPermissions("reset", "com.example.app", newlySupported);
+
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(newlySupported.length);
+    expect(result.results.map(r => r.permission)).toEqual(newlySupported);
+    expect(client.calls).toEqual([{ appId: "com.example.app", permissions: newlySupported }]);
   });
 
   test("reset aggregates partial failure (e.g. unmapped resource) honestly", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #3162: `setAppPermissions action=reset permissions=["all"]` on physical iOS now expands to **every** resettable iOS `XCUIProtectedResource` AutoMobile can honestly support, not just the original eight.

Newly supported permission names (Xcode 26.3 `XCUIProtectedResource.h`):

| AutoMobile name | XCUIProtectedResource | Availability |
| --- | --- | --- |
| `homekit` | `.homeKit` | iOS 15.0 (base) |
| `focus` | `.focus` | iOS 15.0 |
| `local-network` | `.localNetwork` | **iOS 15.4+** (runtime-gated) |
| `bluetooth` | `.bluetooth` | iOS 15.0 (base) |
| `keyboard-network` | `.keyboardNetwork` | iOS 15.0 (base) |
| `health` | `.health` | iOS 14.0 |
| `user-tracking` | `.userTracking` | iOS 15.0 |

Deployment target is iOS 15.0, so all map at base except `local-network`, which is guarded by `if #available(iOS 15.4, *)` and returns nil below 15.4 so it surfaces as an **honest per-permission failure** rather than being silently skipped.

## Changes

- `src/features/action/IosPhysicalPermissions.ts` — extended `IOS_PHYSICAL_RESET_ALL_PERMISSIONS`; kept in lock-step with the authoritative Swift list.
- `ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift` — extended `allResettablePrivacyResourceNames` (drives direct-runner `all` expansion) and `protectedResource(for:)` with availability-gated mappings.
- Tests: TS `all`-expansion + dedupe + explicit newly-supported-name coverage (`IosPhysicalPermissions.test.ts`, `AppPermissions.test.ts`); Swift `expandedPrivacyResourceNames` full-set assertion (`CommandHandlerTests.swift`).

## Design decisions

- **No new simulator TCC aliases.** `simctl privacy` supports a fixed service set that does not include these resources; adding them to `TCC_SERVICE_BY_PERMISSION` would falsely advertise simulator grant/revoke/reset support. They remain physical-reset-only, per the honest support-matrix convention (#2491).
- Tool schema text (`permissions=['all'] supported`) does not enumerate the eight, so it stays accurate — no schema edits needed.

## Validation

- `bun test test/features/action/` — 729 pass, 0 fail
- `(cd ios/control-proxy && swift build)` — Build complete (macOS excludes the iOS mapping branch)
- `(cd ios/control-proxy && swift test --filter ...testResetPermissionsAllExpandsToEveryResettablePrivacyResource)` — pass
- `xcodebuild -scheme CtrlProxyApp -sdk iphonesimulator` — **BUILD SUCCEEDED** (validates the availability-gated iOS mapping compiles, per AC)
- `bun run build`, `bun run typecheck` (no new errors), `bunx eslint` on touched files, `swiftformat --lint` (0/2 need formatting) — all clean

## Caveats / follow-up

- #3134 (unit-test the real `protectedResource(for:)` mapping table) is **not** closed here: that mapping lives inside `#if canImport(XCTest) && os(iOS)` and the macOS `swift test` suite excludes it, so a genuine assertion needs an iOS-simulator test target that does not yet exist in SPM. This PR asserts the macOS-compilable `expandedPrivacyResourceNames` surface only. Leaving #3134 open.
- The direct Swift-runner `all` support applies only when the next iOS CtrlProxy runner artifact is re-cut (or a local `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` override is used); the public tool path expands in TS and works with the existing runner.

Closes #3188
