### PR TITLE
feat(ios): support network error simulation

### DIFF
--- a/docs/design-docs/api-surface/cross-platform-parity.md
+++ b/docs/design-docs/api-surface/cross-platform-parity.md
@@ -117,9 +117,9 @@ Side-by-side comparison of every public API symbol on Android and iOS.
 | `setCaptureBodies` | -- | `setCaptureBodies(Bool)` | iOS-only config |
 | `setMaxBodyBytes` | -- | `setMaxBodyBytes(Int)` | iOS-only config |
 | `setEnabled` | -- | `setEnabled(Bool)` | iOS-only toggle |
-| `NetworkMockRuleStore` | Yes (with BroadcastReceiver) | Yes (via CtrlProxy relay to SDK server) | iOS requires sessions to register `protocolClass()` |
+| `NetworkMockRuleStore` | Yes (with BroadcastReceiver) | Yes (via CtrlProxy relay to SDK server) | Mock rules and error simulation; iOS requires sessions to register `protocolClass()` and error simulation requires the supporting iOS CtrlProxy runner release or a local runner override |
 
-**Why these differ:** Network interception is inherently platform-specific. Android uses OkHttp interceptors; iOS uses URLProtocol. Mock-rule transport also differs: Android uses broadcast intents, while iOS relays through CtrlProxy to the SDK server.
+**Why these differ:** Network interception is inherently platform-specific. Android uses OkHttp interceptors; iOS uses URLProtocol. Mock-rule and error-simulation transport also differs: Android uses broadcast intents, while iOS relays through CtrlProxy to the SDK server.
 
 ## 10. ANR / Hang Detection
 

--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -403,7 +403,7 @@ The SDK uses protocol + fake pattern throughout for testability:
 | Notifications | `AutoMobileNotifications` | `AutoMobileNotifications` | Platform notification APIs |
 | OS events | `AutoMobileOsEvents` | `AutoMobileOsEvents` | Lifecycle, battery, connectivity |
 | Broadcast / System events | `AutoMobileBroadcastInterceptor` | `AutoMobileNotificationObserver` | BroadcastReceiver vs NotificationCenter |
-| Network mock rules | `NetworkMockRuleStore` | `NetworkMockRuleStore` | iOS requires sessions to register `AutoMobileNetwork.shared.protocolClass()` |
+| Network mock rules and error simulation | `NetworkMockRuleStore` | `NetworkMockRuleStore` | DEBUG-only; iOS requires sessions to register `AutoMobileNetwork.shared.protocolClass()`; error simulation also requires the supporting iOS CtrlProxy runner release or a local runner override |
 
 ## See also
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -66,6 +66,7 @@ public struct NetworkRequestRecord: Sendable {
 /// or call ``recordRequest(_:)`` to record requests manually.
 public final class AutoMobileNetwork: @unchecked Sendable {
     public static let shared = AutoMobileNetwork()
+    private static let defaultMaxBodyBytes = 32 * 1024
 
     private let lock = NSLock()
     private var bundleId: String?
@@ -73,12 +74,22 @@ public final class AutoMobileNetwork: @unchecked Sendable {
     private var _isEnabled = true
     private var _captureHeaders = false
     private var _captureBodies = false
-    var _maxBodyBytes: Int = 32 * 1024 // 32KB default (internal for URLProtocol access)
+    var _maxBodyBytes: Int = AutoMobileNetwork.defaultMaxBodyBytes // 32KB default (internal for URLProtocol access)
 
     /// Thread-safe read of maxBodyBytes for URLProtocol callbacks.
     var maxBodyBytes: Int {
         lock.lock()
         defer { lock.unlock() }
+        return _maxBodyBytes
+    }
+
+    /// Byte limit for request body capture, or nil when capture is disabled.
+    var requestBodyCaptureLimit: Int? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard _captureBodies, _maxBodyBytes > 0 else {
+            return nil
+        }
         return _maxBodyBytes
     }
 
@@ -397,6 +408,7 @@ public final class AutoMobileNetwork: @unchecked Sendable {
         _isEnabled = true
         _captureHeaders = false
         _captureBodies = false
+        _maxBodyBytes = AutoMobileNetwork.defaultMaxBodyBytes
         lock.unlock()
     }
 }
@@ -479,6 +491,14 @@ public class AutoMobileURLProtocol: URLProtocol {
             ))
             return
         }
+
+        if AutoMobileSDK.shared.isEnabled,
+           let url = request.url,
+           let simulation = NetworkMockRuleStore.shared.activeErrorSimulation()
+        {
+            serveSimulatedError(simulation, url: url)
+            return
+        }
         #endif
 
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
@@ -505,6 +525,98 @@ public class AutoMobileURLProtocol: URLProtocol {
         urlSession = nil
         dataTask = nil
     }
+
+    #if DEBUG
+    private func capturedRequestBodyData(limit: Int?) -> Data? {
+        guard let limit, limit > 0 else {
+            return nil
+        }
+
+        if let body = request.httpBody {
+            return Data(body.prefix(limit))
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable, data.count < limit {
+            let remaining = limit - data.count
+            let read = stream.read(&buffer, maxLength: min(buffer.count, remaining))
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else {
+                break
+            }
+        }
+        return data.isEmpty ? nil : data
+    }
+
+    private func serveSimulatedError(_ simulation: NetworkMockRuleStore.ErrorSimulation, url: URL) {
+        let method = request.httpMethod ?? "GET"
+        let durationMs = startTime.map { Date().timeIntervalSince($0) * 1000 }
+        let requestBodySize = request.httpBody?.count
+        let requestBodyData: Data?
+        if AutoMobileNetwork.isTextContentType(request.value(forHTTPHeaderField: "Content-Type")) {
+            requestBodyData = capturedRequestBodyData(limit: AutoMobileNetwork.shared.requestBodyCaptureLimit)
+        } else {
+            requestBodyData = nil
+        }
+        let requestBody = requestBodyData.flatMap { AutoMobileNetwork.utf8String(from: $0) }
+
+        if simulation.errorType == "http500" {
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 500,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            AutoMobileNetwork.shared.recordRequest(NetworkRequestRecord(
+                url: url.absoluteString,
+                method: method,
+                requestHeaders: request.allHTTPHeaderFields,
+                requestBodySize: requestBodySize,
+                statusCode: 500,
+                durationMs: durationMs,
+                error: "simulated:\(simulation.errorType)",
+                requestBody: requestBody
+            ))
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        let code: URLError.Code
+        switch simulation.errorType {
+        case "timeout":
+            code = .timedOut
+        case "connectionRefused":
+            code = .cannotConnectToHost
+        case "dnsFailure":
+            code = .cannotFindHost
+        case "tlsFailure":
+            code = .secureConnectionFailed
+        default:
+            code = .cannotConnectToHost
+        }
+
+        AutoMobileNetwork.shared.recordRequest(NetworkRequestRecord(
+            url: url.absoluteString,
+            method: method,
+            requestHeaders: request.allHTTPHeaderFields,
+            requestBodySize: requestBodySize,
+            durationMs: durationMs,
+            error: "simulated:\(simulation.errorType)",
+            requestBody: requestBody
+        ))
+        client?.urlProtocol(self, didFailWithError: URLError(code))
+    }
+    #endif
 }
 
 extension AutoMobileURLProtocol: URLSessionDataDelegate {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
@@ -14,8 +14,19 @@ struct NetworkMockRuleDTO: Codable, Equatable {
     let contentType: String
 }
 
+struct NetworkErrorSimulationDTO: Codable, Equatable {
+    let enabled: Bool
+    let errorType: String?
+    let limit: Int?
+    let expiresAtEpochMs: Int64?
+}
+
 final class NetworkMockRuleStore: @unchecked Sendable {
     static let shared = NetworkMockRuleStore()
+
+    struct ErrorSimulation: Equatable {
+        let errorType: String
+    }
 
     struct MatchedRule: Equatable {
         let mockId: String
@@ -38,7 +49,13 @@ final class NetworkMockRuleStore: @unchecked Sendable {
     }
 
     private let lock = NSLock()
+    private let dateProvider: DateProvider
     private var rules: [CompiledRule] = []
+    private var errorSimulation: CompiledErrorSimulation?
+
+    init(dateProvider: DateProvider = SystemDateProvider()) {
+        self.dateProvider = dateProvider
+    }
 
     func setRules(_ dtos: [NetworkMockRuleDTO]) {
         let compiled = dtos.compactMap { dto -> CompiledRule? in
@@ -65,6 +82,49 @@ final class NetworkMockRuleStore: @unchecked Sendable {
         lock.lock()
         rules = compiled
         lock.unlock()
+    }
+
+    func setErrorSimulation(_ dto: NetworkErrorSimulationDTO) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard dto.enabled, let errorType = dto.errorType else {
+            errorSimulation = nil
+            return
+        }
+
+        errorSimulation = CompiledErrorSimulation(
+            errorType: errorType,
+            remaining: dto.limit,
+            expiresAtEpochMs: dto.expiresAtEpochMs
+        )
+    }
+
+    func activeErrorSimulation() -> ErrorSimulation? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard var simulation = errorSimulation else {
+            return nil
+        }
+
+        if let expiresAtEpochMs = simulation.expiresAtEpochMs,
+           currentEpochMs() >= expiresAtEpochMs
+        {
+            errorSimulation = nil
+            return nil
+        }
+
+        if let remaining = simulation.remaining {
+            guard remaining > 0 else {
+                errorSimulation = nil
+                return nil
+            }
+            simulation.remaining = remaining - 1
+            errorSimulation = simulation.remaining == 0 ? nil : simulation
+        }
+
+        return ErrorSimulation(errorType: simulation.errorType)
     }
 
     func findMatchingRule(host: String, path: String, method: String) -> MatchedRule? {
@@ -97,9 +157,19 @@ final class NetworkMockRuleStore: @unchecked Sendable {
         return nil
     }
 
+    private struct CompiledErrorSimulation {
+        let errorType: String
+        var remaining: Int?
+        let expiresAtEpochMs: Int64?
+    }
+
     private static func matches(_ regex: NSRegularExpression, _ value: String) -> Bool {
         let range = NSRange(value.startIndex ..< value.endIndex, in: value)
         return regex.firstMatch(in: value, range: range) != nil
+    }
+
+    private func currentEpochMs() -> Int64 {
+        Int64(dateProvider.now().timeIntervalSince1970 * 1000)
     }
 }
 #endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -113,6 +113,8 @@ final class SdkHierarchyServer: @unchecked Sendable {
                     self.handleHealth(connection)
                 } else if request.contains("POST /network/mock") {
                     self.handleNetworkMock(connection, initialData: requestData)
+                } else if request.contains("POST /network/error-simulation") {
+                    self.handleNetworkErrorSimulation(connection, initialData: requestData)
                 } else if request.contains("POST /highlight") {
                     self.handleHighlight(connection, initialData: requestData)
                 } else if request.contains("POST /db/execute") {
@@ -187,6 +189,22 @@ final class SdkHierarchyServer: @unchecked Sendable {
                 return
             }
             NetworkMockRuleStore.shared.setRules(payload.rules)
+            self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
+        }
+    }
+
+    private func handleNetworkErrorSimulation(_ connection: NWConnection, initialData: Data) {
+        readCompleteHttpBody(connection, initialData: initialData) { [weak self] body in
+            guard let self = self else {
+                connection.cancel()
+                return
+            }
+            guard let body = body,
+                  let payload = try? JSONDecoder().decode(NetworkErrorSimulationDTO.self, from: body) else {
+                self.sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"bad_request\"}".utf8))
+                return
+            }
+            NetworkMockRuleStore.shared.setErrorSimulation(payload)
             self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
         }
     }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -13,6 +13,12 @@ final class AutoMobileNetworkTests: XCTestCase {
         AutoMobileNetwork.shared.reset()
         #if DEBUG
         NetworkMockRuleStore.shared.setRules([])
+        NetworkMockRuleStore.shared.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: false,
+            errorType: nil,
+            limit: nil,
+            expiresAtEpochMs: nil
+        ))
         #endif
         super.tearDown()
     }
