### PR TITLE
Implement daemon input/tap endpoint

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -257,7 +257,7 @@ Clears all keys from an Android app's SharedPreferences file. <kbd>🤖 Android 
 
 ## Input API
 
-<kbd>🚧 Design Only</kbd> <kbd>❌ Not Implemented</kbd>
+<kbd>🚧 Partially Implemented</kbd>
 
 The daemon input API is the consumer-facing contract for IDE screen control and
 other direct-input clients. These methods use the same newline-delimited JSON
@@ -291,15 +291,15 @@ observation and do not implicitly trigger one. Callers that need post-input
 state should call `observe` through the MCP proxy or subscribe to the observation
 stream after the input response returns.
 
-### Platform support
+### Implementation status
 
 | Method | Android | iOS | Notes |
 |---|---|---|---|
 | `input/tap` | Supported | Supported | Absolute device-screen coordinates. |
-| `input/swipe` | Supported | Supported | Use for drag gestures until `input/drag` has distinct semantics. |
+| `input/swipe` | Contract only | Contract only | Not implemented yet. Use for drag gestures until `input/drag` has distinct semantics. |
 | `input/drag` | Deferred | Deferred | Not a separate method in this contract. |
-| `input/pressButton` | Supported per button | Supported per button | Unsupported buttons fail instead of being ignored. |
-| `input/typeText` | Supported | Supported | Sends committed text only; IME composition is deferred. |
+| `input/pressButton` | Contract only | Contract only | Not implemented yet. Unsupported buttons fail instead of being ignored. |
+| `input/typeText` | Contract only | Contract only | Not implemented yet. Sends committed text only; IME composition is deferred. |
 | `input/key` | Deferred | Deferred | Use `input/pressButton` or `input/typeText`. |
 
 All successful input responses use this result shape:
