### PR TITLE
Improve SharpBackend pipeline materialization

### DIFF
--- a/src/utils/image/backend/SharpBackend.ts
+++ b/src/utils/image/backend/SharpBackend.ts
@@ -76,12 +76,21 @@ export class SharpBackend implements ImageBackend {
   }
 
   private async applyPipeline(sharp: SharpFactory, source: Buffer, pipeline: ImagePipeline): Promise<ReturnType<SharpFactory>> {
-    let current = source;
+    let image = sharp(source);
+    let hasResizeInCurrentPipeline = false;
     for (const operation of pipeline.operations) {
-      current = await this.applyOperation(sharp(current), operation).toBuffer();
+      if (operation.type === "resize" && hasResizeInCurrentPipeline) {
+        // Sharp only applies one resize per pipeline; materialize only at this compatibility boundary.
+        image = sharp(await image.toBuffer());
+        hasResizeInCurrentPipeline = false;
+      }
+      image = this.applyOperation(image, operation);
+      if (operation.type === "resize") {
+        hasResizeInCurrentPipeline = true;
+      }
     }
 
-    return this.applyEncoding(sharp(current), pipeline);
+    return this.applyEncoding(image, pipeline);
   }
 
   public async execute(source: Buffer, pipeline: ImagePipeline): Promise<Buffer> {

--- a/src/utils/image/backend/SharpBackend.ts
+++ b/src/utils/image/backend/SharpBackend.ts
@@ -78,15 +78,22 @@ export class SharpBackend implements ImageBackend {
   private async applyPipeline(sharp: SharpFactory, source: Buffer, pipeline: ImagePipeline): Promise<ReturnType<SharpFactory>> {
     let image = sharp(source);
     let hasResizeInCurrentPipeline = false;
+    let hasCropAfterResizeInCurrentPipeline = false;
     for (const operation of pipeline.operations) {
-      if (operation.type === "resize" && hasResizeInCurrentPipeline) {
-        // Sharp only applies one resize per pipeline; materialize only at this compatibility boundary.
+      if (
+        (operation.type === "resize" && hasResizeInCurrentPipeline)
+        || (operation.type === "crop" && hasResizeInCurrentPipeline && hasCropAfterResizeInCurrentPipeline)
+      ) {
+        // Sharp collapses some repeated operations in one pipeline; materialize only at compatibility boundaries.
         image = sharp(await image.toBuffer());
         hasResizeInCurrentPipeline = false;
+        hasCropAfterResizeInCurrentPipeline = false;
       }
       image = this.applyOperation(image, operation);
       if (operation.type === "resize") {
         hasResizeInCurrentPipeline = true;
+      } else if (hasResizeInCurrentPipeline) {
+        hasCropAfterResizeInCurrentPipeline = true;
       }
     }
 

--- a/src/utils/image/backend/SharpBackend.ts
+++ b/src/utils/image/backend/SharpBackend.ts
@@ -78,22 +78,22 @@ export class SharpBackend implements ImageBackend {
   private async applyPipeline(sharp: SharpFactory, source: Buffer, pipeline: ImagePipeline): Promise<ReturnType<SharpFactory>> {
     let image = sharp(source);
     let hasResizeInCurrentPipeline = false;
-    let hasCropAfterResizeInCurrentPipeline = false;
+    let hasCropInCurrentPipeline = false;
     for (const operation of pipeline.operations) {
       if (
         (operation.type === "resize" && hasResizeInCurrentPipeline)
-        || (operation.type === "crop" && hasResizeInCurrentPipeline && hasCropAfterResizeInCurrentPipeline)
+        || (operation.type === "crop" && hasCropInCurrentPipeline)
       ) {
         // Sharp collapses some repeated operations in one pipeline; materialize only at compatibility boundaries.
         image = sharp(await image.toBuffer());
         hasResizeInCurrentPipeline = false;
-        hasCropAfterResizeInCurrentPipeline = false;
+        hasCropInCurrentPipeline = false;
       }
       image = this.applyOperation(image, operation);
       if (operation.type === "resize") {
         hasResizeInCurrentPipeline = true;
-      } else if (hasResizeInCurrentPipeline) {
-        hasCropAfterResizeInCurrentPipeline = true;
+      } else {
+        hasCropInCurrentPipeline = true;
       }
     }
 

--- a/test/utils/image/backend/SharpBackend.test.ts
+++ b/test/utils/image/backend/SharpBackend.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { SharpBackend } from "../../../../src/utils/image/backend/SharpBackend";
 import type { ImagePipeline } from "../../../../src/utils/image/backend/ImageBackend";
+import type { SharpFactory } from "../../../../src/utils/image/loadSharp";
 
 async function makeSourcePng(width = 8, height = 8): Promise<Buffer> {
   const { Jimp, rgbaToInt } = await import("jimp");
@@ -15,12 +16,73 @@ async function makeSourcePng(width = 8, height = 8): Promise<Buffer> {
 
 const PNG_MAGIC = "89504e47";
 
+interface FakeSharpImage {
+  resize(options: unknown): FakeSharpImage;
+  extract(options: unknown): FakeSharpImage;
+  png(): FakeSharpImage;
+  webp(options?: unknown): FakeSharpImage;
+  toBuffer(): Promise<Buffer>;
+}
+
+function makeRecordingSharpFactory(events: string[]): SharpFactory {
+  const image: FakeSharpImage = {
+    resize(options) {
+      events.push(`resize:${JSON.stringify(options)}`);
+      return image;
+    },
+    extract(options) {
+      events.push(`extract:${JSON.stringify(options)}`);
+      return image;
+    },
+    png() {
+      events.push("png");
+      return image;
+    },
+    webp(options) {
+      events.push(`webp:${JSON.stringify(options)}`);
+      return image;
+    },
+    async toBuffer() {
+      events.push("toBuffer");
+      return Buffer.from("encoded");
+    }
+  };
+
+  return ((source: Buffer) => {
+    events.push(`sharp:${source.toString("utf8")}`);
+    return image;
+  }) as unknown as SharpFactory;
+}
+
 // Production keeps Windows on Jimp because sharp can abort under Bun there.
 // These cases intentionally exercise the real native sharp backend on macOS/Linux only.
 const describeSharp = process.platform === "win32" ? describe.skip : describe;
 
 describeSharp("SharpBackend", () => {
   describe("execute", () => {
+    test("chains multi-operation pipelines without intermediate materialization", async () => {
+      const events: string[] = [];
+      const backend = new SharpBackend({
+        loadSharp: async () => makeRecordingSharpFactory(events)
+      });
+
+      await backend.execute(Buffer.from("source"), {
+        operations: [
+          { type: "resize", width: 5, height: 5, maintainAspectRatio: false },
+          { type: "crop", x: 1, y: 2, width: 3, height: 4 }
+        ],
+        encoding: { mime: "image/png" }
+      });
+
+      expect(events).toEqual([
+        "sharp:source",
+        "resize:{\"width\":5,\"height\":5,\"fit\":\"fill\"}",
+        "extract:{\"left\":1,\"top\":2,\"width\":3,\"height\":4}",
+        "png",
+        "toBuffer"
+      ]);
+    });
+
     test("resize with fill produces exact target dimensions", async () => {
       const backend = new SharpBackend();
       const source = await makeSourcePng(8, 8);

--- a/test/utils/image/backend/SharpBackend.test.ts
+++ b/test/utils/image/backend/SharpBackend.test.ts
@@ -109,6 +109,33 @@ describe("SharpBackend", () => {
         "toBuffer"
       ]);
     });
+
+    test("materializes before a second crop before resize for sharp compatibility", async () => {
+      const events: string[] = [];
+      const backend = new SharpBackend({
+        loadSharp: async () => makeRecordingSharpFactory(events)
+      });
+
+      await backend.execute(Buffer.from("source"), {
+        operations: [
+          { type: "crop", x: 1, y: 1, width: 6, height: 6 },
+          { type: "crop", x: 1, y: 1, width: 4, height: 4 },
+          { type: "resize", width: 2, height: 2, maintainAspectRatio: false }
+        ],
+        encoding: { mime: "image/png" }
+      });
+
+      expect(events).toEqual([
+        "sharp:source",
+        "extract:{\"left\":1,\"top\":1,\"width\":6,\"height\":6}",
+        "toBuffer",
+        "sharp:encoded",
+        "extract:{\"left\":1,\"top\":1,\"width\":4,\"height\":4}",
+        "resize:{\"width\":2,\"height\":2,\"fit\":\"fill\"}",
+        "png",
+        "toBuffer"
+      ]);
+    });
   });
 });
 
@@ -197,6 +224,35 @@ describeSharp("SharpBackend native", () => {
           { type: "resize", width: 6, height: 6, maintainAspectRatio: false },
           { type: "crop", x: 1, y: 1, width: 4, height: 4 },
           { type: "crop", x: 1, y: 1, width: 2, height: 2 }
+        ],
+        encoding: { mime: "image/png" }
+      }));
+
+      expect(actual.width).toBe(2);
+      expect(actual.height).toBe(2);
+      expect(actual.data).toEqual(expected.data);
+    });
+
+    test("preserves repeated crop semantics before resize", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 8);
+      const sharp = (await import("sharp")).default;
+      const firstCrop = await sharp(source)
+        .extract({ left: 1, top: 1, width: 6, height: 6 })
+        .toBuffer();
+      const secondCrop = await sharp(firstCrop)
+        .extract({ left: 1, top: 1, width: 4, height: 4 })
+        .toBuffer();
+      const expected = await backend.rawPixels(await sharp(secondCrop)
+        .resize({ width: 2, height: 2, fit: "fill" })
+        .png()
+        .toBuffer());
+
+      const actual = await backend.rawPixels(await backend.execute(source, {
+        operations: [
+          { type: "crop", x: 1, y: 1, width: 6, height: 6 },
+          { type: "crop", x: 1, y: 1, width: 4, height: 4 },
+          { type: "resize", width: 2, height: 2, maintainAspectRatio: false }
         ],
         encoding: { mime: "image/png" }
       }));

--- a/test/utils/image/backend/SharpBackend.test.ts
+++ b/test/utils/image/backend/SharpBackend.test.ts
@@ -82,6 +82,33 @@ describe("SharpBackend", () => {
         "toBuffer"
       ]);
     });
+
+    test("materializes before a second crop after resize for sharp compatibility", async () => {
+      const events: string[] = [];
+      const backend = new SharpBackend({
+        loadSharp: async () => makeRecordingSharpFactory(events)
+      });
+
+      await backend.execute(Buffer.from("source"), {
+        operations: [
+          { type: "resize", width: 6, height: 6, maintainAspectRatio: false },
+          { type: "crop", x: 1, y: 1, width: 4, height: 4 },
+          { type: "crop", x: 1, y: 1, width: 2, height: 2 }
+        ],
+        encoding: { mime: "image/png" }
+      });
+
+      expect(events).toEqual([
+        "sharp:source",
+        "resize:{\"width\":6,\"height\":6,\"fit\":\"fill\"}",
+        "extract:{\"left\":1,\"top\":1,\"width\":4,\"height\":4}",
+        "toBuffer",
+        "sharp:encoded",
+        "extract:{\"left\":1,\"top\":1,\"width\":2,\"height\":2}",
+        "png",
+        "toBuffer"
+      ]);
+    });
   });
 });
 
