### PR TITLE
Fix navigation path enrichment overhead

### DIFF
--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -874,10 +874,9 @@ export class NavigationGraphManager implements NavigationGraphService {
 
     // Get all edges for BFS
     const dbEdges = await this.repository.getEdges(this.currentAppId);
-    const edges = await this.convertDBEdgesToNavigationEdges(dbEdges);
 
     // BFS to find shortest path
-    const queue: Array<{ screen: string; path: NavigationEdge[] }> = [
+    const queue: Array<{ screen: string; path: DBNavigationEdge[] }> = [
       { screen: startScreen, path: [] },
     ];
     const visited = new Set<string>([startScreen]);
@@ -886,23 +885,27 @@ export class NavigationGraphManager implements NavigationGraphService {
       const { screen, path } = queue.shift()!;
 
       // Find all edges from current screen
-      const outgoingEdges = edges.filter(e => e.from === screen);
+      const outgoingEdges = dbEdges.filter(e => e.from_screen === screen);
 
       for (const edge of outgoingEdges) {
-        if (edge.to === targetScreen) {
+        if (edge.to_screen === targetScreen) {
+          const pathEdges = await this.convertDBEdgesToNavigationEdges([
+            ...path,
+            edge,
+          ]);
           // Found the target
           return {
             found: true,
-            path: [...path, edge],
+            path: pathEdges,
             startScreen,
             targetScreen,
           };
         }
 
-        if (!visited.has(edge.to)) {
-          visited.add(edge.to);
+        if (!visited.has(edge.to_screen)) {
+          visited.add(edge.to_screen);
           queue.push({
-            screen: edge.to,
+            screen: edge.to_screen,
             path: [...path, edge],
           });
         }

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -300,6 +300,62 @@ describe("NavigationGraphManager", () => {
       expect(result.path[1].to).toBe("Advanced");
     });
 
+    test("should enrich only edges in the returned path", async () => {
+      const now = Date.now();
+      await manager.recordNavigationEvent(createEvent("Home", now));
+
+      manager.recordToolCall("tapOn", { text: "Path A" });
+      await manager.recordNavigationEvent(createEvent("PathA", now + 100));
+
+      manager.recordToolCall("tapOn", { text: "Target" });
+      await manager.recordNavigationEvent(createEvent("Target", now + 200));
+
+      manager.recordToolCall("pressButton", { button: "BACK" });
+      await manager.recordNavigationEvent(createEvent("Home", now + 300));
+
+      manager.recordToolCall("tapOn", { text: "Decoy A" });
+      await manager.recordNavigationEvent(createEvent("DecoyA", now + 400));
+
+      manager.recordToolCall("pressButton", { button: "BACK" });
+      await manager.recordNavigationEvent(createEvent("Home", now + 500));
+
+      manager.recordToolCall("tapOn", { text: "Decoy B" });
+      await manager.recordNavigationEvent(createEvent("DecoyB", now + 600));
+
+      manager.recordToolCall("pressButton", { button: "BACK" });
+      await manager.recordNavigationEvent(createEvent("Home", now + 700));
+
+      const uiElementsSpy = spyOn(
+        NavigationRepository.prototype,
+        "getUIElementsForEdge"
+      );
+      const scrollPositionSpy = spyOn(
+        NavigationRepository.prototype,
+        "getScrollPosition"
+      );
+      const edgeModalsSpy = spyOn(
+        NavigationRepository.prototype,
+        "getEdgeModals"
+      );
+
+      try {
+        const result = await manager.findPath("Target");
+
+        expect(result.found).toBe(true);
+        expect(result.path.map(edge => [edge.from, edge.to])).toEqual([
+          ["Home", "PathA"],
+          ["PathA", "Target"],
+        ]);
+        expect(uiElementsSpy).toHaveBeenCalledTimes(result.path.length);
+        expect(scrollPositionSpy).toHaveBeenCalledTimes(result.path.length);
+        expect(edgeModalsSpy).toHaveBeenCalledTimes(result.path.length * 2);
+      } finally {
+        uiElementsSpy.mockRestore();
+        scrollPositionSpy.mockRestore();
+        edgeModalsSpy.mockRestore();
+      }
+    });
+
     test("should return not found when no path exists", async () => {
       await manager.recordNavigationEvent(createEvent("Screen1"));
 

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -300,6 +300,25 @@ describe("NavigationGraphManager", () => {
       expect(result.path[1].to).toBe("Advanced");
     });
 
+    test("should prefer a shorter path over an earlier longer path", async () => {
+      await manager.recordNavigationEvent(createEvent("Home", 1000));
+      await manager.recordNavigationEvent(createEvent("A", 1100));
+      await manager.recordNavigationEvent(createEvent("B", 1200));
+      await manager.recordNavigationEvent(createEvent("Target", 1300));
+      await manager.recordNavigationEvent(createEvent("Home", 1400));
+      await manager.recordNavigationEvent(createEvent("Shortcut", 1500));
+      await manager.recordNavigationEvent(createEvent("Target", 1600));
+      await manager.recordNavigationEvent(createEvent("Home", 1700));
+
+      const result = await manager.findPath("Target");
+
+      expect(result.found).toBe(true);
+      expect(result.path.map(edge => [edge.from, edge.to])).toEqual([
+        ["Home", "Shortcut"],
+        ["Shortcut", "Target"],
+      ]);
+    });
+
     test("should enrich only edges in the returned path", async () => {
       const now = Date.now();
       await manager.recordNavigationEvent(createEvent("Home", now));
@@ -362,6 +381,44 @@ describe("NavigationGraphManager", () => {
       const result = await manager.findPath("UnknownScreen");
       expect(result.found).toBe(false);
       expect(result.path).toHaveLength(0);
+    });
+
+    test("should not enrich any edges when no path exists", async () => {
+      const now = Date.now();
+      await manager.recordNavigationEvent(createEvent("Home", now));
+
+      manager.recordToolCall("tapOn", { text: "A" });
+      await manager.recordNavigationEvent(createEvent("A", now + 100));
+
+      manager.recordToolCall("tapOn", { text: "B" });
+      await manager.recordNavigationEvent(createEvent("B", now + 200));
+
+      const uiElementsSpy = spyOn(
+        NavigationRepository.prototype,
+        "getUIElementsForEdge"
+      );
+      const scrollPositionSpy = spyOn(
+        NavigationRepository.prototype,
+        "getScrollPosition"
+      );
+      const edgeModalsSpy = spyOn(
+        NavigationRepository.prototype,
+        "getEdgeModals"
+      );
+
+      try {
+        const result = await manager.findPath("Missing");
+
+        expect(result.found).toBe(false);
+        expect(result.path).toHaveLength(0);
+        expect(uiElementsSpy).not.toHaveBeenCalled();
+        expect(scrollPositionSpy).not.toHaveBeenCalled();
+        expect(edgeModalsSpy).not.toHaveBeenCalled();
+      } finally {
+        uiElementsSpy.mockRestore();
+        scrollPositionSpy.mockRestore();
+        edgeModalsSpy.mockRestore();
+      }
     });
 
     test("should return not found when no current screen", async () => {


### PR DESCRIPTION
## Summary

`findPath` now runs BFS over raw navigation DB edges and only enriches the edges in the returned path. This removes off-path UI element, scroll position, and modal lookups from the NavigateTo hot path while preserving the returned `NavigationEdge` shape.

## Linked Issue

Closes #3421

## Bug / Regression Context

- **Prior attempts:** None referenced in the issue.
- **Observed symptom:** `findPath` converted every edge for an app before BFS, causing expensive per-edge enrichment queries even though BFS only needs `from`/`to`.
- **Repro steps / conditions:** Search a graph with off-path edges; previously each off-path edge still triggered enrichment reads.

## Validation

- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun test test/features/navigation/NavigationGraphManager.test.ts --bail` passes
- [x] New regression test confirms only returned-path edges are enriched

## Device Verification

N/A: pathfinding DB/read optimization covered by unit tests; no on-device gesture or hierarchy behavior changed.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)