### PR TITLE
fix(ios): warm Reminders before XCTest plans

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -445,6 +445,17 @@ jobs:
       - name: "Boot iOS Simulator (Xcode 26.2)"
         run: ./scripts/ios/boot-simulator.sh
 
+      - name: "Ensure AutoMobile daemon ready"
+        run: ./scripts/ci/ensure-daemon-ready.sh
+
+      - name: "Warm up iOS CtrlProxy"
+        timeout-minutes: 12
+        run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
+
+      - name: "Warm up Reminders target app (Xcode 26.2)"
+        timeout-minutes: 5
+        run: ./scripts/ci/warm-reminders-target-app.sh
+
       - name: "Run Reminders integration tests (Xcode 26.2)"
         timeout-minutes: 10
         env:
@@ -467,6 +478,17 @@ jobs:
 
       - name: "Boot iOS Simulator (Xcode 26.3)"
         run: ./scripts/ios/boot-simulator.sh
+
+      - name: "Ensure AutoMobile daemon ready (Xcode 26.3)"
+        run: ./scripts/ci/ensure-daemon-ready.sh
+
+      - name: "Warm up iOS CtrlProxy (Xcode 26.3)"
+        timeout-minutes: 12
+        run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
+
+      - name: "Warm up Reminders target app (Xcode 26.3)"
+        timeout-minutes: 5
+        run: ./scripts/ci/warm-reminders-target-app.sh
 
       - name: "Run Reminders integration tests (Xcode 26.3)"
         timeout-minutes: 10

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1311,6 +1311,13 @@ jobs:
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
+      # Keep target-app cold bring-up outside the timed Reminders plan. CtrlProxy
+      # is already warm above; this leaves Reminders foregrounded so the plan's
+      # first launch/observe no longer pays the first app launch cost (#3028).
+      - name: "Warm up Reminders target app (Xcode 26.2)"
+        timeout-minutes: 5
+        run: ./scripts/ci/warm-reminders-target-app.sh
+
       - name: "Run Reminders integration tests (Xcode 26.2)"
         timeout-minutes: 10
         env:
