### PR TITLE
test(image): validate sharp Bun repro behavior

### DIFF
--- a/docs/design-docs/image-backend.md
+++ b/docs/design-docs/image-backend.md
@@ -214,6 +214,8 @@ The standalone repro lives in `docs/reproductions/sharp-bun-035`. It pins
 exercises lossy/lossless/near-lossless WebP encodes, and reads WebP metadata.
 Capture local output under `scratch/sharp-bun-0.35-repro/` before posting
 evidence upstream.
+Use `bash scripts/validate-sharp-bun-repro.sh` to run the standalone harness in
+an isolated scratch copy and verify the live output shape.
 
 Local issue #3014 capture on 2026-07-07: `darwin arm64`, Bun `1.3.14`,
 sharp `0.35.3`, and libvips `8.18.3` passed the standalone repro. A Linux

--- a/docs/reproductions/sharp-bun-035/README.md
+++ b/docs/reproductions/sharp-bun-035/README.md
@@ -22,6 +22,18 @@ The script imports sharp, prints Bun/platform/sharp runtime versions, creates a
 small PNG entirely through sharp, exercises lossy/lossless/near-lossless WebP
 encodes, reads WebP metadata, and prints `ok` if the process survives.
 
+To validate the full behavior without mutating this directory, run the repo
+helper from the root:
+
+```bash
+bash scripts/validate-sharp-bun-repro.sh
+```
+
+The helper copies this standalone package into `scratch/`, installs with the
+checked-in lockfile, runs `bun run repro`, and asserts sharp `0.35.3`, WebP
+metadata, nonzero lossy/lossless/near-lossless outputs, and the final `ok`
+marker.
+
 Local result captured for issue #3014 on 2026-07-07:
 
 - `darwin arm64`, Bun `1.3.14`, sharp `0.35.3`, libvips `8.18.3`: passed;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test:coverage": "bun test --coverage",
     "test:startup:bun": "bash scripts/ci/mcp-startup-smoke.sh",
     "test:image:bun": "bun scripts/ci/image-runtime-smoke.ts",
+    "test:image:sharp-bun-repro": "bash scripts/validate-sharp-bun-repro.sh",
     "test:memory-leaks": "bun --expose-gc scripts/detect-memory-leaks.ts",
     "lint": "eslint . --fix",
     "typecheck": "bash scripts/typecheck-baseline.sh",

--- a/scripts/validate-sharp-bun-repro.sh
+++ b/scripts/validate-sharp-bun-repro.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPRO_SOURCE="${PROJECT_ROOT}/docs/reproductions/sharp-bun-035"
+SCRATCH_DIR="${PROJECT_ROOT}/scratch/sharp-bun-0.35-repro"
+RUN_DIR="${SCRATCH_DIR}/run"
+OUTPUT_FILE="${SCRATCH_DIR}/validate-output.txt"
+
+print_status() {
+    printf '[INFO] %s\n' "$1"
+}
+
+fail() {
+    printf '[ERROR] %s\n' "$1" >&2
+    exit 1
+}
+
+if [[ ! -d "$REPRO_SOURCE" ]]; then
+    fail "Repro directory not found: $REPRO_SOURCE"
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+    fail "bun is required to validate the sharp Bun repro"
+fi
+
+rm -rf "$RUN_DIR"
+mkdir -p "$RUN_DIR" "$SCRATCH_DIR"
+cp "$REPRO_SOURCE"/package.json "$REPRO_SOURCE"/bun.lock "$REPRO_SOURCE"/index.ts "$RUN_DIR"/
+
+print_status "Installing sharp Bun repro dependencies in scratch..."
+(
+    cd "$RUN_DIR"
+    bun install --frozen-lockfile
+) > "$OUTPUT_FILE" 2>&1
+
+print_status "Running sharp Bun repro..."
+(
+    cd "$RUN_DIR"
+    bun run repro
+) >> "$OUTPUT_FILE" 2>&1
+
+grep -q '"sharp": "0.35.3"' "$OUTPUT_FILE" || fail "Expected sharp 0.35.3 in runtime output"
+grep -q '"format": "webp"' "$OUTPUT_FILE" || fail "Expected WebP metadata in repro output"
+grep -q '"lossy": [1-9][0-9]*' "$OUTPUT_FILE" || fail "Expected nonzero lossy WebP size"
+grep -q '"lossless": [1-9][0-9]*' "$OUTPUT_FILE" || fail "Expected nonzero lossless WebP size"
+grep -q '"nearLossless": [1-9][0-9]*' "$OUTPUT_FILE" || fail "Expected nonzero near-lossless WebP size"
+grep -q '^ok$' "$OUTPUT_FILE" || fail "Expected final ok marker"
+
+print_status "Sharp Bun repro passed. Output: $OUTPUT_FILE"

