### PR TITLE
fix(observe): gate iOS diffs on confident screen identity

### DIFF
--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -740,10 +740,10 @@ function groupByKey(nodes: FlatObserveNode[]): Map<string, FlatObserveNode[]> {
 /**
  * Whether two observations describe the same screen. Cross-screen diffs are
  * meaningless (issue #2761), so the finalize hook falls back to a full emit when
- * this is false. When both sides carry high-confidence `screenIdentity`, require
- * identity equality. A low-confidence identity is deliberately conservative and
- * forces a full emit. Missing or non-high identities preserve the historical
- * app/activity/package fallback.
+ * this is false. When both sides carry non-low-confidence `screenIdentity`,
+ * require identity equality. A low-confidence identity is deliberately
+ * conservative and forces a full emit. Missing identities preserve the
+ * historical app/activity/package fallback.
  */
 export function isSameObservationScreen(baseline: ObserveResult, next: ObserveResult): boolean {
   const baselineIdentity = baseline.screenIdentity;
@@ -753,10 +753,10 @@ export function isSameObservationScreen(baseline: ObserveResult, next: ObserveRe
     return false;
   }
 
-  if (baselineIdentity?.confidence === "high" && nextIdentity?.confidence === "high") {
-    return baseline.screenIdentity?.platform === next.screenIdentity?.platform
-      && baseline.screenIdentity?.source === next.screenIdentity?.source
-      && baseline.screenIdentity?.key === next.screenIdentity?.key;
+  if (baselineIdentity && nextIdentity) {
+    return baselineIdentity.platform === nextIdentity.platform
+      && baselineIdentity.source === nextIdentity.source
+      && baselineIdentity.key === nextIdentity.key;
   }
   if ((baseline.activeWindow?.appId ?? "") !== (next.activeWindow?.appId ?? "")) {
     return false;

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -740,12 +740,20 @@ function groupByKey(nodes: FlatObserveNode[]): Map<string, FlatObserveNode[]> {
 /**
  * Whether two observations describe the same screen. Cross-screen diffs are
  * meaningless (issue #2761), so the finalize hook falls back to a full emit when
- * this is false. When either side has a derived `screenIdentity`, require the
- * identities to match; otherwise fall back to active window app/activity and the
- * hierarchy package name.
+ * this is false. When both sides carry high-confidence `screenIdentity`, require
+ * identity equality. A low-confidence identity is deliberately conservative and
+ * forces a full emit. Missing or non-high identities preserve the historical
+ * app/activity/package fallback.
  */
 export function isSameObservationScreen(baseline: ObserveResult, next: ObserveResult): boolean {
-  if (baseline.screenIdentity || next.screenIdentity) {
+  const baselineIdentity = baseline.screenIdentity;
+  const nextIdentity = next.screenIdentity;
+
+  if (baselineIdentity?.confidence === "low" || nextIdentity?.confidence === "low") {
+    return false;
+  }
+
+  if (baselineIdentity?.confidence === "high" && nextIdentity?.confidence === "high") {
     return baseline.screenIdentity?.platform === next.screenIdentity?.platform
       && baseline.screenIdentity?.source === next.screenIdentity?.source
       && baseline.screenIdentity?.key === next.screenIdentity?.key;

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -984,6 +984,20 @@ describe("diffObserveResult — volatile `extras` metadata exclusion (#3051)", (
 });
 
 describe("isSameObservationScreen", () => {
+  const iosIdentity = (
+    key: string,
+    confidence: "high" | "medium" | "low" = "high"
+  ): ObserveResult["screenIdentity"] => ({
+    platform: "ios",
+    source: "heuristic",
+    confidence,
+    key,
+    components: {
+      bundleId: "com.apple.reminders",
+      navigationTitle: key,
+    },
+  });
+
   test("same app + activity + package → true", () => {
     const a = obs({ "resource-id": "a" });
     const b = obs({ "resource-id": "b" });
@@ -1005,6 +1019,57 @@ describe("isSameObservationScreen", () => {
   test("different hierarchy packageName → false", () => {
     const a = obs({ "resource-id": "a" });
     const b = obs({ "resource-id": "a" }, { viewHierarchy: { packageName: "com.other", hierarchy: { node: { "resource-id": "a" } as any } } });
+    expect(isSameObservationScreen(a, b)).toBe(false);
+  });
+
+  test("same high-confidence iOS screen identity → true", () => {
+    const a = obs({ "resource-id": "a" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 1 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "a" } as any } },
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|nav=Reminders"),
+    });
+    const b = obs({ "resource-id": "b" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 2 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "b" } as any } },
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|nav=Reminders"),
+    });
+    expect(isSameObservationScreen(a, b)).toBe(true);
+  });
+
+  test("different high-confidence iOS screen identity → false", () => {
+    const a = obs({ "resource-id": "a" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 1 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "a" } as any } },
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|nav=Reminders"),
+    });
+    const b = obs({ "resource-id": "b" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 2 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "b" } as any } },
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|nav=New Reminder"),
+    });
+    expect(isSameObservationScreen(a, b)).toBe(false);
+  });
+
+  test("one missing identity preserves app/activity/package fallback", () => {
+    const a = obs({ "resource-id": "a" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 1 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "a" } as any } },
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|nav=Reminders"),
+    });
+    const b = obs({ "resource-id": "b" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 2 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "b" } as any } },
+    });
+    expect(isSameObservationScreen(a, b)).toBe(true);
+  });
+
+  test("low-confidence screen identity is conservative", () => {
+    const a = obs({ "resource-id": "a" }, {
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|focus=Title", "low"),
+    });
+    const b = obs({ "resource-id": "b" }, {
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|focus=Title", "low"),
+    });
     expect(isSameObservationScreen(a, b)).toBe(false);
   });
 });

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -1050,6 +1050,20 @@ describe("isSameObservationScreen", () => {
     expect(isSameObservationScreen(a, b)).toBe(false);
   });
 