@@ -140,6 +167,35 @@ describeSharp("SharpBackend native", () => {
       const actual = await backend.rawPixels(await backend.execute(source, {
         operations: [
           { type: "resize", width: 4, height: 4, maintainAspectRatio: false },
+          { type: "crop", x: 1, y: 1, width: 2, height: 2 }
+        ],
+        encoding: { mime: "image/png" }
+      }));
+
+      expect(actual.width).toBe(2);
+      expect(actual.height).toBe(2);
+      expect(actual.data).toEqual(expected.data);
+    });
+
+    test("preserves repeated crop semantics after resize", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 8);
+      const sharp = (await import("sharp")).default;
+      const firstResize = await sharp(source)
+        .resize({ width: 6, height: 6, fit: "fill" })
+        .toBuffer();
+      const firstCrop = await sharp(firstResize)
+        .extract({ left: 1, top: 1, width: 4, height: 4 })
+        .toBuffer();
+      const expected = await backend.rawPixels(await sharp(firstCrop)
+        .extract({ left: 1, top: 1, width: 2, height: 2 })
+        .png()
+        .toBuffer());
+
+      const actual = await backend.rawPixels(await backend.execute(source, {
+        operations: [
+          { type: "resize", width: 6, height: 6, maintainAspectRatio: false },
+          { type: "crop", x: 1, y: 1, width: 4, height: 4 },
           { type: "crop", x: 1, y: 1, width: 2, height: 2 }
         ],
         encoding: { mime: "image/png" }

--- a/test/utils/image/backend/SharpBackend.test.ts
+++ b/test/utils/image/backend/SharpBackend.test.ts
@@ -58,7 +58,7 @@ function makeRecordingSharpFactory(events: string[]): SharpFactory {
 // These cases intentionally exercise the real native sharp backend on macOS/Linux only.
 const describeSharp = process.platform === "win32" ? describe.skip : describe;
 
-describeSharp("SharpBackend", () => {
+describe("SharpBackend", () => {
   describe("execute", () => {
     test("chains multi-operation pipelines without intermediate materialization", async () => {
       const events: string[] = [];
@@ -82,7 +82,11 @@ describeSharp("SharpBackend", () => {
         "toBuffer"
       ]);
     });
+  });
+});
 
+describeSharp("SharpBackend native", () => {
+  describe("execute", () => {
     test("resize with fill produces exact target dimensions", async () => {
       const backend = new SharpBackend();
       const source = await makeSourcePng(8, 8);

--- a/test/utils/image/backend/SharpBackend.test.ts
+++ b/test/utils/image/backend/SharpBackend.test.ts
@@ -127,6 +127,29 @@ describeSharp("SharpBackend native", () => {
       expect(meta.height).toBe(2);
     });
 
+    test("applies crop after resize on the resized coordinate space", async () => {
+      const backend = new SharpBackend();
+      const source = await makeSourcePng(8, 8);
+      const sharp = (await import("sharp")).default;
+      const expected = await backend.rawPixels(await sharp(source)
+        .resize({ width: 4, height: 4, fit: "fill" })
+        .extract({ left: 1, top: 1, width: 2, height: 2 })
+        .png()
+        .toBuffer());
+
+      const actual = await backend.rawPixels(await backend.execute(source, {
+        operations: [
+          { type: "resize", width: 4, height: 4, maintainAspectRatio: false },
+          { type: "crop", x: 1, y: 1, width: 2, height: 2 }
+        ],
+        encoding: { mime: "image/png" }
+      }));
+
+      expect(actual.width).toBe(2);
+      expect(actual.height).toBe(2);
+      expect(actual.data).toEqual(expected.data);
+    });
+
     test("applies chained resize operations in pipeline order", async () => {
       const backend = new SharpBackend();
       const source = await makeSourcePng(8, 8);


### PR DESCRIPTION
## Summary

SharpBackend now keeps ordinary multi-operation image transforms on one sharp pipeline, so resize+crop style chains avoid repeated decode/encode/materialize cycles. It still materializes at the narrow repeated-resize compatibility boundary because sharp only applies one resize per pipeline.

## Linked Issue

Closes #3431

## Bug / Regression Context

- **Prior attempts:** None noted in the issue.
- **Observed symptom:** Multi-operation sharp pipelines called `toBuffer()` after each operation, forcing extra encode/decode work before the final result.
- **Repro steps / conditions:** Run a pipeline with resize followed by crop/encoding through `SharpBackend.execute`.

## Validation

- [x] `bun test test/utils/image/backend/SharpBackend.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses loader injection + fake sharp unit coverage; no device validation needed
- [x] Rebased onto latest `main`, conflicts resolved

## Acceptance Criteria

- [x] Applies normal multi-operation sharp pipelines to one `sharp(source)` instance without intermediate `toBuffer()` materialization.
- [x] Preserves resize-before-crop operation order.
- [x] Preserves existing repeated-resize behavior at a narrow compatibility boundary.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)