### PR TITLE
feat(image): add sharp backend for macOS and Linux

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,34 @@ updates:
     open-pull-requests-limit: 10
     # Set versioning strategy appropriate for a library/package
     versioning-strategy: "increase-if-necessary"
+    ignore:
+      # Frozen by docs/design-docs/image-backend.md: sharp 0.35.x can abort
+      # under Bun; keep 0.34.5/@img 1.2.4 pinned until the Bun interop issue is fixed.
+      - dependency-name: "sharp"
+      - dependency-name: "@img/sharp-darwin-arm64"
+      - dependency-name: "@img/sharp-darwin-x64"
+      - dependency-name: "@img/sharp-libvips-darwin-arm64"
+      - dependency-name: "@img/sharp-libvips-darwin-x64"
+      - dependency-name: "@img/sharp-libvips-linux-arm"
+      - dependency-name: "@img/sharp-libvips-linux-arm64"
+      - dependency-name: "@img/sharp-libvips-linux-ppc64"
+      - dependency-name: "@img/sharp-libvips-linux-riscv64"
+      - dependency-name: "@img/sharp-libvips-linux-s390x"
+      - dependency-name: "@img/sharp-libvips-linux-x64"
+      - dependency-name: "@img/sharp-libvips-linuxmusl-arm64"
+      - dependency-name: "@img/sharp-libvips-linuxmusl-x64"
+      - dependency-name: "@img/sharp-linux-arm"
+      - dependency-name: "@img/sharp-linux-arm64"
+      - dependency-name: "@img/sharp-linux-ppc64"
+      - dependency-name: "@img/sharp-linux-riscv64"
+      - dependency-name: "@img/sharp-linux-s390x"
+      - dependency-name: "@img/sharp-linux-x64"
+      - dependency-name: "@img/sharp-linuxmusl-arm64"
+      - dependency-name: "@img/sharp-linuxmusl-x64"
+      - dependency-name: "@img/sharp-wasm32"
+      - dependency-name: "@img/sharp-win32-arm64"
+      - dependency-name: "@img/sharp-win32-ia32"
+      - dependency-name: "@img/sharp-win32-x64"
   # Android Gradle dependencies
   - package-ecosystem: "gradle"
     directory: "/android"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -927,6 +927,10 @@ jobs:
           mkdir -p ci-logs
           turbo run test --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
 
+      - name: "Run Bun image runtime smoke"
+        if: env.RUN_MCP_BUILD_TEST == 'true' && matrix.os == 'macos-latest'
+        run: bun run test:image:bun
+
       - name: "Upload Build/Test Logs"
         if: env.RUN_MCP_BUILD_TEST == 'true' && (failure() || cancelled() || matrix.os == 'windows-latest')
         uses: actions/upload-artifact@v6
@@ -1033,12 +1037,8 @@ jobs:
       - name: "Run Bun MCP startup smoke"
         run: bun run test:startup:bun
 
-      # The smoke exercises @jimp/wasm-webp (Emscripten WASM). Bun's JSC Wasm
-      # OSR tier intermittently miscompiles Emscripten modules on Linux x64
-      # (oven-sh/bun#26366), surfacing as "access to a null reference
-      # (evaluating 'cppInvokerFunc.apply(...)')" in the embind glue. Disable
-      # the OSR tier for this step only; semantics are unchanged, JSC falls
-      # back to its other Wasm tiers. See issue #3189.
+      # Linux uses the sharp backend here. The OSR guard remains until the
+      # Windows cwebp follow-up removes the @jimp/wasm-webp path entirely.
       - name: "Run Bun image runtime smoke"
         env:
           BUN_JSC_useWasmOSR: "0"

