### PR TITLE
Optimize coverage analyzer graph depth scoring

### DIFF
--- a/src/features/navigation/TestCoverageAnalyzer.ts
+++ b/src/features/navigation/TestCoverageAnalyzer.ts
@@ -84,6 +84,9 @@ interface TestScenario {
 
 /**
  * Analyzes test coverage for navigation graphs and generates recommendations.
+ *
+ * @internal Exported for focused unit tests and internal dependency injection;
+ * production callers should use the `testCoverageAnalyzer` singleton.
  */
 export class TestCoverageAnalyzer {
   private coverageRepository: TestCoverageAnalysisRepository;

--- a/src/features/navigation/TestCoverageAnalyzer.ts
+++ b/src/features/navigation/TestCoverageAnalyzer.ts
@@ -4,6 +4,39 @@ import type { NavigationNode, NavigationEdge } from "../../db/types";
 import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
+interface CoverageAnalysis {
+  totalNodes: number;
+  coveredNodes: number;
+  uncoveredNodes: NavigationNode[];
+  totalEdges: number;
+  coveredEdges: number;
+  uncoveredEdges: NavigationEdge[];
+  coveragePercentage: number;
+}
+
+interface TestCoverageAnalysisRepository {
+  getAggregatedCoverageAnalysis(appId: string): Promise<CoverageAnalysis>;
+}
+
+interface NavigationGraphRepository {
+  getNodes(appId: string): Promise<NavigationNode[]>;
+  getEdges(appId: string): Promise<NavigationEdge[]>;
+}
+
+interface TestCoverageAnalyzerOptions {
+  coverageRepository?: TestCoverageAnalysisRepository;
+  navigationRepository?: NavigationGraphRepository;
+  timer?: Timer;
+}
+
+interface GraphAnalysis {
+  nodeByScreen: Map<string, NavigationNode>;
+  inEdgesByScreen: Map<string, NavigationEdge[]>;
+  outEdgesByScreen: Map<string, NavigationEdge[]>;
+  depthsByScreen: Map<string, number>;
+  hasEntryPoints: boolean;
+}
+
 interface CoverageGap {
   type: "node" | "edge";
   id: number;
@@ -52,13 +85,15 @@ interface TestScenario {
 /**
  * Analyzes test coverage for navigation graphs and generates recommendations.
  */
-class TestCoverageAnalyzer {
-  private navigationRepository: NavigationRepository;
+export class TestCoverageAnalyzer {
+  private coverageRepository: TestCoverageAnalysisRepository;
+  private navigationRepository: NavigationGraphRepository;
   private timer: Timer;
 
-  constructor(timer: Timer = defaultTimer) {
-    this.navigationRepository = new NavigationRepository();
-    this.timer = timer;
+  constructor(options: TestCoverageAnalyzerOptions = {}) {
+    this.coverageRepository = options.coverageRepository ?? testCoverageRepository;
+    this.navigationRepository = options.navigationRepository ?? new NavigationRepository();
+    this.timer = options.timer ?? defaultTimer;
   }
 
   /**
@@ -68,7 +103,7 @@ class TestCoverageAnalyzer {
     logger.info(`[TEST_COVERAGE] Generating coverage report for app: ${appId}`);
 
     // Get aggregated coverage data
-    const coverageData = await testCoverageRepository.getAggregatedCoverageAnalysis(appId);
+    const coverageData = await this.coverageRepository.getAggregatedCoverageAnalysis(appId);
 
     // Calculate criticality scores for uncovered elements
     const criticalGaps = await this.identifyCriticalGaps(
@@ -130,18 +165,19 @@ class TestCoverageAnalyzer {
     // Get all nodes and edges for frequency/depth analysis
     const allNodes = await this.navigationRepository.getNodes(appId);
     const allEdges = await this.navigationRepository.getEdges(appId);
+    const graphAnalysis = this.buildGraphAnalysis(allNodes, allEdges);
 
     // Calculate max values for normalization
     const maxVisits = Math.max(...allNodes.map(n => n.visit_count), 1);
 
     // Analyze uncovered nodes
     for (const node of uncoveredNodes) {
-      const inEdges = allEdges.filter(e => e.to_screen === node.screen_name);
-      const outEdges = allEdges.filter(e => e.from_screen === node.screen_name);
+      const inEdges = graphAnalysis.inEdgesByScreen.get(node.screen_name) ?? [];
+      const outEdges = graphAnalysis.outEdgesByScreen.get(node.screen_name) ?? [];
       const edgeCount = inEdges.length + outEdges.length;
 
       // Calculate depth (minimum hops from entry point)
-      const depth = await this.calculateNodeDepth(appId, node.screen_name, allEdges);
+      const depth = this.getNodeDepth(node.screen_name, graphAnalysis);
 
       // Criticality score: high frequency + shallow depth = high criticality
       // Frequency score: 0-50 based on visit count
@@ -162,15 +198,15 @@ class TestCoverageAnalyzer {
     // Analyze uncovered edges
     for (const edge of uncoveredEdges) {
       // Get frequency data for connected nodes
-      const fromNode = allNodes.find(n => n.screen_name === edge.from_screen);
-      const toNode = allNodes.find(n => n.screen_name === edge.to_screen);
+      const fromNode = graphAnalysis.nodeByScreen.get(edge.from_screen);
+      const toNode = graphAnalysis.nodeByScreen.get(edge.to_screen);
 
       if (!fromNode || !toNode) {
         continue;
       }
 
       // Calculate depth of source node
-      const depth = await this.calculateNodeDepth(appId, edge.from_screen, allEdges);
+      const depth = this.getNodeDepth(edge.from_screen, graphAnalysis);
 
       // Edge criticality based on node visit counts and depth
       const avgVisits = (fromNode.visit_count + toNode.visit_count) / 2;
@@ -195,73 +231,86 @@ class TestCoverageAnalyzer {
   }
 
   /**
-   * Calculate the depth (minimum hops) of a node from entry points.
-   * Entry points are nodes with no incoming edges.
+   * Build graph indexes once per report so each coverage gap can be scored with
+   * constant-time lookups.
    */
-  private async calculateNodeDepth(
-    appId: string,
-    screenName: string,
-    allEdges: NavigationEdge[]
-  ): Promise<number> {
-    // Find entry points (nodes with no incoming edges)
+  private buildGraphAnalysis(allNodes: NavigationNode[], allEdges: NavigationEdge[]): GraphAnalysis {
+    const nodeByScreen = new Map<string, NavigationNode>();
+    const inEdgesByScreen = new Map<string, NavigationEdge[]>();
+    const outEdgesByScreen = new Map<string, NavigationEdge[]>();
     const allScreens = new Set<string>();
-    allEdges.forEach(e => {
-      allScreens.add(e.from_screen);
-      allScreens.add(e.to_screen);
-    });
+    const incomingCounts = new Map<string, number>();
 
-    const entryPoints = [...allScreens].filter(screen => {
-      return !allEdges.some(e => e.to_screen === screen);
-    });
+    for (const node of allNodes) {
+      nodeByScreen.set(node.screen_name, node);
+    }
 
-    if (entryPoints.length === 0) {
-      // No clear entry point, assume depth of 1
+    for (const edge of allEdges) {
+      allScreens.add(edge.from_screen);
+      allScreens.add(edge.to_screen);
+      incomingCounts.set(edge.to_screen, (incomingCounts.get(edge.to_screen) ?? 0) + 1);
+
+      const outEdges = outEdgesByScreen.get(edge.from_screen) ?? [];
+      outEdges.push(edge);
+      outEdgesByScreen.set(edge.from_screen, outEdges);
+
+      const inEdges = inEdgesByScreen.get(edge.to_screen) ?? [];
+      inEdges.push(edge);
+      inEdgesByScreen.set(edge.to_screen, inEdges);
+    }
+
+    const entryPoints: string[] = [];
+    for (const screen of allScreens) {
+      if ((incomingCounts.get(screen) ?? 0) === 0) {
+        entryPoints.push(screen);
+      }
+    }
+
+    return {
+      nodeByScreen,
+      inEdgesByScreen,
+      outEdgesByScreen,
+      depthsByScreen: this.calculateDepthsFromEntryPoints(entryPoints, outEdgesByScreen),
+      hasEntryPoints: entryPoints.length > 0,
+    };
+  }
+
+  private calculateDepthsFromEntryPoints(
+    entryPoints: string[],
+    outEdgesByScreen: Map<string, NavigationEdge[]>
+  ): Map<string, number> {
+    const depthsByScreen = new Map<string, number>();
+    const queue: Array<{ screen: string; depth: number }> = [];
+
+    for (const entryPoint of entryPoints) {
+      depthsByScreen.set(entryPoint, 0);
+      queue.push({ screen: entryPoint, depth: 0 });
+    }
+
+    let queueIndex = 0;
+    while (queueIndex < queue.length) {
+      const { screen, depth } = queue[queueIndex++];
+      const outgoing = outEdgesByScreen.get(screen) ?? [];
+
+      for (const edge of outgoing) {
+        if (!depthsByScreen.has(edge.to_screen)) {
+          const nextDepth = depth + 1;
+          depthsByScreen.set(edge.to_screen, nextDepth);
+          queue.push({ screen: edge.to_screen, depth: nextDepth });
+        }
+      }
+    }
+
+    return depthsByScreen;
+  }
+
+  private getNodeDepth(screenName: string, graphAnalysis: GraphAnalysis): number {
+    if (!graphAnalysis.hasEntryPoints) {
+      // No clear entry point, preserve the previous depth fallback.
       return 1;
     }
 
-    // BFS to find shortest path from any entry point
-    let minDepth = Infinity;
-
-    for (const entryPoint of entryPoints) {
-      const depth = this.bfsDepth(entryPoint, screenName, allEdges);
-      if (depth < minDepth) {
-        minDepth = depth;
-      }
-    }
-
-    return minDepth === Infinity ? 99 : minDepth;
-  }
-
-  /**
-   * BFS to find depth from start to target screen.
-   */
-  private bfsDepth(start: string, target: string, edges: NavigationEdge[]): number {
-    if (start === target) {
-      return 0;
-    }
-
-    const queue: Array<{ screen: string; depth: number }> = [{ screen: start, depth: 0 }];
-    const visited = new Set<string>([start]);
-
-    while (queue.length > 0) {
-      const { screen, depth } = queue.shift()!;
-
-      // Find outgoing edges
-      const outgoing = edges.filter(e => e.from_screen === screen);
-
-      for (const edge of outgoing) {
-        if (edge.to_screen === target) {
-          return depth + 1;
-        }
-
-        if (!visited.has(edge.to_screen)) {
-          visited.add(edge.to_screen);
-          queue.push({ screen: edge.to_screen, depth: depth + 1 });
-        }
-      }
-    }
-
-    return Infinity;
+    return graphAnalysis.depthsByScreen.get(screenName) ?? 99;
   }
 
   /**

--- a/test/features/navigation/TestCoverageAnalyzer.test.ts
+++ b/test/features/navigation/TestCoverageAnalyzer.test.ts
@@ -45,6 +45,16 @@ class FakeNavigationRepository {
 }
 
 class NoRepeatedScanEdges extends Array<NavigationEdge> {
+  iterationCount = 0;
+
+  override [Symbol.iterator](): IterableIterator<NavigationEdge> {
+    this.iterationCount++;
+    if (this.iterationCount > 1) {
+      throw new Error("expected edges to be indexed once, not scanned again per gap");
+    }
+    return super[Symbol.iterator]();
+  }
+
   filter(): NavigationEdge[] {
     throw new Error("expected edge lookups to use precomputed maps instead of filter()");
   }
@@ -55,6 +65,16 @@ class NoRepeatedScanEdges extends Array<NavigationEdge> {
 }
 
 class NoRepeatedScanNodes extends Array<NavigationNode> {
+  iterationCount = 0;
+
+  override [Symbol.iterator](): IterableIterator<NavigationNode> {
+    this.iterationCount++;
+    if (this.iterationCount > 1) {
+      throw new Error("expected nodes to be indexed once, not scanned again per gap");
+    }
+    return super[Symbol.iterator]();
+  }
+
   find(): NavigationNode | undefined {
     throw new Error("expected node lookups to use precomputed map instead of find()");
   }
@@ -151,7 +171,10 @@ describe("TestCoverageAnalyzer", () => {
     expect(coverageRepository.getAnalysisCallCount).toBe(1);
     expect(navigationRepository.getNodesCallCount).toBe(1);
     expect(navigationRepository.getEdgesCallCount).toBe(1);
+    expect(nodes.iterationCount).toBe(1);
+    expect(edges.iterationCount).toBe(1);
     expect(report.criticalGaps).toHaveLength(2);
+    expect(report.criticalGaps.map(gap => gap.id)).toEqual([11, 3]);
     const nodeGap = report.criticalGaps.find(gap => gap.type === "node");
     const edgeGap = report.criticalGaps.find(gap => gap.type === "edge");
     expect(nodeGap).toMatchObject({
@@ -169,6 +192,27 @@ describe("TestCoverageAnalyzer", () => {
       criticalityScore: 85,
     });
     expect(edgeGap?.recommendation).toContain("shallow in navigation tree");
+    expect(report.recommendations).toEqual([
+      "Overall coverage is 60.0% - add tests for critical user journeys to reach 80%+ coverage.",
+      "2 high-priority coverage gap(s) identified in frequently-used, shallow screens. Prioritize testing these areas.",
+      "1 screen(s) have no test coverage. Top uncovered: Details",
+    ]);
+    expect(report.suggestedScenarios).toEqual([
+      {
+        title: "Cover Critical Screens",
+        description: "Test 1 frequently-accessed screen(s) that currently have no coverage. These are shallow in the navigation tree and likely part of core user journeys.",
+        priority: "high",
+        targetScreens: ["Details"],
+        estimatedCoverageImprovement: 50,
+      },
+      {
+        title: "Test Critical User Journeys",
+        description: "Test 1 common navigation path(s) between screens. These transitions are frequently used but not covered by tests.",
+        priority: "high",
+        targetScreens: ["Search", "Details"],
+        estimatedCoverageImprovement: 50,
+      },
+    ]);
   });
 
   test("uses shortest depth from multiple entry points", async () => {
@@ -238,7 +282,11 @@ describe("TestCoverageAnalyzer", () => {
       uncoveredNodes: [nodes[0]],
       uncoveredEdges: [],
     };
-    const { analyzer: noEntryAnalyzer } = analyzerFor(noEntryAnalysis, nodes.slice(0, 2), edges.slice(0, 2));
+    const { analyzer: noEntryAnalyzer } = analyzerFor(
+      noEntryAnalysis,
+      nodes.slice(0, 2),
+      edges.slice(0, 2)
+    );
 
     const noEntryReport = await noEntryAnalyzer.generateReport("com.example.app");
 

--- a/test/features/navigation/TestCoverageAnalyzer.test.ts
+++ b/test/features/navigation/TestCoverageAnalyzer.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import type { NavigationEdge, NavigationNode } from "../../../src/db/types";
+import { TestCoverageAnalyzer } from "../../../src/features/navigation/TestCoverageAnalyzer";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+type CoverageAnalysis = Awaited<ReturnType<FakeCoverageRepository["getAggregatedCoverageAnalysis"]>>;
+
+class FakeCoverageRepository {
+  getAnalysisCallCount = 0;
+
+  constructor(private readonly analysis: {
+    totalNodes: number;
+    coveredNodes: number;
+    uncoveredNodes: NavigationNode[];
+    totalEdges: number;
+    coveredEdges: number;
+    uncoveredEdges: NavigationEdge[];
+    coveragePercentage: number;
+  }) {}
+
+  async getAggregatedCoverageAnalysis(_appId: string): Promise<typeof this.analysis> {
+    this.getAnalysisCallCount++;
+    return this.analysis;
+  }
+}
+
+class FakeNavigationRepository {
+  getNodesCallCount = 0;
+  getEdgesCallCount = 0;
+
+  constructor(
+    private readonly nodes: NavigationNode[],
+    private readonly edges: NavigationEdge[]
+  ) {}
+
+  async getNodes(_appId: string): Promise<NavigationNode[]> {
+    this.getNodesCallCount++;
+    return this.nodes;
+  }
+
+  async getEdges(_appId: string): Promise<NavigationEdge[]> {
+    this.getEdgesCallCount++;
+    return this.edges;
+  }
+}
+
+class NoRepeatedScanEdges extends Array<NavigationEdge> {
+  filter(): NavigationEdge[] {
+    throw new Error("expected edge lookups to use precomputed maps instead of filter()");
+  }
+
+  some(): boolean {
+    throw new Error("expected entry-point lookup to use precomputed in-degree map instead of some()");
+  }
+}
+
+class NoRepeatedScanNodes extends Array<NavigationNode> {
+  find(): NavigationNode | undefined {
+    throw new Error("expected node lookups to use precomputed map instead of find()");
+  }
+}
+
+function node(id: number, screenName: string, visitCount: number): NavigationNode {
+  return {
+    id,
+    app_id: "com.example.app",
+    screen_name: screenName,
+    first_seen_at: 1000,
+    last_seen_at: 1000,
+    visit_count: visitCount,
+    back_stack_depth: null,
+    task_id: null,
+    screenshot_path: null,
+    created_at: "2024-01-01T00:00:00.000Z",
+  };
+}
+
+function edge(id: number, fromScreen: string, toScreen: string): NavigationEdge {
+  return {
+    id,
+    app_id: "com.example.app",
+    from_screen: fromScreen,
+    to_screen: toScreen,
+    tool_name: "tapOn",
+    tool_args: null,
+    timestamp: 1000,
+    created_at: "2024-01-01T00:00:00.000Z",
+  };
+}
+
+function analyzerFor(
+  analysis: CoverageAnalysis,
+  nodes: NavigationNode[],
+  edges: NavigationEdge[],
+  timer = new FakeTimer()
+): {
+  analyzer: TestCoverageAnalyzer;
+  coverageRepository: FakeCoverageRepository;
+  navigationRepository: FakeNavigationRepository;
+  timer: FakeTimer;
+} {
+  const coverageRepository = new FakeCoverageRepository(analysis);
+  const navigationRepository = new FakeNavigationRepository(nodes, edges);
+
+  return {
+    analyzer: new TestCoverageAnalyzer({
+      coverageRepository,
+      navigationRepository,
+      timer,
+    }),
+    coverageRepository,
+    navigationRepository,
+    timer,
+  };
+}
+
+describe("TestCoverageAnalyzer", () => {
+  test("uses precomputed graph lookups while preserving critical gap scoring", async () => {
+    const nodes = new NoRepeatedScanNodes(
+      node(1, "Home", 10),
+      node(2, "Search", 6),
+      node(3, "Details", 8),
+      node(4, "Settings", 2)
+    );
+    const edges = new NoRepeatedScanEdges(
+      edge(10, "Home", "Search"),
+      edge(11, "Search", "Details"),
+      edge(12, "Home", "Settings")
+    );
+    const analysis = {
+      totalNodes: nodes.length,
+      coveredNodes: 2,
+      uncoveredNodes: [nodes[2]],
+      totalEdges: edges.length,
+      coveredEdges: 2,
+      uncoveredEdges: [edges[1]],
+      coveragePercentage: 60,
+    };
+    const timer = new FakeTimer();
+    timer.setCurrentTime(123456);
+    const { analyzer, coverageRepository, navigationRepository } = analyzerFor(
+      analysis,
+      nodes,
+      edges,
+      timer
+    );
+
+    const report = await analyzer.generateReport("com.example.app");
+
+    expect(report.generatedAt).toBe(123456);
+    expect(coverageRepository.getAnalysisCallCount).toBe(1);
+    expect(navigationRepository.getNodesCallCount).toBe(1);
+    expect(navigationRepository.getEdgesCallCount).toBe(1);
+    expect(report.criticalGaps).toHaveLength(2);
+    const nodeGap = report.criticalGaps.find(gap => gap.type === "node");
+    const edgeGap = report.criticalGaps.find(gap => gap.type === "edge");
+    expect(nodeGap).toMatchObject({
+      type: "node",
+      id: 3,
+      screenName: "Details",
+      criticalityScore: 65,
+    });
+    expect(nodeGap?.recommendation).toContain("shallow in navigation tree");
+    expect(edgeGap).toMatchObject({
+      type: "edge",
+      id: 11,
+      fromScreen: "Search",
+      toScreen: "Details",
+      criticalityScore: 85,
+    });
+    expect(edgeGap?.recommendation).toContain("shallow in navigation tree");
+  });
+
+  test("uses shortest depth from multiple entry points", async () => {
+    const nodes = [
+      node(1, "PrimaryHome", 10),
+      node(2, "SecondaryHome", 5),
+      node(3, "Intermediate", 4),
+      node(4, "Target", 8),
+    ];
+    const edges = [
+      edge(10, "PrimaryHome", "Intermediate"),
+      edge(11, "Intermediate", "Target"),
+      edge(12, "SecondaryHome", "Target"),
+    ];
+    const analysis = {
+      totalNodes: nodes.length,
+      coveredNodes: 3,
+      uncoveredNodes: [nodes[3]],
+      totalEdges: edges.length,
+      coveredEdges: 3,
+      uncoveredEdges: [],
+      coveragePercentage: 85,
+    };
+    const { analyzer } = analyzerFor(analysis, nodes, edges);
+
+    const report = await analyzer.generateReport("com.example.app");
+
+    expect(report.criticalGaps[0].screenName).toBe("Target");
+    expect(report.criticalGaps[0].criticalityScore).toBe(90);
+    expect(report.criticalGaps[0].recommendation).toContain("shallow in navigation tree");
+  });
+
+  test("keeps depth fallbacks for cyclic and unreachable graphs", async () => {
+    const nodes = [
+      node(1, "CycleA", 10),
+      node(2, "CycleB", 8),
+      node(3, "Entry", 3),
+      node(4, "Unreachable", 4),
+    ];
+    const edges = [
+      edge(10, "CycleA", "CycleB"),
+      edge(11, "CycleB", "CycleA"),
+      edge(12, "Entry", "Other"),
+    ];
+    const analysis = {
+      totalNodes: nodes.length,
+      coveredNodes: 2,
+      uncoveredNodes: [nodes[0], nodes[3]],
+      totalEdges: edges.length,
+      coveredEdges: 3,
+      uncoveredEdges: [],
+      coveragePercentage: 70,
+    };
+    const { analyzer } = analyzerFor(analysis, nodes, edges);
+
+    const report = await analyzer.generateReport("com.example.app");
+
+    const cycleGap = report.criticalGaps.find(gap => gap.screenName === "CycleA");
+    const unreachableGap = report.criticalGaps.find(gap => gap.screenName === "Unreachable");
+    expect(cycleGap?.criticalityScore).toBeCloseTo(50.505, 3);
+    expect(cycleGap?.recommendation).toContain("deep in navigation tree");
+    expect(unreachableGap?.criticalityScore).toBeCloseTo(20.505, 3);
+    expect(unreachableGap?.recommendation).toContain("deep in navigation tree");
+
+    const noEntryAnalysis = {
+      ...analysis,
+      uncoveredNodes: [nodes[0]],
+      uncoveredEdges: [],
+    };
+    const { analyzer: noEntryAnalyzer } = analyzerFor(noEntryAnalysis, nodes.slice(0, 2), edges.slice(0, 2));
+
+    const noEntryReport = await noEntryAnalyzer.generateReport("com.example.app");
+
+    expect(noEntryReport.criticalGaps[0].criticalityScore).toBe(100);
+    expect(noEntryReport.criticalGaps[0].recommendation).toContain("shallow in navigation tree");
+  });
+});


### PR DESCRIPTION
## Summary
- Precompute navigation graph maps and multi-source BFS depths once per coverage report.
- Score uncovered node and edge gaps from O(1) lookups instead of repeated per-gap scans.
- Add fast fake-repository tests covering graph lookup behavior, multi-entry depths, and fallback depth behavior.

## Testing
- `bun test test/features/navigation/TestCoverageAnalyzer.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`

## Acceptance Criteria
- Inferred: graph lookup structures are built once per report for nodes, edges, and screen relationships.
- Inferred: entry points are computed once and depths are assigned with a single multi-source BFS.
- Inferred: uncovered node and edge scoring uses precomputed maps rather than repeated `filter`/`find` scans.
- Inferred: public report behavior remains stable, including sorting, recommendations, and depth fallbacks.

Closes #3424

Made with [Cursor](https://cursor.com)