### PR TITLE
perf(db): cap structured-JSON telemetry fields at backfill boundary (#3182)

### DIFF
--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -13,7 +13,7 @@ import { getDatabase } from "../db/database";
 import type { Database } from "../db/types";
 import type { Kysely } from "kysely";
 import { TELEMETRY_PUSH_SOCKET_CONFIG } from "./daemonFiles";
-import { truncateBodyText } from "../utils/truncateBodyText";
+import { truncateBodyText, boundStructuredField } from "../utils/truncateBodyText";
 
 /**
  * Opaque plain-text fields that the backfill fans out (limit=100) and that can
@@ -21,8 +21,9 @@ import { truncateBodyText } from "../utils/truncateBodyText";
  * (#2801). Network bodies are already capped upstream in the repository
  * `mapRow`; this bounds the remaining plain-text columns at the backfill
  * boundary so the DB read contract for those repos is unchanged. Only opaque
- * text is listed — structured JSON columns (os `details`, layout `detailsJson`,
- * failure blobs) would be corrupted by a blind slice and are tracked in #3182.
+ * text is listed here; structured-JSON columns that would be corrupted by a
+ * blind slice are bounded separately via BOUNDED_BACKFILL_STRUCTURED_FIELDS
+ * (#3182).
  */
 const BOUNDED_BACKFILL_TEXT_FIELDS: Record<string, readonly string[]> = {
   log: ["message"],
@@ -30,23 +31,51 @@ const BOUNDED_BACKFILL_TEXT_FIELDS: Record<string, readonly string[]> = {
 };
 
 /**
- * Cap known large plain-text fields on a backfilled telemetry event to
- * BODY_TRUNCATION_LIMIT, returning a shallow copy when anything changed so the
- * caller's source rows are not mutated. Surrogate-safe (see truncateBodyText).
+ * Structured-JSON fields the backfill fans out (limit=100) that can also
+ * balloon a single subscribe. Slicing these mid-value would emit invalid JSON
+ * (#3182), so they are bounded by total serialized size and replaced wholesale
+ * with a small `{ _truncated, bytes }` marker when over budget — the result
+ * stays valid JSON. `isJsonString` marks fields that arrive already serialized
+ * (layout `detailsJson`) versus parsed objects/arrays (os `details`; failure
+ * `stackTrace` is bounded at its push site since it is composed there).
+ */
+const BOUNDED_BACKFILL_STRUCTURED_FIELDS: Record<
+  string,
+  readonly { field: string; isJsonString: boolean }[]
+> = {
+  os: [{ field: "details", isJsonString: false }],
+  layout: [{ field: "detailsJson", isJsonString: true }],
+};
+
+/**
+ * Cap known large fields on a backfilled telemetry event, returning a shallow
+ * copy when anything changed so the caller's source rows are not mutated. Plain
+ * text is capped to BODY_TRUNCATION_LIMIT (surrogate-safe, see truncateBodyText);
+ * structured-JSON fields are bounded by serialized size and replaced with a
+ * valid-JSON truncation marker when over budget (see boundStructuredField).
  */
 export function boundBackfillEventText(event: TelemetryEvent): TelemetryEvent {
-  const fields = BOUNDED_BACKFILL_TEXT_FIELDS[event.category];
-  if (!fields || event.data === null || typeof event.data !== "object") {
+  const textFields = BOUNDED_BACKFILL_TEXT_FIELDS[event.category];
+  const structuredFields = BOUNDED_BACKFILL_STRUCTURED_FIELDS[event.category];
+  if ((!textFields && !structuredFields) || event.data === null || typeof event.data !== "object") {
     return event;
   }
   const data = event.data as Record<string, unknown>;
   let bounded: Record<string, unknown> | null = null;
-  for (const field of fields) {
+  for (const field of textFields ?? []) {
     const value = data[field];
     if (typeof value !== "string") {
       continue;
     }
     const capped = truncateBodyText(value);
+    if (capped !== value) {
+      bounded = bounded ?? { ...data };
+      bounded[field] = capped;
+    }
+  }
+  for (const { field, isJsonString } of structuredFields ?? []) {
+    const value = data[field];
+    const capped = boundStructuredField(value, isJsonString);
     if (capped !== value) {
       bounded = bounded ?? { ...data };
       bounded[field] = capped;
@@ -223,6 +252,11 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
             } catch { /* ignore parse errors */ }
           }
 
+          // Bound the parsed stack trace by serialized size so a multi-hundred-KB
+          // frame array does not ship raw ×100 (#3182). exceptionType is read
+          // above before bounding, so the marker never loses that summary.
+          const boundedStackTrace = boundStructuredField(stackTrace, false);
+
           events.push({
             category: failureType,
             timestamp: r.timestamp,
@@ -231,7 +265,7 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
             data: {
               type: r.type, occurrenceId: r.occurrenceId, groupId: r.groupId,
               severity: r.severity, title: r.title, exceptionType,
-              screen: r.screen, timestamp: r.timestamp, stackTrace,
+              screen: r.screen, timestamp: r.timestamp, stackTrace: boundedStackTrace,
             },
           });
         }

--- a/src/utils/truncateBodyText.ts
+++ b/src/utils/truncateBodyText.ts
@@ -46,3 +46,68 @@ export function truncateBodyText(
   }
   return text.slice(0, end);
 }
+
+/**
+ * Maximum retained serialized size for a structured-JSON telemetry field, in
+ * UTF-16 code units (10&nbsp;KB, mirrors {@link BODY_TRUNCATION_LIMIT}).
+ */
+export const STRUCTURED_FIELD_LIMIT = 10_240;
+
+/**
+ * Marker substituted for an oversized structured-JSON field. Blindly slicing a
+ * JSON string (or a stringified object) mid-value produces invalid JSON that
+ * breaks the dashboard's `JSON.parse` (#3182), so an over-budget structured
+ * field is replaced wholesale with this small, always-valid marker instead.
+ */
+export interface TruncatedStructuredMarker {
+  _truncated: true;
+  bytes: number;
+}
+
+/**
+ * Bound a structured-JSON telemetry value (object, array, or an already-
+ * serialized JSON string) by total serialized size. When the value serializes
+ * to more than `limit` UTF-16 code units it is replaced with a
+ * {@link TruncatedStructuredMarker} carrying the original size; otherwise the
+ * original value is returned unchanged. The result is always valid JSON — never
+ * a mid-value slice — so the dashboard can still `JSON.parse` it.
+ *
+ * `isJsonString` selects how the input is measured: raw JSON strings (e.g.
+ * layout `detailsJson`) are measured by their own length, while parsed
+ * objects/arrays (os `details`, failure `stackTrace`) are measured by their
+ * `JSON.stringify` length. `null`/`undefined` pass through untouched.
+ */
+export function boundStructuredField(
+  value: unknown,
+  isJsonString: boolean = false,
+  limit: number = STRUCTURED_FIELD_LIMIT
+): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  let serializedLength: number;
+  if (isJsonString) {
+    if (typeof value !== "string") {
+      return value;
+    }
+    serializedLength = value.length;
+  } else {
+    // A value that cannot be serialized (cycle, BigInt) cannot ship anyway;
+    // treat it as within budget and leave it to the caller's serializer.
+    let serialized: string | undefined;
+    try {
+      serialized = JSON.stringify(value);
+    } catch {
+      return value;
+    }
+    if (serialized === undefined) {
+      return value;
+    }
+    serializedLength = serialized.length;
+  }
+  if (serializedLength <= limit) {
+    return value;
+  }
+  const marker: TruncatedStructuredMarker = { _truncated: true, bytes: serializedLength };
+  return marker;
+}

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -4,6 +4,7 @@ import {
   TelemetryPushSocketServer,
   boundBackfillEventText,
 } from "../../src/daemon/telemetryPushSocketServer";
+import { boundStructuredField } from "../../src/utils/truncateBodyText";
 import type { TelemetryEvent } from "../../src/features/telemetry/TelemetryRecorder";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
@@ -122,6 +123,96 @@ describe("boundBackfillEventText", () => {
     const msg = (bounded.data as { message: string }).message;
     expect(msg.length).toBe(10_239);
     expect(msg.isWellFormed()).toBe(true);
+  });
+
+  it("replaces an oversized os details object with a valid-JSON marker", () => {
+    const bigDetails = { blob: "x".repeat(50_000) };
+    const event: TelemetryEvent = {
+      category: "os",
+      timestamp: 1,
+      deviceId: null,
+      data: { category: "lifecycle", kind: "foreground", details: bigDetails },
+    };
+    const bounded = boundBackfillEventText(event);
+    const details = (bounded.data as { details: unknown }).details as {
+      _truncated: boolean; bytes: number;
+    };
+    expect(details._truncated).toBe(true);
+    expect(details.bytes).toBe(JSON.stringify(bigDetails).length);
+    // Result must round-trip through JSON.parse (dashboard contract).
+    expect(() => JSON.parse(JSON.stringify(bounded.data))).not.toThrow();
+  });
+
+  it("leaves a small os details object untouched", () => {
+    const details = { screen: "Home", extra: 1 };
+    const event: TelemetryEvent = {
+      category: "os",
+      timestamp: 1,
+      deviceId: null,
+      data: { category: "lifecycle", kind: "foreground", details },
+    };
+    const bounded = boundBackfillEventText(event);
+    expect((bounded.data as { details: unknown }).details).toBe(details);
+  });
+
+  it("replaces an oversized layout detailsJson raw string with a marker", () => {
+    const raw = JSON.stringify({ frames: "y".repeat(50_000) });
+    const event: TelemetryEvent = {
+      category: "layout",
+      timestamp: 1,
+      deviceId: null,
+      data: { composableId: "c", detailsJson: raw },
+    };
+    const bounded = boundBackfillEventText(event);
+    const dj = (bounded.data as { detailsJson: unknown }).detailsJson as {
+      _truncated: boolean; bytes: number;
+    };
+    expect(dj._truncated).toBe(true);
+    expect(dj.bytes).toBe(raw.length);
+  });
+
+  it("leaves a small layout detailsJson string untouched", () => {
+    const raw = JSON.stringify({ ok: true });
+    const event: TelemetryEvent = {
+      category: "layout",
+      timestamp: 1,
+      deviceId: null,
+      data: { composableId: "c", detailsJson: raw },
+    };
+    const bounded = boundBackfillEventText(event);
+    expect((bounded.data as { detailsJson: unknown }).detailsJson).toBe(raw);
+  });
+});
+
+describe("boundStructuredField", () => {
+  it("passes null/undefined through unchanged", () => {
+    expect(boundStructuredField(null, false)).toBe(null);
+    expect(boundStructuredField(undefined, false)).toBe(undefined);
+  });
+
+  it("keeps a within-budget stack trace array unchanged", () => {
+    const frames = [{ className: "A", line: 1 }, { className: "B", line: 2 }];
+    expect(boundStructuredField(frames, false)).toBe(frames);
+  });
+
+  it("replaces an oversized stack trace array with a valid marker", () => {
+    const frames = Array.from({ length: 5_000 }, (_, i) => ({
+      className: `com.example.Very.Long.Class.Name.${i}`,
+      method: "doSomethingExpensive",
+      line: i,
+    }));
+    const bounded = boundStructuredField(frames, false) as {
+      _truncated: boolean; bytes: number;
+    };
+    expect(bounded._truncated).toBe(true);
+    expect(bounded.bytes).toBe(JSON.stringify(frames).length);
+    expect(() => JSON.parse(JSON.stringify(bounded))).not.toThrow();
+  });
+
+  it("measures raw JSON strings by their own length when isJsonString", () => {
+    const raw = "z".repeat(20_000);
+    const bounded = boundStructuredField(raw, true) as { bytes: number };
+    expect(bounded.bytes).toBe(20_000);
   });
 });
 


