### PR TITLE
fix daemon DB health liveness

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -975,6 +975,13 @@ export class Daemon {
     }
   }
 
+  private stopHealthCheckTimer(): void {
+    if (this.healthCheckTimer) {
+      this.timer.clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = null;
+    }
+  }
+
   /**
    * Start periodic heartbeat checks to cancel stale sessions
    */
@@ -1355,10 +1362,7 @@ export class Daemon {
     logger.info("Stopping daemon...");
 
     // Clear health check timer
-    if (this.healthCheckTimer) {
-      clearInterval(this.healthCheckTimer);
-      this.healthCheckTimer = null;
-    }
+    this.stopHealthCheckTimer();
     if (this.heartbeatMonitor) {
       this.heartbeatMonitor.stop();
       this.heartbeatMonitor = null;

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -29,6 +29,7 @@ import {
   getDbWriteBarrier,
 } from "../db";
 import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
+import { DatabaseHealthProbe, DefaultDatabaseHealthProbe } from "../db/DatabaseHealthProbe";
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
 import { handleFatalDatabaseStartupFailure } from "./daemonStartupGuard";
 import { runStartupPrologue } from "./startupPrologue";
@@ -126,6 +127,7 @@ export class Daemon {
   private timer: Timer;
   private idGenerator: IdGenerator;
   private databaseInitializer: DatabaseInitializer;
+  private databaseHealthProbe: DatabaseHealthProbe;
   private startupFailureTracker: StartupFailureTracker;
   private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
@@ -138,7 +140,8 @@ export class Daemon {
     deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository(),
     idGenerator: IdGenerator = defaultIdGenerator,
     databaseInitializer: DatabaseInitializer = new DefaultDatabaseInitializer(),
-    startupFailureTracker: StartupFailureTracker = new DefaultStartupFailureTracker()
+    startupFailureTracker: StartupFailureTracker = new DefaultStartupFailureTracker(),
+    databaseHealthProbe: DatabaseHealthProbe = new DefaultDatabaseHealthProbe({ timer })
   ) {
     this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
@@ -150,6 +153,7 @@ export class Daemon {
     this.daemonSessionId = this.idGenerator.next();
     this.timer = timer;
     this.databaseInitializer = databaseInitializer;
+    this.databaseHealthProbe = databaseHealthProbe;
     this.startupFailureTracker = startupFailureTracker;
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
@@ -926,7 +930,7 @@ export class Daemon {
     const MAX_FAILED_CHECKS = 3; // Allow 3 consecutive failures before taking action
     let failedCheckCount = 0;
 
-    this.healthCheckTimer = defaultTimer.setInterval(async () => {
+    this.healthCheckTimer = this.timer.setInterval(async () => {
       try {
         // Check if HTTP server is responsive
         if (!this.httpServer) {
@@ -936,14 +940,20 @@ export class Daemon {
           logger.warn("Health check failed: HTTP server not listening");
           failedCheckCount++;
         } else {
-          // Check if socket server is active
+          // Check if socket server is active before probing shared dependencies.
           if (!this.socketServer || !this.socketServer.isListening()) {
             logger.warn("Health check failed: Socket server not listening");
             failedCheckCount++;
           } else {
-            // Health check passed
-            failedCheckCount = 0;
-            logger.debug("Health check passed");
+            try {
+              await this.databaseHealthProbe.check();
+              // Health check passed
+              failedCheckCount = 0;
+              logger.debug("Health check passed");
+            } catch (error) {
+              logger.warn(`Health check failed: Database probe failed: ${error}`);
+              failedCheckCount++;
+            }
           }
         }
 
@@ -960,7 +970,9 @@ export class Daemon {
     }, HEALTH_CHECK_INTERVAL);
 
     // Keep timer alive even if there are no other references
-    this.healthCheckTimer.unref();
+    if (typeof (this.healthCheckTimer as { unref?: () => void }).unref === "function") {
+      (this.healthCheckTimer as { unref: () => void }).unref();
+    }
   }
 
   /**

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -96,6 +96,9 @@ const DB_WRITE_DRAIN_TIMEOUT_MS = 1_000;
 // cannot itself hang shutdown — the timeout wins and shutdown proceeds anyway.
 const MIGRATION_SETTLE_TIMEOUT_MS = 5_000;
 
+type HealthFailureKind = "http" | "socket" | "database" | "unknown";
+type DatabaseHealthFailureRecovery = (code: number) => void;
+
 /**
  * Main daemon process
  *
@@ -129,6 +132,7 @@ export class Daemon {
   private databaseInitializer: DatabaseInitializer;
   private databaseHealthProbe: DatabaseHealthProbe;
   private startupFailureTracker: StartupFailureTracker;
+  private recoverFromDatabaseHealthFailure: DatabaseHealthFailureRecovery;
   private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
@@ -141,7 +145,8 @@ export class Daemon {
     idGenerator: IdGenerator = defaultIdGenerator,
     databaseInitializer: DatabaseInitializer = new DefaultDatabaseInitializer(),
     startupFailureTracker: StartupFailureTracker = new DefaultStartupFailureTracker(),
-    databaseHealthProbe: DatabaseHealthProbe = new DefaultDatabaseHealthProbe({ timer })
+    databaseHealthProbe: DatabaseHealthProbe = new DefaultDatabaseHealthProbe({ timer }),
+    recoverFromDatabaseHealthFailure?: DatabaseHealthFailureRecovery
   ) {
     this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
@@ -155,6 +160,11 @@ export class Daemon {
     this.databaseInitializer = databaseInitializer;
     this.databaseHealthProbe = databaseHealthProbe;
     this.startupFailureTracker = startupFailureTracker;
+    this.recoverFromDatabaseHealthFailure = recoverFromDatabaseHealthFailure ?? (code => {
+      cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
+      logger.close();
+      process.exit(code);
+    });
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
     // Register centralized cleanup for session-scoped state
@@ -929,20 +939,24 @@ export class Daemon {
     const HEALTH_CHECK_INTERVAL = 30000; // 30 seconds
     const MAX_FAILED_CHECKS = 3; // Allow 3 consecutive failures before taking action
     let failedCheckCount = 0;
+    let lastFailureKind: HealthFailureKind = "unknown";
 
     this.healthCheckTimer = this.timer.setInterval(async () => {
       try {
         // Check if HTTP server is responsive
         if (!this.httpServer) {
           logger.warn("Health check failed: HTTP server not initialized");
+          lastFailureKind = "http";
           failedCheckCount++;
         } else if (!this.httpServer.listening) {
           logger.warn("Health check failed: HTTP server not listening");
+          lastFailureKind = "http";
           failedCheckCount++;
         } else {
           // Check if socket server is active before probing shared dependencies.
           if (!this.socketServer || !this.socketServer.isListening()) {
             logger.warn("Health check failed: Socket server not listening");
+            lastFailureKind = "socket";
             failedCheckCount++;
           } else {
             try {
@@ -952,6 +966,7 @@ export class Daemon {
               logger.debug("Health check passed");
             } catch (error) {
               logger.warn(`Health check failed: Database probe failed: ${error}`);
+              lastFailureKind = "database";
               failedCheckCount++;
             }
           }
@@ -960,11 +975,12 @@ export class Daemon {
         // If too many failures, attempt recovery
         if (failedCheckCount >= MAX_FAILED_CHECKS) {
           logger.error(`Health check failed ${failedCheckCount} times, attempting recovery...`);
-          await this.attemptRecovery();
+          await this.attemptRecovery(lastFailureKind);
           failedCheckCount = 0;
         }
       } catch (error) {
         logger.warn(`Health check error: ${error}`);
+        lastFailureKind = "unknown";
         failedCheckCount++;
       }
     }, HEALTH_CHECK_INTERVAL);
@@ -1144,9 +1160,15 @@ export class Daemon {
   /**
    * Attempt to recover daemon components
    */
-  private async attemptRecovery(): Promise<void> {
+  private async attemptRecovery(failureKind: HealthFailureKind = "unknown"): Promise<void> {
     try {
       logger.info("Attempting daemon recovery...");
+
+      if (failureKind === "database") {
+        logger.error("Database health check failed repeatedly; exiting daemon for a clean restart.");
+        this.recoverFromDatabaseHealthFailure(1);
+        return;
+      }
 
       // Try to restart socket server if it's not responding
       if (this.socketServer && !this.socketServer.isListening()) {

--- a/src/db/DatabaseHealthProbe.ts
+++ b/src/db/DatabaseHealthProbe.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { Worker } from "node:worker_threads";
 import { getDatabasePath, getMigrationsError } from "./database";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
@@ -76,10 +75,6 @@ function executeSqliteSelectOneInWorker(
   timeoutMs: number,
   timer: Timer
 ): Promise<void> {
-  if (dbPath !== ":memory:" && !existsSync(dbPath)) {
-    return Promise.reject(new Error(`Database health probe path does not exist: ${dbPath}`));
-  }
-
   const worker = new Worker(`
     const { parentPort, workerData } = require("node:worker_threads");
     try {

--- a/src/db/DatabaseHealthProbe.ts
+++ b/src/db/DatabaseHealthProbe.ts
@@ -1,8 +1,22 @@
-import { sql } from "kysely";
-import { getDatabase, getMigrationsError } from "./database";
+import { existsSync } from "node:fs";
+import { getDatabasePath, getMigrationsError } from "./database";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 
 const DATABASE_HEALTH_PROBE_TIMEOUT_MS = 1_000;
+const DATABASE_HEALTH_PROBE_BUSY_TIMEOUT_MS = 50;
+
+interface SqliteProbeConnection {
+  exec(sql: string): unknown;
+  query(sql: string): {
+    get(): unknown;
+  };
+  close(): void;
+}
+
+type BunDatabaseConstructor = new (
+  dbPath: string,
+  options?: { readonly?: boolean; create?: boolean }
+) => SqliteProbeConnection;
 
 export interface DatabaseHealthProbe {
   check(): Promise<void>;
@@ -12,21 +26,32 @@ interface DatabaseHealthProbeDependencies {
   timer?: Timer;
   getMigrationsError?: () => Error | null;
   executeSelectOne?: () => Promise<unknown>;
+  getDatabasePath?: () => string;
+  openProbeConnection?: (dbPath: string) => SqliteProbeConnection;
   timeoutMs?: number;
+  sqliteBusyTimeoutMs?: number;
 }
 
 export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
   private readonly timer: Timer;
   private readonly getMigrationsError: () => Error | null;
   private readonly executeSelectOne: () => Promise<unknown>;
+  private readonly getDatabasePath: () => string;
+  private readonly openProbeConnection: (dbPath: string) => SqliteProbeConnection;
   private readonly timeoutMs: number;
+  private readonly sqliteBusyTimeoutMs: number;
 
   constructor(dependencies: DatabaseHealthProbeDependencies = {}) {
     this.timer = dependencies.timer ?? defaultTimer;
     this.getMigrationsError = dependencies.getMigrationsError ?? getMigrationsError;
-    this.executeSelectOne =
-      dependencies.executeSelectOne ?? (() => sql<{ ok: number }>`SELECT 1 as ok`.execute(getDatabase()));
+    this.getDatabasePath = dependencies.getDatabasePath ?? getDatabasePath;
+    this.openProbeConnection = dependencies.openProbeConnection ?? openReadonlyProbeConnection;
+    this.executeSelectOne = dependencies.executeSelectOne ?? (() => {
+      this.executeSqliteSelectOne();
+      return Promise.resolve();
+    });
     this.timeoutMs = dependencies.timeoutMs ?? DATABASE_HEALTH_PROBE_TIMEOUT_MS;
+    this.sqliteBusyTimeoutMs = dependencies.sqliteBusyTimeoutMs ?? DATABASE_HEALTH_PROBE_BUSY_TIMEOUT_MS;
   }
 
   async check(): Promise<void> {
@@ -54,4 +79,24 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       }
     }
   }
+
+  private executeSqliteSelectOne(): void {
+    const dbPath = this.getDatabasePath();
+    if (dbPath !== ":memory:" && !existsSync(dbPath)) {
+      throw new Error(`Database health probe path does not exist: ${dbPath}`);
+    }
+
+    const connection = this.openProbeConnection(dbPath);
+    try {
+      connection.exec(`PRAGMA busy_timeout = ${this.sqliteBusyTimeoutMs};`);
+      connection.query("SELECT 1 as ok").get();
+    } finally {
+      connection.close();
+    }
+  }
+}
+
+function openReadonlyProbeConnection(dbPath: string): SqliteProbeConnection {
+  const { Database } = require("bun:sqlite") as { Database: BunDatabaseConstructor };
+  return new Database(dbPath, { readonly: true, create: false }) as SqliteProbeConnection;
 }

--- a/src/db/DatabaseHealthProbe.ts
+++ b/src/db/DatabaseHealthProbe.ts
@@ -1,22 +1,10 @@
 import { existsSync } from "node:fs";
+import { Worker } from "node:worker_threads";
 import { getDatabasePath, getMigrationsError } from "./database";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 
 const DATABASE_HEALTH_PROBE_TIMEOUT_MS = 1_000;
 const DATABASE_HEALTH_PROBE_BUSY_TIMEOUT_MS = 50;
-
-interface SqliteProbeConnection {
-  exec(sql: string): unknown;
-  query(sql: string): {
-    get(): unknown;
-  };
-  close(): void;
-}
-
-type BunDatabaseConstructor = new (
-  dbPath: string,
-  options?: { readonly?: boolean; create?: boolean }
-) => SqliteProbeConnection;
 
 export interface DatabaseHealthProbe {
   check(): Promise<void>;
@@ -27,7 +15,6 @@ interface DatabaseHealthProbeDependencies {
   getMigrationsError?: () => Error | null;
   executeSelectOne?: () => Promise<unknown>;
   getDatabasePath?: () => string;
-  openProbeConnection?: (dbPath: string) => SqliteProbeConnection;
   timeoutMs?: number;
   sqliteBusyTimeoutMs?: number;
 }
@@ -37,7 +24,6 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
   private readonly getMigrationsError: () => Error | null;
   private readonly executeSelectOne: () => Promise<unknown>;
   private readonly getDatabasePath: () => string;
-  private readonly openProbeConnection: (dbPath: string) => SqliteProbeConnection;
   private readonly timeoutMs: number;
   private readonly sqliteBusyTimeoutMs: number;
 
@@ -45,13 +31,16 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
     this.timer = dependencies.timer ?? defaultTimer;
     this.getMigrationsError = dependencies.getMigrationsError ?? getMigrationsError;
     this.getDatabasePath = dependencies.getDatabasePath ?? getDatabasePath;
-    this.openProbeConnection = dependencies.openProbeConnection ?? openReadonlyProbeConnection;
-    this.executeSelectOne = dependencies.executeSelectOne ?? (() => {
-      this.executeSqliteSelectOne();
-      return Promise.resolve();
-    });
     this.timeoutMs = dependencies.timeoutMs ?? DATABASE_HEALTH_PROBE_TIMEOUT_MS;
     this.sqliteBusyTimeoutMs = dependencies.sqliteBusyTimeoutMs ?? DATABASE_HEALTH_PROBE_BUSY_TIMEOUT_MS;
+    this.executeSelectOne =
+      dependencies.executeSelectOne
+      ?? (() => executeSqliteSelectOneInWorker(
+        this.getDatabasePath(),
+        this.sqliteBusyTimeoutMs,
+        this.timeoutMs,
+        this.timer
+      ));
   }
 
   async check(): Promise<void> {
@@ -79,24 +68,80 @@ export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
       }
     }
   }
-
-  private executeSqliteSelectOne(): void {
-    const dbPath = this.getDatabasePath();
-    if (dbPath !== ":memory:" && !existsSync(dbPath)) {
-      throw new Error(`Database health probe path does not exist: ${dbPath}`);
-    }
-
-    const connection = this.openProbeConnection(dbPath);
-    try {
-      connection.exec(`PRAGMA busy_timeout = ${this.sqliteBusyTimeoutMs};`);
-      connection.query("SELECT 1 as ok").get();
-    } finally {
-      connection.close();
-    }
-  }
 }
 
-function openReadonlyProbeConnection(dbPath: string): SqliteProbeConnection {
-  const { Database } = require("bun:sqlite") as { Database: BunDatabaseConstructor };
-  return new Database(dbPath, { readonly: true, create: false }) as SqliteProbeConnection;
+function executeSqliteSelectOneInWorker(
+  dbPath: string,
+  sqliteBusyTimeoutMs: number,
+  timeoutMs: number,
+  timer: Timer
+): Promise<void> {
+  if (dbPath !== ":memory:" && !existsSync(dbPath)) {
+    return Promise.reject(new Error(`Database health probe path does not exist: ${dbPath}`));
+  }
+
+  const worker = new Worker(`
+    const { parentPort, workerData } = require("node:worker_threads");
+    try {
+      const { Database } = require("bun:sqlite");
+      const db = new Database(workerData.dbPath, { readonly: true, create: false });
+      try {
+        db.exec("PRAGMA busy_timeout = " + Number(workerData.sqliteBusyTimeoutMs) + ";");
+        db.query("SELECT 1 as ok").get();
+        parentPort.postMessage({ ok: true });
+      } finally {
+        db.close();
+      }
+    } catch (error) {
+      parentPort.postMessage({
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
+  `, {
+    eval: true,
+    workerData: { dbPath, sqliteBusyTimeoutMs },
+  });
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      timer.clearTimeout(timeoutHandle);
+      callback();
+    };
+    const timeoutHandle = timer.setTimeout(() => {
+      void worker.terminate();
+      finish(() => reject(new Error(`Database health probe timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+    if (typeof (timeoutHandle as { unref?: () => void }).unref === "function") {
+      (timeoutHandle as { unref: () => void }).unref();
+    }
+
+    worker.once("message", (message: { ok: boolean; message?: string; stack?: string }) => {
+      void worker.terminate();
+      if (message.ok) {
+        finish(resolve);
+        return;
+      }
+      const error = new Error(message.message ?? "Database health probe failed");
+      if (message.stack) {
+        error.stack = message.stack;
+      }
+      finish(() => reject(error));
+    });
+    worker.once("error", error => {
+      void worker.terminate();
+      finish(() => reject(error));
+    });
+    worker.once("exit", code => {
+      if (code !== 0) {
+        finish(() => reject(new Error(`Database health probe worker exited with code ${code}`)));
+      }
+    });
+  });
 }

--- a/src/db/DatabaseHealthProbe.ts
+++ b/src/db/DatabaseHealthProbe.ts
@@ -1,0 +1,57 @@
+import { sql } from "kysely";
+import { getDatabase, getMigrationsError } from "./database";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+
+const DATABASE_HEALTH_PROBE_TIMEOUT_MS = 1_000;
+
+export interface DatabaseHealthProbe {
+  check(): Promise<void>;
+}
+
+interface DatabaseHealthProbeDependencies {
+  timer?: Timer;
+  getMigrationsError?: () => Error | null;
+  executeSelectOne?: () => Promise<unknown>;
+  timeoutMs?: number;
+}
+
+export class DefaultDatabaseHealthProbe implements DatabaseHealthProbe {
+  private readonly timer: Timer;
+  private readonly getMigrationsError: () => Error | null;
+  private readonly executeSelectOne: () => Promise<unknown>;
+  private readonly timeoutMs: number;
+
+  constructor(dependencies: DatabaseHealthProbeDependencies = {}) {
+    this.timer = dependencies.timer ?? defaultTimer;
+    this.getMigrationsError = dependencies.getMigrationsError ?? getMigrationsError;
+    this.executeSelectOne =
+      dependencies.executeSelectOne ?? (() => sql<{ ok: number }>`SELECT 1 as ok`.execute(getDatabase()));
+    this.timeoutMs = dependencies.timeoutMs ?? DATABASE_HEALTH_PROBE_TIMEOUT_MS;
+  }
+
+  async check(): Promise<void> {
+    const migrationsError = this.getMigrationsError();
+    if (migrationsError) {
+      throw migrationsError;
+    }
+
+    let timeoutHandle: NodeJS.Timeout | null = null;
+    try {
+      await Promise.race([
+        this.executeSelectOne(),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = this.timer.setTimeout(() => {
+            reject(new Error(`Database health probe timed out after ${this.timeoutMs}ms`));
+          }, this.timeoutMs);
+          if (typeof (timeoutHandle as { unref?: () => void }).unref === "function") {
+            (timeoutHandle as { unref: () => void }).unref();
+          }
+        }),
+      ]);
+    } finally {
+      if (timeoutHandle) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
+  }
+}

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -20,7 +20,7 @@ interface DaemonHealthInternals {
   healthCheckTimer: NodeJS.Timeout | null;
   startHealthCheckTimer(): void;
   stopHealthCheckTimer(): void;
-  attemptRecovery(): Promise<void>;
+  attemptRecovery(failureKind?: string): Promise<void>;
 }
 
 class FakeDatabaseHealthProbe {
@@ -39,7 +39,11 @@ class FakeDatabaseHealthProbe {
   }
 }
 
-function buildDaemon(timer: FakeTimer, databaseHealthProbe: FakeDatabaseHealthProbe): Daemon {
+function buildDaemon(
+  timer: FakeTimer,
+  databaseHealthProbe: FakeDatabaseHealthProbe,
+  exitProcess: (code: number) => void = () => {}
+): Daemon {
   return new Daemon(
     {},
     new FakeInstalledAppsRepository(),
@@ -48,7 +52,8 @@ function buildDaemon(timer: FakeTimer, databaseHealthProbe: FakeDatabaseHealthPr
     new CountingIdGenerator("daemon-session"),
     new FakeDatabaseInitializer(),
     new FakeStartupFailureTracker(),
-    databaseHealthProbe
+    databaseHealthProbe,
+    exitProcess
   );
 }
 
@@ -72,12 +77,12 @@ describe("Daemon database health check", () => {
     const daemon = buildDaemon(timer, databaseHealthProbe);
     const internals = daemon as unknown as DaemonHealthInternals;
     cleanup = { internals, timer };
-    const recoveryTimes: number[] = [];
+    const recoveryCalls: Array<{ at: number; failureKind?: string }> = [];
 
     internals.httpServer = { listening: true };
     internals.socketServer = { isListening: () => true };
-    internals.attemptRecovery = async () => {
-      recoveryTimes.push(timer.now());
+    internals.attemptRecovery = async failureKind => {
+      recoveryCalls.push({ at: timer.now(), failureKind });
     };
 
     internals.startHealthCheckTimer();
@@ -87,7 +92,32 @@ describe("Daemon database health check", () => {
     }
 
     expect(databaseHealthProbe.checkCalls).toBe(MAX_FAILED_CHECKS);
-    expect(recoveryTimes).toEqual([HEALTH_CHECK_INTERVAL_MS * MAX_FAILED_CHECKS]);
+    expect(recoveryCalls).toEqual([{
+      at: HEALTH_CHECK_INTERVAL_MS * MAX_FAILED_CHECKS,
+      failureKind: "database",
+    }]);
+  });
+
+  test("exits the daemon when repeated database probe failures reach recovery", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    databaseHealthProbe.failWith(new Error("database disk image is malformed"));
+    const exitCodes: number[] = [];
+    const daemon = buildDaemon(timer, databaseHealthProbe, code => {
+      exitCodes.push(code);
+    });
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+
+    internals.httpServer = { listening: true };
+    internals.socketServer = { isListening: () => true };
+    internals.startHealthCheckTimer();
+
+    for (let i = 0; i < MAX_FAILED_CHECKS; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    expect(exitCodes).toEqual([1]);
   });
 
   test("clears the health interval through the injected timer", () => {

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { FakeDatabaseInitializer } from "../fakes/FakeDatabaseInitializer";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const HEALTH_CHECK_INTERVAL_MS = 30_000;
+const MAX_FAILED_CHECKS = 3;
+
+interface FakeSocketServer {
+  isListening(): boolean;
+}
+
+interface DaemonHealthInternals {
+  httpServer: { listening: boolean } | null;
+  socketServer: FakeSocketServer | null;
+  healthCheckTimer: NodeJS.Timeout | null;
+  startHealthCheckTimer(): void;
+  attemptRecovery(): Promise<void>;
+}
+
+class FakeDatabaseHealthProbe {
+  checkCalls = 0;
+  private error: Error | null = null;
+
+  failWith(error: Error): void {
+    this.error = error;
+  }
+
+  async check(): Promise<void> {
+    this.checkCalls += 1;
+    if (this.error) {
+      throw this.error;
+    }
+  }
+}
+
+function buildDaemon(timer: FakeTimer, databaseHealthProbe: FakeDatabaseHealthProbe): Daemon {
+  return new Daemon(
+    {},
+    new FakeInstalledAppsRepository(),
+    timer,
+    undefined,
+    new CountingIdGenerator("daemon-session"),
+    new FakeDatabaseInitializer(),
+    new FakeStartupFailureTracker(),
+    databaseHealthProbe
+  );
+}
+
+describe("Daemon database health check", () => {
+  let internalsToCleanUp: DaemonHealthInternals | null = null;
+
+  afterEach(() => {
+    if (internalsToCleanUp?.healthCheckTimer) {
+      clearInterval(internalsToCleanUp.healthCheckTimer);
+      internalsToCleanUp = null;
+    }
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("counts a wedged database probe toward recovery within the existing failure budget", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    databaseHealthProbe.failWith(new Error("SQLITE_BUSY: database is locked"));
+    const daemon = buildDaemon(timer, databaseHealthProbe);
+    const internals = daemon as unknown as DaemonHealthInternals;
+    internalsToCleanUp = internals;
+    const recoveryTimes: number[] = [];
+
+    internals.httpServer = { listening: true };
+    internals.socketServer = { isListening: () => true };
+    internals.attemptRecovery = async () => {
+      recoveryTimes.push(timer.now());
+    };
+
+    internals.startHealthCheckTimer();
+
+    for (let i = 0; i < MAX_FAILED_CHECKS; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    expect(databaseHealthProbe.checkCalls).toBe(MAX_FAILED_CHECKS);
+    expect(recoveryTimes).toEqual([HEALTH_CHECK_INTERVAL_MS * MAX_FAILED_CHECKS]);
+  });
+});

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -19,6 +19,7 @@ interface DaemonHealthInternals {
   socketServer: FakeSocketServer | null;
   healthCheckTimer: NodeJS.Timeout | null;
   startHealthCheckTimer(): void;
+  stopHealthCheckTimer(): void;
   attemptRecovery(): Promise<void>;
 }
 
@@ -52,12 +53,12 @@ function buildDaemon(timer: FakeTimer, databaseHealthProbe: FakeDatabaseHealthPr
 }
 
 describe("Daemon database health check", () => {
-  let internalsToCleanUp: DaemonHealthInternals | null = null;
+  let cleanup: { internals: DaemonHealthInternals; timer: FakeTimer } | null = null;
 
   afterEach(() => {
-    if (internalsToCleanUp?.healthCheckTimer) {
-      clearInterval(internalsToCleanUp.healthCheckTimer);
-      internalsToCleanUp = null;
+    if (cleanup?.internals.healthCheckTimer) {
+      cleanup.timer.clearInterval(cleanup.internals.healthCheckTimer);
+      cleanup = null;
     }
     if (DaemonState.getInstance().isInitialized()) {
       DaemonState.getInstance().reset();
@@ -70,7 +71,7 @@ describe("Daemon database health check", () => {
     databaseHealthProbe.failWith(new Error("SQLITE_BUSY: database is locked"));
     const daemon = buildDaemon(timer, databaseHealthProbe);
     const internals = daemon as unknown as DaemonHealthInternals;
-    internalsToCleanUp = internals;
+    cleanup = { internals, timer };
     const recoveryTimes: number[] = [];
 
     internals.httpServer = { listening: true };
@@ -87,5 +88,23 @@ describe("Daemon database health check", () => {
 
     expect(databaseHealthProbe.checkCalls).toBe(MAX_FAILED_CHECKS);
     expect(recoveryTimes).toEqual([HEALTH_CHECK_INTERVAL_MS * MAX_FAILED_CHECKS]);
+  });
+
+  test("clears the health interval through the injected timer", () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    const daemon = buildDaemon(timer, databaseHealthProbe);
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+    const intervalCountBeforeHealthCheck = timer.getPendingIntervalCount();
+
+    internals.startHealthCheckTimer();
+    expect(timer.getPendingIntervalCount()).toBe(intervalCountBeforeHealthCheck + 1);
+
+    internals.stopHealthCheckTimer();
+
+    expect(timer.getPendingIntervalCount()).toBe(intervalCountBeforeHealthCheck);
+    expect(internals.healthCheckTimer).toBe(null);
+    cleanup = null;
   });
 });

--- a/test/db/DatabaseHealthProbe.test.ts
+++ b/test/db/DatabaseHealthProbe.test.ts
@@ -2,33 +2,61 @@ import { describe, expect, test } from "bun:test";
 import { DefaultDatabaseHealthProbe } from "../../src/db/DatabaseHealthProbe";
 import { FakeTimer } from "../fakes/FakeTimer";
 
+class FakeProbeConnection {
+  execStatements: string[] = [];
+  queryStatements: string[] = [];
+  closed = false;
+
+  exec(sql: string): void {
+    this.execStatements.push(sql);
+  }
+
+  query(sql: string): { get: () => { ok: number } } {
+    this.queryStatements.push(sql);
+    return {
+      get: () => ({ ok: 1 }),
+    };
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
 describe("DefaultDatabaseHealthProbe", () => {
   test("throws a cached migration error without issuing SELECT 1", async () => {
     const migrationError = new Error("startup migration failed");
-    let selectCalls = 0;
+    let openCalls = 0;
     const probe = new DefaultDatabaseHealthProbe({
       getMigrationsError: () => migrationError,
-      executeSelectOne: async () => {
-        selectCalls += 1;
+      openProbeConnection: () => {
+        openCalls += 1;
+        return new FakeProbeConnection();
       },
     });
 
     await expect(probe.check()).rejects.toBe(migrationError);
-    expect(selectCalls).toBe(0);
+    expect(openCalls).toBe(0);
   });
 
-  test("issues a lightweight SELECT 1 when migrations have no cached error", async () => {
-    let selectCalls = 0;
+  test("issues a lightweight SELECT 1 with a short SQLite busy timeout", async () => {
+    const connection = new FakeProbeConnection();
+    const openedPaths: string[] = [];
     const probe = new DefaultDatabaseHealthProbe({
       getMigrationsError: () => null,
-      executeSelectOne: async () => {
-        selectCalls += 1;
+      getDatabasePath: () => ":memory:",
+      openProbeConnection: dbPath => {
+        openedPaths.push(dbPath);
+        return connection;
       },
     });
 
     await probe.check();
 
-    expect(selectCalls).toBe(1);
+    expect(openedPaths).toEqual([":memory:"]);
+    expect(connection.execStatements).toEqual(["PRAGMA busy_timeout = 50;"]);
+    expect(connection.queryStatements).toEqual(["SELECT 1 as ok"]);
+    expect(connection.closed).toBe(true);
   });
 
   test("bounds a wedged SELECT 1 probe", async () => {

--- a/test/db/DatabaseHealthProbe.test.ts
+++ b/test/db/DatabaseHealthProbe.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { DefaultDatabaseHealthProbe } from "../../src/db/DatabaseHealthProbe";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("DefaultDatabaseHealthProbe", () => {
+  test("throws a cached migration error without issuing SELECT 1", async () => {
+    const migrationError = new Error("startup migration failed");
+    let selectCalls = 0;
+    const probe = new DefaultDatabaseHealthProbe({
+      getMigrationsError: () => migrationError,
+      executeSelectOne: async () => {
+        selectCalls += 1;
+      },
+    });
+
+    await expect(probe.check()).rejects.toBe(migrationError);
+    expect(selectCalls).toBe(0);
+  });
+
+  test("issues a lightweight SELECT 1 when migrations have no cached error", async () => {
+    let selectCalls = 0;
+    const probe = new DefaultDatabaseHealthProbe({
+      getMigrationsError: () => null,
+      executeSelectOne: async () => {
+        selectCalls += 1;
+      },
+    });
+
+    await probe.check();
+
+    expect(selectCalls).toBe(1);
+  });
+
+  test("bounds a wedged SELECT 1 probe", async () => {
+    const timer = new FakeTimer();
+    const probe = new DefaultDatabaseHealthProbe({
+      timer,
+      getMigrationsError: () => null,
+      executeSelectOne: () => new Promise(() => {}),
+      timeoutMs: 25,
+    });
+
+    await expect(timer.resolvePromise(probe.check(), 25)).rejects.toThrow(
+      "Database health probe timed out after 25ms"
+    );
+  });
+});

--- a/test/db/DatabaseHealthProbe.test.ts
+++ b/test/db/DatabaseHealthProbe.test.ts
@@ -1,62 +1,62 @@
-import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
 import { DefaultDatabaseHealthProbe } from "../../src/db/DatabaseHealthProbe";
 import { FakeTimer } from "../fakes/FakeTimer";
 
-class FakeProbeConnection {
-  execStatements: string[] = [];
-  queryStatements: string[] = [];
-  closed = false;
+interface SqliteSetupConnection {
+  exec(sql: string): unknown;
+  close(): void;
+}
 
-  exec(sql: string): void {
-    this.execStatements.push(sql);
-  }
+type BunDatabaseConstructor = new (dbPath: string) => SqliteSetupConnection;
 
-  query(sql: string): { get: () => { ok: number } } {
-    this.queryStatements.push(sql);
-    return {
-      get: () => ({ ok: 1 }),
-    };
-  }
-
-  close(): void {
-    this.closed = true;
+function createSqliteFile(dbPath: string): void {
+  const { Database } = require("bun:sqlite") as { Database: BunDatabaseConstructor };
+  const db = new Database(dbPath);
+  try {
+    db.exec("CREATE TABLE probe_smoke (id INTEGER PRIMARY KEY)");
+  } finally {
+    db.close();
   }
 }
 
 describe("DefaultDatabaseHealthProbe", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const tempDir of tempDirs) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
   test("throws a cached migration error without issuing SELECT 1", async () => {
     const migrationError = new Error("startup migration failed");
-    let openCalls = 0;
+    let selectCalls = 0;
     const probe = new DefaultDatabaseHealthProbe({
       getMigrationsError: () => migrationError,
-      openProbeConnection: () => {
-        openCalls += 1;
-        return new FakeProbeConnection();
+      executeSelectOne: async () => {
+        selectCalls += 1;
       },
     });
 
     await expect(probe.check()).rejects.toBe(migrationError);
-    expect(openCalls).toBe(0);
+    expect(selectCalls).toBe(0);
   });
 
-  test("issues a lightweight SELECT 1 with a short SQLite busy timeout", async () => {
-    const connection = new FakeProbeConnection();
-    const openedPaths: string[] = [];
+  test("issues a worker-backed lightweight SELECT 1 against a read-only sqlite file", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "auto-mobile-health-probe-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "auto-mobile.db");
+    createSqliteFile(dbPath);
     const probe = new DefaultDatabaseHealthProbe({
       getMigrationsError: () => null,
-      getDatabasePath: () => ":memory:",
-      openProbeConnection: dbPath => {
-        openedPaths.push(dbPath);
-        return connection;
-      },
+      getDatabasePath: () => dbPath,
     });
 
     await probe.check();
-
-    expect(openedPaths).toEqual([":memory:"]);
-    expect(connection.execStatements).toEqual(["PRAGMA busy_timeout = 50;"]);
-    expect(connection.queryStatements).toEqual(["SELECT 1 as ok"]);
-    expect(connection.closed).toBe(true);
   });
 
   test("bounds a wedged SELECT 1 probe", async () => {


### PR DESCRIPTION
## Summary

Adds a daemon database health probe so the 30s health tick checks cached migration failure state and runs a bounded lightweight `SELECT 1`. Post-startup DB failures now count toward the existing health failure budget and route into daemon recovery instead of reporting healthy.

## Linked Issue

Closes #3402

## Bug / Regression Context

- **Prior attempts:** Startup DB initialization failures were already fatal, but post-startup DB liveness was not part of periodic health checks.
- **Observed symptom:** A wedged or query-dead DB after startup could leave the daemon reporting healthy while DB-backed work failed.
- **Repro steps / conditions:** HTTP and socket health stay good while the DB has a cached migration error or a wedged/erroring query path.

## Validation

- [x] `bun run turbo:validate` passes (`lint` + `build` + `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: not applicable
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not applicable: daemon liveness / DB health unit-test change only.

## Follow-ups

No follow-ups identified.

Made with [Cursor](https://cursor.com)