### PR TITLE
chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -323,4 +323,4 @@ export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (
 // iOS downloads are ever wired (resolveChecksum(<pinned>, "ios")), move this to a
 // per-entry ReleaseChecksumEntry.runnerSha256 or the check would compare the
 // newest runner sha against an older IPA and reject a valid bundle.
-export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "";
+export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982";


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `  apkSha256: string;` | `22aa07e8f2ee68005b5575d3084e08198d71a4f65253f14fea5ee6b8148e1585` | ✅ Yes |
| **IPA** | `  ipaSha256: string;` | `d0dfc7ccdf5e14622743e3a6d672d8d7797d0a73b42c53b81e1c149a514870d7` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow