### PR TITLE
Make action observe diffs policy-aware

### DIFF
--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -46,17 +46,18 @@ Part of the MCP output-context reduction effort. Each flag can be set either as 
 `--actions-diff-observe` chooses the full-vs-diff policy by action class before
 calling the shared diff implementation. Navigation-prone actions (`tapOn`,
 `tapAny`, `homeScreen`, `recentApps`, `openLink`, and `pressButton` for
-back/home/recent/power) use strict screen identity and prefer a full observation
-when identity is uncertain, because a tap or navigation button can move to a new
-screen or modal. In-place mutations (`inputText`, `clearText`, `selectAllText`,
-`imeAction`, keyboard and clipboard operations, and non-navigation
-`pressButton`s such as volume) may diff when the app/activity/package surface is
-stable and any present screen-identity key still matches, even if that identity is
-low confidence. Scroll-like actions (`swipeOn`, `dragAndDrop`) use the same
-stable-surface policy so scroll deltas can stay compact while still falling back
-to full output across screens. The diff shape remains `{ isDiff: true, added,
-removed, changed, fields }` for every class; only the gate that decides whether a
-diff is safe changes.
+back/home/recent/power, plus submit-style IME actions such as done/go/search/send)
+use strict screen identity and prefer a full observation when identity is
+uncertain, because a tap, navigation button, or submit action can move to a new
+screen or modal. In-place mutations (`inputText` without a submit IME action,
+`clearText`, `selectAllText`, focus-traversal `imeAction` values, keyboard and
+clipboard operations, and non-navigation `pressButton`s such as volume) may diff
+when the app/activity/package surface is stable and any present screen-identity
+key still matches, even if that identity is low confidence. Scroll-like actions
+(`swipeOn`, `dragAndDrop`) use the same stable-surface policy so scroll deltas can
+stay compact while still falling back to full output across screens. The diff
+shape remains `{ isDiff: true, added, removed, changed, fields }` for every
+class; only the gate that decides whether a diff is safe changes.
 
 > **Note on persistence:** like the other feature flags above, enabling one of these (via **either** the CLI flag or the env var) writes `enabled=true` to the daemon's feature-flag store, so it **stays on for subsequent daemon runs** until it is turned off through another surface — there is no `--no-*` CLI counterpart today. To clear a flag, toggle it off through the IDE feature-flag integration or reset the store.
 

--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -43,6 +43,20 @@ Part of the MCP output-context reduction effort. Each flag can be set either as 
 | **`--actions-no-observe`** | `AUTOMOBILE_ACTIONS_NO_OBSERVE` | Strip the embedded `observation` from non-observe tool results entirely (deleted from **both** `structuredContent` and the serialized `content[0].text`). Output-only — `BaseVisualChange` still computes the observation internally for its own success detection, so visual-change behavior is unchanged; the `observe` tool's own observation is never stripped. Applied at `finalizeToolResponse`. **Precedence:** when both `--actions-no-observe` and `--actions-diff-observe` are set, no-observe wins — the observation is removed, so there is nothing to diff. |
 | **`--tool-results-compact-json`** | `AUTOMOBILE_TOOL_RESULTS_COMPACT_JSON` | Serialize tool results as compact (non-pretty-printed) JSON — drops the 2-space indentation in `stringifyToolResponse`. Same data (parses back identically, no effect on `tapOn`/text matching); ~35% fewer characters on element-heavy payloads. Composes with the other flags. |
 
+`--actions-diff-observe` chooses the full-vs-diff policy by action class before
+calling the shared diff implementation. Navigation-prone actions (`tapOn`,
+`tapAny`, `homeScreen`, `recentApps`, `openLink`, and `pressButton` for
+back/home/recent/power) use strict screen identity and prefer a full observation
+when identity is uncertain, because a tap or navigation button can move to a new
+screen or modal. In-place mutations (`inputText`, `clearText`, `selectAllText`,
+`imeAction`, keyboard and clipboard operations, and non-navigation
+`pressButton`s such as volume) may diff when the app/activity/package surface is
+stable, even if heuristic screen identity is low confidence. Scroll-like actions
+(`swipeOn`, `dragAndDrop`) use the same stable-surface policy so scroll deltas can
+stay compact while still falling back to full output across screens. The diff
+shape remains `{ isDiff: true, added, removed, changed, fields }` for every
+class; only the gate that decides whether a diff is safe changes.
+
 > **Note on persistence:** like the other feature flags above, enabling one of these (via **either** the CLI flag or the env var) writes `enabled=true` to the daemon's feature-flag store, so it **stays on for subsequent daemon runs** until it is turned off through another surface — there is no `--no-*` CLI counterpart today. To clear a flag, toggle it off through the IDE feature-flag integration or reset the store.
 
 > **Note on the shared daemon:** in the default proxy mode these flags are applied to the daemon at startup. If a daemon is **already running**, a new MCP client that requests a different flag value does **not** restart it — only `--embedded-sdk` (which changes the exposed tool surface) forces a daemon restart on mismatch, because restarting the shared daemon would disrupt any other connected clients. To pick up a changed output-reduction flag on an already-running daemon, restart the daemon (`--daemon restart`). This behavior is shared by all daemon-forwarded feature flags, not specific to these.

--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -51,11 +51,12 @@ when identity is uncertain, because a tap or navigation button can move to a new
 screen or modal. In-place mutations (`inputText`, `clearText`, `selectAllText`,
 `imeAction`, keyboard and clipboard operations, and non-navigation
 `pressButton`s such as volume) may diff when the app/activity/package surface is
