### PR TITLE
feat(ios): generate XCTestRunner version constant from package.json (#2814)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -598,6 +598,13 @@ jobs:
         shell: bash
         run: bats test/bats/
 
+      # Drift gate for the generated iOS runner version constant (#2814). Pure
+      # bash + python3, so it runs on this Ubuntu job rather than the macOS Swift
+      # lane — the committed AutoMobileVersion.swift must match package.json.
+      - name: "Check iOS version constant is in sync with package.json"
+        shell: bash
+        run: bash scripts/versioning/generate-ios-version.sh --check
+
       - name: "Run hadolint"
         uses: hadolint/hadolint-action@v3.1.0
         with:

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift
@@ -1,3 +1,9 @@
+// GENERATED FILE — DO NOT EDIT.
+//
+// Rendered from package.json by scripts/versioning/generate-ios-version.sh.
+// To change the version, bump package.json (scripts/versioning/bump-versions.sh
+// does this and regenerates), then re-run the generator. CI runs
+// `generate-ios-version.sh --check` and fails on drift.
 import Foundation
 
 /// Baked client version the XCTestRunner declares to the AutoMobile daemon.
@@ -7,11 +13,11 @@ import Foundation
 /// rejects a client whose release version does not match its own, so the runner needs
 /// a concrete version to declare — this constant is that value.
 ///
-/// Kept in sync with `package.json` by `scripts/versioning/bump-versions.sh`; mirrors
-/// the Android runner deriving its version from the jar `Implementation-Version`. The
-/// daemon compares only the release portion, so a plain `MAJOR.MINOR.PATCH` here matches
-/// a source-checkout daemon carrying a `+g<sha>` dev stamp at the same release.
+/// Generated from `package.json` so it can't drift from the release it was cut from;
+/// mirrors the Android runner deriving its version from the jar `Implementation-Version`.
+/// The daemon compares only the release portion, so a plain `MAJOR.MINOR.PATCH` here
+/// matches a source-checkout daemon carrying a `+g<sha>` dev stamp at the same release.
 public enum AutoMobileVersion {
-    /// The current AutoMobile release version. Do not edit by hand — run the bump script.
+    /// The current AutoMobile release version. Generated — do not edit by hand.
     public static let current = "0.0.40"
 }

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -2,6 +2,32 @@ import XCTest
 @testable import XCTestRunner
 
 final class AutoMobileVersionTests: XCTestCase {
+    /// AC #2814: the built runner reports the version of the release it was cut from.
+    /// package.json is the canonical source; the constant is generated from it, so this
+    /// pins that the baked value has not drifted. Resolved via `#filePath` so it is
+    /// independent of the test's working directory.
+    func testCurrentVersionMatchesCanonicalPackageJson() throws {
+        // .../ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+        //  -> repo root is five directories up from this source file.
+        var repoRoot = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 {
+            repoRoot.deleteLastPathComponent()
+        }
+        let packageJsonURL = repoRoot.appendingPathComponent("package.json")
+
+        let data = try Data(contentsOf: packageJsonURL)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let packageVersion = try XCTUnwrap(json?["version"] as? String,
+                                           "package.json must have a string version field")
+
+        XCTAssertEqual(
+            AutoMobileVersion.current,
+            packageVersion,
+            "baked runner version must match canonical package.json; regenerate with "
+                + "scripts/versioning/generate-ios-version.sh"
+        )
+    }
+
     func testCurrentVersionIsNonEmptySemver() {
         let version = AutoMobileVersion.current
         XCTAssertFalse(version.isEmpty, "baked client version must not be empty")

--- a/scripts/ci/validate-ios-swift.sh
+++ b/scripts/ci/validate-ios-swift.sh
@@ -30,6 +30,17 @@ fi
 echo "✓ Swift version: $(swift --version | head -n 1)"
 echo ""
 
+# Drift gate: the XCTestRunner's baked version constant is generated from
+# package.json. Fail here if the committed AutoMobileVersion.swift has drifted,
+# rather than shipping a stale version (issue #2814).
+echo "Checking XCTestRunner version constant is in sync with package.json..."
+if ! (cd "${PROJECT_ROOT}" && bash scripts/versioning/generate-ios-version.sh --check); then
+  echo "❌ XCTestRunner version constant is out of sync with package.json"
+  echo "   Run: scripts/versioning/generate-ios-version.sh"
+  exit 1
+fi
+echo ""
+
 # Component directories
 COMPONENTS=(
   "ios/AccessibilityService"

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -27,6 +27,14 @@ if [[ -z "$new_version" ]]; then
   exit 1
 fi
 
+# Validate the version shape up front, before any file is written. The iOS
+# generator (invoked late, below) rejects non-semver; validating here avoids
+# aborting mid-bump with a half-updated tree on operator error.
+if ! [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
+  echo "Invalid --new-version '${new_version}': expected MAJOR.MINOR.PATCH semver." >&2
+  exit 1
+fi
+
 snapshot_version="${new_version}-SNAPSHOT"
 
 update_json_version() {

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -172,11 +172,16 @@ update_marketplace_plugin_version ".claude-plugin/marketplace.json" "$new_versio
 # Keep the iOS XCTestRunner's baked client version in sync (mirrors Android's jar
 # Implementation-Version). The daemon's version handshake compares the release portion,
 # so this carries the plain MAJOR.MINOR.PATCH with no SNAPSHOT suffix.
-replace_optional_single_match \
-  "ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift" \
-  'public static let current = "[^"]*"' \
-  "public static let current = \"${new_version}\"" \
-  "$dry_run"
+#
+# AutoMobileVersion.swift is a generated artifact. package.json is already updated
+# above, so regenerate the Swift constant from it rather than regex-editing in place:
+# this keeps package.json the single source of truth and lets the generator's
+# `--check` drift gate catch any skew in CI. Resolve the generator relative to this
+# script so it works regardless of the caller's cwd.
+if [[ "$dry_run" != true ]]; then
+  bump_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "${bump_script_dir}/generate-ios-version.sh"
+fi
 
 if ! command -v rg >/dev/null 2>&1; then
   echo "ripgrep (rg) is required for fast Gradle scanning." >&2

--- a/scripts/versioning/generate-ios-version.sh
+++ b/scripts/versioning/generate-ios-version.sh
@@ -48,8 +48,12 @@ version="$(python3 - "$package_json" <<'PY'
 import json
 import sys
 
-with open(sys.argv[1], encoding="utf-8") as handle:
-    data = json.load(handle)
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        data = json.load(handle)
+except json.JSONDecodeError as exc:
+    sys.stderr.write(f"ERROR: package.json is not valid JSON: {exc}\n")
+    sys.exit(1)
 
 version = data.get("version")
 if not version:

--- a/scripts/versioning/generate-ios-version.sh
+++ b/scripts/versioning/generate-ios-version.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Generate the XCTestRunner's baked version constant from the canonical
+# package.json version.
+#
+# ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift is a GENERATED
+# artifact: this script is its single source of truth. Baking the constant from
+# package.json (rather than hand-editing, or regex-editing it in-place from the
+# bump script) is what stops it drifting from the release it was cut from — the
+# same guarantee the Android jar gets by stamping Implementation-Version from
+# package.json at build time.
+#
+# Modes:
+#   (default)  Write mode. Render AutoMobileVersion.swift from package.json.
+#   --check    Drift gate. Exit non-zero if the committed file differs from what
+#              this script would generate. CI runs this so a stale constant
+#              fails the build instead of shipping.
+#
+# All paths are resolved relative to the current working directory (the repo
+# root), mirroring scripts/versioning/bump-versions.sh, so the bump script can
+# invoke this generator and both operate on the same tree.
+
+set -euo pipefail
+
+check_only=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      check_only=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+package_json="package.json"
+swift_file="ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift"
+
+if [[ ! -f "$package_json" ]]; then
+  echo "ERROR: ${package_json} not found (run from the repo root)" >&2
+  exit 1
+fi
+
+version="$(python3 - "$package_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+version = data.get("version")
+if not version:
+    sys.stderr.write("ERROR: package.json has no version field\n")
+    sys.exit(1)
+print(version)
+PY
+)"
+
+# Guard against a malformed version leaking into the generated Swift. The daemon
+# handshake compares the MAJOR.MINOR.PATCH release portion, so require that shape.
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
+  echo "ERROR: package.json version '${version}' is not MAJOR.MINOR.PATCH semver" >&2
+  exit 1
+fi
+
+render() {
+  cat <<EOF
+// GENERATED FILE — DO NOT EDIT.
+//
+// Rendered from package.json by scripts/versioning/generate-ios-version.sh.
+// To change the version, bump package.json (scripts/versioning/bump-versions.sh
+// does this and regenerates), then re-run the generator. CI runs
+// \`generate-ios-version.sh --check\` and fails on drift.
+import Foundation
+
+/// Baked client version the XCTestRunner declares to the AutoMobile daemon.
+///
+/// The runner shares one per-uid daemon socket with the TypeScript MCP proxy and the
+/// Android JUnit runner. The daemon runs a server-side version handshake (#2744) and
+/// rejects a client whose release version does not match its own, so the runner needs
+/// a concrete version to declare — this constant is that value.
+///
+/// Generated from \`package.json\` so it can't drift from the release it was cut from;
+/// mirrors the Android runner deriving its version from the jar \`Implementation-Version\`.
+/// The daemon compares only the release portion, so a plain \`MAJOR.MINOR.PATCH\` here
+/// matches a source-checkout daemon carrying a \`+g<sha>\` dev stamp at the same release.
+public enum AutoMobileVersion {
+    /// The current AutoMobile release version. Generated — do not edit by hand.
+    public static let current = "${version}"
+}
+EOF
+}
+
+generated="$(render)"
+
+if [[ "$check_only" == true ]]; then
+  if [[ ! -f "$swift_file" ]]; then
+    echo "ERROR: ${swift_file} is missing — run generate-ios-version.sh to create it" >&2
+    exit 1
+  fi
+  if ! diff -u "$swift_file" <(printf '%s\n' "$generated") >/dev/null; then
+    echo "ERROR: ${swift_file} has drifted from package.json (version ${version})." >&2
+    echo "       Run scripts/versioning/generate-ios-version.sh to regenerate." >&2
+    diff -u "$swift_file" <(printf '%s\n' "$generated") >&2 || true
+    exit 1
+  fi
+  echo "OK: ${swift_file} matches package.json (${version})"
+  exit 0
+fi
+
+printf '%s\n' "$generated" > "$swift_file"
+echo "Generated ${swift_file} for version ${version}"

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -105,8 +105,22 @@ run_bump() {
   grep -q "^VERSION_NAME=${VERSION}-SNAPSHOT$" "${TEST_ROOT}/android/gradle.properties"
   grep -q "^version = \"${VERSION}-SNAPSHOT\"$" "${TEST_ROOT}/android/junit-runner/build.gradle.kts"
   grep -q "versionName = \"${VERSION}-SNAPSHOT\"" "${TEST_ROOT}/android/playground/app/build.gradle.kts"
+  # The Swift constant must be *regenerated* (not regex-edited in place): assert
+  # the generator's output markers so a regression back to an in-place edit fails.
   grep -q "public static let current = \"${VERSION}\"" \
     "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift"
+  grep -q "GENERATED FILE — DO NOT EDIT" \
+    "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift"
+  grep -q "public enum AutoMobileVersion" \
+    "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift"
+}
+
+@test "rejects a non-semver --new-version before writing anything" {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --new-version 'not-a-version'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid --new-version"* ]]
+  # package.json must be untouched (no partial write).
+  [ "$(json_field "${TEST_ROOT}/package.json" 'data["version"]')" = "0.0.1" ]
 }
 
 @test "dry-run output names SNAPSHOT as the Android dev/Maven coordinate policy" {

--- a/test/bats/generate-ios-version.bats
+++ b/test/bats/generate-ios-version.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/versioning/generate-ios-version.sh
+#
+# The generator is the single source of truth for the XCTestRunner's baked
+# version constant: it renders ios/XCTestRunner/.../AutoMobileVersion.swift from
+# the canonical package.json version so the constant can never be hand-edited
+# into drift. `--check` is the drift gate CI runs.
+
+SCRIPT_SRC="scripts/versioning/generate-ios-version.sh"
+SWIFT_REL="ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  SCRIPT_ABS="$(cd "$(dirname "$SCRIPT_SRC")" && pwd)/$(basename "$SCRIPT_SRC")"
+  mkdir -p "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner"
+  write_fixtures
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+write_fixtures() {
+  cat > "${TEST_ROOT}/package.json" <<'EOF'
+{ "name": "@kaeawc/auto-mobile", "version": "1.2.3" }
+EOF
+}
+
+run_generate() {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' $*"
+}
+
+@test "write mode renders the baked constant from package.json" {
+  run_generate
+  [ "$status" -eq 0 ]
+  [ -f "${TEST_ROOT}/${SWIFT_REL}" ]
+  grep -q 'public static let current = "1.2.3"' "${TEST_ROOT}/${SWIFT_REL}"
+}
+
+@test "generated file carries a DO NOT EDIT / generated marker" {
+  run_generate
+  [ "$status" -eq 0 ]
+  grep -qi "do not edit" "${TEST_ROOT}/${SWIFT_REL}"
+  grep -q "generate-ios-version.sh" "${TEST_ROOT}/${SWIFT_REL}"
+}
+
+@test "generated file preserves the public AutoMobileVersion API surface" {
+  run_generate
+  [ "$status" -eq 0 ]
+  grep -q "public enum AutoMobileVersion" "${TEST_ROOT}/${SWIFT_REL}"
+  grep -q "public static let current" "${TEST_ROOT}/${SWIFT_REL}"
+}
+
+@test "write mode is idempotent" {
+  run_generate
+  [ "$status" -eq 0 ]
+  first="$(cat "${TEST_ROOT}/${SWIFT_REL}")"
+  run_generate
+  [ "$status" -eq 0 ]
+  second="$(cat "${TEST_ROOT}/${SWIFT_REL}")"
+  [ "$first" = "$second" ]
+}
+
+@test "--check passes when the committed file matches package.json" {
+  run_generate
+  [ "$status" -eq 0 ]
+  run_generate --check
+  [ "$status" -eq 0 ]
+}
+
+@test "--check fails when the committed file has drifted from package.json" {
+  run_generate
+  [ "$status" -eq 0 ]
+  # Simulate a hand-edit / stale bump: change package.json but not the swift file.
+  cat > "${TEST_ROOT}/package.json" <<'EOF'
+{ "name": "@kaeawc/auto-mobile", "version": "9.9.9" }
+EOF
+  run_generate --check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"drift"* || "$output" == *"9.9.9"* ]]
+}
+
+@test "--check does not modify the committed file" {
+  run_generate
+  [ "$status" -eq 0 ]
+  before="$(cat "${TEST_ROOT}/${SWIFT_REL}")"
+  run_generate --check
+  after="$(cat "${TEST_ROOT}/${SWIFT_REL}")"
+  [ "$before" = "$after" ]
+}

--- a/test/bats/generate-ios-version.bats
+++ b/test/bats/generate-ios-version.bats
@@ -89,3 +89,35 @@ EOF
   after="$(cat "${TEST_ROOT}/${SWIFT_REL}")"
   [ "$before" = "$after" ]
 }
+
+@test "fails cleanly when package.json is missing" {
+  rm -f "${TEST_ROOT}/package.json"
+  run_generate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"package.json not found"* ]]
+}
+
+@test "fails cleanly when package.json has no version field" {
+  cat > "${TEST_ROOT}/package.json" <<'EOF'
+{ "name": "@kaeawc/auto-mobile" }
+EOF
+  run_generate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no version field"* ]]
+}
+
+@test "fails cleanly on invalid JSON instead of a raw traceback" {
+  printf '{ not valid json' > "${TEST_ROOT}/package.json"
+  run_generate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "rejects a non-semver version" {
+  cat > "${TEST_ROOT}/package.json" <<'EOF'
+{ "name": "@kaeawc/auto-mobile", "version": "not-semver" }
+EOF
+  run_generate
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"semver"* ]]
+}


