### PR TITLE
fix(observe): pair stable iOS text input diffs

### DIFF
--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -425,6 +425,11 @@ interface FlatObserveNode {
   /** This node's own local key (resource-id + bounds + text + sibling index), for display. */
   key: string;
   attributes: Record<string, unknown>;
+  ancestorClasses: readonly string[];
+}
+
+interface DiffRepairNode extends ObserveDiffNode {
+  ancestorClasses: readonly string[];
 }
 
 /**
@@ -476,6 +481,11 @@ function nodeAttributes(node: Record<string, unknown>): Record<string, unknown> 
   return attrs;
 }
 
+function classNameForDiff(node: Record<string, unknown>): string {
+  const className = node.className ?? node.class;
+  return typeof className === "string" ? className : "";
+}
+
 /**
  * Pre-order flatten of an observation's hierarchy into positionally-keyed nodes.
  * Each node's `pathKey` is its ancestor chain of local keys plus its own, so the
@@ -484,17 +494,24 @@ function nodeAttributes(node: Record<string, unknown>): Record<string, unknown> 
  */
 function flattenForDiff(obs: ObserveResult): FlatObserveNode[] {
   const out: FlatObserveNode[] = [];
-  const walk = (node: ViewHierarchyNode | undefined, siblingIndex: number, parentPath: string): void => {
+  const walk = (
+    node: ViewHierarchyNode | undefined,
+    siblingIndex: number,
+    parentPath: string,
+    ancestorClasses: readonly string[]
+  ): void => {
     if (!node || typeof node !== "object") {
       return;
     }
     const rec = node as unknown as Record<string, unknown>;
     const localKey = nodeKey(rec, siblingIndex);
     const pathKey = parentPath === "" ? localKey : `${parentPath}${PATH_KEY_SEP}${localKey}`;
-    out.push({ pathKey, key: localKey, attributes: nodeAttributes(rec) });
-    toNodeArray(node.node).forEach((child, index) => walk(child, index, pathKey));
+    out.push({ pathKey, key: localKey, attributes: nodeAttributes(rec), ancestorClasses });
+    const className = classNameForDiff(rec);
+    const childAncestorClasses = className === "" ? ancestorClasses : [...ancestorClasses, className];
+    toNodeArray(node.node).forEach((child, index) => walk(child, index, pathKey, childAncestorClasses));
   };
-  toNodeArray(obs.viewHierarchy?.hierarchy?.node).forEach((root, index) => walk(root, index, ""));
+  toNodeArray(obs.viewHierarchy?.hierarchy?.node).forEach((root, index) => walk(root, index, "", []));
   return out;
 }
 
@@ -690,10 +707,10 @@ function indexByContentKey(nodes: ObserveDiffNode[]): Map<string, number[]> {
  * no `changed` entry (a pure sibling-index move with no visible change).
  */
 function repairByContentIdentity(
-  added: ObserveDiffNode[],
-  removed: ObserveDiffNode[],
+  added: DiffRepairNode[],
+  removed: DiffRepairNode[],
   changed: ObserveDiffNodeChange[]
-): { added: ObserveDiffNode[]; removed: ObserveDiffNode[] } {
+): { added: DiffRepairNode[]; removed: DiffRepairNode[] } {
   const addedByKey = indexByContentKey(added);
   const removedByKey = indexByContentKey(removed);
   const consumedAdded = new Set<number>();
@@ -762,8 +779,18 @@ function isIosEditableClass(className: string): boolean {
 
 function isIosListCellClass(className: string): boolean {
   return className === "XCUIElementTypeCell"
+    || className === "UITableViewCell"
+    || className === "UICollectionViewCell"
     || className === "XCUIElementTypeTable"
     || className === "XCUIElementTypeCollectionView";
+}
+
+function hasIosListCellAncestor(node: DiffRepairNode): boolean {
+  return node.ancestorClasses.some(className => (
+    className === "XCUIElementTypeCell"
+      || className === "UITableViewCell"
+      || className === "UICollectionViewCell"
+  ));
 }
 
 /**
@@ -773,28 +800,31 @@ function isIosListCellClass(className: string): boolean {
  * text entry readable. Reused table/collection cell identifiers deliberately
  * opt out because a lone reused id can describe a different logical row.
  */
-function iosStableIdentityKey(attrs: Record<string, unknown>): string | null {
-  const className = stringAttr(attrs, "className") || stringAttr(attrs, "class");
+function iosStableIdentityKey(node: DiffRepairNode): string | null {
+  const className = stringAttr(node.attributes, "className") || stringAttr(node.attributes, "class");
+  if (hasIosListCellAncestor(node)) {
+    return null;
+  }
   if (isIosListCellClass(className) || !isIosEditableClass(className)) {
     return null;
   }
-  const stableId = stringAttr(attrs, "resource-id")
-    || stringAttr(attrs, "view-id")
-    || stringAttr(attrs, "accessibilityIdentifier");
+  const stableId = stringAttr(node.attributes, "resource-id")
+    || stringAttr(node.attributes, "view-id")
+    || stringAttr(node.attributes, "accessibilityIdentifier");
   if (stableId === "") {
     return null;
   }
-  const boundsRegion = quantizedBoundsKey(attrs.bounds);
+  const boundsRegion = quantizedBoundsKey(node.attributes.bounds);
   if (boundsRegion === "") {
     return null;
   }
   return [stableId, className, boundsRegion].join(" ");
 }
 
-function indexByIosStableKey(nodes: ObserveDiffNode[]): Map<string, number[]> {
+function indexByIosStableKey(nodes: DiffRepairNode[]): Map<string, number[]> {
   const byKey = new Map<string, number[]>();
   nodes.forEach((node, index) => {
-    const key = iosStableIdentityKey(node.attributes);
+    const key = iosStableIdentityKey(node);
     if (key === null) {
       return;
     }
@@ -809,10 +839,10 @@ function indexByIosStableKey(nodes: ObserveDiffNode[]): Map<string, number[]> {
 }
 
 function repairByIosStableIdentity(
-  added: ObserveDiffNode[],
-  removed: ObserveDiffNode[],
+  added: DiffRepairNode[],
+  removed: DiffRepairNode[],
   changed: ObserveDiffNodeChange[]
-): { added: ObserveDiffNode[]; removed: ObserveDiffNode[] } {
+): { added: DiffRepairNode[]; removed: DiffRepairNode[] } {
   const addedByKey = indexByIosStableKey(added);
   const removedByKey = indexByIosStableKey(removed);
   const consumedAdded = new Set<number>();
@@ -840,6 +870,10 @@ function repairByIosStableIdentity(
     added: added.filter((_, index) => !consumedAdded.has(index)),
     removed: removed.filter((_, index) => !consumedRemoved.has(index)),
   };
+}
+
+function toObserveDiffNode(node: DiffRepairNode): ObserveDiffNode {
+  return { key: node.key, attributes: node.attributes };
 }
 
 /** Group flattened nodes by their positional `pathKey`, preserving encounter order. */
@@ -907,8 +941,8 @@ export function diffObserveResult(
   const baseByKey = groupByKey(flattenForDiff(baseline));
   const nextByKey = groupByKey(flattenForDiff(next));
 
-  const added: ObserveDiffNode[] = [];
-  const removed: ObserveDiffNode[] = [];
+  const added: DiffRepairNode[] = [];
+  const removed: DiffRepairNode[] = [];
   const changed: ObserveDiffNodeChange[] = [];
 
   for (const pathKey of new Set([...baseByKey.keys(), ...nextByKey.keys()])) {
@@ -922,10 +956,18 @@ export function diffObserveResult(
       }
     }
     for (let i = paired; i < nextNodes.length; i++) {
-      added.push({ key: nextNodes[i].key, attributes: nextNodes[i].attributes });
+      added.push({
+        key: nextNodes[i].key,
+        attributes: nextNodes[i].attributes,
+        ancestorClasses: nextNodes[i].ancestorClasses,
+      });
     }
     for (let i = paired; i < baseNodes.length; i++) {
-      removed.push({ key: baseNodes[i].key, attributes: baseNodes[i].attributes });
+      removed.push({
+        key: baseNodes[i].key,
+        attributes: baseNodes[i].attributes,
+        ancestorClasses: baseNodes[i].ancestorClasses,
+      });
     }
   }
 
@@ -946,7 +988,12 @@ export function diffObserveResult(
     }
   }
 
-  const diff: ObserveDiff = { isDiff: true, added: finalAdded, removed: finalRemoved, changed };
+  const diff: ObserveDiff = {
+    isDiff: true,
+    added: finalAdded.map(toObserveDiffNode),
+    removed: finalRemoved.map(toObserveDiffNode),
+    changed,
+  };
 
   const scalarFields = cfg?.scalarFields ?? DIFF_SCALAR_FIELDS;
   const elementFields = cfg?.elementFields ?? DIFF_ELEMENT_FIELDS;

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -749,6 +749,24 @@ function isIosObservation(obs: ObserveResult): boolean {
   if (obs.screenIdentity?.platform === "ios") {
     return true;
   }
+  const viewHierarchy = obs.viewHierarchy;
+  if (viewHierarchy) {
+    if (viewHierarchy.screenScale !== undefined) {
+      return true;
+    }
+    const hierarchy = viewHierarchy.hierarchy as Record<string, unknown>;
+    if (hierarchy.type === "XCUIElementTypeApplication" || hierarchy.elementType === "application") {
+      return true;
+    }
+    if (typeof hierarchy.bundleId === "string" && !viewHierarchy.hierarchy.node) {
+      return true;
+    }
+    const roots = toNodeArray(viewHierarchy.hierarchy.node);
+    if (roots.some(root => classNameForDiff(root as unknown as Record<string, unknown>) === "XCUIApplication"
+      || classNameForDiff(root as unknown as Record<string, unknown>) === "XCUIElementTypeApplication")) {
+      return true;
+    }
+  }
   const appId = obs.activeWindow?.appId ?? obs.viewHierarchy?.packageName ?? "";
   return appId.startsWith("com.apple.") || appId.endsWith(".ios");
 }

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -365,6 +365,11 @@ export interface DiffObserveConfig {
    * identity) never re-pairs. Purely additive — it only re-pairs nodes positional
    * matching already left unpaired, so cross-subtree collisions stay disambiguated
    * by the path key. Set `false` for exact positional-only behavior.
+   *
+   * iOS adds one narrower repair pass under this same gate: editable controls
+   * (`XCUIElementTypeTextField` / `TextView` / `SearchField`) with a stable
+   * accessibility identifier and quantized screen region may re-pair across
+   * text/value edits. Reused table/collection cell classes opt out.
    */
   contentIdentity?: boolean;
 }
@@ -723,6 +728,120 @@ function repairByContentIdentity(
   };
 }
 
+function isIosObservation(obs: ObserveResult): boolean {
+  if (obs.screenIdentity?.platform === "ios") {
+    return true;
+  }
+  const appId = obs.activeWindow?.appId ?? obs.viewHierarchy?.packageName ?? "";
+  return appId.startsWith("com.apple.") || appId.endsWith(".ios");
+}
+
+function stringAttr(attrs: Record<string, unknown>, key: string): string {
+  const value = attrs[key];
+  return typeof value === "string" ? value : "";
+}
+
+function quantizedBoundsKey(bounds: unknown): string {
+  const parts = boundsKey(bounds).split(",").map(part => Number(part));
+  if (parts.length !== 4 || parts.some(part => !Number.isFinite(part))) {
+    return "";
+  }
+  return parts.map(part => Math.round(part / 8)).join(",");
+}
+
+function isIosEditableClass(className: string): boolean {
+  return className === "XCUIElementTypeTextField"
+    || className === "XCUIElementTypeSecureTextField"
+    || className === "XCUIElementTypeTextView"
+    || className === "XCUIElementTypeSearchField"
+    || className === "UITextField"
+    || className === "UISecureTextField"
+    || className === "UITextView"
+    || className === "UISearchBar";
+}
+
+function isIosListCellClass(className: string): boolean {
+  return className === "XCUIElementTypeCell"
+    || className === "XCUIElementTypeTable"
+    || className === "XCUIElementTypeCollectionView";
+}
+
+/**
+ * Conservative iOS identity for in-place editable controls (#3318). UIKit /
+ * SwiftUI wrappers commonly churn text/value/focus while preserving an
+ * accessibility identifier and screen region; pairing those as `changed` makes
+ * text entry readable. Reused table/collection cell identifiers deliberately
+ * opt out because a lone reused id can describe a different logical row.
+ */
+function iosStableIdentityKey(attrs: Record<string, unknown>): string | null {
+  const className = stringAttr(attrs, "className") || stringAttr(attrs, "class");
+  if (isIosListCellClass(className) || !isIosEditableClass(className)) {
+    return null;
+  }
+  const stableId = stringAttr(attrs, "resource-id")
+    || stringAttr(attrs, "view-id")
+    || stringAttr(attrs, "accessibilityIdentifier");
+  if (stableId === "") {
+    return null;
+  }
+  const boundsRegion = quantizedBoundsKey(attrs.bounds);
+  if (boundsRegion === "") {
+    return null;
+  }
+  return [stableId, className, boundsRegion].join(" ");
+}
+
+function indexByIosStableKey(nodes: ObserveDiffNode[]): Map<string, number[]> {
+  const byKey = new Map<string, number[]>();
+  nodes.forEach((node, index) => {
+    const key = iosStableIdentityKey(node.attributes);
+    if (key === null) {
+      return;
+    }
+    const bucket = byKey.get(key);
+    if (bucket) {
+      bucket.push(index);
+    } else {
+      byKey.set(key, [index]);
+    }
+  });
+  return byKey;
+}
+
+function repairByIosStableIdentity(
+  added: ObserveDiffNode[],
+  removed: ObserveDiffNode[],
+  changed: ObserveDiffNodeChange[]
+): { added: ObserveDiffNode[]; removed: ObserveDiffNode[] } {
+  const addedByKey = indexByIosStableKey(added);
+  const removedByKey = indexByIosStableKey(removed);
+  const consumedAdded = new Set<number>();
+  const consumedRemoved = new Set<number>();
+
+  for (const [key, addedIndices] of addedByKey) {
+    const removedIndices = removedByKey.get(key);
+    if (!removedIndices || addedIndices.length !== 1 || removedIndices.length !== 1) {
+      continue;
+    }
+    const addedNode = added[addedIndices[0]];
+    const removedNode = removed[removedIndices[0]];
+    consumedAdded.add(addedIndices[0]);
+    consumedRemoved.add(removedIndices[0]);
+    const attrChanges = diffAttributes(removedNode.attributes, addedNode.attributes);
+    if (Object.keys(attrChanges).length > 0) {
+      changed.push({ key: addedNode.key, fromKey: removedNode.key, changes: attrChanges });
+    }
+  }
+
+  if (consumedAdded.size === 0 && consumedRemoved.size === 0) {
+    return { added, removed };
+  }
+  return {
+    added: added.filter((_, index) => !consumedAdded.has(index)),
+    removed: removed.filter((_, index) => !consumedRemoved.has(index)),
+  };
+}
+
 /** Group flattened nodes by their positional `pathKey`, preserving encounter order. */
 function groupByKey(nodes: FlatObserveNode[]): Map<string, FlatObserveNode[]> {
   const map = new Map<string, FlatObserveNode[]>();
@@ -820,6 +939,11 @@ export function diffObserveResult(
     const repaired = repairByContentIdentity(added, removed, changed);
     finalAdded = repaired.added;
     finalRemoved = repaired.removed;
+    if (isIosObservation(baseline) && isIosObservation(next)) {
+      const iosRepaired = repairByIosStableIdentity(finalAdded, finalRemoved, changed);
+      finalAdded = iosRepaired.added;
+      finalRemoved = iosRepaired.removed;
+    }
   }
 
   const diff: ObserveDiff = { isDiff: true, added: finalAdded, removed: finalRemoved, changed };

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -758,6 +758,24 @@ function stringAttr(attrs: Record<string, unknown>, key: string): string {
   return typeof value === "string" ? value : "";
 }
 
+const IOS_GENERATED_VIEW_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function iosStableId(attrs: Record<string, unknown>): string {
+  const resourceId = stringAttr(attrs, "resource-id");
+  if (resourceId !== "") {
+    return resourceId;
+  }
+  const accessibilityIdentifier = stringAttr(attrs, "accessibilityIdentifier");
+  if (accessibilityIdentifier !== "") {
+    return accessibilityIdentifier;
+  }
+  const viewId = stringAttr(attrs, "view-id");
+  if (viewId !== "" && !IOS_GENERATED_VIEW_ID_PATTERN.test(viewId)) {
+    return viewId;
+  }
+  return "";
+}
+
 function quantizedBoundsKey(bounds: unknown): string {
   const parts = boundsKey(bounds).split(",").map(part => Number(part));
   if (parts.length !== 4 || parts.some(part => !Number.isFinite(part))) {
@@ -808,9 +826,7 @@ function iosStableIdentityKey(node: DiffRepairNode): string | null {
   if (isIosListCellClass(className) || !isIosEditableClass(className)) {
     return null;
   }
-  const stableId = stringAttr(node.attributes, "resource-id")
-    || stringAttr(node.attributes, "view-id")
-    || stringAttr(node.attributes, "accessibilityIdentifier");
+  const stableId = iosStableId(node.attributes);
   if (stableId === "") {
     return null;
   }

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -486,6 +486,19 @@ function classNameForDiff(node: Record<string, unknown>): string {
   return typeof className === "string" ? className : "";
 }
 
+function platformClassNameForDiff(node: Record<string, unknown>): string {
+  const className = classNameForDiff(node);
+  if (className !== "") {
+    return className;
+  }
+  const xmlAttrs = node.$;
+  if (!xmlAttrs || typeof xmlAttrs !== "object" || Array.isArray(xmlAttrs)) {
+    return "";
+  }
+  const xmlClassName = (xmlAttrs as Record<string, unknown>).class;
+  return typeof xmlClassName === "string" ? xmlClassName : "";
+}
+
 /**
  * Pre-order flatten of an observation's hierarchy into positionally-keyed nodes.
  * Each node's `pathKey` is its ancestor chain of local keys plus its own, so the
@@ -751,6 +764,9 @@ function isIosObservation(obs: ObserveResult): boolean {
   }
   const viewHierarchy = obs.viewHierarchy;
   if (viewHierarchy) {
+    if (hasAndroidHierarchySignals(viewHierarchy)) {
+      return false;
+    }
     if (viewHierarchy.screenScale !== undefined) {
       return true;
     }
@@ -769,6 +785,16 @@ function isIosObservation(obs: ObserveResult): boolean {
   }
   const appId = obs.activeWindow?.appId ?? obs.viewHierarchy?.packageName ?? "";
   return appId.startsWith("com.apple.") || appId.endsWith(".ios");
+}
+
+function hasAndroidHierarchySignals(viewHierarchy: NonNullable<ObserveResult["viewHierarchy"]>): boolean {
+  if (viewHierarchy.density !== undefined
+    || viewHierarchy.sdkInt !== undefined
+    || viewHierarchy.foregroundActivity !== undefined) {
+    return true;
+  }
+  const roots = toNodeArray(viewHierarchy.hierarchy.node);
+  return roots.some(root => platformClassNameForDiff(root as unknown as Record<string, unknown>).startsWith("android."));
 }
 
 function stringAttr(attrs: Record<string, unknown>, key: string): string {
@@ -818,15 +844,13 @@ function isIosListCellClass(className: string): boolean {
     || className === "UITableViewCell"
     || className === "UICollectionViewCell"
     || className === "XCUIElementTypeTable"
-    || className === "XCUIElementTypeCollectionView";
+    || className === "XCUIElementTypeCollectionView"
+    || className === "UITableView"
+    || className === "UICollectionView";
 }
 
 function hasIosListCellAncestor(node: DiffRepairNode): boolean {
-  return node.ancestorClasses.some(className => (
-    className === "XCUIElementTypeCell"
-      || className === "UITableViewCell"
-      || className === "UICollectionViewCell"
-  ));
+  return node.ancestorClasses.some(className => isIosListCellClass(className));
 }
 
 /**

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -932,6 +932,37 @@ describe("diffObserveResult — conservative iOS stable identity (#3318)", () =>
     expect(diff.changed[0].changes.value).toEqual({ from: "", to: "Buy milk" });
   });
 
+  test("Android-provenance hierarchies with mixed screenScale do not use iOS text-field repair", () => {
+    const androidObs = (node: Record<string, unknown>) => obs(node, {
+      activeWindow: { appId: "com.example.android", activityName: ".MainActivity", layoutSeqSum: 1 },
+      viewHierarchy: {
+        packageName: "com.example.android",
+        density: 440,
+        sdkInt: 34,
+        foregroundActivity: "com.example.android/.MainActivity",
+        screenScale: 3,
+        hierarchy: { node: node as any },
+      },
+    } as ObserveResult);
+    const baseline = androidObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "",
+    });
+    const next = androidObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Buy milk",
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+  });
+
   test("iOS generated UUID view-ids do not re-pair id-less text fields", () => {
     const baseline = iosObs({
       "view-id": "123e4567-e89b-12d3-a456-426614174000",
@@ -1055,6 +1086,35 @@ describe("diffObserveResult — conservative iOS stable identity (#3318)", () =>
       "class": "UITableView",
       "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
       "node": [row("Different row")],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.added[0].attributes.text).toBe("Different row");
+    expect(diff.removed[0].attributes.text).toBe("Old row");
+  });
+
+  test("iOS text fields directly under lists do not re-pair different logical rows", () => {
+    const field = (label: string) => ({
+      "resource-id": "TitleField",
+      "class": "UITextField",
+      "bounds": { left: 16, top: 108, right: 300, bottom: 136 },
+      "text": label,
+      "value": label,
+    });
+    const baseline = iosObs({
+      "view-id": "ReminderList",
+      "class": "UITableView",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
+      "node": [field("Old row")],
+    });
+    const next = iosObs({
+      "view-id": "ReminderList",
+      "class": "UITableView",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
+      "node": [field("Different row")],
     });
 
     const diff = diffObserveResult(baseline, next);

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -903,6 +903,30 @@ describe("diffObserveResult — conservative iOS stable identity (#3318)", () =>
     expect(diff.changed[0].changes.value).toEqual({ from: "", to: "Buy milk" });
   });
 
+  test("iOS generated UUID view-ids do not re-pair id-less text fields", () => {
+    const baseline = iosObs({
+      "view-id": "123e4567-e89b-12d3-a456-426614174000",
+      "class": "UITextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Old field",
+      "value": "Old field",
+    });
+    const next = iosObs({
+      "view-id": "123e4567-e89b-12d3-a456-426614174000",
+      "class": "UITextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Different field",
+      "value": "Different field",
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.added[0].attributes.text).toBe("Different field");
+    expect(diff.removed[0].attributes.text).toBe("Old field");
+  });
+
   test("contentIdentity:false disables the iOS editable-control repair path", () => {
     const baseline = iosObs({
       "resource-id": "TitleField",

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -903,6 +903,35 @@ describe("diffObserveResult — conservative iOS stable identity (#3318)", () =>
     expect(diff.changed[0].changes.value).toEqual({ from: "", to: "Buy milk" });
   });
 
+  test("third-party iOS bundles without screenIdentity still use iOS text-field repair", () => {
+    const root = (text: string) => ({
+      "class": "XCUIApplication",
+      "bounds": { left: 0, top: 0, right: 393, bottom: 852 },
+      "node": [{
+        "resource-id": "TitleField",
+        "class": "UITextField",
+        "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+        "text": text,
+        "value": text,
+      }],
+    });
+    const screen = (text: string) => iosObs(root(text), {
+      activeWindow: { appId: "dev.example.todo", activityName: "", layoutSeqSum: 1 },
+      viewHierarchy: {
+        packageName: "dev.example.todo",
+        hierarchy: { node: root(text) as any },
+      },
+      screenIdentity: undefined,
+    });
+
+    const diff = diffObserveResult(screen(""), screen("Buy milk"));
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes.text).toEqual({ from: "", to: "Buy milk" });
+    expect(diff.changed[0].changes.value).toEqual({ from: "", to: "Buy milk" });
+  });
+
   test("iOS generated UUID view-ids do not re-pair id-less text fields", () => {
     const baseline = iosObs({
       "view-id": "123e4567-e89b-12d3-a456-426614174000",

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../src/features/observe/output/ObserveResultOutput";
 import {
   loadAndroidHomeObserve,
+  loadIosRemindersNoiseObservePair,
   measureValue,
 } from "../../../fixtures/observe/observeFixture";
 
@@ -40,6 +41,24 @@ function obs(node: Record<string, unknown>, extra?: Partial<ObserveResult>): Obs
     },
     ...extra,
   } as ObserveResult;
+}
+
+function iosObs(node: Record<string, unknown>, extra?: Partial<ObserveResult>): ObserveResult {
+  return obs(node, {
+    activeWindow: { appId: "com.apple.reminders", activityName: "", layoutSeqSum: 1 },
+    viewHierarchy: {
+      packageName: "com.apple.reminders",
+      hierarchy: { node: node as any },
+    },
+    screenIdentity: {
+      platform: "ios",
+      source: "heuristic",
+      confidence: "high",
+      key: "bundle=com.apple.reminders|nav=Reminders",
+      components: { bundleId: "com.apple.reminders", navigationTitle: "Reminders" },
+    },
+    ...extra,
+  } as ObserveResult);
 }
 
 describe("diffObserveResult", () => {
@@ -830,6 +849,142 @@ describe("diffObserveResult", () => {
     expect(diff.changed).toEqual([]);
     expect(diff.added.map(n => n.attributes["resource-id"])).toEqual(["fresh"]);
     expect(diff.removed.map(n => n.attributes["resource-id"])).toEqual(["gone"]);
+  });
+});
+
+describe("diffObserveResult — conservative iOS stable identity (#3318)", () => {
+  test("iOS text input edits emit one `changed` entry instead of remove+add", () => {
+    const baseline = iosObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "",
+      "value": "",
+      "focused": "true",
+    });
+    const next = iosObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Buy milk",
+      "value": "Buy milk",
+      "focused": "true",
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes.text).toEqual({ from: "", to: "Buy milk" });
+    expect(diff.changed[0].changes.value).toEqual({ from: "", to: "Buy milk" });
+  });
+
+  test("iOS UIKit text fields emitted by the runner also re-pair text/value edits", () => {
+    const baseline = iosObs({
+      "view-id": "title-field",
+      "class": "UITextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "",
+      "value": "",
+    });
+    const next = iosObs({
+      "view-id": "title-field",
+      "class": "UITextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Buy milk",
+      "value": "Buy milk",
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes.text).toEqual({ from: "", to: "Buy milk" });
+    expect(diff.changed[0].changes.value).toEqual({ from: "", to: "Buy milk" });
+  });
+
+  test("contentIdentity:false disables the iOS editable-control repair path", () => {
+    const baseline = iosObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "",
+      "value": "",
+    });
+    const next = iosObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Buy milk",
+      "value": "Buy milk",
+    });
+
+    const diff = diffObserveResult(baseline, next, { contentIdentity: false });
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+  });
+
+  test("iOS focus and selection remain changed attributes, not identity", () => {
+    const baseline = iosObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Buy milk",
+      "focused": "false",
+      "selected": "false",
+    });
+    const next = iosObs({
+      "resource-id": "TitleField",
+      "className": "XCUIElementTypeTextField",
+      "bounds": { left: 16, top: 120, right: 300, bottom: 160 },
+      "text": "Buy milk",
+      "focused": "true",
+      "selected": "true",
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes.focused).toEqual({ from: "false", to: "true" });
+    expect(diff.changed[0].changes.selected).toEqual({ from: "false", to: "true" });
+  });
+
+  test("iOS reused list cell identifiers do not false-merge different logical rows", () => {
+    const row = (label: string, top: number) => ({
+      "resource-id": "ReusableCell",
+      "className": "XCUIElementTypeCell",
+      "bounds": { left: 0, top, right: 390, bottom: top + 44 },
+      "text": label,
+      "value": label,
+    });
+    const baseline = iosObs({
+      "resource-id": "ReminderList",
+      "className": "XCUIElementTypeTable",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
+      "node": [row("Old row", 100)],
+    });
+    const next = iosObs({
+      "resource-id": "ReminderList",
+      "className": "XCUIElementTypeTable",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
+      "node": [row("Different row", 100)],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+  });
+
+  test("real iOS fixture churn stays neutral with iOS identity enabled", () => {
+    const { before, after } = loadIosRemindersNoiseObservePair();
+    const withIdentity = diffObserveResult(before, after);
+    const positional = diffObserveResult(before, after, { contentIdentity: false });
+    const churn = (diff: typeof withIdentity) => diff.added.length + diff.removed.length + diff.changed.length;
+
+    expect(churn(withIdentity)).toBeLessThanOrEqual(churn(positional));
   });
 });
 

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -978,6 +978,40 @@ describe("diffObserveResult — conservative iOS stable identity (#3318)", () =>
     expect(diff.removed).toHaveLength(1);
   });
 
+  test("iOS text fields inside reused cells do not re-pair different logical rows", () => {
+    const row = (label: string) => ({
+      "view-id": "reused-cell",
+      "class": "UITableViewCell",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 144 },
+      "node": [{
+        "resource-id": "TitleField",
+        "class": "UITextField",
+        "bounds": { left: 16, top: 108, right: 300, bottom: 136 },
+        "text": label,
+        "value": label,
+      }],
+    });
+    const baseline = iosObs({
+      "view-id": "ReminderList",
+      "class": "UITableView",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
+      "node": [row("Old row")],
+    });
+    const next = iosObs({
+      "view-id": "ReminderList",
+      "class": "UITableView",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
+      "node": [row("Different row")],
+    });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.added[0].attributes.text).toBe("Different row");
+    expect(diff.removed[0].attributes.text).toBe("Old row");
+  });
+
   test("real iOS fixture churn stays neutral with iOS identity enabled", () => {
     const { before, after } = loadIosRemindersNoiseObservePair();
     const withIdentity = diffObserveResult(before, after);


### PR DESCRIPTION
## Summary

Improve `diffObserveResult` iOS node identity so stable editable controls re-pair as `changed` when text/value churn changes the positional key. The repair stays under the existing `contentIdentity` gate, requires a stable identifier plus editable iOS class and quantized bounds, and keeps reused table/collection cells out of the repair path to avoid false merges.

## Linked Issue

Closes #3318

## Bug / Regression Context

- **Prior attempts:** #3107 documented the structural identity false-merge risk and kept broader structural matching out of the default path.
- **Observed symptom:** iOS text edits could surface as remove+add because `text` is part of the positional/content key.
- **Repro steps / conditions:** Diff two same-screen iOS observations where the same text field keeps its identifier and bounds but changes `text` / `value`.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
- [x] `bun run turbo:validate` passes (`bun run lint` + build + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Targeted observe diff tests pass: `bun test test/features/observe/output/diffObserveResult.test.ts`
- [x] `git diff --check` passes
- [x] Android/iOS changes: covered with focused TypeScript fixture tests
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- Not run in this environment. The change is pinned with synthetic iOS cases plus the committed iOS Reminders fixture pair.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
