### PR TITLE
feat(daemon): add input swipe socket endpoint

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -296,7 +296,7 @@ stream after the input response returns.
 | Method | Android | iOS | Notes |
 |---|---|---|---|
 | `input/tap` | Supported | Supported | Absolute device-screen coordinates. |
-| `input/swipe` | Contract only | Contract only | Not implemented yet. Use for drag gestures until `input/drag` has distinct semantics. |
+| `input/swipe` | Supported | Supported | Absolute device-screen start/end coordinates. Use for drag gestures until `input/drag` has distinct semantics. |
 | `input/drag` | Deferred | Deferred | Not a separate method in this contract. |
 | `input/pressButton` | Contract only | Contract only | Not implemented yet. Unsupported buttons fail instead of being ignored. |
 | `input/typeText` | Contract only | Contract only | Not implemented yet. Sends committed text only; IME composition is deferred. |
@@ -386,7 +386,7 @@ duration.
 | `startY` | `number` | Yes | Start Y coordinate in physical screen pixels. |
 | `endX` | `number` | Yes | End X coordinate in physical screen pixels. |
 | `endY` | `number` | Yes | End Y coordinate in physical screen pixels. |
-| `durationMs` | `number` | No | Gesture duration in milliseconds. The daemon chooses a platform default when omitted. |
+| `durationMs` | `number` | No | Gesture duration in milliseconds, from 1 to 60 000 inclusive. The daemon uses 300 when omitted. |
 
 **Request**
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -880,7 +880,7 @@ export class UnixSocketServer {
           .requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs)
         : await IOSCtrlProxyClient
           .getInstance(targetDevice)
-          .requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs);
+          .requestDrag(args.startX, args.startY, args.endX, args.endY, 0, args.durationMs, 0, remainingTimeoutMs);
     });
 
     if (!gestureResult.success) {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -640,6 +640,9 @@ export class UnixSocketServer {
     if (request.method === "input/tap") {
       return await this.handleInputTap(request, socketSessionId);
     }
+    if (request.method === "input/swipe") {
+      return await this.handleInputSwipe(request, socketSessionId);
+    }
 
     switch (request.method) {
       case "ide/listFeatureFlags": {
@@ -806,7 +809,12 @@ export class UnixSocketServer {
     const queueEnterMs = this.timer.now();
     const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
     const args = this.parseInputTapParams(request.params);
-    const targetDevice = await this.resolveInputTargetDevice(args.platform, args.deviceId, socketSessionId);
+    const targetDevice = await this.resolveInputTargetDevice(
+      args.platform,
+      args.deviceId,
+      socketSessionId,
+      "input/tap"
+    );
     const gestureResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
       const queueWaitMs = this.timer.now() - queueEnterMs;
       const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
@@ -838,6 +846,55 @@ export class UnixSocketServer {
       deviceId: targetDevice.deviceId,
       success: true,
       coordinates: { x: args.x, y: args.y },
+    };
+  }
+
+  private async handleInputSwipe(
+    request: DaemonRequest,
+    socketSessionId?: string
+  ): Promise<any | undefined> {
+    const queueEnterMs = this.timer.now();
+    const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
+    const args = this.parseInputSwipeParams(request.params);
+    const targetDevice = await this.resolveInputTargetDevice(
+      args.platform,
+      args.deviceId,
+      socketSessionId,
+      "input/swipe"
+    );
+    const gestureResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      const queueWaitMs = this.timer.now() - queueEnterMs;
+      const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
+      if (remainingTimeoutMs <= 0) {
+        throw new McpTimeoutError({
+          toolName: request.method,
+          timeoutMs: totalTimeoutMs,
+          origin: "UnixSocketServer.handleInputSwipe",
+          detail: `spent ${queueWaitMs}ms waiting in queue`,
+        });
+      }
+
+      return args.platform === "android"
+        ? await AndroidCtrlProxyClient
+          .getInstance(targetDevice, defaultAdbClientFactory)
+          .requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs)
+        : await IOSCtrlProxyClient
+          .getInstance(targetDevice)
+          .requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs);
+    });
+
+    if (!gestureResult.success) {
+      throw new Error(gestureResult.error ?? `input/swipe failed on ${args.platform}`);
+    }
+
+    return {
+      action: "input/swipe",
+      platform: args.platform,
+      deviceId: targetDevice.deviceId,
+      success: true,
+      start: { x: args.startX, y: args.startY },
+      end: { x: args.endX, y: args.endY },
+      durationMs: args.durationMs,
     };
   }
 
