### PR TITLE
Consolidate keyed JSON config repositories

### DIFF
--- a/src/db/appearanceConfigRepository.ts
+++ b/src/db/appearanceConfigRepository.ts
@@ -1,75 +1,14 @@
 import type { Kysely } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
 import type { AppearanceConfig } from "../models";
 import type { Database } from "./types";
-import { logger } from "../utils/logger";
+import { KeyedJsonConfigRepository } from "./keyedJsonConfigRepository";
 
-const CONFIG_KEY = "global";
-
-export class AppearanceConfigRepository {
-  private db: Kysely<Database> | null;
-
+export class AppearanceConfigRepository extends KeyedJsonConfigRepository<AppearanceConfig> {
   constructor(db?: Kysely<Database>) {
-    this.db = db ?? null;
-  }
-
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
-  }
-
-  async getConfig(): Promise<AppearanceConfig | null> {
-    const db = await this.getDb();
-    const row = await db
-      .selectFrom("appearance_configs")
-      .select(["config_json"])
-      .where("key", "=", CONFIG_KEY)
-      .executeTakeFirst();
-
-    if (!row) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(row.config_json) as AppearanceConfig;
-    } catch (error) {
-      logger.warn(`[AppearanceConfigRepository] Failed to parse config JSON: ${error}`);
-      return null;
-    }
-  }
-
-  async setConfig(config: AppearanceConfig): Promise<void> {
-    const db = await this.getDb();
-    const now = new Date().toISOString();
-
-    const payload = {
-      key: CONFIG_KEY,
-      config_json: JSON.stringify(config),
-      updated_at: now,
-    };
-
-    // Atomic upsert on the key PRIMARY KEY. A concurrent first-write would otherwise
-    // have one caller lose the SELECT/INSERT race and throw a UNIQUE collision (R2356).
-    await db
-      .insertInto("appearance_configs")
-      .values(payload)
-      .onConflict(oc =>
-        oc.column("key").doUpdateSet({
-          config_json: payload.config_json,
-          updated_at: payload.updated_at,
-        })
-      )
-      .execute();
-  }
-
-  async clearConfig(): Promise<void> {
-    const db = await this.getDb();
-    await db
-      .deleteFrom("appearance_configs")
-      .where("key", "=", CONFIG_KEY)
-      .execute();
+    super({
+      tableName: "appearance_configs",
+      loggerTag: "AppearanceConfigRepository",
+      db,
+    });
   }
 }

--- a/src/db/deviceSnapshotConfigRepository.ts
+++ b/src/db/deviceSnapshotConfigRepository.ts
@@ -1,75 +1,14 @@
 import type { Kysely } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
 import type { DeviceSnapshotConfig } from "../models";
 import type { Database } from "./types";
-import { logger } from "../utils/logger";
+import { KeyedJsonConfigRepository } from "./keyedJsonConfigRepository";
 
-const CONFIG_KEY = "global";
-
-export class DeviceSnapshotConfigRepository {
-  private db: Kysely<Database> | null;
-
+export class DeviceSnapshotConfigRepository extends KeyedJsonConfigRepository<DeviceSnapshotConfig> {
   constructor(db?: Kysely<Database>) {
-    this.db = db ?? null;
-  }
-
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
-  }
-
-  async getConfig(): Promise<DeviceSnapshotConfig | null> {
-    const db = await this.getDb();
-    const row = await db
-      .selectFrom("device_snapshot_configs")
-      .select(["config_json"])
-      .where("key", "=", CONFIG_KEY)
-      .executeTakeFirst();
-
-    if (!row) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(row.config_json) as DeviceSnapshotConfig;
-    } catch (error) {
-      logger.warn(`[DeviceSnapshotConfigRepository] Failed to parse config JSON: ${error}`);
-      return null;
-    }
-  }
-
-  async setConfig(config: DeviceSnapshotConfig): Promise<void> {
-    const db = await this.getDb();
-    const now = new Date().toISOString();
-
-    const payload = {
-      key: CONFIG_KEY,
-      config_json: JSON.stringify(config),
-      updated_at: now,
-    };
-
-    // Atomic upsert on the key PRIMARY KEY. A concurrent first-write would otherwise
-    // have one caller lose the SELECT/INSERT race and throw a UNIQUE collision (R2356).
-    await db
-      .insertInto("device_snapshot_configs")
-      .values(payload)
-      .onConflict(oc =>
-        oc.column("key").doUpdateSet({
-          config_json: payload.config_json,
-          updated_at: payload.updated_at,
-        })
-      )
-      .execute();
-  }
-
-  async clearConfig(): Promise<void> {
-    const db = await this.getDb();
-    await db
-      .deleteFrom("device_snapshot_configs")
-      .where("key", "=", CONFIG_KEY)
-      .execute();
+    super({
+      tableName: "device_snapshot_configs",
+      loggerTag: "DeviceSnapshotConfigRepository",
+      db,
+    });
   }
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -15,6 +15,11 @@ export {
   getDbWriteBarrier,
   resetDbWriteBarrier,
 } from "./dbWriteBarrier";
