### PR TITLE
Consolidate config socket servers

### DIFF
--- a/src/daemon/deviceSnapshotSocketServer.ts
+++ b/src/daemon/deviceSnapshotSocketServer.ts
@@ -1,67 +1,51 @@
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
-import {
-  DeviceSnapshotSocketRequest,
-  DeviceSnapshotSocketResponse,
-} from "./deviceSnapshotSocketTypes";
+import { ConfigSocketServer, getSocketPath } from "./socketServer/index";
 import { getDeviceSnapshotConfig, updateDeviceSnapshotConfig } from "../server/deviceSnapshotManager";
 import { DEVICE_SNAPSHOT_SOCKET_CONFIG } from "./daemonFiles";
+import type { DeviceSnapshotConfig, DeviceSnapshotConfigInput } from "../models";
+
+interface DeviceSnapshotSocketServerDependencies {
+  getConfig: () => Promise<DeviceSnapshotConfig>;
+  updateConfig: (update: DeviceSnapshotConfigInput | null) => Promise<{
+    config: DeviceSnapshotConfig;
+    evictedSnapshotNames: string[];
+  }>;
+}
+
+const defaultDependencies: DeviceSnapshotSocketServerDependencies = {
+  getConfig: getDeviceSnapshotConfig,
+  updateConfig: updateDeviceSnapshotConfig,
+};
 
 /**
  * Socket server for device snapshot configuration.
  * Handles config/get and config/set requests.
  */
