### PR TITLE
perf(db): set read workload SQLite pragmas

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -39,6 +39,27 @@ export const SQLITE_BUSY_TIMEOUT_MS = 5_000;
  */
 export const SQLITE_WAL_SIZE_LIMIT_BYTES = 4 * 1024 * 1024;
 
+/**
+ * Connection-local SQLite page cache budget. Negative cache_size values are
+ * kibibytes, not pages; 16 MiB is enough to keep the SELECT-heavy telemetry and
+ * navigation working sets warm without being surprising for a local daemon.
+ */
+export const SQLITE_CACHE_SIZE_KIB = 16 * 1024;
+
+/**
+ * Upper bound for SQLite memory-mapped reads. 64 MiB gives growing local
+ * telemetry/diagnostics databases a cheap read path while keeping the address
+ * window conservative on developer machines.
+ */
+export const SQLITE_MMAP_SIZE_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Keep temporary sort and b-tree storage in memory. These are local diagnostic
+ * queries over bounded data, so avoiding temp files is a read-performance knob
+ * rather than a durability trade-off.
+ */
+export const SQLITE_TEMP_STORE = "MEMORY";
+
 interface SqlitePragmaDatabase {
   exec(sql: string): unknown;
 }
@@ -70,6 +91,15 @@ export function configureSqliteDatabase(sqliteDb: SqlitePragmaDatabase): void {
   // Truncate the WAL back to this bound after each passive/auto checkpoint
   // instead of leaving it allocated at its high-water mark (issue #2802).
   sqliteDb.exec(`PRAGMA journal_size_limit = ${SQLITE_WAL_SIZE_LIMIT_BYTES};`);
+
+  // Use a modest page cache for the SELECT-heavy observe/nav/stream workload.
+  sqliteDb.exec(`PRAGMA cache_size = -${SQLITE_CACHE_SIZE_KIB};`);
+
+  // Allow SQLite to memory-map the hot prefix of the local diagnostics DB.
+  sqliteDb.exec(`PRAGMA mmap_size = ${SQLITE_MMAP_SIZE_BYTES};`);
+
+  // Keep temporary sort/b-tree structures off disk for local diagnostic queries.
+  sqliteDb.exec(`PRAGMA temp_store = ${SQLITE_TEMP_STORE};`);
 
   // WAL + NORMAL avoids an fsync per commit while remaining corruption-safe.
   // The whole DB stores local telemetry, diagnostics, cache, config, and session

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -10,6 +10,9 @@ import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import {
   configureSqliteDatabase,
   SQLITE_BUSY_TIMEOUT_MS,
+  SQLITE_CACHE_SIZE_KIB,
+  SQLITE_MMAP_SIZE_BYTES,
+  SQLITE_TEMP_STORE,
   SQLITE_WAL_SIZE_LIMIT_BYTES,
 } from "../../src/db/database";
 
@@ -36,7 +39,7 @@ function createDeferred<T = void>(): Deferred<T> {
 }
 
 describe("configureSqliteDatabase", () => {
-  test("enables WAL, busy timeout, WAL size limit, and foreign keys for new connections", () => {
+  test("enables WAL, busy timeout, read pragmas, WAL size limit, and foreign keys for new connections", () => {
     const db = new FakeSqliteDatabase();
 
     configureSqliteDatabase(db);
@@ -45,6 +48,9 @@ describe("configureSqliteDatabase", () => {
       `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};`,
       "PRAGMA journal_mode = WAL;",
       `PRAGMA journal_size_limit = ${SQLITE_WAL_SIZE_LIMIT_BYTES};`,
+      `PRAGMA cache_size = -${SQLITE_CACHE_SIZE_KIB};`,
+      `PRAGMA mmap_size = ${SQLITE_MMAP_SIZE_BYTES};`,
+      `PRAGMA temp_store = ${SQLITE_TEMP_STORE};`,
       "PRAGMA synchronous = NORMAL;",
       "PRAGMA foreign_keys = ON;",
     ]);
@@ -106,6 +112,33 @@ describe("configureSqliteDatabase", () => {
     } finally {
       sqliteDb.close();
       rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("sets read workload pragmas on Bun SQLite databases", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "auto-mobile-sqlite-"));
+    const sqliteDb = new BunDatabase(join(tempDir, "test.db"));
+
+    try {
+      configureSqliteDatabase(sqliteDb);
+
+      const cacheSize = sqliteDb
+        .query<{ cache_size: number }, []>("PRAGMA cache_size;")
+        .get();
+      expect(cacheSize?.cache_size).toBe(-SQLITE_CACHE_SIZE_KIB);
+
+      const mmapSize = sqliteDb
+        .query<{ mmap_size: number }, []>("PRAGMA mmap_size;")
+        .get();
+      expect(mmapSize?.mmap_size).toBe(SQLITE_MMAP_SIZE_BYTES);
+
+      const tempStore = sqliteDb
+        .query<{ temp_store: number }, []>("PRAGMA temp_store;")
+        .get();
+      expect(tempStore?.temp_store).toBe(2);
+    } finally {
+      sqliteDb.close();
+      await removeTempDbDir(tempDir);
     }
   });
 });

--- a/test/db/database.test.ts
+++ b/test/db/database.test.ts
@@ -39,6 +39,12 @@ function createDeferred<T = void>(): Deferred<T> {
 }
 
 describe("configureSqliteDatabase", () => {
+  test("documents conservative read workload pragma sizes", () => {
+    expect(SQLITE_CACHE_SIZE_KIB).toBe(16 * 1024);
+    expect(SQLITE_MMAP_SIZE_BYTES).toBe(64 * 1024 * 1024);
+    expect(SQLITE_TEMP_STORE).toBe("MEMORY");
+  });
+
   test("enables WAL, busy timeout, read pragmas, WAL size limit, and foreign keys for new connections", () => {
     const db = new FakeSqliteDatabase();
 


### PR DESCRIPTION
## Summary

Set conservative SQLite read-workload pragmas on every configured database connection: a 16 MiB page cache, a 64 MiB mmap window, and in-memory temp storage. These apply through `configureSqliteDatabase`, which is shared by both the app connection and the startup migration connection.

## Linked Issue

Closes #3406

## Validation

- [x] `bun test test/db/database.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interface/fake-style pragma coverage; targeted unit tests run in <100ms

## Device Verification

N/A - database connection configuration only.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)