### PR TITLE
test(ios): assert clear data factory device

### DIFF
--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -558,10 +558,10 @@ describe("LaunchApp", () => {
       const deviceAppLauncher = new FakeDeviceAppLauncher(
         opts.launchResult ? { launchResult: opts.launchResult } : {}
       );
-      const clearCalls: string[] = [];
-      const clearAppDataFactory = () => ({
+      const clearCalls: Array<{ bundleId: string; device: BootedDevice; simctl: unknown }> = [];
+      const clearAppDataFactory = (clearDevice: BootedDevice, clearSimctl: unknown) => ({
         execute: async (id: string) => {
-          clearCalls.push(id);
+          clearCalls.push({ bundleId: id, device: clearDevice, simctl: clearSimctl });
           return opts.clearResult ?? { success: true, packageName: id };
         },
       });
@@ -664,7 +664,12 @@ describe("LaunchApp", () => {
       try {
         const result = await iosLaunchApp.execute(userBundleId, /* clearAppData */ true, /* coldBoot */ false);
         expect(result.success).toBe(true);
-        expect(clearCalls).toEqual([userBundleId]);
+        expect(clearCalls).toHaveLength(1);
+        expect(clearCalls[0]).toMatchObject({
+          bundleId: userBundleId,
+          device: { deviceId: physicalUdid, platform: "ios" },
+        });
+        expect(clearCalls[0].simctl).toBe((iosLaunchApp as any).simctl);
         expect(deviceAppLauncher.launchCalls).toEqual([{
           deviceUdid: physicalUdid,
           bundleId: userBundleId,
@@ -686,7 +691,12 @@ describe("LaunchApp", () => {
         const result = await iosLaunchApp.execute(userBundleId, /* clearAppData */ true, /* coldBoot */ false);
         expect(result.success).toBe(false);
         expect(result.error).toContain("Failed to clear app data: reinstall failed");
-        expect(clearCalls).toEqual([userBundleId]);
+        expect(clearCalls).toHaveLength(1);
+        expect(clearCalls[0]).toMatchObject({
+          bundleId: userBundleId,
+          device: { deviceId: physicalUdid, platform: "ios" },
+        });
+        expect(clearCalls[0].simctl).toBe((iosLaunchApp as any).simctl);
         expect(deviceAppLauncher.launchCalls).toHaveLength(0);
         expect(simctlCalls).toEqual([]);
       } finally {


### PR DESCRIPTION
## Summary

Addresses the post-merge review finding from PR #3353 by strengthening the hermetic `LaunchApp` physical-device clear-data tests. The fake clear-data factory now records the `BootedDevice` and `simctl` arguments, and the success/failure tests assert the physical UDID and injected simctl identity are passed through to the clear-data runner.

## Linked Issue

Follow-up to #3353 / #2884.

## Bug / Regression Context

- **Prior attempts:** PR #3353 added the requested `LaunchApp` injection seam and physical-device clear-data tests.
- **Observed symptom:** The new fake recorded only the bundle id, so the tests would not catch `LaunchApp` passing the wrong device identity into the clear-data factory.
- **Repro steps / conditions:** Review finding: https://github.com/kaeawc/auto-mobile/pull/3353#discussion_r3532516061

## Validation

- [x] `bun test test/features/action/LaunchApp.test.ts`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate`
- [x] Android/iOS changes: TypeScript-only hermetic unit coverage; no platform validation needed
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A. This is hermetic LaunchApp unit coverage.

## Follow-ups

None.
