### PR TITLE
test(android): behavioral EXTRACT_HIERARCHY error-frame coverage (#3131)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1944,8 +1944,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
               }
             sendResult(success = true, data = message)
           } else {
-            sendResult(success = false, error = "Failed to extract hierarchy")
-            broadcastHierarchyExtractError(uuid, "Failed to extract hierarchy")
+            sendResult(success = false, error = HierarchyExtractErrorFrames.NULL_HIERARCHY_ERROR)
+            broadcastHierarchyExtractFrame(HierarchyExtractErrorFrames.nullResultFrame(uuid))
           }
         } catch (e: CancellationException) {
           // Cooperative cancellation (service scope shutting down) must never be converted into an
@@ -1955,7 +1955,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           val cause = e.message ?: e::class.simpleName ?: "unknown error"
           Log.e(TAG, "Error extracting hierarchy for uuid=$uuid", e)
           sendResult(success = false, error = cause)
-          broadcastHierarchyExtractError(uuid, "Hierarchy extraction failed: $cause")
+          broadcastHierarchyExtractFrame(HierarchyExtractErrorFrames.thrownFrame(uuid, e))
         }
       }
     }
@@ -2005,8 +2005,9 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   /**
-   * Emit a correlated WebSocket `type:"error"` frame for a failed `EXTRACT_HIERARCHY` broadcast,
-   * keyed by the broadcast's `sync_` [requestId] uuid.
+   * Emit the correlated WebSocket `type:"error"` [frame] for a failed `EXTRACT_HIERARCHY`
+   * broadcast, keyed by the broadcast's `sync_` `requestId` uuid. A null [frame] (blank/absent
+   * uuid, or a cancellation the caller rethrows — see [HierarchyExtractErrorFrames]) is a no-op.
    *
    * The daemon's ADB-broadcast hierarchy fallback awaits that uuid in `waitForFreshData` over this
    * same WebSocket (the response channel the success-path `hierarchy_update` push also travels on).
@@ -2018,10 +2019,14 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * Routed through [ResultBroadcaster.guard] so a throw while *sending* this frame degrades to the
    * daemon's timeout rather than escaping the receiver coroutine (issue #3045 / #3085).
    */
