### PR TITLE
fix(ios): clarify notifyutil registration semantics

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -136,8 +136,12 @@ BiometricKit Darwin notifications inside the simulator via
 
 1. **Enroll** — a registered `notifyutil` set/read/post on
    `com.apple.BiometricKit.enrollmentChanged` ensures a biometry is enrolled.
-   The registration is required because `notifyutil -s` has no effect when no
-   process has registered the key.
+   Apple `notifyutil(1)` documents that state values require a current
+   registration; the helper self-registers so enrollment does not depend on
+   BiometricKit already owning the key. Empirical iOS 18.6 simulator checks
+   showed this specific BiometricKit key also persisted without explicit `-1`,
+   but the shared helper keeps the registration for keys without an external
+   owner.
 2. **Match / non-match** — post the key the app's `LAContext` is waiting on:
    - Touch ID: `com.apple.BiometricKit_Sim.fingerTouch.match` / `…nomatch`
    - Face ID: `com.apple.BiometricKit_Sim.pearl.match` / `…nomatch`
@@ -331,12 +335,12 @@ fresh-process readback.
    `com.apple.donotdisturb.enabled` Darwin notification, driven via
    `xcrun simctl spawn <udid> notifyutil`:
    - `notifyutil -1 com.apple.donotdisturb.enabled ...` creates a temporary
-     registration. This is required because `notifyutil -s` has no effect when
-     no process has registered the key.
+     registration so the state variable exists even if no other process already
+     owns the key.
    - `notifyutil -s com.apple.donotdisturb.enabled <0|1>` sets the value while
-     the registration is alive.
-   - `notifyutil -g com.apple.donotdisturb.enabled` reads the registered state in
-     the same invocation.
+     that registration is alive.
+   - `notifyutil -g com.apple.donotdisturb.enabled` reads the state in the same
+     invocation.
    - `notifyutil -p com.apple.donotdisturb.enabled` posts it so observers react.
    - After a short settle, a separate fresh-process
      `notifyutil -g com.apple.donotdisturb.enabled` verifies that the value
@@ -354,9 +358,10 @@ fresh-process readback.
    `appliedMode: "none"`, a structured `warning`, and `verified: false` (so
    `success` is `false`). The tool never claims a tier it cannot deliver.
 4. **Best effort with behavior verification** — results are `bestEffort: true`.
-   The registered set invocation is not authoritative by itself; the setter only
-   reports success when the independent readback observes the requested binary
-   state.
+   The same-invocation registered set/read/post proves only that the command
+   could set state while its registration existed; it is not authoritative by
+   itself. The setter only reports success when the independent readback
+   observes the requested binary state.
 
 ### Limitations
 

--- a/src/features/action/BiometricAuth.ts
+++ b/src/features/action/BiometricAuth.ts
@@ -8,7 +8,7 @@ import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorDevice } from "./IosSimulatorPermissions";
 import {
   IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
-  iosNotifyutilRegisteredSetCommand,
+  iosNotifyutilRegisteredSetReadPostCommand,
   parseNotifyutilState
 } from "../../utils/ios-cmdline-tools/notifyutil";
 
