### PR TITLE
Add screenshot stream metadata

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -281,6 +281,11 @@ class ObservationStreamClient {
             screenshotBase64 = response.screenshotBase64,
             screenWidth = response.screenWidth ?: 1080,
             screenHeight = response.screenHeight ?: 2340,
+            screenshotMimeType = response.screenshotMimeType,
+            screenshotFormat = response.screenshotFormat,
+            screenshotCaptureSource = response.screenshotCaptureSource,
+            screenshotFallback = response.screenshotFallback,
+            screenshotFallbackReason = response.screenshotFallbackReason,
           )
         _screenshotUpdates.emit(update)
         log.info("Emitted screenshot update to flow")
@@ -434,6 +439,11 @@ data class StreamResponse(
   val screenshotBase64: String? = null,
   val screenWidth: Int? = null,
   val screenHeight: Int? = null,
+  val screenshotMimeType: String? = null,
+  val screenshotFormat: String? = null,
+  val screenshotCaptureSource: String? = null,
+  val screenshotFallback: Boolean? = null,
+  val screenshotFallbackReason: String? = null,
   val navigationGraph: NavigationGraphStreamData? = null,
   val performanceData: PerformanceStreamData? = null,
 )
@@ -476,6 +486,11 @@ data class ScreenshotStreamUpdate(
   val screenshotBase64: String?,
   val screenWidth: Int,
   val screenHeight: Int,
+  val screenshotMimeType: String? = null,
+  val screenshotFormat: String? = null,
+  val screenshotCaptureSource: String? = null,
+  val screenshotFallback: Boolean? = null,
+  val screenshotFallbackReason: String? = null,
 )
 
 data class NavigationGraphStreamUpdate(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -7,6 +7,39 @@ import kotlinx.coroutines.test.runTest
 
 class ObservationStreamClientTest {
   @Test
+  fun `emits screenshot metadata when provided by stream`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.screenshotUpdates.test {
+      client.handleMessage(
+        """
+        {
+          "type": "screenshot_update",
+          "deviceId": "emulator-5554",
+          "timestamp": 1001,
+          "screenshotBase64": "aW1hZ2U=",
+          "screenWidth": 100,
+          "screenHeight": 200,
+          "screenshotMimeType": "image/png",
+          "screenshotFormat": "png",
+          "screenshotCaptureSource": "android_adb_screencap",
+          "screenshotFallback": true,
+          "screenshotFallbackReason": "websocket_unavailable"
+        }
+        """
+          .trimIndent()
+      )
+
+      val update = awaitItem()
+      assertEquals("image/png", update.screenshotMimeType)
+      assertEquals("png", update.screenshotFormat)
+      assertEquals("android_adb_screencap", update.screenshotCaptureSource)
+      assertEquals(true, update.screenshotFallback)
+      assertEquals("websocket_unavailable", update.screenshotFallbackReason)
+    }
+  }
+
+  @Test
   fun `emits device connection lost event for disconnect error message`() = runTest {
     val client = ObservationStreamClient()
 

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -9,6 +9,7 @@ import {
 import type { ObserveResult, ViewHierarchyResult } from "../models";
 import type { StorageChangedEvent } from "../features/storage/storageTypes";
 import { DEVICE_DATA_STREAM_SOCKET_CONFIG } from "./daemonFiles";
+import type { ScreenshotMetadata } from "../features/observe/ScreenshotMetadata";
 
 /**
  * Navigation graph summary for streaming to IDE plugins.
@@ -65,7 +66,7 @@ export interface PerformanceStreamData {
 /**
  * Response/push message format
  */
-interface DeviceDataStreamMessage {
+interface DeviceDataStreamMessage extends ScreenshotMetadata {
   id?: string;
   type:
     | "subscription_response"
@@ -251,8 +252,16 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     deviceId: string,
     screenshotBase64: string,
     screenWidth: number,
-    screenHeight: number
+    screenHeight: number,
+    metadata: ScreenshotMetadata = {}
   ): void {
+    const {
+      screenshotMimeType,
+      screenshotFormat,
+      screenshotCaptureSource,
+      screenshotFallback,
+      screenshotFallbackReason,
+    } = metadata;
     const message: DeviceDataStreamMessage = {
       type: "screenshot_update",
       deviceId,
@@ -260,6 +269,11 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       screenshotBase64,
       screenWidth,
       screenHeight,
+      screenshotMimeType,
+      screenshotFormat,
+      screenshotCaptureSource,
+      screenshotFallback,
+      screenshotFallbackReason,
     };
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -5,17 +5,17 @@ import type { PerformanceTracker } from "../utils/PerformanceTracker";
 import type {
   AccessibilityHierarchy,
   AccessibilityHierarchyResponse,
-  ScreenshotResult,
 } from "../features/observe/android";
+import type { ScreenshotCaptureResult } from "../features/observe/ScreenshotBackoffScheduler";
 import type {
   CtrlProxyHierarchy,
   CtrlProxyHierarchyResponse,
   CtrlProxyScreenshotResult,
 } from "../features/observe/ios/types";
 import {
-  ANDROID_CTRLPROXY_SCREENSHOT_METADATA,
   IOS_CTRLPROXY_SCREENSHOT_METADATA,
   metadataForScreenshotFormat,
+  pickScreenshotMetadata,
 } from "../features/observe/ScreenshotMetadata";
 
 const INITIAL_FRAME_HIERARCHY_TIMEOUT_MS = 3_000;
@@ -47,7 +47,7 @@ export interface ObservationStreamAndroidClient {
     timeoutMs?: number
   ): Promise<{ hierarchy: AccessibilityHierarchy } | null>;
   convertToViewHierarchyResult(hierarchy: AccessibilityHierarchy): ViewHierarchyResult;
-  requestScreenshotWithoutObservationStreamPush(timeoutMs?: number, perf?: PerformanceTracker): Promise<ScreenshotResult>;
+  captureScreenshotForObservationStream(): Promise<ScreenshotCaptureResult>;
 }
 
 export interface ObservationStreamIosClient {
@@ -144,10 +144,7 @@ async function pushAndroidInitialScreenshot(
   streamServer: Pick<DeviceDataStreamSocketServer, "pushScreenshotUpdate">,
   viewHierarchy: ViewHierarchyResult
 ): Promise<void> {
-  // Android's normal screenshot request auto-pushes to the observation stream.
-  // Suppress that side effect so this initial frame is pushed exactly once with
-  // dimensions derived from the paired hierarchy.
-  const screenshot = await client.requestScreenshotWithoutObservationStreamPush(INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS);
+  const screenshot = await client.captureScreenshotForObservationStream();
   if (screenshot.success && screenshot.data) {
     const dimensions = getAndroidScreenshotDimensions(viewHierarchy);
     streamServer.pushScreenshotUpdate(
@@ -155,7 +152,7 @@ async function pushAndroidInitialScreenshot(
       screenshot.data,
       dimensions.width,
       dimensions.height,
-      metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format)
+      pickScreenshotMetadata(screenshot)
     );
   }
 }

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -12,6 +12,11 @@ import type {
   CtrlProxyHierarchyResponse,
   CtrlProxyScreenshotResult,
 } from "../features/observe/ios/types";
+import {
+  ANDROID_CTRLPROXY_SCREENSHOT_METADATA,
+  IOS_CTRLPROXY_SCREENSHOT_METADATA,
+  metadataForScreenshotFormat,
+} from "../features/observe/ScreenshotMetadata";
 
 const INITIAL_FRAME_HIERARCHY_TIMEOUT_MS = 3_000;
 const INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS = 3_000;
@@ -149,7 +154,8 @@ async function pushAndroidInitialScreenshot(
       deviceId,
       screenshot.data,
       dimensions.width,
-      dimensions.height
+      dimensions.height,
+      metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format)
     );
   }
 }
@@ -205,7 +211,8 @@ async function pushIosInitialObservationFrame(
       device.deviceId,
       screenshot.data,
       dimensions.width,
-      dimensions.height
+      dimensions.height,
+      metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format)
     );
   }
 }

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -118,6 +118,7 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
   private pendingTimeouts: ReturnType<Timer["setTimeout"]>[] = [];
   private keepAliveTimeout: ReturnType<Timer["setTimeout"]> | null = null;
   private lastEmittedChecksum: string | null = null;