--- a/build.ts
+++ b/build.ts
@@ -24,9 +24,9 @@ const result = await Bun.build({
   outdir: "./dist/src",
   target: "bun",
   format: "esm",
-  // Keep the jimp ecosystem external so @jimp/wasm-webp resolves its WASM
-  // binary from node_modules at runtime instead of being inlined by the bundler
-  external: ["jimp", "@jimp/*"],
+  // Keep native/asset-backed image dependencies external so sharp's @img
+  // packages and @jimp/wasm-webp resolve their runtime assets from node_modules.
+  external: ["sharp", "@img/sharp-*", "jimp", "@jimp/*"],
   sourcemap: "external",
   minify: true,
   splitting: false,

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "kysely": "^0.29.0",
         "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
+        "sharp": "0.34.5",
         "ws": "^8.19.0",
         "xml2js": "^0.6.2",
         "zod": "^4.3.5",
@@ -41,6 +42,32 @@
         "tsx": "^4.21.0",
         "turbo": "^2.8.10",
         "typescript": "6.0.3",
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5",
       },
     },
   },
@@ -144,6 +171,56 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
@@ -458,6 +535,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
@@ -881,6 +960,8 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -1114,6 +1195,8 @@
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "parse-bmfont-xml/xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "sharp/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "kysely": "^0.29.0",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
+    "sharp": "0.34.5",
     "ws": "^8.19.0",
     "xml2js": "^0.6.2",
     "zod": "^4.3.5"
@@ -112,6 +113,32 @@
     "eslint-plugin-import": {
       "minimatch": "3.1.5"
     }
