### PR TITLE
test(parity): derive pinch golden from JSON + string-literal robustness (#3021)

### DIFF
--- a/test/parity/pinchGoldenVectorParity.test.ts
+++ b/test/parity/pinchGoldenVectorParity.test.ts
@@ -15,11 +15,13 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import {
+  assertNoStringLiterals,
   diffGoldenTables,
   KOTLIN_TEST_PATH,
   loadCanonicalVectors,
   parseKotlinGoldenTable,
   parseSwiftGoldenTable,
+  referencePinchEndpoints,
   SWIFT_TEST_PATH,
   type GoldenVector,
 } from "./pinchGoldenVectors";
@@ -102,6 +104,65 @@ describe("pinch golden vector parity (issue #2997)", function() {
     expect(swiftSource).toContain("XCTAssertEqual");
     expect(kotlinSource).toContain("computePinchPoints(");
     expect(kotlinSource).toContain("assertEquals");
+  });
+
+  test("Item 1 (#3021): every canonical row's expected endpoints are DERIVABLE from its inputs", function() {
+    // Makes the JSON a derived source, not a third hand-copy: recompute each row's four endpoints
+    // from (center, distances, rotation) via the reference port of the platform math and assert they
+    // match the committed `expected` set (order-independent, same tolerance as the runtime loops).
+    for (let i = 0; i < canonical.length; i++) {
+      const row = canonical[i];
+      const computed = referencePinchEndpoints(
+        row.centerX,
+        row.centerY,
+        row.distanceStart,
+        row.distanceEnd,
+        row.rotationDegrees,
+      );
+      const diffs = diffGoldenTables(
+        [{ ...row, expected: computed }],
+        [row],
+      );
+      expect(diffs).toEqual([]);
+    }
+  });
+
+  test("Item 1 (#3021): the reference math catches a corrupted expected value in the source", function() {
+    // Negative control: if a row's expected endpoint were mis-typed, the derivation check must trip.
+    const row = canonical[0];
+    const computed = referencePinchEndpoints(
+      row.centerX,
+      row.centerY,
+      row.distanceStart,
+      row.distanceEnd,
+      row.rotationDegrees,
+    );
+    const corrupted: GoldenVector = {
+      ...row,
+      expected: [
+        [row.expected[0][0] + 7, row.expected[0][1]],
+        ...row.expected.slice(1),
+      ] as GoldenVector["expected"],
+    };
+    expect(diffGoldenTables([{ ...row, expected: computed }], [corrupted]).length)
+      .toBeGreaterThan(0);
+  });
+
+  test("Item 2 (#3021): current platform golden regions contain no string literals", function() {
+    // The live guard: parsing already runs assertNoStringLiterals; assert it passes for today's
+    // tables (both parsed above without throwing) and that the checker is wired.
+    expect(swift.length).toBeGreaterThan(0);
+    expect(kotlin.length).toBeGreaterThan(0);
+  });
+
+  test("Item 2 (#3021): a string literal inside the table region fails loudly", function() {
+    // A digit-bearing inline label like `"row 1"` inside the literal would corrupt positional number
+    // extraction; the checker must throw a targeted error rather than silently mis-parse.
+    expect(() => assertNoStringLiterals('60, 200, "row 1", 140', "fake.kt")).toThrow(
+      /string-literal delimiter/,
+    );
+    // A clean numeric region passes.
+    expect(() => assertNoStringLiterals("60, 200, 140, 200", "fake.kt")).not.toThrow();
   });
 
   test("the guard ignores finger-label ordering differences (no false drift)", function() {

--- a/test/parity/pinchGoldenVectors.ts
+++ b/test/parity/pinchGoldenVectors.ts
@@ -66,6 +66,28 @@ function stripComments(source: string): string {
 }
 
 /**
+ * Assert the carved-out golden-table region contains no string-literal delimiters (Item 2, issue
+ * #3021). Today no string literal exists inside either platform's `let vectors` / `listOf(...)`
+ * region — assertion-message strings live OUTSIDE it. A future edit that placed a digit-bearing
+ * string literal inside the region (e.g. an inline label like `"row 1"`) could corrupt number
+ * extraction. The `NUMBERS_PER_ROW` alignment check usually fails closed, but a label with the
+ * "right" number of digits could slip through and silently mis-parse. Rather than attempt correct
+ * language-aware string stripping (Swift interpolation `\( )`, Kotlin `$`, escapes — brittle to get
+ * right for two languages), fail LOUDLY with a targeted message so the ambiguity is fixed at the
+ * source. Comments have already been stripped, so a `"` here is genuinely inside the literal.
+ */
+export function assertNoStringLiterals(region: string, label: string): void {
+  const quote = region.match(/["']/);
+  if (quote) {
+    throw new Error(
+      `${label}: golden-table region contains a string-literal delimiter (${quote[0]}) at index ` +
+        `${quote.index}. The parser extracts numbers positionally and cannot safely handle string ` +
+        `literals inside the table; move any label/message strings outside the 'vectors' literal.`,
+    );
+  }
+}
+
+/**
  * Return the balanced substring that starts at the first `open` delimiter at or after `fromIndex`
  * and ends at its matching `close` delimiter (inclusive). Used to carve out just the golden table
  * literal from a larger test function body.
@@ -158,6 +180,9 @@ export function parseGoldenTable(
     open,
     close,
   );
+  // Item 2 (#3021): fail loudly if a string literal ever appears inside the table region so a
+  // digit-bearing label can never silently corrupt positional number extraction.
+  assertNoStringLiterals(region, filePath);
   const numbers = extractNumbers(region);
   return rowsFromNumbers(numbers, filePath);
 }
@@ -180,6 +205,43 @@ export function loadCanonicalVectors(): GoldenVector[] {
     throw new Error(`${CANONICAL_JSON_PATH}: missing non-empty "vectors" array`);
   }
   return parsed.vectors;
+}
+
+/**
+ * Reference TypeScript port of the pinch endpoint geometry (Item 1, issue #3021). Mirrors, opcode
+ * for opcode, `PinchGeometry.kt` `computePinchPoints` (Android) and `computePinchPoints` (iOS): the
+ * two fingers sit on a diameter through the center — one at `angle`, the other at `angle + PI`. The
+ * start axis is horizontal (angle 0); the end axis is rotated by `rotationDegrees`. Radius is half
+ * the finger distance.
+ *
+ * This turns the canonical JSON from a THIRD hand-maintained copy into a genuinely *derived* source:
+ * a test recomputes every row's `expected` endpoints from its inputs and asserts they match, so a
+ * bad hand-edit to the JSON's expected values is caught at the root (not just cross-checked against
+ * two equally-hand-maintained platform tables). The platform inline tables remain verified-against
+ * the JSON (they keep their hand-authored design-rationale comments; regenerating them in place
+ * would be lossy — see issue #3021 Item 1 discussion).
+ */
+export function referencePinchEndpoints(
+  centerX: number,
+  centerY: number,
+  distanceStart: number,
+  distanceEnd: number,
+  rotationDegrees: number,
+): Array<[number, number]> {
+  const startRadius = distanceStart / 2;
+  const endRadius = distanceEnd / 2;
+  const startAngle = 0;
+  const endAngle = (rotationDegrees * Math.PI) / 180;
+  const pointAt = (radius: number, angleRad: number): [number, number] => [
+    centerX + radius * Math.cos(angleRad),
+    centerY + radius * Math.sin(angleRad),
+  ];
+  return [
+    pointAt(startRadius, startAngle),
+    pointAt(startRadius, Math.PI + startAngle),
+    pointAt(endRadius, endAngle),
+    pointAt(endRadius, Math.PI + endAngle),
+  ];
 }
 
 /** Deterministic order-independent point sort — mirrors the Swift/Kotlin `sortedPoints` helpers so


### PR DESCRIPTION
Closes #3021

Follow-up to #2997 / PR #3015. Addresses both deferred, low-severity hardening items flagged by reviewers, WITHOUT churning the two annotated platform golden tables (regenerating them in place would be lossy — they carry hand-authored test-design comments).

## Item 1 — make the JSON a genuinely *derived* source
Added `referencePinchEndpoints()` in `test/parity/pinchGoldenVectors.ts`: an opcode-for-opcode TypeScript port of the platform pinch math (`PinchGeometry.kt` / iOS `computePinchPoints`). A new parity test recomputes every canonical row's four `expected` endpoints from its inputs and asserts they match (order-independent, 1e-3 tolerance — same as the runtime loops). This turns the JSON from a third hand-maintained copy into a derivable source: a bad hand-edit to an expected value is now caught at the root, not just cross-checked against two equally-hand-maintained platform tables. A negative-control test proves a corrupted expected value trips the derivation check.

Note: literal in-place regeneration of the Swift/Kotlin tables (the issue's "acceptance idea") was intentionally declined — both regions contain hand-authored design-rationale comments (e.g. PinchGeometryTests.swift:138-140, PinchGeometryTest.kt:170-172) and are ktfmt/swiftformat-controlled; overwriting them is net-negative. Verify-against remains, now backstopped by derive-from at the JSON root.

## Item 2 — parser robustness: fail loudly on string literals in the table region
Added `assertNoStringLiterals()` invoked inside `parseGoldenTable()` (after comment stripping). If a future edit ever places a digit-bearing string literal inside the `let vectors` / `listOf(...)` region, the parser now throws a targeted error instead of risking silent positional mis-parse. Chose fail-loudly over language-aware string stripping (Swift `\( )` interpolation + Kotlin `$` + escapes are brittle to strip correctly for two languages).

## Validation
- `bun test test/parity/pinchGoldenVectorParity.test.ts` — 13 pass, 0 fail (~357ms)
- `turbo run lint build` — pass
- `bun run typecheck` — no new type errors (baseline 280)

## Scope
Only `test/parity/pinchGoldenVectors.ts` and `test/parity/pinchGoldenVectorParity.test.ts` changed. No platform source, no SPM/xcodegen/Gradle wiring, offline, <100ms.