### PR TITLE
feat(observe): add stream screenshot cadence requests

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -765,6 +765,23 @@ export class Daemon {
       }
     });
 
+    server.setOnScreenshotCadenceChanged((deviceId: string | null) => {
+      const devices = this.devicePool.getAllDevices()
+        .filter(device => deviceId === null || device.id === deviceId);
+
+      for (const device of devices) {
+        if (device.platform === "android") {
+          AndroidCtrlProxyClient
+            .getExistingInstance(device.id)
+            ?.refreshObservationStreamScreenshotCadence();
+        } else if (device.platform === "ios") {
+          IOSCtrlProxyClient
+            .getExistingInstance(device.id)
+            ?.refreshObservationStreamScreenshotCadence();
+        }
+      }
+    });
+
     server.setOnObservationRequested(async ({ deviceId, signal }) => {
       const pooledDevices = deviceId
         ? [this.devicePool.getDevice(deviceId)].filter(device => device !== null)

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -95,6 +95,7 @@ interface DeviceDataStreamMessage {
  */
 interface DeviceDataFilter {
   deviceId: string | null; // null means subscribe to all devices
+  screenshotIntervalMs: number | null;
 }
 
 /**
@@ -110,6 +111,11 @@ interface DeviceDataPush {
  * Can be used to trigger device WebSocket connections for real-time updates.
  */
 export type OnSubscriberConnectedCallback = (deviceId: string | null) => void;
+
+/**
+ * Callback invoked when active screenshot cadence may have changed for a device.
+ */
+export type OnScreenshotCadenceChangedCallback = (deviceId: string | null) => void;
 
 /**
  * Observation captured on demand for a stream client.
@@ -139,6 +145,9 @@ export type OnNavigationGraphRequestedCallback = (appId?: string | null) => Prom
 // above that so slow-but-valid iOS captures are not reported as stream errors
 // before the platform observe path has its allotted time to complete.
 const DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS = 20_000;
+const DEFAULT_SCREENSHOT_INTERVAL_MS = 3000;
+const MIN_SCREENSHOT_INTERVAL_MS = 250;
+const MAX_SCREENSHOT_INTERVAL_MS = 2_147_483_647;
 
 /**
  * Socket server that streams device data updates (hierarchy, screenshot, storage) to connected IDE plugins.
@@ -159,6 +168,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   DeviceDataPush
 > {
   private onSubscriberConnected: OnSubscriberConnectedCallback | null = null;
+  private onScreenshotCadenceChanged: OnScreenshotCadenceChangedCallback | null = null;
   private onObservationRequested: OnObservationRequestedCallback | null = null;
   private onNavigationGraphRequested: OnNavigationGraphRequestedCallback | null = null;
   private observationRequestTimeoutMs = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS;
@@ -173,6 +183,13 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    */
   setOnSubscriberConnected(callback: OnSubscriberConnectedCallback): void {
     this.onSubscriberConnected = callback;
+  }
+
+  /**
+   * Set a callback to be invoked when subscription cadence may have changed.
+   */
+  setOnScreenshotCadenceChanged(callback: OnScreenshotCadenceChangedCallback): void {
+    this.onScreenshotCadenceChanged = callback;
   }
 
   /**
@@ -311,6 +328,39 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   /**
+   * Return the fastest active screenshot cadence requested for this device,
+   * or the default low-cost keepalive cadence when none is requested.
+   */
+  getScreenshotIntervalMsForDevice(deviceId: string): number {
+    const probe: DeviceDataPush = {
+      message: {
+        type: "screenshot_update",
+        deviceId,
+      },
+      targetDeviceId: deviceId,
+    };
+    let fastestIntervalMs: number | null = null;
+
+    for (const subscriber of this.subscribers.values()) {
+      if (subscriber.backfilling || subscriber.socket.destroyed) {
+        continue;
+      }
+
+      if (!this.matchesFilter(subscriber.filter, probe)) {
+        continue;
+      }
+
+      const requestedIntervalMs = subscriber.filter.screenshotIntervalMs ?? DEFAULT_SCREENSHOT_INTERVAL_MS;
+
+      fastestIntervalMs = fastestIntervalMs === null
+        ? requestedIntervalMs
+        : Math.min(fastestIntervalMs, requestedIntervalMs);
+    }
+
+    return fastestIntervalMs ?? DEFAULT_SCREENSHOT_INTERVAL_MS;
+  }
+
+  /**
    * Notify subscribers that the underlying device control connection was lost.
    */
   onDeviceConnectionLost(deviceId: string): void {
@@ -398,6 +448,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       // Let base class handle the subscription
       await super.processLine(socket, line);
 
+      this.notifyScreenshotCadenceChanged(request.deviceId ?? null);
+
       // Trigger the callback if set
       if (this.onSubscriberConnected) {
         try {
@@ -409,13 +461,47 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       return;
     }
 
+    if (request.command === "unsubscribe") {
+      const filter = this.findFilterForSocket(socket);
+      await super.processLine(socket, line);
+      if (filter) {
+        this.notifyScreenshotCadenceChanged(filter.deviceId);
+      }
+      return;
+    }
+
     // Delegate to base class for standard commands (subscribe, unsubscribe, pong)
     await super.processLine(socket, line);
+  }
+
+  protected onConnectionClose(socket: Socket): void {
+    const filter = this.findFilterForSocket(socket);
+    super.onConnectionClose(socket);
+    if (filter) {
+      this.notifyScreenshotCadenceChanged(filter.deviceId);
+    }
+  }
+
+  protected onConnectionError(socket: Socket, error: Error): void {
+    const filter = this.findFilterForSocket(socket);
+    super.onConnectionError(socket, error);
+    if (filter) {
+      this.notifyScreenshotCadenceChanged(filter.deviceId);
+    }
+  }
+
+  protected checkKeepalive(): void {
+    const subscriberCountBefore = this.subscribers.size;
+    super.checkKeepalive();
+    if (this.subscribers.size !== subscriberCountBefore) {
+      this.notifyScreenshotCadenceChanged(null);
+    }
   }
 
   protected parseSubscriptionFilter(request: Record<string, unknown>): DeviceDataFilter {
     return {
       deviceId: (request.deviceId as string) ?? null,
+      screenshotIntervalMs: this.parseScreenshotIntervalMs(request.screenshotIntervalMs),
     };
   }
 
@@ -430,6 +516,42 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
   protected createPushMessage(data: DeviceDataPush): DeviceDataStreamMessage {
     return data.message;
+  }
+
+  private parseScreenshotIntervalMs(value: unknown): number | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+      return null;
+    }
+
+    return Math.min(
+      Math.max(Math.round(value), MIN_SCREENSHOT_INTERVAL_MS),
+      MAX_SCREENSHOT_INTERVAL_MS
+    );
+  }
+
+  private findFilterForSocket(socket: Socket): DeviceDataFilter | null {
+    for (const subscriber of this.subscribers.values()) {
+      if (subscriber.socket === socket) {
+        return subscriber.filter;
+      }
+    }
+    return null;
+  }
+
+  private notifyScreenshotCadenceChanged(deviceId: string | null): void {
+    if (!this.onScreenshotCadenceChanged) {
+      return;
+    }
+
+    try {
+      this.onScreenshotCadenceChanged(deviceId);
+    } catch (error) {
+      logger.warn(`[DeviceDataStream] Error in onScreenshotCadenceChanged callback: ${error}`);
+    }
   }
 
   private async handleObservationRequest(

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -59,6 +59,11 @@ export interface ScreenshotBackoffScheduler {
    * Get the number of pending captures remaining in the current sequence.
    */
   getPendingCount(): number;
+
+  /**
+   * Recompute the pending keepalive timeout using the current cadence.
+   */
+  rescheduleKeepAlive(): void;
 }
 
 /**
@@ -77,7 +82,15 @@ interface ScreenshotBackoffConfig {
    * Default: 3000
    */
   keepAliveIntervalMs?: number | null;
+
+  /**
+   * Optional dynamic keepalive interval provider. When set, this is evaluated
+   * each time the next keepalive capture is scheduled.
+   */
+  getKeepAliveIntervalMs?: () => number | null | undefined;
 }
+
+type ScreenshotBackoffConfigInput = Partial<ScreenshotBackoffConfig>;
 
 const DEFAULT_CONFIG: ScreenshotBackoffConfig = {
   intervals: [0, 100, 300, 500, 800, 1300],
@@ -109,7 +122,7 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
   constructor(
     captureCallback: ScreenshotCaptureCallback,
     emitCallback: ScreenshotEmitCallback,
-    config: ScreenshotBackoffConfig = DEFAULT_CONFIG,
+    config: ScreenshotBackoffConfigInput = DEFAULT_CONFIG,
     timer: Timer = defaultTimer,
     shouldKeepAlive: ScreenshotKeepAlivePredicate = () => true
   ) {
@@ -164,6 +177,17 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
 
   getPendingCount(): number {
     return this.pendingTimeouts.length;
+  }
+
+  rescheduleKeepAlive(): void {
+    if (!this.keepAliveTimeout) {
+      this.scheduleKeepAliveIfIdle(this.sequenceId);
+      return;
+    }
+
+    this.timer.clearTimeout(this.keepAliveTimeout);
+    this.keepAliveTimeout = null;
+    this.scheduleKeepAliveIfIdle(this.sequenceId);
   }
 
   /**
@@ -260,7 +284,7 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
       return;
     }
 
-    const keepAliveIntervalMs = this.config.keepAliveIntervalMs;
+    const keepAliveIntervalMs = this.config.getKeepAliveIntervalMs?.() ?? this.config.keepAliveIntervalMs;
     if (keepAliveIntervalMs === null || keepAliveIntervalMs === undefined || keepAliveIntervalMs <= 0) {
       return;
     }
@@ -283,6 +307,7 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
 export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffScheduler {
   public startBackoffSequenceCalls: number = 0;
   public cancelPendingCapturesCalls: number = 0;
+  public rescheduleKeepAliveCalls: number = 0;
   private _isActive: boolean = false;
   private _pendingCount: number = 0;
 
@@ -306,6 +331,10 @@ export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffSchedule
     return this._pendingCount;
   }
 
+  rescheduleKeepAlive(): void {
+    this.rescheduleKeepAliveCalls++;
+  }
+
   // Test helpers
   setActive(active: boolean): void {
     this._isActive = active;
@@ -318,6 +347,7 @@ export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffSchedule
   reset(): void {
     this.startBackoffSequenceCalls = 0;
     this.cancelPendingCapturesCalls = 0;
+    this.rescheduleKeepAliveCalls = 0;
     this._isActive = false;
     this._pendingCount = 0;
   }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -956,6 +956,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     return AndroidCtrlProxyClient.instances.get(deviceId)!;
   }
 
+  public static getExistingInstance(deviceId: string): AndroidCtrlProxyClient | null {
+    return AndroidCtrlProxyClient.instances.get(deviceId) ?? null;
+  }
+
   /**
    * Bind this client to a session for multi-agent NavigationGraphManager isolation.
    * Called when a tool execution context binds a session to this device.
@@ -1989,6 +1993,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
+  refreshObservationStreamScreenshotCadence(): void {
+    this.screenshotBackoffScheduler?.rescheduleKeepAlive();
+  }
+
   // ===========================================================================
   // Connection Management
   // ===========================================================================
@@ -2765,7 +2773,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         (data: string) => {
           this.pushScreenshotToObservationStream(data);
         },
-        { intervals: [0, 100, 300, 500, 800, 1300], keepAliveIntervalMs: 3000 },
+        {
+          intervals: [0, 100, 300, 500, 800, 1300],
+          keepAliveIntervalMs: 3000,
+          getKeepAliveIntervalMs: () => {
+            const server = getDeviceDataStreamServer();
+            return server?.getScreenshotIntervalMsForDevice(this.device.deviceId) ?? 3000;
+          },
+        },
         this.timer,
         () => {
           const server = getDeviceDataStreamServer();

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1564,7 +1564,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
           const screenHeight = this.cachedScreenDimensions?.height ?? 2532;
           this.pushScreenshotToObservationStream(data, screenWidth, screenHeight);
         },
-        undefined, // Use default config
+        {
+          getKeepAliveIntervalMs: () => {
+            const server = getDeviceDataStreamServer();
+            return server?.getScreenshotIntervalMsForDevice(this.device.deviceId) ?? 3000;
+          },
+        },
         this.timer,
         () => {
           const server = getDeviceDataStreamServer();
@@ -1614,6 +1619,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     if (this.screenshotBackoffScheduler) {
       this.screenshotBackoffScheduler.cancelPendingCaptures();
     }
+  }
+
+  refreshObservationStreamScreenshotCadence(): void {
+    this.screenshotBackoffScheduler?.rescheduleKeepAlive();
   }
 
   // ===========================================================================

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -29,6 +29,7 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
 
   simulateSubscription(options: {
     deviceId?: string;
+    screenshotIntervalMs?: number | null;
   }): { socket: FakeSocket; subscriptionId: string } {
     const socket = new FakeSocket();
     const subscriptionId = `devicedatastream-${++(this as any).subscriptionCounter}`;
@@ -39,6 +40,7 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
       lastActivity: timer.now(),
       filter: {
         deviceId: options.deviceId ?? null,
+        screenshotIntervalMs: options.screenshotIntervalMs ?? null,
       },
       backfilling: false,
       drainPending: false,
@@ -48,6 +50,10 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
 
   async processLineForTest(socket: FakeSocket, line: string): Promise<void> {
     await this.processLine(socket as unknown as Socket, line);
+  }
+
+  closeConnectionForTest(socket: FakeSocket): void {
+    this.onConnectionClose(socket as unknown as Socket);
   }
 }
 
@@ -474,6 +480,152 @@ describe("DeviceDataStreamSocketServer", () => {
       socket.destroy();
 
       expect(server.hasSubscriberForDevice("device-1")).toBe(false);
+    });
+  });
+
+  describe("screenshot cadence aggregation", () => {
+    it("uses the default screenshot keepalive cadence when subscribers omit cadence", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+    });
+
+    it("parses requested screenshot cadence from subscribe commands", async () => {
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub-fast",
+        command: "subscribe",
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      }));
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
+    });
+
+    it("clamps requested screenshot cadence to the safe minimum", async () => {
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub-clamped",
+        command: "subscribe",
+        deviceId: "device-1",
+        screenshotIntervalMs: 50,
+      }));
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(250);
+    });
+
+    it("clamps requested screenshot cadence to the maximum timer delay", async () => {
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub-max-clamped",
+        command: "subscribe",
+        deviceId: "device-1",
+        screenshotIntervalMs: 3_000_000_000,
+      }));
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(2_147_483_647);
+    });
+
+    it("uses the fastest active requested cadence for a device", () => {
+      server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 1000 });
+      server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+      server.simulateSubscription({ deviceId: "device-2", screenshotIntervalMs: 250 });
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
+    });
+
+    it("keeps default cadence when another subscriber requests a slower cadence", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+      server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 10_000 });
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+    });
+
+    it("applies all-device subscriber cadence to each device", () => {
+      server.simulateSubscription({ screenshotIntervalMs: 750 });
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(750);
+      expect(server.getScreenshotIntervalMsForDevice("device-2")).toBe(750);
+    });
+
+    it("removes requested cadence after unsubscribe", async () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "unsub-fast",
+        command: "unsubscribe",
+      }));
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+    });
+
+    it("ignores destroyed subscriber sockets when aggregating cadence", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+      socket.destroy();
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+    });
+
+    it("notifies when subscribe changes screenshot cadence", async () => {
+      const changedDevices: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged(deviceId => {
+        changedDevices.push(deviceId);
+      });
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub-fast",
+        command: "subscribe",
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      }));
+
+      expect(changedDevices).toEqual(["device-1"]);
+    });
+
+    it("notifies when unsubscribe removes screenshot cadence", async () => {
+      const changedDevices: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged(deviceId => {
+        changedDevices.push(deviceId);
+      });
+      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "unsub-fast",
+        command: "unsubscribe",
+      }));
+
+      expect(changedDevices).toEqual(["device-1"]);
+    });
+
+    it("does not notify when unsubscribe has no active subscription", async () => {
+      const changedDevices: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged(deviceId => {
+        changedDevices.push(deviceId);
+      });
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "unsub-missing",
+        command: "unsubscribe",
+      }));
+
+      expect(changedDevices).toEqual([]);
+    });
+
+    it("notifies when connection close removes screenshot cadence", () => {
+      const changedDevices: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged(deviceId => {
+        changedDevices.push(deviceId);
+      });
+      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+
+      server.closeConnectionForTest(socket);
+
+      expect(changedDevices).toEqual(["device-1"]);
     });
   });
 

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -232,6 +232,70 @@ describe("DefaultScreenshotBackoffScheduler", () => {
 
       expect(capturedScreenshots).toHaveLength(3);
     });
+
+    it("uses dynamic keepalive interval when provided", async () => {
+      let keepAliveIntervalMs = 500;
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        captureCallback,
+        emitCallback,
+        { intervals: [0], keepAliveIntervalMs: 1000, getKeepAliveIntervalMs: () => keepAliveIntervalMs },
+        fakeTimer
+      );
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+
+      expect(fakeTimer.getPendingTimeouts()).toEqual([500]);
+
+      keepAliveIntervalMs = 250;
+      await fakeTimer.advanceTimersByTimeAsync(500);
+
+      expect(capturedScreenshots).toHaveLength(2);
+      expect(fakeTimer.getPendingTimeouts()).toEqual([250]);
+    });
+
+    it("reschedules a pending keepalive when cadence changes", async () => {
+      let keepAliveIntervalMs = 3000;
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        captureCallback,
+        emitCallback,
+        { intervals: [0], getKeepAliveIntervalMs: () => keepAliveIntervalMs },
+        fakeTimer
+      );
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+
+      expect(fakeTimer.getPendingTimeouts()).toEqual([3000]);
+
+      keepAliveIntervalMs = 250;
+      scheduler.rescheduleKeepAlive();
+
+      expect(fakeTimer.getPendingTimeouts()).toEqual([250]);
+      await fakeTimer.advanceTimersByTimeAsync(250);
+
+      expect(capturedScreenshots).toHaveLength(2);
+    });
+
+    it("starts keepalive when cadence changes without a pending keepalive", async () => {
+      const keepAliveIntervalMs = 250;
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        captureCallback,
+        emitCallback,
+        { intervals: [0], getKeepAliveIntervalMs: () => keepAliveIntervalMs },
+        fakeTimer,
+        () => true
+      );
+
+      expect(fakeTimer.getPendingTimeouts()).toEqual([]);
+
+      scheduler.rescheduleKeepAlive();
+
+      expect(fakeTimer.getPendingTimeouts()).toEqual([250]);
+      await fakeTimer.advanceTimersByTimeAsync(250);
+
+      expect(capturedScreenshots).toHaveLength(1);
+    });
   });
 
   describe("duplicate detection", () => {
@@ -498,6 +562,9 @@ describe("FakeScreenshotBackoffScheduler", () => {
     fake.cancelPendingCaptures();
     expect(fake.cancelPendingCapturesCalls).toBe(1);
     expect(fake.isActive()).toBe(false);
+
+    fake.rescheduleKeepAlive();
+    expect(fake.rescheduleKeepAliveCalls).toBe(1);
   });
 
   it("allows setting state for test scenarios", () => {

--- a/test/features/observe/android/CtrlProxyPackages.test.ts
+++ b/test/features/observe/android/CtrlProxyPackages.test.ts
@@ -113,6 +113,17 @@ describe("CtrlProxyPackages (Android)", function() {
 
       expect(scheduler.cancelPendingCapturesCalls).toBe(1);
     });
+
+    test("refreshes screenshot cadence by rescheduling keepalive", function() {
+      const { factory } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      const scheduler = new FakeScreenshotBackoffScheduler();
+
+      (client as any).screenshotBackoffScheduler = scheduler;
+      client.refreshObservationStreamScreenshotCadence();
+
+      expect(scheduler.rescheduleKeepAliveCalls).toBe(1);
+    });
   });
 
   describe("requestInstalledPackages", function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -132,6 +132,15 @@ describe("IOSCtrlProxyClient", function() {
       expect(scheduler.cancelPendingCapturesCalls).toBe(1);
     });
 
+    test("refreshes screenshot cadence by rescheduling keepalive", function() {
+      const scheduler = new FakeScreenshotBackoffScheduler();
+
+      (ctrlProxyClient as any).screenshotBackoffScheduler = scheduler;
+      ctrlProxyClient.refreshObservationStreamScreenshotCadence();
+
+      expect(scheduler.rescheduleKeepAliveCalls).toBe(1);
+    });
+
     test("notifies the observation stream when the WebSocket connection closes", function() {
       const lostDeviceIds: string[] = [];
       const notifier: DeviceConnectionLostNotifier = {


### PR DESCRIPTION
## Summary

Adds configurable live screenshot cadence for device data stream subscribers. Stream clients can now pass `screenshotIntervalMs` on `subscribe`; the daemon clamps requests to a safe 250ms minimum, aggregates the fastest active request per device, and returns to the default 3000ms keepalive cadence when fast subscribers unsubscribe or disconnect.

Android and iOS screenshot backoff schedulers now resolve keepalive cadence dynamically from active stream subscriptions while preserving existing burst timing and default behavior for subscribers that do not request cadence.

## Linked Issue

Closes #3333

## Validation

- [x] `bun test test/daemon/deviceDataStreamSocketServer.test.ts test/features/observe/ScreenshotBackoffScheduler.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `git diff --check`
- [x] New code uses fakes + FakeTimer; focused unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`

## Follow-ups

- [ ] Optional hierarchy cadence support remains out of scope for this PR.
