### PR TITLE
test(ios): pin physical reset permission mapping

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1285,6 +1285,23 @@ jobs:
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
           echo "xctestrun file: ${XCTESTRUN}"
 
+      - name: "Boot iOS Simulator for CtrlProxy UI tests (Xcode 26.3)"
+        id: ctrlproxy-simulator
+        run: ./scripts/ios/boot-simulator.sh
+
+      - name: "Run CtrlProxy privacy resource mapping UI test (Xcode 26.3)"
+        timeout-minutes: 5
+        run: |
+          XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
+          xcodebuild test-without-building \
+            -xctestrun "${XCTESTRUN}" \
+            -destination "id=${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}" \
+            -only-testing:CtrlProxyUITests/PrivacyResourceMappingTests
+
+      - name: "Shutdown CtrlProxy UI test simulator"
+        if: always()
+        run: xcrun simctl shutdown all || true
+
       - name: "Select Xcode 26.2"
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1BF8D64D9A034BEC375AEE8B /* ObjCExceptionCatcher.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1E92C9DDBA24968595494BA3 /* RequestSnapshotWireParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A158ADBA8E3301E9FF181598 /* RequestSnapshotWireParityTests.swift */; };
 		1F968B5EDB744057F51321EF /* ElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95565999DC108319DEED894A /* ElementLocator.swift */; };
+		22D17AADC9A8AC3CE96D19A5 /* PrivacyResourceMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0C8F550D3A30C87BF84E67 /* PrivacyResourceMappingTests.swift */; };
 		261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */; };
 		2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */; };
 		2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D7B74C318EE243B225B95 /* Protocols.swift */; };
@@ -181,6 +182,7 @@
 		649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridgeTests.swift; sourceTree = "<group>"; };
 		652F5687D2FC57F3D6D4629C /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadRunner.swift; sourceTree = "<group>"; };
+		6E0C8F550D3A30C87BF84E67 /* PrivacyResourceMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyResourceMappingTests.swift; sourceTree = "<group>"; };
 		6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchFallbackTests.swift; sourceTree = "<group>"; };
 		73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridge.swift; sourceTree = "<group>"; };
 		76DC5538569B4FCF89EA7547 /* ErrorResponseTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponseTypeTests.swift; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 			isa = PBXGroup;
 			children = (
 				802717F6B1F37809C4806C23 /* CtrlProxyUITests.swift */,
+				6E0C8F550D3A30C87BF84E67 /* PrivacyResourceMappingTests.swift */,
 			);
 			name = CtrlProxyUITests;
 			path = Tests/CtrlProxyUITests;
@@ -634,6 +637,7 @@
 				4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */,
 				B55A16F80CE62B998CEBC6E0 /* PerformanceMetrics.swift in Sources */,
 				5BE77C31B3E127345E3830A6 /* PinchFallback.swift in Sources */,
