### PR TITLE
feat(db): BUSY/constraint-aware SQLite retry via err.cause.code (#2874)

### DIFF
--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -15,8 +15,26 @@ import {
 import { CompiledQuery } from "kysely";
 import { ActionableError } from "../models/ActionableError";
 import { logger } from "../utils/logger";
+import { BackoffPolicy, exponentialBackoff } from "../utils/Backoff";
+import { classifySqliteError } from "./databaseFailureClassification";
+import { defaultTimer, Timer } from "../utils/SystemTimer";
+import { defaultRandom, Random } from "../utils/Random";
 
 const MAX_CACHED_STATEMENTS = 200;
+
+/**
+ * Bounded retry for `SQLITE_BUSY`/`SQLITE_LOCKED` at the dialect boundary
+ * (issue #2874). Small cap: the daemon runs a single writer behind a JS mutex,
+ * so a busy/locked code is a rare `busy_timeout` expiry or checkpoint
+ * contention that a short backoff clears. Never applied inside an open
+ * transaction (partial re-execution) — see `#shouldRetry`.
+ */
+const DEFAULT_MAX_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_BACKOFF: BackoffPolicy = exponentialBackoff({
+  initialDelayMs: 5,
+  multiplier: 2,
+  maxDelayMs: 50,
+});
 
 type BunStatement = ReturnType<BunDatabase["prepare"]>;
 type SchemaVersionRow = { schema_version?: number | bigint };
@@ -52,6 +70,23 @@ export class BunSqliteDialect implements Dialect {
 interface BunSqliteDialectConfig {
   database: BunDatabase | (() => BunDatabase);
   beforeQuery?: () => Promise<void>;
+  /**
+   * BUSY/LOCKED retry knobs (issue #2874). All injected so tests can drive them
+   * with fakes (a `FakeTimer`, a deterministic `Random`) and keep unit tests
+   * <100ms and non-flaky. Defaults are production-safe.
+   */
+  retry?: BunSqliteRetryConfig;
+}
+
+interface BunSqliteRetryConfig {
+  /** Total attempts including the first. `<= 1` disables retry. */
+  maxAttempts?: number;
+  /** Backoff policy for the delay between attempts. */
+  backoff?: BackoffPolicy;
+  /** Sleep seam so tests avoid real timers. */
+  timer?: Timer;
+  /** Jitter source (0..1). Injected + faked for deterministic tests. */
+  random?: Random;
 }
 
 class BunSqliteDriver implements Driver {
@@ -65,7 +100,8 @@ class BunSqliteDriver implements Driver {
   async init(): Promise<void> {
     this.#connectionState = new BunSqliteConnectionState(
       this.#config.database,
-      this.#config.beforeQuery
+      this.#config.beforeQuery,
+      this.#config.retry
     );
   }
 
@@ -120,11 +156,23 @@ export class BunSqliteConnectionState {
   #statementCache = new Map<string, BunStatement>();
   #observedSchemaVersion: number | null = null;
   #closed = false;
+  readonly #maxRetryAttempts: number;
+  readonly #retryBackoff: BackoffPolicy;
+  readonly #timer: Timer;
+  readonly #random: Random;
 
-  constructor(database: BunDatabase | (() => BunDatabase), beforeQuery?: () => Promise<void>) {
+  constructor(
+    database: BunDatabase | (() => BunDatabase),
+    beforeQuery?: () => Promise<void>,
+    retry?: BunSqliteRetryConfig
+  ) {
     this.#databaseSource = database;
     this.#db = typeof database === "function" ? null : database;
     this.#beforeQuery = beforeQuery;
+    this.#maxRetryAttempts = Math.max(1, retry?.maxAttempts ?? DEFAULT_MAX_RETRY_ATTEMPTS);
+    this.#retryBackoff = retry?.backoff ?? DEFAULT_RETRY_BACKOFF;
+    this.#timer = retry?.timer ?? defaultTimer;
+    this.#random = retry?.random ?? defaultRandom;
   }
 
   async beginTransaction(owner: symbol): Promise<void> {
@@ -169,74 +217,133 @@ export class BunSqliteConnectionState {
     const { sql, parameters } = compiledQuery;
 
     try {
-      // Reject before touching (or reopening) the handle. A query that lost the
-      // shutdown race must fail cleanly here rather than silently reopening a new
-      // handle via #getDatabase() (issue #2792). Thrown outside the SQL-wrapping
-      // catch so callers see the closed-db cause, not a generic "Query failed".
+      // Bounded BUSY/LOCKED retry (issue #2874). Reads the structured
+      // `err.cause.code` preserved in #2793 (by identity, not `.message`
+      // scraping) to decide whether a locking contention is worth retrying.
+      // Only retries in autocommit — never across a transaction boundary, so a
+      // partially-applied statement inside another lease's transaction is never
+      // re-executed. See #shouldRetry.
+      for (let attempt = 1; ; attempt++) {
+        try {
+          return await this.#executeOnce<R>(sql, parameters);
+        } catch (error) {
+          if (!this.#shouldRetry(error, attempt)) {
+            throw error;
+          }
+          const delayMs = this.#retryDelayMs(attempt);
+          logger.warn(
+            `SQLite busy/locked (attempt ${attempt}/${this.#maxRetryAttempts}); ` +
+              `retrying in ${delayMs}ms: ${sql}`
+          );
+          await this.#timer.sleep(delayMs);
+        }
+      }
+    } finally {
+      this.#activeQueries -= 1;
+      this.#notifyWaiters();
+    }
+  }
+
+  /**
+   * Decide whether a caught query error warrants another attempt. Retries only
+   * when: the code (via `err.cause.code`, #2793 contract) is `retryable`
+   * (`SQLITE_BUSY`/`SQLITE_LOCKED`); attempts remain; the handle is still open;
+   * and we are NOT inside a transaction (autocommit only — `#transactionOwner`
+   * is cleared). Never retries `constraint`/`fatal`.
+   */
+  #shouldRetry(error: unknown, attempt: number): boolean {
+    if (attempt >= this.#maxRetryAttempts) {
+      return false;
+    }
+    if (this.#closed) {
+      return false;
+    }
+    // Autocommit only: if any transaction is open, retrying could re-run one
+    // statement of a multi-statement unit (the begin/commit are themselves
+    // routed through executeQuery). #transactionOwner is null exactly when no
+    // lease holds the transaction lock, so this also blocks retrying the raw
+    // begin/commit/rollback control statements.
+    if (this.#transactionOwner !== null) {
+      return false;
+    }
+    return classifySqliteError(error) === "retryable";
+  }
+
+  #retryDelayMs(attempt: number): number {
+    const base = this.#retryBackoff.delayForAttempt(attempt);
+    // Full jitter in [0, base] to avoid synchronized retry storms.
+    return Math.floor(this.#random.next() * (base + 1));
+  }
+
+  async #executeOnce<R>(sql: string, parameters: readonly unknown[]): Promise<QueryResult<R>> {
+    // Reject before touching (or reopening) the handle. A query that lost the
+    // shutdown race must fail cleanly here rather than silently reopening a new
+    // handle via #getDatabase() (issue #2792). Thrown outside the SQL-wrapping
+    // catch so callers see the closed-db cause, not a generic "Query failed".
+    if (this.#closed) {
+      throw new Error("Cannot use a closed database");
+    }
+
+    try {
+      await this.#beforeQuery?.();
+      // beforeQuery can await (e.g. migration gating), during which close() may
+      // run — re-check so a parked query rejects rather than reopening the handle.
       if (this.#closed) {
         throw new Error("Cannot use a closed database");
       }
+      const db = this.#getDatabase();
+
+      const schemaChanging = this.#isSchemaChangingSql(sql);
+      const stmt = schemaChanging ? db.prepare(sql) : this.#getStatement(db, sql);
+
+      // Check if this is a SELECT query or query with RETURNING clause
+      const sqlLower = sql.trim().toLowerCase();
+      const isSelect = sqlLower.startsWith("select");
+      // Word boundary (not a bare substring) so an identifier like
+      // `returning_items` isn't misclassified as a RETURNING clause. `_` is a
+      // word char, so `\breturning\b` correctly rejects `returning_items`.
+      const hasReturning = /\breturning\b/.test(sqlLower);
 
       try {
-        await this.#beforeQuery?.();
-        // beforeQuery can await (e.g. migration gating), during which close() may
-        // run — re-check so a parked query rejects rather than reopening the handle.
-        if (this.#closed) {
-          throw new Error("Cannot use a closed database");
-        }
-        const db = this.#getDatabase();
-
-        const schemaChanging = this.#isSchemaChangingSql(sql);
-        const stmt = schemaChanging ? db.prepare(sql) : this.#getStatement(db, sql);
-
-        // Check if this is a SELECT query or query with RETURNING clause
-        const sqlLower = sql.trim().toLowerCase();
-        const isSelect = sqlLower.startsWith("select");
-        // Word boundary (not a bare substring) so an identifier like
-        // `returning_items` isn't misclassified as a RETURNING clause. `_` is a
-        // word char, so `\breturning\b` correctly rejects `returning_items`.
-        const hasReturning = /\breturning\b/.test(sqlLower);
-
-        try {
-          if (isSelect || hasReturning) {
-            // For SELECT queries or queries with RETURNING, return all rows
-            const rows = stmt.all(...(parameters as any[])) as R[];
-            const result = {
-              rows,
-              numAffectedRows: hasReturning ? BigInt(rows.length) : undefined,
-            };
-            if (schemaChanging) {
-              this.#clearStatementCache();
-            }
-            return result;
-          } else {
-            // For INSERT/UPDATE/DELETE queries without RETURNING, execute and return changes
-            const writeResult = stmt.run(...(parameters as any[]));
-            const result = {
-              rows: [],
-              numAffectedRows: BigInt(writeResult.changes),
-              insertId:
+        if (isSelect || hasReturning) {
+          // For SELECT queries or queries with RETURNING, return all rows
+          const rows = stmt.all(...(parameters as any[])) as R[];
+          const result = {
+            rows,
+            numAffectedRows: hasReturning ? BigInt(rows.length) : undefined,
+          };
+          if (schemaChanging) {
+            this.#clearStatementCache();
+          }
+          return result;
+        } else {
+          // For INSERT/UPDATE/DELETE queries without RETURNING, execute and return changes
+          const writeResult = stmt.run(...(parameters as any[]));
+          const result = {
+            rows: [],
+            numAffectedRows: BigInt(writeResult.changes),
+            insertId:
                 writeResult.lastInsertRowid !== undefined
                   ? BigInt(writeResult.lastInsertRowid)
                   : undefined,
-            };
-            if (schemaChanging) {
-              this.#clearStatementCache();
-            }
-            return result;
-          }
-        } finally {
+          };
           if (schemaChanging) {
-            stmt.finalize();
+            this.#clearStatementCache();
           }
+          return result;
         }
-      } catch (error) {
-        // BigInt-safe: Kysely can bind BigInt params, and a bare
-        // JSON.stringify(parameters) throws on BigInt — which would mask the real
-        // SqliteError with a TypeError from the error reporter itself.
-        const params = JSON.stringify(parameters, (_key, value) =>
-          typeof value === "bigint" ? value.toString() : value
-        );
+      } finally {
+        if (schemaChanging) {
+          stmt.finalize();
+        }
+      }
+    } catch (error) {
+      // BigInt-safe: Kysely can bind BigInt params, and a bare
+      // JSON.stringify(parameters) throws on BigInt — which would mask the real
+      // SqliteError with a TypeError from the error reporter itself.
+      const params = JSON.stringify(parameters, (_key, value) =>
+        typeof value === "bigint" ? value.toString() : value
+      );
         // Preserve the original SqliteError (code/stack) via `cause` so future
         // BUSY/constraint-aware retries and describeUnknownError (which recurses
         // into `.cause`) can reach it. ActionableError drops `cause`, so use a
@@ -246,13 +353,9 @@ export class BunSqliteConnectionState {
         // databaseLazyPath.test.ts asserts that text via `.message`. The inline
         // `${error}` is BigInt-safe (unlike JSON.stringify) since it goes
         // through toString().
-        throw new Error(`Query failed: ${error}\nSQL: ${sql}\nParameters: ${params}`, {
-          cause: error,
-        });
-      }
-    } finally {
-      this.#activeQueries -= 1;
-      this.#notifyWaiters();
+      throw new Error(`Query failed: ${error}\nSQL: ${sql}\nParameters: ${params}`, {
+        cause: error,
+      });
     }
   }
 

--- a/src/db/databaseFailureClassification.ts
+++ b/src/db/databaseFailureClassification.ts
@@ -37,3 +37,74 @@ export function classifyDatabaseFailure(error: unknown): DatabaseFailureKind {
 
   return "permanent";
 }
+
+/**
+ * Classification of a single query error at the dialect boundary, used to decide
+ * whether a bounded, backoff-driven retry is worthwhile:
+ *
+ * - `retryable`: a locking/contention error that a later attempt may clear on
+ *   its own (`SQLITE_BUSY`, `SQLITE_BUSY_SNAPSHOT`, `SQLITE_LOCKED`, …). Safe to
+ *   retry outside an open transaction — the WAL single-writer topology means a
+ *   `busy_timeout` expiry or checkpoint contention is transient.
+ * - `constraint`: a data/logic conflict (`SQLITE_CONSTRAINT*` — unique, foreign
+ *   key, NOT NULL). Retrying is pointless and would mask the caller's bug; the
+ *   error must surface immediately so callers (upserts, `ON CONFLICT`) can react.
+ * - `fatal`: anything else — corruption, misuse, a closed handle, or a
+ *   non-SQLite error. Surface immediately.
+ */
+export type SqliteErrorAction = "retryable" | "constraint" | "fatal";
+
+// SQLite primary-result-code prefixes (`SQLITE_BUSY_SNAPSHOT`,
+// `SQLITE_CONSTRAINT_UNIQUE`, …) all begin with the primary code, so a prefix
+// match covers extended codes without enumerating every variant.
+const RETRYABLE_CODE_PREFIXES = ["SQLITE_BUSY", "SQLITE_LOCKED"] as const;
+const CONSTRAINT_CODE_PREFIX = "SQLITE_CONSTRAINT";
+
+/**
+ * Read the structured `SqliteError.code` reachable by identity from the thrown
+ * error's `.cause` (the contract established in #2793 / PR #2873) and classify
+ * it. Walks exactly one level of `.cause` — the dialect wraps the raw
+ * `SqliteError` in a single `new Error(msg, { cause })` — and also inspects the
+ * error itself so a bare `SqliteError` classifies too.
+ *
+ * Falls back to the message-pattern `classifyDatabaseFailure` ONLY when no
+ * structured code is present, so callers prefer identity over `.message`
+ * scraping (acceptance criterion for #2874) while still catching legacy shapes.
+ */
+export function classifySqliteError(error: unknown): SqliteErrorAction {
+  const code = extractSqliteCode(error);
+  if (code !== undefined) {
+    if (RETRYABLE_CODE_PREFIXES.some(prefix => code.startsWith(prefix))) {
+      return "retryable";
+    }
+    if (code.startsWith(CONSTRAINT_CODE_PREFIX)) {
+      return "constraint";
+    }
+    return "fatal";
+  }
+
+  // No structured code: fall back to the message-based classifier. A transient
+  // (busy/locked) message is the only thing worth retrying; everything else is
+  // fatal here (constraint conflicts do not appear in TRANSIENT_PATTERNS).
+  return classifyDatabaseFailure(error) === "transient" ? "retryable" : "fatal";
+}
+
+/**
+ * Extract a `SqliteError.code` string from an error or its immediate `.cause`,
+ * preferring the identity-preserved cause per the #2793 contract. Returns
+ * `undefined` when no string code is reachable (so the caller can fall back to
+ * message matching).
+ */
+function extractSqliteCode(error: unknown): string | undefined {
+  const direct = readStringCode(error);
+  if (direct !== undefined) {
+    return direct;
+  }
+  const cause = (error as { cause?: unknown } | null | undefined)?.cause;
+  return readStringCode(cause);
+}
+
+function readStringCode(value: unknown): string | undefined {
+  const code = (value as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" ? code : undefined;
+}

--- a/test/db/bunSqliteBusyRetry.test.ts
+++ b/test/db/bunSqliteBusyRetry.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "bun:test";
+import type { Database as BunDatabase } from "bun:sqlite";
+import { CompiledQuery } from "kysely";
+import { BunSqliteConnectionState } from "../../src/db/bunSqliteDialect";
+import { fixedBackoff } from "../../src/utils/Backoff";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { Random } from "../../src/utils/Random";
+
+/**
+ * Issue #2874: consume `err.cause.code` for a BUSY/constraint-aware SQLite
+ * retry. These tests use a fake `bun:sqlite` Database that throws a fake
+ * `SqliteError` carrying a `.code`, plus a `FakeTimer` and a deterministic
+ * `Random`, so they stay <100ms and non-flaky and rely on the `.cause`
+ * identity contract from #2793 (never `.message` scraping).
+ */
+
+// A fake SqliteError: only the `.code` matters for classification.
+class FakeSqliteError extends Error {
+  constructor(
+    message: string,
+    readonly code: string
+  ) {
+    super(message);
+    this.name = "SQLiteError";
+  }
+}
+
+interface StatementScript {
+  // One entry per `run`/`all` call: either an error to throw or `null` to succeed.
+  throws: (FakeSqliteError | null)[];
+}
+
+/**
+ * Minimal fake of the bun:sqlite Database surface the dialect touches:
+ * `prepare(sql)` -> statement with `all`/`run`/`get`/`finalize`, and `exec`.
+ * The script drives what each prepared-statement invocation does.
+ */
+function fakeDatabase(script: StatementScript): {
+  db: BunDatabase;
+  invocations: () => number;
+} {
+  let calls = 0;
+  const makeStatement = () => ({
+    all: (..._params: unknown[]) => {
+      const outcome = script.throws[calls++];
+      if (outcome) {
+        throw outcome;
+      }
+      return [{ v: 1 }];
+    },
+    run: (..._params: unknown[]) => {
+      const outcome = script.throws[calls++];
+      if (outcome) {
+        throw outcome;
+      }
+      return { changes: 1, lastInsertRowid: 1 };
+    },
+    get: (..._params: unknown[]) => ({ schema_version: 0 }),
+    finalize: () => {},
+  });
+  const db = {
+    prepare: (_sql: string) => makeStatement(),
+    exec: (_sql: string) => {},
+    close: () => {},
+  } as unknown as BunDatabase;
+  return { db, invocations: () => calls };
+}
+
+const zeroRandom: Random = {
+  next: () => 0,
+  pick: <T>(items: readonly T[]): T => items[0]!,
+};
+
+const SELECT = CompiledQuery.raw("select 1 as v");
+const INSERT = CompiledQuery.raw("insert into t (v) values (1)");
+
+describe("BunSqliteConnectionState BUSY/constraint-aware retry (issue #2874)", () => {
+  it("retries a SQLITE_BUSY error then succeeds, sleeping via the injected timer", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const { db, invocations } = fakeDatabase({
+      throws: [new FakeSqliteError("database is locked", "SQLITE_BUSY"), null],
+    });
+    const state = new BunSqliteConnectionState(db, undefined, {
+      maxAttempts: 3,
+      backoff: fixedBackoff(10),
+      timer,
+      random: zeroRandom,
+    });
+
+    const result = await state.executeQuery(SELECT, Symbol("owner"));
+
+    expect(result.rows).toEqual([{ v: 1 }] as any);
+    expect(invocations()).toBe(2); // one failure + one success
+    expect(timer.getSleepHistory().length).toBe(1); // exactly one backoff sleep
+  });
+
+  it("retries SQLITE_LOCKED as well", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const { db, invocations } = fakeDatabase({
+      throws: [new FakeSqliteError("locked", "SQLITE_LOCKED"), null],
+    });
+    const state = new BunSqliteConnectionState(db, undefined, {
+      maxAttempts: 3,
+      backoff: fixedBackoff(10),
+      timer,
+      random: zeroRandom,
+    });
+
+    await state.executeQuery(SELECT, Symbol("owner"));
+    expect(invocations()).toBe(2);
+  });
+
+  it("does NOT retry a SQLITE_CONSTRAINT error (surfaces immediately)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const { db, invocations } = fakeDatabase({
+      throws: [new FakeSqliteError("UNIQUE constraint failed", "SQLITE_CONSTRAINT_UNIQUE")],
+    });
+    const state = new BunSqliteConnectionState(db, undefined, {
+      maxAttempts: 3,
+      backoff: fixedBackoff(10),
+      timer,
+      random: zeroRandom,
+    });
+
+    await expect(state.executeQuery(INSERT, Symbol("owner"))).rejects.toThrow();
+    expect(invocations()).toBe(1); // no retry
+    expect(timer.getSleepHistory().length).toBe(0);
+  });
+
+  it("relies on err.cause.code by identity, not message text", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    // Message says nothing about busy/locked; only the structured code marks it
+    // retryable. If classification scraped `.message` this would not retry.
+    const { db, invocations } = fakeDatabase({
+      throws: [new FakeSqliteError("opaque failure", "SQLITE_BUSY_SNAPSHOT"), null],
+    });
+    const state = new BunSqliteConnectionState(db, undefined, {
+      maxAttempts: 3,
+      backoff: fixedBackoff(10),
+      timer,
+      random: zeroRandom,
+    });
+
+    await state.executeQuery(SELECT, Symbol("owner"));
+    expect(invocations()).toBe(2);
+  });
+
+  it("bounds the retry budget: exhausts maxAttempts then throws the wrapped error", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const busy = new FakeSqliteError("database is locked", "SQLITE_BUSY");
+    const { db, invocations } = fakeDatabase({ throws: [busy, busy, busy, busy, busy] });
+    const state = new BunSqliteConnectionState(db, undefined, {
+      maxAttempts: 3,
+      backoff: fixedBackoff(10),
+      timer,
+      random: zeroRandom,
+    });
+
+    const error = await state.executeQuery(SELECT, Symbol("owner")).catch(e => e as Error);
+    expect(error).toBeInstanceOf(Error);
+    // The #2793 cause-identity contract: the original SqliteError is reachable.
+    expect((error as Error).cause).toBe(busy);
+    expect(invocations()).toBe(3); // exactly maxAttempts
+    expect(timer.getSleepHistory().length).toBe(2); // sleeps between the 3 attempts
+  });
+
+  it("does NOT retry while a transaction is open (autocommit only)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const owner = Symbol("txn-owner");
+    // begin succeeds; the in-transaction statement throws BUSY and must NOT retry.
+    const { db, invocations } = fakeDatabase({
+      throws: [null, new FakeSqliteError("database is locked", "SQLITE_BUSY"), null],
+    });
+    const state = new BunSqliteConnectionState(db, undefined, {
+      maxAttempts: 3,
+      backoff: fixedBackoff(10),
+      timer,
+      random: zeroRandom,
+    });
+
+    await state.beginTransaction(owner); // sets #transactionOwner (1 invocation)
+    await expect(state.executeQuery(INSERT, owner)).rejects.toThrow();
+    // begin (1) + the single failing in-txn attempt (1) = 2; no retry attempt.
+    expect(invocations()).toBe(2);
+    expect(timer.getSleepHistory().length).toBe(0);
+  });
+
+  it("disables retry when maxAttempts <= 1", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const { db, invocations } = fakeDatabase({
+      throws: [new FakeSqliteError("database is locked", "SQLITE_BUSY"), null],
+    });
+    const state = new BunSqliteConnectionState(db, undefined, {
+      maxAttempts: 1,
+      backoff: fixedBackoff(10),
+      timer,
+      random: zeroRandom,
+    });
+
+    await expect(state.executeQuery(SELECT, Symbol("owner"))).rejects.toThrow();
+    expect(invocations()).toBe(1);
+  });
+});