@@ -338,6 +338,7 @@ the current device orientation.
 | `deviceId` | `string` | No | Target device; see [Common input fields](#common-input-fields). |
 | `x` | `number` | Yes | X coordinate in physical screen pixels. |
 | `y` | `number` | Yes | Y coordinate in physical screen pixels. |
+| `duration` | `number` | No | Tap duration in milliseconds. |
 
 **Request**
 
@@ -350,7 +351,8 @@ the current device orientation.
     "platform": "android",
     "deviceId": "emulator-5554",
     "x": 240,
-    "y": 640
+    "y": 640,
+    "duration": 50
   }
 }
 ```

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -52,8 +52,10 @@ import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
+import { IOSCtrlProxyClient } from "../features/observe/ios";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import type { KeyValueType } from "../features/storage/storageTypes";
+import type { BootedDevice } from "../models";
 /** Must exceed the longest per-request MCP timeout (executePlan = 10 min), else long tool calls get killed mid-flight. */
 const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 60 * 1000;
 const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
@@ -330,8 +332,8 @@ export class UnixSocketServer {
           };
         }
 
-        // Handle IDE-only requests that don't need the MCP client
-        const localResult = await this.handleLocalIdeRequest(request);
+        // Handle socket-local requests that don't need the MCP client
+        const localResult = await this.handleLocalSocketRequest(request, sessionId);
         if (localResult !== undefined) {
           return {
             id: request.id,
@@ -628,12 +630,17 @@ export class UnixSocketServer {
   }
 
   /**
-   * Handle IDE requests that don't require the MCP client.
+   * Handle socket requests that don't require the MCP client.
    * Returns undefined if the request should be forwarded to MCP.
    */
-  private async handleLocalIdeRequest(
-    request: DaemonRequest
+  private async handleLocalSocketRequest(
+    request: DaemonRequest,
+    socketSessionId?: string
   ): Promise<any | undefined> {
+    if (request.method === "input/tap") {
+      return await this.handleInputTap(request, socketSessionId);
+    }
+
     switch (request.method) {
       case "ide/listFeatureFlags": {
         if (!this.featureFlagService) {
@@ -790,6 +797,125 @@ export class UnixSocketServer {
       default:
         return undefined;
     }
+  }
+
+  private async handleInputTap(
+    request: DaemonRequest,
+    socketSessionId?: string
+  ): Promise<any | undefined> {
+    const queueEnterMs = this.timer.now();
+    const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
+    const args = this.parseInputTapParams(request.params);
+    const targetDevice = await this.resolveInputTargetDevice(args.platform, args.deviceId, socketSessionId);
+    const gestureResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      const queueWaitMs = this.timer.now() - queueEnterMs;
+      const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
+      if (remainingTimeoutMs <= 0) {
+        throw new McpTimeoutError({
+          toolName: request.method,
+          timeoutMs: totalTimeoutMs,
+          origin: "UnixSocketServer.handleInputTap",
+          detail: `spent ${queueWaitMs}ms waiting in queue`,
+        });
+      }
+
+      return args.platform === "android"
+        ? await AndroidCtrlProxyClient
+          .getInstance(targetDevice, defaultAdbClientFactory)
+          .requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs)
+        : await IOSCtrlProxyClient
+          .getInstance(targetDevice)
+          .requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs);
+    });
+
+    if (!gestureResult.success) {
+      throw new Error(gestureResult.error ?? `input/tap failed on ${args.platform}`);
+    }
+
+    return {
+      action: "input/tap",
+      platform: args.platform,
+      deviceId: targetDevice.deviceId,
+      success: true,
+      coordinates: { x: args.x, y: args.y },
+    };
+  }
+
+  private parseInputTapParams(params: unknown): {
+    platform: "android" | "ios";
+    deviceId?: string;
+    x: number;
+    y: number;
+    duration?: number;
+  } {
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new Error("input/tap requires params object");
+    }
+
+    const args = params as Record<string, unknown>;
+    if (args.platform !== "android" && args.platform !== "ios") {
+      throw new Error("input/tap requires platform 'android' or 'ios'");
+    }
+    if (typeof args.x !== "number" || Number.isNaN(args.x) || typeof args.y !== "number" || Number.isNaN(args.y)) {
+      throw new Error("input/tap requires numeric x and y params");
+    }
+    if (args.duration !== undefined && (typeof args.duration !== "number" || Number.isNaN(args.duration))) {
+      throw new Error("input/tap duration must be numeric when provided");
+    }
+    if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
+      throw new Error("input/tap deviceId must be a string when provided");
+    }
+
+    return {
+      platform: args.platform,
+      deviceId: args.deviceId,
+      x: args.x,
+      y: args.y,
+      duration: args.duration,
+    };
+  }
+
+  private async resolveInputTargetDevice(
+    platform: "android" | "ios",
+    deviceId: string | undefined,
+    socketSessionId: string | undefined
+  ): Promise<BootedDevice> {
+    const discovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform);
+    if (!discovery.succeededPlatforms.has(platform)) {
+      throw new Error(`Unable to discover booted ${platform} devices for input/tap`);
+    }
+    const bootedDevices = discovery.devices;
+    if (deviceId) {
+      const targetDevice = bootedDevices.find(device => device.deviceId === deviceId);
+      if (!targetDevice) {
+        throw new Error(`Device not found: ${deviceId}`);
+      }
+      return targetDevice;
+    }
+
+    const autolockSessionId = this.daemonState.isInitialized()
+      ? this.daemonState
+        .getDevicePool()
+        .resolveAutolockSessionForMcpSession?.(socketSessionId, platform)
+      : undefined;
+    const autolockDeviceId = autolockSessionId
+      ? this.daemonState.getSessionManager().getSession(autolockSessionId)?.assignedDevice
+      : undefined;
+    if (autolockDeviceId) {
+      const targetDevice = bootedDevices.find(device => device.deviceId === autolockDeviceId);
+      if (!targetDevice) {
+        throw new Error(`Device not found: ${autolockDeviceId}`);
+      }
+      return targetDevice;
+    }
+
+    if (bootedDevices.length === 1) {
+      return bootedDevices[0];
+    }
+    if (bootedDevices.length === 0) {
+      throw new Error(`No booted ${platform} devices found for input/tap`);
+    }
+    throw new Error(`input/tap requires deviceId when multiple ${platform} devices are booted`);
   }
 
   private async handleIdeRequest(

--- a/test/daemon/socketServerInputTap.test.ts
+++ b/test/daemon/socketServerInputTap.test.ts
@@ -1,0 +1,436 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonRequest, DaemonResponse } from "../../src/daemon/types";
+import type { DeviceLabelMap, Session } from "../../src/daemon/sessionManager";
+import type { BootedDevice } from "../../src/models";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android",
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "ios-sim-1",
+  name: "iPhone 16",
+  platform: "ios",
+};
+
+function createFakeDeviceManager(
+  devices: BootedDevice[],
+  succeededPlatforms: Set<"android" | "ios"> = new Set(["android", "ios"])
+) {
+  return {
+    getBootedDevicesDetailed: mock(async () => ({
+      devices,
+      succeededPlatforms,
+    })),
+  } as unknown as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>;
+}
+
+function createFakeSession(sessionId: string, assignedDevice: string, platform: "android" | "ios"): Session {
+  return {
+    sessionId,
+    assignedDevice,
+    platform,
+    createdAt: 0,
+    lastUsedAt: 0,
+    expiresAt: 60_000,
+    cacheData: {},
+    lastHeartbeat: 0,
+    sessionTimeoutMs: 60_000,
+    heartbeatTimeoutMs: 10_000,
+    heartbeatTimeoutSource: "default",
+    hasReceivedHeartbeat: false,
+  };
+}
+
+function createFakeDaemonState(
+  autolockSessions: Map<string, Session> = new Map(),
+  mcpAutolockSessions: Map<string, string> = new Map()
+) {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: (sessionId: string) => autolockSessions.get(sessionId) ?? null,
+      getDeviceLabels: (_sessionId: string): DeviceLabelMap | undefined => undefined,
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: (mcpSessionId: string | undefined, platform?: "android" | "ios") => {
+        if (!mcpSessionId) {
+          return undefined;
+        }
+        const sessionId = mcpAutolockSessions.get(mcpSessionId);
+        const session = sessionId ? autolockSessions.get(sessionId) : undefined;
+        return session?.platform === platform ? session.sessionId : undefined;
+      },
+    }),
+  };
+}
+
+function sendRequest(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number
+): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+    const request: DaemonRequest = {
+      id: randomUUID(),
+      type: "mcp_request",
+      method,
+      params,
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    };
+
+    client.connect(socketPath, () => {
+      client.write(JSON.stringify(request) + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const response = JSON.parse(line) as DaemonResponse;
+          client.destroy();
+          resolve(response);
+          return;
+        } catch {
+          // Incomplete JSON, keep buffering.
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+function sendRequestAfterConnect(
+  socketPath: string,
+  request: DaemonRequest,
+  onConnect: () => void
+): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+
+    client.connect(socketPath, () => {
+      onConnect();
+      client.write(JSON.stringify(request) + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const response = JSON.parse(line) as DaemonResponse;
+          client.destroy();
+          resolve(response);
+          return;
+        } catch {
+          // Incomplete JSON, keep buffering.
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+describe("UnixSocketServer input/tap", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let fakeTimer: FakeTimer;
+  let originalAndroidGetInstance: typeof AndroidCtrlProxyClient.getInstance;
+  let originalIosGetInstance: typeof IOSCtrlProxyClient.getInstance;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `input-tap-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    PlatformDeviceManagerFactory.reset();
+    AndroidCtrlProxyClient.resetInstances();
+    IOSCtrlProxyClient.resetInstances();
+    originalAndroidGetInstance = AndroidCtrlProxyClient.getInstance;
+    originalIosGetInstance = IOSCtrlProxyClient.getInstance;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+    }
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+    AndroidCtrlProxyClient.getInstance = originalAndroidGetInstance;
+    IOSCtrlProxyClient.getInstance = originalIosGetInstance;
+    PlatformDeviceManagerFactory.reset();
+    AndroidCtrlProxyClient.resetInstances();
+    IOSCtrlProxyClient.resetInstances();
+  });
+
+  test("routes Android coordinate taps without forwarding through tools/call", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    const createMcpClient = mock(async () => {
+      throw new Error("input/tap should not create an MCP client");
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    (server as unknown as { createMcpClient: typeof createMcpClient }).createMcpClient = createMcpClient;
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      x: 12.5,
+      y: 34.25,
+      duration: 80,
+    }, 1234);
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({
+      action: "input/tap",
+      platform: "android",
+      deviceId: "emulator-5554",
+      success: true,
+      coordinates: { x: 12.5, y: 34.25 },
+    });
+    expect(requestTapCoordinates).toHaveBeenCalledWith(12.5, 34.25, 80, 1234);
+    expect(createMcpClient).not.toHaveBeenCalled();
+  });
+
+  test("routes iOS coordinate taps through the iOS gesture client", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      x: 20,
+      y: 30,
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toMatchObject({
+      action: "input/tap",
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      success: true,
+      coordinates: { x: 20, y: 30 },
+    });
+    expect(requestTapCoordinates).toHaveBeenCalledWith(20, 30, undefined, 30_000);
+  });
+
+  test("uses the socket autolock device when deviceId is omitted", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    const session = createFakeSession("session-1", "emulator-5554", "android");
+    const autolockSessions = new Map([[session.sessionId, session]]);
+    const mcpAutolockSessions = new Map<string, string>();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(autolockSessions, mcpAutolockSessions),
+      fakeTimer
+    );
+    await server.start();
+
+    const response = await sendRequestAfterConnect(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "input/tap",
+      params: {
+        platform: "android",
+        x: 1,
+        y: 2,
+      },
+    }, () => {
+      const socketSessionId = [...((server as unknown as { sessions: Map<string, unknown> }).sessions.keys())][0];
+      mcpAutolockSessions.set(socketSessionId, session.sessionId);
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toMatchObject({
+      platform: "android",
+      deviceId: "emulator-5554",
+      coordinates: { x: 1, y: 2 },
+    });
+    expect(requestTapCoordinates).toHaveBeenCalledWith(1, 2, undefined, 30_000);
+  });
+
+  test("serializes concurrent taps for the same device across socket clients", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const requestTapCoordinates = mock(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>(resolve => {
+        fakeTimer.setTimeout(resolve, 40);
+      });
+      inFlight -= 1;
+      return { success: true };
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    fakeTimer.enableAutoAdvance();
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const [first, second] = await Promise.all([
+      sendRequest(socketPath, "input/tap", {
+        platform: "android",
+        deviceId: "emulator-5554",
+        x: 1,
+        y: 1,
+      }),
+      sendRequest(socketPath, "input/tap", {
+        platform: "android",
+        deviceId: "emulator-5554",
+        x: 2,
+        y: 2,
+      }),
+    ]);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    expect(requestTapCoordinates).toHaveBeenCalledTimes(2);
+    expect(maxInFlight).toBe(1);
+    expect(inFlight).toBe(0);
+  });
+
+  test("fails queued taps before dispatch when queue wait exceeds timeout", async () => {
+    let callCount = 0;
+    let releaseBlockingRequest: () => void = () => {};
+    const blockingPromise = new Promise<void>(resolve => {
+      releaseBlockingRequest = resolve;
+    });
+    const requestTapCoordinates = mock(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        await blockingPromise;
+      }
+      return { success: true };
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const first = sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      x: 1,
+      y: 1,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    const second = sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      x: 2,
+      y: 2,
+    }, 500);
+
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    fakeTimer.advanceTime(600);
+    releaseBlockingRequest();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(false);
+    expect(secondResult.error).toContain("waiting in queue");
+    expect(requestTapCoordinates).toHaveBeenCalledTimes(1);
+  });
+
+  test("surfaces platform discovery failures before device targeting errors", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([], new Set()));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      x: 1,
+      y: 1,
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe("Unable to discover booted android devices for input/tap");
+  });
+
+  test("rejects missing and non-numeric coordinates with actionable errors", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const missing = await sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      y: 10,
+    });
+    const nonNumeric = await sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      x: "12",
+      y: 10,
+    });
+
+    expect(missing.success).toBe(false);
+    expect(missing.error).toBe("input/tap requires numeric x and y params");
+    expect(nonNumeric.success).toBe(false);
+    expect(nonNumeric.error).toBe("input/tap requires numeric x and y params");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the first daemon input endpoint, `input/tap`, over the Unix socket. The endpoint validates tap params, resolves the target device by explicit `deviceId`, socket autolock session, or single booted device fallback, and routes directly to the existing Android/iOS coordinate gesture clients instead of requiring callers to use `tools/call` or selector-based `tapOn`.

The implementation also preserves daemon socket behavior by serializing taps per physical device, honoring queue wait in request timeouts, and surfacing platform discovery failures separately from "device not found" targeting errors.

## Linked Issue

Closes #3340

## Bug / Regression Context

- **Prior attempts:** N/A
- **Observed symptom:** The daemon input API contract existed, but `input/tap` was not implemented and fell through to MCP forwarding.
- **Repro steps / conditions:** Send a newline-delimited daemon socket request with `type: "mcp_request"`, `method: "input/tap"`, and coordinate params.

## Validation

- [x] `bun run turbo:validate` passes (`7080 pass`, `2 skip`, `0 fail`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, TypeScript daemon socket routing only
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional focused checks:

- [x] `bun test test/daemon/socketServerInputTap.test.ts`
- [x] adjacent daemon socket tests
- [x] `bun run build`
- [x] `bun run lint`
- [x] `git diff --check`

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Not run: no real device/simulator manual tap verification in this local session. Behavior is covered with fake daemon socket, fake device discovery, and fake platform gesture clients.

## Follow-ups

- [ ] Follow-up issues filed for gaps not addressed here: N/A
