### PR TITLE
ci: describe runner checksum updates in nightly PRs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,7 +63,7 @@ jobs:
           echo "runner_sha256=$RUNNER_CURRENT" >> $GITHUB_OUTPUT
           echo "Current APK SHA256: ${APK_CURRENT:-(empty)}"
           echo "Current IPA SHA256: ${IPA_CURRENT:-(empty)}"
-          echo "Current runner SHA256: ${RUNNER_CURRENT:-(empty)}"
+          echo "Current iOS runner SHA256: ${RUNNER_CURRENT:-(empty)}"
 
       - name: "Check if updates needed"
         id: check
@@ -103,11 +103,11 @@ jobs:
           # wiring) is backfilled even when the IPA is byte-identical.
           if [ "$NEW_RUNNER" != "$OLD_RUNNER" ]; then
             RUNNER_CHANGED="true"
-            echo "Runner SHA256 changed"
+            echo "iOS runner SHA256 changed"
             echo "  Previous: ${OLD_RUNNER:-(empty)}"
             echo "  New:      $NEW_RUNNER"
           else
-            echo "Runner SHA256 unchanged"
+            echo "iOS runner SHA256 unchanged"
           fi
 
           echo "apk_changed=$APK_CHANGED" >> $GITHUB_OUTPUT
@@ -134,13 +134,22 @@ jobs:
         run: |
           APK_CHANGED="${{ steps.check.outputs.apk_changed }}"
           IPA_CHANGED="${{ steps.check.outputs.ipa_changed }}"
+          RUNNER_CHANGED="${{ steps.check.outputs.runner_changed }}"
 
