### PR TITLE
fix(codex): colocate skill metadata with .agents wrapper (#2901)

### DIFF
--- a/.agents/skills/auto-mobile-code-review/agents/openai.yaml
+++ b/.agents/skills/auto-mobile-code-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AutoMobile Code Review"
+  short_description: "Verified AutoMobile PR and diff review"
+  default_prompt: "Use $auto-mobile-code-review to review the current branch diff or a specific AutoMobile PR with verified, file:line findings."

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -199,7 +199,7 @@ See individual script directories for specialized validation:
 - `xml/` - XML validation and formatting
 
 Root-level validation scripts:
-- `validate_codex_skills.sh` - Validate `skills/*/SKILL.md` metadata, optional `agents/openai.yaml` metadata, `.agents/skills` Codex discovery wrappers, and `AGENTS.md` inventory consistency
+- `validate_codex_skills.sh` - Validate `skills/*/SKILL.md` metadata, optional `agents/openai.yaml` interface metadata (colocated with both the canonical skill and the discoverable `.agents/skills/<name>` wrapper, since Codex reads metadata next to the wrapper it discovers), `.agents/skills` Codex discovery wrappers, and `AGENTS.md` inventory consistency
 - `validate_dependabot.sh` - Validate Dependabot config YAML
 - `validate_mkdocs_nav.sh` - Validate MkDocs nav configuration
 

--- a/scripts/validate_codex_skills.sh
+++ b/scripts/validate_codex_skills.sh
@@ -31,6 +31,42 @@ is_quoted() {
   [[ "$value" == \"*\" || "$value" == \'*\' ]]
 }
 
+# Validate a Codex interface metadata file (agents/openai.yaml).
+# Args: <openai_yaml_path> <skill_name>. Sets `errors=1` on any failure.
+validate_openai_yaml() {
+  local openai_yaml="$1"
+  local skill_name="$2"
+  local openai_rel_path="${openai_yaml#"${PROJECT_ROOT}/"}"
+  local display_name short_description default_prompt
+
+  display_name="$(sed -n 's/^[[:space:]]*display_name:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
+  short_description="$(sed -n 's/^[[:space:]]*short_description:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
+  default_prompt="$(sed -n 's/^[[:space:]]*default_prompt:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
+
+  if ! grep -Eq '^interface:[[:space:]]*$' "$openai_yaml"; then
+    echo "[ERROR] ${openai_rel_path}: missing top-level interface block" >&2
+    errors=1
+  fi
+
+  if [[ -z "$display_name" ]]; then
+    echo "[ERROR] ${openai_rel_path}: missing quoted interface.display_name" >&2
+    errors=1
+  fi
+
+  if [[ -z "$short_description" ]]; then
+    echo "[ERROR] ${openai_rel_path}: missing quoted interface.short_description" >&2
+    errors=1
+  fi
+
+  if [[ -z "$default_prompt" ]]; then
+    echo "[ERROR] ${openai_rel_path}: missing quoted interface.default_prompt" >&2
+    errors=1
+  elif [[ -n "$skill_name" && "$default_prompt" != *"\$${skill_name}"* ]]; then
+    echo "[ERROR] ${openai_rel_path}: default_prompt must mention \$${skill_name}" >&2
+    errors=1
+  fi
+}
+
 skill_files=()
 while IFS= read -r file; do
   skill_files+=("$file")
@@ -103,33 +139,7 @@ for file in "${skill_files[@]}"; do
 
   openai_yaml="$(dirname "$file")/agents/openai.yaml"
   if [[ -f "$openai_yaml" ]]; then
-    openai_rel_path="${openai_yaml#"${PROJECT_ROOT}/"}"
-    display_name="$(sed -n 's/^[[:space:]]*display_name:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
-    short_description="$(sed -n 's/^[[:space:]]*short_description:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
-    default_prompt="$(sed -n 's/^[[:space:]]*default_prompt:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' "$openai_yaml" | head -n 1)"
-
-    if ! grep -Eq '^interface:[[:space:]]*$' "$openai_yaml"; then
-      echo "[ERROR] ${openai_rel_path}: missing top-level interface block" >&2
-      errors=1
-    fi
-
-    if [[ -z "$display_name" ]]; then
-      echo "[ERROR] ${openai_rel_path}: missing quoted interface.display_name" >&2
-      errors=1
-    fi
-
-    if [[ -z "$short_description" ]]; then
-      echo "[ERROR] ${openai_rel_path}: missing quoted interface.short_description" >&2
-      errors=1
-    fi
-
-    if [[ -z "$default_prompt" ]]; then
-      echo "[ERROR] ${openai_rel_path}: missing quoted interface.default_prompt" >&2
-      errors=1
-    elif [[ "$default_prompt" != *"\$${skill_name}"* ]]; then
-      echo "[ERROR] ${openai_rel_path}: default_prompt must mention \$${skill_name}" >&2
-      errors=1
-    fi
+    validate_openai_yaml "$openai_yaml" "$skill_name"
 
     if [[ -n "$skill_name" ]]; then
       skills_with_openai_metadata+=("$skill_name")
@@ -218,6 +228,24 @@ if [[ -d "${AGENTS_SKILLS_DIR}" ]]; then
     if ! grep -Fq "../../../${canonical_path}" "$file"; then
       echo "[ERROR] ${rel_path}: wrapper must reference ../../../${canonical_path}" >&2
       errors=1
+    fi
+
+    # Codex reads interface metadata next to the discoverable wrapper, not the
+    # canonical source skill. If the canonical skill ships agents/openai.yaml,
+    # the wrapper must colocate an equivalent one so the display name/default
+    # prompt appears for the repo-discovered skill (issue #2901).
+    canonical_openai_yaml="${PROJECT_ROOT}/skills/${dir_name}/agents/openai.yaml"
+    wrapper_openai_yaml="$(dirname "$file")/agents/openai.yaml"
+    if [[ -f "$canonical_openai_yaml" ]]; then
+      if [[ -L "$wrapper_openai_yaml" ]]; then
+        echo "[ERROR] ${wrapper_openai_yaml#"${PROJECT_ROOT}/"}: .agents skill metadata files must not be symlinks" >&2
+        errors=1
+      elif [[ ! -f "$wrapper_openai_yaml" ]]; then
+        echo "[ERROR] ${wrapper_openai_yaml#"${PROJECT_ROOT}/"}: missing Codex interface metadata next to discoverable wrapper" >&2
+        errors=1
+      else
+        validate_openai_yaml "$wrapper_openai_yaml" "$dir_name"
+      fi
     fi
   done
 fi


### PR DESCRIPTION
Closes #2901

## Summary
Codex discovers the code-review skill through the `.agents/skills/auto-mobile-code-review` wrapper, but the Codex UI interface metadata (`agents/openai.yaml`) only lived beside the canonical `skills/*/SKILL.md`. Codex reads metadata next to the wrapper it discovers, so the display name / default prompt were never present for the repo-discovered skill (PR #2886 follow-up, review thread r3520131796).

Implements option 1 from the issue:
- Add `.agents/skills/auto-mobile-code-review/agents/openai.yaml` colocated with the discoverable wrapper (same interface metadata; no duplication of the canonical SKILL.md workflow).
- Extend `scripts/validate_codex_skills.sh`: extract the openai.yaml checks into a reusable `validate_openai_yaml` and require the colocated wrapper metadata whenever the canonical skill ships it, rejecting missing metadata and symlinked wrapper metadata files.
- Update `scripts/README.md`.

## Validation
- `shellcheck scripts/validate_codex_skills.sh` — clean
- `bash scripts/validate_codex_skills.sh` — passes (16 skills)
- `bash scripts/all_fast_validate_checks.sh --only codex-skills,shellcheck --max-parallel 2` — both OK
- Negative checks (all exit 1): missing wrapper openai.yaml; symlinked wrapper openai.yaml; symlinked wrapper SKILL.md; symlinked wrapper directory. Positive restore passes.
- `find .agents/skills/auto-mobile-code-review -maxdepth 3` now shows `agents/openai.yaml` next to the wrapper.