### PR TITLE
Recover incomplete bunx extraction once

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,10 +1,15 @@
 import { spawn as nodeSpawn, execSync, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { open, readFile, unlink } from "node:fs/promises";
+import { open, readFile, rm, unlink } from "node:fs/promises";
 import { existsSync, openSync, closeSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
+import { tmpdir } from "node:os";
 import { logger } from "../utils/logger";
 import { releaseVersion } from "../utils/mcpVersion";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
+import {
+  INCOMPLETE_EXTRACTION_CODE,
+  INCOMPLETE_EXTRACTION_EXIT_CODE,
+} from "../db/migrationDependencyIntegrity";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
 import { ActionableError } from "../models";
@@ -152,6 +157,49 @@ const nodeDaemonProcessSpawner: DaemonProcessSpawner = {
   spawn: nodeSpawn,
 };
 
+export interface ExtractionCleaner {
+  removeExtractionForEntryScript(entryScript: string): Promise<boolean>;
+}
+
+function resolveExtractionRootForEntryScript(entryScript: string): string | null {
+  const resolved = resolve(entryScript);
+  const parts = resolved.split(sep);
+  const nodeModulesIndex = parts.lastIndexOf("node_modules");
+  if (nodeModulesIndex <= 0) {
+    return null;
+  }
+
+  const packagePath = parts.slice(nodeModulesIndex + 1, nodeModulesIndex + 3).join("/");
+  if (packagePath !== "@kaeawc/auto-mobile") {
+    return null;
+  }
+
+  const root = parts.slice(0, nodeModulesIndex).join(sep) || sep;
+  if (root === sep) {
+    return null;
+  }
+
+  const tempRoot = resolve(tmpdir());
+  if (!root.startsWith(tempRoot + sep)) {
+    return null;
+  }
+  return root;
+}
+
+const fileSystemExtractionCleaner: ExtractionCleaner = {
+  async removeExtractionForEntryScript(entryScript: string): Promise<boolean> {
+    const extractionRoot = resolveExtractionRootForEntryScript(entryScript);
+    if (!extractionRoot) {
+      return false;
+    }
+
+    await rm(extractionRoot, { recursive: true, force: true });
+    return true;
+  },
+};
+
+type DaemonLaunchCommandResolver = () => DaemonLaunchCommand;
+
 function hasProcessLivenessChecker(value: unknown): value is DaemonProcessLivenessChecker {
   return typeof (value as Partial<DaemonProcessLivenessChecker> | undefined)?.isProcessRunning === "function";
 }
@@ -227,6 +275,8 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly processFinder: DaemonProcessFinder;
   private readonly processSpawner: DaemonProcessSpawner;
   private readonly processLivenessChecker: DaemonProcessLivenessChecker;
+  private readonly extractionCleaner: ExtractionCleaner;
+  private readonly launchCommandResolver: DaemonLaunchCommandResolver;
 
   constructor(
     clientFactory: DaemonClientFactory | undefined = undefined,
@@ -236,7 +286,9 @@ export class DaemonManager implements DaemonManagerLike {
     pidFilePath: string = PID_FILE_PATH,
     socketPath: string = SOCKET_PATH,
     processFinderOrSpawner: DaemonProcessFinder | DaemonProcessSpawner = new PsDaemonProcessFinder(),
-    processSpawner: DaemonProcessSpawner = nodeDaemonProcessSpawner
+    processSpawner: DaemonProcessSpawner = nodeDaemonProcessSpawner,
+    extractionCleaner: ExtractionCleaner = fileSystemExtractionCleaner,
+    launchCommandResolver: DaemonLaunchCommandResolver = () => resolveDaemonLaunchCommand()
   ) {
     this.stateProvider = stateProvider;
     this.timer = timer;
@@ -255,6 +307,8 @@ export class DaemonManager implements DaemonManagerLike {
       this.processSpawner = processFinderOrSpawner;
       this.processLivenessChecker = processFinder;
     }
+    this.extractionCleaner = extractionCleaner;
+    this.launchCommandResolver = launchCommandResolver;
     this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath));
   }
 
@@ -452,7 +506,90 @@ export class DaemonManager implements DaemonManagerLike {
     // Resolve the current binary so the daemon uses the same version.
     // process.argv[1] is the entry script (e.g. dist/src/index.js).
     // Falls back to bunx to avoid requiring a global install.
-    const { command: autoMobileCmd, args } = resolveDaemonLaunchCommand();
+    let { command: autoMobileCmd, args } = this.withDaemonOptions(this.launchCommandResolver(), options);
+
+    // Redirect the detached daemon's stdout/stderr into the STABLE logs dir
+    // (`~/.auto-mobile/logs` by default) rather than an ephemeral
+    // `mkdtemp(tmpdir())` directory. Under bunx the temp tree is reaped while the
+    // daemon keeps this fd open, which previously left the on-disk log unlinked
+    // and post-hoc debugging impossible (issue #2724). The logs dir is created
+    // owner-only (0o700) by ensureSecureTempDirSync, so a fixed, predictable
+    // filename inside it is not exposed to other users.
+    const logsDir = ensureSecureTempDirSync(TEMP_SUBDIRS.LOGS);
+    const logPath = join(logsDir, `daemon-launch-${process.pid}.log`);
+    // Open with restricted permissions (0o600 = owner read/write only).
+    // Truncate per launch so a single manager's bootstrap captures don't grow
+    // unbounded across restarts.
+    const logFd = openSync(logPath, "w", 0o600);
+
+    // Propagate any non-default file paths to the child so its constants module
+    // resolves to the same locations this manager polls.
+    const childEnv = { ...process.env };
+    childEnv[DAEMON_LAUNCH_CWD_ENV] = resolveDaemonLaunchWorkingDirectory();
+    if (this.pidFilePath !== PID_FILE_PATH) {
+      childEnv.AUTOMOBILE_DAEMON_PID_FILE_PATH = this.pidFilePath;
+    }
+    if (this.lockFilePath !== LOCK_FILE_PATH) {
+      childEnv.AUTOMOBILE_DAEMON_LOCK_FILE_PATH = this.lockFilePath;
+    }
+    if (this.socketPath !== SOCKET_PATH) {
+      childEnv.AUTOMOBILE_DAEMON_SOCKET_PATH = this.socketPath;
+    }
+
+    try {
+      let retriedIncompleteExtraction = false;
+      while (true) {
+        const daemonProcess = this.processSpawner.spawn(autoMobileCmd, args, {
+          detached: true,
+          cwd: resolveStableDaemonWorkingDirectory(),
+          stdio: ["ignore", logFd, logFd], // Write stdout/stderr to log file
+          shell: true, // Use shell to resolve command from PATH
+          env: childEnv,
+        });
+
+        // Unref so parent process can exit
+        daemonProcess.unref();
+
+        try {
+          await this.waitForDaemonStartup(daemonProcess, logPath, DAEMON_STARTUP_TIMEOUT_MS);
+          break;
+        } catch (error) {
+          if (!this.isIncompleteExtractionStartupError(error) || retriedIncompleteExtraction) {
+            throw error;
+          }
+
+          retriedIncompleteExtraction = true;
+          const entryScript = args[0];
+          let removed = false;
+          try {
+            removed = entryScript ? await this.extractionCleaner.removeExtractionForEntryScript(entryScript) : false;
+          } catch (cleanupError) {
+            throw new ActionableError(
+              `${this.describeError(error)}\nFailed to remove incomplete extraction before retry: ${this.describeError(cleanupError)}`
+            );
+          }
+          if (!removed) {
+            throw error;
+          }
+          ({ command: autoMobileCmd, args } = this.withDaemonOptions(resolveDaemonLaunchCommand(undefined), options));
+          stderrLog(`Detected incomplete daemon package extraction (${INCOMPLETE_EXTRACTION_CODE}); removed it and retrying once...`);
+        }
+      }
+    } finally {
+      // Close our reference to the log file (daemon process still has it open)
+      closeSync(logFd);
+    }
+
+    const newStatus = await this.status();
+    stderrLog(
+      `Daemon started successfully (PID ${newStatus.pid}, port ${newStatus.port})`
+    );
+    stderrLog(`Socket: ${newStatus.socketPath}`);
+    stderrLog(`Logs: ${logPath}`);
+  }
+
+  private withDaemonOptions(launch: DaemonLaunchCommand, options: DaemonOptions): DaemonLaunchCommand {
+    const args = [...launch.args];
     if (options.port) {
       args.push("--port", options.port.toString());
     }
@@ -537,57 +674,7 @@ export class DaemonManager implements DaemonManagerLike {
     // Output-reduction flags (issue #2756): serialized off the shared specs so
     // they can't drift from the daemon-side parse in parseDaemonArgs.
     args.push(...outputReductionFlagsToArgs(options));
-
-    // Redirect the detached daemon's stdout/stderr into the STABLE logs dir
-    // (`~/.auto-mobile/logs` by default) rather than an ephemeral
-    // `mkdtemp(tmpdir())` directory. Under bunx the temp tree is reaped while the
-    // daemon keeps this fd open, which previously left the on-disk log unlinked
-    // and post-hoc debugging impossible (issue #2724). The logs dir is created
-    // owner-only (0o700) by ensureSecureTempDirSync, so a fixed, predictable
-    // filename inside it is not exposed to other users.
-    const logsDir = ensureSecureTempDirSync(TEMP_SUBDIRS.LOGS);
-    const logPath = join(logsDir, `daemon-launch-${process.pid}.log`);
-    // Open with restricted permissions (0o600 = owner read/write only).
-    // Truncate per launch so a single manager's bootstrap captures don't grow
-    // unbounded across restarts.
-    const logFd = openSync(logPath, "w", 0o600);
-
-    // Propagate any non-default file paths to the child so its constants module
-    // resolves to the same locations this manager polls.
-    const childEnv = { ...process.env };
-    childEnv[DAEMON_LAUNCH_CWD_ENV] = resolveDaemonLaunchWorkingDirectory();
-    if (this.pidFilePath !== PID_FILE_PATH) {
-      childEnv.AUTOMOBILE_DAEMON_PID_FILE_PATH = this.pidFilePath;
-    }
-    if (this.lockFilePath !== LOCK_FILE_PATH) {
-      childEnv.AUTOMOBILE_DAEMON_LOCK_FILE_PATH = this.lockFilePath;
-    }
-    if (this.socketPath !== SOCKET_PATH) {
-      childEnv.AUTOMOBILE_DAEMON_SOCKET_PATH = this.socketPath;
-    }
-
-    const daemonProcess = this.processSpawner.spawn(autoMobileCmd, args, {
-      detached: true,
-      cwd: resolveStableDaemonWorkingDirectory(),
-      stdio: ["ignore", logFd, logFd], // Write stdout/stderr to log file
-      shell: true, // Use shell to resolve command from PATH
-      env: childEnv,
-    });
-
-    // Close our reference to the log file (daemon process still has it open)
-    closeSync(logFd);
-
-    // Unref so parent process can exit
-    daemonProcess.unref();
-
-    await this.waitForDaemonStartup(daemonProcess, logPath, DAEMON_STARTUP_TIMEOUT_MS);
-
-    const newStatus = await this.status();
-    stderrLog(
-      `Daemon started successfully (PID ${newStatus.pid}, port ${newStatus.port})`
-    );
-    stderrLog(`Socket: ${newStatus.socketPath}`);
-    stderrLog(`Logs: ${logPath}`);
+    return { command: launch.command, args };
   }
 
   private async waitForDaemonStartup(
@@ -602,7 +689,11 @@ export class DaemonManager implements DaemonManagerLike {
       const rejectWithContext = (summary: string) => {
         void this.formatDaemonStartupFailure(summary, logPath).then(
           message => {
-            reject(new ActionableError(message));
+            const error = new ActionableError(message);
+            if (this.isIncompleteExtractionStartupSummary(summary)) {
+              (error as { code?: string }).code = INCOMPLETE_EXTRACTION_CODE;
+            }
+            reject(error);
             readinessAbort.abort();
           },
           () => {
@@ -618,6 +709,10 @@ export class DaemonManager implements DaemonManagerLike {
       const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
         const exitCode = code === null ? "unknown" : code.toString();
         const signalDetail = signal ? `, signal ${signal}` : "";
+        if (code === INCOMPLETE_EXTRACTION_EXIT_CODE) {
+          rejectWithContext(this.formatIncompleteExtractionStartupSummary(exitCode, signalDetail));
+          return;
+        }
         rejectWithContext(`Daemon subprocess exited before becoming ready (exit code ${exitCode}${signalDetail})`);
       };
 
@@ -646,6 +741,27 @@ export class DaemonManager implements DaemonManagerLike {
       readinessAbort.abort();
       cleanupProcessListeners();
     }
+  }
+
+  private formatIncompleteExtractionStartupSummary(exitCode: string, signalDetail: string): string {
+    return (
+      `Daemon subprocess exited before becoming ready (exit code ${exitCode}${signalDetail}): ` +
+      `database startup migrations reported an incomplete package extraction (${INCOMPLETE_EXTRACTION_CODE}). ` +
+      "remove the incomplete extraction directory and re-run; a fresh extraction from the healthy shared cache should start normally."
+    );
+  }
+
+  private isIncompleteExtractionStartupSummary(summary: string): boolean {
+    return summary.includes(`exit code ${INCOMPLETE_EXTRACTION_EXIT_CODE}`) &&
+      summary.includes("incomplete package extraction");
+  }
+
+  private isIncompleteExtractionStartupError(error: unknown): boolean {
+    return (error as { code?: unknown } | null | undefined)?.code === INCOMPLETE_EXTRACTION_CODE;
+  }
+
+  private describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 
   private formatRawSpawnError(error: Error): string {

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
@@ -19,6 +20,7 @@ import type {
   DaemonProcessLivenessChecker,
   DaemonProcessSpawner,
   DaemonProcessRecord,
+  ExtractionCleaner,
 } from "../../src/daemon/manager";
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
 import type { DaemonClientLike } from "../../src/daemon/client";
@@ -116,6 +118,28 @@ class FakeDaemonProcessFinder implements DaemonProcessFinder, DaemonProcessLiven
 
   isProcessRunning(pid: number): boolean {
     return this.livePids.has(pid);
+  }
+}
+
+class FakeDaemonChildProcess extends EventEmitter {
+  unref(): void {}
+
+  exit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.emit("exit", code, signal);
+  }
+}
+
+function neverReadyAfterExit(child: FakeDaemonChildProcess, code: number): Promise<boolean> {
+  child.exit(code);
+  return new Promise(() => {});
+}
+
+class FakeExtractionCleaner implements ExtractionCleaner {
+  readonly entryScripts: string[] = [];
+
+  async removeExtractionForEntryScript(entryScript: string): Promise<boolean> {
+    this.entryScripts.push(entryScript);
+    return true;
   }
 }
 
@@ -572,6 +596,309 @@ describe("Daemon manager process detection", () => {
       expect(killCalls).toEqual([]);
     } finally {
       killSpy.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("surfaces incomplete-extraction remediation when daemon exits with exit code 75", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-incomplete-extraction-message-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const entryScript = join(
+      dir,
+      "bunx-extract",
+      "node_modules",
+      "@kaeawc",
+      "auto-mobile",
+      "dist",
+      "src",
+      "index.js"
+    );
+    const child = new FakeDaemonChildProcess();
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => child as ChildProcess,
+    };
+    const cleaner = new FakeExtractionCleaner();
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+
+      override async waitForReady(_timeout: number, signal?: AbortSignal): Promise<boolean> {
+        await Promise.resolve();
+        if (!signal?.aborted) {
+          return neverReadyAfterExit(child, 75);
+        }
+        return false;
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        new FakeDaemonProcessFinder([]),
+        processSpawner,
+        cleaner,
+        () => ({ command: process.execPath, args: [entryScript, "--daemon-mode"] })
+      );
+
+      await expect(manager.start()).rejects.toThrow("remove the incomplete extraction directory and re-run");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("removes an incomplete extraction and retries once after exit code 75", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-incomplete-extraction-retry-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const entryScript = join(
+      dir,
+      "bunx-extract",
+      "node_modules",
+      "@kaeawc",
+      "auto-mobile",
+      "dist",
+      "src",
+      "index.js"
+    );
+    const children: FakeDaemonChildProcess[] = [];
+    const spawnCalls: Array<{ command: string; args: string[] }> = [];
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (command: string, args: string[]) => {
+        const child = new FakeDaemonChildProcess();
+        children.push(child);
+        spawnCalls.push({ command, args: [...args] });
+        return child as ChildProcess;
+      },
+    };
+    const cleaner = new FakeExtractionCleaner();
+    let waitCalls = 0;
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+
+      override async waitForReady(_timeout: number, signal?: AbortSignal): Promise<boolean> {
+        waitCalls++;
+        await Promise.resolve();
+        if (waitCalls === 1 && !signal?.aborted) {
+          return neverReadyAfterExit(children[0], 75);
+        }
+        return true;
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        new FakeDaemonProcessFinder([]),
+        processSpawner,
+        cleaner,
+        () => ({ command: process.execPath, args: [entryScript, "--daemon-mode"] })
+      );
+
+      await manager.start({ port: 1234 });
+
+      expect(children).toHaveLength(2);
+      expect(spawnCalls[0].args).toContain(entryScript);
+      expect(spawnCalls[0].args).toContain("--port");
+      expect(spawnCalls[1].args).not.toContain(entryScript);
+      expect(spawnCalls[1].args).toContain("--port");
+      expect(cleaner.entryScripts).toEqual([entryScript]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("default extraction cleaner removes only the temporary extraction root", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-default-extraction-cleaner-test-"));
+    const dataDir = join(dir, "data");
+    process.env.AUTOMOBILE_DATA_DIR = dataDir;
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const extractionRoot = join(dir, "bunx-extract");
+    const packageDir = join(
+      extractionRoot,
+      "node_modules",
+      "@kaeawc",
+      "auto-mobile",
+      "dist",
+      "src"
+    );
+    mkdirSync(packageDir, { recursive: true });
+    const entryScript = join(packageDir, "index.js");
+    writeFileSync(entryScript, "");
+    const children: FakeDaemonChildProcess[] = [];
+    const spawnCalls: Array<{ command: string; args: string[] }> = [];
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (command: string, args: string[]) => {
+        const child = new FakeDaemonChildProcess();
+        children.push(child);
+        spawnCalls.push({ command, args: [...args] });
+        return child as ChildProcess;
+      },
+    };
+    let waitCalls = 0;
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+
+      override async waitForReady(_timeout: number, signal?: AbortSignal): Promise<boolean> {
+        waitCalls++;
+        await Promise.resolve();
+        if (waitCalls === 1 && !signal?.aborted) {
+          return neverReadyAfterExit(children[0], 75);
+        }
+        return true;
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        join(dataDir, "daemon.lock"),
+        join(dataDir, "daemon.pid"),
+        join(dataDir, "daemon.sock"),
+        new FakeDaemonProcessFinder([]),
+        processSpawner,
+        undefined,
+        () => ({ command: process.execPath, args: [entryScript, "--daemon-mode"] })
+      );
+
+      await manager.start();
+
+      expect(children).toHaveLength(2);
+      expect(spawnCalls[0].args).toContain(entryScript);
+      expect(spawnCalls[1].args).not.toContain(entryScript);
+      expect(existsSync(extractionRoot)).toBe(false);
+      expect(existsSync(dataDir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("gives up with remediation when the retry exits with exit code 75 again", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-incomplete-extraction-give-up-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const entryScript = join(
+      dir,
+      "bunx-extract",
+      "node_modules",
+      "@kaeawc",
+      "auto-mobile",
+      "dist",
+      "src",
+      "index.js"
+    );
+    const children: FakeDaemonChildProcess[] = [];
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => {
+        const child = new FakeDaemonChildProcess();
+        children.push(child);
+        return child as ChildProcess;
+      },
+    };
+    const cleaner = new FakeExtractionCleaner();
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+
+      override async waitForReady(_timeout: number, signal?: AbortSignal): Promise<boolean> {
+        await Promise.resolve();
+        if (!signal?.aborted) {
+          return neverReadyAfterExit(children[children.length - 1], 75);
+        }
+        return false;
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        new FakeDaemonProcessFinder([]),
+        processSpawner,
+        cleaner,
+        () => ({ command: process.execPath, args: [entryScript, "--daemon-mode"] })
+      );
+
+      await expect(manager.start()).rejects.toThrow("remove the incomplete extraction directory and re-run");
+      expect(children).toHaveLength(2);
+      expect(cleaner.entryScripts).toEqual([entryScript]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not remove or retry for non-incomplete-extraction daemon exits", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-generic-exit-test-"));
+    process.env.AUTOMOBILE_DATA_DIR = dir;
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const child = new FakeDaemonChildProcess();
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: () => child as ChildProcess,
+    };
+    const cleaner = new FakeExtractionCleaner();
+
+    class TestDaemonManager extends DaemonManager {
+      override async status(): Promise<any> {
+        return { running: false };
+      }
+
+      override async waitForReady(_timeout: number, signal?: AbortSignal): Promise<boolean> {
+        await Promise.resolve();
+        if (!signal?.aborted) {
+          return neverReadyAfterExit(child, 1);
+        }
+        return false;
+      }
+    }
+
+    try {
+      const manager = new TestDaemonManager(
+        undefined,
+        undefined,
+        fakeTimer,
+        join(dir, "daemon.lock"),
+        join(dir, "daemon.pid"),
+        join(dir, "daemon.sock"),
+        new FakeDaemonProcessFinder([]),
+        processSpawner,
+        cleaner,
+        () => ({ command: process.execPath, args: [join(dir, "entry.js"), "--daemon-mode"] })
+      );
+
+      await expect(manager.start()).rejects.toThrow("Daemon subprocess exited before becoming ready (exit code 1)");
+      expect(cleaner.entryScripts).toEqual([]);
+    } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

Teach `DaemonManager` to consume the daemon's incomplete-extraction exit signal (`EX_TEMPFAIL` / 75): it now surfaces the remediation to the client, removes a safe temporary `bunx` extraction root, and retries once through a fresh package-runner launch instead of reusing the deleted entry script. A repeat exit 75 gives up with the same actionable remediation.

## Linked Issue

Closes #2865

## Bug / Regression Context

- **Prior attempts:** #2851 classified incomplete migration dependency resolution and emitted exit code 75, but no manager-level recovery consumed it.
- **Observed symptom:** the manager reported a generic `Daemon subprocess exited before becoming ready (exit code 75)` and kept respawning from the same poisoned extraction.
- **Repro steps / conditions:** a `bunx` extraction has a half-linked `node_modules` tree where migration runtime dependencies such as `kysely` are present in cache but not linked into the extraction.

## Validation

- [x] `bun test test/daemon/manager.test.ts`
- [x] `bun run typecheck` reports no new errors (baseline gate; existing swap-guard warning remains in `AndroidCtrlProxyClient.ts`)
- [x] `bun run turbo:validate` (`turbo run lint build test`) passes
- [x] New code uses interfaces + fakes + FakeTimer; focused unit tests avoid real daemon processes
- [ ] Rebased onto latest `main`, conflicts resolved (`git fetch origin main` hung locally; branch was created from current `origin/main` before changes)

## Device Verification

N/A - daemon startup manager behavior only; no on-device behavior changed.

## Follow-ups

- [x] No follow-up issues filed; the issue acceptance criteria are covered in this PR.