@@ -1348,6 +1355,10 @@ jobs:
       - name: "Warm up iOS CtrlProxy (Xcode 26.3)"
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
+
+      - name: "Warm up Reminders target app (Xcode 26.3)"
+        timeout-minutes: 5
+        run: ./scripts/ci/warm-reminders-target-app.sh
 
       - name: "Run Reminders integration tests (Xcode 26.3)"
         timeout-minutes: 10

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersIntegrationTests.swift
@@ -2,18 +2,6 @@ import XCTest
 @testable import XCTestRunner
 
 class RemindersIntegrationBase: AutoMobileTestCase {
-    var defaultRetryCount: Int {
-        return 1
-    }
-
-    override var retryCount: Int {
-        let environment = AutoMobileEnvironment()
-        if let explicit = environment.intValue(["AUTOMOBILE_TEST_RETRY_COUNT", "RETRY_COUNT"]) {
-            return explicit
-        }
-        return defaultRetryCount
-    }
-
     override var planBundle: Bundle? {
         return Bundle.module
     }
@@ -58,9 +46,6 @@ final class RemindersLaunchPlanTests: RemindersIntegrationBase {
             ?? "launch-reminders-app.yaml"
     }
 
-    // #2998: inherits the shared one-retry default to absorb transient cold Reminders bring-up
-    // observe timeouts; tracked for removal once #2910/#2926/#2952 fix the underlying flake.
-
     func testLaunchRemindersPlan() throws {
         PerfTimer.log("testLaunchRemindersPlan START - planPath: \(planPath)")
         let result = try executePlan()
@@ -74,9 +59,6 @@ final class RemindersAddPlanTests: RemindersIntegrationBase {
             ?? ProcessInfo.processInfo.environment["PLAN_PATH"]
             ?? "add-reminder.yaml"
     }
-
-    // #2811: inherits the shared one-retry default to absorb residual cross-iOS Reminders UI flakes;
-    // tracked for removal once the add-flow guards are proven sufficient in #2855.
 
     func testAddReminderPlan() throws {
         PerfTimer.log("testAddReminderPlan START - planPath: \(planPath)")

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -3,11 +3,11 @@ import XCTest
 
 /// Structural (no-simulator) guards for the bundled `add-reminder.yaml` plan.
 ///
-/// `RemindersAddPlanTests.testAddReminderPlan` was flaky because plan step 5 was a bare
-/// `tapOn text: "Done"` fired immediately after `inputText`; on a slow simulator the "Done"
-/// control isn't present yet and the tap fails with "Element not found" (issue #2811). These tests
-/// encode the determinism invariant — the save tap must be guarded by a preceding `observe`
-/// `waitFor` on the same control — so the plan can't silently regress back to a racy bare tap.
+/// `RemindersAddPlanTests.testAddReminderPlan` was flaky because the plan typed/saved immediately
+/// after tapping `New Reminder`; on a slow simulator the quick-entry sheet or save control may not be
+/// ready yet (issue #2811/#3028). These tests encode the determinism invariant — the title field and
+/// save tap must be guarded by preceding `observe`/`waitFor` steps — so the plan can't silently
+/// regress back to racy bare actions.
 ///
 /// They parse the real bundled resource (not a fixture) and need no booted simulator or daemon,
 /// so they run in the plain `swift test` macOS suite.
@@ -20,54 +20,54 @@ final class RemindersPlanContentTests: XCTestCase {
         return try DefaultPlanLoader().loadPlan(at: "launch-reminders-app.yaml", bundle: Bundle.module)
     }
 
-    /// The save tap must be immediately preceded by an `observe`/`waitFor` guard on "Done", so the
+    /// The save tap must be immediately preceded by an `observe`/`waitFor` guard on "Add", so the
     /// executor polls for the control (and its `awaitTimeout` path fails fast on genuine absence)
     /// instead of racing a bare tap.
-    func testAddReminderPlanWaitsForDoneBeforeTappingIt() throws {
+    func testAddReminderPlanWaitsForAddBeforeTappingIt() throws {
         let steps = PlanStepSequence.parse(try loadAddReminderPlan())
 
-        guard let saveTapIndex = steps.firstIndex(where: { $0.tool == "tapOn" && $0.mentionsDone }) else {
-            XCTFail("Plan is missing the tapOn \"Done\" save step")
+        guard let saveTapIndex = steps.firstIndex(where: { $0.tool == "tapOn" && $0.mentions("Add") }) else {
+            XCTFail("Plan is missing the tapOn \"Add\" save step")
             return
         }
 
         XCTAssertGreaterThan(
             saveTapIndex,
             0,
-            "The tapOn \"Done\" step cannot be the first step; it must follow a wait guard"
+            "The tapOn \"Add\" step cannot be the first step; it must follow a wait guard"
         )
 
         let guardStep = steps[saveTapIndex - 1]
         XCTAssertEqual(
             guardStep.tool,
             "observe",
-            "The step before tapOn \"Done\" must be an observe guard, was \(guardStep.tool)"
+            "The step before tapOn \"Add\" must be an observe guard, was \(guardStep.tool)"
         )
         XCTAssertTrue(
             guardStep.hasWaitFor,
-            "The observe step guarding the \"Done\" tap must use waitFor"
+            "The observe step guarding the \"Add\" tap must use waitFor"
         )
         XCTAssertTrue(
-            guardStep.mentionsDone,
-            "The waitFor guard before the \"Done\" tap must target \"Done\""
+            guardStep.mentions("Add"),
+            "The waitFor guard before the \"Add\" tap must target \"Add\""
         )
     }
 
     /// The guard must be bounded so a genuinely-absent control fails fast instead of hanging for the
     /// whole plan timeout.
-    func testDoneWaitGuardHasBoundedTimeout() throws {
+    func testAddWaitGuardHasBoundedTimeout() throws {
         let steps = PlanStepSequence.parse(try loadAddReminderPlan())
 
-        guard let saveTapIndex = steps.firstIndex(where: { $0.tool == "tapOn" && $0.mentionsDone }),
+        guard let saveTapIndex = steps.firstIndex(where: { $0.tool == "tapOn" && $0.mentions("Add") }),
               saveTapIndex > 0
         else {
-            XCTFail("Plan is missing a guarded tapOn \"Done\" step")
+            XCTFail("Plan is missing a guarded tapOn \"Add\" step")
             return
         }
 
         let guardStep = steps[saveTapIndex - 1]
         guard let timeout = guardStep.waitForTimeoutMs else {
-            XCTFail("The waitFor guard before the \"Done\" tap must declare a timeout")
+            XCTFail("The waitFor guard before the \"Add\" tap must declare a timeout")
             return
         }
         XCTAssertGreaterThan(timeout, 0, "waitFor timeout must be positive")
@@ -78,53 +78,39 @@ final class RemindersPlanContentTests: XCTestCase {
         )
     }
 
-    /// The add-flow test retry-wraps itself (#2811) so the residual cross-iOS-version flake doesn't
-    /// red-flag otherwise-green PRs, while a genuine break still fails on every attempt.
-    func testAddReminderPlanDefaultsToOneRetry() {
+    /// The title field must be visible/focused before `inputText`; otherwise text entry can run while
+    /// the quick-entry sheet is still animating and leave no save control to wait for.
+    func testAddReminderPlanWaitsForTitleFieldBeforeTyping() throws {
+        let steps = PlanStepSequence.parse(try loadAddReminderPlan())
+
+        guard let inputIndex = steps.firstIndex(where: { $0.tool == "inputText" }) else {
+            XCTFail("Plan is missing the inputText title step")
+            return
+        }
+        XCTAssertGreaterThan(inputIndex, 0)
+        let guardStep = steps[inputIndex - 1]
+        XCTAssertEqual(guardStep.tool, "observe", "The title input must follow an observe guard")
+        XCTAssertTrue(guardStep.hasWaitFor, "The title input guard must use waitFor")
+        XCTAssertTrue(guardStep.mentions("Title"), "The title input guard must target the Title field")
+    }
+
+    /// The Reminders tests must run as single-attempt plans by default. CI warms the target app before
+    /// the timed plan step, so retrying here would hide the root-cause fix regressing.
+    func testRemindersPlansDefaultToZeroRetries() {
         // An explicit env override legitimately wins, so only assert the default when unset.
         let env = ProcessInfo.processInfo.environment
         if env["AUTOMOBILE_TEST_RETRY_COUNT"] != nil || env["RETRY_COUNT"] != nil {
             return
         }
-        XCTAssertEqual(RemindersAddPlanTests().retryCount, 1)
-    }
-
-    /// An explicit retry override wins — including 0 to disable retries for CI/local repro runs.
-    func testExplicitZeroRetryOverrideIsHonored() {
-        let key = "AUTOMOBILE_TEST_RETRY_COUNT"
-        let original = ProcessInfo.processInfo.environment[key]
-        setenv(key, "0", 1)
-        defer {
-            if let original = original {
-                setenv(key, original, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-
+        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 0)
         XCTAssertEqual(RemindersAddPlanTests().retryCount, 0)
     }
 
-    /// The launch-flow test retry-wraps itself (#2998) so a transient cold-bring-up `observe waitFor`
-    /// timeout on a CI simulator doesn't red-flag an otherwise-green PR, while a genuine observe
-    /// regression still fails on every attempt. Mirrors the sibling add-flow retry (#2811).
-    func testLaunchRemindersPlanDefaultsToOneRetry() {
-        // An explicit env override legitimately wins, so only assert the default when unset.
-        let env = ProcessInfo.processInfo.environment
-        if env["AUTOMOBILE_TEST_RETRY_COUNT"] != nil || env["RETRY_COUNT"] != nil {
-            return
-        }
-        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 1)
-    }
-
-    /// An explicit retry override wins for the launch flow too — 0 disables retries so a CI/local
-    /// repro run can force a single attempt and surface the transient timeout deterministically, and a
-    /// non-default value is passed through verbatim. The non-`0` case is load-bearing: it diverges from
-    /// both the base default (`0`) and this class's default (`1`), so it fails if the override is ever
-    /// reverted to the base implementation — whereas a `0`-only assertion would pass either way.
-    func testLaunchRemindersPlanExplicitRetryOverrideIsHonored() {
+    /// An explicit retry override wins — including 0 to disable retries for CI/local repro runs.
+    func testExplicitRetryOverrideIsStillHonored() {
         let key = "AUTOMOBILE_TEST_RETRY_COUNT"
         let original = ProcessInfo.processInfo.environment[key]
+        setenv(key, "0", 1)
         defer {
             if let original = original {
                 setenv(key, original, 1)
@@ -133,45 +119,66 @@ final class RemindersPlanContentTests: XCTestCase {
             }
         }
 
-        setenv(key, "0", 1)
-        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 0, "Explicit 0 must disable retries")
+        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 0)
+        XCTAssertEqual(RemindersAddPlanTests().retryCount, 0)
 
         setenv(key, "3", 1)
-        XCTAssertEqual(
-            RemindersLaunchPlanTests().retryCount,
-            3,
-            "A non-default explicit override must be honored verbatim, proving the override reads env"
-        )
+        XCTAssertEqual(RemindersLaunchPlanTests().retryCount, 3)
+        XCTAssertEqual(RemindersAddPlanTests().retryCount, 3)
     }
 
-    /// The retry policy is shared by `RemindersIntegrationBase`; subclasses keep only their
-    /// issue-specific rationale comments instead of duplicating the env/default implementation.
-    func testRemindersRetryCountIsSharedByBaseClass() throws {
+    /// Retry is no longer the stabilization mechanism for Reminders. The integration base should only
+    /// own simulator/daemon readiness; retry behavior comes from `AutoMobileTestCase`.
+    func testRemindersIntegrationBaseDoesNotOverrideRetryCount() throws {
         let source = try loadRemindersIntegrationTestSource()
 
-        XCTAssertTrue(
-            classBody(named: "RemindersIntegrationBase", in: source).contains("override var retryCount"),
-            "RemindersIntegrationBase must own the shared retryCount override"
-        )
-        XCTAssertTrue(
-            classBody(named: "RemindersIntegrationBase", in: source).contains("var defaultRetryCount"),
-            "RemindersIntegrationBase must expose the shared defaultRetryCount hook"
-        )
+        XCTAssertFalse(classBody(named: "RemindersIntegrationBase", in: source).contains("override var retryCount"))
+        XCTAssertFalse(classBody(named: "RemindersIntegrationBase", in: source).contains("var defaultRetryCount"))
         XCTAssertFalse(
             classBody(named: "RemindersLaunchPlanTests", in: source).contains("override var retryCount"),
-            "RemindersLaunchPlanTests should inherit the shared retryCount behavior"
+            "RemindersLaunchPlanTests should inherit AutoMobileTestCase retry behavior"
         )
         XCTAssertFalse(
             classBody(named: "RemindersAddPlanTests", in: source).contains("override var retryCount"),
-            "RemindersAddPlanTests should inherit the shared retryCount behavior"
+            "RemindersAddPlanTests should inherit AutoMobileTestCase retry behavior"
         )
     }
 
-    /// Regression guard preserving acceptance criterion 2 (#2998): the retry only masks a *transient*
-    /// bring-up flake, so the launch plan must keep its bounded `observe`/`waitFor` guard — a genuinely
-    /// broken observe still times out on every attempt and fails, instead of hanging or silently
-    /// passing. The plan must launch Reminders first, gate the launch on a bounded wait, and terminate
-    /// last.
+    /// The CI job must warm Reminders itself before the single-attempt timed plan. Warming only
+    /// CtrlProxy still leaves the first target-app launch/observe on the clock.
+    func testPullRequestWorkflowWarmsTargetAppBeforeRemindersRuns() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
+
+        assertWorkflowWarmsTargetAppBeforeRemindersRun(
+            workflow,
+            warmupStepName: "Warm up Reminders target app (Xcode 26.2)",
+            runStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowWarmsTargetAppBeforeRemindersRun(
+            workflow,
+            warmupStepName: "Warm up Reminders target app (Xcode 26.3)",
+            runStepName: "Run Reminders integration tests (Xcode 26.3)"
+        )
+    }
+
+    func testNightlyWorkflowWarmsTargetAppBeforeRemindersRuns() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/nightly.yml")
+
+        assertWorkflowWarmsTargetAppBeforeRemindersRun(
+            workflow,
+            warmupStepName: "Warm up Reminders target app (Xcode 26.2)",
+            runStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowWarmsTargetAppBeforeRemindersRun(
+            workflow,
+            warmupStepName: "Warm up Reminders target app (Xcode 26.3)",
+            runStepName: "Run Reminders integration tests (Xcode 26.3)"
+        )
+    }
+
+    /// Regression guard preserving the flake-vs-regression distinction: warm-up handles target-app
+    /// bring-up before the plan, but the plan must keep its bounded `observe`/`waitFor` guard so a
+    /// genuinely broken observe still fails instead of hanging or silently passing.
     func testLaunchRemindersPlanIsGuardedAndBounded() throws {
         let content = try loadLaunchRemindersPlan()
         let steps = PlanStepSequence.parse(content)
@@ -256,11 +263,11 @@ final class RemindersPlanContentTests: XCTestCase {
         let toolOrder = steps.map { $0.tool }
         let createIndex = steps.firstIndex { $0.tool == "tapOn" && $0.mentions("New Reminder") }
         let typeIndex = toolOrder.firstIndex(of: "inputText")
-        let saveIndex = steps.firstIndex { $0.tool == "tapOn" && $0.mentionsDone }
+        let saveIndex = steps.firstIndex { $0.tool == "tapOn" && $0.mentions("Add") }
 
         XCTAssertNotNil(createIndex, "Plan must still focus a new reminder")
         XCTAssertNotNil(typeIndex, "Plan must still type the reminder title")
-        XCTAssertNotNil(saveIndex, "Plan must still save via the \"Done\" control")
+        XCTAssertNotNil(saveIndex, "Plan must still save via the \"Add\" control")
         if let createIndex = createIndex, let typeIndex = typeIndex, let saveIndex = saveIndex {
             XCTAssertLessThan(createIndex, typeIndex, "Reminder must be focused before typing")
             XCTAssertLessThan(typeIndex, saveIndex, "Title must be typed before saving")
@@ -290,8 +297,6 @@ private struct PlanStep {
             return trimmed.dropFirst("optional:".count).trimmingCharacters(in: .whitespaces) == "true"
         }
     }
-
-    var mentionsDone: Bool { mentions("Done") }
 
     func mentions(_ needle: String) -> Bool {
         body.contains("\"\(needle)\"") || body.contains(needle)
@@ -365,6 +370,17 @@ private func loadRemindersIntegrationTestSource() throws -> String {
     return try String(contentsOf: sourceURL, encoding: .utf8)
 }
 
+private func loadRepositoryFile(_ path: String) throws -> String {
+    let currentFile = URL(fileURLWithPath: #filePath)
+    let repositoryRoot = currentFile
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    return try String(contentsOf: repositoryRoot.appendingPathComponent(path), encoding: .utf8)
+}
+
 private func classBody(named className: String, in source: String) -> String {
     guard let declarationRange = source.range(of: "class \(className)")
         ?? source.range(of: "final class \(className)")
@@ -390,4 +406,31 @@ private func classBody(named className: String, in source: String) -> String {
         index = source.index(after: index)
     }
     return ""
+}
+
+private func assertWorkflowWarmsTargetAppBeforeRemindersRun(
+    _ workflow: String,
+    warmupStepName: String,
+    runStepName: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    guard let warmupRange = workflow.range(of: #"name: "\#(warmupStepName)""#) else {
+        XCTFail("Workflow is missing step named \(warmupStepName)", file: file, line: line)
+        return
+    }
+    guard let runRange = workflow.range(of: #"name: "\#(runStepName)""#) else {
+        XCTFail("Workflow is missing step named \(runStepName)", file: file, line: line)
+        return
+    }
+
+    XCTAssertLessThan(warmupRange.lowerBound, runRange.lowerBound, "\(warmupStepName) must run before \(runStepName)", file: file, line: line)
+
+    let warmupBlock = workflow[warmupRange.lowerBound..<runRange.lowerBound]
+    XCTAssertTrue(
+        warmupBlock.contains("./scripts/ci/warm-reminders-target-app.sh"),
+        "\(warmupStepName) must invoke the target-app warm-up helper",
+        file: file,
+        line: line
+    )
 }

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/add-reminder.yaml
@@ -1,17 +1,15 @@
 ---
 name: add-reminder
 description: Create a basic reminder in the iOS Reminders app (English UI assumed)
-# NOTE: the system Reminders UI varies by iOS version — the "New Reminder" and "Done" control
-# labels below are pinned to the CI simulator's iOS (English). On some iOS versions the save
-# control is labelled "Add" instead of "Done". Cross-version tolerance is tracked in issue #2855.
+# NOTE: the system Reminders UI varies by iOS version — the "New Reminder" and "Add" control
+# labels below are pinned to the CI simulator's iOS (English).
 # Deliberately does NOT clearAppData: on newer iOS a cleared Reminders launches to a home without
 # the "New Reminder" control, which would break this plan.
 platform: ios
 steps:
-  # coldBoot force-terminates + relaunches so a retry (the test retries once, #2811/#2855) starts
-  # from the Reminders home rather than a partial edit screen left by a failed attempt. A warm iOS
-  # launch would resume that stale screen and then time out waiting for "New Reminder". coldBoot
-  # (unlike clearAppData) keeps the app data, so it avoids the empty-home issue noted above.
+  # coldBoot force-terminates + relaunches so the plan starts from the Reminders home rather than a
+  # partial edit screen left by a failed or interrupted local run. coldBoot (unlike clearAppData)
+  # keeps the app data, so it avoids the empty-home issue noted above.
   - tool: launchApp
     appId: com.apple.reminders
     coldBoot: true
@@ -55,21 +53,29 @@ steps:
     action: "tap"
     label: Focus new reminder field
 
+  # Wait for the quick-entry sheet/title field to become focused before typing. The preceding tap can
+  # return as soon as the press is recognized, while the sheet is still animating in.
+  - tool: observe
+    waitFor:
+      text: "Title"
+      timeout: 10000
+    label: Wait for title field
+
   - tool: inputText
     text: "AutoMobile XCTest demo"
     label: Type reminder title
 
-  # Wait for the "Done" save control to render before tapping it. Without this guard the tap races
-  # the keyboard/nav-bar layout and fails with "Element not found with provided text 'Done'"
+  # Wait for the "Add" save control to render before tapping it. Without this guard the tap races
+  # the keyboard/nav-bar layout and fails with "Element not found with provided text 'Add'"
   # (issue #2811). observe waitFor polls until it appears and fails fast via awaitTimeout otherwise.
   - tool: observe
     waitFor:
-      text: "Done"
+      text: "Add"
       timeout: 10000
-    label: Wait for Done control
+    label: Wait for Add control
 
   - tool: tapOn
-    text: "Done"
+    text: "Add"
     action: "tap"
     label: Save reminder
 

--- a/scripts/ci/warm-reminders-target-app.sh
+++ b/scripts/ci/warm-reminders-target-app.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Warm the iOS Reminders target app before the timed XCTestRunner plan.
+#
+# CtrlProxy warm-up proves hierarchy extraction is serving, but the first target-app
+# launch can still pay app bring-up cost inside a short plan waitFor window. Launch
+# Reminders and take one plain observation here so the real plan starts with the
+# app foregrounded and the first timed observe is not also the first app bring-up.
+
+set -euo pipefail
+
+export PATH="${HOME}/.bun/bin:${PATH}"
+hash -r 2>/dev/null || true
+
+if ! command -v auto-mobile >/dev/null 2>&1; then
+  echo "::error::auto-mobile is not on PATH; run scripts/ci/ensure-daemon-ready.sh before this step." >&2
+  exit 1
+fi
+
+app_id="${REMINDERS_TARGET_APP_ID:-com.apple.reminders}"
+max_attempts="${REMINDERS_TARGET_READY_MAX_ATTEMPTS:-3}"
+delay="${REMINDERS_TARGET_READY_DELAY_SECONDS:-5}"
+
+attempt=1
+while (( attempt <= max_attempts )); do
+  echo "Reminders warm-up ${attempt}/${max_attempts}: launch ${app_id} and observe"
+  if auto-mobile --cli launchApp --platform ios --appId "${app_id}" >/dev/null 2>&1 &&
+     auto-mobile --cli observe --platform ios >/dev/null 2>&1; then
+    echo "Reminders target app ready: launchApp and observe completed."
+    exit 0
+  fi
+  echo "Reminders target app not ready yet; retrying in ${delay}s..."
+  sleep "${delay}"
+  attempt=$((attempt + 1))
+done
+
+echo "::error::Reminders target app did not become ready after ${max_attempts} attempts." >&2
+echo "Diagnostic launch output:" >&2
+auto-mobile --cli launchApp --platform ios --appId "${app_id}" >&2 || true
+echo "Diagnostic observe output:" >&2
+auto-mobile --cli observe --platform ios >&2 || true
+exit 1

--- a/scripts/ios/xctestrunner-integration-tests.sh
+++ b/scripts/ios/xctestrunner-integration-tests.sh
@@ -76,6 +76,12 @@ echo -e "  ${GREEN}✓${NC} Bun available"
 
 echo ""
 
+if [[ "${TEST_FILTER} ${TEST_PLAN}" == *Reminders* || "${TEST_FILTER} ${TEST_PLAN}" == *reminders* ]]; then
+    echo -e "${BLUE}Warming Reminders target app...${NC}"
+    "${PROJECT_ROOT}/scripts/ci/warm-reminders-target-app.sh"
+    echo ""
+fi
+
 # Run tests
 echo -e "${BLUE}Running integration tests...${NC}"
 echo ""

--- a/test/bats/warm-reminders-target-app.bats
+++ b/test/bats/warm-reminders-target-app.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/warm-reminders-target-app.sh
+# Mocks the `auto-mobile` CLI so no real daemon/simulator/Reminders app is required.
+
+SCRIPT="scripts/ci/warm-reminders-target-app.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  ORIG_HOME="$HOME"
+  FAKE_HOME="$(mktemp -d)"
+  export HOME="$FAKE_HOME"
+  export STATE_FILE="${MOCK_BIN}/warmup-calls"
+  export INVOCATION_FILE="${MOCK_BIN}/invocations"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN" "$FAKE_HOME"
+  export PATH="$ORIG_PATH"
+  export HOME="$ORIG_HOME"
+}
+
+make_mock_auto_mobile() {
+  local ready_after="$1"
+  cat > "${MOCK_BIN}/auto-mobile" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${INVOCATION_FILE}"
+if [ "\$1" = "--cli" ] && [ "\$2" = "launchApp" ]; then
+  calls=0
+  [ -f "${STATE_FILE}" ] && calls="\$(cat "${STATE_FILE}")"
+  calls=\$((calls + 1))
+  echo "\$calls" > "${STATE_FILE}"
+  if [ "\$calls" -gt "${ready_after}" ]; then
+    echo '{"success":true}'
+    exit 0
+  fi
+  echo "launch failed" >&2
+  exit 1
+fi
+if [ "\$1" = "--cli" ] && [ "\$2" = "observe" ]; then
+  echo '{"viewHierarchy":{}}'
+  exit 0
+fi
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/auto-mobile"
+  export PATH="${MOCK_BIN}:${PATH}"
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "script has bash shebang" {
+  head -1 "$SCRIPT" | grep -q "bash"
+}
+
+@test "fails fast when auto-mobile is not on PATH" {
+  run env PATH="/usr/bin:/bin" bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"auto-mobile is not on PATH"* ]]
+}
+
+@test "launches Reminders and observes on the first ready attempt" {
+  make_mock_auto_mobile 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Reminders target app ready"* ]]
+  grep -q -- "--cli launchApp --platform ios --appId com.apple.reminders" "$INVOCATION_FILE"
+  grep -q -- "--cli observe --platform ios" "$INVOCATION_FILE"
+}
+
+@test "retries launch and observe until Reminders is ready" {
+  make_mock_auto_mobile 2
+  run env REMINDERS_TARGET_READY_MAX_ATTEMPTS=5 REMINDERS_TARGET_READY_DELAY_SECONDS=0 bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Reminders target app ready"* ]]
+}
+
+@test "fails with a bounded error when Reminders never becomes ready" {
+  make_mock_auto_mobile 999
+  run env REMINDERS_TARGET_READY_MAX_ATTEMPTS=2 REMINDERS_TARGET_READY_DELAY_SECONDS=0 bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"did not become ready after 2 attempts"* ]]
+}

--- a/test/bats/xctestrunner-integration-tests.bats
+++ b/test/bats/xctestrunner-integration-tests.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ios/xctestrunner-integration-tests.sh
+# Runs a copied wrapper with stubbed simulator, Bun, CtrlProxy, warm-up, and Swift commands.
+
+SCRIPT="scripts/ios/xctestrunner-integration-tests.sh"
+
+setup() {
+  WORKDIR="$(mktemp -d)"
+  MOCK_BIN="${WORKDIR}/bin"
+  PROJECT="${WORKDIR}/project"
+  INVOCATIONS="${WORKDIR}/invocations"
+  ORIG_PATH="$PATH"
+
+  mkdir -p "${MOCK_BIN}" "${PROJECT}/scripts/ios" "${PROJECT}/scripts/ci" "${PROJECT}/ios/XCTestRunner"
+  cp "$SCRIPT" "${PROJECT}/scripts/ios/xctestrunner-integration-tests.sh"
+
+  cat > "${PROJECT}/scripts/ios/ctrl-proxy-verify-artifacts.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+
+  cat > "${PROJECT}/scripts/ci/warm-reminders-target-app.sh" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "warm-reminders-target-app" >> "${INVOCATIONS}"
+SCRIPT
+
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ] && [ "$4" = "booted" ] && [ "$5" = "-j" ]; then
+  printf '{"devices":{"iOS 18.0":[{"udid" : "BOOTED-UDID"}]}}\n'
+  exit 0
+fi
+exit 1
+SCRIPT
+
+  cat > "${MOCK_BIN}/bun" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+
+  cat > "${MOCK_BIN}/swift" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "swift \$*" >> "${INVOCATIONS}"
+SCRIPT
+
+  chmod +x \
+    "${PROJECT}/scripts/ios/xctestrunner-integration-tests.sh" \
+    "${PROJECT}/scripts/ios/ctrl-proxy-verify-artifacts.sh" \
+    "${PROJECT}/scripts/ci/warm-reminders-target-app.sh" \
+    "${MOCK_BIN}/xcrun" \
+    "${MOCK_BIN}/bun" \
+    "${MOCK_BIN}/swift"
+
+  export PATH="${MOCK_BIN}:${PATH}"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+  export PATH="$ORIG_PATH"
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "warms Reminders before the default launch integration test" {
+  run "${PROJECT}/scripts/ios/xctestrunner-integration-tests.sh"
+  [ "$status" -eq 0 ]
+  [ "$(sed -n '1p' "$INVOCATIONS")" = "warm-reminders-target-app" ]
+  [ "$(sed -n '2p' "$INVOCATIONS")" = "swift test --filter RemindersLaunchPlanTests" ]
+}
+
+@test "warms Reminders for explicit Reminders test filters" {
+  run "${PROJECT}/scripts/ios/xctestrunner-integration-tests.sh" RemindersAddPlanTests
+  [ "$status" -eq 0 ]
+  grep -q '^warm-reminders-target-app$' "$INVOCATIONS"
+  grep -q '^swift test --filter RemindersAddPlanTests$' "$INVOCATIONS"
+}
+
+@test "skips Reminders warm-up for unrelated filters and plans" {
+  run env AUTOMOBILE_TEST_PLAN=Plans/list-devices.yaml "${PROJECT}/scripts/ios/xctestrunner-integration-tests.sh" ListDevicesPlanTests
+  [ "$status" -eq 0 ]
+  ! grep -q '^warm-reminders-target-app$' "$INVOCATIONS"
+  grep -q '^swift test --filter ListDevicesPlanTests$' "$INVOCATIONS"
+}


### PR DESCRIPTION
## Summary

Warm up the Reminders target app in CI before the timed XCTestRunner Reminders plans run, then remove the temporary shared retry override from the Reminders launch/add integration tests. The add-reminder plan now waits for the quick-entry title field before typing and taps the current "Add" save control, which keeps the plan deterministic without a retry wrapper.

## Linked Issue

Closes #3028

## Bug / Regression Context

- **Prior attempts:** #3007 added a retry wrapper around the Reminders launch test while the cold-start flake was investigated.
- **Observed symptom:** The first `observe waitFor "Reminders"` in a cold CI simulator could time out around 20s, so launch/add plans passed only because the shared retry hook reran them.
- **Repro steps / conditions:** XCTestRunner Simulator Tests on a cold CI simulator, especially when the first target-app launch and observe happened inside the measured plan run.

## Validation

- [x] `bun run turbo:validate` passes (`lint`, `build`, `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] iOS changes: `swift test` from `ios/XCTestRunner` passes
- [x] Script changes: `bats test/bats/warm-reminders-target-app.bats test/bats/ensure-ctrl-proxy-ready.bats` and `shellcheck scripts/ci/warm-reminders-target-app.sh scripts/ci/ensure-ctrl-proxy-ready.sh` pass
- [x] `git diff --check` passes
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [x] Verified on iOS simulator via `swift test --filter RemindersLaunchPlanTests`, `swift test --filter RemindersAddPlanTests`, and the full `swift test` suite in `ios/XCTestRunner`

## Follow-ups

- [x] No follow-up issues filed; no out-of-scope gaps found
