### PR TITLE
[codex] Unify CtrlProxy download skip control

### DIFF
--- a/docs/design-docs/plat/android/control-proxy.md
+++ b/docs/design-docs/plat/android/control-proxy.md
@@ -230,6 +230,7 @@ If the version is incompatible, it surfaces a warning/error advising you to reru
 - `AUTOMOBILE_CTRL_PROXY_APK_PATH`: Override APK source with a local file path.
 - `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM`: Skip checksum validation (development mode).
 - `AUTO_MOBILE_ACCESSIBILITY_SERVICE_SHA_SKIP_CHECK` (deprecated): Legacy alias for skipping checksum validation.
+- `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD`: Skip Android and iOS CtrlProxy downloads/prefetches when set to `1` or `true`.
 - `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED`: Explicitly skip version check if the service is already installed.
 - `AUTOMOBILE_ACCESSIBILITY_TOGGLE_METHOD`: Not supported; settings-based toggling is the only automated path.
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -70,4 +70,5 @@ here for discoverability; most are diagnostic or for advanced testing.
 | `AUTOMOBILE_DEBUG_PERF` | Enables performance/timing debug output. |
 | `AUTOMOBILE_CTRL_PROXY_APK_PATH` | Overrides the path to the Android CtrlProxy APK (for testing a locally-built runner). |
 | `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` | Overrides the path to the iOS CtrlProxy bundle (for testing a locally-built runner). |
+| `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` | Skips Android and iOS CtrlProxy downloads/prefetches when set to `1` or `true`. |
 | `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED` | Skips the accessibility service download when it is already installed. |

