### PR TITLE
refactor(observe/android): consolidate telemetry/crash ingestion behind SdkEventIngestor (#2764)

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -147,19 +147,11 @@ src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'numb
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'string | undefined' is not assignable to type 'string | null'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2339: Property 'event' does not exist on type 'never'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2339: Property 'timestamp' does not exist on type 'never'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AccessibilityHierarchy' is not assignable to parameter of type 'ViewHierarchyResult'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AccessibilityHierarchy' is not assignable to parameter of type 'ViewHierarchyResult'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
 src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
-src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2367: This comparison appears to be unintentional because the types '"screenshot" | "hierarchy_update" | "pinch_result" | "tap_coordinates_result" | "swipe_result" | "drag_result" | "set_text_result" | "select_all_result" | "ime_action_result" | ... 36 more ... | "lifecycle_event"' and '"custom_event"' have no overlap.
 src/features/observe/android/CtrlProxyHierarchy.ts: error TS2554: Expected 0 arguments, but got 1.
 src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type 'null | undefined' is not assignable to type 'NormalizedHighlightBounds | undefined'.
 src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type '{ bounds: NormalizedHighlightBounds | undefined; type: "box"; style?: HighlightStyle | null; }' is not assignable to type 'HighlightShape'.

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -49,13 +49,16 @@ import {
   ScreenshotCaptureResult,
   computeChecksum,
 } from "../ScreenshotBackoffScheduler";
-import { getFailureRecorder } from "../../failures/FailureRecorder";
 import {
   normalizeAnr,
   normalizeCrash,
   type SdkAnrPayload,
   type SdkCrashPayload,
 } from "../crash/sdkCrashIngestion";
+import {
+  AndroidSdkEventIngestor,
+  DefaultAndroidSdkEventIngestor,
+} from "./AndroidSdkEventIngestor";
 import { FailureEventRepository } from "../../../db/failureEventRepository";
 import type { CrashEventSink } from "../../../utils/interfaces/CrashMonitor";
 import { serverConfig } from "../../../utils/ServerConfig";
@@ -599,6 +602,20 @@ export interface StorageTelemetryInput {
  * for legacy runners that omit it (#3000). An explicit null ("no prior value")
  * is honored verbatim and also skips the lookup.
  */
+/**
+ * WebSocket message types that carry an SDK telemetry event to be fanned out to
+ * `TelemetryRecorder` via {@link AndroidSdkEventIngestor.recordSdkEvent} (#2764).
+ * These are not part of the typed `WebSocketMessage` union.
+ */
+const SDK_TELEMETRY_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "network_event",
+  "websocket_frame_event",
+  "log_event",
+  "broadcast_event",
+  "lifecycle_event",
+  "custom_event",
+]);
+
 export function storageTelemetryInputFromWire(
   message: WsStorageChangedMessage,
   resolvedTimestamp: number
@@ -887,6 +904,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private readonly crashEventSink: CrashEventSink;
   private readonly deviceConnectionLostNotifier: DeviceConnectionLostNotifier;
 
+  /**
+   * Owns SDK telemetry/crash/ANR ingestion (issue #2764). Lazily built so it can
+   * close over instance methods (`parseStackTrace`, session-bound nav manager);
+   * injectable for tests.
+   */
+  private sdkEventIngestorInstance: AndroidSdkEventIngestor | null = null;
+
   // Logging tag for base class
   protected readonly logTag = "ACCESSIBILITY_SERVICE";
 
@@ -901,9 +925,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     installedAppsRepository?: InstalledAppsStore,
     retryExecutor?: RetryExecutor,
     crashEventSink?: CrashEventSink,
-    deviceConnectionLostNotifier?: DeviceConnectionLostNotifier
+    deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
+    sdkEventIngestor?: AndroidSdkEventIngestor
   ) {
     super(timer ?? defaultTimer, webSocketFactory ?? defaultWebSocketFactory, {}, retryExecutor ?? defaultRetryExecutor);
+    this.sdkEventIngestorInstance = sdkEventIngestor ?? null;
     this.device = device;
     this.adb = adb;
     this.installedAppsRepository = installedAppsRepository ?? null;
@@ -955,6 +981,23 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   /**
+   * The SDK-event ingestor for this client (issue #2764). Built lazily so it can
+   * close over instance methods and the session-bound navigation manager; a
+   * test-injected instance short-circuits construction.
+   */
+  private getSdkEventIngestor(): AndroidSdkEventIngestor {
+    if (!this.sdkEventIngestorInstance) {
+      this.sdkEventIngestorInstance = new DefaultAndroidSdkEventIngestor({
+        deviceId: this.device.deviceId,
+        getNavigationScreenSource: () => this.getNavigationGraphManager(),
+        parseStackTrace: (stackTrace, packageName) => this.parseStackTrace(stackTrace, packageName),
+        now: () => this.timer.now(),
+      });
+    }
+    return this.sdkEventIngestorInstance;
+  }
+
+  /**
    * Reset all instances (for testing)
    */
   public static resetInstances(): void {
@@ -977,7 +1020,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     installedAppsRepository?: InstalledAppsStore,
     retryExecutor?: RetryExecutor,
     crashEventSink?: CrashEventSink,
-    deviceConnectionLostNotifier?: DeviceConnectionLostNotifier
+    deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
+    sdkEventIngestor?: AndroidSdkEventIngestor
   ): AndroidCtrlProxyClient {
     return new AndroidCtrlProxyClient(
       device,
@@ -987,7 +1031,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       installedAppsRepository,
       retryExecutor,
       crashEventSink,
-      deviceConnectionLostNotifier
+      deviceConnectionLostNotifier,
+      sdkEventIngestor
     );
   }
 
@@ -2513,118 +2558,23 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         }
       }
 
