### PR TITLE
fix(db): await in-flight startup migration before daemon shutdown close (#3044)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -22,7 +22,12 @@ import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
-import { closeDatabase, getDatabasePath, getDbWriteBarrier } from "../db";
+import {
+  awaitInFlightMigrations,
+  closeDatabase,
+  getDatabasePath,
+  getDbWriteBarrier,
+} from "../db";
 import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
 import { handleFatalDatabaseStartupFailure } from "./daemonStartupGuard";
@@ -80,6 +85,13 @@ const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
 // writes to quiesce before closing the connection (issue #2792). Best-effort
 // writes are best-effort: if the bound elapses, shutdown proceeds anyway.
 const DB_WRITE_DRAIN_TIMEOUT_MS = 1_000;
+
+// Ceiling on awaiting an in-flight cold-start migration before closing the DB on
+// shutdown (issue #3044). A SIGTERM arriving mid-startup-migration would otherwise
+// let the detached migration connection's writes/checkpoint contend with the
+// closing app connection (Windows busy_timeout stall). Bounded: a wedged migration
+// cannot itself hang shutdown — the timeout wins and shutdown proceeds anyway.
+const MIGRATION_SETTLE_TIMEOUT_MS = 5_000;
 
 /**
  * Main daemon process
@@ -1342,6 +1354,21 @@ export class Daemon {
     if (!drained) {
       logger.warn(
         `Timed out after ${DB_WRITE_DRAIN_TIMEOUT_MS}ms draining in-flight DB writes; closing database anyway`
+      );
+    }
+
+    // If a SIGTERM arrived mid cold-start migration, the detached migration
+    // connection is still open and writing on its own connection (its writes are
+    // NOT tracked by the write barrier drained above). Let it settle before
+    // closeDatabase() destroys the app connection, so their WAL writes/checkpoint
+    // can't contend and stall shutdown on busy_timeout (Windows; issue #3044).
+    // Bounded so a wedged migration cannot itself hang shutdown.
+    const migrationsSettled = await awaitInFlightMigrations(
+      MIGRATION_SETTLE_TIMEOUT_MS
+    );
+    if (!migrationsSettled) {
+      logger.warn(
+        `Timed out after ${MIGRATION_SETTLE_TIMEOUT_MS}ms awaiting in-flight startup migration; closing database anyway`
       );
     }
 

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -20,6 +20,8 @@ import {
   isMissingMigrationDependencyError,
 } from "./migrationDependencyIntegrity";
 import { resetDbWriteBarrier } from "./dbWriteBarrier";
+import type { Timer } from "../utils/SystemTimer";
+import { defaultTimer } from "../utils/SystemTimer";
 
 type BunDatabaseConstructor = typeof import("bun:sqlite").Database;
 type BunDatabase = import("bun:sqlite").Database;
@@ -554,6 +556,72 @@ export function getMigrationsPromiseForTest(): Promise<void> | null {
 function resetDbLifecycleState(): void {
   lifecycle.reset();
   resetDbWriteBarrier();
+}
+
+/**
+ * Await any in-flight startup migration (the detached, resolve-never-reject
+ * `.then` chain built in {@link ensureMigrationsStarted}) before the daemon tears
+ * down the app connection, bounded by `timeoutMs`.
+ *
+ * `getDatabase()` kicks `startMigrations()` off on a SEPARATE, detached
+ * `migrationDb` connection. `closeDatabase()` only destroys the app connection and
+ * bumps the generation fence so the detached success/failure handler no-ops — it
+ * never awaits that connection's own writes/checkpoint settling. In steady-state
+ * shutdown this is moot: startup already awaited `ensureMigrations()` before the
+ * daemon served traffic, so migrations are long settled. The one reachable window
+ * is a SIGTERM arriving mid cold-start migration, where the still-open
+ * `migrationDb` connection's writes contend with the closing app connection —
+ * the exact WAL contention #3040 removed from the test, which on Windows can
+ * stall shutdown on `busy_timeout` (issue #3044).
+ *
+ * Calling this before `closeDatabase()` in the daemon shutdown path lets the
+ * migration connection finish (and `startMigrations()` destroy it) first. The
+ * underlying promise never rejects (a failed migration caches into
+ * `migrationsError`), so this never throws; a wedged migration cannot itself hang
+ * shutdown — the timeout wins and shutdown proceeds anyway. No-ops when no run is
+ * in flight.
+ *
+ * @returns true if the migration settled within the budget (or none was in
+ *   flight), false if the timeout won.
+ */
+export async function awaitInFlightMigrations(
+  timeoutMs: number,
+  timer: Timer = defaultTimer
+): Promise<boolean> {
+  return awaitPromiseBounded(lifecycle.migrationsPromise, timeoutMs, timer);
+}
+
+/**
+ * Race a resolve-never-reject promise against a bounded timeout, returning true if
+ * it settled first (or was already null) and false if the timeout won. Extracted
+ * from {@link awaitInFlightMigrations} so the timeout branch is unit-testable with
+ * a caller-supplied in-flight promise + {@link Timer} fake, without having to force
+ * a real cold-start migration to block (issue #3044). The bound timer is always
+ * cleared, so a settled promise leaves no dangling timeout.
+ */
+export async function awaitPromiseBounded(
+  inFlight: Promise<void> | null,
+  timeoutMs: number,
+  timer: Timer = defaultTimer
+): Promise<boolean> {
+  if (!inFlight) {
+    return true;
+  }
+
+  let handle: NodeJS.Timeout | undefined;
+  const timeout = new Promise<boolean>(resolve => {
+    handle = timer.setTimeout(() => resolve(false), timeoutMs);
+  });
+
+  try {
+    // `inFlight` is resolve-never-reject by construction (ensureMigrationsStarted),
+    // so this race never rejects.
+    return await Promise.race([inFlight.then(() => true), timeout]);
+  } finally {
+    if (handle !== undefined) {
+      timer.clearTimeout(handle);
+    }
+  }
 }
 
 /**

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,6 +2,7 @@
 export {
   getDatabase,
   closeDatabase,
+  awaitInFlightMigrations,
   getDatabasePath,
   ensureMigrations,
   getMigrationsError,

--- a/test/db/awaitInFlightMigrations.test.ts
+++ b/test/db/awaitInFlightMigrations.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  awaitInFlightMigrations,
+  awaitPromiseBounded,
+  closeDatabase,
+} from "../../src/db/database";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { withInMemorySingletonDatabase } from "./inMemorySingletonDatabase";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("awaitPromiseBounded", () => {
+  it("returns true immediately when nothing is in flight", async () => {
+    const timer = new FakeTimer();
+    expect(await awaitPromiseBounded(null, 5000, timer)).toBe(true);
+    // No bound timer was ever armed.
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  it("returns true when the in-flight promise settles first, clearing the bound", async () => {
+    const timer = new FakeTimer();
+    const d = deferred();
+    const p = awaitPromiseBounded(d.promise, 5000, timer);
+    d.resolve();
+    expect(await p).toBe(true);
+    // The bound timer is cleared once the race resolves.
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  it("returns false when the bound elapses before the migration settles", async () => {
+    const timer = new FakeTimer();
+    // A promise that never resolves models a wedged mid-startup migration.
+    const neverSettles = new Promise<void>(() => {});
+    const p = awaitPromiseBounded(neverSettles, 5000, timer);
+    timer.advanceTime(5000);
+    expect(await p).toBe(false);
+  });
+});
+
+describe("awaitInFlightMigrations (module state)", () => {
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  it("returns true when no migration is in flight (post-close)", async () => {
+    await closeDatabase();
+    expect(await awaitInFlightMigrations(5000, new FakeTimer())).toBe(true);
+  });
+
+  it("returns true once the real :memory: startup migration has settled", async () => {
+    await withInMemorySingletonDatabase(async () => {
+      const { getDatabase, ensureMigrations } = await import(
+        "../../src/db/database"
+      );
+      getDatabase();
+      await ensureMigrations();
+      // Migration already settled: the bound never needs to fire.
+      const timer = new FakeTimer();
+      expect(await awaitInFlightMigrations(5000, timer)).toBe(true);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #3044

## Summary
A SIGTERM arriving **mid cold-start migration** triggered the daemon's `stop()` → write-barrier drain + `closeDatabase()` while `startMigrations()`'s **detached** `migrationDb` connection was still open and writing. Those writes are NOT tracked by the write barrier, so on Windows the migration connection's WAL writes/checkpoint could contend with the closing app connection and stall shutdown on `busy_timeout` (the exact contention #3040 removed from the test side).

This adds a bounded "settle migrations before close" guard to the production shutdown path, mirroring what #3040 added to the test.

## Changes
- `src/db/database.ts`: new `awaitInFlightMigrations(timeoutMs, timer)` — races the detached, resolve-never-reject `lifecycle.migrationsPromise` against a bounded `Timer` timeout; no-ops when nothing is in flight; never throws (a failed migration caches into `migrationsError`). Extracted inner `awaitPromiseBounded(...)` so the timeout branch is unit-testable without forcing a real migration to block.
- `src/db/index.ts`: export `awaitInFlightMigrations`.
- `src/daemon/daemon.ts`: in `stop()`, call `awaitInFlightMigrations(MIGRATION_SETTLE_TIMEOUT_MS=5_000)` after the write-barrier drain and **before** `closeDatabase()`; log-and-continue on timeout so a wedged migration cannot itself hang shutdown.

## Conventions
- Reuses the canonical `Timer`/`defaultTimer` primitive (same as `dbWriteBarrier.drain`), no new `setTimeout` path.
- New unit tests use `FakeTimer` (no real timers) + `withInMemorySingletonDatabase` — never resolve the real file-backed DB. All <100ms.

## Validation
- `bun test test/db/awaitInFlightMigrations.test.ts` — 5 pass.
- `bun test test/db/database.test.ts test/db/dbWriteBarrier.test.ts databaseLifecycleReset dbWriteBarrierResetOnClose` — green (no regressions).
- `bun run lint`, `bun build.ts`, `bun run typecheck` (no new baseline errors) — all clean.

## Caveats
- No daemon-level `start`→SIGTERM→`stop` integration test exists (daemon is not unit-testable); coverage is on the extracted bounded-race primitive + module-state wiring. Steady-state shutdown is unaffected (migrations already settled → returns true on next microtask).