+export {
+  KeyedJsonConfigRepository,
+  type KeyedJsonConfigRepositoryOptions,
+  type KeyedJsonConfigTableName,
+} from "./keyedJsonConfigRepository";
 export type {
   Database,
   DeviceConfigTable,

--- a/src/db/keyedJsonConfigRepository.ts
+++ b/src/db/keyedJsonConfigRepository.ts
@@ -1,0 +1,89 @@
+import type { Kysely } from "kysely";
+import { logger } from "../utils/logger";
+import { ensureMigrations, getDatabase } from "./database";
+import type { Database } from "./types";
+
+const CONFIG_KEY = "global";
+
+export type KeyedJsonConfigTableName =
+  | "appearance_configs"
+  | "device_snapshot_configs"
+  | "video_recording_configs";
+
+export interface KeyedJsonConfigRepositoryOptions {
+  tableName: KeyedJsonConfigTableName;
+  loggerTag?: string;
+  db?: Kysely<Database>;
+}
+
+export class KeyedJsonConfigRepository<TConfig> {
+  private readonly tableName: KeyedJsonConfigTableName;
+  private readonly loggerTag: string;
+  private readonly db: Kysely<Database> | null;
+
+  constructor(options: KeyedJsonConfigRepositoryOptions) {
+    this.tableName = options.tableName;
+    this.loggerTag = options.loggerTag ?? "KeyedJsonConfigRepository";
+    this.db = options.db ?? null;
+  }
+
+  private async getDb(): Promise<Kysely<Database>> {
+    if (this.db) {
+      return this.db;
+    }
+    await ensureMigrations();
+    return getDatabase();
+  }
+
+  async getConfig(): Promise<TConfig | null> {
+    const db = await this.getDb();
+    const row = await db
+      .selectFrom(this.tableName)
+      .select(["config_json"])
+      .where("key", "=", CONFIG_KEY)
+      .executeTakeFirst();
+
+    if (!row) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(row.config_json) as TConfig;
+    } catch (error) {
+      logger.warn(`[${this.loggerTag}] Failed to parse config JSON: ${error}`);
+      return null;
+    }
+  }
+
+  async setConfig(config: TConfig): Promise<void> {
+    const db = await this.getDb();
+    const now = new Date().toISOString();
+
+    const payload = {
+      key: CONFIG_KEY,
+      config_json: JSON.stringify(config),
+      updated_at: now,
+    };
+
+    // Atomic upsert on the key PRIMARY KEY. A concurrent first-write would otherwise
+    // have one caller lose the SELECT/INSERT race and throw a UNIQUE collision (R2356).
+    await db
+      .insertInto(this.tableName)
+      .values(payload)
+      .onConflict(oc =>
+        oc.column("key").doUpdateSet({
+          config_json: payload.config_json,
+          updated_at: payload.updated_at,
+        })
+      )
+      .execute();
+  }
+
+  async clearConfig(): Promise<void> {
+    const db = await this.getDb();
+    await db
+      .deleteFrom(this.tableName)
+      .where("key", "=", CONFIG_KEY)
+      .execute();
+  }
+}