+  private lastEmittedMetadataSignature: string | null = null;
   private sequenceId: number = 0;
 
   constructor(
@@ -196,6 +197,7 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
    */
   resetLastChecksum(): void {
     this.lastEmittedChecksum = null;
+    this.lastEmittedMetadataSignature = null;
   }
 
   private async captureAtInterval(sequenceId: number, interval: number): Promise<void> {
@@ -263,21 +265,36 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
 
       // Compute checksum
       const checksum = result.checksum || computeChecksum(result.data);
+      const metadataSignature = this.createMetadataSignature(result);
+      const isDuplicateCapture =
+        checksum === this.lastEmittedChecksum &&
+        metadataSignature === this.lastEmittedMetadataSignature;
 
-      // Skip if same as last emitted
-      if (!emitDuplicates && checksum === this.lastEmittedChecksum) {
-        logger.debug(`[ScreenshotBackoff] Skipping duplicate screenshot at ${captureLabel} (checksum: ${checksum.substring(0, 8)}...)`);
+      // Skip only when both the image bytes and public screenshot metadata match.
+      if (!emitDuplicates && isDuplicateCapture) {
+        logger.debug(`[ScreenshotBackoff] Skipping duplicate screenshot at ${captureLabel} (checksum: ${checksum.substring(0, 8)}..., metadata: ${metadataSignature})`);
         return;
       }
 
       // Emit the screenshot
       logger.debug(`[ScreenshotBackoff] Emitting screenshot at ${captureLabel} (checksum: ${checksum.substring(0, 8)}..., size: ${result.data.length})`);
       this.lastEmittedChecksum = checksum;
+      this.lastEmittedMetadataSignature = metadataSignature;
       this.emitCallback(result);
 
     } catch (error) {
       logger.warn(`[ScreenshotBackoff] Error capturing screenshot at ${captureLabel}: ${error}`);
     }
+  }
+
+  private createMetadataSignature(metadata: ScreenshotMetadata): string {
+    return JSON.stringify([
+      metadata.screenshotMimeType ?? null,
+      metadata.screenshotFormat ?? null,
+      metadata.screenshotCaptureSource ?? null,
+      metadata.screenshotFallback ?? null,
+      metadata.screenshotFallbackReason ?? null,
+    ]);
   }
 
   private scheduleKeepAliveIfIdle(sequenceId: number): void {

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -1,11 +1,12 @@
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { logger } from "../../utils/logger";
 import crypto from "crypto";
+import type { ScreenshotMetadata } from "./ScreenshotMetadata";
 
 /**
  * Result of a screenshot capture attempt
  */
-export interface ScreenshotCaptureResult {
+export interface ScreenshotCaptureResult extends ScreenshotMetadata {
   success: boolean;
   data?: string; // base64 encoded
   checksum?: string;
@@ -20,7 +21,7 @@ type ScreenshotCaptureCallback = () => Promise<ScreenshotCaptureResult>;
 /**
  * Callback to emit a screenshot to the stream
  */
-type ScreenshotEmitCallback = (data: string) => void;
+type ScreenshotEmitCallback = (result: ScreenshotCaptureResult) => void;
 
 /**
  * Callback to decide whether keepalive screenshots should continue.
@@ -272,7 +273,7 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
       // Emit the screenshot
       logger.debug(`[ScreenshotBackoff] Emitting screenshot at ${captureLabel} (checksum: ${checksum.substring(0, 8)}..., size: ${result.data.length})`);
       this.lastEmittedChecksum = checksum;
-      this.emitCallback(result.data);
+      this.emitCallback(result);
 
     } catch (error) {
       logger.warn(`[ScreenshotBackoff] Error capturing screenshot at ${captureLabel}: ${error}`);

--- a/src/features/observe/ScreenshotMetadata.ts
+++ b/src/features/observe/ScreenshotMetadata.ts
@@ -1,0 +1,66 @@
+export type ScreenshotFormat = "jpeg" | "png";
+
+export type ScreenshotMimeType = "image/jpeg" | "image/png";
+
+export type ScreenshotCaptureSource =
+  | "android_ctrlproxy_a11y"
+  | "android_adb_screencap"
+  | "ios_ctrlproxy";
+
+export type ScreenshotFallbackReason =
+  | "a11y_screenshot_unsupported"
+  | "websocket_unavailable"
+  | "ctrlproxy_failed"
+  | "ctrlproxy_timeout"
+  | "ctrlproxy_exception";
+
+export interface ScreenshotMetadata {
+  screenshotMimeType?: ScreenshotMimeType;
+  screenshotFormat?: ScreenshotFormat;
+  screenshotCaptureSource?: ScreenshotCaptureSource;
+  screenshotFallback?: boolean;
+  screenshotFallbackReason?: ScreenshotFallbackReason | null;
+}
+
+export const ANDROID_CTRLPROXY_SCREENSHOT_METADATA: ScreenshotMetadata = {
+  screenshotMimeType: "image/jpeg",
+  screenshotFormat: "jpeg",
+  screenshotCaptureSource: "android_ctrlproxy_a11y",
+  screenshotFallback: false,
+};
+
+export const ANDROID_ADB_SCREENSHOT_METADATA: ScreenshotMetadata = {
+  screenshotMimeType: "image/png",
+  screenshotFormat: "png",
+  screenshotCaptureSource: "android_adb_screencap",
+  screenshotFallback: true,
+};
+
+export const IOS_CTRLPROXY_SCREENSHOT_METADATA: ScreenshotMetadata = {
+  screenshotMimeType: "image/png",
+  screenshotFormat: "png",
+  screenshotCaptureSource: "ios_ctrlproxy",
+  screenshotFallback: false,
+};
+
+export function metadataForScreenshotFormat(
+  metadata: ScreenshotMetadata,
+  format?: string
+): ScreenshotMetadata {
+  switch (format) {
+    case "jpeg":
+      return {
+        ...metadata,
+        screenshotMimeType: "image/jpeg",
+        screenshotFormat: "jpeg",
+      };
+    case "png":
+      return {
+        ...metadata,
+        screenshotMimeType: "image/png",
+        screenshotFormat: "png",
+      };
+    default:
+      return metadata;
+  }
+}

--- a/src/features/observe/ScreenshotMetadata.ts
+++ b/src/features/observe/ScreenshotMetadata.ts
@@ -47,20 +47,46 @@ export function metadataForScreenshotFormat(
   metadata: ScreenshotMetadata,
   format?: string
 ): ScreenshotMetadata {
+  const metadataWithoutFormat = { ...metadata };
+  delete metadataWithoutFormat.screenshotMimeType;
+  delete metadataWithoutFormat.screenshotFormat;
+
   switch (format) {
     case "jpeg":
       return {
-        ...metadata,
+        ...metadataWithoutFormat,
         screenshotMimeType: "image/jpeg",
         screenshotFormat: "jpeg",
       };
     case "png":
       return {
-        ...metadata,
+        ...metadataWithoutFormat,
         screenshotMimeType: "image/png",
         screenshotFormat: "png",
       };
     default:
-      return metadata;
+      return metadataWithoutFormat;
   }
+}
+
+export function pickScreenshotMetadata(metadata: ScreenshotMetadata): ScreenshotMetadata {
+  const pickedMetadata: ScreenshotMetadata = {};
+
+  if (metadata.screenshotMimeType !== undefined) {
+    pickedMetadata.screenshotMimeType = metadata.screenshotMimeType;
+  }
+  if (metadata.screenshotFormat !== undefined) {
+    pickedMetadata.screenshotFormat = metadata.screenshotFormat;
+  }
+  if (metadata.screenshotCaptureSource !== undefined) {
+    pickedMetadata.screenshotCaptureSource = metadata.screenshotCaptureSource;
+  }
+  if (metadata.screenshotFallback !== undefined) {
+    pickedMetadata.screenshotFallback = metadata.screenshotFallback;
+  }
+  if (metadata.screenshotFallbackReason !== undefined) {
+    pickedMetadata.screenshotFallbackReason = metadata.screenshotFallbackReason;
+  }
+
+  return pickedMetadata;
 }

--- a/src/features/observe/TakeScreenshot.ts
+++ b/src/features/observe/TakeScreenshot.ts
@@ -16,6 +16,10 @@ import { selectScreenshotsToEvict, SCREENSHOT_MIN_EVICT_AGE_MS } from "./screens
 import { IOSCtrlProxyClient } from "./ios";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import {
+  ANDROID_ADB_SCREENSHOT_METADATA,
+  IOS_CTRLPROXY_SCREENSHOT_METADATA,
+} from "./ScreenshotMetadata";
 
 /** Secure file mode: owner read/write only */
 const SECURE_FILE_MODE = 0o600;
@@ -317,7 +321,13 @@ export class TakeScreenshot implements ScreenshotService {
     }
 
     try {
-      server.pushScreenshotUpdate(this.device.deviceId, base64Data, width, height);
+      server.pushScreenshotUpdate(
+        this.device.deviceId,
+        base64Data,
+        width,
+        height,
+        this.device.platform === "ios" ? IOS_CTRLPROXY_SCREENSHOT_METADATA : ANDROID_ADB_SCREENSHOT_METADATA
+      );
     } catch (error) {
       logger.debug(`[SCREENSHOT] Failed to push screenshot to observation stream: ${error}`);
     }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -50,6 +50,13 @@ import {
   computeChecksum,
 } from "../ScreenshotBackoffScheduler";
 import {
+  ANDROID_ADB_SCREENSHOT_METADATA,
+  ANDROID_CTRLPROXY_SCREENSHOT_METADATA,
+  metadataForScreenshotFormat,
+  type ScreenshotFallbackReason,
+  type ScreenshotMetadata,
+} from "../ScreenshotMetadata";
+import {
   normalizeAnr,
   normalizeCrash,
   type SdkAnrPayload,
@@ -2170,7 +2177,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       if (message.type === "screenshot" && message.requestId) {
         const suppressObservationStreamPush = this.screenshotObservationStreamSuppressions.delete(message.requestId);
         if (!suppressObservationStreamPush) {
-          this.pushScreenshotToObservationStream(message.data);
+          this.pushScreenshotToObservationStream(
+            message.data,
+            metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, message.format)
+          );
         } else {
           logger.debug("[CTRL_PROXY] Suppressed screenshot observation stream push for explicit initial-frame request");
         }
@@ -2748,7 +2758,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
-  private pushScreenshotToObservationStream(screenshotBase64: string): void {
+  private pushScreenshotToObservationStream(
+    screenshotBase64: string,
+    metadata: ScreenshotMetadata = ANDROID_CTRLPROXY_SCREENSHOT_METADATA
+  ): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
       return;
@@ -2758,7 +2771,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     const screenHeight = this.cachedScreenDimensions?.height ?? 2340;
 
     try {
-      server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight);
+      server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata);
     } catch (error) {
       logger.debug(`[CTRL_PROXY] Failed to push screenshot to observation stream: ${error}`);
     }
@@ -2797,8 +2810,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         async (): Promise<ScreenshotCaptureResult> => {
           return this.captureScreenshotForBackoff();
         },
-        (data: string) => {
-          this.pushScreenshotToObservationStream(data);
+        (result: ScreenshotCaptureResult) => {
+          if (result.data) {
+            this.pushScreenshotToObservationStream(result.data, result);
+          }
         },
         {
           intervals: [0, 100, 300, 500, 800, 1300],
@@ -2826,11 +2841,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
     // If we know the device doesn't support a11y screenshots, go straight to ADB fallback
     if (this.a11yScreenshotSupported === false) {
-      return this.captureScreenshotViaAdb();
+      return this.captureScreenshotViaAdb("a11y_screenshot_unsupported");
     }
 
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      return this.captureScreenshotViaAdb();
+      return this.captureScreenshotViaAdb("websocket_unavailable");
     }
 
     const requestId = this.requestManager.generateId("screenshot-backoff");
@@ -2854,24 +2869,33 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
             `${this.a11yScreenshotFailures} consecutive failures, falling back to ADB screencap`);
           this.a11yScreenshotSupported = false;
         }
-        return this.captureScreenshotViaAdb();
+        return this.captureScreenshotViaAdb(this.fallbackReasonForCtrlProxyFailure(result.error));
       }
 
       this.a11yScreenshotFailures = 0;
       this.a11yScreenshotSupported = true;
       const checksum = computeChecksum(result.data);
 
-      return { success: true, data: result.data, checksum };
+      return {
+        success: true,
+        data: result.data,
+        checksum,
+        ...metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, result.format),
+      };
     } catch (error) {
-      return this.captureScreenshotViaAdb();
+      return this.captureScreenshotViaAdb("ctrlproxy_exception");
     }
