### PR TITLE
ci(ios): raise XCTestRunner daemon startup budget to 60s (#3110)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1233,9 +1233,18 @@ jobs:
     # generous health-poll window (240 × 500ms = 120s) so it doesn't give up (and
     # then kill+respawn) a runner still coming up, and let an `observe` request wait
     # (150s > 120s) for that cold start instead of aborting at the 30s default (#2834).
+    #
+    # The daemon's own readiness budget (DAEMON_STARTUP_TIMEOUT_MS, default 10s) must
+    # cover the entire serial bring-up: Bun cold start + from-scratch migrations +
+    # `initializeDevicePoolWithTimeout(5s)` + `initializeIosServices(5s)`. On a cold
+    # macOS runner the two 5s device probes alone can exhaust 10s before Bun start and
+    # migrations are even counted, hard-failing the Swift tests' daemon start. Raise it
+    # to 60s here, consistent with the sibling budgets above (#3110). The env var name
+    # must match src/daemon/constants.ts exactly — a typo silently falls back to 10000.
     env:
       AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS: "240"
       AUTOMOBILE_OBSERVE_MCP_TIMEOUT_MS: "150000"
+      AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "60000"
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6


### PR DESCRIPTION
Closes #3110

## Summary
The **XCTestRunner Simulator Tests** job intermittently hard-fails with `Daemon failed to start within 10000ms`. The 10s daemon readiness budget (`DAEMON_STARTUP_TIMEOUT_MS`, `src/daemon/constants.ts:96`) must cover the entire serial cold bring-up on a fresh macOS runner: Bun cold start + from-scratch migrations + `initializeDevicePoolWithTimeout(5s)` + `initializeIosServices(5s)`. The two 5s device probes alone can exhaust the budget before Bun start and migrations are counted.

This ships issue #3110's **B1 (tactical)** fix: set `AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "60000"` in the job env, alongside the sibling cold-CI budgets already raised for this job (#2834).

## Validation
- Env var name matches `src/daemon/constants.ts:91` exactly (avoids the silent 10000 fallback at `constants.ts:96-99`).
- Value/pattern mirrors the established `scripts/android/run-emulator-tests.sh:325` (`AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS=60000`).
- Workflow YAML validated via `yaml.safe_load`.

## Caveats
- Tactical/tuned budget, not derived — noted in the issue as the tradeoff vs the structural B2 (open socket/PID before iOS warm-up), left as a follow-up.