### PR TITLE
Run PRAGMA optimize on database close

### DIFF
--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -377,6 +377,12 @@ export class BunSqliteConnectionState {
         // load and safe to ignore — db.close() still persists committed data.
         logger.debug(`WAL checkpoint on close failed: ${error}`);
       }
+      try {
+        this.#db.exec("PRAGMA optimize;");
+      } catch (error) {
+        // Best-effort: stale planner stats are preferable to blocking shutdown.
+        logger.debug(`PRAGMA optimize on close failed: ${error}`);
+      }
       this.#db.close();
       this.#db = null;
     }

--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -367,8 +367,15 @@ export class BunSqliteConnectionState {
     this.#clearStatementCache();
     if (this.#db) {
       try {
+        this.#db.exec("PRAGMA optimize;");
+      } catch (error) {
+        // Best-effort: stale planner stats are preferable to blocking shutdown.
+        logger.debug(`PRAGMA optimize on close failed: ${error}`);
+      }
+      try {
         // Flush the WAL into the main DB and truncate the `-wal`/`-shm`
         // sidecars so a clean shutdown leaves a single-file artifact. Stays
+        // after PRAGMA optimize because optimize may write planner stats.
         // synchronous — close() runs inside destroy() and must not introduce
         // an await point that could reorder with the mutex (issue #2802).
         this.#db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
@@ -376,12 +383,6 @@ export class BunSqliteConnectionState {
         // Best-effort: a busy/failed checkpoint at shutdown is expected under
         // load and safe to ignore — db.close() still persists committed data.
         logger.debug(`WAL checkpoint on close failed: ${error}`);
-      }
-      try {
-        this.#db.exec("PRAGMA optimize;");
-      } catch (error) {
-        // Best-effort: stale planner stats are preferable to blocking shutdown.
-        logger.debug(`PRAGMA optimize on close failed: ${error}`);
       }
       this.#db.close();
       this.#db = null;

--- a/test/db/bunSqliteDialect.test.ts
+++ b/test/db/bunSqliteDialect.test.ts
@@ -163,6 +163,7 @@ class FakeDatabase {
   schemaVersion = 1;
   throwOn?: unknown;
   throwOnExec?: unknown;
+  readonly throwOnExecSql = new Map<string, unknown>();
 
   prepare(sql: string): FakeStatement {
     const statement = new FakeStatement(this, sql);
@@ -177,6 +178,10 @@ class FakeDatabase {
 
   exec(sql: string): void {
     this.lifecycleEvents.push(`exec:${sql}`);
+    const sqlError = this.throwOnExecSql.get(sql);
+    if (sqlError) {
+      throw sqlError;
+    }
     if (this.throwOnExec) {
       throw this.throwOnExec;
     }
@@ -535,8 +540,8 @@ describe("BunSqliteConnectionState — C6 word-boundary RETURNING detection", ()
   });
 });
 
-describe("BunSqliteConnectionState — WAL checkpoint on close (issue #2802)", () => {
-  test("issues wal_checkpoint(TRUNCATE) before closing the handle", () => {
+describe("BunSqliteConnectionState — close-time database maintenance", () => {
+  test("issues wal_checkpoint(TRUNCATE) and PRAGMA optimize before closing the handle", () => {
     const db = new FakeDatabase();
     const state = makeState(db);
 
@@ -544,6 +549,7 @@ describe("BunSqliteConnectionState — WAL checkpoint on close (issue #2802)", (
 
     expect(db.lifecycleEvents).toEqual([
       "exec:PRAGMA wal_checkpoint(TRUNCATE);",
+      "exec:PRAGMA optimize;",
       "close",
     ]);
   });
@@ -558,11 +564,27 @@ describe("BunSqliteConnectionState — WAL checkpoint on close (issue #2802)", (
 
     expect(db.lifecycleEvents).toEqual([
       "exec:PRAGMA wal_checkpoint(TRUNCATE);",
+      "exec:PRAGMA optimize;",
       "close",
     ]);
   });
 
-  test("close is idempotent: the checkpoint and close run once", () => {
+  test("a failing optimize never blocks the close", () => {
+    const db = new FakeDatabase();
+    db.throwOnExecSql.set("PRAGMA optimize;", new Error("optimize failed"));
+    const state = makeState(db);
+
+    // Best-effort: optimize failures must be swallowed, not rethrown.
+    expect(() => state.close()).not.toThrow();
+
+    expect(db.lifecycleEvents).toEqual([
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
+      "exec:PRAGMA optimize;",
+      "close",
+    ]);
+  });
+
+  test("close is idempotent: maintenance and close run once", () => {
     const db = new FakeDatabase();
     const state = makeState(db);
 
@@ -571,11 +593,12 @@ describe("BunSqliteConnectionState — WAL checkpoint on close (issue #2802)", (
 
     expect(db.lifecycleEvents).toEqual([
       "exec:PRAGMA wal_checkpoint(TRUNCATE);",
+      "exec:PRAGMA optimize;",
       "close",
     ]);
   });
 
-  test("does not open a lazily-unopened database just to checkpoint it", () => {
+  test("does not open a lazily-unopened database just to run maintenance", () => {
     let opened = false;
     const state = new BunSqliteConnectionState(() => {
       opened = true;

--- a/test/db/bunSqliteDialect.test.ts
+++ b/test/db/bunSqliteDialect.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, test } from "bun:test";
+import { describe, it, expect, spyOn, test } from "bun:test";
 import { CompiledQuery, Kysely, sql } from "kysely";
 import { Database } from "bun:sqlite";
 import { BunSqliteConnectionState, BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { ActionableError } from "../../src/models/ActionableError";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { logger } from "../../src/utils/logger";
 
 /**
  * Regression for issue #2792: destroy() racing queries queued in Kysely's
@@ -573,9 +574,17 @@ describe("BunSqliteConnectionState — close-time database maintenance", () => {
     const db = new FakeDatabase();
     db.throwOnExecSql.set("PRAGMA optimize;", new Error("optimize failed"));
     const state = makeState(db);
+    const debugSpy = spyOn(logger, "debug");
 
-    // Best-effort: optimize failures must be swallowed, not rethrown.
-    expect(() => state.close()).not.toThrow();
+    try {
+      // Best-effort: optimize failures must be logged and swallowed, not rethrown.
+      expect(() => state.close()).not.toThrow();
+      expect(debugSpy).toHaveBeenCalledWith(
+        "PRAGMA optimize on close failed: Error: optimize failed"
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
 
     expect(db.lifecycleEvents).toEqual([
       "exec:PRAGMA wal_checkpoint(TRUNCATE);",

--- a/test/db/bunSqliteDialect.test.ts
+++ b/test/db/bunSqliteDialect.test.ts
@@ -542,30 +542,30 @@ describe("BunSqliteConnectionState — C6 word-boundary RETURNING detection", ()
 });
 
 describe("BunSqliteConnectionState — close-time database maintenance", () => {
-  test("issues wal_checkpoint(TRUNCATE) and PRAGMA optimize before closing the handle", () => {
+  test("issues PRAGMA optimize before the final wal_checkpoint(TRUNCATE)", () => {
     const db = new FakeDatabase();
     const state = makeState(db);
 
     state.close();
 
     expect(db.lifecycleEvents).toEqual([
-      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "exec:PRAGMA optimize;",
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "close",
     ]);
   });
 
   test("a failing checkpoint never blocks the close", () => {
     const db = new FakeDatabase();
-    db.throwOnExec = new Error("database is locked");
+    db.throwOnExecSql.set("PRAGMA wal_checkpoint(TRUNCATE);", new Error("database is locked"));
     const state = makeState(db);
 
     // Best-effort: the checkpoint error must be swallowed, not rethrown.
     expect(() => state.close()).not.toThrow();
 
     expect(db.lifecycleEvents).toEqual([
-      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "exec:PRAGMA optimize;",
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "close",
     ]);
   });
@@ -587,8 +587,8 @@ describe("BunSqliteConnectionState — close-time database maintenance", () => {
     }
 
     expect(db.lifecycleEvents).toEqual([
-      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "exec:PRAGMA optimize;",
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "close",
     ]);
   });
@@ -601,8 +601,8 @@ describe("BunSqliteConnectionState — close-time database maintenance", () => {
     state.close();
 
     expect(db.lifecycleEvents).toEqual([
-      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "exec:PRAGMA optimize;",
+      "exec:PRAGMA wal_checkpoint(TRUNCATE);",
       "close",
     ]);
   });


### PR DESCRIPTION
## Summary
Run `PRAGMA optimize;` during SQLite connection close so a long-lived daemon refreshes query-planner statistics at least once per lifetime without adding work to the query hot path.

## Linked Issue
Closes #3407

## Bug / Regression Context
- **Prior attempts:** N/A
- **Observed symptom:** Query planner statistics could grow stale over a daemon lifetime because close-time DB maintenance only checkpointed WAL files.
- **Repro steps / conditions:** Any daemon lifetime that opens the DB and later shuts down should run close-time maintenance.

## Validation
- [x] `bun run turbo:validate` passes (`lint` + `build` + `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved
- [x] `bun test test/db/bunSqliteDialect.test.ts`

## Device Verification
N/A - DB lifecycle-only change.

## Acceptance Criteria
- [x] `PRAGMA optimize` runs at least once per daemon lifetime on close.
- [x] Optimize failures are best-effort, logged at debug, and do not block shutdown.
- [x] No periodic timer was added, so there is no process-lifetime timer to bound or unref.
- [x] No query hot-path work was added.

## Follow-ups
None.

Made with [Cursor](https://cursor.com)