### PR TITLE
fix(ktfmt): normalize 2-part vs 3-part version comparison (#3004)

### DIFF
--- a/scripts/ktfmt/ktfmt_version.sh
+++ b/scripts/ktfmt/ktfmt_version.sh
@@ -29,18 +29,34 @@ installed_ktfmt_version() {
     }' <<<"$version_output"
 }
 
-# Fingerprint gate (issue #2966): assert the ktfmt on PATH is EXACTLY the pinned
+# Normalize a version string for comparison so a 2-part pin (e.g. "0.64") and a
+# 3-part printed version (e.g. "0.64.0") are treated as equal (issue #3004).
+# Strategy: strip any trailing ".0" release-patch component, collapsing an
+# `x.y.0` to `x.y`, so the pin and the parsed `ktfmt --version` compare equal
+# regardless of whether either side carries the redundant zero patch. A non-zero
+# patch (e.g. "0.64.1") is preserved and therefore still fails the gate, since it
+# IS a different formatter build. Empty input normalizes to empty.
+normalize_ktfmt_version() {
+    local version="$1"
+    # Drop a single trailing ".0" (redundant patch); leaves "x.y" or "x.y.z".
+    printf '%s' "${version%.0}"
+}
+
+# Fingerprint gate (issue #2966): assert the ktfmt on PATH matches the pinned
 # version, else print an actionable message and `exit 1`. Both the validate
 # (read) and apply (write) paths call this before touching any file, so a
 # formatter whose version differs from the pin fails loudly instead of silently
 # reformatting -- on the PR, post-merge, or on a developer's `apply` run. A
 # matching version also implies `--google-style` support, so this subsumes the
-# older flag probe. Colours are referenced via ${RED:-} so this is safe to call
-# even before the caller defines them.
+# older flag probe. The comparison normalizes both sides (issue #3004) so a
+# future ktfmt that prints a 3-part "x.y.0" while the pin stays 2-part "x.y"
+# still matches; a genuinely different build (differing major/minor, or a
+# non-zero patch) still fails loudly. Colours are referenced via ${RED:-} so
+# this is safe to call even before the caller defines them.
 require_pinned_ktfmt_version() {
     local found
     found="$(installed_ktfmt_version)"
-    if [[ "$found" == "$KTFMT_VERSION" ]]; then
+    if [[ "$(normalize_ktfmt_version "$found")" == "$(normalize_ktfmt_version "$KTFMT_VERSION")" ]]; then
         return 0
     fi
 

--- a/test/bats/validate-ktfmt.bats
+++ b/test/bats/validate-ktfmt.bats
@@ -258,6 +258,34 @@ STUB
   [[ "$output" != *"version mismatch"* ]]
 }
 
+@test "a 3-part x.y.0 version equals the 2-part pin (issue #3004)" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+
+  # A future ktfmt that prints "ktfmt version 0.64.0" must still match the
+  # 2-part pin "0.64": the trailing ".0" is a redundant patch component. Without
+  # normalization this false-fails the gate ("0.64.0" != "0.64").
+  run env KTFMT_STUB_VERSION="0.64.0" ONLY_CHANGED_SINCE_SHA="" \
+    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 1 Kotlin file(s) to process"* ]]
+  [[ "$output" != *"version mismatch"* ]]
+}
+
+@test "a non-zero patch (x.y.1) still fails the pin gate (issue #3004)" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+
+  # Only a redundant trailing ".0" is normalized away; a real patch build like
+  # "0.64.1" IS a different formatter and must still fail loudly.
+  run env KTFMT_STUB_VERSION="0.64.1" ONLY_CHANGED_SINCE_SHA="" \
+    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"version mismatch"* ]]
+  [[ "$output" == *"0.64.1"* ]]
+  [[ "$output" != *"Kotlin file(s) to process"* ]]
+}
+
 @test "the gate reads the pin from the shared ktfmt_version.sh (single source)" {
   # Prove single-sourcing without mutating the tracked tree: copy the validator
   # and its sibling pin file into a temp dir, bump the *copy's* pin to 0.99, and


### PR DESCRIPTION
Closes #3004

## Summary
The shared ktfmt version-pin gate in `scripts/ktfmt/ktfmt_version.sh` compared the parsed `ktfmt --version` output against the pin with exact string equality. If a future ktfmt printed a 3-part `x.y.0` while the pin stayed 2-part `x.y`, the gate would false-fail (`0.65.0` != `0.65`).

Fix: added `normalize_ktfmt_version()` which strips a redundant trailing `.0` patch, and `require_pinned_ktfmt_version` now normalizes **both** sides before comparing. A genuinely different build (differing major/minor, or a non-zero patch like `0.64.1`) still fails loudly. Empty/unparseable input still normalizes to empty and fails the gate.

## Validation
- `shellcheck scripts/ktfmt/*.sh` — clean
- `bats test/bats/validate-ktfmt.bats` — 16/16 pass, including two new tests:
  - `0.64.0` (3-part x.y.0) now equals the 2-part pin
  - `0.64.1` (non-zero patch) still fails loudly

## Caveats
- Shell-only change; touches no TypeScript. Pre-existing local `typecheck` noise (adm-zip/ajv in node_modules) and an unrelated `verify-runtime-deps.bats` failure are outside this lane.