### PR TITLE
fix(image): clean up ImageBackend follow-ups

### DIFF
--- a/src/features/accessibility/ContrastChecker.ts
+++ b/src/features/accessibility/ContrastChecker.ts
@@ -125,6 +125,10 @@ interface CacheStats {
   };
 }
 
+interface ContrastCheckerDependencies {
+  readFile: (path: string) => Promise<Buffer>;
+}
+
 /**
  * Screenshot cache entry
  */
@@ -171,7 +175,8 @@ export class ContrastChecker {
   constructor(
     config: ContrastCheckConfig = {},
     timer: Timer = defaultTimer,
-    backend: ImageBackend = resolveImageBackend()
+    backend: ImageBackend = resolveImageBackend(),
+    private readonly deps: ContrastCheckerDependencies = { readFile: fs.readFile }
   ) {
     this.timer = timer;
     this.backend = backend;
@@ -487,7 +492,7 @@ export class ContrastChecker {
    * decode the same PNG), so contrast sampling is byte-for-byte unchanged.
    */
   private async decodeScreenshot(path: string): Promise<RawImage> {
-    const buffer = await fs.readFile(path);
+    const buffer = await this.deps.readFile(path);
     return this.backend.rawPixels(buffer);
   }
 
@@ -668,12 +673,7 @@ export class ContrastChecker {
     for (let x = centerX - sampleSize; x <= centerX + sampleSize; x++) {
       for (let y = centerY - sampleSize; y <= centerY + sampleSize; y++) {
         if (x >= left && x < right && y >= top && y < bottom) {
-          try {
-            const color = this.resolvePixelColor(image, x, y);
-            colors.push(color);
-          } catch (e) {
-            // Skip invalid pixels
-          }
+          colors.push(this.resolvePixelColor(image, x, y));
         }
       }
     }
@@ -751,35 +751,19 @@ export class ContrastChecker {
 
     for (let x = left; x < right; x += 3) {
       for (let y = top; y < top + edgeSampleSize; y++) {
-        try {
-          colors.push(this.resolvePixelColor(image, x, y));
-        } catch (e) {
-          // Skip
-        }
+        colors.push(this.resolvePixelColor(image, x, y));
       }
       for (let y = bottom - edgeSampleSize; y < bottom; y++) {
-        try {
-          colors.push(this.resolvePixelColor(image, x, y));
-        } catch (e) {
-          // Skip
-        }
+        colors.push(this.resolvePixelColor(image, x, y));
       }
     }
 
     for (let y = top; y < bottom; y += 3) {
       for (let x = left; x < left + edgeSampleSize; x++) {
-        try {
-          colors.push(this.resolvePixelColor(image, x, y));
-        } catch (e) {
-          // Skip
-        }
+        colors.push(this.resolvePixelColor(image, x, y));
       }
       for (let x = right - edgeSampleSize; x < right; x++) {
-        try {
-          colors.push(this.resolvePixelColor(image, x, y));
-        } catch (e) {
-          // Skip
-        }
+        colors.push(this.resolvePixelColor(image, x, y));
       }
     }
 
@@ -787,11 +771,7 @@ export class ContrastChecker {
       const margin = 5;
       for (let x = Math.max(0, left - margin); x < left; x++) {
         for (let y = top; y < bottom; y += 3) {
-          try {
-            colors.push(this.resolvePixelColor(image, x, y));
-          } catch (e) {
-            // Skip
-          }
+          colors.push(this.resolvePixelColor(image, x, y));
         }
       }
     }

--- a/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
+++ b/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
@@ -1,11 +1,13 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 import type { Sha256Source, CtrlProxyIosBundleDownloader } from "../../src/utils/IOSCtrlProxyBundleDownloader";
+import { resolveRunnerChecksum } from "../../src/constants/release";
 
 export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownloader {
   public downloadedUrls: string[] = [];
   public extractedPaths: string[] = [];
   public checksum: string = "fake-checksum";
+  public runnerChecksum: string = resolveRunnerChecksum();
   public checksumSource: Sha256Source = "node";
   public extractedSubdir: string = "";
 
@@ -16,7 +18,10 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
     await fs.writeFile(destination, payload);
   }
 
-  public async computeFileSha256(_filePath: string): Promise<{ checksum: string; source: Sha256Source }> {
+  public async computeFileSha256(filePath: string): Promise<{ checksum: string; source: Sha256Source }> {
+    if (path.basename(filePath) === "CtrlProxyUITests-Runner") {
+      return { checksum: this.runnerChecksum, source: this.checksumSource };
+    }
     return { checksum: this.checksum, source: this.checksumSource };
   }
 

--- a/test/fakes/FakeImageBackend.test.ts
+++ b/test/fakes/FakeImageBackend.test.ts
@@ -30,6 +30,17 @@ describe("FakeImageBackend", () => {
       expect(raw.height).toBe(2);
       expect(raw.data.length).toBe(2 * 2 * 4);
     });
+
+    test("rawPixels returns a defensive copy of canned pixels", async () => {
+      const first = await backend.rawPixels(source);
+      first.data[0] = 1;
+
+      const second = await backend.rawPixels(source);
+
+      expect(second).not.toBe(first);
+      expect(second.data).not.toBe(first.data);
+      expect(second.data[0]).toBe(255);
+    });
   });
 
   describe("configuration", () => {

--- a/test/fakes/FakeImageBackend.ts
+++ b/test/fakes/FakeImageBackend.ts
@@ -53,7 +53,11 @@ export class FakeImageBackend implements ImageBackend {
   }
 
   setRawPixelsResult(raw: RawImage): void {
-    this.rawPixelsResult = raw;
+    this.rawPixelsResult = {
+      width: raw.width,
+      height: raw.height,
+      data: Buffer.from(raw.data)
+    };
   }
 
   setShouldThrowOnExecute(shouldThrow: boolean): void {
@@ -94,6 +98,10 @@ export class FakeImageBackend implements ImageBackend {
     if (this.shouldThrowOnRawPixels) {
       throw new Error("Simulated error in rawPixels");
     }
-    return this.rawPixelsResult;
+    return {
+      width: this.rawPixelsResult.width,
+      height: this.rawPixelsResult.height,
+      data: Buffer.from(this.rawPixelsResult.data)
+    };
   }
 }

--- a/test/features/accessibility/ContrastChecker.test.ts
+++ b/test/features/accessibility/ContrastChecker.test.ts
@@ -26,6 +26,7 @@ function uniformRaw(width: number, height: number, r: number, g: number, b: numb
 describe("ContrastChecker", function() {
   let checker: ContrastChecker;
   const fixturesDir = path.join(__dirname, "../../fixtures/screenshots");
+  const syntheticScreenshotPath = "/synthetic/contrast.png";
 
   beforeEach(function() {
     checker = new ContrastChecker();
@@ -399,27 +400,29 @@ describe("ContrastChecker", function() {
     it("decodes screenshots through the injected ImageBackend.rawPixels", async function() {
       const backend = new FakeImageBackend();
       backend.setRawPixelsResult(uniformRaw(100, 50, 255, 255, 255));
-      const seamChecker = new ContrastChecker({}, undefined, backend);
-      // A real file must exist for fs.readFile; its bytes are ignored because the
-      // fake backend returns canned pixels regardless of buffer content.
-      const screenshotPath = path.join(fixturesDir, "black-on-white.png");
+      const screenshotBytes = Buffer.from("synthetic screenshot");
+      const seamChecker = new ContrastChecker({}, undefined, backend, {
+        readFile: async path => path === syntheticScreenshotPath ? screenshotBytes : Buffer.from("unexpected"),
+      });
       const element: Element = {
         bounds: { left: 0, top: 0, right: 100, bottom: 50 },
         text: "Sample",
       };
 
-      const result = await seamChecker.checkContrast(screenshotPath, element, "AA");
+      const result = await seamChecker.checkContrast(syntheticScreenshotPath, element, "AA");
 
       expect(result).not.toBeNull();
       // Decoded exactly once via the seam (screenshot cache holds the RawImage).
       expect(backend.rawPixelsCalls).toHaveLength(1);
+      expect(backend.rawPixelsCalls[0]).toBe(screenshotBytes);
     });
 
     it("tolerates element bounds beyond the image via edge clamping", async function() {
       const backend = new FakeImageBackend();
       backend.setRawPixelsResult(uniformRaw(20, 20, 0, 0, 0));
-      const seamChecker = new ContrastChecker({}, undefined, backend);
-      const screenshotPath = path.join(fixturesDir, "black-on-white.png");
+      const seamChecker = new ContrastChecker({}, undefined, backend, {
+        readFile: async () => Buffer.from("synthetic screenshot"),
+      });
       // Bounds extend past the 20x20 image; jimp getPixelColor edge-extends, so
       // sampling must not throw and should resolve to the (uniform black) edge.
       const element: Element = {
@@ -427,7 +430,7 @@ describe("ContrastChecker", function() {
         text: "Sample",
       };
 
-      const result = await seamChecker.checkContrast(screenshotPath, element, "AA");
+      const result = await seamChecker.checkContrast(syntheticScreenshotPath, element, "AA");
 
       expect(result).not.toBeNull();
     });


### PR DESCRIPTION
## Summary

Clean up the minor ImageBackend follow-ups from PR #3036. This removes dead defensive pixel-sampling catches in `ContrastChecker`, makes `FakeImageBackend.rawPixels()` return defensive copies like the production backends, and makes the backend-seam contrast tests hermetic by injecting screenshot bytes instead of relying on a fixture file.

Also fixes the PR CI failure in `IOSCtrlProxyBuilder` tests by teaching `FakeIOSCtrlProxyBundleDownloader` to model the runner-binary checksum separately from the IPA checksum, matching the production verifier.

## Linked Issue

Closes #3041

## Bug / Regression Context

- **Prior attempts:** PR #3036 migrated pixel consumers to the `ImageBackend` seam and shipped green.
- **Observed symptom:** follow-up review found dead `try/catch` wrappers, a fake backend aliasing footgun, and backend-seam tests that used a real fixture only to satisfy `fs.readFile`.
- **Repro steps / conditions:** mutate the `RawImage.data` returned from `FakeImageBackend.rawPixels()` and call `rawPixels()` again; before this change, the second call observed the mutation.

## Validation

- [x] `bun run turbo:validate` passes (`lint` + `build` + `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, TypeScript-only test/fake cleanup
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional local checks:
- [x] `bun test test/fakes/FakeImageBackend.test.ts test/features/accessibility/ContrastChecker.test.ts`
- [x] `bun test test/utils/IOSCtrlProxyBuilder.test.ts`
- [x] `git diff --check`
- [x] `auto-mobile-code-review` alternate perspective found no confirmed findings

## Device Verification

- [x] N/A, no on-device behavior changes

## Follow-ups

- [ ] Follow-up issues filed for gaps not addressed here: N/A
