### PR TITLE
fix(release): store iOS runner checksum per entry

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,16 @@ jobs:
         run: |
           APK_CURRENT=$(grep 'apkSha256' src/constants/release.ts | head -1 | sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/')
           IPA_CURRENT=$(grep 'ipaSha256' src/constants/release.ts | head -1 | sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/')
-          RUNNER_CURRENT=$(grep '^export const IOS_CTRL_PROXY_RUNNER_SHA256' src/constants/release.ts | sed 's/.*= "\([a-f0-9]*\)".*/\1/')
+          RUNNER_CURRENT=$(awk '
+            /^[[:space:]]+version: "/ { in_first = 1 }
+            in_first && /^[[:space:]]+runnerSha256: "/ {
+              sub(/.*runnerSha256: "/, "")
+              sub(/".*/, "")
+              print
+              exit
+            }
+            in_first && /^[[:space:]]+}/ { exit }
+          ' src/constants/release.ts)
           echo "apk_sha256=$APK_CURRENT" >> $GITHUB_OUTPUT
           echo "ipa_sha256=$IPA_CURRENT" >> $GITHUB_OUTPUT
           echo "runner_sha256=$RUNNER_CURRENT" >> $GITHUB_OUTPUT

--- a/scripts/ci/verify-release-integrity.sh
+++ b/scripts/ci/verify-release-integrity.sh
@@ -5,7 +5,7 @@
 #   1. Version equality — the npm version, every release manifest, the checksum
 #      registry, and the git tag must all name the SAME version. Nothing else
 #      enforces this; bump-versions.sh merely writes them together.
-#   2. iOS runner-binary checksum — IOS_CTRL_PROXY_RUNNER_SHA256 must be a real
+#   2. iOS runner-binary checksum — registry[0].runnerSha256 must be a real
 #      sha256, not the "" default. Empty silently disables runner integrity
 #      verification for the simulator path.
 #
@@ -17,7 +17,7 @@
 #   <version>  release version / git tag. A leading "v" is stripped.
 #   [ipa-path] optional built control-proxy.ipa. When given, the runner binary is
 #              hashed straight out of the IPA and required to match the recorded
-#              IOS_CTRL_PROXY_RUNNER_SHA256 — this *binds* the constant to the
+#              registry[0].runnerSha256 — this *binds* the recorded hash to the
 #              artifact that ships. Without it, only the syntactic (64-hex,
 #              non-empty) floor is checked.
 set -euo pipefail
@@ -98,10 +98,19 @@ registry_version="$(grep -m1 -E '^[[:space:]]+version: "' "$RELEASE_TS" \
   | sed 's/.*version: "\([^"]*\)".*/\1/')"
 check "src/constants/release.ts registry[0].version" "$registry_version"
 
-# Runner-binary checksum must be populated. Empty ("" default) means integrity
-# verification is silently skipped — exactly the gap this gate exists to catch.
-runner_sha="$(grep -E '^export const IOS_CTRL_PROXY_RUNNER_SHA256' "$RELEASE_TS" \
-  | sed 's/.*= "\([^"]*\)".*/\1/')"
+# Runner-binary checksum must be populated on the newest registry entry. Empty
+# means integrity verification is silently skipped — exactly the gap this gate
+# exists to catch.
+runner_sha="$(awk '
+  /^[[:space:]]+version: "/ { in_first = 1 }
+  in_first && /^[[:space:]]+runnerSha256: "/ {
+    sub(/.*runnerSha256: "/, "")
+    sub(/".*/, "")
+    print
+    exit
+  }
+  in_first && /^[[:space:]]+}/ { exit }
+' "$RELEASE_TS")"
 
 sha256_stdin() {
   if command -v sha256sum >/dev/null 2>&1; then
@@ -125,16 +134,16 @@ if [ -n "$IPA_PATH" ]; then
     else
       actual_runner_sha="$(unzip -p "$IPA_PATH" "$runner_entry" | sha256_stdin)"
       if [ "$runner_sha" = "$actual_runner_sha" ]; then
-        echo "  OK  IOS_CTRL_PROXY_RUNNER_SHA256 matches the runner inside the IPA"
+        echo "  OK  registry[0].runnerSha256 matches the runner inside the IPA"
       else
-        errors+=("IOS_CTRL_PROXY_RUNNER_SHA256 ('${runner_sha:-empty}') does not match the runner binary shipped in ${IPA_PATH} ('${actual_runner_sha}')")
+        errors+=("registry[0].runnerSha256 ('${runner_sha:-empty}') does not match the runner binary shipped in ${IPA_PATH} ('${actual_runner_sha}')")
       fi
     fi
   fi
 elif [[ "$runner_sha" =~ ^[a-f0-9]{64}$ ]]; then
-  echo "  OK  IOS_CTRL_PROXY_RUNNER_SHA256 populated (syntactic; pass the IPA path to bind it)"
+  echo "  OK  registry[0].runnerSha256 populated (syntactic; pass the IPA path to bind it)"
 else
-  errors+=("IOS_CTRL_PROXY_RUNNER_SHA256 must be a 64-char hex sha256, got '${runner_sha}' (empty disables runner integrity verification)")
+  errors+=("registry[0].runnerSha256 must be a 64-char hex sha256, got '${runner_sha}' (empty disables runner integrity verification)")
 fi
 
 if [ "${#errors[@]}" -gt 0 ]; then

--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -96,6 +96,44 @@ prepend_registry_entry() {
   mv "$next_file" "$file"
 }
 
+update_registry_field() {
+  local file="$1"
+  local version="$2"
+  local field="$3"
+  local value="$4"
+
+  python3 - "$file" "$version" "$field" "$value" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+version = sys.argv[2]
+field = sys.argv[3]
+value = sys.argv[4]
+text = path.read_text()
+
+if version == "__FIRST__":
+    match = re.search(r'(\{\n\s+version: "[^"]+",\n.*?\n\s+\})', text, re.S)
+else:
+    match = re.search(r'(\{\n\s+version: "' + re.escape(version) + r'",\n.*?\n\s+\})', text, re.S)
+
+if not match:
+    sys.stderr.write(f"failed to locate release registry entry for {version}\n")
+    sys.exit(1)
+
+entry = match.group(1)
+field_re = re.compile(r'(^\s+' + re.escape(field) + r': ")[^"]*(",?$)', re.M)
+if field_re.search(entry):
+    updated_entry = field_re.sub(r'\g<1>' + value + r'\2', entry, count=1)
+else:
+    ipa_re = re.compile(r'(^\s+ipaSha256: "[^"]+",\n)', re.M)
+    updated_entry = ipa_re.sub(r'\1    ' + field + f': "{value}",\n', entry, count=1)
+
+path.write_text(text[:match.start(1)] + updated_entry + text[match.end(1):])
+PY
+}
+
 if [ -n "$release_version" ]; then
   # Mode: add new registry entry (requires all three)
   if [ -z "$apk_checksum" ] || [ -z "$ios_checksum" ]; then
@@ -105,16 +143,17 @@ if [ -n "$release_version" ]; then
 
   if grep -q "version: \"${release_version}\"" "$constants_path"; then
     # Version already registered — do NOT duplicate the entry, but fall through
-    # to the scalar-constant updates below (app hash / runner sha). The release
+    # to the per-entry runner-sha update below. The release
     # job re-runs this after prepare-release already added the entry; skipping
-    # entirely would leave IOS_CTRL_PROXY_RUNNER_SHA256 empty (verification
-    # disabled) whenever prepare-release predates the runner-sha wiring.
+    # entirely would leave runnerSha256 empty (verification disabled) whenever
+    # prepare-release predates the runner-sha wiring.
     echo "INFO: Version ${release_version} already in registry — refreshing scalar constants only"
   else
     new_entry="  {
     version: \"${release_version}\",
     apkSha256: \"${apk_checksum}\",
     ipaSha256: \"${ios_checksum}\",
+    runnerSha256: \"${ios_runner_sha256}\",
   },"
 
     # Prepend new entry after the opening bracket of RELEASE_CHECKSUM_REGISTRY
@@ -127,7 +166,7 @@ if [ -n "$release_version" ]; then
       for ((i = 0; i < excess; i++)); do
         last_version_line=$(grep -n 'version: "' "$tmp_file" | tail -1 | cut -d: -f1)
         start_line=$((last_version_line - 1))
-        end_line=$((last_version_line + 3))
+        end_line=$((last_version_line + 4))
         sed_inplace "${start_line},${end_line}d" "$tmp_file"
       done
     fi
@@ -153,6 +192,10 @@ else
     fi
   fi
 
+  if [ -n "$ios_runner_sha256" ]; then
+    update_registry_field "$tmp_file" "__FIRST__" "runnerSha256" "$ios_runner_sha256"
+  fi
+
   echo "Updated release constants:"
   if [ -n "$apk_checksum" ]; then
     echo "   APK checksum (registry[0]): ${apk_checksum}"
@@ -169,7 +212,9 @@ if [ -n "$ios_app_hash" ]; then
 fi
 
 if [ -n "$ios_runner_sha256" ]; then
-  sed_inplace_extended "s/^export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \".*\";/export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${ios_runner_sha256}\";/" "$tmp_file"
+  if [ -n "$release_version" ]; then
+    update_registry_field "$tmp_file" "$release_version" "runnerSha256" "$ios_runner_sha256"
+  fi
   echo "   iOS runner SHA256: ${ios_runner_sha256}"
 fi
 

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -18,6 +18,7 @@ export interface ReleaseChecksumEntry {
   version: string;
   apkSha256: string;
   ipaSha256: string;
+  runnerSha256: string;
 }
 
 /**
@@ -29,96 +30,115 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     version: "0.0.40",
     apkSha256: "8e89fbab6462ac1ead1f3f0a334aff4f5f299e7ae72e192045cf75e893ca87aa",
     ipaSha256: "38adaed641ac6a8590773682e127a80a86c54e5804d47394e1b0cd437009b9ff",
+    runnerSha256: "",
   },
   {
     version: "0.0.39",
     apkSha256: "eaad59dd85e17c4633098b772b9f761f2124ffb73a5ca7ede703a9b435046942",
     ipaSha256: "87a720544c83718e5b70c987aecf30d2e43bdb0f23163ac75ac225bb4aec0ae4",
+    runnerSha256: "",
   },
   {
     version: "0.0.38",
     apkSha256: "0fb955a617654695036642662634d042c2e3d278b8e1dce20ccb37e425f059f3",
     ipaSha256: "f5a4a485ff8ebf3bfd0d73c8b7b10769177b419ccd62e48db188bb5122a2fcde",
+    runnerSha256: "",
   },
   {
     version: "0.0.37",
     apkSha256: "f9b0cc92bf8f7416cdb0c458e16c7a41e4fdeefb80bb9429ab7c603388c99083",
     ipaSha256: "caccbfaa4da0015bab701a36b81ac87e3f3f3330cee77bb10ec8553724275f4f",
+    runnerSha256: "",
   },
   {
     version: "0.0.36",
     apkSha256: "b5f56bb0ab065c60385a22013c97ee706213eb16deb5d4bcfa42f0a707b8620a",
     ipaSha256: "40e973dc8c87149e40a616658c74d90e648c6514cc642a5c3dd4a45a187e7600",
+    runnerSha256: "",
   },
   {
     version: "0.0.35",
     apkSha256: "039b359bcf35f1ab6cc666005a57823d71a771a96bd9bcaf4f82f2ec945e306d",
     ipaSha256: "e6afdfd04a90d2388dc4604e7957d3eef87b90a51ca37c5457b8139a54728108",
+    runnerSha256: "",
   },
   {
     version: "0.0.34",
     apkSha256: "4dcee4f6a7359847d081c5e184c57ed100ad135af2e62f3abfc7b0defaa1153c",
     ipaSha256: "c2a26ca065c85e9f8d5cfcd6dbad1dbaf3ce38b18d770b0983f7bad62129e4a3",
+    runnerSha256: "",
   },
   {
     version: "0.0.33",
     apkSha256: "7289eba90b22890d3c36e05e99db72a545fa4becdf46df079885783a919e6aed",
     ipaSha256: "425dfa4db4ad5a4febc9f05ffc97df38f3a1098ccdd9330adff1c0b5c877697d",
+    runnerSha256: "",
   },
   {
     version: "0.0.32",
     apkSha256: "4c4a743af5d18ed58214e64b85986c9e2f2332b015edcf7d9d68a24cd6dfda21",
     ipaSha256: "40f4d9084d3368995b57c0e81c4fe85f38851353da9f789eaff93027aee456a0",
+    runnerSha256: "",
   },
   {
     version: "0.0.31",
     apkSha256: "0b5802ada8d9adccdb69ee140ae788b3251832c0605d2f6baa3e9b7a78260764",
     ipaSha256: "e60f8689fb6ddd5c06a5d2ff57569b264f407229afb986258d1ce20326dc24c7",
+    runnerSha256: "",
   },
   {
     version: "0.0.30",
     apkSha256: "a1be5e6240f204ee99540e99cc198f7c0b592dbaf3699330c14f6ded7d333ec3",
     ipaSha256: "5ac285dd5be16439d3a8a8973c98606920461acfce489830e54ee20759a7b235",
+    runnerSha256: "",
   },
   {
     version: "0.0.29",
     apkSha256: "b33a67c7efa84aca2b07faa965aecb3b1819b4defd441dcc8d3bf7e2af209cd8",
     ipaSha256: "d47c1aea4495270c1489cae361286ea1439c2ba4e7d5bcfd73f66e4580a6c45d",
+    runnerSha256: "",
   },
   {
     version: "0.0.28",
     apkSha256: "0f683d5939bc308afe038ea1259eb29997dff38af0795136a281ad305986e40e",
     ipaSha256: "eee7accfbca717bb8b89fafd0676f10d8bb08561c3fbd7a04750c9b12c2a7104",
+    runnerSha256: "",
   },
   {
     version: "0.0.27",
     apkSha256: "9966113ae44f38f3cf34544b1375d3c9a3706701edba45a1eec1f220b9c676cc",
     ipaSha256: "8620de6b014df18465876334f9ba8c106292f6c3059370eea2349f1e44db4f4d",
+    runnerSha256: "",
   },
   {
     version: "0.0.26",
     apkSha256: "2eb2f156fd27602c85003ab8f6e00d3e06850e84f5453d75b7494aa5bbed7be0",
     ipaSha256: "905df276d2224d31cbc5aa2258d2dcc60eaeb9813727081ddd32c95394fec411",
+    runnerSha256: "",
   },
   {
     version: "0.0.25",
     apkSha256: "f727079edb4906e3b7928dbb641e788543e86b11fff3fc1b76f0c51b9c8d6e5d",
     ipaSha256: "d8032cc1cebcb456b7232aa67fc42c89ff62729bacf141aa8f594ce6f8bcd980",
+    runnerSha256: "",
   },
   {
     version: "0.0.24",
     apkSha256: "9047795bc6098f4ec687c126123c73c423806a9fd52888af391d6fb5b94ac93f",
     ipaSha256: "1dd3e0370cb8ed01d8e1020558d8a2808f208bd947bafcf6688211eddc928bf8",
+    runnerSha256: "",
   },
   {
     version: "0.0.18",
     apkSha256: "fd3c8d9f0b8542eaad56c78b18cf8e5666367b04ae8c4af74d8aa6dd1c8d1834",
     ipaSha256: "2a5eec63bce2f9dfc227c0732fcce67378305e945604d5eedd0e3df48e37fd39",
+    runnerSha256: "",
   },
   {
     version: "0.0.17",
     apkSha256: "916033440931666644474f227c8e39d13d9c80c3515e4292cc5581fd5bd4cc2f",
     ipaSha256: "e4dcf064d024f2371b8fd79281000e2d49751ef95b8817d1494d685aeda746ac",
+    runnerSha256: "",
   },
 ];
 
@@ -144,6 +164,20 @@ export function resolveChecksum(
     return "";
   }
   return platform === "android" ? entry.apkSha256 : entry.ipaSha256;
+}
+
+export function resolveRunnerChecksum(
+  env: EnvLike = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
+  if (registry.length === 0) {
+    return "";
+  }
+  const pinned = resolvePinnedVersion(env);
+  const entry = pinned === LATEST_RELEASE_VERSION
+    ? registry[0]
+    : registry.find(e => e.version === pinned);
+  return entry?.runnerSha256 ?? "";
 }
 
 /**
@@ -317,10 +351,6 @@ export const IOS_CTRL_PROXY_IPA_URL: string = resolveIpaUrl();
 export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveIpaChecksum();
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 // SHA256 of the simulator runner binary (CtrlProxyUITests-Runner), empty = skip
-// verification. This is a single global scalar, valid only for the runner inside
-// the *latest* IPA (registry[0]) — the runner lives inside that IPA, so its
-// integrity is transitively covered by registry[0].ipaSha256. If pinned-older
-// iOS downloads are ever wired (resolveChecksum(<pinned>, "ios")), move this to a
-// per-entry ReleaseChecksumEntry.runnerSha256 or the check would compare the
-// newest runner sha against an older IPA and reject a valid bundle.
-export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "";
+// verification. Resolved through RELEASE_CHECKSUM_REGISTRY so pinned iOS
+// downloads verify against the runner hash recorded for the same release entry.
+export const IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM: string = resolveRunnerChecksum();

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -6,14 +6,14 @@ import { defaultTimer, type Timer } from "./SystemTimer";
 import { NoOpPerformanceTracker, type PerformanceTracker } from "./PerformanceTracker";
 import {
   IOS_CTRL_PROXY_APP_HASH,
-  IOS_CTRL_PROXY_RUNNER_SHA256,
   LATEST_RELEASE_VERSION,
   isExplicitPin,
   isPinnedVersionKnown,
   resolveAssetVersion,
   resolveIpaChecksum,
   resolveIpaUrl,
-  resolvePinnedVersion
+  resolvePinnedVersion,
+  resolveRunnerChecksum
 } from "../constants/release";
 import {
   DefaultIOSCtrlProxyBundleDownloader,
@@ -924,7 +924,7 @@ export class IOSCtrlProxyBuilder {
 
     // Verify runner binary SHA256 for simulator (used by simctl spawn)
     if (platform === "simulator") {
-      const expectedRunnerSha256 = IOS_CTRL_PROXY_RUNNER_SHA256;
+      const expectedRunnerSha256 = resolveRunnerChecksum();
       if (expectedRunnerSha256 && expectedRunnerSha256.length > 0) {
         const runnerBinaryPath = await this.getRunnerBinaryPath(platform);
         if (!runnerBinaryPath) {

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -24,6 +24,7 @@ teardown() {
     RELEASE_VERSION="99.99.99" \
     APK_SHA256_CHECKSUM="$APK_SHA" \
     IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
     bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
 
   [ "$status" -eq 0 ]
@@ -33,9 +34,10 @@ teardown() {
   [[ "$first_version" == *'version: "99.99.99"'* ]]
   grep -q "apkSha256: \"${APK_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
   grep -q "ipaSha256: \"${IPA_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+  grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
 }
 
-@test "writes IOS_CTRL_PROXY_RUNNER_SHA256 in release mode" {
+@test "writes runnerSha256 in release mode" {
   run env \
     RELEASE_VERSION="99.99.99" \
     APK_SHA256_CHECKSUM="$APK_SHA" \
@@ -44,19 +46,17 @@ teardown() {
     bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
 
   [ "$status" -eq 0 ]
-  grep -q "export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${RUNNER_SHA}\";" \
-    "${TEST_ROOT}/src/constants/release.ts"
+  grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
 }
 
-@test "writes IOS_CTRL_PROXY_RUNNER_SHA256 in checksum-only mode" {
+@test "writes registry[0].runnerSha256 in checksum-only mode" {
   run env \
     IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
     IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
     bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
 
   [ "$status" -eq 0 ]
-  grep -q "export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${RUNNER_SHA}\";" \
-    "${TEST_ROOT}/src/constants/release.ts"
+  grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
 }
 
 @test "refreshes runner sha for an already-registered version (no duplicate entry)" {
@@ -69,7 +69,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   # Re-running for the SAME version must not duplicate the entry, but must still
-  # populate the runner sha scalar (self-heal at release time).
+  # populate the per-entry runner sha (self-heal at release time).
   run env \
     RELEASE_VERSION="99.99.99" \
     APK_SHA256_CHECKSUM="$APK_SHA" \
@@ -80,8 +80,50 @@ teardown() {
 
   entry_count="$(grep -c 'version: "99.99.99"' "${TEST_ROOT}/src/constants/release.ts")"
   [ "$entry_count" -eq 1 ]
-  grep -q "export const IOS_CTRL_PROXY_RUNNER_SHA256: string = \"${RUNNER_SHA}\";" \
-    "${TEST_ROOT}/src/constants/release.ts"
+  grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+}
+
+@test "caps registry without orphan braces when entries include runnerSha256" {
+  python3 - "${TEST_ROOT}/src/constants/release.ts" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+entries = []
+for i in range(100):
+    entries.append(f'''  {{
+    version: "1.0.{i}",
+    apkSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ipaSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    runnerSha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  }},''')
+
+text = path.read_text()
+replacement = "export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [\n" + "\n".join(entries) + "\n];"
+text = re.sub(
+    r'export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry\[\] = \[\n.*?\n\];',
+    replacement,
+    text,
+    count=1,
+    flags=re.S,
+)
+path.write_text(text)
+PY
+
+  run env \
+    RELEASE_VERSION="99.99.99" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  version_count="$(grep -c 'version: "' "${TEST_ROOT}/src/constants/release.ts")"
+  open_count="$(grep -c '^  {$' "${TEST_ROOT}/src/constants/release.ts")"
+  close_count="$(grep -c '^  },$' "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$version_count" -eq 100 ]
+  [ "$open_count" -eq "$close_count" ]
 }
 
 @test "rejects a malformed IOS_CTRL_PROXY_RUNNER_SHA256" {

--- a/test/bats/verify-release-integrity.bats
+++ b/test/bats/verify-release-integrity.bats
@@ -55,10 +55,10 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     version: "${registry}",
     apkSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     ipaSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    runnerSha256: "${runner}",
   },
 ];
 export const IOS_CTRL_PROXY_APP_HASH: string = "";
-export const IOS_CTRL_PROXY_RUNNER_SHA256: string = "${runner}";
 EOF
 }
 
@@ -178,14 +178,14 @@ PY
   write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" ""
   run_gate "$VERSION"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"IOS_CTRL_PROXY_RUNNER_SHA256"* ]]
+  [[ "$output" == *"registry[0].runnerSha256"* ]]
 }
 
 @test "fails when runner sha256 is malformed" {
   write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "not-a-valid-sha"
   run_gate "$VERSION"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"IOS_CTRL_PROXY_RUNNER_SHA256"* ]]
+  [[ "$output" == *"registry[0].runnerSha256"* ]]
 }
 
 @test "binds recorded runner sha to the runner inside the IPA (match passes)" {

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -7,7 +7,7 @@ import {
   DAEMON_PACKAGE_NAME,
   DEFAULT_ASSET_BASE_URL,
   IOS_CTRL_PROXY_IPA_URL,
-  IOS_CTRL_PROXY_RUNNER_SHA256,
+  IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
   RELEASE_CHECKSUM_REGISTRY,
   isExplicitPin,
@@ -22,6 +22,7 @@ import {
   resolveIpaUrl,
   resolveLatestVersion,
   resolvePinnedVersion,
+  resolveRunnerChecksum,
   type ReleaseChecksumEntry,
 } from "../../src/constants/release";
 
@@ -70,9 +71,9 @@ describe("resolveChecksum", function() {
 
   test("multi-entry registry resolves each version independently", function() {
     const registry: ReleaseChecksumEntry[] = [
-      { version: "0.0.20", apkSha256: "apk20", ipaSha256: "ipa20" },
-      { version: "0.0.19", apkSha256: "apk19", ipaSha256: "ipa19" },
-      { version: "0.0.18", apkSha256: "apk18", ipaSha256: "ipa18" },
+      { version: "0.0.20", apkSha256: "apk20", ipaSha256: "ipa20", runnerSha256: "runner20" },
+      { version: "0.0.19", apkSha256: "apk19", ipaSha256: "ipa19", runnerSha256: "runner19" },
+      { version: "0.0.18", apkSha256: "apk18", ipaSha256: "ipa18", runnerSha256: "runner18" },
     ];
     expect(resolveChecksum("latest", "android", registry)).toBe("apk20");
     expect(resolveChecksum("0.0.19", "android", registry)).toBe("apk19");
@@ -111,6 +112,10 @@ describe("module-level URL and checksum exports", function() {
   test("APK and IPA checksums match the newest registered entry", function() {
     expect(APK_SHA256_CHECKSUM).toBe(newest.apkSha256);
     expect(IOS_CTRL_PROXY_SHA256_CHECKSUM).toBe(newest.ipaSha256);
+  });
+
+  test("iOS runner checksum matches the newest registered entry", function() {
+    expect(IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM).toBe(newest.runnerSha256);
   });
 });
 
@@ -210,6 +215,36 @@ describe("resolveApkChecksum / resolveIpaChecksum (EC1, EC4)", function() {
   });
 });
 
+describe("resolveRunnerChecksum", function() {
+  test("unset env resolves to the latest entry runner checksum", function() {
+    const newest = RELEASE_CHECKSUM_REGISTRY[0];
+    expect(resolveRunnerChecksum({})).toBe(newest.runnerSha256);
+  });
+
+  test("AUTOMOBILE_VERSION selects that version's runner checksum", function() {
+    const registry: ReleaseChecksumEntry[] = [
+      {
+        version: "0.0.20",
+        apkSha256: "apk20",
+        ipaSha256: "ipa20",
+        runnerSha256: "runner20",
+      },
+      {
+        version: "0.0.18",
+        apkSha256: "apk18",
+        ipaSha256: "ipa18",
+        runnerSha256: "runner18",
+      },
+    ];
+
+    expect(resolveRunnerChecksum({ AUTOMOBILE_VERSION: "0.0.18" }, registry)).toBe("runner18");
+  });
+
+  test("unknown pinned version yields an empty checksum", function() {
+    expect(resolveRunnerChecksum({ AUTOMOBILE_VERSION: "99.99.99" })).toBe("");
+  });
+});
+
 describe("resolveDaemonInstallSpecifier (EC5)", function() {
   const newest = RELEASE_CHECKSUM_REGISTRY[0];
 
@@ -282,7 +317,7 @@ describe("isPinnedVersionKnown", function() {
 
 describe("resolveApkUrl / resolveIpaUrl with an injected registry", function() {
   const registry: ReleaseChecksumEntry[] = [
-    { version: "0.0.20", apkSha256: "apk20", ipaSha256: "ipa20" },
+    { version: "0.0.20", apkSha256: "apk20", ipaSha256: "ipa20", runnerSha256: "runner20" },
   ];
 
   test("uses the injected registry's newest version", function() {
@@ -318,10 +353,13 @@ describe("package.json as canonical version source", function() {
 });
 
 describe("iOS runner-binary checksum", function() {
-  test("is empty or a well-formed 64-char sha256", function() {
-    // Empty is the local-dev default (verification skipped). When populated by
-    // the release pipeline it must be a lowercase 64-hex sha256 so the runner
-    // integrity check in IOSCtrlProxyBuilder can actually run.
-    expect(IOS_CTRL_PROXY_RUNNER_SHA256 === "" || /^[a-f0-9]{64}$/.test(IOS_CTRL_PROXY_RUNNER_SHA256)).toBe(true);
+  test("registry entries carry empty or well-formed 64-char runner sha256 values", function() {
+    for (const entry of RELEASE_CHECKSUM_REGISTRY) {
+      expect(entry.runnerSha256 === "" || /^[a-f0-9]{64}$/.test(entry.runnerSha256)).toBe(true);
+    }
+  });
+
+  test("module-level runner checksum export resolves from registry[0]", function() {
+    expect(IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM).toBe(RELEASE_CHECKSUM_REGISTRY[0].runnerSha256);
   });
 });

--- a/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
+++ b/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
@@ -30,7 +30,9 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
     const xctestrunFile = path.join(extractionRoot, "Build", "Products", "CtrlProxyApp_iphonesimulator.xctestrun");
     await fs.writeFile(xctestrunFile, "fake xctestrun");
     await fs.mkdir(path.join(productsDir, "CtrlProxyApp.app"), { recursive: true });
-    await fs.mkdir(path.join(productsDir, "CtrlProxyUITests-Runner.app"), { recursive: true });
+    const runnerDir = path.join(productsDir, "CtrlProxyUITests-Runner.app");
+    await fs.mkdir(runnerDir, { recursive: true });
+    await fs.writeFile(path.join(runnerDir, "CtrlProxyUITests-Runner"), "fake runner");
     await fs.mkdir(path.join(productsDir, "CtrlProxyTests.xctest"), { recursive: true });
   }
 }


### PR DESCRIPTION
## Summary

Store the iOS CtrlProxy runner SHA256 on each release registry entry instead of as a single global scalar. `IOSCtrlProxyBuilder` now resolves the runner checksum through the active pinned version, so pinned iOS downloads verify against the runner hash recorded for the same release entry.

## Linked Issue

Closes #2806

## Bug / Regression Context

- **Prior attempts:** #2747 wired runner checksum generation and the release gate, but kept the runner SHA as a global scalar with a warning that pinned older iOS downloads would need per-entry data.
- **Observed symptom:** once `AUTOMOBILE_VERSION` pins an older iOS bundle, a global runner checksum can only represent the newest IPA and can reject a valid older bundle's runner.
- **Repro steps / conditions:** set `AUTOMOBILE_VERSION` to a concrete older release and use the iOS CtrlProxy download path; the IPA checksum resolves per version, but the runner checksum must resolve per version too.

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, release metadata and iOS builder checksum resolution only
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Focused checks run locally:

- [x] `bun test test/constants/release.test.ts test/utils/IOSCtrlProxyBuilder.test.ts --bail`
- [x] `bats test/bats/generate-release-constants.bats test/bats/verify-release-integrity.bats test/bats/release-workflow-wiring.bats`
- [x] `shellcheck scripts/generate-release-constants.sh scripts/ci/verify-release-integrity.sh`
- [x] `bun run validate:yaml`
- [x] `git diff --check`

## Device Verification

N/A. This changes release checksum metadata and local verification lookup, not on-device behavior.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
