### PR TITLE
Fix Explore progress graph counting

### DIFF
--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -321,8 +321,8 @@ export class Explore extends BaseVisualChange {
             );
           } else {
             // Report discovery progress
-            const currentGraph = await this.navigationManager.exportGraph();
-            const currentNodeCount = currentGraph.nodes.length;
+            const currentStats = await this.navigationManager.getStats();
+            const currentNodeCount = currentStats.nodeCount;
             await progress(
               this.interactionCount,
               maxInteractions,

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -155,8 +155,52 @@ describe("Explore", () => {
   }
 
   describe("execute", () => {
-    // Core execute functionality is tested through the unit tests below
-    // Full device integration tests are in JUnitRunner and XCTestRunner
+    test("should use graph stats instead of exporting the full graph for progress node counts", async () => {
+      fakeGraph.recordNavigationEvent({
+        destination: "Home",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: fakeTimer.now(),
+        sequenceNumber: 1,
+        applicationId: "com.test.app"
+      });
+
+      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+      (explore as any).observeScreen = {
+        execute: async () => createMockObservation()
+      };
+      (explore as any).performInteraction = async () => {
+        fakeGraph.recordNavigationEvent({
+          destination: "Settings",
+          source: "TEST",
+          arguments: {},
+          metadata: {},
+          timestamp: fakeTimer.now(),
+          sequenceNumber: 2,
+          applicationId: "com.test.app"
+        });
+        return true;
+      };
+
+      fakeGraph.clearCallHistory();
+      const progressMessages: string[] = [];
+
+      await explore.execute(
+        {
+          maxInteractions: 1,
+          timeoutMs: 5000,
+          packageName: "com.test.app"
+        },
+        (_current, _total, message) => {
+          progressMessages.push(message);
+        }
+      );
+
+      expect(fakeGraph.getMethodCallCount("getStats")).toBe(1);
+      expect(fakeGraph.getMethodCallCount("exportGraph")).toBe(2);
+      expect(progressMessages).toContain("Explored 1 new screens (1/1 interactions)");
+    });
   });
 
   describe("element selection", () => {

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -155,52 +155,56 @@ describe("Explore", () => {
   }
 
   describe("execute", () => {
-    test("should use graph stats instead of exporting the full graph for progress node counts", async () => {
-      fakeGraph.recordNavigationEvent({
-        destination: "Home",
-        source: "TEST",
-        arguments: {},
-        metadata: {},
-        timestamp: fakeTimer.now(),
-        sequenceNumber: 1,
-        applicationId: "com.test.app"
-      });
-
-      explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
-      (explore as any).observeScreen = {
-        execute: async () => createMockObservation()
-      };
-      (explore as any).performInteraction = async () => {
+    for (const mode of ["hybrid", "discover"] as const) {
+      test(`should use graph stats instead of exporting the full graph for ${mode} progress node counts`, async () => {
         fakeGraph.recordNavigationEvent({
-          destination: "Settings",
+          destination: "Home",
           source: "TEST",
           arguments: {},
           metadata: {},
           timestamp: fakeTimer.now(),
-          sequenceNumber: 2,
+          sequenceNumber: 1,
           applicationId: "com.test.app"
         });
-        return true;
-      };
 
-      fakeGraph.clearCallHistory();
-      const progressMessages: string[] = [];
+        explore = new Explore(device, mockAdb, fakeTimer, fakeGraph);
+        (explore as any).observeScreen = {
+          execute: async () => createMockObservation()
+        };
+        (explore as any).performInteraction = async () => {
+          fakeGraph.recordNavigationEvent({
+            destination: "Settings",
+            source: "TEST",
+            arguments: {},
+            metadata: {},
+            timestamp: fakeTimer.now(),
+            sequenceNumber: 2,
+            applicationId: "com.test.app"
+          });
+          return true;
+        };
 
-      await explore.execute(
-        {
-          maxInteractions: 1,
-          timeoutMs: 5000,
-          packageName: "com.test.app"
-        },
-        (_current, _total, message) => {
-          progressMessages.push(message);
-        }
-      );
+        fakeGraph.clearCallHistory();
+        const progressMessages: string[] = [];
 
-      expect(fakeGraph.getMethodCallCount("getStats")).toBe(1);
-      expect(fakeGraph.getMethodCallCount("exportGraph")).toBe(2);
-      expect(progressMessages).toContain("Explored 1 new screens (1/1 interactions)");
-    });
+        const result = await explore.execute(
+          {
+            maxInteractions: 1,
+            timeoutMs: 5000,
+            packageName: "com.test.app",
+            mode
+          },
+          (_current, _total, message) => {
+            progressMessages.push(message);
+          }
+        );
+
+        expect(fakeGraph.getMethodCallCount("getStats")).toBe(1);
+        expect(fakeGraph.getMethodCallCount("exportGraph")).toBe(2);
+        expect(progressMessages).toContain("Explored 1 new screens (1/1 interactions)");
+        expect(result.screensDiscovered).toBe(1);
+      });
+    }
   });
 
   describe("element selection", () => {


### PR DESCRIPTION
## Summary

Use lightweight navigation graph stats for Explore progress reporting so each discovery/hybrid loop iteration no longer exports and enriches the full graph just to count screens.

## Linked Issue

Closes #3422

## Bug / Regression Context

- **Prior attempts:** None found.
- **Observed symptom:** Explore progress reporting called `exportGraph()` on every interaction and only used `nodes.length`, causing unnecessary full graph materialization during runs of up to 200 interactions.
- **Repro steps / conditions:** Run Explore with progress reporting in discovery/hybrid mode against a graph with recorded screens.

## Acceptance Criteria

- [x] Discovery/hybrid progress node counts use `getStats().nodeCount` instead of per-iteration `exportGraph().nodes.length`.
- [x] Initial graph export/report generation behavior remains unchanged.
- [x] Progress message behavior is preserved.

## Validation

- [x] `bun test test/features/navigation/Explore.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms

## Device Verification

N/A. This is an internal graph-counting performance fix covered by unit tests.

## Follow-ups

None.
