### PR TITLE
perf: reuse flattened observe entries for media

### DIFF
--- a/src/features/observe/IdentifyMediaViews.ts
+++ b/src/features/observe/IdentifyMediaViews.ts
@@ -5,6 +5,7 @@ import { DefaultElementParser } from "../utility/ElementParser";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 
 export type MediaType = "image" | "video" | "loading" | "mixed";
+export type FlattenedElementEntry = { element: Element; index: number; depth: number; text?: string };
 
 export interface MediaView {
   viewId?: string;
@@ -89,9 +90,13 @@ export class IdentifyMediaViews {
     this.parser = parser;
   }
 
-  classify(viewHierarchy: ViewHierarchyResult, platform: "android" | "ios"): MediaView[] {
+  classify(
+    viewHierarchy: ViewHierarchyResult,
+    platform: "android" | "ios",
+    flattenedEntries?: FlattenedElementEntry[]
+  ): MediaView[] {
     const patterns = platform === "ios" ? iosPatterns : androidPatterns;
-    const entries = this.parser.flattenViewHierarchy(viewHierarchy, {
+    const entries = flattenedEntries ?? this.parser.flattenViewHierarchy(viewHierarchy, {
       includeWindows: true,
       windowOrder: "topmost-first"
     });

--- a/src/features/observe/ObserveElementsBuilder.ts
+++ b/src/features/observe/ObserveElementsBuilder.ts
@@ -23,11 +23,14 @@ export class ObserveElementsBuilder {
   build(viewHierarchy: ViewHierarchyResult, platform: "android" | "ios" = "android"): ObserveResult["elements"] {
     const clickable = this.finder.findClickableElements(viewHierarchy);
     const scrollable = this.finder.findScrollableElements(viewHierarchy);
-    const text = this.parser
-      .flattenViewHierarchy(viewHierarchy, { includeWindows: true, windowOrder: "topmost-first" })
+    const flattenedEntries = this.parser.flattenViewHierarchy(viewHierarchy, {
+      includeWindows: true,
+      windowOrder: "topmost-first"
+    });
+    const text = flattenedEntries
       .filter(entry => typeof entry.text === "string" && entry.text.trim().length > 0)
       .map(entry => entry.element);
-    const media = this.mediaClassifier.classify(viewHierarchy, platform);
+    const media = this.mediaClassifier.classify(viewHierarchy, platform, flattenedEntries);
 
     return { clickable, scrollable, text, media };
   }

--- a/test/features/observe/IdentifyMediaViews.test.ts
+++ b/test/features/observe/IdentifyMediaViews.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect } from "bun:test";
 import { IdentifyMediaViews } from "../../../src/features/observe/IdentifyMediaViews";
 import { ViewHierarchyResult } from "../../../src/models/ViewHierarchyResult";
 import { ElementBounds } from "../../../src/models/ElementBounds";
+import type { Element } from "../../../src/models/Element";
+import { FakeElementParser } from "../../fakes/FakeElementParser";
 
 function buildHierarchy(
   elements: Array<{
@@ -186,5 +188,29 @@ describe("IdentifyMediaViews", () => {
     const h: ViewHierarchyResult = { hierarchy: {} };
     const result = classifier.classify(h, "android");
     expect(result).toHaveLength(0);
+  });
+
+  test("classifies media from pre-flattened entries without flattening hierarchy", () => {
+    class NoFlattenParser extends FakeElementParser {
+      override flattenViewHierarchy(): Array<{ element: Element; index: number; depth: number; text?: string }> {
+        throw new Error("flattenViewHierarchy should not be called");
+      }
+    }
+
+    const imageElement: Element = {
+      "bounds": defaultBounds,
+      "class": "android.widget.ImageView"
+    };
+    const result = new IdentifyMediaViews(new NoFlattenParser()).classify(
+      { hierarchy: {} },
+      "android",
+      [{ element: imageElement, index: 0, depth: 0 }]
+    );
+
+    expect(result).toEqual([{
+      className: "android.widget.ImageView",
+      mediaType: "image",
+      bounds: defaultBounds
+    }]);
   });
 });

--- a/test/features/observe/ObserveElementsBuilder.test.ts
+++ b/test/features/observe/ObserveElementsBuilder.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, test } from "bun:test";
 import { ObserveElementsBuilder } from "../../../src/features/observe/ObserveElementsBuilder";
 import { Element, ViewHierarchyResult } from "../../../src/models";
+import { IdentifyMediaViews } from "../../../src/features/observe/IdentifyMediaViews";
 import { FakeElementFinder } from "../../fakes/FakeElementFinder";
 import { FakeElementParser } from "../../fakes/FakeElementParser";
 
 const createElement = (bounds: Element["bounds"]): Element => ({
   bounds
 });
+
+class CountingElementParser extends FakeElementParser {
+  flattenCallCount = 0;
+
+  override flattenViewHierarchy(
+    viewHierarchy: ViewHierarchyResult,
+    options?: { includeWindows?: boolean; windowOrder?: "topmost-first" | "bottommost-first" }
+  ): Array<{ element: Element; index: number; depth: number; text?: string }> {
+    this.flattenCallCount++;
+    return super.flattenViewHierarchy(viewHierarchy, options);
+  }
+}
 
 describe("ObserveElementsBuilder", () => {
   test("builds clickable, scrollable, and text elements with filtering", () => {
@@ -32,5 +45,40 @@ describe("ObserveElementsBuilder", () => {
     expect(elements.clickable).toEqual([clickable]);
     expect(elements.scrollable).toEqual([scrollable]);
     expect(elements.text).toEqual([textElement]);
+  });
+
+  test("reuses one flattened hierarchy for text and media elements", () => {
+    const clickable = createElement({ left: 0, top: 0, right: 10, bottom: 10 });
+    const scrollable = createElement({ left: 5, top: 5, right: 15, bottom: 15 });
+    const textElement = createElement({ left: 10, top: 10, right: 20, bottom: 20 });
+    const imageElement: Element = {
+      "bounds": { left: 20, top: 20, right: 30, bottom: 30 },
+      "class": "android.widget.ImageView"
+    };
+
+    const fakeFinder = new FakeElementFinder();
+    fakeFinder.nextClickableElements = [clickable];
+    fakeFinder.nextScrollableElements = [scrollable];
+
+    const fakeParser = new CountingElementParser();
+    fakeParser.nextFlattenedElements = [
+      { element: textElement, index: 0, depth: 0, text: "Hello" },
+      { element: imageElement, index: 1, depth: 0 }
+    ];
+
+    const builder = new ObserveElementsBuilder(
+      fakeFinder,
+      fakeParser,
+      new IdentifyMediaViews(fakeParser)
+    );
+    const elements = builder.build({ hierarchy: { node: {} } } as ViewHierarchyResult);
+
+    expect(fakeParser.flattenCallCount).toBe(1);
+    expect(elements.text).toEqual([textElement]);
+    expect(elements.media).toEqual([{
+      className: "android.widget.ImageView",
+      mediaType: "image",
+      bounds: imageElement.bounds
+    }]);
   });
 });


### PR DESCRIPTION
## Summary

Reuse the flattened observe hierarchy entries when deriving media elements, so `ObserveElementsBuilder` no longer performs the same `flattenViewHierarchy({ includeWindows: true, windowOrder: "topmost-first" })` pass twice per observe.

## Linked Issue

Closes #3419

## Bug / Regression Context

- **Prior attempts:** None referenced in the issue.
- **Observed symptom:** Observe element building flattened once for text and then `IdentifyMediaViews.classify` flattened the same hierarchy again for media.
- **Repro steps / conditions:** Any observe with a view hierarchy that derives both text and media elements.

## Validation

- [x] `bun run turbo:validate` passes (`lint` + `build` + full `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, TypeScript observe derivation only
- [x] New code uses interfaces + fakes + FakeTimer; focused unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Acceptance Criteria

- [x] `IdentifyMediaViews.classify` accepts pre-flattened entries while preserving the existing hierarchy-backed call path.
- [x] `ObserveElementsBuilder` flattens once for text/media derivation and passes those entries to media classification.
- [x] Existing media classification behavior remains covered by the current classifier tests.

## Follow-ups

- [ ] Full single-pass clickable/scrollable/text/media collection was intentionally left out to keep this PR focused; file separately if desired.

Made with [Cursor](https://cursor.com)