### PR TITLE
Cache tool definition schema conversions

### DIFF
--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -71,6 +71,11 @@ interface ToolListingOptions {
   includeUnavailable?: boolean;
 }
 
+interface CachedToolDefinitionSchemas {
+  inputSchema: Record<string, unknown>;
+  outputSchemasByRuntimeFlags: Map<string, Record<string, unknown> | undefined>;
+}
+
 // Interface for a registered tool
 export interface RegisteredTool {
   name: string;
@@ -676,6 +681,7 @@ class ToolRegistryClass {
   private navigationToolCallRecorder: NavigationToolCallRecorder;
   private afterToolCall: AfterToolCallHandler;
   private planLifecycleManager: PlanLifecycleManager;
+  private toolDefinitionSchemaCache: Map<string, CachedToolDefinitionSchemas> = new Map();
 
   constructor(timer: Timer = defaultTimer) {
     this.deviceSessionManager = DeviceSessionManager.getInstance();
@@ -712,6 +718,7 @@ class ToolRegistryClass {
     handler: ToolHandler,
     options: ToolRegistrationOptions = {}
   ): void {
+    this.invalidateToolDefinitionSchemaCache();
     this.tools.set(name, {
       name,
       description,
@@ -733,6 +740,7 @@ class ToolRegistryClass {
     handler: DeviceAwareToolHandler,
     options: DeviceAwareToolOptions = {}
   ): void {
+    this.invalidateToolDefinitionSchemaCache();
     // Create a wrapper that handles device ID injection
     const wrappedHandler: ToolHandler = async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
       const toolStartMs = this.timer.now();
@@ -1004,6 +1012,7 @@ class ToolRegistryClass {
   // connected DaemonMcpProxy clients, which invalidate their tool cache and
   // re-emit to their own external clients.
   notifyToolListChanged(): void {
+    this.invalidateToolDefinitionSchemaCache();
     for (const server of this.servers) {
       try {
         server.sendToolListChanged();
@@ -1031,12 +1040,11 @@ class ToolRegistryClass {
     // `suppressOutputSchema` above keeps the two in sync for the strip flag.
     const compactBounds = serverConfig.isObserveResultCompactEnabled();
     return this.getAllTools(options).map(tool => {
-      const outputSchema = toolHasOutputSchema(tool) && !suppressOutputSchema
-        ? advertiseBoundsForCompact(
-          flattenTopLevelUnion(toJSONSchema(tool.outputSchema)),
-          compactBounds
-        ) as Record<string, unknown>
-        : undefined;
+      const { inputSchema, outputSchema } = this.getCachedToolDefinitionSchemas(
+        tool,
+        suppressOutputSchema,
+        compactBounds
+      );
 
       const definition: {
         name: string;
@@ -1047,7 +1055,7 @@ class ToolRegistryClass {
       } = {
         name: tool.name,
         description: tool.description,
-        inputSchema: flattenTopLevelUnion(toJSONSchema(tool.schema)),
+        inputSchema,
       };
       if (outputSchema) {
         definition.outputSchema = outputSchema;
@@ -1057,6 +1065,41 @@ class ToolRegistryClass {
       }
       return definition;
     });
+  }
+
+  private getCachedToolDefinitionSchemas(
+    tool: RegisteredTool,
+    suppressOutputSchema: boolean,
+    compactBounds: boolean
+  ): { inputSchema: Record<string, unknown>; outputSchema: Record<string, unknown> | undefined } {
+    let cached = this.toolDefinitionSchemaCache.get(tool.name);
+    if (!cached) {
+      cached = {
+        inputSchema: flattenTopLevelUnion(toJSONSchema(tool.schema)) as Record<string, unknown>,
+        outputSchemasByRuntimeFlags: new Map(),
+      };
+      this.toolDefinitionSchemaCache.set(tool.name, cached);
+    }
+
+    const outputSchemaCacheKey = `${suppressOutputSchema}:${compactBounds}`;
+    if (!cached.outputSchemasByRuntimeFlags.has(outputSchemaCacheKey)) {
+      const outputSchema = toolHasOutputSchema(tool) && !suppressOutputSchema
+        ? advertiseBoundsForCompact(
+          flattenTopLevelUnion(toJSONSchema(tool.outputSchema)),
+          compactBounds
+        ) as Record<string, unknown>
+        : undefined;
+      cached.outputSchemasByRuntimeFlags.set(outputSchemaCacheKey, outputSchema);
+    }
+
+    return {
+      inputSchema: cached.inputSchema,
+      outputSchema: cached.outputSchemasByRuntimeFlags.get(outputSchemaCacheKey),
+    };
+  }
+
+  private invalidateToolDefinitionSchemaCache(): void {
+    this.toolDefinitionSchemaCache.clear();
   }
 
   // Get a map of all schema
@@ -1111,6 +1154,7 @@ class ToolRegistryClass {
 
   // Clear all registered tools (for testing)
   clearTools(): void {
+    this.invalidateToolDefinitionSchemaCache();
     this.tools.clear();
   }
 }

--- a/test/server/toolRegistry.getToolDefinitions.test.ts
+++ b/test/server/toolRegistry.getToolDefinitions.test.ts
@@ -76,6 +76,31 @@ describe("ToolRegistry.getToolDefinitions", () => {
     expect(JSON.stringify(replacement.inputSchema)).toContain("after");
   });
 
+  test("invalidates converted schemas when adding a normal tool registration", () => {
+    ToolRegistry.register(
+      "existingTool",
+      "Existing tool",
+      z.object({ existing: z.string() }),
+      async () => ({ content: [{ type: "text", text: "existing" }] })
+    );
+    const originalExisting = ToolRegistry.getToolDefinitions()[0];
+
+    ToolRegistry.register(
+      "addedTool",
+      "Added tool",
+      z.object({ added: z.number() }),
+      async () => ({ content: [{ type: "text", text: "added" }] })
+    );
+    const definitions = ToolRegistry.getToolDefinitions();
+    const existing = definitions.find(tool => tool.name === "existingTool");
+    const added = definitions.find(tool => tool.name === "addedTool");
+
+    expect(existing).toBeDefined();
+    expect(added).toBeDefined();
+    expect(existing!.inputSchema).not.toBe(originalExisting.inputSchema);
+    expect(JSON.stringify(added!.inputSchema)).toContain("added");
+  });
+
   test("reconverts a replaced device-aware tool registration", () => {
     ToolRegistry.registerDeviceAware(
       "replaceDeviceTool",
@@ -96,6 +121,31 @@ describe("ToolRegistry.getToolDefinitions", () => {
     expect(replacement.description).toBe("Replacement device tool");
     expect(replacement.inputSchema).not.toBe(original.inputSchema);
     expect(JSON.stringify(replacement.inputSchema)).toContain("after");
+  });
+
+  test("invalidates converted schemas when adding a device-aware tool registration", () => {
+    ToolRegistry.registerDeviceAware(
+      "existingDeviceTool",
+      "Existing device tool",
+      z.object({ existing: z.string() }),
+      async () => ({ content: [{ type: "text", text: "existing" }] })
+    );
+    const originalExisting = ToolRegistry.getToolDefinitions()[0];
+
+    ToolRegistry.registerDeviceAware(
+      "addedDeviceTool",
+      "Added device tool",
+      z.object({ added: z.number() }),
+      async () => ({ content: [{ type: "text", text: "added" }] })
+    );
+    const definitions = ToolRegistry.getToolDefinitions();
+    const existing = definitions.find(tool => tool.name === "existingDeviceTool");
+    const added = definitions.find(tool => tool.name === "addedDeviceTool");
+
+    expect(existing).toBeDefined();
+    expect(added).toBeDefined();
+    expect(existing!.inputSchema).not.toBe(originalExisting.inputSchema);
+    expect(JSON.stringify(added!.inputSchema)).toContain("added");
   });
 
   test("caches output schema variants per structured-content and compact-bounds flags", () => {

--- a/test/server/toolRegistry.getToolDefinitions.test.ts
+++ b/test/server/toolRegistry.getToolDefinitions.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { serverConfig } from "../../src/utils/ServerConfig";
+
+describe("ToolRegistry.getToolDefinitions", () => {
+  const originalStructuredContentSuppressed = serverConfig.isToolResultsNoStructuredContentEnabled();
+  const originalCompactBounds = serverConfig.isObserveResultCompactEnabled();
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    serverConfig.setToolResultsNoStructuredContentEnabled(false);
+    serverConfig.setObserveResultCompactEnabled(false);
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+    serverConfig.setToolResultsNoStructuredContentEnabled(originalStructuredContentSuppressed);
+    serverConfig.setObserveResultCompactEnabled(originalCompactBounds);
+  });
+
+  test("reuses converted input and output schemas across steady-state listings", () => {
+    ToolRegistry.register(
+      "cachedTool",
+      "A tool with schemas worth caching",
+      z.object({ value: z.string() }),
+      async () => ({ content: [{ type: "text", text: "ok" }] }),
+      { outputSchema: z.object({ ok: z.boolean() }) }
+    );
+
+    const first = ToolRegistry.getToolDefinitions()[0];
+    const second = ToolRegistry.getToolDefinitions()[0];
+
+    expect(second.inputSchema).toBe(first.inputSchema);
+    expect(second.outputSchema).toBe(first.outputSchema);
+  });
+
+  test("invalidates converted schemas when the tool list changes", () => {
+    ToolRegistry.register(
+      "invalidateTool",
+      "A tool that should be reconverted after invalidation",
+      z.object({ value: z.string() }),
+      async () => ({ content: [{ type: "text", text: "ok" }] }),
+      { outputSchema: z.object({ ok: z.boolean() }) }
+    );
+
+    const cached = ToolRegistry.getToolDefinitions()[0];
+    expect(ToolRegistry.getToolDefinitions()[0].inputSchema).toBe(cached.inputSchema);
+
+    ToolRegistry.notifyToolListChanged();
+    const afterInvalidation = ToolRegistry.getToolDefinitions()[0];
+
+    expect(afterInvalidation.inputSchema).not.toBe(cached.inputSchema);
+    expect(afterInvalidation.outputSchema).not.toBe(cached.outputSchema);
+  });
+
+  test("reconverts a replaced normal tool registration", () => {
+    ToolRegistry.register(
+      "replaceTool",
+      "Original tool",
+      z.object({ before: z.string() }),
+      async () => ({ content: [{ type: "text", text: "before" }] })
+    );
+    const original = ToolRegistry.getToolDefinitions()[0];
+
+    ToolRegistry.register(
+      "replaceTool",
+      "Replacement tool",
+      z.object({ after: z.number() }),
+      async () => ({ content: [{ type: "text", text: "after" }] })
+    );
+    const replacement = ToolRegistry.getToolDefinitions()[0];
+
+    expect(replacement.description).toBe("Replacement tool");
+    expect(replacement.inputSchema).not.toBe(original.inputSchema);
+    expect(JSON.stringify(replacement.inputSchema)).toContain("after");
+  });
+
+  test("reconverts a replaced device-aware tool registration", () => {
+    ToolRegistry.registerDeviceAware(
+      "replaceDeviceTool",
+      "Original device tool",
+      z.object({ before: z.string() }),
+      async () => ({ content: [{ type: "text", text: "before" }] })
+    );
+    const original = ToolRegistry.getToolDefinitions()[0];
+
+    ToolRegistry.registerDeviceAware(
+      "replaceDeviceTool",
+      "Replacement device tool",
+      z.object({ after: z.number() }),
+      async () => ({ content: [{ type: "text", text: "after" }] })
+    );
+    const replacement = ToolRegistry.getToolDefinitions()[0];
+
+    expect(replacement.description).toBe("Replacement device tool");
+    expect(replacement.inputSchema).not.toBe(original.inputSchema);
+    expect(JSON.stringify(replacement.inputSchema)).toContain("after");
+  });
+
+  test("caches output schema variants per structured-content and compact-bounds flags", () => {
+    const boundsSchema = z.object({
+      bounds: z.union([
+        z.object({ left: z.number(), top: z.number(), width: z.number(), height: z.number() }),
+        z.tuple([z.number(), z.number(), z.number(), z.number()]),
+      ]).describe("Element bounds. Default: object; compact: [left, top, right, bottom]."),
+    });
+
+    ToolRegistry.register(
+      "boundsTool",
+      "A tool whose output schema follows runtime flags",
+      z.object({}),
+      async () => ({ content: [{ type: "text", text: "ok" }] }),
+      { outputSchema: boundsSchema }
+    );
+
+    const defaultOutput = ToolRegistry.getToolDefinitions()[0].outputSchema;
+    expect(JSON.stringify(defaultOutput)).not.toContain("prefixItems");
+    expect(ToolRegistry.getToolDefinitions()[0].outputSchema).toBe(defaultOutput);
+
+    serverConfig.setObserveResultCompactEnabled(true);
+    ToolRegistry.notifyToolListChanged();
+    const compactOutput = ToolRegistry.getToolDefinitions()[0].outputSchema;
+    expect(JSON.stringify(compactOutput)).toContain("prefixItems");
+    expect(compactOutput).not.toBe(defaultOutput);
+    expect(ToolRegistry.getToolDefinitions()[0].outputSchema).toBe(compactOutput);
+
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
+    ToolRegistry.notifyToolListChanged();
+    expect(ToolRegistry.getToolDefinitions()[0].outputSchema).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Memoizes the JSON-schema conversion work used by `tools/list` so steady-state calls reuse converted input and output schemas instead of rerunning Zod conversion for every tool. Cache invalidation is wired through normal and device-aware registrations, test cleanup, and `notifyToolListChanged()` so runtime tool-list changes still refresh the advertised definitions.

## Linked Issue

Closes #3426

## Bug / Regression Context

- **Prior attempts:** None found in the issue.
- **Observed symptom:** `ToolRegistry.getToolDefinitions()` recomputed converted schemas on every `tools/list` request.
- **Repro steps / conditions:** Call `ToolRegistry.getToolDefinitions()` repeatedly with the same registered tools and runtime flags; converted schema objects were recreated each time before this change.

## Validation

- [x] `bun test test/server/toolRegistry.getToolDefinitions.test.ts`
- [x] `bun test test/server/observeOutputSchema.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: not applicable
- [x] New code uses fast unit coverage; no device or DB dependency added
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A - server-side tools/list performance change only.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)