### PR TITLE
test(ios): cover physical clearAppData launch path

### DIFF
--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1,6 +1,6 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { BaseVisualChange } from "./BaseVisualChange";
-import { BootedDevice, LaunchAppResult, ObserveResult } from "../../models";
+import { BootedDevice, ClearAppDataResult, LaunchAppResult, ObserveResult } from "../../models";
 import { ActionableError } from "../../models";
 import { TerminateApp } from "./TerminateApp";
 import { ClearAppData } from "./ClearAppData";
@@ -30,6 +30,10 @@ export interface InstalledAppsProvider {
   listInstalledApps(): Promise<string[]>;
 }
 
+export interface IosClearAppDataRunner {
+  execute(bundleId: string): Promise<ClearAppDataResult>;
+}
+
 /**
  * Launch an app on a physical iOS device via devicectl. Narrow injection point
  * so tests never shell out; parallels `DeviceAppUninstaller` in UninstallApp.
@@ -50,6 +54,7 @@ interface LaunchAppDependencies {
   installedAppsProvider?: InstalledAppsProvider;
   performanceTrackerFactory?: () => PerformanceTracker;
   deviceAppLauncher?: DeviceAppLauncher;
+  clearAppDataFactory?: (device: BootedDevice, simctl: SimCtlClient) => IosClearAppDataRunner;
 }
 
 export class LaunchApp extends BaseVisualChange {
@@ -59,6 +64,7 @@ export class LaunchApp extends BaseVisualChange {
   private targetUserDetector: TargetUserDetector;
   private installedAppsProvider: InstalledAppsProvider;
   private performanceTrackerFactory: () => PerformanceTracker;
+  private clearAppDataFactory: (device: BootedDevice, simctl: SimCtlClient) => IosClearAppDataRunner;
   /**
    * Create an LaunchApp instance
    * @param device - Optional device
@@ -83,6 +89,9 @@ export class LaunchApp extends BaseVisualChange {
       listInstalledApps: () => this.listInstalledApps()
     };
     this.performanceTrackerFactory = dependencies.performanceTrackerFactory ?? createGlobalPerformanceTracker;
+    this.clearAppDataFactory = dependencies.clearAppDataFactory ?? (
+      (device, simctl) => new ClearAppDataIos(device, simctl)
+    );
   }
 
   /**
@@ -320,7 +329,7 @@ export class LaunchApp extends BaseVisualChange {
           // we never want to wipe SpringBoard/Settings data.
           if (clearAppData && !isSystemBundleId) {
             const clearResult = await perf.track("clearAppData", () =>
-              new ClearAppDataIos(this.device, this.simctl).execute(bundleId)
+              this.clearAppDataFactory(this.device, this.simctl).execute(bundleId)
             );
             if (!clearResult.success) {
               // Do NOT launch with stale data — callers request clearAppData to

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -538,6 +538,7 @@ describe("LaunchApp", () => {
     function createDeviceHarness(opts: {
       deviceId: string;
       launchResult?: { success: boolean; pid?: number; error?: string };
+      clearResult?: { success: boolean; packageName: string; error?: string };
     }) {
       const iosDevice: BootedDevice = { name: "test-ios", platform: "ios", deviceId: opts.deviceId };
       const fakeCtrlProxy = new FakeIOSCtrlProxy();
@@ -557,6 +558,13 @@ describe("LaunchApp", () => {
       const deviceAppLauncher = new FakeDeviceAppLauncher(
         opts.launchResult ? { launchResult: opts.launchResult } : {}
       );
+      const clearCalls: string[] = [];
+      const clearAppDataFactory = () => ({
+        execute: async (id: string) => {
+          clearCalls.push(id);
+          return opts.clearResult ?? { success: true, packageName: id };
+        },
+      });
 
       const iosObserveScreen = new FakeObserveScreen();
       iosObserveScreen.setObserveResult({
@@ -572,13 +580,14 @@ describe("LaunchApp", () => {
       const iosLaunchApp = new LaunchApp(iosDevice, fakeAdb as unknown as any, fakeSimctl as any, fakeTimer, {
         installedAppsProvider: installedApps,
         deviceAppLauncher,
+        clearAppDataFactory,
       });
       (iosLaunchApp as any).awaitIdle = new FakeAwaitIdle();
       (iosLaunchApp as any).observeScreen = iosObserveScreen;
       (iosLaunchApp as any).window = iosWindow;
       (iosLaunchApp as any).waitForIosHierarchyReady = async () => {};
 
-      return { iosLaunchApp, deviceAppLauncher, simctlCalls, cleanup: () => { ctrlProxySpy.mockRestore(); managerSpy.mockRestore(); } };
+      return { iosLaunchApp, deviceAppLauncher, simctlCalls, clearCalls, cleanup: () => { ctrlProxySpy.mockRestore(); managerSpy.mockRestore(); } };
     }
 
     test("cold boot on a physical device launches via devicectl (not simctl) and propagates the PID", async () => {
@@ -644,6 +653,42 @@ describe("LaunchApp", () => {
         const result = await iosLaunchApp.execute(userBundleId, false, true);
         expect(result.success).toBe(false);
         expect(result.error).toContain("Application not found on device");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("clearAppData on a physical device clears via injected transport before devicectl relaunch", async () => {
+      fakeTimer.enableAutoAdvance();
+      const { iosLaunchApp, deviceAppLauncher, simctlCalls, clearCalls, cleanup } = createDeviceHarness({ deviceId: physicalUdid });
+      try {
+        const result = await iosLaunchApp.execute(userBundleId, /* clearAppData */ true, /* coldBoot */ false);
+        expect(result.success).toBe(true);
+        expect(clearCalls).toEqual([userBundleId]);
+        expect(deviceAppLauncher.launchCalls).toEqual([{
+          deviceUdid: physicalUdid,
+          bundleId: userBundleId,
+          terminateExisting: true,
+        }]);
+        expect(simctlCalls).toEqual([]);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("clearAppData failure on a physical device aborts without devicectl relaunch", async () => {
+      fakeTimer.enableAutoAdvance();
+      const { iosLaunchApp, deviceAppLauncher, simctlCalls, clearCalls, cleanup } = createDeviceHarness({
+        deviceId: physicalUdid,
+        clearResult: { success: false, packageName: userBundleId, error: "reinstall failed" },
+      });
+      try {
+        const result = await iosLaunchApp.execute(userBundleId, /* clearAppData */ true, /* coldBoot */ false);
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Failed to clear app data: reinstall failed");
+        expect(clearCalls).toEqual([userBundleId]);
+        expect(deviceAppLauncher.launchCalls).toHaveLength(0);
+        expect(simctlCalls).toEqual([]);
       } finally {
         cleanup();
       }


### PR DESCRIPTION
## Summary

Adds hermetic LaunchApp-level coverage for `clearAppData: true` on physical iOS devices by injecting the iOS clear-data runner. The default production path still constructs `ClearAppDataIos`, while tests can now prove physical-device clear failures and relaunch routing without shelling out to `devicectl`.

## Linked Issue

Closes #2884

## Bug / Regression Context

- **Prior attempts:** PR #2876 added physical-device launch coverage but left the `clearAppData` device path untested at the `LaunchApp` layer.
- **Observed symptom:** `LaunchApp.executeiOS` constructed `ClearAppDataIos` inline, so tests could not stub the reinstall transport.
- **Repro steps / conditions:** Run `LaunchApp.execute(bundleId, true, false)` against a physical-device UDID.

## Validation

- [x] `bun test test/features/action/LaunchApp.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: TypeScript-only hermetic unit coverage; no platform validation needed
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A. This is hermetic LaunchApp unit coverage for the physical-device transport path.

## Follow-ups

None.