-  private suspend fun broadcastHierarchyExtractError(requestId: String?, error: String) {
-    resultBroadcaster.guard(requestId, "hierarchy_extract_error") {
+  private suspend fun broadcastHierarchyExtractFrame(frame: ErrorResponse?) {
+    // A null frame means there was nothing to correlate (blank/absent uuid, or a cooperative
+    // cancellation that must propagate); HierarchyExtractErrorFrames already made that decision, so
+    // there is no WebSocket frame to send here. See issue #3131.
+    if (frame == null) return
+    resultBroadcaster.guard(frame.requestId, "hierarchy_extract_error") {
       if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
-        webSocketServer.broadcast(ErrorResponse(requestId = requestId, error = error))
+        webSocketServer.broadcast(frame)
       }
     }
   }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyExtractErrorFrames.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyExtractErrorFrames.kt
@@ -1,0 +1,49 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Pure failure-decision + frame-construction for the `ACTION_EXTRACT_HIERARCHY` branch of
+ * [CtrlProxy.handleCommand] (PR #3126, issue #3089). Isolated as an Android-free helper — mirroring
+ * how [BroadcastGuardScanner]/[LaunchCancellationScanner] factor out testable logic — so the
+ * correlated-error-frame contract can be unit-tested behaviorally without a Robolectric
+ * `AccessibilityService` harness (issue #3131).
+ *
+ * The daemon's ADB-broadcast hierarchy fallback awaits the request `uuid` over the WebSocket in
+ * `waitForFreshData`. On extraction failure the runner must emit a correlated
+ * [ErrorResponse]`(requestId = uuid)` so that wait fails fast instead of hanging to timeout; a
+ * cooperative [CancellationException] must instead propagate untouched so the coroutine unwinds
+ * cleanly. This object encodes exactly that mapping; [CtrlProxy.handleCommand] applies its result
+ * to the (guarded) WebSocket sink.
+ */
+object HierarchyExtractErrorFrames {
+
+  /** Error string emitted when `extractHierarchy` returns a null hierarchy. */
+  const val NULL_HIERARCHY_ERROR = "Failed to extract hierarchy"
+
+  /** Prefix for the error string emitted when `extractHierarchy` throws. */
+  const val THROWN_PREFIX = "Hierarchy extraction failed: "
+
+  /**
+   * The correlated error frame to broadcast when `extractHierarchy` returns `null`, or `null` when
+   * the request carried no `uuid` to correlate against (only the legacy ADB result is sent then, so
+   * no WebSocket frame is produced).
+   */
+  fun nullResultFrame(uuid: String?): ErrorResponse? =
+    if (uuid.isNullOrBlank()) null
+    else ErrorResponse(requestId = uuid, error = NULL_HIERARCHY_ERROR)
+
+  /**
+   * The correlated error frame to broadcast when `extractHierarchy` throws [error]. Returns `null`
+   * for a [CancellationException] (the caller must rethrow it so cooperative cancellation unwinds)
+   * or for a blank/absent [uuid] (no id to correlate a frame to). The error string mirrors the
+   * production message, carrying the throwable's `message` (falling back to its simple class name).
+   */
+  fun thrownFrame(uuid: String?, error: Throwable): ErrorResponse? {
+    if (error is CancellationException) return null
+    if (uuid.isNullOrBlank()) return null
+    val cause = error.message ?: error::class.simpleName ?: "unknown error"
+    return ErrorResponse(requestId = uuid, error = THROWN_PREFIX + cause)
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyExtractErrorFramesTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyExtractErrorFramesTest.kt
@@ -1,0 +1,106 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import java.io.IOException
+import java.util.concurrent.CancellationException as JavaCancellationException
+import kotlinx.coroutines.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behavioral coverage for the `ACTION_EXTRACT_HIERARCHY` error-frame emission (PR #3126,
+ * issue #3089), the runner-side follow-up requested in issue #3131. The daemon side is covered by
+ * `test/features/observe/CtrlProxyClient.test.ts`; before this test the runner side was covered
+ * only structurally (`BroadcastGuardAdoptionTest`) and by compilation — nothing asserted the actual
+ * `ErrorResponse(requestId = uuid)` frame content on each failure branch.
+ *
+ * `handleCommand` is a private `AccessibilityService` method, so rather than stand up a Robolectric
+ * harness the failure-decision + frame-construction was extracted into the pure
+ * [HierarchyExtractErrorFrames] (mirroring how [BroadcastGuardScanner] isolates testable logic);
+ * these tests exercise that helper directly against every branch enumerated in the issue.
+ */
+class HierarchyExtractErrorFramesTest {
+
+  private companion object {
+    const val UUID = "req-1234"
+  }
+
+  // extractHierarchy returns null → frame with error = "Failed to extract hierarchy",
+  // requestId = uuid.
+  @Test
+  fun `null hierarchy emits correlated failure frame`() {
+    val frame = HierarchyExtractErrorFrames.nullResultFrame(UUID)
+
+    assertEquals(
+      ErrorResponse(
+        timestamp = frame!!.timestamp,
+        requestId = UUID,
+        error = "Failed to extract hierarchy",
+      ),
+      frame,
+    )
+  }
+
+  // extractHierarchy throws → frame with error containing the cause, requestId = uuid.
+  @Test
+  fun `thrown extraction emits correlated frame carrying the cause`() {
+    val frame = HierarchyExtractErrorFrames.thrownFrame(UUID, IOException("adb pipe closed"))
+
+    assertEquals(UUID, frame!!.requestId)
+    assertEquals("Hierarchy extraction failed: adb pipe closed", frame.error)
+  }
+
+  // A throwable with no message falls back to its simple class name rather than emitting a blank
+  // cause — the awaiting daemon still gets an actionable frame.
+  @Test
+  fun `thrown extraction with no message falls back to the class name`() {
+    val frame = HierarchyExtractErrorFrames.thrownFrame(UUID, IllegalStateException())
+
+    assertEquals("Hierarchy extraction failed: IllegalStateException", frame!!.error)
+  }
+
+  // CancellationException during extraction → no error frame (the caller rethrows it so cooperative
+  // cancellation unwinds cleanly).
+  @Test
+  fun `kotlin CancellationException emits no frame`() {
+    assertNull(HierarchyExtractErrorFrames.thrownFrame(UUID, CancellationException("cancelled")))
+  }
+
+  @Test
+  fun `java CancellationException emits no frame`() {
+    // kotlinx's CancellationException is a typealias for
+    // java.util.concurrent.CancellationException;
+    // guard against the JDK type explicitly so a JobCancellationException subtype is never
+    // converted into a client-facing error frame.
+    assertNull(
+      HierarchyExtractErrorFrames.thrownFrame(UUID, JavaCancellationException("cancelled"))
+    )
+  }
+
+  // blank/missing uuid → no WebSocket frame (only the legacy ADB ACTION_OPERATION_RESULT is sent).
+  @Test
+  fun `null uuid produces no frame on either failure branch`() {
+    assertNull(HierarchyExtractErrorFrames.nullResultFrame(null))
+    assertNull(HierarchyExtractErrorFrames.thrownFrame(null, IOException("boom")))
+  }
+
+  @Test
+  fun `blank uuid produces no frame on either failure branch`() {
+    assertNull(HierarchyExtractErrorFrames.nullResultFrame("   "))
+    assertNull(HierarchyExtractErrorFrames.thrownFrame("", IOException("boom")))
+  }
+
+  // The helper's error strings must stay in lock-step with what handleCommand also passes to the
+  // legacy ADB sendResult path, so both channels report the same failure.
+  @Test
+  fun `error strings match the documented contract`() {
+    assertEquals("Failed to extract hierarchy", HierarchyExtractErrorFrames.NULL_HIERARCHY_ERROR)
+    assertTrue(
+      HierarchyExtractErrorFrames.thrownFrame(UUID, IOException("x"))!!
+        .error
+        .startsWith(HierarchyExtractErrorFrames.THROWN_PREFIX)
+    )
+  }
+}


### PR DESCRIPTION
Closes #3131

## Summary
Adds the runner-side behavioral test for `ACTION_EXTRACT_HIERARCHY` error-frame emission deferred in #3126 (closes #3089). Rather than stand up a Robolectric `AccessibilityService` harness, the failure-decision + frame-construction was extracted from `CtrlProxy.handleCommand` into a pure, Android-free `HierarchyExtractErrorFrames` helper (mirroring how `BroadcastGuardScanner`/`LaunchCancellationScanner` isolate testable logic), and `HierarchyExtractErrorFramesTest` exercises every branch the issue enumerated.

## Changes
- `HierarchyExtractErrorFrames.kt` (new): `nullResultFrame(uuid)` and `thrownFrame(uuid, error)` map a request uuid + extraction outcome to the correlated `ErrorResponse(requestId = uuid)` frame (or `null` for a blank/absent uuid or a `CancellationException`). Error strings (`"Failed to extract hierarchy"`, `"Hierarchy extraction failed: <cause>"`) are the single source of truth, reused by production.
- `CtrlProxy.kt`: the `EXTRACT_HIERARCHY` branch now derives its frame via the helper; `broadcastHierarchyExtractError(uuid, string)` → `broadcastHierarchyExtractFrame(frame)` (a null frame is a no-op). Still routed through `resultBroadcaster.guard` so `BroadcastGuardAdoptionTest` stays green. Behavior is identical: the null-result branch is unreachable with a blank uuid (early-returned at the top of the handler), and `CancellationException` is rethrown before the thrown-branch is reached.
- `HierarchyExtractErrorFramesTest.kt` (new): asserts each AC — null hierarchy → correlated frame; thrown → frame carrying the cause (+ class-name fallback for a message-less throwable); kotlin & JDK `CancellationException` → no frame; null/blank uuid → no frame on either branch; error-string contract.

## Validation
- `./gradlew -p android :control-proxy:testDebugUnitTest --tests '*HierarchyExtractErrorFramesTest*'` — BUILD SUCCESSFUL (JDK 21).
- `BroadcastGuardAdoptionTest` + `LaunchCancellationRethrowTest` — BUILD SUCCESSFUL (guard wrapping and cancellation-rethrow contracts preserved).
- ktfmt 0.64 `--google-style` applied to all touched Kotlin files (idempotent).

## Caveats
- Pure-helper approach (per the issue's own suggestion) rather than Robolectric — the private `handleCommand` still owns the try/catch control flow; the helper covers the failure-decision + frame content, which is the untested surface #3131 identified. The runner change from #3126 remains inert until the pinned runner is re-cut (`RELEASE_CHECKSUM_REGISTRY`), unchanged by this PR.