### PR TITLE
test(ios): cover TerminateApp observed path + fix perf.end() tree ownership (#3037)

### DIFF
--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -113,7 +113,6 @@ export class TerminateApp extends BaseVisualChange {
       });
 
       if (!isInstalled) {
-        perf.end();
         return {
           success: true,
           packageName,
@@ -128,7 +127,6 @@ export class TerminateApp extends BaseVisualChange {
       const isRunning = true;
 
       if (!isRunning) {
-        perf.end();
         return {
           success: true,
           packageName,
@@ -151,7 +149,6 @@ export class TerminateApp extends BaseVisualChange {
         await this.adb.executeCommand(`shell am force-stop --user ${targetUserId} ${packageName}`);
       });
 
-      perf.end();
       return {
         success: true,
         packageName,
@@ -162,9 +159,13 @@ export class TerminateApp extends BaseVisualChange {
       };
     };
 
-    // Skip observation when called internally (e.g., from LaunchApp)
+    // Skip observation when called internally (e.g., from LaunchApp).
+    // `execute` owns the "terminateApp" perf block, so it — not `terminateLogic`
+    // — closes it (issue #3037; see the executeiOS note for rationale).
     if (options?.skipObservation) {
-      return terminateLogic();
+      const result = await terminateLogic();
+      perf.end();
+      return result;
     }
 
     return this.observedInteraction(
@@ -195,8 +196,17 @@ export class TerminateApp extends BaseVisualChange {
       ? () => this.terminateSimulator(bundleId, perf)
       : () => this.terminatePhysicalDevice(bundleId, perf);
 
+    // Perf-tree ownership (issue #3037): `executeiOS` opens the "terminateApp"
+    // block, so it — the single owner — must close it. The terminate helpers no
+    // longer call `perf.end()` themselves: doing so inside `observedInteraction`
+    // popped the block mid-observation, reparenting the later finalObserve /
+    // uiStability entries to the root. In the observed path the block stays open
+    // and `getTimings()` (in `takeObservation`) closes it after observation, so
+    // those entries nest correctly under "terminateApp".
     if (options?.skipObservation) {
-      return terminateLogic();
+      const result = await terminateLogic();
+      perf.end();
+      return result;
     }
 
     return this.observedInteraction(
@@ -223,7 +233,6 @@ export class TerminateApp extends BaseVisualChange {
     const wasInstalled = installedApps.some(app => this.getBundleId(app) === bundleId);
 
     if (!wasInstalled) {
-      perf.end();
       return {
         success: true,
         packageName: bundleId,
@@ -253,7 +262,6 @@ export class TerminateApp extends BaseVisualChange {
       }
     }
 
-    perf.end();
     return {
       success: !errorMessage,
       packageName: bundleId,
@@ -281,7 +289,6 @@ export class TerminateApp extends BaseVisualChange {
         "terminateApp",
         () => this.deviceTerminator.terminateApp(this.device.deviceId, bundleId)
       );
-      perf.end();
       return {
         success: true,
         packageName: bundleId,
@@ -295,7 +302,6 @@ export class TerminateApp extends BaseVisualChange {
       // but log first so the trace survives even when the client only sees the
       // summarized error (CLAUDE.md error-handling convention #2).
       logger.warn(`[TerminateApp] Physical iOS terminate failed for ${bundleId}: ${message}`, error);
-      perf.end();
       // Omit wasInstalled/wasRunning: install state is unknown at throw time (a
       // devicectl failure can occur after the app was confirmed installed), so
       // reporting them as `false` would assert a fact we never established.

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -1,10 +1,15 @@
-import { expect, describe, test, beforeEach } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach } from "bun:test";
 import { TerminateApp } from "../../../src/features/action/TerminateApp";
-import type { BootedDevice } from "../../../src/models";
+import type { BootedDevice, ObserveResult } from "../../../src/models";
 import { FakeSimctl } from "../../fakes/FakeSimctl";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeDeviceAppTerminator } from "../../fakes/FakeDeviceAppTerminator";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
+import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
+import { FakeWindow } from "../../fakes/FakeWindow";
+import { setDebugPerfEnabled } from "../../../src/utils/PerformanceTracker";
+import type { TimingData, TimingEntry } from "../../../src/utils/PerformanceTracker";
 
 describe("TerminateApp (iOS)", () => {
   // Simulator UDIDs are 8-4-4-4-12 UUIDs; isIosSimulatorUdid keys the simctl vs
@@ -290,5 +295,196 @@ describe("TerminateApp (Android)", () => {
     expect(result.wasForeground).toBe(false);
     expect(result.userId).toBe(0);
     expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
+  });
+});
+
+/**
+ * Observed-interaction coverage for the DEFAULT production path (issue #3037).
+ * Every other suite passes `{ skipObservation: true }`, so the path that runs
+ * the terminate logic *inside* `observedInteraction` had zero coverage — and it
+ * is where the perf-tree ownership bug lived: the terminate helpers used to call
+ * `perf.end()` mid-observation, popping the "terminateApp" block early so the
+ * subsequent `finalObserve` (and `uiStability`) entries reparented to the root.
+ * These tests assert both the result AND a well-formed perf tree with no
+ * reparented entries. All I/O is faked (observeScreen / awaitIdle / window), so
+ * no real device is touched and each test stays well under the 100ms budget.
+ */
+describe("TerminateApp (observed interaction, perf-tree ownership)", () => {
+  const iosSimDevice: BootedDevice = {
+    deviceId: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+    name: "iPhone 15",
+    platform: "ios"
+  };
+  const iosPhysicalDevice: BootedDevice = {
+    deviceId: "00008110-001A2B3C4D5E6F70",
+    name: "iPhone 15 Pro (physical)",
+    platform: "ios"
+  };
+  const androidDevice: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel 7",
+    platform: "android"
+  };
+
+  // Names that `observedInteraction`/`takeObservation` add AFTER the block runs.
+  // If any of these appears at the top level of the tree, the "terminateApp"
+  // block was popped early and they reparented — the exact bug this fixes.
+  const POST_BLOCK_ENTRY_NAMES = ["finalObserve", "uiStability"];
+
+  const createObserveResult = (): ObserveResult => ({
+    updatedAt: Date.now(),
+    screenSize: { width: 1170, height: 2532 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: {
+      hierarchy: { node: [] },
+      packageName: "com.example.app",
+      updatedAt: Date.now()
+    }
+  });
+
+  const topLevelNames = (timings: TimingData): string[] =>
+    Array.isArray(timings) ? timings.map(e => e.name) : Object.keys(timings);
+
+  const findEntry = (timings: TimingData, name: string): TimingEntry | undefined => {
+    const list = Array.isArray(timings) ? timings : Object.values(timings);
+    return list.find(e => e.name === name);
+  };
+
+  // Recursively collect every entry name anywhere in the tree.
+  const allNames = (timings: TimingData): string[] => {
+    const list = Array.isArray(timings) ? timings : Object.values(timings);
+    return list.flatMap(e => [e.name, ...(e.children ? allNames(e.children) : [])]);
+  };
+
+  /**
+   * Assert the perf tree is well-formed: a single top-level "terminateApp"
+   * block that OWNS the post-observation entries, with none of them leaked to
+   * the root. Returns the observation's perfTiming for further assertions.
+   */
+  const assertWellFormedPerfTree = (result: any): TimingData => {
+    const timings: TimingData | undefined = result?.observation?.perfTiming;
+    expect(timings).toBeDefined();
+    const roots = topLevelNames(timings!);
+    // The owner block must be the single root, not a sibling of observe entries.
+    expect(roots).toEqual(["terminateApp"]);
+    // No post-block entry may sit at the root (that is the reparenting symptom).
+    for (const leaked of POST_BLOCK_ENTRY_NAMES) {
+      expect(roots).not.toContain(leaked);
+    }
+    // finalObserve must be present and nested UNDER terminateApp.
+    const terminate = findEntry(timings!, "terminateApp");
+    expect(terminate?.children).toBeDefined();
+    expect(allNames(terminate!.children!)).toContain("finalObserve");
+    return timings!;
+  };
+
+  let fakeSimctl: FakeSimctl;
+  let fakeAdb: FakeAdbClient;
+  let fakeTimer: FakeTimer;
+  let fakeObserveScreen: FakeObserveScreen;
+  let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeWindow: FakeWindow;
+
+  const wireDeps = (terminateApp: TerminateApp): void => {
+    (terminateApp as any).observeScreen = fakeObserveScreen;
+    (terminateApp as any).awaitIdle = fakeAwaitIdle;
+    (terminateApp as any).window = fakeWindow;
+  };
+
+  beforeEach(() => {
+    setDebugPerfEnabled(true); // exercise DefaultPerformanceTracker (NoOp hides the tree)
+    fakeSimctl = new FakeSimctl();
+    fakeAdb = new FakeAdbClient();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    fakeObserveScreen = new FakeObserveScreen();
+    fakeObserveScreen.setObserveResult(() => createObserveResult());
+    fakeAwaitIdle = new FakeAwaitIdle();
+    fakeWindow = new FakeWindow();
+    fakeWindow.configureCachedActiveWindow(null);
+  });
+
+  afterEach(() => {
+    setDebugPerfEnabled(false);
+  });
+
+  test("iOS simulator: terminates via simctl and produces a well-formed perf tree", async () => {
+    fakeSimctl.setInstalledApps([{ bundleId: "com.example.app" }]);
+
+    const terminateApp = new TerminateApp(iosSimDevice, null, fakeSimctl, fakeTimer);
+    wireDeps(terminateApp);
+    const result = await terminateApp.execute("com.example.app");
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(true);
+    expect(result.wasRunning).toBe(true);
+    expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(true);
+    assertWellFormedPerfTree(result);
+  });
+
+  test("iOS simulator (not installed): still nests the perf tree correctly", async () => {
+    fakeSimctl.setInstalledApps([{ bundleId: "com.example.other" }]);
+
+    const terminateApp = new TerminateApp(iosSimDevice, null, fakeSimctl, fakeTimer);
+    wireDeps(terminateApp);
+    const result = await terminateApp.execute("com.example.app");
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(false);
+    expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(false);
+    // Even the early-return (not-installed) branch must not pop the block early.
+    assertWellFormedPerfTree(result);
+  });
+
+  test("iOS physical: terminates via devicectl and produces a well-formed perf tree", async () => {
+    const terminator = new FakeDeviceAppTerminator({ result: { wasInstalled: true, wasRunning: true } });
+
+    const terminateApp = new TerminateApp(iosPhysicalDevice, null, fakeSimctl, fakeTimer, terminator);
+    wireDeps(terminateApp);
+    const result = await terminateApp.execute("com.example.app");
+
+    expect(result.success).toBe(true);
+    expect(result.wasInstalled).toBe(true);
+    expect(result.wasRunning).toBe(true);
+    expect(terminator.terminateCalls).toEqual([
+      { deviceUdid: "00008110-001A2B3C4D5E6F70", bundleId: "com.example.app" }
+    ]);
+    expect(fakeSimctl.wasMethodCalled("terminateApp")).toBe(false);
+    assertWellFormedPerfTree(result);
+  });
+
+  test("iOS physical (failure): surfaces a typed error without corrupting the perf tree", async () => {
+    const terminator = new FakeDeviceAppTerminator();
+    terminator.setError(new Error("Physical iOS device app termination requires macOS"));
+
+    const terminateApp = new TerminateApp(iosPhysicalDevice, null, fakeSimctl, fakeTimer, terminator);
+    wireDeps(terminateApp);
+    const result = await terminateApp.execute("com.example.app");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("macOS");
+    // A caught failure must still leave the block open for the owner to close.
+    assertWellFormedPerfTree(result);
+  });
+
+  test("Android: force-stops and produces a well-formed perf tree", async () => {
+    fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setCommandResult(
+      "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
+      "1"
+    );
+    fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
+
+    const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
+    wireDeps(terminateApp);
+    // skipUiStability keeps the Android gfxinfo path out of the test; the perf
+    // ownership under observedInteraction is what we are covering here.
+    const result = await terminateApp.execute("com.example.app", { skipUiStability: true });
+
+    expect(result.success).toBe(true);
+    expect(result.wasRunning).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(true);
+    assertWellFormedPerfTree(result);
   });
 });


### PR DESCRIPTION
Closes #3037

## Summary
Covers the default production `TerminateApp` path (`skipObservation:false`, run inside `observedInteraction`) that previously had **zero** iOS coverage for both the simulator and physical branches, and fixes the latent perf-tree ownership bug that path exposed.

## The fix
`executeiOS`/`execute` open the `"terminateApp"` perf block, but the terminate helpers (`terminateSimulator`, `terminatePhysicalDevice`, Android `terminateLogic`) each called `perf.end()` internally. Inside `observedInteraction` that popped the block mid-observation, so the later `finalObserve`/`uiStability` entries reparented to the root (`PerformanceTracker.end()` reparents to `current.parent`).

Now the **single owner** closes the block:
- Removed every `perf.end()` from the terminate helpers and Android `terminateLogic`.
- The owner (`execute`/`executeiOS`) closes the block only in the `skipObservation` branch (`await terminateLogic(); perf.end()`).
- In the observed branch the block stays open and `getTimings()` (in `takeObservation`) closes it after observation, so observe entries nest correctly under `terminateApp`.

## Tests
New `TerminateApp (observed interaction, perf-tree ownership)` suite: iOS simulator (installed + not-installed), iOS physical (success + failure), and Android — each asserts the result AND a well-formed perf tree (single `terminateApp` root, `finalObserve` nested under it, no reparented entries). All I/O faked (observeScreen/awaitIdle/window), no real device.

## Validation
- `bun test test/features/action/TerminateApp.test.ts` → 19 pass (244ms). Regression check: re-adding a stray `perf.end()` fails the new assertions.
- `bun test .../LaunchApp.test.ts .../TerminateApp.test.ts` → 41 pass.
- `bun run typecheck` → no new type errors.
- `turbo run lint build` → success.
