### PR TITLE
Support iOS hierarchy cadence requests

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -22,6 +22,7 @@ public class CommandHandler: CommandHandling {
     private let sdkHierarchyClient: (any SdkHierarchyFetching)?
     private let sdkHierarchyCache: (any SdkHierarchyCaching)?
     private let sdkDatabaseClient: (any SdkDatabaseFetching)?
+    private let hierarchyDebouncer: (any HierarchyDebouncing)?
 
     public init(
         elementLocator: ElementLocating,
@@ -30,7 +31,8 @@ public class CommandHandler: CommandHandling {
         storageInspector: StorageInspecting? = nil,
         sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
-        sdkDatabaseClient: (any SdkDatabaseFetching)? = nil
+        sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
+        hierarchyDebouncer: (any HierarchyDebouncing)? = nil
     ) {
         self.elementLocator = elementLocator
         self.gesturePerformer = gesturePerformer
@@ -39,6 +41,7 @@ public class CommandHandler: CommandHandling {
         self.sdkHierarchyClient = sdkHierarchyClient
         self.sdkHierarchyCache = sdkHierarchyCache
         self.sdkDatabaseClient = sdkDatabaseClient
+        self.hierarchyDebouncer = hierarchyDebouncer
     }
 
     /// Factory for testing - allows injecting fakes
@@ -49,7 +52,8 @@ public class CommandHandler: CommandHandling {
         storageInspector: StorageInspecting? = nil,
         sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
-        sdkDatabaseClient: (any SdkDatabaseFetching)? = nil
+        sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
+        hierarchyDebouncer: (any HierarchyDebouncing)? = nil
     )
         -> CommandHandler
     {
@@ -60,7 +64,8 @@ public class CommandHandler: CommandHandling {
             storageInspector: storageInspector,
             sdkHierarchyClient: sdkHierarchyClient,
             sdkHierarchyCache: sdkHierarchyCache,
-            sdkDatabaseClient: sdkDatabaseClient
+            sdkDatabaseClient: sdkDatabaseClient,
+            hierarchyDebouncer: hierarchyDebouncer
         )
     }
 
@@ -77,6 +82,9 @@ public class CommandHandler: CommandHandling {
             // View hierarchy commands
             case let .requestHierarchy(payload), let .requestHierarchyIfStale(payload):
                 return try handleRequestHierarchy(payload, startTime: startTime)
+
+            case let .setHierarchyPollInterval(payload):
+                return try handleSetHierarchyPollInterval(payload, startTime: startTime)
 
             case let .requestScreenshot(payload):
                 return try handleRequestScreenshot(payload, startTime: startTime)
@@ -249,6 +257,23 @@ public class CommandHandler: CommandHandling {
     }
 
     // MARK: - View Hierarchy
+
+    private func handleSetHierarchyPollInterval(
+        _ request: RequestSetHierarchyPollInterval,
+        startTime: Date
+    )
+        throws -> WebSocketResponse
+    {
+        guard request.intervalMs > 0 else {
+            throw CommandError.invalidParameter("intervalMs", String(request.intervalMs))
+        }
+        hierarchyDebouncer?.updatePollIntervalMs(request.intervalMs)
+        return WebSocketResponse.success(
+            type: ResponseType.setHierarchyPollIntervalResult.rawValue,
+            requestId: request.requestId,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
 
     private func handleRequestHierarchy(
         _ request: RequestHierarchy,

--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -33,16 +33,17 @@ public class CtrlProxy {
         sdkHierarchyCache = SdkHierarchyCache()
         sdkHierarchyClient = SdkHierarchyClient()
         sdkDatabaseClient = SdkDatabaseClient()
+        hierarchyDebouncer = HierarchyDebouncer(elementLocator: elementLocator, timer: timer)
         commandHandler = CommandHandler(
             elementLocator: elementLocator,
             gesturePerformer: gesturePerformer,
             storageInspector: storageInspector,
             sdkHierarchyClient: sdkHierarchyClient,
             sdkHierarchyCache: sdkHierarchyCache,
-            sdkDatabaseClient: sdkDatabaseClient
+            sdkDatabaseClient: sdkDatabaseClient,
+            hierarchyDebouncer: hierarchyDebouncer
         )
         server = WebSocketServer(port: port, commandHandler: commandHandler, sdkHierarchyCache: sdkHierarchyCache)
-        hierarchyDebouncer = HierarchyDebouncer(elementLocator: elementLocator, timer: timer)
         fpsMonitor = DisplayLinkFPSMonitor()
     }
 

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
@@ -29,6 +29,9 @@ public protocol HierarchyDebouncing {
     /// Perform an immediate extraction and wait for it to complete (blocking)
     func extractNowBlocking(skipFlowEmit: Bool) -> ViewHierarchy?
 
+    /// Update the polling interval used for future hierarchy checks
+    func updatePollIntervalMs(_ pollIntervalMs: Int64)
+
     /// Set callback for hierarchy results
     func setOnResult(_ callback: @escaping (HierarchyResult) -> Void)
 
@@ -66,7 +69,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
 
     private let elementLocator: ElementLocating
     private let timer: Timer
-    private let pollIntervalMs: Int64
+    private var pollIntervalMs: Int64
 
     // MARK: - State
 
@@ -80,6 +83,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
     private let lock = NSLock()
     private var _isRunning = false
     private var pollScheduled = false
+    private var pollGeneration = 0
     private var onResult: ((HierarchyResult) -> Void)?
 
     public var isRunning: Bool {
@@ -129,6 +133,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         lock.lock()
         _isRunning = false
         pollScheduled = false
+        pollGeneration += 1
         lock.unlock()
 
     }
@@ -152,6 +157,19 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         let hierarchy = lastHierarchy
         lock.unlock()
         return hierarchy
+    }
+
+    public func updatePollIntervalMs(_ pollIntervalMs: Int64) {
+        lock.lock()
+        self.pollIntervalMs = pollIntervalMs
+        pollGeneration += 1
+        let running = _isRunning
+        pollScheduled = false
+        lock.unlock()
+
+        if running {
+            scheduleNextPoll()
+        }
     }
 
     public func getLastHierarchy() -> ViewHierarchy? {
@@ -180,12 +198,18 @@ public class HierarchyDebouncer: HierarchyDebouncing {
             return
         }
         pollScheduled = true
+        let scheduledGeneration = pollGeneration
+        let intervalMs = pollIntervalMs
         lock.unlock()
 
-        timer.schedule(after: pollIntervalMs) { [weak self] in
+        timer.schedule(after: intervalMs) { [weak self] in
             guard let self = self else { return }
 
             self.lock.lock()
+            guard scheduledGeneration == self.pollGeneration else {
+                self.lock.unlock()
+                return
+            }
             self.pollScheduled = false
             let shouldContinue = self._isRunning
             self.lock.unlock()
@@ -398,6 +422,7 @@ public class FakeHierarchyDebouncer: HierarchyDebouncing {
     public private(set) var stopCallCount = 0
     public private(set) var extractNowCallCount = 0
     public private(set) var extractNowBlockingCallCount = 0
+    public private(set) var updatePollIntervalMsCallCount = 0
     public private(set) var setOnResultCallCount = 0
     public private(set) var resetCallCount = 0
 
@@ -409,6 +434,7 @@ public class FakeHierarchyDebouncer: HierarchyDebouncing {
 
     /// Configure what hierarchy to return from extractNowBlocking
     public var hierarchyToReturn: ViewHierarchy?
+    public private(set) var lastPollIntervalMs: Int64?
 
     public var isRunning: Bool {
         lock.lock()
@@ -445,6 +471,13 @@ public class FakeHierarchyDebouncer: HierarchyDebouncing {
         lastHierarchy = hierarchy
         lock.unlock()
         return hierarchy
+    }
+
+    public func updatePollIntervalMs(_ pollIntervalMs: Int64) {
+        lock.lock()
+        updatePollIntervalMsCallCount += 1
+        lastPollIntervalMs = pollIntervalMs
+        lock.unlock()
     }
 
     public func setOnResult(_ callback: @escaping (HierarchyResult) -> Void) {
@@ -487,8 +520,10 @@ public class FakeHierarchyDebouncer: HierarchyDebouncing {
         stopCallCount = 0
         extractNowCallCount = 0
         extractNowBlockingCallCount = 0
+        updatePollIntervalMsCallCount = 0
         setOnResultCallCount = 0
         resetCallCount = 0
+        lastPollIntervalMs = nil
         lock.unlock()
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -34,6 +34,11 @@ public struct RequestHierarchy: Decodable {
     public var sinceTimestamp: Int64?
 }
 
+public struct RequestSetHierarchyPollInterval: Decodable {
+    public var requestId: String?
+    public var intervalMs: Int64
+}
+
 // MARK: Gestures
 
 // Coordinate fields are `Double`, not `Int`: the iOS TS wire path runs with
@@ -279,6 +284,7 @@ public protocol CommandPayload {
 
 extension RequestEnvelope: CommandPayload {}
 extension RequestHierarchy: CommandPayload {}
+extension RequestSetHierarchyPollInterval: CommandPayload {}
 extension RequestTapCoordinates: CommandPayload {}
 extension RequestSwipe: CommandPayload {}
 extension RequestMultiFingerSwipe: CommandPayload {}
@@ -317,6 +323,7 @@ extension RequestGetTableStructure: CommandPayload {}
 public enum WebSocketRequest: Decodable {
     case requestHierarchy(RequestHierarchy)
     case requestHierarchyIfStale(RequestHierarchy)
+    case setHierarchyPollInterval(RequestSetHierarchyPollInterval)
     case requestScreenshot(RequestEnvelope)
 
     case tapCoordinates(RequestTapCoordinates)
@@ -385,6 +392,8 @@ public enum WebSocketRequest: Decodable {
             self = try .requestHierarchy(RequestHierarchy(from: decoder))
         case .requestHierarchyIfStale:
             self = try .requestHierarchyIfStale(RequestHierarchy(from: decoder))
+        case .setHierarchyPollInterval:
+            self = try .setHierarchyPollInterval(RequestSetHierarchyPollInterval(from: decoder))
         case .requestScreenshot:
             self = try .requestScreenshot(RequestEnvelope(from: decoder))
         case .requestTapCoordinates:
@@ -471,6 +480,7 @@ public enum WebSocketRequest: Decodable {
         switch self {
         case .requestHierarchy: return .requestHierarchy
         case .requestHierarchyIfStale: return .requestHierarchyIfStale
+        case .setHierarchyPollInterval: return .setHierarchyPollInterval
         case .requestScreenshot: return .requestScreenshot
         case .tapCoordinates: return .requestTapCoordinates
         case .swipe: return .requestSwipe
@@ -526,6 +536,7 @@ public enum WebSocketRequest: Decodable {
         switch self {
         case let .requestHierarchy(payload), let .requestHierarchyIfStale(payload):
             return payload
+        case let .setHierarchyPollInterval(payload): return payload
         case let .requestScreenshot(payload),
              let .selectAll(payload),
              let .pressHome(payload),
@@ -1469,6 +1480,7 @@ public enum RequestType: String, CaseIterable {
     // View hierarchy
     case requestHierarchy = "request_hierarchy"
     case requestHierarchyIfStale = "request_hierarchy_if_stale"
+    case setHierarchyPollInterval = "set_hierarchy_poll_interval"
     case requestScreenshot = "request_screenshot"
 
     // Gestures
@@ -1534,6 +1546,7 @@ public enum RequestType: String, CaseIterable {
 
 public enum ResponseType: String {
     case hierarchyUpdate = "hierarchy_update"
+    case setHierarchyPollIntervalResult = "set_hierarchy_poll_interval_result"
     case screenshot
     case screenshotError = "screenshot_error"
     case tapCoordinatesResult = "tap_coordinates_result"
@@ -1597,6 +1610,7 @@ extension RequestType {
     public var responseType: ResponseType {
         switch self {
         case .requestHierarchy, .requestHierarchyIfStale: return .hierarchyUpdate
+        case .setHierarchyPollInterval: return .setHierarchyPollIntervalResult
         case .requestScreenshot: return .screenshot
         case .requestTapCoordinates: return .tapCoordinatesResult
         case .requestSwipe: return .swipeResult

--- a/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
@@ -14,6 +14,7 @@ final class ErrorResponseTypeTests: XCTestCase {
         let expected: [RequestType: ResponseType] = [
             .requestHierarchy: .hierarchyUpdate,
             .requestHierarchyIfStale: .hierarchyUpdate,
+            .setHierarchyPollInterval: .setHierarchyPollIntervalResult,
             .requestScreenshot: .screenshot,
             .requestTapCoordinates: .tapCoordinatesResult,
             .requestSwipe: .swipeResult,

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyDebouncerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyDebouncerTests.swift
@@ -135,6 +135,50 @@ final class HierarchyDebouncerTests: XCTestCase {
         XCTAssertEqual(fakeLocator.hierarchyRequestCount, initialCount)
     }
 
+    func testUpdatePollIntervalWhileRunningChangesNextPollCadence() {
+        let hierarchy = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(
+                text: "Root",
+                className: "UIView",
+                bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 812)
+            ),
+            windowInfo: WindowInfo(id: 0, type: 1, isActive: true, isFocused: true)
+        )
+        fakeLocator.setHierarchy(hierarchy)
+        debouncer.start()
+        let initialCount = fakeLocator.hierarchyRequestCount
+
+        debouncer.updatePollIntervalMs(50)
+        fakeTimer.advance(by: 49)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, initialCount)
+
+        fakeTimer.advance(by: 1)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, initialCount + 1)
+    }
+
+    func testResetPollIntervalUsesDefaultCadenceForFuturePolls() {
+        let hierarchy = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(
+                text: "Root",
+                className: "UIView",
+                bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 812)
+            ),
+            windowInfo: WindowInfo(id: 0, type: 1, isActive: true, isFocused: true)
+        )
+        fakeLocator.setHierarchy(hierarchy)
+        debouncer.start()
+        debouncer.updatePollIntervalMs(HierarchyDebouncer.defaultPollIntervalMs)
+        let initialCount = fakeLocator.hierarchyRequestCount
+
+        fakeTimer.advance(by: HierarchyDebouncer.defaultPollIntervalMs - 1)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, initialCount)
+
+        fakeTimer.advance(by: 1)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, initialCount + 1)
+    }
+
     func testExtractNowBlockingReturnsHierarchy() {
         let hierarchy = ViewHierarchy(
             packageName: "com.test.app",

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -50,6 +50,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
     var fakeStorage: FakeStorageInspecting!
     var fakeSdkHierarchy: FakeSdkHierarchyFetcher!
     var fakeDatabase: FakeSdkDatabaseFetcher!
+    var fakeHierarchyDebouncer: FakeHierarchyDebouncer!
     var commandHandler: CommandHandler!
 
     override func setUp() {
@@ -62,13 +63,15 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         fakeSdkHierarchy = FakeSdkHierarchyFetcher()
         fakeSdkHierarchy.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.example.app"))
         fakeDatabase = FakeSdkDatabaseFetcher()
+        fakeHierarchyDebouncer = FakeHierarchyDebouncer()
         commandHandler = CommandHandler.createForTesting(
             elementLocator: fakeElementLocator,
             gesturePerformer: fakeGesturePerformer,
             perfProvider: perfProvider,
             storageInspector: fakeStorage,
             sdkHierarchyClient: fakeSdkHierarchy,
-            sdkDatabaseClient: fakeDatabase
+            sdkDatabaseClient: fakeDatabase,
+            hierarchyDebouncer: fakeHierarchyDebouncer
         )
         fakeElementLocator.setHierarchy(ViewHierarchy(packageName: "com.example.app"))
     }
@@ -122,6 +125,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         let payloads: [RequestType: String] = [
             .requestHierarchy: "{}",
             .requestHierarchyIfStale: "{}",
+            .setHierarchyPollInterval: #"{"intervalMs":500}"#,
             .requestScreenshot: "{}",
             .requestTapCoordinates: #"{"x":1,"y":2}"#,
             .requestSwipe: #"{"x1":1,"y1":2,"x2":3,"y2":4}"#,
@@ -532,6 +536,19 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             return XCTFail("Expected .requestHierarchyIfStale, got \(request)")
         }
         XCTAssertEqual(payload.sinceTimestamp, 1234)
+    }
+
+    func testSetHierarchyPollIntervalDecodeDispatchUpdatesDebouncer() {
+        let response = dispatch(
+            #"{"type":"set_hierarchy_poll_interval","requestId":"poll-1","intervalMs":500}"#,
+            as: WebSocketResponse.self
+        )
+
+        XCTAssertEqual(response?.type, "set_hierarchy_poll_interval_result")
+        XCTAssertEqual(response?.requestId, "poll-1")
+        XCTAssertEqual(response?.success, true)
+        XCTAssertEqual(fakeHierarchyDebouncer.updatePollIntervalMsCallCount, 1)
+        XCTAssertEqual(fakeHierarchyDebouncer.lastPollIntervalMs, 500)
     }
 
     func testScreenshotDecodeDispatch() {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -782,6 +782,31 @@ export class Daemon {
       }
     });
 
+    server.setOnHierarchyCadenceChanged((deviceId: string | null) => {
+      const devices = this.devicePool.getAllDevices()
+        .filter(device => deviceId === null || device.id === deviceId);
+
+      for (const device of devices) {
+        if (device.platform !== "ios") {
+          continue;
+        }
+
+        const client = IOSCtrlProxyClient.getExistingInstance(device.id);
+        if (!client) {
+          continue;
+        }
+
+        const intervalMs = server.getHierarchyIntervalMsForDevice(device.id);
+        void client.ensureConnected().then(connected => {
+          if (connected) {
+            client.refreshObservationStreamHierarchyCadence(intervalMs);
+          }
+        }).catch(error => {
+          logger.warn(`[Daemon] Failed to refresh iOS hierarchy cadence for ${device.id}: ${error}`);
+        });
+      }
+    });
+
     server.setOnObservationRequested(async ({ deviceId, signal }) => {
       const pooledDevices = deviceId
         ? [this.devicePool.getDevice(deviceId)].filter(device => device !== null)
@@ -825,7 +850,16 @@ export class Daemon {
   private createObservationStreamIosClient(device: BootedDevice): ObservationStreamIosClient {
     const client = IOSCtrlProxyClient.getInstance(device);
     return {
-      ensureConnected: () => client.ensureConnected(),
+      ensureConnected: async () => {
+        const connected = await client.ensureConnected();
+        const server = getDeviceDataStreamServer();
+        if (connected && server) {
+          client.refreshObservationStreamHierarchyCadence(
+            server.getHierarchyIntervalMsForDevice(device.deviceId)
+          );
+        }
+        return connected;
+      },
       getLatestHierarchy: (...args) => client.getLatestHierarchy(...args),
       requestHierarchySyncWithoutObservationStreamPush: async (...args) => {
         const result = await client.requestHierarchySyncWithoutObservationStreamPush(...args);

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -96,6 +96,7 @@ interface DeviceDataStreamMessage {
 interface DeviceDataFilter {
   deviceId: string | null; // null means subscribe to all devices
   screenshotIntervalMs: number | null;
+  hierarchyIntervalMs: number | null;
 }
 
 /**
@@ -116,6 +117,11 @@ export type OnSubscriberConnectedCallback = (deviceId: string | null) => void;
  * Callback invoked when active screenshot cadence may have changed for a device.
  */
 export type OnScreenshotCadenceChangedCallback = (deviceId: string | null) => void;
+
+/**
+ * Callback invoked when active hierarchy cadence may have changed for a device.
+ */
+export type OnHierarchyCadenceChangedCallback = (deviceId: string | null) => void;
 
 /**
  * Observation captured on demand for a stream client.
@@ -146,8 +152,11 @@ export type OnNavigationGraphRequestedCallback = (appId?: string | null) => Prom
 // before the platform observe path has its allotted time to complete.
 const DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS = 20_000;
 const DEFAULT_SCREENSHOT_INTERVAL_MS = 3000;
+const DEFAULT_HIERARCHY_INTERVAL_MS = 1000;
 const MIN_SCREENSHOT_INTERVAL_MS = 250;
+const MIN_HIERARCHY_INTERVAL_MS = 250;
 const MAX_SCREENSHOT_INTERVAL_MS = 2_147_483_647;
+const MAX_HIERARCHY_INTERVAL_MS = 2_147_483_647;
 
 /**
  * Socket server that streams device data updates (hierarchy, screenshot, storage) to connected IDE plugins.
@@ -169,6 +178,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 > {
   private onSubscriberConnected: OnSubscriberConnectedCallback | null = null;
   private onScreenshotCadenceChanged: OnScreenshotCadenceChangedCallback | null = null;
+  private onHierarchyCadenceChanged: OnHierarchyCadenceChangedCallback | null = null;
   private onObservationRequested: OnObservationRequestedCallback | null = null;
   private onNavigationGraphRequested: OnNavigationGraphRequestedCallback | null = null;
   private observationRequestTimeoutMs = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS;
@@ -190,6 +200,13 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    */
   setOnScreenshotCadenceChanged(callback: OnScreenshotCadenceChangedCallback): void {
     this.onScreenshotCadenceChanged = callback;
+  }
+
+  /**
+   * Set a callback to be invoked when active hierarchy polling cadence may have changed.
+   */
+  setOnHierarchyCadenceChanged(callback: OnHierarchyCadenceChangedCallback): void {
+    this.onHierarchyCadenceChanged = callback;
   }
 
   /**
@@ -332,9 +349,36 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * or the default low-cost keepalive cadence when none is requested.
    */
   getScreenshotIntervalMsForDevice(deviceId: string): number {
+    return this.getFastestIntervalMsForDevice(
+      deviceId,
+      "screenshot_update",
+      DEFAULT_SCREENSHOT_INTERVAL_MS,
+      filter => filter.screenshotIntervalMs
+    );
+  }
+
+  /**
+   * Return the fastest active hierarchy cadence requested for this device,
+   * or the default iOS hierarchy polling cadence when none is requested.
+   */
+  getHierarchyIntervalMsForDevice(deviceId: string): number {
+    return this.getFastestIntervalMsForDevice(
+      deviceId,
+      "hierarchy_update",
+      DEFAULT_HIERARCHY_INTERVAL_MS,
+      filter => filter.hierarchyIntervalMs
+    );
+  }
+
+  private getFastestIntervalMsForDevice(
+    deviceId: string,
+    messageType: "screenshot_update" | "hierarchy_update",
+    defaultIntervalMs: number,
+    requestedIntervalMs: (filter: DeviceDataFilter) => number | null
+  ): number {
     const probe: DeviceDataPush = {
       message: {
-        type: "screenshot_update",
+        type: messageType,
         deviceId,
       },
       targetDeviceId: deviceId,
@@ -350,14 +394,14 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         continue;
       }
 
-      const requestedIntervalMs = subscriber.filter.screenshotIntervalMs ?? DEFAULT_SCREENSHOT_INTERVAL_MS;
+      const requestedInterval = requestedIntervalMs(subscriber.filter) ?? defaultIntervalMs;
 
       fastestIntervalMs = fastestIntervalMs === null
-        ? requestedIntervalMs
-        : Math.min(fastestIntervalMs, requestedIntervalMs);
+        ? requestedInterval
+        : Math.min(fastestIntervalMs, requestedInterval);
     }
 
-    return fastestIntervalMs ?? DEFAULT_SCREENSHOT_INTERVAL_MS;
+    return fastestIntervalMs ?? defaultIntervalMs;
   }
 
   /**
@@ -449,6 +493,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       await super.processLine(socket, line);
 
       this.notifyScreenshotCadenceChanged(request.deviceId ?? null);
+      this.notifyHierarchyCadenceChanged(request.deviceId ?? null);
 
       // Trigger the callback if set
       if (this.onSubscriberConnected) {
@@ -466,6 +511,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       await super.processLine(socket, line);
       if (filter) {
         this.notifyScreenshotCadenceChanged(filter.deviceId);
+        this.notifyHierarchyCadenceChanged(filter.deviceId);
       }
       return;
     }
@@ -479,6 +525,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     super.onConnectionClose(socket);
     if (filter) {
       this.notifyScreenshotCadenceChanged(filter.deviceId);
+      this.notifyHierarchyCadenceChanged(filter.deviceId);
     }
   }
 
@@ -487,6 +534,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     super.onConnectionError(socket, error);
     if (filter) {
       this.notifyScreenshotCadenceChanged(filter.deviceId);
+      this.notifyHierarchyCadenceChanged(filter.deviceId);
     }
   }
 
@@ -495,6 +543,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     super.checkKeepalive();
     if (this.subscribers.size !== subscriberCountBefore) {
       this.notifyScreenshotCadenceChanged(null);
+      this.notifyHierarchyCadenceChanged(null);
     }
   }
 
@@ -502,6 +551,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     return {
       deviceId: (request.deviceId as string) ?? null,
       screenshotIntervalMs: this.parseScreenshotIntervalMs(request.screenshotIntervalMs),
+      hierarchyIntervalMs: this.parseHierarchyIntervalMs(request.hierarchyIntervalMs),
     };
   }
 
@@ -519,6 +569,14 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   private parseScreenshotIntervalMs(value: unknown): number | null {
+    return this.parseClampedIntervalMs(value, MIN_SCREENSHOT_INTERVAL_MS, MAX_SCREENSHOT_INTERVAL_MS);
+  }
+
+  private parseHierarchyIntervalMs(value: unknown): number | null {
+    return this.parseClampedIntervalMs(value, MIN_HIERARCHY_INTERVAL_MS, MAX_HIERARCHY_INTERVAL_MS);
+  }
+
+  private parseClampedIntervalMs(value: unknown, minIntervalMs: number, maxIntervalMs: number): number | null {
     if (value === null || value === undefined) {
       return null;
     }
@@ -528,8 +586,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     }
 
     return Math.min(
-      Math.max(Math.round(value), MIN_SCREENSHOT_INTERVAL_MS),
-      MAX_SCREENSHOT_INTERVAL_MS
+      Math.max(Math.round(value), minIntervalMs),
+      maxIntervalMs
     );
   }
 
@@ -543,14 +601,26 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   private notifyScreenshotCadenceChanged(deviceId: string | null): void {
-    if (!this.onScreenshotCadenceChanged) {
+    this.notifyCadenceChanged(this.onScreenshotCadenceChanged, "onScreenshotCadenceChanged", deviceId);
+  }
+
+  private notifyHierarchyCadenceChanged(deviceId: string | null): void {
+    this.notifyCadenceChanged(this.onHierarchyCadenceChanged, "onHierarchyCadenceChanged", deviceId);
+  }
+
+  private notifyCadenceChanged(
+    callback: ((deviceId: string | null) => void) | null,
+    callbackName: string,
+    deviceId: string | null
+  ): void {
+    if (!callback) {
       return;
     }
 
     try {
-      this.onScreenshotCadenceChanged(deviceId);
+      callback(deviceId);
     } catch (error) {
-      logger.warn(`[DeviceDataStream] Error in onScreenshotCadenceChanged callback: ${error}`);
+      logger.warn(`[DeviceDataStream] Error in ${callbackName} callback: ${error}`);
     }
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -800,6 +800,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
     this.syncNetworkMockRulesToDevice();
     this.syncNetworkErrorSimulationToDevice();
+    this.syncHierarchyCadenceToDevice();
 
     // Start polling for SDK events from the CtrlProxy HTTP endpoint
     this.startSdkEventPolling();
@@ -849,6 +850,17 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     } catch (e) {
       logger.warn(`[IOSCtrlProxyClient] Failed to sync network error simulation on reconnect: ${e}`);
     }
+  }
+
+  private syncHierarchyCadenceToDevice(): void {
+    const server = getDeviceDataStreamServer();
+    if (!server) {
+      return;
+    }
+
+    this.refreshObservationStreamHierarchyCadence(
+      server.getHierarchyIntervalMsForDevice(this.device.deviceId)
+    );
   }
 
   protected onConnectionClosed(): void {
@@ -1689,6 +1701,18 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   refreshObservationStreamScreenshotCadence(): void {
     this.screenshotBackoffScheduler?.rescheduleKeepAlive();
+  }
+
+  refreshObservationStreamHierarchyCadence(intervalMs: number): void {
+    if (!this.isCommandSupported("set_hierarchy_poll_interval")) {
+      logger.info("[IOSCtrlProxyClient] Skipping hierarchy cadence sync; runner does not advertise set_hierarchy_poll_interval");
+      return;
+    }
+
+    this.sendMessage(JSON.stringify({
+      type: "set_hierarchy_poll_interval",
+      intervalMs,
+    }));
   }
 
   // ===========================================================================

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -22,6 +22,7 @@ export const IOS_KNOWN_REQUEST_TYPES = [
   // View hierarchy
   "request_hierarchy",
   "request_hierarchy_if_stale",
+  "set_hierarchy_poll_interval",
   "request_screenshot",
 
   // Gestures

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -30,6 +30,7 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
   simulateSubscription(options: {
     deviceId?: string;
     screenshotIntervalMs?: number | null;
+    hierarchyIntervalMs?: number | null;
   }): { socket: FakeSocket; subscriptionId: string } {
     const socket = new FakeSocket();
     const subscriptionId = `devicedatastream-${++(this as any).subscriptionCounter}`;
@@ -41,6 +42,7 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
       filter: {
         deviceId: options.deviceId ?? null,
         screenshotIntervalMs: options.screenshotIntervalMs ?? null,
+        hierarchyIntervalMs: options.hierarchyIntervalMs ?? null,
       },
       backfilling: false,
       drainPending: false,
@@ -622,6 +624,95 @@ describe("DeviceDataStreamSocketServer", () => {
         changedDevices.push(deviceId);
       });
       const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+
+      server.closeConnectionForTest(socket);
+
+      expect(changedDevices).toEqual(["device-1"]);
+    });
+  });
+
+  describe("hierarchy cadence aggregation", () => {
+    it("uses the default hierarchy polling cadence when subscribers omit cadence", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+    });
+
+    it("parses requested hierarchy cadence from subscribe commands", async () => {
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub-fast-hierarchy",
+        command: "subscribe",
+        deviceId: "device-1",
+        hierarchyIntervalMs: 500,
+      }));
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
+    });
+
+    it("clamps requested hierarchy cadence to the safe minimum", async () => {
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub-clamped-hierarchy",
+        command: "subscribe",
+        deviceId: "device-1",
+        hierarchyIntervalMs: 50,
+      }));
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(250);
+    });
+
+    it("uses the fastest active requested hierarchy cadence for a device", () => {
+      server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 1000 });
+      server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+      server.simulateSubscription({ deviceId: "device-2", hierarchyIntervalMs: 250 });
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
+    });
+
+    it("keeps default hierarchy cadence when another subscriber requests a slower cadence", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+      server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 10_000 });
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+    });
+
+    it("removes requested hierarchy cadence after unsubscribe", async () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "unsub-fast-hierarchy",
+        command: "unsubscribe",
+      }));
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+    });
+
+    it("notifies when subscribe changes hierarchy cadence", async () => {
+      const changedDevices: Array<string | null> = [];
+      server.setOnHierarchyCadenceChanged((deviceId: string | null) => {
+        changedDevices.push(deviceId);
+      });
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub-fast-hierarchy",
+        command: "subscribe",
+        deviceId: "device-1",
+        hierarchyIntervalMs: 500,
+      }));
+
+      expect(changedDevices).toEqual(["device-1"]);
+    });
+
+    it("notifies when connection close removes hierarchy cadence", () => {
+      const changedDevices: Array<string | null> = [];
+      server.setOnHierarchyCadenceChanged((deviceId: string | null) => {
+        changedDevices.push(deviceId);
+      });
+      const { socket } = server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
 
       server.closeConnectionForTest(socket);
 

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -151,6 +151,34 @@ describe("IOSCtrlProxyClient", function() {
       expect(scheduler.rescheduleKeepAliveCalls).toBe(1);
     });
 
+    test("sends hierarchy cadence updates to the runner", function() {
+      const sentMessages: string[] = [];
+      (ctrlProxyClient as any).sendMessage = (message: string) => {
+        sentMessages.push(message);
+        return true;
+      };
+
+      (ctrlProxyClient as any).refreshObservationStreamHierarchyCadence(500);
+
+      expect(sentMessages.map(message => JSON.parse(message))).toEqual([{
+        type: "set_hierarchy_poll_interval",
+        intervalMs: 500,
+      }]);
+    });
+
+    test("does not send hierarchy cadence updates to stale runners without command support", function() {
+      const sentMessages: string[] = [];
+      (ctrlProxyClient as any).supportedCommands = new Set(["request_hierarchy"]);
+      (ctrlProxyClient as any).sendMessage = (message: string) => {
+        sentMessages.push(message);
+        return true;
+      };
+
+      (ctrlProxyClient as any).refreshObservationStreamHierarchyCadence(500);
+
+      expect(sentMessages).toEqual([]);
+    });
+
     test("notifies the observation stream when the WebSocket connection closes", function() {
       const lostDeviceIds: string[] = [];
       const notifier: DeviceConnectionLostNotifier = {

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -41,6 +41,7 @@ const MODELS_SWIFT = resolve(REPO_ROOT, "ios/control-proxy/Sources/CtrlProxy/Mod
 const SWIFT_REQUEST_TYPES = [
   "request_hierarchy",
   "request_hierarchy_if_stale",
+  "set_hierarchy_poll_interval",
   "request_screenshot",
   "request_tap_coordinates",
   "request_swipe",

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-listAvds.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-listAvds.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { AvdConfigReader } from "../../../src/utils/android-cmdline-tools/AvdConfigReader";
 import type { ExecResult } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
@@ -13,6 +14,12 @@ const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
   trim: () => stdout.trim(),
   includes: (s: string) => stdout.includes(s),
 });
+
+const noAvdConfigReader: AvdConfigReader = {
+  async readConfig() {
+    return null;
+  },
+};
 
 describe("AndroidEmulatorClient listAvds", () => {
   test("reports deleted daemon cwd failures separately from a missing emulator binary", async () => {
@@ -121,7 +128,7 @@ describe("AndroidEmulatorClient listAvds", () => {
   test("returns AVDs when emulator command succeeds", async () => {
     const execAsync = async (_command: string): Promise<ExecResult> =>
       createExecResult("Pixel_9\nPixel_Tablet\n");
-    const client = new AndroidEmulatorClient(execAsync, null, new FakeTimer());
+    const client = new AndroidEmulatorClient(execAsync, null, new FakeTimer(), undefined, noAvdConfigReader);
     (client as any).ensureEmulatorPath = async () => "emulator";
 
     await expect(client.listAvds()).resolves.toEqual([


### PR DESCRIPTION
## Summary
- Add `hierarchyIntervalMs` subscription parsing, clamping, aggregation, and cleanup alongside screenshot cadence handling.
- Propagate active iOS hierarchy cadence to CtrlProxy via a new capability-gated `set_hierarchy_poll_interval` command.
- Update Swift runner debouncer/protocol coverage and isolate one Android AVD unit from local machine metadata.

Closes #3381.

## Test plan
- `bun run turbo:validate`
- `bun run typecheck`
- `swift test` in `ios/control-proxy`
- `bun test test/daemon/deviceDataStreamSocketServer.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts test/features/observe/ios/ctrlProxyWireParity.test.ts test/utils/android-cmdline-tools/AndroidEmulatorClient-listAvds.test.ts`
- `swift test --filter 'HierarchyDebouncerTests|TypedRequestDecodeDispatchTests|ErrorResponseTypeTests'` in `ios/control-proxy`

Made with [Cursor](https://cursor.com)