### PR TITLE
feat(doctor): report image backend provisioning

### DIFF
--- a/docs/design-docs/image-backend.md
+++ b/docs/design-docs/image-backend.md
@@ -1,6 +1,6 @@
 # Image backend: sharp primary + native cwebp on Windows
 
-Status: proposed
+Status: accepted
 Related: #2974 (Windows WebP daemon crash), #2920 (sharp→jimp migration), #2939 (screenshot cache format), #2424 (original sharp-under-Bun pin)
 
 ## Problem
@@ -154,9 +154,9 @@ resize kernel ≠ jimp's:
 
 - pHash values change again on macOS/Linux (jimp→sharp), and Windows (jimp)
   produces different hashes than macOS/Linux (sharp) for the same screenshot →
-  **nav-screenshot caches are not portable across platforms**. Within one
-  machine it is self-consistent (one backend), matching still works, and nav
-  caches are local — tolerable, but document as the cache contract (ties to #2939).
+  **nav-screenshot caches are per-machine and are not portable across platforms**.
+  Within one machine it is self-consistent (one backend), matching still works,
+  and nav caches are local — this is the accepted cache contract (ties to #2939).
 - WebP format is now uniform across platforms (bundled cwebp, no PNG downgrade),
   so the only cross-platform difference is the resize-kernel pixel delta, not a
   format mismatch.
@@ -176,8 +176,8 @@ resize kernel ≠ jimp's:
 
 ## doctor + observability
 
-Add a `doctor` check (log-then-return-typed-failure, CLAUDE.md strategy 2)
-reporting: active backend, sharp load status (macOS/Linux), cwebp/dwebp
+`doctor` includes a log-then-return-typed-failure check (CLAUDE.md strategy 2)
+reporting: active backend, sharp load status (macOS/Linux), and cwebp/dwebp
 resolution (Windows).
 
 ## Phasing

--- a/docs/design-docs/plat/android/observe.md
+++ b/docs/design-docs/plat/android/observe.md
@@ -43,6 +43,11 @@
   - If the accessibility service is not installed or not enabled yet, we fall back to `uiautomator` output that is
     cached based on a perceptual hash plus pixel matching within a tolerance threshold.
 
+  - Per-machine cache contract: nav-screenshot caches are local to the machine that produced them. The active image
+    backend affects resize kernels and decoded pixels (`sharp` on macOS/Linux, `jimp` on Windows), so pHash and
+    pixelmatch results can differ for the same screenshot across platforms. These caches are not portable across platforms;
+    do not copy them between machines or platforms. Let each machine rebuild its own cache.
+
     ```mermaid
     flowchart LR
     A["Observe()"] --> B["Screenshot<br/>+perceptual hash"];

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -5,6 +5,7 @@
 
 import { CheckResult } from "../types";
 import type { DoctorOptions } from "../types";
+import { platform as getHostPlatform } from "node:os";
 import { DaemonManager } from "../../daemon/manager";
 import { getDaemonHealthReport } from "../../daemon/debugTools";
 import type { DaemonHealthReport } from "../../daemon/debugTools";
@@ -26,6 +27,8 @@ import { getMcpServerVersion } from "../../utils/mcpVersion";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
+import { loadSharp, type SharpFactory } from "../../utils/image/loadSharp";
+import { WebpBinaryResolver, type ResolvedWebpBinaries } from "../../utils/image/webp/WebpBinaryResolver";
 import { logger } from "../../utils/logger";
 
 const RELEASES_URL = "https://github.com/kaeawc/auto-mobile/releases";
@@ -45,9 +48,22 @@ export interface DaemonBuildIdentityDependencies {
 }
 
 export interface AutoMobileCheckDependencies {
+  checkImageBackend?: () => Promise<CheckResult>;
   checkDaemonStatus?: () => Promise<CheckResult>;
   checkDaemonConnectivity?: () => Promise<CheckResult>;
   checkDaemonBuildIdentity?: () => Promise<CheckResult>;
+}
+
+export interface ImageBackendDoctorLogger {
+  warn(message: string, ...args: unknown[]): void;
+}
+
+export interface ImageBackendDoctorDependencies {
+  platform?: NodeJS.Platform;
+  hostPlatform?: NodeJS.Platform;
+  sharpLoader?: () => Promise<SharpFactory>;
+  webpBinaryResolver?: { resolve(): Promise<ResolvedWebpBinaries> };
+  logger?: ImageBackendDoctorLogger;
 }
 
 /**
@@ -76,6 +92,76 @@ export function checkCtrlProxyVersion(): CheckResult {
     status: "pass",
     message: `Version ${resolved}${pinned === LATEST_RELEASE_VERSION ? " (latest)" : ""}`,
     value: resolved,
+  };
+}
+
+/**
+ * Report the active image backend and the platform-specific provisioning that
+ * makes it usable without doing real image work.
+ */
+export async function checkImageBackend(
+  dependencies: ImageBackendDoctorDependencies = {}
+): Promise<CheckResult> {
+  const platform = dependencies.platform ?? process.platform;
+  const hostPlatform = dependencies.hostPlatform ?? getHostPlatform();
+  const log = dependencies.logger ?? logger;
+
+  if (platform === "win32") {
+    try {
+      const binaries = await (dependencies.webpBinaryResolver ?? new WebpBinaryResolver()).resolve();
+      return {
+        name: "Image Backend",
+        status: "pass",
+        message: `active=jimp-cli; cwebp=${binaries.cwebp}; dwebp=${binaries.dwebp}`,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.warn(`Image backend doctor check failed: ${message}`, error);
+      return {
+        name: "Image Backend",
+        status: "fail",
+        message: `active=jimp-cli; cwebp=unavailable; dwebp=unavailable; error=${message}`,
+        recommendation:
+          "Ensure bundled vendor/libwebp/win32-x64/cwebp.exe and dwebp.exe are present, " +
+          "or set AUTOMOBILE_CWEBP_PATH and AUTOMOBILE_DWEBP_PATH to executable libwebp binaries.",
+      };
+    }
+  }
+
+  if (platform === "darwin" || platform === "linux") {
+    if (!dependencies.sharpLoader && platform !== hostPlatform) {
+      return {
+        name: "Image Backend",
+        status: "skip",
+        message: `active=sharp; sharp=not checked; platform=${platform}; host=${hostPlatform}`,
+      };
+    }
+
+    try {
+      await (dependencies.sharpLoader ?? loadSharp)();
+      return {
+        name: "Image Backend",
+        status: "pass",
+        message: "active=sharp; sharp=loaded",
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.warn(`Image backend doctor check failed: ${message}`, error);
+      return {
+        name: "Image Backend",
+        status: "fail",
+        message: `active=sharp; sharp=unavailable; webp=unavailable; error=${message}`,
+        recommendation:
+          "Reinstall dependencies from the lockfile and re-run doctor. " +
+          "Navigation screenshots require sharp-backed WebP support on macOS/Linux.",
+      };
+    }
+  }
+
+  return {
+    name: "Image Backend",
+    status: "pass",
+    message: "active=jimp",
   };
 }
 
@@ -467,6 +553,7 @@ export async function runAutoMobileChecks(
 
   results.push(checkDaemonVersion());
   results.push(checkCtrlProxyVersion());
+  results.push(await (dependencies.checkImageBackend ?? (() => checkImageBackend()))());
   results.push(await (dependencies.checkDaemonStatus ?? (() => checkDaemonStatus()))());
   results.push(await (dependencies.checkDaemonConnectivity ?? (() => checkDaemonConnectivity()))());
   results.push(await (dependencies.checkDaemonBuildIdentity ?? (() => checkDaemonBuildIdentity()))());

--- a/src/utils/image/loadSharp.ts
+++ b/src/utils/image/loadSharp.ts
@@ -6,6 +6,9 @@ export async function loadSharp(): Promise<SharpFactory> {
   sharpFactoryPromise ??= import("sharp").then(mod => {
     const loaded = mod as unknown as { default?: SharpFactory } & SharpFactory;
     return loaded.default ?? loaded;
+  }).catch(error => {
+    sharpFactoryPromise = undefined;
+    throw error;
   });
   return sharpFactoryPromise;
 }

--- a/test/docs/imageBackendCacheContract.test.ts
+++ b/test/docs/imageBackendCacheContract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../..");
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return readFile(join(repoRoot, relativePath), "utf-8");
+}
+
+describe("image backend cache contract docs", () => {
+  test("design doc is accepted and documents per-machine nav screenshot caches", async () => {
+    const designDoc = await readRepoFile("docs/design-docs/image-backend.md");
+
+    expect(designDoc).toContain("Status: accepted");
+    expect(designDoc).toContain("nav-screenshot caches are per-machine");
+    expect(designDoc).toContain("not portable across platforms");
+    expect(designDoc).toContain("sharp");
+    expect(designDoc).toContain("jimp");
+  });
+
+  test("observe docs surface the per-machine cache contract near perceptual matching", async () => {
+    const observeDoc = await readRepoFile("docs/design-docs/plat/android/observe.md");
+
+    expect(observeDoc).toContain("Per-machine cache contract");
+    expect(observeDoc).toContain("nav-screenshot caches are local to the machine");
+    expect(observeDoc).toContain("not portable across platforms");
+  });
+});

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  checkImageBackend,
   checkCtrlProxy,
   checkCtrlProxyVersion,
   checkDaemonBuildIdentity,
@@ -63,6 +64,95 @@ describe("checkCtrlProxyVersion", () => {
         process.env.AUTOMOBILE_VERSION = prev;
       }
     }
+  });
+});
+
+describe("checkImageBackend", () => {
+  test("reports active sharp backend and load status on macOS and Linux", async () => {
+    const result = await checkImageBackend({
+      platform: "linux",
+      sharpLoader: async () => ({} as never),
+    });
+
+    expect(result).toEqual({
+      name: "Image Backend",
+      status: "pass",
+      message: "active=sharp; sharp=loaded",
+    });
+  });
+
+  test("logs and returns a typed failure when sharp cannot load", async () => {
+    const warnings: string[] = [];
+
+    const result = await checkImageBackend({
+      platform: "darwin",
+      sharpLoader: async () => {
+        throw new Error("sharp import failed");
+      },
+      logger: {
+        warn: message => warnings.push(message),
+      },
+    });
+
+    expect(result.name).toBe("Image Backend");
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("active=sharp; sharp=unavailable; webp=unavailable; error=sharp import failed");
+    expect(result.recommendation).toContain("Reinstall dependencies");
+    expect(result.recommendation).toContain("WebP support");
+    expect(warnings).toEqual(["Image backend doctor check failed: sharp import failed"]);
+  });
+
+  test("skips real sharp loading when tests spoof process.platform away from the host OS", async () => {
+    const result = await checkImageBackend({
+      platform: "linux",
+      hostPlatform: "darwin",
+    });
+
+    expect(result).toEqual({
+      name: "Image Backend",
+      status: "skip",
+      message: "active=sharp; sharp=not checked; platform=linux; host=darwin",
+    });
+  });
+
+  test("reports active jimp-cli backend and cwebp/dwebp resolution on Windows", async () => {
+    const result = await checkImageBackend({
+      platform: "win32",
+      webpBinaryResolver: {
+        resolve: async () => ({
+          cwebp: "C:\\auto-mobile\\vendor\\libwebp\\cwebp.exe",
+          dwebp: "C:\\auto-mobile\\vendor\\libwebp\\dwebp.exe",
+        }),
+      },
+    });
+
+    expect(result).toEqual({
+      name: "Image Backend",
+      status: "pass",
+      message: "active=jimp-cli; cwebp=C:\\auto-mobile\\vendor\\libwebp\\cwebp.exe; dwebp=C:\\auto-mobile\\vendor\\libwebp\\dwebp.exe",
+    });
+  });
+
+  test("logs and returns a typed failure when Windows WebP binaries are unavailable", async () => {
+    const warnings: string[] = [];
+
+    const result = await checkImageBackend({
+      platform: "win32",
+      webpBinaryResolver: {
+        resolve: async () => {
+          throw new Error("Unable to resolve cwebp");
+        },
+      },
+      logger: {
+        warn: message => warnings.push(message),
+      },
+    });
+
+    expect(result.name).toBe("Image Backend");
+    expect(result.status).toBe("fail");
+    expect(result.message).toBe("active=jimp-cli; cwebp=unavailable; dwebp=unavailable; error=Unable to resolve cwebp");
+    expect(result.recommendation).toContain("AUTOMOBILE_CWEBP_PATH");
+    expect(warnings).toEqual(["Image backend doctor check failed: Unable to resolve cwebp"]);
   });
 });
 
@@ -374,6 +464,11 @@ describe("checkCtrlProxy", () => {
 
 describe("runAutoMobileChecks", () => {
   const stubChecks = {
+    checkImageBackend: async () => ({
+      name: "Image Backend",
+      status: "pass" as const,
+      message: "active=sharp; sharp=loaded",
+    }),
     checkDaemonStatus: async () => ({
       name: "Daemon Status",
       status: "pass" as const,
@@ -408,5 +503,15 @@ describe("runAutoMobileChecks", () => {
 
     expect(buildIdentity).toBeDefined();
     expect(buildIdentity?.status).toBe("pass");
+  });
+
+  test("includes the image backend provisioning check", async () => {
+    const results = await runAutoMobileChecks({ ios: true }, stubChecks);
+
+    const imageBackend = results.find(result => result.name === "Image Backend");
+
+    expect(imageBackend).toBeDefined();
+    expect(imageBackend?.status).toBe("pass");
+    expect(imageBackend?.message).toBe("active=sharp; sharp=loaded");
   });
 });

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -412,6 +412,12 @@ describe("runDoctor", () => {
       expect(report.android).toBeUndefined();
       expect(report.ios?.checks.length).toBeGreaterThan(0);
       expect(report.ios?.checks.every(check => check.status === "skip")).toBe(true);
+      const imageBackend = report.autoMobile.checks.find(check => check.name === "Image Backend");
+      expect(imageBackend).toBeDefined();
+      expect(imageBackend?.message).toContain("active=sharp");
+      expect(report.summary.total).toBe(
+        report.system.checks.length + (report.ios?.checks.length ?? 0) + report.autoMobile.checks.length
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Adds an AutoMobile doctor check for image backend provisioning. The check reports the active image backend, verifies sharp loading on macOS/Linux, resolves cwebp/dwebp on Windows, and fails when the selected platform cannot satisfy the WebP navigation-screenshot contract. The docs now mark the image backend decision accepted and document that nav-screenshot caches are per-machine, not portable across platforms.

## Linked Issue

Closes #3013

## Bug / Regression Context

- **Prior attempts:** #3012 completed the Windows Jimp CLI backend and left doctor/docs for this follow-up.
- **Observed symptom:** Doctor did not report the active image backend or image-codec provisioning state, and the per-machine nav-screenshot cache contract was not surfaced in user-facing docs.
- **Repro steps / conditions:** Run `auto-mobile --cli doctor` on macOS/Linux or Windows after the sharp+cwebp backend rollout; before this PR there was no Image Backend diagnostic entry.

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + build + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, TypeScript/docs only
- [x] New code uses interfaces + fakes; unit tests run in <100ms where applicable
- [x] Rebased onto latest `main`, conflicts resolved

Focused checks also run:

- `bun test test/doctor/automobile.test.ts test/doctor/index.test.ts test/docs/imageBackendCacheContract.test.ts test/utils/image/backend/SharpBackend.test.ts`

## Device Verification

N/A. This is a doctor/docs change with fake-backed unit coverage and no on-device behavior change.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