+  },
+  "optionalDependencies": {
+    "@img/sharp-darwin-arm64": "0.34.5",
+    "@img/sharp-darwin-x64": "0.34.5",
+    "@img/sharp-libvips-darwin-arm64": "1.2.4",
+    "@img/sharp-libvips-darwin-x64": "1.2.4",
+    "@img/sharp-libvips-linux-arm": "1.2.4",
+    "@img/sharp-libvips-linux-arm64": "1.2.4",
+    "@img/sharp-libvips-linux-ppc64": "1.2.4",
+    "@img/sharp-libvips-linux-riscv64": "1.2.4",
+    "@img/sharp-libvips-linux-s390x": "1.2.4",
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+    "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+    "@img/sharp-linux-arm": "0.34.5",
+    "@img/sharp-linux-arm64": "0.34.5",
+    "@img/sharp-linux-ppc64": "0.34.5",
+    "@img/sharp-linux-riscv64": "0.34.5",
+    "@img/sharp-linux-s390x": "0.34.5",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@img/sharp-linuxmusl-arm64": "0.34.5",
+    "@img/sharp-linuxmusl-x64": "0.34.5",
+    "@img/sharp-wasm32": "0.34.5",
+    "@img/sharp-win32-arm64": "0.34.5",
+    "@img/sharp-win32-ia32": "0.34.5",
+    "@img/sharp-win32-x64": "0.34.5"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.2.0",

--- a/src/utils/image/ImageTransformer.ts
+++ b/src/utils/image/ImageTransformer.ts
@@ -79,16 +79,10 @@ class JimpImageTransformer {
       throw new Error("WebP quality must be between 1 and 100");
     }
 
-    // The wasm-webp encoder takes libwebp-style numeric flags. Keys are
-    // camelCase (validated by the plugin's zod schema — an unknown key is
-    // silently dropped, and `quality` defaults to 100). In lossless mode
-    // `quality` still controls compression effort/ratio, so pass it through.
-    // near-lossless runs inside lossless mode; sharp used `quality` as the
-    // near-lossless preprocessing level, so mirror that.
     const webpOptions: Record<string, unknown> = options?.lossless
-      ? { lossless: 1, quality }
+      ? { lossless: true, quality }
       : options?.nearLossless
-        ? { lossless: 1, nearLossless: quality }
+        ? { nearLossless: true, quality }
         : { quality };
 
     this.pipeline.encoding = { mime: "image/webp", options: webpOptions };

--- a/src/utils/image/backend/ImageBackend.ts
+++ b/src/utils/image/backend/ImageBackend.ts
@@ -4,10 +4,9 @@
  * `ImageTransformer` records the caller's resize/crop/encode requests into a
  * declarative `ImagePipeline`, then hands the source buffer + pipeline to an
  * `ImageBackend` for execution. This decouples the fluent transform API from
- * the concrete decoder/encoder (jimp today; sharp + cwebp later — see the
- * "Sharp + CWebP" milestone), so later issues can swap backends without
- * touching call sites. Behavior-preserving: the jimp backend reproduces the
- * exact operations the transformer used to run inline.
+ * the concrete decoder/encoder (sharp on macOS/Linux; jimp on Windows until
+ * the cwebp follow-up lands), so later issues can swap backends without
+ * touching call sites.
  */
 
 /** Basic image metadata surfaced by every backend. */
@@ -43,8 +42,8 @@ export type ImageOperation =
 /**
  * The requested output encoding. `null` (on the pipeline) means "re-encode in
  * the decoded input format", matching the transformer's historical fallback.
- * `options` carries backend-agnostic encoder flags (e.g. the libwebp-style
- * numeric flags the jimp wasm-webp encoder expects).
+ * `options` carries backend-agnostic encoder intent (e.g. quality/lossless
+ * booleans). Concrete backends translate that intent to codec-specific flags.
  */
 export interface ImageEncoding {
   mime: "image/png" | "image/webp";
@@ -67,7 +66,8 @@ export interface RawImage {
 
 /**
  * Executes declarative image pipelines and exposes metadata / raw pixels.
- * Implemented by `JimpBackend` (production) and `FakeImageBackend` (tests).
+ * Implemented by production backends (`SharpBackend`, `JimpBackend`) and
+ * `FakeImageBackend` for tests.
  */
 export interface ImageBackend {
   /** Decode `source`, apply `pipeline.operations`, encode per `pipeline.encoding`. */

--- a/src/utils/image/backend/JimpBackend.ts
+++ b/src/utils/image/backend/JimpBackend.ts
@@ -12,11 +12,29 @@ import type { ImageBackend, ImageMetadata, ImageOperation, ImagePipeline, RawIma
  */
 const NEAREST_NEIGHBOR = "nearestNeighbor" as ResizeStrategy;
 
+export function toJimpWebpOptions(options?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  const quality = typeof options.quality === "number" ? options.quality : undefined;
+  if (options.lossless === true) {
+    return quality === undefined ? { lossless: 1 } : { lossless: 1, quality };
+  }
+  if (options.nearLossless === true) {
+    // wasm-webp models near-lossless as a lossless-mode preprocessing level.
+    // Use the public quality value for that level, matching the former
+    // ImageTransformer shaping and the sharp backend's neutral option intent.
+    return quality === undefined ? { lossless: 1, nearLossless: 75 } : { lossless: 1, nearLossless: quality };
+  }
+  return options;
+}
+
 /**
  * Jimp-backed `ImageBackend`. Reproduces exactly what `ImageTransformer` used
  * to run inline, including WebP encode/decode via the `@jimp/wasm-webp` plugin
- * (wired in `loadJimp`). Kept pure-jimp for now; sharp/cwebp backends land in
- * later issues (#3010/#3011).
+ * (wired in `loadJimp`). Used as the Windows backend until the cwebp backend
+ * lands, and as the catchable-discovery fallback for sharp on macOS/Linux.
  */
 export class JimpBackend implements ImageBackend {
   private applyOperation(image: JimpImage, op: ImageOperation): JimpImage {
@@ -49,9 +67,12 @@ export class JimpBackend implements ImageBackend {
     }
     // Fall back to the decoded input format when no output encoding was requested.
     const mime = pipeline.encoding?.mime ?? image.mime ?? "image/png";
+    const options = mime === "image/webp"
+      ? toJimpWebpOptions(pipeline.encoding?.options)
+      : pipeline.encoding?.options;
     return (image.getBuffer as (m: string, o?: Record<string, unknown>) => Promise<Buffer>)(
       mime,
-      pipeline.encoding?.options
+      options
     );
   }
 

--- a/src/utils/image/backend/SharpBackend.ts
+++ b/src/utils/image/backend/SharpBackend.ts
@@ -1,0 +1,125 @@
+import { loadSharp, type SharpFactory } from "../loadSharp";
+import type { ImageBackend, ImageMetadata, ImageOperation, ImagePipeline, RawImage } from "./ImageBackend";
+
+export type SharpLoader = () => Promise<SharpFactory>;
+
+export interface SharpBackendOptions {
+  loadSharp?: SharpLoader;
+  fallbackBackend?: ImageBackend;
+}
+
+/**
+ * sharp-backed `ImageBackend` used on macOS/Linux. The sharp module is loaded
+ * lazily so image processing does not add native startup work to the MCP server.
+ * If module discovery fails, operations delegate to the configured JimpBackend
+ * fallback; native sharp aborts are not catchable and remain out of scope.
+ */
+export class SharpBackend implements ImageBackend {
+  private readonly loadSharp: SharpLoader;
+  private readonly fallbackBackend: ImageBackend | undefined;
+
+  constructor(options: SharpBackendOptions = {}) {
+    this.loadSharp = options.loadSharp ?? loadSharp;
+    this.fallbackBackend = options.fallbackBackend;
+  }
+
+  private async withSharp<T>(
+    operation: (sharp: SharpFactory) => Promise<T>,
+    fallback: () => Promise<T>
+  ): Promise<T> {
+    let sharp: SharpFactory;
+    try {
+      sharp = await this.loadSharp();
+    } catch {
+      if (this.fallbackBackend) {
+        return fallback();
+      }
+      throw new Error("sharp is not available");
+    }
+    return operation(sharp);
+  }
+
+  private applyOperation(image: ReturnType<SharpFactory>, op: ImageOperation): ReturnType<SharpFactory> {
+    switch (op.type) {
+      case "resize": {
+        const kernel = op.mode === "nearest" ? "nearest" : undefined;
+        if (op.height === undefined) {
+          return image.resize({ width: op.width, kernel });
+        }
+        return image.resize({
+          width: op.width,
+          height: op.height,
+          fit: op.maintainAspectRatio ? "cover" : "fill",
+          kernel
+        });
+      }
+      case "crop":
+        return image.extract({ left: op.x, top: op.y, width: op.width, height: op.height });
+    }
+  }
+
+  private applyEncoding(image: ReturnType<SharpFactory>, pipeline: ImagePipeline): ReturnType<SharpFactory> {
+    switch (pipeline.encoding?.mime) {
+      case "image/png":
+        return image.png();
+      case "image/webp": {
+        const options = pipeline.encoding.options;
+        return image.webp({
+          quality: typeof options?.quality === "number" ? options.quality : undefined,
+          lossless: options?.lossless === true ? true : undefined,
+          nearLossless: options?.nearLossless === true ? true : undefined
+        });
+      }
+      default:
+        return image;
+    }
+  }
+
+  private async applyPipeline(sharp: SharpFactory, source: Buffer, pipeline: ImagePipeline): Promise<ReturnType<SharpFactory>> {
+    let current = source;
+    for (const operation of pipeline.operations) {
+      current = await this.applyOperation(sharp(current), operation).toBuffer();
+    }
+
+    return this.applyEncoding(sharp(current), pipeline);
+  }
+
+  public async execute(source: Buffer, pipeline: ImagePipeline): Promise<Buffer> {
+    return this.withSharp(
+      async sharp => (await this.applyPipeline(sharp, source, pipeline)).toBuffer(),
+      () => this.fallbackBackend!.execute(source, pipeline)
+    );
+  }
+
+  public async metadata(source: Buffer): Promise<ImageMetadata> {
+    return this.withSharp(
+      async sharp => {
+        const metadata = await sharp(source).metadata();
+        return {
+          width: metadata.width ?? 0,
+          height: metadata.height ?? 0,
+          format: metadata.format ?? "",
+          size: source.length
+        };
+      },
+      () => this.fallbackBackend!.metadata(source)
+    );
+  }
+
+  public async rawPixels(source: Buffer): Promise<RawImage> {
+    return this.withSharp(
+      async sharp => {
+        const { data, info } = await sharp(source)
+          .ensureAlpha()
+          .raw()
+          .toBuffer({ resolveWithObject: true });
+        return {
+          width: info.width,
+          height: info.height,
+          data: Buffer.from(data)
+        };
+      },
+      () => this.fallbackBackend!.rawPixels(source)
+    );
+  }
+}

--- a/src/utils/image/backend/resolveImageBackend.ts
+++ b/src/utils/image/backend/resolveImageBackend.ts
@@ -1,14 +1,29 @@
 import type { ImageBackend } from "./ImageBackend";
 import { JimpBackend } from "./JimpBackend";
+import { SharpBackend, type SharpLoader } from "./SharpBackend";
+
+export interface ResolveImageBackendOptions {
+  platform?: NodeJS.Platform;
+  sharpLoader?: SharpLoader;
+}
 
 /**
  * Selects the image backend for the current platform.
  *
- * Returns `JimpBackend` unconditionally for now — platform-aware selection
- * (sharp on most platforms, cwebp on Windows) lands with later issues in the
- * "Sharp + CWebP" milestone (#3010/#3011). Kept as a function seam so those
- * issues change selection here without touching `ImageTransformer`.
+ * Returns sharp on macOS/Linux and jimp on Windows. The next milestone step
+ * replaces the Windows jimp WebP leg with cwebp while keeping this selection
+ * seam stable for call sites.
  */
-export function resolveImageBackend(): ImageBackend {
+export function resolveImageBackend(options: ResolveImageBackendOptions = {}): ImageBackend {
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    return new JimpBackend();
+  }
+  if (platform === "darwin" || platform === "linux") {
+    return new SharpBackend({
+      loadSharp: options.sharpLoader,
+      fallbackBackend: new JimpBackend()
+    });
+  }
   return new JimpBackend();
 }

--- a/src/utils/image/loadSharp.ts
+++ b/src/utils/image/loadSharp.ts
@@ -1,0 +1,11 @@
+export type SharpFactory = typeof import("sharp");
+
+let sharpFactoryPromise: Promise<SharpFactory> | undefined;
+
+export async function loadSharp(): Promise<SharpFactory> {
+  sharpFactoryPromise ??= import("sharp").then(mod => {
+    const loaded = mod as unknown as { default?: SharpFactory } & SharpFactory;
+    return loaded.default ?? loaded;
+  });
+  return sharpFactoryPromise;
+}

--- a/test/utils/image/ImageTransformer.test.ts
+++ b/test/utils/image/ImageTransformer.test.ts
@@ -67,19 +67,19 @@ describe("ImageTransformer (declarative pipeline + backend delegation)", () => {
       });
     });
 
-    test("webp lossless records libwebp lossless flags", async () => {
+    test("webp lossless records backend-neutral lossless intent", async () => {
       await imageOf().webp({ lossless: true, quality: 90 }).disableCache().toBuffer();
       expect(backend.lastPipeline!.encoding).toEqual({
         mime: "image/webp",
-        options: { lossless: 1, quality: 90 }
+        options: { lossless: true, quality: 90 }
       });
     });
 
-    test("webp nearLossless records nearLossless preprocessing level", async () => {
+    test("webp nearLossless records backend-neutral nearLossless intent", async () => {
       await imageOf().webp({ nearLossless: true, quality: 40 }).disableCache().toBuffer();
       expect(backend.lastPipeline!.encoding).toEqual({
         mime: "image/webp",
-        options: { lossless: 1, nearLossless: 40 }
+        options: { nearLossless: true, quality: 40 }
       });
     });
   });

--- a/test/utils/image/backend/JimpBackend.test.ts
+++ b/test/utils/image/backend/JimpBackend.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { JimpBackend } from "../../../../src/utils/image/backend/JimpBackend";
+import { JimpBackend, toJimpWebpOptions } from "../../../../src/utils/image/backend/JimpBackend";
 import type { ImagePipeline } from "../../../../src/utils/image/backend/ImageBackend";
 
 // Build a small, non-uniform source PNG. Solid colors survive any resize kernel
@@ -139,6 +139,12 @@ describe("JimpBackend", () => {
       });
 
       expect(nearLossless.length).not.toBe(lossless.length);
+    });
+
+    test("maps backend-neutral WebP options to wasm-webp libwebp flags", () => {
+      expect(toJimpWebpOptions({ lossless: true, quality: 90 })).toEqual({ lossless: 1, quality: 90 });
+      expect(toJimpWebpOptions({ nearLossless: true, quality: 40 })).toEqual({ lossless: 1, nearLossless: 40 });
+      expect(toJimpWebpOptions({ quality: 60 })).toEqual({ quality: 60 });
     });
 
     test("resize mode:nearest picks source pixels (distinct from default kernel)", async () => {

--- a/test/utils/image/backend/SharpBackend.test.ts
+++ b/test/utils/image/backend/SharpBackend.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { SharpBackend } from "../../../../src/utils/image/backend/SharpBackend";
+import type { ImagePipeline } from "../../../../src/utils/image/backend/ImageBackend";
+
+async function makeSourcePng(width = 8, height = 8): Promise<Buffer> {
+  const { Jimp, rgbaToInt } = await import("jimp");
+  const image = new Jimp({ width, height, color: 0x000000ff });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      image.setPixelColor(rgbaToInt((x * 16) % 256, (y * 16) % 256, (x * y) % 256, 255), x, y);
+    }
+  }
+  return image.getBuffer("image/png");
+}
+
+const PNG_MAGIC = "89504e47";
+
+// Production keeps Windows on Jimp because sharp can abort under Bun there.
+// These cases intentionally exercise the real native sharp backend on macOS/Linux only.
+const describeSharp = process.platform === "win32" ? describe.skip : describe;
+
+describeSharp("SharpBackend", () => {
+  describe("execute", () => {
+    test("resize with fill produces exact target dimensions", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 8);
+      const pipeline: ImagePipeline = {
+        operations: [{ type: "resize", width: 4, height: 2, maintainAspectRatio: false }],
+        encoding: { mime: "image/png" }
+      };
+
+      const out = await backend.execute(source, pipeline);
+      const meta = await backend.metadata(out);
+
+      expect(meta.width).toBe(4);
+      expect(meta.height).toBe(2);
+      expect(out.subarray(0, 4).toString("hex")).toBe(PNG_MAGIC);
+    });
+
+    test("resize with maintainAspectRatio covers to exact WxH", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 4);
+      const meta = await backend.metadata(await backend.execute(source, {
+        operations: [{ type: "resize", width: 6, height: 6, maintainAspectRatio: true }],
+        encoding: { mime: "image/png" }
+      }));
+
+      expect(meta.width).toBe(6);
+      expect(meta.height).toBe(6);
+    });
+
+    test("width-only resize preserves aspect ratio", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 4);
+      const meta = await backend.metadata(await backend.execute(source, {
+        operations: [{ type: "resize", width: 4, maintainAspectRatio: true }],
+        encoding: { mime: "image/png" }
+      }));
+
+      expect(meta.width).toBe(4);
+      expect(meta.height).toBe(2);
+    });
+
+    test("applies chained resize operations in pipeline order", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 8);
+      const sharp = (await import("sharp")).default;
+      const firstResize = await sharp(source)
+        .resize({ width: 5, height: 5, fit: "fill" })
+        .toBuffer();
+      const expected = await backend.rawPixels(await sharp(firstResize)
+        .resize({ width: 3, height: 7, fit: "fill" })
+        .png()
+        .toBuffer());
+
+      const actual = await backend.rawPixels(await backend.execute(source, {
+        operations: [
+          { type: "resize", width: 5, height: 5, maintainAspectRatio: false },
+          { type: "resize", width: 3, height: 7, maintainAspectRatio: false }
+        ],
+        encoding: { mime: "image/png" }
+      }));
+
+      expect(actual.width).toBe(3);
+      expect(actual.height).toBe(7);
+      expect(actual.data).toEqual(expected.data);
+    });
+
+    test("crop produces the requested region at the requested offset", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 8);
+
+      const raw = await backend.rawPixels(await backend.execute(source, {
+        operations: [{ type: "crop", x: 1, y: 1, width: 3, height: 2 }],
+        encoding: { mime: "image/png" }
+      }));
+
+      expect(raw.width).toBe(3);
+      expect(raw.height).toBe(2);
+      expect([raw.data[0], raw.data[1], raw.data[2], raw.data[3]]).toEqual([16, 16, 1, 255]);
+    });
+
+    test("webp encodes all supported WebP option modes", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng();
+
+      for (const options of [
+        { quality: 60 },
+        { lossless: true, quality: 75 },
+        { nearLossless: true, quality: 40 }
+      ]) {
+        const out = await backend.execute(source, {
+          operations: [],
+          encoding: { mime: "image/webp", options }
+        });
+        expect(out.subarray(0, 4).toString()).toBe("RIFF");
+        expect(out.subarray(8, 12).toString()).toBe("WEBP");
+      }
+    });
+  });
+
+  describe("metadata", () => {
+    test("reports dimensions, format, and source byte size", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 4);
+
+      const meta = await backend.metadata(source);
+
+      expect(meta.width).toBe(8);
+      expect(meta.height).toBe(4);
+      expect(meta.format).toBe("png");
+      expect(meta.size).toBe(source.length);
+    });
+  });
+
+  describe("rawPixels", () => {
+    test("returns RGBA data sized width*height*4", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 4);
+
+      const raw = await backend.rawPixels(source);
+
+      expect(raw.width).toBe(8);
+      expect(raw.height).toBe(4);
+      expect(raw.data.length).toBe(8 * 4 * 4);
+    });
+  });
+});

