### PR TITLE
refactor(scripts): extract scripts/lib/tool-install.sh (#2822)

### DIFF
--- a/scripts/hadolint/install_hadolint.sh
+++ b/scripts/hadolint/install_hadolint.sh
@@ -4,63 +4,14 @@ set -euo pipefail
 
 HADOLINT_VERSION="2.12.0" # Change this to the desired version
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Detect operating system
-detect_os() {
-    case "$(uname -s)" in
-        Darwin*)
-            echo "macos"
-            ;;
-        Linux*)
-            echo "linux"
-            ;;
-        CYGWIN*|MINGW*|MSYS*)
-            echo "windows"
-            ;;
-        *)
-            echo "unknown"
-            ;;
-    esac
-}
-
-# Detect architecture
-detect_arch() {
-    case "$(uname -m)" in
-        x86_64|amd64)
-            echo "x86_64"
-            ;;
-        aarch64|arm64)
-            echo "arm64"
-            ;;
-        *)
-            echo "unknown"
-            ;;
-    esac
-}
-
-# Check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
+# Shared colors + command_exists + detect_os/detect_arch (issue #2822).
+# shellcheck source=scripts/lib/tool-install.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
 
 # Install hadolint on macOS
 install_macos() {
-    echo -e "${YELLOW}Installing hadolint on macOS...${NC}"
-
-    if command_exists brew; then
-        echo -e "${GREEN}Using Homebrew to install hadolint${NC}"
-        brew install hadolint
-        return $?
-    else
-        echo -e "${YELLOW}Homebrew not found. Falling back to manual installation...${NC}"
-        install_manual
-        return $?
-    fi
+    install_via_brew_or_manual "hadolint" "hadolint" install_manual
+    return $?
 }
 
 # Install hadolint on Linux

--- a/scripts/ktfmt/install_ktfmt.sh
+++ b/scripts/ktfmt/install_ktfmt.sh
@@ -5,34 +5,9 @@
 # shellcheck source=scripts/ktfmt/ktfmt_version.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Detect operating system
-detect_os() {
-    case "$(uname -s)" in
-        Darwin*)
-            echo "macos"
-            ;;
-        Linux*)
-            echo "linux"
-            ;;
-        CYGWIN*|MINGW*|MSYS*)
-            echo "windows"
-            ;;
-        *)
-            echo "unknown"
-            ;;
-    esac
-}
-
-# Check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
+# Shared colors + command_exists + detect_os/detect_arch (issue #2822).
+# shellcheck source=scripts/lib/tool-install.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
 
 # Note: installed_ktfmt_version() is provided by the sourced ktfmt_version.sh.
 

