### PR TITLE
Fix offscreen filter debug serialization

### DIFF
--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -1,5 +1,5 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
-import { logger } from "../../utils/logger";
+import { logger, LogLevel } from "../../utils/logger";
 import { BootedDevice } from "../../models";
 import { Element } from "../../models";
 import { ViewHierarchyResult } from "../../models";
@@ -423,16 +423,17 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       return viewHierarchy;
     }
 
-    const originalSize = JSON.stringify(viewHierarchy.hierarchy).length;
-
     const result = { ...viewHierarchy };
     result.hierarchy = this.filterOffscreenNode(viewHierarchy.hierarchy, screenWidth, screenHeight, margin);
 
-    const filteredSize = JSON.stringify(result.hierarchy).length;
-    const reduction = Math.round((1 - filteredSize / originalSize) * 100);
+    if (logger.getLogLevel() <= LogLevel.DEBUG) {
+      const originalSize = JSON.stringify(viewHierarchy.hierarchy).length;
+      const filteredSize = JSON.stringify(result.hierarchy).length;
+      const reduction = Math.round((1 - filteredSize / originalSize) * 100);
 
-    if (reduction > 10) {
-      logger.debug(`Offscreen filtering reduced hierarchy by ${reduction}% (${originalSize} -> ${filteredSize} bytes)`);
+      if (reduction > 10) {
+        logger.debug(`Offscreen filtering reduced hierarchy by ${reduction}% (${originalSize} -> ${filteredSize} bytes)`);
+      }
     }
 
     return result;

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -5,6 +5,7 @@ import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { logger, LogLevel } from "../../../src/utils/logger";
 
 // Note: the previous version of this file patched fs-extra's readFile to mock
 // screenshot reads. That dependency has been removed from production code, so
@@ -763,8 +764,10 @@ describe("Offscreen Node Filtering", function() {
   let viewHierarchy: ViewHierarchy;
   let fakeAdb: FakeAdbExecutor;
   let mockDevice: BootedDevice;
+  let originalLogLevel: LogLevel;
 
   beforeEach(function() {
+    originalLogLevel = logger.getLogLevel();
     mockDevice = {
       deviceId: "test-device",
       name: "Test Device",
@@ -772,6 +775,10 @@ describe("Offscreen Node Filtering", function() {
     };
     fakeAdb = new FakeAdbExecutor();
     viewHierarchy = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(fakeAdb));
+  });
+
+  afterEach(function() {
+    logger.setLogLevel(originalLogLevel);
   });
 
   test("should filter out nodes completely below the screen", function() {
@@ -898,6 +905,55 @@ describe("Offscreen Node Filtering", function() {
     const result = viewHierarchy.filterOffscreenNodes(hierarchy, 0, 0);
 
     expect(result).toEqual(hierarchy);
+  });
+
+  test("should not serialize hierarchy size metrics when debug logging is disabled", function() {
+    logger.setLogLevel(LogLevel.INFO);
+    const stringifySpy = spyOn(JSON, "stringify");
+    const hierarchy = {
+      hierarchy: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        node: [
+          { text: "Visible", bounds: { left: 0, top: 100, right: 500, bottom: 200 } },
+          { text: "Below Screen", bounds: { left: 0, top: 3000, right: 500, bottom: 3200 } }
+        ]
+      }
+    };
+
+    try {
+      const result = viewHierarchy.filterOffscreenNodes(hierarchy, 1080, 2400);
+
+      expect(result.hierarchy.node.text).toBe("Visible");
+      expect(stringifySpy).not.toHaveBeenCalled();
+    } finally {
+      stringifySpy.mockRestore();
+    }
+  });
+
+  test("should keep hierarchy size metrics when debug logging is enabled", function() {
+    logger.setLogLevel(LogLevel.DEBUG);
+    const stringifySpy = spyOn(JSON, "stringify");
+    const debugSpy = spyOn(logger, "debug");
+    const hierarchy = {
+      hierarchy: {
+        bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+        node: [
+          { text: "Visible", bounds: { left: 0, top: 100, right: 500, bottom: 200 } },
+          { text: "Below Screen", bounds: { left: 0, top: 3000, right: 500, bottom: 3200 } },
+          { text: "Way Below", bounds: { left: 0, top: 3400, right: 500, bottom: 3600 } }
+        ]
+      }
+    };
+
+    try {
+      viewHierarchy.filterOffscreenNodes(hierarchy, 1080, 2400);
+
+      expect(stringifySpy).toHaveBeenCalledTimes(2);
+      expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("Offscreen filtering reduced hierarchy by"));
+    } finally {
+      debugSpy.mockRestore();
+      stringifySpy.mockRestore();
+    }
   });
 
   test("should preserve visible children of offscreen parents", function() {


### PR DESCRIPTION
## Summary

Avoid computing offscreen hierarchy byte-size metrics unless debug logging is enabled, removing two full-tree `JSON.stringify` passes from the normal observe path while preserving the existing debug diagnostic.

## Linked Issue

Closes #3418

## Bug / Regression Context

- **Prior attempts:** None referenced.
- **Observed symptom:** `filterOffscreenNodes` serialized the full hierarchy before and after filtering on every observe just to compute a debug-only reduction metric.
- **Repro steps / conditions:** Call `filterOffscreenNodes` while logger level is `INFO`; before this change it still called `JSON.stringify` twice.

## Validation

- [x] `bun run turbo:validate` passes (`lint` + `build` + `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: not applicable; TypeScript observe filtering only
- [x] New code uses existing logger interface; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not run. This is a logger-gated performance fix covered by unit tests; it does not change hierarchy filtering output or on-device protocol behavior.

## Acceptance Criteria

- [x] Normal offscreen filtering does not serialize hierarchy size metrics when debug logging is disabled.
- [x] Debug size/reduction logging remains available when debug logging is enabled.
- [x] Filtering behavior remains unchanged for visible/offscreen nodes.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)