### PR TITLE
test(navigation): cover dismissTopModal bottom-sheet back-button fallback (#3125)

### DIFF
--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -183,6 +183,55 @@ describe("DefaultUIStateSetup", () => {
       expect(capturedArgs![INTERNAL_NO_DIFF_PARAM]).toBe(true);
     });
 
+    // Build a minimal view hierarchy that UIStateExtractor classifies as a
+    // `bottomsheet` modal with the given windowId: a flat node whose `class`
+    // contains "sheet" (classifyModalType) and an explicit `window-id`
+    // (getWindowId). No `windows` array => collectModalStack runs on the
+    // top-level hierarchy traversal.
+    const bottomSheetHierarchy = (windowId: number): ObserveResult => ({
+      viewHierarchy: {
+        hierarchy: { "class": "BottomSheetDialog", "window-id": String(windowId) },
+      },
+    } as unknown as ObserveResult);
+
+    test("falls through to the back button when the swipe leaves the bottom sheet present (#3125)", async () => {
+      ToolRegistry.register("swipeOn", "swipeOn", {}, async () =>
+        createStructuredToolResponse({ success: true })
+      );
+
+      // Stateful observe provider: the first post-swipe observation still
+      // contains the bottomsheet's windowId (swipe did NOT dismiss it), forcing
+      // the code past the swipe dismissal check into the back-button fallback;
+      // the second (post-back) observation has a null hierarchy => the sheet is
+      // gone, so the back-button path reports dismissal.
+      let observeCalls = 0;
+      const statefulObserve = (): ObserveScreenLike => ({
+        execute: async () => {
+          observeCalls++;
+          return observeCalls === 1
+            ? bottomSheetHierarchy(42)
+            : ({ viewHierarchy: null } as unknown as ObserveResult);
+        },
+      });
+
+      const setup = makeSetup(statefulObserve);
+      const dismissed = await (
+        setup as unknown as {
+          dismissTopModal: (modal: ModalState, platform: string) => Promise<boolean>;
+        }
+      ).dismissTopModal(bottomSheet, "android");
+
+      expect(dismissed).toBe(true);
+      // The swipe ran but did not dismiss (windowId still present on observe #1),
+      // so both post-swipe and post-back observations were consulted.
+      expect(observeCalls).toBe(2);
+      // The back-button fallback fired via the ADB keyevent seam — the
+      // AndroidCtrlProxy accessibility path is not connected in a unit context
+      // (requestGlobalAction fast-fails), so pressBack falls through to ADB.
+      const fakeAdb = (setup as unknown as { adb: FakeAdbClient }).adb;
+      expect(fakeAdb.wasCommandExecuted("shell input keyevent 4")).toBe(true);
+    });
+
     test("does not mistakenly resolve a tool registered under the old name `swipe`", async () => {
       let legacySwipeCalls = 0;
       // Register ONLY the wrong name. With the bug this would be the tool the


### PR DESCRIPTION
Closes #3125

## Summary
Adds the deferred coverage-gap test flagged in the multi-perspective review of #3118: the bottom-sheet branch of `DefaultUIStateSetup.dismissTopModal` where the swipe-down runs but does NOT dismiss the sheet, so the code falls through to the back-button fallback.

## What the test does
- Registers a `swipeOn` fake (success) so the swipe branch runs.
- Provides a **stateful** observe provider: the first post-swipe observation is a minimal hierarchy that `UIStateExtractor` classifies as a `bottomsheet` with `windowId: 42` (sheet still present); the second (post-back-button) has a null hierarchy (sheet gone).
- Asserts `dismissTopModal` returns `true` via the back-button path, that both observations were consulted (`observeCalls === 2`), and that the ADB back-button seam fired (`FakeAdbClient.wasCommandExecuted("shell input keyevent 4")`). `pressBack`'s CtrlProxy accessibility path fast-fails (not connected in a unit context) and falls through to ADB.

This is pre-existing behavior (not changed by #3118) — a standing coverage gap, not a regression.

## Validation
- `bun test test/features/navigation/DefaultUIStateSetup.test.ts` — 8 pass, 0 fail (448ms; all Interface+Fake+FakeTimer, no real device/network).
- `turbo run lint build test` — 6812 pass, 0 fail.
- `bun run typecheck` — no new type errors.

## Scope
Single test file (`test/features/navigation/DefaultUIStateSetup.test.ts`). No production code touched.