### PR TITLE
test(server): make #2962 DEBUG-gate omission trace deterministic (#3256)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -52,6 +52,14 @@ export interface Logger {
   disableStdoutLogging(): void;
 
   /**
+   * Awaits any in-flight fire-and-forget log writes so callers (chiefly tests)
+   * can deterministically observe a just-emitted line at the sink instead of
+   * racing the async write with a real-timer poll. Resolves once the most
+   * recent write settled; never rejects (write failures are already swallowed).
+   */
+  flush(): Promise<void>;
+
+  /**
    * Closes the log stream
    */
   close(): void;
@@ -106,6 +114,16 @@ let currentLogLevel: LogLevel = LogLevel.INFO;
 
 // Flag to control whether to also log to STDOUT (in addition to files)
 let logToStdout = false;
+
+// Tracks the most recent in-flight write so `flush()` can await it. Writes are
+// fire-and-forget for latency, but tests need a deterministic barrier to observe
+// a just-emitted line at the sink without racing a real-timer poll. Each level
+// method appends its write to this chain; `flush()` awaits the tail. The chain
+// never rejects (write errors are swallowed inside writeToLogFile).
+let lastWrite: Promise<void> = Promise.resolve();
+const trackWrite = (write: Promise<void>): void => {
+  lastWrite = lastWrite.then(() => write);
+};
 
 // Create logs directory if it doesn't exist. Use getTempDir so the location
 // honors TMPDIR and matches the rest of the auto-mobile temp tree (rather than a
@@ -306,9 +324,9 @@ export const logger: Logger = {
    */
   debug(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.DEBUG) {
-      writeToLogFile("DEBUG", message, args).catch(err => {
+      trackWrite(writeToLogFile("DEBUG", message, args).catch(err => {
         console.error("Failed to write debug log:", err);
-      });
+      }));
     }
   },
 
@@ -317,9 +335,9 @@ export const logger: Logger = {
    */
   info(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.INFO) {
-      writeToLogFile("INFO", message, args).catch(err => {
+      trackWrite(writeToLogFile("INFO", message, args).catch(err => {
         console.error("Failed to write info log:", err);
-      });
+      }));
     }
   },
 
@@ -328,9 +346,9 @@ export const logger: Logger = {
    */
   warn(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.WARN) {
-      writeToLogFile("WARN", message, args).catch(err => {
+      trackWrite(writeToLogFile("WARN", message, args).catch(err => {
         console.error("Failed to write warn log:", err);
-      });
+      }));
     }
   },
 
@@ -339,10 +357,17 @@ export const logger: Logger = {
    */
   error(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.ERROR) {
-      writeToLogFile("ERROR", message, args).catch(err => {
+      trackWrite(writeToLogFile("ERROR", message, args).catch(err => {
         console.error("Failed to write error log:", err);
-      });
+      }));
     }
+  },
+
+  /**
+   * Awaits any in-flight fire-and-forget log writes. See interface docs.
+   */
+  async flush(): Promise<void> {
+    await lastWrite;
   },
 
   /**

--- a/test/fakes/FakeLogger.ts
+++ b/test/fakes/FakeLogger.ts
@@ -40,6 +40,8 @@ export class FakeLogger implements Logger {
 
   enableStdoutLogging(): void {}
   disableStdoutLogging(): void {}
+  // Writes are synchronous in the fake, so there is nothing in flight to await.
+  async flush(): Promise<void> {}
   close(): void {}
 
   /** Messages emitted at the given level. */