-stable, even if heuristic screen identity is low confidence. Scroll-like actions
-(`swipeOn`, `dragAndDrop`) use the same stable-surface policy so scroll deltas can
-stay compact while still falling back to full output across screens. The diff
-shape remains `{ isDiff: true, added, removed, changed, fields }` for every
-class; only the gate that decides whether a diff is safe changes.
+stable and any present screen-identity key still matches, even if that identity is
+low confidence. Scroll-like actions (`swipeOn`, `dragAndDrop`) use the same
+stable-surface policy so scroll deltas can stay compact while still falling back
+to full output across screens. The diff shape remains `{ isDiff: true, added,
+removed, changed, fields }` for every class; only the gate that decides whether a
+diff is safe changes.
 
 > **Note on persistence:** like the other feature flags above, enabling one of these (via **either** the CLI flag or the env var) writes `enabled=true` to the daemon's feature-flag store, so it **stays on for subsequent daemon runs** until it is turned off through another surface — there is no `--no-*` CLI counterpart today. To clear a flag, toggle it off through the IDE feature-flag integration or reset the store.
 

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -6,16 +6,13 @@ import { IOSCtrlProxyClient } from "../observe/ios";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { logger } from "../../utils/logger";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { isNavigationPressButton } from "./pressButtonPolicy";
 
 export class PressButton extends BaseVisualChange {
   constructor(device: BootedDevice, adb: AdbClient | null = null) {
     super(device, adb);
     this.device = device;
   }
-
-  // Buttons that typically cause UI/navigation changes (dismiss keyboard, go home, lock screen, etc.)
-  // These should wait for hierarchy changes to ensure fresh observation data
-  private static readonly NAVIGATION_BUTTONS = new Set(["back", "home", "recent", "power"]);
 
   async execute(
     button: string,
@@ -28,7 +25,7 @@ export class PressButton extends BaseVisualChange {
     // dismissing keyboard, navigating screens, or showing lock screen. We set
     // changeExpected=true so the observation waits for the hierarchy to actually change.
     // Hardware buttons (volume, menu) don't change the hierarchy.
-    const isNavigationButton = PressButton.NAVIGATION_BUTTONS.has(button.toLowerCase());
+    const isNavigationButton = isNavigationPressButton(button);
 
     return this.observedInteraction(
       async () => {

--- a/src/features/action/pressButtonPolicy.ts
+++ b/src/features/action/pressButtonPolicy.ts
@@ -1,0 +1,10 @@
+const NAVIGATION_PRESS_BUTTONS = new Set(["back", "home", "recent", "power"]);
+const IN_PLACE_PRESS_BUTTONS = new Set(["menu", "volume_up", "volume_down"]);
+
+export function isNavigationPressButton(button: unknown): boolean {
+  return typeof button === "string" && NAVIGATION_PRESS_BUTTONS.has(button.toLowerCase());
+}
+
+export function isInPlacePressButton(button: unknown): boolean {
+  return typeof button === "string" && IN_PLACE_PRESS_BUTTONS.has(button.toLowerCase());
+}

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -156,7 +156,7 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
   {
     key: "actions-diff-observe",
     label: "Actions: diff observe",
-    description: "Return only the diff of the observation after an action instead of the full observation.",
+    description: "Return action-aware observation diffs after non-observe tools, falling back to full observations for navigation-prone or uncertain screen changes.",
     defaultValue: false,
   },
   {

--- a/src/models/ImeActionResult.ts
+++ b/src/models/ImeActionResult.ts
@@ -1,5 +1,11 @@
 export type ImeAction = "done" | "next" | "search" | "send" | "go" | "previous";
 
+const SUBMIT_IME_ACTIONS: ReadonlySet<ImeAction> = new Set(["done", "go", "search", "send"]);
+
+export function isSubmitImeAction(action: unknown): action is ImeAction {
+  return typeof action === "string" && SUBMIT_IME_ACTIONS.has(action as ImeAction);
+}
+
 export interface ImeActionResult {
     success: boolean;
     action: string;

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -5,8 +5,10 @@ import {
   isSameObservationScreen,
   type SanitizeObserveConfig,
 } from "../features/observe/output/ObserveResultOutput";
+import { isInPlacePressButton, isNavigationPressButton } from "../features/action/pressButtonPolicy";
 import { serverConfig } from "../utils/ServerConfig";
 import { getStructuredPayload, stringifyToolResponse } from "../utils/toolUtils";
+import { isSubmitImeAction } from "../models/ImeActionResult";
 
 /**
  * Read/write access to the per-session diff baseline — the "last observation
@@ -20,13 +22,9 @@ export interface ObservationBaselineStore {
   set(sessionUuid: string, observation: ObserveResult): void;
 }
 
-export type ObservationActionClass = "navigation" | "inPlace" | "scroll" | "unknown";
+type ObservationActionClass = "navigation" | "inPlace" | "scroll" | "unknown";
 
-const NAVIGATION_PRESS_BUTTONS = new Set(["back", "home", "recent", "power"]);
-const IN_PLACE_PRESS_BUTTONS = new Set(["menu", "volume_up", "volume_down"]);
-const NAVIGATION_IME_ACTIONS = new Set(["done", "go", "search", "send"]);
-
-export function classifyObservationAction(
+function classifyObservationAction(
   name: string,
   args?: Record<string, unknown>
 ): ObservationActionClass {
@@ -38,34 +36,29 @@ export function classifyObservationAction(
     case "openLink":
       return "navigation";
     case "pressButton": {
-      const button = typeof args?.button === "string" ? args.button.toLowerCase() : "";
-      if (NAVIGATION_PRESS_BUTTONS.has(button)) {
+      if (isNavigationPressButton(args?.button)) {
         return "navigation";
       }
-      if (IN_PLACE_PRESS_BUTTONS.has(button)) {
+      if (isInPlacePressButton(args?.button)) {
         return "inPlace";
       }
       return "unknown";
     }
     case "inputText":
-      return isNavigationImeAction(args?.imeAction) ? "navigation" : "inPlace";
+      return isSubmitImeAction(args?.imeAction) ? "navigation" : "inPlace";
     case "clearText":
     case "selectAllText":
     case "keyboard":
     case "clipboard":
       return "inPlace";
     case "imeAction":
-      return isNavigationImeAction(args?.action) ? "navigation" : "inPlace";
+      return isSubmitImeAction(args?.action) ? "navigation" : "inPlace";
     case "swipeOn":
     case "dragAndDrop":
       return "scroll";
     default:
       return "unknown";
   }
-}
-
-function isNavigationImeAction(action: unknown): boolean {
-  return typeof action === "string" && NAVIGATION_IME_ACTIONS.has(action);
 }
 
 /**
@@ -81,7 +74,6 @@ export interface FinalizeToolResponseContext {
   args?: Record<string, unknown>;
   sessionUuid?: string;
   baselineStore?: ObservationBaselineStore;
-  actionClass?: ObservationActionClass;
   /**
    * Internal tool-to-tool invocation guard (issue #3053). PlanExecutor calls the
    * wrapped `tool.handler` (so this hook runs) with an injected `sessionUuid`, so a
@@ -246,7 +238,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
             fromScreen: observationScreenIdentity(baseline),
             toScreen: observationScreenIdentity(sanitized),
           };
-        } else if (shouldDiffObservation(baseline, sanitized, ctx.actionClass ?? classifyObservationAction(ctx.name, ctx.args))) {
+        } else if (shouldDiffObservation(baseline, sanitized, classifyObservationAction(ctx.name, ctx.args))) {
           observationOut = diffObserveResult(baseline, sanitized);
           observationDiff = {
             mode: "diff",

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -20,6 +20,47 @@ export interface ObservationBaselineStore {
   set(sessionUuid: string, observation: ObserveResult): void;
 }
 
+export type ObservationActionClass = "navigation" | "inPlace" | "scroll" | "unknown";
+
+const NAVIGATION_PRESS_BUTTONS = new Set(["back", "home", "recent", "power"]);
+const IN_PLACE_PRESS_BUTTONS = new Set(["menu", "volume_up", "volume_down"]);
+
+export function classifyObservationAction(
+  name: string,
+  args?: Record<string, unknown>
+): ObservationActionClass {
+  switch (name) {
+    case "tapOn":
+    case "tapAny":
+    case "homeScreen":
+    case "recentApps":
+    case "openLink":
+      return "navigation";
+    case "pressButton": {
+      const button = typeof args?.button === "string" ? args.button.toLowerCase() : "";
+      if (NAVIGATION_PRESS_BUTTONS.has(button)) {
+        return "navigation";
+      }
+      if (IN_PLACE_PRESS_BUTTONS.has(button)) {
+        return "inPlace";
+      }
+      return "unknown";
+    }
+    case "inputText":
+    case "clearText":
+    case "selectAllText":
+    case "imeAction":
+    case "keyboard":
+    case "clipboard":
+      return "inPlace";
+    case "swipeOn":
+    case "dragAndDrop":
+      return "scroll";
+    default:
+      return "unknown";
+  }
+}
+
 /**
  * Context needed to finalize a tool response at the serialization chokepoint.
  * `name` selects where the `ObserveResult` lives (top-level for `observe`, else
@@ -32,6 +73,7 @@ export interface FinalizeToolResponseContext {
   name: string;
   sessionUuid?: string;
   baselineStore?: ObservationBaselineStore;
+  actionClass?: ObservationActionClass;
   /**
    * Internal tool-to-tool invocation guard (issue #3053). PlanExecutor calls the
    * wrapped `tool.handler` (so this hook runs) with an injected `sessionUuid`, so a
@@ -196,7 +238,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
             fromScreen: observationScreenIdentity(baseline),
             toScreen: observationScreenIdentity(sanitized),
           };
-        } else if (isSameObservationScreen(baseline, sanitized)) {
+        } else if (shouldDiffObservation(baseline, sanitized, ctx.actionClass ?? classifyObservationAction(ctx.name))) {
           observationOut = diffObserveResult(baseline, sanitized);
           observationDiff = {
             mode: "diff",
@@ -286,4 +328,55 @@ function observationScreenIdentity(observation: ObserveResult): ObservationDiffS
     identity.screenIdentity = observation.screenIdentity;
   }
   return identity;
+}
+
+function shouldDiffObservation(
+  baseline: ObserveResult,
+  next: ObserveResult,
+  actionClass: ObservationActionClass
+): boolean {
+  if (actionClass === "inPlace" || actionClass === "scroll") {
+    return isSameStableMutationSurface(baseline, next);
+  }
+  return isSameObservationScreen(baseline, next);
+}
+
+function isSameStableMutationSurface(baseline: ObserveResult, next: ObserveResult): boolean {
+  if (!hasSameWindowPackageSurface(baseline, next)) {
+    return false;
+  }
+
+  return hasCompatibleStableMutationIdentity(baseline, next);
+}
+
+function hasCompatibleStableMutationIdentity(baseline: ObserveResult, next: ObserveResult): boolean {
+  const baselineIdentity = baseline.screenIdentity;
+  const nextIdentity = next.screenIdentity;
+  if (!baselineIdentity || !nextIdentity) {
+    return true;
+  }
+
+  // Low-confidence screen identity is too uncertain for navigation-prone actions,
+  // but in-place edits and scrolls can still diff when the app/activity/package
+  // surface stayed stable.
+  if (baselineIdentity.confidence === "low" || nextIdentity.confidence === "low") {
+    return true;
+  }
+
+  return baselineIdentity.platform === nextIdentity.platform
+    && baselineIdentity.source === nextIdentity.source
+    && baselineIdentity.key === nextIdentity.key;
+}
+
+function hasSameWindowPackageSurface(baseline: ObserveResult, next: ObserveResult): boolean {
+  if ((baseline.activeWindow?.appId ?? "") !== (next.activeWindow?.appId ?? "")) {
+    return false;
+  }
+  if ((baseline.activeWindow?.activityName ?? "") !== (next.activeWindow?.activityName ?? "")) {
+    return false;
+  }
+  if ((baseline.viewHierarchy?.packageName ?? "") !== (next.viewHierarchy?.packageName ?? "")) {
+    return false;
+  }
+  return true;
 }

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -24,6 +24,7 @@ export type ObservationActionClass = "navigation" | "inPlace" | "scroll" | "unkn
 
 const NAVIGATION_PRESS_BUTTONS = new Set(["back", "home", "recent", "power"]);
 const IN_PLACE_PRESS_BUTTONS = new Set(["menu", "volume_up", "volume_down"]);
+const NAVIGATION_IME_ACTIONS = new Set(["done", "go", "search", "send"]);
 
 export function classifyObservationAction(
   name: string,
@@ -47,18 +48,24 @@ export function classifyObservationAction(
       return "unknown";
     }
     case "inputText":
+      return isNavigationImeAction(args?.imeAction) ? "navigation" : "inPlace";
     case "clearText":
     case "selectAllText":
-    case "imeAction":
     case "keyboard":
     case "clipboard":
       return "inPlace";
+    case "imeAction":
+      return isNavigationImeAction(args?.action) ? "navigation" : "inPlace";
     case "swipeOn":
     case "dragAndDrop":
       return "scroll";
     default:
       return "unknown";
   }
+}
+
+function isNavigationImeAction(action: unknown): boolean {
+  return typeof action === "string" && NAVIGATION_IME_ACTIONS.has(action);
 }
 
 /**

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -71,6 +71,7 @@ export function classifyObservationAction(
  */
 export interface FinalizeToolResponseContext {
   name: string;
+  args?: Record<string, unknown>;
   sessionUuid?: string;
   baselineStore?: ObservationBaselineStore;
   actionClass?: ObservationActionClass;
@@ -238,7 +239,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
             fromScreen: observationScreenIdentity(baseline),
             toScreen: observationScreenIdentity(sanitized),
           };
-        } else if (shouldDiffObservation(baseline, sanitized, ctx.actionClass ?? classifyObservationAction(ctx.name))) {
+        } else if (shouldDiffObservation(baseline, sanitized, ctx.actionClass ?? classifyObservationAction(ctx.name, ctx.args))) {
           observationOut = diffObserveResult(baseline, sanitized);
           observationDiff = {
             mode: "diff",
@@ -353,13 +354,6 @@ function hasCompatibleStableMutationIdentity(baseline: ObserveResult, next: Obse
   const baselineIdentity = baseline.screenIdentity;
   const nextIdentity = next.screenIdentity;
   if (!baselineIdentity || !nextIdentity) {
-    return true;
-  }
-
-  // Low-confidence screen identity is too uncertain for navigation-prone actions,
-  // but in-place edits and scrolls can still diff when the app/activity/package
-  // surface stayed stable.
-  if (baselineIdentity.confidence === "low" || nextIdentity.confidence === "low") {
     return true;
   }
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -615,6 +615,7 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
       durationMs,
       finalizedResponse: finalizeToolResponse(response, {
         name,
+        args,
         sessionUuid,
         baselineStore,
         actionClass: classifyObservationAction(name, args),

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -25,7 +25,11 @@ import { getMcpRecorder } from "./mcpRecordingManager";
 import { formatToolResultLog } from "./toolResultLog";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
-import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
+import {
+  classifyObservationAction,
+  finalizeToolResponse,
+  type ObservationBaselineStore,
+} from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
 import { ListChangedBroadcaster } from "./listChangedBroadcast";
 import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
@@ -609,7 +613,13 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
 
     return {
       durationMs,
-      finalizedResponse: finalizeToolResponse(response, { name, sessionUuid, baselineStore, internal: internalCall }),
+      finalizedResponse: finalizeToolResponse(response, {
+        name,
+        sessionUuid,
+        baselineStore,
+        actionClass: classifyObservationAction(name, args),
+        internal: internalCall,
+      }),
     };
   }
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -25,11 +25,7 @@ import { getMcpRecorder } from "./mcpRecordingManager";
 import { formatToolResultLog } from "./toolResultLog";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
-import {
-  classifyObservationAction,
-  finalizeToolResponse,
-  type ObservationBaselineStore,
-} from "./finalizeToolResponse";
+import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
 import { ListChangedBroadcaster } from "./listChangedBroadcast";
 import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
@@ -618,7 +614,6 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
         args,
         sessionUuid,
         baselineStore,
-        actionClass: classifyObservationAction(name, args),
         internal: internalCall,
       }),
     };

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  classifyObservationAction,
-  finalizeToolResponse,
-} from "../../src/server/finalizeToolResponse";
+import { finalizeToolResponse } from "../../src/server/finalizeToolResponse";
 import {
   createStructuredToolResponse,
   stringifyToolResponse,
@@ -907,17 +904,58 @@ describe("finalizeToolResponse", () => {
       expectObservationDiff(imePrevious, { mode: "diff", reason: "diff_emitted" });
     });
 
-    test("classifies non-observe actions for policy selection", () => {
-      expect(classifyObservationAction("tapOn", { action: "tap" })).toBe("navigation");
-      expect(classifyObservationAction("pressButton", { button: "back" })).toBe("navigation");
-      expect(classifyObservationAction("pressButton", { button: "volume_up" })).toBe("inPlace");
-      expect(classifyObservationAction("inputText", { text: "hello" })).toBe("inPlace");
-      expect(classifyObservationAction("inputText", { text: "hello", imeAction: "search" })).toBe("navigation");
-      expect(classifyObservationAction("clearText", {})).toBe("inPlace");
-      expect(classifyObservationAction("imeAction", { action: "send" })).toBe("navigation");
-      expect(classifyObservationAction("imeAction", { action: "next" })).toBe("inPlace");
-      expect(classifyObservationAction("swipeOn", { direction: "up" })).toBe("scroll");
-      expect(classifyObservationAction("dragAndDrop", {})).toBe("scroll");
+    test("action policy: documented navigation-prone actions emit full on uncertain identity", () => {
+      const cases: Array<[string, Record<string, unknown>]> = [
+        ["tapOn", { action: "tap" }],
+        ["tapAny", { action: "tap" }],
+        ["homeScreen", {}],
+        ["recentApps", {}],
+        ["openLink", { url: "https://example.com" }],
+        ["pressButton", { button: "back" }],
+        ["pressButton", { button: "home" }],
+        ["pressButton", { button: "recent" }],
+        ["pressButton", { button: "power" }],
+        ["inputText", { text: "query", imeAction: "done" }],
+        ["inputText", { text: "query", imeAction: "go" }],
+        ["inputText", { text: "query", imeAction: "search" }],
+        ["inputText", { text: "query", imeAction: "send" }],
+        ["imeAction", { action: "done" }],
+        ["imeAction", { action: "go" }],
+        ["imeAction", { action: "search" }],
+        ["imeAction", { action: "send" }],
+      ];
+
+      for (const [name, args] of cases) {
+        const finalized = finalizeChangedLowConfidenceAction(name, args);
+        expect((finalized.structuredContent as any).observation.isDiff).toBeUndefined();
+        expect((finalized.structuredContent as any).observation.viewHierarchy).toBeDefined();
+        expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+      }
+    });
+
+    test("action policy: documented in-place and scroll actions diff on stable uncertain identity", () => {
+      const cases: Array<[string, Record<string, unknown>]> = [
+        ["inputText", { text: "hello" }],
+        ["inputText", { text: "hello", imeAction: "next" }],
+        ["inputText", { text: "hello", imeAction: "previous" }],
+        ["clearText", {}],
+        ["selectAllText", {}],
+        ["imeAction", { action: "next" }],
+        ["imeAction", { action: "previous" }],
+        ["keyboard", { action: "open" }],
+        ["clipboard", { action: "paste" }],
+        ["pressButton", { button: "menu" }],
+        ["pressButton", { button: "volume_up" }],
+        ["pressButton", { button: "volume_down" }],
+        ["swipeOn", { direction: "up" }],
+        ["dragAndDrop", {}],
+      ];
+
+      for (const [name, args] of cases) {
+        const finalized = finalizeChangedLowConfidenceAction(name, args);
+        expect((finalized.structuredContent as any).observation.isDiff).toBe(true);
+        expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
+      }
     });
 
     test("falls back to full when there is no sessionUuid (legacy single-agent path)", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -504,7 +504,8 @@ describe("finalizeToolResponse", () => {
     function finalizeChangedLowConfidenceAction(
       name: string,
       actionArgs: Record<string, unknown>,
-      key = "bundle=com.apple.reminders|focus=Title"
+      key = "bundle=com.apple.reminders|focus=Title",
+      nextKey = key
     ): StructuredToolResponse<{ success: boolean; observation: ObserveResult }> {
       const { store } = makeStore();
       const baseline = iosScreenObserve(key, "low");
@@ -514,10 +515,10 @@ describe("finalizeToolResponse", () => {
       );
 
       return finalizeToolResponse(
-        createStructuredToolResponse({ success: true, observation: checkedIosScreenObserve(key, "low") }),
+        createStructuredToolResponse({ success: true, observation: checkedIosScreenObserve(nextKey, "low") }),
         {
           name,
-          actionClass: classifyObservationAction(name, actionArgs),
+          args: actionArgs,
           sessionUuid: "s1",
           baselineStore: store,
         }
@@ -843,6 +844,45 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.isDiff).toBe(true);
       expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
       expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
+    });
+
+    test("action policy: inputText emits full when uncertain identity key changes", () => {
+      const finalized = finalizeChangedLowConfidenceAction(
+        "inputText",
+        { text: "hello" },
+        "bundle=com.apple.reminders|focus=Title",
+        "bundle=com.apple.reminders|focus=Search"
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+    });
+
+    test("action policy: swipeOn emits full when uncertain identity key changes", () => {
+      const finalized = finalizeChangedLowConfidenceAction(
+        "swipeOn",
+        { direction: "up" },
+        "bundle=com.apple.reminders|list=Inbox",
+        "bundle=com.apple.reminders|list=Search"
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+    });
+
+    test("action policy: finalizer derives pressButton policy from args", () => {
+      const volume = finalizeChangedLowConfidenceAction("pressButton", { button: "volume_up" });
+      expect((volume.structuredContent as any).observation.isDiff).toBe(true);
+      expectObservationDiff(volume, { mode: "diff", reason: "diff_emitted" });
+
+      const back = finalizeChangedLowConfidenceAction("pressButton", { button: "back" });
+      expect((back.structuredContent as any).observation.isDiff).toBeUndefined();
+      expect((back.structuredContent as any).observation.viewHierarchy).toBeDefined();
+      expectObservationDiff(back, { mode: "full", reason: "screen_changed" });
     });
 
     test("classifies non-observe actions for policy selection", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { finalizeToolResponse } from "../../src/server/finalizeToolResponse";
-import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
+import {
+  classifyObservationAction,
+  finalizeToolResponse,
+} from "../../src/server/finalizeToolResponse";
+import {
+  createStructuredToolResponse,
+  stringifyToolResponse,
+  type StructuredToolResponse,
+} from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { GFXINFO_DUMP_MARKER } from "../../src/features/observe/output/ObserveResultOutput";
 import type { ObserveResult } from "../../src/models/ObserveResult";
@@ -485,6 +492,38 @@ describe("finalizeToolResponse", () => {
       } as ObserveResult;
     }
 
+    function checkedIosScreenObserve(
+      key: string,
+      confidence: "high" | "medium" | "low" = "high"
+    ): ObserveResult {
+      const observation = iosScreenObserve(key, confidence);
+      (observation.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      return observation;
+    }
+
+    function finalizeChangedLowConfidenceAction(
+      name: string,
+      actionArgs: Record<string, unknown>,
+      key = "bundle=com.apple.reminders|focus=Title"
+    ): StructuredToolResponse<{ success: boolean; observation: ObserveResult }> {
+      const { store } = makeStore();
+      const baseline = iosScreenObserve(key, "low");
+      finalizeToolResponse(
+        createStructuredToolResponse(baseline),
+        { name: "observe", sessionUuid: "s1", baselineStore: store }
+      );
+
+      return finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: checkedIosScreenObserve(key, "low") }),
+        {
+          name,
+          actionClass: classifyObservationAction(name, actionArgs),
+          sessionUuid: "s1",
+          baselineStore: store,
+        }
+      );
+    }
+
     beforeEach(() => {
       originalDiff = serverConfig.isActionsDiffObserveEnabled();
       serverConfig.setActionsDiffObserveEnabled(true);
@@ -676,8 +715,7 @@ describe("finalizeToolResponse", () => {
       const baseline = iosScreenObserve("bundle=com.apple.reminders|nav=Reminders");
       finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
 
-      const next = iosScreenObserve("bundle=com.apple.reminders|nav=New Reminder");
-      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      const next = checkedIosScreenObserve("bundle=com.apple.reminders|nav=New Reminder");
 
       const finalized = finalizeToolResponse(
         createStructuredToolResponse({ success: true, observation: next }),
@@ -698,8 +736,7 @@ describe("finalizeToolResponse", () => {
       const baseline = iosScreenObserve("bundle=com.apple.reminders|nav=Reminders");
       finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
 
-      const next = iosScreenObserve("bundle=com.apple.reminders|nav=Reminders");
-      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      const next = checkedIosScreenObserve("bundle=com.apple.reminders|nav=Reminders");
 
       const finalized = finalizeToolResponse(
         createStructuredToolResponse({ success: true, observation: next }),
@@ -744,8 +781,7 @@ describe("finalizeToolResponse", () => {
       const baseline = iosScreenObserve("bundle=com.apple.reminders|tab=Inbox", "medium");
       finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
 
-      const next = iosScreenObserve("bundle=com.apple.reminders|tab=Search", "medium");
-      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      const next = checkedIosScreenObserve("bundle=com.apple.reminders|tab=Search", "medium");
 
       const finalized = finalizeToolResponse(
         createStructuredToolResponse({ success: true, observation: next }),
@@ -764,8 +800,7 @@ describe("finalizeToolResponse", () => {
       const baseline = iosScreenObserve("bundle=com.apple.reminders|focus=Title", "low");
       finalizeToolResponse(createStructuredToolResponse(baseline), { name: "observe", sessionUuid: "s1", baselineStore: store });
 
-      const next = iosScreenObserve("bundle=com.apple.reminders|focus=Title", "low");
-      (next.viewHierarchy!.hierarchy.node as any).node[0].checked = "true";
+      const next = checkedIosScreenObserve("bundle=com.apple.reminders|focus=Title", "low");
 
       const finalized = finalizeToolResponse(
         createStructuredToolResponse({ success: true, observation: next }),
@@ -777,6 +812,47 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.viewHierarchy).toBeDefined();
       expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
       expect((map.get("s1")!.viewHierarchy!.hierarchy.node as any).node[0].checked).toBe("true");
+    });
+
+    test("action policy: navigation-prone tap stays full on uncertain identity", () => {
+      const finalized = finalizeChangedLowConfidenceAction("tapOn", { action: "tap" });
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBeUndefined();
+      expect(obsSc.viewHierarchy).toBeDefined();
+      expectObservationDiff(finalized, { mode: "full", reason: "screen_changed" });
+    });
+
+    test("action policy: inputText diffs on stable surface despite uncertain identity", () => {
+      const finalized = finalizeChangedLowConfidenceAction("inputText", { text: "hello" });
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
+      expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
+    });
+
+    test("action policy: swipeOn diffs on stable surface despite uncertain identity", () => {
+      const finalized = finalizeChangedLowConfidenceAction(
+        "swipeOn",
+        { direction: "up" },
+        "bundle=com.apple.reminders|list=Inbox"
+      );
+
+      const obsSc = (finalized.structuredContent as any).observation;
+      expect(obsSc.isDiff).toBe(true);
+      expect(obsSc.changed[0].changes.checked).toEqual({ from: undefined, to: "true" });
+      expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
+    });
+
+    test("classifies non-observe actions for policy selection", () => {
+      expect(classifyObservationAction("tapOn", { action: "tap" })).toBe("navigation");
+      expect(classifyObservationAction("pressButton", { button: "back" })).toBe("navigation");
+      expect(classifyObservationAction("pressButton", { button: "volume_up" })).toBe("inPlace");
+      expect(classifyObservationAction("inputText", { text: "hello" })).toBe("inPlace");
+      expect(classifyObservationAction("clearText", {})).toBe("inPlace");
+      expect(classifyObservationAction("swipeOn", { direction: "up" })).toBe("scroll");
+      expect(classifyObservationAction("dragAndDrop", {})).toBe("scroll");
     });
 
     test("falls back to full when there is no sessionUuid (legacy single-agent path)", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -885,12 +885,37 @@ describe("finalizeToolResponse", () => {
       expectObservationDiff(back, { mode: "full", reason: "screen_changed" });
     });
 
+    test("action policy: submit-style IME actions are navigation-prone", () => {
+      const inputSearch = finalizeChangedLowConfidenceAction("inputText", { text: "query", imeAction: "search" });
+      expect((inputSearch.structuredContent as any).observation.isDiff).toBeUndefined();
+      expect((inputSearch.structuredContent as any).observation.viewHierarchy).toBeDefined();
+      expectObservationDiff(inputSearch, { mode: "full", reason: "screen_changed" });
+
+      const imeGo = finalizeChangedLowConfidenceAction("imeAction", { action: "go" });
+      expect((imeGo.structuredContent as any).observation.isDiff).toBeUndefined();
+      expect((imeGo.structuredContent as any).observation.viewHierarchy).toBeDefined();
+      expectObservationDiff(imeGo, { mode: "full", reason: "screen_changed" });
+    });
+
+    test("action policy: focus-traversal IME actions remain in-place", () => {
+      const inputNext = finalizeChangedLowConfidenceAction("inputText", { text: "value", imeAction: "next" });
+      expect((inputNext.structuredContent as any).observation.isDiff).toBe(true);
+      expectObservationDiff(inputNext, { mode: "diff", reason: "diff_emitted" });
+
+      const imePrevious = finalizeChangedLowConfidenceAction("imeAction", { action: "previous" });
+      expect((imePrevious.structuredContent as any).observation.isDiff).toBe(true);
+      expectObservationDiff(imePrevious, { mode: "diff", reason: "diff_emitted" });
+    });
+
     test("classifies non-observe actions for policy selection", () => {
       expect(classifyObservationAction("tapOn", { action: "tap" })).toBe("navigation");
       expect(classifyObservationAction("pressButton", { button: "back" })).toBe("navigation");
       expect(classifyObservationAction("pressButton", { button: "volume_up" })).toBe("inPlace");
       expect(classifyObservationAction("inputText", { text: "hello" })).toBe("inPlace");
+      expect(classifyObservationAction("inputText", { text: "hello", imeAction: "search" })).toBe("navigation");
       expect(classifyObservationAction("clearText", {})).toBe("inPlace");
+      expect(classifyObservationAction("imeAction", { action: "send" })).toBe("navigation");
+      expect(classifyObservationAction("imeAction", { action: "next" })).toBe("inPlace");
       expect(classifyObservationAction("swipeOn", { direction: "up" })).toBe("scroll");
       expect(classifyObservationAction("dragAndDrop", {})).toBe("scroll");
     });

--- a/test/server/toolRegistry.internalNoDiff.test.ts
+++ b/test/server/toolRegistry.internalNoDiff.test.ts
@@ -89,6 +89,60 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     );
   }
 
+  function lowConfidenceObserve(checked = false): ObserveResult {
+    const observation = sameScreenObserve();
+    observation.activeWindow = { appId: "com.example", activityName: ".Main", layoutSeqSum: 1 };
+    observation.screenIdentity = {
+      platform: "ios",
+      source: "heuristic",
+      confidence: "low",
+      key: "bundle=com.example|focus=Search",
+      components: { bundleId: "com.example", focusedField: "Search" } as any,
+    };
+    observation.viewHierarchy = {
+      packageName: "com.example",
+      hierarchy: {
+        node: {
+          "resource-id": "com.example:id/root",
+          "content-desc": "keep",
+          "node": [
+            {
+              "resource-id": "com.example:id/field",
+              "checked": checked ? "true" : undefined,
+            } as any,
+          ],
+        } as any,
+      },
+    };
+    return observation;
+  }
+
+  function registerObserveAndTextActions(): void {
+    ToolRegistry.registerDeviceAware(
+      "observe",
+      "observe",
+      baseSchema,
+      async () => createStructuredToolResponse(lowConfidenceObserve(false))
+    );
+    ToolRegistry.registerDeviceAware(
+      "inputText",
+      "inputText",
+      baseSchema.extend({
+        text: z.string().optional(),
+        imeAction: z.string().optional(),
+      }),
+      async () => createStructuredToolResponse({ success: true, observation: lowConfidenceObserve(true) })
+    );
+    ToolRegistry.registerDeviceAware(
+      "imeAction",
+      "imeAction",
+      baseSchema.extend({
+        action: z.string().optional(),
+      }),
+      async () => createStructuredToolResponse({ success: true, observation: lowConfidenceObserve(true) })
+    );
+  }
+
   beforeEach(() => {
     ToolRegistry.clearTools();
     fakeDeviceSessionManager = new FakeDeviceSessionManager();
@@ -166,5 +220,71 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     });
     expect((internal.structuredContent as any).observation).toBeDefined();
     expect((internal.structuredContent as any).observation.viewHierarchy).toBeDefined();
+  });
+
+  test("action policy: ToolRegistry forwards submit IME args so they emit full on uncertain identity", async () => {
+    serverConfig.setActionsDiffObserveEnabled(true);
+    serverConfig.setActionsNoObserveEnabled(false);
+    await setupAutolockedSession();
+    registerObserveAndTextActions();
+
+    await ToolRegistry.getTool("observe")!.handler({ platform: "android", __mcpSessionId: "mcp-session-1" });
+    const inputSearch = await ToolRegistry.getTool("inputText")!.handler({
+      platform: "android",
+      __mcpSessionId: "mcp-session-1",
+      text: "query",
+      imeAction: "search",
+    });
+    expect((inputSearch.structuredContent as any).observation.isDiff).toBeUndefined();
+    expect((inputSearch.structuredContent as any).observation.viewHierarchy).toBeDefined();
+    expect((inputSearch.structuredContent as any).observationDiff).toMatchObject({
+      mode: "full",
+      reason: "screen_changed",
+    });
+
+    await ToolRegistry.getTool("observe")!.handler({ platform: "android", __mcpSessionId: "mcp-session-1" });
+    const imeGo = await ToolRegistry.getTool("imeAction")!.handler({
+      platform: "android",
+      __mcpSessionId: "mcp-session-1",
+      action: "go",
+    });
+    expect((imeGo.structuredContent as any).observation.isDiff).toBeUndefined();
+    expect((imeGo.structuredContent as any).observation.viewHierarchy).toBeDefined();
+    expect((imeGo.structuredContent as any).observationDiff).toMatchObject({
+      mode: "full",
+      reason: "screen_changed",
+    });
+  });
+
+  test("action policy: ToolRegistry forwards traversal IME args so they still diff", async () => {
+    serverConfig.setActionsDiffObserveEnabled(true);
+    serverConfig.setActionsNoObserveEnabled(false);
+    await setupAutolockedSession();
+    registerObserveAndTextActions();
+
+    await ToolRegistry.getTool("observe")!.handler({ platform: "android", __mcpSessionId: "mcp-session-1" });
+    const inputNext = await ToolRegistry.getTool("inputText")!.handler({
+      platform: "android",
+      __mcpSessionId: "mcp-session-1",
+      text: "query",
+      imeAction: "next",
+    });
+    expect((inputNext.structuredContent as any).observation.isDiff).toBe(true);
+    expect((inputNext.structuredContent as any).observationDiff).toMatchObject({
+      mode: "diff",
+      reason: "diff_emitted",
+    });
+
+    await ToolRegistry.getTool("observe")!.handler({ platform: "android", __mcpSessionId: "mcp-session-1" });
+    const imePrevious = await ToolRegistry.getTool("imeAction")!.handler({
+      platform: "android",
+      __mcpSessionId: "mcp-session-1",
+      action: "previous",
+    });
+    expect((imePrevious.structuredContent as any).observation.isDiff).toBe(true);
+    expect((imePrevious.structuredContent as any).observationDiff).toMatchObject({
+      mode: "diff",
+      reason: "diff_emitted",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds action-aware policy metadata around the existing `--actions-diff-observe` finalizer path so navigation-prone actions stay conservative while in-place text mutations and scroll-like actions can keep compact diffs on a stable surface. The shared observe diff implementation is unchanged.

## Linked Issue

Closes #3319

## Bug / Regression Context

- **Prior attempts:** #2761/#3026 introduced the baseline diff path; #3051 signed off the real-device diff format.
- **Observed symptom:** all non-observe actions used the same identity policy, so navigation-like taps and same-screen mutations could not be handled with different strictness.
- **Repro steps / conditions:** enable `--actions-diff-observe`, seed a baseline with `observe`, then run non-observe actions with low-confidence/stable screen identity.

## Validation

- [x] `bun test test/server/finalizeToolResponse.test.ts`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate` passes (`lint`, `build`, `test`)
- [x] New unit coverage pins navigation-like tap full output, inputText diff output, and swipeOn diff output
- [ ] Android/iOS changes: not applicable, TypeScript finalizer policy only
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not run. This change is output finalization policy around existing observation fixtures and does not change gesture execution or capture code.

## Acceptance Criteria

- [x] The finalizer receives/derives an action class for non-observe tools.
- [x] Tests cover navigation-like tap -> full on identity change, inputText -> diff on stable identity, swipe -> diff on stable identity.
- [x] No behavior changes when `--actions-diff-observe` is off.
- [x] The policy is documented near the flag so users understand why some actions return full observations.

## Follow-ups

- [x] No follow-up issues filed; no out-of-scope gaps identified.

Made with [Cursor](https://cursor.com)