--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -107,9 +107,9 @@ mirror can only serve unverified assets if you deliberately opt out of verificat
    export AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH=/opt/automobile/control-proxy.ipa
    ```
    The daemon copies (and extracts) this local bundle directly — no network fetch, no
-   Xcode build. **Do not also set `AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=1`**: that flag
+   Xcode build. **Do not also set `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=1`**: that flag
    short-circuits `needsRebuild()` and returns *before* the vendored IPA is consumed, so
-   on a fresh host CtrlProxy would never be installed. Use `AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=1`
+   on a fresh host CtrlProxy would never be installed. Use `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=1`
    only when the extracted xctestrun artifacts are *already* present on the host.
    Alternatively, set `AUTOMOBILE_ASSET_BASE_URL` to your mirror for a checksummed
    download of a registry-known version (leave the IPA path unset).

--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -242,7 +242,7 @@ reload_mcp_daemon() {
     # Run daemon restart in background with timeout to prevent hanging
     local daemon_log="${PROJECT_ROOT}/scratch/daemon-restart.log"
     if [[ "${should_skip_ios_build}" == "true" ]]; then
-      AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD=true \
+      AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=true \
         auto-mobile --daemon restart --debug --debug-perf > "${daemon_log}" 2>&1 &
     else
       auto-mobile --daemon restart --debug --debug-perf > "${daemon_log}" 2>&1 &

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -7,6 +7,7 @@ import { releaseVersion } from "../utils/mcpVersion";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
+import { shouldSkipCtrlProxyDownload } from "../utils/ctrlProxyDownloadControl";
 import { ActionableError } from "../models";
 import {
   PID_FILE_PATH,
@@ -953,8 +954,10 @@ export class DaemonManager implements DaemonManagerLike {
   }
 }
 
-export function parseDaemonArgs(args: string[]): DaemonOptions {
-  const options: DaemonOptions = {};
+export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process.env): DaemonOptions {
+  const options: DaemonOptions = shouldSkipCtrlProxyDownload(args, env)
+    ? { skipCtrlProxyDownload: true }
+    : {};
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--port") {
       options.port = parseInt(args[i + 1], 10);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,11 @@ import { getGlobalVersionOutput } from "./cli/versionFlag";
 import { startupBenchmark } from "./utils/startupBenchmark";
 import { getMcpServerVersion } from "./utils/mcpVersion";
 import {
+  SKIP_CTRL_PROXY_DOWNLOAD_ENV,
+  SKIP_CTRL_PROXY_DOWNLOAD_FLAG,
+  shouldSkipCtrlProxyDownload,
+} from "./utils/ctrlProxyDownloadControl";
+import {
   installProcessLifecycleHandlers,
   setFatalProcessHandler,
   setProcessShutdownHandler,
@@ -157,7 +162,7 @@ function parseArgs(log: ParseLogger): {
   let a11yUseBaseline = false;
   const predictiveUi = args.includes("--predictive") || args.includes("--predictive-ui");
   const rawElementSearch = args.includes("--raw-element-search");
-  const skipCtrlProxyDownload = args.includes("--skip-ctrl-proxy-download") || args.includes("--skip-accessibility-download");
+  const skipCtrlProxyDownload = shouldSkipCtrlProxyDownload(args);
   const embeddedSdk = args.includes("--embedded-sdk");
   const networkMockable = args.includes("--network-mockable");
   const dismissKeyboardAfterInput = args.includes("--dismiss-keyboard-after-input");
@@ -464,7 +469,7 @@ async function main() {
     serverConfig.setNetworkMockableEnabled(networkMockable);
     serverConfig.setDismissKeyboardAfterInputEnabled(dismissKeyboardAfterInput);
     if (skipCtrlProxyDownload) {
-      logger.info("CtrlProxy APK download disabled (--skip-ctrl-proxy-download)");
+      logger.info(`CtrlProxy downloads disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
     } else {
       // Start prefetching the accessibility service APK in the background
       // This runs asynchronously and will be ready when first device connects
@@ -475,7 +480,11 @@ async function main() {
     // the build prefetch asynchronously so it can be ready for first use.
     if (process.platform === "darwin") {
       await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup();
-      IOSCtrlProxyBuilder.prefetchBuild();
+      if (skipCtrlProxyDownload) {
+        logger.info(`CtrlProxy iOS prefetch disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
+      } else {
+        IOSCtrlProxyBuilder.prefetchBuild();
+      }
     }
 
     const featureFlagService = FeatureFlagService.getInstance();

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -28,6 +28,10 @@ import {
   type PlistValue
 } from "./ios-cmdline-tools/XctestrunPlist";
 import { ActionableError, toActionableError } from "../models/ActionableError";
+import {
+  SKIP_CTRL_PROXY_DOWNLOAD_ENV,
+  isTruthyEnvValue,
+} from "./ctrlProxyDownloadControl";
 
 /**
  * Result of CtrlProxy download/install
@@ -360,9 +364,8 @@ export class IOSCtrlProxyBuilder {
    * Check if a download/extract is needed
    */
   public async needsRebuild(platform?: IOSCtrlProxyPlatform): Promise<boolean> {
-    if (process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD === "true" ||
-        process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD === "1") {
-      logger.info("[IOSCtrlProxyBuilder] Download skipped via AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD");
+    if (isTruthyEnvValue(process.env[SKIP_CTRL_PROXY_DOWNLOAD_ENV])) {
+      logger.info(`[IOSCtrlProxyBuilder] Download skipped via ${SKIP_CTRL_PROXY_DOWNLOAD_ENV}`);
       return false;
     }
 
@@ -426,13 +429,12 @@ export class IOSCtrlProxyBuilder {
   ): Promise<CtrlProxyIosBuildResult> {
     perf.serial("xcTestServiceDownload");
 
-    if (process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD === "true" ||
-        process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD === "1") {
+    if (isTruthyEnvValue(process.env[SKIP_CTRL_PROXY_DOWNLOAD_ENV])) {
       perf.end();
       return {
         success: false,
         message: "CtrlProxy download skipped",
-        error: "AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD is set"
+        error: `${SKIP_CTRL_PROXY_DOWNLOAD_ENV} is set`
       };
     }
 
@@ -493,12 +495,6 @@ export class IOSCtrlProxyBuilder {
 
     if (IOSCtrlProxyBuilder.prefetchPromise !== null) {
       logger.info("[IOSCtrlProxyBuilder] Prefetch already initiated, skipping");
-      return;
-    }
-
-    if (process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD === "true" ||
-        process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD === "1") {
-      logger.info("[IOSCtrlProxyBuilder] Prefetch skipped via environment variable");
       return;
     }
 

--- a/src/utils/ctrlProxyDownloadControl.ts
+++ b/src/utils/ctrlProxyDownloadControl.ts
@@ -1,0 +1,18 @@
+export const SKIP_CTRL_PROXY_DOWNLOAD_FLAG = "--skip-ctrl-proxy-download";
+export const LEGACY_SKIP_ACCESSIBILITY_DOWNLOAD_FLAG = "--skip-accessibility-download";
+export const SKIP_CTRL_PROXY_DOWNLOAD_ENV = "AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD";
+
+export function isTruthyEnvValue(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+export function shouldSkipCtrlProxyDownload(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return (
+    args.includes(SKIP_CTRL_PROXY_DOWNLOAD_FLAG) ||
+    args.includes(LEGACY_SKIP_ACCESSIBILITY_DOWNLOAD_FLAG) ||
+    isTruthyEnvValue(env[SKIP_CTRL_PROXY_DOWNLOAD_ENV])
+  );
+}

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -10,7 +10,7 @@ import { parsePlist } from "../../src/utils/ios-cmdline-tools/XctestrunPlist";
 describe("IOSCtrlProxyBuilder", function() {
   let originalProjectRoot: string | undefined;
   let originalDerivedDataPath: string | undefined;
-  let originalSkipBuild: string | undefined;
+  let originalSkipDownload: string | undefined;
   let originalCacheDir: string | undefined;
   let originalIpaPath: string | undefined;
   let originalBundlePath: string | undefined;
@@ -21,7 +21,7 @@ describe("IOSCtrlProxyBuilder", function() {
     // Save original environment
     originalProjectRoot = process.env.AUTOMOBILE_PROJECT_ROOT;
     originalDerivedDataPath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA;
-    originalSkipBuild = process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD;
+    originalSkipDownload = process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD;
     originalCacheDir = process.env.AUTOMOBILE_CTRL_PROXY_IOS_CACHE_DIR;
     originalIpaPath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH;
     originalBundlePath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
@@ -48,10 +48,10 @@ describe("IOSCtrlProxyBuilder", function() {
       process.env.AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA = originalDerivedDataPath;
     }
 
-    if (originalSkipBuild === undefined) {
-      delete process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD;
+    if (originalSkipDownload === undefined) {
+      delete process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD;
     } else {
-      process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD = originalSkipBuild;
+      process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD = originalSkipDownload;
     }
 
     if (originalCacheDir === undefined) {
@@ -182,8 +182,8 @@ describe("IOSCtrlProxyBuilder", function() {
   });
 
   describe("needsRebuild", function() {
-    test("should return false when AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD is true", async function() {
-      process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD = "true";
+    test("should return false when AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD is true", async function() {
+      process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD = "true";
 
       // Reset instances to pick up new env
       IOSCtrlProxyBuilder.resetInstances();
@@ -194,8 +194,8 @@ describe("IOSCtrlProxyBuilder", function() {
       expect(result).toBe(false);
     });
 
-    test("should return false when AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD is 1", async function() {
-      process.env.AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD = "1";
+    test("should return false when AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD is 1", async function() {
+      process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD = "1";
 
       // Reset instances to pick up new env
       IOSCtrlProxyBuilder.resetInstances();

--- a/test/utils/ctrlProxyDownloadControl.test.ts
+++ b/test/utils/ctrlProxyDownloadControl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { parseDaemonArgs } from "../../src/daemon/manager";
+import { shouldSkipCtrlProxyDownload } from "../../src/utils/ctrlProxyDownloadControl";
+
+describe("ctrlProxyDownloadControl", function() {
+  test("uses the CtrlProxy skip flag for both platforms", function() {
+    expect(shouldSkipCtrlProxyDownload(["--skip-ctrl-proxy-download"], {})).toBe(true);
+  });
+
+  test("keeps the legacy accessibility flag as a CLI alias", function() {
+    expect(shouldSkipCtrlProxyDownload(["--skip-accessibility-download"], {})).toBe(true);
+  });
+
+  test("uses AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD as the shared env var", function() {
+    expect(shouldSkipCtrlProxyDownload([], { AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: "1" })).toBe(true);
+    expect(shouldSkipCtrlProxyDownload([], { AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: "true" })).toBe(true);
+    expect(shouldSkipCtrlProxyDownload([], { AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: "false" })).toBe(false);
+  });
+
+  test("daemon arg parsing honors the shared env var", function() {
+    const options = parseDaemonArgs([], { AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: "true" });
+
+    expect(options.skipCtrlProxyDownload).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add one shared CtrlProxy download skip control: `--skip-ctrl-proxy-download` or `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=1|true`.
- Apply the shared control to Android APK startup prefetch, iOS bundle startup prefetch, daemon arg parsing, and iOS builder download guards.
- Update docs, local hot-reload usage, and focused tests for the new shared env var.

## Why

Android and iOS previously used different controls for the same behavior. Android startup prefetch honored `--skip-ctrl-proxy-download`, while iOS builder paths used `AUTOMOBILE_SKIP_CTRL_PROXY_IOS_BUILD`. This made daemon startup behavior inconsistent across platforms.

## Testing

- `bun test test/utils/ctrlProxyDownloadControl.test.ts test/utils/IOSCtrlProxyBuilder.test.ts`
- `bun run build`
- `shellcheck scripts/local-dev/hot-reload.sh`
- `bun run lint`
- `git diff --check`
- `bun test --bail`
