### PR TITLE
test(observe): cover node trim with raw capture fixture

### DIFF
--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../src/features/observe/output/ObserveResultOutput";
 import {
   loadAndroidHomeObserve,
+  loadAndroidRawTrimCandidatesObserve,
   measureValue,
 } from "../../../fixtures/observe/observeFixture";
 
@@ -52,6 +53,17 @@ function allHierarchyNodes(obs: ObserveResult): ViewHierarchyNode[] {
 const DROP_NONE = { dropElements: false } as const;
 const DROP_ELEMENTS = { dropElements: true } as const;
 const COMPACT = { dropElements: false, compact: true } as const;
+const DEFAULT_FALSE_BOOLEAN_KEYS = [
+  "clickable",
+  "long-clickable",
+  "focusable",
+  "focused",
+  "scrollable",
+  "checkable",
+  "checked",
+  "selected",
+  "password",
+] as const;
 
 /** The documented positional order of a compacted bounds tuple. */
 type BoundsTuple = [number, number, number, number];
@@ -398,38 +410,71 @@ describe("sanitizeObserveResult", () => {
       expect(measureValue(perfStripped).bytes).toBeLessThan(measureValue(trimOff).bytes);
     });
 
-    test("measurably shrinks a hierarchy carrying false booleans, empty strings, and enabled=true", () => {
-      // The committed fixture is already boolean/empty-string-clean (the extractor
-      // only emits meaningful attrs), so this synthetic tree exercises the
-      // boolean/empty-string/enabled drop paths against a real byte measurement.
-      const node = (id: number): Record<string, unknown> => ({
-        "view-id": `v-${id}`,
-        "resource-id": `r-${id}`,
-        "className": "android.widget.TextView",
-        "clickable": "false",
-        "long-clickable": "false",
-        "scrollable": "false",
-        "checkable": "false",
-        "checked": "false",
-        "selected": "false",
-        "focused": "false",
-        "enabled": "true",
-        "text": "",
-        "content-desc": `desc ${id}`,
-        "node": [],
+    test("measurably shrinks false booleans over a real raw hierarchy capture", () => {
+      const obs = loadAndroidRawTrimCandidatesObserve();
+      for (const node of allHierarchyNodes(obs)) {
+        const attrs = node as unknown as Record<string, unknown>;
+        delete attrs.enabled;
+        for (const [key, value] of Object.entries(attrs)) {
+          if (value === "") {
+            delete attrs[key];
+          }
+        }
+      }
+      const falseBooleanCandidates = allHierarchyNodes(obs).filter(node => {
+        const attrs = node as unknown as Record<string, unknown>;
+        return DEFAULT_FALSE_BOOLEAN_KEYS.some(key => attrs[key] === "false");
       });
-      const obs: ObserveResult = {
-        updatedAt: 0,
-        screenSize: { width: 1, height: 1 },
-        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
-        viewHierarchy: {
-          hierarchy: { node: Array.from({ length: 20 }, (_, i) => node(i)) as any },
-        },
-      };
+      expect(falseBooleanCandidates.length).toBeGreaterThan(0);
 
       const trimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: true });
       const untrimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: false });
       expect(measureValue(trimmed).bytes).toBeLessThan(measureValue(untrimmed).bytes);
+      expect(measureValue(trimmed).tokens).toBeLessThan(measureValue(untrimmed).tokens);
+    });
+
+    test("measurably shrinks empty-string fields over a real raw hierarchy capture", () => {
+      const obs = loadAndroidRawTrimCandidatesObserve();
+      for (const node of allHierarchyNodes(obs)) {
+        const attrs = node as unknown as Record<string, unknown>;
+        delete attrs.enabled;
+        for (const key of DEFAULT_FALSE_BOOLEAN_KEYS) {
+          delete attrs[key];
+        }
+      }
+      const emptyStringCandidates = allHierarchyNodes(obs).filter(node =>
+        Object.values(node as unknown as Record<string, unknown>).some(value => value === "")
+      );
+      expect(emptyStringCandidates.length).toBeGreaterThan(0);
+
+      const trimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: true });
+      const untrimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: false });
+      expect(measureValue(trimmed).bytes).toBeLessThan(measureValue(untrimmed).bytes);
+      expect(measureValue(trimmed).tokens).toBeLessThan(measureValue(untrimmed).tokens);
+    });
+
+    test("measurably shrinks enabled=true over a real raw hierarchy capture", () => {
+      const obs = loadAndroidRawTrimCandidatesObserve();
+      for (const node of allHierarchyNodes(obs)) {
+        const attrs = node as unknown as Record<string, unknown>;
+        for (const key of DEFAULT_FALSE_BOOLEAN_KEYS) {
+          delete attrs[key];
+        }
+        for (const [key, value] of Object.entries(attrs)) {
+          if (value === "") {
+            delete attrs[key];
+          }
+        }
+      }
+      const enabledTrueCandidates = allHierarchyNodes(obs).filter(node =>
+        (node as unknown as Record<string, unknown>).enabled === "true"
+      );
+      expect(enabledTrueCandidates.length).toBeGreaterThan(0);
+
+      const trimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: true });
+      const untrimmed = sanitizeObserveResult(obs, { dropElements: false, trimNodes: false });
+      expect(measureValue(trimmed).bytes).toBeLessThan(measureValue(untrimmed).bytes);
+      expect(measureValue(trimmed).tokens).toBeLessThan(measureValue(untrimmed).tokens);
     });
 
     test("does not touch rawViewHierarchy (raw stays raw)", () => {

--- a/test/fixtures/observe/android-playground-raw-trim-candidates.json
+++ b/test/fixtures/observe/android-playground-raw-trim-candidates.json
@@ -1,0 +1,120 @@
+{
+  "updatedAt": 0,
+  "screenSize": {
+    "width": 1080,
+    "height": 2400
+  },
+  "systemInsets": {
+    "top": 63,
+    "bottom": 63,
+    "left": 0,
+    "right": 0
+  },
+  "viewHierarchy": {
+    "hierarchy": {
+      "node": {
+        "text": "",
+        "resource-id": "",
+        "$": {},
+        "className": "android.widget.FrameLayout",
+        "packageName": "dev.jasonpearson.automobile.playground",
+        "content-desc": "",
+        "checkable": "false",
+        "checked": "false",
+        "clickable": "false",
+        "enabled": "true",
+        "focusable": "false",
+        "focused": "false",
+        "scrollable": "false",
+        "long-clickable": "false",
+        "password": "false",
+        "selected": "false",
+        "bounds": {
+          "left": 0,
+          "top": 0,
+          "right": 1080,
+          "bottom": 2400
+        },
+        "node": [
+          {
+            "text": "",
+            "resource-id": "android:id/content",
+            "$": {},
+            "className": "android.widget.FrameLayout",
+            "packageName": "dev.jasonpearson.automobile.playground",
+            "content-desc": "",
+            "checkable": "false",
+            "checked": "false",
+            "clickable": "false",
+            "enabled": "true",
+            "focusable": "false",
+            "focused": "false",
+            "scrollable": "false",
+            "long-clickable": "false",
+            "password": "false",
+            "selected": "false",
+            "bounds": {
+              "left": 0,
+              "top": 0,
+              "right": 1080,
+              "bottom": 2400
+            },
+            "node": [
+              {
+                "text": "",
+                "resource-id": "navigation.HomeDestination",
+                "$": {},
+                "className": "android.view.View",
+                "packageName": "dev.jasonpearson.automobile.playground",
+                "content-desc": "",
+                "checkable": "false",
+                "checked": "false",
+                "clickable": "false",
+                "enabled": "true",
+                "focusable": "false",
+                "focused": "false",
+                "scrollable": "false",
+                "long-clickable": "false",
+                "password": "false",
+                "selected": "false",
+                "bounds": {
+                  "left": 0,
+                  "top": 0,
+                  "right": 1080,
+                  "bottom": 2400
+                },
+                "node": [
+                  {
+                    "text": "Swipe",
+                    "resource-id": "",
+                    "$": {},
+                    "className": "android.widget.TextView",
+                    "packageName": "dev.jasonpearson.automobile.playground",
+                    "content-desc": "",
+                    "checkable": "false",
+                    "checked": "false",
+                    "clickable": "false",
+                    "enabled": "true",
+                    "focusable": "false",
+                    "focused": "false",
+                    "scrollable": "false",
+                    "long-clickable": "false",
+                    "password": "false",
+                    "selected": "false",
+                    "bounds": {
+                      "left": 274,
+                      "top": 330,
+                      "right": 374,
+                      "bottom": 383
+                    },
+                    "node": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/observe/observeFixture.ts
+++ b/test/fixtures/observe/observeFixture.ts
@@ -56,6 +56,24 @@ export function loadIosFractionalObserve(): ObserveResult {
 }
 
 /**
+ * Excerpt from a real Android uiautomator hierarchy capture of the Playground
+ * app. It intentionally preserves the Android direct-attribute runtime shape
+ * that reaches output trimming before `cleanNodeProperties` removes default
+ * values: default-false booleans, default-true `enabled`, and empty strings.
+ * Each node still includes an empty `$` bag so it remains compatible with the
+ * declared `ViewHierarchyNode` contract.
+ */
+export const ANDROID_RAW_TRIM_CANDIDATES_FIXTURE_PATH = join(
+  import.meta.dir,
+  "android-playground-raw-trim-candidates.json"
+);
+
+/** Load the raw Android trim-candidate fixture as a parsed `ObserveResult`. */
+export function loadAndroidRawTrimCandidatesObserve(): ObserveResult {
+  return JSON.parse(readFileSync(ANDROID_RAW_TRIM_CANDIDATES_FIXTURE_PATH, "utf8")) as ObserveResult;
+}
+
+/**
  * Real-device before/after observation pairs captured for the `--actions-diff-observe`
  * sign-off (issue #3051; see
  * `docs/design-docs/plat/android/actions-diff-observe-signoff.md`). Each file is a


### PR DESCRIPTION
## Summary

Adds a real Android raw hierarchy trim-candidate fixture and uses it to verify `sanitizeObserveResult` node trimming with byte and token assertions. The false-boolean, empty-string, and `enabled=true` reduction paths now each have real-capture coverage instead of relying only on synthetic hierarchy objects.

## Linked Issue

Closes #2879

## Bug / Regression Context

- **Prior attempts:** PR #2872 added `sanitizeObserveResult` and synthetic coverage for default booleans / empty strings / `enabled`, but the committed `android-home.json` baseline only exercised real-data `view-id` dedup.
- **Observed symptom:** Real-data byte/token reduction coverage for node trim was carried by `view-id === resource-id`; the other trim rules were only measured with synthetic nodes.
- **Repro steps / conditions:** Run `bun test test/features/observe/output/ObserveResultOutput.test.ts`; before this change, there was no real captured hierarchy fixture containing `clickable="false"`, `enabled="true"`, and empty-string fields for those reduction assertions.

## Validation

- [x] `turbo run lint build test` passes (`bun run turbo:validate`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, test fixture only
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional local validation:
- `bun test test/fixtures/observe/androidHomeFixture.test.ts test/features/observe/output/ObserveResultOutput.test.ts` passed: 49 pass, 0 fail.
- `git diff --check` passed.

## Device Verification

- [x] Verified on Android emulator via raw hierarchy capture (`adb -s emulator-5554 exec-out uiautomator dump /dev/tty`), saved during development under `scratch/android-home-uiautomator.xml`.
- [ ] Screenshots or before/after attached

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