@@ -207,7 +207,7 @@ export class BiometricAuth extends BaseVisualChange {
     try {
       // Ensure biometry is enrolled before attempting a match.
       const enrollmentResult = await simctl.executeCommand(
-        iosNotifyutilRegisteredSetCommand(udid, keys.enrollment, "1"),
+        iosNotifyutilRegisteredSetReadPostCommand(udid, keys.enrollment, "1"),
         IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS
       );
       if (enrollmentResult.stderr && enrollmentResult.stderr.trim().length > 0) {

--- a/src/features/utility/DeviceState.ts
+++ b/src/features/utility/DeviceState.ts
@@ -10,7 +10,7 @@ import { defaultTimer } from "../../utils/SystemTimer";
 import {
   IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
   iosNotifyutilGetCommand,
-  iosNotifyutilRegisteredSetCommand,
+  iosNotifyutilRegisteredSetReadPostCommand,
   parseNotifyutilState
 } from "../../utils/ios-cmdline-tools/notifyutil";
 import {
@@ -455,8 +455,10 @@ export class DeviceState {
     }
 
     // Simulator legacy path: the only lever is the binary `com.apple.donotdisturb.enabled`
-    // Darwin notification. `notifyutil -s` is a no-op unless the key has a
-    // registration, so set/read/post must happen in one registered invocation.
+    // Darwin notification. The set command self-registers so keys without some
+    // other live owner are still writable in-process, but that same-invocation
+    // set/read/post is not authoritative: donotdisturbd can reclaim the key
+    // immediately, so success depends on the independent fresh-process readback below.
     // There is no per-mode (priority/alarms) Darwin notification analogous to
     // Android's `zen_mode` integer, so `priority`/`alarms` requests are applied
     // as plain DND ("none") and reported honestly rather than silently claiming
@@ -468,7 +470,7 @@ export class DeviceState {
     try {
       const value = requestedEnabled ? "1" : "0";
       const writeResult = await simctl.executeCommand(
-        iosNotifyutilRegisteredSetCommand(this.device.deviceId, IOS_DND_NOTIFICATION, value),
+        iosNotifyutilRegisteredSetReadPostCommand(this.device.deviceId, IOS_DND_NOTIFICATION, value),
         IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS
       );
       const writeStderr = writeResult.stderr?.trim();

--- a/src/utils/ios-cmdline-tools/notifyutil.ts
+++ b/src/utils/ios-cmdline-tools/notifyutil.ts
@@ -15,7 +15,7 @@ export function iosNotifyutilGetCommand(deviceId: string, key: string): string {
   return `spawn ${deviceId} notifyutil -g ${key}`;
 }
 
-export function iosNotifyutilRegisteredSetCommand(
+export function iosNotifyutilRegisteredSetReadPostCommand(
   deviceId: string,
   key: string,
   value: "0" | "1"

--- a/test/features/utility/DeviceState.test.ts
+++ b/test/features/utility/DeviceState.test.ts
@@ -243,7 +243,7 @@ describe("DeviceState", () => {
     ]);
   });
 
-  test("sets iOS simulator Do Not Disturb with a temporary notifyutil registration", async () => {
+  test("sets iOS simulator Do Not Disturb with a registered notifyutil set/read/post", async () => {
     const simctl = new FakeSimCtlClient();
     const timer = autoAdvanceTimer();
     simctl.setCommandResult(


### PR DESCRIPTION
## Summary

Keeps the shared iOS `notifyutil` set-state helper self-registered with `-1`, renames it to describe the registered set/read/post command shape, and updates the DND and BiometricAuth comments/docs to match both the empirical simulator result and `notifyutil(1)` registration semantics.

Empirically on iOS 18.6, BiometricKit enrollment persists with or without an explicit `-1`, while the DND key reverts with or without `-1` because `donotdisturbd` reclaims it. Since Apple `notifyutil(1)` documents state values as registration-scoped in the general case, the helper keeps `-1` so keys without an external owner remain writable during the set/read/post invocation.

## Linked Issue

Closes #2864

## Bug / Regression Context

- **Prior attempts:** PR #2856 corrected the DND unsupported behavior on iOS 18+, but left the shared helper command shape and registration-required wording intact.
- **Observed symptom:** Helper/docs treated `-1` as proof of independent persistence, while the actual behavior depends on key ownership and fresh-process readback. Removing `-1` would break keys with no existing registration owner.
- **Repro steps / conditions:** On a booted iOS 18.6 simulator, compare `notifyutil -s <key> <value> -g <key> -p <key>` against `notifyutil -1 <key> -s <key> <value> -g <key> -p <key>` for `com.apple.donotdisturb.enabled` and `com.apple.BiometricKit.enrollmentChanged`.

## Validation

- [x] `bun test test/features/action/BiometricAuthIos.test.ts test/features/utility/DeviceState.test.ts` passes: 32 pass, 0 fail.
- [x] `./node_modules/.bin/turbo run lint build test` passes: 6957 pass, 2 skip, 0 fail.
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] `git diff --check` passes.
- [x] Android/iOS changes: TypeScript/docs only; no Swift/Kotlin/shell/schema surfaces changed.
- [x] New code uses existing fakes/FakeTimer test coverage; focused unit tests remain under 100ms each.
- [x] Rebased onto latest `origin/main`, conflicts resolved.

## Device Verification

- [x] Verified on a real iOS 18.6 simulator via `xcrun simctl spawn <udid> notifyutil`.
- DND key: fresh-process readback stays `0` with and without `-1`.
- BiometricKit enrollment key: fresh-process readback stays `1` immediately, after 2s, and after 8s with and without `-1`.
- Raw local evidence: `scratch/notifyutil-issue-2864-empirical.log`.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: none; #2862 continues to track iOS <=17 DND runtime verification.
