### PR TITLE
Fix test execution recording atomicity

### DIFF
--- a/src/db/testExecutionRepository.ts
+++ b/src/db/testExecutionRepository.ts
@@ -142,6 +142,15 @@ export class TestExecutionRepository {
   async recordExecution(record: TestExecutionRecord): Promise<number> {
     const db = this.getDb();
 
+    const executionId = db.isTransaction
+      ? await this.recordExecutionWithin(db, record)
+      : await db.transaction().execute(trx => this.recordExecutionWithin(trx, record));
+
+    await this.cleanupRetention();
+    return executionId;
+  }
+
+  private async recordExecutionWithin(db: Kysely<Database>, record: TestExecutionRecord): Promise<number> {
     const entry: NewTestExecution = {
       test_class: record.testClass,
       test_method: record.testMethod,
@@ -198,7 +207,6 @@ export class TestExecutionRepository {
       await db.insertInto("test_execution_screens").values(screenEntries).execute();
     }
 
-    await this.cleanupRetention();
     return executionId;
   }
 

--- a/test/db/testExecutionRepository.test.ts
+++ b/test/db/testExecutionRepository.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, afterEach, describe, expect, test } from "bun:test";
 import { Database as BunDatabase } from "bun:sqlite";
 import type { Kysely } from "kysely";
-import { Kysely as KyselyRuntime } from "kysely";
+import { Kysely as KyselyRuntime, sql } from "kysely";
 import type { Database } from "../../src/db/types";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { SQLITE_MAX_BOUND_PARAMETERS } from "../../src/db/sqliteBatch";
@@ -153,6 +153,46 @@ describe("TestExecutionRepository", () => {
       const runs = await repo.getTestRuns();
       expect(runs[0].steps).toEqual([]);
       expect(runs[0].screensVisited).toEqual([]);
+    });
+
+    test("rolls back the execution row when inserting steps fails", async () => {
+      await sql`
+        CREATE TEMP TRIGGER fail_test_execution_steps_insert
+        BEFORE INSERT ON test_execution_steps
+        BEGIN
+          SELECT RAISE(ABORT, 'injected step insert failure');
+        END
+      `.execute(db);
+
+      await expect(
+        repo.recordExecution(makeExecution({ steps: [makeStep()] }))
+      ).rejects.toThrow("injected step insert failure");
+
+      const row = await db
+        .selectFrom("test_executions")
+        .select(db.fn.count<number>("id").as("count"))
+        .executeTakeFirstOrThrow();
+      expect(Number(row.count)).toBe(0);
+    });
+
+    test("runs on an enclosing transaction executor without opening a nested transaction", async () => {
+      let executionId = 0;
+
+      await db.transaction().execute(async trx => {
+        const boundRepo = new TestExecutionRepository(timer, trx);
+        executionId = await boundRepo.recordExecution(
+          makeExecution({
+            steps: [makeStep()],
+            screensVisited: [{ screenName: "LoginScreen", timestamp: 1000 }],
+          })
+        );
+      });
+
+      const runs = await repo.getTestRuns();
+      expect(runs).toHaveLength(1);
+      expect(runs[0].id).toBe(executionId);
+      expect(runs[0].steps).toHaveLength(1);
+      expect(runs[0].screensVisited).toEqual(["LoginScreen"]);
     });
   });
 

--- a/test/db/testExecutionRepository.test.ts
+++ b/test/db/testExecutionRepository.test.ts
@@ -175,6 +175,36 @@ describe("TestExecutionRepository", () => {
       expect(Number(row.count)).toBe(0);
     });
 
+    test("rolls back execution and steps when inserting screens fails", async () => {
+      await sql`
+        CREATE TEMP TRIGGER fail_test_execution_screens_insert
+        BEFORE INSERT ON test_execution_screens
+        BEGIN
+          SELECT RAISE(ABORT, 'injected screen insert failure');
+        END
+      `.execute(db);
+
+      await expect(
+        repo.recordExecution(
+          makeExecution({
+            steps: [makeStep()],
+            screensVisited: [{ screenName: "LoginScreen", timestamp: 1000 }],
+          })
+        )
+      ).rejects.toThrow("injected screen insert failure");
+
+      const executionRow = await db
+        .selectFrom("test_executions")
+        .select(db.fn.count<number>("id").as("count"))
+        .executeTakeFirstOrThrow();
+      const stepRow = await db
+        .selectFrom("test_execution_steps")
+        .select(db.fn.count<number>("id").as("count"))
+        .executeTakeFirstOrThrow();
+      expect(Number(executionRow.count)).toBe(0);
+      expect(Number(stepRow.count)).toBe(0);
+    });
+
     test("runs on an enclosing transaction executor without opening a nested transaction", async () => {
       let executionId = 0;
 


### PR DESCRIPTION
## Summary

Wrap `TestExecutionRepository.recordExecution` parent, step, and screen inserts in one transaction so a mid-write failure cannot leave orphaned execution rows, while preserving the returned execution id.

## Linked Issue

Closes #3403

## Bug / Regression Context

- **Prior attempts:** None referenced in the issue.
- **Observed symptom:** `recordExecution` wrote `test_executions`, `test_execution_steps`, and `test_execution_screens` as separate awaited statements, so a steps/screens failure could leave a parent row without children.
- **Repro steps / conditions:** Inject a failure on `test_execution_steps` insert after the parent insert; before this fix, the parent row remains.

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun test test/db/testExecutionRepository.test.ts` passes
- [x] New repository tests use an in-memory DB and avoid the file-backed singleton
- [x] Rebased onto latest `main`, conflicts resolved

## Acceptance Criteria

- [x] Execution, steps, and screens inserts commit atomically in one transaction.
- [x] Returned `executionId` contract is preserved.
- [x] Already-bound transaction executors avoid opening a nested transaction.
- [x] Injected steps-insert failure leaves no orphaned `test_executions` row.

## Device Verification

N/A — database repository change only.

## Follow-ups

No follow-ups identified.

Made with [Cursor](https://cursor.com)