-          if [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256" >> $GITHUB_OUTPUT
+          if [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$APK_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$IPA_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy iOS IPA and iOS runner SHA256" >> "$GITHUB_OUTPUT"
           elif [ "$APK_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy APK SHA256" >> $GITHUB_OUTPUT
+            echo "title=chore: update CtrlProxy APK SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy iOS runner SHA256" >> "$GITHUB_OUTPUT"
           else
-            echo "title=chore: update CtrlProxy iOS IPA SHA256" >> $GITHUB_OUTPUT
+            echo "title=chore: update CtrlProxy iOS IPA SHA256" >> "$GITHUB_OUTPUT"
           fi
 
       - name: "Create PR for SHA256 update"
@@ -154,6 +163,7 @@ jobs:
 
             APK: ${{ steps.current.outputs.apk_sha256 || '(empty)' }} -> ${{ needs.build-control-proxy-apk.outputs.sha256 }}${{ steps.check.outputs.apk_changed == 'true' && ' (changed)' || ' (unchanged)' }}
             IPA: ${{ steps.current.outputs.ipa_sha256 || '(empty)' }} -> ${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}${{ steps.check.outputs.ipa_changed == 'true' && ' (changed)' || ' (unchanged)' }}
+            iOS Runner: ${{ steps.current.outputs.runner_sha256 || '(empty)' }} -> ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}${{ steps.check.outputs.runner_changed == 'true' && ' (changed)' || ' (unchanged)' }}
           title: ${{ steps.pr-title.outputs.title }}
           body: |
             ## Automated Checksum Update
@@ -164,6 +174,7 @@ jobs:
             |----------|----------|-----|---------|
             | **APK** | `${{ steps.current.outputs.apk_sha256 || '(empty)' }}` | `${{ needs.build-control-proxy-apk.outputs.sha256 }}` | ${{ steps.check.outputs.apk_changed == 'true' && '✅ Yes' || 'No' }} |
             | **IPA** | `${{ steps.current.outputs.ipa_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}` | ${{ steps.check.outputs.ipa_changed == 'true' && '✅ Yes' || 'No' }} |
+            | **iOS Runner** | `${{ steps.current.outputs.runner_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}` | ${{ steps.check.outputs.runner_changed == 'true' && '✅ Yes' || 'No' }} |
 
             ### Why did this happen?
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -107,7 +107,12 @@ jobs:
 
             // Check if title matches the automated SHA256 update pattern
             const titleMatches = pr.title === 'chore: update CtrlProxy APK SHA256' ||
-                                 pr.title === 'chore: update CtrlProxy iOS IPA SHA256';
+                                 pr.title === 'chore: update CtrlProxy iOS IPA SHA256' ||
+                                 pr.title === 'chore: update CtrlProxy iOS runner SHA256' ||
+                                 pr.title === 'chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256' ||
+                                 pr.title === 'chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256' ||
+                                 pr.title === 'chore: update CtrlProxy iOS IPA and iOS runner SHA256' ||
+                                 pr.title === 'chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256';
 
             // Get list of changed files
             const { data: files } = await github.rest.pulls.listFiles({

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -19,6 +19,22 @@
   grep -q "runner_sha256" ".github/workflows/nightly.yml"
 }
 
+@test "nightly.yml includes runner sha256 in generated PR metadata" {
+  grep -Fq "RUNNER_CHANGED=\"\${{ steps.check.outputs.runner_changed }}\"" ".github/workflows/nightly.yml"
+  grep -q "chore: update CtrlProxy iOS runner SHA256" ".github/workflows/nightly.yml"
+  grep -q "chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256" ".github/workflows/nightly.yml"
+  grep -q "chore: update CtrlProxy iOS IPA and iOS runner SHA256" ".github/workflows/nightly.yml"
+  grep -q "chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256" ".github/workflows/nightly.yml"
+  grep -Fq "| **iOS Runner** |" ".github/workflows/nightly.yml"
+}
+
+@test "pull_request.yml treats iOS runner checksum PR titles as sha256-only" {
+  grep -q "chore: update CtrlProxy iOS runner SHA256" ".github/workflows/pull_request.yml"
+  grep -q "chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256" ".github/workflows/pull_request.yml"
+  grep -q "chore: update CtrlProxy iOS IPA and iOS runner SHA256" ".github/workflows/pull_request.yml"
+  grep -q "chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256" ".github/workflows/pull_request.yml"
+}
+
 @test "release.yml runs the release-integrity gate" {
   grep -q "verify-release-integrity.sh" ".github/workflows/release.yml"
 }


### PR DESCRIPTION
## Summary

Fixes the nightly checksum update PR metadata for iOS-runner-only SHA256 changes. The nightly workflow now reads `runner_changed` when building the automated PR title, includes iOS-runner-aware title combinations, and adds an iOS Runner row to the generated commit message and PR body. The pull request workflow also recognizes the new automated iOS runner checksum titles as SHA256-only PRs.

## Linked Issue

Closes #2816

## Bug / Regression Context

- **Prior attempts:** #2747 added `runner_changed` detection to the nightly update decision, but the downstream PR title/body generation still only described APK and IPA changes.
- **Observed symptom:** an iOS-runner-only checksum update could create a PR titled as an IPA checksum update while the body table showed APK and IPA as unchanged.
- **Repro steps / conditions:** nightly checksum update where `apk_changed=false`, `ipa_changed=false`, and `runner_changed=true`.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
- [ ] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, workflow-only change
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Focused checks run locally:

- [x] `bats test/bats/release-workflow-wiring.bats`
- [x] `shellcheck --shell=bash test/bats/release-workflow-wiring.bats`
- [x] `yq eval '.' .github/workflows/nightly.yml >/dev/null && yq eval '.' .github/workflows/pull_request.yml >/dev/null`
- [x] `git diff --check`

Known validation note:

- `actionlint .github/workflows/nightly.yml .github/workflows/pull_request.yml` still reports pre-existing workflow issues outside this patch: unquoted `$GITHUB_OUTPUT` redirects in earlier nightly steps and local action metadata parse warnings.

## Device Verification

N/A. This only changes GitHub Actions workflow metadata.

## Follow-ups

- [ ] Follow-up issues filed for gaps not addressed here: N/A
