### PR TITLE
chore(db): incarnation-aware lock release + positional-format helpers (#3006)

### DIFF
--- a/src/db/migrationLock.ts
+++ b/src/db/migrationLock.ts
@@ -137,7 +137,10 @@ export class FileMigrationLock implements MigrationLock {
   }
 
   async release(): Promise<void> {
-    releaseExclusiveLock(this.lockFilePath, this.pid);
+    // Pass the owner token so release is incarnation-aware and symmetric with
+    // acquire: a same-PID lock bearing a different token belongs to another
+    // incarnation that recycled our PID and must not be deleted (#3006).
+    releaseExclusiveLock(this.lockFilePath, this.pid, this.ownerToken);
   }
 
   private tryAcquire(): boolean {

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -52,7 +52,10 @@ export interface ExclusiveLockOptions {
    * Only consulted for the same-PID reclaim decision. When omitted, `reclaimOwnPid`
    * behaves exactly as it did before this token existed (any same-PID lock is a
    * reclaimable leak). The PID stays on the first line so daemon liveness reads and
-   * {@link releaseExclusiveLock}'s `parseInt` are unaffected.
+   * {@link releaseExclusiveLock}'s PID compare are unaffected. The positional format
+   * ("line 1 = bare integer PID, line 2 = token") is centralized in the
+   * {@link formatLockContent} / {@link parseLockContent} pair, so a future third
+   * field is added there and cannot silently move the PID off line 1 (#3006).
    *
    * Must be a NON-EMPTY, single-line, whitespace-free token (a UUID satisfies
    * this). The lock body is `trim()`-ed on read to tolerate a trailing newline, so
@@ -61,6 +64,43 @@ export interface ExclusiveLockOptions {
    * from `IdGenerator`; a future caller must uphold the same shape.
    */
   ownerToken?: string;
+}
+
+/**
+ * The parsed contents of a lock file.
+ *
+ * The on-disk format is positional and MUST keep line 1 a bare integer PID so
+ * `parseInt`-based readers (daemon liveness, and historically {@link releaseExclusiveLock})
+ * stay correct; the per-process token, when present, is line 2. This helper pair
+ * ({@link formatLockContent} / {@link parseLockContent}) is the single place that
+ * encodes that contract, so any future third field is added HERE — line 1 stays a
+ * bare integer by construction rather than by every call site remembering to
+ * (issue #3006, follow-up 2).
+ */
+export interface LockContent {
+  /** Owner PID (line 1). `NaN` when the PID line is not a readable integer. */
+  pid: number;
+  /** Per-process-instance token (line 2), or `undefined` when absent. */
+  token: string | undefined;
+}
+
+/**
+ * Serialize a lock file body. PID on line 1 (bare integer, always), token on an
+ * optional line 2. Inverse of {@link parseLockContent}. Centralizes the positional
+ * format so a future field can't silently move the PID off line 1 (#3006).
+ */
+export function formatLockContent(pid: number, ownerToken?: string): string {
+  return ownerToken === undefined ? String(pid) : `${pid}\n${ownerToken}`;
+}
+
+/**
+ * Parse a lock file body (already `trim()`-ed by the caller) into its PID and
+ * optional token. Line 1 is parsed as an integer PID (`NaN` when unreadable); line
+ * 2, if present, is the token. Inverse of {@link formatLockContent} (#3006).
+ */
+export function parseLockContent(content: string): LockContent {
+  const [pidLine, tokenLine] = content.split("\n", 2);
+  return { pid: Number.parseInt(pidLine, 10), token: tokenLine };
 }
 
 /**
@@ -101,9 +141,9 @@ export function tryAcquireExclusiveLock(
   }
 
   // The PID is the first line; a per-process-instance token (if any) is the
-  // second (see `writeExclusiveLockFile`). `parseInt` reads only the PID.
-  const [pidLine, tokenLine] = content.split("\n", 2);
-  const ownerPid = Number.parseInt(pidLine, 10);
+  // second (see `writeExclusiveLockFile`). `parseLockContent` reads only the PID
+  // off line 1, keeping the positional contract in one place (#3006).
+  const { pid: ownerPid, token: tokenLine } = parseLockContent(content);
   if (Number.isNaN(ownerPid)) {
     // Unreadable PID — a writer may still be filling it in; treat as held.
     return false;
@@ -153,8 +193,21 @@ export function tryAcquireExclusiveLock(
  * Release a lock owned by `pid`. Compare-and-delete: the file is removed only if
  * it still holds `pid`, so a reclaim race can't delete a lock that a *different*
  * opener now owns (mirrors `shouldCleanupForExpectedPid` in `daemonFiles.ts`).
+ *
+ * When `ownerToken` is supplied, release is incarnation-aware: it unlinks only if
+ * BOTH the PID and the token match, so it is symmetric with the reclaim decision
+ * in {@link tryAcquireExclusiveLock}. This closes the recycled-PID window where a
+ * process could delete a lock now held by a *different* incarnation that recycled
+ * the same PID and wrote a different token (issue #3006, follow-up 1). A lock file
+ * with NO token line (a pre-token incarnation) is treated as ours on a PID match,
+ * preserving the legacy PID-only behavior. The daemon caller passes no token and
+ * stays PID-only, as before.
  */
-export function releaseExclusiveLock(lockFilePath: string, pid: number = process.pid): void {
+export function releaseExclusiveLock(
+  lockFilePath: string,
+  pid: number = process.pid,
+  ownerToken?: string
+): void {
   let content: string;
   try {
     content = readFileSync(lockFilePath, "utf-8").trim();
@@ -163,8 +216,15 @@ export function releaseExclusiveLock(lockFilePath: string, pid: number = process
     return;
   }
 
-  if (Number.parseInt(content, 10) !== pid) {
+  const { pid: ownerPid, token: lockToken } = parseLockContent(content);
+  if (ownerPid !== pid) {
     // The lock is no longer ours — do not delete another opener's file.
+    return;
+  }
+  // Incarnation check: with a token supplied, a same-PID lock bearing a DIFFERENT
+  // token belongs to another incarnation that recycled our PID — leave it. A lock
+  // with no token line predates tokens and is treated as ours (PID match).
+  if (ownerToken !== undefined && lockToken !== undefined && lockToken !== ownerToken) {
     return;
   }
 
@@ -186,7 +246,7 @@ function writeExclusiveLockFile(lockFilePath: string, pid: number, ownerToken?: 
   try {
     mkdirSync(dirname(lockFilePath), { recursive: true });
     const fd = openSync(lockFilePath, "wx", 0o600);
-    writeFileSync(fd, ownerToken === undefined ? String(pid) : `${pid}\n${ownerToken}`);
+    writeFileSync(fd, formatLockContent(pid, ownerToken));
     closeSync(fd);
     return true;
   } catch {

--- a/test/db/migrationLock.test.ts
+++ b/test/db/migrationLock.test.ts
@@ -205,6 +205,36 @@ describe("FileMigrationLock", () => {
     expect(readFileSync(lockPath, "utf-8").trim()).toBe("9999");
   });
 
+  test("release is incarnation-aware: leaves a same-PID lock from another token (#3006)", async () => {
+    // A recycled-PID incarnation holds the lock with a DIFFERENT token. A PID-only
+    // release would wrongly delete it; the token guard leaves it intact.
+    writeFileSync(lockPath, "4242\ntok-OTHER");
+    const lock = new FileMigrationLock(lockPath, {
+      timer: new FakeTimer(),
+      pid: 4242,
+      ownerToken: "tok-MINE",
+    });
+
+    await lock.release();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, "utf-8")).toBe("4242\ntok-OTHER");
+  });
+
+  test("release removes our own pid+token lock (#3006)", async () => {
+    const lock = new FileMigrationLock(lockPath, {
+      timer: new FakeTimer(),
+      pid: 4242,
+      isProcessRunning: () => true,
+      ownerToken: "tok-MINE",
+    });
+    await lock.acquire();
+    expect(existsSync(lockPath)).toBe(true);
+
+    await lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
   test("release is inert when the lock was never acquired", async () => {
     const lock = new FileMigrationLock(lockPath, { timer: new FakeTimer(), pid: 4242 });
     await lock.release();

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { basename, join } from "path";
-import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../../src/utils/fileLock";
+import {
+  formatLockContent,
+  parseLockContent,
+  releaseExclusiveLock,
+  tryAcquireExclusiveLock,
+} from "../../src/utils/fileLock";
 
 describe("fileLock primitive", () => {
   let dir: string;
@@ -163,6 +168,54 @@ describe("fileLock primitive", () => {
       writeFileSync(lockPath, "100\ntok-A");
       releaseExclusiveLock(lockPath, 100);
       expect(existsSync(lockPath)).toBe(false);
+    });
+  });
+
+  describe("incarnation-aware release (#3006 follow-up 1)", () => {
+    test("releases a matching pid+token lock when the token is supplied", () => {
+      writeFileSync(lockPath, "100\ntok-A");
+      releaseExclusiveLock(lockPath, 100, "tok-A");
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    test("does NOT delete a same-PID lock bearing a DIFFERENT token (recycled-PID incarnation)", () => {
+      // Another incarnation recycled our PID and wrote its own token; a PID-only
+      // release would wrongly delete its live lock. The token guard leaves it.
+      writeFileSync(lockPath, "100\ntok-OTHER");
+      releaseExclusiveLock(lockPath, 100, "tok-A");
+      expect(existsSync(lockPath)).toBe(true);
+      expect(readFileSync(lockPath, "utf-8")).toBe("100\ntok-OTHER");
+    });
+
+    test("releases a tokenless legacy lock on a PID match even when a token is supplied", () => {
+      // A pre-token incarnation wrote only the PID; treat it as ours (PID match)
+      // so a token-aware release stays backward compatible.
+      writeFileSync(lockPath, "100");
+      releaseExclusiveLock(lockPath, 100, "tok-A");
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
+    test("PID-only release (no token) deletes any same-PID lock (daemon behavior unchanged)", () => {
+      writeFileSync(lockPath, "100\ntok-A");
+      releaseExclusiveLock(lockPath, 100);
+      expect(existsSync(lockPath)).toBe(false);
+    });
+  });
+
+  describe("lock content format helpers (#3006 follow-up 2)", () => {
+    test("formatLockContent keeps the PID a bare integer on line 1", () => {
+      expect(formatLockContent(100)).toBe("100");
+      expect(formatLockContent(100, "tok-A")).toBe("100\ntok-A");
+      expect(Number.parseInt(formatLockContent(100, "tok-A"), 10)).toBe(100);
+    });
+
+    test("parseLockContent round-trips formatLockContent", () => {
+      expect(parseLockContent(formatLockContent(100))).toEqual({ pid: 100, token: undefined });
+      expect(parseLockContent(formatLockContent(100, "tok-A"))).toEqual({ pid: 100, token: "tok-A" });
+    });
+
+    test("parseLockContent reports NaN for an unreadable PID line", () => {
+      expect(parseLockContent("not-a-pid").pid).toBeNaN();
     });
   });
 


### PR DESCRIPTION
Closes #3006

Ships both latent fileLock hardening follow-ups deferred from PR #2995 (per-process `ownerToken`, issue #2947).

## Follow-up 1 — incarnation-aware `releaseExclusiveLock`
`releaseExclusiveLock` now accepts an optional `ownerToken` and unlinks only when BOTH pid and token match, symmetric with the reclaim decision in `tryAcquireExclusiveLock`. Closes the recycled-PID window where a process could delete a lock now held by a *different* incarnation that recycled the same PID. A lock with no token line (pre-token incarnation) is treated as ours on a PID match, preserving legacy behavior. `FileMigrationLock.release()` passes `this.ownerToken`; the daemon caller passes none (PID-only, unchanged).

## Follow-up 2 — centralized positional format
New `formatLockContent` / `parseLockContent` pair is the single place encoding the "line 1 = bare integer PID, line 2 = token" contract. `writeExclusiveLockFile`, `tryAcquireExclusiveLock`, and `releaseExclusiveLock` now go through them, so a future third field is added in one place and can't silently move the PID off line 1 and break `parseInt` readers.

## Validation
- `bun test test/utils/fileLock.test.ts test/db/migrationLock.test.ts` — 49 pass (added incarnation-aware release + round-trip helper tests; FakeTimer, <100ms)
- `turbo run lint build` — green
- `bun run typecheck` — no new errors

## Caveats
- Both fixes are latent hardening (no reachable bug today); daemon coordinator lock behavior is byte-for-byte unchanged.
- No files outside owned scope touched.