--- a/test/db/classifySqliteError.test.ts
+++ b/test/db/classifySqliteError.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test";
+import { classifySqliteError } from "../../src/db/databaseFailureClassification";
+
+/**
+ * Issue #2874: `classifySqliteError` must prefer the structured
+ * `err.cause.code` (the #2793 identity contract) and fall back to message
+ * matching only when no code is present.
+ */
+describe("classifySqliteError", () => {
+  const wrap = (code: string): Error =>
+    new Error("Query failed: ...", { cause: Object.assign(new Error("x"), { code }) });
+
+  it("maps SQLITE_BUSY / SQLITE_LOCKED (and extended codes) to retryable", () => {
+    expect(classifySqliteError(wrap("SQLITE_BUSY"))).toBe("retryable");
+    expect(classifySqliteError(wrap("SQLITE_BUSY_SNAPSHOT"))).toBe("retryable");
+    expect(classifySqliteError(wrap("SQLITE_LOCKED"))).toBe("retryable");
+    expect(classifySqliteError(wrap("SQLITE_LOCKED_SHAREDCACHE"))).toBe("retryable");
+  });
+
+  it("maps SQLITE_CONSTRAINT* to constraint (never retryable)", () => {
+    expect(classifySqliteError(wrap("SQLITE_CONSTRAINT"))).toBe("constraint");
+    expect(classifySqliteError(wrap("SQLITE_CONSTRAINT_UNIQUE"))).toBe("constraint");
+    expect(classifySqliteError(wrap("SQLITE_CONSTRAINT_FOREIGNKEY"))).toBe("constraint");
+  });
+
+  it("maps unknown / corruption / misuse codes to fatal", () => {
+    expect(classifySqliteError(wrap("SQLITE_CORRUPT"))).toBe("fatal");
+    expect(classifySqliteError(wrap("SQLITE_MISUSE"))).toBe("fatal");
+    expect(classifySqliteError(wrap("SQLITE_ERROR"))).toBe("fatal");
+  });
+
+  it("reads a bare SqliteError's own code (not only via cause)", () => {
+    expect(classifySqliteError(Object.assign(new Error("x"), { code: "SQLITE_BUSY" }))).toBe(
+      "retryable"
+    );
+  });
+
+  it("falls back to message matching only when no structured code is present", () => {
+    expect(classifySqliteError(new Error("database is locked"))).toBe("retryable");
+    expect(classifySqliteError(new Error("UNIQUE constraint failed"))).toBe("fatal");
+    expect(classifySqliteError("some string")).toBe("fatal");
+    expect(classifySqliteError(undefined)).toBe("fatal");
+  });
+
+  it("prefers the structured code over a misleading message", () => {
+    // message screams 'locked' but code is a constraint -> constraint wins.
+    const err = new Error("database is locked", {
+      cause: Object.assign(new Error("x"), { code: "SQLITE_CONSTRAINT_UNIQUE" }),
+    });
+    expect(classifySqliteError(err)).toBe("constraint");
+  });
+});