-export class DeviceSnapshotSocketServer extends RequestResponseSocketServer<
-  DeviceSnapshotSocketRequest,
-  DeviceSnapshotSocketResponse
+export class DeviceSnapshotSocketServer extends ConfigSocketServer<
+  DeviceSnapshotConfig,
+  DeviceSnapshotConfigInput,
+  "device_snapshot_request",
+  "device_snapshot_response",
+  "evictedSnapshotNames"
 > {
-  constructor(socketPath: string = getSocketPath(DEVICE_SNAPSHOT_SOCKET_CONFIG), timer: Timer = defaultTimer) {
-    super(socketPath, timer, "DeviceSnapshot");
-  }
-
-  protected async handleRequest(
-    request: DeviceSnapshotSocketRequest
-  ): Promise<DeviceSnapshotSocketResponse> {
-    switch (request.method) {
-      case "config/get": {
-        const config = await getDeviceSnapshotConfig();
-        return {
-          id: request.id,
-          type: "device_snapshot_response",
-          success: true,
-          result: { config },
-        };
-      }
-      case "config/set": {
-        if (!request.params || !("config" in request.params)) {
-          throw new Error("config/set requires params.config");
-        }
-        const update = request.params.config ?? null;
-        const { config, evictedSnapshotNames } = await updateDeviceSnapshotConfig(update);
-        return {
-          id: request.id,
-          type: "device_snapshot_response",
-          success: true,
-          result: {
-            config,
-            evictedSnapshotNames: evictedSnapshotNames.length > 0
-              ? evictedSnapshotNames
-              : undefined,
-          },
-        };
-      }
-      default:
-        throw new Error(`Unsupported device snapshot method: ${request.method}`);
-    }
-  }
-
-  protected createErrorResponse(id: string | undefined, error: string): DeviceSnapshotSocketResponse {
-    return {
-      id: id ?? "unknown",
-      type: "device_snapshot_response",
-      success: false,
-      error,
-    };
+  constructor(
+    socketPath: string = getSocketPath(DEVICE_SNAPSHOT_SOCKET_CONFIG),
+    timer: Timer = defaultTimer,
+    dependencies: DeviceSnapshotSocketServerDependencies = defaultDependencies
+  ) {
+    super({
+      socketPath,
+      timer,
+      serverName: "DeviceSnapshot",
+      responseType: "device_snapshot_response",
+      evictedKey: "evictedSnapshotNames",
+      methodLabel: "device snapshot",
+      getConfig: dependencies.getConfig,
+      updateConfig: async update => {
+        const { config, evictedSnapshotNames } = await dependencies.updateConfig(update);
+        return { config, evictedItems: evictedSnapshotNames };
+      },
+    });
   }
 }
 

--- a/src/daemon/deviceSnapshotSocketTypes.ts
+++ b/src/daemon/deviceSnapshotSocketTypes.ts
@@ -7,13 +7,13 @@ import type {
 
 export type DeviceSnapshotSocketMethod = ConfigSocketMethod;
 
-export type DeviceSnapshotSocketRequest = ConfigSocketRequest<
+export interface DeviceSnapshotSocketRequest extends ConfigSocketRequest<
   "device_snapshot_request",
   DeviceSnapshotConfigInput
->;
+> {}
 
-export type DeviceSnapshotSocketResponse = ConfigSocketResponse<
+export interface DeviceSnapshotSocketResponse extends ConfigSocketResponse<
   "device_snapshot_response",
   DeviceSnapshotConfig,
   "evictedSnapshotNames"
->;
+> {}

--- a/src/daemon/deviceSnapshotSocketTypes.ts
+++ b/src/daemon/deviceSnapshotSocketTypes.ts
@@ -1,23 +1,19 @@
 import type { DeviceSnapshotConfig, DeviceSnapshotConfigInput } from "../models";
+import type {
+  ConfigSocketMethod,
+  ConfigSocketRequest,
+  ConfigSocketResponse,
+} from "./socketServer/index";
 
-export type DeviceSnapshotSocketMethod = "config/get" | "config/set";
+export type DeviceSnapshotSocketMethod = ConfigSocketMethod;
 
-export interface DeviceSnapshotSocketRequest {
-  id: string;
-  type: "device_snapshot_request";
-  method: DeviceSnapshotSocketMethod;
-  params?: {
-    config?: DeviceSnapshotConfigInput | null;
-  };
-}
+export type DeviceSnapshotSocketRequest = ConfigSocketRequest<
+  "device_snapshot_request",
+  DeviceSnapshotConfigInput
+>;
 
-export interface DeviceSnapshotSocketResponse {
-  id: string;
-  type: "device_snapshot_response";
-  success: boolean;
-  result?: {
-    config: DeviceSnapshotConfig;
-    evictedSnapshotNames?: string[];
-  };
-  error?: string;
-}
+export type DeviceSnapshotSocketResponse = ConfigSocketResponse<
+  "device_snapshot_response",
+  DeviceSnapshotConfig,
+  "evictedSnapshotNames"
+>;

--- a/src/daemon/socketServer/ConfigSocketServer.ts
+++ b/src/daemon/socketServer/ConfigSocketServer.ts
@@ -1,0 +1,136 @@
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { RequestResponseSocketServer } from "./RequestResponseSocketServer";
+import { SocketRequest, SocketResponse } from "./SocketServerTypes";
+
+export type ConfigSocketMethod = "config/get" | "config/set";
+
+export interface ConfigSocketRequest<
+  TRequestType extends string,
+  TInput,
+> extends SocketRequest {
+  id: string;
+  type: TRequestType;
+  method: ConfigSocketMethod;
+  params?: {
+    config?: TInput | null;
+  };
+}
+
+export type ConfigSocketResult<
+  TConfig,
+  TEvictedKey extends string,
+> = {
+  config: TConfig;
+} & Partial<Record<TEvictedKey, string[]>>;
+
+export interface ConfigSocketResponse<
+  TResponseType extends string,
+  TConfig,
+  TEvictedKey extends string,
+> extends SocketResponse {
+  id: string;
+  type: TResponseType;
+  success: boolean;
+  result?: ConfigSocketResult<TConfig, TEvictedKey>;
+  error?: string;
+}
+
+interface ConfigSocketUpdateResult<TConfig> {
+  config: TConfig;
+  evictedItems: string[];
+}
+
+interface ConfigSocketServerOptions<
+  TConfig,
+  TInput,
+  TResponseType extends string,
+  TEvictedKey extends string,
+> {
+  socketPath: string;
+  timer?: Timer;
+  serverName: string;
+  responseType: TResponseType;
+  evictedKey: TEvictedKey;
+  methodLabel: string;
+  getConfig: () => Promise<TConfig>;
+  updateConfig: (update: TInput | null) => Promise<ConfigSocketUpdateResult<TConfig>>;
+}
+
+/**
+ * Request-response socket server for daemon config endpoints.
+ * Handles the shared config/get and config/set protocol used by config-only sockets.
+ */
+export class ConfigSocketServer<
+  TConfig,
+  TInput,
+  TRequestType extends string,
+  TResponseType extends string,
+  TEvictedKey extends string,
+> extends RequestResponseSocketServer<
+  ConfigSocketRequest<TRequestType, TInput>,
+  ConfigSocketResponse<TResponseType, TConfig, TEvictedKey>
+> {
+  private readonly responseType: TResponseType;
+  private readonly evictedKey: TEvictedKey;
+  private readonly methodLabel: string;
+  private readonly getConfig: () => Promise<TConfig>;
+  private readonly updateConfig: (update: TInput | null) => Promise<ConfigSocketUpdateResult<TConfig>>;
+
+  constructor(
+    options: ConfigSocketServerOptions<TConfig, TInput, TResponseType, TEvictedKey>
+  ) {
+    super(options.socketPath, options.timer ?? defaultTimer, options.serverName);
+    this.responseType = options.responseType;
+    this.evictedKey = options.evictedKey;
+    this.methodLabel = options.methodLabel;
+    this.getConfig = options.getConfig;
+    this.updateConfig = options.updateConfig;
+  }
+
+  protected async handleRequest(
+    request: ConfigSocketRequest<TRequestType, TInput>
+  ): Promise<ConfigSocketResponse<TResponseType, TConfig, TEvictedKey>> {
+    switch (request.method) {
+      case "config/get": {
+        const config = await this.getConfig();
+        return {
+          id: request.id,
+          type: this.responseType,
+          success: true,
+          result: { config } as ConfigSocketResult<TConfig, TEvictedKey>,
+        };
+      }
+      case "config/set": {
+        if (!request.params || !("config" in request.params)) {
+          throw new Error("config/set requires params.config");
+        }
+        const update = request.params.config ?? null;
+        const { config, evictedItems } = await this.updateConfig(update);
+        const result = { config } as ConfigSocketResult<TConfig, TEvictedKey>;
+        if (evictedItems.length > 0) {
+          (result as Record<string, unknown>)[this.evictedKey] = evictedItems;
+        }
+        return {
+          id: request.id,
+          type: this.responseType,
+          success: true,
+          result,
+        };
+      }
+      default:
+        throw new Error(`Unsupported ${this.methodLabel} method: ${String(request.method)}`);
+    }
+  }
+
+  protected createErrorResponse(
+    id: string | undefined,
+    error: string
+  ): ConfigSocketResponse<TResponseType, TConfig, TEvictedKey> {
+    return {
+      id: id ?? "unknown",
+      type: this.responseType,
+      success: false,
+      error,
+    };
+  }
+}

--- a/src/daemon/socketServer/index.ts
+++ b/src/daemon/socketServer/index.ts
@@ -1,4 +1,11 @@
 export { BaseSocketServer } from "./BaseSocketServer";
+export {
+  ConfigSocketServer,
+  type ConfigSocketMethod,
+  type ConfigSocketRequest,
+  type ConfigSocketResponse,
+  type ConfigSocketResult,
+} from "./ConfigSocketServer";
 export { RequestResponseSocketServer } from "./RequestResponseSocketServer";
 export {
   PushSubscriptionSocketServer,

--- a/src/daemon/videoRecordingSocketServer.ts
+++ b/src/daemon/videoRecordingSocketServer.ts
@@ -1,65 +1,51 @@
 import { Timer, defaultTimer } from "../utils/SystemTimer";
-import { RequestResponseSocketServer, getSocketPath } from "./socketServer/index";
-import {
-  VideoRecordingSocketRequest,
-  VideoRecordingSocketResponse,
-} from "./videoRecordingSocketTypes";
+import { ConfigSocketServer, getSocketPath } from "./socketServer/index";
 import { getVideoRecordingConfig, updateVideoRecordingConfig } from "../server/videoRecordingManager";
 import { VIDEO_RECORDING_SOCKET_CONFIG } from "./daemonFiles";
+import type { VideoRecordingConfig, VideoRecordingConfigInput } from "../models";
+
+interface VideoRecordingSocketServerDependencies {
+  getConfig: () => Promise<VideoRecordingConfig>;
+  updateConfig: (update: VideoRecordingConfigInput | null) => Promise<{
+    config: VideoRecordingConfig;
+    evictedRecordingIds: string[];
+  }>;
+}
+
+const defaultDependencies: VideoRecordingSocketServerDependencies = {
+  getConfig: getVideoRecordingConfig,
+  updateConfig: updateVideoRecordingConfig,
+};
 
 /**
  * Socket server for video recording configuration.
  * Handles config/get and config/set requests.
  */
-export class VideoRecordingSocketServer extends RequestResponseSocketServer<
-  VideoRecordingSocketRequest,
-  VideoRecordingSocketResponse
+export class VideoRecordingSocketServer extends ConfigSocketServer<
+  VideoRecordingConfig,
+  VideoRecordingConfigInput,
+  "video_recording_request",
+  "video_recording_response",
+  "evictedRecordingIds"
 > {
-  constructor(socketPath: string = getSocketPath(VIDEO_RECORDING_SOCKET_CONFIG), timer: Timer = defaultTimer) {
-    super(socketPath, timer, "VideoRecording");
-  }
-
-  protected async handleRequest(
-    request: VideoRecordingSocketRequest
-  ): Promise<VideoRecordingSocketResponse> {
-    switch (request.method) {
-      case "config/get": {
-        const config = await getVideoRecordingConfig();
-        return {
-          id: request.id,
-          type: "video_recording_response",
-          success: true,
-          result: { config },
-        };
-      }
-      case "config/set": {
-        if (!request.params || !("config" in request.params)) {
-          throw new Error("config/set requires params.config");
-        }
-        const update = request.params.config ?? null;
-        const { config, evictedRecordingIds } = await updateVideoRecordingConfig(update);
-        return {
-          id: request.id,
-          type: "video_recording_response",
-          success: true,
-          result: {
-            config,
-            evictedRecordingIds: evictedRecordingIds.length > 0 ? evictedRecordingIds : undefined,
-          },
-        };
-      }
-      default:
-        throw new Error(`Unsupported video recording method: ${request.method}`);
-    }
-  }
-
-  protected createErrorResponse(id: string | undefined, error: string): VideoRecordingSocketResponse {
-    return {
-      id: id ?? "unknown",
-      type: "video_recording_response",
-      success: false,
-      error,
-    };
+  constructor(
+    socketPath: string = getSocketPath(VIDEO_RECORDING_SOCKET_CONFIG),
+    timer: Timer = defaultTimer,
+    dependencies: VideoRecordingSocketServerDependencies = defaultDependencies
+  ) {
+    super({
+      socketPath,
+      timer,
+      serverName: "VideoRecording",
+      responseType: "video_recording_response",
+      evictedKey: "evictedRecordingIds",
+      methodLabel: "video recording",
+      getConfig: dependencies.getConfig,
+      updateConfig: async update => {
+        const { config, evictedRecordingIds } = await dependencies.updateConfig(update);
+        return { config, evictedItems: evictedRecordingIds };
+      },
+    });
   }
 }
 

--- a/src/daemon/videoRecordingSocketTypes.ts
+++ b/src/daemon/videoRecordingSocketTypes.ts
@@ -1,23 +1,19 @@
 import type { VideoRecordingConfig, VideoRecordingConfigInput } from "../models";
+import type {
+  ConfigSocketMethod,
+  ConfigSocketRequest,
+  ConfigSocketResponse,
+} from "./socketServer/index";
 
-export type VideoRecordingSocketMethod = "config/get" | "config/set";
+export type VideoRecordingSocketMethod = ConfigSocketMethod;
 
-export interface VideoRecordingSocketRequest {
-  id: string;
-  type: "video_recording_request";
-  method: VideoRecordingSocketMethod;
-  params?: {
-    config?: VideoRecordingConfigInput | null;
-  };
-}
+export type VideoRecordingSocketRequest = ConfigSocketRequest<
+  "video_recording_request",
+  VideoRecordingConfigInput
+>;
 
-export interface VideoRecordingSocketResponse {
-  id: string;
-  type: "video_recording_response";
-  success: boolean;
-  result?: {
-    config: VideoRecordingConfig;
-    evictedRecordingIds?: string[];
-  };
-  error?: string;
-}
+export type VideoRecordingSocketResponse = ConfigSocketResponse<
+  "video_recording_response",
+  VideoRecordingConfig,
+  "evictedRecordingIds"
+>;

--- a/src/daemon/videoRecordingSocketTypes.ts
+++ b/src/daemon/videoRecordingSocketTypes.ts
@@ -7,13 +7,13 @@ import type {
 
 export type VideoRecordingSocketMethod = ConfigSocketMethod;
 
-export type VideoRecordingSocketRequest = ConfigSocketRequest<
+export interface VideoRecordingSocketRequest extends ConfigSocketRequest<
   "video_recording_request",
   VideoRecordingConfigInput
->;
+> {}
 
-export type VideoRecordingSocketResponse = ConfigSocketResponse<
+export interface VideoRecordingSocketResponse extends ConfigSocketResponse<
   "video_recording_response",
   VideoRecordingConfig,
   "evictedRecordingIds"
->;
+> {}

--- a/test/daemon/socketServer/ConfigSocketServer.test.ts
+++ b/test/daemon/socketServer/ConfigSocketServer.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Socket } from "node:net";
+import {
+  ConfigSocketRequest,
+  ConfigSocketResponse,
+  ConfigSocketServer,
+} from "../../../src/daemon/socketServer/ConfigSocketServer";
+import { DeviceSnapshotSocketServer } from "../../../src/daemon/deviceSnapshotSocketServer";
+import type {
+  DeviceSnapshotSocketRequest,
+  DeviceSnapshotSocketResponse,
+} from "../../../src/daemon/deviceSnapshotSocketTypes";
+import { VideoRecordingSocketServer } from "../../../src/daemon/videoRecordingSocketServer";
+import type {
+  VideoRecordingSocketRequest,
+  VideoRecordingSocketResponse,
+} from "../../../src/daemon/videoRecordingSocketTypes";
+import type {
+  DeviceSnapshotConfig,
+  DeviceSnapshotConfigInput,
+  VideoRecordingConfig,
+  VideoRecordingConfigInput,
+} from "../../../src/models";
+import { FakeSocket } from "../../fakes/FakeNetServer";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+interface TestConfig {
+  enabled: boolean;
+  limit: number;
+}
+
+interface TestConfigInput {
+  enabled?: boolean;
+  limit?: number;
+}
+
+type TestRequest = ConfigSocketRequest<"test_config_request", TestConfigInput>;
+type TestResponse = ConfigSocketResponse<
+  "test_config_response",
+  TestConfig,
+  "evictedItemIds"
+>;
+
+class TestableConfigSocketServer extends ConfigSocketServer<
+  TestConfig,
+  TestConfigInput,
+  "test_config_request",
+  "test_config_response",
+  "evictedItemIds"
+> {
+  public getCalls = 0;
+  public updateCalls: Array<TestConfigInput | null> = [];
+  public nextConfig: TestConfig = { enabled: true, limit: 5 };
+  public nextEvictedItemIds: string[] = [];
+
+  constructor(timer: FakeTimer) {
+    super({
+      socketPath: "/fake/path/config.sock",
+      timer,
+      serverName: "TestConfig",
+      responseType: "test_config_response",
+      evictedKey: "evictedItemIds",
+      methodLabel: "test config",
+      getConfig: async () => {
+        this.getCalls += 1;
+        return this.nextConfig;
+      },
+      updateConfig: async update => {
+        this.updateCalls.push(update);
+        return {
+          config: this.nextConfig,
+          evictedItems: this.nextEvictedItemIds,
+        };
+      },
+    });
+  }
+
+  async simulateLine(socket: FakeSocket, line: string): Promise<void> {
+    await (this as any).processLine(socket as unknown as Socket, line);
+    const pending = (this as any).pendingBySocket.get(socket);
+    if (pending) {
+      await pending;
+    }
+  }
+}
+
+describe("ConfigSocketServer", () => {
+  let timer: FakeTimer;
+  let server: TestableConfigSocketServer;
+  let socket: FakeSocket;
+
+  beforeEach(() => {
+    timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    server = new TestableConfigSocketServer(timer);
+    socket = new FakeSocket();
+  });
+
+  it("returns config for config/get requests", async () => {
+    const request: TestRequest = {
+      id: "get-1",
+      type: "test_config_request",
+      method: "config/get",
+    };
+
+    await server.simulateLine(socket, JSON.stringify(request));
+
+    const messages = socket.getWrittenMessages<TestResponse>();
+    expect(server.getCalls).toBe(1);
+    expect(messages).toEqual([
+      {
+        id: "get-1",
+        type: "test_config_response",
+        success: true,
+        result: { config: { enabled: true, limit: 5 } },
+      },
+    ]);
+  });
+
+  it("passes config/set updates through and includes non-empty evictions under the configured key", async () => {
+    server.nextConfig = { enabled: false, limit: 3 };
+    server.nextEvictedItemIds = ["old-1", "old-2"];
+    const request: TestRequest = {
+      id: "set-1",
+      type: "test_config_request",
+      method: "config/set",
+      params: {
+        config: { enabled: false },
+      },
+    };
+
+    await server.simulateLine(socket, JSON.stringify(request));
+
+    const messages = socket.getWrittenMessages<TestResponse>();
+    expect(server.updateCalls).toEqual([{ enabled: false }]);
+    expect(messages).toEqual([
+      {
+        id: "set-1",
+        type: "test_config_response",
+        success: true,
+        result: {
+          config: { enabled: false, limit: 3 },
+          evictedItemIds: ["old-1", "old-2"],
+        },
+      },
+    ]);
+  });
+
+  it("passes null config/set updates through and omits empty eviction arrays", async () => {
+    const request: TestRequest = {
+      id: "reset-1",
+      type: "test_config_request",
+      method: "config/set",
+      params: {
+        config: null,
+      },
+    };
+
+    await server.simulateLine(socket, JSON.stringify(request));
+
+    const messages = socket.getWrittenMessages<TestResponse>();
+    expect(server.updateCalls).toEqual([null]);
+    expect(messages).toEqual([
+      {
+        id: "reset-1",
+        type: "test_config_response",
+        success: true,
+        result: {
+          config: { enabled: true, limit: 5 },
+        },
+      },
+    ]);
+  });
+
+  it("returns an error response when config/set omits params.config", async () => {
+    const request: TestRequest = {
+      id: "bad-set",
+      type: "test_config_request",
+      method: "config/set",
+    };
+
+    await server.simulateLine(socket, JSON.stringify(request));
+
+    const messages = socket.getWrittenMessages<TestResponse>();
+    expect(server.updateCalls).toEqual([]);
+    expect(messages).toEqual([
+      {
+        id: "bad-set",
+        type: "test_config_response",
+        success: false,
+        error: "config/set requires params.config",
+      },
+    ]);
+  });
+
+  it("returns an error response for unsupported methods", async () => {
+    const request = {
+      id: "bad-method",
+      type: "test_config_request",
+      method: "config/delete",
+    };
+
+    await server.simulateLine(socket, JSON.stringify(request));
+
+    const messages = socket.getWrittenMessages<TestResponse>();
+    expect(messages).toEqual([
+      {
+        id: "bad-method",
+        type: "test_config_response",
+        success: false,
+        error: "Unsupported test config method: config/delete",
+      },
+    ]);
+  });
+});
+
+async function simulateLine(
+  server: unknown,
+  socket: FakeSocket,
+  line: string
+): Promise<void> {
+  await (server as any).processLine(socket as unknown as Socket, line);
+  const pending = (server as any).pendingBySocket.get(socket);
+  if (pending) {
+    await pending;
+  }
+}
+
+describe("config socket wrappers", () => {
+  it("keeps the device snapshot response type and eviction key", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const socket = new FakeSocket();
+    const config = { includeAppData: true } as DeviceSnapshotConfig;
+    const updates: Array<DeviceSnapshotConfigInput | null> = [];
+    const server = new DeviceSnapshotSocketServer("/fake/path/device.sock", timer, {
+      getConfig: async () => config,
+      updateConfig: async update => {
+        updates.push(update);
+        return {
+          config,
+          evictedSnapshotNames: ["snapshot-a"],
+        };
+      },
+    });
+    const request: DeviceSnapshotSocketRequest = {
+      id: "device-set",
+      type: "device_snapshot_request",
+      method: "config/set",
+      params: {
+        config: { includeAppData: true },
+      },
+    };
+
+    await simulateLine(server, socket, JSON.stringify(request));
+
+    expect(updates).toEqual([{ includeAppData: true }]);
+    expect(socket.getWrittenMessages<DeviceSnapshotSocketResponse>()).toEqual([
+      {
+        id: "device-set",
+        type: "device_snapshot_response",
+        success: true,
+        result: {
+          config,
+          evictedSnapshotNames: ["snapshot-a"],
+        },
+      },
+    ]);
+  });
+
+  it("keeps the video recording response type and eviction key", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const socket = new FakeSocket();
+    const config = { format: "mp4" } as VideoRecordingConfig;
+    const updates: Array<VideoRecordingConfigInput | null> = [];
+    const server = new VideoRecordingSocketServer("/fake/path/video.sock", timer, {
+      getConfig: async () => config,
+      updateConfig: async update => {
+        updates.push(update);
+        return {
+          config,
+          evictedRecordingIds: ["recording-a"],
+        };
+      },
+    });
+    const request: VideoRecordingSocketRequest = {
+      id: "video-set",
+      type: "video_recording_request",
+      method: "config/set",
+      params: {
+        config: { format: "mp4" },
+      },
+    };
+
+    await simulateLine(server, socket, JSON.stringify(request));
+
+    expect(updates).toEqual([{ format: "mp4" }]);
+    expect(socket.getWrittenMessages<VideoRecordingSocketResponse>()).toEqual([
+      {
+        id: "video-set",
+        type: "video_recording_response",
+        success: true,
+        result: {
+          config,
+          evictedRecordingIds: ["recording-a"],
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates the structurally identical device snapshot and video recording config socket handlers behind a shared generic `ConfigSocketServer`, while keeping their existing request/response type tags, method names, reset semantics, and eviction result keys.

## Linked Issue

Closes #3447

## Validation

- [x] `bun test test/daemon/socketServer/ConfigSocketServer.test.ts`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate` passed (`lint`, `build`, `test`)
- [x] New socket tests use fakes/FakeTimer and run in under 100ms per test

## Device Verification

N/A - daemon socket refactor only; no on-device behavior changed.

## Follow-ups

N/A - broader daemon socket singleton/start/stop boilerplate remains out of scope for this issue.

Made with [Cursor](https://cursor.com)