### PR TITLE
Add worktree bootstrap for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,24 @@ This document summarizes the AutoMobile repo layout and where to find key compon
 
 Bun is the primary task runner for TypeScript tooling.
 
+On a fresh worktree, run `bun run bootstrap:worktree` before validation. It
+installs Bun dependencies from the lockfile when `node_modules/` or local
+binaries are missing, and intentionally skips slow platform setup such as
+Gradle, Android SDK, Xcode, and Homebrew-managed tools.
+
 ```bash
 bun run build          # Compile TypeScript
 bun run lint           # Lint with auto-fix (run before manual fixes)
 bun test               # Run all tests
 bun test --bail        # Stop on first failure
 bun test <file>        # Run specific test file
+bun run turbo:validate # Run local Turbo lint/build/test
 ```
+
+`turbo` is a local dependency and may not be on the shell `PATH`. Do not run
+bare `turbo ...`; use the `package.json` scripts such as `bun run
+turbo:validate`, `bun run turbo:build`, `bun run turbo:lint`, or `bun run
+turbo:test`.
 
 # Validate Shell Scripts
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "watch": "bun --watch src/index.ts",
     "build": "bun build.ts && chmod +x dist/src/index.js",
     "clean": "rm -rf dist",
+    "bootstrap:worktree": "bash scripts/codex/bootstrap-worktree.sh",
     "dev:android": "bash scripts/local-dev/android-hot-reload.sh --skip-ai",
     "dev:android:hot-reload": "bash scripts/local-dev/android-hot-reload.sh",
     "dev:ios": "bash scripts/local-dev/ios-hot-reload.sh --skip-ai",

--- a/scripts/codex/bootstrap-worktree.sh
+++ b/scripts/codex/bootstrap-worktree.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Cheap Codex/worktree bootstrap. Keep this limited to fast repo-local setup;
+# do not install Android, Gradle, Xcode, Homebrew, or platform toolchains here.
+#
+# Usage:
+#   bash scripts/codex/bootstrap-worktree.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+mkdir -p scratch
+
+if [[ ! -d node_modules || ! -x node_modules/.bin/turbo ]]; then
+  echo "Installing Bun dependencies from bun.lock..."
+  bun install --frozen-lockfile
+else
+  echo "Bun dependencies already installed."
+fi
+
+echo "Worktree bootstrap complete."

--- a/skills/ship-issue/SKILL.md
+++ b/skills/ship-issue/SKILL.md
@@ -23,8 +23,8 @@ Two phases are hard STOP gates; do not cross them without the stated condition.
    `getDatabase()`).
 3. **Implement (green).** Minimum change to pass the tests and realize the plan;
    no scope creep — extras become follow-ups.
-4. **Pre-PR validation — STOP GATE.** Before any PR: `turbo run lint build test`
-   (whole suite, for regressions), `bun run typecheck` (new-error gate; run
+4. **Pre-PR validation — STOP GATE.** Before any PR: `bun run turbo:validate`
+   (local Turbo lint/build/test whole suite, for regressions), `bun run typecheck` (new-error gate; run
    `typecheck:update` if you fixed errors), `validate` for touched
    shell/Swift/Docker/schema surfaces, and re-confirm every criterion test is
    green. Never open a PR on red.

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -15,6 +15,7 @@ Run the lightest validation that covers the touched code, then widen only when n
 
 - `bun run lint`
 - `bun run build`
+- `bun run turbo:validate` for the local Turbo lint/build/test gate
 
 ## Repo Script Validation
 
@@ -32,6 +33,7 @@ Run the lightest validation that covers the touched code, then widen only when n
 ## Selection Rules
 
 - TypeScript-only changes usually need `lint`, `build`, and relevant tests.
+- Use `bun run turbo:*` scripts instead of bare `turbo ...`; Turbo is installed locally and may not be on the shell `PATH`.
 - Shell or docs/config changes should prefer the matching script in `scripts/`.
 - Android changes should use the Gradle wrapper from `android/`.
 - iOS changes should use the existing `scripts/ios/` entry points.


### PR DESCRIPTION
## Summary

Adds a fast Codex worktree bootstrap command so fresh worktrees install Bun dependencies before validation, making local package binaries such as `turbo` available without running slow platform setup. Updates agent guidance and validation workflow docs to use the bootstrap command and `bun run turbo:*` scripts instead of bare `turbo ...`.

## Linked Issue

N/A

## Bug / Regression Context

- **Prior attempts:** Agents tried `turbo run lint build test` in fresh worktrees where `turbo` was not on `PATH`.
- **Observed symptom:** Validation failed with `command not found: turbo` until `bun install` created local binaries.
- **Repro steps / conditions:** Fresh Codex worktree with no `node_modules/`, then run a Turbo validation command before installing Bun dependencies.

## Validation

- [x] `bun run bootstrap:worktree`
- [x] `bun run turbo:validate`
- [x] `shellcheck scripts/codex/bootstrap-worktree.sh`
- [x] `bash scripts/validate_codex_skills.sh`
- [x] `git diff --check`
- [ ] `bun run typecheck` reports no new errors (not run; docs/tooling bootstrap change)
- [ ] Android/iOS changes: ran the matching `scripts/` validation (N/A)
- [ ] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms (N/A)
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A

## Follow-ups

N/A