+  }
+
+  private fallbackReasonForCtrlProxyFailure(error?: string): ScreenshotFallbackReason {
+    return error === "Screenshot timeout" ? "ctrlproxy_timeout" : "ctrlproxy_failed";
   }
 
   /**
    * Fallback screenshot capture via ADB screencap for devices that don't support
    * accessibility service screenshots (API < 30).
    */
-  private async captureScreenshotViaAdb(): Promise<ScreenshotCaptureResult> {
+  private async captureScreenshotViaAdb(fallbackReason?: ScreenshotFallbackReason): Promise<ScreenshotCaptureResult> {
     try {
       const tempFile = "/sdcard/screenshot_stream.png";
       const command = `shell "screencap -p ${tempFile} && base64 ${tempFile} && rm ${tempFile}"`;
@@ -2885,7 +2909,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       const data = result.stdout.replace(/[\r\n]/g, "");
       const checksum = computeChecksum(data);
 
-      return { success: true, data, checksum };
+      return {
+        success: true,
+        data,
+        checksum,
+        ...ANDROID_ADB_SCREENSHOT_METADATA,
+        screenshotFallbackReason: fallbackReason,
+      };
     } catch (error) {
       return { success: false, error: `ADB screencap failed: ${error}` };
     }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2839,6 +2839,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       return { success: false, error: "No subscribers" };
     }
 
+    return this.captureScreenshotForObservationStream();
+  }
+
+  async captureScreenshotForObservationStream(): Promise<ScreenshotCaptureResult> {
     // If we know the device doesn't support a11y screenshots, go straight to ADB fallback
     if (this.a11yScreenshotSupported === false) {
       return this.captureScreenshotViaAdb("a11y_screenshot_unsupported");
@@ -2852,6 +2856,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     const message = serializeCtrlProxyRequest(ctrlProxyRequests.requestScreenshot({ requestId }));
 
     try {
+      this.screenshotObservationStreamSuppressions.add(requestId);
       const screenshotPromise = this.requestManager.register<ScreenshotResult>(
         requestId, "screenshot", 3000,
         (_id, _type, _timeout) => ({ success: false, error: "Screenshot timeout" })
@@ -2883,7 +2888,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         ...metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, result.format),
       };
     } catch (error) {
+      this.requestManager.resolve<ScreenshotResult>(requestId, { success: false, error: `${error}` });
       return this.captureScreenshotViaAdb("ctrlproxy_exception");
+    } finally {
+      this.screenshotObservationStreamSuppressions.delete(requestId);
     }
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -60,6 +60,11 @@ import {
   DefaultScreenshotBackoffScheduler,
   ScreenshotCaptureResult,
 } from "../ScreenshotBackoffScheduler";
+import {
+  IOS_CTRLPROXY_SCREENSHOT_METADATA,
+  metadataForScreenshotFormat,
+  type ScreenshotMetadata,
+} from "../ScreenshotMetadata";
 
 /**
  * Factory function type for creating CtrlProxyIosManager instances.
@@ -1599,14 +1604,19 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   /**
    * Push screenshot update to the device data stream for IDE plugins.
    */
-  private pushScreenshotToObservationStream(screenshotBase64: string, screenWidth: number, screenHeight: number): void {
+  private pushScreenshotToObservationStream(
+    screenshotBase64: string,
+    screenWidth: number,
+    screenHeight: number,
+    metadata: ScreenshotMetadata = IOS_CTRLPROXY_SCREENSHOT_METADATA
+  ): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
       return;
     }
 
     try {
-      server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight);
+      server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata);
     } catch (error) {
       logger.debug(`[IOSCtrlProxyClient] Failed to push screenshot to observation stream: ${error}`);
     }
