### PR TITLE
feat(observe): support Android hierarchy cadence requests

### DIFF
--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -353,7 +353,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       deviceId,
       "screenshot_update",
       DEFAULT_SCREENSHOT_INTERVAL_MS,
-      filter => filter.screenshotIntervalMs
+      filter => filter.screenshotIntervalMs,
+      true
     );
   }
 
@@ -366,7 +367,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       deviceId,
       "hierarchy_update",
       DEFAULT_HIERARCHY_INTERVAL_MS,
-      filter => filter.hierarchyIntervalMs
+      filter => filter.hierarchyIntervalMs,
+      false
     );
   }
 
@@ -374,7 +376,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     deviceId: string,
     messageType: "screenshot_update" | "hierarchy_update",
     defaultIntervalMs: number,
-    requestedIntervalMs: (filter: DeviceDataFilter) => number | null
+    getRequestedIntervalMs: (filter: DeviceDataFilter) => number | null,
+    useDefaultWhenRequestMissing: boolean
   ): number {
     const probe: DeviceDataPush = {
       message: {
@@ -394,11 +397,15 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         continue;
       }
 
-      const requestedInterval = requestedIntervalMs(subscriber.filter) ?? defaultIntervalMs;
+      const requestedIntervalMs = getRequestedIntervalMs(subscriber.filter);
+      if (requestedIntervalMs === null && !useDefaultWhenRequestMissing) {
+        continue;
+      }
+      const intervalMs = requestedIntervalMs ?? defaultIntervalMs;
 
       fastestIntervalMs = fastestIntervalMs === null
-        ? requestedInterval
-        : Math.min(fastestIntervalMs, requestedInterval);
+        ? intervalMs
+        : Math.min(fastestIntervalMs, intervalMs);
     }
 
     return fastestIntervalMs ?? defaultIntervalMs;

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -362,11 +362,11 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * Return the fastest active hierarchy cadence requested for this device,
    * or the default iOS hierarchy polling cadence when none is requested.
    */
-  getHierarchyIntervalMsForDevice(deviceId: string): number {
+  getHierarchyIntervalMsForDevice(deviceId: string, defaultIntervalMs: number = DEFAULT_HIERARCHY_INTERVAL_MS): number {
     return this.getFastestIntervalMsForDevice(
       deviceId,
       "hierarchy_update",
-      DEFAULT_HIERARCHY_INTERVAL_MS,
+      defaultIntervalMs,
       filter => filter.hierarchyIntervalMs,
       false
     );

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2007,7 +2007,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
 
     const resolvedIntervalMs = intervalMs === undefined
-      ? getDeviceDataStreamServer()?.getHierarchyIntervalMsForDevice(this.device.deviceId) ?? null
+      ? getDeviceDataStreamServer()?.getHierarchyIntervalMsForDevice(
+        this.device.deviceId,
+        AndroidCtrlProxyClient.DEFAULT_HIERARCHY_BROADCAST_INTERVAL_MS
+      ) ?? AndroidCtrlProxyClient.DEFAULT_HIERARCHY_BROADCAST_INTERVAL_MS
       : intervalMs;
 
     this.sendMessage(serializeCtrlProxyRequest(ctrlProxyRequests.setHierarchyInterval({

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -841,6 +841,8 @@ const VERIFY_READY_IDENTICAL_RUNNER_ERROR_LIMIT = 2;
  * Uses singleton pattern per device to maintain persistent WebSocket connection.
  */
 export class AndroidCtrlProxyClient extends DeviceServiceClient implements AndroidCtrlProxy {
+  private static readonly DEFAULT_HIERARCHY_BROADCAST_INTERVAL_MS = 250;
+
   private device: BootedDevice;
   private adb: AdbExecutor;
 

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -638,6 +638,12 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
     });
 
+    it("uses a caller-provided hierarchy fallback when subscribers omit cadence", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1", 250)).toBe(250);
+    });
+
     it("parses requested hierarchy cadence from subscribe commands", async () => {
       const socket = new FakeSocket();
 

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -692,11 +692,18 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getHierarchyIntervalMsForDevice("device-2")).toBe(750);
     });
 
-    it("keeps default hierarchy cadence when another subscriber requests a slower cadence", () => {
+    it("uses the slowest explicit hierarchy cadence when omitted subscribers do not request one", () => {
       server.simulateSubscription({ deviceId: "device-1" });
       server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 10_000 });
 
-      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(10_000);
+    });
+
+    it("ignores subscribers that omit hierarchy cadence when another subscriber requests one", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+      server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
     });
 
     it("removes requested hierarchy cadence after unsubscribe", async () => {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -20,11 +20,7 @@ import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
 import type { HierarchySyncDiagnostics } from "../../../src/features/observe/android/types";
 import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
 import { logger } from "../../../src/utils/logger";
-import {
-  startDeviceDataStreamSocketServer,
-  stopDeviceDataStreamSocketServer,
-} from "../../../src/daemon/deviceDataStreamSocketServer";
-import { FakeSocket } from "../../fakes/FakeNetServer";
+import { stopDeviceDataStreamSocketServer } from "../../../src/daemon/deviceDataStreamSocketServer";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -144,34 +140,6 @@ describe("AndroidCtrlProxyClient", function() {
       await new Promise(resolve => setImmediate(resolve));
     }
   };
-
-  const subscribeToObservationStreamForTest = async (options: {
-    deviceId?: string;
-    hierarchyIntervalMs?: number;
-  }): Promise<FakeSocket> => {
-    const server = await startDeviceDataStreamSocketServer();
-    const socket = new FakeSocket();
-    await (server as any).processLine(socket, JSON.stringify({
-      id: "test-subscribe",
-      command: "subscribe",
-      deviceId: options.deviceId,
-      hierarchyIntervalMs: options.hierarchyIntervalMs,
-    }));
-    return socket;
-  };
-
-  const unsubscribeFromObservationStreamForTest = async (socket: FakeSocket): Promise<void> => {
-    const server = await startDeviceDataStreamSocketServer();
-    await (server as any).processLine(socket, JSON.stringify({
-      id: "test-unsubscribe",
-      command: "unsubscribe",
-    }));
-  };
-
-  const findThrottleMessage = (socket: CapturingWebSocket): { type: string; intervalMs: number } | undefined =>
-    socket.sentMessages
-      .map(raw => JSON.parse(raw))
-      .find(message => message.type === "set_hierarchy_broadcast_interval");
 
   test("setupPortForwarding reallocates when the current local port becomes busy before adb forward", async function() {
     await accessibilityServiceClient.close();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -20,6 +20,11 @@ import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
 import type { HierarchySyncDiagnostics } from "../../../src/features/observe/android/types";
 import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
 import { logger } from "../../../src/utils/logger";
+import {
+  startDeviceDataStreamSocketServer,
+  stopDeviceDataStreamSocketServer,
+} from "../../../src/daemon/deviceDataStreamSocketServer";
+import { FakeSocket } from "../../fakes/FakeNetServer";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -72,6 +77,7 @@ describe("AndroidCtrlProxyClient", function() {
     if (accessibilityServiceClient) {
       await accessibilityServiceClient.close();
     }
+    await stopDeviceDataStreamSocketServer();
   });
 
   class CapturingWebSocket extends FakeWebSocket {
@@ -138,6 +144,34 @@ describe("AndroidCtrlProxyClient", function() {
       await new Promise(resolve => setImmediate(resolve));
     }
   };
+
+  const subscribeToObservationStreamForTest = async (options: {
+    deviceId?: string;
+    hierarchyIntervalMs?: number;
+  }): Promise<FakeSocket> => {
+    const server = await startDeviceDataStreamSocketServer();
+    const socket = new FakeSocket();
+    await (server as any).processLine(socket, JSON.stringify({
+      id: "test-subscribe",
+      command: "subscribe",
+      deviceId: options.deviceId,
+      hierarchyIntervalMs: options.hierarchyIntervalMs,
+    }));
+    return socket;
+  };
+
+  const unsubscribeFromObservationStreamForTest = async (socket: FakeSocket): Promise<void> => {
+    const server = await startDeviceDataStreamSocketServer();
+    await (server as any).processLine(socket, JSON.stringify({
+      id: "test-unsubscribe",
+      command: "unsubscribe",
+    }));
+  };
+
+  const findThrottleMessage = (socket: CapturingWebSocket): { type: string; intervalMs: number } | undefined =>
+    socket.sentMessages
+      .map(raw => JSON.parse(raw))
+      .find(message => message.type === "set_hierarchy_broadcast_interval");
 
   test("setupPortForwarding reallocates when the current local port becomes busy before adb forward", async function() {
     await accessibilityServiceClient.close();


### PR DESCRIPTION
## Summary

Thread observation stream `hierarchyIntervalMs` requests into Android hierarchy broadcasts so active subscribers can lower the control-proxy throttle while preserving the existing default when no hierarchy cadence is requested.

## Linked Issue

Closes #3380

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android changes: `./gradlew :control-proxy:testDebugUnitTest`
- [x] Focused acceptance tests: `bun test test/daemon/deviceDataStreamSocketServer.test.ts test/features/observe/android/ctrlProxyProtocol.test.ts test/features/observe/CtrlProxyClient.test.ts`
- [x] Focused Android tests: `./gradlew :control-proxy:testDebugUnitTest --tests "dev.jasonpearson.automobile.ctrlproxy.BroadcastThrottlerTest" --tests "dev.jasonpearson.automobile.ctrlproxy.CtrlProxyMessageHandlerTest"`
- [x] `git diff --check`
- [x] New code uses fakes + FakeTimer where applicable; focused TypeScript unit tests run in <100ms except existing Android client tests with broader setup

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Follow-ups

- [ ] None currently identified

Made with [Cursor](https://cursor.com)