### PR TITLE
test(daemon): extract #2871 startup-ordering seams for unit testing

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -26,6 +26,7 @@ import { closeDatabase, getDatabasePath, getDbWriteBarrier } from "../db";
 import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
 import { handleFatalDatabaseStartupFailure } from "./daemonStartupGuard";
+import { runStartupPrologue } from "./startupPrologue";
 import { startupBenchmark } from "../utils/startupBenchmark";
 import { startVideoRecordingSocketServer, stopVideoRecordingSocketServer } from "./videoRecordingSocketServer";
 import { startTestRecordingSocketServer, stopTestRecordingSocketServer } from "./testRecordingSocketServer";
@@ -236,10 +237,12 @@ export class Daemon {
     // Publish the owned DB path in the PID file BEFORE opening the DB so the
     // direct-mode DB-ownership guard can tell a same-file collision from an
     // isolated-path launch during our own multi-second startup window, instead
-    // of failing closed on an unknown path. Issue #2871.
-    await this.writeEarlyOwnerRecord();
-
-    await this.initializeDatabase();
+    // of failing closed on an unknown path. The ordering lives behind
+    // runStartupPrologue() so it can be asserted with fakes (issue #2871).
+    await runStartupPrologue({
+      writeEarlyOwnerRecord: () => this.writeEarlyOwnerRecord(),
+      initializeDatabase: () => this.initializeDatabase(),
+    });
 
     // Find an available port
     this.port = await this.findAvailablePort(this.port);

--- a/src/daemon/directModeStartup.ts
+++ b/src/daemon/directModeStartup.ts
@@ -1,0 +1,38 @@
+/**
+ * The direct-mode (non-daemon) startup ordering, extracted behind an interface
+ * so the invariant can be unit-tested directly instead of only by reading
+ * `src/index.ts` (there is no `main()` test harness). Issue #2871 stretch AC.
+ *
+ * The invariant: under `--no-proxy`/`--direct` the DB-ownership guard MUST run
+ * BEFORE the first DB touch. When proxy mode is used (`noProxy` false), the guard
+ * is skipped entirely — the daemon owns the DB and the guard doesn't apply.
+ */
+export interface DirectModeStartupSteps {
+  /** True only under `--no-proxy`/`--direct`. */
+  noProxy: boolean;
+  /**
+   * Refuse startup if a live daemon already owns this DB file (see
+   * {@link import("./directModeGuard").assertDirectModeDbOwnership}). Invoked
+   * ONLY under `noProxy`, and always BEFORE {@link applyFeatureFlagStartup}.
+   */
+  assertDbOwnership(): Promise<void>;
+  /**
+   * The first DB touch: migration-gated feature-flag initialize() reads plus the
+   * CLI-override setFlag() writes. Opens the shared SQLite DB and runs migrations.
+   */
+  applyFeatureFlagStartup(): Promise<void>;
+}
+
+/**
+ * Run the direct-mode startup steps in the required order. Under `--no-proxy`
+ * the ownership guard runs before the first DB touch so a second writer on a
+ * daemon-owned SQLite file is refused before this process opens it (issue #2795).
+ * With an isolated `AUTOMOBILE_DB_PATH` the guard is a no-op and startup proceeds
+ * normally. In proxy mode the guard is skipped altogether.
+ */
+export async function runDirectModeStartup(steps: DirectModeStartupSteps): Promise<void> {
+  if (steps.noProxy) {
+    await steps.assertDbOwnership();
+  }
+  await steps.applyFeatureFlagStartup();
+}

--- a/src/daemon/startupPrologue.ts
+++ b/src/daemon/startupPrologue.ts
@@ -1,0 +1,32 @@
+/**
+ * The two database-bringup steps that must run — in this exact order — at the
+ * very front of {@link import("./daemon").Daemon.start}: publish the daemon's
+ * owned DB path in the PID file, THEN open and migrate the shared SQLite DB.
+ *
+ * They live behind this interface so the ordering can be asserted directly with
+ * fakes — no real PID-file write, no real DB, and none of `start()`'s process
+ * side effects (lifecycle handlers, `process.chdir`) — per the #2871 stretch AC.
+ */
+export interface StartupPrologueSteps {
+  /**
+   * Publish this daemon's resolved DB path in the PID file BEFORE the DB is
+   * opened, so the direct-mode ownership guard can distinguish a same-file
+   * collision from an isolated-path launch during startup. Issue #2871.
+   */
+  writeEarlyOwnerRecord(): Promise<void>;
+  /** Open the shared SQLite DB and await startup migrations. */
+  initializeDatabase(): Promise<void>;
+}
+
+/**
+ * Run the startup DB-bringup prologue in the fixed order the direct-mode
+ * ownership guard depends on: the early owner record (which records `dbPath`)
+ * MUST be persisted before {@link StartupPrologueSteps.initializeDatabase} opens
+ * the DB. Otherwise a concurrent direct-mode launch could observe a live daemon
+ * with an unknown owned path during the multi-second startup window and fail
+ * closed even against an isolated `AUTOMOBILE_DB_PATH`. Issue #2871.
+ */
+export async function runStartupPrologue(steps: StartupPrologueSteps): Promise<void> {
+  await steps.writeEarlyOwnerRecord();
+  await steps.initializeDatabase();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -542,16 +542,22 @@ async function main() {
     } else {
       // Direct mode (--no-proxy/--direct) opens the shared SQLite DB in-process
       // with no cross-process lock. Refuse BEFORE the first DB touch (feature-flag
-      // startup below opens the DB and runs migrations) if a live daemon already
-      // owns the SAME resolved DB file, to avoid two writers on one sqlite file
+      // startup opens the DB and runs migrations) if a live daemon already owns
+      // the SAME resolved DB file, to avoid two writers on one sqlite file
       // (SQLITE_BUSY stalls, competing migrations, aux-socket bind conflicts).
       // File-scoped, so an isolated AUTOMOBILE_DB_PATH still starts normally. #2795
-      if (noProxy) {
-        const { assertDirectModeDbOwnership, createDefaultDirectModeGuardDeps } =
-          await import("./daemon/directModeGuard");
-        assertDirectModeDbOwnership(createDefaultDirectModeGuardDeps());
-      }
-      await applyFeatureFlagStartup();
+      // The ordering (guard before the DB touch, only under noProxy) lives behind
+      // runDirectModeStartup() so it can be unit-tested with fakes (issue #2871).
+      const { runDirectModeStartup } = await import("./daemon/directModeStartup");
+      await runDirectModeStartup({
+        noProxy,
+        assertDbOwnership: async () => {
+          const { assertDirectModeDbOwnership, createDefaultDirectModeGuardDeps } =
+            await import("./daemon/directModeGuard");
+          assertDirectModeDbOwnership(createDefaultDirectModeGuardDeps());
+        },
+        applyFeatureFlagStartup,
+      });
     }
 
     if (noWaitForPollingOverhead) {

--- a/test/daemon/directModeStartup.test.ts
+++ b/test/daemon/directModeStartup.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import {
+  runDirectModeStartup,
+  type DirectModeStartupSteps,
+} from "../../src/daemon/directModeStartup";
+
+/**
+ * Fake direct-mode steps that record call order with no real guard or DB touch.
+ * Exercises the #2871 stretch AC — the direct-mode ordering invariant (guard runs
+ * before the first DB touch, only under noProxy) is unit-tested directly instead
+ * of only by reading src/index.ts (there is no main() test harness).
+ */
+function recordingSteps(
+  noProxy: boolean,
+  overrides: Partial<DirectModeStartupSteps> = {}
+): { steps: DirectModeStartupSteps; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    steps: {
+      noProxy,
+      assertDbOwnership: async () => {
+        calls.push("assertDbOwnership");
+      },
+      applyFeatureFlagStartup: async () => {
+        calls.push("applyFeatureFlagStartup");
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe("runDirectModeStartup", () => {
+  test("runs the ownership guard BEFORE the first DB touch under --no-proxy", async () => {
+    const { steps, calls } = recordingSteps(true);
+
+    await runDirectModeStartup(steps);
+
+    expect(calls).toEqual(["assertDbOwnership", "applyFeatureFlagStartup"]);
+  });
+
+  test("skips the ownership guard entirely in proxy mode", async () => {
+    const { steps, calls } = recordingSteps(false);
+
+    await runDirectModeStartup(steps);
+
+    expect(calls).toEqual(["applyFeatureFlagStartup"]);
+  });
+
+  test("does not touch the DB when the guard refuses (guard throws)", async () => {
+    const calls: string[] = [];
+    const refusal = new Error("a live daemon already owns this DB");
+
+    await expect(
+      runDirectModeStartup({
+        noProxy: true,
+        assertDbOwnership: async () => {
+          calls.push("assertDbOwnership");
+          throw refusal;
+        },
+        applyFeatureFlagStartup: async () => {
+          calls.push("applyFeatureFlagStartup");
+        },
+      })
+    ).rejects.toBe(refusal);
+
+    // Feature-flag startup (the first DB touch) must never run once the guard
+    // refuses — otherwise a second writer opens the daemon-owned SQLite file.
+    expect(calls).toEqual(["assertDbOwnership"]);
+  });
+
+  test("awaits the guard to settle before the DB touch", async () => {
+    const calls: string[] = [];
+    let guardResolved = false;
+
+    await runDirectModeStartup({
+      noProxy: true,
+      assertDbOwnership: async () => {
+        await Promise.resolve();
+        guardResolved = true;
+        calls.push("assertDbOwnership");
+      },
+      applyFeatureFlagStartup: async () => {
+        expect(guardResolved).toBe(true);
+        calls.push("applyFeatureFlagStartup");
+      },
+    });
+
+    expect(calls).toEqual(["assertDbOwnership", "applyFeatureFlagStartup"]);
+  });
+});

--- a/test/daemon/startupPrologue.test.ts
+++ b/test/daemon/startupPrologue.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+  runStartupPrologue,
+  type StartupPrologueSteps,
+} from "../../src/daemon/startupPrologue";
+
+/**
+ * Fake prologue steps that record the exact order their methods run in, with no
+ * real PID-file write or DB. Exercises the #2871 invariant — writeEarlyOwnerRecord
+ * (which publishes dbPath) must run BEFORE initializeDatabase opens the DB —
+ * directly, without Daemon.start()'s process side effects (chdir, lifecycle
+ * handlers). Each step also records whether the previous one had already resolved.
+ */
+function recordingSteps(): { steps: StartupPrologueSteps; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    steps: {
+      writeEarlyOwnerRecord: async () => {
+        calls.push("writeEarlyOwnerRecord");
+      },
+      initializeDatabase: async () => {
+        calls.push("initializeDatabase");
+      },
+    },
+  };
+}
+
+describe("runStartupPrologue", () => {
+  test("publishes the early owner record BEFORE opening the DB (#2871)", async () => {
+    const { steps, calls } = recordingSteps();
+
+    await runStartupPrologue(steps);
+
+    expect(calls).toEqual(["writeEarlyOwnerRecord", "initializeDatabase"]);
+  });
+
+  test("awaits the owner-record write to settle before the DB touch", async () => {
+    const calls: string[] = [];
+    let earlyOwnerResolved = false;
+
+    await runStartupPrologue({
+      writeEarlyOwnerRecord: async () => {
+        // Defer resolution a microtask so a non-awaiting caller would let
+        // initializeDatabase start first; the seam must serialize them.
+        await Promise.resolve();
+        earlyOwnerResolved = true;
+        calls.push("writeEarlyOwnerRecord");
+      },
+      initializeDatabase: async () => {
+        expect(earlyOwnerResolved).toBe(true);
+        calls.push("initializeDatabase");
+      },
+    });
+
+    expect(calls).toEqual(["writeEarlyOwnerRecord", "initializeDatabase"]);
+  });
+
+  test("does not open the DB when the early owner record fails", async () => {
+    const calls: string[] = [];
+    const failure = new Error("owner record write failed");
+
+    await expect(
+      runStartupPrologue({
+        writeEarlyOwnerRecord: async () => {
+          calls.push("writeEarlyOwnerRecord");
+          throw failure;
+        },
+        initializeDatabase: async () => {
+          calls.push("initializeDatabase");
+        },
+      })
+    ).rejects.toBe(failure);
+
+    // The DB is never touched if we could not publish the owned path first.
+    expect(calls).toEqual(["writeEarlyOwnerRecord"]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the deferred **stretch acceptance criterion** from #2871 (the follow-up PR #3264 fixed the guard but left this unimplemented). Two daemon startup-ordering invariants were previously verified only by reading; this extracts each behind a small interface so it can be asserted directly with interface+fakes — no real DB, PID-file writes, or process side effects.

### 1. Direct-mode ordering (`src/daemon/directModeStartup.ts`)
`runDirectModeStartup()` encodes: under `--no-proxy`/`--direct` the DB-ownership guard runs **before** the first DB touch (`applyFeatureFlagStartup`), and in proxy mode the guard is skipped entirely. Wired into the non-daemon branch of `src/index.ts` (guard import stays lazy — only awaited under `noProxy`). Previously verifiable by reading only, since nothing imports `src/index` (no `main()` harness).

### 2. Daemon startup prologue (`src/daemon/startupPrologue.ts`)
`runStartupPrologue()` encodes that `writeEarlyOwnerRecord()` runs **before** `initializeDatabase()`. `Daemon.start()` delegates to it via thunks bound to its (still-private) methods, so the ordering is assertable with fakes and none of `start()`'s real side effects (`process.chdir`, lifecycle handlers, real DB/PID writes).

## Tests
`test/daemon/startupPrologue.test.ts` + `test/daemon/directModeStartup.test.ts` (7 tests, <100ms). Interface + Fake only (respects the unit-test DB guard). Assert call order, guard-skipped-in-proxy-mode, real serialization (microtask-deferred step still settles first), and that the DB is never touched when the prior step throws.

## Validation
- New + existing `directModeGuard` tests pass (28 total).
- Lint clean; `bun run build` succeeds.
- Both call sites are provably behavior-identical to the inline code they replaced.

Closes the stretch AC of #2871.