### PR TITLE
fix(android): target postNotification app correctly

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4812,7 +4812,7 @@
         "appId": {
           "type": "string",
           "minLength": 1,
-          "description": "Android target package name or iOS target bundle ID"
+          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted"
         },
         "platform": {
           "type": "string",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4812,7 +4812,7 @@
         "appId": {
           "type": "string",
           "minLength": 1,
-          "description": "iOS target bundle ID"
+          "description": "Android target package name or iOS target bundle ID"
         },
         "platform": {
           "type": "string",

--- a/src/features/utility/PostNotification.ts
+++ b/src/features/utility/PostNotification.ts
@@ -212,7 +212,7 @@ export class PostNotification {
     imageType: "normal" | "bigPicture",
     signal?: AbortSignal
   ): Promise<PostNotificationResult> {
-    const appId = await this.getActiveAppId();
+    const appId = options.appId ?? (await this.getLiveActiveAppId());
     if (!appId) {
       return {
         success: false,
@@ -395,14 +395,9 @@ export class PostNotification {
     return resolvePathFromDaemonLaunchWorkingDirectory(imagePath);
   }
 
-  private async getActiveAppId(): Promise<string | null> {
+  private async getLiveActiveAppId(): Promise<string | null> {
     try {
-      const cached = await this.window.getCachedActiveWindow();
-      if (cached?.appId) {
-        return cached.appId;
-      }
-
-      const active = await this.window.getActive();
+      const active = await this.window.getActive(true);
       return active?.appId ?? null;
     } catch (error) {
       logger.warn(`[PostNotification] Failed to read active window: ${error}`);

--- a/src/features/utility/PostNotification.ts
+++ b/src/features/utility/PostNotification.ts
@@ -32,6 +32,7 @@ const NOTIFICATION_ACTION = "dev.jasonpearson.automobile.sdk.NOTIFICATION_POST";
 const NOTIFICATION_RECEIVER = "dev.jasonpearson.automobile.sdk.notifications.AutoMobileNotificationReceiver";
 const SDK_RESULT_SUCCESS = 1;
 const DEVICE_IMAGE_DIR = "/sdcard/Download/automobile";
+export const ANDROID_PACKAGE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)+$/;
 
 export class PostNotification {
   private device: BootedDevice;
@@ -220,6 +221,14 @@ export class PostNotification {
         supported: false,
         imageType,
         error: "Unable to determine the active app for SDK notifications."
+      };
+    }
+    if (!ANDROID_PACKAGE_NAME_PATTERN.test(appId)) {
+      return {
+        success: false,
+        supported: false,
+        imageType,
+        error: "Invalid Android appId. Provide an Android package name such as com.example.app."
       };
     }
 

--- a/src/features/utility/PostNotification.ts
+++ b/src/features/utility/PostNotification.ts
@@ -2,6 +2,7 @@ import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-c
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BootedDevice, PostNotificationResult } from "../../models";
 import { Window } from "../observe/Window";
+import type { Window as WindowInterface } from "../observe/interfaces/Window";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
@@ -36,13 +37,13 @@ export class PostNotification {
   private device: BootedDevice;
   private adb: AdbExecutor;
   private adbFactory: AdbClientFactory;
-  private window: Window;
+  private window: WindowInterface;
   private simctl: SimCtlClient;
 
   constructor(
     device: BootedDevice,
     adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = defaultAdbClientFactory,
-    window: Window | null = null,
+    window: WindowInterface | null = null,
     simctl: SimCtlClient | null = null
   ) {
     this.device = device;

--- a/src/features/utility/PostNotification.ts
+++ b/src/features/utility/PostNotification.ts
@@ -23,7 +23,7 @@ export interface PostNotificationOptions {
   imagePath?: string;
   actions?: PostNotificationAction[];
   channelId?: string;
-  /** iOS bundle identifier to target (required on iOS; maps to APNs "Simulator Target Bundle"). */
+  /** Android package name or iOS bundle identifier to target; required on iOS. */
   appId?: string;
 }
 

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -26,17 +26,19 @@ const postNotificationCommonShape = {
   channelId: z.string().optional().describe("Android channel ID / iOS APNs category"),
 };
 
+const postNotificationAppIdDescription = "Android target package name or iOS target bundle ID";
+
 export const postNotificationSchema = withAppIdAliases(z.discriminatedUnion("platform", [
   addDeviceTargetingToSchema(z.object({
     ...postNotificationCommonShape,
     appId: z.string({ error: iosAppIdRequiredMessage })
       .min(1, iosAppIdRequiredMessage)
-      .describe("iOS target bundle ID"),
+      .describe(postNotificationAppIdDescription),
     platform: z.literal("ios")
   })),
   addDeviceTargetingToSchema(z.object({
     ...postNotificationCommonShape,
-    appId: z.string().min(1).optional().describe("iOS target bundle ID"),
+    appId: z.string().min(1).optional().describe(postNotificationAppIdDescription),
     platform: z.literal("android")
   }))
 ]));

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -3,7 +3,7 @@ import { ToolRegistry } from "./toolRegistry";
 import { ActionableError, BootedDevice, Platform } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
-import { PostNotification, PostNotificationOptions } from "../features/utility/PostNotification";
+import { ANDROID_PACKAGE_NAME_PATTERN, PostNotification, PostNotificationOptions } from "../features/utility/PostNotification";
 import { NotificationPolicy } from "../features/utility/NotificationPolicy";
 
 export interface PostNotificationArgs extends PostNotificationOptions {
@@ -39,7 +39,11 @@ export const postNotificationSchema = withAppIdAliases(z.discriminatedUnion("pla
   })),
   addDeviceTargetingToSchema(z.object({
     ...postNotificationCommonShape,
-    appId: z.string().min(1).optional().describe(postNotificationAppIdDescription),
+    appId: z.string()
+      .min(1)
+      .regex(ANDROID_PACKAGE_NAME_PATTERN, "appId must be an Android package name")
+      .optional()
+      .describe(postNotificationAppIdDescription),
     platform: z.literal("android")
   }))
 ]));

--- a/src/server/notificationTools.ts
+++ b/src/server/notificationTools.ts
@@ -26,7 +26,8 @@ const postNotificationCommonShape = {
   channelId: z.string().optional().describe("Android channel ID / iOS APNs category"),
 };
 
-const postNotificationAppIdDescription = "Android target package name or iOS target bundle ID";
+const postNotificationAppIdDescription =
+  "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted";
 
 export const postNotificationSchema = withAppIdAliases(z.discriminatedUnion("platform", [
   addDeviceTargetingToSchema(z.object({

--- a/test/fakes/FakeWindow.ts
+++ b/test/fakes/FakeWindow.ts
@@ -11,7 +11,6 @@ export class FakeWindow implements Window {
   private configuredActiveWindow: ActiveWindow | null = null;
   private cachedActiveWindowCallCount: number = 0;
   private getActiveCallCount: number = 0;
-  private lastGetActiveForceRefresh: boolean | undefined;
   private configuredActiveHash: string = "fake-active-hash";
 
   /**
@@ -79,10 +78,6 @@ export class FakeWindow implements Window {
     return this.getActiveCallCount;
   }
 
-  getLastGetActiveForceRefresh(): boolean | undefined {
-    return this.lastGetActiveForceRefresh;
-  }
-
   // Implementation of Window interface
 
   async getCachedActiveWindow(): Promise<ActiveWindow | null> {
@@ -91,10 +86,12 @@ export class FakeWindow implements Window {
     return this.configuredCachedActiveWindow;
   }
 
-  async getActive(forceRefresh?: boolean): Promise<ActiveWindow> {
+  async getActive(forceRefresh: boolean = false): Promise<ActiveWindow> {
     this.executedOperations.push("getActive");
     this.getActiveCallCount++;
-    this.lastGetActiveForceRefresh = forceRefresh;
+    if (!forceRefresh && this.configuredCachedActiveWindow) {
+      return this.configuredCachedActiveWindow;
+    }
     if (!this.configuredActiveWindow) {
       throw new Error("No active window configured");
     }

--- a/test/fakes/FakeWindow.ts
+++ b/test/fakes/FakeWindow.ts
@@ -11,6 +11,7 @@ export class FakeWindow implements Window {
   private configuredActiveWindow: ActiveWindow | null = null;
   private cachedActiveWindowCallCount: number = 0;
   private getActiveCallCount: number = 0;
+  private lastGetActiveForceRefresh: boolean | undefined;
   private configuredActiveHash: string = "fake-active-hash";
 
   /**
@@ -78,6 +79,10 @@ export class FakeWindow implements Window {
     return this.getActiveCallCount;
   }
 
+  getLastGetActiveForceRefresh(): boolean | undefined {
+    return this.lastGetActiveForceRefresh;
+  }
+
   // Implementation of Window interface
 
   async getCachedActiveWindow(): Promise<ActiveWindow | null> {
@@ -86,9 +91,10 @@ export class FakeWindow implements Window {
     return this.configuredCachedActiveWindow;
   }
 
-  async getActive(): Promise<ActiveWindow> {
+  async getActive(forceRefresh?: boolean): Promise<ActiveWindow> {
     this.executedOperations.push("getActive");
     this.getActiveCallCount++;
+    this.lastGetActiveForceRefresh = forceRefresh;
     if (!this.configuredActiveWindow) {
       throw new Error("No active window configured");
     }

--- a/test/features/utility/PostNotification.test.ts
+++ b/test/features/utility/PostNotification.test.ts
@@ -90,6 +90,20 @@ describe("PostNotification", () => {
     expect(fakeWindow.getGetActiveCallCount()).toBe(0);
   });
 
+  test("rejects invalid explicit Android appId before SDK broadcast", async () => {
+    const postNotification = new PostNotification(device, fakeAdb as any, fakeWindow as any);
+    const result = await postNotification.execute({
+      title: "AutoMobile Test",
+      body: "Body",
+      appId: "dev.jasonpearson.automobile.playground; echo injected"
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(false);
+    expect(result.error).toContain("Invalid Android appId");
+    expect(fakeAdb.wasCommandExecuted("am broadcast")).toBe(false);
+  });
+
   test("refreshes active window instead of using stale cache when appId is omitted", async () => {
     fakeWindow.configureCachedActiveWindow({
       appId: "com.google.android.apps.nexuslauncher",

--- a/test/features/utility/PostNotification.test.ts
+++ b/test/features/utility/PostNotification.test.ts
@@ -27,6 +27,11 @@ describe("PostNotification", () => {
       activityName: "MainActivity",
       layoutSeqSum: 1
     } as any);
+    fakeWindow.configureActiveWindow({
+      appId: "com.example.app",
+      activityName: "MainActivity",
+      layoutSeqSum: 1
+    } as any);
   });
 
   afterEach(() => {
@@ -57,6 +62,61 @@ describe("PostNotification", () => {
       .toBe(true);
     expect(fakeAdb.wasCommandExecuted("actions_json"))
       .toBe(true);
+  });
+
+  test("honors explicit Android appId instead of cached active window", async () => {
+    fakeWindow.configureCachedActiveWindow({
+      appId: "com.google.android.apps.nexuslauncher",
+      activityName: "NexusLauncherActivity",
+      layoutSeqSum: 1
+    } as any);
+    fakeAdb.setCommandResponse("am broadcast", {
+      stdout: "Broadcast completed: result=1",
+      stderr: ""
+    });
+
+    const postNotification = new PostNotification(device, fakeAdb as any, fakeWindow as any);
+    const result = await postNotification.execute({
+      title: "AutoMobile Test",
+      body: "Body",
+      appId: "dev.jasonpearson.automobile.playground"
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.appId).toBe("dev.jasonpearson.automobile.playground");
+    expect(fakeAdb.wasCommandExecuted("am broadcast -n dev.jasonpearson.automobile.playground")).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("am broadcast -n com.google.android.apps.nexuslauncher")).toBe(false);
+    expect(fakeWindow.getGetCachedActiveWindowCallCount()).toBe(0);
+    expect(fakeWindow.getGetActiveCallCount()).toBe(0);
+  });
+
+  test("refreshes active window instead of using stale cache when appId is omitted", async () => {
+    fakeWindow.configureCachedActiveWindow({
+      appId: "com.google.android.apps.nexuslauncher",
+      activityName: "NexusLauncherActivity",
+      layoutSeqSum: 1
+    } as any);
+    fakeWindow.configureActiveWindow({
+      appId: "dev.jasonpearson.automobile.playground",
+      activityName: "MainActivity",
+      layoutSeqSum: 2
+    } as any);
+    fakeAdb.setCommandResponse("am broadcast", {
+      stdout: "Broadcast completed: result=1",
+      stderr: ""
+    });
+
+    const postNotification = new PostNotification(device, fakeAdb as any, fakeWindow as any);
+    const result = await postNotification.execute({
+      title: "AutoMobile Test",
+      body: "Body"
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.appId).toBe("dev.jasonpearson.automobile.playground");
+    expect(fakeAdb.wasCommandExecuted("am broadcast -n dev.jasonpearson.automobile.playground")).toBe(true);
+    expect(fakeAdb.wasCommandExecuted("am broadcast -n com.google.android.apps.nexuslauncher")).toBe(false);
+    expect(fakeWindow.getGetActiveCallCount()).toBe(1);
   });
 
   test("fails when SDK receiver is missing", async () => {

--- a/test/features/utility/PostNotification.test.ts
+++ b/test/features/utility/PostNotification.test.ts
@@ -117,6 +117,7 @@ describe("PostNotification", () => {
     expect(fakeAdb.wasCommandExecuted("am broadcast -n dev.jasonpearson.automobile.playground")).toBe(true);
     expect(fakeAdb.wasCommandExecuted("am broadcast -n com.google.android.apps.nexuslauncher")).toBe(false);
     expect(fakeWindow.getGetActiveCallCount()).toBe(1);
+    expect(fakeWindow.getLastGetActiveForceRefresh()).toBe(true);
   });
 
   test("fails when SDK receiver is missing", async () => {

--- a/test/features/utility/PostNotification.test.ts
+++ b/test/features/utility/PostNotification.test.ts
@@ -117,7 +117,6 @@ describe("PostNotification", () => {
     expect(fakeAdb.wasCommandExecuted("am broadcast -n dev.jasonpearson.automobile.playground")).toBe(true);
     expect(fakeAdb.wasCommandExecuted("am broadcast -n com.google.android.apps.nexuslauncher")).toBe(false);
     expect(fakeWindow.getGetActiveCallCount()).toBe(1);
-    expect(fakeWindow.getLastGetActiveForceRefresh()).toBe(true);
   });
 
   test("fails when SDK receiver is missing", async () => {

--- a/test/server/notificationTools.test.ts
+++ b/test/server/notificationTools.test.ts
@@ -58,6 +58,21 @@ describe("notification tools", () => {
     expect(result.success).toBe(true);
   });
 
+  test("accepts Android packageName alias when posting notifications", () => {
+    const result = postNotificationSchema.safeParse({
+      platform: "android",
+      title: "T",
+      body: "B",
+      packageName: "dev.jasonpearson.automobile.playground",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.appId).toBe("dev.jasonpearson.automobile.playground");
+      expect("packageName" in result.data).toBe(false);
+    }
+  });
+
   test("keeps generated tool definition free of top-level combinators", () => {
     const toolDefinition = ToolRegistry.getToolDefinitions()
       .find(tool => tool.name === "postNotification");
@@ -66,6 +81,7 @@ describe("notification tools", () => {
     const schema = toolDefinition!.inputSchema as any;
     expect(schema.required).toEqual(["title", "body", "platform"]);
     expect(schema.properties.platform.enum).toEqual(["ios", "android"]);
+    expect(schema.properties.appId.description).toContain("Android defaults to the live foreground app");
     expect(schema.anyOf).toBeUndefined();
     expect(schema.oneOf).toBeUndefined();
     expect(schema.allOf).toBeUndefined();

--- a/test/server/notificationTools.test.ts
+++ b/test/server/notificationTools.test.ts
@@ -73,6 +73,20 @@ describe("notification tools", () => {
     }
   });
 
+  test("rejects invalid Android appId when posting notifications", () => {
+    const result = postNotificationSchema.safeParse({
+      platform: "android",
+      title: "T",
+      body: "B",
+      appId: "dev.jasonpearson.automobile.playground; echo injected",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("appId must be an Android package name");
+    }
+  });
+
   test("keeps generated tool definition free of top-level combinators", () => {
     const toolDefinition = ToolRegistry.getToolDefinitions()
       .find(tool => tool.name === "postNotification");


### PR DESCRIPTION
## Summary

Android `postNotification` now honors an explicit `appId` before consulting foreground state, and when no `appId` is provided it refreshes the live active window instead of trusting the cached active-window package. This prevents SDK notification broadcasts from being sent to stale packages such as the launcher.

## Linked Issue

Closes #3392

## Bug / Regression Context

- **Prior attempts:** #2544 covered an iOS schema mismatch only; Android targeting remained unchanged.
- **Observed symptom:** Android `postNotification` reported SDK receiver failure while returning a stale launcher `appId`, even when the SDK app was foreground or explicitly provided.
- **Repro steps / conditions:** A stale cached active window differs from the intended SDK app, then `postNotification` is called with either no `appId` or an explicit Android `appId`.

## Acceptance Criteria

- Explicit Android `appId` is used as the SDK broadcast target.
- Omitted Android `appId` resolves the live foreground app instead of stale cached active-window state.
- Successful SDK notification results report the resolved target app.

## Validation

- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun test test/features/utility/PostNotification.test.ts` passes
- [x] Android/iOS changes: no platform project or schema validation needed; TypeScript tool behavior only
- [x] New code uses interfaces + fakes; focused unit suite runs in <100ms per test
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Follow-ups

- [x] No out-of-scope gaps identified

Made with [Cursor](https://cursor.com)