### PR TITLE
fix(daemon): add Windows process detection

### DIFF
--- a/src/daemon/directModeGuard.ts
+++ b/src/daemon/directModeGuard.ts
@@ -48,8 +48,6 @@ export interface DefaultDirectModeGuardDepsOptions {
   manager?: LiveDaemonProcessSource;
   readPidFileData?: (pidFilePath?: string) => PidFileData | null;
   resolveDbPath?: () => string;
-  /** Host platform; injected so tests can exercise the Windows `ps`-absent path. */
-  platform?: NodeJS.Platform;
 }
 
 /**
@@ -162,7 +160,6 @@ export function createDefaultDirectModeGuardDeps(
   const manager = options.manager ?? new DaemonManager();
   const readPidFileData = options.readPidFileData ?? readPidFileDataSync;
   const resolveDbPath = options.resolveDbPath ?? getDatabasePath;
-  const platform = options.platform ?? process.platform;
 
   return {
     resolveDbPath,
@@ -172,21 +169,13 @@ export function createDefaultDirectModeGuardDeps(
         livePids = manager.findLiveDaemonProcesses();
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
-        if (platform === "win32") {
-          // `ps` is unavailable on Windows, where the daemon manager's own scan
-          // also fails — so direct mode is effectively the only path and a scan
-          // failure is expected, not an anomaly. There is no ps-discoverable
-          // daemon to collide with; fail OPEN so direct mode still starts. #2795
-          logger.warn(
-            `Direct-mode guard: process-table scan unavailable on this platform; ` +
-              `proceeding without a same-DB conflict check. ${detail}`,
-            error
-          );
-          return [];
-        }
-        // On a platform where `ps` should work, an indeterminate scan means we
-        // cannot rule out a live daemon on this DB file. Fail CLOSED — refuse
-        // rather than risk a second writer. #2795
+        logger.warn(
+          `Direct-mode guard: process-table scan failed; refusing direct mode ` +
+            `because same-DB daemon ownership cannot be verified. ${detail}`,
+          error
+        );
+        // An indeterminate scan means we cannot rule out a live daemon on this DB
+        // file. Fail CLOSED — refuse rather than risk a second writer. #2795
         throw new ActionableError(
           `Cannot verify daemon ownership before starting direct mode ` +
             `(--no-proxy/--direct): failed to inspect the process table (${detail}). ` +

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -97,14 +97,33 @@ type ProcessTableCommandRunner = (
   options: { encoding: "utf-8"; maxBuffer: number }
 ) => string;
 
+function normalizeProcessCommand(command: string): string {
+  return command.replace(/\\/g, "/").replace(/\/+/g, "/");
+}
+
 function isAutoMobileDaemonCommand(command: string): boolean {
-  return command.includes("--daemon-mode") &&
-    (command.includes("auto-mobile") || command.includes("dist/src/index.js"));
+  const normalizedCommand = normalizeProcessCommand(command);
+  return normalizedCommand.includes("--daemon-mode") &&
+    (normalizedCommand.includes("auto-mobile") || normalizedCommand.includes("dist/src/index.js"));
 }
 
 function isShellCommandWrapper(command: string): boolean {
-  const executable = command.trim().split(/\s+/, 1)[0] ?? "";
-  return /(^|\/)(?:ba|da|z)?sh$/.test(executable) && command.includes(" -c ");
+  const normalizedCommand = normalizeProcessCommand(command);
+  const trimmedCommand = normalizedCommand.trim();
+  const executable = trimmedCommand.startsWith("\"")
+    ? trimmedCommand.slice(1, trimmedCommand.indexOf("\"", 1))
+    : trimmedCommand.split(/\s+/, 1)[0] ?? "";
+
+  if (/(^|\/)(?:ba|da|z)?sh$/.test(executable) && normalizedCommand.includes(" -c ")) {
+    return true;
+  }
+
+  if (/(^|\/)cmd(?:\.exe)?$/i.test(executable) && /(?:^|\s)\/c(?:\s|$)/i.test(normalizedCommand)) {
+    return true;
+  }
+
+  return /(^|\/)(?:powershell|pwsh)(?:\.exe)?$/i.test(executable) &&
+    /(?:^|\s)-(?:command|encodedcommand|c|ec)(?:\s|$)/i.test(normalizedCommand);
 }
 
 export function parseDaemonProcessTable(psOutput: string): DaemonProcessRecord[] {
@@ -130,6 +149,57 @@ export function parseDaemonProcessTable(psOutput: string): DaemonProcessRecord[]
   return records;
 }
 
+interface WindowsProcessTableEntry {
+  ProcessId?: unknown;
+  ParentProcessId?: unknown;
+  CommandLine?: unknown;
+}
+
+function parseWindowsProcessId(value: unknown): number | undefined {
+  if (typeof value !== "number" && typeof value !== "string") {
+    return undefined;
+  }
+
+  const parsed = typeof value === "number" ? value : parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseWindowsProcessTableEntry(entry: WindowsProcessTableEntry): DaemonProcessRecord | undefined {
+  const pid = parseWindowsProcessId(entry.ProcessId);
+  const ppid = parseWindowsProcessId(entry.ParentProcessId);
+  const command = entry.CommandLine;
+
+  if (
+    pid === undefined ||
+    ppid === undefined ||
+    typeof command !== "string" ||
+    !isAutoMobileDaemonCommand(command)
+  ) {
+    return undefined;
+  }
+
+  return { pid, ppid, command };
+}
+
+export function parseWindowsDaemonProcessTable(processTableJson: string): DaemonProcessRecord[] {
+  const parsed: unknown = JSON.parse(processTableJson);
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+  const records: DaemonProcessRecord[] = [];
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const record = parseWindowsProcessTableEntry(entry);
+    if (record) {
+      records.push(record);
+    }
+  }
+
+  return records;
+}
+
 export interface DaemonProcessLivenessChecker {
   isProcessRunning(pid: number): boolean;
 }
@@ -148,6 +218,31 @@ export class PsDaemonProcessFinder implements DaemonProcessFinder, DaemonProcess
   isProcessRunning(pid: number): boolean {
     return isDaemonProcessRunning(pid);
   }
+}
+
+export class WindowsDaemonProcessFinder implements DaemonProcessFinder, DaemonProcessLivenessChecker {
+  constructor(private readonly runCommand: ProcessTableCommandRunner = execSync) {}
+
+  findDaemonProcesses(): DaemonProcessRecord[] {
+    const processTableJson = this.runCommand(
+      "powershell.exe -NoProfile -NonInteractive -Command \"Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress\"",
+      {
+        encoding: "utf-8",
+        maxBuffer: DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
+      }
+    );
+    return parseWindowsDaemonProcessTable(processTableJson);
+  }
+
+  isProcessRunning(pid: number): boolean {
+    return isDaemonProcessRunning(pid);
+  }
+}
+
+export function createDefaultDaemonProcessFinder(
+  platform: NodeJS.Platform = process.platform
+): DaemonProcessFinder & DaemonProcessLivenessChecker {
+  return platform === "win32" ? new WindowsDaemonProcessFinder() : new PsDaemonProcessFinder();
 }
 
 export interface DaemonProcessSpawner {
@@ -286,7 +381,7 @@ export class DaemonManager implements DaemonManagerLike {
     lockFilePath: string = LOCK_FILE_PATH,
     pidFilePath: string = PID_FILE_PATH,
     socketPath: string = SOCKET_PATH,
-    processFinderOrSpawner: DaemonProcessFinder | DaemonProcessSpawner = new PsDaemonProcessFinder(),
+    processFinderOrSpawner: DaemonProcessFinder | DaemonProcessSpawner = createDefaultDaemonProcessFinder(),
     processSpawner: DaemonProcessSpawner = nodeDaemonProcessSpawner,
     extractionCleaner: ExtractionCleaner = fileSystemExtractionCleaner,
     launchCommandResolver: DaemonLaunchCommandResolver = () => resolveDaemonLaunchCommand()
@@ -301,9 +396,9 @@ export class DaemonManager implements DaemonManagerLike {
       this.processSpawner = processSpawner;
       this.processLivenessChecker = hasProcessLivenessChecker(processFinderOrSpawner)
         ? processFinderOrSpawner
-        : new PsDaemonProcessFinder();
+        : createDefaultDaemonProcessFinder();
     } else {
-      const processFinder = new PsDaemonProcessFinder();
+      const processFinder = createDefaultDaemonProcessFinder();
       this.processFinder = processFinder;
       this.processSpawner = processFinderOrSpawner;
       this.processLivenessChecker = processFinder;

--- a/test/daemon/directModeGuard.test.ts
+++ b/test/daemon/directModeGuard.test.ts
@@ -215,21 +215,18 @@ describe("createDefaultDirectModeGuardDeps", () => {
     expect(() => assertDirectModeDbOwnership(deps)).toThrow(ActionableError);
   });
 
-  test("on Windows, an unavailable `ps` fails OPEN so direct mode still starts", () => {
-    // `ps` is absent on Windows (the daemon manager's scan also fails there), so a
-    // scan failure is expected, not evidence of a daemon. #2795
+  test("an indeterminate process scan fails CLOSED (refuses)", () => {
     const deps = createDefaultDirectModeGuardDeps({
-      platform: "win32",
       manager: {
         findLiveDaemonProcesses: () => {
-          throw new Error("'ps' is not recognized as a command");
+          throw new Error("powershell.exe: command failed");
         },
       },
       readPidFileData: () => null,
       resolveDbPath: () => DEFAULT_DB,
     });
-    expect(deps.findLiveDaemonDbOwners()).toEqual([]);
-    expect(() => assertDirectModeDbOwnership(deps)).not.toThrow();
+    expect(() => deps.findLiveDaemonDbOwners()).toThrow(ActionableError);
+    expect(() => assertDirectModeDbOwnership(deps)).toThrow(ActionableError);
   });
 
   test("on non-Windows, an indeterminate `ps` scan fails CLOSED (refuses)", () => {

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -6,12 +6,14 @@ import { tmpdir } from "node:os";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import {
   DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
+  createDefaultDaemonProcessFinder,
   daemonBuildIdentityStatusLines,
   DaemonManager,
   parseDaemonProcessTable,
   PsDaemonProcessFinder,
   resolveDaemonLaunchCommand,
-  runDaemonCommand
+  runDaemonCommand,
+  WindowsDaemonProcessFinder,
 } from "../../src/daemon/manager";
 import type { BuildIdentity } from "../../src/daemon/buildIdentity";
 import type { DaemonStatus } from "../../src/daemon/types";
@@ -245,6 +247,81 @@ describe("Daemon manager process detection", () => {
     expect(DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES).toBeGreaterThan(1024 * 1024);
   });
 
+  test("parses daemon processes from Windows PowerShell JSON output", () => {
+    const finder = new WindowsDaemonProcessFinder(() => JSON.stringify([
+      {
+        ProcessId: 10,
+        ParentProcessId: 1,
+        CommandLine: "C:\\\\Windows\\\\System32\\\\cmd.exe /c unrelated --daemon-mode",
+      },
+      {
+        ProcessId: 20,
+        ParentProcessId: 1,
+        CommandLine: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
+      },
+      {
+        ProcessId: 21,
+        ParentProcessId: 20,
+        CommandLine: "C:\\\\Program Files\\\\nodejs\\\\node.exe C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode",
+      },
+      {
+        ProcessId: 22,
+        ParentProcessId: 1,
+        CommandLine: null,
+      },
+    ]));
+
+    expect(finder.findDaemonProcesses()).toEqual([
+      {
+        pid: 20,
+        ppid: 1,
+        command: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
+      },
+      {
+        pid: 21,
+        ppid: 20,
+        command: "C:\\\\Program Files\\\\nodejs\\\\node.exe C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode",
+      },
+    ]);
+  });
+
+  test("uses a Windows-native process table command with the expanded buffer", () => {
+    const calls: Array<{
+      command: string;
+      options: { encoding: "utf-8"; maxBuffer: number };
+    }> = [];
+    const finder = new WindowsDaemonProcessFinder((command, options) => {
+      calls.push({ command, options });
+      return JSON.stringify({
+        ProcessId: 30,
+        ParentProcessId: 1,
+        CommandLine: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
+      });
+    });
+
+    expect(finder.findDaemonProcesses()).toEqual([
+      {
+        pid: 30,
+        ppid: 1,
+        command: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
+      },
+    ]);
+    expect(calls).toEqual([
+      {
+        command: "powershell.exe -NoProfile -NonInteractive -Command \"Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress\"",
+        options: {
+          encoding: "utf-8",
+          maxBuffer: DAEMON_PROCESS_TABLE_MAX_BUFFER_BYTES,
+        },
+      },
+    ]);
+  });
+
+  test("selects Windows process detection by platform", () => {
+    expect(createDefaultDaemonProcessFinder("win32")).toBeInstanceOf(WindowsDaemonProcessFinder);
+    expect(createDefaultDaemonProcessFinder("linux")).toBeInstanceOf(PsDaemonProcessFinder);
+  });
+
   function managerWithProcesses(
     records: DaemonProcessRecord[],
     options: { livePids?: Set<number>; pidFilePath?: string } = {}
@@ -286,6 +363,33 @@ describe("Daemon manager process detection", () => {
     ]);
 
     expect(manager.findAllDaemonProcesses()).toEqual([101]);
+  });
+
+  test("reports Windows shell-launched daemons once using the long-lived child PID", () => {
+    const manager = managerWithProcesses([
+      {
+        pid: 100,
+        ppid: 1,
+        command: `C:\\\\Windows\\\\System32\\\\cmd.exe /d /s /c "${process.execPath} C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode"`,
+      },
+      {
+        pid: 101,
+        ppid: 100,
+        command: `${process.execPath} C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode`,
+      },
+      {
+        pid: 200,
+        ppid: 1,
+        command: `C:\\\\Windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe -NoProfile -Command "${process.execPath} C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode"`,
+      },
+      {
+        pid: 201,
+        ppid: 200,
+        command: `${process.execPath} C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode`,
+      },
+    ]);
+
+    expect(manager.findAllDaemonProcesses()).toEqual([101, 201]);
   });
 
   test("does not report the current daemon's shell wrapper as another daemon", () => {


### PR DESCRIPTION
## Summary

Implements Windows daemon process detection behind the existing `DaemonProcessFinder` interface. `DaemonManager` now selects a PowerShell/CIM-backed finder on `win32`, preserves the POSIX `ps` finder elsewhere, and normalizes Windows path separators when identifying `dist/src/index.js --daemon-mode` commands.

## Linked Issue

Closes #2870

## Bug / Regression Context

- **Prior attempts:** #2795 / PR #2852 added a direct-mode Windows fail-open workaround because daemon process detection used POSIX `ps` unconditionally.
- **Observed symptom:** Windows daemon singleton enforcement and `--daemon status` other-daemon warnings could not inspect daemon processes.
- **Repro steps / conditions:** Run daemon process scanning on Windows where `ps -eo pid=,ppid=,command=` is unavailable.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalent covered by `bunx turbo run lint build test` (`bun run lint` + `bun test`, plus build)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional checks:

- [x] `bun test test/daemon/manager.test.ts test/daemon/directModeGuard.test.ts`
- [x] `git diff --check`

## Device Verification

N/A: daemon process-table detection is host process management logic, covered by fake command runners and manager unit tests.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
