### PR TITLE
docs(image): add sharp Bun repro artifact

### DIFF
--- a/docs/design-docs/image-backend.md
+++ b/docs/design-docs/image-backend.md
@@ -206,3 +206,17 @@ task off the critical path: build a minimal reproducible repro of the
 (reference the closed-for-no-repro
 [sharp#4042](https://github.com/lovell/sharp/issues/4042)). If Bun fixes the
 interop, sharp can later be unfrozen and Windows collapsed onto it.
+
+### Issue #3014 upstream repro record
+
+The standalone repro lives in `docs/reproductions/sharp-bun-035`. It pins
+`sharp@0.35.3`, imports no AutoMobile code, creates a tiny PNG through sharp,
+exercises lossy/lossless/near-lossless WebP encodes, and reads WebP metadata.
+Capture local output under `scratch/sharp-bun-0.35-repro/` before posting
+evidence upstream.
+
+Local issue #3014 capture on 2026-07-07: `darwin arm64`, Bun `1.3.14`,
+sharp `0.35.3`, and libvips `8.18.3` passed the standalone repro. A Linux
+container attempt could not run because the Docker daemon was unavailable, so
+the recorded evidence is a minimal sharp 0.35.x interop repro package plus a
+macOS pass result, not a Linux/Windows crash log.

--- a/docs/reproductions/sharp-bun-035/README.md
+++ b/docs/reproductions/sharp-bun-035/README.md
@@ -1,0 +1,53 @@
+# sharp 0.35.x Bun repro
+
+Minimal standalone reproduction for AutoMobile issue
+[#3014](https://github.com/kaeawc/auto-mobile/issues/3014). It intentionally
+has no AutoMobile dependencies and pins `sharp@0.35.3`, the sharp 0.35.x line
+called out in the image-backend design record.
+
+Upstream tracking:
+
+- [oven-sh/bun#20372](https://github.com/oven-sh/bun/issues/20372)
+- [oven-sh/bun#29352](https://github.com/oven-sh/bun/issues/29352)
+- [lovell/sharp#4042](https://github.com/lovell/sharp/issues/4042)
+
+Run from this directory:
+
+```bash
+bun install
+bun run repro
+```
+
+The script imports sharp, prints Bun/platform/sharp runtime versions, creates a
+small PNG entirely through sharp, exercises lossy/lossless/near-lossless WebP
+encodes, reads WebP metadata, and prints `ok` if the process survives.
+
+Local result captured for issue #3014 on 2026-07-07:
+
+- `darwin arm64`, Bun `1.3.14`, sharp `0.35.3`, libvips `8.18.3`: passed;
+  output is in `scratch/sharp-bun-0.35-repro/local-output.txt`.
+- Linux container check was not exercised because the local Docker daemon was
+  unavailable; attempted output is in
+  `scratch/sharp-bun-0.35-repro/linux-container-output.txt`.
+
+For issue #3014 validation, capture output from the repo root:
+
+```bash
+mkdir -p scratch/sharp-bun-0.35-repro
+(
+  cd docs/reproductions/sharp-bun-035
+  bun install
+  bun run repro
+) > scratch/sharp-bun-0.35-repro/local-output.txt 2>&1
+```
+
+Optional Linux container check:
+
+```bash
+docker run --rm \
+  -v "$PWD/docs/reproductions/sharp-bun-035:/repro" \
+  -w /repro \
+  oven/bun:1.3.14 \
+  sh -lc 'bun install && bun run repro' \
+  > scratch/sharp-bun-0.35-repro/linux-container-output.txt 2>&1
+```

--- a/docs/reproductions/sharp-bun-035/bun.lock
+++ b/docs/reproductions/sharp-bun-035/bun.lock
@@ -1,0 +1,77 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "sharp-bun-0.35-repro",
+      "dependencies": {
+        "sharp": "0.35.3",
+      },
+    },
+  },
+  "packages": {
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
+
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+  }
+}

--- a/docs/reproductions/sharp-bun-035/index.ts
+++ b/docs/reproductions/sharp-bun-035/index.ts
@@ -1,0 +1,44 @@
+import sharp from "sharp";
+
+const runtime = {
+  bun: Bun.version,
+  platform: process.platform,
+  arch: process.arch,
+  sharp: sharp.versions,
+};
+
+console.log("runtime", JSON.stringify(runtime, null, 2));
+
+const source = await sharp({
+  create: {
+    width: 32,
+    height: 32,
+    channels: 4,
+    background: { r: 16, g: 96, b: 192, alpha: 1 },
+  },
+})
+  .png()
+  .toBuffer();
+
+const lossyWebp = await sharp(source)
+  .resize(16, 16)
+  .webp({ quality: 60 })
+  .toBuffer();
+
+const losslessWebp = await sharp(source)
+  .webp({ lossless: true })
+  .toBuffer();
+
+const nearLosslessWebp = await sharp(source)
+  .webp({ nearLossless: true, quality: 40 })
+  .toBuffer();
+
+const metadata = await sharp(lossyWebp).metadata();
+
+console.log("metadata", JSON.stringify(metadata, null, 2));
+console.log("webpSizes", JSON.stringify({
+  lossy: lossyWebp.length,
+  lossless: losslessWebp.length,
+  nearLossless: nearLosslessWebp.length,
+}, null, 2));
+console.log("ok");

--- a/docs/reproductions/sharp-bun-035/package.json
+++ b/docs/reproductions/sharp-bun-035/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sharp-bun-0.35-repro",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "repro": "bun run index.ts"
+  },
+  "dependencies": {
+    "sharp": "0.35.3"
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - 'Overview': design-docs/index.md
       - 'Status Glossary': design-docs/status-glossary.md
       - 'Image Backend': design-docs/image-backend.md
+      - 'Sharp Bun 0.35 Repro': reproductions/sharp-bun-035/README.md
       - 'API Surface':
           - 'Autocomplete Audit': design-docs/api-surface/autocomplete-audit.md
           - 'Cross-Platform Parity': design-docs/api-surface/cross-platform-parity.md

--- a/test/docs/sharpBunRepro.test.ts
+++ b/test/docs/sharpBunRepro.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../..");
+const reproDir = "docs/reproductions/sharp-bun-035";
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return readFile(join(repoRoot, relativePath), "utf-8");
+}
+
+describe("sharp 0.35.x Bun repro artifact", () => {
+  test("is a standalone package with no AutoMobile dependencies", async () => {
+    const packageJson = JSON.parse(await readRepoFile(`${reproDir}/package.json`)) as {
+      scripts?: Record<string, string>;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.repro).toBe("bun run index.ts");
+    expect(packageJson.dependencies).toEqual({ sharp: "0.35.3" });
+    expect(packageJson.devDependencies ?? {}).toEqual({});
+  });
+
+  test("documents upstream filing targets and captured local result", async () => {
+    const readme = await readRepoFile(`${reproDir}/README.md`);
+    const script = await readRepoFile(`${reproDir}/index.ts`);
+    const lockfile = await readRepoFile(`${reproDir}/bun.lock`);
+    const designDoc = await readRepoFile("docs/design-docs/image-backend.md");
+
+    expect(readme).toContain("https://github.com/oven-sh/bun/issues/20372");
+    expect(readme).toContain("https://github.com/oven-sh/bun/issues/29352");
+    expect(readme).toContain("https://github.com/lovell/sharp/issues/4042");
+    expect(readme).toContain("scratch/sharp-bun-0.35-repro");
+    expect(readme).toContain("bun run repro");
+    expect(readme).toContain("darwin arm64");
+    expect(readme).toContain("Docker daemon was");
+
+    expect(script).toContain("import sharp from \"sharp\"");
+    expect(script).toContain("sharp.versions");
+    expect(script).toContain("nearLossless");
+    expect(script).not.toContain("@kaeawc/auto-mobile");
+
+    expect(lockfile).toContain("\"sharp\": \"0.35.3\"");
+    expect(lockfile).not.toContain("@kaeawc/auto-mobile");
+
+    expect(designDoc).toContain("Issue #3014 upstream repro record");
+    expect(designDoc).toContain("docs/reproductions/sharp-bun-035");
+    expect(designDoc).toContain("not a Linux/Windows crash log");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a standalone `sharp@0.35.3` Bun repro artifact for the non-blocking upstream image-backend investigation. The repro has its own minimal package/lockfile, imports no AutoMobile code, exercises sharp import plus PNG and lossy/lossless/near-lossless WebP operations, and records the local capture result in the image backend design doc.

## Linked Issue

Closes #3014

## Bug / Regression Context

- **Prior attempts:** `docs/design-docs/image-backend.md` identifies sharp 0.35.x + Bun native interop as upstream leverage, with sharp#4042 closed for lack of a minimal standalone repro.
- **Observed symptom:** AutoMobile keeps sharp pinned to 0.34.5 because the 0.35.x/libvips line is suspected to abort under Bun on affected platforms.
- **Repro steps / conditions:** From `docs/reproductions/sharp-bun-035`, run `bun install` and `bun run repro`. Local capture on this host (`darwin arm64`, Bun `1.3.14`, sharp `0.35.3`, libvips `8.18.3`) passed. Linux container reproduction was attempted but the local Docker daemon was unavailable, so this PR records the minimal repro artifact plus macOS pass result, not a Linux/Windows crash log.

## Validation

- [x] `bun test test/docs/sharpBunRepro.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `git diff --check`
- [x] Standalone repro run captured under `scratch/sharp-bun-0.35-repro/local-output.txt`
- [x] Android/iOS changes: not applicable
- [x] New code uses interfaces + fakes + FakeTimer; not applicable (docs/repro artifact only)
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not applicable; no on-device behavior changed.

## Follow-ups

- [x] Attached the PR/repro link to oven-sh/bun#20372 and oven-sh/bun#29352.
