### PR TITLE
fix(android): surface Compose toggle state-description in view hierarchy (#3139)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -38,6 +38,12 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     private const val MIN_HIDDEN_REGION_SCREEN_AREA = 0.25
     private const val MAX_VISIBLE_CHILD_COVERAGE = 0.25
 
+    // androidx AccessibilityNodeInfoCompat stashes the state description in the node's extras
+    // bundle under this key on API < 30, where the direct getter is unavailable. Compose relies
+    // on this shim to expose toggleable/selectable state (issue #3139).
+    private const val STATE_DESCRIPTION_EXTRA_KEY =
+      "androidx.view.accessibility.AccessibilityNodeInfoCompat.STATE_DESCRIPTION_KEY"
+
     private val GENERIC_CLASS_NAMES =
       setOf(
         "android.view.View",
@@ -801,7 +807,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       }
 
       // Extract extra semantics fields
-      var stateDescription: String? = null
       var text: String? = null
       var textSize: Float? = null
       var textColor: String? = null
@@ -817,10 +822,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val extrasMap = extractExtras(node)
       val testTag = extractTestTag(extrasMap)
 
-      // Check direct APIs if available
-      if (Build.VERSION.SDK_INT >= 30) {
-        stateDescription = node.stateDescription?.toString()
-      }
+      // Check direct APIs if available (API 30+) with an extras fallback for Compose on API < 30
+      val stateDescription: String? = extractStateDescription(node, extrasMap)
       // AccessibilityNodeInfo.getHintText requires API 26 (minSdk is 24)
       val hintText: String? = if (Build.VERSION.SDK_INT >= 26) node.hintText?.toString() else null
       val errorMessage: String? = node.error?.toString()
@@ -1092,6 +1095,38 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       emptyList()
     }
   }
+
+  /**
+   * Resolve the accessibility state description for a node.
+   *
+   * Jetpack Compose surfaces toggleable/selectable state (Switch, CheckBox, RadioButton,
+   * `Modifier.toggleable`/`selectable`) as an accessibility state description ("On"/"Off",
+   * "Checked"/"Unchecked"). When Compose sets a state description it deliberately does NOT set
+   * [AccessibilityNodeInfo.isChecked] (to avoid double-announcement in TalkBack), so the toggle
+   * flip is invisible unless the state description is captured (issue #3139).
+   *
+   * On API 30+ the value is available via the direct getter. On API 24-29 the androidx
+   * accessibility compat shim stores it in the node's extras bundle under
+   * [STATE_DESCRIPTION_EXTRA_KEY], so fall back to reading it there.
+   */
+  private fun extractStateDescription(
+    node: AccessibilityNodeInfo,
+    extras: Map<String, String>?,
+  ): String? {
+    if (Build.VERSION.SDK_INT >= 30) {
+      node.stateDescription?.toString()?.let {
+        if (it.isNotBlank()) return it
+      }
+    }
+    return stateDescriptionFromExtras(extras)
+  }
+
+  /**
+   * Pure extras-bundle fallback for the accessibility state description (see
+   * [extractStateDescription]). Exposed for unit testing without a live [AccessibilityNodeInfo].
+   */
+  internal fun stateDescriptionFromExtras(extras: Map<String, String>?): String? =
+    extras?.get(STATE_DESCRIPTION_EXTRA_KEY)?.takeIf { it.isNotBlank() }
 
   private fun extractExtras(node: AccessibilityNodeInfo): Map<String, String>? {
     val extras = node.extras ?: return null
@@ -1813,10 +1848,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val extrasMap = extractExtras(focusedNode)
       val testTag = extractTestTag(extrasMap)
 
-      var stateDescription: String? = null
-      if (Build.VERSION.SDK_INT >= 30) {
-        stateDescription = focusedNode.stateDescription?.toString()
-      }
+      val stateDescription: String? = extractStateDescription(focusedNode, extrasMap)
       // AccessibilityNodeInfo.getHintText requires API 26 (minSdk is 24)
       val hintText: String? =
         if (Build.VERSION.SDK_INT >= 26) focusedNode.hintText?.toString() else null

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -318,6 +318,33 @@ class ViewHierarchyExtractorTest {
     assertEquals(mapOf("custom-property" to "custom-value"), element.extras)
   }
 
+  // MARK: - Compose toggle state description (issue #3139)
+
+  private val stateDescriptionExtraKey =
+    "androidx.view.accessibility.AccessibilityNodeInfoCompat.STATE_DESCRIPTION_KEY"
+
+  @Test
+  fun `stateDescriptionFromExtras reads androidx compat key`() {
+    assertEquals(
+      "On",
+      extractor.stateDescriptionFromExtras(mapOf(stateDescriptionExtraKey to "On")),
+    )
+    assertEquals(
+      "Checked",
+      extractor.stateDescriptionFromExtras(
+        mapOf("other" to "x", stateDescriptionExtraKey to "Checked")
+      ),
+    )
+  }
+
+  @Test
+  fun `stateDescriptionFromExtras returns null when key absent, blank, or extras null`() {
+    assertNull(extractor.stateDescriptionFromExtras(null))
+    assertNull(extractor.stateDescriptionFromExtras(emptyMap()))
+    assertNull(extractor.stateDescriptionFromExtras(mapOf("unrelated" to "value")))
+    assertNull(extractor.stateDescriptionFromExtras(mapOf(stateDescriptionExtraKey to "   ")))
+  }
+
   @Test
   fun `semantic fields are serialized to JSON correctly`() {
     val element =


### PR DESCRIPTION
Closes #3139

## Summary
Compose toggleables (Switch, CheckBox, RadioButton, `Modifier.toggleable`/`selectable`) surface their state as an accessibility **state description** ("On"/"Off", "Checked"/"Unchecked"). When Compose sets a state description it deliberately does NOT set `AccessibilityNodeInfo.isChecked` (to avoid double-announcement in TalkBack), so a toggle flip was invisible to `observe`/`diffObserveResult` — the exact capture-layer gap called out in the #3051 sign-off (AC#2).

`ViewHierarchyExtractor` only read `node.stateDescription` on API 30+. This adds an extras-bundle fallback (androidx `AccessibilityNodeInfoCompat` STATE_DESCRIPTION key) for API 24-29, where Compose's a11y shim stashes the value. The extracted `state-description` field is already an allowed, diffable property in the TS layer (`ViewHierarchy.cleanNodeProperties`), so a toggle now produces a `state-description: { from, to }` delta under `observe` and `--actions-diff-observe`.

Changes:
- New `extractStateDescription(node, extras)` helper (direct API 30+ getter, blank-skip, extras fallback) used at both the main and accessibility-focused extraction paths.
- `state-description` extras key hoisted to a named companion constant.
- Extracted a pure, `internal` `stateDescriptionFromExtras` for testability.

## Validation
- `./gradlew :control-proxy:testDebugUnitTest --tests ViewHierarchyExtractorTest --rerun-tasks` (JDK 21): BUILD SUCCESSFUL, added 2 tests pass.
- `bun test test/features/observe/output/diffObserveResult.test.ts`: 63 pass.
- ktfmt 0.64 (--google-style) applied to both Kotlin files.

## Caveats
- No real-device run in this environment; the CtrlProxy runner change rides the standard Android APK release path.
- The state-description key may also appear in the raw `extras` map on API < 30 (harmless duplication); the diffable `state-description` field is the canonical surface.