+				22D17AADC9A8AC3CE96D19A5 /* PrivacyResourceMappingTests.swift in Sources */,
 				2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */,
 				9E975A4E407F93A21BD80EB4 /* SdkDatabaseClient.swift in Sources */,
 				EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -1376,7 +1376,7 @@ public class GesturePerformer: GesturePerforming {
         /// support matrix is advertised honestly — see issue #2491). The mapping is
         /// authoritative here rather than duplicated on the TS host, since
         /// `XCUIProtectedResource` only exists in this process.
-        private static func protectedResource(for name: String) -> XCUIProtectedResource? {
+        static func protectedResource(for name: String) -> XCUIProtectedResource? {
             switch name {
             case "camera": return .camera
             case "photos", "photos-add": return .photos

--- a/ios/control-proxy/Tests/CtrlProxyUITests/PrivacyResourceMappingTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyUITests/PrivacyResourceMappingTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+
+final class PrivacyResourceMappingTests: XCTestCase {
+    func testProtectedResourceMapsSupportedPermissionNames() {
+        let mappings: [(name: String, resource: XCUIProtectedResource)] = [
+            ("camera", .camera),
+            ("photos", .photos),
+            ("photos-add", .photos),
+            ("microphone", .microphone),
+            ("contacts", .contacts),
+            ("contacts-limited", .contacts),
+            ("location", .location),
+            ("location-always", .location),
+            ("calendar", .calendar),
+            ("reminders", .reminders),
+            ("media-library", .mediaLibrary),
+            ("homekit", .homeKit),
+            ("focus", .focus),
+            ("bluetooth", .bluetooth),
+            ("keyboard-network", .keyboardNetwork),
+            ("health", .health),
+            ("user-tracking", .userTracking),
+        ]
+
+        for mapping in mappings {
+            XCTAssertEqual(
+                GesturePerformer.protectedResource(for: mapping.name),
+                mapping.resource,
+                "\(mapping.name) should map to \(mapping.resource)"
+            )
+        }
+
+        if #available(iOS 15.4, *) {
+            XCTAssertEqual(
+                GesturePerformer.protectedResource(for: "local-network"),
+                .localNetwork
+            )
+        } else {
+            XCTAssertNil(GesturePerformer.protectedResource(for: "local-network"))
+        }
+    }
+
+    func testProtectedResourceRejectsUnsupportedPermissionNames() {
+        for name in ["siri", "motion", "unknown-permission"] {
+            XCTAssertNil(
+                GesturePerformer.protectedResource(for: name),
+                "\(name) should not claim an XCUIProtectedResource mapping"
+            )
+        }
+    }
+
+    func testResetPermissionsSurfacesUnsupportedNamesAsStructuredFailures() {
+        let commandHandler = CommandHandler.createForTesting(
+            elementLocator: PrivacyResourceMappingElementLocator(),
+            gesturePerformer: GesturePerformer(elementLocator: PrivacyResourceMappingElementLocator()),
+            perfProvider: PerfProvider.createForTesting(timeProvider: FakeTimeProvider(initialTime: 1000))
+        )
+
+        for name in ["siri", "motion", "unknown-permission"] {
+            let request = WebSocketRequest.resetPermissions(RequestResetPermissions(
+                requestId: "reset-\(name)",
+                bundleId: "com.example.app",
+                permissions: [name]
+            ))
+
+            guard let response = commandHandler.handle(request) as? WebSocketResponse else {
+                XCTFail("Expected WebSocketResponse for \(name)")
+                continue
+            }
+
+            XCTAssertEqual(response.type, ResponseType.resetPermissionsResult.rawValue)
+            XCTAssertEqual(response.requestId, "reset-\(name)")
+            XCTAssertEqual(response.success, false)
+            XCTAssertEqual(
+                response.error,
+                CommandError.invalidParameter("permission", name).localizedDescription
+            )
+        }
+    }
+}
+
+private final class PrivacyResourceMappingElementLocator: ElementLocating {
+    var foregroundBundleId: String?
+
+    func getViewHierarchy(disableAllFiltering _: Bool) throws -> ViewHierarchy {
+        throw CommandError.executionFailed("view hierarchy is not used by privacy resource mapping tests")
+    }
+
+    func findElement(byResourceId _: String) -> Any? {
+        nil
+    }
+
+    func findElement(byText _: String) -> Any? {
+        nil
+    }
+
+    func trackObservedBundleId(_: String) {}
+
+    func switchForegroundApp(bundleId: String) {
+        foregroundBundleId = bundleId
+    }
+
+    func getAppState(bundleId _: String) -> ObservedAppState {
+        .unknown
+    }
+
+    func awaitAppState(bundleId _: String, expectedState _: AppStateExpectation) -> Bool {
+        false
+    }
+}


### PR DESCRIPTION
## Summary

Adds an iOS simulator CtrlProxy UI test that pins the physical-device permission reset mapping from AutoMobile permission names to `XCUIProtectedResource`. The mapping helper is widened from `private` to internal so the iOS-target test can assert the real XCTest enum values, and unsupported names are verified through the `request_reset_permissions` handler path.

## Linked Issue

Closes #3134

## Bug / Regression Context

- **Prior attempts:** #2491 / #3127 added the physical-device reset path and intentionally deferred this mapping-table test.
- **Observed symptom:** The load-bearing support matrix lived only in `GesturePerformer.protectedResource(for:)`, which was private and compiled only in an iOS/XCTest target, so macOS Swift Package tests and TypeScript fakes could not catch mapping drift.
- **Repro steps / conditions:** Accidentally remove or change a mapping such as `contacts-limited`, or accidentally map unsupported names such as `siri`/`motion`; before this PR no iOS-target test failed on that drift.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran the matching `scripts/` validation
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

Additional validation:

- [x] `xcodebuild test -quiet -project ios/control-proxy/CtrlProxy.xcodeproj -scheme CtrlProxyApp -destination 'id=0749A13C-D7E7-49EC-8F18-CE8B6178EE87' -only-testing:CtrlProxyUITests/PrivacyResourceMappingTests`
- [x] `cd ios/control-proxy && swift test -Xswiftc -warnings-as-errors`
- [x] `git diff --check`

## Device Verification

- [x] Verified on an iOS simulator via the focused `CtrlProxyUITests/PrivacyResourceMappingTests` run.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: none.
