### PR TITLE
fix(action): fix ReferenceError in snapshot backup/restore catch blocks (#2866)

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -76,8 +76,6 @@ src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimest
 src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 src/features/action/BaseVisualChange.ts: error TS2339: Property 'signal' does not exist on type '{ changeExpected: boolean; tolerancePercent?: number | undefined; queryOptions?: ViewHierarchyQueryOptions | undefined; gfxMetrics?: GfxMetrics | null | undefined; perf?: PerformanceTracker | undefined; actionStartTime?: number | undefined; predictionContext?: PredictionActionContext | undefined; }'.
 src/features/action/BaseVisualChange.ts: error TS2339: Property 'signal' does not exist on type '{ changeExpected: boolean; tolerancePercent?: number | undefined; queryOptions?: ViewHierarchyQueryOptions | undefined; gfxMetrics?: GfxMetrics | null | undefined; perf?: PerformanceTracker | undefined; actionStartTime?: number | undefined; predictionContext?: PredictionActionContext | undefined; }'.
-src/features/action/CaptureSnapshot.ts: error TS2304: Cannot find name 'timeoutHandle'.
-src/features/action/CaptureSnapshot.ts: error TS2304: Cannot find name 'timeoutHandle'.
 src/features/action/InstallApp.ts: error TS2554: Expected 0 arguments, but got 1.
 src/features/action/InstallApp.ts: error TS2554: Expected 0 arguments, but got 1.
 src/features/action/IosSimulatorPermissions.ts: error TS2352: Conversion of type 'TccPermissionRow' to type 'Record<string, string | number | null>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
@@ -87,8 +85,6 @@ src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' 
 src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 src/features/action/OpenURL.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
-src/features/action/RestoreSnapshot.ts: error TS2304: Cannot find name 'timeoutHandle'.
-src/features/action/RestoreSnapshot.ts: error TS2304: Cannot find name 'timeoutHandle'.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
@@ -256,7 +252,6 @@ src/utils/CtrlProxyManager.ts: error TS7006: Parameter 'entry' implicitly has an
 src/utils/CtrlProxyManager.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
-src/utils/DeviceSessionManager.ts: error TS2304: Cannot find name 'AdbClient'.
 src/utils/IOSCtrlProxyBundleDownloader.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 src/utils/ProcessExecutor.ts: error TS2769: No overload matches this call.
 src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.

--- a/src/features/action/CaptureSnapshot.ts
+++ b/src/features/action/CaptureSnapshot.ts
@@ -559,6 +559,9 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
     logger.info(`Starting adb backup for ${packages.length} packages (timeout: ${timeoutMs}ms)`);
     logger.info("Please confirm the backup on your device if prompted");
 
+    // Declared outside try so the catch block can clear a pending timeout.
+    let timeoutHandle: NodeJS.Timeout | null = null;
+
     try {
       // Build adb backup command
       // -f: file path, -noapk: don't backup APK files, -obb: include OBB files
@@ -567,7 +570,6 @@ export class CaptureSnapshot implements SnapshotCaptureProvider {
       const command = `backup -f "${backupFilePath}" -noapk ${packageList}`;
 
       // Execute backup with timeout using timer
-      let timeoutHandle: NodeJS.Timeout | null = null;
       let timedOut = false;
 
       const result = await Promise.race([

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -316,9 +316,11 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
     backupFilePath: string,
     timeoutMs: number = 30000
   ): Promise<{ success: boolean; timedOut: boolean }> {
+    // Declared outside try so the catch block can clear a pending timeout.
+    let timeoutHandle: NodeJS.Timeout | null = null;
+
     try {
       // Execute restore with timeout using timer
-      let timeoutHandle: NodeJS.Timeout | null = null;
       let timedOut = false;
 
       const result = await Promise.race([

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -78,7 +78,7 @@ class DefaultDeviceClientProvider implements DeviceClientProvider {
   getDeviceUtils(): PlatformDeviceManager {
     if (!this._deviceUtils) {
       this._deviceUtils = new MultiPlatformDeviceManager(
-        this.getAdb() as AdbClient,
+        this.getAdb(),
         this.getSimctl()!,
         this.getAndroidEmulator()!
       );

--- a/test/features/action/CaptureSnapshot.test.ts
+++ b/test/features/action/CaptureSnapshot.test.ts
@@ -536,6 +536,28 @@ describe("CaptureSnapshot", () => {
       expect(fakeTimer.getPendingTimeoutCount()).toBe(0); // Should be cleared after completion
     });
 
+    it("should clear the pending timeout when the backup command throws (regression #2866)", async () => {
+      // Regression guard: timeoutHandle used to be declared inside the try block
+      // but referenced in the catch block, causing a ReferenceError instead of a
+      // graceful failure when adb executeCommand throws mid-backup.
+      const backupFilePath = store.getBackupFilePath("test-throw");
+      fakeAdb.setCommandError(
+        `backup -f "${backupFilePath}" -noapk com.example.app`,
+        new Error("adb connection dropped")
+      );
+
+      const result = await (captureSnapshot as any).performAdbBackup(
+        ["com.example.app"],
+        backupFilePath,
+        30000
+      );
+
+      // Catch path returns a graceful failure, no ReferenceError thrown.
+      expect(result).toEqual({ timedOut: false });
+      // The timeout scheduled before the throw must be cleared to avoid a leak.
+      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    });
+
     it("should handle backup when file is not created", async () => {
       const snapshotName = "test-snapshot-no-file";
 

--- a/test/features/action/RestoreSnapshot.test.ts
+++ b/test/features/action/RestoreSnapshot.test.ts
@@ -667,6 +667,24 @@ describe("RestoreSnapshot", () => {
   });
 
   describe("app data restore with timeout", () => {
+    it("should clear the pending timeout when the restore command throws (regression #2866)", async () => {
+      // Regression guard: timeoutHandle used to be declared inside the try block
+      // but referenced in the catch block, causing a ReferenceError instead of a
+      // graceful failure when adb executeCommand throws mid-restore.
+      const backupFilePath = "/tmp/backup.ab";
+      fakeAdb.setCommandError(
+        `restore "${backupFilePath}"`,
+        new Error("adb connection dropped")
+      );
+
+      const result = await (restoreSnapshot as any).performAdbRestore(backupFilePath, 30000);
+
+      // Catch path returns a graceful failure, no ReferenceError thrown.
+      expect(result).toEqual({ success: false, timedOut: false });
+      // The timeout scheduled before the throw must be cleared to avoid a leak.
+      expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
+    });
+
     it("should restore successfully when user confirms within timeout", async () => {
       const snapshotName = "test-snapshot";
 


### PR DESCRIPTION
Closes #2866

## Summary
Fixes 6 out-of-scope TS2304 identifiers, including 2 latent runtime `ReferenceError`s:

- `src/features/action/CaptureSnapshot.ts` and `RestoreSnapshot.ts`: `timeoutHandle` was declared inside the `try` block but referenced in the `catch` block. When `adb executeCommand` throws mid-backup/restore, the `catch` handler hit a `ReferenceError` (TS2304 x4) instead of gracefully clearing the pending timeout and returning a typed failure. Hoisted the declaration above `try`.
- `src/utils/DeviceSessionManager.ts`: removed an `as AdbClient` cast referencing an unimported type (TS2304); `getAdb()` already returns `AdbExecutor`, which `MultiPlatformDeviceManager`'s constructor accepts directly.

## Tests
Added regression guards in both action test suites that set the adb command to throw and assert (a) no `ReferenceError` — a graceful typed failure is returned, and (b) the pending timeout is cleared (`getPendingTimeoutCount() === 0`). Verified each test fails on the pre-fix code and passes after. Uses existing `FakeAdbClient.setCommandError` + `FakeTimer`; unit tests run in <1ms each.

## Validation
- `bun test` CaptureSnapshot + RestoreSnapshot: 54 pass, 0 fail
- `bunx turbo run lint build`: green
- `bun run typecheck`: no new errors; ratcheted baseline DOWN by 5 (280 -> 275) via `typecheck:update`

## Caveats
Only touched files strictly in scope plus their tests and the typecheck baseline.