--- a/src/db/videoRecordingConfigRepository.ts
+++ b/src/db/videoRecordingConfigRepository.ts
@@ -1,75 +1,14 @@
 import type { Kysely } from "kysely";
-import { ensureMigrations, getDatabase } from "./database";
 import type { VideoRecordingConfig } from "../models";
 import type { Database } from "./types";
-import { logger } from "../utils/logger";
+import { KeyedJsonConfigRepository } from "./keyedJsonConfigRepository";
 
-const CONFIG_KEY = "global";
-
-export class VideoRecordingConfigRepository {
-  private db: Kysely<Database> | null;
-
+export class VideoRecordingConfigRepository extends KeyedJsonConfigRepository<VideoRecordingConfig> {
   constructor(db?: Kysely<Database>) {
-    this.db = db ?? null;
-  }
-
-  private async getDb(): Promise<Kysely<Database>> {
-    if (this.db) {
-      return this.db;
-    }
-    await ensureMigrations();
-    return getDatabase();
-  }
-
-  async getConfig(): Promise<VideoRecordingConfig | null> {
-    const db = await this.getDb();
-    const row = await db
-      .selectFrom("video_recording_configs")
-      .select(["config_json"])
-      .where("key", "=", CONFIG_KEY)
-      .executeTakeFirst();
-
-    if (!row) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(row.config_json) as VideoRecordingConfig;
-    } catch (error) {
-      logger.warn(`[VideoRecordingConfigRepository] Failed to parse config JSON: ${error}`);
-      return null;
-    }
-  }
-
-  async setConfig(config: VideoRecordingConfig): Promise<void> {
-    const db = await this.getDb();
-    const now = new Date().toISOString();
-
-    const payload = {
-      key: CONFIG_KEY,
-      config_json: JSON.stringify(config),
-      updated_at: now,
-    };
-
-    // Atomic upsert on the key PRIMARY KEY. A concurrent first-write would otherwise
-    // have one caller lose the SELECT/INSERT race and throw a UNIQUE collision (R2356).
-    await db
-      .insertInto("video_recording_configs")
-      .values(payload)
-      .onConflict(oc =>
-        oc.column("key").doUpdateSet({
-          config_json: payload.config_json,
-          updated_at: payload.updated_at,
-        })
-      )
-      .execute();
-  }
-
-  async clearConfig(): Promise<void> {
-    const db = await this.getDb();
-    await db
-      .deleteFrom("video_recording_configs")
-      .where("key", "=", CONFIG_KEY)
-      .execute();
+    super({
+      tableName: "video_recording_configs",
+      loggerTag: "VideoRecordingConfigRepository",
+      db,
+    });
   }
 }

--- a/test/db/keyedJsonConfigRepository.test.ts
+++ b/test/db/keyedJsonConfigRepository.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import { KeyedJsonConfigRepository } from "../../src/db/keyedJsonConfigRepository";
+import type { Database } from "../../src/db/types";
+import { logger } from "../../src/utils/logger";
+import { createTestDatabase } from "./testDbHelper";
+
+describe("KeyedJsonConfigRepository", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("stores the singleton config in the configured table only", async () => {
+    const repo = new KeyedJsonConfigRepository<{ theme: string }>({
+      tableName: "appearance_configs",
+      db,
+    });
+
+    await repo.setConfig({ theme: "dark" });
+
+    expect(await repo.getConfig()).toEqual({ theme: "dark" });
+    expect(await db.selectFrom("appearance_configs").selectAll().execute()).toHaveLength(1);
+    expect(await db.selectFrom("device_snapshot_configs").selectAll().execute()).toHaveLength(0);
+    expect(await db.selectFrom("video_recording_configs").selectAll().execute()).toHaveLength(0);
+  });
+
+  test("updates concurrent first writes with one row for the singleton key", async () => {
+    const repo = new KeyedJsonConfigRepository<{ enabled: boolean }>({
+      tableName: "video_recording_configs",
+      db,
+    });
+
+    await expect(
+      Promise.all(
+        Array.from({ length: 10 }, (_unused, index) =>
+          repo.setConfig({ enabled: index % 2 === 0 })
+        )
+      )
+    ).resolves.toBeDefined();
+
+    expect(await db.selectFrom("video_recording_configs").selectAll().execute()).toHaveLength(1);
+  });
+
+  test("returns null and logs a warning for malformed config JSON", async () => {
+    const warnings: string[] = [];
+    const originalWarn = logger.warn;
+    logger.warn = (message: string) => {
+      warnings.push(message);
+    };
+
+    try {
+      const repo = new KeyedJsonConfigRepository<{ autoCapture: boolean }>({
+        tableName: "device_snapshot_configs",
+        loggerTag: "DeviceSnapshotConfigRepository",
+        db,
+      });
+      await db
+        .insertInto("device_snapshot_configs")
+        .values({
+          key: "global",
+          config_json: "{not-json",
+          updated_at: new Date().toISOString(),
+        })
+        .execute();
+
+      expect(await repo.getConfig()).toBeNull();
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("[DeviceSnapshotConfigRepository] Failed to parse config JSON:");
+    } finally {
+      logger.warn = originalWarn;
+    }
+  });
+});

