### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 ![Platform: macOS](https://img.shields.io/badge/platform-macOS-lightgrey)
 ![Platform: Linux](https://img.shields.io/badge/platform-Linux-lightgrey)
 
-![TypeScript tests: 6,581](https://img.shields.io/badge/TypeScript_tests-6%2C581-3178C6)
-![Kotlin tests: 1,407](https://img.shields.io/badge/Kotlin_tests-1%2C407-7F52FF)
+![TypeScript tests: 6,605](https://img.shields.io/badge/TypeScript_tests-6%2C605-3178C6)
+![Kotlin tests: 1,424](https://img.shields.io/badge/Kotlin_tests-1%2C424-7F52FF)
 ![Swift tests: 686](https://img.shields.io/badge/Swift_tests-686-F05138)
 ![Kotlin coverage](https://img.shields.io/endpoint?url=https://kaeawc.github.io/auto-mobile/kotlin-coverage-badge.json)
 ![Swift coverage](https://img.shields.io/endpoint?url=https://kaeawc.github.io/auto-mobile/swift-coverage-badge.json)
@@ -54,6 +54,16 @@ curl -fsSL https://raw.githubusercontent.com/kaeawc/auto-mobile/refs/heads/main/
 ```
 
 or you can read and follow the [step-by-step manual guide](docs/install.md).
+
+### Optional You.com search tool
+
+If you want the MCP server to pull in live web context while investigating apps or reproducing issues, set:
+
+```bash
+export YDC_API_KEY="your-key-here"
+```
+
+This enables the optional `youcomSearch` tool. If the variable is unset, nothing changes for existing users.
 
 ## Documentation
 

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -11,6 +11,91 @@ import { BootedDevice, Platform } from "../models";
 import { addDeviceTargetingToSchema, addSessionUuidToSchema, platformSchema } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
 
+const YDC_SEARCH_URL = "https://ydc-index.io/v1/search";
+const YDC_API_KEY_ENV = "YDC_API_KEY";
+
+const youcomSearchSchema = z.object({
+  query: z.string().min(1).describe("Search query"),
+  count: z.number().int().min(1).max(100).optional().describe("Results per section (1-100)"),
+  freshness: z.string().min(1).optional().describe("Freshness filter, for example day, week, month, year, or YYYY-MM-DDtoYYYY-MM-DD"),
+  offset: z.number().int().min(0).max(9).optional().describe("Pagination offset"),
+  country: z.string().length(2).optional().describe("Country code such as US or GB"),
+  language: z.string().min(2).max(5).optional().describe("Language code such as EN"),
+  safesearch: z.enum(["off", "moderate", "strict"]).optional(),
+  livecrawl: z.enum(["web", "news", "all"]).optional(),
+  livecrawlFormats: z.enum(["html", "markdown"]).optional().describe("Requires livecrawl"),
+  crawlTimeout: z.number().int().min(1).max(60).optional().describe("Live crawl timeout in seconds"),
+});
+
+type YoucomSearchArgs = z.infer<typeof youcomSearchSchema>;
+
+function buildYoucomSearchUrl(args: YoucomSearchArgs): URL {
+  const url = new URL(YDC_SEARCH_URL);
+  url.searchParams.set("query", args.query);
+  if (args.count !== undefined) {
+    url.searchParams.set("count", String(args.count));
+  }
+  if (args.freshness) {
+    url.searchParams.set("freshness", args.freshness);
+  }
+  if (args.offset !== undefined) {
+    url.searchParams.set("offset", String(args.offset));
+  }
+  if (args.country) {
+    url.searchParams.set("country", args.country);
+  }
+  if (args.language) {
+    url.searchParams.set("language", args.language);
+  }
+  if (args.safesearch) {
+    url.searchParams.set("safesearch", args.safesearch);
+  }
+  if (args.livecrawl) {
+    url.searchParams.set("livecrawl", args.livecrawl);
+  }
+  if (args.livecrawlFormats) {
+    url.searchParams.set("livecrawl_formats", args.livecrawlFormats);
+  }
+  if (args.crawlTimeout !== undefined) {
+    url.searchParams.set("crawl_timeout", String(args.crawlTimeout));
+  }
+  return url;
+}
+
+async function runYoucomSearch(args: YoucomSearchArgs) {
+  const apiKey = process.env[YDC_API_KEY_ENV];
+  if (!apiKey) {
+    return createJSONToolResponse({
+      success: false,
+      error: `Set ${YDC_API_KEY_ENV} to enable the optional You.com search tool.`,
+    });
+  }
+
+  const response = await fetch(buildYoucomSearchUrl(args), {
+    headers: { "X-API-Key": apiKey },
+  });
+
+  const bodyText = await response.text();
+  if (!response.ok) {
+    return createJSONToolResponse({
+      success: false,
+      error: `You.com Search API error ${response.status}: ${bodyText}`,
+    });
+  }
+
+  const payload = JSON.parse(bodyText) as {
+    results?: { web?: Array<Record<string, unknown>>; news?: Array<Record<string, unknown>> };
+    metadata?: Record<string, unknown>;
+  };
+
+  return createJSONToolResponse({
+    success: true,
+    query: args.query,
+    results: payload.results ?? {},
+    metadata: payload.metadata ?? {},
+  });
+}
+
 // Schema definitions
 export const setActiveDeviceSchema = addSessionUuidToSchema(z.object({
   deviceId: z.string(),
@@ -72,6 +157,8 @@ export interface ChangeLocalizationArgs {
 export type GetDeviceStateArgs = z.infer<typeof getDeviceStateSchema>;
 
 export type SetDeviceStateArgs = z.infer<typeof setDeviceStateSchema>;
+
+export type YoucomSearchToolArgs = YoucomSearchArgs;
 
 // Register tools
 export function registerUtilityTools() {
@@ -247,6 +334,8 @@ export function registerUtilityTools() {
     });
   };
 
+  const youcomSearchHandler = async (args: YoucomSearchArgs) => runYoucomSearch(args);
+
   // Register with the tool registry
   ToolRegistry.register(
     "setActiveDevice",
@@ -274,5 +363,12 @@ export function registerUtilityTools() {
     "Set device state such as Do Not Disturb.",
     setDeviceStateSchema,
     setDeviceStateHandler
+  );
+
+  ToolRegistry.register(
+    "youcomSearch",
+    "Search the web with the optional You.com Search API",
+    youcomSearchSchema,
+    youcomSearchHandler
   );
 }

--- a/test/server/utilityTools.youcomSearch.test.ts
+++ b/test/server/utilityTools.youcomSearch.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerUtilityTools } from "../../src/server/utilityTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+describe("youcomSearch tool", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    registerUtilityTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+    delete process.env.YDC_API_KEY;
+  });
+
+  test("registers an optional search tool", () => {
+    const tool = ToolRegistry.getTool("youcomSearch");
+
+    expect(tool).toBeDefined();
+    expect(tool?.requiresDevice).toBe(false);
+    expect(() => tool!.schema.parse({ query: "playwright locators", count: 5 })).not.toThrow();
+  });
+
+  test("returns a setup error when YDC_API_KEY is missing", async () => {
+    const tool = ToolRegistry.getTool("youcomSearch");
+    const response = await tool!.handler({ query: "playwright locators" });
+    const payload = JSON.parse(response.content[0].text) as { success: boolean; error: string };
+
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain("YDC_API_KEY");
+  });
+
+  test("returns search results from You.com", async () => {
+    process.env.YDC_API_KEY = "test-key";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("ydc-index.io/v1/search");
+      return new Response(JSON.stringify({
+        results: { web: [{ url: "https://example.com", title: "Example" }] },
+        metadata: { query: "playwright locators", search_uuid: "abc" },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    try {
+      const tool = ToolRegistry.getTool("youcomSearch");
+      const response = await tool!.handler({ query: "playwright locators", count: 3 });
+      const payload = JSON.parse(response.content[0].text) as {
+        success: boolean;
+        query: string;
+        results: { web: Array<{ url: string; title: string }> };
+      };
+
+      expect(payload.success).toBe(true);
+      expect(payload.query).toBe("playwright locators");
+      expect(payload.results.web[0].url).toBe("https://example.com");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
This adds an optional You.com search tool to AutoMobile's MCP utility tools.

Why this is useful here
- When reproducing issues or exploring app behavior, it helps to pull in live web context without leaving the MCP workflow.
- It stays opt-in, so existing users see no change.

What changed
- Added `youcomSearch` to the utility tool registry.
- Wired it to the You.com Search API via direct HTTP.
- Added schema validation, missing-key handling, and upstream error surfacing.
- Documented the opt-in env var in the README.
- Added tests for registration, missing-key behavior, and a happy path.

Setup
- `YDC_API_KEY=...`

Usage
- `youcomSearch({ "query": "playwright locators", "count": 5 })`

Validation
- `bun test test/server/utilityTools.youcomSearch.test.ts test/server/utilityTools.deviceState.test.ts`
- `bunx eslint src/server/utilityTools.ts test/server/utilityTools.youcomSearch.test.ts`

Fallback/error handling
- If `YDC_API_KEY` is unset, the tool returns a clear setup error.
- If the API returns a non-200, the tool returns the status code and response body.

Tracking issue
- https://github.com/youdotcom-oss/integration-tracking/issues/43