--- a/scripts/lib/tool-install.sh
+++ b/scripts/lib/tool-install.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Shared boilerplate for the per-tool installer scripts (install_<tool>.sh).
+#
+# Historically every installer (ktfmt, swiftformat, swiftlint, hadolint, lychee,
+# shfmt, ...) re-declared the same ANSI-color block, command_exists(), detect_os()
+# and (some of them) detect_arch(). The copies drifted -- e.g. the Swift
+# installers dropped the Windows detect_os case and the arch helper -- so this
+# file is the single source of truth for those primitives (issue #2822). Each
+# installer sources it and keeps only its tool-specific config + install logic.
+#
+# Sourcing convention mirrors scripts/local-dev/lib/common.sh:
+#   # shellcheck source=scripts/lib/tool-install.sh disable=SC1091
+#   source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
+#
+# Exports:
+#   RED / GREEN / YELLOW / NC  - ANSI color escapes for `echo -e`
+#   command_exists <cmd>       - true if <cmd> is on PATH
+#   detect_os                  - echoes macos|linux|windows|unknown
+#   detect_arch                - echoes x86_64|arm64|armv7|386|unknown (normalized)
+#   install_via_brew_or_manual - generic macOS brew-or-manual install helper
+
+# Colors for output. Guarded so re-sourcing (or a caller that already set them)
+# does not clobber existing definitions.
+: "${RED:=$'\033[0;31m'}"
+: "${GREEN:=$'\033[0;32m'}"
+: "${YELLOW:=$'\033[1;33m'}"
+: "${NC:=$'\033[0m'}" # No Color
+
+# Check if a command exists on PATH.
+command_exists() {
+  command -v "$1" > /dev/null 2>&1
+}
+
+# Detect the operating system family. Echoes one of: macos|linux|windows|unknown.
+# The Windows (CYGWIN/MINGW/MSYS) case is included for every tool -- installers
+# that don't ship a Windows binary simply won't route to it.
+detect_os() {
+  case "$(uname -s)" in
+    Darwin*)
+      echo "macos"
+      ;;
+    Linux*)
+      echo "linux"
+      ;;
+    CYGWIN* | MINGW* | MSYS*)
+      echo "windows"
+      ;;
+    *)
+      echo "unknown"
+      ;;
+  esac
+}
+
+# Detect the CPU architecture, normalized to a canonical token. Echoes one of:
+# x86_64|arm64|armv7|386|unknown. Callers map this canonical token to the
+# per-release asset naming their tool uses (e.g. amd64, aarch64, x86_64).
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      echo "x86_64"
+      ;;
+    aarch64 | arm64)
+      echo "arm64"
+      ;;
+    armv7l)
+      echo "armv7"
+      ;;
+    i386 | i686)
+      echo "386"
+      ;;
+    *)
+      echo "unknown"
+      ;;
+  esac
+}
+
+# Generic "use Homebrew if present, else fall back to a manual installer" helper
+# for the macOS path. Consolidates the identical brew-or-manual skeleton that
+# swiftformat/swiftlint/hadolint each hand-rolled.
+#
+#   install_via_brew_or_manual <display-name> <brew-formula> <manual-install-fn>
+#
+# The manual-install function is invoked by name when brew is absent or the
+# `brew install` itself fails, and this helper returns that function's status.
+install_via_brew_or_manual() {
+  local display_name="$1"
+  local brew_formula="$2"
+  local manual_fn="$3"
+
+  echo -e "${YELLOW}Installing ${display_name} on macOS...${NC}"
+
+  if command_exists brew; then
+    echo -e "${GREEN}Using Homebrew to install ${display_name}${NC}"
+    if brew install "$brew_formula"; then
+      return 0
+    fi
+    echo -e "${YELLOW}Homebrew installation failed. Falling back to manual installation...${NC}"
+    "$manual_fn"
+    return $?
+  fi
+
+  echo -e "${YELLOW}Homebrew not found. Falling back to manual installation...${NC}"
+  "$manual_fn"
+  return $?
+}

--- a/scripts/lychee/install_lychee.sh
+++ b/scripts/lychee/install_lychee.sh
@@ -2,52 +2,11 @@
 
 LYCHEE_VERSION="0.22.0" # Change this to the desired version
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Detect operating system
-detect_os() {
-    case "$(uname -s)" in
-        Darwin*)
-            echo "macos"
-            ;;
-        Linux*)
-            echo "linux"
-            ;;
-        CYGWIN*|MINGW*|MSYS*)
-            echo "windows"
-            ;;
-        *)
-            echo "unknown"
-            ;;
-    esac
-}
-
-# Detect architecture
-detect_arch() {
-    case "$(uname -m)" in
-        x86_64|amd64)
-            echo "x86_64"
-            ;;
-        aarch64|arm64)
-            echo "aarch64"
-            ;;
-        armv7l)
-            echo "armv7"
-            ;;
-        *)
-            echo "unknown"
-            ;;
-    esac
-}
-
-# Check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
+# Shared colors + command_exists + detect_os/detect_arch (issue #2822).
+# detect_arch echoes the canonical "arm64" token for aarch64/arm64 hosts (the
+# old local copy echoed "aarch64"); the asset-name cases below key off "arm64".
+# shellcheck source=scripts/lib/tool-install.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
 
 # Install lychee on macOS
 install_macos() {
@@ -163,7 +122,7 @@ install_manual() {
                     echo -e "${YELLOW}No native x86_64 macOS binary. Using arm64 (Rosetta 2 required)${NC}"
                     binary_name="lychee-arm64-macos.tar.gz"
                     ;;
-                aarch64)
+                arm64)
                     binary_name="lychee-arm64-macos.tar.gz"
                     ;;
                 *)