--- a/test/server/stripToolResultWireBoundary.test.ts
+++ b/test/server/stripToolResultWireBoundary.test.ts
@@ -203,15 +203,11 @@ describe("CallTool wire boundary debug-logs structuredContent omission (issue #2
   // ---- Real level-gate coverage (issue #3215) ----
   //
   // The logger's file/stdout writes are fire-and-forget async (each performs one
-  // real fs.stat before writing), so sink assertions flush with a bounded
-  // event-loop poll rather than a fixed sleep. This is I/O settling, not
-  // time-based logic, so FakeTimer does not apply; the loop exits on the first
-  // tick the predicate holds (typically 1-2 ticks).
-  const flushSink = async (done: () => boolean): Promise<void> => {
-    for (let i = 0; i < 200 && !done(); i++) {
-      await new Promise<void>(resolve => setImmediate(resolve));
-    }
-  };
+  // real fs.stat before writing). Rather than race that async write with a
+  // real-timer poll (which timed out under concurrent CI load and produced the
+  // intermittent `Received: []` flake tracked in #3256), we await the logger's
+  // own `flush()` barrier — it resolves once the most recent write has settled,
+  // so the sink assertion is deterministic regardless of host load.
 
   // Extract the level and structured fields of omission traces that actually
   // reached the stdout sink for the given probe tool. Anchored to the exact
@@ -244,7 +240,7 @@ describe("CallTool wire boundary debug-logs structuredContent omission (issue #2
       // landed. info() passes the INFO gate; the omission trace must not have.
       const SENTINEL = "__sink_flush_sentinel_3215__";
       logger.info(SENTINEL);
-      await flushSink(() => stdoutSpy.mock.calls.some(args => String(args[0] ?? "").includes(SENTINEL)));
+      await logger.flush();
       expect(stdoutSpy.mock.calls.some(args => String(args[0] ?? "").includes(SENTINEL))).toBe(true);
 
       expect(sinkOmissionFields(stdoutSpy.mock.calls, NOSCHEMA_TOOL)).toEqual([]);
@@ -265,7 +261,10 @@ describe("CallTool wire boundary debug-logs structuredContent omission (issue #2
       const { client } = fixture.getContext();
       await client.callTool({ name: NOSCHEMA_TOOL, arguments: {} });
 
-      await flushSink(() => sinkOmissionFields(stdoutSpy.mock.calls, NOSCHEMA_TOOL).length > 0);
+      // Deterministic barrier: await the logger's in-flight write instead of
+      // polling with a real-timer loop (the #3256 flake). Once flush() resolves
+      // the DEBUG omission trace has reached the stdout sink.
+      await logger.flush();
       // Structured fields (issue #3216) are asserted by object equality — the
       // sink line carries the exact { tool, reason } payload, exactly once, at
       // DEBUG level specifically.


### PR DESCRIPTION
## Summary
Makes the flaky #2962 DEBUG-gate omission-trace test deterministic. This test intermittently blocked CI (it failed PRs #3253 and #3260) with `Received: []` under concurrent load, while passing in isolation.

Closes #3256

## Root cause
`test/server/stripToolResultWireBoundary.test.ts` (the "real gate at DEBUG" test) waited for the async, fire-and-forget log write to reach the stdout sink via a **real-timer poll** (`flushSink` → bounded `setImmediate` loop). `logger.debug()` calls `writeToLogFile(...)` — which performs a real `fs.stat` before writing — and discards the promise. Under concurrent CI load the poll's 200-iteration budget exhausted before that async write landed, so the assertion saw an empty array. This is the same load-sensitive real-timer poll flake class already documented in the repo.

## Fix
- Add a small `flush(): Promise<void>` barrier to the `Logger` interface + implementation. Each level method now chains its write into a tracked `lastWrite` promise; `flush()` awaits the tail. Never rejects (write errors are already swallowed).
- The test awaits `logger.flush()` instead of polling — deterministic regardless of host load. Assertion is unchanged (still asserts exactly one DEBUG trace with `{ tool, reason: "no-schema" }`).
- `FakeLogger` implements the new interface method (no-op; fake writes are synchronous).

The assertion was not weakened and no timeout was bumped — the wait is now a real barrier.

## Validation
- `bun test test/server/stripToolResultWireBoundary.test.ts` → 8 pass
- Ordering stress: `bun test test/server/` run 5x → 860 pass / 0 fail every run (exercises the INFO-before-DEBUG suite ordering that could bleed level state)
- `bun run typecheck` → no new errors
- `turbo run lint build` → clean
