### PR TITLE
test(db): serialize DB-reset suites to kill cross-file env bleed (#2942)

### DIFF
--- a/test/db/databaseLazyPath.test.ts
+++ b/test/db/databaseLazyPath.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { createFileBackedDbHarness, WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./withFileBackedDb";
+import { runExclusiveResetTest } from "./resetTestSerialLock";
 
 /**
  * Regression test for the module-load-time-vs-runtime path hazard.
@@ -26,93 +27,97 @@ describe("database path lazy resolution", () => {
     await harness.cleanup();
   });
 
-  test("resolves relative AUTOMOBILE_DB_DIR against the launch cwd set AFTER import", async () => {
-    const importTimeCwd = process.cwd();
-    const launchCwd = path.resolve("/project/auto-mobile");
+  test("resolves relative AUTOMOBILE_DB_DIR against the launch cwd set AFTER import", () =>
+    runExclusiveResetTest(async () => {
+      const importTimeCwd = process.cwd();
+      const launchCwd = path.resolve("/project/auto-mobile");
 
-    // Simulate the direct-launch ordering: a relative DB dir is configured, but the
-    // launch cwd env is NOT yet set when the module is imported.
-    process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      // Simulate the direct-launch ordering: a relative DB dir is configured, but the
+      // launch cwd env is NOT yet set when the module is imported.
+      process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await harness.importFreshDatabaseModule();
+      const databaseModule = await harness.importFreshDatabaseModule();
 
-    // Daemon.start() records the launch cwd only after import / before first use.
-    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
+      // Daemon.start() records the launch cwd only after import / before first use.
+      process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
 
-    const resolved = databaseModule.getDatabasePath();
+      const resolved = databaseModule.getDatabasePath();
 
-    // Must follow the launch cwd, NOT the cwd that was current when the module loaded.
-    expect(resolved).toBe(path.join(launchCwd, ".automobile-db", "auto-mobile.db"));
-    expect(resolved.startsWith(importTimeCwd)).toBe(false);
-  });
+      // Must follow the launch cwd, NOT the cwd that was current when the module loaded.
+      expect(resolved).toBe(path.join(launchCwd, ".automobile-db", "auto-mobile.db"));
+      expect(resolved.startsWith(importTimeCwd)).toBe(false);
+    }));
 
-  test("caches the resolved path so it stays stable for the process lifetime", async () => {
-    process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+  test("caches the resolved path so it stays stable for the process lifetime", () =>
+    runExclusiveResetTest(async () => {
+      process.env.AUTOMOBILE_DB_DIR = ".automobile-db";
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await harness.importFreshDatabaseModule();
+      const databaseModule = await harness.importFreshDatabaseModule();
 
-    process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
-    const first = databaseModule.getDatabasePath();
+      process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/project/auto-mobile");
+      const first = databaseModule.getDatabasePath();
 
-    // A later env change must not move the database the daemon already opened against.
-    process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/elsewhere/launch-cwd");
-    const second = databaseModule.getDatabasePath();
+      // A later env change must not move the database the daemon already opened against.
+      process.env[DAEMON_LAUNCH_CWD_ENV] = path.resolve("/elsewhere/launch-cwd");
+      const second = databaseModule.getDatabasePath();
 
-    expect(second).toBe(first);
-  });
+      expect(second).toBe(first);
+    }));
 
-  test("queries issued immediately after getDatabase wait for startup migrations", async () => {
-    const dbDir = await harness.makeTempDbDir("auto-mobile-db-startup-");
-    process.env.AUTOMOBILE_DB_DIR = dbDir;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+  test("queries issued immediately after getDatabase wait for startup migrations", () =>
+    runExclusiveResetTest(async () => {
+      const dbDir = await harness.makeTempDbDir("auto-mobile-db-startup-");
+      process.env.AUTOMOBILE_DB_DIR = dbDir;
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await harness.importFreshDatabaseModule();
-    const db = databaseModule.getDatabase();
+      const databaseModule = await harness.importFreshDatabaseModule();
+      const db = databaseModule.getDatabase();
 
-    try {
-      const rows = await db
-        .selectFrom("tool_calls" as any)
-        .selectAll()
-        .execute();
+      try {
+        const rows = await db
+          .selectFrom("tool_calls" as any)
+          .selectAll()
+          .execute();
 
-      expect(rows).toEqual([]);
-    } finally {
-      await databaseModule.closeDatabase();
-    }
+        expect(rows).toEqual([]);
+      } finally {
+        await databaseModule.closeDatabase();
+      }
     // Opens a real temp DB and runs the full startup migration set. A cold,
     // loaded windows-latest runner legitimately needs more than bun's 5s
     // default per-test timeout, so a slow-but-correct migration would otherwise
     // read as a failure (#2992).
-  }, WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
+    }), WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
 
-  test("queries fail clearly and consistently when startup migrations fail", async () => {
-    const dbDir = await harness.makeTempDbDir("auto-mobile-db-startup-fail-");
-    process.env.AUTOMOBILE_DB_DIR = dbDir;
-    process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(dbDir, "missing-migrations");
-    delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+  test("queries fail clearly and consistently when startup migrations fail", () =>
+    runExclusiveResetTest(async () => {
+      const dbDir = await harness.makeTempDbDir("auto-mobile-db-startup-fail-");
+      process.env.AUTOMOBILE_DB_DIR = dbDir;
+      process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(dbDir, "missing-migrations");
+      delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await harness.importFreshDatabaseModule();
-    const db = databaseModule.getDatabase();
-    const query = () =>
-      db
-        .selectFrom("tool_calls" as any)
-        .selectAll()
-        .execute();
+      const databaseModule = await harness.importFreshDatabaseModule();
+      const db = databaseModule.getDatabase();
+      const query = () =>
+        db
+          .selectFrom("tool_calls" as any)
+          .selectAll()
+          .execute();
 
-    try {
-      await expect(query()).rejects.toThrow(
-        "Database startup migrations failed; refusing to run queries until the daemon restarts."
-      );
-      await expect(query()).rejects.toThrow(
-        "Database startup migrations failed; refusing to run queries until the daemon restarts."
-      );
-    } finally {
-      await databaseModule.closeDatabase();
-    }
+      try {
+        await expect(query()).rejects.toThrow(
+          "Database startup migrations failed; refusing to run queries until the daemon restarts."
+        );
+        await expect(query()).rejects.toThrow(
+          "Database startup migrations failed; refusing to run queries until the daemon restarts."
+        );
+      } finally {
+        await databaseModule.closeDatabase();
+      }
     // File-backed like the sibling above; the same generous ceiling covers a
     // slow Windows startup-migration attempt before it fails clearly (#2992).
-  }, WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
+    }), WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
 });

--- a/test/db/databaseLifecycleReset.test.ts
+++ b/test/db/databaseLifecycleReset.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { createFileBackedDbHarness, WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./withFileBackedDb";
+import { runExclusiveResetTest } from "./resetTestSerialLock";
 
 /**
  * Structural guard for issue #2900.
@@ -48,59 +49,60 @@ describe("closeDatabase resets the migration/path lifecycle as one set (issue #2
       .execute();
   }
 
-  test("a FAILED boot + close makes the reopen a total cold start on every axis", async () => {
+  test("a FAILED boot + close makes the reopen a total cold start on every axis", () =>
+    runExclusiveResetTest(async () => {
     // The first boot must FAIL so `migrationsError` is actually populated before
     // close. A successful first boot leaves migrationsError null, so the healthy
     // reopen's `getMigrationsError() === null` would pass trivially and a dropped
     // `migrationsError` reset would go undetected — the axis would be un-proven.
     // Booting failed-then-healthy exercises all four axes in one flow so a
     // partial `reset()` that skips ANY single field fails here.
-    const failDir = await harness.makeTempDbDir("auto-mobile-lifecycle-fail-");
-    process.env.AUTOMOBILE_DB_DIR = failDir;
-    // Force a startup-migration failure: a migrations dir that does not exist.
-    process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(failDir, "missing-migrations");
-    delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      const failDir = await harness.makeTempDbDir("auto-mobile-lifecycle-fail-");
+      process.env.AUTOMOBILE_DB_DIR = failDir;
+      // Force a startup-migration failure: a migrations dir that does not exist.
+      process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(failDir, "missing-migrations");
+      delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await harness.importFreshDatabaseModule();
+      const databaseModule = await harness.importFreshDatabaseModule();
 
-    // Cold start on the first DB: path resolves + caches, migrations START and
-    // FAIL, so migrationsPromise settles and migrationsError is cached non-null.
-    const failingDb = databaseModule.getDatabase();
-    expect(databaseModule.getDatabasePath()).toBe(path.join(failDir, "auto-mobile.db"));
-    await expect(queryToolCalls(failingDb)).rejects.toThrow(
-      "Database startup migrations failed; refusing to run queries until the daemon restarts."
-    );
-    // Precondition for the migrationsError axis: the error is really set before close.
-    expect(databaseModule.getMigrationsError()).not.toBeNull();
+      // Cold start on the first DB: path resolves + caches, migrations START and
+      // FAIL, so migrationsPromise settles and migrationsError is cached non-null.
+      const failingDb = databaseModule.getDatabase();
+      expect(databaseModule.getDatabasePath()).toBe(path.join(failDir, "auto-mobile.db"));
+      await expect(queryToolCalls(failingDb)).rejects.toThrow(
+        "Database startup migrations failed; refusing to run queries until the daemon restarts."
+      );
+      // Precondition for the migrationsError axis: the error is really set before close.
+      expect(databaseModule.getMigrationsError()).not.toBeNull();
 
-    await databaseModule.closeDatabase();
+      await databaseModule.closeDatabase();
 
-    // Point at a brand-new, empty DB dir with a VALID migrations dir and reopen in
-    // the same process. A single un-reset axis breaks this flow:
-    //   - stale resolvedDbPath  -> path assertion below redirects to the old dir
-    //   - stale migrationsRun   -> ensureMigrationsStarted() no-ops, query hits an
-    //                              unmigrated schema ("no such table: tool_calls")
-    //   - stale migrationsPromise -> ditto (re-arm is gated on it being null)
-    //   - stale migrationsError -> the cached failed-boot error rethrows on query
-    //                              against the otherwise-healthy reopened DB
-    const healthyDir = await harness.makeTempDbDir("auto-mobile-lifecycle-healthy-");
-    process.env.AUTOMOBILE_DB_DIR = healthyDir;
-    delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
+      // Point at a brand-new, empty DB dir with a VALID migrations dir and reopen in
+      // the same process. A single un-reset axis breaks this flow:
+      //   - stale resolvedDbPath  -> path assertion below redirects to the old dir
+      //   - stale migrationsRun   -> ensureMigrationsStarted() no-ops, query hits an
+      //                              unmigrated schema ("no such table: tool_calls")
+      //   - stale migrationsPromise -> ditto (re-arm is gated on it being null)
+      //   - stale migrationsError -> the cached failed-boot error rethrows on query
+      //                              against the otherwise-healthy reopened DB
+      const healthyDir = await harness.makeTempDbDir("auto-mobile-lifecycle-healthy-");
+      process.env.AUTOMOBILE_DB_DIR = healthyDir;
+      delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
 
-    // resolvedDbPath reset: the reopen must bind the fresh file.
-    expect(databaseModule.getDatabasePath()).toBe(path.join(healthyDir, "auto-mobile.db"));
+      // resolvedDbPath reset: the reopen must bind the fresh file.
+      expect(databaseModule.getDatabasePath()).toBe(path.join(healthyDir, "auto-mobile.db"));
 
-    // migrationsError reset: the cached failed-boot error must not survive close.
-    expect(databaseModule.getMigrationsError()).toBeNull();
+      // migrationsError reset: the cached failed-boot error must not survive close.
+      expect(databaseModule.getMigrationsError()).toBeNull();
 
-    // migrationsRun + migrationsPromise + migrationsError reset: migrations must
-    // re-run against the fresh file and the query must succeed (not rethrow the
-    // stale error) against a migrated schema.
-    const healthyDb = databaseModule.getDatabase();
-    expect(await queryToolCalls(healthyDb)).toEqual([]);
-    expect(databaseModule.getMigrationsError()).toBeNull();
+      // migrationsRun + migrationsPromise + migrationsError reset: migrations must
+      // re-run against the fresh file and the query must succeed (not rethrow the
+      // stale error) against a migrated schema.
+      const healthyDb = databaseModule.getDatabase();
+      expect(await queryToolCalls(healthyDb)).toEqual([]);
+      expect(databaseModule.getMigrationsError()).toBeNull();
 
-    await databaseModule.closeDatabase();
-  }, WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
+      await databaseModule.closeDatabase();
+    }), WINDOWS_FILE_DB_TEST_TIMEOUT_MS);
 });

--- a/test/db/databaseReset.test.ts
+++ b/test/db/databaseReset.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import path from "path";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { createFileBackedDbHarness, WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./withFileBackedDb";
+import { runExclusiveResetTest } from "./resetTestSerialLock";
 
 /**
  * Regression tests for issue #2796.
@@ -54,36 +55,38 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
       .execute();
   }
 
-  test("reopen after close re-runs migrations against a fresh DB (migrationsRun reset)", async () => {
+  test("reopen after close re-runs migrations against a fresh DB (migrationsRun reset)", () =>
+    runExclusiveResetTest(async () => {
     // Cold start on the first DB via the shared open helper — fresh module +
     // tracked temp dir + `getDatabase()` then awaited migrations (the #2992/#3040
     // ordering). Querying a migrated table proves migrations actually ran
     // (migrationsRun became true).
-    const first = await harness.openLifecycleTestDb("auto-mobile-reset-first-");
-    const databaseModule = first.module;
-    expect(await queryToolCalls(databaseModule.getDatabase())).toEqual([]);
+      const first = await harness.openLifecycleTestDb("auto-mobile-reset-first-");
+      const databaseModule = first.module;
+      expect(await queryToolCalls(databaseModule.getDatabase())).toEqual([]);
 
-    await first.close();
+      await first.close();
 
-    // Point at a brand-new, empty DB dir and reopen in the same process.
-    const secondDir = await makeTempDbDir("auto-mobile-reset-second-");
-    process.env.AUTOMOBILE_DB_DIR = secondDir;
+      // Point at a brand-new, empty DB dir and reopen in the same process.
+      const secondDir = await makeTempDbDir("auto-mobile-reset-second-");
+      process.env.AUTOMOBILE_DB_DIR = secondDir;
 
-    // The reopen must bind the fresh file (resolvedDbPath reset), otherwise the
-    // stale path cache silently redirects back to the first (already-migrated)
-    // DB and masks the migrationsRun bug below.
-    expect(databaseModule.getDatabasePath()).toBe(path.join(secondDir, "auto-mobile.db"));
+      // The reopen must bind the fresh file (resolvedDbPath reset), otherwise the
+      // stale path cache silently redirects back to the first (already-migrated)
+      // DB and masks the migrationsRun bug below.
+      expect(databaseModule.getDatabasePath()).toBe(path.join(secondDir, "auto-mobile.db"));
 
-    // And against that fresh, empty file migrations must re-run (migrationsRun
-    // reset). If they don't, ensureMigrationsStarted() no-ops and the query
-    // hits an unmigrated schema -> "no such table: tool_calls".
-    const secondDb = databaseModule.getDatabase();
-    expect(await queryToolCalls(secondDb)).toEqual([]);
+      // And against that fresh, empty file migrations must re-run (migrationsRun
+      // reset). If they don't, ensureMigrationsStarted() no-ops and the query
+      // hits an unmigrated schema -> "no such table: tool_calls".
+      const secondDb = databaseModule.getDatabase();
+      expect(await queryToolCalls(secondDb)).toEqual([]);
 
-    await databaseModule.closeDatabase();
-  }, FILE_BACKED_TEST_TIMEOUT_MS);
+      await databaseModule.closeDatabase();
+    }), FILE_BACKED_TEST_TIMEOUT_MS);
 
-  test("reopen after close re-resolves the DB path under a changed env (resolvedDbPath reset)", async () => {
+  test("reopen after close re-resolves the DB path under a changed env (resolvedDbPath reset)", () =>
+    runExclusiveResetTest(async () => {
     // This assertion is on the pure path-resolution cache (`resolvedDbPath`),
     // which `resolveDatabasePathFromEnvironment()` computes as a string without
     // touching the filesystem. Drive it through `getDatabasePath()` alone and
@@ -91,55 +94,56 @@ describe("closeDatabase resets migration + path globals (issue #2796)", () => {
     // file-handle release (issue #2916). `closeDatabase()` resets the path cache
     // unconditionally — even with no open connection — so the reset is still
     // exercised here.
-    const firstDir = await makeTempDbDir("auto-mobile-reset-path-first-");
-    process.env.AUTOMOBILE_DB_DIR = firstDir;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      const firstDir = await makeTempDbDir("auto-mobile-reset-path-first-");
+      process.env.AUTOMOBILE_DB_DIR = firstDir;
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await harness.importFreshDatabaseModule();
+      const databaseModule = await harness.importFreshDatabaseModule();
 
-    // Resolve once so resolvedDbPath is cached (no DB file opened).
-    expect(databaseModule.getDatabasePath()).toBe(path.join(firstDir, "auto-mobile.db"));
+      // Resolve once so resolvedDbPath is cached (no DB file opened).
+      expect(databaseModule.getDatabasePath()).toBe(path.join(firstDir, "auto-mobile.db"));
 
-    await databaseModule.closeDatabase();
+      await databaseModule.closeDatabase();
 
-    // A changed env after close must be re-read (cache cleared).
-    const secondDir = await makeTempDbDir("auto-mobile-reset-path-second-");
-    process.env.AUTOMOBILE_DB_DIR = secondDir;
+      // A changed env after close must be re-read (cache cleared).
+      const secondDir = await makeTempDbDir("auto-mobile-reset-path-second-");
+      process.env.AUTOMOBILE_DB_DIR = secondDir;
 
-    expect(databaseModule.getDatabasePath()).toBe(path.join(secondDir, "auto-mobile.db"));
-  });
+      expect(databaseModule.getDatabasePath()).toBe(path.join(secondDir, "auto-mobile.db"));
+    }));
 
-  test("reopen after a failed boot behaves like a cold start (migrationsError reset)", async () => {
-    const failDir = await makeTempDbDir("auto-mobile-reset-fail-");
-    process.env.AUTOMOBILE_DB_DIR = failDir;
-    // Force a startup-migration failure: a migrations dir that does not exist.
-    process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(failDir, "missing-migrations");
-    delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+  test("reopen after a failed boot behaves like a cold start (migrationsError reset)", () =>
+    runExclusiveResetTest(async () => {
+      const failDir = await makeTempDbDir("auto-mobile-reset-fail-");
+      process.env.AUTOMOBILE_DB_DIR = failDir;
+      // Force a startup-migration failure: a migrations dir that does not exist.
+      process.env.AUTOMOBILE_MIGRATIONS_DIR = path.join(failDir, "missing-migrations");
+      delete process.env.AUTO_MOBILE_MIGRATIONS_DIR;
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await harness.importFreshDatabaseModule();
+      const databaseModule = await harness.importFreshDatabaseModule();
 
-    const failingDb = databaseModule.getDatabase();
-    await expect(queryToolCalls(failingDb)).rejects.toThrow(
-      "Database startup migrations failed; refusing to run queries until the daemon restarts."
-    );
-    expect(databaseModule.getMigrationsError()).not.toBeNull();
+      const failingDb = databaseModule.getDatabase();
+      await expect(queryToolCalls(failingDb)).rejects.toThrow(
+        "Database startup migrations failed; refusing to run queries until the daemon restarts."
+      );
+      expect(databaseModule.getMigrationsError()).not.toBeNull();
 
-    await databaseModule.closeDatabase();
+      await databaseModule.closeDatabase();
 
-    // The cached error must not survive the close.
-    expect(databaseModule.getMigrationsError()).toBeNull();
+      // The cached error must not survive the close.
+      expect(databaseModule.getMigrationsError()).toBeNull();
 
-    // Reopen with a valid migrations dir + fresh DB: it must migrate cleanly and
-    // NOT rethrow the stale error from the failed boot.
-    const healthyDir = await makeTempDbDir("auto-mobile-reset-healthy-");
-    process.env.AUTOMOBILE_DB_DIR = healthyDir;
-    delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
+      // Reopen with a valid migrations dir + fresh DB: it must migrate cleanly and
+      // NOT rethrow the stale error from the failed boot.
+      const healthyDir = await makeTempDbDir("auto-mobile-reset-healthy-");
+      process.env.AUTOMOBILE_DB_DIR = healthyDir;
+      delete process.env.AUTOMOBILE_MIGRATIONS_DIR;
 
-    const healthyDb = databaseModule.getDatabase();
-    expect(await queryToolCalls(healthyDb)).toEqual([]);
-    expect(databaseModule.getMigrationsError()).toBeNull();
+      const healthyDb = databaseModule.getDatabase();
+      expect(await queryToolCalls(healthyDb)).toEqual([]);
+      expect(databaseModule.getMigrationsError()).toBeNull();
 
-    await databaseModule.closeDatabase();
-  }, FILE_BACKED_TEST_TIMEOUT_MS);
+      await databaseModule.closeDatabase();
+    }), FILE_BACKED_TEST_TIMEOUT_MS);
 });

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -10,6 +10,7 @@ import {
   migrationLockPathFor,
 } from "../../src/db/migrationLock";
 import { importFreshDatabaseModule, restoreEnv, snapshotEnv } from "./freshDatabaseModule";
+import { runExclusiveResetTest } from "./resetTestSerialLock";
 
 /**
  * Regression tests for issue #2896 (follow-up to #2796), on a `:memory:`
@@ -66,111 +67,115 @@ describe("closeDatabase cold-starts the dbWriteBarrier drain latch (issue #2896)
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
   }
 
-  test("a tracked best-effort write after drain -> close -> reopen is NOT skipped", async () => {
-    useInMemoryDatabase();
+  test("a tracked best-effort write after drain -> close -> reopen is NOT skipped", () =>
+    runExclusiveResetTest(async () => {
+      useInMemoryDatabase();
 
-    const databaseModule = await importFreshDatabaseModule();
+      const databaseModule = await importFreshDatabaseModule();
 
-    // Cold start on the first in-memory DB. Await migrations so the detached
-    // `:memory:` migration run is fully owned by the test rather than left in
-    // flight past teardown — cheap on an in-memory DB (no file/WAL/lock) and
-    // deterministic. The barrier assertions below need neither a real file nor a
-    // completed migration (issue #3047); this is purely lifecycle hygiene.
-    databaseModule.getDatabase();
-    await databaseModule.ensureMigrations();
+      // Cold start on the first in-memory DB. Await migrations so the detached
+      // `:memory:` migration run is fully owned by the test rather than left in
+      // flight past teardown — cheap on an in-memory DB (no file/WAL/lock) and
+      // deterministic. The barrier assertions below need neither a real file nor a
+      // completed migration (issue #3047); this is purely lifecycle hygiene.
+      databaseModule.getDatabase();
+      await databaseModule.ensureMigrations();
 
-    // Model the daemon shutdown ordering: drain in-flight best-effort writes,
-    // then close the connection (issue #2792).
-    const shutdownBarrier = getDbWriteBarrier();
-    expect(await shutdownBarrier.drain(1000)).toBe(true);
-    expect(shutdownBarrier.isDraining()).toBe(true);
+      // Model the daemon shutdown ordering: drain in-flight best-effort writes,
+      // then close the connection (issue #2792).
+      const shutdownBarrier = getDbWriteBarrier();
+      expect(await shutdownBarrier.drain(1000)).toBe(true);
+      expect(shutdownBarrier.isDraining()).toBe(true);
 
-    await databaseModule.closeDatabase();
+      await databaseModule.closeDatabase();
 
-    // Reopen in the same process against a fresh in-memory DB (config reload / DB
-    // path switch / restart-without-exit). Each `new Database(":memory:")` is a
-    // brand-new private DB, so this naturally models a distinct reopened DB.
-    databaseModule.getDatabase();
-    await databaseModule.ensureMigrations();
+      // Reopen in the same process against a fresh in-memory DB (config reload / DB
+      // path switch / restart-without-exit). Each `new Database(":memory:")` is a
+      // brand-new private DB, so this naturally models a distinct reopened DB.
+      databaseModule.getDatabase();
+      await databaseModule.ensureMigrations();
 
-    // The barrier must have cold-started: a distinct, non-draining instance.
-    const reopenedBarrier = getDbWriteBarrier();
-    expect(reopenedBarrier).not.toBe(shutdownBarrier);
-    expect(reopenedBarrier.isDraining()).toBe(false);
+      // The barrier must have cold-started: a distinct, non-draining instance.
+      const reopenedBarrier = getDbWriteBarrier();
+      expect(reopenedBarrier).not.toBe(shutdownBarrier);
+      expect(reopenedBarrier.isDraining()).toBe(false);
 
-    // The core contract: a tracked best-effort write actually runs against the
-    // reopened barrier instead of being silently skipped by a latched barrier.
-    let ran = false;
-    const result = await reopenedBarrier.track(async () => {
-      ran = true;
-      return "ok";
-    });
-    expect(ran).toBe(true);
-    expect(result).toBe("ok");
+      // The core contract: a tracked best-effort write actually runs against the
+      // reopened barrier instead of being silently skipped by a latched barrier.
+      let ran = false;
+      const result = await reopenedBarrier.track(async () => {
+        ran = true;
+        return "ok";
+      });
+      expect(ran).toBe(true);
+      expect(result).toBe("ok");
 
-    await databaseModule.closeDatabase();
-  });
+      await databaseModule.closeDatabase();
+    }));
 
-  test("reopens an in-memory DB with a live queryable connection and no bogus lock file", async () => {
-    useInMemoryDatabase();
+  test("reopens an in-memory DB with a live queryable connection and no bogus lock file", () =>
+    runExclusiveResetTest(async () => {
+      useInMemoryDatabase();
 
-    const databaseModule = await importFreshDatabaseModule();
+      const databaseModule = await importFreshDatabaseModule();
 
-    // Drive the full open + migration lifecycle on `:memory:`. This reconciles the
-    // reopen-query assertion added in #3040 for the file-backed test: with a
-    // private in-memory DB the app connection never sees the migration
-    // connection's schema, so instead of querying a migrated table we prove the
-    // reopened connection is live with a schema-independent `select 1` that still
-    // routes through `waitForMigrationsBeforeQuery` (proving migrations settle).
-    databaseModule.getDatabase();
-    await databaseModule.ensureMigrations();
+      // Drive the full open + migration lifecycle on `:memory:`. This reconciles the
+      // reopen-query assertion added in #3040 for the file-backed test: with a
+      // private in-memory DB the app connection never sees the migration
+      // connection's schema, so instead of querying a migrated table we prove the
+      // reopened connection is live with a schema-independent `select 1` that still
+      // routes through `waitForMigrationsBeforeQuery` (proving migrations settle).
+      databaseModule.getDatabase();
+      await databaseModule.ensureMigrations();
 
-    const rows = await sql`select 1 as one`.execute(databaseModule.getDatabase());
-    expect(rows.rows).toEqual([{ one: 1 }]);
+      const rows = await sql`select 1 as one`.execute(databaseModule.getDatabase());
+      expect(rows.rows).toEqual([{ one: 1 }]);
 
-    // The blocker this migration fixes: a `:memory:` opener must use a
-    // NoOpMigrationLock, never `createFileMigrationLock`, so it must not create a
-    // bogus `:memory:.migrate.lock` file (nor a `:memory:` DB file) in the cwd.
-    // Assert against the EXACT path the production lock would derive
-    // (`migrationLockPathFor`) rather than a hand-rolled cwd join, so the guard
-    // can't drift from the code under a symlinked / non-canonical cwd.
-    expect(existsSync(migrationLockPathFor(IN_MEMORY_DATABASE_PATH))).toBe(false);
-    expect(existsSync(path.join(process.cwd(), IN_MEMORY_DATABASE_PATH))).toBe(false);
+      // The blocker this migration fixes: a `:memory:` opener must use a
+      // NoOpMigrationLock, never `createFileMigrationLock`, so it must not create a
+      // bogus `:memory:.migrate.lock` file (nor a `:memory:` DB file) in the cwd.
+      // Assert against the EXACT path the production lock would derive
+      // (`migrationLockPathFor`) rather than a hand-rolled cwd join, so the guard
+      // can't drift from the code under a symlinked / non-canonical cwd.
+      expect(existsSync(migrationLockPathFor(IN_MEMORY_DATABASE_PATH))).toBe(false);
+      expect(existsSync(path.join(process.cwd(), IN_MEMORY_DATABASE_PATH))).toBe(false);
 
-    await databaseModule.closeDatabase();
-  });
+      await databaseModule.closeDatabase();
+    }));
 
-  test("closeDatabase clears a drain latch even with no open connection", async () => {
-    useInMemoryDatabase();
+  test("closeDatabase clears a drain latch even with no open connection", () =>
+    runExclusiveResetTest(async () => {
+      useInMemoryDatabase();
 
-    const databaseModule = await importFreshDatabaseModule();
+      const databaseModule = await importFreshDatabaseModule();
 
-    // Latch the barrier without ever opening the DB, then close. The reset is
-    // unconditional (mirrors the migration-global reset), so the latch clears
-    // even on a partially-initialized shutdown.
-    const latched = getDbWriteBarrier();
-    latched.beginDrain();
-    expect(latched.isDraining()).toBe(true);
+      // Latch the barrier without ever opening the DB, then close. The reset is
+      // unconditional (mirrors the migration-global reset), so the latch clears
+      // even on a partially-initialized shutdown.
+      const latched = getDbWriteBarrier();
+      latched.beginDrain();
+      expect(latched.isDraining()).toBe(true);
 
-    await databaseModule.closeDatabase();
+      await databaseModule.closeDatabase();
 
-    const fresh = getDbWriteBarrier();
-    expect(fresh).not.toBe(latched);
-    expect(fresh.isDraining()).toBe(false);
-  });
+      const fresh = getDbWriteBarrier();
+      expect(fresh).not.toBe(latched);
+      expect(fresh.isDraining()).toBe(false);
+    }));
 
-  test("getDatabase() fails fast when `:memory:` is set without the opt-in (issue #3065)", async () => {
+  test("getDatabase() fails fast when `:memory:` is set without the opt-in (issue #3065)", () =>
+    runExclusiveResetTest(async () => {
     // A real daemon that set AUTOMOBILE_DB_PATH=:memory: without the test opt-in
     // must fail legibly at open time, not silently run against a
     // migrated-but-empty app connection. The guard lives at the single path-
     // resolution choke point, so getDatabase() surfaces it.
-    process.env.AUTOMOBILE_DB_PATH = IN_MEMORY_DATABASE_PATH;
-    delete process.env[IN_MEMORY_DB_OPT_IN_ENV];
-    delete process.env.AUTOMOBILE_DB_DIR;
-    delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      process.env.AUTOMOBILE_DB_PATH = IN_MEMORY_DATABASE_PATH;
+      delete process.env[IN_MEMORY_DB_OPT_IN_ENV];
+      delete process.env.AUTOMOBILE_DB_DIR;
+      delete process.env[DAEMON_LAUNCH_CWD_ENV];
 
-    const databaseModule = await importFreshDatabaseModule();
+      const databaseModule = await importFreshDatabaseModule();
 
-    expect(() => databaseModule.getDatabase()).toThrow(/:memory:/);
-  });
+      expect(() => databaseModule.getDatabase()).toThrow(/:memory:/);
+    }));
 });

--- a/test/db/resetTestSerialLock.ts
+++ b/test/db/resetTestSerialLock.ts
@@ -1,0 +1,58 @@
+/**
+ * Cross-file serialization lock for the DB-reset test suites (issue #2942).
+ *
+ * The three reset suites — `databaseReset.test.ts`, `databaseLazyPath.test.ts`,
+ * `databaseLifecycleReset.test.ts` (and relatedly `dbWriteBarrierResetOnClose`) —
+ * each mutate the PROCESS-GLOBAL `process.env.AUTOMOBILE_DB_DIR` /
+ * `AUTOMOBILE_DB_PATH` / `AUTOMOBILE_MIGRATIONS_DIR` and then `await` a fresh
+ * `database.ts` module import (a `?query`-string cache-bust). The `?query` bust
+ * gives each file a PRIVATE module instance but NOT a private `process.env`.
+ *
+ * `bun test test/db/` loads every matched file into ONE process. Each file passes
+ * in isolation, but the `await` inside a test body yields the microtask queue,
+ * letting a test in another reset file run its own env mutation + fresh-module
+ * resolution during that window. The victim then resolves its DB path against a
+ * half-mutated env belonging to the other file — the intermittent
+ * `databaseReset.test.ts:135`-style flake seen during the PR #2930 review.
+ *
+ * The `createFileBackedDbHarness()` per-test env snapshot/restore is correct but
+ * insufficient: restoration happens in `afterEach`, AFTER the interleaving window
+ * has already closed. This lock removes the interleave itself — a single shared
+ * FIFO async mutex that every reset TEST (across every reset file) acquires for
+ * its whole body, so no two reset tests ever hold the shared env + fresh-module
+ * resolution surface at the same time.
+ *
+ * The lock is module-scoped, so all files that `import` it share the SAME queue
+ * — that shared identity is the whole point (a per-file lock would not serialize
+ * across files). Kept as a bare promise-chain FIFO (no external primitive):
+ * `runExclusive` chains each caller behind the previous release, and a `finally`
+ * guarantees release even if the body throws, so one failing test cannot deadlock
+ * the rest of the queue.
+ */
+
+let tail: Promise<void> = Promise.resolve();
+
+/**
+ * Run `body` with exclusive access to the shared reset-test env surface. Callers
+ * across all reset files queue FIFO; the returned promise resolves/rejects with
+ * `body`'s outcome so `await runExclusiveResetTest(...)` preserves normal test
+ * semantics.
+ */
+export async function runExclusiveResetTest<T>(body: () => Promise<T>): Promise<T> {
+  // Chain onto the current tail: our turn starts only once every prior caller has
+  // released. `.catch(() => {})` on the awaited predecessor prevents an upstream
+  // rejection from propagating into (and failing) an unrelated later test — each
+  // caller still surfaces its OWN body error below.
+  const prior = tail;
+  let release!: () => void;
+  tail = new Promise<void>(resolve => {
+    release = resolve;
+  });
+
+  await prior.catch(() => {});
+  try {
+    return await body();
+  } finally {
+    release();
+  }
+}


### PR DESCRIPTION
Closes #2942

## Summary
The DB-reset suites (`databaseReset.test.ts`, `databaseLazyPath.test.ts`, `databaseLifecycleReset.test.ts`) and the related `dbWriteBarrierResetOnClose.test.ts` each mutate the **process-global** `AUTOMOBILE_DB_DIR`/`AUTOMOBILE_DB_PATH`/`AUTOMOBILE_MIGRATIONS_DIR` env and then `await` a `?query`-cache-busted fresh `database.ts` import. The `?query` bust gives each file a private module instance but **not** a private `process.env`. `bun test` loads all files into one process, so an `await` inside one test body yields the microtask queue and lets another reset file resolve its fresh module against a **half-mutated env** — the intermittent `databaseReset.test.ts:135` flake surfaced by the PR #2930 multi-agent review.

## Fix
New `test/db/resetTestSerialLock.ts`: a **module-scoped FIFO async mutex** shared across all reset files (shared identity is the point — a per-file lock wouldn't serialize across files). Every reset test now runs its whole body via `runExclusiveResetTest()`, so no two reset tests hold the shared env + fresh-module-resolution surface at once. `release()` is guaranteed by `finally` (a throwing body can't deadlock the queue) and upstream rejections are isolated per-caller.

The existing `createFileBackedDbHarness()` per-test env snapshot/restore is correct but insufficient: restoration happens in `afterEach`, **after** the interleave window has already closed. This removes the interleave itself.

## Validation
- `bun test` on the 4 reset files: 12 pass, 0 fail; **5x stress runs** all green.
- `bun test test/db/`: 741 pass, 0 fail (59 files).
- eslint clean on all touched files; `bun run typecheck` gate: no new errors.
- No unhandled-rejection warnings.

## Caveats
- These suites stay integration-style (real temp DB + real migrations) by necessity — the module globals are unexported, per the issue's guardrail. No assertions were weakened.
- Scope limited to the db-resettest-env-bleed lane; only the 5 listed files changed.