+  test("different medium-confidence iOS screen identity → false", () => {
+    const a = obs({ "resource-id": "a" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 1 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "a" } as any } },
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|tab=Inbox", "medium"),
+    });
+    const b = obs({ "resource-id": "b" }, {
+      activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 2 },
+      viewHierarchy: { packageName: "com.apple.reminders", hierarchy: { node: { "resource-id": "b" } as any } },
+      screenIdentity: iosIdentity("bundle=com.apple.reminders|tab=Search", "medium"),
+    });
+    expect(isSameObservationScreen(a, b)).toBe(false);
+  });
+
   test("one missing identity preserves app/activity/package fallback", () => {
     const a = obs({ "resource-id": "a" }, {
       activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 1 },

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -450,6 +450,30 @@ describe("finalizeToolResponse", () => {
       };
     }
 
+    function iosScreenObserve(
+      key: string,
+      confidence: "high" | "medium" | "low" = "high"
+    ): ObserveResult {
+      return {
+        ...sameScreenObserve(),
+        activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 0 },
+        screenIdentity: {
+          platform: "ios",
+          source: "heuristic",
+          confidence,
+          key,
+          components: {
+            bundleId: "com.apple.reminders",
+            navigationTitle: key,
+          },
+        },
+        viewHierarchy: {
+          packageName: "com.apple.reminders",
+          hierarchy: sameScreenObserve().viewHierarchy!.hierarchy,
+        },
+      } as ObserveResult;
+    }
+
     beforeEach(() => {
       originalDiff = serverConfig.isActionsDiffObserveEnabled();
       serverConfig.setActionsDiffObserveEnabled(true);
@@ -595,39 +619,10 @@ describe("finalizeToolResponse", () => {
 
     test("falls back to full when an iOS screen identity changes under the same app", () => {
       const { store } = makeStore();
-      const baseline = {
-        ...sameScreenObserve(),
-        activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 0 },
-        screenIdentity: {
-          platform: "ios",
-          source: "heuristic",
-          confidence: "high",
-          key: "bundle=com.apple.reminders|nav=Reminders",
-          components: {
-            bundleId: "com.apple.reminders",
-            navigationTitle: "Reminders",
-          },
-        },
-        viewHierarchy: {
-          packageName: "com.apple.reminders",
-          hierarchy: sameScreenObserve().viewHierarchy!.hierarchy,
-        },
-      } as ObserveResult;
+      const baseline = iosScreenObserve("bundle=com.apple.reminders|nav=Reminders");
       finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
 
-      const next = {
-        ...baseline,
-        screenIdentity: {
-          platform: "ios",
-          source: "heuristic",
-          confidence: "high",
-          key: "bundle=com.apple.reminders|nav=New Reminder",
-          components: {
-            bundleId: "com.apple.reminders",
-            navigationTitle: "New Reminder",
-          },
-        },
-      } as ObserveResult;
+      const next = iosScreenObserve("bundle=com.apple.reminders|nav=New Reminder");
       (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
 
       const finalized = finalizeToolResponse(
@@ -639,6 +634,70 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
       expect(obsSc.screenIdentity.key).toBe("bundle=com.apple.reminders|nav=New Reminder");
+    });
+
+    test("emits a diff when high-confidence iOS screen identity stays stable", () => {
+      const { store } = makeStore();
+      const baseline = iosScreenObserve("bundle=com.apple.reminders|nav=Reminders");
+      finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
+
+      const next = iosScreenObserve("bundle=com.apple.reminders|nav=Reminders");
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
+    });
+
+    test("preserves app/activity/package fallback when only one iOS identity is present", () => {
+      const { store } = makeStore();
+      finalizeToolResponse(
+        createStructuredToolResponse(iosScreenObserve("bundle=com.apple.reminders|nav=Reminders")),
+        { name: "observe", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const next = {
+        ...sameScreenObserve(),
+        activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 0 },
+        viewHierarchy: {
+          packageName: "com.apple.reminders",
+          hierarchy: sameScreenObserve().viewHierarchy!.hierarchy,
+        },
+      } as ObserveResult;
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
+    });
+
+    test("falls back to full and updates baseline when iOS screen identity is low confidence", () => {
+      const { store, map } = makeStore();
+      const baseline = iosScreenObserve("bundle=com.apple.reminders|focus=Title", "low");
+      finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
+
+      const next = iosScreenObserve("bundle=com.apple.reminders|focus=Title", "low");
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      expect((map.get("s1")!.viewHierarchy!.hierarchy.node as any).node[0].checked).toBe("true");
     });
 
     test("falls back to full when there is no sessionUuid (legacy single-agent path)", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -681,6 +681,25 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
     });
 
+    test("falls back to full when medium-confidence iOS screen identity changes under the same app", () => {
+      const { store } = makeStore();
+      const baseline = iosScreenObserve("bundle=com.apple.reminders|tab=Inbox", "medium");
+      finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
+
+      const next = iosScreenObserve("bundle=com.apple.reminders|tab=Search", "medium");
+      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      expect(obsSc.screenIdentity.key).toBe("bundle=com.apple.reminders|tab=Search");
+    });
+
     test("falls back to full and updates baseline when iOS screen identity is low confidence", () => {
       const { store, map } = makeStore();
       const baseline = iosScreenObserve("bundle=com.apple.reminders|focus=Title", "low");


### PR DESCRIPTION
## Summary

Teach the action observation diff gate to use iOS `screenIdentity` only when it is high confidence. Matching high-confidence identities can emit diffs, changed high-confidence identities emit the full observation, missing identities preserve the existing app/activity/package fallback, and low-confidence identities force a conservative full emit.

## Linked Issue

Closes #3315

## Bug / Regression Context

- **Prior attempts:** `--actions-diff-observe` originally gated same-screen diffs with Android-oriented app/activity/package checks; iOS later added typed `screenIdentity`.
- **Observed symptom:** iOS screens under the same bundle could produce misleading cross-screen diffs, while one-sided identity availability could block the legacy fallback.
- **Repro steps / conditions:** With `--actions-diff-observe`, compare consecutive iOS action observations where Reminders main list and New Reminder sheet share the same bundle/package but differ by high-confidence `screenIdentity`.

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + `bun run build` + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: no platform script changes; TypeScript output-gate tests cover the behavior
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Not run: this is a unit-tested output gate change; no platform capture code changed.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: none
