### PR TITLE
Fix startDevice readiness checks

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -203,7 +203,8 @@ export function registerDeviceTools() {
         perf.endOperation("directLookup");
 
         if (found) {
-          return await buildBootedResponse(found, "booted", perf, args);
+          const readyDevice = await waitForAlreadyRunningDevice(found, deviceUtils, perf, args);
+          return await buildBootedResponse(readyDevice, "booted", perf, args);
         }
 
         // Check images — need to boot
@@ -248,7 +249,8 @@ export function registerDeviceTools() {
           if (progress) {
             await progress(100, 100, "Found matching running device");
           }
-          return await buildBootedResponse(match, "booted", perf, args);
+          const readyDevice = await waitForAlreadyRunningDevice(match, deviceUtils, perf, args);
+          return await buildBootedResponse(readyDevice, "booted", perf, args);
         }
       }
 
@@ -263,8 +265,9 @@ export function registerDeviceTools() {
           const booted = await deviceUtils.getBootedDevices(args.platform);
           const running = booted.find(d => d.name === imageMatch.name || d.deviceId === imageMatch.deviceId);
           if (running) {
+            const readyDevice = await waitForAlreadyRunningDevice(running, deviceUtils, perf, args);
             return await buildBootedResponse(
-              { ...running, osVersion: imageMatch.osVersion, formFactor: imageMatch.formFactor, screenWidth: imageMatch.screenWidth, screenHeight: imageMatch.screenHeight },
+              { ...readyDevice, osVersion: imageMatch.osVersion, formFactor: imageMatch.formFactor, screenWidth: imageMatch.screenWidth, screenHeight: imageMatch.screenHeight },
               "booted",
               perf,
               args,
@@ -292,6 +295,21 @@ export function registerDeviceTools() {
       throw new ActionableError(`Failed to start ${args.platform} device: ${error}`);
     }
   };
+
+  async function waitForAlreadyRunningDevice(
+    device: BootedDevice,
+    deviceUtils: PlatformDeviceManager,
+    perf: ReturnType<typeof createPerformanceTracker>,
+    args: StartDeviceArgs,
+  ): Promise<BootedDevice> {
+    perf.startOperation("waitForReady");
+    const readyDevice = await deviceUtils.waitForDeviceReady(
+      { ...device, isRunning: true },
+      args.timeoutMs,
+    );
+    perf.endOperation("waitForReady");
+    return { ...device, ...readyDevice };
+  }
 
   async function bootAndRespond(
     image: DeviceInfo,

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -35,6 +35,11 @@ function getAdbPathCache(): TTLCache<string, string> {
   return adbPathCache;
 }
 
+export function resetAdbClientCaches(): void {
+  deviceListCache = null;
+  adbPathCache = null;
+}
+
 
 // Enhance the standard execFileAsync result to implement the ExecResult interface
 const execFileAsync: ExecFileAsync = async (
@@ -674,9 +679,14 @@ export class AdbClient implements AdbExecutor {
 
     const devices = lines
       .filter(line => line.trim().length > 0)
-      .map(line => {
+      .flatMap(line => {
         const parts = line.split("\t");
-        return { name: parts[0], platform: "android", deviceId: parts[0] } as BootedDevice;
+        const deviceId = parts[0]?.trim();
+        const state = parts[1]?.trim();
+        if (!deviceId || state !== "device") {
+          return [];
+        }
+        return [{ name: deviceId, platform: "android", deviceId } as BootedDevice];
       });
 
     // Cache the result

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1242,23 +1242,41 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             if (emulator && emulator.deviceId) {
               logger.debug(`Target emulator found: ${emulator.name} (${emulator.deviceId}) - starting readiness checks`);
 
-              // Check if the device is online and ready
-              // Run device state and package manager checks in parallel for faster detection
-              logger.debug(`[PARALLEL] Running device state and package manager checks for ${emulator.deviceId}...`);
+              // Check if the device is online and ready.
+              // Run ADB state, package manager, and boot-complete checks in parallel for faster detection.
+              logger.debug(`[PARALLEL] Running device state, package manager, and boot-complete checks for ${emulator.deviceId}...`);
               const adb = this.adbFactory.create(emulator);
               try {
                 perf.startOperation("adbParallelChecks");
-                const [deviceStateResult, packageManagerResult] = await Promise.allSettled([
+                const [
+                  deviceStateResult,
+                  packageManagerResult,
+                  sysBootCompletedResult,
+                  bootAnimationResult,
+                ] = await Promise.allSettled([
                   adb.executeCommand("get-state"),
-                  adb.executeCommand("shell pm list packages")
+                  adb.executeCommand("shell pm list packages"),
+                  adb.executeCommand("shell getprop sys.boot_completed"),
+                  adb.executeCommand("shell getprop init.svc.bootanim"),
                 ]);
                 perf.endOperation("adbParallelChecks");
 
                 // Check device state result
-                if (deviceStateResult.status !== "fulfilled" || packageManagerResult.status !== "fulfilled") {
-                  logger.debug(`[PARALLEL] Checks not yet complete: deviceStatus: ${deviceStateResult.status}, packageManager: ${packageManagerResult.status}`);
+                if (
+                  deviceStateResult.status !== "fulfilled" ||
+                  packageManagerResult.status !== "fulfilled" ||
+                  sysBootCompletedResult.status !== "fulfilled" ||
+                  bootAnimationResult.status !== "fulfilled"
+                ) {
+                  logger.debug(
+                    `[PARALLEL] Checks not yet complete: deviceStatus: ${deviceStateResult.status}, ` +
+                    `packageManager: ${packageManagerResult.status}, ` +
+                    `sysBootCompleted: ${sysBootCompletedResult.status}, bootAnimation: ${bootAnimationResult.status}`,
+                  );
                 } else {
                   const stateOutput = deviceStateResult.value.stdout.trim();
+                  const sysBootCompleted = sysBootCompletedResult.value.stdout.trim();
+                  const bootAnimationState = bootAnimationResult.value.stdout.trim();
                   logger.debug(`[PARALLEL] Package manager command completed for ${emulator.deviceId} - output: ${packageManagerResult.value.stdout.length} bytes`);
                   if (!stateOutput.includes("device")) {
                     logger.debug(`[PARALLEL] ❌ Device state check failed for ${emulator.deviceId}: state="${stateOutput}"`);
@@ -1266,9 +1284,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
                     logger.debug(`[PARALLEL] ❌ Package manager returned no packages for ${emulator.deviceId} (${packageManagerResult.value.stdout.length} bytes output)`);
                   } else if (packageManagerResult.value.stderr || packageManagerResult.value.stderr.includes("Failure")) {
                     logger.debug(`[PARALLEL] ❌ Package manager returned failure for ${emulator.deviceId}: ${packageManagerResult.value.stderr}`);
+                  } else if (sysBootCompleted !== "1") {
+                    logger.debug(`[PARALLEL] ❌ sys.boot_completed is not set for ${emulator.deviceId}: "${sysBootCompleted}"`);
+                  } else if (bootAnimationState && bootAnimationState !== "stopped") {
+                    logger.debug(`[PARALLEL] ❌ boot animation is still active for ${emulator.deviceId}: "${bootAnimationState}"`);
                   } else {
                     logger.debug(`[PARALLEL] ✅ Device state check passed for ${emulator.deviceId}`);
                     logger.debug(`[PARALLEL] ✅ Package manager is responsive for ${emulator.deviceId} - emulator is ready!`);
+                    logger.debug(`[PARALLEL] ✅ Android boot-complete signals are ready for ${emulator.deviceId}`);
                     logger.debug(`[PARALLEL] ✅ No package manager errors detected - marking emulator as ready`);
                     foundDeviceId = emulator.deviceId;
                     return;

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -70,9 +70,10 @@ interface AndroidEmulator {
    * @param avdName - The AVD name to wait for
    * @param timeoutMs - Maximum time to wait in milliseconds (default: 120000 = 2 minutes)
    * @param childProcess - Optional child process to monitor for early exit
+   * @param targetDeviceId - Optional adb device id to require when waiting for an already-running device
    * @returns Promise that resolves with device ID when emulator is ready
    */
-  waitForEmulatorReady(avdName: string, timeoutMs?: number, childProcess?: ChildProcess | null): Promise<BootedDevice>;
+  waitForEmulatorReady(avdName: string, timeoutMs?: number, childProcess?: ChildProcess | null, targetDeviceId?: string): Promise<BootedDevice>;
 }
 
 /**
@@ -1147,7 +1148,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param timeoutMs - Maximum time to wait in milliseconds (default: 120000 = 2 minutes)
    * @returns Promise that resolves with device ID when emulator is ready
    */
-  async waitForEmulatorReady(avdName: string, timeoutMs: number = 120000, childProcess?: ChildProcess | null): Promise<BootedDevice> {
+  async waitForEmulatorReady(
+    avdName: string,
+    timeoutMs: number = 120000,
+    childProcess?: ChildProcess | null,
+    targetDeviceId?: string,
+  ): Promise<BootedDevice> {
     const startTime = this.timer.now();
     const perf = createGlobalPerformanceTracker();
 
@@ -1225,12 +1231,22 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           if (runningEmulators.length > 0) {
             logger.debug(`Found ${runningEmulators.length} running emulators: ${runningEmulators.map(e => `${e.name}(${e.deviceId})`).join(", ")}`);
 
-            // Look for emulator by name first
-            let emulator = runningEmulators.find(emu => emu.name === avdName);
-            logger.debug(`Exact name match for '${avdName}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`);
+            // Prefer an exact deviceId when startDevice already selected a running device.
+            let emulator = targetDeviceId
+              ? runningEmulators.find(emu => emu.deviceId === targetDeviceId)
+              : undefined;
+            if (targetDeviceId) {
+              logger.debug(`Exact deviceId match for '${targetDeviceId}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`);
+            }
+
+            // Look for emulator by name next.
+            if (!emulator) {
+              emulator = runningEmulators.find(emu => emu.name === avdName);
+              logger.debug(`Exact name match for '${avdName}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`);
+            }
 
             // If not found by exact name, try to find any local emulator
-            if (!emulator) {
+            if (!emulator && !targetDeviceId) {
               emulator = runningEmulators.find(emu => emu.source === "local");
               if (emulator) {
                 logger.debug(`Found local emulator with deviceId ${emulator.deviceId}, but name mismatch. Expected: ${avdName}, Found: ${emulator.name}`);

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -311,7 +311,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   ): Promise<BootedDevice> {
     switch (device.platform) {
       case "android":
-        return this.emulator.waitForEmulatorReady(device.name, timeoutMs, childProcess);
+        return this.emulator.waitForEmulatorReady(device.name, timeoutMs, childProcess, device.deviceId);
       case "ios":
         return this.simctl.waitForSimulatorReady(device.deviceId ?? device.name, timeoutMs);
       default:

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -99,6 +99,19 @@ describe("startDevice handler", () => {
     expect(typeof result.sessionId).toBe("string");
   });
 
+  it("waits for readiness before returning a matched booted device", async () => {
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    fakeMatcher.setBootedResult(androidDevice);
+
+    const result = await callStartDevice({ platform: "android", timeoutMs: 42_000 });
+
+    expect(result.deviceId).toBe("emulator-5554");
+    expect(result.source).toBe("booted");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
+      "waitForDeviceReady:Pixel_7_API_34:42000",
+    );
+  });
+
   it("falls through to image when no booted device matches", async () => {
     fakeDeviceUtils.setBootedDevices("android", []);
     fakeDeviceUtils.setDeviceImages("android", [androidImage]);
@@ -122,6 +135,22 @@ describe("startDevice handler", () => {
 
     expect(result.deviceId).toBe("emulator-5554");
     expect(result.source).toBe("booted");
+  });
+
+  it("waits for readiness before returning a direct deviceId match", async () => {
+    fakeDeviceUtils.setBootedDevices("ios", [iosDevice]);
+
+    const result = await callStartDevice({
+      platform: "ios",
+      deviceId: "ABCD-1234",
+      timeoutMs: 30_000,
+    });
+
+    expect(result.deviceId).toBe("ABCD-1234");
+    expect(result.source).toBe("booted");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
+      "waitForDeviceReady:iPhone 15:30000",
+    );
   });
 
   it("boots image when deviceId matches an image name", async () => {
@@ -169,6 +198,30 @@ describe("startDevice handler", () => {
 
     expect(result.source).toBe("cold-boot");
     expect(fakeDeviceUtils.wasMethodCalled("startDevice")).toBe(true);
+  });
+
+  it("waits for readiness before returning a matched running image", async () => {
+    const runningImage: DeviceInfo = {
+      ...androidImage,
+      deviceId: "emulator-5554",
+      isRunning: true,
+    };
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    fakeDeviceUtils.setDeviceImages("android", [runningImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(runningImage);
+
+    const result = await callStartDevice({
+      platform: "android",
+      preferRunning: false,
+      timeoutMs: 15_000,
+    });
+
+    expect(result.deviceId).toBe("emulator-5554");
+    expect(result.source).toBe("booted");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
+      "waitForDeviceReady:Pixel_7_API_34:15000",
+    );
   });
 
   it("returns structured metadata with screen size", async () => {

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AdbClient, resetAdbClientCaches } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import type { ExecResult } from "../../../src/models";
+
+function createExecResult(stdout: string, stderr: string = ""): ExecResult {
+  return {
+    stdout,
+    stderr,
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (searchString: string) => stdout.includes(searchString),
+  };
+}
+
+describe("AdbClient.getBootedAndroidDevices", () => {
+  beforeEach(() => {
+    resetAdbClientCaches();
+  });
+
+  afterEach(() => {
+    resetAdbClientCaches();
+  });
+
+  test("only reports adb rows in device state as booted", async () => {
+    const execAsync = async (command: string): Promise<ExecResult> => {
+      if (command.includes("adb devices")) {
+        return createExecResult([
+          "List of devices attached",
+          "emulator-5554\tdevice",
+          "emulator-5556\tbooting",
+          "emulator-5558\toffline",
+          "emulator-5560\tunauthorized",
+          "",
+        ].join("\n"));
+      }
+      return createExecResult("");
+    };
+    const adb = new AdbClient(null, execAsync);
+
+    const devices = await adb.getBootedAndroidDevices();
+
+    expect(devices).toEqual([
+      { name: "emulator-5554", platform: "android", deviceId: "emulator-5554" },
+    ]);
+  });
+});

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -286,4 +286,34 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
       expect(error.message).toContain("failed to become ready within 100ms");
     }
   });
+
+  test("waits for Android boot-complete signals before reporting readiness", async () => {
+    fakeTimer.enableAutoAdvance();
+    fakeAdb.setDevices([{
+      name: "Pixel_9_Pro",
+      platform: "android",
+      deviceId: "emulator-5554",
+      source: "local",
+    }]);
+    fakeAdb.setCommandResponse("get-state", createExecResult("device\n"));
+    fakeAdb.setCommandResponse("shell pm list packages", createExecResult("package:android\n"));
+    fakeAdb.setCommandResponseSequence("shell getprop sys.boot_completed", [
+      createExecResult("0\n"),
+      createExecResult("1\n"),
+    ]);
+    fakeAdb.setCommandResponse("shell getprop init.svc.bootanim", createExecResult("stopped\n"));
+
+    const client = new AndroidEmulatorClient(mockExecAsync, null, fakeTimer, fakeFactory);
+    skipEmulatorPathDetection(client);
+
+    const result = await client.waitForEmulatorReady("Pixel_9_Pro", 5_000);
+
+    expect(result.deviceId).toBe("emulator-5554");
+    expect(fakeAdb.wasCommandExecuted("shell getprop sys.boot_completed")).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("shell getprop init.svc.bootanim")).toBe(true);
+    expect(
+      fakeAdb.getExecutedCommands()
+        .filter(command => command.includes("shell getprop sys.boot_completed")),
+    ).toHaveLength(2);
+  });
 });

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -17,6 +17,53 @@ class TestAdbClientFactory implements AdbClientFactory {
   }
 }
 
+class DeviceScopedAdbExecutor extends FakeAdbExecutor {
+  constructor(
+    private readonly device: BootedDevice | null,
+    private readonly devices: BootedDevice[],
+    private readonly commandLog: string[],
+  ) {
+    super();
+  }
+
+  async getBootedAndroidDevices(): Promise<BootedDevice[]> {
+    return this.devices;
+  }
+
+  async executeCommand(command: string): Promise<ExecResult> {
+    this.commandLog.push(`${this.device?.deviceId ?? "global"}:${command}`);
+    if (command === "emu avd name") {
+      return createExecResult("");
+    }
+    if (command === "shell getprop ro.product.model") {
+      return createExecResult("");
+    }
+    if (command === "get-state") {
+      return createExecResult("device\n");
+    }
+    if (command === "shell pm list packages") {
+      return createExecResult("package:android\n");
+    }
+    if (command === "shell getprop sys.boot_completed") {
+      return createExecResult("1\n");
+    }
+    if (command === "shell getprop init.svc.bootanim") {
+      return createExecResult("stopped\n");
+    }
+    return createExecResult("");
+  }
+}
+
+class DeviceScopedAdbClientFactory implements AdbClientFactory {
+  readonly commandLog: string[] = [];
+
+  constructor(private readonly devices: BootedDevice[]) {}
+
+  create(device?: BootedDevice | null): AdbExecutor {
+    return new DeviceScopedAdbExecutor(device ?? null, this.devices, this.commandLog);
+  }
+}
+
 const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
   stdout,
   stderr,
@@ -315,5 +362,26 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
       fakeAdb.getExecutedCommands()
         .filter(command => command.includes("shell getprop sys.boot_completed")),
     ).toHaveLength(2);
+  });
+
+  test("targets the selected emulator deviceId during already-running readiness waits", async () => {
+    fakeTimer.enableAutoAdvance();
+    const scopedFactory = new DeviceScopedAdbClientFactory([
+      { name: "Unknown (emulator-5554)", platform: "android", deviceId: "emulator-5554" },
+      { name: "Unknown (emulator-5556)", platform: "android", deviceId: "emulator-5556" },
+    ]);
+    const client = new AndroidEmulatorClient(mockExecAsync, null, fakeTimer, scopedFactory);
+    skipEmulatorPathDetection(client);
+
+    const result = await client.waitForEmulatorReady(
+      "Pixel_9_Pro",
+      5_000,
+      null,
+      "emulator-5556",
+    );
+
+    expect(result.deviceId).toBe("emulator-5556");
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5556:get-state"))).toBe(true);
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5554:get-state"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes `startDevice` readiness reporting so already-running devices go through the platform readiness gate before returning `isReady: true`. Android discovery now ignores `adb devices` rows that are not in `device` state, and Android emulator readiness waits for boot-complete properties in addition to adb state and package-manager responsiveness.

## Linked Issue

Closes #3334

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** `startDevice` could return a booted/ready response for an Android emulator or iOS simulator whose OS was still finishing startup, causing immediate `installApp`, `launchApp`, or interaction calls to fail.
- **Repro steps / conditions:** Reuse an already-running-but-not-ready device, or match an Android emulator visible to adb before package installation is safe.

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + build + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: covered by focused TypeScript tests with fakes/FakeTimer; no shell/Swift/Docker/schema validation needed
- [x] New code uses interfaces + fakes + FakeTimer; focused unit tests run in <100ms per test
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: none needed