-      // Handle telemetry events from SDK event batch
-      if (message.type === "network_event") {
-        const event = message.event;
+      // Handle telemetry events from SDK event batch. The fan-out to
+      // TelemetryRecorder is owned by AndroidSdkEventIngestor (issue #2764); the
+      // client only recognizes the wire type and forwards the typed event. These
+      // telemetry messages are not part of the typed WebSocketMessage union, so
+      // compare against a plain string type.
+      const messageType = (message as { type: string }).type;
+      if (SDK_TELEMETRY_EVENT_TYPES.has(messageType)) {
+        const event = (message as { event?: Record<string, unknown> }).event;
         if (event) {
-          const recorder = TelemetryRecorder.getInstance();
-          recorder.setContext(this.device.deviceId, null);
-          await recorder.recordNetworkEvent({
-            timestamp: message.timestamp,
-            applicationId: event.applicationId ?? null,
-            url: event.url,
-            method: event.method,
-            statusCode: event.statusCode ?? 0,
-            durationMs: event.durationMs ?? 0,
-            requestBodySize: event.requestBodySize ?? -1,
-            responseBodySize: event.responseBodySize ?? -1,
-            protocol: event.protocol ?? null,
-            host: event.host ?? null,
-            path: event.path ?? null,
-            error: event.error ?? null,
-            requestHeaders: event.requestHeaders ?? null,
-            responseHeaders: event.responseHeaders ?? null,
-            requestBody: event.requestBody ?? null,
-            responseBody: event.responseBody ?? null,
-            contentType: event.contentType ?? null,
-          });
-        }
-      }
-
-      if (message.type === "websocket_frame_event") {
-        const event = message.event;
-        if (event) {
-          const recorder = TelemetryRecorder.getInstance();
-          recorder.setContext(this.device.deviceId, null);
-          await recorder.recordOsEvent({
-            timestamp: message.timestamp,
-            applicationId: event.applicationId ?? null,
-            category: "websocket_frame",
-            kind: event.frameType ?? "unknown",
-            details: {
-              connectionId: event.connectionId ?? "",
-              url: event.url ?? "",
-              direction: event.direction ?? "",
-              payloadSize: String(event.payloadSize ?? 0),
+          await this.getSdkEventIngestor().recordSdkEvent(
+            {
+              type: messageType,
+              timestamp: message.timestamp ?? this.timer.now(),
+              payload: { event },
             },
-          });
-        }
-      }
-
-      if (message.type === "log_event") {
-        const event = message.event;
-        if (event) {
-          const recorder = TelemetryRecorder.getInstance();
-          recorder.setContext(this.device.deviceId, null);
-          await recorder.recordLogEvent({
-            timestamp: message.timestamp,
-            applicationId: event.applicationId ?? null,
-            level: event.level ?? 0,
-            tag: event.tag ?? "",
-            message: event.message ?? "",
-            filterName: event.filterName ?? "",
-          });
-        }
-      }
-
-      if (message.type === "broadcast_event") {
-        const event = message.event;
-        if (event) {
-          const recorder = TelemetryRecorder.getInstance();
-          recorder.setContext(this.device.deviceId, null);
-          await recorder.recordOsEvent({
-            timestamp: message.timestamp,
-            applicationId: event.applicationId ?? null,
-            category: "broadcast",
-            kind: event.action ?? "unknown",
-            details: event.extraKeys ?? null,
-          });
-        }
-      }
-
-      if (message.type === "lifecycle_event") {
-        const event = message.event;
-        if (event) {
-          const recorder = TelemetryRecorder.getInstance();
-          recorder.setContext(this.device.deviceId, null);
-          await recorder.recordOsEvent({
-            timestamp: message.timestamp,
-            applicationId: event.applicationId ?? null,
-            category: "lifecycle",
-            kind: event.kind ?? "unknown",
-            details: event.details ?? null,
-          });
-        }
-      }
-
-      if (message.type === "custom_event") {
-        const event = message.event;
-        if (event) {
-          const recorder = TelemetryRecorder.getInstance();
-          recorder.setContext(this.device.deviceId, null);
-
-          // Custom events are merged into log events
-          const propsStr = event.properties && Object.keys(event.properties).length > 0
-            ? ` ${JSON.stringify(event.properties)}`
-            : "";
-          await recorder.recordLogEvent({
-            timestamp: message.timestamp,
-            applicationId: event.applicationId ?? null,
-            level: 4, // INFO
-            tag: "CustomEvent",
-            message: `${event.name ?? ""}${propsStr}`,
-            filterName: "custom",
-          });
+            (event.applicationId as string) ?? null
+          );
         }
       }
 
@@ -2645,10 +2595,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           server.pushStorageUpdate(this.device.deviceId, storageEvent);
         }
 
-        // Record to telemetry timeline
-        const recorder = TelemetryRecorder.getInstance();
-        recorder.setContext(this.device.deviceId, null);
-        recorder.recordStorageEvent(storageTelemetryInputFromWire(message, storageEvent.timestamp));
+        // Record to telemetry timeline (fan-out owned by the ingestor, #2764).
+        this.getSdkEventIngestor().recordStorageEvent(
+          storageTelemetryInputFromWire(message, storageEvent.timestamp)
+        );
       }
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error handling WebSocket message: ${error}`);
@@ -2995,39 +2945,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   private async handleHandledExceptionEvent(event: HandledExceptionEvent): Promise<void> {
     logger.info(`[CTRL_PROXY] Received handled exception: ${event.exceptionClass} from ${event.packageName}`);
-
-    try {
-      const failureRecorder = getFailureRecorder();
-      const stackTraceElements = this.parseStackTrace(event.stackTrace, event.packageName);
-
-      let currentScreen = event.currentScreen;
-      if (!currentScreen) {
-        try {
-          const navManager = this.getNavigationGraphManager();
-          currentScreen = navManager.getCurrentScreen() ?? undefined;
-        } catch {
-          // Continue without screen
-        }
-      }
-
-      const nonFatalInput = {
-        exceptionType: event.exceptionClass,
-        exceptionMessage: event.exceptionMessage ?? "Handled exception",
-        stackTrace: stackTraceElements,
-        customMessage: event.customMessage,
-        deviceId: this.device.deviceId,
-        deviceModel: event.deviceInfo.model,
-        os: `Android ${event.deviceInfo.osVersion} (API ${event.deviceInfo.sdkInt})`,
-        appVersion: event.appVersion ?? "unknown",
-        sessionId: `handled-${event.packageName}-${this.timer.now()}`,
-        currentScreen,
-      };
-
-      const occurrenceId = await failureRecorder.recordNonFatal(nonFatalInput);
-      logger.info(`[CTRL_PROXY] Recorded non-fatal exception: ${occurrenceId}`);
-    } catch (error) {
-      logger.error(`[CTRL_PROXY] Failed to record handled exception: ${error}`);
-    }
+    await this.getSdkEventIngestor().recordHandledException(event);
   }
 
   private async persistCrash(event: SdkCrashPayload): Promise<void> {
@@ -3038,44 +2956,12 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
-  private async recordCrashAnalytics(event: SdkCrashPayload): Promise<void> {
-    try {
-      const failureRecorder = getFailureRecorder();
-      const stackTraceElements = this.parseStackTrace(event.stackTrace, event.packageName);
-
-      let currentScreen = event.currentScreen;
-      if (!currentScreen) {
-        try {
-          const navManager = this.getNavigationGraphManager();
-          currentScreen = navManager.getCurrentScreen() ?? undefined;
-        } catch {
-          // Continue without screen
-        }
-      }
-
-      const crashInput = {
-        exceptionType: event.exceptionClass,
-        exceptionMessage: event.message ?? "Application crashed",
-        stackTrace: stackTraceElements,
-        threadName: event.threadName,
-        deviceId: this.device.deviceId,
-        deviceModel: event.deviceInfo.model,
-        os: `Android ${event.deviceInfo.osVersion} (API ${event.deviceInfo.sdkInt})`,
-        appVersion: event.appVersion ?? "unknown",
-        sessionId: `crash-${event.packageName}-${this.timer.now()}`,
-        currentScreen,
-      };
-
-      const occurrenceId = await failureRecorder.recordCrash(crashInput);
-      logger.info(`[CTRL_PROXY] Recorded crash: ${occurrenceId}`);
-    } catch (error) {
-      logger.error(`[CTRL_PROXY] Failed to record crash: ${error}`);
-    }
-  }
-
   private async handleCrashEvent(event: SdkCrashPayload): Promise<void> {
     logger.info(`[CTRL_PROXY] Received crash: ${event.exceptionClass} on thread ${event.threadName} from ${event.packageName}`);
-    await Promise.all([this.persistCrash(event), this.recordCrashAnalytics(event)]);
+    await Promise.all([
+      this.persistCrash(event),
+      this.getSdkEventIngestor().recordCrashAnalytics(event),
+    ]);
   }
 
   private async persistAnr(event: SdkAnrPayload): Promise<void> {
@@ -3086,45 +2972,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
-  private async recordAnrAnalytics(event: SdkAnrPayload, packageName: string): Promise<void> {
-    try {
-      const failureRecorder = getFailureRecorder();
-
-      // Parse stack trace if available
-      const stackTraceElements = event.trace
-        ? this.parseStackTrace(event.trace, packageName)
-        : [];
-
-      let currentScreen: string | undefined;
-      try {
-        const navManager = this.getNavigationGraphManager();
-        currentScreen = navManager.getCurrentScreen() ?? undefined;
-      } catch {
-        // Continue without screen
-      }
-
-      const anrInput = {
-        reason: event.reason,
-        stackTrace: stackTraceElements.length > 0 ? stackTraceElements : undefined,
-        deviceId: this.device.deviceId,
-        deviceModel: event.deviceInfo.model,
-        os: `Android ${event.deviceInfo.osVersion} (API ${event.deviceInfo.sdkInt})`,
-        appVersion: event.appVersion ?? "unknown",
-        sessionId: `anr-${packageName}-${this.timer.now()}`,
-        currentScreen,
-      };
-
-      const occurrenceId = await failureRecorder.recordAnr(anrInput);
-      logger.info(`[CTRL_PROXY] Recorded ANR: ${occurrenceId}`);
-    } catch (error) {
-      logger.error(`[CTRL_PROXY] Failed to record ANR: ${error}`);
-    }
-  }
-
   private async handleAnrEvent(event: SdkAnrPayload): Promise<void> {
     logger.info(`[CTRL_PROXY] Received ANR: pid=${event.pid}, process=${event.processName}, importance=${event.importance}`);
     const packageName = event.packageName ?? event.processName;
-    await Promise.all([this.persistAnr(event), this.recordAnrAnalytics(event, packageName)]);
+    await Promise.all([
+      this.persistAnr(event),
+      this.getSdkEventIngestor().recordAnrAnalytics(event, packageName),
+    ]);
   }
 
   private parseStackTrace(stackTrace: string, packageName: string): StackTraceElement[] {

--- a/src/features/observe/android/AndroidSdkEventIngestor.ts
+++ b/src/features/observe/android/AndroidSdkEventIngestor.ts
@@ -1,0 +1,350 @@
+/**
+ * AndroidSdkEventIngestor - owns SDK-event ingestion for the Android CtrlProxy
+ * client.
+ *
+ * Extracted from `AndroidCtrlProxyClient` (issue #2764) so the client is
+ * responsible only for connection lifecycle + request routing. This module fans
+ * decoded SDK telemetry events (network / websocket_frame / log / broadcast /
+ * lifecycle / custom / storage_changed) out to `TelemetryRecorder`, and records
+ * crash / ANR / handled-exception analytics through `FailureRecorder`.
+ *
+ * It implements the shared `SdkEventIngestor` interface (issue #2763); the iOS
+ * companion (`IosSdkEventIngestor`) implements the same contract for its own
+ * transport. Android delivers already-typed event objects on its WebSocket, so
+ * it specializes the generic payload to {@link AndroidSdkEventPayload}.
+ *
+ * All ingestion is best-effort: the shared `recordSdkEvent` never throws, and the
+ * crash/ANR/handled analytics helpers log-and-continue on failure — telemetry
+ * must never break observation.
+ */
+
+import { TelemetryRecorder } from "../../telemetry/TelemetryRecorder";
+import { getFailureRecorder } from "../../failures/FailureRecorder";
+import type { FailureRecorderService } from "../../failures/interfaces/FailureRecorderService";
+import { logger } from "../../../utils/logger";
+import type { StackTraceElement } from "../../../server/failuresResources";
+import type { SdkAnrPayload, SdkCrashPayload } from "../crash/sdkCrashIngestion";
+import type { SdkEvent, SdkEventIngestor } from "../interfaces/SdkEventIngestor";
+import type { StorageTelemetryInput } from "./AndroidCtrlProxyClient";
+
+/**
+ * The subset of `TelemetryRecorder` the ingestor depends on. Narrow so tests can
+ * substitute a double; the production default is the shared singleton.
+ */
+export type AndroidTelemetryRecorder = Pick<
+  TelemetryRecorder,
+  "setContext" | "recordNetworkEvent" | "recordLogEvent" | "recordOsEvent" | "recordStorageEvent"
+>;
+
+/**
+ * A handled-exception SDK event as delivered on the Android WebSocket. Mirrors
+ * the client-side `HandledExceptionEvent` shape without importing it (the type is
+ * not exported).
+ */
+export interface AndroidHandledExceptionEvent {
+  timestamp: number;
+  exceptionClass: string;
+  exceptionMessage?: string;
+  stackTrace: string;
+  customMessage?: string;
+  currentScreen?: string;
+  packageName: string;
+  appVersion?: string;
+  deviceInfo: {
+    model: string;
+    manufacturer: string;
+    osVersion: string;
+    sdkInt: number;
+  };
+}
+
+/**
+ * The navigation-graph operations the ingestor needs for screen attribution.
+ * Provided via a getter so session rebinds are honored on each event.
+ */
+export interface NavigationScreenSource {
+  getCurrentScreen(): string | null;
+}
+
+/**
+ * Payload for an Android SDK telemetry event. The client narrows `type` to the
+ * WebSocket message type and passes the already-typed `event` object plus the
+ * owning device id through as the payload.
+ */
+export interface AndroidSdkEventPayload {
+  /** The typed SDK event object from the WebSocket message. */
+  event: Record<string, unknown>;
+}
+
+/**
+ * Android-specific ingestor: the shared SDK-event routing plus crash / ANR /
+ * handled-exception analytics that have no cross-platform analogue.
+ */
+export interface AndroidSdkEventIngestor extends SdkEventIngestor<AndroidSdkEventPayload> {
+  /**
+   * Record a `storage_changed` telemetry event from an input the client already
+   * built from the wire message. Best-effort; never throws.
+   */
+  recordStorageEvent(input: StorageTelemetryInput): void;
+  /** Record a handled (non-fatal) exception through the failure recorder. */
+  recordHandledException(event: AndroidHandledExceptionEvent): Promise<void>;
+  /** Record a crash through the failure recorder analytics timeline. */
+  recordCrashAnalytics(event: SdkCrashPayload): Promise<void>;
+  /** Record an ANR through the failure recorder analytics timeline. */
+  recordAnrAnalytics(event: SdkAnrPayload, packageName: string): Promise<void>;
+}
+
+/** Injected dependencies for {@link DefaultAndroidSdkEventIngestor}. */
+export interface AndroidSdkEventIngestorDeps {
+  /** The Android device serial that owns these events. */
+  deviceId: string;
+  /** Returns the navigation graph for the current session (session-bound). */
+  getNavigationScreenSource: () => NavigationScreenSource;
+  /** Parse a raw stack trace string into structured frames. */
+  parseStackTrace: (stackTrace: string, packageName: string) => StackTraceElement[];
+  /** Monotonic clock; used to stamp failure session ids. */
+  now: () => number;
+  /** Telemetry recorder; defaults to the shared singleton. */
+  telemetryRecorder?: AndroidTelemetryRecorder;
+  /** Failure recorder; defaults to the shared singleton. */
+  failureRecorder?: FailureRecorderService;
+}
+
+export class DefaultAndroidSdkEventIngestor implements AndroidSdkEventIngestor {
+  private readonly deviceId: string;
+  private readonly getNavigationScreenSource: () => NavigationScreenSource;
+  private readonly parseStackTrace: (stackTrace: string, packageName: string) => StackTraceElement[];
+  private readonly now: () => number;
+  private readonly telemetryRecorderOverride?: AndroidTelemetryRecorder;
+  private readonly failureRecorderOverride?: FailureRecorderService;
+
+  constructor(deps: AndroidSdkEventIngestorDeps) {
+    this.deviceId = deps.deviceId;
+    this.getNavigationScreenSource = deps.getNavigationScreenSource;
+    this.parseStackTrace = deps.parseStackTrace;
+    this.now = deps.now;
+    this.telemetryRecorderOverride = deps.telemetryRecorder;
+    this.failureRecorderOverride = deps.failureRecorder;
+  }
+
+  /**
+   * Resolve the telemetry recorder fresh per call (matching the pre-extraction
+   * behavior) so a runtime singleton swap is honored; tests inject an override.
+   */
+  private get telemetryRecorder(): AndroidTelemetryRecorder {
+    return this.telemetryRecorderOverride ?? TelemetryRecorder.getInstance();
+  }
+
+  /** Resolve the failure recorder fresh per call; tests inject an override. */
+  private get failureRecorder(): FailureRecorderService {
+    return this.failureRecorderOverride ?? getFailureRecorder();
+  }
+
+  /**
+   * Route one Android SDK telemetry event to `TelemetryRecorder`. Best-effort:
+   * never throws so a recorder failure cannot break observation.
+   */
+  async recordSdkEvent(
+    sdkEvent: SdkEvent<AndroidSdkEventPayload>,
+    _applicationId: string | null
+  ): Promise<void> {
+    try {
+      const recorder = this.telemetryRecorder;
+      recorder.setContext(this.deviceId, null);
+      const ts = sdkEvent.timestamp;
+      const event = sdkEvent.payload.event;
+      const appId = (event.applicationId as string) ?? null;
+
+      switch (sdkEvent.type) {
+        case "network_event":
+          await recorder.recordNetworkEvent({
+            timestamp: ts,
+            applicationId: appId,
+            url: event.url as string,
+            method: event.method as string,
+            statusCode: (event.statusCode as number) ?? 0,
+            durationMs: (event.durationMs as number) ?? 0,
+            requestBodySize: (event.requestBodySize as number) ?? -1,
+            responseBodySize: (event.responseBodySize as number) ?? -1,
+            protocol: (event.protocol as string) ?? null,
+            host: (event.host as string) ?? null,
+            path: (event.path as string) ?? null,
+            error: (event.error as string) ?? null,
+            requestHeaders: (event.requestHeaders as Record<string, string>) ?? null,
+            responseHeaders: (event.responseHeaders as Record<string, string>) ?? null,
+            requestBody: (event.requestBody as string) ?? null,
+            responseBody: (event.responseBody as string) ?? null,
+            contentType: (event.contentType as string) ?? null,
+          });
+          break;
+        case "websocket_frame_event":
+          await recorder.recordOsEvent({
+            timestamp: ts,
+            applicationId: appId,
+            category: "websocket_frame",
+            kind: (event.frameType as string) ?? "unknown",
+            details: {
+              connectionId: (event.connectionId as string) ?? "",
+              url: (event.url as string) ?? "",
+              direction: (event.direction as string) ?? "",
+              payloadSize: String((event.payloadSize as number) ?? 0),
+            },
+          });
+          break;
+        case "log_event":
+          await recorder.recordLogEvent({
+            timestamp: ts,
+            applicationId: appId,
+            level: (event.level as number) ?? 0,
+            tag: (event.tag as string) ?? "",
+            message: (event.message as string) ?? "",
+            filterName: (event.filterName as string) ?? "",
+          });
+          break;
+        case "broadcast_event":
+          await recorder.recordOsEvent({
+            timestamp: ts,
+            applicationId: appId,
+            category: "broadcast",
+            kind: (event.action as string) ?? "unknown",
+            details: (event.extraKeys as Record<string, string>) ?? null,
+          });
+          break;
+        case "lifecycle_event":
+          await recorder.recordOsEvent({
+            timestamp: ts,
+            applicationId: appId,
+            category: "lifecycle",
+            kind: (event.kind as string) ?? "unknown",
+            details: (event.details as Record<string, string>) ?? null,
+          });
+          break;
+        case "custom_event": {
+          // Custom events are merged into log events
+          const properties = event.properties as Record<string, unknown> | undefined;
+          const propsStr =
+            properties && Object.keys(properties).length > 0 ? ` ${JSON.stringify(properties)}` : "";
+          await recorder.recordLogEvent({
+            timestamp: ts,
+            applicationId: appId,
+            level: 4, // INFO
+            tag: "CustomEvent",
+            message: `${(event.name as string) ?? ""}${propsStr}`,
+            filterName: "custom",
+          });
+          break;
+        }
+        default:
+          logger.debug(`[AndroidSdkEventIngestor] Ignoring unknown SDK event type: ${sdkEvent.type}`);
+      }
+    } catch (error) {
+      // Non-fatal — telemetry recording must never break observation.
+      logger.debug(`[AndroidSdkEventIngestor] recordSdkEvent(${sdkEvent.type}) failed: ${error}`);
+    }
+  }
+
+  /**
+   * Record a `storage_changed` telemetry event. Kept separate from
+   * {@link recordSdkEvent} because the client already builds the recorder input
+   * from the wire message (via `storageTelemetryInputFromWire`) for the storage
+   * listener/stream fan-out. Best-effort.
+   */
+  recordStorageEvent(input: StorageTelemetryInput): void {
+    try {
+      const recorder = this.telemetryRecorder;
+      recorder.setContext(this.deviceId, null);
+      void recorder.recordStorageEvent(input);
+    } catch (error) {
+      // Non-fatal — telemetry recording must never break observation.
+      logger.debug(`[AndroidSdkEventIngestor] recordStorageEvent failed: ${error}`);
+    }
+  }
+
+  async recordHandledException(event: AndroidHandledExceptionEvent): Promise<void> {
+    try {
+      const failureRecorder = this.failureRecorder;
+      const stackTraceElements = this.parseStackTrace(event.stackTrace, event.packageName);
+
+      const nonFatalInput = {
+        exceptionType: event.exceptionClass,
+        exceptionMessage: event.exceptionMessage ?? "Handled exception",
+        stackTrace: stackTraceElements,
+        customMessage: event.customMessage,
+        deviceId: this.deviceId,
+        deviceModel: event.deviceInfo.model,
+        os: `Android ${event.deviceInfo.osVersion} (API ${event.deviceInfo.sdkInt})`,
+        appVersion: event.appVersion ?? "unknown",
+        sessionId: `handled-${event.packageName}-${this.now()}`,
+        currentScreen: event.currentScreen ?? this.resolveCurrentScreen(),
+      };
+
+      const occurrenceId = await failureRecorder.recordNonFatal(nonFatalInput);
+      logger.info(`[CTRL_PROXY] Recorded non-fatal exception: ${occurrenceId}`);
+    } catch (error) {
+      logger.error(`[CTRL_PROXY] Failed to record handled exception: ${error}`);
+    }
+  }
+
+  async recordCrashAnalytics(event: SdkCrashPayload): Promise<void> {
+    try {
+      const failureRecorder = this.failureRecorder;
+      const stackTraceElements = this.parseStackTrace(event.stackTrace, event.packageName);
+
+      const crashInput = {
+        exceptionType: event.exceptionClass,
+        exceptionMessage: event.message ?? "Application crashed",
+        stackTrace: stackTraceElements,
+        threadName: event.threadName,
+        deviceId: this.deviceId,
+        deviceModel: event.deviceInfo.model,
+        os: `Android ${event.deviceInfo.osVersion} (API ${event.deviceInfo.sdkInt})`,
+        appVersion: event.appVersion ?? "unknown",
+        sessionId: `crash-${event.packageName}-${this.now()}`,
+        currentScreen: event.currentScreen ?? this.resolveCurrentScreen(),
+      };
+
+      const occurrenceId = await failureRecorder.recordCrash(crashInput);
+      logger.info(`[CTRL_PROXY] Recorded crash: ${occurrenceId}`);
+    } catch (error) {
+      logger.error(`[CTRL_PROXY] Failed to record crash: ${error}`);
+    }
+  }
+
+  async recordAnrAnalytics(event: SdkAnrPayload, packageName: string): Promise<void> {
+    try {
+      const failureRecorder = this.failureRecorder;
+
+      // Parse stack trace if available
+      const stackTraceElements = event.trace ? this.parseStackTrace(event.trace, packageName) : [];
+
+      const anrInput = {
+        reason: event.reason,
+        stackTrace: stackTraceElements.length > 0 ? stackTraceElements : undefined,
+        deviceId: this.deviceId,
+        deviceModel: event.deviceInfo.model,
+        os: `Android ${event.deviceInfo.osVersion} (API ${event.deviceInfo.sdkInt})`,
+        appVersion: event.appVersion ?? "unknown",
+        sessionId: `anr-${packageName}-${this.now()}`,
+        currentScreen: this.resolveCurrentScreen(),
+      };
+
+      const occurrenceId = await failureRecorder.recordAnr(anrInput);
+      logger.info(`[CTRL_PROXY] Recorded ANR: ${occurrenceId}`);
+    } catch (error) {
+      logger.error(`[CTRL_PROXY] Failed to record ANR: ${error}`);
+    }
+  }
+
+  /**
+   * Resolve the current screen from the navigation graph, tolerating a
+   * not-yet-bound session. Returns undefined when unavailable.
+   */
+  private resolveCurrentScreen(): string | undefined {
+    try {
+      return this.getNavigationScreenSource().getCurrentScreen() ?? undefined;
+    } catch {
+      // Continue without screen — screen attribution is best-effort.
+      return undefined;
+    }
+  }
+}

--- a/test/features/observe/android/AndroidSdkEventIngestor.test.ts
+++ b/test/features/observe/android/AndroidSdkEventIngestor.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  DefaultAndroidSdkEventIngestor,
+  type AndroidTelemetryRecorder,
+  type AndroidHandledExceptionEvent,
+} from "../../../../src/features/observe/android/AndroidSdkEventIngestor";
+import type { FailureRecorderService } from "../../../../src/features/failures/interfaces/FailureRecorderService";
+import type { StackTraceElement } from "../../../../src/server/failuresResources";
+import type { SdkAnrPayload, SdkCrashPayload } from "../../../../src/features/observe/crash/sdkCrashIngestion";
+
+/** Records every telemetry call for assertion. */
+class FakeTelemetryRecorder implements AndroidTelemetryRecorder {
+  contexts: Array<{ deviceId: string; sessionId: string | null }> = [];
+  network: any[] = [];
+  logs: any[] = [];
+  os: any[] = [];
+  storage: any[] = [];
+  throwOn: string | null = null;
+
+  setContext(deviceId: string, sessionId: string | null): void {
+    this.contexts.push({ deviceId, sessionId });
+  }
+  async recordNetworkEvent(input: any): Promise<number> {
+    if (this.throwOn === "network") { throw new Error("boom"); }
+    this.network.push(input);
+    return 1;
+  }
+  async recordLogEvent(input: any): Promise<void> { this.logs.push(input); }
+  async recordOsEvent(input: any): Promise<void> { this.os.push(input); }
+  async recordStorageEvent(input: any): Promise<void> { this.storage.push(input); }
+}
+
+class FakeFailureRecorder implements FailureRecorderService {
+  crashes: any[] = [];
+  anrs: any[] = [];
+  nonFatals: any[] = [];
+  async recordToolFailure(): Promise<string> { return "tool"; }
+  async recordCrash(input: any): Promise<string> { this.crashes.push(input); return "crash-1"; }
+  async recordAnr(input: any): Promise<string> { this.anrs.push(input); return "anr-1"; }
+  async recordNonFatal(input: any): Promise<string> { this.nonFatals.push(input); return "nf-1"; }
+}
+
+const STACK: StackTraceElement[] = [
+  { className: "com.x.Foo", methodName: "bar", fileName: "Foo.kt", lineNumber: 12, isAppCode: true },
+];
+
+function makeIngestor(overrides?: {
+  telemetry?: FakeTelemetryRecorder;
+  failure?: FakeFailureRecorder;
+  currentScreen?: string | null;
+  parse?: (s: string, p: string) => StackTraceElement[];
+}) {
+  const telemetry = overrides?.telemetry ?? new FakeTelemetryRecorder();
+  const failure = overrides?.failure ?? new FakeFailureRecorder();
+  const ingestor = new DefaultAndroidSdkEventIngestor({
+    deviceId: "emulator-5554",
+    getNavigationScreenSource: () => ({
+      getCurrentScreen: () => overrides?.currentScreen ?? null,
+    }),
+    parseStackTrace: overrides?.parse ?? (() => STACK),
+    now: () => 1000,
+    telemetryRecorder: telemetry,
+    failureRecorder: failure,
+  });
+  return { ingestor, telemetry, failure };
+}
+
+const deviceInfo = { model: "Pixel", manufacturer: "Google", osVersion: "14", sdkInt: 34 };
+
+describe("AndroidSdkEventIngestor.recordSdkEvent", () => {
+  let telemetry: FakeTelemetryRecorder;
+  let ingestor: DefaultAndroidSdkEventIngestor;
+
+  beforeEach(() => {
+    const made = makeIngestor();
+    telemetry = made.telemetry;
+    ingestor = made.ingestor;
+  });
+
+  it("sets device context before recording", async () => {
+    await ingestor.recordSdkEvent(
+      { type: "log_event", timestamp: 5, payload: { event: { applicationId: "com.x", message: "hi" } } },
+      "com.x"
+    );
+    expect(telemetry.contexts[0]).toEqual({ deviceId: "emulator-5554", sessionId: null });
+  });
+
+  it("routes network_event with wire defaults", async () => {
+    await ingestor.recordSdkEvent(
+      { type: "network_event", timestamp: 5, payload: { event: { url: "http://x", method: "GET" } } },
+      null
+    );
+    expect(telemetry.network).toHaveLength(1);
+    expect(telemetry.network[0]).toMatchObject({
+      timestamp: 5, url: "http://x", method: "GET", statusCode: 0,
+      requestBodySize: -1, responseBodySize: -1, applicationId: null,
+    });
+  });
+
+  it("routes websocket_frame_event to an os event", async () => {
+    await ingestor.recordSdkEvent(
+      { type: "websocket_frame_event", timestamp: 7, payload: { event: { frameType: "text", payloadSize: 3 } } },
+      null
+    );
+    expect(telemetry.os[0]).toMatchObject({
+      category: "websocket_frame", kind: "text",
+      details: { payloadSize: "3", connectionId: "", url: "", direction: "" },
+    });
+  });
+
+  it("routes broadcast_event and lifecycle_event to os events", async () => {
+    await ingestor.recordSdkEvent(
+      { type: "broadcast_event", timestamp: 1, payload: { event: { action: "BOOT" } } }, null);
+    await ingestor.recordSdkEvent(
+      { type: "lifecycle_event", timestamp: 2, payload: { event: { kind: "resumed" } } }, null);
+    expect(telemetry.os.map(e => e.category)).toEqual(["broadcast", "lifecycle"]);
+    expect(telemetry.os[0].kind).toBe("BOOT");
+    expect(telemetry.os[1].kind).toBe("resumed");
+  });
+
+  it("merges custom_event into a log event with serialized properties", async () => {
+    await ingestor.recordSdkEvent(
+      { type: "custom_event", timestamp: 9, payload: { event: { name: "checkout", properties: { step: "1" } } } },
+      "com.x"
+    );
+    expect(telemetry.logs[0]).toMatchObject({ tag: "CustomEvent", filterName: "custom", level: 4 });
+    expect(telemetry.logs[0].message).toBe(`checkout ${JSON.stringify({ step: "1" })}`);
+  });
+
+  it("never throws when the recorder fails", async () => {
+    const t = new FakeTelemetryRecorder();
+    t.throwOn = "network";
+    const { ingestor: ing } = makeIngestor({ telemetry: t });
+    await expect(
+      ing.recordSdkEvent({ type: "network_event", timestamp: 1, payload: { event: {} } }, null)
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores unknown event types without recording", async () => {
+    await ingestor.recordSdkEvent({ type: "mystery", timestamp: 1, payload: { event: {} } }, null);
+    expect(telemetry.network).toHaveLength(0);
+    expect(telemetry.logs).toHaveLength(0);
+    expect(telemetry.os).toHaveLength(0);
+  });
+});
+
+describe("AndroidSdkEventIngestor.recordStorageEvent", () => {
+  it("sets context and forwards the prebuilt input", () => {
+    const { ingestor, telemetry } = makeIngestor();
+    ingestor.recordStorageEvent({
+      timestamp: 5, applicationId: "com.x", fileName: "prefs",
+      key: "k", value: "v", valueType: "STRING", changeType: "modify",
+    });
+    expect(telemetry.contexts[0].deviceId).toBe("emulator-5554");
+    expect(telemetry.storage[0]).toMatchObject({ fileName: "prefs", key: "k" });
+  });
+});
+
+describe("AndroidSdkEventIngestor failure analytics", () => {
+  const handled: AndroidHandledExceptionEvent = {
+    timestamp: 1, exceptionClass: "NPE", stackTrace: "at x", packageName: "com.x",
+    deviceInfo,
+  };
+  const crash: SdkCrashPayload = {
+    timestamp: 1, exceptionClass: "RTE", stackTrace: "at x", threadName: "main",
+    packageName: "com.x", deviceInfo,
+  };
+  const anr: SdkAnrPayload = {
+    timestamp: 1, pid: 9, processName: "com.x", importance: "fg", reason: "input",
+    packageName: "com.x", deviceInfo,
+  };
+
+  it("records a handled exception with parsed stack and default message", async () => {
+    const { ingestor, failure } = makeIngestor();
+    await ingestor.recordHandledException(handled);
+    expect(failure.nonFatals[0]).toMatchObject({
+      exceptionType: "NPE", exceptionMessage: "Handled exception",
+      stackTrace: STACK, sessionId: "handled-com.x-1000", deviceModel: "Pixel",
+      os: "Android 14 (API 34)",
+    });
+  });
+
+  it("prefers the event currentScreen over the nav graph", async () => {
+    const { ingestor, failure } = makeIngestor({ currentScreen: "NavScreen" });
+    await ingestor.recordHandledException({ ...handled, currentScreen: "EventScreen" });
+    expect(failure.nonFatals[0].currentScreen).toBe("EventScreen");
+  });
+
+  it("falls back to the nav graph screen when the event omits it", async () => {
+    const { ingestor, failure } = makeIngestor({ currentScreen: "NavScreen" });
+    await ingestor.recordHandledException(handled);
+    expect(failure.nonFatals[0].currentScreen).toBe("NavScreen");
+  });
+
+  it("records crash analytics", async () => {
+    const { ingestor, failure } = makeIngestor();
+    await ingestor.recordCrashAnalytics(crash);
+    expect(failure.crashes[0]).toMatchObject({
+      exceptionType: "RTE", threadName: "main", sessionId: "crash-com.x-1000",
+      exceptionMessage: "Application crashed",
+    });
+  });
+
+  it("records ANR analytics, omitting an empty stack", async () => {
+    const { ingestor, failure } = makeIngestor({ parse: () => [] });
+    await ingestor.recordAnrAnalytics(anr, "com.x");
+    expect(failure.anrs[0]).toMatchObject({ reason: "input", sessionId: "anr-com.x-1000" });
+    expect(failure.anrs[0].stackTrace).toBeUndefined();
+  });
+
+  it("swallows failure-recorder errors", async () => {
+    const failure = new FakeFailureRecorder();
+    failure.recordCrash = async () => { throw new Error("db down"); };
+    const { ingestor } = makeIngestor({ failure });
+    await expect(ingestor.recordCrashAnalytics(crash)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #2764

## Summary
Consolidates the scattered SDK telemetry/crash/ANR ingestion in `AndroidCtrlProxyClient` behind a new `AndroidSdkEventIngestor` implementing the shared `SdkEventIngestor` interface (introduced by the iOS companion #2763). The client now recognizes the wire event type and forwards to the ingestor instead of calling `TelemetryRecorder.getInstance()`/`getFailureRecorder()` inline in ~9 sites.

- New `src/features/observe/android/AndroidSdkEventIngestor.ts`:
  - `recordSdkEvent` fans network / websocket_frame / log / broadcast / lifecycle / custom events out to `TelemetryRecorder` (best-effort, never throws).
  - `recordStorageEvent` forwards the client-built storage input.
  - `recordHandledException` / `recordCrashAnalytics` / `recordAnrAnalytics` route crash/ANR/handled-exception analytics to `FailureRecorder`.
- Client holds a lazily-built, injectable ingestor (getter closes over `parseStackTrace` + session-bound nav manager). Public interface / `getInstance` / method signatures unchanged (facade preserved).
- Removed the six inline telemetry `if` blocks and the `recordCrashAnalytics`/`recordAnrAnalytics`/`handleHandledExceptionEvent` bodies (net -154 lines in the client).

## Validation
- New unit tests: `test/features/observe/android/AndroidSdkEventIngestor.test.ts` (14 tests, interface+fakes, no real timers/DB, ~150ms) covering every event route, context-setting, error-swallowing, and the screen-resolution precedence.
- `bun test test/features/observe/` — 904 pass / 0 fail.
- `bun build.ts` green; eslint clean on touched files.
- `bun run typecheck` gate: no new errors; ratcheted baseline **down by 8** (the old inline `.event` accesses on the typed union were baseline errors, now gone). Committed the smaller `scripts/typecheck-baseline.txt`.

## Caveats
- Layout-telemetry recording in `handleHierarchyUpdate` (a distinct `recordLayoutEvent` path with nav-detection side effects, not part of the event fan-out) was intentionally left inline to keep the change a pure routing move; it can move to the ingestor as a follow-up.
- Telemetry events now default their timestamp to `timer.now()` when the wire message omits it (previously passed `undefined`), matching the pre-existing `storage_changed` behavior. Behavior-identical in practice since the runner always stamps these.

Scope: only files under the android-sdk-event-ingestor lane touched.