### PR TITLE
Add iOS heuristic screen identity

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3487,6 +3487,71 @@
           },
           "additionalProperties": {}
         },
+        "screenIdentity": {
+          "type": "object",
+          "properties": {
+            "platform": {
+              "type": "string",
+              "enum": [
+                "ios",
+                "android"
+              ]
+            },
+            "source": {
+              "type": "string",
+              "enum": [
+                "heuristic",
+                "sdk"
+              ]
+            },
+            "confidence": {
+              "type": "string",
+              "enum": [
+                "high",
+                "medium",
+                "low"
+              ]
+            },
+            "key": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object",
+              "properties": {
+                "bundleId": {
+                  "type": "string"
+                },
+                "navigationTitle": {
+                  "type": "string"
+                },
+                "selectedTab": {
+                  "type": "string"
+                },
+                "modalClass": {
+                  "type": "string"
+                },
+                "modalTitle": {
+                  "type": "string"
+                },
+                "focusedElementId": {
+                  "type": "string"
+                },
+                "keyboardVisible": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": {}
+            }
+          },
+          "required": [
+            "platform",
+            "source",
+            "confidence",
+            "key",
+            "components"
+          ],
+          "additionalProperties": {}
+        },
         "elements": {
           "type": "object",
           "properties": {
@@ -7035,6 +7100,71 @@
                   "type": "string"
                 }
               },
+              "additionalProperties": {}
+            },
+            "screenIdentity": {
+              "type": "object",
+              "properties": {
+                "platform": {
+                  "type": "string",
+                  "enum": [
+                    "ios",
+                    "android"
+                  ]
+                },
+                "source": {
+                  "type": "string",
+                  "enum": [
+                    "heuristic",
+                    "sdk"
+                  ]
+                },
+                "confidence": {
+                  "type": "string",
+                  "enum": [
+                    "high",
+                    "medium",
+                    "low"
+                  ]
+                },
+                "key": {
+                  "type": "string"
+                },
+                "components": {
+                  "type": "object",
+                  "properties": {
+                    "bundleId": {
+                      "type": "string"
+                    },
+                    "navigationTitle": {
+                      "type": "string"
+                    },
+                    "selectedTab": {
+                      "type": "string"
+                    },
+                    "modalClass": {
+                      "type": "string"
+                    },
+                    "modalTitle": {
+                      "type": "string"
+                    },
+                    "focusedElementId": {
+                      "type": "string"
+                    },
+                    "keyboardVisible": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": {}
+                }
+              },
+              "required": [
+                "platform",
+                "source",
+                "confidence",
+                "key",
+                "components"
+              ],
               "additionalProperties": {}
             }
           },