@@ -875,14 +932,70 @@ export class UnixSocketServer {
     };
   }
 
+  private parseInputSwipeParams(params: unknown): {
+    platform: "android" | "ios";
+    deviceId?: string;
+    startX: number;
+    startY: number;
+    endX: number;
+    endY: number;
+    durationMs: number;
+  } {
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new Error("input/swipe requires params object");
+    }
+
+    const args = params as Record<string, unknown>;
+    if (args.platform !== "android" && args.platform !== "ios") {
+      throw new Error("input/swipe requires platform 'android' or 'ios'");
+    }
+    if (
+      typeof args.startX !== "number" ||
+      !Number.isFinite(args.startX) ||
+      typeof args.startY !== "number" ||
+      !Number.isFinite(args.startY) ||
+      typeof args.endX !== "number" ||
+      !Number.isFinite(args.endX) ||
+      typeof args.endY !== "number" ||
+      !Number.isFinite(args.endY)
+    ) {
+      throw new Error("input/swipe requires numeric startX, startY, endX, and endY params");
+    }
+    if (
+      args.durationMs !== undefined &&
+      (
+        typeof args.durationMs !== "number" ||
+        !Number.isFinite(args.durationMs) ||
+        args.durationMs < 1 ||
+        args.durationMs > 60_000
+      )
+    ) {
+      throw new Error("input/swipe durationMs must be between 1 and 60000 milliseconds");
+    }
+    if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
+      throw new Error("input/swipe deviceId must be a string when provided");
+    }
+
+    return {
+      platform: args.platform,
+      deviceId: args.deviceId,
+      startX: args.startX,
+      startY: args.startY,
+      endX: args.endX,
+      endY: args.endY,
+      durationMs: args.durationMs ?? 300,
+    };
+  }
+
   private async resolveInputTargetDevice(
     platform: "android" | "ios",
     deviceId: string | undefined,
-    socketSessionId: string | undefined
+    socketSessionId: string | undefined,
+    action: "input/tap" | "input/swipe"
   ): Promise<BootedDevice> {
     const discovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform);
     if (!discovery.succeededPlatforms.has(platform)) {
-      throw new Error(`Unable to discover booted ${platform} devices for input/tap`);
+      throw new Error(`Unable to discover booted ${platform} devices for ${action}`);
     }
     const bootedDevices = discovery.devices;
     if (deviceId) {
@@ -913,9 +1026,9 @@ export class UnixSocketServer {
       return bootedDevices[0];
     }
     if (bootedDevices.length === 0) {
-      throw new Error(`No booted ${platform} devices found for input/tap`);
+      throw new Error(`No booted ${platform} devices found for ${action}`);
     }
-    throw new Error(`input/tap requires deviceId when multiple ${platform} devices are booted`);
+    throw new Error(`${action} requires deviceId when multiple ${platform} devices are booted`);
   }
 
   private async handleIdeRequest(

--- a/test/daemon/socketServerInputSwipe.test.ts
+++ b/test/daemon/socketServerInputSwipe.test.ts
@@ -1,0 +1,489 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonRequest, DaemonResponse } from "../../src/daemon/types";
+import type { DeviceLabelMap, Session } from "../../src/daemon/sessionManager";
+import type { BootedDevice } from "../../src/models";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android",
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "ios-sim-1",
+  name: "iPhone 16",
+  platform: "ios",
+};
+
+function createFakeDeviceManager(
+  devices: BootedDevice[],
+  succeededPlatforms: Set<"android" | "ios"> = new Set(["android", "ios"])
+) {
+  return {
+    getBootedDevicesDetailed: mock(async () => ({
+      devices,
+      succeededPlatforms,
+    })),
+  } as unknown as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>;
+}
+
+function createFakeSession(sessionId: string, assignedDevice: string, platform: "android" | "ios"): Session {
+  return {
+    sessionId,
+    assignedDevice,
+    platform,
+    createdAt: 0,
+    lastUsedAt: 0,
+    expiresAt: 60_000,
+    cacheData: {},
+    lastHeartbeat: 0,
+    sessionTimeoutMs: 60_000,
+    heartbeatTimeoutMs: 10_000,
+    heartbeatTimeoutSource: "default",
+    hasReceivedHeartbeat: false,
+  };
+}
+
+function createFakeDaemonState(
+  autolockSessions: Map<string, Session> = new Map(),
+  mcpAutolockSessions: Map<string, string> = new Map()
+) {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: (sessionId: string) => autolockSessions.get(sessionId) ?? null,
+      getDeviceLabels: (_sessionId: string): DeviceLabelMap | undefined => undefined,
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: (mcpSessionId: string | undefined, platform?: "android" | "ios") => {
+        if (!mcpSessionId) {
+          return undefined;
+        }
+        const sessionId = mcpAutolockSessions.get(mcpSessionId);
+        const session = sessionId ? autolockSessions.get(sessionId) : undefined;
+        return session?.platform === platform ? session.sessionId : undefined;
+      },
+    }),
+  };
+}
+
+function sendRequest(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number
+): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+    const request: DaemonRequest = {
+      id: randomUUID(),
+      type: "mcp_request",
+      method,
+      params,
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    };
+
+    client.connect(socketPath, () => {
+      client.write(JSON.stringify(request) + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const response = JSON.parse(line) as DaemonResponse;
+          client.destroy();
+          resolve(response);
+          return;
+        } catch {
+          // Incomplete JSON, keep buffering.
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+function sendRequestAfterConnect(
+  socketPath: string,
+  request: DaemonRequest,
+  onConnect: () => void
+): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+
+    client.connect(socketPath, () => {
+      onConnect();
+      client.write(JSON.stringify(request) + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const response = JSON.parse(line) as DaemonResponse;
+          client.destroy();
+          resolve(response);
+          return;
+        } catch {
+          // Incomplete JSON, keep buffering.
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+describe("UnixSocketServer input/swipe", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let fakeTimer: FakeTimer;
+  let originalAndroidGetInstance: typeof AndroidCtrlProxyClient.getInstance;
+  let originalIosGetInstance: typeof IOSCtrlProxyClient.getInstance;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `input-swipe-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    PlatformDeviceManagerFactory.reset();
+    AndroidCtrlProxyClient.resetInstances();
+    IOSCtrlProxyClient.resetInstances();
+    originalAndroidGetInstance = AndroidCtrlProxyClient.getInstance;
+    originalIosGetInstance = IOSCtrlProxyClient.getInstance;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+    }
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+    AndroidCtrlProxyClient.getInstance = originalAndroidGetInstance;
+    IOSCtrlProxyClient.getInstance = originalIosGetInstance;
+    PlatformDeviceManagerFactory.reset();
+    AndroidCtrlProxyClient.resetInstances();
+    IOSCtrlProxyClient.resetInstances();
+  });
+
+  test("routes Android coordinate swipes without forwarding through tools/call", async () => {
+    const requestSwipe = mock(async () => ({ success: true }));
+    const createMcpClient = mock(async () => {
+      throw new Error("input/swipe should not create an MCP client");
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSwipe,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    (server as unknown as { createMcpClient: typeof createMcpClient }).createMcpClient = createMcpClient;
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      startX: 12.5,
+      startY: 34.25,
+      endX: 56.75,
+      endY: 78.5,
+      durationMs: 420,
+    }, 1234);
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({
+      action: "input/swipe",
+      platform: "android",
+      deviceId: "emulator-5554",
+      success: true,
+      start: { x: 12.5, y: 34.25 },
+      end: { x: 56.75, y: 78.5 },
+      durationMs: 420,
+    });
+    expect(requestSwipe).toHaveBeenCalledWith(12.5, 34.25, 56.75, 78.5, 420, 1234);
+    expect(createMcpClient).not.toHaveBeenCalled();
+  });
+
+  test("routes iOS coordinate swipes through the iOS gesture client", async () => {
+    const requestSwipe = mock(async () => ({ success: true }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestSwipe,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/swipe", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      startX: 20,
+      startY: 30,
+      endX: 80,
+      endY: 90,
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({
+      action: "input/swipe",
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      success: true,
+      start: { x: 20, y: 30 },
+      end: { x: 80, y: 90 },
+      durationMs: 300,
+    });
+    expect(requestSwipe).toHaveBeenCalledWith(20, 30, 80, 90, 300, 30_000);
+  });
+
+  test("uses the socket autolock device when deviceId is omitted", async () => {
+    const requestSwipe = mock(async () => ({ success: true }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSwipe,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    const session = createFakeSession("session-1", "emulator-5554", "android");
+    const autolockSessions = new Map([[session.sessionId, session]]);
+    const mcpAutolockSessions = new Map<string, string>();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(autolockSessions, mcpAutolockSessions),
+      fakeTimer
+    );
+    await server.start();
+
+    const response = await sendRequestAfterConnect(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "input/swipe",
+      params: {
+        platform: "android",
+        startX: 1,
+        startY: 2,
+        endX: 3,
+        endY: 4,
+      },
+    }, () => {
+      const socketSessionId = [...((server as unknown as { sessions: Map<string, unknown> }).sessions.keys())][0];
+      mcpAutolockSessions.set(socketSessionId, session.sessionId);
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toMatchObject({
+      platform: "android",
+      deviceId: "emulator-5554",
+      start: { x: 1, y: 2 },
+      end: { x: 3, y: 4 },
+    });
+    expect(requestSwipe).toHaveBeenCalledWith(1, 2, 3, 4, 300, 30_000);
+  });
+
+  test("serializes concurrent swipes for the same device across socket clients", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const requestSwipe = mock(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>(resolve => {
+        fakeTimer.setTimeout(resolve, 40);
+      });
+      inFlight -= 1;
+      return { success: true };
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSwipe,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    fakeTimer.enableAutoAdvance();
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const [first, second] = await Promise.all([
+      sendRequest(socketPath, "input/swipe", {
+        platform: "android",
+        deviceId: "emulator-5554",
+        startX: 1,
+        startY: 1,
+        endX: 2,
+        endY: 2,
+      }),
+      sendRequest(socketPath, "input/swipe", {
+        platform: "android",
+        deviceId: "emulator-5554",
+        startX: 3,
+        startY: 3,
+        endX: 4,
+        endY: 4,
+      }),
+    ]);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    expect(requestSwipe).toHaveBeenCalledTimes(2);
+    expect(maxInFlight).toBe(1);
+    expect(inFlight).toBe(0);
+  });
+
+  test("fails queued swipes before dispatch when queue wait exceeds timeout", async () => {
+    let callCount = 0;
+    let releaseBlockingRequest: () => void = () => {};
+    const blockingPromise = new Promise<void>(resolve => {
+      releaseBlockingRequest = resolve;
+    });
+    const requestSwipe = mock(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        await blockingPromise;
+      }
+      return { success: true };
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSwipe,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const first = sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      startX: 1,
+      startY: 1,
+      endX: 2,
+      endY: 2,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    const second = sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      startX: 3,
+      startY: 3,
+      endX: 4,
+      endY: 4,
+    }, 500);
+
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    fakeTimer.advanceTime(600);
+    releaseBlockingRequest();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(false);
+    expect(secondResult.error).toContain("waiting in queue");
+    expect(requestSwipe).toHaveBeenCalledTimes(1);
+  });
+
+  test("surfaces platform discovery failures before device targeting errors", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([], new Set()));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      startX: 1,
+      startY: 1,
+      endX: 2,
+      endY: 2,
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe("Unable to discover booted android devices for input/swipe");
+  });
+
+  test("rejects missing and non-numeric coordinates with actionable errors", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const missing = await sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      startY: 10,
+      endX: 20,
+      endY: 30,
+    });
+    const nonNumeric = await sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      startX: "12",
+      startY: 10,
+      endX: 20,
+      endY: 30,
+    });
+
+    expect(missing.success).toBe(false);
+    expect(missing.error).toBe("input/swipe requires numeric startX, startY, endX, and endY params");
+    expect(nonNumeric.success).toBe(false);
+    expect(nonNumeric.error).toBe("input/swipe requires numeric startX, startY, endX, and endY params");
+  });
+
+  test("rejects duration outside the supported bounds", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const zero = await sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      startX: 1,
+      startY: 1,
+      endX: 2,
+      endY: 2,
+      durationMs: 0,
+    });
+    const tooLarge = await sendRequest(socketPath, "input/swipe", {
+      platform: "android",
+      startX: 1,
+      startY: 1,
+      endX: 2,
+      endY: 2,
+      durationMs: 60_001,
+    });
+
+    expect(zero.success).toBe(false);
+    expect(zero.error).toBe("input/swipe durationMs must be between 1 and 60000 milliseconds");
+    expect(tooLarge.success).toBe(false);
+    expect(tooLarge.error).toBe("input/swipe durationMs must be between 1 and 60000 milliseconds");
+  });
+});

--- a/test/daemon/socketServerInputSwipe.test.ts
+++ b/test/daemon/socketServerInputSwipe.test.ts
@@ -239,10 +239,10 @@ describe("UnixSocketServer input/swipe", () => {
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
-  test("routes iOS coordinate swipes through the iOS gesture client", async () => {
-    const requestSwipe = mock(async () => ({ success: true }));
+  test("routes iOS coordinate swipes through the duration-aware iOS drag gesture", async () => {
+    const requestDrag = mock(async () => ({ success: true }));
     IOSCtrlProxyClient.getInstance = mock(() => ({
-      requestSwipe,
+      requestDrag,
     })) as unknown as typeof IOSCtrlProxyClient.getInstance;
     PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
     server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
@@ -255,6 +255,7 @@ describe("UnixSocketServer input/swipe", () => {
       startY: 30,
       endX: 80,
       endY: 90,
+      durationMs: 750,
     });
 
     expect(response.success).toBe(true);
@@ -265,9 +266,9 @@ describe("UnixSocketServer input/swipe", () => {
       success: true,
       start: { x: 20, y: 30 },
       end: { x: 80, y: 90 },
-      durationMs: 300,
+      durationMs: 750,
     });
-    expect(requestSwipe).toHaveBeenCalledWith(20, 30, 80, 90, 300, 30_000);
+    expect(requestDrag).toHaveBeenCalledWith(20, 30, 80, 90, 0, 750, 0, 30_000);
   });
 
   test("uses the socket autolock device when deviceId is omitted", async () => {

--- a/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
+++ b/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs/promises";
 import * as path from "path";
+import { resolveRunnerChecksum } from "../../src/constants/release";
 import type { Sha256Source, CtrlProxyIosBundleDownloader } from "../../src/utils/IOSCtrlProxyBundleDownloader";
 
 export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownloader {
@@ -8,6 +9,7 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
   public checksum: string = "fake-checksum";
   public checksumSource: Sha256Source = "node";
   public extractedSubdir: string = "";
+  public runnerChecksum: string = resolveRunnerChecksum();
 
   public async download(url: string, destination: string): Promise<void> {
     this.downloadedUrls.push(url);
@@ -16,7 +18,10 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
     await fs.writeFile(destination, payload);
   }
 
-  public async computeFileSha256(_filePath: string): Promise<{ checksum: string; source: Sha256Source }> {
+  public async computeFileSha256(filePath: string): Promise<{ checksum: string; source: Sha256Source }> {
+    if (path.basename(filePath) === "CtrlProxyUITests-Runner") {
+      return { checksum: this.runnerChecksum, source: this.checksumSource };
+    }
     return { checksum: this.checksum, source: this.checksumSource };
   }
 


### PR DESCRIPTION
## Summary

Adds the daemon Unix socket `input/swipe` endpoint from #3341. The endpoint accepts absolute start/end coordinates, optional `durationMs`, resolves the target device with the existing input/tap targeting rules, serializes gesture dispatch per device, and routes to the existing Android and iOS CtrlProxy swipe clients. The daemon input API docs now mark `input/swipe` supported while keeping `input/drag` deferred per the approved contract.

Also updates the iOS CtrlProxy bundle downloader fake so full-suite validation can satisfy the existing runner-binary checksum check independently from the IPA checksum.

## Linked Issue

Closes #3341

## Validation

- [x] `bun test test/daemon/socketServerInputSwipe.test.ts`
- [x] `bun test test/daemon/socketServerInputTap.test.ts test/daemon/socketServerInputSwipe.test.ts`
- [x] `bun test test/utils/IOSCtrlProxyBuilder.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via daemon socket client

## Follow-ups

- [ ] `input/drag` remains deferred until a distinct drag contract is approved
