### PR TITLE
feat(android): add typed daemon input client helpers

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -72,41 +72,41 @@ interface AutoMobileClient {
   fun updateService(deviceId: String, platform: String): UpdateServiceResult
 
   fun inputTap(
-    x: Int,
-    y: Int,
+    x: Double,
+    y: Double,
     platform: String = "android",
     deviceId: String? = null,
     duration: Int? = null,
-  ): InputActionResult = unsupportedInputAction("input/tap")
+  ): InputActionResult
 
   fun inputSwipe(
-    startX: Int,
-    startY: Int,
-    endX: Int,
-    endY: Int,
+    startX: Double,
+    startY: Double,
+    endX: Double,
+    endY: Double,
     platform: String = "android",
     deviceId: String? = null,
     durationMs: Int? = null,
-  ): InputActionResult = unsupportedInputAction("input/swipe")
+  ): InputActionResult
 
   fun inputPressButton(
     button: String,
     platform: String = "android",
     deviceId: String? = null,
-  ): InputActionResult = unsupportedInputAction("input/pressButton")
+  ): InputActionResult
 
   fun inputTypeText(
     text: String,
     platform: String = "android",
     deviceId: String? = null,
     submit: Boolean? = null,
-  ): InputActionResult = unsupportedInputAction("input/typeText")
+  ): InputActionResult
 
   fun inputKey(
     key: String,
     platform: String = "android",
     deviceId: String? = null,
-  ): InputActionResult = unsupportedInputAction("input/key")
+  ): InputActionResult
 
   fun setKeyValue(
     deviceId: String,
@@ -133,13 +133,6 @@ interface AutoMobileClient {
   fun callTool(name: String, arguments: JsonObject): JsonElement
 
   fun close() {}
-
-  private fun unsupportedInputAction(action: String): InputActionResult =
-    InputActionResult(
-      action = action,
-      success = false,
-      error = "$transportName does not support direct daemon input helpers",
-    )
 }
 
 @Serializable
@@ -202,16 +195,16 @@ data class ObserveScreenSize(
 
 @Serializable
 data class InputCoordinates(
-  val x: Int,
-  val y: Int,
+  val x: Double,
+  val y: Double,
 )
 
 @Serializable
 data class InputActionResult(
-  val action: String? = null,
+  val action: String,
+  val success: Boolean,
   val platform: String? = null,
   val deviceId: String? = null,
-  val success: Boolean = true,
   val error: String? = null,
   val coordinates: InputCoordinates? = null,
   val start: InputCoordinates? = null,
@@ -222,6 +215,13 @@ data class InputActionResult(
   val submitted: Boolean? = null,
   val key: String? = null,
 )
+
+internal fun unsupportedInputAction(transportName: String, action: String): InputActionResult =
+  InputActionResult(
+    action = action,
+    success = false,
+    error = "$transportName does not support direct daemon input helpers",
+  )
 
 open class McpConnectionException(message: String, cause: Throwable? = null) :
   Exception(message, cause)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -71,6 +71,43 @@ interface AutoMobileClient {
 
   fun updateService(deviceId: String, platform: String): UpdateServiceResult
 
+  fun inputTap(
+    x: Int,
+    y: Int,
+    platform: String = "android",
+    deviceId: String? = null,
+    duration: Int? = null,
+  ): InputActionResult = unsupportedInputAction("input/tap")
+
+  fun inputSwipe(
+    startX: Int,
+    startY: Int,
+    endX: Int,
+    endY: Int,
+    platform: String = "android",
+    deviceId: String? = null,
+    durationMs: Int? = null,
+  ): InputActionResult = unsupportedInputAction("input/swipe")
+
+  fun inputPressButton(
+    button: String,
+    platform: String = "android",
+    deviceId: String? = null,
+  ): InputActionResult = unsupportedInputAction("input/pressButton")
+
+  fun inputTypeText(
+    text: String,
+    platform: String = "android",
+    deviceId: String? = null,
+    submit: Boolean? = null,
+  ): InputActionResult = unsupportedInputAction("input/typeText")
+
+  fun inputKey(
+    key: String,
+    platform: String = "android",
+    deviceId: String? = null,
+  ): InputActionResult = unsupportedInputAction("input/key")
+
   fun setKeyValue(
     deviceId: String,
     appId: String,
@@ -96,6 +133,13 @@ interface AutoMobileClient {
   fun callTool(name: String, arguments: JsonObject): JsonElement
 
   fun close() {}
+
+  private fun unsupportedInputAction(action: String): InputActionResult =
+    InputActionResult(
+      action = action,
+      success = false,
+      error = "$transportName does not support direct daemon input helpers",
+    )
 }
 
 @Serializable
@@ -154,6 +198,29 @@ data class ObserveResult(
 data class ObserveScreenSize(
   val width: Int? = null,
   val height: Int? = null,
+)
+
+@Serializable
+data class InputCoordinates(
+  val x: Int,
+  val y: Int,
+)
+
+@Serializable
+data class InputActionResult(
+  val action: String? = null,
+  val platform: String? = null,
+  val deviceId: String? = null,
+  val success: Boolean = true,
+  val error: String? = null,
+  val coordinates: InputCoordinates? = null,
+  val start: InputCoordinates? = null,
+  val end: InputCoordinates? = null,
+  val durationMs: Int? = null,
+  val button: String? = null,
+  val textLength: Int? = null,
+  val submitted: Boolean? = null,
+  val key: String? = null,
 )
 
 open class McpConnectionException(message: String, cause: Throwable? = null) :

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -266,6 +267,95 @@ class McpDaemonClient(
     return json.decodeFromJsonElement(UpdateServiceResult.serializer(), response.result!!)
   }
 
+  override fun inputTap(
+    x: Int,
+    y: Int,
+    platform: String,
+    deviceId: String?,
+    duration: Int?,
+  ): InputActionResult {
+    return sendInputRequest(
+      "input/tap",
+      buildJsonObject {
+        put("platform", JsonPrimitive(platform))
+        putOptionalString("deviceId", deviceId)
+        put("x", JsonPrimitive(x))
+        put("y", JsonPrimitive(y))
+        putOptionalInt("duration", duration)
+      },
+    )
+  }
+
+  override fun inputSwipe(
+    startX: Int,
+    startY: Int,
+    endX: Int,
+    endY: Int,
+    platform: String,
+    deviceId: String?,
+    durationMs: Int?,
+  ): InputActionResult {
+    return sendInputRequest(
+      "input/swipe",
+      buildJsonObject {
+        put("platform", JsonPrimitive(platform))
+        putOptionalString("deviceId", deviceId)
+        put("startX", JsonPrimitive(startX))
+        put("startY", JsonPrimitive(startY))
+        put("endX", JsonPrimitive(endX))
+        put("endY", JsonPrimitive(endY))
+        putOptionalInt("durationMs", durationMs)
+      },
+    )
+  }
+
+  override fun inputPressButton(
+    button: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult {
+    return sendInputRequest(
+      "input/pressButton",
+      buildJsonObject {
+        put("platform", JsonPrimitive(platform))
+        putOptionalString("deviceId", deviceId)
+        put("button", JsonPrimitive(button))
+      },
+    )
+  }
+
+  override fun inputTypeText(
+    text: String,
+    platform: String,
+    deviceId: String?,
+    submit: Boolean?,
+  ): InputActionResult {
+    return sendInputRequest(
+      "input/typeText",
+      buildJsonObject {
+        put("platform", JsonPrimitive(platform))
+        putOptionalString("deviceId", deviceId)
+        put("text", JsonPrimitive(text))
+        putOptionalBoolean("submit", submit)
+      },
+    )
+  }
+
+  override fun inputKey(
+    key: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult {
+    return sendInputRequest(
+      "input/key",
+      buildJsonObject {
+        put("platform", JsonPrimitive(platform))
+        putOptionalString("deviceId", deviceId)
+        put("key", JsonPrimitive(key))
+      },
+    )
+  }
+
   override fun setKeyValue(
     deviceId: String,
     appId: String,
@@ -353,6 +443,21 @@ class McpDaemonClient(
     return response.result ?: JsonObject(emptyMap())
   }
 
+  private fun sendInputRequest(method: String, params: JsonObject): InputActionResult {
+    val response = sendRequest(method, params)
+    if (!response.success) {
+      return InputActionResult(action = method, success = false, error = response.error)
+    }
+    val result =
+      response.result
+        ?: return InputActionResult(
+          action = method,
+          success = false,
+          error = "Daemon response missing result",
+        )
+    return json.decodeFromJsonElement(InputActionResult.serializer(), result)
+  }
+
   private fun sendRequest(
     method: String,
     params: JsonObject = JsonObject(emptyMap()),
@@ -398,6 +503,33 @@ class McpDaemonClient(
     }
     if (response.result == null) {
       throw DaemonUnavailableException("Daemon response missing result")
+    }
+  }
+
+  private fun JsonObjectBuilder.putOptionalString(
+    key: String,
+    value: String?,
+  ) {
+    if (value != null) {
+      put(key, JsonPrimitive(value))
+    }
+  }
+
+  private fun JsonObjectBuilder.putOptionalInt(
+    key: String,
+    value: Int?,
+  ) {
+    if (value != null) {
+      put(key, JsonPrimitive(value))
+    }
+  }
+
+  private fun JsonObjectBuilder.putOptionalBoolean(
+    key: String,
+    value: Boolean?,
+  ) {
+    if (value != null) {
+      put(key, JsonPrimitive(value))
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -268,8 +268,8 @@ class McpDaemonClient(
   }
 
   override fun inputTap(
-    x: Int,
-    y: Int,
+    x: Double,
+    y: Double,
     platform: String,
     deviceId: String?,
     duration: Int?,
@@ -287,10 +287,10 @@ class McpDaemonClient(
   }
 
   override fun inputSwipe(
-    startX: Int,
-    startY: Int,
-    endX: Int,
-    endY: Int,
+    startX: Double,
+    startY: Double,
+    endX: Double,
+    endY: Double,
     platform: String,
     deviceId: String?,
     durationMs: Int?,
@@ -455,7 +455,15 @@ class McpDaemonClient(
           success = false,
           error = "Daemon response missing result",
         )
-    return json.decodeFromJsonElement(InputActionResult.serializer(), result)
+    val inputResult = json.decodeFromJsonElement(InputActionResult.serializer(), result)
+    if (inputResult.action != method) {
+      return InputActionResult(
+        action = method,
+        success = false,
+        error = "Daemon response action ${inputResult.action} did not match $method",
+      )
+    }
+    return inputResult
   }
 
   private fun sendRequest(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -356,6 +356,43 @@ class McpHttpClient(
     }
   }
 
+  override fun inputTap(
+    x: Double,
+    y: Double,
+    platform: String,
+    deviceId: String?,
+    duration: Int?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/tap")
+
+  override fun inputSwipe(
+    startX: Double,
+    startY: Double,
+    endX: Double,
+    endY: Double,
+    platform: String,
+    deviceId: String?,
+    durationMs: Int?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/swipe")
+
+  override fun inputPressButton(
+    button: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/pressButton")
+
+  override fun inputTypeText(
+    text: String,
+    platform: String,
+    deviceId: String?,
+    submit: Boolean?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/typeText")
+
+  override fun inputKey(
+    key: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/key")
+
   override fun callTool(name: String, arguments: JsonObject): JsonElement {
     ensureInitialized()
     val response =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -345,6 +345,43 @@ class McpStdioClient(
     }
   }
 
+  override fun inputTap(
+    x: Double,
+    y: Double,
+    platform: String,
+    deviceId: String?,
+    duration: Int?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/tap")
+
+  override fun inputSwipe(
+    startX: Double,
+    startY: Double,
+    endX: Double,
+    endY: Double,
+    platform: String,
+    deviceId: String?,
+    durationMs: Int?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/swipe")
+
+  override fun inputPressButton(
+    button: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/pressButton")
+
+  override fun inputTypeText(
+    text: String,
+    platform: String,
+    deviceId: String?,
+    submit: Boolean?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/typeText")
+
+  override fun inputKey(
+    key: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult = unsupportedInputAction(transportName, "input/key")
+
   override fun callTool(name: String, arguments: JsonObject): JsonElement {
     ensureInitialized()
     val response =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
@@ -129,18 +129,18 @@ class FakeAutoMobileClient : AutoMobileClient {
   )
 
   data class InputTapCall(
-    val x: Int,
-    val y: Int,
+    val x: Double,
+    val y: Double,
     val platform: String,
     val deviceId: String?,
     val duration: Int?,
   )
 
   data class InputSwipeCall(
-    val startX: Int,
-    val startY: Int,
-    val endX: Int,
-    val endY: Int,
+    val startX: Double,
+    val startY: Double,
+    val endX: Double,
+    val endY: Double,
     val platform: String,
     val deviceId: String?,
     val durationMs: Int?,
@@ -292,8 +292,8 @@ class FakeAutoMobileClient : AutoMobileClient {
   }
 
   override fun inputTap(
-    x: Int,
-    y: Int,
+    x: Double,
+    y: Double,
     platform: String,
     deviceId: String?,
     duration: Int?,
@@ -304,10 +304,10 @@ class FakeAutoMobileClient : AutoMobileClient {
   }
 
   override fun inputSwipe(
-    startX: Int,
-    startY: Int,
-    endX: Int,
-    endY: Int,
+    startX: Double,
+    startY: Double,
+    endX: Double,
+    endY: Double,
     platform: String,
     deviceId: String?,
     durationMs: Int?,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
@@ -4,6 +4,7 @@ import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.ClearKeyValueResult
 import dev.jasonpearson.automobile.desktop.core.daemon.ExecutePlanResult
 import dev.jasonpearson.automobile.desktop.core.daemon.FeatureFlagState
+import dev.jasonpearson.automobile.desktop.core.daemon.InputActionResult
 import dev.jasonpearson.automobile.desktop.core.daemon.KillDeviceResult
 import dev.jasonpearson.automobile.desktop.core.daemon.McpResource
 import dev.jasonpearson.automobile.desktop.core.daemon.McpResourceContent
@@ -74,6 +75,14 @@ class FakeAutoMobileClient : AutoMobileClient {
   var killDeviceResult: KillDeviceResult = KillDeviceResult(success = true)
   var getDaemonStatusResult: DaemonStatusResponse = DaemonStatusResponse()
   var updateServiceResult: UpdateServiceResult = UpdateServiceResult(success = true)
+  var inputTapResult: InputActionResult = InputActionResult(action = "input/tap", success = true)
+  var inputSwipeResult: InputActionResult =
+    InputActionResult(action = "input/swipe", success = true)
+  var inputPressButtonResult: InputActionResult =
+    InputActionResult(action = "input/pressButton", success = true)
+  var inputTypeTextResult: InputActionResult =
+    InputActionResult(action = "input/typeText", success = true)
+  var inputKeyResult: InputActionResult = InputActionResult(action = "input/key", success = true)
   var setKeyValueResult: SetKeyValueResult = SetKeyValueResult(success = true)
   var removeKeyValueResult: RemoveKeyValueResult = RemoveKeyValueResult(success = true)
   var clearKeyValueFileResult: ClearKeyValueResult = ClearKeyValueResult(success = true)
@@ -119,9 +128,51 @@ class FakeAutoMobileClient : AutoMobileClient {
     val fileName: String,
   )
 
+  data class InputTapCall(
+    val x: Int,
+    val y: Int,
+    val platform: String,
+    val deviceId: String?,
+    val duration: Int?,
+  )
+
+  data class InputSwipeCall(
+    val startX: Int,
+    val startY: Int,
+    val endX: Int,
+    val endY: Int,
+    val platform: String,
+    val deviceId: String?,
+    val durationMs: Int?,
+  )
+
+  data class InputPressButtonCall(
+    val button: String,
+    val platform: String,
+    val deviceId: String?,
+  )
+
+  data class InputTypeTextCall(
+    val text: String,
+    val platform: String,
+    val deviceId: String?,
+    val submit: Boolean?,
+  )
+
+  data class InputKeyCall(
+    val key: String,
+    val platform: String,
+    val deviceId: String?,
+  )
+
   val setKeyValueCalls = mutableListOf<SetKeyValueCall>()
   val removeKeyValueCalls = mutableListOf<RemoveKeyValueCall>()
   val clearKeyValueFileCalls = mutableListOf<ClearKeyValueFileCall>()
+  val inputTapCalls = mutableListOf<InputTapCall>()
+  val inputSwipeCalls = mutableListOf<InputSwipeCall>()
+  val inputPressButtonCalls = mutableListOf<InputPressButtonCall>()
+  val inputTypeTextCalls = mutableListOf<InputTypeTextCall>()
+  val inputKeyCalls = mutableListOf<InputKeyCall>()
 
   // -- AutoMobileClient implementation --
 
@@ -238,6 +289,63 @@ class FakeAutoMobileClient : AutoMobileClient {
   override fun updateService(deviceId: String, platform: String): UpdateServiceResult {
     calls.add("updateService")
     return updateServiceResult
+  }
+
+  override fun inputTap(
+    x: Int,
+    y: Int,
+    platform: String,
+    deviceId: String?,
+    duration: Int?,
+  ): InputActionResult {
+    calls.add("inputTap")
+    inputTapCalls.add(InputTapCall(x, y, platform, deviceId, duration))
+    return inputTapResult
+  }
+
+  override fun inputSwipe(
+    startX: Int,
+    startY: Int,
+    endX: Int,
+    endY: Int,
+    platform: String,
+    deviceId: String?,
+    durationMs: Int?,
+  ): InputActionResult {
+    calls.add("inputSwipe")
+    inputSwipeCalls.add(InputSwipeCall(startX, startY, endX, endY, platform, deviceId, durationMs))
+    return inputSwipeResult
+  }
+
+  override fun inputPressButton(
+    button: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult {
+    calls.add("inputPressButton")
+    inputPressButtonCalls.add(InputPressButtonCall(button, platform, deviceId))
+    return inputPressButtonResult
+  }
+
+  override fun inputTypeText(
+    text: String,
+    platform: String,
+    deviceId: String?,
+    submit: Boolean?,
+  ): InputActionResult {
+    calls.add("inputTypeText")
+    inputTypeTextCalls.add(InputTypeTextCall(text, platform, deviceId, submit))
+    return inputTypeTextResult
+  }
+
+  override fun inputKey(
+    key: String,
+    platform: String,
+    deviceId: String?,
+  ): InputActionResult {
+    calls.add("inputKey")
+    inputKeyCalls.add(InputKeyCall(key, platform, deviceId))
+    return inputKeyResult
   }
 
   override fun setKeyValue(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -12,6 +12,8 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -31,7 +33,7 @@ class McpDaemonClientInputTest {
         "platform": "android",
         "deviceId": "emulator-5554",
         "success": true,
-        "coordinates": { "x": 240, "y": 640 }
+        "coordinates": { "x": 240.5, "y": 640.25 }
       }
       """
         .trimIndent()
@@ -39,8 +41,8 @@ class McpDaemonClientInputTest {
     val result =
       captureInputRequest(responseResult) { client ->
         client.inputTap(
-          x = 240,
-          y = 640,
+          x = 240.5,
+          y = 640.25,
           platform = "android",
           deviceId = "emulator-5554",
           duration = 50,
@@ -52,14 +54,14 @@ class McpDaemonClientInputTest {
       mapOf(
         "platform" to JsonPrimitive("android"),
         "deviceId" to JsonPrimitive("emulator-5554"),
-        "x" to JsonPrimitive(240),
-        "y" to JsonPrimitive(640),
+        "x" to JsonPrimitive(240.5),
+        "y" to JsonPrimitive(640.25),
         "duration" to JsonPrimitive(50),
       ),
       result.request.params,
     )
     assertEquals(true, result.response.success)
-    assertEquals(InputCoordinates(x = 240, y = 640), result.response.coordinates)
+    assertEquals(InputCoordinates(x = 240.5, y = 640.25), result.response.coordinates)
   }
 
   @Test
@@ -71,8 +73,8 @@ class McpDaemonClientInputTest {
         "platform": "android",
         "deviceId": "emulator-5554",
         "success": true,
-        "start": { "x": 520, "y": 1700 },
-        "end": { "x": 520, "y": 500 },
+        "start": { "x": 520.75, "y": 1700.5 },
+        "end": { "x": 520.25, "y": 500.5 },
         "durationMs": 350
       }
       """
@@ -81,10 +83,10 @@ class McpDaemonClientInputTest {
     val result =
       captureInputRequest(responseResult) { client ->
         client.inputSwipe(
-          startX = 520,
-          startY = 1700,
-          endX = 520,
-          endY = 500,
+          startX = 520.75,
+          startY = 1700.5,
+          endX = 520.25,
+          endY = 500.5,
           platform = "android",
           deviceId = "emulator-5554",
           durationMs = 350,
@@ -96,17 +98,17 @@ class McpDaemonClientInputTest {
       mapOf(
         "platform" to JsonPrimitive("android"),
         "deviceId" to JsonPrimitive("emulator-5554"),
-        "startX" to JsonPrimitive(520),
-        "startY" to JsonPrimitive(1700),
-        "endX" to JsonPrimitive(520),
-        "endY" to JsonPrimitive(500),
+        "startX" to JsonPrimitive(520.75),
+        "startY" to JsonPrimitive(1700.5),
+        "endX" to JsonPrimitive(520.25),
+        "endY" to JsonPrimitive(500.5),
         "durationMs" to JsonPrimitive(350),
       ),
       result.request.params,
     )
     assertEquals(true, result.response.success)
-    assertEquals(InputCoordinates(x = 520, y = 1700), result.response.start)
-    assertEquals(InputCoordinates(x = 520, y = 500), result.response.end)
+    assertEquals(InputCoordinates(x = 520.75, y = 1700.5), result.response.start)
+    assertEquals(InputCoordinates(x = 520.25, y = 500.5), result.response.end)
     assertEquals(350, result.response.durationMs)
   }
 
@@ -176,6 +178,43 @@ class McpDaemonClientInputTest {
     assertEquals("input/key", result.request.method)
     assertEquals(false, result.response.success)
     assertEquals("input/key is unsupported on ios", result.response.error)
+  }
+
+  @Test
+  fun `input helpers reject malformed success payloads`() {
+    TestDaemonSocket(resultJson = "{}", error = null).use { server ->
+      assertFailsWith<SerializationException> {
+        McpDaemonClient(socketPathValue = server.socketPath.toString()).inputTap(x = 10.0, y = 20.0)
+      }
+      assertEquals("input/tap", server.awaitRequest().method)
+    }
+  }
+
+  @Test
+  fun `input helpers reject success payloads for a different action`() {
+    val result =
+      captureInputRequest("""{ "action": "input/swipe", "success": true }""") { client ->
+        client.inputTap(x = 10.0, y = 20.0)
+      }
+
+    assertEquals(false, result.response.success)
+    assertEquals(
+      "Daemon response action input/swipe did not match input/tap",
+      result.response.error,
+    )
+  }
+
+  @Test
+  fun `non socket clients explicitly report unsupported typed input`() {
+    val httpResult = McpHttpClient("http://localhost:1/auto-mobile/streamable").inputTap(1.0, 2.0)
+    val stdioResult = McpStdioClient("unused").inputTap(1.0, 2.0)
+
+    assertEquals(false, httpResult.success)
+    assertEquals("input/tap", httpResult.action)
+    assertEquals("MCP HTTP does not support direct daemon input helpers", httpResult.error)
+    assertEquals(false, stdioResult.success)
+    assertEquals("input/tap", stdioResult.action)
+    assertEquals("MCP STDIO does not support direct daemon input helpers", stdioResult.error)
   }
 
   private fun captureInputRequest(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -1,0 +1,273 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+
+class McpDaemonClientInputTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `inputTap serializes to input tap socket request`() {
+    val responseResult =
+      """
+      {
+        "action": "input/tap",
+        "platform": "android",
+        "deviceId": "emulator-5554",
+        "success": true,
+        "coordinates": { "x": 240, "y": 640 }
+      }
+      """
+        .trimIndent()
+
+    val result =
+      captureInputRequest(responseResult) { client ->
+        client.inputTap(
+          x = 240,
+          y = 640,
+          platform = "android",
+          deviceId = "emulator-5554",
+          duration = 50,
+        )
+      }
+
+    assertEquals("input/tap", result.request.method)
+    assertEquals(
+      mapOf(
+        "platform" to JsonPrimitive("android"),
+        "deviceId" to JsonPrimitive("emulator-5554"),
+        "x" to JsonPrimitive(240),
+        "y" to JsonPrimitive(640),
+        "duration" to JsonPrimitive(50),
+      ),
+      result.request.params,
+    )
+    assertEquals(true, result.response.success)
+    assertEquals(InputCoordinates(x = 240, y = 640), result.response.coordinates)
+  }
+
+  @Test
+  fun `inputSwipe serializes documented coordinate and duration params`() {
+    val responseResult =
+      """
+      {
+        "action": "input/swipe",
+        "platform": "android",
+        "deviceId": "emulator-5554",
+        "success": true,
+        "start": { "x": 520, "y": 1700 },
+        "end": { "x": 520, "y": 500 },
+        "durationMs": 350
+      }
+      """
+        .trimIndent()
+
+    val result =
+      captureInputRequest(responseResult) { client ->
+        client.inputSwipe(
+          startX = 520,
+          startY = 1700,
+          endX = 520,
+          endY = 500,
+          platform = "android",
+          deviceId = "emulator-5554",
+          durationMs = 350,
+        )
+      }
+
+    assertEquals("input/swipe", result.request.method)
+    assertEquals(
+      mapOf(
+        "platform" to JsonPrimitive("android"),
+        "deviceId" to JsonPrimitive("emulator-5554"),
+        "startX" to JsonPrimitive(520),
+        "startY" to JsonPrimitive(1700),
+        "endX" to JsonPrimitive(520),
+        "endY" to JsonPrimitive(500),
+        "durationMs" to JsonPrimitive(350),
+      ),
+      result.request.params,
+    )
+    assertEquals(true, result.response.success)
+    assertEquals(InputCoordinates(x = 520, y = 1700), result.response.start)
+    assertEquals(InputCoordinates(x = 520, y = 500), result.response.end)
+    assertEquals(350, result.response.durationMs)
+  }
+
+  @Test
+  fun `button text and key helpers serialize to their input socket methods`() {
+    val pressButton =
+      captureInputRequest(
+        """{ "action": "input/pressButton", "success": true, "button": "back" }"""
+      ) { client ->
+        client.inputPressButton(button = "back", platform = "android", deviceId = "device-1")
+      }
+    val typeText =
+      captureInputRequest(
+        """{ "action": "input/typeText", "success": true, "textLength": 5, "submitted": true }"""
+      ) { client ->
+        client.inputTypeText(text = "hello", platform = "ios", deviceId = "device-2", submit = true)
+      }
+    val key =
+      captureInputRequest("""{ "action": "input/key", "success": true, "key": "enter" }""") { client ->
+        client.inputKey(key = "enter", platform = "android", deviceId = "device-3")
+      }
+
+    assertEquals("input/pressButton", pressButton.request.method)
+    assertEquals(
+      mapOf(
+        "platform" to JsonPrimitive("android"),
+        "deviceId" to JsonPrimitive("device-1"),
+        "button" to JsonPrimitive("back"),
+      ),
+      pressButton.request.params,
+    )
+    assertEquals("back", pressButton.response.button)
+
+    assertEquals("input/typeText", typeText.request.method)
+    assertEquals(
+      mapOf(
+        "platform" to JsonPrimitive("ios"),
+        "deviceId" to JsonPrimitive("device-2"),
+        "text" to JsonPrimitive("hello"),
+        "submit" to JsonPrimitive(true),
+      ),
+      typeText.request.params,
+    )
+    assertEquals(5, typeText.response.textLength)
+    assertEquals(true, typeText.response.submitted)
+
+    assertEquals("input/key", key.request.method)
+    assertEquals(
+      mapOf(
+        "platform" to JsonPrimitive("android"),
+        "deviceId" to JsonPrimitive("device-3"),
+        "key" to JsonPrimitive("enter"),
+      ),
+      key.request.params,
+    )
+    assertEquals("enter", key.response.key)
+  }
+
+  @Test
+  fun `input helpers decode failure envelopes into result errors`() {
+    val result =
+      captureInputRequest(error = "input/key is unsupported on ios") { client ->
+        client.inputKey(key = "enter", platform = "ios", deviceId = "simulator-1")
+      }
+
+    assertEquals("input/key", result.request.method)
+    assertEquals(false, result.response.success)
+    assertEquals("input/key is unsupported on ios", result.response.error)
+  }
+
+  private fun captureInputRequest(
+    resultJson: String? = null,
+    error: String? = null,
+    call: (McpDaemonClient) -> InputActionResult,
+  ): CapturedInputCall {
+    TestDaemonSocket(resultJson = resultJson, error = error).use { server ->
+      val response = call(McpDaemonClient(socketPathValue = server.socketPath.toString()))
+      return CapturedInputCall(server.awaitRequest(), response)
+    }
+  }
+
+  private inner class TestDaemonSocket(
+    private val resultJson: String?,
+    private val error: String?,
+  ) : AutoCloseable {
+    private val tempDir = Files.createTempDirectory(Path.of("/tmp"), "amk-")
+    val socketPath = tempDir.resolve("daemon.sock")
+    private val serverChannel =
+      ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        .bind(UnixDomainSocketAddress.of(socketPath))
+    private var capturedRequest: CapturedDaemonRequest? = null
+    private var failure: Throwable? = null
+    private val thread = Thread {
+      try {
+        serverChannel.accept().use { channel ->
+          val reader =
+            BufferedReader(
+              InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+            )
+          val writer =
+            BufferedWriter(
+              OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+            )
+          val requestLine = reader.readLine()
+          val request = json.parseToJsonElement(requestLine).jsonObject
+          capturedRequest =
+            CapturedDaemonRequest(
+              method = request.getValue("method").jsonPrimitive.content,
+              params = request.getValue("params").jsonObject,
+            )
+          writer.write(responseLine(request.getValue("id").jsonPrimitive.content))
+          writer.newLine()
+          writer.flush()
+        }
+      } catch (throwable: Throwable) {
+        failure = throwable
+      }
+    }
+      .also { it.start() }
+
+    fun awaitRequest(): CapturedDaemonRequest {
+      thread.join(REQUEST_TIMEOUT_MILLIS)
+      if (thread.isAlive) {
+        throw AssertionError("Daemon client did not send a request before timeout")
+      }
+      failure?.let { throw AssertionError("Test daemon socket failed", it) }
+      return capturedRequest ?: throw AssertionError("Daemon client did not send a request")
+    }
+
+    private fun responseLine(requestId: String): String {
+      val body =
+        if (error == null) {
+          """"result": ${compactJson(resultJson ?: "{}")}"""
+        } else {
+          """"error": ${JsonPrimitive(error)}"""
+        }
+      val success = error == null
+      return """{ "id": "$requestId", "type": "mcp_response", "success": $success, $body }"""
+    }
+
+    private fun compactJson(value: String): String =
+      value.lineSequence().joinToString(separator = "") { it.trim() }
+
+    override fun close() {
+      serverChannel.close()
+      Files.deleteIfExists(socketPath)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+
+  private companion object {
+    const val REQUEST_TIMEOUT_MILLIS = 5_000L
+  }
+}
+
+private data class CapturedInputCall(
+  val request: CapturedDaemonRequest,
+  val response: InputActionResult,
+)
+
+private data class CapturedDaemonRequest(
+  val method: String,
+  val params: JsonObject,
+)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -125,7 +125,8 @@ class McpDaemonClientInputTest {
         client.inputTypeText(text = "hello", platform = "ios", deviceId = "device-2", submit = true)
       }
     val key =
-      captureInputRequest("""{ "action": "input/key", "success": true, "key": "enter" }""") { client ->
+      captureInputRequest("""{ "action": "input/key", "success": true, "key": "enter" }""") { client
+        ->
         client.inputKey(key = "enter", platform = "android", deviceId = "device-3")
       }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
@@ -431,6 +431,43 @@ class FakeAutoMobileClient : AutoMobileClient {
 
   override fun updateService(deviceId: String, platform: String) = notImplemented()
 
+  override fun inputTap(
+    x: Double,
+    y: Double,
+    platform: String,
+    deviceId: String?,
+    duration: Int?,
+  ) = notImplemented()
+
+  override fun inputSwipe(
+    startX: Double,
+    startY: Double,
+    endX: Double,
+    endY: Double,
+    platform: String,
+    deviceId: String?,
+    durationMs: Int?,
+  ) = notImplemented()
+
+  override fun inputPressButton(
+    button: String,
+    platform: String,
+    deviceId: String?,
+  ) = notImplemented()
+
+  override fun inputTypeText(
+    text: String,
+    platform: String,
+    deviceId: String?,
+    submit: Boolean?,
+  ) = notImplemented()
+
+  override fun inputKey(
+    key: String,
+    platform: String,
+    deviceId: String?,
+  ) = notImplemented()
+
   override fun setKeyValue(
     deviceId: String,
     appId: String,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClientTest.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.testing
 
+import dev.jasonpearson.automobile.desktop.core.daemon.InputActionResult
+import dev.jasonpearson.automobile.desktop.core.daemon.InputCoordinates
 import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.daemon.McpResource
 import dev.jasonpearson.automobile.desktop.core.daemon.McpTool
@@ -21,9 +23,10 @@ class FakeAutoMobileClientTest {
     client.ping()
     client.listTools()
     client.observe()
+    client.inputTap(x = 10, y = 20)
     client.close()
 
-    assertEquals(listOf("ping", "listTools", "observe", "close"), client.calls)
+    assertEquals(listOf("ping", "listTools", "observe", "inputTap", "close"), client.calls)
   }
 
   @Test
@@ -139,6 +142,96 @@ class FakeAutoMobileClientTest {
     assertEquals("device-1", call.deviceId)
     assertEquals("com.app", call.appId)
     assertEquals("prefs", call.fileName)
+  }
+
+  @Test
+  fun `records typed input calls with arguments`() {
+    val client = FakeAutoMobileClient()
+
+    client.inputTap(x = 10, y = 20, platform = "android", deviceId = "device-1", duration = 50)
+    client.inputSwipe(
+      startX = 1,
+      startY = 2,
+      endX = 3,
+      endY = 4,
+      platform = "ios",
+      deviceId = "device-2",
+      durationMs = 500,
+    )
+    client.inputPressButton(button = "back", platform = "android", deviceId = "device-3")
+    client.inputTypeText(text = "hello", platform = "ios", deviceId = "device-4", submit = true)
+    client.inputKey(key = "enter", platform = "android", deviceId = "device-5")
+
+    assertEquals(
+      listOf("inputTap", "inputSwipe", "inputPressButton", "inputTypeText", "inputKey"),
+      client.calls,
+    )
+    assertEquals(
+      FakeAutoMobileClient.InputTapCall(
+        x = 10,
+        y = 20,
+        platform = "android",
+        deviceId = "device-1",
+        duration = 50,
+      ),
+      client.inputTapCalls.single(),
+    )
+    assertEquals(
+      FakeAutoMobileClient.InputSwipeCall(
+        startX = 1,
+        startY = 2,
+        endX = 3,
+        endY = 4,
+        platform = "ios",
+        deviceId = "device-2",
+        durationMs = 500,
+      ),
+      client.inputSwipeCalls.single(),
+    )
+    assertEquals(
+      FakeAutoMobileClient.InputPressButtonCall(
+        button = "back",
+        platform = "android",
+        deviceId = "device-3",
+      ),
+      client.inputPressButtonCalls.single(),
+    )
+    assertEquals(
+      FakeAutoMobileClient.InputTypeTextCall(
+        text = "hello",
+        platform = "ios",
+        deviceId = "device-4",
+        submit = true,
+      ),
+      client.inputTypeTextCalls.single(),
+    )
+    assertEquals(
+      FakeAutoMobileClient.InputKeyCall(
+        key = "enter",
+        platform = "android",
+        deviceId = "device-5",
+      ),
+      client.inputKeyCalls.single(),
+    )
+  }
+
+  @Test
+  fun `returns configurable typed input results`() {
+    val client = FakeAutoMobileClient()
+    client.inputTapResult =
+      InputActionResult(
+        action = "input/tap",
+        platform = "android",
+        deviceId = "device-1",
+        success = true,
+        coordinates = InputCoordinates(x = 10, y = 20),
+      )
+
+    val result = client.inputTap(x = 10, y = 20)
+
+    assertEquals(true, result.success)
+    assertEquals("input/tap", result.action)
+    assertEquals(InputCoordinates(x = 10, y = 20), result.coordinates)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClientTest.kt
@@ -23,7 +23,7 @@ class FakeAutoMobileClientTest {
     client.ping()
     client.listTools()
     client.observe()
-    client.inputTap(x = 10, y = 20)
+    client.inputTap(x = 10.0, y = 20.0)
     client.close()
 
     assertEquals(listOf("ping", "listTools", "observe", "inputTap", "close"), client.calls)
@@ -148,12 +148,12 @@ class FakeAutoMobileClientTest {
   fun `records typed input calls with arguments`() {
     val client = FakeAutoMobileClient()
 
-    client.inputTap(x = 10, y = 20, platform = "android", deviceId = "device-1", duration = 50)
+    client.inputTap(x = 10.0, y = 20.0, platform = "android", deviceId = "device-1", duration = 50)
     client.inputSwipe(
-      startX = 1,
-      startY = 2,
-      endX = 3,
-      endY = 4,
+      startX = 1.0,
+      startY = 2.0,
+      endX = 3.0,
+      endY = 4.0,
       platform = "ios",
       deviceId = "device-2",
       durationMs = 500,
@@ -168,8 +168,8 @@ class FakeAutoMobileClientTest {
     )
     assertEquals(
       FakeAutoMobileClient.InputTapCall(
-        x = 10,
-        y = 20,
+        x = 10.0,
+        y = 20.0,
         platform = "android",
         deviceId = "device-1",
         duration = 50,
@@ -178,10 +178,10 @@ class FakeAutoMobileClientTest {
     )
     assertEquals(
       FakeAutoMobileClient.InputSwipeCall(
-        startX = 1,
-        startY = 2,
-        endX = 3,
-        endY = 4,
+        startX = 1.0,
+        startY = 2.0,
+        endX = 3.0,
+        endY = 4.0,
         platform = "ios",
         deviceId = "device-2",
         durationMs = 500,
@@ -224,14 +224,14 @@ class FakeAutoMobileClientTest {
         platform = "android",
         deviceId = "device-1",
         success = true,
-        coordinates = InputCoordinates(x = 10, y = 20),
+        coordinates = InputCoordinates(x = 10.0, y = 20.0),
       )
 
-    val result = client.inputTap(x = 10, y = 20)
+    val result = client.inputTap(x = 10.0, y = 20.0)
 
     assertEquals(true, result.success)
     assertEquals("input/tap", result.action)
-    assertEquals(InputCoordinates(x = 10, y = 20), result.coordinates)
+    assertEquals(InputCoordinates(x = 10.0, y = 20.0), result.coordinates)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds typed Kotlin client helpers for the daemon input socket API so desktop/IDE code can call direct input actions without assembling raw JSON payloads.

Closes #3345

## Changes

- Exposes typed `AutoMobileClient` helpers for `input/tap`, `input/swipe`, `input/pressButton`, `input/typeText`, and `input/key`.
- Implements exact `input/*` socket serialization in `McpDaemonClient`, including typed success and failure result decoding.
- Extends `FakeAutoMobileClient` so UI tests can assert typed input calls and configured results.

## Testing

- Red-first targeted tests failed on missing typed API.
- `./android/gradlew -p android :desktop-core:test --tests dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClientTest --tests dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClientInputTest`
- `bun run turbo:validate`
- `bun run typecheck`
- `./android/gradlew -p android :desktop-core:test`
- `scripts/ktfmt/validate_ktfmt.sh`

## Acceptance Criteria

- Typed client methods cover each implemented daemon input endpoint.
- Socket serialization tests assert exact `input/*` methods and params.
- Fake client tests record typed input calls for UI assertions.
- Success and failure response decoding are covered.
- IDE consumers can depend on helpers instead of `callTool` or raw socket payloads.

Made with [Cursor](https://cursor.com)