@@ -177,7 +136,7 @@ install_manual() {
                 x86_64)
                     binary_name="lychee-x86_64-unknown-linux-gnu.tar.gz"
                     ;;
-                aarch64)
+                arm64)
                     binary_name="lychee-aarch64-unknown-linux-gnu.tar.gz"
                     ;;
                 armv7)

--- a/scripts/shellcheck/install_shfmt.sh
+++ b/scripts/shellcheck/install_shfmt.sh
@@ -2,32 +2,14 @@
 
 SHFMT_VERSION="3.10.0" # Change this to the desired version
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# Shared colors + command_exists + detect_os (issue #2822).
+# shellcheck source=scripts/lib/tool-install.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
 
-# Detect operating system
-detect_os() {
-  case "$(uname -s)" in
-    Darwin*)
-      echo "macos"
-      ;;
-    Linux*)
-      echo "linux"
-      ;;
-    CYGWIN* | MINGW* | MSYS*)
-      echo "windows"
-      ;;
-    *)
-      echo "unknown"
-      ;;
-  esac
-}
-
-# Detect architecture
-detect_arch() {
+# shfmt's GitHub release assets use Go's GOARCH tokens (amd64/arm/386), which
+# differ from the shared detect_arch's canonical tokens, so keep a tool-local
+# mapping rather than reusing the shared helper.
+shfmt_release_arch() {
   case "$(uname -m)" in
     x86_64 | amd64)
       echo "amd64"
@@ -45,11 +27,6 @@ detect_arch() {
       echo "unknown"
       ;;
   esac
-}
-
-# Check if command exists
-command_exists() {
-  command -v "$1" > /dev/null 2>&1
 }
 
 # Install shfmt on macOS
@@ -97,7 +74,7 @@ install_windows() {
 install_binary() {
   local os="$1"
   local arch
-  arch=$(detect_arch)
+  arch=$(shfmt_release_arch)
 
   echo -e "${YELLOW}Installing shfmt binary for $os ($arch)...${NC}"
 

--- a/scripts/swiftformat/install_swiftformat.sh
+++ b/scripts/swiftformat/install_swiftformat.sh
@@ -2,45 +2,16 @@
 
 SWIFTFORMAT_VERSION="0.54.6" # Change this to the desired version
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Detect operating system
-detect_os() {
-    case "$(uname -s)" in
-        Darwin*)
-            echo "macos"
-            ;;
-        Linux*)
-            echo "linux"
-            ;;
-        *)
-            echo "unknown"
-            ;;
-    esac
-}
-
-# Check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
+# Shared colors + command_exists + detect_os/detect_arch (issue #2822).
+# Note: SwiftFormat intentionally ships only macOS/Linux paths; detect_os may
+# return "windows" but main() routes that to the unsupported branch.
+# shellcheck source=scripts/lib/tool-install.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
 
 # Install SwiftFormat on macOS
 install_macos() {
-    echo -e "${YELLOW}Installing SwiftFormat on macOS...${NC}"
-
-    if command_exists brew; then
-        echo -e "${GREEN}Using Homebrew to install SwiftFormat${NC}"
-        brew install swiftformat
-        return $?
-    else
-        echo -e "${YELLOW}Homebrew not found. Attempting manual installation...${NC}"
-        install_manual
-        return $?
-    fi
+    install_via_brew_or_manual "SwiftFormat" "swiftformat" install_manual
+    return $?
 }
 
 # Install SwiftFormat on Linux