### PR DESCRIPTION
## Summary

The XCTestRunner's baked `AutoMobileVersion.current` was kept in sync by a regex edit in `scripts/versioning/bump-versions.sh`. That mechanism uses `replace_optional_single_match`, which is a **no-op on zero matches** — so a refactor of the Swift file could silently leave the constant stale and drift from `package.json`. This makes `package.json` the single source of truth for the iOS runner version and adds a drift gate, mirroring how the Android jar stamps `Implementation-Version` from `package.json`.

- Add `scripts/versioning/generate-ios-version.sh` — renders `AutoMobileVersion.swift` from `package.json`, with a `--check` mode that fails on drift.
- `AutoMobileVersion.swift` is now a generated artifact (regenerated in place; header marks it DO NOT EDIT). The value (`0.0.40`) and public API are unchanged.
- `bump-versions.sh` regenerates the constant via the generator instead of regex-editing it.
- Wire the `--check` drift gate into `scripts/ci/validate-ios-swift.sh` so stale constants fail PR CI.

## Linked Issue

Closes #2814

## Acceptance Criteria

- [x] "The built XCTestRunner reports a concrete version that matches the release it was cut from." — pinned by Swift `AutoMobileVersionTests.testCurrentVersionMatchesCanonicalPackageJson` (reads canonical `package.json` via `#filePath`, asserts equality with `AutoMobileVersion.current`).
- [x] "The value is generated (not hand-edited) so it can't drift from `package.json`." — pinned by `test/bats/generate-ios-version.bats` (generation, generated marker, `--check` pass in-sync / fail on drift) + the CI drift gate.

## Validation

- [x] `bats test/bats/generate-ios-version.bats test/bats/bump-versions.bats` — green
- [x] `shellcheck` on all three touched scripts — clean
- [x] `cd ios/XCTestRunner && swift test -Xswiftc -warnings-as-errors --filter AutoMobileVersionTests` — green
- [x] New Swift/BATS tests run <100ms
- Note: an unrelated `RemindersAddPlanTests` integration test (22s, requires simulator Reminders state) fails independently of this change.

## Follow-ups

- [ ] None required; the release-integrity gate (`verify-release-integrity.sh`) already checks `package.json` at release time and could optionally also assert the generated Swift constant — captured as a possible follow-up.