--- a/src/features/observe/HierarchyPlatformValidator.ts
+++ b/src/features/observe/HierarchyPlatformValidator.ts
@@ -98,6 +98,7 @@ export function discardHierarchyDerivedData(result: ObserveResult): void {
   result.notificationPermissionDetected = undefined;
   result.predictions = undefined;
   result.activeWindow = undefined;
+  result.screenIdentity = undefined;
 
   // Screen metrics copied from the rejected hierarchy — reset to base defaults.
   result.screenSize = { width: 0, height: 0 };

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -42,6 +42,7 @@ import {
   HierarchyPlatformValidator,
   RealHierarchyPlatformValidator
 } from "./HierarchyPlatformValidator";
+import { deriveIosScreenIdentity } from "./ios/IosScreenIdentity";
 
 /**
  * Observe command class that combines screen details, view hierarchy and screenshot.
@@ -527,6 +528,8 @@ export class RealObserveScreen implements ObserveScreen {
             layoutSeqSum: 0
           };
         }
+
+        result.screenIdentity = deriveIosScreenIdentity(result.viewHierarchy);
 
         perf.end();
         break;

--- a/src/features/observe/ios/IosScreenIdentity.ts
+++ b/src/features/observe/ios/IosScreenIdentity.ts
@@ -1,0 +1,283 @@
+import type { ScreenIdentity } from "../../../models/ObserveResult";
+import type { ViewHierarchyNode, ViewHierarchyResult } from "../../../models/ViewHierarchyResult";
+
+type NodeAttrs = Record<string, unknown>;
+type HierarchyNodeLike = ViewHierarchyNode & Record<string, unknown>;
+
+const MODAL_CLASSES = new Set([
+  "UIActionSheet",
+  "UIAlertController",
+  "UIAlertView",
+  "UIPopoverPresentationController",
+  "XCUIElementTypeAlert",
+  "XCUIElementTypeSheet",
+]);
+
+interface CandidateSignals {
+  bundleId?: string;
+  navigationTitle?: string;
+  selectedTab?: string;
+  modalClass?: string;
+  modalTitle?: string;
+  focusedElementId?: string;
+  keyboardVisible?: boolean;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function isTrue(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+function className(attrs: NodeAttrs): string | undefined {
+  return asString(attrs["class"]) ?? asString(attrs["className"]);
+}
+
+function textOf(attrs: NodeAttrs): string | undefined {
+  return asString(attrs["text"]) ?? asString(attrs["content-desc"]);
+}
+
+function attrsOf(node: ViewHierarchyNode | undefined): NodeAttrs {
+  if (!node) {
+    return {};
+  }
+  if (node.$ && typeof node.$ === "object") {
+    return node.$;
+  }
+  return node as unknown as NodeAttrs;
+}
+
+function nodeChildren(node: ViewHierarchyNode | undefined): ViewHierarchyNode[] {
+  if (!node?.node) {
+    return [];
+  }
+  return Array.isArray(node.node) ? node.node : [node.node];
+}
+
+function hasNodeAttrs(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return Boolean(
+    record.$ ||
+    record["class"] ||
+    record["className"] ||
+    record["text"] ||
+    record["content-desc"] ||
+    record["resource-id"] ||
+    record["view-id"]
+  );
+}
+
+function rootNode(viewHierarchy: ViewHierarchyResult | undefined): ViewHierarchyNode | undefined {
+  const hierarchy = viewHierarchy?.hierarchy as unknown as HierarchyNodeLike | undefined;
+  if (!hierarchy) {
+    return undefined;
+  }
+  if (Array.isArray(hierarchy.node)) {
+    if (hasNodeAttrs(hierarchy)) {
+      return hierarchy;
+    }
+    return { $: {}, node: hierarchy.node };
+  }
+  return hierarchy.node ?? (hasNodeAttrs(hierarchy) ? hierarchy : undefined);
+}
+
+function walk(node: ViewHierarchyNode | undefined, visit: (node: ViewHierarchyNode) => void): void {
+  if (!node) {
+    return;
+  }
+  visit(node);
+  for (const child of nodeChildren(node)) {
+    walk(child, visit);
+  }
+}
+
+function collectText(node: ViewHierarchyNode): string[] {
+  const out: string[] = [];
+  walk(node, current => {
+    const text = textOf(attrsOf(current));
+    if (text) {
+      out.push(text);
+    }
+  });
+  return out;
+}
+
+function findNavigationTitle(root: ViewHierarchyNode | undefined): string | undefined {
+  let fallback: string | undefined;
+  let title: string | undefined;
+  walk(root, node => {
+    if (title) {
+      return;
+    }
+    const attrs = attrsOf(node);
+    const cls = className(attrs);
+    if (cls !== "UINavigationBar" && cls !== "XCUIElementTypeNavigationBar") {
+      return;
+    }
+    fallback = textOf(attrs) ?? fallback;
+    walk(node, descendant => {
+      if (title) {
+        return;
+      }
+      const descendantAttrs = attrsOf(descendant);
+      const descendantClass = className(descendantAttrs);
+      if (
+        descendantClass === "_UINavigationBarTitleControl" ||
+        descendantClass === "UILabel" ||
+        descendantClass === "XCUIElementTypeStaticText"
+      ) {
+        title = textOf(descendantAttrs);
+      }
+    });
+  });
+  return title ?? fallback;
+}
+
+function findSelectedTab(root: ViewHierarchyNode | undefined): string | undefined {
+  let selectedTab: string | undefined;
+  const walkForTab = (node: ViewHierarchyNode | undefined, inTabBar: boolean): void => {
+    if (!node || selectedTab) {
+      return;
+    }
+    const attrs = attrsOf(node);
+    const cls = className(attrs);
+    const role = asString(attrs["role"]);
+    const nextInTabBar = inTabBar || cls === "UITabBar" || cls === "XCUIElementTypeTabBar";
+    if (isTrue(attrs["selected"])) {
+      const selectedByRole = role === "tab";
+      const selectedByTabBarChild = nextInTabBar &&
+        (cls === "UITabBarButton" || cls === "UIButton" || cls === "XCUIElementTypeButton");
+      if (selectedByRole || selectedByTabBarChild) {
+        selectedTab = textOf(attrs) ?? asString(attrs["resource-id"]);
+        return;
+      }
+    }
+    for (const child of nodeChildren(node)) {
+      walkForTab(child, nextInTabBar);
+      if (selectedTab) {
+        return;
+      }
+    }
+  };
+  walkForTab(root, false);
+  return selectedTab;
+}
+
+function findModal(root: ViewHierarchyNode | undefined): Pick<CandidateSignals, "modalClass" | "modalTitle"> {
+  let modalNode: ViewHierarchyNode | undefined;
+  walk(root, node => {
+    if (modalNode) {
+      return;
+    }
+    const cls = className(attrsOf(node));
+    if (cls && MODAL_CLASSES.has(cls)) {
+      modalNode = node;
+    }
+  });
+  if (!modalNode) {
+    return {};
+  }
+  const attrs = attrsOf(modalNode);
+  return {
+    modalClass: className(attrs),
+    modalTitle: collectText(modalNode)[0],
+  };
+}
+
+function findFocusedElementId(root: ViewHierarchyNode | undefined): string | undefined {
+  let focused: string | undefined;
+  walk(root, node => {
+    const attrs = attrsOf(node);
+    if (focused || !isTrue(attrs["focused"])) {
+      return;
+    }
+    focused = asString(attrs["resource-id"])
+      ?? asString(attrs["view-id"])
+      ?? textOf(attrs)
+      ?? className(attrs);
+  });
+  return focused;
+}
+
+function hasKeyboard(root: ViewHierarchyNode | undefined): boolean {
+  let keyboardVisible = false;
+  walk(root, node => {
+    if (keyboardVisible) {
+      return;
+    }
+    const cls = className(attrsOf(node));
+    keyboardVisible = cls === "UIKeyboard" || cls === "UIKeyboardKey" || cls === "XCUIElementTypeKeyboard";
+  });
+  return keyboardVisible;
+}
+
+function makeKey(signals: CandidateSignals): string {
+  const parts = [
+    ["bundle", signals.bundleId],
+    ["nav", signals.navigationTitle],
+    ["modalClass", signals.modalClass],
+    ["modalTitle", signals.modalTitle],
+    ["tab", signals.selectedTab],
+    ["focus", signals.focusedElementId],
+    ["keyboard", signals.keyboardVisible ? "true" : undefined],
+  ];
+  return JSON.stringify(parts.filter(([, value]) => value !== undefined));
+}
+
+function confidence(signals: CandidateSignals): ScreenIdentity["confidence"] {
+  if (signals.modalClass || signals.navigationTitle) {
+    return "high";
+  }
+  if (signals.selectedTab || signals.focusedElementId || signals.keyboardVisible) {
+    return "medium";
+  }
+  return "low";
+}
+
+export function deriveIosScreenIdentity(viewHierarchy: ViewHierarchyResult | undefined): ScreenIdentity | undefined {
+  const root = rootNode(viewHierarchy);
+  if (!root) {
+    return undefined;
+  }
+
+  const modal = findModal(root);
+  const signals: CandidateSignals = {
+    bundleId: viewHierarchy?.packageName,
+    navigationTitle: findNavigationTitle(root),
+    selectedTab: findSelectedTab(root),
+    ...modal,
+    focusedElementId: findFocusedElementId(root),
+    keyboardVisible: hasKeyboard(root) || undefined,
+  };
+
+  const hasUsefulSignal = Boolean(
+    signals.navigationTitle ||
+    signals.selectedTab ||
+    signals.modalClass ||
+    signals.modalTitle ||
+    signals.focusedElementId ||
+    signals.keyboardVisible
+  );
+  if (!hasUsefulSignal) {
+    return undefined;
+  }
+
+  return {
+    platform: "ios",
+    source: "heuristic",
+    confidence: confidence(signals),
+    key: makeKey(signals),
+    components: Object.fromEntries(
+      Object.entries(signals).filter(([, value]) => value !== undefined)
+    ) as ScreenIdentity["components"],
+  };
+}

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -740,10 +740,16 @@ function groupByKey(nodes: FlatObserveNode[]): Map<string, FlatObserveNode[]> {
 /**
  * Whether two observations describe the same screen. Cross-screen diffs are
  * meaningless (issue #2761), so the finalize hook falls back to a full emit when
- * this is false. Compares the active window app/activity and the hierarchy
- * package name.
+ * this is false. When either side has a derived `screenIdentity`, require the
+ * identities to match; otherwise fall back to active window app/activity and the
+ * hierarchy package name.
  */
 export function isSameObservationScreen(baseline: ObserveResult, next: ObserveResult): boolean {
+  if (baseline.screenIdentity || next.screenIdentity) {
+    return baseline.screenIdentity?.platform === next.screenIdentity?.platform
+      && baseline.screenIdentity?.source === next.screenIdentity?.source
+      && baseline.screenIdentity?.key === next.screenIdentity?.key;
+  }
   if ((baseline.activeWindow?.appId ?? "") !== (next.activeWindow?.appId ?? "")) {
     return false;
   }

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -54,6 +54,25 @@ export interface Predictions {
   interactableElements: InteractablePrediction[];
 }
 
+export type ScreenIdentitySource = "heuristic" | "sdk";
+export type ScreenIdentityConfidence = "high" | "medium" | "low";
+
+export interface ScreenIdentity {
+  platform: "ios" | "android";
+  source: ScreenIdentitySource;
+  confidence: ScreenIdentityConfidence;
+  key: string;
+  components: {
+    bundleId?: string;
+    navigationTitle?: string;
+    selectedTab?: string;
+    modalClass?: string;
+    modalTitle?: string;
+    focusedElementId?: string;
+    keyboardVisible?: boolean;
+  };
+}
+
 /**
  * Represents the result of observing the device state
  */
@@ -79,6 +98,9 @@ export interface ObserveResult {
 
   /** Active window information */
   activeWindow?: ActiveWindowInfo;
+
+  /** Best-effort stable identity for the currently visible screen. */
+  screenIdentity?: ScreenIdentity;
 
   /**
    * Categorized elements from the view hierarchy

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -100,11 +100,28 @@ export const activeWindowSchema = z.object({
   type: z.string().optional()
 }).passthrough();
 
+const screenIdentitySchema = z.object({
+  platform: z.enum(["ios", "android"]),
+  source: z.enum(["heuristic", "sdk"]),
+  confidence: z.enum(["high", "medium", "low"]),
+  key: z.string(),
+  components: z.object({
+    bundleId: z.string().optional(),
+    navigationTitle: z.string().optional(),
+    selectedTab: z.string().optional(),
+    modalClass: z.string().optional(),
+    modalTitle: z.string().optional(),
+    focusedElementId: z.string().optional(),
+    keyboardVisible: z.boolean().optional()
+  }).passthrough()
+}).passthrough();
+
 export const observationSummarySchema = z.object({
   selectedElements: z.array(selectedElementSchema).optional(),
   focusedElement: elementSchema.optional(),
   accessibilityFocusedElement: elementSchema.optional(),
-  activeWindow: activeWindowSchema.optional()
+  activeWindow: activeWindowSchema.optional(),
+  screenIdentity: screenIdentitySchema.optional()
 }).passthrough();
 
 const tapOnSearchUntilSchema = z.object({
@@ -311,6 +328,7 @@ export const observeResultSchema = z.object({
   systemInsets: systemInsetsSchema.optional(),
   viewHierarchy: viewHierarchyResultSchema.optional(),
   activeWindow: activeWindowSchema.optional(),
+  screenIdentity: screenIdentitySchema.optional(),
   elements: observeElementsSchema.optional(),
   selectedElements: z.array(selectedElementSchema).optional(),
   focusedElement: elementSchema.optional(),

--- a/test/features/observe/HierarchyPlatformValidator.test.ts
+++ b/test/features/observe/HierarchyPlatformValidator.test.ts
@@ -214,6 +214,13 @@ describe("discardHierarchyDerivedData", () => {
     intentChooserDetected: true,
     notificationPermissionDetected: true,
     activeWindow: { appId: "com.other.platform", activityName: "", layoutSeqSum: 0 },
+    screenIdentity: {
+      platform: "ios",
+      source: "heuristic",
+      confidence: "medium",
+      key: JSON.stringify([["bundle", "com.other.platform"], ["focus", "stale-id"]]),
+      components: { bundleId: "com.other.platform", focusedElementId: "stale-id" },
+    },
     predictions: { } as never,
   } as unknown as ObserveResult);
 
@@ -231,6 +238,7 @@ describe("discardHierarchyDerivedData", () => {
     expect(result.notificationPermissionDetected).toBeUndefined();
     expect(result.predictions).toBeUndefined();
     expect(result.activeWindow).toBeUndefined();
+    expect(result.screenIdentity).toBeUndefined();
   });
 
   test("resets hierarchy-derived screen metrics to base defaults", () => {
@@ -270,6 +278,13 @@ describe("enforceHierarchyPlatform", () => {
     focusedElement: { "text": "Stale" } as unknown as Element,
     intentChooserDetected: true,
     elements: { clickable: [], scrollable: [], text: [], media: [] },
+    screenIdentity: {
+      platform: "ios",
+      source: "heuristic",
+      confidence: "medium",
+      key: JSON.stringify([["bundle", "com.other.platform"], ["focus", "stale-id"]]),
+      components: { bundleId: "com.other.platform", focusedElementId: "stale-id" },
+    },
   } as unknown as ObserveResult);
 
   test("rejects an opposite-platform hierarchy and scrubs all derived fields", () => {
@@ -289,6 +304,7 @@ describe("enforceHierarchyPlatform", () => {
     expect(result.elements).toBeUndefined();
     expect(result.focusedElement).toBeUndefined();
     expect(result.intentChooserDetected).toBeUndefined();
+    expect(result.screenIdentity).toBeUndefined();
     expect(result.error).toContain("iOS hierarchy for Android device");
   });
 
@@ -305,6 +321,7 @@ describe("enforceHierarchyPlatform", () => {
     expect(result.viewHierarchy).toBeDefined();
     expect(result.elements).toBeDefined();
     expect(result.focusedElement).toBeDefined();
+    expect(result.screenIdentity).toBeDefined();
     expect(result.error).toBeUndefined();
   });
 

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -156,6 +156,63 @@ describe("ObserveScreen", function() {
         resetObserveCacheStore();
       }
     });
+
+    test("should populate iOS heuristic screen identity from the view hierarchy", async function() {
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({
+        packageName: "com.apple.reminders",
+        updatedAt: 123,
+        screenScale: 3,
+        screenWidth: 402,
+        screenHeight: 874,
+        hierarchy: {
+          node: {
+            $: { class: "XCUIApplication" },
+            node: [
+              {
+                $: { class: "UINavigationBar", text: "New Reminder" },
+                node: [
+                  { $: { class: "_UINavigationBarTitleControl", text: "New Reminder" } },
+                ],
+              },
+              {
+                $: {
+                  "class": "UITextField",
+                  "text": "Title",
+                  "resource-id": "Quick Entry Title Field",
+                  "focused": "true",
+                },
+              },
+            ],
+          },
+        },
+      } as any);
+
+      try {
+        const screen = new RealObserveScreen(
+          { deviceId: "ios-test-device", name: "iPhone", platform: "ios" },
+          new FakeAdbClientFactory(fakeAdb),
+          {
+            viewHierarchy,
+            cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+            performanceAuditor: { run: async () => undefined } as any,
+            accessibilityAuditor: { run: async () => undefined } as any,
+            accessibilityStateDetector: { run: async () => undefined } as any,
+          }
+        );
+
+        const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+        expect(result.screenIdentity?.platform).toBe("ios");
+        expect(result.screenIdentity?.source).toBe("heuristic");
+        expect(result.screenIdentity?.confidence).toBe("high");
+        expect(result.screenIdentity?.components.bundleId).toBe("com.apple.reminders");
+        expect(result.screenIdentity?.components.navigationTitle).toBe("New Reminder");
+        expect(result.screenIdentity?.components.focusedElementId).toBe("Quick Entry Title Field");
+      } finally {
+        resetObserveCacheStore();
+      }
+    });
   });
 
   describe("Unit Tests for Focused Element Functionality", function() {

--- a/test/features/observe/ios/IosScreenIdentity.test.ts
+++ b/test/features/observe/ios/IosScreenIdentity.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+import { deriveIosScreenIdentity } from "../../../../src/features/observe/ios/IosScreenIdentity";
+import type { ViewHierarchyNode, ViewHierarchyResult } from "../../../../src/models/ViewHierarchyResult";
+
+type Attrs = Record<string, unknown>;
+
+function node(attrs: Attrs, children: ViewHierarchyNode[] = []): ViewHierarchyNode {
+  return {
+    $: attrs,
+    ...(children.length > 0 ? { node: children } : {}),
+  };
+}
+
+function hierarchy(children: ViewHierarchyNode[], packageName = "com.apple.reminders"): ViewHierarchyResult {
+  return {
+    packageName,
+    screenScale: 3,
+    hierarchy: {
+      node: node({ class: "XCUIApplication" }, children),
+    },
+  };
+}
+
+function navigationBar(title: string): ViewHierarchyNode {
+  return node({ class: "UINavigationBar", text: title }, [
+    node({ class: "_UINavigationBarTitleControl", text: title }),
+  ]);
+}
+
+describe("deriveIosScreenIdentity", () => {
+  test("distinguishes Reminders main list, new reminder sheet, discard action sheet, and keyboard editor", () => {
+    const main = deriveIosScreenIdentity(hierarchy([
+      navigationBar("Reminders"),
+      node({ class: "UIToolbar", text: "Toolbar" }, [
+        node({ class: "UIButton", text: "New Reminder", clickable: "true" }),
+      ]),
+    ]));
+
+    const sheet = deriveIosScreenIdentity(hierarchy([
+      navigationBar("New Reminder"),
+      node({
+        "class": "UITextField",
+        "text": "Title",
+        "resource-id": "Quick Entry Title Field",
+        "focused": "true",
+      }),
+      node({ class: "UIView", text: "Quick bar" }),
+    ]));
+
+    const actionSheet = deriveIosScreenIdentity(hierarchy([
+      node({ class: "UIActionSheet" }, [
+        node({ class: "UIButton", text: "Discard Changes", clickable: "true" }),
+        node({ class: "UIButton", text: "Cancel", clickable: "true" }),
+      ]),
+    ]));
+
+    const keyboardEditor = deriveIosScreenIdentity(hierarchy([
+      navigationBar("New Reminder"),
+      node({
+        "class": "UITextField",
+        "text": "Title",
+        "value": "Diff test",
+        "resource-id": "Quick Entry Title Field",
+        "focused": "true",
+      }),
+      node({ class: "UIKeyboard" }, [
+        node({ class: "UIKeyboardKey", text: "Q", clickable: "true" }),
+      ]),
+    ]));
+
+    const keys = [main, sheet, actionSheet, keyboardEditor].map(identity => identity?.key);
+
+    expect(keys.every(Boolean)).toBe(true);
+    expect(new Set(keys).size).toBe(4);
+    expect(actionSheet?.components.modalClass).toBe("UIActionSheet");
+    expect(keyboardEditor?.components.keyboardVisible).toBe(true);
+  });
+
+  test("is stable across minor bounds churn", () => {
+    const first = deriveIosScreenIdentity(hierarchy([
+      navigationBar("Reminders"),
+      node({ class: "UITableViewCell", text: "Reminders, 1 reminder", bounds: { left: 20, top: 559, right: 382, bottom: 614 } }),
+    ]));
+    const second = deriveIosScreenIdentity(hierarchy([
+      navigationBar("Reminders"),
+      node({ class: "UITableViewCell", text: "Reminders, 1 reminder", bounds: { left: 21, top: 560, right: 383, bottom: 615 } }),
+    ]));
+
+    expect(first?.key).toBe(second?.key);
+    expect(first?.components).toEqual(second?.components);
+  });
+
+  test("is deterministic for a Playground tab screen", () => {
+    const playground = hierarchy([
+      navigationBar("Demos"),
+      node({ class: "UITabBar", text: "Tab Bar" }, [
+        node({ class: "UIButton", text: "Discover" }),
+        node({ "class": "UIButton", "text": "Demos", "selected": "true", "resource-id": "play.fill" }),
+        node({ class: "UIButton", text: "Settings" }),
+      ]),
+    ], "dev.jasonpearson.automobile.Playground");
+
+    const first = deriveIosScreenIdentity(playground);
+    const second = deriveIosScreenIdentity(JSON.parse(JSON.stringify(playground)));
+
+    expect(first).toEqual(second);
+    expect(first?.components.selectedTab).toBe("Demos");
+    expect(first?.components.navigationTitle).toBe("Demos");
+  });
+
+  test("uses selected role-based tab items even when class is generic", () => {
+    const identity = deriveIosScreenIdentity(hierarchy([
+      navigationBar("Home"),
+      node({ class: "UITabBar", text: "Tab Bar" }, [
+        node({ "class": "UIView", "role": "tab", "text": "Inbox" }),
+        node({ "class": "UIView", "role": "tab", "text": "Search", "selected": "true" }),
+      ]),
+    ]));
+
+    expect(identity?.components.navigationTitle).toBe("Home");
+    expect(identity?.components.selectedTab).toBe("Search");
+    expect(JSON.parse(identity!.key)).toEqual([
+      ["bundle", "com.apple.reminders"],
+      ["nav", "Home"],
+      ["tab", "Search"],
+    ]);
+  });
+
+  test("ignores selected non-tab buttons before the selected tab bar item", () => {
+    const screen = (selectedTab: string): ViewHierarchyResult => hierarchy([
+      navigationBar("Home"),
+      node({ class: "UIView", text: "Filters" }, [
+        node({ "class": "UIButton", "text": "Pinned", "selected": "true" }),
+      ]),
+      node({ class: "UITabBar", text: "Tab Bar" }, [
+        node({ "class": "UIButton", "text": "Inbox", "selected": selectedTab === "Inbox" ? "true" : "false" }),
+        node({ "class": "UIButton", "text": "Search", "selected": selectedTab === "Search" ? "true" : "false" }),
+      ]),
+    ]);
+
+    const inbox = deriveIosScreenIdentity(screen("Inbox"));
+    const search = deriveIosScreenIdentity(screen("Search"));
+
+    expect(inbox?.components.selectedTab).toBe("Inbox");
+    expect(search?.components.selectedTab).toBe("Search");
+    expect(inbox?.key).not.toBe(search?.key);
+  });
+
+  test("encodes key components without delimiter collisions", () => {
+    const titledAndTabbed = deriveIosScreenIdentity(hierarchy([
+      navigationBar("Foo"),
+      node({ class: "UITabBar", text: "Tab Bar" }, [
+        node({ "class": "UIButton", "text": "Bar", "selected": "true" }),
+      ]),
+    ]));
+    const delimiterTitle = deriveIosScreenIdentity(hierarchy([
+      navigationBar("Foo|tab=Bar"),
+    ]));
+
+    expect(titledAndTabbed?.key).not.toBe(delimiterTitle?.key);
+    expect(JSON.parse(titledAndTabbed!.key)).toEqual([
+      ["bundle", "com.apple.reminders"],
+      ["nav", "Foo"],
+      ["tab", "Bar"],
+    ]);
+  });
+
+  test("handles raw XCTest root nodes with direct attrs and child arrays", () => {
+    const identity = deriveIosScreenIdentity({
+      packageName: "com.apple.reminders",
+      screenScale: 3,
+      hierarchy: {
+        "class": "XCUIElementTypeApplication",
+        "view-id": "root",
+        "node": [
+          {
+            class: "XCUIElementTypeNavigationBar",
+            node: [
+              { "class": "XCUIElementTypeStaticText", "text": "Reminders", "view-id": "title" },
+            ],
+          },
+          {
+            "class": "XCUIElementTypeButton",
+            "text": "New Reminder",
+            "clickable": "true",
+          },
+        ],
+      } as any,
+    });
+
+    expect(identity?.components.bundleId).toBe("com.apple.reminders");
+    expect(identity?.components.navigationTitle).toBe("Reminders");
+    expect(identity?.key).toBe(JSON.stringify([
+      ["bundle", "com.apple.reminders"],
+      ["nav", "Reminders"],
+    ]));
+  });
+
+  test("omits identity when no useful signal is available", () => {
+    expect(deriveIosScreenIdentity(hierarchy([
+      node({ class: "XCUIApplication" }),
+      node({ class: "UIView" }),
+    ]))).toBeUndefined();
+  });
+});

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -593,6 +593,54 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.viewHierarchy).toBeDefined();
     });
 
+    test("falls back to full when an iOS screen identity changes under the same app", () => {
+      const { store } = makeStore();
+      const baseline = {
+        ...sameScreenObserve(),
+        activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 0 },
+        screenIdentity: {
+          platform: "ios",
+          source: "heuristic",
+          confidence: "high",
+          key: "bundle=com.apple.reminders|nav=Reminders",
+          components: {
+            bundleId: "com.apple.reminders",
+            navigationTitle: "Reminders",
+          },
+        },
+        viewHierarchy: {
+          packageName: "com.apple.reminders",
+          hierarchy: sameScreenObserve().viewHierarchy!.hierarchy,
+        },
+      } as ObserveResult;
+      finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
+
+      const next = {
+        ...baseline,
+        screenIdentity: {
+          platform: "ios",
+          source: "heuristic",
+          confidence: "high",
+          key: "bundle=com.apple.reminders|nav=New Reminder",
+          components: {
+            bundleId: "com.apple.reminders",
+            navigationTitle: "New Reminder",
+          },
+        },
+      } as ObserveResult;
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      expect(obsSc.screenIdentity.key).toBe("bundle=com.apple.reminders|nav=New Reminder");
+    });
+
     test("falls back to full when there is no sessionUuid (legacy single-agent path)", () => {
       const { store, map } = makeStore();
       const finalized = finalizeToolResponse(


### PR DESCRIPTION
## Summary

Adds an iOS fallback `screenIdentity` heuristic for `observe` results so action diffing can distinguish common Apple app states even when iOS does not expose Android-style screen, activity, or fragment names. The identity is derived from stable accessibility hierarchy signals such as bundle id, navigation titles, selected tabs, modal/action sheet markers, focused fields, and keyboard visibility while ignoring bounds churn. The action diff gate now uses this identity conservatively: if either side has an identity, both sides must have the same platform/source/key before emitting a diff.

## Linked Issue

Closes #3314

## Validation

- [x] `bun test --bail` passes
- [x] `bun run turbo:validate` passes (`bun run lint` + `bun run build` + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Focused observe tests pass: `bun test test/features/observe/ios/IosScreenIdentity.test.ts test/features/observe/ObserveScreen.test.ts test/server/compactBoundsAdvertisement.test.ts test/server/finalizeToolResponse.test.ts`
- [x] New code uses deterministic pure helpers and fast unit fixtures
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Follow-ups

- [ ] Follow-up issues filed for gaps not addressed here: N/A