### PR DESCRIPTION
Closes #2874

## Summary
Builds the BUSY/constraint-aware SQLite retry consumer that #2793 (PR #2873) enabled by preserving the raw `SqliteError` via `{ cause }`.

- **`classifySqliteError(error)`** (`src/db/databaseFailureClassification.ts`) — reads the structured `err.cause.code` **by identity** (per the #2793 contract), mapping `SQLITE_BUSY*`/`SQLITE_LOCKED*` → `retryable`, `SQLITE_CONSTRAINT*` → `constraint`, everything else → `fatal`. Falls back to the existing message-pattern classifier ONLY when no structured code is present (so a misleading message can't override a real code).
- **Bounded retry in `BunSqliteConnectionState.executeQuery`** (`src/db/bunSqliteDialect.ts`) — retries `retryable` codes with the canonical `Backoff` primitive (`exponentialBackoff`, full jitter via injected `Random`) and an injected `Timer.sleep` seam. Cap defaults to 3 attempts.
- **Transaction safety** — retry is autocommit-only (`#transactionOwner === null`). Because `#reserveTransaction` waits for `#activeQueries === 0`, an in-flight retrying query blocks any concurrent `begin`, so no retry ever crosses or re-runs a statement inside another lease's transaction. `begin`/`commit`/`rollback` control statements are never retried.
- All retry knobs (`maxAttempts`, `backoff`, `timer`, `random`) are injectable via new optional `retry` config; production defaults are safe.

## Acceptance criteria
- [x] Consumer reads `err.cause.code` by identity, not flattened `.message`.
- [x] `SQLITE_BUSY`/`SQLITE_LOCKED` → bounded retry via injected `Backoff`; `SQLITE_CONSTRAINT*`/unknown → no retry.
- [x] No retry crosses a transaction boundary owned by a different lease.
- [x] Unit tests with fakes + faked backoff/timer, <100ms, non-flaky.
- [x] `turbo run lint build test` green.

## Validation
- `bun test test/db/` — 748 pass, 0 fail.
- New tests: `test/db/classifySqliteError.test.ts` (code-vs-message precedence, extended codes), `test/db/bunSqliteBusyRetry.test.ts` (BUSY/LOCKED retry-then-succeed, CONSTRAINT no-retry, bounded budget with `cause`-identity assertion, no-retry-in-transaction, disable via maxAttempts<=1). Fake bun:sqlite Database + `FakeTimer` (autoAdvance) + deterministic `Random`.
- `bunx turbo run lint build` green; `bun run typecheck` gate green (no new errors).

## Caveats
- Each retry re-invokes `#beforeQuery` (migration gate); it is idempotent so this is safe.
