### PR TITLE
chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -30,7 +30,7 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     version: "0.0.40",
     apkSha256: "8e89fbab6462ac1ead1f3f0a334aff4f5f299e7ae72e192045cf75e893ca87aa",
     ipaSha256: "38adaed641ac6a8590773682e127a80a86c54e5804d47394e1b0cd437009b9ff",
-    runnerSha256: "",
+    runnerSha256: "b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982",
   },
   {
     version: "0.0.39",


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `  apkSha256: string;` | `ee1dff240e4dfc89b016197c80e929797485aa23292e061eee361b7404c772b4` | ✅ Yes |
| **IPA** | `  ipaSha256: string;` | `900e84f92c93955f4d5433f8a1df4bd4d5fe1776188a1063012eefc0fe445413` | ✅ Yes |
| **iOS Runner** | `(empty)` | `b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow