### PR TITLE
docs(versioning): accept snapshot dev coordinates

### DIFF
--- a/docs/design-docs/plat/android/junit-runner/project-setup.md
+++ b/docs/design-docs/plat/android/junit-runner/project-setup.md
@@ -39,6 +39,17 @@ module whose UI you want to test.
 If you need unreleased features or are iterating on the runner itself, publish the module locally and
 reference it from `mavenLocal()`.
 
+AutoMobile intentionally uses different version strings for local development coordinates and
+runtime/package identity:
+
+- Android Gradle/Maven coordinates use `<version>-SNAPSHOT` in local source builds. This is standard
+  Maven development semantics and lets `mavenLocal()` consumers resolve unpublished changes.
+- The runner jar's `Implementation-Version`, npm package version, plugin metadata, server manifest,
+  and iOS runner version use the plain `<version>` value.
+- Release publishing overrides the Gradle coordinate with the release tag, while the release
+  integrity gate compares the SNAPSHOT-stripped base version against the package and manifest
+  versions.
+
 ```bash
 # Inside the auto-mobile repo
 cd android

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -122,7 +122,9 @@ PY
 }
 update_server_json_version "server.json" "$new_version" "$dry_run"
 
-# Update VERSION_NAME in android/gradle.properties (single source of truth for Android libraries)
+# Update VERSION_NAME in android/gradle.properties. This is the Android
+# dev/Maven coordinate version, so local source builds intentionally keep the
+# -SNAPSHOT suffix while package/runtime identity surfaces use plain semver.
 update_gradle_properties_version() {
   local path="$1"
   local version="$2"
@@ -196,6 +198,7 @@ while IFS= read -r -d '' gradle_file; do
 done < <(rg -l --null -g 'build.gradle.kts' -e 'versionName\s*=' -e '^version\s*=' android)
 
 if [[ "$dry_run" == true ]]; then
-  echo "Dry run complete. package.json -> ${new_version}"
-  echo "Gradle version -> ${snapshot_version}"
+  echo "Dry run complete."
+  echo "Package/runtime version -> ${new_version}"
+  echo "Android dev/Maven coordinate -> ${snapshot_version}"
 fi

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/versioning/bump-versions.sh
+#
+# The version bump script intentionally writes plain semver to runtime/package
+# identity surfaces and writes -SNAPSHOT to Android Gradle dev/Maven coordinates.
+
+SCRIPT_SRC="scripts/versioning/bump-versions.sh"
+VERSION="1.2.3"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  SCRIPT_ABS="$(cd "$(dirname "$SCRIPT_SRC")" && pwd)/$(basename "$SCRIPT_SRC")"
+  BIN_DIR="${TEST_ROOT}/bin"
+  mkdir -p "${TEST_ROOT}/.claude-plugin" \
+    "${TEST_ROOT}/android/junit-runner" \
+    "${TEST_ROOT}/android/playground/app" \
+    "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner" \
+    "$BIN_DIR"
+  write_fake_rg
+  write_fixtures
+  PATH="${BIN_DIR}:$PATH"
+  export PATH
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+write_fake_rg() {
+  cat > "${BIN_DIR}/rg" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+find android -name build.gradle.kts -type f -print0
+EOF
+  chmod +x "${BIN_DIR}/rg"
+}
+
+write_fixtures() {
+  cat > "${TEST_ROOT}/package.json" <<'EOF'
+{ "name": "@kaeawc/auto-mobile", "version": "0.0.1" }
+EOF
+
+  cat > "${TEST_ROOT}/.claude-plugin/plugin.json" <<'EOF'
+{ "name": "auto-mobile", "version": "0.0.1" }
+EOF
+
+  cat > "${TEST_ROOT}/.claude-plugin/marketplace.json" <<'EOF'
+{ "plugins": [ { "name": "auto-mobile", "version": "0.0.1" } ] }
+EOF
+
+  cat > "${TEST_ROOT}/server.json" <<'EOF'
+{ "version": "0.0.1", "packages": [ { "identifier": "@kaeawc/auto-mobile", "version": "0.0.1" } ] }
+EOF
+
+  cat > "${TEST_ROOT}/android/gradle.properties" <<'EOF'
+GROUP=dev.jasonpearson.auto-mobile
+VERSION_NAME=0.0.1-SNAPSHOT
+EOF
+
+  cat > "${TEST_ROOT}/android/junit-runner/build.gradle.kts" <<'EOF'
+version = "0.0.1-SNAPSHOT"
+EOF
+
+  cat > "${TEST_ROOT}/android/playground/app/build.gradle.kts" <<'EOF'
+android {
+  defaultConfig {
+    versionName = "0.0.1-SNAPSHOT"
+  }
+}
+EOF
+
+  cat > "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift" <<'EOF'
+enum AutoMobileVersion {
+  public static let current = "0.0.1"
+}
+EOF
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+print(eval(sys.argv[2]))
+PY
+}
+
+run_bump() {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --new-version '${VERSION}'"
+}
+
+@test "writes plain semver to package/runtime surfaces and SNAPSHOT to Android dev coordinates" {
+  run_bump
+  [ "$status" -eq 0 ]
+
+  [ "$(json_field "${TEST_ROOT}/package.json" 'data["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/plugin.json" 'data["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/.claude-plugin/marketplace.json" 'data["plugins"][0]["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/server.json" 'data["version"]')" = "$VERSION" ]
+  [ "$(json_field "${TEST_ROOT}/server.json" 'data["packages"][0]["version"]')" = "$VERSION" ]
+
+  grep -q "^VERSION_NAME=${VERSION}-SNAPSHOT$" "${TEST_ROOT}/android/gradle.properties"
+  grep -q "^version = \"${VERSION}-SNAPSHOT\"$" "${TEST_ROOT}/android/junit-runner/build.gradle.kts"
+  grep -q "versionName = \"${VERSION}-SNAPSHOT\"" "${TEST_ROOT}/android/playground/app/build.gradle.kts"
+  grep -q "public static let current = \"${VERSION}\"" \
+    "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift"
+}
+
+@test "dry-run output names SNAPSHOT as the Android dev/Maven coordinate policy" {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --new-version '${VERSION}' --dry-run"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Package/runtime version -> ${VERSION}"* ]]
+  [[ "$output" == *"Android dev/Maven coordinate -> ${VERSION}-SNAPSHOT"* ]]
+}


### PR DESCRIPTION
## Summary

Formally accepts the local Android `-SNAPSHOT` coordinate divergence as intentional Maven development semantics. Documents the policy in the JUnit runner setup guide, clarifies the version bump script's dry-run wording, and adds BATS coverage proving package/runtime surfaces stay on plain semver while Android dev coordinates keep `-SNAPSHOT`.

## Linked Issue

Closes #2807

## Bug / Regression Context

- **Prior attempts:** #2747 tolerated the divergence in the release gate by comparing the SNAPSHOT-stripped base version, but #2807 remained open for the maintainer decision.
- **Observed symptom:** A local source build can produce a `0.0.x-SNAPSHOT` Maven coordinate while the runner jar's `Implementation-Version` remains `0.0.x`.
- **Repro steps / conditions:** Run the version bump script or publish local Android Gradle artifacts from source; Android Gradle coordinates use `VERSION_NAME=<version>-SNAPSHOT`, while package/runtime identity surfaces use the plain package version.

## Validation

- [x] `bats test/bats/bump-versions.bats` passes
- [x] `bats test/bats/verify-release-integrity.bats` passes
- [x] `bats test/bats/` passes
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck` passes
- [x] `bun run turbo:validate` passes (`lint`, `build`, `test`)
- [x] `bun run typecheck` reports no new errors (253 known baseline errors)
- [x] Rebased onto latest `origin/main`, conflicts resolved

## Device Verification

N/A - documentation and versioning-script coverage only.

## Follow-ups

None.
