### PR TITLE
[codex] Make iOS simulator boot idempotent

### DIFF
--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -86,6 +86,42 @@ fi
 
 echo "Using runtime: ${RUNTIME_ID}" >&2
 
+get_device_state() {
+  xcrun simctl list devices -j \
+    | jq -r --arg udid "$1" '
+        .devices | to_entries[] | .value[]
+        | select(.udid == $udid)
+        | .state // empty
+      ' \
+    | head -1
+}
+
+wait_for_shutdown_if_needed() {
+  local udid="$1"
+  local state="$2"
+  local waited=0
+  local max_wait="${AUTOMOBILE_SIMULATOR_SHUTDOWN_WAIT_SECONDS:-60}"
+
+  if [[ "${state}" != "Shutting Down" ]]; then
+    echo "${state}"
+    return 0
+  fi
+
+  echo "Simulator is still shutting down; waiting up to ${max_wait}s..." >&2
+  while (( waited < max_wait )); do
+    sleep 1
+    waited=$((waited + 1))
+    state=$(get_device_state "${udid}")
+    if [[ "${state}" != "Shutting Down" ]]; then
+      echo "${state}"
+      return 0
+    fi
+  done
+
+  echo "error: simulator ${udid} still shutting down after ${max_wait}s" >&2
+  exit 1
+}
+
 # Find the first available iPhone device for the requested iOS version
 UDID=$(xcrun simctl list devices available -j \
   | jq -r --arg runtime "${RUNTIME_ID}" '
@@ -125,8 +161,14 @@ DEVICE_NAME=$(xcrun simctl list devices available -j \
       | select(.udid == $udid) | .name
     ')
 
-echo "Booting ${DEVICE_NAME} (${UDID})..." >&2
-xcrun simctl boot "${UDID}"
+DEVICE_STATE=$(get_device_state "${UDID}")
+DEVICE_STATE=$(wait_for_shutdown_if_needed "${UDID}" "${DEVICE_STATE}")
+if [[ "${DEVICE_STATE}" == "Booted" ]]; then
+  echo "${DEVICE_NAME} (${UDID}) is already booted; waiting for readiness..." >&2
+else
+  echo "Ensuring ${DEVICE_NAME} (${UDID}) is booted..." >&2
+fi
+
 xcrun simctl bootstatus "${UDID}" -b >&2
 
 echo "Booted: ${DEVICE_NAME} (${UDID})" >&2

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -595,9 +595,11 @@ export class SimCtlClient implements SimCtl {
     logger.debug(`Starting iOS simulator ${udid}`);
     const perf = createGlobalPerformanceTracker();
 
-    perf.startOperation("simctlBoot");
-    await this.executeCommand(`boot ${udid}`);
-    perf.endOperation("simctlBoot");
+    // `bootstatus -b` is idempotent: it boots shutdown simulators, accepts
+    // already-booted simulators, and waits until CoreSimulator reports ready.
+    perf.startOperation("bootstatus");
+    await this.executeCommand(`bootstatus ${udid} -b`);
+    perf.endOperation("bootstatus");
 
     // Open Simulator.app focused on this specific device (no-op on headless hosts)
     try {
@@ -609,7 +611,7 @@ export class SimCtlClient implements SimCtl {
       logger.debug("Could not open Simulator.app (non-fatal)");
     }
 
-    // simctl boot is synchronous, so we return a mock process handle
+    // simctl bootstatus is synchronous, so we return a mock process handle
     // with the minimal subset of ChildProcess fields used by callers
     return {
       pid: this.timer.now(), // Use timestamp as mock PID

--- a/test/bats/boot-simulator.bats
+++ b/test/bats/boot-simulator.bats
@@ -72,9 +72,8 @@ elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
   fi
 elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
   echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-4":[{"name":"iPhone 16","udid":"FAKE-UDID","state":"Shutdown"}]}}'
-elif [ "$1" = "simctl" ] && [ "$2" = "boot" ]; then
-  exit 0
 elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  [ "$4" = "-b" ] || exit 2
   exit 0
 fi
 SCRIPT
@@ -96,4 +95,85 @@ SCRIPT
 @test "uses jq to find runtime identifier from simctl output" {
   grep -q 'simctl list runtimes iOS --json' "$SCRIPT"
   grep -q '.identifier' "$SCRIPT"
+}
+
+@test "uses bootstatus -b so already-booted simulators are accepted" {
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.2"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.2.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-2"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-2":[{"name":"iPhone 17 Pro","udid":"BOOTED-UDID","state":"Booted"}]}}'
+elif [ "$1" = "simctl" ] && [ "$2" = "boot" ]; then
+  echo "boot should not be called" >&2
+  exit 149
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  [ "$3" = "BOOTED-UDID" ] || exit 2
+  [ "$4" = "-b" ] || exit 2
+  exit 0
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  run bash "$SCRIPT" --ios-version 26.2
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BOOTED-UDID"* ]]
+  [[ "$output" != *"boot should not be called"* ]]
+}
+
+@test "waits for shutting down simulator before bootstatus -b" {
+  CALLS_FILE="${MOCK_BIN}/calls.log"
+  STATE_CALLS_FILE="${MOCK_BIN}/state-calls"
+  export CALLS_FILE
+  export STATE_CALLS_FILE
+  cat > "${MOCK_BIN}/sleep" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/sleep"
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.2"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.2.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-2"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  if [ "${4:-}" = "available" ]; then
+    echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-2":[{"name":"iPhone 17 Pro","udid":"SHUTTING-DOWN-UDID","state":"Shutting Down"}]}}'
+  else
+    count=0
+    if [ -f "${STATE_CALLS_FILE}" ]; then
+      count=$(cat "${STATE_CALLS_FILE}")
+    fi
+    count=$((count + 1))
+    echo "${count}" > "${STATE_CALLS_FILE}"
+    if [ "${count}" -eq 1 ]; then
+      echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-2":[{"name":"iPhone 17 Pro","udid":"SHUTTING-DOWN-UDID","state":"Shutting Down"}]}}'
+    else
+      echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-2":[{"name":"iPhone 17 Pro","udid":"SHUTTING-DOWN-UDID","state":"Shutdown"}]}}'
+    fi
+  fi
+elif [ "$1" = "simctl" ] && [ "$2" = "boot" ]; then
+  echo "boot should not be called" >&2
+  exit 99
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  echo "bootstatus" >> "${CALLS_FILE}"
+  [ "$3" = "SHUTTING-DOWN-UDID" ] || exit 2
+  [ "$4" = "-b" ] || exit 2
+  exit 0
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  run env AUTOMOBILE_SIMULATOR_SHUTDOWN_WAIT_SECONDS=5 bash "$SCRIPT" --ios-version 26.2
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"still shutting down"* ]]
+  [[ "$output" == *"SHUTTING-DOWN-UDID"* ]]
+  [[ "$output" != *"boot should not be called"* ]]
+  grep -q '^bootstatus$' "${CALLS_FILE}"
 }

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -162,6 +162,41 @@ describe("Simctl", function() {
     });
   });
 
+  describe("startSimulator", function() {
+    test("uses bootstatus -b instead of raw boot so already-booted simulators are accepted", async function() {
+      const commands: string[][] = [];
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        commands.push([file, ...args]);
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 1.0.0", "");
+        }
+        if (file === "xcrun" && args.join(" ") === "simctl boot test-ios-device-id") {
+          throw new Error("raw boot should not be called");
+        }
+        return createExecResult("command executed", "");
+      };
+
+      simctl = new Simctl(mockDevice, mockExecAsync);
+
+      const childProcess = await simctl.startSimulator("test-ios-device-id");
+
+      expect(childProcess.exitCode).toBe(0);
+      expect(commands).toContainEqual([
+        "xcrun",
+        "simctl",
+        "bootstatus",
+        "test-ios-device-id",
+        "-b",
+      ]);
+      expect(commands).not.toContainEqual([
+        "xcrun",
+        "simctl",
+        "boot",
+        "test-ios-device-id",
+      ]);
+    });
+  });
+
   describe("docker host-control mode (iOS unsupported)", function() {
     // Driving the iOS simulator from inside Docker is intentionally unsupported
     // for now (see SimCtlClient.executeCommand). The simctl surface must fail fast


### PR DESCRIPTION
## Summary

- Make the CI iOS simulator boot script use `simctl bootstatus -b` instead of raw `simctl boot`.
- Wait out transient `Shutting Down` simulator state before invoking `bootstatus -b`.
- Harden AutoMobile's iOS `startDevice` cold-boot path by making `SimCtlClient.startSimulator()` use the same idempotent CoreSimulator primitive.
- Add regression coverage for already-booted and shutting-down simulators in the BATS CI script tests plus focused SimCtl unit coverage.

## Root Cause

`simctl boot <udid>` fails when CoreSimulator reports the target simulator is already `Booted`. That made CI fail even when the simulator was already in the desired state. Raw `boot` also leaves a race window after state inspection; `bootstatus -b` is the safer primitive because it boots if needed and waits until readiness.

## Validation

- `bun run bootstrap:worktree`
- `bun test test/utils/ios-cmdline-tools/simctl.test.ts`
- `bats test/bats/boot-simulator.bats`
- `shellcheck scripts/ios/boot-simulator.sh`
- `bun run build`
- `bun run lint`
- `git diff --check`
- `bun test --bail` (`7036 pass, 2 skip, 0 fail`)
