### PR TITLE
refactor(video): extract child process tracker

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -173,23 +173,10 @@ src/features/utility/ElementParser.ts: error TS2339: Property 'hierarchy' does n
 src/features/utility/ElementParser.ts: error TS2345: Argument of type 'ViewHierarchyWindowInfo[]' is not assignable to parameter of type '{ windowLayer: number; }[]'.
 src/features/utility/ios/IosNotificationAuthorizationReader.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/features/video/FfmpegVideoProcessingBackend.ts: error TS2339: Property 'getBaseCommandParts' does not exist on type 'AdbExecutor'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/FfmpegVideoProcessingBackend.ts: error TS2349: This expression is not callable.
 src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.
 src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.
 src/features/video/PlatformVideoCaptureBackend.ts: error TS2339: Property 'getBaseCommandParts' does not exist on type 'AdbExecutor'.
 src/features/video/PlatformVideoCaptureBackend.ts: error TS2339: Property 'getBaseCommandParts' does not exist on type 'AdbExecutor'.
-src/features/video/PlatformVideoCaptureBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/PlatformVideoCaptureBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/PlatformVideoCaptureBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/PlatformVideoCaptureBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
-src/features/video/PlatformVideoCaptureBackend.ts: error TS2349: This expression is not callable.
 src/index.ts: error TS2322: Type '["debug", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 src/index.ts: error TS2322: Type '["debug-perf", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 src/index.ts: error TS2322: Type '["mcp-recording", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
@@ -278,12 +265,9 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 11 :: src/features/action/swipeon/ScrollUntilVisible.ts: error TS2322: Type 'ViewHierarchyResult | undefined' is not assignable to type 'ViewHierarchyResult | null'.
 # swap-fp: 11 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number | null'.
 # swap-fp: 11 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'string | undefined' is not assignable to type 'string | null'.
-# swap-fp: 11 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2367: This comparison appears to be unintentional because the types '"screenshot" | "hierarchy_update" | "pinch_result" | "tap_coordinates_result" | "swipe_result" | "drag_result" | "set_text_result" | "select_all_result" | "ime_action_result" | ... 36 more ... | "lifecycle_event"' and '"custom_event"' have no overlap.
 # swap-fp: 11 :: src/features/observe/audits/AccessibilityAuditor.ts: error TS2345: Argument of type 'Hierarchy' is not assignable to parameter of type 'ViewHierarchyNode'.
 # swap-fp: 11 :: src/features/record/android/DualTrackRecorder.ts: error TS2322: Type 'AndroidCtrlProxyClient | A11ySource' is not assignable to type 'A11ySource'.
 # swap-fp: 11,11 :: src/daemon/testRecordingSocketServer.ts: error TS2322: Type 'string' is not assignable to type 'Platform | undefined'.
-# swap-fp: 11,33 :: src/features/action/CaptureSnapshot.ts: error TS2304: Cannot find name 'timeoutHandle'.
-# swap-fp: 11,33 :: src/features/action/RestoreSnapshot.ts: error TS2304: Cannot find name 'timeoutHandle'.
 # swap-fp: 11,53,57,65 :: src/features/navigation/Explore.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
 # swap-fp: 12 :: src/utils/image/loadJimp.ts: error TS2307: Cannot find module '@jimp/wasm-webp' or its corresponding type declarations.
 # swap-fp: 12,12 :: src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
@@ -292,7 +276,7 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 13 :: src/db/migrations/2026_01_27_000_failures.ts: error TS2769: No overload matches this call.
 # swap-fp: 13 :: src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2769: No overload matches this call.
 # swap-fp: 13 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type '(Element | null)[]' is not assignable to type 'Element[]'.
-# swap-fp: 13,13,13,13,13,13,13,27 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
+# swap-fp: 13,13,27 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 # swap-fp: 14 :: src/db/failureAnalyticsRepository.ts: error TS2678: Type '"nonfatal"' is not comparable to type '"crash" | "anr" | "tool_failure"'.
 # swap-fp: 14 :: src/features/accessibility/WcagAudit.ts: error TS2352: Conversion of type 'ViewHierarchyNode[]' to type 'ViewHierarchyNode' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 # swap-fp: 14,32 :: src/features/accessibility/WcagAudit.ts: error TS2339: Property 'children' does not exist on type 'ViewHierarchyNode'.
@@ -316,7 +300,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 25 :: src/daemon/client.ts: error TS2345: Argument of type 'string | NonSharedBuffer' is not assignable to parameter of type 'Buffer<ArrayBufferLike>'.
 # swap-fp: 25,27 :: src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 # swap-fp: 26 :: src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not exist on type '{ type: "crash" | "anr" | "tool_failure"; title: string; severity: "critical" | "high" | "medium" | "low"; stack_trace_json: string | null; timestamp: number; occurrenceId: string; groupId: string; deviceId: string | null; screen: string | null; }'.
-# swap-fp: 26 :: src/utils/DeviceSessionManager.ts: error TS2304: Cannot find name 'AdbClient'.
 # swap-fp: 27 :: src/db/migrator.ts: error TS7006: Parameter 'index' implicitly has an 'any' type.
 # swap-fp: 27 :: src/features/navigation/NavigateTo.ts: error TS2339: Property 'shouldUseBack' does not exist on type 'Promise<BackButtonRecommendation>'.
 # swap-fp: 27,45 :: src/db/database.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
@@ -335,10 +318,7 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 30 :: src/server/appResources.ts: error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'readonly ("platform" | "type" | "search" | "deviceId" | "profile")[]'.
 # swap-fp: 30 :: src/server/observeTools.ts: error TS2322: Type 'TimingData' is not assignable to type 'TimingEntry'.
 # swap-fp: 30,32 :: src/db/performanceAuditRepository.ts: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "performance_audit_results", "timestamp">'.
-# swap-fp: 31 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2339: Property 'event' does not exist on type 'never'.
-# swap-fp: 31,31,58,58 :: src/features/video/PlatformVideoCaptureBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
 # swap-fp: 32 :: src/features/accessibility/WcagAudit.ts: error TS2339: Property 'class' does not exist on type 'ViewHierarchyNode'.
-# swap-fp: 32 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2339: Property 'timestamp' does not exist on type 'never'.
 # swap-fp: 32 :: src/features/observe/ios/CtrlProxyGestures.ts: error TS2459: Module '"./types"' declares 'GestureTimingResult' locally, but it is not exported.
 # swap-fp: 32,36,56 :: src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
 # swap-fp: 33 :: src/db/migrator.ts: error TS7006: Parameter 'table' implicitly has an 'any' type.
@@ -385,8 +365,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 48 :: src/db/migrator.ts: error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
 # swap-fp: 5 :: src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type '{ bounds: NormalizedHighlightBounds | undefined; type: "box"; style?: HighlightStyle | null; }' is not assignable to type 'HighlightShape'.
 # swap-fp: 5 :: src/features/observe/ios/CtrlProxyHighlights.ts: error TS2322: Type '{ bounds: { x: number; y: number; width: number; height: number; sourceWidth: number | null | undefined; sourceHeight: number | null | undefined; } | null | undefined; type: "box"; style?: HighlightStyle | null; }' is not assignable to type 'HighlightShape'.
-# swap-fp: 5 :: src/features/video/FfmpegVideoProcessingBackend.ts: error TS2349: This expression is not callable.
-# swap-fp: 5 :: src/features/video/PlatformVideoCaptureBackend.ts: error TS2349: This expression is not callable.
 # swap-fp: 5 :: src/index.ts: error TS2353: Object literal may only specify known properties, and 'networkMockable' does not exist in type '{ cliMode: boolean; cliArgs: string[]; daemonPort: number | undefined; daemonHost: string | undefined; debugPerf: boolean; debug: boolean; uiPerfMode: boolean; memPerfAuditMode: boolean; ... 23 more ...; outputReduction: OutputReductionFlags; }'.
 # swap-fp: 5 :: src/server/bootedDeviceResources.ts: error TS2322: Type '"local" | "remote"' is not assignable to type '"local" | undefined'.
 # swap-fp: 5,21,76 :: src/db/migrator.ts: error TS7006: Parameter 'name' implicitly has an 'any' type.
@@ -426,7 +404,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 7 :: src/index.ts: error TS2339: Property 'networkMockable' does not exist on type '{ cliMode: boolean; cliArgs: string[]; daemonPort: number | undefined; daemonHost: string | undefined; debugPerf: boolean; debug: boolean; uiPerfMode: boolean; memPerfAuditMode: boolean; ... 23 more ...; outputReduction: OutputReductionFlags; }'.
 # swap-fp: 7 :: src/server/deviceTools.ts: error TS2322: Type 'TimingData | null' is not assignable to type 'Record<string, number>'.
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
-# swap-fp: 7,31,31,31,40,41,41 :: src/features/video/FfmpegVideoProcessingBackend.ts: error TS2345: Argument of type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to parameter of type 'ChildProcessWithoutNullStreams'.
 # swap-fp: 7,7 :: src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.
 # swap-fp: 74 :: src/features/utility/ElementParser.ts: error TS2339: Property 'hierarchy' does not exist on type '{ windowLayer: number; }'.
 # swap-fp: 74,75,76,77,77 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn } from "node:child_process";
 import { platform } from "node:os";
 import path from "node:path";
 import { promises as fsPromises } from "node:fs";
@@ -14,6 +14,16 @@ import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbCl
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { logger } from "../../utils/logger";
+import {
+  getFileSize,
+  PROCESS_EXIT_TIMEOUT_MS,
+  trackProcess,
+  waitForExit,
+  waitForSpawn,
+  type ProcessExitState,
+  type ProcessTracker,
+  type StoppableProcess,
+} from "../../utils/ChildProcessTracker";
 import type {
   RecordingHandle,
   RecordingResult,
@@ -21,7 +31,8 @@ import type {
   VideoCaptureConfig,
 } from "./VideoRecorderService";
 
-export const PROCESS_EXIT_TIMEOUT_MS = 5000;
+export { PROCESS_EXIT_TIMEOUT_MS, waitForExit };
+export type { ProcessTracker, StoppableProcess };
 // `xcrun simctl io ... recordVideo` only writes the MP4/MOV moov atom after it
 // receives SIGINT. If we SIGKILL it before the flush finishes the on-disk file is
 // truncated (often 0 bytes), and the downstream ffmpeg `-c copy` remux fails with
@@ -44,19 +55,6 @@ const IOS_RECORDING_START_MESSAGES = [
   "Recording started",
   "Defaulting to display:",
 ];
-
-interface ProcessExitState {
-  exitCode?: number | null;
-  signal?: NodeJS.Signals | null;
-  endedAt?: string;
-}
-
-export interface ProcessTracker {
-  process: ChildProcessWithoutNullStreams;
-  exitState: ProcessExitState;
-  exitPromise: Promise<void>;
-  stderr: string[];
-}
 
 interface HardwareAccelInfo {
   encoder: string;
@@ -86,104 +84,6 @@ interface FfmpegBackendHandle {
   ffmpegTracker?: ProcessTracker;
   capturePath?: string;
   config: VideoCaptureConfig;
-}
-
-function createExitTracker(
-  process: ChildProcessWithoutNullStreams,
-  stderr: string[]
-): { exitState: ProcessExitState; exitPromise: Promise<void> } {
-  const exitState: ProcessExitState = {};
-  let resolvePromise: (() => void) | null = null;
-  let rejectPromise: ((error: Error) => void) | null = null;
-
-  const exitPromise = new Promise<void>((resolve, reject) => {
-    resolvePromise = resolve;
-    rejectPromise = reject;
-  });
-
-  process.once("error", error => {
-    rejectPromise?.(error instanceof Error ? error : new Error(String(error)));
-  });
-
-  process.once("exit", (code, signal) => {
-    exitState.exitCode = code;
-    exitState.signal = signal;
-    exitState.endedAt = new Date().toISOString();
-    resolvePromise?.();
-  });
-
-  process.stderr.on("data", chunk => {
-    stderr.push(chunk.toString());
-  });
-
-  if (process.exitCode !== null) {
-    exitState.exitCode = process.exitCode;
-    exitState.signal = process.signalCode;
-    exitState.endedAt = new Date().toISOString();
-    resolvePromise?.();
-  }
-
-  return { exitState, exitPromise };
-}
-
-function trackProcess(process: ChildProcessWithoutNullStreams): ProcessTracker {
-  const stderr: string[] = [];
-  const { exitState, exitPromise } = createExitTracker(process, stderr);
-  return { process, exitState, exitPromise, stderr };
-}
-
-/**
- * Minimal child-process surface needed to gracefully stop a recording. Narrowed
- * from `ChildProcessWithoutNullStreams` so the SIGINT→SIGKILL escalation can be
- * unit-tested with a fake process instead of a real spawn.
- */
-export interface StoppableProcess {
-  exitCode: number | null;
-  killed: boolean;
-  kill(signal?: NodeJS.Signals | number): boolean;
-}
-
-/**
- * Stop a capture process by sending SIGINT first (which lets `simctl`/`screenrecord`
- * flush and finalize the file), then escalating to SIGKILL only if the process has
- * not exited within `timeoutMs`. Callers that record formats requiring a trailing
- * moov-atom flush (iOS simctl) should pass a generous `timeoutMs`.
- */
-export async function waitForExit(
-  process: StoppableProcess,
-  exitPromise: Promise<void>,
-  timeoutMs: number = PROCESS_EXIT_TIMEOUT_MS,
-  timer: Timer = defaultTimer
-): Promise<void> {
-  if (process.exitCode !== null) {
-    await exitPromise;
-    return;
-  }
-
-  if (process.killed) {
-    await exitPromise;
-    return;
-  }
-
-  process.kill("SIGINT");
-
-  let timeoutId: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<void>(resolve => {
-    timeoutId = timer.setTimeout(() => {
-      if (process.exitCode === null) {
-        process.kill("SIGKILL");
-      }
-      resolve();
-    }, timeoutMs);
-  });
-
-  await Promise.race([exitPromise, timeoutPromise]);
-
-  if (timeoutId) {
-    timer.clearTimeout(timeoutId);
-  }
-
-  await exitPromise;
 }
 
 /**
@@ -269,35 +169,6 @@ export async function waitForRecordingFileReady(
 
     await timer.sleep(backoff.delayForAttempt(attempt));
   }
-}
-
-async function waitForProcessCompletion(
-  process: ChildProcessWithoutNullStreams,
-  exitPromise: Promise<void>,
-  timeoutMs: number
-): Promise<void> {
-  if (process.exitCode !== null || process.killed) {
-    await exitPromise;
-    return;
-  }
-
-  let timeoutId: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<void>(resolve => {
-    timeoutId = defaultTimer.setTimeout(() => {
-      if (process.exitCode === null) {
-        process.kill("SIGKILL");
-      }
-      resolve();
-    }, timeoutMs);
-  });
-
-  await Promise.race([exitPromise, timeoutPromise]);
-
-  if (timeoutId) {
-    clearTimeout(timeoutId);
-  }
-
-  await exitPromise;
 }
 
 function stderrMessages(messages: string | string[]): string[] {
@@ -420,12 +291,12 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       await waitForExit(
         backendHandle.captureTracker.process,
         backendHandle.captureTracker.exitPromise,
-        IOS_RECORDING_STOP_TIMEOUT_MS
+        { timeoutMs: IOS_RECORDING_STOP_TIMEOUT_MS }
       );
       await this.postProcessRecording(backendHandle);
     }
 
-    const sizeBytes = await this.getFileSize(handle.outputPath);
+    const sizeBytes = await getFileSize(handle.outputPath);
     const codec = "h264";
 
     this.logProcessWarnings("capture", backendHandle.captureTracker);
@@ -477,7 +348,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     });
 
     try {
-      await this.waitForSpawn(captureProcess);
+      await waitForSpawn(captureProcess);
       logger.info(`[FfmpegVideo] screenrecord process spawned`);
     } catch (error) {
       logger.error(`[FfmpegVideo] Failed to spawn screenrecord: ${error}`);
@@ -497,7 +368,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     logger.info(`[FfmpegVideo] Piped screenrecord stdout to ffmpeg stdin`);
 
     try {
-      await this.waitForSpawn(ffmpegProcess);
+      await waitForSpawn(ffmpegProcess);
       logger.info(`[FfmpegVideo] ffmpeg process spawned`);
     } catch (error) {
       logger.error(`[FfmpegVideo] Failed to spawn ffmpeg: ${error}`);
@@ -550,7 +421,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     const captureProcess = spawn("xcrun", args, { stdio: ["ignore", "pipe", "pipe"] });
 
     try {
-      await this.waitForSpawn(captureProcess);
+      await waitForSpawn(captureProcess);
     } catch (error) {
       throw new ActionableError(`Failed to start iOS recording: ${error}`);
     }
@@ -644,7 +515,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     });
 
     try {
-      await this.waitForSpawn(ffmpegProcess);
+      await waitForSpawn(ffmpegProcess);
     } catch (error) {
       throw new ActionableError(`Failed to start FFmpeg post-processing: ${error}`);
     }
@@ -652,10 +523,10 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     const ffmpegTracker = trackProcess(ffmpegProcess);
     backendHandle.ffmpegTracker = ffmpegTracker;
 
-    await waitForProcessCompletion(
+    await waitForExit(
       ffmpegProcess,
       ffmpegTracker.exitPromise,
-      FFMPEG_POST_PROCESS_TIMEOUT_MS
+      { timeoutMs: FFMPEG_POST_PROCESS_TIMEOUT_MS, signal: null }
     );
 
     if (isFailedExitState(ffmpegTracker.exitState)) {
@@ -914,22 +785,6 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     });
   }
 
-  private async waitForSpawn(process: ChildProcessWithoutNullStreams): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      process.once("spawn", () => resolve());
-      process.once("error", error => reject(error));
-    });
-  }
-
-  private async getFileSize(filePath: string): Promise<number | undefined> {
-    try {
-      const stats = await fsPromises.stat(filePath);
-      return stats.size;
-    } catch {
-      return undefined;
-    }
-  }
-
   private async assertFfmpegOutputReady(
     outputPath: string,
     args: string[],
@@ -947,7 +802,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       );
     }
 
-    const sizeBytes = await this.getFileSize(outputPath);
+    const sizeBytes = await getFileSize(outputPath);
     if (!sizeBytes || sizeBytes <= 0) {
       throw new ActionableError(
         this.buildFfmpegFailureMessage(

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -10,6 +10,14 @@ import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbCl
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { logger } from "../../utils/logger";
+import {
+  createExitTracker,
+  getFileSize,
+  PROCESS_EXIT_TIMEOUT_MS,
+  waitForExit,
+  waitForSpawn,
+  type ProcessExitState,
+} from "../../utils/ChildProcessTracker";
 import type {
   RecordingHandle,
   RecordingResult,
@@ -17,13 +25,6 @@ import type {
   VideoCaptureConfig,
 } from "./VideoRecorderService";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "./androidScreenrecord";
-const PROCESS_EXIT_TIMEOUT_MS = 5000;
-
-interface ProcessExitState {
-  exitCode?: number | null;
-  signal?: NodeJS.Signals | null;
-  endedAt?: string;
-}
 
 interface AndroidBackendHandle {
   kind: "android";
@@ -48,79 +49,6 @@ interface IosBackendHandle {
 }
 
 type BackendHandle = AndroidBackendHandle | IosBackendHandle;
-
-function createExitTracker(
-  process: ChildProcessWithoutNullStreams,
-  stderr: string[]
-): { exitState: ProcessExitState; exitPromise: Promise<void> } {
-  const exitState: ProcessExitState = {};
-  let resolvePromise: (() => void) | null = null;
-  let rejectPromise: ((error: Error) => void) | null = null;
-
-  const exitPromise = new Promise<void>((resolve, reject) => {
-    resolvePromise = resolve;
-    rejectPromise = reject;
-  });
-
-  process.once("error", error => {
-    rejectPromise?.(error instanceof Error ? error : new Error(String(error)));
-  });
-
-  process.once("exit", (code, signal) => {
-    exitState.exitCode = code;
-    exitState.signal = signal;
-    exitState.endedAt = new Date().toISOString();
-    resolvePromise?.();
-  });
-
-  process.stderr.on("data", chunk => {
-    stderr.push(chunk.toString());
-  });
-
-  if (process.exitCode !== null) {
-    exitState.exitCode = process.exitCode;
-    exitState.signal = process.signalCode;
-    exitState.endedAt = new Date().toISOString();
-    resolvePromise?.();
-  }
-
-  return { exitState, exitPromise };
-}
-
-async function waitForExit(
-  process: ChildProcessWithoutNullStreams,
-  exitPromise: Promise<void>
-): Promise<void> {
-  if (process.exitCode !== null) {
-    await exitPromise;
-    return;
-  }
-
-  if (process.killed) {
-    await exitPromise;
-    return;
-  }
-
-  process.kill("SIGINT");
-
-  let timeoutId: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<void>(resolve => {
-    timeoutId = defaultTimer.setTimeout(() => {
-      if (process.exitCode === null) {
-        process.kill("SIGKILL");
-      }
-      resolve();
-    }, PROCESS_EXIT_TIMEOUT_MS);
-  });
-
-  await Promise.race([exitPromise, timeoutPromise]);
-
-  if (timeoutId) {
-    clearTimeout(timeoutId);
-  }
-
-  await exitPromise;
-}
 
 function clampBitrateKbps(config: VideoCaptureConfig): number {
   const maxBitrateKbps = Math.max(0, Math.floor(config.maxThroughputMbps * 1000));
@@ -213,7 +141,9 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       logger.info(`[VideoCapture] Waiting 1 second for file to finalize on device`);
       await this.timer.sleep(1000);
     } else {
-      await waitForExit(backendHandle.process, backendHandle.exitPromise);
+      await waitForExit(backendHandle.process, backendHandle.exitPromise, {
+        timeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+      });
       logger.info(
         `[VideoCapture] Process exited with code: ${backendHandle.exitState.exitCode}, signal: ${backendHandle.exitState.signal}`
       );
@@ -259,7 +189,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       await this.finalizeIosRecording(backendHandle);
     }
 
-    const sizeBytes = await this.getFileSize(handle.outputPath);
+    const sizeBytes = await getFileSize(handle.outputPath);
     logger.info(`[VideoCapture] Final file size: ${sizeBytes} bytes at ${handle.outputPath}`);
 
     const codec = "h264";
@@ -328,7 +258,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     const process = spawn(adbPath, args, { stdio: ["ignore", "pipe", "pipe"] });
 
     try {
-      await this.waitForSpawn(process);
+      await waitForSpawn(process);
     } catch (error) {
       throw new ActionableError(`Failed to start Android recording: ${error}`);
     }
@@ -387,7 +317,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     const process = spawn("xcrun", args, { stdio: ["ignore", "pipe", "pipe"] });
 
     try {
-      await this.waitForSpawn(process);
+      await waitForSpawn(process);
     } catch (error) {
       throw new ActionableError(`Failed to start iOS recording: ${error}`);
     }
@@ -445,22 +375,6 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     } catch (error) {
       logger.warn(`[VideoCapture] Failed to scale iOS recording: ${error}`);
       await this.replaceOutputFile(handle.rawOutputPath, handle.outputPath);
-    }
-  }
-
-  private async waitForSpawn(process: ChildProcessWithoutNullStreams): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      process.once("spawn", () => resolve());
-      process.once("error", error => reject(error));
-    });
-  }
-
-  private async getFileSize(filePath: string): Promise<number | undefined> {
-    try {
-      const stats = await fsPromises.stat(filePath);
-      return stats.size;
-    } catch {
-      return undefined;
     }
   }
 

--- a/src/utils/ChildProcessTracker.ts
+++ b/src/utils/ChildProcessTracker.ts
@@ -1,0 +1,161 @@
+import { promises as fsPromises } from "node:fs";
+import { defaultTimer, type Timer } from "./SystemTimer";
+
+export const PROCESS_EXIT_TIMEOUT_MS = 5000;
+
+export interface ProcessExitState {
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  endedAt?: string;
+}
+
+export interface ProcessTracker {
+  process: TrackedChildProcess;
+  exitState: ProcessExitState;
+  exitPromise: Promise<void>;
+  stderr: string[];
+}
+
+/**
+ * Minimal child-process surface needed to gracefully stop a recording. Narrowed
+ * from `ChildProcessWithoutNullStreams` so the SIGINT->SIGKILL escalation can be
+ * unit-tested with a fake process instead of a real spawn.
+ */
+export interface StoppableProcess {
+  exitCode: number | null;
+  killed: boolean;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+export interface WaitForExitOptions {
+  timeoutMs?: number;
+  timer?: Timer;
+  signal?: NodeJS.Signals | null;
+}
+
+export interface SpawnableProcess {
+  once(event: "spawn", listener: () => void): unknown;
+  once(event: "error", listener: (error: Error) => void): unknown;
+}
+
+export interface TrackedChildProcess extends StoppableProcess {
+  signalCode: NodeJS.Signals | null;
+  stderr: {
+    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+    off(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+  };
+  once(event: "spawn", listener: () => void): unknown;
+  once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  once(event: "error", listener: (error: Error) => void): unknown;
+  off(event: "exit", listener: () => void): unknown;
+  off(event: "error", listener: (error: Error) => void): unknown;
+}
+
+export function createExitTracker(
+  process: TrackedChildProcess,
+  stderr: string[]
+): { exitState: ProcessExitState; exitPromise: Promise<void> } {
+  const exitState: ProcessExitState = {};
+  let resolvePromise: () => void = () => undefined;
+  let rejectPromise: (error: Error) => void = () => undefined;
+
+  const exitPromise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  process.once("error", error => {
+    rejectPromise(error instanceof Error ? error : new Error(String(error)));
+  });
+
+  process.once("exit", (code, signal) => {
+    exitState.exitCode = code;
+    exitState.signal = signal;
+    exitState.endedAt = new Date().toISOString();
+    resolvePromise();
+  });
+
+  process.stderr.on("data", chunk => {
+    stderr.push(chunk.toString());
+  });
+
+  if (process.exitCode !== null) {
+    exitState.exitCode = process.exitCode;
+    exitState.signal = process.signalCode;
+    exitState.endedAt = new Date().toISOString();
+    resolvePromise();
+  }
+
+  return { exitState, exitPromise };
+}
+
+export function trackProcess(process: TrackedChildProcess): ProcessTracker {
+  const stderr: string[] = [];
+  const { exitState, exitPromise } = createExitTracker(process, stderr);
+  return { process, exitState, exitPromise, stderr };
+}
+
+/**
+ * Stop a capture process by sending SIGINT first (which lets `simctl`/`screenrecord`
+ * flush and finalize the file), then escalating to SIGKILL only if the process has
+ * not exited within `timeoutMs`. Callers that record formats requiring a trailing
+ * moov-atom flush (iOS simctl) should pass a generous `timeoutMs`. Callers that
+ * only need to await normal process completion can pass `signal: null`.
+ */
+export async function waitForExit(
+  process: StoppableProcess,
+  exitPromise: Promise<void>,
+  options: WaitForExitOptions = {}
+): Promise<void> {
+  const timer = options.timer ?? defaultTimer;
+  const timeoutMs = options.timeoutMs ?? PROCESS_EXIT_TIMEOUT_MS;
+  const signal = options.signal === undefined ? "SIGINT" : options.signal;
+
+  if (process.exitCode !== null) {
+    await exitPromise;
+    return;
+  }
+
+  if (process.killed) {
+    await exitPromise;
+    return;
+  }
+
+  if (signal !== null) {
+    process.kill(signal);
+  }
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<void>(resolve => {
+    timeoutId = timer.setTimeout(() => {
+      if (process.exitCode === null) {
+        process.kill("SIGKILL");
+      }
+      resolve();
+    }, timeoutMs);
+  });
+
+  await Promise.race([exitPromise, timeoutPromise]);
+
+  if (timeoutId) {
+    timer.clearTimeout(timeoutId);
+  }
+
+  await exitPromise;
+}
+
+export async function waitForSpawn(process: SpawnableProcess): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    process.once("spawn", () => resolve());
+    process.once("error", error => reject(error));
+  });
+}
+
+export async function getFileSize(filePath: string): Promise<number | undefined> {
+  try {
+    const stats = await fsPromises.stat(filePath);
+    return stats.size;
+  } catch {
+    return undefined;
+  }
+}

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -535,7 +535,10 @@ describe("waitForExit - graceful capture stop", function() {
     const timer = new FakeTimer();
     const { process, exitPromise, killSignals, exit } = createFakeProcess();
 
-    const pending = waitForExit(process, exitPromise, IOS_RECORDING_STOP_TIMEOUT_MS, timer);
+    const pending = waitForExit(process, exitPromise, {
+      timeoutMs: IOS_RECORDING_STOP_TIMEOUT_MS,
+      timer,
+    });
 
     // SIGINT is delivered synchronously so simctl can begin flushing the moov atom.
     expect(killSignals).toEqual(["SIGINT"]);
@@ -556,7 +559,10 @@ describe("waitForExit - graceful capture stop", function() {
     const timer = new FakeTimer();
     const { process, exitPromise, killSignals } = createFakeProcess();
 
-    const pending = waitForExit(process, exitPromise, PROCESS_EXIT_TIMEOUT_MS, timer);
+    const pending = waitForExit(process, exitPromise, {
+      timeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+      timer,
+    });
 
     expect(killSignals).toEqual(["SIGINT"]);
 
@@ -580,8 +586,10 @@ describe("waitForExit - graceful capture stop", function() {
     const legacyPending = waitForExit(
       legacy.process,
       legacy.exitPromise,
-      PROCESS_EXIT_TIMEOUT_MS,
-      legacyTimer
+      {
+        timeoutMs: PROCESS_EXIT_TIMEOUT_MS,
+        timer: legacyTimer,
+      }
     );
     legacyTimer.advanceTime(slowFlushMs);
     await legacyPending;
@@ -593,8 +601,10 @@ describe("waitForExit - graceful capture stop", function() {
     const iosPending = waitForExit(
       ios.process,
       ios.exitPromise,
-      IOS_RECORDING_STOP_TIMEOUT_MS,
-      iosTimer
+      {
+        timeoutMs: IOS_RECORDING_STOP_TIMEOUT_MS,
+        timer: iosTimer,
+      }
     );
     iosTimer.advanceTime(slowFlushMs);
     await Promise.resolve();

--- a/test/utils/ChildProcessTracker.test.ts
+++ b/test/utils/ChildProcessTracker.test.ts
@@ -1,0 +1,165 @@
+import { EventEmitter } from "node:events";
+import { promises as fsPromises } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  getFileSize,
+  waitForExit,
+  waitForSpawn,
+  type StoppableProcess,
+} from "../../src/utils/ChildProcessTracker";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+class FakeStoppableProcess extends EventEmitter implements StoppableProcess {
+  exitCode: number | null = null;
+  killed = false;
+  readonly signals: Array<NodeJS.Signals | number | undefined> = [];
+
+  constructor(private readonly resolveOnSignal?: NodeJS.Signals | number) {
+    super();
+  }
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.signals.push(signal);
+    if (signal === this.resolveOnSignal) {
+      this.exitCode = null;
+      this.killed = true;
+      this.emit("exit");
+    }
+    return true;
+  }
+}
+
+function createExitPromise(process: EventEmitter): Promise<void> {
+  return new Promise<void>(resolve => {
+    process.once("exit", () => resolve());
+  });
+}
+
+describe("ChildProcessTracker", () => {
+  describe("waitForExit", () => {
+    test("sends SIGINT first and escalates to SIGKILL after the configured timeout", async () => {
+      const timer = new FakeTimer();
+      const process = new FakeStoppableProcess("SIGKILL");
+      const waitPromise = waitForExit(process, createExitPromise(process), {
+        timeoutMs: 1234,
+        timer,
+      });
+
+      expect(process.signals).toEqual(["SIGINT"]);
+      expect(timer.getPendingTimeouts()).toEqual([1234]);
+
+      timer.advanceTime(1234);
+      await waitPromise;
+
+      expect(process.signals).toEqual(["SIGINT", "SIGKILL"]);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    test("does not escalate when the process exits before the timeout", async () => {
+      const timer = new FakeTimer();
+      const process = new FakeStoppableProcess();
+      const waitPromise = waitForExit(process, createExitPromise(process), {
+        timeoutMs: 5000,
+        timer,
+      });
+
+      expect(process.signals).toEqual(["SIGINT"]);
+
+      process.exitCode = 0;
+      process.emit("exit");
+      await waitPromise;
+
+      expect(process.signals).toEqual(["SIGINT"]);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    test("does not signal an already-exited process", async () => {
+      const timer = new FakeTimer();
+      const process = new FakeStoppableProcess();
+      process.exitCode = 0;
+
+      await waitForExit(process, Promise.resolve(), { timer });
+
+      expect(process.signals).toEqual([]);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+  });
+
+  describe("waitForExit without an initial signal", () => {
+    test("waits for normal completion without sending SIGINT", async () => {
+      const timer = new FakeTimer();
+      const process = new FakeStoppableProcess();
+      const waitPromise = waitForExit(process, createExitPromise(process), {
+        timeoutMs: 60000,
+        timer,
+        signal: null,
+      });
+
+      expect(process.signals).toEqual([]);
+
+      process.exitCode = 0;
+      process.emit("exit");
+      await waitPromise;
+
+      expect(process.signals).toEqual([]);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    test("kills a process that does not complete before timeout", async () => {
+      const timer = new FakeTimer();
+      const process = new FakeStoppableProcess("SIGKILL");
+      const waitPromise = waitForExit(process, createExitPromise(process), {
+        timeoutMs: 60000,
+        timer,
+        signal: null,
+      });
+
+      expect(process.signals).toEqual([]);
+
+      timer.advanceTime(60000);
+      await waitPromise;
+
+      expect(process.signals).toEqual(["SIGKILL"]);
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+  });
+
+  describe("waitForSpawn", () => {
+    test("resolves when the process emits spawn", async () => {
+      const process = new EventEmitter();
+      const spawnPromise = waitForSpawn(process);
+
+      process.emit("spawn");
+
+      await spawnPromise;
+    });
+
+    test("rejects when the process emits error before spawn", async () => {
+      const process = new EventEmitter();
+      const spawnPromise = waitForSpawn(process);
+      const error = new Error("spawn failed");
+
+      process.emit("error", error);
+
+      await expect(spawnPromise).rejects.toBe(error);
+    });
+  });
+
+  describe("getFileSize", () => {
+    test("returns file size or undefined when missing", async () => {
+      const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "child-process-tracker-"));
+      const filePath = path.join(tempDir, "recording.mp4");
+      try {
+        expect(await getFileSize(filePath)).toBeUndefined();
+
+        await fsPromises.writeFile(filePath, "video");
+
+        expect(await getFileSize(filePath)).toBe(5);
+      } finally {
+        await fsPromises.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the duplicated child-process exit tracking from the ffmpeg and platform video backends into `src/utils/ChildProcessTracker.ts`. Both backends now share the same exit tracker, spawn waiter, file-size helper, and SIGINT-then-SIGKILL shutdown path while preserving the ffmpeg iOS 30s moov-atom flush timeout and the platform backend's 5s default.

## Linked Issue

Closes #2767

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
  - Covered by `bun run turbo:validate` (`turbo run lint build test`): 6,959 pass, 2 skip, 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate)
  - `bun run typecheck`: no new type errors, 254 known baseline errors
- [x] Android/iOS changes: ran the matching `scripts/` validation
  - N/A: TypeScript-only process utility extraction
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
  - `bun test test/utils/ChildProcessTracker.test.ts test/features/video/FfmpegVideoProcessingBackend.test.ts test/features/video/PlatformVideoCaptureBackend.test.ts`: 57 pass, 0 fail
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