@@ -1636,11 +1646,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         async (): Promise<ScreenshotCaptureResult> => {
           return this.captureScreenshotForBackoff();
         },
-        (data: string) => {
+        (result: ScreenshotCaptureResult) => {
+          if (!result.data) {
+            return;
+          }
           // Get screen dimensions from cached hierarchy or use defaults
           const screenWidth = this.cachedScreenDimensions?.width ?? 1170;
           const screenHeight = this.cachedScreenDimensions?.height ?? 2532;
-          this.pushScreenshotToObservationStream(data, screenWidth, screenHeight);
+          this.pushScreenshotToObservationStream(result.data, screenWidth, screenHeight, result);
         },
         {
           getKeepAliveIntervalMs: () => {
@@ -1684,6 +1697,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       return {
         success: true,
         data: result.data,
+        ...metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, result.format),
       };
     } catch (error) {
       return { success: false, error: `${error}` };

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -454,6 +454,54 @@ describe("DeviceDataStreamSocketServer", () => {
     });
   });
 
+  describe("screenshot updates", () => {
+    it("includes optional screenshot metadata when pushing updates", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+
+      server.pushScreenshotUpdate(
+        "device-1",
+        "png-frame",
+        1080,
+        2340,
+        {
+          screenshotMimeType: "image/png",
+          screenshotFormat: "png",
+          screenshotCaptureSource: "android_adb_screencap",
+          screenshotFallback: true,
+          screenshotFallbackReason: "websocket_unavailable",
+          checksum: "internal-checksum",
+        } as any
+      );
+
+      const msgs = socket.getWrittenMessages<{
+        type: string;
+        deviceId?: string;
+        screenshotBase64?: string;
+        screenWidth?: number;
+        screenHeight?: number;
+        screenshotMimeType?: string;
+        screenshotFormat?: string;
+        screenshotCaptureSource?: string;
+        screenshotFallback?: boolean;
+        screenshotFallbackReason?: string;
+      }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]).toMatchObject({
+        type: "screenshot_update",
+        deviceId: "device-1",
+        screenshotBase64: "png-frame",
+        screenWidth: 1080,
+        screenHeight: 2340,
+        screenshotMimeType: "image/png",
+        screenshotFormat: "png",
+        screenshotCaptureSource: "android_adb_screencap",
+        screenshotFallback: true,
+        screenshotFallbackReason: "websocket_unavailable",
+      });
+      expect(msgs[0]).not.toHaveProperty("checksum");
+    });
+  });
+
   describe("hasSubscriberForDevice", () => {
     it("returns false when there are no subscribers", () => {
       expect(server.hasSubscriberForDevice("device-1")).toBe(false);

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -9,8 +9,8 @@ import type { ViewHierarchyResult } from "../../src/models";
 import type {
   AccessibilityHierarchy,
   AccessibilityHierarchyResponse,
-  ScreenshotResult,
 } from "../../src/features/observe/android";
+import type { ScreenshotCaptureResult } from "../../src/features/observe/ScreenshotBackoffScheduler";
 import type {
   CtrlProxyHierarchy,
   CtrlProxyHierarchyResponse,
@@ -57,14 +57,21 @@ class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
     skipWaitForFresh?: boolean;
   }> = [];
   readonly suppressedSyncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
-  readonly suppressedScreenshotCalls: Array<{ timeoutMs?: number }> = [];
+  observationScreenshotCallCount = 0;
 
   constructor(
     private readonly connected: boolean,
     private readonly latestHierarchy: AccessibilityHierarchy | null,
     private readonly syncHierarchy: AccessibilityHierarchy | null = latestHierarchy,
     private readonly latestHierarchyFresh: boolean = true,
-    private readonly screenshot: ScreenshotResult = { success: true, data: "android-shot" }
+    private readonly screenshot: ScreenshotCaptureResult = {
+      success: true,
+      data: "android-shot",
+      screenshotMimeType: "image/jpeg",
+      screenshotFormat: "jpeg",
+      screenshotCaptureSource: "android_ctrlproxy_a11y",
+      screenshotFallback: false,
+    }
   ) {}
 
   async ensureConnected(): Promise<boolean> {
@@ -105,8 +112,8 @@ class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
     };
   }
 
-  async requestScreenshotWithoutObservationStreamPush(timeoutMs?: number): Promise<ScreenshotResult> {
-    this.suppressedScreenshotCalls.push({ timeoutMs });
+  async captureScreenshotForObservationStream(): Promise<ScreenshotCaptureResult> {
+    this.observationScreenshotCallCount += 1;
     return this.screenshot;
   }
 }
@@ -120,7 +127,7 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
     private readonly connected: boolean,
     private readonly latestHierarchy: CtrlProxyHierarchy | null,
     private readonly syncHierarchy: CtrlProxyHierarchy | null = latestHierarchy,
-    private readonly screenshot: CtrlProxyScreenshotResult = { success: true, data: "ios-shot" },
+    private readonly screenshot: CtrlProxyScreenshotResult = { success: true, data: "ios-shot", format: "png" },
     private readonly latestHierarchyFresh: boolean = true
   ) {}
 
@@ -238,7 +245,56 @@ describe("pushInitialObservationFramesForSubscriber", () => {
       { waitForFresh: false, timeout: 3000, skipWaitForFresh: true },
     ]);
     expect(androidClient.suppressedSyncHierarchyCalls).toHaveLength(0);
-    expect(androidClient.suppressedScreenshotCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(androidClient.observationScreenshotCallCount).toBe(1);
+  });
+
+  it("pushes Android initial ADB fallback screenshots with fallback metadata", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const androidClient = new FakeAndroidInitialFrameClient(
+      true,
+      {
+        updatedAt: 123,
+        packageName: "com.example",
+        screenWidth: 1440,
+        screenHeight: 3120,
+        hierarchy: { text: "Home", bounds: { left: 0, top: 0, right: 1440, bottom: 3120 } },
+      },
+      undefined,
+      true,
+      {
+        success: true,
+        data: "android-adb-shot",
+        screenshotMimeType: "image/png",
+        screenshotFormat: "png",
+        screenshotCaptureSource: "android_adb_screencap",
+        screenshotFallback: true,
+        screenshotFallbackReason: "websocket_unavailable",
+      }
+    );
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(streamServer.screenshotUpdates).toEqual([
+      {
+        deviceId: androidDevice.id,
+        screenshotBase64: "android-adb-shot",
+        screenWidth: 1440,
+        screenHeight: 3120,
+        metadata: {
+          screenshotMimeType: "image/png",
+          screenshotFormat: "png",
+          screenshotCaptureSource: "android_adb_screencap",
+          screenshotFallback: true,
+          screenshotFallbackReason: "websocket_unavailable",
+        },
+      },
+    ]);
   });
 
   it("captures Android hierarchy without an automatic stream push when the initial cache is empty", async () => {
@@ -267,7 +323,7 @@ describe("pushInitialObservationFramesForSubscriber", () => {
       { waitForFresh: false, timeout: 3000, skipWaitForFresh: true },
     ]);
     expect(androidClient.suppressedSyncHierarchyCalls).toEqual([{ timeoutMs: 3000 }]);
-    expect(androidClient.suppressedScreenshotCalls).toEqual([{ timeoutMs: 3000 }]);
+    expect(androidClient.observationScreenshotCallCount).toBe(1);
     expect(streamServer.hierarchyUpdates[0].hierarchy.updatedAt).toBe(789);
     expect(streamServer.screenshotUpdates[0]).toMatchObject({
       deviceId: androidDevice.id,

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -19,12 +19,7 @@ import type {
 
 class FakeObservationStreamServer {
   readonly hierarchyUpdates: Array<{ deviceId: string; hierarchy: ViewHierarchyResult }> = [];
-  readonly screenshotUpdates: Array<{
-    deviceId: string;
-    screenshotBase64: string;
-    screenWidth: number;
-    screenHeight: number;
-  }> = [];
+  readonly screenshotUpdates: ScreenshotUpdate[] = [];
 
   pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult): void {
     this.hierarchyUpdates.push({ deviceId, hierarchy });
@@ -34,10 +29,25 @@ class FakeObservationStreamServer {
     deviceId: string,
     screenshotBase64: string,
     screenWidth: number,
-    screenHeight: number
+    screenHeight: number,
+    metadata?: Record<string, unknown>
   ): void {
-    this.screenshotUpdates.push({ deviceId, screenshotBase64, screenWidth, screenHeight });
+    this.screenshotUpdates.push({
+      deviceId,
+      screenshotBase64,
+      screenWidth,
+      screenHeight,
+      ...(metadata === undefined ? {} : { metadata }),
+    });
   }
+}
+
+interface ScreenshotUpdate {
+  deviceId: string;
+  screenshotBase64: string;
+  screenWidth: number;
+  screenHeight: number;
+  metadata?: Record<string, unknown>;
 }
 
 class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
@@ -216,6 +226,12 @@ describe("pushInitialObservationFramesForSubscriber", () => {
         screenshotBase64: "android-shot",
         screenWidth: 1440,
         screenHeight: 3120,
+        metadata: {
+          screenshotMimeType: "image/jpeg",
+          screenshotFormat: "jpeg",
+          screenshotCaptureSource: "android_ctrlproxy_a11y",
+          screenshotFallback: false,
+        },
       },
     ]);
     expect(androidClient.latestHierarchyCalls).toEqual([
@@ -322,6 +338,12 @@ describe("pushInitialObservationFramesForSubscriber", () => {
         screenshotBase64: "ios-shot",
         screenWidth: 1170,
         screenHeight: 2532,
+        metadata: {
+          screenshotMimeType: "image/png",
+          screenshotFormat: "png",
+          screenshotCaptureSource: "ios_ctrlproxy",
+          screenshotFallback: false,
+        },
       },
     ]);
     expect(iosClient.syncHierarchyCalls).toHaveLength(0);

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -103,6 +103,7 @@ describe("PressButton", () => {
       name: "Pixel"
     };
 
+    const fakeTimer = new FakeTimer();
     const capturedTimeouts: (number | undefined)[] = [];
     const fakeAdb = {
       executeCommand: async (_command: string, timeoutMs?: number) => {
@@ -113,6 +114,7 @@ describe("PressButton", () => {
 
     // "menu" is not a global-action button, so it goes straight to the ADB keyevent path.
     const pressButton = new PressButton(androidDevice, fakeAdb);
+    (pressButton as any).timer = fakeTimer;
     const result = await pressButton.press("menu", 500);
 
     expect(result.success).toBe(true);

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -20,7 +20,11 @@ import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
 import type { HierarchySyncDiagnostics } from "../../../src/features/observe/android/types";
 import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
 import { logger } from "../../../src/utils/logger";
-import { stopDeviceDataStreamSocketServer } from "../../../src/daemon/deviceDataStreamSocketServer";
+import {
+  startDeviceDataStreamSocketServer,
+  stopDeviceDataStreamSocketServer,
+} from "../../../src/daemon/deviceDataStreamSocketServer";
+import { FakeSocket } from "../../fakes/FakeNetServer";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -141,6 +145,22 @@ describe("AndroidCtrlProxyClient", function() {
     }
   };
 
+  const startStreamServerWithScreenshotSubscriber = async (): Promise<void> => {
+    await stopDeviceDataStreamSocketServer();
+    const server = await startDeviceDataStreamSocketServer(fakeTimer);
+    (server as any).subscribers.set("screenshot-metadata-test", {
+      socket: new FakeSocket() as any,
+      subscriptionId: "screenshot-metadata-test",
+      lastActivity: fakeTimer.now(),
+      filter: {
+        deviceId: testDevice.deviceId,
+        screenshotIntervalMs: null,
+      },
+      backfilling: false,
+      drainPending: false,
+    });
+  };
+
   test("reports ADB screencap fallback screenshots as PNG fallback with reason", async () => {
     fakeAdb.setCommandResponse("screencap -p", {
       stdout: "png-base64\n",
@@ -157,6 +177,65 @@ describe("AndroidCtrlProxyClient", function() {
       screenshotCaptureSource: "android_adb_screencap",
       screenshotFallback: true,
       screenshotFallbackReason: "websocket_unavailable",
+    });
+  });
+
+  test("reports websocket-unavailable backoff captures as ADB PNG fallback", async () => {
+    await startStreamServerWithScreenshotSubscriber();
+    fakeAdb.setCommandResponse("screencap -p", {
+      stdout: "png-base64\n",
+      stderr: "",
+    });
+
+    const result = await (accessibilityServiceClient as any).captureScreenshotForBackoff();
+
+    expect(result).toMatchObject({
+      success: true,
+      data: "png-base64",
+      screenshotMimeType: "image/png",
+      screenshotFormat: "png",
+      screenshotCaptureSource: "android_adb_screencap",
+      screenshotFallback: true,
+      screenshotFallbackReason: "websocket_unavailable",
+    });
+  });
+
+  test("reports CtrlProxy backoff captures as JPEG non-fallback", async () => {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    const { factory, getSocket } = createCapturingWebSocketFactory(fakeTimer);
+    accessibilityServiceClient = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      factory,
+      fakeTimer
+    );
+    await startStreamServerWithScreenshotSubscriber();
+
+    await accessibilityServiceClient.ensureConnected();
+    const socket = await waitForSocket(getSocket) as CapturingWebSocket | null;
+    await waitForSocketOpen(socket);
+
+    const capturePromise = (accessibilityServiceClient as any).captureScreenshotForBackoff();
+    await waitForSentMessages(socket);
+    const request = JSON.parse(socket!.sentMessages.at(-1)!);
+    socket!.emit("message", JSON.stringify({
+      type: "screenshot",
+      requestId: request.requestId,
+      data: "jpeg-base64",
+      format: "jpeg",
+      timestamp: 123,
+    }));
+
+    const result = await capturePromise;
+
+    expect(result).toMatchObject({
+      success: true,
+      data: "jpeg-base64",
+      screenshotMimeType: "image/jpeg",
+      screenshotFormat: "jpeg",
+      screenshotCaptureSource: "android_ctrlproxy_a11y",
+      screenshotFallback: false,
     });
   });
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -145,20 +145,106 @@ describe("AndroidCtrlProxyClient", function() {
     }
   };
 
-  const startStreamServerWithScreenshotSubscriber = async (): Promise<void> => {
+  interface ScreenshotUpdateMessage {
+    type: string;
+    deviceId?: string;
+    screenshotBase64?: string;
+    screenshotMimeType?: string;
+    screenshotFormat?: string;
+    screenshotCaptureSource?: string;
+    screenshotFallback?: boolean;
+    screenshotFallbackReason?: string | null;
+  }
+
+  const startStreamServerWithScreenshotSubscriber = async (): Promise<FakeSocket> => {
     await stopDeviceDataStreamSocketServer();
     const server = await startDeviceDataStreamSocketServer(fakeTimer);
-    (server as any).subscribers.set("screenshot-metadata-test", {
-      socket: new FakeSocket() as any,
-      subscriptionId: "screenshot-metadata-test",
-      lastActivity: fakeTimer.now(),
-      filter: {
+    const socket = new FakeSocket();
+    await (server as any).processLine(
+      socket as any,
+      JSON.stringify({
+        id: "subscribe-screenshot-metadata-test",
+        command: "subscribe",
         deviceId: testDevice.deviceId,
-        screenshotIntervalMs: null,
-      },
-      backfilling: false,
-      drainPending: false,
+        screenshotIntervalMs: 250,
+      })
+    );
+    socket.reset();
+    return socket;
+  };
+
+  const getScreenshotUpdates = (socket: FakeSocket): ScreenshotUpdateMessage[] => {
+    return socket.getWrittenMessages<ScreenshotUpdateMessage>()
+      .filter(message => message.type === "screenshot_update");
+  };
+
+  const expectSingleScreenshotUpdate = (
+    socket: FakeSocket,
+    expected: Partial<ScreenshotUpdateMessage>
+  ): void => {
+    expect(getScreenshotUpdates(socket)).toEqual([expect.objectContaining(expected)]);
+  };
+
+  const setAdbPngScreenshotResponse = (): void => {
+    fakeAdb.setCommandResponse("screencap -p", {
+      stdout: "png-base64\n",
+      stderr: "",
     });
+  };
+
+  const startScreenshotBackoffAndFlush = async (): Promise<void> => {
+    (accessibilityServiceClient as any).startScreenshotBackoff();
+    await fakeTimer.advanceTimersByTimeAsync(0);
+    await flushPromises();
+  };
+
+  const startScreenshotBackoffAndReadRequest = async (
+    ctrlProxySocket: CapturingWebSocket
+  ): Promise<{ requestId: string }> => {
+    (accessibilityServiceClient as any).startScreenshotBackoff();
+    await fakeTimer.advanceTimersByTimeAsync(0);
+    await waitForSentMessages(ctrlProxySocket);
+    return JSON.parse(ctrlProxySocket.sentMessages.at(-1)!) as { requestId: string };
+  };
+
+  const recreateClientForManualTimerTest = async (): Promise<void> => {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeTimer = new FakeTimer();
+    accessibilityServiceClient = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(fakeTimer),
+      fakeTimer
+    );
+    accessibilityServiceClient.invalidateCache();
+  };
+
+  const startCapturingBackoffStreamTest = async (): Promise<{
+    streamSocket: FakeSocket;
+    ctrlProxySocket: CapturingWebSocket;
+  }> => {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    fakeTimer = new FakeTimer();
+    const { factory, getSocket } = createCapturingWebSocketFactory(fakeTimer);
+    accessibilityServiceClient = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      factory,
+      fakeTimer
+    );
+    accessibilityServiceClient.invalidateCache();
+    const streamSocket = await startStreamServerWithScreenshotSubscriber();
+
+    await accessibilityServiceClient.ensureConnected();
+    const ctrlProxySocket = await waitForSocket(getSocket) as CapturingWebSocket | null;
+    await waitForSocketOpen(ctrlProxySocket);
+    if (!ctrlProxySocket) {
+      throw new Error("Expected capturing CtrlProxy socket");
+    }
+
+    return { streamSocket, ctrlProxySocket };
   };
 
   test("reports ADB screencap fallback screenshots as PNG fallback with reason", async () => {
@@ -181,17 +267,14 @@ describe("AndroidCtrlProxyClient", function() {
   });
 
   test("reports websocket-unavailable backoff captures as ADB PNG fallback", async () => {
-    await startStreamServerWithScreenshotSubscriber();
-    fakeAdb.setCommandResponse("screencap -p", {
-      stdout: "png-base64\n",
-      stderr: "",
-    });
+    await recreateClientForManualTimerTest();
+    const streamSocket = await startStreamServerWithScreenshotSubscriber();
+    setAdbPngScreenshotResponse();
 
-    const result = await (accessibilityServiceClient as any).captureScreenshotForBackoff();
+    await startScreenshotBackoffAndFlush();
 
-    expect(result).toMatchObject({
-      success: true,
-      data: "png-base64",
+    expectSingleScreenshotUpdate(streamSocket, {
+      screenshotBase64: "png-base64",
       screenshotMimeType: "image/png",
       screenshotFormat: "png",
       screenshotCaptureSource: "android_adb_screencap",
@@ -201,41 +284,105 @@ describe("AndroidCtrlProxyClient", function() {
   });
 
   test("reports CtrlProxy backoff captures as JPEG non-fallback", async () => {
-    await accessibilityServiceClient.close();
-    AndroidCtrlProxyClient.resetInstances();
-    const { factory, getSocket } = createCapturingWebSocketFactory(fakeTimer);
-    accessibilityServiceClient = AndroidCtrlProxyClient.createForTesting(
-      testDevice,
-      fakeAdb,
-      factory,
-      fakeTimer
-    );
-    await startStreamServerWithScreenshotSubscriber();
+    const { streamSocket, ctrlProxySocket } = await startCapturingBackoffStreamTest();
 
-    await accessibilityServiceClient.ensureConnected();
-    const socket = await waitForSocket(getSocket) as CapturingWebSocket | null;
-    await waitForSocketOpen(socket);
-
-    const capturePromise = (accessibilityServiceClient as any).captureScreenshotForBackoff();
-    await waitForSentMessages(socket);
-    const request = JSON.parse(socket!.sentMessages.at(-1)!);
-    socket!.emit("message", JSON.stringify({
+    const request = await startScreenshotBackoffAndReadRequest(ctrlProxySocket);
+    ctrlProxySocket.emit("message", JSON.stringify({
       type: "screenshot",
       requestId: request.requestId,
       data: "jpeg-base64",
       format: "jpeg",
       timestamp: 123,
     }));
+    await flushPromises();
 
-    const result = await capturePromise;
-
-    expect(result).toMatchObject({
-      success: true,
-      data: "jpeg-base64",
+    expectSingleScreenshotUpdate(streamSocket, {
+      screenshotBase64: "jpeg-base64",
       screenshotMimeType: "image/jpeg",
       screenshotFormat: "jpeg",
       screenshotCaptureSource: "android_ctrlproxy_a11y",
       screenshotFallback: false,
+    });
+  });
+
+  test("reports unsupported a11y screenshots as emitted ADB PNG fallback frames", async () => {
+    await recreateClientForManualTimerTest();
+    const streamSocket = await startStreamServerWithScreenshotSubscriber();
+    setAdbPngScreenshotResponse();
+    (accessibilityServiceClient as any).a11yScreenshotSupported = false;
+
+    await startScreenshotBackoffAndFlush();
+
+    expectSingleScreenshotUpdate(streamSocket, {
+      screenshotBase64: "png-base64",
+      screenshotMimeType: "image/png",
+      screenshotFormat: "png",
+      screenshotCaptureSource: "android_adb_screencap",
+      screenshotFallback: true,
+      screenshotFallbackReason: "a11y_screenshot_unsupported",
+    });
+  });
+
+  test("reports CtrlProxy screenshot errors as emitted ADB PNG fallback frames", async () => {
+    const { streamSocket, ctrlProxySocket } = await startCapturingBackoffStreamTest();
+    setAdbPngScreenshotResponse();
+
+    const request = await startScreenshotBackoffAndReadRequest(ctrlProxySocket);
+    ctrlProxySocket.emit("message", JSON.stringify({
+      type: "screenshot_error",
+      requestId: request.requestId,
+      error: "Runner failed to capture screenshot",
+    }));
+    await flushPromises();
+
+    expectSingleScreenshotUpdate(streamSocket, {
+      screenshotBase64: "png-base64",
+      screenshotMimeType: "image/png",
+      screenshotFormat: "png",
+      screenshotCaptureSource: "android_adb_screencap",
+      screenshotFallback: true,
+      screenshotFallbackReason: "ctrlproxy_failed",
+    });
+  });
+
+  test("reports CtrlProxy screenshot timeout errors as emitted ADB PNG fallback frames", async () => {
+    const { streamSocket, ctrlProxySocket } = await startCapturingBackoffStreamTest();
+    setAdbPngScreenshotResponse();
+
+    const request = await startScreenshotBackoffAndReadRequest(ctrlProxySocket);
+    ctrlProxySocket.emit("message", JSON.stringify({
+      type: "screenshot_error",
+      requestId: request.requestId,
+      error: "Screenshot timeout",
+    }));
+    await flushPromises();
+
+    expectSingleScreenshotUpdate(streamSocket, {
+      screenshotBase64: "png-base64",
+      screenshotMimeType: "image/png",
+      screenshotFormat: "png",
+      screenshotCaptureSource: "android_adb_screencap",
+      screenshotFallback: true,
+      screenshotFallbackReason: "ctrlproxy_timeout",
+    });
+  });
+
+  test("reports CtrlProxy screenshot exceptions as emitted ADB PNG fallback frames", async () => {
+    const { streamSocket, ctrlProxySocket } = await startCapturingBackoffStreamTest();
+    setAdbPngScreenshotResponse();
+    ctrlProxySocket.send = () => {
+      throw new Error("boom");
+    };
+
+    await startScreenshotBackoffAndFlush();
+
+    expectSingleScreenshotUpdate(streamSocket, {
+      screenshotBase64: "png-base64",
+      screenshotMimeType: "image/png",
+      screenshotFormat: "png",
+      screenshotCaptureSource: "android_adb_screencap",
+      screenshotFallback: true,
+      screenshotFallbackReason: "ctrlproxy_exception",
     });
   });
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -141,6 +141,25 @@ describe("AndroidCtrlProxyClient", function() {
     }
   };
 
+  test("reports ADB screencap fallback screenshots as PNG fallback with reason", async () => {
+    fakeAdb.setCommandResponse("screencap -p", {
+      stdout: "png-base64\n",
+      stderr: "",
+    });
+
+    const result = await (accessibilityServiceClient as any).captureScreenshotViaAdb("websocket_unavailable");
+
+    expect(result).toMatchObject({
+      success: true,
+      data: "png-base64",
+      screenshotMimeType: "image/png",
+      screenshotFormat: "png",
+      screenshotCaptureSource: "android_adb_screencap",
+      screenshotFallback: true,
+      screenshotFallbackReason: "websocket_unavailable",
+    });
+  });
+
   test("setupPortForwarding reallocates when the current local port becomes busy before adb forward", async function() {
     await accessibilityServiceClient.close();
     AndroidCtrlProxyClient.resetInstances();

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -35,7 +35,7 @@ describe("DefaultScreenshotBackoffScheduler", () => {
   let emittedScreenshots: string[];
   let captureCount: number;
   let captureCallback: () => Promise<ScreenshotCaptureResult>;
-  let emitCallback: (data: string) => void;
+  let emitCallback: (result: ScreenshotCaptureResult) => void;
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
@@ -51,12 +51,49 @@ describe("DefaultScreenshotBackoffScheduler", () => {
       return { success: true, data };
     };
 
-    emitCallback = (data: string) => {
-      emittedScreenshots.push(data);
+    emitCallback = (result: ScreenshotCaptureResult) => {
+      if (result.data) {
+        emittedScreenshots.push(result.data);
+      }
     };
   });
 
   describe("startBackoffSequence", () => {
+    it("emits the full capture result so screenshot metadata is preserved", async () => {
+      const emittedResults: ScreenshotCaptureResult[] = [];
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        async () => ({
+          success: true,
+          data: "jpeg-frame",
+          checksum: "jpeg-checksum",
+          screenshotMimeType: "image/jpeg",
+          screenshotFormat: "jpeg",
+          screenshotCaptureSource: "android_ctrlproxy_a11y",
+          screenshotFallback: false,
+        }),
+        result => {
+          emittedResults.push(result);
+        },
+        { intervals: [0], keepAliveIntervalMs: null },
+        fakeTimer
+      );
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+
+      expect(emittedResults).toEqual([
+        {
+          success: true,
+          data: "jpeg-frame",
+          checksum: "jpeg-checksum",
+          screenshotMimeType: "image/jpeg",
+          screenshotFormat: "jpeg",
+          screenshotCaptureSource: "android_ctrlproxy_a11y",
+          screenshotFallback: false,
+        },
+      ]);
+    });
+
     it("schedules captures at default intervals", () => {
       const scheduler = new DefaultScreenshotBackoffScheduler(
         captureCallback,

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -363,6 +363,56 @@ describe("DefaultScreenshotBackoffScheduler", () => {
       expect(emittedScreenshots[0]).toBe("same-data");
     });
 
+    it("emits when screenshot metadata changes even if image bytes are unchanged", async () => {
+      const emittedResults: ScreenshotCaptureResult[] = [];
+      const captures: ScreenshotCaptureResult[] = [
+        {
+          success: true,
+          data: "same-data",
+          screenshotMimeType: "image/jpeg",
+          screenshotFormat: "jpeg",
+          screenshotCaptureSource: "android_ctrlproxy_a11y",
+          screenshotFallback: false,
+        },
+        {
+          success: true,
+          data: "same-data",
+          screenshotMimeType: "image/png",
+          screenshotFormat: "png",
+          screenshotCaptureSource: "android_adb_screencap",
+          screenshotFallback: true,
+          screenshotFallbackReason: "websocket_unavailable",
+        },
+        {
+          success: true,
+          data: "same-data",
+          screenshotMimeType: "image/png",
+          screenshotFormat: "png",
+          screenshotCaptureSource: "android_adb_screencap",
+          screenshotFallback: true,
+          screenshotFallbackReason: "websocket_unavailable",
+        },
+      ];
+      let captureIndex = 0;
+      captureCallback = async () => captures[captureIndex++]!;
+
+      const scheduler = new DefaultScreenshotBackoffScheduler(
+        captureCallback,
+        result => {
+          emittedResults.push(result);
+        },
+        { intervals: [0, 100, 200], keepAliveIntervalMs: null },
+        fakeTimer
+      );
+
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(0);
+      await fakeTimer.advanceTimersByTimeAsync(100);
+      await fakeTimer.advanceTimersByTimeAsync(100);
+
+      expect(emittedResults).toEqual([captures[0], captures[1]]);
+    });
+
     it("emits when screenshot changes", async () => {
       let screenshotIndex = 0;
       const screenshots = ["frame1", "frame1", "frame2", "frame2", "frame3"];

--- a/test/features/observe/ScreenshotMetadata.test.ts
+++ b/test/features/observe/ScreenshotMetadata.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ANDROID_CTRLPROXY_SCREENSHOT_METADATA,
+  metadataForScreenshotFormat,
+} from "../../../src/features/observe/ScreenshotMetadata";
+
+describe("metadataForScreenshotFormat", () => {
+  test("sets MIME type and format for known screenshot formats", () => {
+    expect(metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, "png")).toEqual({
+      screenshotMimeType: "image/png",
+      screenshotFormat: "png",
+      screenshotCaptureSource: "android_ctrlproxy_a11y",
+      screenshotFallback: false,
+    });
+  });
+
+  test("does not label unknown formats as the platform default", () => {
+    expect(metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, "webp")).toEqual({
+      screenshotCaptureSource: "android_ctrlproxy_a11y",
+      screenshotFallback: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional screenshot metadata to observation stream `screenshot_update` frames so clients can distinguish image format, capture source, and Android fallback frames without inspecting bytes.

## Linked Issue

Closes #3385

## Bug / Regression Context

- **Prior attempts:** None noted in the issue.
- **Observed symptom:** Stream clients received screenshot bytes and dimensions but not MIME/format/source/fallback context.
- **Repro steps / conditions:** Subscribe to observation stream screenshots on Android/iOS and compare CtrlProxy versus ADB fallback frames.

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] `bun test test/features/observe/ScreenshotBackoffScheduler.test.ts test/daemon/deviceDataStreamSocketServer.test.ts test/daemon/observationInitialFrame.test.ts test/features/observe/CtrlProxyClient.test.ts`
- [x] `./gradlew :desktop-core:test --tests dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClientTest`
- [x] New code uses existing fakes/FakeTimer patterns; metadata unit tests are targeted and fast.

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Follow-ups

- [ ] Follow-up issues filed for gaps not addressed here: N/A

Made with [Cursor](https://cursor.com)