### PR TITLE
fix(daemon): enforce shared daemon asset pin

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -90,6 +90,15 @@ internal object DaemonSocketClientManager {
     val socketPath = DaemonSocketPaths.socketPath()
     val forceRestart = DaemonSocketPaths.resolveForceRestart()
     val daemonAvailable = DaemonSocketClient.isAvailable(socketPath)
+    val daemonAssetVersion =
+      DaemonSocketPaths.readDaemonAssetVersionFromPidFile(DaemonSocketPaths.pidFilePath())
+    val callerAssetVersion = DaemonSocketPaths.resolveCallerAssetVersionPin()
+    val assetVersionSkew =
+      daemonAvailable &&
+        DaemonSocketPaths.requiresAssetVersionPinFailure(
+          daemonAssetVersion,
+          callerAssetVersion,
+        )
 
     // A daemon of a different build already owning the shared per-uid socket would
     // silently serve the wrong tool set (#2744). Before reusing it, compare the version
@@ -113,7 +122,21 @@ internal object DaemonSocketClientManager {
           DaemonSocketPaths.resolveClientBuildId(),
           DaemonSocketPaths.resolveLocalDaemonEntryScript(),
         )
-    val skew = versionSkew || buildSkew
+    if (
+      DaemonSocketPaths.requiresImmediateAssetVersionPinFailure(
+        assetVersionSkew,
+        versionSkew,
+        buildSkew,
+        forceRestart,
+      )
+    ) {
+      throw DaemonUnavailableException(
+        "AutoMobile daemon AUTOMOBILE_VERSION mismatch: the shared daemon was started with " +
+          "${daemonAssetVersion ?: "unknown"}, but this runner requested $callerAssetVersion. " +
+          "Restart the daemon from this runner's environment before reusing it."
+      )
+    }
+    val skew = versionSkew || buildSkew || assetVersionSkew
 
     if (!forceRestart && daemonAvailable && !skew) {
       return
@@ -169,7 +192,12 @@ internal object DaemonSocketClientManager {
         DaemonSocketPaths.resolveClientBuildId(),
         DaemonSocketPaths.resolveLocalDaemonEntryScript(),
       )
-    if (stillVersionSkewed || stillBuildSkewed) {
+    val stillAssetVersionSkewed =
+      DaemonSocketPaths.requiresAssetVersionPinFailure(
+        DaemonSocketPaths.readDaemonAssetVersionFromPidFile(pidFilePath),
+        DaemonSocketPaths.resolveCallerAssetVersionPin(),
+      )
+    if (stillVersionSkewed || stillBuildSkewed || stillAssetVersionSkewed) {
       throw DaemonUnavailableException(
         "AutoMobile daemon still differs from this runner after (re)start; the shared socket is " +
           "served by a different build. Ensure the same @kaeawc/auto-mobile version starts the " +
@@ -524,6 +552,10 @@ internal object DaemonSocketPaths {
   internal fun readDaemonVersionFromPidFile(path: String): String? =
     readPidFileString(path, "version")
 
+  /** Read the daemon's recorded CtrlProxy asset version from its PID file, or null. */
+  internal fun readDaemonAssetVersionFromPidFile(path: String): String? =
+    readPidFileString(path, "assetVersion")
+
   /** Read the daemon's recorded build-identity hash from its PID file, or null. */
   internal fun readDaemonBuildIdFromPidFile(path: String): String? =
     readPidFileString(path, "buildId")
@@ -616,6 +648,35 @@ internal object DaemonSocketPaths {
     val clientBase = releaseVersion(clientVersion?.trim().orEmpty())
     if (daemonBase.isEmpty() || clientBase.isEmpty()) return false
     return daemonBase != clientBase
+  }
+
+  internal fun resolveCallerAssetVersionPin(): String? {
+    val pinned = System.getenv("AUTOMOBILE_VERSION")?.trim().orEmpty()
+    if (pinned.isEmpty() || ignoredPackageVersions.contains(pinned.lowercase())) {
+      return null
+    }
+    return pinned
+  }
+
+  internal fun requiresAssetVersionPinFailure(
+    daemonAssetVersion: String?,
+    callerPinnedVersion: String?,
+  ): Boolean {
+    val daemon = daemonAssetVersion?.trim().orEmpty()
+    val caller = callerPinnedVersion?.trim().orEmpty()
+    if (caller.isEmpty() || ignoredPackageVersions.contains(caller.lowercase())) {
+      return false
+    }
+    return daemon != caller
+  }
+
+  internal fun requiresImmediateAssetVersionPinFailure(
+    assetVersionSkew: Boolean,
+    versionSkew: Boolean,
+    buildSkew: Boolean,
+    forceRestart: Boolean,
+  ): Boolean {
+    return assetVersionSkew && !versionSkew && !buildSkew && !forceRestart
   }
 
   /**

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonVersionHandshakeTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonVersionHandshakeTest.kt
@@ -61,6 +61,62 @@ class DaemonVersionHandshakeTest {
   }
 
   @Test
+  fun `requiresAssetVersionPinFailure is true only for explicit mismatched pins`() {
+    assertTrue(DaemonSocketPaths.requiresAssetVersionPinFailure("0.0.18", "0.0.39"))
+    assertFalse(DaemonSocketPaths.requiresAssetVersionPinFailure("0.0.18", "0.0.18"))
+    assertFalse(DaemonSocketPaths.requiresAssetVersionPinFailure("0.0.18", null))
+    assertFalse(DaemonSocketPaths.requiresAssetVersionPinFailure("0.0.18", ""))
+    assertFalse(DaemonSocketPaths.requiresAssetVersionPinFailure("0.0.18", "latest"))
+    assertTrue(DaemonSocketPaths.requiresAssetVersionPinFailure(null, "0.0.18"))
+    assertTrue(DaemonSocketPaths.requiresAssetVersionPinFailure("", "0.0.18"))
+    assertTrue(DaemonSocketPaths.requiresAssetVersionPinFailure("  ", "0.0.18"))
+  }
+
+  @Test
+  fun `requiresImmediateAssetVersionPinFailure preserves restartable skew paths`() {
+    assertTrue(
+      DaemonSocketPaths.requiresImmediateAssetVersionPinFailure(
+        assetVersionSkew = true,
+        versionSkew = false,
+        buildSkew = false,
+        forceRestart = false,
+      )
+    )
+    assertFalse(
+      DaemonSocketPaths.requiresImmediateAssetVersionPinFailure(
+        assetVersionSkew = true,
+        versionSkew = true,
+        buildSkew = false,
+        forceRestart = false,
+      )
+    )
+    assertFalse(
+      DaemonSocketPaths.requiresImmediateAssetVersionPinFailure(
+        assetVersionSkew = true,
+        versionSkew = false,
+        buildSkew = true,
+        forceRestart = false,
+      )
+    )
+    assertFalse(
+      DaemonSocketPaths.requiresImmediateAssetVersionPinFailure(
+        assetVersionSkew = true,
+        versionSkew = false,
+        buildSkew = false,
+        forceRestart = true,
+      )
+    )
+    assertFalse(
+      DaemonSocketPaths.requiresImmediateAssetVersionPinFailure(
+        assetVersionSkew = false,
+        versionSkew = false,
+        buildSkew = false,
+        forceRestart = false,
+      )
+    )
+  }
+
+  @Test
   fun `readDaemonVersionFromPidFile reads version field`() {
     val pidFile = File.createTempFile("automobile-pid", ".pid")
     try {
@@ -68,6 +124,20 @@ class DaemonVersionHandshakeTest {
       assertEquals(
         "0.0.40+gabc123",
         DaemonSocketPaths.readDaemonVersionFromPidFile(pidFile.absolutePath),
+      )
+    } finally {
+      pidFile.delete()
+    }
+  }
+
+  @Test
+  fun `readDaemonAssetVersionFromPidFile reads assetVersion field`() {
+    val pidFile = File.createTempFile("automobile-pid-asset", ".pid")
+    try {
+      pidFile.writeText("""{"pid":123,"port":3000,"assetVersion":"0.0.18"}""")
+      assertEquals(
+        "0.0.18",
+        DaemonSocketPaths.readDaemonAssetVersionFromPidFile(pidFile.absolutePath),
       )
     } finally {
       pidFile.delete()

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -101,6 +101,7 @@ public enum DaemonStartupResult: Equatable {
     case launchFailed
     case readinessTimeout
     case versionSkew
+    case assetVersionSkew
 
     public var isReady: Bool { self == .ready }
 
@@ -121,6 +122,9 @@ public enum DaemonStartupResult: Equatable {
         case .versionSkew:
             return "Failed to start AutoMobile Daemon: a different-version daemon owns the socket and could "
                 + "not be reconciled with this runner."
+        case .assetVersionSkew:
+            return "Failed to start AutoMobile Daemon: the shared daemon was started with a different "
+                + "AUTOMOBILE_VERSION pin than this runner. Restart the daemon from this runner's environment."
         }
     }
 }
@@ -140,6 +144,7 @@ public enum DaemonManager {
         public let socketPath: String?
         public let startedAt: Int64?
         public let version: String?
+        public let assetVersion: String?
         public let entryScript: String?
         public let buildId: String?
     }
@@ -271,6 +276,18 @@ public enum DaemonManager {
         return version
     }
 
+    /// The daemon's recorded CtrlProxy asset version from its PID file, trimmed, or nil.
+    static func readDaemonAssetVersionFromPidFile() -> String? {
+        guard let data = FileManager.default.contents(atPath: pidFilePath),
+              let pidData = try? JSONDecoder().decode(PidFileData.self, from: data),
+              let assetVersion = pidData.assetVersion?.trimmingCharacters(in: .whitespaces),
+              !assetVersion.isEmpty
+        else {
+            return nil
+        }
+        return assetVersion
+    }
+
     /// The daemon's recorded entry-script path from its PID file, trimmed, or nil when absent.
     static func readDaemonEntryScriptFromPidFile() -> String? {
         guard let data = FileManager.default.contents(atPath: pidFilePath),
@@ -355,6 +372,42 @@ public enum DaemonManager {
         return releaseVersion(daemonVersion) != releaseVersion(client)
     }
 
+    static func resolveCallerAssetVersionPin(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        guard let pinned = environment["AUTOMOBILE_VERSION"]?.trimmingCharacters(in: .whitespaces),
+              !pinned.isEmpty,
+              pinned.lowercased() != "latest",
+              pinned.lowercased() != "unknown"
+        else {
+            return nil
+        }
+        return pinned
+    }
+
+    static func requiresAssetVersionPinFailure(
+        daemonAssetVersion: String?,
+        callerPinnedVersion: String?
+    ) -> Bool {
+        let daemon = daemonAssetVersion?.trimmingCharacters(in: .whitespaces) ?? ""
+        guard let caller = callerPinnedVersion?.trimmingCharacters(in: .whitespaces),
+              !caller.isEmpty,
+              caller.lowercased() != "latest",
+              caller.lowercased() != "unknown"
+        else {
+            return false
+        }
+        return daemon != caller
+    }
+
+    static func requiresImmediateAssetVersionPinFailure(
+        assetVersionSkew: Bool,
+        versionSkew: Bool,
+        buildSkew: Bool
+    ) -> Bool {
+        assetVersionSkew && !versionSkew && !buildSkew
+    }
+
     public static func ensureDaemonRunning(repoRoot: String? = nil, timeoutSeconds: TimeInterval = 15) -> Bool {
         return ensureDaemonRunningResult(repoRoot: repoRoot, timeoutSeconds: timeoutSeconds).isReady
     }
@@ -376,11 +429,24 @@ public enum DaemonManager {
                 daemonVersion: readDaemonVersionFromPidFile(),
                 clientVersion: AutoMobileVersion.current
             )
-            if versionSkew || requiresRepoRootBuildSkew(
+            let buildSkew = requiresRepoRootBuildSkew(
                 daemonBuildId: readDaemonBuildIdFromPidFile(),
                 daemonEntryScript: readDaemonEntryScriptFromPidFile(),
                 repoRoot: repoRoot
+            )
+            let assetVersionSkew = requiresAssetVersionPinFailure(
+                daemonAssetVersion: readDaemonAssetVersionFromPidFile(),
+                callerPinnedVersion: resolveCallerAssetVersionPin()
+            )
+            if requiresImmediateAssetVersionPinFailure(
+                assetVersionSkew: assetVersionSkew,
+                versionSkew: versionSkew,
+                buildSkew: buildSkew
             ) {
+                PerfTimer.log("ensureDaemonRunning: daemon AUTOMOBILE_VERSION pin mismatch")
+                return .assetVersionSkew
+            }
+            if versionSkew || buildSkew || assetVersionSkew {
                 PerfTimer.log("ensureDaemonRunning: daemon version/build skew, restarting")
                 if let failure = startupFailure(for: runDaemonSubcommand("restart", repoRoot: repoRoot)) {
                     PerfTimer.log("ensureDaemonRunning: restartDaemon failed - \(failure)")
@@ -422,8 +488,17 @@ public enum DaemonManager {
             daemonBuildId: readDaemonBuildIdFromPidFile(),
             daemonEntryScript: readDaemonEntryScriptFromPidFile(),
             repoRoot: repoRoot
+        ) || requiresAssetVersionPinFailure(
+            daemonAssetVersion: readDaemonAssetVersionFromPidFile(),
+            callerPinnedVersion: resolveCallerAssetVersionPin()
         ) {
             PerfTimer.log("ensureDaemonRunning: daemon still differs from runner after launch")
+            if requiresAssetVersionPinFailure(
+                daemonAssetVersion: readDaemonAssetVersionFromPidFile(),
+                callerPinnedVersion: resolveCallerAssetVersionPin()
+            ) {
+                return .assetVersionSkew
+            }
             return .versionSkew
         }
         return .ready

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -41,6 +41,64 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertFalse(DaemonManager.requiresVersionSkewRestart(daemonVersion: "0.0.40", clientVersion: ""))
     }
 
+    func testRequiresAssetVersionPinFailureOnlyForExplicitMismatchedPins() {
+        XCTAssertTrue(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: "0.0.18",
+            callerPinnedVersion: "0.0.39"
+        ))
+        XCTAssertFalse(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: "0.0.18",
+            callerPinnedVersion: "0.0.18"
+        ))
+        XCTAssertFalse(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: "0.0.18",
+            callerPinnedVersion: nil
+        ))
+        XCTAssertFalse(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: "0.0.18",
+            callerPinnedVersion: ""
+        ))
+        XCTAssertFalse(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: "0.0.18",
+            callerPinnedVersion: "latest"
+        ))
+        XCTAssertTrue(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: nil,
+            callerPinnedVersion: "0.0.18"
+        ))
+        XCTAssertTrue(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: "",
+            callerPinnedVersion: "0.0.18"
+        ))
+        XCTAssertTrue(DaemonManager.requiresAssetVersionPinFailure(
+            daemonAssetVersion: "  ",
+            callerPinnedVersion: "0.0.18"
+        ))
+    }
+
+    func testRequiresImmediateAssetVersionPinFailurePreservesRestartableSkewPaths() {
+        XCTAssertTrue(DaemonManager.requiresImmediateAssetVersionPinFailure(
+            assetVersionSkew: true,
+            versionSkew: false,
+            buildSkew: false
+        ))
+        XCTAssertFalse(DaemonManager.requiresImmediateAssetVersionPinFailure(
+            assetVersionSkew: true,
+            versionSkew: true,
+            buildSkew: false
+        ))
+        XCTAssertFalse(DaemonManager.requiresImmediateAssetVersionPinFailure(
+            assetVersionSkew: true,
+            versionSkew: false,
+            buildSkew: true
+        ))
+        XCTAssertFalse(DaemonManager.requiresImmediateAssetVersionPinFailure(
+            assetVersionSkew: false,
+            versionSkew: false,
+            buildSkew: false
+        ))
+    }
+
     func testResolveRepoRootDaemonEntryScript() throws {
         XCTAssertNil(DaemonManager.resolveRepoRootDaemonEntryScript(nil))
         XCTAssertNil(DaemonManager.resolveRepoRootDaemonEntryScript(""))

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -302,7 +302,7 @@ final class XCTestRunnerTests: XCTestCase {
 
     func testDaemonStartupResultReadyIsTheOnlyReadyCase() {
         XCTAssertTrue(DaemonStartupResult.ready.isReady)
-        for result: DaemonStartupResult in [.executableNotFound, .launchFailed, .readinessTimeout, .versionSkew] {
+        for result: DaemonStartupResult in [.executableNotFound, .launchFailed, .readinessTimeout, .versionSkew, .assetVersionSkew] {
             XCTAssertFalse(result.isReady, "\(result) must not report ready")
         }
     }
@@ -318,6 +318,7 @@ final class XCTestRunnerTests: XCTestCase {
         XCTAssertTrue(DaemonStartupResult.launchFailed.diagnosticMessage.contains("exited non-zero"))
         XCTAssertTrue(DaemonStartupResult.readinessTimeout.diagnosticMessage.contains("did not"))
         XCTAssertTrue(DaemonStartupResult.versionSkew.diagnosticMessage.contains("different-version"))
+        XCTAssertTrue(DaemonStartupResult.assetVersionSkew.diagnosticMessage.contains("AUTOMOBILE_VERSION"))
 
         // Each failure reason is distinct so a CI log names the specific cause.
         let messages = [
@@ -325,6 +326,7 @@ final class XCTestRunnerTests: XCTestCase {
             DaemonStartupResult.launchFailed,
             DaemonStartupResult.readinessTimeout,
             DaemonStartupResult.versionSkew,
+            DaemonStartupResult.assetVersionSkew,
         ].map { $0.diagnosticMessage }
         XCTAssertEqual(Set(messages).count, messages.count)
     }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -78,6 +78,7 @@ import {
   safeProcessCwd,
   resolveStableDaemonWorkingDirectory,
 } from "../utils/workingDirectory";
+import { resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
@@ -703,6 +704,7 @@ export class Daemon {
       dbPath: getDatabasePath(),
       startedAt: this.timer.now(),
       version: DAEMON_VERSION,
+      assetVersion: resolveAssetVersion(resolvePinnedVersion()),
       options: this.options,
     };
     await this.persistPidFileData(pidData);
@@ -722,6 +724,7 @@ export class Daemon {
       dbPath: getDatabasePath(),
       startedAt: this.timer.now(),
       version: DAEMON_VERSION,
+      assetVersion: resolveAssetVersion(resolvePinnedVersion()),
       entryScript: buildIdentity.entryScript,
       buildId: buildIdentity.buildId,
       options: this.options,

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -8,6 +8,7 @@ import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { isExplicitPin, resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
 import {
   type BuildIdentity,
   buildIdentitiesMatch,
@@ -102,6 +103,22 @@ export class DaemonBuildMismatchError extends DaemonUnavailableError {
     this.daemonEntryScript = params.daemon.entryScript;
     this.reason = params.reason;
     this.retryAfterMs = params.retryAfterMs;
+  }
+}
+
+export class DaemonAssetVersionMismatchError extends DaemonUnavailableError {
+  readonly clientAssetVersion: string;
+  readonly daemonAssetVersion: string;
+
+  constructor(clientAssetVersion: string, daemonAssetVersion: string) {
+    super(
+      `AutoMobile AUTOMOBILE_VERSION mismatch: caller requested ${clientAssetVersion}, ` +
+      `but the shared daemon was started with ${daemonAssetVersion}. Restart the daemon ` +
+      `from the caller's environment (for example, run auto-mobile --daemon restart) before reusing it.`
+    );
+    this.name = "DaemonAssetVersionMismatchError";
+    this.clientAssetVersion = clientAssetVersion;
+    this.daemonAssetVersion = daemonAssetVersion;
   }
 }
 
@@ -243,6 +260,7 @@ export class DaemonMcpProxy {
   private readonly timer: Pick<Timer, "now">;
   private readonly buildIdentity: BuildIdentity;
   private readonly clientVersion: string;
+  private readonly clientAssetVersion: string | null;
   private connecting: Promise<void> | null = null;
   private connected: boolean = false;
 
@@ -274,6 +292,9 @@ export class DaemonMcpProxy {
     this.timer = config.timer ?? defaultTimer;
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
     this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
+    this.clientAssetVersion = isExplicitPin()
+      ? resolveAssetVersion(resolvePinnedVersion())
+      : null;
   }
 
   /**
@@ -312,10 +333,12 @@ export class DaemonMcpProxy {
       logger.info("[DaemonMcpProxy] Daemon not available, starting daemon...");
       await this.startDaemon();
       await this.ensureVersionMatches();
+      await this.ensureAssetVersionPinMatches();
       await this.ensureBuildMatches();
       await this.ensureStartupOptionsMatch();
     } else {
       await this.ensureVersionMatches();
+      await this.ensureAssetVersionPinMatches();
       await this.ensureBuildMatches();
       await this.ensureStartupOptionsMatch();
     }
@@ -502,6 +525,24 @@ export class DaemonMcpProxy {
       detail,
       retryAfterMs,
     });
+  }
+
+  private async ensureAssetVersionPinMatches(): Promise<void> {
+    if (!this.clientAssetVersion) {
+      return;
+    }
+    const status = await this.daemonManager.status();
+    if (!status.running) {
+      return;
+    }
+    const daemonAssetVersion = status.assetVersion?.trim() ?? "";
+    if (daemonAssetVersion === this.clientAssetVersion) {
+      return;
+    }
+    throw new DaemonAssetVersionMismatchError(
+      this.clientAssetVersion,
+      daemonAssetVersion.length > 0 ? daemonAssetVersion : "unknown"
+    );
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -991,6 +991,7 @@ export class DaemonManager implements DaemonManagerLike {
         dbPath: pidData.dbPath,
         startedAt: pidData.startedAt,
         version: pidData.version,
+        assetVersion: pidData.assetVersion,
         entryScript: pidData.entryScript,
         buildId: pidData.buildId,
         options: pidData.options,

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -104,6 +104,8 @@ export interface DaemonStatus {
   startedAt?: number;
   /** Daemon version */
   version?: string;
+  /** Concrete CtrlProxy asset version resolved from AUTOMOBILE_VERSION at daemon start */
+  assetVersion?: string;
   /** Absolute path to the daemon's entry script (build identity) */
   entryScript?: string;
   /** Content hash of the daemon's entry script (build identity) */
@@ -134,6 +136,8 @@ export interface PidFileData {
   startedAt: number;
   /** Daemon version */
   version: string;
+  /** Concrete CtrlProxy asset version resolved from AUTOMOBILE_VERSION at daemon start */
+  assetVersion?: string;
   /** Absolute path to the daemon's entry script (build identity) */
   entryScript?: string;
   /** Content hash of the daemon's entry script (build identity) */

--- a/test/daemon/integration/versionMismatchRestart.test.ts
+++ b/test/daemon/integration/versionMismatchRestart.test.ts
@@ -30,13 +30,14 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
   let isAvailableSpy: ReturnType<typeof spyOn>;
   let fakeTimer: FakeTimer;
 
-  function writePidFile(fields: { version?: string; startedAt?: number }): void {
+  function writePidFile(fields: { version?: string; startedAt?: number; assetVersion?: string }): void {
     const data: PidFileData = {
       pid: process.pid,
       socketPath: join(tempDir, "test.sock"),
       port: 0,
       startedAt: fields.startedAt ?? 1,
       version: fields.version ?? "",
+      assetVersion: fields.assetVersion,
     };
     writeFileSync(pidFilePath, JSON.stringify(data));
   }
@@ -144,6 +145,85 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
     }
   });
 
+  test("real PID file with mismatched explicit asset pin fails without attaching", async () => {
+    writePidFile({ version: CLIENT_VERSION, assetVersion: "0.0.18", startedAt: 1 });
+    const previousVersion = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "0.0.39";
+    const tracked = makeTracked();
+    const fakeClient = new FakeDaemonClient();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: tracked,
+      autoStartDaemon: true,
+      timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
+    });
+    try {
+      await expect(proxy.listTools()).rejects.toThrow(/AUTOMOBILE_VERSION.*0\.0\.39.*0\.0\.18/);
+      expect(tracked.restartCalled).toBe(false);
+      expect(fakeClient.isConnected()).toBe(false);
+    } finally {
+      if (previousVersion === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = previousVersion;
+      }
+      await proxy.close();
+    }
+  });
+
+  test("real PID file with explicit asset pin and missing daemon stamp fails without attaching", async () => {
+    writePidFile({ version: CLIENT_VERSION, startedAt: 1 });
+    const previousVersion = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "0.0.39";
+    const tracked = makeTracked();
+    const fakeClient = new FakeDaemonClient();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => fakeClient,
+      daemonManager: tracked,
+      autoStartDaemon: true,
+      timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
+    });
+    try {
+      await expect(proxy.listTools()).rejects.toThrow(/AUTOMOBILE_VERSION.*0\.0\.39.*unknown/);
+      expect(tracked.restartCalled).toBe(false);
+      expect(fakeClient.isConnected()).toBe(false);
+    } finally {
+      if (previousVersion === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = previousVersion;
+      }
+      await proxy.close();
+    }
+  });
+
+  test("real PID file with matching explicit asset pin does not block reuse", async () => {
+    writePidFile({ version: CLIENT_VERSION, assetVersion: "0.0.18", startedAt: 1 });
+    const previousVersion = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "0.0.18";
+    const tracked = makeTracked();
+    const proxy = new DaemonMcpProxy({
+      clientFactory: () => new FakeDaemonClient(),
+      daemonManager: tracked,
+      autoStartDaemon: true,
+      timer: fakeTimer,
+      clientVersion: CLIENT_VERSION,
+    });
+    try {
+      await proxy.listTools();
+      expect(tracked.restartCalled).toBe(false);
+    } finally {
+      if (previousVersion === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = previousVersion;
+      }
+      await proxy.close();
+    }
+  });
+
   test("real PID file with older version inside cooldown window fails without attaching", async () => {
     writePidFile({
       version: "0.0.1",
@@ -219,6 +299,15 @@ describe("DaemonMcpProxy + real DaemonManager (version-mismatch integration)", (
 
     expect(status.running).toBe(true);
     expect(status.sockets).toEqual(sockets);
+  });
+
+  test("real PID file exposes stamped asset version through status", async () => {
+    writePidFile({ version: CLIENT_VERSION, assetVersion: "0.0.18", startedAt: 1 });
+
+    const status = await realManager.status();
+
+    expect(status.running).toBe(true);
+    expect(status.assetVersion).toBe("0.0.18");
   });
 
   test("PID file pointing at a dead PID is treated as not running, no restart attempted", async () => {


### PR DESCRIPTION
## Summary

Enforces `AUTOMOBILE_VERSION` across reused shared daemons by stamping the daemon's resolved CtrlProxy asset version into the PID file and checking that stamp before TypeScript, Android, or iOS clients attach to an existing daemon.

## Linked Issue

Closes #2812

## Bug / Regression Context

- **Prior attempts:** #2748 documented the shared daemon caveat but did not enforce it at runtime.
- **Observed symptom:** A second job with a different `AUTOMOBILE_VERSION` could silently reuse a daemon launched by another job and receive the daemon's old pin.
- **Repro steps / conditions:** Start an AutoMobile daemon with one `AUTOMOBILE_VERSION`, then run a caller with a different explicit `AUTOMOBILE_VERSION` while the shared per-UID daemon is still running.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalent passes (`bun run lint` + `bun test --bail`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran matching focused runner validation
- [x] New code uses fast unit/integration tests for the PID stamp and mismatch rules
- [x] Rebased onto latest `main`, conflicts resolved

Additional checks run:

- `bun test test/daemon/integration/versionMismatchRestart.test.ts`
- `cd android && ./gradlew :junit-runner:test --tests dev.jasonpearson.automobile.junit.DaemonVersionHandshakeTest`
- `cd ios/XCTestRunner && swift test --filter AutoMobileVersionTests`
- `cd ios/XCTestRunner && swift test --filter XCTestRunnerTests/testDaemonStartupResult`
- `bun run build`
- `bunx turbo run lint build test`
- `git diff --check`

## Device Verification

N/A: this change is daemon and runner reuse logic covered by PID-file and runner unit/integration tests.

## Follow-ups

- [x] No follow-up issues identified.