### PR DESCRIPTION
Closes #3182

## Summary
Follow-up to #2801 / PR #3180. The `limit=100` telemetry backfill in `telemetryPushSocketServer.ts` still shipped structured-JSON fields uncapped. This bounds them by **total serialized size**, replacing an over-budget field wholesale with a small `{ "_truncated": true, "bytes": N }` marker so the result stays **valid JSON** (no mid-value slice that would break the dashboard's `JSON.parse`).

Bounded fields:
- os `details` (parsed object) — via `BOUNDED_BACKFILL_STRUCTURED_FIELDS` in `boundBackfillEventText`.
- layout `detailsJson` (raw JSON string) — measured by its own length.
- failure `stackTrace` (parsed frame array) — bounded at the failure push site; `exceptionType` is read before bounding so the summary is preserved.

New canonical primitive `boundStructuredField` lives alongside `truncateBodyText` in `src/utils/truncateBodyText.ts` (one primitive per concern).

## Scope notes
- failure `tool_call_info_json` / `tool_args_json` are **not selected** by the backfill SELECT (only `stack_trace_json` is), so they never ship ×100 — no change needed, matching the adversarial-review comment on #3182.
- Plain-text handling from #2801 (network/log/storage) is unchanged.

## Validation
- `bun test test/daemon/telemetryPushSocketServer.test.ts` — 25 pass (added os/layout/failure + primitive tests, Interface/Fake, <100ms).
- `turbo run lint build` green.
- `bun run typecheck` gate: no new type errors.