### PR TITLE
Fix duplicate media repository inserts

### DIFF
--- a/src/db/deviceSnapshotRepository.ts
+++ b/src/db/deviceSnapshotRepository.ts
@@ -127,18 +127,7 @@ export class DeviceSnapshotRepository {
       .insertInto("device_snapshots")
       .values(row)
       .onConflict(oc =>
-        oc.column("snapshot_name").doUpdateSet({
-          device_id: row.device_id,
-          device_name: row.device_name,
-          platform: row.platform,
-          snapshot_type: row.snapshot_type,
-          include_app_data: row.include_app_data,
-          include_settings: row.include_settings,
-          created_at: row.created_at,
-          last_accessed_at: row.last_accessed_at,
-          size_bytes: row.size_bytes,
-          manifest_json: row.manifest_json,
-        })
+        oc.column("snapshot_name").doNothing()
       )
       .execute();
   }

--- a/src/db/deviceSnapshotRepository.ts
+++ b/src/db/deviceSnapshotRepository.ts
@@ -123,7 +123,24 @@ export class DeviceSnapshotRepository {
       manifest_json: JSON.stringify(record.manifest),
     };
 
-    await db.insertInto("device_snapshots").values(row).execute();
+    await db
+      .insertInto("device_snapshots")
+      .values(row)
+      .onConflict(oc =>
+        oc.column("snapshot_name").doUpdateSet({
+          device_id: row.device_id,
+          device_name: row.device_name,
+          platform: row.platform,
+          snapshot_type: row.snapshot_type,
+          include_app_data: row.include_app_data,
+          include_settings: row.include_settings,
+          created_at: row.created_at,
+          last_accessed_at: row.last_accessed_at,
+          size_bytes: row.size_bytes,
+          manifest_json: row.manifest_json,
+        })
+      )
+      .execute();
   }
 
   async updateSnapshot(

--- a/src/db/deviceSnapshotRepository.ts
+++ b/src/db/deviceSnapshotRepository.ts
@@ -127,7 +127,18 @@ export class DeviceSnapshotRepository {
       .insertInto("device_snapshots")
       .values(row)
       .onConflict(oc =>
-        oc.column("snapshot_name").doNothing()
+        oc.column("snapshot_name").doUpdateSet({
+          device_id: row.device_id,
+          device_name: row.device_name,
+          platform: row.platform,
+          snapshot_type: row.snapshot_type,
+          include_app_data: row.include_app_data,
+          include_settings: row.include_settings,
+          created_at: row.created_at,
+          last_accessed_at: row.last_accessed_at,
+          size_bytes: row.size_bytes,
+          manifest_json: row.manifest_json,
+        })
       )
       .execute();
   }

--- a/src/db/videoRecordingRepository.ts
+++ b/src/db/videoRecordingRepository.ts
@@ -165,7 +165,30 @@ export class VideoRecordingRepository {
       highlights_json: record.highlights ? JSON.stringify(record.highlights) : null,
     };
 
-    await db.insertInto("video_recordings").values(row).execute();
+    await db
+      .insertInto("video_recordings")
+      .values(row)
+      .onConflict(oc =>
+        oc.column("recording_id").doUpdateSet({
+          device_id: row.device_id,
+          platform: row.platform,
+          status: row.status,
+          output_name: row.output_name,
+          file_name: row.file_name,
+          file_path: row.file_path,
+          format: row.format,
+          size_bytes: row.size_bytes,
+          duration_ms: row.duration_ms,
+          codec: row.codec,
+          created_at: row.created_at,
+          started_at: row.started_at,
+          ended_at: row.ended_at,
+          last_accessed_at: row.last_accessed_at,
+          config_json: row.config_json,
+          highlights_json: row.highlights_json,
+        })
+      )
+      .execute();
   }
 
   async updateRecording(

--- a/test/db/deviceSnapshotRepository.test.ts
+++ b/test/db/deviceSnapshotRepository.test.ts
@@ -68,6 +68,48 @@ describe("DeviceSnapshotRepository", () => {
     expect(result!.manifest.snapshotName).toBe("snap-1");
   });
 
+  test("insertSnapshot upserts an existing snapshot name", async () => {
+    await repo.insertSnapshot(makeRecord());
+
+    await repo.insertSnapshot(
+      makeRecord({
+        snapshotName: "snap-1",
+        deviceId: "device-B",
+        deviceName: "Pixel_8",
+        platform: "ios",
+        snapshotType: "adb",
+        includeAppData: true,
+        includeSettings: true,
+        createdAt: "2024-02-01T00:00:00.000Z",
+        lastAccessedAt: "2024-02-02T00:00:00.000Z",
+        sizeBytes: 2048,
+        manifest: makeManifest({
+          snapshotName: "snap-1",
+          deviceId: "device-B",
+          deviceName: "Pixel_8",
+          platform: "ios",
+          snapshotType: "adb",
+          includeAppData: true,
+          includeSettings: true,
+          osVersion: "17",
+        }),
+      })
+    );
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result).not.toBeNull();
+    expect(result!.deviceId).toBe("device-B");
+    expect(result!.deviceName).toBe("Pixel_8");
+    expect(result!.platform).toBe("ios");
+    expect(result!.snapshotType).toBe("adb");
+    expect(result!.includeAppData).toBe(true);
+    expect(result!.includeSettings).toBe(true);
+    expect(result!.createdAt).toBe("2024-02-01T00:00:00.000Z");
+    expect(result!.lastAccessedAt).toBe("2024-02-02T00:00:00.000Z");
+    expect(result!.sizeBytes).toBe(2048);
+    expect(result!.manifest.osVersion).toBe("17");
+  });
+
   test("getSnapshot returns null for unknown snapshot", async () => {
     const result = await repo.getSnapshot("nonexistent");
     expect(result).toBeNull();

--- a/test/db/deviceSnapshotRepository.test.ts
+++ b/test/db/deviceSnapshotRepository.test.ts
@@ -68,8 +68,12 @@ describe("DeviceSnapshotRepository", () => {
     expect(result!.manifest.snapshotName).toBe("snap-1");
   });
 
-  test("insertSnapshot upserts an existing snapshot name", async () => {
-    await repo.insertSnapshot(makeRecord());
+  test("insertSnapshot ignores an existing snapshot name", async () => {
+    await repo.insertSnapshot(
+      makeRecord({
+        manifest: makeManifest({ osVersion: "14" }),
+      })
+    );
 
     await repo.insertSnapshot(
       makeRecord({
@@ -98,16 +102,16 @@ describe("DeviceSnapshotRepository", () => {
 
     const result = await repo.getSnapshot("snap-1");
     expect(result).not.toBeNull();
-    expect(result!.deviceId).toBe("device-B");
-    expect(result!.deviceName).toBe("Pixel_8");
-    expect(result!.platform).toBe("ios");
-    expect(result!.snapshotType).toBe("adb");
-    expect(result!.includeAppData).toBe(true);
-    expect(result!.includeSettings).toBe(true);
-    expect(result!.createdAt).toBe("2024-02-01T00:00:00.000Z");
-    expect(result!.lastAccessedAt).toBe("2024-02-02T00:00:00.000Z");
-    expect(result!.sizeBytes).toBe(2048);
-    expect(result!.manifest.osVersion).toBe("17");
+    expect(result!.deviceId).toBe("emulator-5554");
+    expect(result!.deviceName).toBe("Pixel_6");
+    expect(result!.platform).toBe("android");
+    expect(result!.snapshotType).toBe("vm");
+    expect(result!.includeAppData).toBe(false);
+    expect(result!.includeSettings).toBe(false);
+    expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(result!.lastAccessedAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(result!.sizeBytes).toBe(1024);
+    expect(result!.manifest.osVersion).toBe("14");
   });
 
   test("getSnapshot returns null for unknown snapshot", async () => {

--- a/test/db/deviceSnapshotRepository.test.ts
+++ b/test/db/deviceSnapshotRepository.test.ts
@@ -68,12 +68,8 @@ describe("DeviceSnapshotRepository", () => {
     expect(result!.manifest.snapshotName).toBe("snap-1");
   });
 
-  test("insertSnapshot ignores an existing snapshot name", async () => {
-    await repo.insertSnapshot(
-      makeRecord({
-        manifest: makeManifest({ osVersion: "14" }),
-      })
-    );
+  test("insertSnapshot upserts an existing snapshot name", async () => {
+    await repo.insertSnapshot(makeRecord());
 
     await repo.insertSnapshot(
       makeRecord({
@@ -102,16 +98,16 @@ describe("DeviceSnapshotRepository", () => {
 
     const result = await repo.getSnapshot("snap-1");
     expect(result).not.toBeNull();
-    expect(result!.deviceId).toBe("emulator-5554");
-    expect(result!.deviceName).toBe("Pixel_6");
-    expect(result!.platform).toBe("android");
-    expect(result!.snapshotType).toBe("vm");
-    expect(result!.includeAppData).toBe(false);
-    expect(result!.includeSettings).toBe(false);
-    expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
-    expect(result!.lastAccessedAt).toBe("2024-01-01T00:00:00.000Z");
-    expect(result!.sizeBytes).toBe(1024);
-    expect(result!.manifest.osVersion).toBe("14");
+    expect(result!.deviceId).toBe("device-B");
+    expect(result!.deviceName).toBe("Pixel_8");
+    expect(result!.platform).toBe("ios");
+    expect(result!.snapshotType).toBe("adb");
+    expect(result!.includeAppData).toBe(true);
+    expect(result!.includeSettings).toBe(true);
+    expect(result!.createdAt).toBe("2024-02-01T00:00:00.000Z");
+    expect(result!.lastAccessedAt).toBe("2024-02-02T00:00:00.000Z");
+    expect(result!.sizeBytes).toBe(2048);
+    expect(result!.manifest.osVersion).toBe("17");
   });
 
   test("getSnapshot returns null for unknown snapshot", async () => {

--- a/test/db/videoRecordingRepository.test.ts
+++ b/test/db/videoRecordingRepository.test.ts
@@ -119,6 +119,40 @@ describe("VideoRecordingRepository", () => {
     expect(result!.highlights![0].description).toBe("second insert highlight");
   });
 
+  test("insertRecording upsert clears stale optional fields", async () => {
+    await repo.insertRecording(
+      makeRecord({
+        recordingId: "rec-1",
+        outputName: "first-recording",
+        durationMs: 5000,
+        codec: "h264",
+        endedAt: "2024-01-01T00:05:00.000Z",
+        highlights: [
+          {
+            description: "first insert highlight",
+            shape: { type: "circle", cx: 100, cy: 200, r: 30 },
+            timeline: { appearedAtSeconds: 1.0 },
+          },
+        ],
+      })
+    );
+
+    await repo.insertRecording(
+      makeRecord({
+        recordingId: "rec-1",
+        status: "recording",
+      })
+    );
+
+    const result = await repo.getRecording("rec-1");
+    expect(result).not.toBeNull();
+    expect(result!.outputName).toBeUndefined();
+    expect(result!.durationMs).toBeUndefined();
+    expect(result!.codec).toBeUndefined();
+    expect(result!.endedAt).toBeUndefined();
+    expect(result!.highlights).toBeUndefined();
+  });
+
   test("getRecording returns null for unknown id", async () => {
     const result = await repo.getRecording("nonexistent");
     expect(result).toBeNull();

--- a/test/db/videoRecordingRepository.test.ts
+++ b/test/db/videoRecordingRepository.test.ts
@@ -67,6 +67,58 @@ describe("VideoRecordingRepository", () => {
     expect(result!.config.fps).toBe(15);
   });
 
+  test("insertRecording upserts an existing recording id", async () => {
+    await repo.insertRecording(makeRecord());
+
+    await repo.insertRecording(
+      makeRecord({
+        recordingId: "rec-1",
+        deviceId: "device-B",
+        platform: "ios",
+        status: "completed",
+        outputName: "second-recording",
+        fileName: "second.mp4",
+        filePath: "/tmp/second.mp4",
+        format: "mp4",
+        sizeBytes: 4096,
+        durationMs: 6000,
+        codec: "h265",
+        createdAt: "2024-02-01T00:00:00.000Z",
+        startedAt: "2024-02-01T00:00:01.000Z",
+        endedAt: "2024-02-01T00:00:07.000Z",
+        lastAccessedAt: "2024-02-02T00:00:00.000Z",
+        config: makeConfig({ qualityPreset: "high", fps: 30 }),
+        highlights: [
+          {
+            description: "second insert highlight",
+            shape: { type: "circle", cx: 12, cy: 34, r: 5 },
+            timeline: { appearedAtSeconds: 1.5 },
+          },
+        ],
+      })
+    );
+
+    const result = await repo.getRecording("rec-1");
+    expect(result).not.toBeNull();
+    expect(result!.deviceId).toBe("device-B");
+    expect(result!.platform).toBe("ios");
+    expect(result!.status).toBe("completed");
+    expect(result!.outputName).toBe("second-recording");
+    expect(result!.fileName).toBe("second.mp4");
+    expect(result!.filePath).toBe("/tmp/second.mp4");
+    expect(result!.sizeBytes).toBe(4096);
+    expect(result!.durationMs).toBe(6000);
+    expect(result!.codec).toBe("h265");
+    expect(result!.createdAt).toBe("2024-02-01T00:00:00.000Z");
+    expect(result!.startedAt).toBe("2024-02-01T00:00:01.000Z");
+    expect(result!.endedAt).toBe("2024-02-01T00:00:07.000Z");
+    expect(result!.lastAccessedAt).toBe("2024-02-02T00:00:00.000Z");
+    expect(result!.config.qualityPreset).toBe("high");
+    expect(result!.config.fps).toBe(30);
+    expect(result!.highlights).toHaveLength(1);
+    expect(result!.highlights![0].description).toBe("second insert highlight");
+  });
+
   test("getRecording returns null for unknown id", async () => {
     const result = await repo.getRecording("nonexistent");
     expect(result).toBeNull();

--- a/test/fakes/FakeDeviceSnapshotRepository.test.ts
+++ b/test/fakes/FakeDeviceSnapshotRepository.test.ts
@@ -36,7 +36,7 @@ function makeRecord(overrides: Partial<DeviceSnapshotRecord> = {}): DeviceSnapsh
 }
 
 describe("FakeDeviceSnapshotRepository", () => {
-  test("insertSnapshot preserves the first record for an existing snapshot name", async () => {
+  test("insertSnapshot overwrites an existing snapshot name", async () => {
     const repo = new FakeDeviceSnapshotRepository();
 
     await repo.insertSnapshot(
@@ -60,8 +60,8 @@ describe("FakeDeviceSnapshotRepository", () => {
 
     const result = await repo.getSnapshot("snap-1");
     expect(result).not.toBeNull();
-    expect(result!.deviceId).toBe("emulator-5554");
-    expect(result!.deviceName).toBe("Pixel_6");
-    expect(result!.manifest.osVersion).toBe("14");
+    expect(result!.deviceId).toBe("device-B");
+    expect(result!.deviceName).toBe("Pixel_8");
+    expect(result!.manifest.osVersion).toBe("17");
   });
 });

--- a/test/fakes/FakeDeviceSnapshotRepository.test.ts
+++ b/test/fakes/FakeDeviceSnapshotRepository.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { DeviceSnapshotRecord } from "../../src/db/deviceSnapshotRepository";
+import type { DeviceSnapshotManifest } from "../../src/models";
+import { FakeDeviceSnapshotRepository } from "./FakeDeviceSnapshotRepository";
+
+function makeManifest(overrides: Partial<DeviceSnapshotManifest> = {}): DeviceSnapshotManifest {
+  return {
+    snapshotName: "snap-1",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    deviceId: "emulator-5554",
+    deviceName: "Pixel_6",
+    platform: "android",
+    snapshotType: "vm",
+    includeAppData: false,
+    includeSettings: false,
+    ...overrides,
+  };
+}
+
+function makeRecord(overrides: Partial<DeviceSnapshotRecord> = {}): DeviceSnapshotRecord {
+  const snapshotName = overrides.snapshotName ?? "snap-1";
+  return {
+    snapshotName,
+    deviceId: "emulator-5554",
+    deviceName: "Pixel_6",
+    platform: "android",
+    snapshotType: "vm",
+    includeAppData: false,
+    includeSettings: false,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    lastAccessedAt: "2024-01-01T00:00:00.000Z",
+    sizeBytes: 1024,
+    manifest: makeManifest({ snapshotName }),
+    ...overrides,
+  };
+}
+
+describe("FakeDeviceSnapshotRepository", () => {
+  test("insertSnapshot preserves the first record for an existing snapshot name", async () => {
+    const repo = new FakeDeviceSnapshotRepository();
+
+    await repo.insertSnapshot(
+      makeRecord({
+        manifest: makeManifest({ osVersion: "14" }),
+      })
+    );
+    await repo.insertSnapshot(
+      makeRecord({
+        snapshotName: "snap-1",
+        deviceId: "device-B",
+        deviceName: "Pixel_8",
+        manifest: makeManifest({
+          snapshotName: "snap-1",
+          deviceId: "device-B",
+          deviceName: "Pixel_8",
+          osVersion: "17",
+        }),
+      })
+    );
+
+    const result = await repo.getSnapshot("snap-1");
+    expect(result).not.toBeNull();
+    expect(result!.deviceId).toBe("emulator-5554");
+    expect(result!.deviceName).toBe("Pixel_6");
+    expect(result!.manifest.osVersion).toBe("14");
+  });
+});

--- a/test/fakes/FakeDeviceSnapshotRepository.ts
+++ b/test/fakes/FakeDeviceSnapshotRepository.ts
@@ -7,9 +7,6 @@ export class FakeDeviceSnapshotRepository {
   private readonly records = new Map<string, DeviceSnapshotRecord>();
 
   async insertSnapshot(record: DeviceSnapshotRecord): Promise<void> {
-    if (this.records.has(record.snapshotName)) {
-      return;
-    }
     this.records.set(record.snapshotName, { ...record });
   }
 

--- a/test/fakes/FakeDeviceSnapshotRepository.ts
+++ b/test/fakes/FakeDeviceSnapshotRepository.ts
@@ -7,6 +7,9 @@ export class FakeDeviceSnapshotRepository {
   private readonly records = new Map<string, DeviceSnapshotRecord>();
 
   async insertSnapshot(record: DeviceSnapshotRecord): Promise<void> {
+    if (this.records.has(record.snapshotName)) {
+      return;
+    }
     this.records.set(record.snapshotName, { ...record });
   }
 


### PR DESCRIPTION
## Summary

Make PK-keyed device snapshot and video recording repository inserts atomic upserts so duplicate/concurrent creates update the existing row instead of surfacing raw SQLite primary-key crashes.

## Linked Issue

Closes #3404

## Bug / Regression Context

- **Prior attempts:** None noted on the issue.
- **Observed symptom:** Re-creating a snapshot/recording under an existing primary key could throw `UNIQUE constraint failed` to the caller.
- **Repro steps / conditions:** Insert a `device_snapshots.snapshot_name` or `video_recordings.recording_id`, then insert the same key again through the repository.

## Validation

- [x] `bun test test/fakes/FakeDeviceSnapshotRepository.test.ts test/db/deviceSnapshotRepository.test.ts test/db/videoRecordingRepository.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: not applicable
- [x] New code uses existing repository interfaces and in-memory DB tests; focused tests complete quickly
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not applicable; repository-only DB change.

## Acceptance Criteria

- [x] `insertSnapshot` / `insertRecording` handle duplicate primary keys via `onConflict` upserts.
- [x] Existing rows are replaced by updating all non-PK mutable columns.
- [x] Regression tests cover a second insert with the same key and assert no bare SQLite error is thrown.

## Follow-ups

None.