### PR TITLE
test(ios): make control-proxy wire-parity scan structural (AST + import-graph) (#2955)

### DIFF
--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -25,10 +25,12 @@ import {
   IOS_KNOWN_REQUEST_TYPE_SET,
 } from "../../../../src/features/observe/ios/ctrlProxyRequestTypes";
 import { IOS_RUNNER_FEATURE_COMMANDS } from "../../../../src/features/observe/ios/IOSCtrlProxyClient";
+import { deriveIosSharedEmitFiles, scanFile } from "./ctrlProxyWireScan";
 
 const REPO_ROOT = resolve(import.meta.dir, "../../../..");
 const IOS_OBSERVE_DIR = resolve(REPO_ROOT, "src/features/observe/ios");
 const SHARED_OBSERVE_DIR = resolve(REPO_ROOT, "src/features/observe/shared");
+const IOS_CLIENT_ENTRY = resolve(IOS_OBSERVE_DIR, "IOSCtrlProxyClient.ts");
 const MODELS_SWIFT = resolve(REPO_ROOT, "ios/control-proxy/Sources/CtrlProxy/Models.swift");
 
 /**
@@ -82,9 +84,14 @@ const SWIFT_REQUEST_TYPES = [
 /**
  * Response-payload discriminators that share the `type:` JSON key with outbound
  * requests but are *inbound* shapes, not wire commands. `CtrlProxyDatabase.executeSQL`
- * classifies its result as `{ type: "mutation" }` / `{ type: "query" }`. They must be
- * excluded from the emit scan; a new non-request `type:` literal that is not listed
- * here will (correctly) fail the subset assertion and force a decision.
+ * classifies its result as `{ type: "mutation" }` / `{ type: "query" }`.
+ *
+ * The AST scanner scopes emit detection to the `JSON.stringify(...)` / `sendCommand(...)`
+ * sinks, so these result-classifier objects are no longer picked up at all — this
+ * denylist is now defense-in-depth: if a future refactor DID serialize a `{ type }`
+ * result over the wire, the literal would still be excluded here rather than tripping
+ * the subset assertion. A genuinely-new non-request literal not listed here will
+ * (correctly) fail the subset assertion and force a decision.
  */
 const NON_REQUEST_TYPE_LITERALS = new Set(["mutation", "query"]);
 
@@ -95,80 +102,42 @@ const EXCLUDED_IOS_FILES = new Set([
   "types.ts",
 ]);
 
-/**
- * Shared delegates the iOS text + gesture paths route through. These files serve BOTH
- * platforms, so every command they emit must be valid on the iOS runner too — an
- * Android-only command added to a shared delegate would (correctly) fail this guard.
- * The list is hardcoded because iOS routes through exactly these two today; a new
- * shared delegate the iOS client adopts must be added here (tracked follow-up: derive
- * this from the iOS import graph so a missed delegate can't silently go unscanned).
- */
-const SHARED_EMIT_FILES = ["SharedTextDelegate.ts", "SharedGestureDelegate.ts"];
-
-function iosEmitSourceFiles(): string[] {
-  const iosFiles = readdirSync(IOS_OBSERVE_DIR)
-    .filter(f => f.endsWith(".ts") && !f.endsWith(".test.ts") && !EXCLUDED_IOS_FILES.has(f))
-    .map(f => resolve(IOS_OBSERVE_DIR, f));
-  const sharedFiles = SHARED_EMIT_FILES.map(f => resolve(SHARED_OBSERVE_DIR, f));
-  return [...iosFiles, ...sharedFiles];
-}
-
 // A wire command discriminator: lowercase snake_case, may contain digits (e.g. a
 // hypothetical `request_swipe_v2`). Must match the Swift-side rawValue class so a
 // digit-bearing command can't slip past either side of the guard.
 const COMMAND_TOKEN = "[a-z][a-z0-9_]*";
 
 /**
- * Extract every command `type` string a source file can put on the wire.
- *
- * This is a textual scan, not a full parse, so it recognizes only *literal* command
- * discriminators in three syntactic shapes (below). It deliberately cannot follow a
- * value hoisted into a `const` or built from a template — see `guardAgainstDynamicCommandTypes`,
- * which fails loudly on the template case, and the tracked follow-up for a structural
- * (AST/lint) replacement.
+ * The iOS emit source files: every non-test `.ts` in the iOS observe dir (minus inbound
+ * decode/registry files) plus the shared delegates DERIVED from the iOS client's
+ * transitive import graph (issue #2955). A new shared delegate the iOS client routes
+ * through is discovered automatically, so it cannot silently go unscanned — no hardcoded
+ * `SHARED_EMIT_FILES` allowlist to fall out of date.
  */
-function extractEmittedTypes(source: string): Set<string> {
-  const found = new Set<string>();
-
-  // 1. `messageType: "..."` — the shared sendCommand discriminator (never anything else).
-  for (const m of source.matchAll(new RegExp(`messageType:\\s*"(${COMMAND_TOKEN})"`, "g"))) {
-    found.add(m[1]);
-  }
-  // 2a. A string literal directly after the `type:` JSON key, tolerating a line break
-  //     between key and value (`type:\n  "get_preferences"`). `messageType:`/
-  //     `responseType:` (capital T) are not matched by \btype:.
-  for (const m of source.matchAll(new RegExp(`\\btype:\\s*"(${COMMAND_TOKEN})"`, "g"))) {
-    found.add(m[1]);
-  }
-  // 2b. Any string literal on a line carrying the `type:` key — catches the hierarchy
-  //     ternary (`type: cond ? "request_hierarchy" : "request_hierarchy_if_stale"`).
-  for (const line of source.split("\n")) {
-    if (!/\btype:/.test(line)) { continue; }
-    for (const m of line.matchAll(new RegExp(`"(${COMMAND_TOKEN})"`, "g"))) {
-      found.add(m[1]);
-    }
-  }
-  // 3. `CtrlProxyDatabase.request(<T>)("execute_sql", ...)` first-arg sends.
-  for (const m of source.matchAll(new RegExp(`\\.request<[^>]*>\\(\\s*"(${COMMAND_TOKEN})"`, "g"))) {
-    found.add(m[1]);
-  }
-
-  for (const denied of NON_REQUEST_TYPE_LITERALS) {
-    found.delete(denied);
-  }
-  return found;
+function iosEmitSourceFiles(): string[] {
+  const iosFiles = readdirSync(IOS_OBSERVE_DIR)
+    .filter(f => f.endsWith(".ts") && !f.endsWith(".test.ts") && !EXCLUDED_IOS_FILES.has(f))
+    .map(f => resolve(IOS_OBSERVE_DIR, f));
+  const sharedFiles = deriveIosSharedEmitFiles(IOS_CLIENT_ENTRY, SHARED_OBSERVE_DIR);
+  return [...iosFiles, ...sharedFiles];
 }
 
 /**
- * The scan only understands *literal* command strings. A template-literal discriminator
- * (`` type: `request_${kind}` ``) would evade it entirely, silently dropping coverage.
- * Rather than parse it, forbid it in the scanned files so the scan's assumption is
- * enforced: a build using a dynamic command `type` must be made statically analyzable
- * (or this guard updated deliberately). Ternaries-of-literals and `{ type }` shorthand
- * (a variable, covered by rule 3) are intentionally allowed.
+ * Extract every command `type`/`messageType` string a source file can put on the wire,
+ * using the TypeScript AST (issue #2955). Unlike the retired textual scan, this follows
+ * const-hoisted and parameter-forwarded discriminators to their literal (see
+ * `ctrlProxyWireScan.ts`). An emit site whose discriminator is NOT statically decidable
+ * (template literal, opaque expression) is returned in `unresolved` so the guard fails
+ * loudly rather than dropping coverage — the structural analog of the old template guard.
  */
-function findDynamicCommandTypes(source: string): string[] {
-  return [...source.matchAll(/\b(?:messageType|type):\s*`/g)].map(m => m[0]);
+function extractEmittedTypes(file: string, source: string): { emitted: Set<string>; unresolved: string[] } {
+  const result = scanFile(file, source);
+  const emitted = new Set(result.emitted.map(e => e.type));
+  for (const denied of NON_REQUEST_TYPE_LITERALS) {
+    emitted.delete(denied);
+  }
+  const unresolved = result.unresolved.map(u => `${u.file}:${u.line} ${u.text}`);
+  return { emitted, unresolved };
 }
 
 function readSwiftRequestTypeRawValues(): string[] {
@@ -208,18 +177,33 @@ describe("iOS control-proxy — RequestType contract coverage", () => {
 describe("iOS control-proxy — emitted commands are a subset of the runner contract", () => {
   const files = iosEmitSourceFiles();
   const allEmitted = new Set<string>();
+  const allUnresolved: string[] = [];
   for (const file of files) {
-    for (const type of extractEmittedTypes(readFileSync(file, "utf8"))) {
+    const { emitted, unresolved } = extractEmittedTypes(file, readFileSync(file, "utf8"));
+    for (const type of emitted) {
       allEmitted.add(type);
     }
+    allUnresolved.push(...unresolved);
   }
 
+  test("the shared-delegate scan set is derived from the iOS import graph", () => {
+    // Regression guard for #2955 gap 2: the shared files must be discovered via the
+    // import graph, not a hardcoded allowlist. The two delegates the client routes
+    // through today must both appear; a new one would appear automatically.
+    const shared = deriveIosSharedEmitFiles(IOS_CLIENT_ENTRY, SHARED_OBSERVE_DIR).map(f =>
+      f.slice(SHARED_OBSERVE_DIR.length + 1)
+    );
+    expect(shared).toContain("SharedTextDelegate.ts");
+    expect(shared).toContain("SharedGestureDelegate.ts");
+  });
+
   test("the scan actually finds emit sites (guards against a broken scanner)", () => {
-    // Anchors that must always be present, spanning all three emit patterns.
+    // Anchors that must always be present, spanning every resolvable emit shape.
     expect(allEmitted.has("request_tap_coordinates")).toBe(true); // messageType via shared delegate
     expect(allEmitted.has("get_preferences")).toBe(true); // type: object literal
-    expect(allEmitted.has("request_hierarchy")).toBe(true); // type: ternary
-    expect(allEmitted.has("execute_sql")).toBe(true); // .request(...) first arg
+    expect(allEmitted.has("request_hierarchy")).toBe(true); // type: ternary of literals
+    expect(allEmitted.has("request_hierarchy_if_stale")).toBe(true); // ternary other branch
+    expect(allEmitted.has("execute_sql")).toBe(true); // parameter-forwarded { type } shorthand
     expect(allEmitted.size).toBeGreaterThan(20);
   });
 
@@ -230,13 +214,12 @@ describe("iOS control-proxy — emitted commands are a subset of the runner cont
     expect(unknown).toEqual([]);
   });
 
-  test("no scanned file builds a command type from a template literal", () => {
-    // The literal scan can't follow `` type: `request_${kind}` `` and would silently
-    // drop coverage for it. Forbid the pattern so the scan's assumption stays valid.
-    const offenders = files.flatMap(file =>
-      findDynamicCommandTypes(readFileSync(file, "utf8")).map(hit => `${file}: ${hit}`)
-    );
-    expect(offenders).toEqual([]);
+  test("no scanned emit site has a statically-unresolvable command type", () => {
+    // The AST scanner resolves literals, ternaries-of-literals, const-hoisted and
+    // parameter-forwarded discriminators. Anything it CANNOT decide (a template literal,
+    // an opaque call) would silently drop coverage — fail loudly and force it to be made
+    // statically analyzable, the structural successor to the old template-literal guard.
+    expect(allUnresolved).toEqual([]);
   });
 
   test("IOS_RUNNER_FEATURE_COMMANDS is a subset of the known RequestType set", () => {

--- a/test/features/observe/ios/ctrlProxyWireScan.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireScan.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the structural (AST) wire scanner (issue #2955).
+ *
+ * These prove the scanner catches the two false-negatives the textual regex scan of
+ * #2857/#2950 missed — a const-hoisted discriminator and a parameter-forwarded
+ * `{ type }` shorthand — and that its emit-site detection is scoped to the outbound
+ * sinks so an inbound record carrying a `type` key is NOT counted as a wire command.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { deriveIosSharedEmitFiles, extractImportSpecifiers, scanFile } from "./ctrlProxyWireScan";
+
+const VIRTUAL = "/virtual/File.ts";
+
+function typesOf(source: string): string[] {
+  return scanFile(VIRTUAL, source).emitted.map(e => e.type).sort();
+}
+
+describe("ctrlProxyWireScan.scanFile — discriminator resolution", () => {
+  test("resolves a direct string-literal messageType in a sendCommand object", () => {
+    const src = `sendCommand(ctx, { messageType: "request_tap_coordinates", params });`;
+    expect(typesOf(src)).toEqual(["request_tap_coordinates"]);
+  });
+
+  test("resolves both branches of a ternary type in a JSON.stringify object", () => {
+    const src = `ws.send(JSON.stringify({ type: cond ? "request_hierarchy" : "request_hierarchy_if_stale", requestId }));`;
+    expect(typesOf(src)).toEqual(["request_hierarchy", "request_hierarchy_if_stale"]);
+  });
+
+  test("resolves a JSON.stringify of a const-bound object literal", () => {
+    const src = `
+      const message = { type: "list_preference_files", requestId };
+      ws.send(JSON.stringify(message));
+    `;
+    expect(typesOf(src)).toEqual(["list_preference_files"]);
+  });
+
+  // ---- #2955 gap 1: const-hoisted discriminator (regex scan missed this) ----
+  test("resolves a const-hoisted discriminator identifier (issue #2955 gap 1)", () => {
+    const src = `
+      const cmd = "request_shake";
+      ws.send(JSON.stringify({ type: cmd, requestId }));
+    `;
+    expect(typesOf(src)).toEqual(["request_shake"]);
+  });
+
+  // ---- #2955 gap 1b: parameter-forwarded { type } shorthand (CtrlProxyDatabase) ----
+  test("resolves a parameter-forwarded { type } shorthand via its call sites (issue #2955)", () => {
+    const src = `
+      class C {
+        run() { return this.request("execute_sql", "execute_sql_result"); }
+        other() { return this.request("list_tables", "list_tables_result"); }
+        private request(type: string, responseType: string) {
+          ws.send(JSON.stringify({ type, requestId }));
+        }
+      }
+    `;
+    expect(typesOf(src)).toEqual(["execute_sql", "list_tables"]);
+  });
+
+  test("reports an unresolved template-literal discriminator (does not silently drop it)", () => {
+    const src = "ws.send(JSON.stringify({ type: `request_${kind}`, requestId }));";
+    const result = scanFile(VIRTUAL, src);
+    expect(result.emitted).toEqual([]);
+    expect(result.unresolved).toHaveLength(1);
+    expect(result.unresolved[0].text).toContain("type:");
+  });
+
+  test("reports an unresolved opaque-expression discriminator", () => {
+    const src = `ws.send(JSON.stringify({ type: resolveKind(), requestId }));`;
+    const result = scanFile(VIRTUAL, src);
+    expect(result.emitted).toEqual([]);
+    expect(result.unresolved).toHaveLength(1);
+  });
+
+  // ---- sink-scoping: an inbound record carrying a `type` key is NOT a wire command ----
+  test("ignores a non-emit object's type key (not inside a sink)", () => {
+    const src = `recordSdkEvent({ type: envelope.eventType, timestamp, payload });`;
+    const result = scanFile(VIRTUAL, src);
+    expect(result.emitted).toEqual([]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  test("ignores a result classifier's type literal (not inside a sink)", () => {
+    const src = `return result.mode === "w" ? { type: "mutation", rows } : { type: "query", rows };`;
+    expect(typesOf(src)).toEqual([]);
+  });
+
+  test("ignores a non-command-like value (uppercase / non snake_case)", () => {
+    const src = `ws.send(JSON.stringify({ type: "NotACommand", requestId }));`;
+    const result = scanFile(VIRTUAL, src);
+    // Non-command-like literal is dropped from emitted but is a resolvable literal, so
+    // it is not flagged as unresolved either.
+    expect(result.emitted).toEqual([]);
+    expect(result.unresolved).toEqual([]);
+  });
+});
+
+describe("ctrlProxyWireScan.extractImportSpecifiers", () => {
+  test("collects static import and export-from specifiers", () => {
+    const src = `
+      import { A } from "../shared/SharedTextDelegate";
+      import type { B } from "./types";
+      export { C } from "../shared/SharedGestureDelegate";
+      const x = 1;
+    `;
+    expect(extractImportSpecifiers(src, VIRTUAL).sort()).toEqual([
+      "../shared/SharedGestureDelegate",
+      "../shared/SharedTextDelegate",
+      "./types",
+    ]);
+  });
+});
+
+describe("ctrlProxyWireScan.deriveIosSharedEmitFiles — import-graph derivation (issue #2955 gap 2)", () => {
+  test("discovers a shared delegate reachable transitively, skipping types.ts and tests", () => {
+    const root = mkdtempSync(join(tmpdir(), "wirescan-"));
+    try {
+      const iosDir = join(root, "ios");
+      const sharedDir = join(root, "shared");
+      mkdirSync(iosDir);
+      mkdirSync(sharedDir);
+
+      // Entry imports a delegate directly and another indirectly through it.
+      writeFileSync(
+        join(iosDir, "Client.ts"),
+        `import { Text } from "../shared/SharedTextDelegate";\nimport type { T } from "../shared/types";\n`
+      );
+      writeFileSync(
+        join(sharedDir, "SharedTextDelegate.ts"),
+        `import { Nav } from "./SharedNavDelegate";\nexport const Text = 1;\n`
+      );
+      // A NEW shared delegate reached only transitively — must be discovered.
+      writeFileSync(join(sharedDir, "SharedNavDelegate.ts"), `export const Nav = 1;\n`);
+      writeFileSync(join(sharedDir, "types.ts"), `export type T = string;\n`);
+      writeFileSync(join(sharedDir, "SharedTextDelegate.test.ts"), `export const t = 1;\n`);
+
+      const derived = deriveIosSharedEmitFiles(join(iosDir, "Client.ts"), sharedDir).map(f =>
+        f.slice(sharedDir.length + 1)
+      );
+
+      expect(derived).toEqual(["SharedNavDelegate.ts", "SharedTextDelegate.ts"]);
+      // types.ts (type-only) and the .test.ts are excluded.
+      expect(derived).not.toContain("types.ts");
+      expect(derived).not.toContain("SharedTextDelegate.test.ts");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns empty when the entry reaches no shared file", () => {
+    const root = mkdtempSync(join(tmpdir(), "wirescan-"));
+    try {
+      const iosDir = join(root, "ios");
+      const sharedDir = join(root, "shared");
+      mkdirSync(iosDir);
+      mkdirSync(sharedDir);
+      writeFileSync(join(iosDir, "Client.ts"), `export const x = 1;\n`);
+      writeFileSync(join(sharedDir, "SharedTextDelegate.ts"), `export const Text = 1;\n`);
+      expect(deriveIosSharedEmitFiles(join(iosDir, "Client.ts"), sharedDir)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/features/observe/ios/ctrlProxyWireScan.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireScan.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { deriveIosSharedEmitFiles, extractImportSpecifiers, scanFile } from "./ctrlProxyWireScan";
+import { deriveIosSharedEmitFiles, extractImportSpecifiers, scanFile, toPosixPath } from "./ctrlProxyWireScan";
 
 const VIRTUAL = "/virtual/File.ts";
 
@@ -112,6 +112,25 @@ describe("ctrlProxyWireScan.extractImportSpecifiers", () => {
       "../shared/SharedTextDelegate",
       "./types",
     ]);
+  });
+});
+
+describe("ctrlProxyWireScan.toPosixPath — separator-independence guard (issue #2955, Windows CI)", () => {
+  // The import-graph derivation prefix-compares resolved fs paths against the shared
+  // directory. On Windows `path.resolve` yields backslash separators; comparing those
+  // against a forward-slash-joined prefix never matches and silently empties the derived
+  // set. This pins that any backslash-containing path is normalized to forward slashes so
+  // the comparison is OS-agnostic — Windows cannot regress silently.
+  test("normalizes backslash-separated paths to forward slashes", () => {
+    expect(toPosixPath("C:\\repo\\src\\shared\\SharedTextDelegate.ts")).toBe(
+      "C:/repo/src/shared/SharedTextDelegate.ts"
+    );
+  });
+
+  test("leaves already-posix paths unchanged", () => {
+    expect(toPosixPath("/repo/src/shared/SharedTextDelegate.ts")).toBe(
+      "/repo/src/shared/SharedTextDelegate.ts"
+    );
   });
 });
 

--- a/test/features/observe/ios/ctrlProxyWireScan.ts
+++ b/test/features/observe/ios/ctrlProxyWireScan.ts
@@ -1,0 +1,398 @@
+/**
+ * Structural (TypeScript-AST) scanner for the iOS control-proxy wire-parity tripwire.
+ *
+ * This replaces the textual-regex `extractEmittedTypes` that shipped with #2857/#2950.
+ * The regex scan caught direct drift but was defeated by ordinary refactors that the
+ * PR #2950 3-perspective review reproduced (issue #2955):
+ *
+ *   1. **Const-hoisted discriminator** —
+ *      `const cmd = "request_x"; ws.send(JSON.stringify({ type: cmd, requestId }))`.
+ *      The `type:` property has no literal on its line, so a textual scan misses it.
+ *   2. **Parameter-forwarded discriminator** — `CtrlProxyDatabase` sends via
+ *      `JSON.stringify({ type, requestId, ... })` shorthand where `type` is a method
+ *      parameter; the real command literal only exists at the call site
+ *      (`this.request("execute_sql", ...)`).
+ *   3. **Hardcoded shared-file allowlist** — `SHARED_EMIT_FILES` was a literal array; a
+ *      new shared delegate the iOS client routes through could silently go unscanned.
+ *
+ * The AST scanner resolves `type`/`messageType` property values to their literal by
+ * following simple, statically-decidable bindings: string literals, ternaries of
+ * literals, and identifiers bound to a `const`/`let` string literal or a parameter that
+ * only ever receives string-literal arguments across the file's call sites. The shared
+ * file list is derived from the iOS client's transitive import graph (see
+ * `deriveIosSharedEmitFiles`), so a missed delegate cannot go unscanned.
+ */
+
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import ts from "typescript";
+
+/** A resolved command discriminator plus where it was found (for diagnostics). */
+export interface EmittedType {
+  readonly type: string;
+  readonly file: string;
+}
+
+/** An emit site whose discriminator could not be statically resolved to a literal. */
+export interface UnresolvedEmit {
+  readonly file: string;
+  /** 1-based line number of the offending `type:`/`messageType:` property. */
+  readonly line: number;
+  /** The source text of the property, for the failure message. */
+  readonly text: string;
+}
+
+/** Result of scanning one source file. */
+export interface FileScanResult {
+  readonly emitted: EmittedType[];
+  readonly unresolved: UnresolvedEmit[];
+}
+
+const COMMAND_TOKEN = /^[a-z][a-z0-9_]*$/;
+
+function isCommandLike(value: string): boolean {
+  return COMMAND_TOKEN.test(value);
+}
+
+function parseSourceFile(file: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(file, source, ts.ScriptTarget.Latest, /* setParentNodes*/ true, ts.ScriptKind.TS);
+}
+
+/**
+ * Collect, for every string-literal `.request(...)` / `sendCommand(...)` / method call
+ * argument in the file, which parameter names of which functions receive a string
+ * literal. Keyed by parameter name so an identifier forwarded through a `{ type }`
+ * shorthand can be resolved to the literal(s) that flow into that parameter.
+ *
+ * This is deliberately conservative: it maps a *parameter name* to every string literal
+ * passed positionally to a same-named parameter of any function/method in the file. That
+ * over-approximates (it does not do call-graph-precise binding), which is exactly the
+ * safe direction for a tripwire — it can only add real literals that appear in source,
+ * never invent one, and a genuinely-unknown command still fails the subset assertion.
+ */
+function collectParameterLiterals(sourceFile: ts.SourceFile): Map<string, Set<string>> {
+  // paramName -> declaring function's positional index (first declaration wins).
+  const paramIndex = new Map<string, number>();
+  // function-like nodes keyed by nothing; we only need the (paramName -> index) map and
+  // then the literal args at each positional index across call sites.
+  const indexLiterals = new Map<number, Set<string>>();
+
+  const recordParam = (name: string, index: number): void => {
+    if (!paramIndex.has(name)) {
+      paramIndex.set(name, index);
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isConstructorDeclaration(node)
+    ) {
+      node.parameters.forEach((param, index) => {
+        if (ts.isIdentifier(param.name)) {
+          recordParam(param.name.text, index);
+        }
+      });
+    }
+    if (ts.isCallExpression(node)) {
+      node.arguments.forEach((arg, index) => {
+        if (ts.isStringLiteralLike(arg) && isCommandLike(arg.text)) {
+          let set = indexLiterals.get(index);
+          if (!set) {
+            set = new Set<string>();
+            indexLiterals.set(index, set);
+          }
+          set.add(arg.text);
+        }
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  const result = new Map<string, Set<string>>();
+  for (const [name, index] of paramIndex) {
+    const literals = indexLiterals.get(index);
+    if (literals && literals.size > 0) {
+      result.set(name, new Set(literals));
+    }
+  }
+  return result;
+}
+
+/** Collect `const`/`let` identifiers initialized to a command-like string literal. */
+function collectConstStringBindings(sourceFile: ts.SourceFile): Map<string, string> {
+  const bindings = new Map<string, string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isStringLiteralLike(node.initializer) &&
+      isCommandLike(node.initializer.text)
+    ) {
+      // First binding wins; shadowing across scopes is not modeled (safe over-approx).
+      if (!bindings.has(node.name.text)) {
+        bindings.set(node.name.text, node.initializer.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return bindings;
+}
+
+/**
+ * Resolve the string values an expression assigned to a `type`/`messageType` property
+ * can take. Returns the resolved literals, or `null` if the expression is not
+ * statically decidable (which the caller records as an unresolved emit site).
+ */
+function resolveDiscriminatorValues(
+  expr: ts.Expression,
+  constBindings: Map<string, string>,
+  paramLiterals: Map<string, Set<string>>
+): string[] | null {
+  if (ts.isStringLiteralLike(expr)) {
+    return isCommandLike(expr.text) ? [expr.text] : [];
+  }
+  if (ts.isConditionalExpression(expr)) {
+    const whenTrue = resolveDiscriminatorValues(expr.whenTrue, constBindings, paramLiterals);
+    const whenFalse = resolveDiscriminatorValues(expr.whenFalse, constBindings, paramLiterals);
+    if (whenTrue === null || whenFalse === null) {
+      return null;
+    }
+    return [...whenTrue, ...whenFalse];
+  }
+  if (ts.isIdentifier(expr)) {
+    const bound = constBindings.get(expr.text);
+    if (bound !== undefined) {
+      return [bound];
+    }
+    const fromParams = paramLiterals.get(expr.text);
+    if (fromParams && fromParams.size > 0) {
+      return [...fromParams];
+    }
+    // Unknown identifier — cannot decide statically.
+    return null;
+  }
+  // Template literals, calls, property access, etc. are not statically decidable here.
+  return null;
+}
+
+/**
+ * The property key that carries the command discriminator, per emit sink:
+ *   - `sendCommand(ctx, { messageType, ... })` — the shared delegate sink.
+ *   - `JSON.stringify({ type, ... })` / `ws.send(JSON.stringify(msg))` — the raw sink.
+ * Scoping detection to these sinks (rather than every `type:` property in the file) is
+ * what distinguishes an OUTBOUND wire command from an inbound record that happens to
+ * carry a `type` key (e.g. `recordSdkEvent({ type: envelope.eventType })`).
+ */
+type SinkKind = "sendCommand" | "jsonStringify";
+const SINK_DISCRIMINATOR: Record<SinkKind, string> = {
+  sendCommand: "messageType",
+  jsonStringify: "type",
+};
+
+/** Map `const foo = { ... }` object-literal bindings so `JSON.stringify(foo)` resolves. */
+function collectObjectLiteralBindings(sourceFile: ts.SourceFile): Map<string, ts.ObjectLiteralExpression> {
+  const bindings = new Map<string, ts.ObjectLiteralExpression>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isObjectLiteralExpression(node.initializer) &&
+      !bindings.has(node.name.text)
+    ) {
+      bindings.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return bindings;
+}
+
+/**
+ * Scan one source file with the TS AST for every command discriminator it can emit.
+ *
+ * Detection is scoped to the two outbound sinks (`sendCommand(...)` and
+ * `JSON.stringify(...)`). Within an emit object literal the discriminator property value
+ * is resolved structurally: string literals, ternaries of literals, `const`-hoisted
+ * identifiers, and parameter-forwarded `{ type }` shorthand (the `CtrlProxyDatabase`
+ * case). An unresolved discriminator (template literal, opaque call, unknown identifier)
+ * is reported so the guard fails loudly rather than silently dropping coverage — the
+ * structural successor to the old `findDynamicCommandTypes` template guard.
+ */
+export function scanFile(file: string, source: string): FileScanResult {
+  const sourceFile = parseSourceFile(file, source);
+  const constBindings = collectConstStringBindings(sourceFile);
+  const paramLiterals = collectParameterLiterals(sourceFile);
+  const objectBindings = collectObjectLiteralBindings(sourceFile);
+
+  const emitted: EmittedType[] = [];
+  const unresolved: UnresolvedEmit[] = [];
+
+  const recordEmitObject = (obj: ts.ObjectLiteralExpression, key: string): void => {
+    for (const prop of obj.properties) {
+      if (ts.isPropertyAssignment(prop) && !ts.isComputedPropertyName(prop.name)) {
+        const propKey =
+          ts.isIdentifier(prop.name) || ts.isStringLiteralLike(prop.name) ? prop.name.text : undefined;
+        if (propKey === key) {
+          recordDiscriminator(prop.initializer, prop);
+        }
+      } else if (ts.isShorthandPropertyAssignment(prop) && prop.name.text === key) {
+        // `{ type }` shorthand — resolve the identifier through the binding maps.
+        recordDiscriminator(prop.name, prop);
+      }
+    }
+  };
+
+  function recordDiscriminator(valueExpr: ts.Expression, node: ts.Node): void {
+    const resolved = resolveDiscriminatorValues(valueExpr, constBindings, paramLiterals);
+    if (resolved === null) {
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      unresolved.push({ file, line: line + 1, text: node.getText(sourceFile).trim() });
+      return;
+    }
+    for (const value of resolved) {
+      emitted.push({ type: value, file });
+    }
+  }
+
+  /** Resolve a sink argument to its object literal (directly or via a const binding). */
+  const resolveSinkObject = (arg: ts.Expression | undefined): ts.ObjectLiteralExpression | undefined => {
+    if (!arg) {
+      return undefined;
+    }
+    if (ts.isObjectLiteralExpression(arg)) {
+      return arg;
+    }
+    if (ts.isIdentifier(arg)) {
+      return objectBindings.get(arg.text);
+    }
+    return undefined;
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      // `sendCommand(context, { messageType, ... })` — discriminator in the 2nd arg.
+      if (ts.isIdentifier(callee) && callee.text === "sendCommand") {
+        const obj = resolveSinkObject(node.arguments[1]);
+        if (obj) {
+          recordEmitObject(obj, SINK_DISCRIMINATOR.sendCommand);
+        }
+      }
+      // `JSON.stringify({ type, ... })` — discriminator in the sole arg.
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) &&
+        callee.expression.text === "JSON" &&
+        callee.name.text === "stringify"
+      ) {
+        const obj = resolveSinkObject(node.arguments[0]);
+        if (obj) {
+          recordEmitObject(obj, SINK_DISCRIMINATOR.jsonStringify);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  return { emitted, unresolved };
+}
+
+/**
+ * Extract the module specifiers imported by a source file (static `import` + `export
+ * from` only; dynamic `import()` is not followed — the iOS client uses none for
+ * delegates). Returns raw specifier strings (e.g. `"../shared/SharedTextDelegate"`).
+ */
+export function extractImportSpecifiers(source: string, file: string): string[] {
+  const sourceFile = parseSourceFile(file, source);
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return specifiers;
+}
+
+/** Resolve a relative module specifier to an absolute `.ts` path, if it exists. */
+function resolveTsModule(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) {
+    return null; // package import — not part of the first-party emit graph.
+  }
+  const base = resolve(dirname(fromFile), specifier);
+  const candidates = [`${base}.ts`, resolve(base, "index.ts")];
+  for (const candidate of candidates) {
+    try {
+      readFileSync(candidate, "utf8");
+      return candidate;
+    } catch {
+      // Not this candidate; try the next. Missing module is expected during probing.
+    }
+  }
+  return null;
+}
+
+/**
+ * Derive the set of shared-directory emit files reachable from the iOS client's
+ * transitive first-party import graph. This replaces the hardcoded `SHARED_EMIT_FILES`
+ * allowlist (issue #2955 gap 2): a new `shared/` delegate the iOS client routes through
+ * is discovered automatically, so a missed delegate can't silently go unscanned.
+ *
+ * @param entry            Absolute path of the iOS client entrypoint to walk from.
+ * @param sharedDir        Absolute path of `src/features/observe/shared`.
+ * @returns Absolute paths of files under `sharedDir` (excluding `*.test.ts` and pure
+ *          type-only `types.ts`) reachable from `entry`.
+ */
+export function deriveIosSharedEmitFiles(entry: string, sharedDir: string): string[] {
+  const visited = new Set<string>();
+  const sharedHits = new Set<string>();
+  const normalizedSharedDir = resolve(sharedDir);
+
+  const walk = (file: string): void => {
+    if (visited.has(file)) {
+      return;
+    }
+    visited.add(file);
+
+    let source: string;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch {
+      // A resolved-but-unreadable module is unexpected; skip it rather than crash the
+      // scan. resolveTsModule already confirmed readability, so this is belt-and-braces.
+      return;
+    }
+
+    if (resolve(file).startsWith(`${normalizedSharedDir}/`)) {
+      const isTest = file.endsWith(".test.ts");
+      const isTypesOnly = file.endsWith("/types.ts");
+      if (!isTest && !isTypesOnly) {
+        sharedHits.add(resolve(file));
+      }
+    }
+
+    for (const specifier of extractImportSpecifiers(source, file)) {
+      const resolved = resolveTsModule(file, specifier);
+      if (resolved) {
+        walk(resolved);
+      }
+    }
+  };
+
+  walk(resolve(entry));
+  return [...sharedHits].sort();
+}

--- a/test/features/observe/ios/ctrlProxyWireScan.ts
+++ b/test/features/observe/ios/ctrlProxyWireScan.ts
@@ -27,6 +27,21 @@ import { readFileSync } from "fs";
 import { dirname, resolve } from "path";
 import ts from "typescript";
 
+/**
+ * Normalize a filesystem path to forward-slash (posix) separators so that path
+ * comparisons and prefix checks in the import graph are OS-agnostic. On Windows,
+ * `path.resolve` yields backslash separators; comparing those against a
+ * forward-slash-joined prefix (or a forward-slash import-derived key) never
+ * matches, which silently empties the derived emit set (issue #2955, Windows CI).
+ *
+ * Exported so a unit test can pin the separator-independence directly. Unconditionally
+ * rewrites backslashes so the guard is meaningful on posix CI too (a no-op for paths
+ * that already use forward slashes).
+ */
+export function toPosixPath(p: string): string {
+  return p.replaceAll("\\", "/");
+}
+
 /** A resolved command discriminator plus where it was found (for diagnostics). */
 export interface EmittedType {
   readonly type: string;
@@ -360,7 +375,9 @@ function resolveTsModule(fromFile: string, specifier: string): string | null {
 export function deriveIosSharedEmitFiles(entry: string, sharedDir: string): string[] {
   const visited = new Set<string>();
   const sharedHits = new Set<string>();
-  const normalizedSharedDir = resolve(sharedDir);
+  // Compare in posix space so backslash-separated resolved paths on Windows still
+  // prefix-match the shared directory (issue #2955).
+  const normalizedSharedDir = toPosixPath(resolve(sharedDir));
 
   const walk = (file: string): void => {
     if (visited.has(file)) {
@@ -377,9 +394,10 @@ export function deriveIosSharedEmitFiles(entry: string, sharedDir: string): stri
       return;
     }
 
-    if (resolve(file).startsWith(`${normalizedSharedDir}/`)) {
-      const isTest = file.endsWith(".test.ts");
-      const isTypesOnly = file.endsWith("/types.ts");
+    const posixFile = toPosixPath(resolve(file));
+    if (posixFile.startsWith(`${normalizedSharedDir}/`)) {
+      const isTest = posixFile.endsWith(".test.ts");
+      const isTypesOnly = posixFile.endsWith("/types.ts");
       if (!isTest && !isTypesOnly) {
         sharedHits.add(resolve(file));
       }


### PR DESCRIPTION
Closes #2955.

Follow-up to #2857 / #2950 (and the #2954 field backstop): replaces the textual-regex iOS control-proxy wire-parity scan with a **structural TypeScript-AST scan** and an **import-graph-derived shared-file list**, closing the two residual false-negatives the PR #2950 3-perspective review reproduced.

## What changed
- **New `test/features/observe/ios/ctrlProxyWireScan.ts`** — an AST scanner that:
  - Scopes emit-site detection to the two real outbound sinks (`sendCommand(ctx, { messageType })` and `JSON.stringify({ type })`, incl. a `const msg = {...}; JSON.stringify(msg)` binding), so an inbound record that merely carries a `type` key (`recordSdkEvent({ type: envelope.eventType })`, the `{ type: "mutation" }` result classifier) is **not** miscounted as a wire command.
  - Resolves the discriminator value structurally: string literals, ternaries-of-literals, **const-hoisted identifiers** (`const cmd = "request_x"; JSON.stringify({ type: cmd })` — gap 1), and **parameter-forwarded `{ type }` shorthand** (`CtrlProxyDatabase.request(type, ...)` fed by `this.request("execute_sql", ...)` call sites — gap 1b).
  - Flags any discriminator it **cannot** decide statically (template literal, opaque call) as `unresolved` so the guard fails loudly instead of silently dropping coverage — the structural successor to the old `findDynamicCommandTypes` template guard.
  - `deriveIosSharedEmitFiles()` walks the iOS client's transitive first-party import graph and returns the reachable `shared/` emit files (excluding `*.test.ts` and type-only `types.ts`), **replacing the hardcoded `SHARED_EMIT_FILES` allowlist** (gap 2) — a new iOS-routed shared delegate is scanned automatically.
- **`ctrlProxyWireParity.test.ts`** now uses the AST scanner + derived shared list; adds a "shared set is derived, not hardcoded" regression test and a "no statically-unresolvable emit site" guard; drops the retired regex helpers.
- **New `ctrlProxyWireScan.test.ts`** — unit tests proving both #2955 gaps are caught, the sink-scoping excludes inbound records, and the import-graph derivation discovers a transitively-reached delegate.

## Acceptance criteria
- ✅ A const-hoisted / dynamically-referenced command `type` in a scanned iOS emit file is caught (unit tests `resolves a const-hoisted discriminator identifier`, `resolves a parameter-forwarded { type } shorthand`).
- ✅ The scanned shared-file set is derived, not hardcoded; a new iOS-routed shared delegate is scanned automatically (`deriveIosSharedEmitFiles` + regression test).

## Validation
- `bun test test/features/observe/ios/` → 191 pass / 0 fail.
- **No regression:** the AST scanner emits the **exact same 37-command set** as the retired regex scanner (verified by diffing both emit sets) — nothing dropped or spuriously added — while additionally catching the const-hoist / parameter-forward cases.
- `bunx turbo run lint build` → pass. `bun run typecheck` → no new type errors.

## Caveats
- Test-only change; no `src/` production code, no Swift/pbxproj changes (scanner is a pure-TS test helper), so no release re-cut needed.
- Parameter-forwarding maps a param name to every string literal passed to that positional arg across the file (a conservative over-approximation). This can only add source-present literals, never invent one; a genuinely-unknown command still fails the subset assertion. Documented inline.