--- a/test/db/keyedJsonConfigRepository.test.ts
+++ b/test/db/keyedJsonConfigRepository.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { Kysely } from "kysely";
+import * as databaseModule from "../../src/db/database";
 import { KeyedJsonConfigRepository } from "../../src/db/keyedJsonConfigRepository";
 import type { Database } from "../../src/db/types";
 import { logger } from "../../src/utils/logger";
@@ -45,6 +46,29 @@ describe("KeyedJsonConfigRepository", () => {
     ).resolves.toBeDefined();
 
     expect(await db.selectFrom("video_recording_configs").selectAll().execute()).toHaveLength(1);
+  });
+
+  test("defers default database resolution until the first operation", async () => {
+    const ensureMigrationsSpy = spyOn(databaseModule, "ensureMigrations").mockResolvedValue();
+    const getDatabaseSpy = spyOn(databaseModule, "getDatabase").mockReturnValue(db);
+
+    try {
+      const repo = new KeyedJsonConfigRepository<{ theme: string }>({
+        tableName: "appearance_configs",
+      });
+
+      expect(ensureMigrationsSpy).toHaveBeenCalledTimes(0);
+      expect(getDatabaseSpy).toHaveBeenCalledTimes(0);
+
+      await repo.setConfig({ theme: "dark" });
+
+      expect(ensureMigrationsSpy).toHaveBeenCalledTimes(1);
+      expect(getDatabaseSpy).toHaveBeenCalledTimes(1);
+      expect(await db.selectFrom("appearance_configs").selectAll().execute()).toHaveLength(1);
+    } finally {
+      ensureMigrationsSpy.mockRestore();
+      getDatabaseSpy.mockRestore();
+    }
   });
 
   test("returns null and logs a warning for malformed config JSON", async () => {


### PR DESCRIPTION
## Summary

Consolidates the three byte-identical singleton JSON config repositories behind a shared `KeyedJsonConfigRepository<T>`, while keeping the existing public repository class names and import paths intact.

## Linked Issue

Closes #3446

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun test test/db/keyedJsonConfigRepository.test.ts test/db/appearanceConfigRepository.test.ts test/db/deviceSnapshotConfigRepository.test.ts test/db/videoRecordingConfigRepository.test.ts`
- [x] New unit tests use injected in-memory DB via `createTestDatabase()` and complete under 100ms each

## Acceptance Criteria

- [x] Introduced generic `KeyedJsonConfigRepository<T>` parameterized by keyed JSON config table name
- [x] Collapsed appearance, device snapshot, and video recording config repositories into typed wrappers over the generic repository
- [x] Preserved singleton `global` key CRUD behavior, malformed JSON warning behavior, lazy DB access, and atomic upsert behavior
- [x] Kept existing public repository class names/import paths usable by consumers

## Device Verification

Not applicable; DB repository refactor only.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)