### PR TITLE
refactor(scripts): extract scripts/lib/file-selection.sh (#2823)

### DIFF
--- a/scripts/ktfmt/apply_ktfmt.sh
+++ b/scripts/ktfmt/apply_ktfmt.sh
@@ -8,6 +8,10 @@ ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 # shellcheck source=scripts/ktfmt/ktfmt_version.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
+# Shared git file-selection + install-when-missing helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -26,29 +30,8 @@ echo "PROJECT_ROOT: $PROJECT_ROOT"
 # Check for required commands and install missing commands if allowed
 echo -e "${YELLOW}Checking for required commands...${NC}"
 
-# Check if ktfmt is installed
-if ! command_exists ktfmt; then
-    echo -e "${RED}ktfmt is not installed${NC}"
-    if [[ "${INSTALL_KTFMT_WHEN_MISSING}" == "true" ]]; then
-        echo -e "${YELLOW}Installing ktfmt...${NC}"
-        if [[ -f "$PROJECT_ROOT/scripts/ktfmt/install_ktfmt.sh" ]]; then
-            if ! bash "$PROJECT_ROOT/scripts/ktfmt/install_ktfmt.sh"; then
-                echo -e "${RED}Failed to install ktfmt${NC}"
-                exit 1
-            fi
-        else
-            echo -e "${RED}ktfmt installation script not found${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${RED}ktfmt is required. Set INSTALL_KTFMT_WHEN_MISSING=true to auto-install or install manually${NC}"
-        exit 1
-    fi
-fi
-
-# Verify ktfmt is available
-if ! command_exists ktfmt; then
-    echo -e "${RED}ktfmt is still not available after installation attempt${NC}"
+# Check if ktfmt is installed (install-when-missing gate + re-verify).
+if ! ensure_tool ktfmt "$PROJECT_ROOT/scripts/ktfmt/install_ktfmt.sh" "${INSTALL_KTFMT_WHEN_MISSING}"; then
     exit 1
 fi
 
@@ -91,24 +74,8 @@ find_all_kotlin_files() {
         | sort | uniq
 }
 
-# Function to get touched/staged files
-get_touched_files() {
-    {
-        # Get staged files
-        git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^.*\.(kt|kts)$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-
-        # Get modified but not staged files
-        git diff --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^.*\.(kt|kts)$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-    } | sort | uniq
-}
+# Per-tool file regex for the shared collectors (issue #2823).
+KOTLIN_FILE_REGEX='^.*\.(kt|kts)$'
 
 # Determine which files to process
 declare -a files_to_process
@@ -118,7 +85,7 @@ if [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
     echo -e "${YELLOW}Processing only touched/staged files${NC}"
 
     # Get list of changed files
-    touched_files=$(get_touched_files)
+    touched_files=$(collect_touched_files "$PROJECT_ROOT" "$KOTLIN_FILE_REGEX")
     while IFS= read -r file; do
         [[ -n "$file" ]] && files_to_process+=("$file")
     done <<< "$touched_files"

--- a/scripts/ktfmt/validate_ktfmt.sh
+++ b/scripts/ktfmt/validate_ktfmt.sh
@@ -10,6 +10,10 @@ ONLY_CHANGED_SINCE_SHA=${ONLY_CHANGED_SINCE_SHA:-""}
 # shellcheck source=scripts/ktfmt/ktfmt_version.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
+# Shared git file-selection + install-when-missing helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -26,29 +30,8 @@ PROJECT_ROOT="$(pwd)"
 # Check for required commands and install missing commands if allowed
 echo -e "${YELLOW}Checking for required commands...${NC}"
 
-# Check if ktfmt is installed
-if ! command_exists ktfmt; then
-    echo -e "${RED}ktfmt is not installed${NC}"
-    if [[ "${INSTALL_KTFMT_WHEN_MISSING}" == "true" ]]; then
-        echo -e "${YELLOW}Installing ktfmt...${NC}"
-        if [[ -f "$PROJECT_ROOT/scripts/ktfmt/install_ktfmt.sh" ]]; then
-            if ! bash "$PROJECT_ROOT/scripts/ktfmt/install_ktfmt.sh"; then
-                echo -e "${RED}Failed to install ktfmt${NC}"
-                exit 1
-            fi
-        else
-            echo -e "${RED}ktfmt installation script not found${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${RED}ktfmt is required. Set INSTALL_KTFMT_WHEN_MISSING=true to auto-install or install manually${NC}"
-        exit 1
-    fi
-fi
-
-# Verify ktfmt is available
-if ! command_exists ktfmt; then
-    echo -e "${RED}ktfmt is still not available after installation attempt${NC}"
+# Check if ktfmt is installed (install-when-missing gate + re-verify).
+if ! ensure_tool ktfmt "$PROJECT_ROOT/scripts/ktfmt/install_ktfmt.sh" "${INSTALL_KTFMT_WHEN_MISSING}"; then
     exit 1
 fi
 
@@ -96,51 +79,8 @@ find_all_kotlin_files() {
         | sort | uniq
 }
 
-# Function to get changed files since SHA
-get_changed_files_since_sha() {
-    local sha="$1"
-    local changed_files
-
-    # Verify SHA exists
-    if ! git rev-parse --verify "$sha" >/dev/null 2>&1; then
-        echo -e "${RED}SHA '$sha' does not exist in the repository${NC}" >&2
-        return 1
-    fi
-
-    # Get list of changed files since SHA
-    if ! changed_files="$(git diff --name-only "$sha"...HEAD)"; then
-        return 1
-    fi
-
-    printf '%s\n' "$changed_files" | while read -r file; do
-        if [[ "$file" =~ ^.*\.(kt|kts)$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-            echo "$PROJECT_ROOT/$file"
-        fi
-    done | sort | uniq
-}
-
-# Function to get touched/staged files
-get_touched_files() {
-    local staged_files
-    local modified_files
-
-    if ! staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"; then
-        return 1
-    fi
-
-    if ! modified_files="$(git diff --name-only --diff-filter=ACMR)"; then
-        return 1
-    fi
-
-    {
-        printf '%s\n' "$staged_files"
-        printf '%s\n' "$modified_files"
-    } | while read -r file; do
-        if [[ "$file" =~ ^.*\.(kt|kts)$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-            echo "$PROJECT_ROOT/$file"
-        fi
-    done | sort | uniq
-}
+# Per-tool file regex for the shared collectors (issue #2823).
+KOTLIN_FILE_REGEX='^.*\.(kt|kts)$'
 
 # Determine which files to process
 declare -a files_to_process
@@ -160,10 +100,10 @@ load_files_to_process() {
 
     if ! case "$mode" in
         changed)
-            get_changed_files_since_sha "$@" > "$file_list"
+            collect_changed_since_sha "$PROJECT_ROOT" "$1" "$KOTLIN_FILE_REGEX" > "$file_list"
             ;;
         touched)
-            get_touched_files > "$file_list"
+            collect_touched_files "$PROJECT_ROOT" "$KOTLIN_FILE_REGEX" > "$file_list"
             ;;
         all)
             find_all_kotlin_files > "$file_list"
@@ -192,7 +132,7 @@ load_files_to_process() {
 
 # If a base SHA was requested but does not resolve in this checkout (base branch
 # force-pushed/rebased, or its commit was never fetched), fall back to a
-# full-tree check instead of silently passing. get_changed_files_since_sha also
+# full-tree check instead of silently passing. collect_changed_since_sha also
 # guards the SHA, and load_files_to_process checks producer failures in the main
 # shell, but this up-front branch preserves the intended CI behavior: scoped
 # mode degrades to a full-tree validation when a fetched base is unavailable.

--- a/scripts/lib/file-selection.sh
+++ b/scripts/lib/file-selection.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Shared git file-selection boilerplate for the per-tool formatter/linter
+# validate_<tool>.sh / apply_<tool>.sh scripts (issue #2823).
+#
+# Historically every formatter/linter re-declared the same three primitives:
+#   * get_touched_files()          - staged + working-tree files, regex-filtered
+#   * get_changed_files_since_sha() - files changed vs a base SHA, regex-filtered
+#   * the INSTALL_<TOOL>_WHEN_MISSING install-when-missing gate + re-verify
+# The copies drifted. This file is the single source of truth (issue #2823).
+# Only the per-tool file-extension/path regex and the tool binary differ, so the
+# regex and PROJECT_ROOT are passed in as arguments rather than closed over.
+#
+# Sourcing convention mirrors scripts/local-dev/lib/common.sh and
+# scripts/lib/tool-install.sh (issue #2822):
+#   # shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+#   source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+#
+# Exports:
+#   collect_touched_files <project_root> <regex>
+#       Emit absolute paths of staged (--cached) and working-tree modified files
+#       whose repo-relative path matches <regex> and that still exist on disk.
+#       Deduplicated + sorted. Returns non-zero if either `git diff` fails, so a
+#       caller can distinguish "no matching files" from "git failed" (a producer
+#       failure must never be mistaken for a clean tree).
+#
+#   collect_changed_since_sha <project_root> <sha> <regex>
+#       Emit absolute paths of files changed in <sha>...HEAD whose repo-relative
+#       path matches <regex> and that still exist on disk. Deduplicated + sorted.
+#       Verifies the SHA resolves; returns non-zero (with a message on stderr) if
+#       it does not, or if `git diff` fails.
+#
+#   ensure_tool <name> <installer_path> <install_when_missing>
+#       The install-when-missing gate: if <name> is absent from PATH, either run
+#       <installer_path> (when <install_when_missing> == "true") or fail with an
+#       actionable message; then re-verify <name> is available. Returns non-zero
+#       on any failure so the caller can `exit 1`.
+
+# Colors. Guarded so re-sourcing (or a caller that already set them) does not
+# clobber existing definitions. Match the escape style callers use with echo -e.
+: "${RED:=\033[0;31m}"
+: "${GREEN:=\033[0;32m}"
+: "${YELLOW:=\033[1;33m}"
+: "${NC:=\033[0m}"
+
+# True if <cmd> is on PATH. Guarded so we don't redefine a caller's copy.
+if ! declare -F command_exists > /dev/null 2>&1; then
+  command_exists() {
+    command -v "$1" > /dev/null 2>&1
+  }
+fi
+
+# Filter a newline-delimited list of repo-relative paths on stdin: echo the
+# absolute "$project_root/$file" for each entry that matches <regex> and exists.
+_filter_matching_files() {
+  local project_root="$1"
+  local regex="$2"
+  local file
+  while read -r file; do
+    if [[ "$file" =~ $regex ]] && [[ -f "$project_root/$file" ]]; then
+      echo "$project_root/$file"
+    fi
+  done
+}
+
+collect_touched_files() {
+  local project_root="$1"
+  local regex="$2"
+  local staged_files
+  local modified_files
+
+  if ! staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"; then
+    return 1
+  fi
+  if ! modified_files="$(git diff --name-only --diff-filter=ACMR)"; then
+    return 1
+  fi
+
+  {
+    printf '%s\n' "$staged_files"
+    printf '%s\n' "$modified_files"
+  } | _filter_matching_files "$project_root" "$regex" | sort | uniq
+}
+
+collect_changed_since_sha() {
+  local project_root="$1"
+  local sha="$2"
+  local regex="$3"
+  local changed_files
+
+  # Verify the SHA resolves before diffing so a bad base fails loudly here.
+  if ! git rev-parse --verify "$sha" > /dev/null 2>&1; then
+    echo -e "${RED}SHA '$sha' does not exist in the repository${NC}" >&2
+    return 1
+  fi
+
+  if ! changed_files="$(git diff --name-only "$sha"...HEAD)"; then
+    return 1
+  fi
+
+  printf '%s\n' "$changed_files" \
+    | _filter_matching_files "$project_root" "$regex" | sort | uniq
+}
+
+ensure_tool() {
+  local name="$1"
+  local installer_path="$2"
+  local install_when_missing="$3"
+
+  if ! command_exists "$name"; then
+    echo -e "${RED}${name} is not installed${NC}"
+    if [[ "$install_when_missing" == "true" ]]; then
+      echo -e "${YELLOW}Installing ${name}...${NC}"
+      if [[ -f "$installer_path" ]]; then
+        if ! bash "$installer_path"; then
+          echo -e "${RED}Failed to install ${name}${NC}"
+          return 1
+        fi
+      else
+        echo -e "${RED}${name} installation script not found${NC}"
+        return 1
+      fi
+    else
+      local upper
+      upper="$(printf '%s' "$name" | tr '[:lower:]' '[:upper:]')"
+      echo -e "${RED}${name} is required. Set INSTALL_${upper}_WHEN_MISSING=true to auto-install or install manually${NC}"
+      return 1
+    fi
+  fi
+
+  # Re-verify after any install attempt.
+  if ! command_exists "$name"; then
+    echo -e "${RED}${name} is still not available after installation attempt${NC}"
+    return 1
+  fi
+
+  return 0
+}

--- a/scripts/shellcheck/apply_shfmt.sh
+++ b/scripts/shellcheck/apply_shfmt.sh
@@ -3,6 +3,13 @@
 INSTALL_SHFMT_WHEN_MISSING=${INSTALL_SHFMT_WHEN_MISSING:-false}
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 
+# Shared git file-selection + install-when-missing helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
+# Per-tool file regex for the shared collectors (issue #2823).
+SHELL_FILE_REGEX='^.*\.sh$'
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -21,29 +28,8 @@ echo "PROJECT_ROOT: $PROJECT_ROOT"
 # Check for required commands and install missing commands if allowed
 echo -e "${YELLOW}Checking for required commands...${NC}"
 
-# Check if shfmt is installed
-if ! command_exists shfmt; then
-  echo -e "${RED}shfmt is not installed${NC}"
-  if [[ "${INSTALL_SHFMT_WHEN_MISSING}" == "true" ]]; then
-    echo -e "${YELLOW}Installing shfmt...${NC}"
-    if [[ -f "$PROJECT_ROOT/scripts/shellcheck/install_shfmt.sh" ]]; then
-      if ! bash "$PROJECT_ROOT/scripts/shellcheck/install_shfmt.sh"; then
-        echo -e "${RED}Failed to install shfmt${NC}"
-        exit 1
-      fi
-    else
-      echo -e "${RED}shfmt installation script not found${NC}"
-      exit 1
-    fi
-  else
-    echo -e "${RED}shfmt is required. Set INSTALL_SHFMT_WHEN_MISSING=true to auto-install or install manually${NC}"
-    exit 1
-  fi
-fi
-
-# Verify shfmt is available
-if ! command_exists shfmt; then
-  echo -e "${RED}shfmt is still not available after installation attempt${NC}"
+# Check if shfmt is installed (install-when-missing gate + re-verify).
+if ! ensure_tool shfmt "$PROJECT_ROOT/scripts/shellcheck/install_shfmt.sh" "${INSTALL_SHFMT_WHEN_MISSING}"; then
   exit 1
 fi
 
@@ -75,25 +61,6 @@ find_all_shell_files() {
     | uniq
 }
 
-# Function to get touched/staged files
-get_touched_files() {
-  {
-    # Get staged files
-    git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
-      if [[ "$file" =~ ^.*\.sh$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-        echo "$PROJECT_ROOT/$file"
-      fi
-    done
-
-    # Get modified but not staged files
-    git diff --name-only --diff-filter=ACMR | while read -r file; do
-      if [[ "$file" =~ ^.*\.sh$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-        echo "$PROJECT_ROOT/$file"
-      fi
-    done
-  } | sort | uniq
-}
-
 # Determine which files to process
 declare -a files_to_process
 errors=""
@@ -102,7 +69,7 @@ if [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
   echo -e "${YELLOW}Processing only touched/staged files${NC}"
 
   # Get list of changed files
-  touched_files=$(get_touched_files)
+  touched_files=$(collect_touched_files "$PROJECT_ROOT" "$SHELL_FILE_REGEX")
   while IFS= read -r file; do
     [[ -n "$file" ]] && files_to_process+=("$file")
   done <<< "$touched_files"

--- a/scripts/swiftformat/apply_swiftformat.sh
+++ b/scripts/swiftformat/apply_swiftformat.sh
@@ -3,6 +3,13 @@
 INSTALL_SWIFTFORMAT_WHEN_MISSING=${INSTALL_SWIFTFORMAT_WHEN_MISSING:-false}
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 
+# Shared git file-selection + install-when-missing helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
+# Per-tool file regex for the shared collectors (issue #2823).
+SWIFT_FILE_REGEX='^ios/.*\.swift$'
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -21,29 +28,8 @@ echo "PROJECT_ROOT: $PROJECT_ROOT"
 # Check for required commands and install missing commands if allowed
 echo -e "${YELLOW}Checking for required commands...${NC}"
 
-# Check if swiftformat is installed
-if ! command_exists swiftformat; then
-    echo -e "${RED}swiftformat is not installed${NC}"
-    if [[ "${INSTALL_SWIFTFORMAT_WHEN_MISSING}" == "true" ]]; then
-        echo -e "${YELLOW}Installing swiftformat...${NC}"
-        if [[ -f "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh" ]]; then
-            if ! bash "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh"; then
-                echo -e "${RED}Failed to install swiftformat${NC}"
-                exit 1
-            fi
-        else
-            echo -e "${RED}swiftformat installation script not found${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${RED}swiftformat is required. Set INSTALL_SWIFTFORMAT_WHEN_MISSING=true to auto-install or install manually${NC}"
-        exit 1
-    fi
-fi
-
-# Verify swiftformat is available
-if ! command_exists swiftformat; then
-    echo -e "${RED}swiftformat is still not available after installation attempt${NC}"
+# Check if swiftformat is installed (install-when-missing gate + re-verify).
+if ! ensure_tool swiftformat "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh" "${INSTALL_SWIFTFORMAT_WHEN_MISSING}"; then
     exit 1
 fi
 
@@ -75,25 +61,6 @@ find_all_swift_files() {
         2>/dev/null | sort | uniq
 }
 
-# Function to get touched/staged files
-get_touched_files() {
-    {
-        # Get staged files
-        git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-
-        # Get modified but not staged files
-        git diff --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-    } | sort | uniq
-}
-
 # Determine which files to process
 declare -a files_to_process
 
@@ -101,7 +68,7 @@ if [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
     echo -e "${YELLOW}Processing only touched/staged files${NC}"
     while IFS= read -r file; do
         [[ -n "$file" ]] && files_to_process+=("$file")
-    done < <(get_touched_files)
+    done < <(collect_touched_files "$PROJECT_ROOT" "$SWIFT_FILE_REGEX")
 
 else
     echo -e "${YELLOW}Processing all Swift files in ios/ directory${NC}"

--- a/scripts/swiftformat/validate_swiftformat.sh
+++ b/scripts/swiftformat/validate_swiftformat.sh
@@ -4,6 +4,10 @@ INSTALL_SWIFTFORMAT_WHEN_MISSING=${INSTALL_SWIFTFORMAT_WHEN_MISSING:-false}
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-false}
 ONLY_CHANGED_SINCE_SHA=${ONLY_CHANGED_SINCE_SHA:-""}
 
+# Shared git file-selection + install-when-missing helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -17,32 +21,14 @@ command_exists() {
 
 PROJECT_ROOT="$(pwd)"
 
+# Per-tool file regex for the shared collectors (issue #2823).
+SWIFT_FILE_REGEX='^ios/.*\.swift$'
+
 # Check for required commands and install missing commands if allowed
 echo -e "${YELLOW}Checking for required commands...${NC}"
 
-# Check if swiftformat is installed
-if ! command_exists swiftformat; then
-    echo -e "${RED}swiftformat is not installed${NC}"
-    if [[ "${INSTALL_SWIFTFORMAT_WHEN_MISSING}" == "true" ]]; then
-        echo -e "${YELLOW}Installing swiftformat...${NC}"
-        if [[ -f "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh" ]]; then
-            if ! bash "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh"; then
-                echo -e "${RED}Failed to install swiftformat${NC}"
-                exit 1
-            fi
-        else
-            echo -e "${RED}swiftformat installation script not found${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${RED}swiftformat is required. Set INSTALL_SWIFTFORMAT_WHEN_MISSING=true to auto-install or install manually${NC}"
-        exit 1
-    fi
-fi
-
-# Verify swiftformat is available
-if ! command_exists swiftformat; then
-    echo -e "${RED}swiftformat is still not available after installation attempt${NC}"
+# Check if swiftformat is installed (install-when-missing gate + re-verify).
+if ! ensure_tool swiftformat "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh" "${INSTALL_SWIFTFORMAT_WHEN_MISSING}"; then
     exit 1
 fi
 
@@ -74,43 +60,6 @@ find_all_swift_files() {
         2>/dev/null | sort | uniq
 }
 
-# Function to get changed files since SHA
-get_changed_files_since_sha() {
-    local sha="$1"
-
-    # Verify SHA exists
-    if ! git rev-parse --verify "$sha" >/dev/null 2>&1; then
-        echo -e "${RED}SHA '$sha' does not exist in the repository${NC}" >&2
-        exit 1
-    fi
-
-    # Get list of changed files since SHA
-    git diff --name-only "$sha"...HEAD | while read -r file; do
-        if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-            echo "$PROJECT_ROOT/$file"
-        fi
-    done | sort | uniq
-}
-
-# Function to get touched/staged files
-get_touched_files() {
-    {
-        # Get staged files
-        git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-
-        # Get modified but not staged files
-        git diff --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-    } | sort | uniq
-}
-
 # Determine which files to process
 declare -a files_to_process
 
@@ -118,13 +67,13 @@ if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]]; then
     echo -e "${YELLOW}Processing files changed since SHA: $ONLY_CHANGED_SINCE_SHA${NC}"
     while IFS= read -r file; do
         [[ -n "$file" ]] && files_to_process+=("$file")
-    done < <(get_changed_files_since_sha "$ONLY_CHANGED_SINCE_SHA")
+    done < <(collect_changed_since_sha "$PROJECT_ROOT" "$ONLY_CHANGED_SINCE_SHA" "$SWIFT_FILE_REGEX")
 
 elif [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
     echo -e "${YELLOW}Processing only touched/staged files${NC}"
     while IFS= read -r file; do
         [[ -n "$file" ]] && files_to_process+=("$file")
-    done < <(get_touched_files)
+    done < <(collect_touched_files "$PROJECT_ROOT" "$SWIFT_FILE_REGEX")
 
 else
     echo -e "${YELLOW}Processing all Swift files in ios/ directory${NC}"

--- a/scripts/swiftlint/apply_swiftlint.sh
+++ b/scripts/swiftlint/apply_swiftlint.sh
@@ -3,6 +3,13 @@
 INSTALL_SWIFTLINT_WHEN_MISSING=${INSTALL_SWIFTLINT_WHEN_MISSING:-false}
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 
+# Shared git file-selection + install-when-missing helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
+# Per-tool file regex for the shared collectors (issue #2823).
+SWIFT_FILE_REGEX='^ios/.*\.swift$'
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -21,29 +28,8 @@ echo "PROJECT_ROOT: $PROJECT_ROOT"
 # Check for required commands and install missing commands if allowed
 echo -e "${YELLOW}Checking for required commands...${NC}"
 
-# Check if swiftlint is installed
-if ! command_exists swiftlint; then
-    echo -e "${RED}swiftlint is not installed${NC}"
-    if [[ "${INSTALL_SWIFTLINT_WHEN_MISSING}" == "true" ]]; then
-        echo -e "${YELLOW}Installing swiftlint...${NC}"
-        if [[ -f "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh" ]]; then
-            if ! bash "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh"; then
-                echo -e "${RED}Failed to install swiftlint${NC}"
-                exit 1
-            fi
-        else
-            echo -e "${RED}swiftlint installation script not found${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${RED}swiftlint is required. Set INSTALL_SWIFTLINT_WHEN_MISSING=true to auto-install or install manually${NC}"
-        exit 1
-    fi
-fi
-
-# Verify swiftlint is available
-if ! command_exists swiftlint; then
-    echo -e "${RED}swiftlint is still not available after installation attempt${NC}"
+# Check if swiftlint is installed (install-when-missing gate + re-verify).
+if ! ensure_tool swiftlint "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh" "${INSTALL_SWIFTLINT_WHEN_MISSING}"; then
     exit 1
 fi
 
@@ -75,25 +61,6 @@ find_all_swift_files() {
         2>/dev/null | sort | uniq
 }
 
-# Function to get touched/staged files
-get_touched_files() {
-    {
-        # Get staged files
-        git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-
-        # Get modified but not staged files
-        git diff --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-    } | sort | uniq
-}
-
 # Determine which files to process
 declare -a files_to_process
 
@@ -101,7 +68,7 @@ if [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
     echo -e "${YELLOW}Processing only touched/staged files${NC}"
     while IFS= read -r file; do
         [[ -n "$file" ]] && files_to_process+=("$file")
-    done < <(get_touched_files)
+    done < <(collect_touched_files "$PROJECT_ROOT" "$SWIFT_FILE_REGEX")
 
 else
     echo -e "${YELLOW}Processing all Swift files in ios/ directory${NC}"

--- a/scripts/swiftlint/validate_swiftlint.sh
+++ b/scripts/swiftlint/validate_swiftlint.sh
@@ -4,6 +4,13 @@ INSTALL_SWIFTLINT_WHEN_MISSING=${INSTALL_SWIFTLINT_WHEN_MISSING:-false}
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-false}
 STRICT_MODE=${STRICT_MODE:-false}
 
+# Shared git file-selection + install-when-missing helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
+# Per-tool file regex for the shared collectors (issue #2823).
+SWIFT_FILE_REGEX='^ios/.*\.swift$'
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -20,29 +27,8 @@ PROJECT_ROOT="$(pwd)"
 # Check for required commands and install missing commands if allowed
 echo -e "${YELLOW}Checking for required commands...${NC}"
 
-# Check if swiftlint is installed
-if ! command_exists swiftlint; then
-    echo -e "${RED}swiftlint is not installed${NC}"
-    if [[ "${INSTALL_SWIFTLINT_WHEN_MISSING}" == "true" ]]; then
-        echo -e "${YELLOW}Installing swiftlint...${NC}"
-        if [[ -f "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh" ]]; then
-            if ! bash "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh"; then
-                echo -e "${RED}Failed to install swiftlint${NC}"
-                exit 1
-            fi
-        else
-            echo -e "${RED}swiftlint installation script not found${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${RED}swiftlint is required. Set INSTALL_SWIFTLINT_WHEN_MISSING=true to auto-install or install manually${NC}"
-        exit 1
-    fi
-fi
-
-# Verify swiftlint is available
-if ! command_exists swiftlint; then
-    echo -e "${RED}swiftlint is still not available after installation attempt${NC}"
+# Check if swiftlint is installed (install-when-missing gate + re-verify).
+if ! ensure_tool swiftlint "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh" "${INSTALL_SWIFTLINT_WHEN_MISSING}"; then
     exit 1
 fi
 
@@ -74,25 +60,6 @@ find_all_swift_files() {
         2>/dev/null | sort | uniq
 }
 
-# Function to get touched/staged files
-get_touched_files() {
-    {
-        # Get staged files
-        git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-
-        # Get modified but not staged files
-        git diff --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^ios/.*\.swift$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-    } | sort | uniq
-}
-
 # Determine which files to process
 declare -a files_to_process
 
@@ -100,7 +67,7 @@ if [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
     echo -e "${YELLOW}Processing only touched/staged files${NC}"
     while IFS= read -r file; do
         [[ -n "$file" ]] && files_to_process+=("$file")
-    done < <(get_touched_files)
+    done < <(collect_touched_files "$PROJECT_ROOT" "$SWIFT_FILE_REGEX")
 
 else
     echo -e "${YELLOW}Processing all Swift files in ios/ directory${NC}"

--- a/scripts/xml/format_xml.sh
+++ b/scripts/xml/format_xml.sh
@@ -2,6 +2,13 @@
 
 ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 
+# Shared git file-selection helpers (issue #2823).
+# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+
+# Per-tool file regex for the shared collectors (issue #2823).
+XML_FILE_REGEX='^.*\.xml$'
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -79,25 +86,6 @@ find_all_xml_files() {
       xargs -0 -I {} echo "$PROJECT_ROOT/{}"
 }
 
-# Function to get touched/staged files
-get_touched_files() {
-    {
-        # Get staged files
-        git diff --cached --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^.*\.xml$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-
-        # Get modified but not staged files
-        git diff --name-only --diff-filter=ACMR | while read -r file; do
-            if [[ "$file" =~ ^.*\.xml$ ]] && [[ -f "$PROJECT_ROOT/$file" ]]; then
-                echo "$PROJECT_ROOT/$file"
-            fi
-        done
-    } | sort | uniq
-}
-
 # Determine which files to process
 declare -a files_to_process
 
@@ -105,7 +93,7 @@ if [[ "${ONLY_TOUCHED_FILES}" == "true" ]]; then
     echo -e "${YELLOW}Processing only touched/staged files${NC}"
 
     # Get list of changed files
-    touched_files=$(get_touched_files)
+    touched_files=$(collect_touched_files "$PROJECT_ROOT" "$XML_FILE_REGEX")
     while IFS= read -r file; do
         [[ -n "$file" ]] && files_to_process+=("$file")
     done <<< "$touched_files"

--- a/test/bats/validate-ktfmt.bats
+++ b/test/bats/validate-ktfmt.bats
@@ -267,6 +267,10 @@ STUB
   mkdir -p "$copy_dir"
   cp "$REPO_ROOT/scripts/ktfmt/validate_ktfmt.sh" "$copy_dir/"
   cp "$REPO_ROOT/scripts/ktfmt/ktfmt_version.sh" "$copy_dir/"
+  # The validator sources ../lib/file-selection.sh relative to its own dir
+  # (issue #2823), so mirror scripts/lib next to the copied ktfmt dir.
+  mkdir -p "$TEST_DIR/lib"
+  cp "$REPO_ROOT/scripts/lib/file-selection.sh" "$TEST_DIR/lib/"
   # Bump ONLY the pin line in the copy, preserving the shared helper functions.
   sed -i.bak 's/^KTFMT_VERSION=.*/KTFMT_VERSION="0.99"/' "$copy_dir/ktfmt_version.sh"
   rm -f "$copy_dir/ktfmt_version.sh.bak"


### PR DESCRIPTION
Closes #2823

## Summary
De-duplicates the git file-selection + install-when-missing boilerplate that was copy-pasted (and had drifted) across the formatter/linter `validate_<tool>.sh` / `apply_<tool>.sh` scripts.

Adds `scripts/lib/file-selection.sh` (companion to `scripts/lib/tool-install.sh` from #2822, same sourcing convention) exporting:
- `collect_touched_files <project_root> <regex>` — staged + working-tree files, regex-filtered, sorted/uniq; returns non-zero if `git diff` fails (a producer failure is never mistaken for a clean tree).
- `collect_changed_since_sha <project_root> <sha> <regex>` — files changed in `sha...HEAD`, regex-filtered; verifies the SHA resolves.
- `ensure_tool <name> <installer_path> <install_when_missing>` — the install-when-missing gate + re-verify, with the actionable `INSTALL_<TOOL>_WHEN_MISSING` message derived from the tool name.

Migrated sites (each now keeps only its per-tool file regex):
- ktfmt validate + apply
- swiftformat validate + apply
- swiftlint validate + apply
- shfmt apply
- format_xml

Per-tool regexes and touched/since-sha/all mode behavior are preserved exactly. The ktfmt validate `load_files_to_process` dispatch, mapfile fallback, full-tree-fallback on unresolvable base SHA, and producer-failure propagation are unchanged.

## Validation
- `shellcheck` clean on the new lib + all 9 migrated scripts (SC1091 disabled on each `source` directive).
- `bats test/bats/validate-ktfmt.bats test/bats/apply-ktfmt.bats` — 16/16 green (covers empty-SHA full-tree, scoped-by-SHA, deleted-file exclusion, unresolvable-SHA fallback, git-diff/find failure non-pass, version-pin gate, and single-sourcing).
- Functional equivalence spot-check in a scratch git repo: collectors produce identical file sets to the old inline logic (ios/ matched, non-ios excluded; bad SHA returns rc=1).
- Full `bats test/bats/` otherwise green (only the known env-flaky `verify-runtime-deps.bats` #144 fails locally; unrelated, CI-covered).

## Caveats
- `validate-ktfmt.bats` test 14 (single-source proof) now also mirrors `scripts/lib/` next to the copied ktfmt dir, since the validator sources `../lib/file-selection.sh` relative to its own dir.
- `swiftformat/swiftlint` validate/apply scripts still source no `set -euo pipefail` (pre-existing); behavior unchanged.