### PR TITLE
Fix daemon database health failure streak

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -940,34 +940,43 @@ export class Daemon {
     const MAX_FAILED_CHECKS = 3; // Allow 3 consecutive failures before taking action
     let failedCheckCount = 0;
     let lastFailureKind: HealthFailureKind = "unknown";
+    const recordHealthCheckFailure = (failureKind: HealthFailureKind): void => {
+      // Recovery behavior depends on the failure kind, so only same-kind streaks
+      // should reach a kind-specific recovery action.
+      if (lastFailureKind !== failureKind) {
+        failedCheckCount = 0;
+      }
+      lastFailureKind = failureKind;
+      failedCheckCount++;
+    };
+    const resetHealthCheckFailures = (): void => {
+      failedCheckCount = 0;
+      lastFailureKind = "unknown";
+    };
 
     this.healthCheckTimer = this.timer.setInterval(async () => {
       try {
         // Check if HTTP server is responsive
         if (!this.httpServer) {
           logger.warn("Health check failed: HTTP server not initialized");
-          lastFailureKind = "http";
-          failedCheckCount++;
+          recordHealthCheckFailure("http");
         } else if (!this.httpServer.listening) {
           logger.warn("Health check failed: HTTP server not listening");
-          lastFailureKind = "http";
-          failedCheckCount++;
+          recordHealthCheckFailure("http");
         } else {
           // Check if socket server is active before probing shared dependencies.
           if (!this.socketServer || !this.socketServer.isListening()) {
             logger.warn("Health check failed: Socket server not listening");
-            lastFailureKind = "socket";
-            failedCheckCount++;
+            recordHealthCheckFailure("socket");
           } else {
             try {
               await this.databaseHealthProbe.check();
               // Health check passed
-              failedCheckCount = 0;
+              resetHealthCheckFailures();
               logger.debug("Health check passed");
             } catch (error) {
               logger.warn(`Health check failed: Database probe failed: ${error}`);
-              lastFailureKind = "database";
-              failedCheckCount++;
+              recordHealthCheckFailure("database");
             }
           }
         }
@@ -976,12 +985,11 @@ export class Daemon {
         if (failedCheckCount >= MAX_FAILED_CHECKS) {
           logger.error(`Health check failed ${failedCheckCount} times, attempting recovery...`);
           await this.attemptRecovery(lastFailureKind);
-          failedCheckCount = 0;
+          resetHealthCheckFailures();
         }
       } catch (error) {
         logger.warn(`Health check error: ${error}`);
-        lastFailureKind = "unknown";
-        failedCheckCount++;
+        recordHealthCheckFailure("unknown");
       }
     }, HEALTH_CHECK_INTERVAL);
 

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -120,6 +120,39 @@ describe("Daemon database health check", () => {
     expect(exitCodes).toEqual([1]);
   });
 
+  test("does not exit for database recovery after mixed health failure kinds", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    databaseHealthProbe.failWith(new Error("database disk image is malformed"));
+    const exitCodes: number[] = [];
+    const daemon = buildDaemon(timer, databaseHealthProbe, code => {
+      exitCodes.push(code);
+    });
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+
+    internals.httpServer = { listening: false };
+    internals.socketServer = { isListening: () => true };
+    internals.startHealthCheckTimer();
+
+    for (let i = 0; i < MAX_FAILED_CHECKS - 1; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    internals.httpServer = { listening: true };
+    await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+
+    expect(databaseHealthProbe.checkCalls).toBe(1);
+    expect(exitCodes).toEqual([]);
+
+    for (let i = 0; i < MAX_FAILED_CHECKS - 1; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    expect(databaseHealthProbe.checkCalls).toBe(MAX_FAILED_CHECKS);
+    expect(exitCodes).toEqual([1]);
+  });
+
   test("clears the health interval through the injected timer", () => {
     const timer = new FakeTimer();
     const databaseHealthProbe = new FakeDatabaseHealthProbe();

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -153,6 +153,41 @@ describe("Daemon database health check", () => {
     expect(exitCodes).toEqual([1]);
   });
 
+  test("does not exit for database recovery after mixed http socket and database failures", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    databaseHealthProbe.failWith(new Error("database disk image is malformed"));
+    const exitCodes: number[] = [];
+    const daemon = buildDaemon(timer, databaseHealthProbe, code => {
+      exitCodes.push(code);
+    });
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+
+    internals.httpServer = { listening: false };
+    internals.socketServer = { isListening: () => true };
+    internals.startHealthCheckTimer();
+
+    await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+
+    internals.httpServer = { listening: true };
+    internals.socketServer = { isListening: () => false };
+    await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+
+    internals.socketServer = { isListening: () => true };
+    await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+
+    expect(databaseHealthProbe.checkCalls).toBe(1);
+    expect(exitCodes).toEqual([]);
+
+    for (let i = 0; i < MAX_FAILED_CHECKS - 1; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    expect(databaseHealthProbe.checkCalls).toBe(MAX_FAILED_CHECKS);
+    expect(exitCodes).toEqual([1]);
+  });
+
   test("clears the health interval through the injected timer", () => {
     const timer = new FakeTimer();
     const databaseHealthProbe = new FakeDatabaseHealthProbe();


### PR DESCRIPTION
## Summary
- Require health-check failures to be consecutive by kind before triggering kind-specific recovery.
- Prevent mixed HTTP/socket failures from making a single database probe failure exit the daemon.
- Add a regression test covering mixed health failure kinds before DB recovery.

## Test plan
- [x] `bun test test/daemon/daemonDatabaseHealthCheck.test.ts test/db/DatabaseHealthProbe.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`