--- a/test/utils/image/backend/resolveImageBackend.test.ts
+++ b/test/utils/image/backend/resolveImageBackend.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { resolveImageBackend } from "../../../../src/utils/image/backend/resolveImageBackend";
 import { JimpBackend } from "../../../../src/utils/image/backend/JimpBackend";
+import { SharpBackend } from "../../../../src/utils/image/backend/SharpBackend";
 
 describe("resolveImageBackend", () => {
   const originalPlatform = process.platform;
@@ -11,15 +12,37 @@ describe("resolveImageBackend", () => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
   });
 
-  test("returns a JimpBackend on the current platform", () => {
-    expect(resolveImageBackend()).toBeInstanceOf(JimpBackend);
+  test("returns a backend on the current platform", () => {
+    const backend = resolveImageBackend();
+    if (process.platform === "darwin" || process.platform === "linux") {
+      expect(backend).toBeInstanceOf(SharpBackend);
+    } else {
+      expect(backend).toBeInstanceOf(JimpBackend);
+    }
   });
 
-  test("returns a JimpBackend on every platform (selection logic lands later)", () => {
-    for (const platform of ["win32", "darwin", "linux"]) {
-      Object.defineProperty(process, "platform", { value: platform, configurable: true });
-      expect(resolveImageBackend()).toBeInstanceOf(JimpBackend);
-    }
+  test("returns JimpBackend on Windows", () => {
+    expect(resolveImageBackend({ platform: "win32" })).toBeInstanceOf(JimpBackend);
+  });
+
+  test("returns SharpBackend on macOS and Linux", () => {
+    expect(resolveImageBackend({ platform: "darwin" })).toBeInstanceOf(SharpBackend);
+    expect(resolveImageBackend({ platform: "linux" })).toBeInstanceOf(SharpBackend);
+  });
+
+  test("falls back to JimpBackend behavior when sharp discovery fails", async () => {
+    const { Jimp, rgbaToInt } = await import("jimp");
+    const source = await new Jimp({ width: 2, height: 2, color: rgbaToInt(1, 2, 3, 255) })
+      .getBuffer("image/png");
+    const backend = resolveImageBackend({
+      platform: "linux",
+      sharpLoader: async () => {
+        throw new Error("sharp unavailable");
+      }
+    });
+
+    expect(backend).toBeInstanceOf(SharpBackend);
+    await expect(backend.metadata(source)).resolves.toMatchObject({ width: 2, height: 2, format: "png" });
   });
 
   test("returns a fresh instance per call", () => {

--- a/test/utils/screenshot/PerceptualHasher.test.ts
+++ b/test/utils/screenshot/PerceptualHasher.test.ts
@@ -2,31 +2,6 @@ import { describe, expect, test } from "bun:test";
 import { PerceptualHasher } from "../../../src/utils/screenshot/PerceptualHasher";
 import { FakeImageBackend } from "../../fakes/FakeImageBackend";
 
-// Compute the hash the way the pre-seam PerceptualHasher did — via the real jimp
-// resize(8x8, NEAREST)+greyscale+red-channel pipeline — so the backend-routed
-// implementation can be pinned byte-for-byte against jimp (no silent drift).
-//
-// TODO(#3010): this jimp-golden pin is intentional ONLY for the JimpBackend
-// phase. When the sharp backend lands, its resize kernel produces different
-// pHash values by design — retire this byte-identity assertion and replace it
-// with backend-relative checks (A vs A′ similarity, A vs B distinctness).
-async function jimpGoldenHash(buffer: Buffer): Promise<string> {
-  const { Jimp, ResizeStrategy } = await import("jimp");
-  const image = await Jimp.fromBuffer(buffer);
-  image.resize({ w: 8, h: 8, mode: ResizeStrategy.NEAREST_NEIGHBOR }).greyscale();
-  const data = image.bitmap.data;
-  let sum = 0;
-  for (let i = 0; i < 64; i++) {
-    sum += data[i * 4];
-  }
-  const avg = sum / 64;
-  let hash = "";
-  for (let i = 0; i < 64; i++) {
-    hash += data[i * 4] > avg ? "1" : "0";
-  }
-  return hash;
-}
-
 async function gradientPng(width = 24, height = 24): Promise<Buffer> {
   const { Jimp, rgbaToInt } = await import("jimp");
   const image = new Jimp({ width, height, color: 0x000000ff });
@@ -124,16 +99,19 @@ describe("PerceptualHasher", () => {
       expect(similarity).toBeGreaterThan(80);
     });
 
-    test("matches the jimp nearest+greyscale pipeline byte-for-byte (no drift)", async () => {
-      // Non-uniform gradient so the hash exercises both 0 and 1 bits and any
-      // downscale/greyscale rounding divergence would flip a bit.
-      const buffer = await gradientPng(24, 24);
-      const golden = await jimpGoldenHash(buffer);
+    test("backend-relative hashes keep similar images close and distinct images apart", async () => {
+      const base = await gradientPng(24, 24);
+      const similar = await gradientPng(25, 24);
+      const different = await gradientPng(24, 40);
 
-      const hash = await PerceptualHasher.generatePerceptualHash(buffer);
+      const baseHash = await PerceptualHasher.generatePerceptualHash(base);
+      const similarHash = await PerceptualHasher.generatePerceptualHash(similar);
+      const differentHash = await PerceptualHasher.generatePerceptualHash(different);
 
-      expect(hash).toBe(golden);
-      expect(hash).toMatch(/[1]/); // sanity: not an all-zero degenerate hash
+      expect(baseHash).toHaveLength(64);
+      expect(baseHash).toMatch(/[1]/);
+      expect(PerceptualHasher.getPerceptualSimilarity(baseHash, similarHash)).toBeGreaterThan(80);
+      expect(PerceptualHasher.getPerceptualSimilarity(baseHash, differentHash)).toBeLessThan(95);
     });
 
     test("routes decode through backend.rawPixels (no direct jimp dependency)", async () => {


### PR DESCRIPTION
## Summary

Adds a lazy sharp 0.34.5 image backend for macOS/Linux while keeping Windows on the existing Jimp path until the cwebp follow-up. The image pipeline now carries backend-neutral WebP intent, Jimp translates that intent to the current wasm-webp flags, and sharp handles resize/crop/png/webp/metadata/raw pixels behind the existing `Image` API.

## Linked Issue

Closes #3010

## Bug / Regression Context

- **Prior attempts:** #2920 moved image processing to Jimp + `@jimp/wasm-webp`; #3008/#3009 added the backend seam and pixel-consumer migration needed before reintroducing sharp.
- **Observed symptom:** sharp 0.35.x is unsafe under Bun, but macOS/Linux can use pinned sharp 0.34.5; Windows must remain on Jimp until cwebp lands in #3011/#3012.
- **Repro steps / conditions:** navigation/plan image flows exercise WebP encode/decode and pHash/pixel comparison paths.

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional local validation:
- [x] `bun test --bail`
- [x] `bun run build`
- [x] `bun run test:image:bun`
- [x] `bun run benchmark-npm-unpacked-size`
- [x] `git diff --check`

## Follow-ups

- [ ] #3011 bundles cwebp/dwebp and adds `CliWebpCodec`.
- [ ] #3012 wires Windows to Jimp+cwebp and removes `@jimp/wasm-webp`.
- [ ] #3013 adds doctor visibility and final cache-portability docs.
