### PR TITLE
docs(db): scope cold-start barrier claims to use-time consumers (#2934)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -546,7 +546,12 @@ export function getMigrationsPromiseForTest(): Promise<void> | null {
  *   Every shared-barrier consumer resolves `getDbWriteBarrier()` at use-time (per
  *   write), so this identity swap reaches all of them — the former
  *   construction-captured consumers were converted to per-write resolution in
- *   #2912, leaving no reopen exception. It stays a sibling call here rather than a
+ *   #2912, leaving no reopen exception. The swap short-circuits only writes that
+ *   resolve the still-draining barrier; a use-time write firing *after* the reset
+ *   (`AndroidCtrlProxyClient.markInstalledAppsStale()`) resolves the fresh,
+ *   non-draining barrier and is not short-circuited — it is bounded instead by the
+ *   synchronous reset→`process.exit(0)` window plus its own `try/catch` (#2912
+ *   sub-item 2). It stays a sibling call here rather than a
  *   field on `MigrationLifecycleState` because it is an identity swap in a
  *   separate, already-encapsulated module (`dbWriteBarrier.ts`), not part of the
  *   migration/path state machine.

--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -220,7 +220,13 @@ export function getDbWriteBarrier(): DbWriteBarrier {
  * {@link beginDrain}), the swap reaches all of them: in the drain→close window a
  * late write still resolves the *previous*, still-draining barrier and
  * short-circuits (the #2792 safety margin); only after this reset does a new
- * write resolve the fresh non-draining barrier. Kept as an identity swap rather
+ * write resolve the fresh non-draining barrier. Note the short-circuit protects
+ * only writes that resolve the still-draining barrier: a use-time consumer firing
+ * *after* the reset (e.g. `AndroidCtrlProxyClient.markInstalledAppsStale()`,
+ * fire-and-forget from `onConnectionClosed()`) resolves the fresh, non-draining
+ * barrier and is NOT short-circuited — it attempts a write against the just-closed
+ * connection, protected only by the synchronous reset→`process.exit(0)` window
+ * plus its own `try/catch` (#2912 sub-item 2), not by this swap. Kept as an identity swap rather
  * than an in-place `#draining` clear because, with all consumers per-write, the
  * two are behaviorally equivalent — so in-place reset (issue option (b)) would
  * only grow the {@link DbWriteBarrier} interface with a `reset()` for no benefit

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -27,8 +27,11 @@ import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatab
  * the DB in the same process after that drain (config reload, DB path switch,
  * restart-without-exit) without also cold-starting the barrier, the reopened DB
  * would silently skip every tracked best-effort write. `closeDatabase()` now
- * clears the barrier via `resetDbWriteBarrier()` so the cold-start contract is
- * fully true.
+ * clears the barrier via `resetDbWriteBarrier()` so the cold-start contract holds
+ * for consumers that resolve `getDbWriteBarrier()` at use-time; the three
+ * construction-captured consumers (`TelemetryRecorder`, `FailureAnalyticsRepository`,
+ * `SessionManager`) pin the barrier at construction and never observe the identity
+ * swap, and remain the documented reopen exception (#2912).
  *
  * These assertions are about `getDbWriteBarrier()` **identity** and
  * `isDraining()` across the `getDatabase()`/`closeDatabase()` lifecycle — they


### PR DESCRIPTION
Closes #2934

## Summary
Fixes two inaccurate DB comments left by PR #2905. Documentation-only, no runtime impact.

1. **Test docblock over-claim** (`test/db/dbWriteBarrierResetOnClose.test.ts`): removed the "cold-start contract is **fully true**" claim. It is now scoped to use-time consumers, and names the three construction-captured consumers (TelemetryRecorder, FailureAnalyticsRepository, SessionManager) as the documented reopen exception (#2912).

2. **Null-swap safety rationale** (`src/db/dbWriteBarrier.ts` and mirrored in `src/db/database.ts`): the identity-swap comment implied late writes are short-circuited generally. Added a clause noting a use-time consumer firing *after* the reset (`AndroidCtrlProxyClient.markInstalledAppsStale()`, fire-and-forget from `onConnectionClosed()`) resolves a fresh non-draining barrier and is NOT short-circuited — bounded only by the synchronous reset→`process.exit(0)` window plus its own try/catch (#2912 sub-item 2).

## Validation
- `bun test test/db/dbWriteBarrierResetOnClose.test.ts` — 4 pass
- `bun run typecheck` — no new errors
- `eslint` on all 3 touched files — clean

## Caveats
Comment/docs-only; verified referenced code facts at `AndroidCtrlProxyClient.ts:1185/3157/3166`.