### PR TITLE
feat(ios): explicit 'requires iOS 17+' error for physical terminateApp/launchApp on iOS<=16 (#3056)

### DIFF
--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -5,6 +5,7 @@ import type { ExecResult } from "../../models";
 import { ActionableError, toActionableError } from "../../models/ActionableError";
 import { hashAppBundle } from "./AppBundleHasher";
 import { isProcessAlreadyGoneError } from "./iosProcessErrors";
+import { iosMajorVersionFromDevicectlDetails } from "./iosVersion";
 import { logger } from "../logger";
 import { isRunningInDocker } from "../dockerEnv";
 import { getDeviceAppBundleHash, installDeviceApp, isHostControlAvailable, shouldUseHostControl, uninstallDeviceApp } from "../hostControlClient";
@@ -68,6 +69,20 @@ const defaultDependencies: DeviceAppManagerDependencies = {
 };
 
 const quoteShell = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
+
+/**
+ * Lowest major iOS version whose physical-device process management
+ * (`devicectl device process launch`/`terminate`) is supported. devicectl gained
+ * process management with iOS 17 / Xcode 15; on iOS ≤16 devices the underlying
+ * call fails with a generic tool error, so callers gate on this and surface an
+ * explicit, version-specific message instead. See issue #3056.
+ */
+const MIN_DEVICECTL_PROCESS_IOS_MAJOR = 17;
+
+/** Actionable "requires iOS 17+" message for a physical-device `verb` on an iOS ≤16 device. */
+const requiresIos17Message = (verb: string, bundleId: string, major: number): string =>
+  `${verb} ${bundleId} on a physical iOS device requires iOS ${MIN_DEVICECTL_PROCESS_IOS_MAJOR}+ ` +
+  `(devicectl process management); this device reports iOS ${major}.`;
 
 const parseJsonOutputPath = (command: string): string | null => {
   const match = command.match(/--json-output\s+([^\s]+)/);
@@ -739,6 +754,14 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       return { success: false, error: "Physical device app launch requires macOS" };
     }
 
+    // iOS ≤16 devices lack devicectl process management (#3056): detect the
+    // version first and return the explicit "requires iOS 17+" error rather than
+    // a generic launch failure. Unknown versions (null) proceed to the real call.
+    const major = await this.resolveDeviceMajorIosVersion(deviceUdid);
+    if (major !== null && major < MIN_DEVICECTL_PROCESS_IOS_MAJOR) {
+      return { success: false, error: requiresIos17Message("Launching", bundleId, major) };
+    }
+
     const tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-launch-"));
     const jsonPath = join(tempDir, "launch.json");
     try {
@@ -801,6 +824,14 @@ export class DeviceAppManager implements DeviceUrlLauncher {
 
     if (this.deps.platform() !== "darwin") {
       throw new ActionableError("Physical iOS device app termination requires macOS");
+    }
+
+    // iOS ≤16 devices lack devicectl process management (#3056): detect the
+    // version first and throw the explicit "requires iOS 17+" error rather than a
+    // generic devicectl terminate failure. Unknown versions (null) proceed.
+    const major = await this.resolveDeviceMajorIosVersion(deviceUdid);
+    if (major !== null && major < MIN_DEVICECTL_PROCESS_IOS_MAJOR) {
+      throw new ActionableError(requiresIos17Message("Terminating", bundleId, major));
     }
 
     const bundlePath = await this.resolveInstalledBundlePathOnDevice(deviceUdid, bundleId);
@@ -915,6 +946,44 @@ export class DeviceAppManager implements DeviceUrlLauncher {
 
       const raw = await this.deps.readFile(jsonPath);
       return findRunningProcessPid(JSON.parse(raw), bundlePath);
+    } finally {
+      await this.deps.rm(tempDir);
+    }
+  }
+
+  /**
+   * Best-effort resolve the device's major iOS version via
+   * `devicectl device info details --json-output`. Returns null when the version
+   * can't be determined (devicectl failure, unrecognized JSON envelope) so the
+   * version gate stays advisory: an unknown version proceeds to the real call
+   * rather than blocking a possibly-supported device. macOS-only (callers guard
+   * the platform before invoking this).
+   */
+  private async resolveDeviceMajorIosVersion(deviceUdid: string): Promise<number | null> {
+    const tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-"));
+    const jsonPath = join(tempDir, "details.json");
+    try {
+      const command = [
+        "xcrun",
+        "devicectl",
+        "device",
+        "info",
+        "details",
+        "--device", deviceUdid,
+        "--json-output", quoteShell(jsonPath),
+        "--quiet"
+      ].join(" ");
+      await this.deps.exec(command);
+      const raw = await this.deps.readFile(jsonPath);
+      return iosMajorVersionFromDevicectlDetails(raw);
+    } catch (error) {
+      // Version detection is a best-effort probe: a failure here must not block a
+      // possibly-supported device, so log-and-continue with an "unknown" (null)
+      // version. The subsequent real devicectl call still surfaces any true error.
+      this.deps.logger.debug(
+        `[DeviceAppManager] Could not resolve iOS version for ${deviceUdid}: ${getErrorMessage(error)}`
+      );
+      return null;
     } finally {
       await this.deps.rm(tempDir);
     }

--- a/src/utils/ios-cmdline-tools/iosVersion.ts
+++ b/src/utils/ios-cmdline-tools/iosVersion.ts
@@ -53,3 +53,65 @@ export function iosMajorVersionFromSimctlListDevices(json: string, udid: string)
   }
   return null;
 }
+
+/**
+ * Resolve the major iOS version for a physical device from the JSON emitted by
+ * `devicectl device info details --json-output`. Apple does not formally document
+ * the envelope, so we deep-walk it and accept the several field spellings
+ * observed across Xcode builds: `osVersionNumber` (the plain "18.6" string) is
+ * preferred, then `osVersion`/`productVersion`/`operatingSystemVersion`. Returns
+ * `null` when nothing parses, so callers treat the version as "unknown" (and must
+ * NOT block on an unresolved version) rather than guessing.
+ */
+export function iosMajorVersionFromDevicectlDetails(json: string): number | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (error) {
+    // Malformed/empty devicectl output is a best-effort probe failure: the caller
+    // treats an unresolved version as "unknown" and proceeds without a version gate.
+    logger.debug(`iosMajorVersionFromDevicectlDetails: could not parse devicectl JSON: ${error}`);
+    return null;
+  }
+
+  const versionFields = [
+    "osVersionNumber",
+    "osVersion",
+    "productVersion",
+    "operatingSystemVersion"
+  ];
+
+  const walk = (node: unknown): number | null => {
+    if (!node || typeof node !== "object") {
+      return null;
+    }
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const found = walk(item);
+        if (found !== null) {
+          return found;
+        }
+      }
+      return null;
+    }
+    const record = node as Record<string, unknown>;
+    for (const field of versionFields) {
+      const value = record[field];
+      if (typeof value === "string") {
+        const major = parseIosMajorVersion(value);
+        if (major !== null) {
+          return major;
+        }
+      }
+    }
+    for (const value of Object.values(record)) {
+      const found = walk(value);
+      if (found !== null) {
+        return found;
+      }
+    }
+    return null;
+  };
+
+  return walk(parsed);
+}

