### PR TITLE
feat(daemon): add input pressButton socket endpoint

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -298,7 +298,7 @@ stream after the input response returns.
 | `input/tap` | Supported | Supported | Absolute device-screen coordinates. |
 | `input/swipe` | Supported | Supported | Absolute device-screen start/end coordinates. Use for drag gestures until `input/drag` has distinct semantics. |
 | `input/drag` | Deferred | Deferred | Not a separate method in this contract. |
-| `input/pressButton` | Contract only | Contract only | Not implemented yet. Unsupported buttons fail instead of being ignored. |
+| `input/pressButton` | Supported | Supported with platform gaps | Device/navigation buttons aligned with MCP `pressButton`. Unsupported buttons fail instead of being ignored. |
 | `input/typeText` | Contract only | Contract only | Not implemented yet. Sends committed text only; IME composition is deferred. |
 | `input/key` | Deferred | Deferred | Use `input/pressButton` or `input/typeText`. |
 
@@ -430,7 +430,7 @@ Presses a device or navigation button.
 |---|---|---|---|
 | `platform` | `"android" \| "ios"` | Yes | Target platform. |
 | `deviceId` | `string` | No | Target device; see [Common input fields](#common-input-fields). |
-| `button` | `"back" \| "home" \| "app_switch" \| "volume_up" \| "volume_down" \| "power" \| "enter"` | Yes | Button to press. Unsupported buttons fail with `success: false`. |
+| `button` | `"back" \| "home" \| "app_switch" \| "volume_up" \| "volume_down" \| "power" \| "enter"` plus MCP aliases `"menu"` and `"recent"` | Yes | Button to press. Unsupported buttons fail with `success: false`. |
 
 **Request**
 
@@ -457,6 +457,33 @@ Presses a device or navigation button.
   "button": "back"
 }
 ```
+
+**Examples**
+
+Examples for supported Android navigation and hardware actions:
+
+```json
+{ "method": "input/pressButton", "params": { "platform": "android", "button": "back" } }
+{ "method": "input/pressButton", "params": { "platform": "android", "button": "home" } }
+{ "method": "input/pressButton", "params": { "platform": "android", "button": "app_switch" } }
+{ "method": "input/pressButton", "params": { "platform": "android", "button": "power" } }
+{ "method": "input/pressButton", "params": { "platform": "android", "button": "volume_up" } }
+{ "method": "input/pressButton", "params": { "platform": "android", "button": "volume_down" } }
+```
+
+`app_switch` is the socket API name for the app switcher and maps to the MCP
+`recent` button implementation. The daemon also accepts the MCP alias `recent`.
+
+`enter` is reserved by the socket contract but is not implemented by
+`input/pressButton`; callers should use `input/typeText` for committed text and
+wait for `input/key` for discrete key forwarding. `enter` currently returns a
+clear unsupported error instead of being treated as an unknown field value.
+
+iOS supports `home`, `back`, and `app_switch` through CtrlProxy navigation. On
+physical iOS devices, `power`, `volume_up`, and `volume_down` route to the
+hardware button endpoint. iOS simulators return clear unsupported errors for
+hardware buttons, and all iOS targets return an unsupported error for `menu`
+because iOS has no menu hardware button.
 
 ### `input/typeText`
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -927,7 +927,7 @@ export class UnixSocketServer {
         });
       }
 
-      return await new PressButton(targetDevice).press(args.button);
+      return await new PressButton(targetDevice).press(args.button, remainingTimeoutMs);
     });
 
     if (!buttonResult.success) {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -53,6 +53,7 @@ import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
+import { PressButton } from "../features/action/PressButton";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import type { KeyValueType } from "../features/storage/storageTypes";
 import type { BootedDevice } from "../models";
@@ -643,6 +644,9 @@ export class UnixSocketServer {
     if (request.method === "input/swipe") {
       return await this.handleInputSwipe(request, socketSessionId);
     }
+    if (request.method === "input/pressButton") {
+      return await this.handleInputPressButton(request, socketSessionId);
+    }
 
     switch (request.method) {
       case "ide/listFeatureFlags": {
@@ -898,6 +902,47 @@ export class UnixSocketServer {
     };
   }
 
+  private async handleInputPressButton(
+    request: DaemonRequest,
+    socketSessionId?: string
+  ): Promise<any | undefined> {
+    const queueEnterMs = this.timer.now();
+    const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
+    const args = this.parseInputPressButtonParams(request.params);
+    const targetDevice = await this.resolveInputTargetDevice(
+      args.platform,
+      args.deviceId,
+      socketSessionId,
+      "input/pressButton"
+    );
+    const buttonResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      const queueWaitMs = this.timer.now() - queueEnterMs;
+      const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
+      if (remainingTimeoutMs <= 0) {
+        throw new McpTimeoutError({
+          toolName: request.method,
+          timeoutMs: totalTimeoutMs,
+          origin: "UnixSocketServer.handleInputPressButton",
+          detail: `spent ${queueWaitMs}ms waiting in queue`,
+        });
+      }
+
+      return await new PressButton(targetDevice).press(args.button);
+    });
+
+    if (!buttonResult.success) {
+      throw new Error(buttonResult.error ?? `input/pressButton failed on ${args.platform}`);
+    }
+
+    return {
+      action: "input/pressButton",
+      platform: args.platform,
+      deviceId: targetDevice.deviceId,
+      success: true,
+      button: args.responseButton,
+    };
+  }
+
   private parseInputTapParams(params: unknown): {
     platform: "android" | "ios";
     deviceId?: string;
@@ -987,11 +1032,45 @@ export class UnixSocketServer {
     };
   }
 
+  private parseInputPressButtonParams(params: unknown): {
+    platform: "android" | "ios";
+    deviceId?: string;
+    button: string;
+    responseButton: string;
+  } {
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new Error("input/pressButton requires params object");
+    }
+
+    const args = params as Record<string, unknown>;
+    if (args.platform !== "android" && args.platform !== "ios") {
+      throw new Error("input/pressButton requires platform 'android' or 'ios'");
+    }
+    if (typeof args.button !== "string") {
+      throw new Error("input/pressButton requires button");
+    }
+    const supportedButtons = ["home", "back", "menu", "power", "volume_up", "volume_down", "recent", "app_switch", "enter"];
+    if (!supportedButtons.includes(args.button)) {
+      throw new Error(`input/pressButton button must be one of: ${supportedButtons.join(", ")}`);
+    }
+    if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
+      throw new Error("input/pressButton deviceId must be a string when provided");
+    }
+    const button = args.button === "app_switch" ? "recent" : args.button;
+
+    return {
+      platform: args.platform,
+      deviceId: args.deviceId,
+      button,
+      responseButton: args.button,
+    };
+  }
+
   private async resolveInputTargetDevice(
     platform: "android" | "ios",
     deviceId: string | undefined,
     socketSessionId: string | undefined,
-    action: "input/tap" | "input/swipe"
+    action: "input/tap" | "input/swipe" | "input/pressButton"
   ): Promise<BootedDevice> {
     const discovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform);
     if (!discovery.succeededPlatforms.has(platform)) {

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -32,30 +32,7 @@ export class PressButton extends BaseVisualChange {
 
     return this.observedInteraction(
       async () => {
-        try {
-          // Platform-specific button press execution
-          switch (this.device.platform) {
-            case "android":
-              return await perf.track("androidButtonPress", () =>
-                this.executeAndroidButtonPress(button)
-              );
-            case "ios":
-              return await perf.track("iOSButtonPress", () =>
-                this.executeiOSButtonPress(button)
-              );
-            default:
-              perf.end();
-              throw new Error(`Unsupported platform: ${this.device.platform}`);
-          }
-        } catch (error) {
-          perf.end();
-          return {
-            success: false,
-            button,
-            keyCode: -1,
-            error: `Failed to press button: ${error instanceof Error ? error.message : String(error)}`
-          };
-        }
+        return await perf.track("buttonPress", () => this.press(button));
       },
       {
         changeExpected: isNavigationButton,
@@ -64,6 +41,26 @@ export class PressButton extends BaseVisualChange {
         perf
       }
     );
+  }
+
+  async press(button: string): Promise<PressButtonResult> {
+    try {
+      switch (this.device.platform) {
+        case "android":
+          return await this.executeAndroidButtonPress(button);
+        case "ios":
+          return await this.executeiOSButtonPress(button);
+        default:
+          throw new Error(`Unsupported platform: ${this.device.platform}`);
+      }
+    } catch (error) {
+      return {
+        success: false,
+        button,
+        keyCode: -1,
+        error: `Failed to press button: ${error instanceof Error ? error.message : String(error)}`
+      };
+    }
   }
 
   // Buttons that can be handled via accessibility service global actions

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -43,13 +43,23 @@ export class PressButton extends BaseVisualChange {
     );
   }
 
-  async press(button: string): Promise<PressButtonResult> {
+  /**
+   * Press a hardware/navigation button.
+   *
+   * @param button - Button name to press
+   * @param timeoutMs - Optional deadline budget (e.g. the socket request's
+   *   remaining time). When provided it is threaded into every underlying
+   *   runner/ADB call so the caller's timeout is honored instead of the
+   *   per-transport hard-coded defaults. When omitted, the existing defaults
+   *   apply.
+   */
+  async press(button: string, timeoutMs?: number): Promise<PressButtonResult> {
     try {
       switch (this.device.platform) {
         case "android":
-          return await this.executeAndroidButtonPress(button);
+          return await this.executeAndroidButtonPress(button, timeoutMs);
         case "ios":
-          return await this.executeiOSButtonPress(button);
+          return await this.executeiOSButtonPress(button, timeoutMs);
         default:
           throw new Error(`Unsupported platform: ${this.device.platform}`);
       }
@@ -73,7 +83,11 @@ export class PressButton extends BaseVisualChange {
    * Uses accessibility service global actions for back/home/recent (faster),
    * falls back to ADB keyevent for all buttons.
    */
-  private async executeAndroidButtonPress(button: string): Promise<PressButtonResult> {
+  // Default fast-fail budget for the accessibility-service global-action path
+  // before we fall back to ADB keyevent.
+  private static readonly GLOBAL_ACTION_TIMEOUT_MS = 3000;
+
+  private async executeAndroidButtonPress(button: string, timeoutMs?: number): Promise<PressButtonResult> {
     const keyCodeMap: Record<string, number> = {
       "home": 3,
       "back": 4,
@@ -95,22 +109,36 @@ export class PressButton extends BaseVisualChange {
       };
     }
 
+    // When a budget is supplied, honor it as an absolute deadline shared across
+    // the (optional) global-action attempt and the ADB fallback so the caller's
+    // timeout is not exceeded by the sum of the two per-transport defaults.
+    const deadlineMs = timeoutMs !== undefined ? this.timer.now() + timeoutMs : undefined;
+    const remainingMs = (): number | undefined =>
+      deadlineMs !== undefined ? deadlineMs - this.timer.now() : undefined;
+
     // Try accessibility service global action for supported buttons
     if (PressButton.GLOBAL_ACTION_BUTTONS.has(normalized)) {
-      try {
-        const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-        const result = await client.requestGlobalAction(normalized, 3000);
-        if (result.success) {
-          logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
-          return { success: true, button, keyCode };
+      const budget = remainingMs();
+      // Skip straight to ADB if the deadline is already exhausted.
+      if (budget === undefined || budget > 0) {
+        const globalActionTimeout = budget === undefined
+          ? PressButton.GLOBAL_ACTION_TIMEOUT_MS
+          : Math.min(PressButton.GLOBAL_ACTION_TIMEOUT_MS, budget);
+        try {
+          const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+          const result = await client.requestGlobalAction(normalized, globalActionTimeout);
+          if (result.success) {
+            logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
+            return { success: true, button, keyCode };
+          }
+          logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
+        } catch {
+          // Fall through to ADB
         }
-        logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
-      } catch {
-        // Fall through to ADB
       }
     }
 
-    await this.adb.executeCommand(`shell input keyevent ${keyCode}`);
+    await this.adb.executeCommand(`shell input keyevent ${keyCode}`, remainingMs());
     return { success: true, button, keyCode };
   }
 
@@ -119,11 +147,11 @@ export class PressButton extends BaseVisualChange {
    * @param button - Button name to press
    * @returns Result of the button press operation
    */
-  private async executeiOSButtonPress(button: string): Promise<PressButtonResult> {
+  private async executeiOSButtonPress(button: string, timeoutMs?: number): Promise<PressButtonResult> {
     const normalizedButton = button.toLowerCase();
     if (PressButton.IOS_NAVIGATION_BUTTONS.has(normalizedButton)) {
       const client = IOSCtrlProxyClient.getInstance(this.device);
-      const result = await this.executeiOSNavigationButton(client, normalizedButton);
+      const result = await this.executeiOSNavigationButton(client, normalizedButton, timeoutMs);
 
       if (!result.success) {
         return {
@@ -152,7 +180,7 @@ export class PressButton extends BaseVisualChange {
       }
 
       const client = IOSCtrlProxyClient.getInstance(this.device);
-      const result = await client.requestPressButton(normalizedButton);
+      const result = await client.requestPressButton(normalizedButton, timeoutMs);
 
       if (!result.success) {
         return {
@@ -185,15 +213,16 @@ export class PressButton extends BaseVisualChange {
 
   private async executeiOSNavigationButton(
     client: IOSCtrlProxyClient,
-    button: string
+    button: string,
+    timeoutMs?: number
   ): Promise<{ success: boolean; error?: string }> {
     switch (button) {
       case "home":
-        return client.requestPressHome();
+        return client.requestPressHome(timeoutMs);
       case "back":
-        return client.requestPressBack();
+        return client.requestPressBack(timeoutMs);
       case "recent":
-        return client.requestRecentApps();
+        return client.requestRecentApps(timeoutMs);
       default:
         return { success: false, error: `Unsupported iOS button: ${button}` };
     }

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -138,7 +138,21 @@ export class PressButton extends BaseVisualChange {
       }
     }
 
-    await this.adb.executeCommand(`shell input keyevent ${keyCode}`, remainingMs());
+    // Fail fast if the (optional) deadline was fully consumed by the global-action
+    // attempt above. Passing 0 to executeCommand would arm NO timeout (the
+    // `if (timeoutMs)` check treats 0 as falsy), leaving the ADB keyevent
+    // unbounded — the exact overrun this budget threading exists to prevent.
+    const adbBudget = remainingMs();
+    if (adbBudget !== undefined && adbBudget <= 0) {
+      return {
+        success: false,
+        button,
+        keyCode: -1,
+        error: `Button press deadline exhausted before ADB keyevent for ${button}`
+      };
+    }
+
+    await this.adb.executeCommand(`shell input keyevent ${keyCode}`, adbBudget);
     return { success: true, button, keyCode };
   }
 

--- a/test/daemon/socketServerInputPressButton.test.ts
+++ b/test/daemon/socketServerInputPressButton.test.ts
@@ -223,7 +223,7 @@ describe("UnixSocketServer input/pressButton", () => {
       success: true,
       button: "volume_up",
     });
-    expect(press).toHaveBeenCalledWith("volume_up");
+    expect(press).toHaveBeenCalledWith("volume_up", expect.any(Number));
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
@@ -252,7 +252,35 @@ describe("UnixSocketServer input/pressButton", () => {
       success: true,
       button: "home",
     });
-    expect(press).toHaveBeenCalledWith("home");
+    expect(press).toHaveBeenCalledWith("home", expect.any(Number));
+  });
+
+  test("threads the client-supplied timeout budget into the button implementation", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: true,
+      button,
+      keyCode: -1,
+    }));
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    // With the FakeTimer no wall-clock elapses in the queue, so the remaining
+    // budget threaded into press() equals the client's requested timeout.
+    const response = await sendRequest(
+      socketPath,
+      "input/pressButton",
+      {
+        platform: "ios",
+        deviceId: "ios-sim-1",
+        button: "home",
+      },
+      500
+    );
+
+    expect(response.success).toBe(true);
+    expect(press).toHaveBeenCalledWith("home", 500);
   });
 
   test("maps the socket app_switch contract name to the existing recent button implementation", async () => {
@@ -280,7 +308,7 @@ describe("UnixSocketServer input/pressButton", () => {
       success: true,
       button: "app_switch",
     });
-    expect(press).toHaveBeenCalledWith("recent");
+    expect(press).toHaveBeenCalledWith("recent", expect.any(Number));
   });
 
   test("uses the socket autolock device when deviceId is omitted", async () => {
@@ -321,7 +349,7 @@ describe("UnixSocketServer input/pressButton", () => {
       deviceId: "emulator-5554",
       button: "back",
     });
-    expect(press).toHaveBeenCalledWith("back");
+    expect(press).toHaveBeenCalledWith("back", expect.any(Number));
   });
 
   test("propagates clear unsupported platform-gap errors from the button implementation", async () => {
@@ -344,7 +372,7 @@ describe("UnixSocketServer input/pressButton", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toBe("iOS has no menu hardware button");
-    expect(press).toHaveBeenCalledWith("menu");
+    expect(press).toHaveBeenCalledWith("menu", expect.any(Number));
   });
 
   test("accepts enter as a socket contract button and reports the current platform unsupported result", async () => {
@@ -367,7 +395,7 @@ describe("UnixSocketServer input/pressButton", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toBe("Unsupported button: enter");
-    expect(press).toHaveBeenCalledWith("enter");
+    expect(press).toHaveBeenCalledWith("enter", expect.any(Number));
   });
 
   test("rejects missing, non-string, and unsupported button values with actionable errors", async () => {

--- a/test/daemon/socketServerInputPressButton.test.ts
+++ b/test/daemon/socketServerInputPressButton.test.ts
@@ -1,0 +1,399 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { PressButton } from "../../src/features/action/PressButton";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonRequest, DaemonResponse } from "../../src/daemon/types";
+import type { DeviceLabelMap, Session } from "../../src/daemon/sessionManager";
+import type { BootedDevice, PressButtonResult } from "../../src/models";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android",
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "ios-sim-1",
+  name: "iPhone 16",
+  platform: "ios",
+};
+
+function createFakeDeviceManager(
+  devices: BootedDevice[],
+  succeededPlatforms: Set<"android" | "ios"> = new Set(["android", "ios"])
+) {
+  return {
+    getBootedDevicesDetailed: mock(async () => ({
+      devices,
+      succeededPlatforms,
+    })),
+  } as unknown as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>;
+}
+
+function createFakeSession(sessionId: string, assignedDevice: string, platform: "android" | "ios"): Session {
+  return {
+    sessionId,
+    assignedDevice,
+    platform,
+    createdAt: 0,
+    lastUsedAt: 0,
+    expiresAt: 60_000,
+    cacheData: {},
+    lastHeartbeat: 0,
+    sessionTimeoutMs: 60_000,
+    heartbeatTimeoutMs: 10_000,
+    heartbeatTimeoutSource: "default",
+    hasReceivedHeartbeat: false,
+  };
+}
+
+function createFakeDaemonState(
+  autolockSessions: Map<string, Session> = new Map(),
+  mcpAutolockSessions: Map<string, string> = new Map()
+) {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: (sessionId: string) => autolockSessions.get(sessionId) ?? null,
+      getDeviceLabels: (_sessionId: string): DeviceLabelMap | undefined => undefined,
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: (mcpSessionId: string | undefined, platform?: "android" | "ios") => {
+        if (!mcpSessionId) {
+          return undefined;
+        }
+        const sessionId = mcpAutolockSessions.get(mcpSessionId);
+        const session = sessionId ? autolockSessions.get(sessionId) : undefined;
+        return session?.platform === platform ? session.sessionId : undefined;
+      },
+    }),
+  };
+}
+
+function sendRequest(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number
+): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+    const request: DaemonRequest = {
+      id: randomUUID(),
+      type: "mcp_request",
+      method,
+      params,
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    };
+
+    client.connect(socketPath, () => {
+      client.write(JSON.stringify(request) + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const response = JSON.parse(line) as DaemonResponse;
+          client.destroy();
+          resolve(response);
+          return;
+        } catch {
+          // Incomplete JSON, keep buffering.
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+function sendRequestAfterConnect(
+  socketPath: string,
+  request: DaemonRequest,
+  onConnect: () => void
+): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+
+    client.connect(socketPath, () => {
+      onConnect();
+      client.write(JSON.stringify(request) + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        try {
+          const response = JSON.parse(line) as DaemonResponse;
+          client.destroy();
+          resolve(response);
+          return;
+        } catch {
+          // Incomplete JSON, keep buffering.
+        }
+      }
+    });
+
+    client.on("error", reject);
+    client.on("close", () => {
+      if (!buffer.trim()) {
+        reject(new Error("Connection closed without response"));
+      }
+    });
+  });
+}
+
+describe("UnixSocketServer input/pressButton", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let fakeTimer: FakeTimer;
+  let originalPress: typeof PressButton.prototype.press;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `input-press-button-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    PlatformDeviceManagerFactory.reset();
+    originalPress = PressButton.prototype.press;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+    }
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+    PressButton.prototype.press = originalPress;
+    PlatformDeviceManagerFactory.reset();
+  });
+
+  test("routes Android button presses without forwarding through tools/call", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: true,
+      button,
+      keyCode: 24,
+    }));
+    const createMcpClient = mock(async () => {
+      throw new Error("input/pressButton should not create an MCP client");
+    });
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    (server as unknown as { createMcpClient: typeof createMcpClient }).createMcpClient = createMcpClient;
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/pressButton", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      button: "volume_up",
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({
+      action: "input/pressButton",
+      platform: "android",
+      deviceId: "emulator-5554",
+      success: true,
+      button: "volume_up",
+    });
+    expect(press).toHaveBeenCalledWith("volume_up");
+    expect(createMcpClient).not.toHaveBeenCalled();
+  });
+
+  test("routes iOS button presses through the existing pressButton implementation", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: true,
+      button,
+      keyCode: -1,
+    }));
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/pressButton", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      button: "home",
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({
+      action: "input/pressButton",
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      success: true,
+      button: "home",
+    });
+    expect(press).toHaveBeenCalledWith("home");
+  });
+
+  test("maps the socket app_switch contract name to the existing recent button implementation", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: true,
+      button,
+      keyCode: -1,
+    }));
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/pressButton", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      button: "app_switch",
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({
+      action: "input/pressButton",
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      success: true,
+      button: "app_switch",
+    });
+    expect(press).toHaveBeenCalledWith("recent");
+  });
+
+  test("uses the socket autolock device when deviceId is omitted", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: true,
+      button,
+      keyCode: 4,
+    }));
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    const session = createFakeSession("session-1", "emulator-5554", "android");
+    const autolockSessions = new Map([[session.sessionId, session]]);
+    const mcpAutolockSessions = new Map<string, string>();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(autolockSessions, mcpAutolockSessions),
+      fakeTimer
+    );
+    await server.start();
+
+    const response = await sendRequestAfterConnect(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "input/pressButton",
+      params: {
+        platform: "android",
+        button: "back",
+      },
+    }, () => {
+      const socketSessionId = [...((server as unknown as { sessions: Map<string, unknown> }).sessions.keys())][0];
+      mcpAutolockSessions.set(socketSessionId, session.sessionId);
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.result).toMatchObject({
+      platform: "android",
+      deviceId: "emulator-5554",
+      button: "back",
+    });
+    expect(press).toHaveBeenCalledWith("back");
+  });
+
+  test("propagates clear unsupported platform-gap errors from the button implementation", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: false,
+      button,
+      keyCode: -1,
+      error: "iOS has no menu hardware button",
+    }));
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/pressButton", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      button: "menu",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe("iOS has no menu hardware button");
+    expect(press).toHaveBeenCalledWith("menu");
+  });
+
+  test("accepts enter as a socket contract button and reports the current platform unsupported result", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: false,
+      button,
+      keyCode: -1,
+      error: "Unsupported button: enter",
+    }));
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/pressButton", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      button: "enter",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe("Unsupported button: enter");
+    expect(press).toHaveBeenCalledWith("enter");
+  });
+
+  test("rejects missing, non-string, and unsupported button values with actionable errors", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const missing = await sendRequest(socketPath, "input/pressButton", {
+      platform: "android",
+    });
+    const nonString = await sendRequest(socketPath, "input/pressButton", {
+      platform: "android",
+      button: 4,
+    });
+    const unsupported = await sendRequest(socketPath, "input/pressButton", {
+      platform: "android",
+      button: "camera",
+    });
+
+    expect(missing.success).toBe(false);
+    expect(missing.error).toBe("input/pressButton requires button");
+    expect(nonString.success).toBe(false);
+    expect(nonString.error).toBe("input/pressButton requires button");
+    expect(unsupported.success).toBe(false);
+    expect(unsupported.error).toBe(
+      "input/pressButton button must be one of: home, back, menu, power, volume_up, volume_down, recent, app_switch, enter"
+    );
+  });
+});

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { PressButton } from "../../../src/features/action/PressButton";
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { BootedDevice } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 describe("PressButton", () => {
   const iosDevice: BootedDevice = {
@@ -137,6 +139,94 @@ describe("PressButton", () => {
 
     expect(result.success).toBe(true);
     expect(capturedTimeouts).toEqual([undefined]);
+  });
+
+  test("android global-action fallback shares the deadline budget with the ADB keyevent", async () => {
+    const androidDevice: BootedDevice = {
+      deviceId: "android-device",
+      platform: "android",
+      name: "Pixel"
+    };
+
+    const fakeTimer = new FakeTimer();
+    const globalActionTimeouts: number[] = [];
+    const adbTimeouts: (number | undefined)[] = [];
+
+    // Fails the accessibility path (forcing the ADB fallback) after consuming
+    // part of the shared deadline.
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestGlobalAction: async (action: string, timeoutMs: number) => {
+        globalActionTimeouts.push(timeoutMs);
+        fakeTimer.advanceTime(300);
+        return { success: false, action, totalTimeMs: 300, error: "WebSocket not connected" };
+      }
+    } as any);
+
+    const fakeAdb = {
+      executeCommand: async (_command: string, timeoutMs?: number) => {
+        adbTimeouts.push(timeoutMs);
+        return { stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false };
+      }
+    } as any;
+
+    try {
+      const pressButton = new PressButton(androidDevice, fakeAdb);
+      (pressButton as any).timer = fakeTimer;
+
+      // "back" is a global-action button, so this exercises the two-call path.
+      const result = await pressButton.press("back", 500);
+
+      expect(result.success).toBe(true);
+      // Global action capped at min(3000, 500).
+      expect(globalActionTimeouts).toEqual([500]);
+      // ADB fallback receives the REMAINING budget after 300ms was consumed,
+      // proving total time is bounded by the caller's budget, not the sum of
+      // per-transport defaults.
+      expect(adbTimeouts).toEqual([200]);
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("android fails fast when the global action exhausts the deadline before the ADB fallback", async () => {
+    const androidDevice: BootedDevice = {
+      deviceId: "android-device",
+      platform: "android",
+      name: "Pixel"
+    };
+
+    const fakeTimer = new FakeTimer();
+    let adbCalled = false;
+
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestGlobalAction: async (action: string, timeoutMs: number) => {
+        // Consume the entire budget.
+        fakeTimer.advanceTime(timeoutMs);
+        return { success: false, action, totalTimeMs: timeoutMs, error: "timeout" };
+      }
+    } as any);
+
+    const fakeAdb = {
+      executeCommand: async () => {
+        adbCalled = true;
+        return { stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false };
+      }
+    } as any;
+
+    try {
+      const pressButton = new PressButton(androidDevice, fakeAdb);
+      (pressButton as any).timer = fakeTimer;
+
+      const result = await pressButton.press("back", 500);
+
+      // Deadline exhausted -> structured failure, and the unbounded ADB keyevent
+      // is never dispatched.
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("deadline exhausted");
+      expect(adbCalled).toBe(false);
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
   });
 
   test("ios menu remains unsupported", async () => {

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -62,6 +62,38 @@ describe("PressButton", () => {
     }
   });
 
+  test("press delegates to platform button handling without observing", async () => {
+    let homeCalls = 0;
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressBack: async () => ({ success: true, totalTimeMs: 5 }),
+      requestPressHome: async () => {
+        homeCalls++;
+        return { success: true, totalTimeMs: 5 };
+      },
+      requestRecentApps: async () => ({ success: true, totalTimeMs: 5 })
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+      (pressButton as any).observeScreen = {
+        getMostRecentCachedObserveResult: async () => {
+          throw new Error("press should not read cached observations");
+        },
+        execute: async () => {
+          throw new Error("press should not observe");
+        }
+      };
+
+      const result = await pressButton.press("home");
+
+      expect(result.success).toBe(true);
+      expect(homeCalls).toBe(1);
+      expect(getInstanceSpy).toHaveBeenCalled();
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
   test("ios menu remains unsupported", async () => {
     const pressButton = new PressButton(iosDevice);
     const result = await (pressButton as any).executeiOSButtonPress("menu");

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -94,6 +94,51 @@ describe("PressButton", () => {
     }
   });
 
+  test("android ADB keyevent honors the caller timeout budget", async () => {
+    const androidDevice: BootedDevice = {
+      deviceId: "android-device",
+      platform: "android",
+      name: "Pixel"
+    };
+
+    const capturedTimeouts: (number | undefined)[] = [];
+    const fakeAdb = {
+      executeCommand: async (_command: string, timeoutMs?: number) => {
+        capturedTimeouts.push(timeoutMs);
+        return { stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false };
+      }
+    } as any;
+
+    // "menu" is not a global-action button, so it goes straight to the ADB keyevent path.
+    const pressButton = new PressButton(androidDevice, fakeAdb);
+    const result = await pressButton.press("menu", 500);
+
+    expect(result.success).toBe(true);
+    expect(capturedTimeouts).toEqual([500]);
+  });
+
+  test("android ADB keyevent leaves timeout unset when no budget is given", async () => {
+    const androidDevice: BootedDevice = {
+      deviceId: "android-device",
+      platform: "android",
+      name: "Pixel"
+    };
+
+    const capturedTimeouts: (number | undefined)[] = [];
+    const fakeAdb = {
+      executeCommand: async (_command: string, timeoutMs?: number) => {
+        capturedTimeouts.push(timeoutMs);
+        return { stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false };
+      }
+    } as any;
+
+    const pressButton = new PressButton(androidDevice, fakeAdb);
+    const result = await pressButton.press("menu");
+
+    expect(result.success).toBe(true);
+    expect(capturedTimeouts).toEqual([undefined]);
+  });
+
   test("ios menu remains unsupported", async () => {
     const pressButton = new PressButton(iosDevice);
     const result = await (pressButton as any).executeiOSButtonPress("menu");
@@ -148,6 +193,56 @@ describe("PressButton", () => {
       }
 
       expect(getInstanceSpy).not.toHaveBeenCalled();
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios press threads the caller timeout budget into the runner", async () => {
+    const homeTimeouts: (number | undefined)[] = [];
+    const buttonTimeouts: (number | undefined)[] = [];
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressBack: async () => ({ success: true, totalTimeMs: 5 }),
+      requestPressHome: async (timeoutMs?: number) => {
+        homeTimeouts.push(timeoutMs);
+        return { success: true, totalTimeMs: 5 };
+      },
+      requestRecentApps: async () => ({ success: true, totalTimeMs: 5 }),
+      requestPressButton: async (_button: string, timeoutMs?: number) => {
+        buttonTimeouts.push(timeoutMs);
+        return { success: true, totalTimeMs: 5 };
+      }
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+
+      await pressButton.press("home", 500);
+      await pressButton.press("volume_up", 750);
+
+      expect(homeTimeouts).toEqual([500]);
+      expect(buttonTimeouts).toEqual([750]);
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test("ios press without a budget leaves runner defaults untouched", async () => {
+    const homeTimeouts: (number | undefined)[] = [];
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressBack: async () => ({ success: true, totalTimeMs: 5 }),
+      requestPressHome: async (timeoutMs?: number) => {
+        homeTimeouts.push(timeoutMs);
+        return { success: true, totalTimeMs: 5 };
+      },
+      requestRecentApps: async () => ({ success: true, totalTimeMs: 5 })
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+      await pressButton.press("home");
+
+      expect(homeTimeouts).toEqual([undefined]);
     } finally {
       getInstanceSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Adds the daemon Unix socket `input/pressButton` endpoint so direct-input clients can forward device/navigation button presses without constructing MCP `tools/call` payloads. The endpoint reuses the existing platform `PressButton` implementation, keeps daemon input responses action-only with no implicit observation, and preserves the socket contract names from #3339 while accepting MCP aliases where useful.

## Linked Issue

Closes #3342

## Validation

- [x] `bun test test/daemon/socketServerInputPressButton.test.ts test/daemon/socketServerInputTap.test.ts test/daemon/socketServerInputSwipe.test.ts test/features/action/PressButton.test.ts`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate`
- [x] `git diff --check`
- [x] New daemon endpoint tests use fakes and `FakeTimer`
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A. This PR adds daemon/socket routing over existing platform button behavior and covers it with fake-backed socket tests rather than requiring real devices.

## Follow-ups

None.
