### PR TITLE
fix(ios): collapse UIKit observe noise

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -879,7 +879,8 @@ public class ElementLocator: ElementLocating {
                 let optimized = children.flatMap { child in
                     optimizeHierarchy(child, isRoot: false)
                 }
-                optimizedChildren = optimized.isEmpty ? nil : optimized
+                let cleaned = ElementLocator.cleanupXCTestUIKitNoise(parent: element, children: optimized)
+                optimizedChildren = cleaned.isEmpty ? nil : cleaned
             }
 
             // Root element is always kept
@@ -1292,5 +1293,136 @@ public class ElementLocator: ElementLocating {
             result.append(child)
         }
         return result
+    }
+
+    /// Collapse common XCTest/UIKit hierarchy noise that survives the generic
+    /// structural wrapper pass. The rules are intentionally conservative:
+    /// discard duplicated labels/scroll bars/accessory nodes only when the node
+    /// is non-actionable, while preserving tappable controls, text inputs, ids,
+    /// focus/selection state, and meaningful descendants.
+    static func cleanupXCTestUIKitNoise(parent: UIElementInfo, children: [UIElementInfo]) -> [UIElementInfo] {
+        var seenNoiseKeys: Set<String> = []
+        var result: [UIElementInfo] = []
+
+        for child in children {
+            if isDuplicateLabel(child, of: parent) {
+                continue
+            }
+            if isStructuralWrapperWithOnlyScrollBarNoise(child) {
+                continue
+            }
+            if let key = dedupeNoiseKey(child) {
+                if seenNoiseKeys.contains(key) {
+                    continue
+                }
+                seenNoiseKeys.insert(key)
+            }
+            result.append(child)
+        }
+
+        return result
+    }
+
+    private static func isDuplicateLabel(_ child: UIElementInfo, of parent: UIElementInfo) -> Bool {
+        guard let parentText = parent.text,
+              let childText = child.text,
+              parentText == childText,
+              child.className == "UILabel",
+              isActionableContainer(parent),
+              !isActionable(child)
+        else {
+            return false
+        }
+        return true
+    }
+
+    private static func isActionableContainer(_ element: UIElementInfo) -> Bool {
+        return element.clickable == "true"
+            || element.role == "button"
+            || element.role == "listitem"
+            || element.className == "UIButton"
+            || element.className == "UITableViewCell"
+            || element.className == "UICollectionViewCell"
+    }
+
+    private static func isActionable(_ element: UIElementInfo) -> Bool {
+        return element.clickable == "true"
+            || element.resourceId != nil
+            || hasProtectedMetadata(element)
+    }
+
+    private static func isStructuralWrapperWithOnlyScrollBarNoise(_ element: UIElementInfo) -> Bool {
+        guard element.className == "UIView",
+              !isActionable(element),
+              element.text == nil,
+              element.value == nil,
+              element.contentDesc == nil,
+              element.resourceId == nil,
+              element.hintText == nil,
+              let children = element.node,
+              !children.isEmpty
+        else {
+            return false
+        }
+        return children.allSatisfy { isScrollBarNoise($0) && !isActionable($0) }
+    }
+
+    private static func dedupeNoiseKey(_ element: UIElementInfo) -> String? {
+        guard element.node?.isEmpty ?? true else {
+            return nil
+        }
+
+        if isScrollBarNoise(element) && !isActionable(element) {
+            return "\(element.className ?? "")|\(normalizedText(element.text))|\(boundsKey(element.bounds))|\(element.resourceId ?? "")"
+        }
+        if isKeyboardAccessoryNoise(element) && !hasProtectedMetadata(element) {
+            return "\(element.className ?? "")|\(normalizedText(element.text))|\(boundsKey(element.bounds))|\(element.resourceId ?? "")"
+        }
+        return nil
+    }
+
+    private static func hasProtectedMetadata(_ element: UIElementInfo) -> Bool {
+        return element.longClickable == "true"
+            || element.focused == "true"
+            || element.accessibilityFocused == "true"
+            || element.selected == "true"
+            || element.checkable == "true"
+            || element.checked == "true"
+            || element.scrollable == "true"
+            || element.testTag != nil
+            || hasProtectedRoleMetadata(element)
+            || element.stateDescription != nil
+            || element.errorMessage != nil
+            || element.hintText != nil
+            || element.extras?.isEmpty == false
+            || element.actions?.isEmpty == false
+            || textInputClassNames.contains(element.className ?? "")
+    }
+
+    private static func hasProtectedRoleMetadata(_ element: UIElementInfo) -> Bool {
+        guard let role = element.role else {
+            return false
+        }
+        return role != "text" && role != "button"
+    }
+
+    private static func isScrollBarNoise(_ element: UIElementInfo) -> Bool {
+        return normalizedText(element.text).contains("scroll bar")
+    }
+
+    private static func isKeyboardAccessoryNoise(_ element: UIElementInfo) -> Bool {
+        let text = normalizedText(element.text)
+        return text == "dictation" || text == "dictate"
+    }
+
+    private static func normalizedText(_ text: String?) -> String {
+        return text?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    }
+
+    private static func boundsKey(_ bounds: ElementBounds?) -> String {
+        guard let bounds = bounds else {
+            return "nobounds"
+        }
+        return "\(bounds.left),\(bounds.top),\(bounds.right),\(bounds.bottom)"
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -917,6 +917,9 @@ public class ElementLocator: ElementLocating {
             // Only promote children (flatten hierarchy) if this is a bounds-only wrapper AND not interactive
             if isBoundsOnlyWrapper && !isInteractive {
                 if let children = optimizedChildren {
+                    if ElementLocator.containsOnlyUnprotectedScrollBarNoise(children) {
+                        return []
+                    }
                     // Promote children - flatten this wrapper node
                     return children
                 }
@@ -1364,7 +1367,11 @@ public class ElementLocator: ElementLocating {
         else {
             return false
         }
-        return children.allSatisfy { isScrollBarNoise($0) && !isActionable($0) }
+        return containsOnlyUnprotectedScrollBarNoise(children)
+    }
+
+    private static func containsOnlyUnprotectedScrollBarNoise(_ children: [UIElementInfo]) -> Bool {
+        return !children.isEmpty && children.allSatisfy { isScrollBarNoise($0) && !isActionable($0) }
     }
 
     private static func dedupeNoiseKey(_ element: UIElementInfo) -> String? {

--- a/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
@@ -223,6 +223,138 @@ final class ElementLocatorTests: XCTestCase {
         XCTAssertEqual(result[0].className, "UIView")
     }
 
+    // MARK: - XCTest/UIKit structural noise cleanup (#3317)
+
+    func testCleanup_dedupesDuplicateScrollBarsWithTextAndBounds() {
+        let bounds = ElementBounds(left: 383, top: 156, right: 390, bottom: 742)
+        let first = UIElementInfo(text: "Vertical scroll bar, 1 page", className: "UIView", bounds: bounds)
+        let duplicate = UIElementInfo(text: "Vertical scroll bar, 1 page", className: "UIView", bounds: bounds)
+        let reminder = UIElementInfo(text: "Groceries", className: "UITableViewCell", bounds: ElementBounds(left: 0, top: 156, right: 393, bottom: 200))
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(className: "UITableView", scrollable: "true"),
+            children: [first, duplicate, reminder]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.filter { $0.text == "Vertical scroll bar, 1 page" }.count, 1)
+        XCTAssertEqual(result[1].text, "Groceries")
+    }
+
+    func testCleanup_removesLabelChildDuplicatingActionableParentText() {
+        let duplicateLabel = UIElementInfo(text: "New Reminder", className: "UILabel", bounds: ElementBounds(left: 16, top: 786, right: 201, bottom: 823), role: "text")
+        let icon = UIElementInfo(resourceId: "plus", className: "UIImageView", bounds: ElementBounds(left: 16, top: 790, right: 36, bottom: 810))
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(text: "New Reminder", className: "UIButton", clickable: "true"),
+            children: [duplicateLabel, icon]
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].resourceId, "plus")
+    }
+
+    func testCleanup_removesStructuralWrapperContainingOnlyScrollbarNoise() {
+        let scrollBar = UIElementInfo(text: "Horizontal scroll bar, 1 page", className: "UIView", bounds: ElementBounds(left: 30, top: 830, right: 363, bottom: 837))
+        let wrapper = UIElementInfo(className: "UIView", bounds: ElementBounds(left: 0, top: 786, right: 393, bottom: 852), node: [scrollBar])
+        let toolbarButton = UIElementInfo(text: "Lists", className: "UIButton", bounds: ElementBounds(left: 300, top: 786, right: 370, bottom: 823), clickable: "true")
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(className: "UIView"),
+            children: [wrapper, toolbarButton]
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].text, "Lists")
+    }
+
+    func testCleanup_dedupesRepeatedKeyboardAccessoryAndDictationNodes() {
+        let bounds = ElementBounds(left: 0, top: 720, right: 393, bottom: 760)
+        let first = UIElementInfo(text: "dictation", className: "UIButton", bounds: bounds, clickable: "true", role: "button")
+        let duplicate = UIElementInfo(text: "dictation", className: "UIButton", bounds: bounds, clickable: "true", role: "button")
+        let done = UIElementInfo(text: "Done", className: "UIButton", bounds: ElementBounds(left: 335, top: 720, right: 383, bottom: 760), clickable: "true")
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(className: "UIKeyboard"),
+            children: [first, duplicate, done]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.filter { $0.text == "dictation" }.count, 1)
+        XCTAssertEqual(result[1].text, "Done")
+    }
+
+    func testCleanup_preservesKeyboardAccessoryNodesWithDistinctResourceIds() {
+        let bounds = ElementBounds(left: 0, top: 720, right: 393, bottom: 760)
+        let first = UIElementInfo(text: "dictation", resourceId: "dictation-primary", className: "UIButton", bounds: bounds, clickable: "true", role: "button")
+        let second = UIElementInfo(text: "dictation", resourceId: "dictation-secondary", className: "UIButton", bounds: bounds, clickable: "true", role: "button")
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(className: "UIKeyboard"),
+            children: [first, second]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].resourceId, "dictation-primary")
+        XCTAssertEqual(result[1].resourceId, "dictation-secondary")
+    }
+
+    func testCleanup_preservesActionableControlEvenWhenTextDuplicatesParent() {
+        let childButton = UIElementInfo(text: "New Reminder", resourceId: "new_reminder_child", className: "UIButton", clickable: "true")
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(text: "New Reminder", className: "UIButton", clickable: "true"),
+            children: [childButton]
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].resourceId, "new_reminder_child")
+        XCTAssertEqual(result[0].clickable, "true")
+    }
+
+    func testCleanup_preservesLongClickableNodeThatLooksLikeDuplicateNoise() {
+        let bounds = ElementBounds(left: 12, top: 120, right: 380, bottom: 164)
+        let first = UIElementInfo(text: "More", className: "UIView", bounds: bounds, longClickable: "true")
+        let second = UIElementInfo(text: "More", className: "UIView", bounds: bounds, longClickable: "true")
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(className: "UIView"),
+            children: [first, second]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].longClickable, "true")
+        XCTAssertEqual(result[1].longClickable, "true")
+    }
+
+    func testCleanup_preservesRoleBearingContainerAroundScrollBarText() {
+        let scrollBar = UIElementInfo(text: "Vertical scroll bar, 1 page", className: "UIView", bounds: ElementBounds(left: 383, top: 156, right: 390, bottom: 704))
+        let container = UIElementInfo(className: "UIView", bounds: ElementBounds(left: 0, top: 120, right: 393, bottom: 720), role: "listitem", node: [scrollBar])
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(className: "UIView"),
+            children: [container]
+        )
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].role, "listitem")
+        XCTAssertEqual(result[0].node?.first?.text, "Vertical scroll bar, 1 page")
+    }
+
+    func testCleanup_preservesSdkOrCustomActionMetadata() {
+        let bounds = ElementBounds(left: 0, top: 720, right: 393, bottom: 760)
+        let withActions = UIElementInfo(text: "dictation", className: "UIButton", bounds: bounds, actions: ["custom_action"])
+        let withExtras = UIElementInfo(text: "dictation", className: "UIButton", bounds: bounds, extras: ["sdk.gestureRecognizers": "UILongPressGestureRecognizer"])
+
+        let result = ElementLocator.cleanupXCTestUIKitNoise(
+            parent: UIElementInfo(className: "UIKeyboard"),
+            children: [withActions, withExtras]
+        )
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].actions, ["custom_action"])
+        XCTAssertEqual(result[1].extras?["sdk.gestureRecognizers"], "UILongPressGestureRecognizer")
+    }
+
     func testDedup_sameType_differentBounds_kept() {
         let a = UIElementInfo(className: "UIView", bounds: ElementBounds(left: 0, top: 0, right: 100, bottom: 50))
         let b = UIElementInfo(className: "UIView", bounds: ElementBounds(left: 0, top: 50, right: 100, bottom: 100))

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -10,6 +10,7 @@ import { DefaultElementGeometry } from "../utility/ElementGeometry";
 import { ViewHierarchyQueryOptions } from "../../models";
 import { AndroidCtrlProxyClient } from "./android";
 import { IOSCtrlProxyClient } from "./ios";
+import { cleanupIosXCTestHierarchy } from "./ios/cleanupIosHierarchy";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { serverConfig } from "../../utils/ServerConfig";
 import { attachRawViewHierarchy } from "../../utils/viewHierarchySearch";
@@ -151,8 +152,9 @@ export class ViewHierarchy implements ViewHierarchyInterface {
    * Convert XCTestHierarchy to ViewHierarchyResult format
    */
   private convertXCTestHierarchy(hierarchy: any, updatedAt?: number, ctrlProxyReconnect?: ViewHierarchyResult["ctrlProxyReconnect"]): ViewHierarchyResult {
+    const cleanedHierarchy = cleanupIosXCTestHierarchy(hierarchy);
     const result = {
-      ...hierarchy,
+      ...cleanedHierarchy,
       updatedAt: updatedAt ?? hierarchy.updatedAt ?? this.timer.now()
     };
     if (ctrlProxyReconnect) {

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -25,6 +25,8 @@ interface ConvertedNode {
   node?: ConvertedNode[];
 }
 
+const GENERATED_VIEW_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Delegate class for handling hierarchy operations.
  */
@@ -283,10 +285,12 @@ export class CtrlProxyHierarchy {
     if (node.checked) {attrs["checked"] = node.checked;}
     if (node.selected) {attrs["selected"] = node.selected;}
     if (longClickable) {attrs["long-clickable"] = longClickable;}
+    if (node.role) {attrs["role"] = node.role;}
     if (stateDescription) {attrs["state-description"] = stateDescription;}
     if (errorMessage) {attrs["error-message"] = errorMessage;}
     if (hintText) {attrs["hint-text"] = hintText;}
     if (viewId) {attrs["view-id"] = viewId;}
+    if (node.actions && node.actions.length > 0) {attrs["actions"] = node.actions;}
 
     const result: ConvertedNode = { $: attrs };
 
@@ -323,7 +327,8 @@ export class CtrlProxyHierarchy {
       (attrs["resource-id"] && attrs["resource-id"] !== "") ||
       (attrs["content-desc"] && attrs["content-desc"] !== "") ||
       (attrs["test-tag"] && attrs["test-tag"] !== "") ||
-      (attrs["view-id"] && attrs["view-id"] !== "")
+      (attrs["role"] && attrs["role"] !== "") ||
+      this.hasMeaningfulViewId(attrs)
     );
   }
 
@@ -335,6 +340,7 @@ export class CtrlProxyHierarchy {
     return Boolean(
       attrs["scrollable"] === "true" ||
       attrs["focused"] === "true" ||
+      attrs["accessibility-focused"] === "true" ||
       attrs["selected"] === "true" ||
       attrs["checked"] === "true"
     );
@@ -345,7 +351,7 @@ export class CtrlProxyHierarchy {
    */
   private isStructuralWrapper(attrs: Record<string, unknown>, hasChildren: boolean): boolean {
     const className = typeof attrs["class"] === "string" ? attrs["class"] : "";
-    const isContainerClass = className === "UIView" || className === "UIImageView";
+    const isContainerClass = className === "UIWindow" || className === "UIView" || className === "UIImageView";
 
     // Not a wrapper if it has content or is focused/selected/scrollable
     if (this.hasContentProperties(attrs) || this.hasInteractionProperties(attrs)) {
@@ -362,7 +368,7 @@ export class CtrlProxyHierarchy {
    */
   private cleanAttributes(attrs: Record<string, unknown>): Record<string, unknown> {
     const cleaned: Record<string, unknown> = {};
-    const booleanFields = ["clickable", "enabled", "focusable", "focused", "scrollable",
+    const booleanFields = ["clickable", "enabled", "focusable", "focused", "accessibility-focused", "scrollable",
       "password", "checkable", "checked", "selected", "long-clickable"];
 
     for (const [key, value] of Object.entries(attrs)) {
@@ -411,24 +417,26 @@ export class CtrlProxyHierarchy {
         }
       }
     }
+    const compactedChildren = this.dropRedundantStaticTextChildren(attrs, filteredChildren);
+    const dedupedChildren = this.dedupeNoiseSiblings(compactedChildren);
 
     // Root node is always kept
     if (isRoot) {
       const cleanedAttrs = this.cleanAttributes(attrs);
       const result: ConvertedNode = { $: cleanedAttrs };
       if (node.extras) { result.extras = node.extras; }
-      if (filteredChildren.length > 0) {
-        result.node = filteredChildren;
+      if (dedupedChildren.length > 0) {
+        result.node = dedupedChildren;
       }
       return result;
     }
 
     // Check if this node is a structural wrapper
-    if (this.isStructuralWrapper(attrs, filteredChildren.length > 0)) {
+    if (this.isStructuralWrapper(attrs, dedupedChildren.length > 0)) {
       // Promote children (collapse this wrapper)
-      if (filteredChildren.length > 0) {
+      if (dedupedChildren.length > 0) {
         // Return children to be flattened into parent
-        return filteredChildren as unknown as ConvertedNode;
+        return dedupedChildren as unknown as ConvertedNode;
       }
       // No children and no content - filter out completely
       return null;
@@ -444,7 +452,7 @@ export class CtrlProxyHierarchy {
     // 2. Has interaction properties (scrollable, focused, selected)
     // 3. Is clickable and is a leaf node (actual tappable element)
     // 4. Has meaningful filtered children
-    const keepNode = hasContent || hasInteraction || (isClickable && filteredChildren.length === 0) || filteredChildren.length > 0;
+    const keepNode = hasContent || hasInteraction || (isClickable && dedupedChildren.length === 0) || dedupedChildren.length > 0;
 
     if (!keepNode) {
       return null;
@@ -453,9 +461,141 @@ export class CtrlProxyHierarchy {
     const cleanedAttrs = this.cleanAttributes(attrs);
     const result: ConvertedNode = { $: cleanedAttrs };
     if (node.extras) { result.extras = node.extras; }
-    if (filteredChildren.length > 0) {
-      result.node = filteredChildren;
+    if (dedupedChildren.length > 0) {
+      result.node = dedupedChildren;
     }
     return result;
+  }
+
+  private dedupeNoiseSiblings(children: ConvertedNode[]): ConvertedNode[] {
+    const seen = new Set<string>();
+    const result: ConvertedNode[] = [];
+
+    for (const child of children) {
+      const key = this.noiseSiblingKey(child);
+      if (key) {
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+      }
+      result.push(child);
+    }
+
+    return result;
+  }
+
+  private dropRedundantStaticTextChildren(
+    parentAttrs: Record<string, unknown>,
+    children: ConvertedNode[]
+  ): ConvertedNode[] {
+    const parentText = this.normalizedText(parentAttrs["text"]);
+    if (!parentText || !this.canOwnStaticText(parentAttrs)) {
+      return children;
+    }
+
+    return children.filter(child => !this.isRedundantStaticTextChild(parentText, child));
+  }
+
+  private canOwnStaticText(attrs: Record<string, unknown>): boolean {
+    const role = typeof attrs["role"] === "string" ? attrs["role"] : "";
+    return attrs["clickable"] === "true" || role === "button" || role === "link" || role === "listitem";
+  }
+
+  private isRedundantStaticTextChild(parentText: string, child: ConvertedNode): boolean {
+    if (child.node && child.node.length > 0) {
+      return false;
+    }
+    if (child.extras && Object.keys(child.extras).length > 0) {
+      return false;
+    }
+
+    const attrs = child.$ ?? {};
+    const className = typeof attrs["class"] === "string" ? attrs["class"] : "";
+    const role = typeof attrs["role"] === "string" ? attrs["role"] : "";
+    if (className !== "UILabel" || (role !== "" && role !== "text")) {
+      return false;
+    }
+    if (this.normalizedText(attrs["text"]) !== parentText) {
+      return false;
+    }
+    if (Array.isArray(attrs["actions"]) && attrs["actions"].length > 0) {
+      return false;
+    }
+    if (this.hasStateProperties(attrs) || this.hasDirectActionProperties(attrs)) {
+      return false;
+    }
+
+    return !this.hasStandaloneContentProperties(attrs);
+  }
+
+  private hasStandaloneContentProperties(attrs: Record<string, unknown>): boolean {
+    return Boolean(
+      (attrs["value"] && attrs["value"] !== "") ||
+      (attrs["resource-id"] && attrs["resource-id"] !== "") ||
+      (attrs["content-desc"] && attrs["content-desc"] !== "") ||
+      (attrs["test-tag"] && attrs["test-tag"] !== "") ||
+      this.hasMeaningfulViewId(attrs)
+    );
+  }
+
+  private hasMeaningfulViewId(attrs: Record<string, unknown>): boolean {
+    const viewId = attrs["view-id"];
+    return typeof viewId === "string" &&
+      viewId !== "" &&
+      !GENERATED_VIEW_ID_PATTERN.test(viewId);
+  }
+
+  private hasDirectActionProperties(attrs: Record<string, unknown>): boolean {
+    return Boolean(
+      attrs["clickable"] === "true" ||
+      attrs["focusable"] === "true" ||
+      attrs["long-clickable"] === "true" ||
+      attrs["checkable"] === "true"
+    );
+  }
+
+  private hasStateProperties(attrs: Record<string, unknown>): boolean {
+    return Boolean(
+      attrs["scrollable"] === "true" ||
+      attrs["focused"] === "true" ||
+      attrs["accessibility-focused"] === "true" ||
+      attrs["selected"] === "true" ||
+      attrs["checked"] === "true"
+    );
+  }
+
+  private normalizedText(value: unknown): string {
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  private noiseSiblingKey(node: ConvertedNode): string | null {
+    if (node.node && node.node.length > 0) {
+      return null;
+    }
+    if (node.extras && Object.keys(node.extras).length > 0) {
+      return null;
+    }
+
+    const attrs = node.$ ?? {};
+    if (Array.isArray(attrs["actions"]) && attrs["actions"].length > 0) {
+      return null;
+    }
+    if (this.hasStateProperties(attrs)) {
+      return null;
+    }
+
+    const text = typeof attrs["text"] === "string" ? attrs["text"].trim().toLowerCase() : "";
+    const isKnownNoise = text.includes("scroll bar") || text === "dictate" || text === "dictation";
+    if (!isKnownNoise) {
+      return null;
+    }
+
+    return JSON.stringify([
+      attrs["class"] ?? "",
+      attrs["text"] ?? "",
+      attrs["resource-id"] ?? "",
+      attrs["bounds"] ?? null,
+    ]);
   }
 }

--- a/src/features/observe/ios/cleanupIosHierarchy.ts
+++ b/src/features/observe/ios/cleanupIosHierarchy.ts
@@ -1,0 +1,305 @@
+const GENERATED_VIEW_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type IosHierarchyNode = Record<string, unknown> & {
+  node?: IosHierarchyNode | IosHierarchyNode[];
+};
+
+export function cleanupIosXCTestHierarchy<T>(hierarchy: T): T {
+  if (!hierarchy || typeof hierarchy !== "object") {
+    return hierarchy;
+  }
+
+  const root = hierarchy as Record<string, unknown>;
+  return {
+    ...root,
+    hierarchy: cleanupNodeSlot(root.hierarchy)
+  } as T;
+}
+
+function cleanupNodeSlot(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.flatMap(child => {
+      const cleaned = cleanupNode(child as IosHierarchyNode);
+      return cleaned ? [cleaned] : [];
+    });
+  }
+  if (node && typeof node === "object") {
+    return cleanupNode(node as IosHierarchyNode);
+  }
+  return node;
+}
+
+function cleanupNode(node: IosHierarchyNode): IosHierarchyNode | null {
+  const children = normalizeChildren(node.node)
+    .map(cleanupNode)
+    .filter((child): child is IosHierarchyNode => child !== null);
+  const compactedChildren = dedupeNoiseSiblings(
+    dropStructuralScrollBarWrappers(dropRedundantStaticTextChildren(node, children))
+  );
+  if (isSingleChildStructuralWrapper(node, compactedChildren)) {
+    return compactedChildren[0];
+  }
+  const result: IosHierarchyNode = { ...node };
+
+  if (compactedChildren.length === 0) {
+    delete result.node;
+  } else {
+    result.node = compactedChildren.length === 1 ? compactedChildren[0] : compactedChildren;
+  }
+
+  return result;
+}
+
+function normalizeChildren(node: IosHierarchyNode["node"]): IosHierarchyNode[] {
+  if (!node) {
+    return [];
+  }
+  return Array.isArray(node) ? node : [node];
+}
+
+function dropRedundantStaticTextChildren(
+  parent: IosHierarchyNode,
+  children: IosHierarchyNode[]
+): IosHierarchyNode[] {
+  const parentText = normalizedText(parent.text);
+  if (!parentText || !canOwnStaticText(parent)) {
+    return children;
+  }
+
+  return children.filter(child => !isRedundantStaticTextChild(parentText, child));
+}
+
+function canOwnStaticText(node: IosHierarchyNode): boolean {
+  const role = typeof node.role === "string" ? node.role : "";
+  return node.clickable === "true" || role === "button" || role === "link" || role === "listitem";
+}
+
+function isRedundantStaticTextChild(parentText: string, child: IosHierarchyNode): boolean {
+  if (child.node) {
+    return false;
+  }
+  if (hasExtras(child)) {
+    return false;
+  }
+
+  const className = readClassName(child);
+  const role = typeof child.role === "string" ? child.role : "";
+  if (className !== "UILabel" || (role !== "" && role !== "text")) {
+    return false;
+  }
+  if (normalizedText(child.text) !== parentText) {
+    return false;
+  }
+  if (hasActions(child) || hasStateProperties(child) || hasDirectActionProperties(child)) {
+    return false;
+  }
+
+  return !hasStandaloneContentProperties(child);
+}
+
+function dedupeNoiseSiblings(children: IosHierarchyNode[]): IosHierarchyNode[] {
+  const seen = new Set<string>();
+
+  return children
+    .map(child => dedupeNoiseDescendants(child, seen))
+    .filter((child): child is IosHierarchyNode => child !== null);
+}
+
+function dropStructuralScrollBarWrappers(children: IosHierarchyNode[]): IosHierarchyNode[] {
+  return children.filter(child => !isStructuralWrapperWithOnlyScrollBarNoise(child));
+}
+
+function dedupeNoiseDescendants(
+  node: IosHierarchyNode,
+  seen: Set<string>
+): IosHierarchyNode | null {
+  const key = noiseSiblingKey(node);
+  if (key) {
+    if (seen.has(key)) {
+      return null;
+    }
+    seen.add(key);
+  }
+
+  const children = normalizeChildren(node.node);
+  if (children.length === 0) {
+    return node;
+  }
+
+  const result: IosHierarchyNode[] = [];
+  let changed = false;
+
+  for (const child of children) {
+    const cleaned = dedupeNoiseDescendants(child, seen);
+    if (cleaned) {
+      result.push(cleaned);
+      if (cleaned !== child) {
+        changed = true;
+      }
+    } else {
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return node;
+  }
+
+  const cleanedNode = { ...node };
+  if (result.length === 0) {
+    delete cleanedNode.node;
+  } else {
+    cleanedNode.node = result.length === 1 ? result[0] : result;
+  }
+  return cleanedNode;
+}
+
+function noiseSiblingKey(node: IosHierarchyNode): string | null {
+  if (node.node) {
+    return null;
+  }
+  if (hasExtras(node) || hasActions(node)) {
+    return null;
+  }
+  if (hasStateProperties(node)) {
+    return null;
+  }
+
+  const text = normalizedText(node.text).toLowerCase();
+  const isKnownNoise = text.includes("scroll bar") || text === "dictate" || text === "dictation";
+  if (!isKnownNoise) {
+    return null;
+  }
+
+  return JSON.stringify([
+    readClassName(node),
+    node.text ?? "",
+    readResourceId(node),
+    node.bounds ?? null,
+  ]);
+}
+
+function hasStandaloneContentProperties(node: IosHierarchyNode): boolean {
+  return Boolean(
+    hasNonEmptyString(node.value) ||
+    hasNonEmptyString(readResourceId(node)) ||
+    hasNonEmptyString(readContentDesc(node)) ||
+    hasNonEmptyString(readHintText(node)) ||
+    hasNonEmptyString(node["test-tag"]) ||
+    hasNonEmptyString(node.testTag) ||
+    hasMeaningfulViewId(node)
+  );
+}
+
+function isStructuralWrapperWithOnlyScrollBarNoise(node: IosHierarchyNode): boolean {
+  const children = normalizeChildren(node.node);
+  if (
+    readClassName(node) !== "UIView" ||
+    children.length === 0 ||
+    normalizedText(node.text) ||
+    hasStandaloneContentProperties(node) ||
+    hasExtras(node) ||
+    hasActions(node) ||
+    hasStateProperties(node) ||
+    hasDirectActionProperties(node)
+  ) {
+    return false;
+  }
+
+  return children.every(child => isScrollBarNoise(child) && !isProtectedNoiseNode(child));
+}
+
+function isSingleChildStructuralWrapper(
+  node: IosHierarchyNode,
+  children: IosHierarchyNode[]
+): boolean {
+  if (children.length !== 1 || hasExtras(node) || hasActions(node)) {
+    return false;
+  }
+  if (readClassName(node) !== "WKWebView") {
+    return false;
+  }
+  if (normalizedText(node.text) || hasStandaloneContentProperties(node)) {
+    return false;
+  }
+
+  return !hasStateProperties(node) && !hasDirectActionProperties(node);
+}
+
+function hasStateProperties(node: IosHierarchyNode): boolean {
+  return Boolean(
+    node.scrollable === "true" ||
+    node.focused === "true" ||
+    node.accessibilityFocused === "true" ||
+    node["accessibility-focused"] === "true" ||
+    node.selected === "true" ||
+    node.checked === "true"
+  );
+}
+
+function hasMeaningfulViewId(node: IosHierarchyNode): boolean {
+  const viewId = readViewId(node);
+  return typeof viewId === "string" &&
+    viewId !== "" &&
+    !GENERATED_VIEW_ID_PATTERN.test(viewId);
+}
+
+function hasDirectActionProperties(node: IosHierarchyNode): boolean {
+  return Boolean(
+    node.clickable === "true" ||
+    node.focusable === "true" ||
+    node["long-clickable"] === "true" ||
+    node.longClickable === "true" ||
+    node.checkable === "true"
+  );
+}
+
+function isProtectedNoiseNode(node: IosHierarchyNode): boolean {
+  return Boolean(
+    hasExtras(node) ||
+    hasActions(node) ||
+    hasStateProperties(node) ||
+    hasDirectActionProperties(node) ||
+    hasStandaloneContentProperties(node)
+  );
+}
+
+function isScrollBarNoise(node: IosHierarchyNode): boolean {
+  return normalizedText(node.text).toLowerCase().includes("scroll bar");
+}
+
+function hasActions(node: IosHierarchyNode): boolean {
+  return Array.isArray(node.actions) && node.actions.length > 0;
+}
+
+function hasExtras(node: IosHierarchyNode): boolean {
+  return !!node.extras && typeof node.extras === "object" && Object.keys(node.extras).length > 0;
+}
+
+function readClassName(node: IosHierarchyNode): unknown {
+  return node.className ?? node.class ?? "";
+}
+
+function readResourceId(node: IosHierarchyNode): unknown {
+  return node["resource-id"] ?? node.resourceId;
+}
+
+function readContentDesc(node: IosHierarchyNode): unknown {
+  return node["content-desc"] ?? node.contentDesc;
+}
+
+function readHintText(node: IosHierarchyNode): unknown {
+  return node["hint-text"] ?? node.hintText;
+}
+
+function readViewId(node: IosHierarchyNode): unknown {
+  return node["view-id"] ?? node.viewId;
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value !== "";
+}
+
+function normalizedText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/test/features/observe/ios/CtrlProxyHierarchy.test.ts
+++ b/test/features/observe/ios/CtrlProxyHierarchy.test.ts
@@ -16,6 +16,18 @@ function findFirstNodeWith(
   return null;
 }
 
+function countNodesWith(
+  node: any,
+  predicate: (attrs: Record<string, string>) => boolean
+): number {
+  if (!node) {return 0;}
+  const current = node.$ && predicate(node.$) ? 1 : 0;
+  return current + (node.node ?? []).reduce(
+    (count: number, child: any) => count + countNodesWith(child, predicate),
+    0
+  );
+}
+
 function makeHierarchy(root: CtrlProxyNode): any {
   return {
     updatedAt: 0,
@@ -101,5 +113,502 @@ describe("CtrlProxyHierarchy.convertToViewHierarchyResult", () => {
     expect(label).not.toBeNull();
     expect(label.$["value"]).toBeUndefined();
     expect(label.$["text"]).toBe("Static label");
+  });
+
+  test("collapses structural wrappers whose only content is a generated view-id", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIWindow",
+          viewId: "5513e3ea-bba6-d754-02c1-c34c7365c6fa",
+          bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+          node: [
+            {
+              className: "UIView",
+              viewId: "54b54709-d08c-3814-4e4f-c66bf50820d8",
+              bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+              node: [
+                {
+                  className: "UIButton",
+                  text: "New Reminder",
+                  role: "button",
+                  clickable: "true",
+                  bounds: { left: 16, top: 806, right: 166, bottom: 830 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+
+    expect(countNodesWith(result.hierarchy.node, attrs => attrs["class"] === "UIWindow")).toBe(0);
+    expect(countNodesWith(result.hierarchy.node, attrs => attrs["class"] === "UIView")).toBe(0);
+    expect(findFirstNodeWith(result.hierarchy.node, attrs => attrs["text"] === "New Reminder")).not.toBeNull();
+  });
+
+  test("preserves structural wrapper with a non-generated view-id", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIView",
+          viewId: "custom-container-id",
+          bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+          node: [
+            {
+              className: "UILabel",
+              text: "Child",
+              bounds: { left: 20, top: 20, right: 120, bottom: 44 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const wrapper = findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["view-id"] === "custom-container-id"
+    );
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.$["class"]).toBe("UIView");
+  });
+
+  test("preserves accessibility-focused structural wrapper", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIView",
+          accessibilityFocused: "true",
+          bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+          node: [
+            {
+              className: "UILabel",
+              text: "Child",
+              bounds: { left: 20, top: 20, right: 120, bottom: 44 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const wrapper = findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["class"] === "UIView" && attrs["accessibility-focused"] === "true"
+    );
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.node).toHaveLength(1);
+  });
+
+  test("omits false accessibility-focused attribute", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UILabel",
+          text: "Child",
+          accessibilityFocused: "false",
+          bounds: { left: 20, top: 20, right: 120, bottom: 44 },
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const label = findFirstNodeWith(result.hierarchy.node, attrs => attrs["text"] === "Child");
+
+    expect(label).not.toBeNull();
+    expect(label.$["accessibility-focused"]).toBeUndefined();
+  });
+
+  test("dedupes exact duplicate Dictate noise leaves", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UISearchBar",
+          text: "Search",
+          bounds: { left: 16, top: 101, right: 386, bottom: 137 },
+          node: [
+            {
+              className: "UIButton",
+              text: "Dictate",
+              resourceId: "Dictate",
+              role: "button",
+              clickable: "true",
+              bounds: { left: 360, top: 108, right: 378, bottom: 130 },
+            },
+            {
+              className: "UIButton",
+              text: "Dictate",
+              resourceId: "Dictate",
+              role: "button",
+              clickable: "true",
+              bounds: { left: 360, top: 108, right: 378, bottom: 130 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+
+    expect(countNodesWith(result.hierarchy.node, attrs => attrs["text"] === "Dictate")).toBe(1);
+  });
+
+  test("preserves focused duplicate Dictate noise leaf", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UISearchBar",
+          text: "Search",
+          bounds: { left: 16, top: 101, right: 386, bottom: 137 },
+          node: [
+            {
+              className: "UIButton",
+              text: "Dictate",
+              resourceId: "Dictate",
+              role: "button",
+              clickable: "true",
+              bounds: { left: 360, top: 108, right: 378, bottom: 130 },
+            },
+            {
+              className: "UIButton",
+              text: "Dictate",
+              resourceId: "Dictate",
+              role: "button",
+              clickable: "true",
+              focused: "true",
+              bounds: { left: 360, top: 108, right: 378, bottom: 130 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+
+    expect(countNodesWith(result.hierarchy.node, attrs => attrs["text"] === "Dictate")).toBe(2);
+    expect(findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["text"] === "Dictate" && attrs["focused"] === "true"
+    )).not.toBeNull();
+  });
+
+  test("preserves accessibility-focused duplicate Dictate noise leaf", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UISearchBar",
+          text: "Search",
+          bounds: { left: 16, top: 101, right: 386, bottom: 137 },
+          node: [
+            {
+              className: "UIButton",
+              text: "Dictate",
+              resourceId: "Dictate",
+              role: "button",
+              clickable: "true",
+              bounds: { left: 360, top: 108, right: 378, bottom: 130 },
+            },
+            {
+              className: "UIButton",
+              text: "Dictate",
+              resourceId: "Dictate",
+              role: "button",
+              clickable: "true",
+              accessibilityFocused: "true",
+              bounds: { left: 360, top: 108, right: 378, bottom: 130 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+
+    expect(countNodesWith(result.hierarchy.node, attrs => attrs["text"] === "Dictate")).toBe(2);
+    expect(findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["text"] === "Dictate" && attrs["accessibility-focused"] === "true"
+    )).not.toBeNull();
+  });
+
+  test("dedupes exact duplicate action-sheet scrollbar leaves", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIScrollView",
+          scrollable: "true",
+          bounds: { left: 8, top: 718, right: 394, bottom: 775 },
+          node: [
+            {
+              className: "UIButton",
+              text: "Discard Changes",
+              role: "button",
+              clickable: "true",
+              bounds: { left: 8, top: 718, right: 394, bottom: 775 },
+            },
+            {
+              className: "UIView",
+              text: "Vertical scroll bar, 1 page",
+              bounds: { left: 361, top: 718, right: 391, bottom: 775 },
+            },
+            {
+              className: "UIView",
+              text: "Vertical scroll bar, 1 page",
+              bounds: { left: 361, top: 718, right: 391, bottom: 775 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+
+    expect(countNodesWith(
+      result.hierarchy.node,
+      attrs => attrs["text"] === "Vertical scroll bar, 1 page"
+    )).toBe(1);
+    expect(findFirstNodeWith(result.hierarchy.node, attrs => attrs["text"] === "Discard Changes")).not.toBeNull();
+  });
+
+  test("preserves role and custom actions", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UITextField",
+          text: "Title",
+          role: "textbox",
+          actions: ["set_text", "clear_text"],
+          bounds: { left: 16, top: 120, right: 386, bottom: 166 },
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const field = findFirstNodeWith(result.hierarchy.node, attrs => attrs["text"] === "Title");
+
+    expect(field).not.toBeNull();
+    expect(field.$["role"]).toBe("textbox");
+    expect(field.$["actions"]).toEqual(["set_text", "clear_text"]);
+  });
+
+  test("drops redundant static text child when actionable parent already has the same text", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIButton",
+          text: "New Reminder",
+          role: "button",
+          clickable: "true",
+          bounds: { left: 16, top: 806, right: 166, bottom: 830 },
+          node: [
+            {
+              className: "UILabel",
+              text: "New Reminder",
+              role: "text",
+              bounds: { left: 51, top: 808, right: 166, bottom: 828 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const button = findFirstNodeWith(result.hierarchy.node, attrs => attrs["class"] === "UIButton");
+
+    expect(button).not.toBeNull();
+    expect(button.$["text"]).toBe("New Reminder");
+    expect(button.node).toBeUndefined();
+  });
+
+  test("preserves duplicate static text child when it has standalone metadata", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIButton",
+          text: "New Reminder",
+          role: "button",
+          clickable: "true",
+          bounds: { left: 16, top: 806, right: 166, bottom: 830 },
+          node: [
+            {
+              className: "UILabel",
+              text: "New Reminder",
+              role: "text",
+              resourceId: "button-title-label",
+              actions: ["custom_action"],
+              bounds: { left: 51, top: 808, right: 166, bottom: 828 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const label = findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["resource-id"] === "button-title-label"
+    );
+
+    expect(label).not.toBeNull();
+    expect(label.$["actions"]).toEqual(["custom_action"]);
+  });
+
+  test("preserves duplicate static text child when it has direct interaction properties", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIButton",
+          text: "Options",
+          role: "button",
+          clickable: "true",
+          bounds: { left: 16, top: 120, right: 166, bottom: 166 },
+          node: [
+            {
+              className: "UILabel",
+              text: "Options",
+              role: "text",
+              longClickable: "true",
+              bounds: { left: 51, top: 128, right: 140, bottom: 150 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const label = findFirstNodeWith(
+      result.hierarchy.node,
+      attrs => attrs["class"] === "UILabel" && attrs["text"] === "Options"
+    );
+
+    expect(label).not.toBeNull();
+    expect(label.$["long-clickable"]).toBe("true");
+  });
+
+  test("drops redundant static text child whose only metadata is a generated view-id", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIButton",
+          text: "Options",
+          role: "button",
+          clickable: "true",
+          bounds: { left: 16, top: 120, right: 166, bottom: 166 },
+          node: [
+            {
+              className: "UILabel",
+              text: "Options",
+              role: "text",
+              viewId: "5513e3ea-bba6-d754-02c1-c34c7365c6fa",
+              bounds: { left: 51, top: 128, right: 140, bottom: 150 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const button = findFirstNodeWith(result.hierarchy.node, attrs => attrs["class"] === "UIButton");
+
+    expect(button).not.toBeNull();
+    expect(button.node).toBeUndefined();
+  });
+
+  test("preserves focused static text child when link parent already has the same text", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UILink",
+          text: "Privacy",
+          role: "link",
+          clickable: "true",
+          bounds: { left: 239, top: 710, right: 285, bottom: 727 },
+          node: [
+            {
+              className: "UILabel",
+              text: "Privacy",
+              role: "text",
+              focused: "true",
+              bounds: { left: 239, top: 710, right: 285, bottom: 727 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const link = findFirstNodeWith(result.hierarchy.node, attrs => attrs["class"] === "UILink");
+
+    expect(link).not.toBeNull();
+    expect(link.$["text"]).toBe("Privacy");
+    expect(link.node).toHaveLength(1);
+    expect(link.node?.[0]?.$["class"]).toBe("UILabel");
+    expect(link.node?.[0]?.$["focused"]).toBe("true");
+  });
+
+  test("preserves accessibility-focused static text child when parent already has the same text", () => {
+    const root: CtrlProxyNode = {
+      className: "XCUIApplication",
+      bounds: { left: 0, top: 0, right: 402, bottom: 874 },
+      node: [
+        {
+          className: "UIButton",
+          text: "Continue",
+          role: "button",
+          clickable: "true",
+          bounds: { left: 20, top: 700, right: 370, bottom: 744 },
+          node: [
+            {
+              className: "UILabel",
+              text: "Continue",
+              role: "text",
+              accessibilityFocused: "true",
+              bounds: { left: 44, top: 710, right: 346, bottom: 734 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = subject.convertToViewHierarchyResult(makeHierarchy(root));
+    const button = findFirstNodeWith(result.hierarchy.node, attrs => attrs["class"] === "UIButton");
+
+    expect(button).not.toBeNull();
+    expect(button.node).toHaveLength(1);
+    expect(button.node?.[0]?.$["class"]).toBe("UILabel");
+    expect(button.node?.[0]?.$["accessibility-focused"]).toBe("true");
   });
 });

--- a/test/features/observe/ios/cleanupIosHierarchy.test.ts
+++ b/test/features/observe/ios/cleanupIosHierarchy.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, test } from "bun:test";
+import { cleanupIosXCTestHierarchy } from "../../../../src/features/observe/ios/cleanupIosHierarchy";
+import { loadIosRemindersNoiseObservePair } from "../../../fixtures/observe/observeFixture";
+
+function collectNodes(node: any): any[] {
+  if (!node) {
+    return [];
+  }
+  const children = Array.isArray(node.node) ? node.node : node.node ? [node.node] : [];
+  return [node, ...children.flatMap(collectNodes)];
+}
+
+describe("cleanupIosXCTestHierarchy", () => {
+  test("dedupes exact duplicate known-noise siblings", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: [
+          {
+            "className": "UIButton",
+            "text": "Dictate",
+            "resource-id": "Dictate",
+            "clickable": "true",
+            "bounds": [360, 108, 378, 130],
+          },
+          {
+            "className": "UIButton",
+            "text": "Dictate",
+            "resource-id": "Dictate",
+            "clickable": "true",
+            "bounds": [360, 108, 378, 130],
+          },
+        ],
+      },
+    });
+
+    expect(collectNodes(result.hierarchy).filter(node => node.text === "Dictate")).toHaveLength(1);
+  });
+
+  test("preserves focused known-noise leaf while deduping matching unfocused leaves", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: [
+          {
+            "className": "UIButton",
+            "text": "Dictate",
+            "resource-id": "Dictate",
+            "clickable": "true",
+            "bounds": [360, 108, 378, 130],
+          },
+          {
+            "className": "UIButton",
+            "text": "Dictate",
+            "resource-id": "Dictate",
+            "clickable": "true",
+            "focused": "true",
+            "bounds": [360, 108, 378, 130],
+          },
+        ],
+      },
+    });
+
+    const dictateNodes = collectNodes(result.hierarchy).filter(node => node.text === "Dictate");
+    expect(dictateNodes).toHaveLength(2);
+    expect(dictateNodes.some(node => node.focused === "true")).toBe(true);
+  });
+
+  test("preserves accessibility-focused known-noise leaf while deduping matching unfocused leaves", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: [
+          {
+            "className": "UIButton",
+            "text": "Dictate",
+            "resource-id": "Dictate",
+            "clickable": "true",
+            "bounds": [360, 108, 378, 130],
+          },
+          {
+            "className": "UIButton",
+            "text": "Dictate",
+            "resource-id": "Dictate",
+            "clickable": "true",
+            "accessibility-focused": "true",
+            "bounds": [360, 108, 378, 130],
+          },
+        ],
+      },
+    });
+
+    const dictateNodes = collectNodes(result.hierarchy).filter(node => node.text === "Dictate");
+    expect(dictateNodes).toHaveLength(2);
+    expect(dictateNodes.some(node => node["accessibility-focused"] === "true")).toBe(true);
+  });
+
+  test("drops redundant static label child represented by actionable parent text", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: {
+          className: "UIButton",
+          text: "New Reminder",
+          role: "button",
+          clickable: "true",
+          bounds: [16, 806, 166, 830],
+          node: {
+            className: "UILabel",
+            text: "New Reminder",
+            role: "text",
+            bounds: [51, 808, 166, 828],
+          },
+        },
+      },
+    });
+
+    const button = collectNodes(result.hierarchy).find(node => node.className === "UIButton");
+    expect(button.text).toBe("New Reminder");
+    expect(button.node).toBeUndefined();
+  });
+
+  test("preserves redundant-looking label child when it has operations or metadata", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: {
+          className: "UIButton",
+          text: "Options",
+          role: "button",
+          clickable: "true",
+          bounds: [16, 120, 166, 166],
+          node: [
+            {
+              className: "UILabel",
+              text: "Options",
+              role: "text",
+              actions: ["custom_action"],
+              bounds: [51, 128, 140, 150],
+            },
+            {
+              "className": "UILabel",
+              "text": "Options",
+              "role": "text",
+              "long-clickable": "true",
+              "bounds": [51, 152, 140, 174],
+            },
+            {
+              "className": "UILabel",
+              "text": "Options",
+              "role": "text",
+              "resource-id": "options-label",
+              "bounds": [51, 176, 140, 198],
+            },
+            {
+              "className": "UILabel",
+              "text": "Options",
+              "role": "text",
+              "hint-text": "Options hint",
+              "bounds": [51, 200, 140, 222],
+            },
+          ],
+        },
+      },
+    });
+
+    const labels = collectNodes(result.hierarchy).filter(node => node.className === "UILabel");
+    expect(labels.map(node => node["resource-id"] ?? node.actions?.[0] ?? node["long-clickable"] ?? node["hint-text"])).toEqual([
+      "custom_action",
+      "true",
+      "options-label",
+      "Options hint",
+    ]);
+  });
+
+  test("drops redundant static label child whose only metadata is a generated view-id", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: {
+          className: "UITableViewCell",
+          text: "List",
+          role: "listitem",
+          clickable: "true",
+          bounds: [20, 369, 382, 417],
+          node: {
+            "className": "UILabel",
+            "text": "List",
+            "role": "text",
+            "view-id": "5513e3ea-bba6-d754-02c1-c34c7365c6fa",
+            "bounds": [85, 383, 249, 403],
+          },
+        },
+      },
+    });
+
+    expect(collectNodes(result.hierarchy).filter(node => node.className === "UILabel")).toHaveLength(0);
+  });
+
+  test("dedupes known-noise leaves repeated in different descendant branches", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: [
+          {
+            className: "WKWebView",
+            node: {
+              className: "UIView",
+              text: "Horizontal scroll bar, 1 page",
+              bounds: [47, 811, 342, 841],
+            },
+          },
+          {
+            className: "UIScrollView",
+            node: {
+              className: "UIView",
+              text: "Horizontal scroll bar, 1 page",
+              bounds: [47, 811, 342, 841],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(collectNodes(result.hierarchy).filter(node => node.text === "Horizontal scroll bar, 1 page")).toHaveLength(1);
+  });
+
+  test("drops structural wrappers containing only scroll bar noise", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: [
+          {
+            className: "UIView",
+            bounds: [383, 156, 390, 704],
+            node: {
+              className: "UIView",
+              text: "Vertical scroll bar, 1 page",
+              bounds: [383, 156, 390, 704],
+            },
+          },
+          {
+            className: "UIView",
+            text: "Vertical scroll bar, 1 page",
+            bounds: [383, 156, 390, 704],
+          },
+        ],
+      },
+    });
+
+    const nodes = collectNodes(result.hierarchy);
+    expect(nodes.filter(node => node.text === "Vertical scroll bar, 1 page")).toHaveLength(1);
+    expect(nodes.some(node => {
+      const children = Array.isArray(node.node) ? node.node : node.node ? [node.node] : [];
+      return node.className === "UIView" &&
+        children.length > 0 &&
+        children.every(child => child.text === "Vertical scroll bar, 1 page");
+    })).toBe(false);
+  });
+
+  test("drops Reminders fixture scroll bar wrappers in raw TS cleanup", () => {
+    const { before } = loadIosRemindersNoiseObservePair();
+    const result = cleanupIosXCTestHierarchy(before.viewHierarchy);
+    const nodes = collectNodes(result.hierarchy);
+
+    expect(nodes.some(node => {
+      const children = Array.isArray(node.node) ? node.node : node.node ? [node.node] : [];
+      return node.class === "UIView" &&
+        children.length > 0 &&
+        children.every(child => typeof child.text === "string" && child.text.toLowerCase().includes("scroll bar"));
+    })).toBe(false);
+  });
+
+  test("preserves focused static label child represented by a link parent", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: {
+          className: "UILink",
+          text: "Privacy",
+          role: "link",
+          clickable: "true",
+          bounds: [239, 710, 285, 727],
+          node: {
+            className: "UILabel",
+            text: "Privacy",
+            role: "text",
+            focused: "true",
+            bounds: [239, 710, 285, 727],
+          },
+        },
+      },
+    });
+
+    const link = collectNodes(result.hierarchy).find(node => node.className === "UILink");
+    expect(link.text).toBe("Privacy");
+    expect(link.node).toEqual({
+      className: "UILabel",
+      text: "Privacy",
+      role: "text",
+      focused: "true",
+      bounds: [239, 710, 285, 727],
+    });
+  });
+
+  test("preserves accessibility-focused static label child represented by actionable parent text", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: {
+          className: "UIButton",
+          text: "Continue",
+          role: "button",
+          clickable: "true",
+          bounds: [20, 700, 370, 744],
+          node: {
+            "className": "UILabel",
+            "text": "Continue",
+            "role": "text",
+            "accessibility-focused": "true",
+            "bounds": [44, 710, 346, 734],
+          },
+        },
+      },
+    });
+
+    const button = collectNodes(result.hierarchy).find(node => node.className === "UIButton");
+    expect(button.node).toEqual({
+      "className": "UILabel",
+      "text": "Continue",
+      "role": "text",
+      "accessibility-focused": "true",
+      "bounds": [44, 710, 346, 734],
+    });
+  });
+
+  test("collapses idless single-child WKWebView wrappers with identical bounds", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: {
+          "className": "WKWebView",
+          "resource-id": "WebView",
+          "bounds": [0, 0, 390, 844],
+          "node": {
+            className: "WKWebView",
+            bounds: [0, 0, 390, 844],
+            node: {
+              className: "WKWebView",
+              bounds: [0, 0, 390, 844],
+              node: {
+                className: "UIView",
+                text: "Google",
+                bounds: [0, 47, 390, 781],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const webViews = collectNodes(result.hierarchy).filter(node => node.className === "WKWebView");
+    expect(webViews).toHaveLength(1);
+    expect(webViews[0]["resource-id"]).toBe("WebView");
+    expect(collectNodes(result.hierarchy).some(node => node.text === "Google")).toBe(true);
+  });
+
+  test("preserves scrollable idless single-child WKWebView wrappers", () => {
+    const result = cleanupIosXCTestHierarchy({
+      updatedAt: 1,
+      hierarchy: {
+        className: "XCUIApplication",
+        node: {
+          className: "WKWebView",
+          bounds: [0, 0, 390, 844],
+          scrollable: "true",
+          node: {
+            className: "UIView",
+            text: "Google",
+            bounds: [0, 47, 390, 781],
+          },
+        },
+      },
+    });
+
+    const webViews = collectNodes(result.hierarchy).filter(node => node.className === "WKWebView");
+    expect(webViews).toHaveLength(1);
+    expect(webViews[0].scrollable).toBe("true");
+    expect(collectNodes(result.hierarchy).some(node => node.text === "Google")).toBe(true);
+  });
+});

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   loadAndroidHomeObserve,
   loadAndroidRawTrimCandidatesObserve,
+  loadIosRemindersNoiseObservePair,
   measureValue,
 } from "../../../fixtures/observe/observeFixture";
 
@@ -667,6 +668,52 @@ describe("sanitizeObserveResult", () => {
       expect(node.clickable).toBeUndefined();
       expect(node.text).toBeUndefined();
       expect(out.elements).toBeUndefined();
+    });
+  });
+
+  describe("iOS XCTest/UIKit cleanup fixture (#3317)", () => {
+    function nodeText(node: ViewHierarchyNode): string | undefined {
+      return (node as unknown as Record<string, unknown>).text as string | undefined;
+    }
+
+    function nodeClass(node: ViewHierarchyNode): string | undefined {
+      return ((node as unknown as Record<string, unknown>).class
+        ?? (node as unknown as Record<string, unknown>).className) as string | undefined;
+    }
+
+    test("Reminders compact observe is smaller after structural-noise cleanup", () => {
+      const { before, after } = loadIosRemindersNoiseObservePair();
+
+      const beforeCompact = sanitizeObserveResult(before, COMPACT);
+      const afterCompact = sanitizeObserveResult(after, COMPACT);
+
+      expect(measureValue(afterCompact).bytes).toBeLessThan(measureValue(beforeCompact).bytes);
+      expect(measureValue(afterCompact).tokens).toBeLessThan(measureValue(beforeCompact).tokens);
+    });
+
+    test("Reminders cleanup preserves actionable buttons, text fields, toolbar controls, and list cells", () => {
+      const { after } = loadIosRemindersNoiseObservePair();
+      const nodes = allHierarchyNodes(after);
+
+      expect(nodes.some(node => nodeText(node) === "New Reminder")).toBe(true);
+      expect(nodes.some(node => nodeClass(node) === "UITextField" && nodeText(node) === "Title")).toBe(true);
+      expect(nodes.some(node => nodeText(node) === "Details")).toBe(true);
+      expect(nodes.some(node => nodeText(node) === "Today")).toBe(true);
+      expect(nodes.some(node => nodeClass(node) === "UITableViewCell" && nodeText(node) === "Buy milk")).toBe(true);
+    });
+
+    test("Playground-style iOS hierarchy remains navigable after cleanup", () => {
+      const { after } = loadIosRemindersNoiseObservePair();
+      const nodes = allHierarchyNodes(after);
+      const actionable = nodes.filter(node => {
+        const attrs = node as unknown as Record<string, unknown>;
+        return attrs.clickable === "true" || attrs.scrollable === "true" || attrs.actions !== undefined;
+      });
+
+      expect(actionable.map(nodeText)).toContain("New Reminder");
+      expect(actionable.map(nodeText)).toContain("Done");
+      expect(actionable.some(node => nodeClass(node) === "UITextField")).toBe(true);
+      expect(nodes.some(node => nodeText(node)?.includes("scroll bar"))).toBe(false);
     });
   });
 

--- a/test/fixtures/observe/ios-reminders-xctest-noise-after.json
+++ b/test/fixtures/observe/ios-reminders-xctest-noise-after.json
@@ -1,0 +1,167 @@
+{
+  "updatedAt": 1751840000001,
+  "screenSize": {
+    "width": 1179,
+    "height": 2556
+  },
+  "viewHierarchy": {
+    "hierarchy": {
+      "bounds": {
+        "right": 393,
+        "bottom": 852
+      },
+      "node": {
+        "class": "XCUIApplication",
+        "view-id": "root",
+        "bounds": {
+          "left": 0,
+          "top": 0,
+          "right": 393,
+          "bottom": 852
+        },
+        "node": [
+          {
+            "class": "UINavigationBar",
+            "text": "Reminders",
+            "view-id": "nav",
+            "bounds": {
+              "left": 0,
+              "top": 59,
+              "right": 393,
+              "bottom": 104
+            }
+          },
+          {
+            "class": "UITableView",
+            "scrollable": "true",
+            "view-id": "list",
+            "bounds": {
+              "left": 0,
+              "top": 120,
+              "right": 393,
+              "bottom": 720
+            },
+            "node": [
+              {
+                "class": "UITableViewCell",
+                "text": "Buy milk",
+                "clickable": "true",
+                "view-id": "reminder-buy-milk",
+                "bounds": {
+                  "left": 0,
+                  "top": 156,
+                  "right": 393,
+                  "bottom": 204
+                }
+              }
+            ]
+          },
+          {
+            "class": "UITextField",
+            "text": "Title",
+            "value": "Buy milk",
+            "focused": "true",
+            "actions": [
+              "set_text",
+              "clear_text"
+            ],
+            "view-id": "title-field",
+            "bounds": {
+              "left": 16,
+              "top": 728,
+              "right": 377,
+              "bottom": 772
+            }
+          },
+          {
+            "class": "UIToolbar",
+            "bounds": {
+              "left": 0,
+              "top": 772,
+              "right": 393,
+              "bottom": 852
+            },
+            "node": [
+              {
+                "class": "UIButton",
+                "text": "New Reminder",
+                "clickable": "true",
+                "view-id": "new-reminder",
+                "bounds": {
+                  "left": 16,
+                  "top": 786,
+                  "right": 201,
+                  "bottom": 823
+                }
+              },
+              {
+                "class": "UIButton",
+                "text": "Details",
+                "clickable": "true",
+                "bounds": {
+                  "left": 220,
+                  "top": 786,
+                  "right": 286,
+                  "bottom": 823
+                }
+              },
+              {
+                "class": "UIButton",
+                "text": "Today",
+                "clickable": "true",
+                "bounds": {
+                  "left": 300,
+                  "top": 786,
+                  "right": 370,
+                  "bottom": 823
+                }
+              }
+            ]
+          },
+          {
+            "class": "UIKeyboard",
+            "bounds": {
+              "left": 0,
+              "top": 620,
+              "right": 393,
+              "bottom": 852
+            },
+            "node": [
+              {
+                "class": "UIButton",
+                "text": "dictation",
+                "bounds": {
+                  "left": 16,
+                  "top": 804,
+                  "right": 64,
+                  "bottom": 848
+                }
+              },
+              {
+                "class": "UIButton",
+                "text": "Done",
+                "clickable": "true",
+                "bounds": {
+                  "left": 330,
+                  "top": 804,
+                  "right": 380,
+                  "bottom": 848
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "packageName": "com.apple.reminders",
+    "screenScale": 3,
+    "screenWidth": 393,
+    "screenHeight": 852
+  },
+  "elements": {
+    "clickable": [],
+    "scrollable": [],
+    "text": [],
+    "media": []
+  }
+}

--- a/test/fixtures/observe/ios-reminders-xctest-noise-before.json
+++ b/test/fixtures/observe/ios-reminders-xctest-noise-before.json
@@ -1,0 +1,244 @@
+{
+  "updatedAt": 1751840000000,
+  "screenSize": {
+    "width": 1179,
+    "height": 2556
+  },
+  "viewHierarchy": {
+    "hierarchy": {
+      "bounds": {
+        "right": 393,
+        "bottom": 852
+      },
+      "node": {
+        "class": "XCUIApplication",
+        "view-id": "root",
+        "bounds": {
+          "left": 0,
+          "top": 0,
+          "right": 393,
+          "bottom": 852
+        },
+        "node": [
+          {
+            "class": "UINavigationBar",
+            "text": "Reminders",
+            "view-id": "nav",
+            "bounds": {
+              "left": 0,
+              "top": 59,
+              "right": 393,
+              "bottom": 104
+            },
+            "node": [
+              {
+                "class": "UILabel",
+                "text": "Reminders",
+                "bounds": {
+                  "left": 20,
+                  "top": 68,
+                  "right": 168,
+                  "bottom": 95
+                }
+              }
+            ]
+          },
+          {
+            "class": "UITableView",
+            "scrollable": "true",
+            "view-id": "list",
+            "bounds": {
+              "left": 0,
+              "top": 120,
+              "right": 393,
+              "bottom": 720
+            },
+            "node": [
+              {
+                "class": "UITableViewCell",
+                "text": "Buy milk",
+                "clickable": "true",
+                "view-id": "reminder-buy-milk",
+                "bounds": {
+                  "left": 0,
+                  "top": 156,
+                  "right": 393,
+                  "bottom": 204
+                },
+                "node": [
+                  {
+                    "class": "UILabel",
+                    "text": "Buy milk",
+                    "bounds": {
+                      "left": 56,
+                      "top": 168,
+                      "right": 142,
+                      "bottom": 192
+                    }
+                  }
+                ]
+              },
+              {
+                "class": "UIView",
+                "bounds": {
+                  "left": 383,
+                  "top": 156,
+                  "right": 390,
+                  "bottom": 704
+                },
+                "node": [
+                  {
+                    "class": "UIView",
+                    "text": "Vertical scroll bar, 1 page",
+                    "bounds": {
+                      "left": 383,
+                      "top": 156,
+                      "right": 390,
+                      "bottom": 704
+                    }
+                  }
+                ]
+              },
+              {
+                "class": "UIView",
+                "text": "Vertical scroll bar, 1 page",
+                "bounds": {
+                  "left": 383,
+                  "top": 156,
+                  "right": 390,
+                  "bottom": 704
+                }
+              }
+            ]
+          },
+          {
+            "class": "UITextField",
+            "text": "Title",
+            "value": "Buy milk",
+            "focused": "true",
+            "actions": [
+              "set_text",
+              "clear_text"
+            ],
+            "view-id": "title-field",
+            "bounds": {
+              "left": 16,
+              "top": 728,
+              "right": 377,
+              "bottom": 772
+            }
+          },
+          {
+            "class": "UIToolbar",
+            "bounds": {
+              "left": 0,
+              "top": 772,
+              "right": 393,
+              "bottom": 852
+            },
+            "node": [
+              {
+                "class": "UIButton",
+                "text": "New Reminder",
+                "clickable": "true",
+                "view-id": "new-reminder",
+                "bounds": {
+                  "left": 16,
+                  "top": 786,
+                  "right": 201,
+                  "bottom": 823
+                },
+                "node": [
+                  {
+                    "class": "UILabel",
+                    "text": "New Reminder",
+                    "bounds": {
+                      "left": 48,
+                      "top": 792,
+                      "right": 190,
+                      "bottom": 817
+                    }
+                  }
+                ]
+              },
+              {
+                "class": "UIButton",
+                "text": "Details",
+                "clickable": "true",
+                "bounds": {
+                  "left": 220,
+                  "top": 786,
+                  "right": 286,
+                  "bottom": 823
+                }
+              },
+              {
+                "class": "UIButton",
+                "text": "Today",
+                "clickable": "true",
+                "bounds": {
+                  "left": 300,
+                  "top": 786,
+                  "right": 370,
+                  "bottom": 823
+                }
+              }
+            ]
+          },
+          {
+            "class": "UIKeyboard",
+            "bounds": {
+              "left": 0,
+              "top": 620,
+              "right": 393,
+              "bottom": 852
+            },
+            "node": [
+              {
+                "class": "UIButton",
+                "text": "dictation",
+                "bounds": {
+                  "left": 16,
+                  "top": 804,
+                  "right": 64,
+                  "bottom": 848
+                }
+              },
+              {
+                "class": "UIButton",
+                "text": "dictation",
+                "bounds": {
+                  "left": 16,
+                  "top": 804,
+                  "right": 64,
+                  "bottom": 848
+                }
+              },
+              {
+                "class": "UIButton",
+                "text": "Done",
+                "clickable": "true",
+                "bounds": {
+                  "left": 330,
+                  "top": 804,
+                  "right": 380,
+                  "bottom": 848
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "packageName": "com.apple.reminders",
+    "screenScale": 3,
+    "screenWidth": 393,
+    "screenHeight": 852
+  },
+  "elements": {
+    "clickable": [],
+    "scrollable": [],
+    "text": [],
+    "media": []
+  }
+}

--- a/test/fixtures/observe/observeFixture.ts
+++ b/test/fixtures/observe/observeFixture.ts
@@ -56,6 +56,29 @@ export function loadIosFractionalObserve(): ObserveResult {
 }
 
 /**
+ * Representative iOS Reminders observe pair for XCTest/UIKit structural-noise
+ * cleanup (#3317). The `before` fixture preserves duplicated UIKit/XCTest noise
+ * around Reminders rows, toolbar buttons, scroll bars, and keyboard accessory
+ * controls; the `after` fixture is the same hierarchy after CtrlProxy cleanup.
+ */
+export const IOS_REMINDERS_NOISE_BEFORE_FIXTURE_PATH = join(
+  import.meta.dir,
+  "ios-reminders-xctest-noise-before.json"
+);
+export const IOS_REMINDERS_NOISE_AFTER_FIXTURE_PATH = join(
+  import.meta.dir,
+  "ios-reminders-xctest-noise-after.json"
+);
+
+/** Load the Reminders XCTest/UIKit noise before/after pair for #3317 size tests. */
+export function loadIosRemindersNoiseObservePair(): { before: ObserveResult; after: ObserveResult } {
+  return {
+    before: JSON.parse(readFileSync(IOS_REMINDERS_NOISE_BEFORE_FIXTURE_PATH, "utf8")) as ObserveResult,
+    after: JSON.parse(readFileSync(IOS_REMINDERS_NOISE_AFTER_FIXTURE_PATH, "utf8")) as ObserveResult,
+  };
+}
+
+/**
  * Excerpt from a real Android uiautomator hierarchy capture of the Playground
  * app. It intentionally preserves the Android direct-attribute runtime shape
  * that reaches output trimming before `cleanNodeProperties` removes default


### PR DESCRIPTION
## Summary

Adds iOS CtrlProxy hierarchy cleanup for common XCTest/UIKit structural noise before observe output and action diffing. The cleanup removes duplicate scroll bars, duplicate label children under actionable parents, structural scroll-bar-only wrappers, and repeated keyboard dictation/accessory nodes while preserving actionable controls, text input state, ids, focus/selection/check state, and meaningful descendants.

## Linked Issue

Closes #3317

## Bug / Regression Context

- **Prior attempts:** Follow-up to the output-reduction and actions-diff work in #2761/#3026/#3051.
- **Observed symptom:** iOS observes can include repeated UIKit/XCTest structure such as duplicate scroll bars, label-inside-button duplicates, scroll-bar-only wrappers, and duplicate dictation controls.
- **Repro steps / conditions:** Apple Reminders-style iOS hierarchy with compact observe/diff enabled; noisy structural nodes inflate the hierarchy without adding actionable targets.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
  - Ran equivalent required gate: `bunx turbo run lint build test` (6,963 pass, 2 skip, 0 fail; build cache hit).
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran the matching `scripts/` validation
  - `swift test -Xswiftc -warnings-as-errors` in `ios/control-proxy` (378 tests, 0 failures).
  - `swift test --filter ElementLocatorTests` (53 tests, 0 failures).
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
  - Not completed in this Codex run. A booted simulator was present, but live verification would require building/starting CtrlProxy and capturing the WebSocket hierarchy.
- [ ] Screenshots or before/after attached
  - Added representative before/after Reminders hierarchy fixtures and byte/token assertions.

## Follow-ups

- [ ] Follow-up issues filed for gaps not addressed here: not filed; live iOS observe sign-off is the remaining manual verification before marking this ready.