@@ -317,6 +323,49 @@ final class AutoMobileNetworkTests: XCTestCase {
         XCTAssertNil(store.findMatchingRule(host: "api.example.com", path: "/one", method: "GET"))
     }
 
+    func testNetworkMockRuleStoreHonorsErrorSimulationLimitAndExpiry() {
+        let dateProvider = FakeDateProvider(initialDate: Date(timeIntervalSince1970: 100))
+        let store = NetworkMockRuleStore(dateProvider: dateProvider)
+        store.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: true,
+            errorType: "http500",
+            limit: 1,
+            expiresAtEpochMs: 101_000
+        ))
+
+        XCTAssertEqual(store.activeErrorSimulation()?.errorType, "http500")
+        XCTAssertNil(store.activeErrorSimulation())
+
+        store.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: true,
+            errorType: "timeout",
+            limit: nil,
+            expiresAtEpochMs: 101_000
+        ))
+        dateProvider.advance(by: 2)
+
+        XCTAssertNil(store.activeErrorSimulation())
+    }
+
+    func testNetworkMockRuleStoreClearsErrorSimulationWhenDisabled() {
+        let store = NetworkMockRuleStore()
+        store.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: true,
+            errorType: "http500",
+            limit: nil,
+            expiresAtEpochMs: nil
+        ))
+
+        store.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: false,
+            errorType: nil,
+            limit: nil,
+            expiresAtEpochMs: nil
+        ))
+
+        XCTAssertNil(store.activeErrorSimulation())
+    }
+
     func testNetworkMockRuleStoreSkipsInvalidRegexRules() {
         let store = NetworkMockRuleStore()
         store.setRules([
@@ -391,6 +440,165 @@ final class AutoMobileNetworkTests: XCTestCase {
         XCTAssertEqual(event?.responseBody, "{\"error\":\"mocked\"}")
         XCTAssertEqual(event?.contentType, "application/json")
         XCTAssertEqual(event?.error, "mocked:mock-1")
+    }
+
+    func testURLProtocolPrefersMockRuleOverErrorSimulation() async throws {
+        let collector = EventCollector()
+        let buffer = SdkEventBuffer(maxBufferSize: 100, flushIntervalMs: 60000) { events in
+            collector.collect(events)
+        }
+        AutoMobileNetwork.shared.initialize(bundleId: "test", buffer: buffer)
+        AutoMobileNetwork.shared.setCaptureBodies(true)
+        NetworkMockRuleStore.shared.setRules([
+            NetworkMockRuleDTO(
+                mockId: "mock-1",
+                host: "api\\.example\\.com",
+                path: "^/v1/items$",
+                method: "GET",
+                limit: nil,
+                remaining: nil,
+                statusCode: 418,
+                responseHeaders: ["x-mocked": "true"],
+                responseBody: "mock-wins",
+                contentType: "text/plain"
+            ),
+        ])
+        NetworkMockRuleStore.shared.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: true,
+            errorType: "timeout",
+            limit: nil,
+            expiresAtEpochMs: nil
+        ))
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AutoMobileNetwork.shared.protocolClass()]
+        let session = URLSession(configuration: config)
+
+        let (data, response) = try await session.data(from: URL(string: "https://api.example.com/v1/items")!)
+
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 418)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "mock-wins")
+        XCTAssertEqual((response as? HTTPURLResponse)?.value(forHTTPHeaderField: "x-mocked"), "true")
+        buffer.flush()
+        let event = collector.events.first as? SdkNetworkRequestEvent
+        XCTAssertEqual(event?.url, "https://api.example.com/v1/items")
+        XCTAssertEqual(event?.statusCode, 418)
+        XCTAssertEqual(event?.responseBody, "mock-wins")
+        XCTAssertEqual(event?.error, "mocked:mock-1")
+    }
+
+    func testURLProtocolServesSimulatedHttp500AndRecordsRequest() async throws {
+        let collector = EventCollector()
+        let buffer = SdkEventBuffer(maxBufferSize: 100, flushIntervalMs: 60000) { events in
+            collector.collect(events)
+        }
+        AutoMobileNetwork.shared.initialize(bundleId: "test", buffer: buffer)
+        AutoMobileNetwork.shared.setCaptureBodies(true)
+        NetworkMockRuleStore.shared.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: true,
+            errorType: "http500",
+            limit: nil,
+            expiresAtEpochMs: nil
+        ))
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AutoMobileNetwork.shared.protocolClass()]
+        let session = URLSession(configuration: config)
+        var request = URLRequest(url: URL(string: "https://api.example.com/fail")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data("{\"query\":\"mutation\"}".utf8)
+
+        let (data, response) = try await session.data(for: request)
+
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 500)
+        XCTAssertTrue(data.isEmpty)
+        buffer.flush()
+        let event = collector.events.first as? SdkNetworkRequestEvent
+        XCTAssertEqual(event?.url, "https://api.example.com/fail")
+        XCTAssertEqual(event?.method, "POST")
+        XCTAssertEqual(event?.requestBody, "{\"query\":\"mutation\"}")
+        XCTAssertEqual(event?.statusCode, 500)
+        XCTAssertEqual(event?.error, "simulated:http500")
+    }
+
+    func testURLProtocolCapsSimulatedErrorStreamBodyCapture() async throws {
+        let collector = EventCollector()
+        let buffer = SdkEventBuffer(maxBufferSize: 100, flushIntervalMs: 60000) { events in
+            collector.collect(events)
+        }
+        AutoMobileNetwork.shared.initialize(bundleId: "test", buffer: buffer)
+        AutoMobileNetwork.shared.setCaptureBodies(true)
+        AutoMobileNetwork.shared.setMaxBodyBytes(8)
+        NetworkMockRuleStore.shared.setErrorSimulation(NetworkErrorSimulationDTO(
+            enabled: true,
+            errorType: "http500",
+            limit: nil,
+            expiresAtEpochMs: nil
+        ))
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [AutoMobileNetwork.shared.protocolClass()]
+        let session = URLSession(configuration: config)
+        var request = URLRequest(url: URL(string: "https://api.example.com/stream")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBodyStream = InputStream(data: Data("{\"query\":\"mutation with a long payload\"}".utf8))
+
+        let (_, response) = try await session.data(for: request)
+
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 500)
+        buffer.flush()
+        let event = collector.events.first as? SdkNetworkRequestEvent
+        XCTAssertEqual(event?.url, "https://api.example.com/stream")
+        XCTAssertEqual(event?.method, "POST")
+        XCTAssertEqual(event?.requestBody, "{\"query\"")
+        XCTAssertEqual(event?.statusCode, 500)
+        XCTAssertEqual(event?.error, "simulated:http500")
+    }
+
+    func testURLProtocolServesTransportErrorSimulationsAndRecordsRequests() async {
+        let cases: [(String, URLError.Code)] = [
+            ("timeout", .timedOut),
+            ("connectionRefused", .cannotConnectToHost),
+            ("dnsFailure", .cannotFindHost),
+            ("tlsFailure", .secureConnectionFailed),
+        ]
+
+        for (errorType, expectedCode) in cases {
+            let collector = EventCollector()
+            let buffer = SdkEventBuffer(maxBufferSize: 100, flushIntervalMs: 60000) { events in
+                collector.collect(events)
+            }
+            AutoMobileNetwork.shared.reset()
+            AutoMobileNetwork.shared.initialize(bundleId: "test", buffer: buffer)
+            AutoMobileNetwork.shared.setCaptureBodies(true)
+            NetworkMockRuleStore.shared.setErrorSimulation(NetworkErrorSimulationDTO(
+                enabled: true,
+                errorType: errorType,
+                limit: nil,
+                expiresAtEpochMs: nil
+            ))
+            let config = URLSessionConfiguration.ephemeral
+            config.protocolClasses = [AutoMobileNetwork.shared.protocolClass()]
+            let session = URLSession(configuration: config)
+            var request = URLRequest(url: URL(string: "https://api.example.com/\(errorType)")!)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = Data("{\"operation\":\"\(errorType)\"}".utf8)
+
+            do {
+                _ = try await session.data(for: request)
+                XCTFail("Expected \(errorType) to fail")
+            } catch {
+                XCTAssertEqual((error as? URLError)?.code, expectedCode)
+            }
+
+            buffer.flush()
+            let event = collector.events.first as? SdkNetworkRequestEvent
+            XCTAssertEqual(event?.url, "https://api.example.com/\(errorType)")
+            XCTAssertEqual(event?.method, "POST")
+            XCTAssertEqual(event?.requestBody, "{\"operation\":\"\(errorType)\"}")
+            XCTAssertNil(event?.statusCode)
+            XCTAssertEqual(event?.error, "simulated:\(errorType)")
+        }
     }
     #endif
 }

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -183,6 +183,9 @@ public class CommandHandler: CommandHandling {
             case let .setNetworkMockRules(payload):
                 return try handleSetNetworkMockRules(payload, startTime: startTime)
 
+            case let .setNetworkErrorSimulation(payload):
+                return try handleSetNetworkErrorSimulation(payload, startTime: startTime)
+
             // Database commands
             case let .executeSql(payload):
                 return handleExecuteSql(payload, startTime: startTime)
@@ -219,6 +222,26 @@ public class CommandHandler: CommandHandling {
     {
         let succeeded = sdkHierarchyClient?.setMockRules(request.rules) ?? false
         return SetNetworkMockRulesResponse(
+            requestId: request.requestId,
+            ok: succeeded,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
+
+    private func handleSetNetworkErrorSimulation(
+        _ request: RequestSetNetworkErrorSimulation,
+        startTime: Date
+    )
+        throws -> SetNetworkErrorSimulationResponse
+    {
+        let config = NetworkErrorSimulationDTO(
+            enabled: request.enabled,
+            errorType: request.errorType,
+            limit: request.limit,
+            expiresAtEpochMs: request.expiresAtEpochMs
+        )
+        let succeeded = sdkHierarchyClient?.setNetworkErrorSimulation(config) ?? false
+        return SetNetworkErrorSimulationResponse(
             requestId: request.requestId,
             ok: succeeded,
             totalTimeMs: totalTimeMs(from: startTime)

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -791,10 +791,13 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
     private var _fetchServerInfoCallCount = 0
     private var _isAvailableCallCount = 0
     private var _setMockRulesCallCount = 0
+    private var _setNetworkErrorSimulationCallCount = 0
     private var _addHighlightCallCount = 0
     private var _lastMockRules: [NetworkMockRuleDTO]?
+    private var _lastNetworkErrorSimulation: NetworkErrorSimulationDTO?
     private var _lastHighlight: (id: String, shape: HighlightShape)?
     public var setMockRulesResult = true
+    public var setNetworkErrorSimulationResult = true
     public var addHighlightResult: SdkHighlightOutcome = .unavailable
 
     public init() {}
@@ -857,6 +860,12 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         return _setMockRulesCallCount
     }
 
+    public var setNetworkErrorSimulationCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _setNetworkErrorSimulationCallCount
+    }
+
     public var addHighlightCallCount: Int {
         lock.lock()
         defer { lock.unlock() }
@@ -867,6 +876,12 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         lock.lock()
         defer { lock.unlock() }
         return _lastMockRules
+    }
+
+    public var lastNetworkErrorSimulation: NetworkErrorSimulationDTO? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _lastNetworkErrorSimulation
     }
 
     public var lastHighlight: (id: String, shape: HighlightShape)? {
@@ -882,8 +897,10 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         _fetchServerInfoCallCount = 0
         _isAvailableCallCount = 0
         _setMockRulesCallCount = 0
+        _setNetworkErrorSimulationCallCount = 0
         _addHighlightCallCount = 0
         _lastMockRules = nil
+        _lastNetworkErrorSimulation = nil
         _lastHighlight = nil
         lock.unlock()
     }
@@ -927,6 +944,15 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         _setMockRulesCallCount += 1
         _lastMockRules = rules
         let result = setMockRulesResult
+        lock.unlock()
+        return result
+    }
+
+    public func setNetworkErrorSimulation(_ config: NetworkErrorSimulationDTO) -> Bool {
+        lock.lock()
+        _setNetworkErrorSimulationCallCount += 1
+        _lastNetworkErrorSimulation = config
+        let result = setNetworkErrorSimulationResult
         lock.unlock()
         return result
     }

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -216,6 +216,14 @@ public struct RequestSetNetworkMockRules: Decodable {
     public var rules: [NetworkMockRuleDTO]
 }
 
+public struct RequestSetNetworkErrorSimulation: Decodable {
+    public var requestId: String?
+    public var enabled: Bool
+    public var errorType: String?
+    public var limit: Int?
+    public var expiresAtEpochMs: Int64?
+}
+
 // MARK: Database inspection
 
 public struct RequestExecuteSql: Decodable {
@@ -293,6 +301,7 @@ extension RequestSetPreference: CommandPayload {}
 extension RequestRemovePreference: CommandPayload {}
 extension RequestClearPreferences: CommandPayload {}
 extension RequestSetNetworkMockRules: CommandPayload {}
+extension RequestSetNetworkErrorSimulation: CommandPayload {}
 extension RequestExecuteSql: CommandPayload {}
 extension RequestListDatabases: CommandPayload {}
 extension RequestListTables: CommandPayload {}
@@ -347,6 +356,7 @@ public enum WebSocketRequest: Decodable {
     case clearPreferences(RequestClearPreferences)
 
     case setNetworkMockRules(RequestSetNetworkMockRules)
+    case setNetworkErrorSimulation(RequestSetNetworkErrorSimulation)
 
     case executeSql(RequestExecuteSql)
     case listDatabases(RequestListDatabases)
@@ -441,6 +451,8 @@ public enum WebSocketRequest: Decodable {
             self = try .clearPreferences(RequestClearPreferences(from: decoder))
         case .setNetworkMockRules:
             self = try .setNetworkMockRules(RequestSetNetworkMockRules(from: decoder))
+        case .setNetworkErrorSimulation:
+            self = try .setNetworkErrorSimulation(RequestSetNetworkErrorSimulation(from: decoder))
         case .executeSql:
             self = try .executeSql(RequestExecuteSql(from: decoder))
         case .listDatabases:
@@ -492,6 +504,7 @@ public enum WebSocketRequest: Decodable {
         case .removePreference: return .removePreference
         case .clearPreferences: return .clearPreferences
         case .setNetworkMockRules: return .setNetworkMockRules
+        case .setNetworkErrorSimulation: return .setNetworkErrorSimulation
         case .executeSql: return .executeSql
         case .listDatabases: return .listDatabases
         case .listTables: return .listTables
@@ -547,6 +560,7 @@ public enum WebSocketRequest: Decodable {
         case let .removePreference(payload): return payload
         case let .clearPreferences(payload): return payload
         case let .setNetworkMockRules(payload): return payload
+        case let .setNetworkErrorSimulation(payload): return payload
         case let .executeSql(payload): return payload
         case let .listDatabases(payload): return payload
         case let .listTables(payload): return payload
@@ -595,6 +609,20 @@ public struct NetworkMockRuleDTO: Codable, Sendable, Equatable {
         self.responseHeaders = responseHeaders
         self.responseBody = responseBody
         self.contentType = contentType
+    }
+}
+
+public struct NetworkErrorSimulationDTO: Codable, Sendable, Equatable {
+    public let enabled: Bool
+    public let errorType: String?
+    public let limit: Int?
+    public let expiresAtEpochMs: Int64?
+
+    public init(enabled: Bool, errorType: String?, limit: Int?, expiresAtEpochMs: Int64?) {
+        self.enabled = enabled
+        self.errorType = errorType
+        self.limit = limit
+        self.expiresAtEpochMs = expiresAtEpochMs
     }
 }
 
@@ -683,6 +711,22 @@ public struct SetNetworkMockRulesResponse: Codable {
 
     public init(requestId: String?, ok: Bool, totalTimeMs: Int64?) {
         type = ResponseType.setNetworkMockRulesResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.ok = ok
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
+public struct SetNetworkErrorSimulationResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let ok: Bool
+    public let totalTimeMs: Int64?
+
+    public init(requestId: String?, ok: Bool, totalTimeMs: Int64?) {
+        type = ResponseType.setNetworkErrorSimulationResult.rawValue
         timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.ok = ok
@@ -1476,6 +1520,7 @@ public enum RequestType: String, CaseIterable {
 
     /// Network mocking
     case setNetworkMockRules = "set_network_mock_rules"
+    case setNetworkErrorSimulation = "set_network_error_simulation"
 
     // Database inspection
     case executeSql = "execute_sql"
@@ -1525,6 +1570,7 @@ public enum ResponseType: String {
     case removePreferenceResult = "remove_preference_result"
     case clearPreferencesResult = "clear_preferences_result"
     case setNetworkMockRulesResult = "set_network_mock_rules_result"
+    case setNetworkErrorSimulationResult = "set_network_error_simulation_result"
 
     // Database inspection
     case executeSqlResult = "execute_sql_result"
@@ -1583,6 +1629,7 @@ extension RequestType {
         case .removePreference: return .removePreferenceResult
         case .clearPreferences: return .clearPreferencesResult
         case .setNetworkMockRules: return .setNetworkMockRulesResult
+        case .setNetworkErrorSimulation: return .setNetworkErrorSimulationResult
         case .executeSql: return .executeSqlResult
         case .listDatabases: return .listDatabasesResult
         case .listTables: return .listTablesResult

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -265,6 +265,8 @@ public protocol SdkHierarchyFetching {
     func isAvailable() -> Bool
     /// Replace network mock rules in the in-app SDK.
     func setMockRules(_ rules: [NetworkMockRuleDTO]) -> Bool
+    /// Replace active network error simulation in the in-app SDK.
+    func setNetworkErrorSimulation(_ config: NetworkErrorSimulationDTO) -> Bool
     /// Draw a highlight in the in-app SDK process.
     func addHighlight(id: String, shape: HighlightShape) -> SdkHighlightOutcome
 }

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
@@ -44,6 +44,13 @@ public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable
         return postSync(path: "/network/mock", body: body, session: urlSession)
     }
 
+    public func setNetworkErrorSimulation(_ config: NetworkErrorSimulationDTO) -> Bool {
+        guard let body = try? JSONEncoder().encode(config) else {
+            return false
+        }
+        return postSync(path: "/network/error-simulation", body: body, session: urlSession)
+    }
+
     /// Draw a highlight in the target app through the SDK's in-app server.
     public func addHighlight(id: String, shape: HighlightShape) -> SdkHighlightOutcome {
         guard let body = try? JSONEncoder().encode(AddHighlightBody(id: id, shape: shape)) else {

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -147,6 +147,37 @@ final class CommandHandlerTests: XCTestCase {
         )
     }
 
+    func testSetNetworkErrorSimulationRelaysConfigToSdkClient() {
+        let fetcher = FakeSdkHierarchyFetcher()
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher
+        )
+
+        let response = commandHandler.handle(WebSocketRequest.setNetworkErrorSimulation(RequestSetNetworkErrorSimulation(
+            requestId: "sim-sync-1",
+            enabled: true,
+            errorType: "timeout",
+            limit: 2,
+            expiresAtEpochMs: 1_720_000_000_000
+        )))
+
+        guard let typed = response as? SetNetworkErrorSimulationResponse else {
+            XCTFail("Expected SetNetworkErrorSimulationResponse, got \(Swift.type(of: response))")
+            return
+        }
+        XCTAssertEqual(typed.type, ResponseType.setNetworkErrorSimulationResult.rawValue)
+        XCTAssertEqual(typed.requestId, "sim-sync-1")
+        XCTAssertTrue(typed.ok)
+        XCTAssertEqual(fetcher.setNetworkErrorSimulationCallCount, 1)
+        XCTAssertEqual(fetcher.lastNetworkErrorSimulation?.enabled, true)
+        XCTAssertEqual(fetcher.lastNetworkErrorSimulation?.errorType, "timeout")
+        XCTAssertEqual(fetcher.lastNetworkErrorSimulation?.limit, 2)
+        XCTAssertEqual(fetcher.lastNetworkErrorSimulation?.expiresAtEpochMs, 1_720_000_000_000)
+    }
+
     // MARK: - Hierarchy Request Tests
 
     func testRequestHierarchyIncludesPerfTiming() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
@@ -47,6 +47,7 @@ final class ErrorResponseTypeTests: XCTestCase {
             .removePreference: .removePreferenceResult,
             .clearPreferences: .clearPreferencesResult,
             .setNetworkMockRules: .setNetworkMockRulesResult,
+            .setNetworkErrorSimulation: .setNetworkErrorSimulationResult,
             .executeSql: .executeSqlResult,
             .listDatabases: .listDatabasesResult,
             .listTables: .listTablesResult,

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -154,6 +154,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             .removePreference: #"{"key":"k"}"#,
             .clearPreferences: "{}",
             .setNetworkMockRules: #"{"rules":[]}"#,
+            .setNetworkErrorSimulation: #"{"enabled":false}"#,
             .executeSql: "{}",
             .listDatabases: "{}",
             .listTables: "{}",
@@ -653,6 +654,20 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         )
         XCTAssertEqual(response?.type, "set_network_mock_rules_result")
         XCTAssertEqual(fakeSdkHierarchy.lastMockRules?.first?.mockId, "m1")
+    }
+
+    func testSetNetworkErrorSimulationDecodeDispatchRelaysConfig() {
+        let response = dispatch(
+            #"""
+            {"type":"set_network_error_simulation","requestId":"nes-1","enabled":true,"errorType":"tlsFailure","limit":3,"expiresAtEpochMs":1720000000000}
+            """#,
+            as: SetNetworkErrorSimulationResponse.self
+        )
+        XCTAssertEqual(response?.type, "set_network_error_simulation_result")
+        XCTAssertEqual(fakeSdkHierarchy.lastNetworkErrorSimulation?.enabled, true)
+        XCTAssertEqual(fakeSdkHierarchy.lastNetworkErrorSimulation?.errorType, "tlsFailure")
+        XCTAssertEqual(fakeSdkHierarchy.lastNetworkErrorSimulation?.limit, 3)
+        XCTAssertEqual(fakeSdkHierarchy.lastNetworkErrorSimulation?.expiresAtEpochMs, 1_720_000_000_000)
     }
 
     // MARK: - Database

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -44,11 +44,14 @@ import {
   WebSocketFactory,
   defaultWebSocketFactory,
 } from "../DeviceServiceClient";
+import { sendCommand } from "../DeviceServiceUtils";
 import {
   observationStreamDeviceConnectionLostNotifier,
   type DeviceConnectionLostNotifier,
 } from "../DeviceConnectionLostNotifier";
+import type { BaseResult } from "../shared/types";
 import type { SetTextOptions } from "../DeviceService";
+import type { SimulatedErrorType } from "../../../server/NetworkState";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { getDeviceDataStreamServer, PerformanceStreamData } from "../../../daemon/deviceDataStreamSocketServer";
 import { getPerformanceMonitor } from "../../performance/PerformanceMonitor";
@@ -176,6 +179,12 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     perf?: PerformanceTracker
   ): Promise<CtrlProxyHighlightResult>;
 
+  setNetworkErrorSimulation(
+    config: IosNetworkErrorSimulationConfig,
+    timeoutMs?: number,
+    perf?: PerformanceTracker
+  ): Promise<BaseResult>;
+
   requestHierarchySyncWithoutObservationStreamPush(
     perf?: PerformanceTracker,
     disableAllFiltering?: boolean,
@@ -298,12 +307,20 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   onPushUpdate(callback: (hierarchy: XCTestHierarchy) => void): () => void;
 }
 
+export interface IosNetworkErrorSimulationConfig {
+  enabled: boolean;
+  errorType?: SimulatedErrorType | null;
+  limit?: number | null;
+  expiresAtEpochMs?: number | null;
+}
+
 /**
  * Command rawValues a *fresh* iOS CtrlProxy runner advertises in its `connected`
  * handshake that the released v0.0.38 runner predates. The runner exposes no
  * version/hash, so presence of all of these in `supportedCommands` is the runner
  * identity used by diagnostics (doctor) and the booted-devices resource to tell a
- * current runner from a stale one.
+ * current runner from a stale one. Keep unreleased feature-gated commands out of
+ * this list until they are present in the released runner registry.
  */
 export const IOS_RUNNER_FEATURE_COMMANDS = [
   "request_shake",
@@ -782,6 +799,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     logger.info(`[IOSCtrlProxyClient] Connection established, reset failure counter`);
 
     this.syncNetworkMockRulesToDevice();
+    this.syncNetworkErrorSimulationToDevice();
 
     // Start polling for SDK events from the CtrlProxy HTTP endpoint
     this.startSdkEventPolling();
@@ -804,6 +822,32 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       this.sendMessage(JSON.stringify({ type: "set_network_mock_rules", rules }));
     } catch (e) {
       logger.warn(`[IOSCtrlProxyClient] Failed to sync network mock rules on reconnect: ${e}`);
+    }
+  }
+
+  private syncNetworkErrorSimulationToDevice(): void {
+    if (!this.isCommandSupported("set_network_error_simulation")) {
+      logger.info("[IOSCtrlProxyClient] Skipping network error simulation sync; runner does not advertise set_network_error_simulation");
+      return;
+    }
+    try {
+      const sim = NetworkState.getInstance().simulation;
+      if (sim === null) {
+        this.sendMessage(JSON.stringify({
+          type: "set_network_error_simulation",
+          enabled: false,
+        }));
+        return;
+      }
+      this.sendMessage(JSON.stringify({
+        type: "set_network_error_simulation",
+        enabled: true,
+        errorType: sim.errorType,
+        limit: sim.limit,
+        expiresAtEpochMs: sim.expiresAt,
+      }));
+    } catch (e) {
+      logger.warn(`[IOSCtrlProxyClient] Failed to sync network error simulation on reconnect: ${e}`);
     }
   }
 
@@ -1160,6 +1204,28 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<CtrlProxyHighlightResult> {
     return this.highlights.requestAddHighlight(id, shape, timeoutMs, perf);
+  }
+
+  async setNetworkErrorSimulation(
+    config: IosNetworkErrorSimulationConfig,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<BaseResult> {
+    return sendCommand<BaseResult>(this.createDelegateContext(), {
+      idPrefix: "networkErrorSimulation",
+      responseType: "set_network_error_simulation_result",
+      messageType: "set_network_error_simulation",
+      params: {
+        enabled: config.enabled,
+        errorType: config.errorType ?? null,
+        limit: config.limit ?? null,
+        expiresAtEpochMs: config.expiresAtEpochMs ?? null,
+      },
+      timeoutMs,
+      perf,
+      cancelScreenshotBackoff: false,
+      errorLabel: "Network error simulation",
+    });
   }
 
   // ===========================================================================

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -73,6 +73,7 @@ export const IOS_KNOWN_REQUEST_TYPES = [
 
   // Network mocking
   "set_network_mock_rules",
+  "set_network_error_simulation",
 
   // Database inspection
   "execute_sql",

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -205,8 +205,9 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
     case "set_preference_result":
     case "remove_preference_result":
     case "clear_preferences_result":
+    case "set_network_error_simulation_result":
       result = {
-        success: message.success ?? false,
+        success: message.success ?? message.ok ?? false,
         totalTimeMs: message.totalTimeMs ?? 0,
         error: message.error,
       };

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -118,6 +118,7 @@ export interface WebSocketMessage {
   performanceData?: CtrlProxyPerformanceSnapshot;
   format?: string;
   success?: boolean;
+  ok?: boolean;
   open?: boolean;
   totalTimeMs?: number;
   error?: string;

--- a/src/server/NetworkState.ts
+++ b/src/server/NetworkState.ts
@@ -145,10 +145,23 @@ export class NetworkState {
     durationSeconds: number,
     limit: number | null
   ): void {
+    this.startSimulationUntil(errorType, Math.ceil(this.timer.now() + durationSeconds * 1000), limit);
+  }
+
+  startSimulationUntil(
+    errorType: SimulatedErrorType,
+    expiresAt: number,
+    limit: number | null
+  ): void {
     if (this._simulationTimeout) {
       this.timer.clearTimeout(this._simulationTimeout);
+      this._simulationTimeout = null;
     }
-    const expiresAt = this.timer.now() + durationSeconds * 1000;
+    const timeoutMs = Math.max(0, expiresAt - this.timer.now());
+    if (timeoutMs === 0) {
+      this._simulation = null;
+      return;
+    }
     this._simulation = {
       errorType,
       limit,
@@ -158,7 +171,7 @@ export class NetworkState {
     this._simulationTimeout = this.timer.setTimeout(() => {
       this._simulation = null;
       this._simulationTimeout = null;
-    }, durationSeconds * 1000);
+    }, timeoutMs);
   }
 
   cancelSimulation(): void {

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -13,8 +13,18 @@ import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
 import type { BootedDevice } from "../utils/deviceUtils";
 import { logger } from "../utils/logger";
+import {
+  LATEST_RELEASE_VERSION,
+  RELEASE_CHECKSUM_REGISTRY,
+  resolveAssetVersion,
+  resolvePinnedVersion,
+  isPinnedVersionKnown,
+  type ReleaseChecksumEntry,
+} from "../constants/release";
 
 // --- network tool ---
+
+export const IOS_NETWORK_ERROR_SIMULATION_MIN_RELEASE = "0.0.41";
 
 const simulateErrorsSchema = z.object({
   errorType: z
@@ -117,6 +127,62 @@ const getNetworkGraphSchema = addDeviceTargetingToSchema(
 
 type GetNetworkGraphArgs = z.infer<typeof getNetworkGraphSchema>;
 
+function compareDottedVersion(a: string, b: string): number {
+  const aParts = a.split(".").map(part => Number(part));
+  const bParts = b.split(".").map(part => Number(part));
+  const length = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < length; i += 1) {
+    const left = Number.isFinite(aParts[i]) ? aParts[i] : 0;
+    const right = Number.isFinite(bParts[i]) ? bParts[i] : 0;
+    if (left !== right) {
+      return left - right;
+    }
+  }
+  return 0;
+}
+
+function hasIosCtrlProxyRunnerOverride(env: NodeJS.ProcessEnv = process.env): boolean {
+  const ipaPath = env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH?.trim();
+  const bundlePath = env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH?.trim();
+  return (
+    (ipaPath !== undefined && ipaPath.length > 0) ||
+    (bundlePath !== undefined && bundlePath.length > 0)
+  );
+}
+
+export function isIosNetworkErrorSimulationAvailable(
+  env: NodeJS.ProcessEnv = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): boolean {
+  if (hasIosCtrlProxyRunnerOverride(env)) {
+    return true;
+  }
+
+  const pinned = resolvePinnedVersion(env);
+  if (pinned !== LATEST_RELEASE_VERSION && !isPinnedVersionKnown(env, registry)) {
+    return false;
+  }
+
+  return compareDottedVersion(
+    resolveAssetVersion(pinned, registry),
+    IOS_NETWORK_ERROR_SIMULATION_MIN_RELEASE
+  ) >= 0;
+}
+
+function assertIosNetworkErrorSimulationAvailable(): void {
+  if (isIosNetworkErrorSimulationAvailable()) {
+    return;
+  }
+  const resolvedVersion = resolveAssetVersion(resolvePinnedVersion());
+  throw new ActionableError(
+    `Network error simulation is not enabled for the bundled iOS CtrlProxy runner ` +
+    `(${resolvedVersion}); it requires iOS CtrlProxy ${IOS_NETWORK_ERROR_SIMULATION_MIN_RELEASE} ` +
+    `or newer with set_network_error_simulation. Use Android for this scenario, ` +
+    `provide a locally built iOS runner via AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH or ` +
+    `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH, or retry after the updated runner ships.`
+  );
+}
+
 function syncMockRulesToDevice(device: BootedDevice, state: NetworkState): void {
   if (device.platform !== "android" && device.platform !== "ios") {return;}
   try {
@@ -134,12 +200,24 @@ function syncMockRulesToDevice(device: BootedDevice, state: NetworkState): void 
   }
 }
 
-function syncErrorSimulationToDevice(device: BootedDevice, state: NetworkState): void {
-  if (device.platform !== "android") {return;}
+async function syncErrorSimulationToDevice(device: BootedDevice, state: NetworkState): Promise<void> {
+  if (device.platform !== "android" && device.platform !== "ios") {return;}
   try {
-    const client = AndroidCtrlProxyClient.getInstance(device);
     const sim = state.simulation;
-    client.sendMessage(JSON.stringify({
+    if (device.platform === "ios") {
+      const result = await IOSCtrlProxyClient.getInstance(device).setNetworkErrorSimulation({
+        enabled: sim !== null,
+        errorType: sim?.errorType ?? null,
+        limit: sim?.limit ?? null,
+        expiresAtEpochMs: sim?.expiresAt ?? null,
+      });
+      if (!result.success) {
+        throw new ActionableError(result.error ?? "Failed to sync iOS network error simulation.");
+      }
+      return;
+    }
+
+    AndroidCtrlProxyClient.getInstance(device).sendMessage(JSON.stringify({
       type: "set_network_error_simulation",
       enabled: sim !== null,
       errorType: sim?.errorType ?? null,
@@ -147,8 +225,39 @@ function syncErrorSimulationToDevice(device: BootedDevice, state: NetworkState):
       expiresAtEpochMs: sim?.expiresAt ?? null,
     }));
   } catch (e) {
+    if (device.platform === "ios") {
+      throw e;
+    }
     logger.debug(`[networkTools] Failed to sync error simulation to device: ${e}`);
   }
+}
+
+async function setIosErrorSimulation(
+  device: BootedDevice,
+  state: NetworkState,
+  config: { errorType: SimulatedErrorType; durationSeconds: number; limit: number | null } | null
+): Promise<void> {
+  if (config === null) {
+    state.cancelSimulation();
+  }
+
+  const expiresAtEpochMs = config
+    ? Math.ceil(state.timer.now() + config.durationSeconds * 1000)
+    : null;
+  const result = await IOSCtrlProxyClient.getInstance(device).setNetworkErrorSimulation({
+    enabled: config !== null,
+    errorType: config?.errorType ?? null,
+    limit: config?.limit ?? null,
+    expiresAtEpochMs,
+  });
+  if (!result.success) {
+    throw new ActionableError(result.error ?? "Failed to sync iOS network error simulation.");
+  }
+
+  if (config === null) {
+    return;
+  }
+  state.startSimulationUntil(config.errorType, expiresAtEpochMs!, config.limit);
 }
 
 export function registerNetworkTools(): void {
@@ -161,26 +270,41 @@ export function registerNetworkTools(): void {
     }
 
     if (args.simulateErrors !== undefined) {
-      if (device.platform !== "android") {
-        throw new ActionableError(
-          "Network error simulation is only supported on Android devices."
-        );
-      }
-      if (args.simulateErrors.cancel) {
-        state.cancelSimulation();
-      } else {
-        if (!args.simulateErrors.durationSeconds) {
-          throw new ActionableError("durationSeconds is required unless cancel is true");
+      if (device.platform === "ios") {
+        if (args.simulateErrors.cancel) {
+          if (isIosNetworkErrorSimulationAvailable()) {
+            await setIosErrorSimulation(device, state, null);
+          } else {
+            state.cancelSimulation();
+          }
+        } else {
+          assertIosNetworkErrorSimulationAvailable();
+          if (!args.simulateErrors.durationSeconds) {
+            throw new ActionableError("durationSeconds is required unless cancel is true");
+          }
+          await setIosErrorSimulation(device, state, {
+            errorType: args.simulateErrors.errorType ?? "http500",
+            durationSeconds: args.simulateErrors.durationSeconds,
+            limit: args.simulateErrors.limit ?? null,
+          });
         }
-        const errorType: SimulatedErrorType =
-                args.simulateErrors.errorType ?? "http500";
-        state.startSimulation(
-          errorType,
-          args.simulateErrors.durationSeconds,
-          args.simulateErrors.limit ?? null
-        );
+      } else {
+        if (args.simulateErrors.cancel) {
+          state.cancelSimulation();
+        } else {
+          if (!args.simulateErrors.durationSeconds) {
+            throw new ActionableError("durationSeconds is required unless cancel is true");
+          }
+          const errorType: SimulatedErrorType =
+                  args.simulateErrors.errorType ?? "http500";
+          state.startSimulation(
+            errorType,
+            args.simulateErrors.durationSeconds,
+            args.simulateErrors.limit ?? null
+          );
+        }
+        await syncErrorSimulationToDevice(device, state);
       }
-      syncErrorSimulationToDevice(device, state);
     }
 
     if (args.notifFilter !== undefined) {

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -93,6 +93,7 @@ export class IOSCtrlProxyBuilder {
   private static prefetchResult: CtrlProxyIosBuildResult | null = null;
   private static prefetchError: Error | null = null;
   private static expectedChecksumOverride: string | null = null;
+  private static expectedRunnerChecksumOverride: string | null = null;
   private static timer: Timer = defaultTimer;
 
   // Singleton instances per configuration
@@ -156,6 +157,7 @@ export class IOSCtrlProxyBuilder {
     IOSCtrlProxyBuilder.prefetchResult = null;
     IOSCtrlProxyBuilder.prefetchError = null;
     IOSCtrlProxyBuilder.expectedChecksumOverride = null;
+    IOSCtrlProxyBuilder.expectedRunnerChecksumOverride = null;
     IOSCtrlProxyBuilder.timer = defaultTimer;
   }
 
@@ -171,6 +173,10 @@ export class IOSCtrlProxyBuilder {
    */
   public static setExpectedChecksumForTesting(checksum: string | null): void {
     IOSCtrlProxyBuilder.expectedChecksumOverride = checksum;
+  }
+
+  public static setExpectedRunnerChecksumForTesting(checksum: string | null): void {
+    IOSCtrlProxyBuilder.expectedRunnerChecksumOverride = checksum;
   }
 
   /**
@@ -676,6 +682,14 @@ export class IOSCtrlProxyBuilder {
     return resolveIpaChecksum();
   }
 
+  private getExpectedRunnerChecksum(): string {
+    const override = IOSCtrlProxyBuilder.expectedRunnerChecksumOverride;
+    if (override !== null) {
+      return override;
+    }
+    return resolveRunnerChecksum();
+  }
+
   public getExpectedAppHash(platform: IOSCtrlProxyPlatform): string {
     const envPlatform = platform.toUpperCase();
     // Check for platform-specific override first
@@ -924,7 +938,7 @@ export class IOSCtrlProxyBuilder {
 
     // Verify runner binary SHA256 for simulator (used by simctl spawn)
     if (platform === "simulator") {
-      const expectedRunnerSha256 = resolveRunnerChecksum();
+      const expectedRunnerSha256 = this.getExpectedRunnerChecksum();
       if (expectedRunnerSha256 && expectedRunnerSha256.length > 0) {
         const runnerBinaryPath = await this.getRunnerBinaryPath(platform);
         if (!runnerBinaryPath) {

--- a/test/features/observe/ios/CtrlProxyDatabase.test.ts
+++ b/test/features/observe/ios/CtrlProxyDatabase.test.ts
@@ -62,10 +62,20 @@ describe("CtrlProxyDatabase (iOS)", function() {
   const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount = 1): Promise<void> => {
     if (!socket) { return; }
     for (let i = 0; i < 10; i += 1) {
-      if (socket.sentMessages.length >= minCount) { return; }
+      if (commandPayloads(socket).length >= minCount) { return; }
       await new Promise(resolve => setImmediate(resolve));
     }
   };
+
+  const syncMessageTypes = new Set([
+    "set_network_mock_rules",
+    "set_network_error_simulation",
+  ]);
+
+  const commandPayloads = (socket: CapturingWebSocket): any[] =>
+    socket.sentMessages
+      .map(message => JSON.parse(message))
+      .filter(payload => !syncMessageTypes.has(payload.type));
 
   test("executeSQLForIos sends execute_sql and returns query rows including blob strings", async function() {
     const { factory, getSocket } = createCapturingFactory();
@@ -77,7 +87,7 @@ describe("CtrlProxyDatabase (iOS)", function() {
       await waitForSocketOpen(socket);
       await waitForSentMessages(socket);
 
-      const sentMessage = JSON.parse(socket!.sentMessages[0]);
+      const sentMessage = commandPayloads(socket!)[0];
       expect(sentMessage.type).toBe("execute_sql");
       expect(sentMessage.appId).toBe("com.example.app");
       expect(sentMessage.databasePath).toBe("/app/Documents/app.db");
@@ -113,7 +123,7 @@ describe("CtrlProxyDatabase (iOS)", function() {
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       await waitForSentMessages(socket);
-      const sentMessage = JSON.parse(socket!.sentMessages[0]);
+      const sentMessage = commandPayloads(socket!)[0];
 
       socket!.simulateMessage(JSON.stringify({
         type: "execute_sql_result",
@@ -142,7 +152,7 @@ describe("CtrlProxyDatabase (iOS)", function() {
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       await waitForSentMessages(socket);
-      const sentMessage = JSON.parse(socket!.sentMessages[0]);
+      const sentMessage = commandPayloads(socket!)[0];
 
       socket!.simulateMessage(JSON.stringify({
         type: "execute_sql_result",

--- a/test/features/observe/ios/CtrlProxyStorage.test.ts
+++ b/test/features/observe/ios/CtrlProxyStorage.test.ts
@@ -74,10 +74,20 @@ describe("CtrlProxyStorage (iOS)", function() {
   ): Promise<void> => {
     if (!socket) {return;}
     for (let i = 0; i < 10; i++) {
-      if (socket.sentMessages.length >= minCount) {return;}
+      if (commandPayloads(socket).length >= minCount) {return;}
       await new Promise(r => setImmediate(r));
     }
   };
+
+  const syncMessageTypes = new Set([
+    "set_network_mock_rules",
+    "set_network_error_simulation",
+  ]);
+
+  const commandPayloads = (socket: CapturingWebSocket): any[] =>
+    socket.sentMessages
+      .map(message => JSON.parse(message))
+      .filter(payload => !syncMessageTypes.has(payload.type));
 
   // ---------------------------------------------------------------------------
   // listPreferenceFiles
@@ -95,7 +105,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("list_preference_files");
         expect(typeof sentMsg.requestId).toBe("string");
 
@@ -152,7 +162,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("get_preferences");
         expect(sentMsg.fileName).toBe("Standard");
 
@@ -194,7 +204,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("get_preference");
         expect(sentMsg.fileName).toBe("Standard");
         expect(sentMsg.key).toBe("theme");
@@ -230,7 +240,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
 
         socket!.simulateMessage(JSON.stringify({
           type: "get_preference_result",
@@ -263,7 +273,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("set_preference");
         expect(sentMsg.fileName).toBe("Standard");
         expect(sentMsg.key).toBe("theme");
@@ -293,7 +303,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
 
         socket!.simulateMessage(JSON.stringify({
           type: "set_preference_result",
@@ -325,7 +335,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("remove_preference");
         expect(sentMsg.fileName).toBe("Standard");
         expect(sentMsg.key).toBe("theme");
@@ -359,7 +369,7 @@ describe("CtrlProxyStorage (iOS)", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("clear_preferences");
         expect(sentMsg.fileName).toBe("com.example.settings");
 

--- a/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
+++ b/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
@@ -75,10 +75,20 @@ describe("CtrlProxyVoiceOver", function() {
   ): Promise<void> => {
     if (!socket) {return;}
     for (let i = 0; i < 10; i++) {
-      if (socket.sentMessages.length >= minCount) {return;}
+      if (commandPayloads(socket).length >= minCount) {return;}
       await new Promise(r => setImmediate(r));
     }
   };
+
+  const syncMessageTypes = new Set([
+    "set_network_mock_rules",
+    "set_network_error_simulation",
+  ]);
+
+  const commandPayloads = (socket: CapturingWebSocket): any[] =>
+    socket.sentMessages
+      .map(message => JSON.parse(message))
+      .filter(payload => !syncMessageTypes.has(payload.type));
 
   // ---------------------------------------------------------------------------
   // Tests
@@ -96,7 +106,7 @@ describe("CtrlProxyVoiceOver", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("get_voiceover_state");
         expect(typeof sentMsg.requestId).toBe("string");
 
@@ -126,7 +136,7 @@ describe("CtrlProxyVoiceOver", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
 
         socket!.simulateMessage(JSON.stringify({
           type: "voiceover_state_result",
@@ -172,7 +182,7 @@ describe("CtrlProxyVoiceOver", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("get_voiceover_state");
 
         // Resolve the pending request to avoid leaking
@@ -204,7 +214,7 @@ describe("CtrlProxyVoiceOver", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("request_action");
         expect(sentMsg.type).not.toBe("request_voiceover_action");
         expect(sentMsg.label).toBe("Submit");
@@ -237,7 +247,7 @@ describe("CtrlProxyVoiceOver", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMsg = JSON.parse(socket!.sentMessages[0]);
+        const sentMsg = commandPayloads(socket!)[0];
         expect(sentMsg.type).toBe("request_action");
         expect(sentMsg.action).toBe("long_press");
 
@@ -305,7 +315,7 @@ describe("CtrlProxyVoiceOver", function() {
         expect(result.totalTimeMs).toBe(0);
         expect(result.error).toContain("request_action");
         // Unsupported commands short-circuit before hitting the wire.
-        expect(socket!.sentMessages).toHaveLength(0);
+        expect(commandPayloads(socket!)).toHaveLength(0);
       } finally {
         await client.close();
       }

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -109,12 +109,22 @@ describe("IOSCtrlProxyClient", function() {
       return;
     }
     for (let attempt = 0; attempt < 10; attempt++) {
-      if (socket.sentMessages.length >= minCount) {
+      if (commandPayloads(socket).length >= minCount) {
         return;
       }
       await new Promise(resolve => setImmediate(resolve));
     }
   };
+
+  const syncMessageTypes = new Set([
+    "set_network_mock_rules",
+    "set_network_error_simulation",
+  ]);
+
+  const commandPayloads = (socket: CapturingWebSocket): any[] =>
+    socket.sentMessages
+      .map(message => JSON.parse(message))
+      .filter(payload => !syncMessageTypes.has(payload.type));
 
   const flushPromises = async (iterations: number = 3): Promise<void> => {
     for (let i = 0; i < iterations; i += 1) {
@@ -193,7 +203,11 @@ describe("IOSCtrlProxyClient", function() {
 
       (ctrlProxyClient as any).onConnectionEstablished();
 
-      expect(sentMessages).toHaveLength(1);
+      expect(sentMessages).toHaveLength(2);
+      expect(sentMessages.map(message => JSON.parse(message).type)).toEqual([
+        "set_network_mock_rules",
+        "set_network_error_simulation",
+      ]);
       expect(JSON.parse(sentMessages[0])).toEqual({
         type: "set_network_mock_rules",
         rules: [{
@@ -209,6 +223,171 @@ describe("IOSCtrlProxyClient", function() {
           contentType: "application/json",
         }],
       });
+      expect(JSON.parse(sentMessages[1])).toEqual({
+        type: "set_network_error_simulation",
+        enabled: false,
+      });
+    });
+
+    test("clears stale network error simulation when the connection (re)establishes without an active simulation", function() {
+      const sentMessages: string[] = [];
+
+      (ctrlProxyClient as any).sendMessage = (message: string) => {
+        sentMessages.push(message);
+        return true;
+      };
+      (ctrlProxyClient as any).startSdkEventPolling = () => { /* no-op */ };
+      (ctrlProxyClient as any).startScreenshotBackoff = () => { /* no-op */ };
+
+      (ctrlProxyClient as any).onConnectionEstablished();
+
+      expect(sentMessages).toHaveLength(1);
+      expect(JSON.parse(sentMessages[0])).toEqual({
+        type: "set_network_error_simulation",
+        enabled: false,
+      });
+    });
+
+    test("does not sync network error simulation to stale runners without command support", function() {
+      const sentMessages: string[] = [];
+
+      (ctrlProxyClient as any).supportedCommands = new Set(["set_network_mock_rules"]);
+      (ctrlProxyClient as any).sendMessage = (message: string) => {
+        sentMessages.push(message);
+        return true;
+      };
+      (ctrlProxyClient as any).startSdkEventPolling = () => { /* no-op */ };
+      (ctrlProxyClient as any).startScreenshotBackoff = () => { /* no-op */ };
+
+      (ctrlProxyClient as any).onConnectionEstablished();
+
+      expect(sentMessages.map(message => JSON.parse(message).type)).not.toContain("set_network_error_simulation");
+    });
+
+    test("syncs active network error simulation when the connection (re)establishes", function() {
+      const state = NetworkState.getInstance();
+      state.startSimulation("tlsFailure", 20, 4);
+      const sentMessages: string[] = [];
+
+      (ctrlProxyClient as any).sendMessage = (message: string) => {
+        sentMessages.push(message);
+        return true;
+      };
+      (ctrlProxyClient as any).startSdkEventPolling = () => { /* no-op */ };
+      (ctrlProxyClient as any).startScreenshotBackoff = () => { /* no-op */ };
+
+      (ctrlProxyClient as any).onConnectionEstablished();
+
+      expect(sentMessages).toHaveLength(1);
+      expect(JSON.parse(sentMessages[0])).toEqual({
+        type: "set_network_error_simulation",
+        enabled: true,
+        errorType: "tlsFailure",
+        limit: 4,
+        expiresAtEpochMs: expect.any(Number),
+      });
+    });
+  });
+
+  describe("setNetworkErrorSimulation", function() {
+    test("sends capability-gated request and resolves runner acknowledgement", async function() {
+      const testTimer = fakeTimer;
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          supportedCommands: ["set_network_error_simulation"],
+        }));
+
+        const resultPromise = testClient.setNetworkErrorSimulation({
+          enabled: true,
+          errorType: "timeout",
+          limit: 2,
+          expiresAtEpochMs: 1_720_000_000_000,
+        });
+        for (let attempt = 0; attempt < 10; attempt += 1) {
+          if (socket!.sentMessages.some(message => {
+            const payload = JSON.parse(message);
+            return payload.type === "set_network_error_simulation" && payload.requestId !== undefined;
+          })) {
+            break;
+          }
+          await new Promise(resolve => setImmediate(resolve));
+        }
+        const sentMessage = socket!.sentMessages
+          .map(message => JSON.parse(message))
+          .find(message => message.type === "set_network_error_simulation" && message.requestId !== undefined);
+        expect(sentMessage).toEqual({
+          type: "set_network_error_simulation",
+          requestId: expect.any(String),
+          enabled: true,
+          errorType: "timeout",
+          limit: 2,
+          expiresAtEpochMs: 1_720_000_000_000,
+        });
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "set_network_error_simulation_result",
+          requestId: sentMessage.requestId,
+          ok: true,
+          totalTimeMs: 4,
+        }));
+
+        expect(await resultPromise).toEqual({
+          success: true,
+          totalTimeMs: 4,
+          error: undefined,
+        });
+      } finally {
+        await testClient.close();
+      }
+    });
+
+    test("fails without sending when the runner does not advertise network error simulation", async function() {
+      const testTimer = fakeTimer;
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          supportedCommands: ["request_recent_apps"],
+        }));
+
+        const result = await testClient.setNetworkErrorSimulation({
+          enabled: true,
+          errorType: "timeout",
+          limit: null,
+          expiresAtEpochMs: 1_720_000_000_000,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.totalTimeMs).toBe(0);
+        expect(result.error).toContain("does not support set_network_error_simulation");
+        expect(commandPayloads(socket!)).toHaveLength(0);
+      } finally {
+        await testClient.close();
+      }
     });
   });
 
@@ -251,7 +430,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSentMessages(socket, 1);
 
         // Parse sent message to get requestId
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_hierarchy_if_stale");
 
         // Respond with matching requestId
@@ -309,7 +488,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_hierarchy_if_stale");
         expect(suppressionIds()).toEqual([sentMessage.requestId]);
 
@@ -547,7 +726,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSentMessages(socket, 1);
 
         // Parse sent message to get requestId
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_swipe");
         expect(sentMessage.x1).toBe(100);
         expect(sentMessage.y1).toBe(200);
@@ -611,7 +790,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_tap_coordinates");
         expect(sentMessage.x).toBe(150);
         expect(sentMessage.y).toBe(300);
@@ -651,7 +830,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_set_text");
         expect(sentMessage.text).toBe("Hello World");
         expect(sentMessage.resourceId).toBe("text_field_1");
@@ -761,7 +940,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const payload = JSON.parse(socket!.sentMessages[0]);
+        const payload = commandPayloads(socket!)[0];
         socket!.simulateMessage(JSON.stringify({
           type: "highlight_response",
           requestId: payload.requestId,
@@ -794,7 +973,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_screenshot");
 
         const fakeBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
@@ -835,7 +1014,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_ime_action");
         expect(sentMessage.action).toBe("done");
 
@@ -875,7 +1054,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_keyboard");
         expect(sentMessage.action).toBe("detect");
 
@@ -924,7 +1103,7 @@ describe("IOSCtrlProxyClient", function() {
         expect(result.open).toBe(false);
         expect(result.error).toContain("does not support request_keyboard");
         expect(result.error).toContain("out of sync");
-        expect(socket!.sentMessages).toHaveLength(0);
+        expect(commandPayloads(socket!)).toHaveLength(0);
       } finally {
         await testClient.close();
       }
@@ -981,7 +1160,7 @@ describe("IOSCtrlProxyClient", function() {
         expect(voiceOver.totalTimeMs).toBe(0);
         expect(voiceOver.error).toContain("does not support get_voiceover_state");
 
-        expect(socket!.sentMessages).toHaveLength(0);
+        expect(commandPayloads(socket!)).toHaveLength(0);
       } finally {
         await testClient.close();
       }
@@ -1092,7 +1271,7 @@ describe("IOSCtrlProxyClient", function() {
 
         const keyboardPromise = testClient.requestKeyboard("detect", 5000);
         await waitForSentMessages(socket as CapturingWebSocket, 1);
-        const keyboardMessage = JSON.parse(socket!.sentMessages[0]);
+        const keyboardMessage = commandPayloads(socket!)[0];
         socket!.simulateMessage(JSON.stringify({
           type: "error",
           requestId: keyboardMessage.requestId,
@@ -1106,7 +1285,7 @@ describe("IOSCtrlProxyClient", function() {
 
         const imeActionPromise = testClient.requestImeAction("done", 5000);
         await waitForSentMessages(socket as CapturingWebSocket, 2);
-        const imeActionMessage = JSON.parse(socket!.sentMessages[1]);
+        const imeActionMessage = commandPayloads(socket!)[1];
         socket!.simulateMessage(JSON.stringify({
           type: "error",
           requestId: imeActionMessage.requestId,
@@ -1120,7 +1299,7 @@ describe("IOSCtrlProxyClient", function() {
 
         const rotatePromise = testClient.requestRotate("landscape", 5000);
         await waitForSentMessages(socket as CapturingWebSocket, 3);
-        const rotateMessage = JSON.parse(socket!.sentMessages[2]);
+        const rotateMessage = commandPayloads(socket!)[2];
         socket!.simulateMessage(JSON.stringify({
           type: "error",
           requestId: rotateMessage.requestId,
@@ -1137,7 +1316,7 @@ describe("IOSCtrlProxyClient", function() {
 
         const clipboardPromise = testClient.requestClipboard("get", undefined, 5000);
         await waitForSentMessages(socket as CapturingWebSocket, 4);
-        const clipboardMessage = JSON.parse(socket!.sentMessages[3]);
+        const clipboardMessage = commandPayloads(socket!)[3];
         socket!.simulateMessage(JSON.stringify({
           type: "error",
           requestId: clipboardMessage.requestId,
@@ -1173,7 +1352,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_recent_apps");
 
         socket!.simulateMessage(JSON.stringify({
@@ -1210,7 +1389,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_shake");
 
         socket!.simulateMessage(JSON.stringify({
@@ -1247,7 +1426,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_launch_app");
         expect(sentMessage.bundleId).toBe("com.apple.Preferences");
 
@@ -1286,7 +1465,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_press_back");
 
         socket!.simulateMessage(JSON.stringify({
@@ -1322,7 +1501,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_press_back");
 
         socket!.simulateMessage(JSON.stringify({
@@ -1362,7 +1541,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_press_button");
         expect(sentMessage.action).toBe("volume_up");
 
@@ -1581,7 +1760,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_clear_text");
         expect(sentMessage.resourceId).toBeUndefined();
 
@@ -1617,7 +1796,7 @@ describe("IOSCtrlProxyClient", function() {
         await waitForSocketOpen(socket);
         await waitForSentMessages(socket, 1);
 
-        const sentMessage = JSON.parse(socket!.sentMessages[0]);
+        const sentMessage = commandPayloads(socket!)[0];
         expect(sentMessage.type).toBe("request_clear_text");
         expect(sentMessage.resourceId).toBe("com.app:id/email_field");
 

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -73,6 +73,7 @@ const SWIFT_REQUEST_TYPES = [
   "remove_preference",
   "clear_preferences",
   "set_network_mock_rules",
+  "set_network_error_simulation",
   "execute_sql",
   "list_databases",
   "list_tables",
@@ -225,5 +226,10 @@ describe("iOS control-proxy — emitted commands are a subset of the runner cont
   test("IOS_RUNNER_FEATURE_COMMANDS is a subset of the known RequestType set", () => {
     const unknown = IOS_RUNNER_FEATURE_COMMANDS.filter(c => !IOS_KNOWN_REQUEST_TYPE_SET.has(c));
     expect(unknown).toEqual([]);
+  });
+
+  test("IOS_RUNNER_FEATURE_COMMANDS excludes feature-gated unreleased commands", () => {
+    const baselineCommands: readonly string[] = IOS_RUNNER_FEATURE_COMMANDS;
+    expect(baselineCommands).not.toContain("set_network_error_simulation");
   });
 });

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -245,6 +245,20 @@ describe("decodeCtrlProxyMessage", () => {
     });
   }
 
+  test("set_network_error_simulation_result maps ok to success", () => {
+    const decoded = decodeCtrlProxyMessage(msg({
+      type: "set_network_error_simulation_result",
+      ok: true,
+      totalTimeMs: 7,
+    }));
+
+    expect(decoded?.result).toEqual({
+      success: true,
+      totalTimeMs: 7,
+      error: undefined,
+    });
+  });
+
   test("execute_sql_result carries query fields", () => {
     const decoded = decodeCtrlProxyMessage(msg({
       type: "execute_sql_result",

--- a/test/server/NetworkState.test.ts
+++ b/test/server/NetworkState.test.ts
@@ -64,6 +64,32 @@ describe("NetworkState", () => {
       expect(sim!.expiresAt).toBe(30_000);
     });
 
+    it("rounds fractional duration expirations up to integer milliseconds", () => {
+      state.startSimulation("http500", 1.2345, null);
+
+      expect(state.simulation?.expiresAt).toBe(1_235);
+    });
+
+    it("starts simulation with an absolute expiration", () => {
+      timer.advanceTime(5_000);
+      state.startSimulationUntil("http500", 30_000, null);
+      const sim = state.simulation;
+      expect(sim).not.toBeNull();
+      expect(sim!.expiresAt).toBe(30_000);
+
+      timer.advanceTime(24_999);
+      expect(state.simulation).not.toBeNull();
+      timer.advanceTime(1);
+      expect(state.simulation).toBeNull();
+    });
+
+    it("does not keep already-expired absolute simulations active", () => {
+      timer.advanceTime(30_000);
+      state.startSimulationUntil("http500", 30_000, null);
+
+      expect(state.simulation).toBeNull();
+    });
+
     it("expires simulation after duration", () => {
       state.startSimulation("timeout", 10, null);
       expect(state.simulation).not.toBeNull();

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -3,7 +3,10 @@ import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
 import type { BootedDevice } from "../../src/models";
 import { NetworkState } from "../../src/server/NetworkState";
-import { registerNetworkTools } from "../../src/server/networkTools";
+import {
+  isIosNetworkErrorSimulationAvailable,
+  registerNetworkTools,
+} from "../../src/server/networkTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { serverConfig } from "../../src/utils/ServerConfig";
 
@@ -14,8 +17,12 @@ function parseToolJson(response: any): any {
 describe("network tool schema", () => {
   let iosMessages: string[];
   let androidMessages: string[];
+  let iosErrorSimulations: unknown[];
   let iosGetInstanceSpy: ReturnType<typeof spyOn>;
   let androidGetInstanceSpy: ReturnType<typeof spyOn>;
+  let originalIosBundlePath: string | undefined;
+  let originalIosIpaPath: string | undefined;
+  let originalSkipDownload: string | undefined;
 
   const iosDevice: BootedDevice = {
     deviceId: "ios-sim-1",
@@ -32,14 +39,25 @@ describe("network tool schema", () => {
   beforeEach(() => {
     ToolRegistry.clearTools();
     NetworkState.resetInstance();
+    originalIosBundlePath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+    originalIosIpaPath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH;
+    originalSkipDownload = process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD;
+    delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+    delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH;
+    delete process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD;
     serverConfig.setEmbeddedSdkEnabled(true);
     serverConfig.setNetworkMockableEnabled(true);
     iosMessages = [];
+    iosErrorSimulations = [];
     androidMessages = [];
     iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
       sendMessage: (message: string) => {
         iosMessages.push(message);
         return true;
+      },
+      setNetworkErrorSimulation: async (config: unknown) => {
+        iosErrorSimulations.push(config);
+        return { success: true, totalTimeMs: 0 };
       },
     } as IOSCtrlProxyClient);
     androidGetInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
@@ -58,7 +76,22 @@ describe("network tool schema", () => {
     serverConfig.setNetworkMockableEnabled(false);
     iosGetInstanceSpy.mockRestore();
     androidGetInstanceSpy.mockRestore();
+    restoreEnv("AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH", originalIosBundlePath);
+    restoreEnv("AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH", originalIosIpaPath);
+    restoreEnv("AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD", originalSkipDownload);
   });
+
+  function restoreEnv(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+      return;
+    }
+    process.env[key] = value;
+  }
+
+  function allowLocalIosRunner(): void {
+    process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = "/tmp/CtrlProxyUITests-Runner.app";
+  }
 
   test("requires durationSeconds when starting error simulation", () => {
     const tool = ToolRegistry.getTool("network");
@@ -84,6 +117,255 @@ describe("network tool schema", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  test("network simulateErrors syncs iOS error simulation through IOSCtrlProxyClient", async () => {
+    allowLocalIosRunner();
+    const tool = ToolRegistry.getTool("network");
+
+    const response = await tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        errorType: "timeout",
+        durationSeconds: 30,
+        limit: 2,
+      },
+    });
+
+    expect(parseToolJson(response).simulatingErrors).toEqual({
+      errorType: "timeout",
+      remainingSeconds: 30,
+      limit: 2,
+    });
+    expect(iosGetInstanceSpy).toHaveBeenCalledWith(iosDevice);
+    expect(androidGetInstanceSpy).not.toHaveBeenCalled();
+    expect(iosMessages).toHaveLength(0);
+    expect(iosErrorSimulations).toEqual([{
+      enabled: true,
+      errorType: "timeout",
+      limit: 2,
+      expiresAtEpochMs: expect.any(Number),
+    }]);
+  });
+
+  test("network simulateErrors rounds fractional iOS expiry before syncing", async () => {
+    allowLocalIosRunner();
+    const state = NetworkState.getInstance();
+    const nowSpy = spyOn(state.timer, "now").mockReturnValue(1_000);
+    const tool = ToolRegistry.getTool("network");
+
+    try {
+      const response = await tool!.deviceAwareHandler!(iosDevice, {
+        simulateErrors: {
+          errorType: "timeout",
+          durationSeconds: 1.2345,
+        },
+      });
+
+      expect(parseToolJson(response).simulatingErrors).toEqual({
+        errorType: "timeout",
+        remainingSeconds: 2,
+        limit: undefined,
+      });
+      expect(iosErrorSimulations).toEqual([{
+        enabled: true,
+        errorType: "timeout",
+        limit: null,
+        expiresAtEpochMs: 2_235,
+      }]);
+      expect(state.simulation?.expiresAt).toBe(2_235);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test("network simulateErrors on iOS reuses device expiry for local state", async () => {
+    allowLocalIosRunner();
+    let nowMs = 1_000;
+    const state = NetworkState.getInstance();
+    const nowSpy = spyOn(state.timer, "now").mockImplementation(() => nowMs);
+    iosGetInstanceSpy.mockRestore();
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      setNetworkErrorSimulation: async (config: unknown) => {
+        iosErrorSimulations.push(config);
+        nowMs += 5_000;
+        return { success: true, totalTimeMs: 0 };
+      },
+    } as IOSCtrlProxyClient);
+    const tool = ToolRegistry.getTool("network");
+
+    try {
+      await tool!.deviceAwareHandler!(iosDevice, {
+        simulateErrors: {
+          errorType: "timeout",
+          durationSeconds: 30,
+        },
+      });
+
+      const sent = iosErrorSimulations[0] as { expiresAtEpochMs: number };
+      expect(sent.expiresAtEpochMs).toBe(31_000);
+      expect(state.simulation?.expiresAt).toBe(sent.expiresAtEpochMs);
+      expect(state.getSnapshot().simulatingErrors?.remainingSeconds).toBe(25);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test("network simulateErrors cancel clears iOS error simulation on device", async () => {
+    allowLocalIosRunner();
+    const tool = ToolRegistry.getTool("network");
+
+    await tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        errorType: "http500",
+        durationSeconds: 30,
+      },
+    });
+    iosMessages = [];
+
+    const response = await tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        cancel: true,
+      },
+    });
+
+    expect(parseToolJson(response).simulatingErrors).toBeUndefined();
+    expect(iosMessages).toHaveLength(0);
+    expect(iosErrorSimulations.at(-1)).toEqual({
+      enabled: false,
+      errorType: null,
+      limit: null,
+      expiresAtEpochMs: null,
+    });
+  });
+
+  test("network simulateErrors cancel clears local iOS state when device sync fails", async () => {
+    allowLocalIosRunner();
+    const tool = ToolRegistry.getTool("network");
+
+    await tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        errorType: "http500",
+        durationSeconds: 30,
+      },
+    });
+    expect(NetworkState.getInstance().getSnapshot().simulatingErrors).toEqual({
+      errorType: "http500",
+      remainingSeconds: 30,
+      limit: undefined,
+    });
+    iosGetInstanceSpy.mockRestore();
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      setNetworkErrorSimulation: async () => ({
+        success: false,
+        totalTimeMs: 0,
+        error: "in-app server is unreachable",
+      }),
+    } as IOSCtrlProxyClient);
+
+    await expect(tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        cancel: true,
+      },
+    })).rejects.toThrow("in-app server is unreachable");
+
+    expect(NetworkState.getInstance().getSnapshot().simulatingErrors).toBeUndefined();
+  });
+
+  test("network simulateErrors on iOS fails closed when CtrlProxy rejects the command", async () => {
+    allowLocalIosRunner();
+    iosGetInstanceSpy.mockRestore();
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      setNetworkErrorSimulation: async () => ({
+        success: false,
+        totalTimeMs: 0,
+        error: "iOS CtrlProxy runner does not support set_network_error_simulation",
+      }),
+    } as IOSCtrlProxyClient);
+    const tool = ToolRegistry.getTool("network");
+
+    await expect(tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        errorType: "timeout",
+        durationSeconds: 30,
+      },
+    })).rejects.toThrow("does not support set_network_error_simulation");
+
+    expect(NetworkState.getInstance().getSnapshot().simulatingErrors).toBeUndefined();
+  });
+
+  test("network simulateErrors on iOS stays gated until a supporting runner is shipped or overridden", async () => {
+    const tool = ToolRegistry.getTool("network");
+
+    await expect(tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        errorType: "timeout",
+        durationSeconds: 30,
+      },
+    })).rejects.toThrow("not enabled for the bundled iOS CtrlProxy runner");
+
+    expect(iosGetInstanceSpy).not.toHaveBeenCalled();
+    expect(NetworkState.getInstance().getSnapshot().simulatingErrors).toBeUndefined();
+  });
+
+  test("network simulateErrors cancel clears local iOS state when the runner gate is closed", async () => {
+    const state = NetworkState.getInstance();
+    state.startSimulation("timeout", 30, null);
+    const tool = ToolRegistry.getTool("network");
+
+    const response = await tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        cancel: true,
+      },
+    });
+
+    expect(parseToolJson(response).simulatingErrors).toBeUndefined();
+    expect(iosGetInstanceSpy).not.toHaveBeenCalled();
+    expect(state.getSnapshot().simulatingErrors).toBeUndefined();
+  });
+
+  test("network simulateErrors on iOS stays gated when CtrlProxy downloads are skipped", async () => {
+    process.env.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD = "1";
+    const tool = ToolRegistry.getTool("network");
+
+    await expect(tool!.deviceAwareHandler!(iosDevice, {
+      simulateErrors: {
+        errorType: "timeout",
+        durationSeconds: 30,
+      },
+    })).rejects.toThrow("not enabled for the bundled iOS CtrlProxy runner");
+
+    expect(iosGetInstanceSpy).not.toHaveBeenCalled();
+    expect(NetworkState.getInstance().getSnapshot().simulatingErrors).toBeUndefined();
+  });
+
+  test("iOS network error simulation release gate opens for a supporting released runner", () => {
+    expect(isIosNetworkErrorSimulationAvailable({}, [{
+      version: "0.0.41",
+      apkSha256: "apk",
+      ipaSha256: "ipa",
+      runnerSha256: "runner",
+    }])).toBe(true);
+  });
+
+  test("network simulateErrors still syncs Android through AndroidCtrlProxyClient", async () => {
+    const tool = ToolRegistry.getTool("network");
+
+    await tool!.deviceAwareHandler!(androidDevice, {
+      simulateErrors: {
+        errorType: "dnsFailure",
+        durationSeconds: 15,
+      },
+    });
+
+    expect(androidGetInstanceSpy).toHaveBeenCalledWith(androidDevice);
+    expect(iosGetInstanceSpy).not.toHaveBeenCalled();
+    expect(androidMessages).toHaveLength(1);
+    expect(JSON.parse(androidMessages[0])).toMatchObject({
+      type: "set_network_error_simulation",
+      enabled: true,
+      errorType: "dnsFailure",
+      limit: null,
+    });
   });
 
   test("mockNetwork creates an iOS rule and syncs through IOSCtrlProxyClient", async () => {

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -32,6 +32,7 @@ describe("IOSCtrlProxyBuilder", function() {
 
     // Reset singleton instances
     IOSCtrlProxyBuilder.resetInstances();
+    IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("");
   });
 
   afterEach(async function() {
@@ -721,6 +722,7 @@ describe("IOSCtrlProxyBuilder", function() {
 
       IOSCtrlProxyBuilder.resetInstances();
       IOSCtrlProxyBuilder.setExpectedChecksumForTesting("");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("");
       const builder = IOSCtrlProxyBuilder.getInstance(
         {
           derivedDataPath,


### PR DESCRIPTION
## Summary

Add iOS support for `network.simulateErrors`, matching Android fault injection for `http500`, `timeout`, `connectionRefused`, `dnsFailure`, and `tlsFailure`. The TypeScript handler now routes iOS simulation through CtrlProxy with capability-aware acknowledgement before mutating local state, and the iOS SDK enforces the active simulation in `AutoMobileURLProtocol` while preserving mock-rule precedence.

## Linked Issue

Refs #2499

## Bug / Regression Context

- **Prior attempts:** N/A
- **Observed symptom:** `network` rejected `simulateErrors` on iOS even though other network tooling and SDK capture already worked cross-platform.
- **Repro steps / conditions:** Target an iOS device/simulator and call the `network` tool with `simulateErrors`; before this change it threw `Network error simulation is only supported on Android devices.`

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran the matching `scripts/` validation
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

Additional validation run:
- [x] `bun test test/server/networkTools.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts test/features/observe/ios/decodeCtrlProxyMessage.test.ts`
- [x] `bun test test/features/observe/ios/ctrlProxyWireParity.test.ts test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts`
- [x] `swift test --package-path ios/control-proxy --filter 'CommandHandlerTests|TypedRequestDecodeDispatchTests|ErrorResponseTypeTests'`
- [x] `swift test --package-path ios/auto-mobile-sdk --filter AutoMobileNetworkTests`
- [x] `bun run turbo:validate`
- [x] `bash scripts/ios/validate-network-mock-debug-only.sh`
- [x] `git diff --check`

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Covered by fast unit-level TypeScript and Swift tests using fakes; no live device verification was run in this worktree.

## Follow-ups

- [ ] Cut and register the iOS CtrlProxy runner release that includes `set_network_error_simulation` before closing #2499 for bundled-runner users.