### PR TITLE
Add observation diff metadata

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7170,6 +7170,223 @@
           },
           "additionalProperties": {}
         },
+        "observationDiff": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "diff",
+                "full"
+              ]
+            },
+            "reason": {
+              "type": "string",
+              "enum": [
+                "diff_emitted",
+                "missing_baseline",
+                "screen_changed",
+                "missing_session",
+                "unrenderable_hierarchy",
+                "disabled",
+                "stripped_by_actions_no_observe"
+              ]
+            },
+            "fromScreen": {
+              "type": "object",
+              "properties": {
+                "activeWindow": {
+                  "type": "object",
+                  "properties": {
+                    "appId": {
+                      "type": "string"
+                    },
+                    "activityName": {
+                      "type": "string"
+                    },
+                    "layoutSeqSum": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": {}
+                },
+                "hierarchyPackageName": {
+                  "type": "string"
+                },
+                "screenIdentity": {
+                  "type": "object",
+                  "properties": {
+                    "platform": {
+                      "type": "string",
+                      "enum": [
+                        "ios",
+                        "android"
+                      ]
+                    },
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "heuristic",
+                        "sdk"
+                      ]
+                    },
+                    "confidence": {
+                      "type": "string",
+                      "enum": [
+                        "high",
+                        "medium",
+                        "low"
+                      ]
+                    },
+                    "key": {
+                      "type": "string"
+                    },
+                    "components": {
+                      "type": "object",
+                      "properties": {
+                        "bundleId": {
+                          "type": "string"
+                        },
+                        "navigationTitle": {
+                          "type": "string"
+                        },
+                        "selectedTab": {
+                          "type": "string"
+                        },
+                        "modalClass": {
+                          "type": "string"
+                        },
+                        "modalTitle": {
+                          "type": "string"
+                        },
+                        "focusedElementId": {
+                          "type": "string"
+                        },
+                        "keyboardVisible": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "platform",
+                    "source",
+                    "confidence",
+                    "key",
+                    "components"
+                  ],
+                  "additionalProperties": {}
+                }
+              },
+              "additionalProperties": {}
+            },
+            "toScreen": {
+              "type": "object",
+              "properties": {
+                "activeWindow": {
+                  "type": "object",
+                  "properties": {
+                    "appId": {
+                      "type": "string"
+                    },
+                    "activityName": {
+                      "type": "string"
+                    },
+                    "layoutSeqSum": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": {}
+                },
+                "hierarchyPackageName": {
+                  "type": "string"
+                },
+                "screenIdentity": {
+                  "type": "object",
+                  "properties": {
+                    "platform": {
+                      "type": "string",
+                      "enum": [
+                        "ios",
+                        "android"
+                      ]
+                    },
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "heuristic",
+                        "sdk"
+                      ]
+                    },
+                    "confidence": {
+                      "type": "string",
+                      "enum": [
+                        "high",
+                        "medium",
+                        "low"
+                      ]
+                    },
+                    "key": {
+                      "type": "string"
+                    },
+                    "components": {
+                      "type": "object",
+                      "properties": {
+                        "bundleId": {
+                          "type": "string"
+                        },
+                        "navigationTitle": {
+                          "type": "string"
+                        },
+                        "selectedTab": {
+                          "type": "string"
+                        },
+                        "modalClass": {
+                          "type": "string"
+                        },
+                        "modalTitle": {
+                          "type": "string"
+                        },
+                        "focusedElementId": {
+                          "type": "string"
+                        },
+                        "keyboardVisible": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "platform",
+                    "source",
+                    "confidence",
+                    "key",
+                    "components"
+                  ],
+                  "additionalProperties": {}
+                }
+              },
+              "additionalProperties": {}
+            }
+          },
+          "required": [
+            "mode",
+            "reason"
+          ],
+          "additionalProperties": {}
+        },
         "selectedElement": {
           "type": "object",
           "properties": {

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -46,6 +46,29 @@ export interface FinalizeToolResponseContext {
   internal?: boolean;
 }
 
+type ObservationDiffMode = "diff" | "full";
+type ObservationDiffReason =
+  | "diff_emitted"
+  | "missing_baseline"
+  | "screen_changed"
+  | "missing_session"
+  | "unrenderable_hierarchy"
+  | "disabled"
+  | "stripped_by_actions_no_observe";
+
+interface ObservationDiffScreenIdentity {
+  activeWindow?: ObserveResult["activeWindow"];
+  hierarchyPackageName?: string;
+  screenIdentity?: ObserveResult["screenIdentity"];
+}
+
+interface ObservationDiffMetadata {
+  mode: ObservationDiffMode;
+  reason: ObservationDiffReason;
+  fromScreen?: ObservationDiffScreenIdentity;
+  toScreen?: ObservationDiffScreenIdentity;
+}
+
 /**
  * Single post-handler serialization hook (issue #2758). Handlers pre-serialize
  * via `createStructuredToolResponse` into an MCP envelope
@@ -133,19 +156,61 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
       // own success detection). Wins over the diff flag: nothing left to diff.
       const stripped = { ...payload };
       delete stripped.observation;
+      stripped.observationDiff = {
+        mode: "full",
+        reason: "stripped_by_actions_no_observe",
+      } satisfies ObservationDiffMetadata;
       sanitizedPayload = stripped;
     } else if (isObserveResult(payload.observation)) {
       const sanitized = sanitizeObserveResult(payload.observation as ObserveResult, cfg);
       let observationOut: unknown = sanitized;
-      if (canDiff && hasRenderableHierarchy(sanitized)) {
+      let observationDiff: ObservationDiffMetadata | undefined;
+      if (ctx.internal) {
+        // Internal envelopes are consumed by in-process tool callers, not agents.
+        // Keep them on the pre-diff/pre-strip shape without agent-facing metadata.
+      } else if (!diffActive) {
+        observationDiff = { mode: "full", reason: "disabled" };
+      } else if (!ctx.sessionUuid || !ctx.baselineStore) {
+        observationDiff = { mode: "full", reason: "missing_session", toScreen: observationScreenIdentity(sanitized) };
+      } else if (!hasRenderableHierarchy(sanitized)) {
+        const baseline = ctx.baselineStore.get(ctx.sessionUuid);
+        observationDiff = {
+          mode: "full",
+          reason: "unrenderable_hierarchy",
+          fromScreen: baseline ? observationScreenIdentity(baseline) : undefined,
+          toScreen: observationScreenIdentity(sanitized),
+        };
+      } else if (canDiff) {
         // Emit a diff vs the baseline when it exists and the screen is unchanged;
         // otherwise fall back to the full observation (cross-screen diffs are
         // meaningless, and there is nothing to diff on the first action). Either
         // way, update the baseline to this observation so the next action diffs
         // against current state.
         const baseline = ctx.baselineStore!.get(ctx.sessionUuid!);
-        if (baseline && hasRenderableHierarchy(baseline) && isSameObservationScreen(baseline, sanitized)) {
+        if (!baseline) {
+          observationDiff = { mode: "full", reason: "missing_baseline", toScreen: observationScreenIdentity(sanitized) };
+        } else if (!hasRenderableHierarchy(baseline)) {
+          observationDiff = {
+            mode: "full",
+            reason: "unrenderable_hierarchy",
+            fromScreen: observationScreenIdentity(baseline),
+            toScreen: observationScreenIdentity(sanitized),
+          };
+        } else if (isSameObservationScreen(baseline, sanitized)) {
           observationOut = diffObserveResult(baseline, sanitized);
+          observationDiff = {
+            mode: "diff",
+            reason: "diff_emitted",
+            fromScreen: observationScreenIdentity(baseline),
+            toScreen: observationScreenIdentity(sanitized),
+          };
+        } else {
+          observationDiff = {
+            mode: "full",
+            reason: "screen_changed",
+            fromScreen: observationScreenIdentity(baseline),
+            toScreen: observationScreenIdentity(sanitized),
+          };
         }
         ctx.baselineStore!.set(ctx.sessionUuid!, sanitized);
       }
@@ -153,6 +218,9 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         ...payload,
         observation: observationOut,
       };
+      if (observationDiff) {
+        sanitizedPayload.observationDiff = observationDiff;
+      }
     }
   }
 
@@ -204,4 +272,18 @@ function isObserveResult(value: unknown): value is ObserveResult {
 
 function hasRenderableHierarchy(observation: ObserveResult): boolean {
   return !!observation.viewHierarchy?.hierarchy;
+}
+
+function observationScreenIdentity(observation: ObserveResult): ObservationDiffScreenIdentity {
+  const identity: ObservationDiffScreenIdentity = {};
+  if (observation.activeWindow) {
+    identity.activeWindow = observation.activeWindow;
+  }
+  if (observation.viewHierarchy?.packageName) {
+    identity.hierarchyPackageName = observation.viewHierarchy.packageName;
+  }
+  if (observation.screenIdentity) {
+    identity.screenIdentity = observation.screenIdentity;
+  }
+  return identity;
 }

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -124,6 +124,27 @@ export const observationSummarySchema = z.object({
   screenIdentity: screenIdentitySchema.optional()
 }).passthrough();
 
+const observationDiffScreenIdentitySchema = z.object({
+  activeWindow: activeWindowSchema.optional(),
+  hierarchyPackageName: z.string().optional(),
+  screenIdentity: screenIdentitySchema.optional()
+}).passthrough();
+
+const observationDiffMetadataSchema = z.object({
+  mode: z.enum(["diff", "full"]),
+  reason: z.enum([
+    "diff_emitted",
+    "missing_baseline",
+    "screen_changed",
+    "missing_session",
+    "unrenderable_hierarchy",
+    "disabled",
+    "stripped_by_actions_no_observe"
+  ]),
+  fromScreen: observationDiffScreenIdentitySchema.optional(),
+  toScreen: observationDiffScreenIdentitySchema.optional()
+}).passthrough();
+
 const tapOnSearchUntilSchema = z.object({
   durationMs: z.number().int(),
   requestCount: z.number().int(),
@@ -136,6 +157,7 @@ export const tapOnResultSchema = z.object({
   message: z.string().optional(),
   element: elementSchema.optional(),
   observation: observationSummarySchema.optional(),
+  observationDiff: observationDiffMetadataSchema.optional(),
   selectedElement: selectedElementSchema.optional(),
   selectedElements: z.array(selectedElementSchema).optional(),
   error: z.string().optional(),

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -450,6 +450,17 @@ describe("finalizeToolResponse", () => {
       };
     }
 
+    function expectObservationDiff(
+      finalized: { structuredContent?: unknown; content: Array<{ text: string }> },
+      expected: Record<string, unknown>
+    ): any {
+      const metadata = (finalized.structuredContent as any).observationDiff;
+      expect(metadata).toMatchObject(expected);
+      const parsed = JSON.parse(finalized.content[0].text);
+      expect(parsed.observationDiff).toEqual(metadata);
+      return metadata;
+    }
+
     function iosScreenObserve(
       key: string,
       confidence: "high" | "medium" | "low" = "high"
@@ -492,6 +503,7 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "disabled" });
       expect(map.size).toBe(0);
     });
 
@@ -530,6 +542,7 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.changed).toHaveLength(1);
       expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
       expect((finalized.structuredContent as any).success).toBe(true);
+      expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
 
       // Text mirrors the diffed structuredContent exactly.
       const parsed = JSON.parse(finalized.content[0].text);
@@ -564,6 +577,8 @@ describe("finalizeToolResponse", () => {
       const secondObs = (second.structuredContent as any).observation;
       expect(firstObs.isDiff).toBeUndefined();
       expect(secondObs.isDiff).toBeUndefined();
+      expectObservationDiff(first, { mode: "full", reason: "unrenderable_hierarchy" });
+      expectObservationDiff(second, { mode: "full", reason: "unrenderable_hierarchy" });
       expect(firstObs.errors[0].message).toBe("service unavailable");
       expect(secondObs.errors[0].message).toBe("service unavailable");
       expect(firstObs.perfTiming).toBeUndefined();
@@ -572,6 +587,30 @@ describe("finalizeToolResponse", () => {
       expect(map.get("s1")!.viewHierarchy).toBeDefined();
       expect(first.content[0].text).toBe(stringifyToolResponse(first.structuredContent));
       expect(second.content[0].text).toBe(stringifyToolResponse(second.structuredContent));
+    });
+
+    test("falls back to full when the stored baseline has no renderable hierarchy", () => {
+      const { store, map } = makeStore();
+      map.set("s1", {
+        updatedAt: 1,
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        activeWindow: { appId: "com.example", activityName: ".Main", layoutSeqSum: 1 },
+        viewHierarchy: { packageName: "com.example" } as any,
+      } as ObserveResult);
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: sameScreenObserve() }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      const metadata = expectObservationDiff(finalized, { mode: "full", reason: "unrenderable_hierarchy" });
+      expect(metadata.fromScreen.activeWindow.appId).toBe("com.example");
+      expect(metadata.toScreen.activeWindow.appId).toBe("com.example");
+      expect(map.get("s1")!.viewHierarchy?.hierarchy).toBeDefined();
     });
 
     test("a non-observe action updates the baseline to its own observation (next diff is against current state)", () => {
@@ -596,8 +635,20 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "missing_baseline" });
       // Baseline is now seeded for the next action.
       expect(map.get("s1")).toBeDefined();
+    });
+
+    test("falls back to the full observation when the session baseline store is missing", () => {
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: sameScreenObserve() }),
+        { name: "tapOn", sessionUuid: "s1" }
+      );
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "missing_session" });
     });
 
     test("falls back to full when the screen (app/activity/package) changed", () => {
@@ -615,6 +666,9 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
+      const metadata = expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+      expect(metadata.fromScreen.activeWindow.appId).toBe("com.example");
+      expect(metadata.toScreen.activeWindow.appId).toBe("com.other");
     });
 
     test("falls back to full when an iOS screen identity changes under the same app", () => {
@@ -634,6 +688,9 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
       expect(obsSc.screenIdentity.key).toBe("bundle=com.apple.reminders|nav=New Reminder");
+      const metadata = expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+      expect(metadata.fromScreen.screenIdentity.key).toBe("bundle=com.apple.reminders|nav=Reminders");
+      expect(metadata.toScreen.screenIdentity.key).toBe("bundle=com.apple.reminders|nav=New Reminder");
     });
 
     test("emits a diff when high-confidence iOS screen identity stays stable", () => {
@@ -652,6 +709,7 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc.isDiff).toBe(true);
       expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
+      expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
     });
 
     test("preserves app/activity/package fallback when only one iOS identity is present", () => {
@@ -698,6 +756,7 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
       expect(obsSc.screenIdentity.key).toBe("bundle=com.apple.reminders|tab=Search");
+      expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
     });
 
     test("falls back to full and updates baseline when iOS screen identity is low confidence", () => {
@@ -716,6 +775,7 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
       expect((map.get("s1")!.viewHierarchy!.hierarchy.node as any).node[0].checked).toBe("true");
     });
 
@@ -728,6 +788,7 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc.isDiff).toBeUndefined();
       expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "missing_session" });
       expect(map.size).toBe(0);
     });
 
@@ -783,6 +844,7 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.isDiff).toBe(true);
       expect(obsSc.added).toHaveLength(1);
       expect(obsSc.added[0].attributes.bounds).toEqual([5, 6, 7, 8]);
+      expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
     });
   });
 
@@ -811,9 +873,14 @@ describe("finalizeToolResponse", () => {
       const finalized = finalizeToolResponse(response, { name: "tapOn", sessionUuid: "s1" });
 
       expect((finalized.structuredContent as any).observation).toBeUndefined();
+      expect((finalized.structuredContent as any).observationDiff).toEqual({
+        mode: "full",
+        reason: "stripped_by_actions_no_observe",
+      });
       expect((finalized.structuredContent as any).success).toBe(true);
       const parsed = JSON.parse(finalized.content[0].text);
       expect(parsed.observation).toBeUndefined();
+      expect(parsed.observationDiff).toEqual((finalized.structuredContent as any).observationDiff);
       expect(parsed.success).toBe(true);
       expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
     });
@@ -846,6 +913,10 @@ describe("finalizeToolResponse", () => {
       );
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc).toBeUndefined(); // stripped, not a diff
+      expect((finalized.structuredContent as any).observationDiff).toEqual({
+        mode: "full",
+        reason: "stripped_by_actions_no_observe",
+      });
       // Diff moot → baseline never touched.
       expect(map.size).toBe(0);
     });
@@ -914,6 +985,7 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc.isDiff).toBeUndefined(); // full observation, not a diff
       expect(obsSc.viewHierarchy).toBeDefined();
+      expect((finalized.structuredContent as any).observationDiff).toBeUndefined();
       // A future internal consumer can still read the hierarchy off the envelope.
       expect(obsSc.viewHierarchy.hierarchy.node["resource-id"]).toBe("com.example:id/root");
     });
@@ -946,6 +1018,7 @@ describe("finalizeToolResponse", () => {
       const obsSc = (finalized.structuredContent as any).observation;
       expect(obsSc).toBeDefined();
       expect(obsSc.viewHierarchy).toBeDefined();
+      expect((finalized.structuredContent as any).observationDiff).toBeUndefined();
     });
 
     test("EC2.2: internal call still sanitizes the observation (view-id dedup applies)", () => {

--- a/test/server/stripToolResultWireBoundary.test.ts
+++ b/test/server/stripToolResultWireBoundary.test.ts
@@ -21,7 +21,23 @@ describe("CallTool wire boundary strips structuredContent (issue #2899)", () => 
   const TOOL = "__strip_probe_2899__";
 
   beforeAll(async () => {
-    ToolRegistry.register(TOOL, "probe tool for structuredContent strip", z.object({}).passthrough(), async () => createStructuredToolResponse({ success: true, marker: "probe" }), { outputSchema: z.object({ success: z.boolean(), marker: z.string() }) });
+    ToolRegistry.register(
+      TOOL,
+      "probe tool for structuredContent strip",
+      z.object({}).passthrough(),
+      async () => createStructuredToolResponse({
+        success: true,
+        marker: "probe",
+        observationDiff: { mode: "full", reason: "screen_changed" },
+      }),
+      {
+        outputSchema: z.object({
+          success: z.boolean(),
+          marker: z.string(),
+          observationDiff: z.object({ mode: z.string(), reason: z.string() }),
+        }),
+      }
+    );
     fixture = new McpTestFixture();
     await fixture.setup();
   });
@@ -57,7 +73,9 @@ describe("CallTool wire boundary strips structuredContent (issue #2899)", () => 
     const res: any = await client.callTool({ name: TOOL, arguments: {} });
     expect(res.structuredContent).toBeUndefined();
     // No data lost: the full payload is still recoverable from content[0].text.
-    expect(JSON.parse(res.content[0].text).marker).toBe("probe");
+    const payload = JSON.parse(res.content[0].text);
+    expect(payload.marker).toBe("probe");
+    expect(payload.observationDiff).toEqual({ mode: "full", reason: "screen_changed" });
   });
 });
 


### PR DESCRIPTION
## Summary

- add `observationDiff` metadata to action results finalized by `finalizeToolResponse`
- report diff/full mode with specific fallback reasons, including screen identity details for `screen_changed`
- advertise the new `tapOn` output field and regenerate `schemas/tool-definitions.json`

Closes #3316

## Validation

- `bun test test/server/finalizeToolResponse.test.ts test/server/stripToolResultWireBoundary.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`

No PR template file was present in this worktree.