--- a/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
@@ -675,6 +675,80 @@ describe("DeviceAppManager launch (devicectl)", () => {
     expect(result.error).toContain("Application not found");
   });
 
+  const writeDeviceDetailsJson = async (command: string, osVersion: string) => {
+    const jsonPath = parseDevicectlJsonOutputPath(command);
+    if (jsonPath) {
+      await fs.writeFile(jsonPath, JSON.stringify({
+        result: { deviceProperties: { osVersionNumber: osVersion } }
+      }), "utf-8");
+    }
+  };
+
+  test("launchApp returns an explicit 'requires iOS 17+' error on an iOS 16 device without launching", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info details")) {
+        await writeDeviceDetailsJson(command, "16.7.1");
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const result = await inspector.launchApp("device-udid", bundleId, { terminateExisting: true });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("requires iOS 17+");
+    expect(result.error).toContain("reports iOS 16");
+    // Version gate short-circuits before the launch shell-out.
+    expect(commands.some(c => c.includes("device process launch"))).toBe(false);
+  });
+
+  test("launchApp proceeds when the iOS version cannot be resolved (unknown => not blocked)", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      // No details JSON written => version resolves to null => must not gate.
+      if (command.includes("device process launch")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({ result: { process: { processIdentifier: 77 } } }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const result = await inspector.launchApp("device-udid", bundleId);
+
+    expect(result.success).toBe(true);
+    expect(result.pid).toBe(77);
+  });
+
+  test("launchApp proceeds on iOS 17 (boundary is satisfied, not gated)", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info details")) {
+        await writeDeviceDetailsJson(command, "17.0");
+      }
+      if (command.includes("device process launch")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({ result: { process: { processIdentifier: 88 } } }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const result = await inspector.launchApp("device-udid", bundleId);
+
+    expect(result.success).toBe(true);
+    expect(result.pid).toBe(88);
+    expect(commands.some(c => c.includes("device process launch"))).toBe(true);
+  });
+
   test("launchApp returns an explicit macOS error on non-darwin without shelling out", async () => {
     const commands: string[] = [];
     const exec = async (command: string) => { commands.push(command); return makeExecResult(); };
@@ -948,6 +1022,65 @@ describe("DeviceAppManager terminate (devicectl)", () => {
     expect(result).toEqual({ wasInstalled: false, wasRunning: false });
     expect(commands.some(c => c.includes("device info processes"))).toBe(false);
     expect(commands.some(c => c.includes("device process terminate"))).toBe(false);
+  });
+
+  const writeTerminateDetailsJson = async (command: string, osVersion: string) => {
+    const jsonPath = parseDevicectlJsonOutputPath(command);
+    if (jsonPath) {
+      await fs.writeFile(jsonPath, JSON.stringify({
+        result: { deviceProperties: { osVersionNumber: osVersion } }
+      }), "utf-8");
+    }
+  };
+
+  test("throws an explicit 'requires iOS 17+' ActionableError on an iOS 16 device without terminating", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info details")) {
+        await writeTerminateDetailsJson(command, "16.4");
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+
+    const thrown = await inspector.terminateApp("device-udid", bundleId).then(
+      () => { throw new Error("expected terminateApp to reject"); },
+      (e: unknown) => e
+    );
+    expect(thrown).toBeInstanceOf(ActionableError);
+    expect((thrown as Error).message).toContain("requires iOS 17+");
+    expect((thrown as Error).message).toContain("reports iOS 16");
+    // Version gate short-circuits before any bundle/process resolution or terminate.
+    expect(commands.some(c => c.includes("device info apps"))).toBe(false);
+    expect(commands.some(c => c.includes("device process terminate"))).toBe(false);
+  });
+
+  test("proceeds to terminate when the iOS version cannot be resolved (unknown => not blocked)", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      // No details JSON written => version resolves to null => must not gate.
+      if (command.includes("device info apps")) {
+        await writeAppsJson(command, true);
+      }
+      if (command.includes("device info processes")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({
+            result: { runningProcesses: [{ processIdentifier: 4321, executable: `${bundlePath}/CtrlProxyApp` }] }
+          }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const result = await inspector.terminateApp("device-udid", bundleId);
+
+    expect(result).toEqual({ wasInstalled: true, wasRunning: true });
+    expect(commands.some(c => c.includes("device process terminate"))).toBe(true);
   });
 
   test("throws a clear macOS error on non-darwin without shelling out", async () => {

--- a/test/utils/ios-cmdline-tools/iosVersion.test.ts
+++ b/test/utils/ios-cmdline-tools/iosVersion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   parseIosMajorVersion,
   iosMajorVersionFromSimctlListDevices,
+  iosMajorVersionFromDevicectlDetails,
 } from "../../../src/utils/ios-cmdline-tools/iosVersion";
 
 describe("parseIosMajorVersion", () => {
@@ -84,5 +85,39 @@ describe("iosMajorVersionFromSimctlListDevices", () => {
       },
     });
     expect(iosMajorVersionFromSimctlListDevices(multi, udid)).toBe(18);
+  });
+});
+
+describe("iosMajorVersionFromDevicectlDetails", () => {
+  test("reads osVersionNumber from the deviceProperties envelope", () => {
+    const json = JSON.stringify({
+      result: { deviceProperties: { osVersionNumber: "18.6" } },
+    });
+    expect(iosMajorVersionFromDevicectlDetails(json)).toBe(18);
+  });
+
+  test("resolves an iOS 16 device", () => {
+    const json = JSON.stringify({
+      result: { deviceProperties: { osVersionNumber: "16.7.1" } },
+    });
+    expect(iosMajorVersionFromDevicectlDetails(json)).toBe(16);
+  });
+
+  test("accepts alternate field spellings (productVersion)", () => {
+    const json = JSON.stringify({ result: { hardware: { productVersion: "17.0" } } });
+    expect(iosMajorVersionFromDevicectlDetails(json)).toBe(17);
+  });
+
+  test("returns null for malformed JSON", () => {
+    expect(iosMajorVersionFromDevicectlDetails("{not json")).toBeNull();
+  });
+
+  test("returns null when no version field is present", () => {
+    const json = JSON.stringify({ result: { deviceProperties: { name: "iPhone" } } });
+    expect(iosMajorVersionFromDevicectlDetails(json)).toBeNull();
+  });
+
+  test("returns null for a non-object scalar payload", () => {
+    expect(iosMajorVersionFromDevicectlDetails("42")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #3056

## Summary
Physical-device `terminateApp`/`launchApp` in `DeviceAppManager` (aliased as `DeviceAppInspector`) require devicectl process management, which exists only on iOS 17+ / Xcode 15. On an iOS <=16 device the devicectl call previously failed with a generic tool error. This adds an explicit, version-specific "requires iOS 17+" error surfaced *before* the operation.

- New canonical parser `iosMajorVersionFromDevicectlDetails(json)` in `iosVersion.ts` (deep-walks the `devicectl device info details --json-output` envelope; accepts `osVersionNumber`/`osVersion`/`productVersion`/`operatingSystemVersion`; returns `null` when unresolvable).
- `DeviceAppManager.resolveDeviceMajorIosVersion()` runs `xcrun devicectl device info details ... --json-output` (macOS-only, log-and-continue on failure).
- `launchApp` returns `{ success:false, error }` and `terminateApp` throws `ActionableError` when the device reports iOS < 17.
- **Fail-open:** an unresolved/unknown version (`null`) proceeds to the real devicectl call, so iOS 17+ devices are never wrongly blocked if the JSON envelope shape differs.

## Validation
- `bun test` DeviceAppManager + iosVersion + TerminateApp + LaunchApp + drift/urlLaunch suites: all pass (111 tests).
- `turbo run lint build` green; `bun run typecheck` gate: no new type errors.

## Scope / caveats
- Only `src/utils/ios-cmdline-tools/{DeviceAppManager,iosVersion}.ts` + their tests touched. No imports/registrations outside scope.
- Adds one extra `device info details` exec per physical launch/terminate (intrinsic to the gate). Requires real iOS <=16 hardware to observe end-to-end; unit-tested via injected fake exec.