--- a/scripts/swiftlint/install_swiftlint.sh
+++ b/scripts/swiftlint/install_swiftlint.sh
@@ -2,45 +2,16 @@
 
 SWIFTLINT_VERSION="0.57.0" # Change this to the desired version
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Detect operating system
-detect_os() {
-    case "$(uname -s)" in
-        Darwin*)
-            echo "macos"
-            ;;
-        Linux*)
-            echo "linux"
-            ;;
-        *)
-            echo "unknown"
-            ;;
-    esac
-}
-
-# Check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
+# Shared colors + command_exists + detect_os/detect_arch (issue #2822).
+# Note: SwiftLint intentionally ships only macOS/Linux paths; detect_os may
+# return "windows" but main() routes that to the unsupported branch.
+# shellcheck source=scripts/lib/tool-install.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
 
 # Install SwiftLint on macOS
 install_macos() {
-    echo -e "${YELLOW}Installing SwiftLint on macOS...${NC}"
-
-    if command_exists brew; then
-        echo -e "${GREEN}Using Homebrew to install SwiftLint${NC}"
-        brew install swiftlint
-        return $?
-    else
-        echo -e "${YELLOW}Homebrew not found. Attempting manual installation...${NC}"
-        install_manual
-        return $?
-    fi
+    install_via_brew_or_manual "SwiftLint" "swiftlint" install_manual
+    return $?
 }
 
 # Install SwiftLint on Linux


### PR DESCRIPTION
Closes #2822

## Summary
De-duplicates the installer boilerplate that was copy-pasted (and had already drifted) across the per-tool `install_<tool>.sh` scripts. Adds a single shared `scripts/lib/tool-install.sh` and migrates the six installers to source it.

### `scripts/lib/tool-install.sh` exports
- `RED`/`GREEN`/`YELLOW`/`NC` ANSI colors (guarded so re-sourcing won't clobber)
- `command_exists`
- `detect_os` (macos|linux|windows|unknown)
- `detect_arch` (canonical x86_64|arm64|armv7|386|unknown)
- `install_via_brew_or_manual <display> <formula> <manual-fn>` — the brew-or-manual macOS skeleton that swiftformat/swiftlint/hadolint each hand-rolled

### Migrated installers
ktfmt, swiftformat, swiftlint, hadolint, lychee, shfmt — each now sources the lib and keeps only its tool-specific config/logic. Sourcing follows the existing `scripts/local-dev/lib/common.sh` convention.

### Drift reconciled without losing behavior
- **detect_arch unified to canonical tokens.** lychee's local copy echoed `aarch64`; the shared helper echoes `arm64`. Updated lychee's asset-name cases (`aarch64` → `arm64`) so the mapping is unchanged.
- **shfmt keeps a tool-local `shfmt_release_arch`** — its GitHub release assets use Go GOARCH tokens (`amd64`/`arm`/`386`), which differ from the canonical tokens, so it does NOT reuse the shared `detect_arch`.
- **No Windows support added to the Swift installers** — their `main()` has no `windows)` case, so `windows` routes to the unsupported branch and fails (verified).
- **hadolint's `detect_arch` + already-installed short-circuit retained.**

## Validation
- `shellcheck` clean per-file for all 7 files (per-file run trips SC1091 on `source`; added `# shellcheck disable=SC1091` on each source directive).
- `bats test/bats/install-ktfmt.bats` — all 5 tests green (the suite that exercises these installers).
- Functional smoke tests: shared `detect_os`/`detect_arch` resolve correctly; `install_via_brew_or_manual` falls through to manual and propagates the manual fn's exit code; hadolint already-installed short-circuit works; swiftformat Windows path stays unsupported.
- Color escapes byte-identical between the old `RED='\033...'` literal (rendered via `echo -e`) and the new `$'\033...'` guard form (verified with `od -c`).

## Caveats
- The repo's shell CI gate (`scripts/shellcheck/validate_shell_scripts.sh`) runs **shellcheck only**, not shfmt; edits preserve each file's existing indentation to keep the diff minimal.
- Pre-existing unrelated failure: `test/bats/verify-runtime-deps.bats:137` (tests `scripts/ci/verify-runtime-deps.sh`, not touched here) fails on this machine due to a missing runtime dep — environment artifact, not caused by this change.
- Companion #2823 (file-selection.sh) is a separate file/lane and is not touched here.