### PR TITLE
fix(db): normalize storage_events value_type vocabulary across platforms (#3173)

### DIFF
--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -17,6 +17,51 @@ export interface RecordStorageEventInput {
   previousValue?: string | null;
 }
 
+/**
+ * The recorder-contract fields whose canonical defaults the shared normalizer
+ * owns. Callers (iOS ingestor, Android wire builder) supply partial, platform-
+ * shaped values; the normalizer folds them into a single canonical vocabulary so
+ * that a `storage_events` row is platform-independent (issue #3173).
+ */
+export type PartialStorageEvent = Omit<
+  RecordStorageEventInput,
+  "valueType" | "changeType"
+> & {
+  valueType?: string | null;
+  changeType?: string | null;
+};
+
+/**
+ * The canonical, lower-cased `value_type` token persisted regardless of source
+ * platform. Absent/blank/`unknown` all collapse to `"unknown"`, so a query,
+ * grouping, or UI filter on `value_type` never sees platform-dependent casing
+ * (`"STRING"` vs `"string"`) or a NULL/`"unknown"` split.
+ */
+export function normalizeValueType(valueType: string | null | undefined): string {
+  const trimmed = valueType?.trim();
+  if (!trimmed) {
+    return "unknown";
+  }
+  return trimmed.toLowerCase();
+}
+
+/**
+ * Fold a platform-shaped partial storage event into the canonical
+ * `RecordStorageEventInput` recorder contract. This is the SINGLE source of the
+ * recorder-contract defaults (`changeType ?? "modify"`, canonical `valueType`),
+ * preventing the wire-shape/contract-mismatch bug class that #3001 exposed and
+ * the cross-platform vocabulary divergence #3173 tracks. Both the iOS and
+ * Android call sites persist through here, so a string change on either platform
+ * yields the same canonical `value_type` token.
+ */
+export function normalizeStorageEvent(input: PartialStorageEvent): RecordStorageEventInput {
+  return {
+    ...input,
+    valueType: normalizeValueType(input.valueType),
+    changeType: input.changeType?.trim() || "modify",
+  };
+}
+
 const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
 
 function getDb(db?: Kysely<Database>): Kysely<Database> {
@@ -24,10 +69,16 @@ function getDb(db?: Kysely<Database>): Kysely<Database> {
 }
 
 export async function recordStorageEvent(
-  input: RecordStorageEventInput,
+  rawInput: RecordStorageEventInput,
   db?: Kysely<Database>
 ): Promise<void> {
   const d = getDb(db);
+
+  // Canonicalize the recorder-contract fields at this single seam so a row's
+  // `value_type`/`change_type` is platform-independent regardless of caller
+  // (issue #3173). Both the iOS ingestor and the Android wire builder persist
+  // through here, so neither can reintroduce divergent casing/defaults.
+  const input = normalizeStorageEvent(rawInput);
 
   // Look up the previous value for this key only when the caller did not supply
   // one. `!== undefined` (not `?? null`) is deliberate: a caller that passes an

--- a/test/db/normalizeStorageEvent.test.ts
+++ b/test/db/normalizeStorageEvent.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "./testDbHelper";
+import {
+  normalizeStorageEvent,
+  normalizeValueType,
+  recordStorageEvent,
+  getStorageEvents,
+  type RecordStorageEventInput,
+} from "../../src/db/storageEventRepository";
+
+const base: Omit<RecordStorageEventInput, "valueType" | "changeType"> = {
+  deviceId: "d1",
+  timestamp: 1000,
+  applicationId: "com.example",
+  sessionId: null,
+  fileName: "prefs.xml",
+  key: "theme",
+  value: "dark",
+};
+
+describe("normalizeValueType (#3173)", () => {
+  test("lower-cases platform casing so STRING and string collapse", () => {
+    expect(normalizeValueType("STRING")).toBe("string");
+    expect(normalizeValueType("string")).toBe("string");
+    expect(normalizeValueType("Boolean")).toBe("boolean");
+  });
+
+  test("absent / blank / null all canonicalize to unknown (no NULL split)", () => {
+    expect(normalizeValueType(null)).toBe("unknown");
+    expect(normalizeValueType(undefined)).toBe("unknown");
+    expect(normalizeValueType("")).toBe("unknown");
+    expect(normalizeValueType("   ")).toBe("unknown");
+    expect(normalizeValueType("unknown")).toBe("unknown");
+    expect(normalizeValueType("UNKNOWN")).toBe("unknown");
+  });
+});
+
+describe("normalizeStorageEvent (#3173)", () => {
+  test("defaults changeType to modify and canonicalizes valueType", () => {
+    const out = normalizeStorageEvent({ ...base, valueType: "STRING", changeType: undefined });
+    expect(out.changeType).toBe("modify");
+    expect(out.valueType).toBe("string");
+  });
+
+  test("preserves an explicit changeType", () => {
+    const out = normalizeStorageEvent({ ...base, valueType: "INT", changeType: "add" });
+    expect(out.changeType).toBe("add");
+    expect(out.valueType).toBe("int");
+  });
+
+  test("blank changeType falls back to modify", () => {
+    const out = normalizeStorageEvent({ ...base, valueType: null, changeType: "  " });
+    expect(out.changeType).toBe("modify");
+    expect(out.valueType).toBe("unknown");
+  });
+});
+
+describe("recordStorageEvent persists canonical value_type (#3173)", () => {
+  let db: Kysely<Database>;
+  beforeEach(async () => { db = await createTestDatabase(); });
+  afterEach(async () => { await db.destroy(); });
+
+  test("Android STRING and iOS string persist the same token", async () => {
+    await recordStorageEvent({
+      ...base, deviceId: "android", valueType: "STRING", changeType: "modify",
+    }, db);
+    await recordStorageEvent({
+      ...base, deviceId: "ios", valueType: "string", changeType: "modify",
+    }, db);
+
+    const android = await getStorageEvents({ deviceId: "android", limit: 1 }, db);
+    const ios = await getStorageEvents({ deviceId: "ios", limit: 1 }, db);
+    expect(android[0].valueType).toBe("string");
+    expect(ios[0].valueType).toBe("string");
+    expect(android[0].valueType).toBe(ios[0].valueType);
+  });
+
+  test("null valueType lands as canonical unknown, not NULL", async () => {
+    await recordStorageEvent({
+      ...base, deviceId: "d2", value: null, valueType: null, changeType: "modify",
+    }, db);
+    const rows = await getStorageEvents({ deviceId: "d2", limit: 1 }, db);
+    expect(rows[0].valueType).toBe("unknown");
+  });
+});


### PR DESCRIPTION
Closes #3173

## Summary
`storage_events.value_type` was populated with platform-inconsistent vocabulary — Android defaulted to `"STRING"` (uppercase), while iOS emitted lowercase `"string"`/`"unknown"` and the ingestor fell back to `null`. Any query/grouping/UI filter on `value_type` saw platform-dependent values.

This adds a shared normalization seam in `src/db/storageEventRepository.ts`:
- `normalizeValueType(v)` — lower-cases the token; blank/`null`/absent all collapse to `"unknown"` (removes the NULL vs `"unknown"` split and STRING vs string casing split).
- `normalizeStorageEvent(partial) -> RecordStorageEventInput` — the single source of the recorder-contract defaults (`changeType ?? "modify"`, canonical `valueType`).
- `recordStorageEvent` applies `normalizeStorageEvent` at the single persistence seam, so **both** the iOS ingestor and the Android wire builder funnel through it — neither can reintroduce divergent casing/defaults, guarding against the #3001 wire-shape/contract-mismatch bug class.

Wire-shape helpers (`storageTelemetryInputFromWire`, `IosSdkEventIngestor`) keep their platform-shaped values on the recorder boundary; only the persisted row is canonicalized.

## Evaluation criteria
- A string change on iOS (`"string"`) and Android (`"STRING"`) now persist the same canonical `value_type` token (`"string"`) — proven in `test/db/normalizeStorageEvent.test.ts`.
- Shared helper is the single source of the recorder-contract defaults.

## Validation
- `bun test test/db/normalizeStorageEvent.test.ts` — 7 pass
- `bun test test/features/storage/ test/features/observe/ios/IosSdkEventIngestor.test.ts test/features/observe/android/storageChangedWireToDb.test.ts` — all pass
- `bun run typecheck` — no new errors
- `bunx turbo run lint build` — pass

## Caveats
- No iOS/Android runner changes; this is TS-only recorder/mapping. No release re-cut needed.
- Existing rows are not backfilled (issue lists that as optional); normalization applies to new inserts.