--- a/test/docs/sharpBunRepro.test.ts
+++ b/test/docs/sharpBunRepro.test.ts
@@ -27,10 +27,12 @@ describe("sharp 0.35.x Bun repro artifact", () => {
     const script = await readRepoFile(`${reproDir}/index.ts`);
     const lockfile = await readRepoFile(`${reproDir}/bun.lock`);
     const designDoc = await readRepoFile("docs/design-docs/image-backend.md");
+    const validationScript = await readRepoFile("scripts/validate-sharp-bun-repro.sh");
 
     expect(readme).toContain("https://github.com/oven-sh/bun/issues/20372");
     expect(readme).toContain("https://github.com/oven-sh/bun/issues/29352");
     expect(readme).toContain("https://github.com/lovell/sharp/issues/4042");
+    expect(readme).toContain("bash scripts/validate-sharp-bun-repro.sh");
     expect(readme).toContain("scratch/sharp-bun-0.35-repro");
     expect(readme).toContain("bun run repro");
     expect(readme).toContain("darwin arm64");
@@ -44,8 +46,14 @@ describe("sharp 0.35.x Bun repro artifact", () => {
     expect(lockfile).toContain("\"sharp\": \"0.35.3\"");
     expect(lockfile).not.toContain("@kaeawc/auto-mobile");
 
+    expect(validationScript).toContain("bun install --frozen-lockfile");
+    expect(validationScript).toContain("bun run repro");
+    expect(validationScript).toContain("\"format\": \"webp\"");
+    expect(validationScript).toContain("\"nearLossless\": [1-9][0-9]*");
+
     expect(designDoc).toContain("Issue #3014 upstream repro record");
     expect(designDoc).toContain("docs/reproductions/sharp-bun-035");
+    expect(designDoc).toContain("bash scripts/validate-sharp-bun-repro.sh");
     expect(designDoc).toContain("not a Linux/Windows crash log");
   });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in behavior validator for the sharp 0.35.x Bun repro artifact from #3014. The script copies the standalone repro into `scratch/`, installs from the checked-in lockfile, runs `bun run repro`, and asserts the live output includes sharp `0.35.3`, WebP metadata, nonzero lossy/lossless/near-lossless output sizes, and the final `ok` marker.

## Linked Issue

Follow-up to #3014 and #3371.

## Bug / Regression Context

- **Prior attempts:** #3371 added the standalone repro artifact and docs, but the fast unit test only checked text drift.
- **Observed symptom:** A syntactically broken or behaviorally incomplete repro script could keep passing the docs test as long as key strings stayed present.
- **Repro steps / conditions:** Run `bash scripts/validate-sharp-bun-repro.sh` from the repo root to execute the repro behavior in an isolated scratch copy.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional validation run:

- [x] `shellcheck scripts/validate-sharp-bun-repro.sh`
- [x] `bun test test/docs/sharpBunRepro.test.ts`
- [x] `bash scripts/validate_mkdocs_nav.sh`
- [x] `bun run test:image:sharp-bun-repro`
- [x] `bun run validate:yaml`
- [x] `bun run build`
- [x] `bun run lint`
- [x] `git diff --check`
- [x] `bun test --bail`

## Follow-ups

- [ ] A Linux/Windows crash capture for the upstream Bun issue remains separate; this PR only verifies that the checked-in standalone harness still executes and emits the expected output shape.
