### PR TITLE
fix(test): remove duplicate iOS bundle fake fields

### DIFF
--- a/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
+++ b/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
@@ -2,7 +2,6 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { resolveRunnerChecksum } from "../../src/constants/release";
 import type { Sha256Source, CtrlProxyIosBundleDownloader } from "../../src/utils/IOSCtrlProxyBundleDownloader";
-import { resolveRunnerChecksum } from "../../src/constants/release";
 
 export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownloader {
   public downloadedUrls: string[] = [];
@@ -11,7 +10,6 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
   public runnerChecksum: string = resolveRunnerChecksum();
   public checksumSource: Sha256Source = "node";
   public extractedSubdir: string = "";
-  public runnerChecksum: string = resolveRunnerChecksum();
 
   public async download(url: string, destination: string): Promise<void> {
     this.downloadedUrls.push(url);


### PR DESCRIPTION
## Summary

- remove the duplicate `resolveRunnerChecksum` import in `FakeIOSCtrlProxyBundleDownloader`
- remove the duplicate `runnerChecksum` property declaration

## Root cause

The squash-merged `main` version of the input swipe PR picked up duplicate declarations in the iOS bundle fake. The branch head had passed validation, but the landed merge commit made the test fake invalid TypeScript.

## Issue references

- Related issue: #3341
- Follow-up to PR: #3365

## Validation

- `bun test test/utils/IOSCtrlProxyBuilder.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `git diff --check`
