### PR TITLE
fix: optimize navigation pathfinding BFS

### DIFF
--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -876,24 +876,35 @@ export class NavigationGraphManager implements NavigationGraphService {
     const dbEdges = await this.repository.getEdges(this.currentAppId);
     const edges = await this.convertDBEdgesToNavigationEdges(dbEdges);
 
+    const edgesBySource = new Map<string, NavigationEdge[]>();
+    for (const edge of edges) {
+      const source = edge.from;
+      const outgoingEdges = edgesBySource.get(source);
+      if (outgoingEdges) {
+        outgoingEdges.push(edge);
+      } else {
+        edgesBySource.set(source, [edge]);
+      }
+    }
+
     // BFS to find shortest path
-    const queue: Array<{ screen: string; path: NavigationEdge[] }> = [
-      { screen: startScreen, path: [] },
-    ];
+    const queue: string[] = [startScreen];
+    let queueHead = 0;
     const visited = new Set<string>([startScreen]);
+    const predecessor = new Map<string, NavigationEdge>();
 
-    while (queue.length > 0) {
-      const { screen, path } = queue.shift()!;
-
-      // Find all edges from current screen
-      const outgoingEdges = edges.filter(e => e.from === screen);
+    while (queueHead < queue.length) {
+      const screen = queue[queueHead++];
+      const outgoingEdges = edgesBySource.get(screen) ?? [];
 
       for (const edge of outgoingEdges) {
         if (edge.to === targetScreen) {
+          predecessor.set(edge.to, edge);
+
           // Found the target
           return {
             found: true,
-            path: [...path, edge],
+            path: this.reconstructPath(startScreen, targetScreen, predecessor),
             startScreen,
             targetScreen,
           };
@@ -901,10 +912,8 @@ export class NavigationGraphManager implements NavigationGraphService {
 
         if (!visited.has(edge.to)) {
           visited.add(edge.to);
-          queue.push({
-            screen: edge.to,
-            path: [...path, edge],
-          });
+          predecessor.set(edge.to, edge);
+          queue.push(edge.to);
         }
       }
     }
@@ -916,6 +925,27 @@ export class NavigationGraphManager implements NavigationGraphService {
       startScreen,
       targetScreen,
     };
+  }
+
+  private reconstructPath(
+    startScreen: string,
+    targetScreen: string,
+    predecessor: Map<string, NavigationEdge>
+  ): NavigationEdge[] {
+    const path: NavigationEdge[] = [];
+    let screen = targetScreen;
+
+    while (screen !== startScreen) {
+      const edge = predecessor.get(screen);
+      if (!edge) {
+        return [];
+      }
+
+      path.push(edge);
+      screen = edge.from;
+    }
+
+    return path.reverse();
   }
 
   /**

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -318,12 +318,28 @@ describe("NavigationGraphManager", () => {
         "convertDBEdgesToNavigationEdges"
       ).mockResolvedValue(edges);
 
-      const result = await manager.findPath("Screen40");
+      const result = await manager
+        .findPath("Screen40")
+        .finally(() => conversionSpy.mockRestore());
 
-      conversionSpy.mockRestore();
       expect(result.found).toBe(true);
       expect(result.path).toHaveLength(40);
       expect(fromReadCount).toBeLessThanOrEqual(edges.length + result.path.length);
+    });
+
+    test("should keep BFS queue and path tracking linear in source", () => {
+      const managerSource = readFileSync(
+        join(import.meta.dir, "../../../src/features/navigation/NavigationGraphManager.ts"),
+        "utf8"
+      );
+      const findPathBody = extractMethodBody(managerSource, "public async findPath");
+
+      expect(findPathBody).toContain("const edgesBySource = new Map");
+      expect(findPathBody).toContain("let queueHead = 0");
+      expect(findPathBody).not.toContain(".shift(");
+      expect(findPathBody).toContain("const predecessor = new Map");
+      expect(findPathBody).not.toContain("[...path");
+      expect(findPathBody).toContain("this.reconstructPath(");
     });
 
     test("should return not found when no path exists", async () => {
@@ -487,6 +503,31 @@ function createCountingEdge(
   });
 
   return edge;
+}
+
+function extractMethodBody(source: string, signature: string): string {
+  const signatureIndex = source.indexOf(signature);
+  if (signatureIndex < 0) {
+    throw new Error(`Could not find method signature: ${signature}`);
+  }
+
+  const openingBrace = source.indexOf("{", signatureIndex);
+  if (openingBrace < 0) {
+    throw new Error(`Could not find method body: ${signature}`);
+  }
+
+  let depth = 1;
+  let index = openingBrace + 1;
+  for (; index < source.length && depth > 0; index++) {
+    const char = source[index];
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+    }
+  }
+
+  return source.slice(openingBrace + 1, index - 1);
 }
 
 describe("NavigationGraphManager - Scroll Position", () => {

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -2,7 +2,8 @@ import { expect, describe, test, beforeEach, afterEach, beforeAll, afterAll, it,
 import type { Kysely } from "kysely";
 import {
   NavigationGraphManager,
-  NavigationEvent
+  NavigationEvent,
+  type NavigationEdge
 } from "../../../src/features/navigation/NavigationGraphManager";
 import { runMigrations } from "../../helpers/database";
 import { createTestDatabase } from "../../db/testDbHelper";
@@ -300,6 +301,31 @@ describe("NavigationGraphManager", () => {
       expect(result.path[1].to).toBe("Advanced");
     });
 
+    test("should read edge sources linearly while searching a long path", async () => {
+      await manager.recordNavigationEvent(createEvent("Screen0", 1000));
+
+      let fromReadCount = 0;
+      const edges = Array.from({ length: 40 }, (_, index) =>
+        createCountingEdge(`Screen${index}`, `Screen${index + 1}`, () => {
+          fromReadCount++;
+        })
+      );
+
+      const conversionSpy = spyOn(
+        manager as unknown as {
+          convertDBEdgesToNavigationEdges: () => Promise<NavigationEdge[]>;
+        },
+        "convertDBEdgesToNavigationEdges"
+      ).mockResolvedValue(edges);
+
+      const result = await manager.findPath("Screen40");
+
+      conversionSpy.mockRestore();
+      expect(result.found).toBe(true);
+      expect(result.path).toHaveLength(40);
+      expect(fromReadCount).toBeLessThanOrEqual(edges.length + result.path.length);
+    });
+
     test("should return not found when no path exists", async () => {
       await manager.recordNavigationEvent(createEvent("Screen1"));
 
@@ -439,6 +465,28 @@ function createEventWithApp(
     sequenceNumber: 0,
     applicationId
   };
+}
+
+function createCountingEdge(
+  from: string,
+  to: string,
+  onFromRead: () => void
+): NavigationEdge {
+  const edge = {
+    to,
+    timestamp: 1000,
+    edgeType: "unknown" as const,
+  } as NavigationEdge;
+
+  Object.defineProperty(edge, "from", {
+    enumerable: true,
+    get: () => {
+      onFromRead();
+      return from;
+    },
+  });
+
+  return edge;
 }
 
 describe("NavigationGraphManager - Scroll Position", () => {


### PR DESCRIPTION
## Summary

Optimizes `NavigationGraphManager.findPath` so BFS builds adjacency once, uses a head-index queue, and reconstructs the path from predecessors instead of copying paths on every enqueue. This keeps pathfinding linear on large navigation graphs.

## Linked Issue

Closes #3423

## Bug / Regression Context

- **Prior attempts:** None referenced in the issue.
- **Observed symptom:** `findPath` scanned all edges for each dequeued screen, used `Array.shift()`, and copied the accumulated path on every enqueue.
- **Repro steps / conditions:** Searching a long navigation path caused repeated edge source reads; the new regression test failed red with 1600 source reads for a 40-edge path before the fix.

## Validation

- [x] `bun test test/features/navigation/NavigationGraphManager.test.ts --test-name-pattern "should read edge sources linearly while searching a long path"` passes
- [x] `bun test test/features/navigation/NavigationGraphManager.test.ts` passes
- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: not applicable
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A - internal pathfinding algorithm only; no on-device behavior or tool schema changes.

## Follow-ups

No follow-ups identified.

Made with [Cursor](https://cursor.com)