### PR TITLE
Refactor threshold managers around shared descriptor

### DIFF
--- a/src/features/memory/MemoryThresholdManager.ts
+++ b/src/features/memory/MemoryThresholdManager.ts
@@ -1,14 +1,24 @@
 import type { Kysely } from "kysely";
-import { getDatabase } from "../../db/database";
 import { Database, NewMemoryThresholds, MemoryThresholds } from "../../db/types";
 import { logger } from "../../utils/logger";
-import { sql } from "kysely";
 import { MemoryBaseline } from "../../db/types";
 import {
-  calculateWeightedAverage,
-  WEIGHT_BOUNDS,
-  DEFAULT_TTL,
-} from "../shared/MetricsUtils";
+  GenericThresholdManager,
+  type ThresholdDescriptor,
+  type ThresholdWhere,
+} from "../shared/GenericThresholdManager";
+
+const MEMORY_THRESHOLD_DESCRIPTOR: ThresholdDescriptor<MemoryThresholds> = {
+  tableName: "memory_thresholds",
+  logPrefix: "MemoryThresholdManager",
+  weightedColumns: [
+    { column: "heap_growth_threshold_mb" },
+    { column: "native_heap_growth_threshold_mb" },
+    { column: "gc_count_threshold", round: true },
+    { column: "gc_duration_threshold_ms" },
+    { column: "unreachable_objects_threshold", round: true },
+  ],
+};
 
 /**
  * Default memory thresholds for different app profiles
@@ -44,7 +54,7 @@ const DEFAULT_THRESHOLDS = {
  * Manages memory thresholds with TTL, per-app profiles, and weighted averaging
  */
 export class MemoryThresholdManager {
-  private readonly injectedDb: Kysely<Database> | null;
+  private readonly thresholds: GenericThresholdManager<MemoryThresholds>;
 
   /**
    * @param db Optional Kysely handle, resolved LAZILY (per use, via {@link db})
@@ -53,12 +63,12 @@ export class MemoryThresholdManager {
    * paths (issue #3067).
    */
   constructor(db?: Kysely<Database>) {
-    this.injectedDb = db ?? null;
+    this.thresholds = new GenericThresholdManager(MEMORY_THRESHOLD_DESCRIPTOR, db);
   }
 
   /** The injected DB, or the shared singleton resolved on first use. */
   private get db(): Kysely<Database> {
-    return this.injectedDb ?? getDatabase();
+    return this.thresholds.db;
   }
 
   /**
@@ -72,25 +82,11 @@ export class MemoryThresholdManager {
     db: Kysely<Database>,
     deviceId: string
   ): Promise<void> {
-    try {
-      const deleted = await db
-        .deleteFrom("memory_thresholds")
-        .where("device_id", "=", deviceId)
-        .where(
-          sql`datetime(created_at, '+' || ttl_hours || ' hours')`,
-          "<",
-          sql`datetime('now')`
-        )
-        .execute();
-
-      if (deleted.length > 0) {
-        logger.info(
-          `[MemoryThresholdManager] Cleaned up ${deleted.length} expired thresholds for device ${deviceId}`
-        );
-      }
-    } catch (error) {
-      logger.warn(`[MemoryThresholdManager] Failed to cleanup expired thresholds: ${error}`);
-    }
+    await this.thresholds.cleanupExpiredThresholds(
+      this.deviceWhere(deviceId),
+      `device ${deviceId}`,
+      db
+    );
   }
 
   /**
@@ -100,7 +96,7 @@ export class MemoryThresholdManager {
     deviceId: string,
     packageName: string
   ): Promise<MemoryThresholds[]> {
-    return this.getValidThresholdsWith(this.db, deviceId, packageName);
+    return await this.getValidThresholdsWith(this.db, deviceId, packageName);
   }
 
   private async getValidThresholdsWith(
@@ -108,22 +104,12 @@ export class MemoryThresholdManager {
     deviceId: string,
     packageName: string
   ): Promise<MemoryThresholds[]> {
-    await this.cleanupExpiredThresholdsWith(db, deviceId);
-
-    const thresholds = await db
-      .selectFrom("memory_thresholds")
-      .selectAll()
-      .where("device_id", "=", deviceId)
-      .where("package_name", "=", packageName)
-      .where(
-        sql`datetime(created_at, '+' || ttl_hours || ' hours')`,
-        ">=",
-        sql`datetime('now')`
-      )
-      .orderBy("created_at", "desc")
-      .execute();
-
-    return thresholds;
+    return await this.thresholds.getValidThresholds(
+      this.packageWhere(deviceId, packageName),
+      this.deviceWhere(deviceId),
+      `device ${deviceId}`,
+      db
+    );
   }
 
   /**
@@ -132,44 +118,9 @@ export class MemoryThresholdManager {
   calculateWeightedAverageThresholds(
     thresholds: MemoryThresholds[]
   ): Omit<NewMemoryThresholds, "device_id" | "package_name" | "created_at"> | null {
-    if (thresholds.length === 0) {
-      return null;
-    }
-
-    const getWeight = (t: MemoryThresholds) => t.weight;
-
-    const heapGrowth = calculateWeightedAverage(
-      thresholds,
-      t => t.heap_growth_threshold_mb,
-      getWeight
-    );
-    if (heapGrowth === null) {return null;}
-
-    return {
-      heap_growth_threshold_mb: heapGrowth,
-      native_heap_growth_threshold_mb: calculateWeightedAverage(
-        thresholds,
-        t => t.native_heap_growth_threshold_mb,
-        getWeight
-      )!,
-      gc_count_threshold: Math.round(
-        calculateWeightedAverage(thresholds, t => t.gc_count_threshold, getWeight)!
-      ),
-      gc_duration_threshold_ms: calculateWeightedAverage(
-        thresholds,
-        t => t.gc_duration_threshold_ms,
-        getWeight
-      )!,
-      unreachable_objects_threshold: Math.round(
-        calculateWeightedAverage(
-          thresholds,
-          t => t.unreachable_objects_threshold,
-          getWeight
-        )!
-      ),
-      weight: WEIGHT_BOUNDS.max / 2, // Start at 1.0
-      ttl_hours: DEFAULT_TTL.thresholdHours,
-    };
+    return this.thresholds.calculateWeightedAverageThresholds(thresholds) as
+      | Omit<NewMemoryThresholds, "device_id" | "package_name" | "created_at">
+      | null;
   }
 
   /**
@@ -216,7 +167,7 @@ export class MemoryThresholdManager {
   }> {
     const db = this.db;
     const run = async (executor: Kysely<Database>) => {
-    // Try to get existing weighted thresholds
+      // Try to get existing weighted thresholds
       const existingThresholds = await this.getValidThresholdsWith(executor, deviceId, packageName);
 
       if (existingThresholds.length > 0) {
@@ -311,19 +262,11 @@ export class MemoryThresholdManager {
       ttl_hours: ttlHours,
     };
 
-    try {
-      await db
-        .insertInto("memory_thresholds")
-        .values(newThresholds)
-        .execute();
-
-      logger.info(
-        `[MemoryThresholdManager] Stored new thresholds for ${packageName} on device ${deviceId}`
-      );
-    } catch (error) {
-      logger.error(`[MemoryThresholdManager] Failed to store thresholds: ${error}`);
-      throw error;
-    }
+    await this.thresholds.storeThresholds(
+      newThresholds,
+      `${packageName} on device ${deviceId}`,
+      db
+    );
   }
 
   /**
@@ -335,35 +278,28 @@ export class MemoryThresholdManager {
     packageName: string,
     passed: boolean
   ): Promise<void> {
-    try {
-      await this.cleanupExpiredThresholds(deviceId);
-      const adjustedWeight = passed
-        ? sql<number>`min(weight * ${WEIGHT_BOUNDS.successMultiplier}, ${WEIGHT_BOUNDS.max})`
-        : sql<number>`max(weight * ${WEIGHT_BOUNDS.failureMultiplier}, ${WEIGHT_BOUNDS.min})`;
-      const result = await this.db
-        .updateTable("memory_thresholds")
-        .set({ weight: adjustedWeight })
-        .where("id", "=", sql<number>`(
-          select id from memory_thresholds
-          where device_id = ${deviceId} and package_name = ${packageName}
-            and datetime(created_at, '+' || ttl_hours || ' hours') >= datetime('now')
-          order by created_at desc
-          limit 1
-        )`)
-        .executeTakeFirst();
-
-      if (Number(result.numUpdatedRows) === 0) {
-        logger.warn(
-          `[MemoryThresholdManager] No thresholds found for ${packageName} on device ${deviceId}`
-        );
-        return;
+    await this.thresholds.updateThresholdWeight(
+      this.packageWhere(deviceId, packageName),
+      passed,
+      {
+        cleanupWhere: this.deviceWhere(deviceId),
+        missingMessage: `No thresholds found for ${packageName} on device ${deviceId}`,
+        updatedMessage: `Updated threshold weight for ${packageName} (${passed ? "passed" : "failed"})`,
       }
+    );
+  }
 
-      logger.debug(
-        `[MemoryThresholdManager] Updated threshold weight for ${packageName} (${passed ? "passed" : "failed"})`
-      );
-    } catch (error) {
-      logger.warn(`[MemoryThresholdManager] Failed to update threshold weight: ${error}`);
-    }
+  private deviceWhere(deviceId: string): Array<ThresholdWhere<MemoryThresholds>> {
+    return [{ column: "device_id", value: deviceId }];
+  }
+
+  private packageWhere(
+    deviceId: string,
+    packageName: string
+  ): Array<ThresholdWhere<MemoryThresholds>> {
+    return [
+      ...this.deviceWhere(deviceId),
+      { column: "package_name", value: packageName },
+    ];
   }
 }

--- a/src/features/performance/ThresholdManager.ts
+++ b/src/features/performance/ThresholdManager.ts
@@ -1,21 +1,34 @@
 import type { Kysely } from "kysely";
-import { getDatabase } from "../../db/database";
 import { Database, NewPerformanceThresholds, PerformanceThresholds } from "../../db/types";
 import { logger } from "../../utils/logger";
 import { DeviceCapabilities, DeviceCapabilitiesDetector } from "../../utils/DeviceCapabilities";
-import { sql } from "kysely";
 import {
-  calculateWeightedAverage,
-  calculateMode,
-  WEIGHT_BOUNDS,
-  DEFAULT_TTL,
-} from "../shared/MetricsUtils";
+  GenericThresholdManager,
+  type ThresholdDescriptor,
+  type ThresholdWhere,
+} from "../shared/GenericThresholdManager";
+
+const PERFORMANCE_THRESHOLD_DESCRIPTOR: ThresholdDescriptor<PerformanceThresholds> = {
+  tableName: "performance_thresholds",
+  logPrefix: "ThresholdManager",
+  modeColumns: ["refresh_rate"],
+  weightedColumns: [
+    { column: "frame_time_threshold_ms" },
+    { column: "p50_threshold_ms" },
+    { column: "p90_threshold_ms" },
+    { column: "p95_threshold_ms" },
+    { column: "p99_threshold_ms" },
+    { column: "jank_count_threshold", round: true },
+    { column: "cpu_usage_threshold_percent" },
+    { column: "touch_latency_threshold_ms" },
+  ],
+};
 
 /**
  * Manages performance thresholds with TTL and weighted averaging
  */
 export class ThresholdManager {
-  private readonly injectedDb: Kysely<Database> | null;
+  private readonly thresholds: GenericThresholdManager<PerformanceThresholds>;
 
   /**
    * @param db Optional Kysely handle, resolved LAZILY (per use, via {@link db})
@@ -24,12 +37,12 @@ export class ThresholdManager {
    * exercising the query paths (issue #3067).
    */
   constructor(db?: Kysely<Database>) {
-    this.injectedDb = db ?? null;
+    this.thresholds = new GenericThresholdManager(PERFORMANCE_THRESHOLD_DESCRIPTOR, db);
   }
 
   /** The injected DB, or the shared singleton resolved on first use. */
   private get db(): Kysely<Database> {
-    return this.injectedDb ?? getDatabase();
+    return this.thresholds.db;
   }
 
   /**
@@ -54,54 +67,30 @@ export class ThresholdManager {
     db: Kysely<Database>,
     deviceId: string
   ): Promise<void> {
-    try {
-      // Delete thresholds where created_at + ttl_hours < now
-      const deleted = await db
-        .deleteFrom("performance_thresholds")
-        .where("device_id", "=", deviceId)
-        .where(
-          sql`datetime(created_at, '+' || ttl_hours || ' hours')`,
-          "<",
-          sql`datetime('now')`
-        )
-        .execute();
-
-      if (deleted.length > 0) {
-        logger.info(`[ThresholdManager] Cleaned up ${deleted.length} expired thresholds for device ${deviceId}`);
-      }
-    } catch (error) {
-      logger.warn(`[ThresholdManager] Failed to cleanup expired thresholds: ${error}`);
-    }
+    await this.thresholds.cleanupExpiredThresholds(
+      this.deviceWhere(deviceId),
+      `device ${deviceId}`,
+      db
+    );
   }
 
   /**
    * Get valid (non-expired) thresholds for a device
    */
   async getValidThresholds(deviceId: string): Promise<PerformanceThresholds[]> {
-    return this.getValidThresholdsWith(this.db, deviceId);
+    return await this.getValidThresholdsWith(this.db, deviceId);
   }
 
   private async getValidThresholdsWith(
     db: Kysely<Database>,
     deviceId: string
   ): Promise<PerformanceThresholds[]> {
-    // First cleanup expired thresholds
-    await this.cleanupExpiredThresholdsWith(db, deviceId);
-
-    // Get all valid thresholds
-    const thresholds = await db
-      .selectFrom("performance_thresholds")
-      .selectAll()
-      .where("device_id", "=", deviceId)
-      .where(
-        sql`datetime(created_at, '+' || ttl_hours || ' hours')`,
-        ">=",
-        sql`datetime('now')`
-      )
-      .orderBy("created_at", "desc")
-      .execute();
-
-    return thresholds;
+    return await this.thresholds.getValidThresholds(
+      this.deviceWhere(deviceId),
+      this.deviceWhere(deviceId),
+      `device ${deviceId}`,
+      db
+    );
   }
 
   /**
@@ -110,45 +99,9 @@ export class ThresholdManager {
   calculateWeightedAverageThresholds(
     thresholds: PerformanceThresholds[]
   ): Omit<NewPerformanceThresholds, "device_id" | "session_id" | "created_at"> | null {
-    if (thresholds.length === 0) {
-      return null;
-    }
-
-    const getWeight = (t: PerformanceThresholds) => t.weight;
-
-    const frameTime = calculateWeightedAverage(
-      thresholds,
-      t => t.frame_time_threshold_ms,
-      getWeight
-    );
-    if (frameTime === null) {return null;}
-
-    // Use the most common refresh rate (mode)
-    const refreshRate = calculateMode(thresholds.map(t => t.refresh_rate)) ?? 60;
-
-    return {
-      refresh_rate: refreshRate,
-      frame_time_threshold_ms: frameTime,
-      p50_threshold_ms: calculateWeightedAverage(thresholds, t => t.p50_threshold_ms, getWeight)!,
-      p90_threshold_ms: calculateWeightedAverage(thresholds, t => t.p90_threshold_ms, getWeight)!,
-      p95_threshold_ms: calculateWeightedAverage(thresholds, t => t.p95_threshold_ms, getWeight)!,
-      p99_threshold_ms: calculateWeightedAverage(thresholds, t => t.p99_threshold_ms, getWeight)!,
-      jank_count_threshold: Math.round(
-        calculateWeightedAverage(thresholds, t => t.jank_count_threshold, getWeight)!
-      ),
-      cpu_usage_threshold_percent: calculateWeightedAverage(
-        thresholds,
-        t => t.cpu_usage_threshold_percent,
-        getWeight
-      )!,
-      touch_latency_threshold_ms: calculateWeightedAverage(
-        thresholds,
-        t => t.touch_latency_threshold_ms,
-        getWeight
-      )!,
-      weight: WEIGHT_BOUNDS.max / 2, // New thresholds start with weight 1.0
-      ttl_hours: DEFAULT_TTL.thresholdHours,
-    };
+    return this.thresholds.calculateWeightedAverageThresholds(thresholds) as
+      | Omit<NewPerformanceThresholds, "device_id" | "session_id" | "created_at">
+      | null;
   }
 
   /**
@@ -171,7 +124,7 @@ export class ThresholdManager {
   }> {
     const db = this.db;
     const run = async (executor: Kysely<Database>) => {
-    // Get existing valid thresholds
+      // Get existing valid thresholds
       const existingThresholds = await this.getValidThresholdsWith(executor, deviceId);
 
       // If we have existing thresholds, calculate weighted average
@@ -267,17 +220,11 @@ export class ThresholdManager {
       ttl_hours: ttlHours,
     };
 
-    try {
-      await db
-        .insertInto("performance_thresholds")
-        .values(newThresholds)
-        .execute();
-
-      logger.info(`[ThresholdManager] Stored new thresholds for device ${deviceId} session ${sessionId}`);
-    } catch (error) {
-      logger.error(`[ThresholdManager] Failed to store thresholds: ${error}`);
-      throw error;
-    }
+    await this.thresholds.storeThresholds(
+      newThresholds,
+      `device ${deviceId} session ${sessionId}`,
+      db
+    );
   }
 
   /**
@@ -289,33 +236,20 @@ export class ThresholdManager {
     sessionId: string,
     passed: boolean
   ): Promise<void> {
-    try {
-      await this.cleanupExpiredThresholds(deviceId);
-      const adjustedWeight = passed
-        ? sql<number>`min(weight * ${WEIGHT_BOUNDS.successMultiplier}, ${WEIGHT_BOUNDS.max})`
-        : sql<number>`max(weight * ${WEIGHT_BOUNDS.failureMultiplier}, ${WEIGHT_BOUNDS.min})`;
-      const result = await this.db
-        .updateTable("performance_thresholds")
-        .set({ weight: adjustedWeight })
-        .where("id", "=", sql<number>`(
-          select id from performance_thresholds
-          where device_id = ${deviceId} and session_id = ${sessionId}
-            and datetime(created_at, '+' || ttl_hours || ' hours') >= datetime('now')
-          order by created_at desc
-          limit 1
-        )`)
-        .executeTakeFirst();
-
-      if (Number(result.numUpdatedRows) === 0) {
-        logger.warn(`[ThresholdManager] No threshold found for device ${deviceId} session ${sessionId}`);
-        return;
+    await this.thresholds.updateThresholdWeight(
+      [
+        ...this.deviceWhere(deviceId),
+        { column: "session_id", value: sessionId },
+      ],
+      passed,
+      {
+        missingMessage: `No threshold found for device ${deviceId} session ${sessionId}`,
+        updatedMessage: `Updated threshold weight (${passed ? "passed" : "failed"})`,
       }
+    );
+  }
 
-      logger.debug(
-        `[ThresholdManager] Updated threshold weight (${passed ? "passed" : "failed"})`
-      );
-    } catch (error) {
-      logger.warn(`[ThresholdManager] Failed to update threshold weight: ${error}`);
-    }
+  private deviceWhere(deviceId: string): Array<ThresholdWhere<PerformanceThresholds>> {
+    return [{ column: "device_id", value: deviceId }];
   }
 }

--- a/src/features/shared/GenericThresholdManager.ts
+++ b/src/features/shared/GenericThresholdManager.ts
@@ -1,0 +1,215 @@
+import { sql, type Kysely } from "kysely";
+import { getDatabase } from "../../db/database";
+import type { Database } from "../../db/types";
+import { logger } from "../../utils/logger";
+import {
+  calculateMode,
+  calculateWeightedAverage,
+  DEFAULT_TTL,
+  WEIGHT_BOUNDS,
+} from "./MetricsUtils";
+
+type ThresholdValue = string | number;
+
+export interface ThresholdWhere<Row> {
+  column: Extract<keyof Row, string>;
+  value: ThresholdValue;
+}
+
+export interface WeightedThresholdColumn<Row> {
+  column: Extract<keyof Row, string>;
+  round?: boolean;
+}
+
+export interface ThresholdDescriptor<Row> {
+  tableName: keyof Database & string;
+  logPrefix: string;
+  weightedColumns: WeightedThresholdColumn<Row>[];
+  modeColumns?: Array<Extract<keyof Row, string>>;
+}
+
+export type WeightedThresholdResult<Row> = Partial<
+  Record<Extract<keyof Row, string>, number>
+> & {
+  weight: number;
+  ttl_hours: number;
+};
+
+interface UpdateThresholdWeightOptions<Row> {
+  cleanupWhere?: Array<ThresholdWhere<Row>>;
+  missingMessage: string;
+  updatedMessage: string;
+}
+
+interface ThresholdRow {
+  id: number;
+  created_at: string;
+  ttl_hours: number;
+  weight: number;
+}
+
+export class GenericThresholdManager<Row extends ThresholdRow> {
+  private readonly injectedDb: Kysely<Database> | null;
+  private readonly descriptor: ThresholdDescriptor<Row>;
+
+  constructor(descriptor: ThresholdDescriptor<Row>, db?: Kysely<Database>) {
+    this.descriptor = descriptor;
+    this.injectedDb = db ?? null;
+  }
+
+  /** The injected DB, or the shared singleton resolved on first use. */
+  get db(): Kysely<Database> {
+    return this.injectedDb ?? getDatabase();
+  }
+
+  async cleanupExpiredThresholds(
+    where: Array<ThresholdWhere<Row>>,
+    description: string,
+    db: Kysely<Database> = this.db
+  ): Promise<void> {
+    try {
+      let query = (db as any)
+        .deleteFrom(this.descriptor.tableName)
+        .where(
+          sql`datetime(created_at, '+' || ttl_hours || ' hours')`,
+          "<",
+          sql`datetime('now')`
+        );
+
+      query = this.applyWhere(query, where);
+      const deleted = await query.executeTakeFirst();
+      const deletedCount = Number(deleted.numDeletedRows) || 0;
+
+      if (deletedCount > 0) {
+        logger.info(
+          `[${this.descriptor.logPrefix}] Cleaned up ${deletedCount} expired thresholds for ${description}`
+        );
+      }
+    } catch (error) {
+      logger.warn(`[${this.descriptor.logPrefix}] Failed to cleanup expired thresholds: ${error}`);
+    }
+  }
+
+  async getValidThresholds(
+    where: Array<ThresholdWhere<Row>>,
+    cleanupWhere: Array<ThresholdWhere<Row>>,
+    cleanupDescription: string,
+    db: Kysely<Database> = this.db
+  ): Promise<Row[]> {
+    await this.cleanupExpiredThresholds(cleanupWhere, cleanupDescription, db);
+
+    let query = (db as any)
+      .selectFrom(this.descriptor.tableName)
+      .selectAll()
+      .where(
+        sql`datetime(created_at, '+' || ttl_hours || ' hours')`,
+        ">=",
+        sql`datetime('now')`
+      );
+
+    query = this.applyWhere(query, where);
+    return await query.orderBy("created_at", "desc").execute();
+  }
+
+  calculateWeightedAverageThresholds(rows: Row[]): WeightedThresholdResult<Row> | null {
+    if (rows.length === 0) {
+      return null;
+    }
+
+    const result: Record<string, number> = {
+      weight: WEIGHT_BOUNDS.max / 2,
+      ttl_hours: DEFAULT_TTL.thresholdHours,
+    };
+
+    for (const column of this.descriptor.modeColumns ?? []) {
+      result[column] = calculateMode(rows.map(row => Number(row[column]))) ?? 60;
+    }
+
+    for (const { column, round } of this.descriptor.weightedColumns) {
+      const average = calculateWeightedAverage(
+        rows,
+        row => Number(row[column]),
+        row => row.weight
+      );
+      if (average === null) {
+        return null;
+      }
+      result[column] = round ? Math.round(average) : average;
+    }
+
+    return result as WeightedThresholdResult<Row>;
+  }
+
+  async storeThresholds(
+    values: Record<string, unknown>,
+    description: string,
+    db: Kysely<Database> = this.db
+  ): Promise<void> {
+    try {
+      await (db as any)
+        .insertInto(this.descriptor.tableName)
+        .values(values)
+        .execute();
+
+      logger.info(`[${this.descriptor.logPrefix}] Stored new thresholds for ${description}`);
+    } catch (error) {
+      logger.error(`[${this.descriptor.logPrefix}] Failed to store thresholds: ${error}`);
+      throw error;
+    }
+  }
+
+  async updateThresholdWeight(
+    where: Array<ThresholdWhere<Row>>,
+    passed: boolean,
+    options: UpdateThresholdWeightOptions<Row>
+  ): Promise<void> {
+    try {
+      await this.cleanupExpiredThresholds(
+        options.cleanupWhere ?? where,
+        this.describeWhere(options.cleanupWhere ?? where)
+      );
+      const adjustedWeight = passed
+        ? sql<number>`min(weight * ${WEIGHT_BOUNDS.successMultiplier}, ${WEIGHT_BOUNDS.max})`
+        : sql<number>`max(weight * ${WEIGHT_BOUNDS.failureMultiplier}, ${WEIGHT_BOUNDS.min})`;
+
+      let latestValidThreshold = (this.db as any)
+        .selectFrom(this.descriptor.tableName)
+        .select("id")
+        .where(
+          sql`datetime(created_at, '+' || ttl_hours || ' hours')`,
+          ">=",
+          sql`datetime('now')`
+        )
+        .orderBy("created_at", "desc")
+        .limit(1);
+
+      latestValidThreshold = this.applyWhere(latestValidThreshold, where);
+
+      const result = await (this.db as any)
+        .updateTable(this.descriptor.tableName)
+        .set({ weight: adjustedWeight })
+        .where("id", "=", latestValidThreshold)
+        .executeTakeFirst();
+
+      if (Number(result.numUpdatedRows) === 0) {
+        logger.warn(`[${this.descriptor.logPrefix}] ${options.missingMessage}`);
+        return;
+      }
+
+      logger.debug(`[${this.descriptor.logPrefix}] ${options.updatedMessage}`);
+    } catch (error) {
+      logger.warn(`[${this.descriptor.logPrefix}] Failed to update threshold weight: ${error}`);
+    }
+  }
+
+  private applyWhere<Query>(query: Query, where: Array<ThresholdWhere<Row>>): Query {
+    return where.reduce(
+      (currentQuery, clause) => (currentQuery as any).where(clause.column, "=", clause.value),
+      query
+    );
+  }
+
+  private describeWhere(where: Array<ThresholdWhere<Row>>): string {
+    return where.map(clause => `${clause.column} ${clause.value}`).join(", ");
+  }
+}

--- a/test/features/shared/GenericThresholdManager.test.ts
+++ b/test/features/shared/GenericThresholdManager.test.ts
@@ -13,6 +13,7 @@ import {
   GenericThresholdManager,
   type ThresholdDescriptor,
 } from "../../../src/features/shared/GenericThresholdManager";
+import { DeviceCapabilitiesDetector } from "../../../src/utils/DeviceCapabilities";
 import { createTestDatabase } from "../../db/testDbHelper";
 
 function hoursAgo(hours: number): string {
@@ -187,6 +188,80 @@ describe("ThresholdManager wrappers", function() {
     ]);
   });
 
+  test("performance thresholds create capability-derived defaults and persist them", async function() {
+    const manager = new ThresholdManager(db);
+    const capabilities = {
+      refreshRate: 120,
+      frameTimeMs: 1000 / 120,
+    };
+
+    const thresholds = await manager.getOrCreateThresholds("device-1", capabilities);
+    const expected = DeviceCapabilitiesDetector.calculateDefaultThresholds(capabilities);
+    const rows = await db.selectFrom("performance_thresholds").selectAll().execute();
+
+    expect(thresholds).toEqual(expected);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      device_id: "device-1",
+      session_id: new Date().toISOString().split("T")[0],
+      refresh_rate: 120,
+      frame_time_threshold_ms: expected.frameTimeThresholdMs,
+      p50_threshold_ms: expected.p50ThresholdMs,
+      p90_threshold_ms: expected.p90ThresholdMs,
+      p95_threshold_ms: expected.p95ThresholdMs,
+      p99_threshold_ms: expected.p99ThresholdMs,
+      jank_count_threshold: expected.jankCountThreshold,
+      cpu_usage_threshold_percent: expected.cpuUsageThresholdPercent,
+      touch_latency_threshold_ms: expected.touchLatencyThresholdMs,
+      weight: 1,
+      ttl_hours: 24,
+    });
+  });
+
+  test("performance public methods store, read, average, and cleanup thresholds", async function() {
+    const manager = new ThresholdManager(db);
+    const capabilities = { refreshRate: 60, frameTimeMs: 16.67 };
+    await manager.storeThresholds(
+      "device-1",
+      capabilities,
+      {
+        frameTimeThresholdMs: 16,
+        p50ThresholdMs: 10,
+        p90ThresholdMs: 20,
+        p95ThresholdMs: 30,
+        p99ThresholdMs: 40,
+        jankCountThreshold: 5,
+        cpuUsageThresholdPercent: 50,
+        touchLatencyThresholdMs: 100,
+      },
+      1,
+      24
+    );
+    await db.insertInto("performance_thresholds").values(
+      performanceRow({
+        device_id: "device-1",
+        session_id: "expired-session",
+        created_at: hoursAgo(48),
+        ttl_hours: 1,
+      })
+    ).execute();
+
+    await manager.cleanupExpiredThresholds("device-1");
+    const valid = await manager.getValidThresholds("device-1");
+    const weighted = manager.calculateWeightedAverageThresholds(valid);
+
+    expect(valid).toHaveLength(1);
+    expect(valid[0].session_id).not.toBe("expired-session");
+    expect(weighted).toMatchObject({
+      refresh_rate: 60,
+      frame_time_threshold_ms: 16,
+      p50_threshold_ms: 10,
+      jank_count_threshold: 5,
+      weight: 1,
+      ttl_hours: 24,
+    });
+  });
+
   test("memory thresholds stay scoped by package and use weighted averages", async function() {
     const manager = new MemoryThresholdManager(db);
     const rows: NewMemoryThresholds[] = [
@@ -269,6 +344,37 @@ describe("ThresholdManager wrappers", function() {
       gcDurationThresholdMs: 1000,
       unreachableObjectsThreshold: 2000,
     });
+
+    const rows = await db
+      .selectFrom("memory_thresholds")
+      .selectAll()
+      .orderBy("package_name")
+      .execute();
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual([
+      expect.objectContaining({
+        device_id: "device-1",
+        package_name: "com.example.app",
+        heap_growth_threshold_mb: 80,
+        native_heap_growth_threshold_mb: 40,
+        gc_count_threshold: 6,
+        gc_duration_threshold_ms: 300,
+        unreachable_objects_threshold: 160,
+        weight: 1,
+        ttl_hours: 24,
+      }),
+      expect.objectContaining({
+        device_id: "device-1",
+        package_name: "com.relaxed.app",
+        heap_growth_threshold_mb: 100,
+        native_heap_growth_threshold_mb: 75,
+        gc_count_threshold: 20,
+        gc_duration_threshold_ms: 1000,
+        unreachable_objects_threshold: 2000,
+        weight: 1,
+        ttl_hours: 24,
+      }),
+    ]);
   });
 
   test("memory threshold weight updates the most recent valid package threshold", async function() {
@@ -311,5 +417,46 @@ describe("ThresholdManager wrappers", function() {
       { heap_growth_threshold_mb: 10, weight: 1 },
       { heap_growth_threshold_mb: 30, weight: 0.9 },
     ]);
+  });
+
+  test("memory public methods store, read, average, and cleanup package thresholds", async function() {
+    const manager = new MemoryThresholdManager(db);
+    await manager.storeThresholds("device-1", "com.example.app", {
+      heapGrowthThresholdMb: 20,
+      nativeHeapGrowthThresholdMb: 30,
+      gcCountThreshold: 4,
+      gcDurationThresholdMs: 200,
+      unreachableObjectsThreshold: 100,
+    });
+    await db.insertInto("memory_thresholds").values({
+      device_id: "device-1",
+      package_name: "com.example.app",
+      heap_growth_threshold_mb: 999,
+      native_heap_growth_threshold_mb: 999,
+      gc_count_threshold: 999,
+      gc_duration_threshold_ms: 999,
+      unreachable_objects_threshold: 999,
+      weight: 999,
+      ttl_hours: 1,
+      created_at: hoursAgo(48),
+    }).execute();
+
+    await manager.cleanupExpiredThresholds("device-1");
+    const valid = await manager.getValidThresholds("device-1", "com.example.app");
+    const weighted = manager.calculateWeightedAverageThresholds(valid);
+
+    expect(valid).toHaveLength(1);
+    expect(valid[0]).toMatchObject({
+      package_name: "com.example.app",
+      heap_growth_threshold_mb: 20,
+      gc_count_threshold: 4,
+    });
+    expect(weighted).toMatchObject({
+      heap_growth_threshold_mb: 20,
+      native_heap_growth_threshold_mb: 30,
+      gc_count_threshold: 4,
+      weight: 1,
+      ttl_hours: 24,
+    });
   });
 });

--- a/test/features/shared/GenericThresholdManager.test.ts
+++ b/test/features/shared/GenericThresholdManager.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type {
+  Database,
+  MemoryBaseline,
+  NewMemoryThresholds,
+  NewPerformanceThresholds,
+  PerformanceThresholds,
+} from "../../../src/db/types";
+import { MemoryThresholdManager } from "../../../src/features/memory/MemoryThresholdManager";
+import { ThresholdManager } from "../../../src/features/performance/ThresholdManager";
+import {
+  GenericThresholdManager,
+  type ThresholdDescriptor,
+} from "../../../src/features/shared/GenericThresholdManager";
+import { createTestDatabase } from "../../db/testDbHelper";
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+function performanceRow(
+  overrides: Partial<NewPerformanceThresholds> = {}
+): NewPerformanceThresholds {
+  return {
+    device_id: "device-1",
+    session_id: "session-1",
+    refresh_rate: 60,
+    frame_time_threshold_ms: 16,
+    p50_threshold_ms: 10,
+    p90_threshold_ms: 20,
+    p95_threshold_ms: 30,
+    p99_threshold_ms: 40,
+    jank_count_threshold: 5,
+    cpu_usage_threshold_percent: 50,
+    touch_latency_threshold_ms: 100,
+    weight: 1,
+    created_at: new Date().toISOString(),
+    ttl_hours: 24,
+    ...overrides,
+  };
+}
+
+function memoryBaseline(overrides: Partial<MemoryBaseline> = {}): MemoryBaseline {
+  return {
+    id: 1,
+    device_id: "device-1",
+    package_name: "com.example.app",
+    tool_name: "tapOn",
+    java_heap_baseline_mb: 40,
+    native_heap_baseline_mb: 20,
+    gc_count_baseline: 3,
+    gc_duration_baseline_ms: 150,
+    unreachable_objects_baseline: 80,
+    sample_count: 3,
+    last_updated: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("GenericThresholdManager", function() {
+  const descriptor: ThresholdDescriptor<PerformanceThresholds> = {
+    tableName: "performance_thresholds",
+    logPrefix: "TestThresholdManager",
+    weightedColumns: [
+      { column: "frame_time_threshold_ms" },
+      { column: "jank_count_threshold", round: true },
+    ],
+    modeColumns: ["refresh_rate"],
+  };
+
+  test("calculates descriptor-driven weighted averages and modes", function() {
+    const manager = new GenericThresholdManager(descriptor);
+    const rows = [
+      {
+        ...performanceRow({ refresh_rate: 60, frame_time_threshold_ms: 10, jank_count_threshold: 1, weight: 1 }),
+        id: 1,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        ...performanceRow({ refresh_rate: 120, frame_time_threshold_ms: 20, jank_count_threshold: 4, weight: 3 }),
+        id: 2,
+        created_at: "2026-01-02T00:00:00.000Z",
+      },
+      {
+        ...performanceRow({ refresh_rate: 120, frame_time_threshold_ms: 40, jank_count_threshold: 10, weight: 0 }),
+        id: 3,
+        created_at: "2026-01-03T00:00:00.000Z",
+      },
+    ] as PerformanceThresholds[];
+
+    const weighted = manager.calculateWeightedAverageThresholds(rows);
+
+    expect(weighted).toEqual({
+      refresh_rate: 120,
+      frame_time_threshold_ms: 17.5,
+      jank_count_threshold: 3,
+      weight: 1,
+      ttl_hours: 24,
+    });
+  });
+});
+
+describe("ThresholdManager wrappers", function() {
+  let db: Kysely<Database>;
+
+  beforeEach(async function() {
+    db = await createTestDatabase();
+  });
+
+  afterEach(async function() {
+    await db.destroy();
+  });
+
+  test("performance thresholds keep weighted averages, refresh-rate mode, and rounded jank", async function() {
+    const manager = new ThresholdManager(db);
+    await db.insertInto("performance_thresholds").values([
+      performanceRow({
+        refresh_rate: 60,
+        p50_threshold_ms: 10,
+        p90_threshold_ms: 20,
+        p95_threshold_ms: 30,
+        p99_threshold_ms: 40,
+        frame_time_threshold_ms: 16,
+        jank_count_threshold: 1,
+        cpu_usage_threshold_percent: 50,
+        touch_latency_threshold_ms: 100,
+        weight: 1,
+      }),
+      performanceRow({
+        session_id: "session-2",
+        refresh_rate: 120,
+        p50_threshold_ms: 30,
+        p90_threshold_ms: 60,
+        p95_threshold_ms: 90,
+        p99_threshold_ms: 120,
+        frame_time_threshold_ms: 32,
+        jank_count_threshold: 4,
+        cpu_usage_threshold_percent: 70,
+        touch_latency_threshold_ms: 140,
+        weight: 3,
+      }),
+      performanceRow({
+        session_id: "session-3",
+        refresh_rate: 120,
+        created_at: hoursAgo(48),
+        ttl_hours: 1,
+        weight: 100,
+      }),
+    ]).execute();
+
+    const thresholds = await manager.getOrCreateThresholds("device-1", {
+      refreshRate: 60,
+      frameTimeMs: 16.67,
+    });
+
+    expect(thresholds).toEqual({
+      frameTimeThresholdMs: 28,
+      p50ThresholdMs: 25,
+      p90ThresholdMs: 50,
+      p95ThresholdMs: 75,
+      p99ThresholdMs: 100,
+      jankCountThreshold: 3,
+      cpuUsageThresholdPercent: 65,
+      touchLatencyThresholdMs: 130,
+    });
+  });
+
+  test("performance threshold weight updates the requested session", async function() {
+    const manager = new ThresholdManager(db);
+    await db.insertInto("performance_thresholds").values([
+      performanceRow({ session_id: "old-session", weight: 1 }),
+      performanceRow({ session_id: "target-session", weight: 1 }),
+    ]).execute();
+
+    await manager.updateThresholdWeight("device-1", "target-session", true);
+
+    const rows = await db
+      .selectFrom("performance_thresholds")
+      .select(["session_id", "weight"])
+      .orderBy("session_id")
+      .execute();
+    expect(rows).toEqual([
+      { session_id: "old-session", weight: 1 },
+      { session_id: "target-session", weight: 1.1 },
+    ]);
+  });
+
+  test("memory thresholds stay scoped by package and use weighted averages", async function() {
+    const manager = new MemoryThresholdManager(db);
+    const rows: NewMemoryThresholds[] = [
+      {
+        device_id: "device-1",
+        package_name: "com.example.app",
+        heap_growth_threshold_mb: 10,
+        native_heap_growth_threshold_mb: 20,
+        gc_count_threshold: 1,
+        gc_duration_threshold_ms: 100,
+        unreachable_objects_threshold: 50,
+        weight: 1,
+        created_at: new Date().toISOString(),
+        ttl_hours: 24,
+      },
+      {
+        device_id: "device-1",
+        package_name: "com.example.app",
+        heap_growth_threshold_mb: 30,
+        native_heap_growth_threshold_mb: 60,
+        gc_count_threshold: 4,
+        gc_duration_threshold_ms: 300,
+        unreachable_objects_threshold: 150,
+        weight: 3,
+        created_at: new Date().toISOString(),
+        ttl_hours: 24,
+      },
+      {
+        device_id: "device-1",
+        package_name: "com.other.app",
+        heap_growth_threshold_mb: 999,
+        native_heap_growth_threshold_mb: 999,
+        gc_count_threshold: 999,
+        gc_duration_threshold_ms: 999,
+        unreachable_objects_threshold: 999,
+        weight: 999,
+        created_at: new Date().toISOString(),
+        ttl_hours: 24,
+      },
+    ];
+    await db.insertInto("memory_thresholds").values(rows).execute();
+
+    const thresholds = await manager.getOrCreateThresholds("device-1", "com.example.app");
+
+    expect(thresholds).toEqual({
+      heapGrowthThresholdMb: 25,
+      nativeHeapGrowthThresholdMb: 50,
+      gcCountThreshold: 3,
+      gcDurationThresholdMs: 250,
+      unreachableObjectsThreshold: 125,
+    });
+  });
+
+  test("memory thresholds preserve baseline and default-profile fallbacks", async function() {
+    const manager = new MemoryThresholdManager(db);
+
+    const adaptive = await manager.getOrCreateThresholds(
+      "device-1",
+      "com.example.app",
+      memoryBaseline()
+    );
+    const relaxed = await manager.getOrCreateThresholds(
+      "device-1",
+      "com.relaxed.app",
+      null,
+      "relaxed"
+    );
+
+    expect(adaptive).toEqual({
+      heapGrowthThresholdMb: 80,
+      nativeHeapGrowthThresholdMb: 40,
+      gcCountThreshold: 6,
+      gcDurationThresholdMs: 300,
+      unreachableObjectsThreshold: 160,
+    });
+    expect(relaxed).toEqual({
+      heapGrowthThresholdMb: 100,
+      nativeHeapGrowthThresholdMb: 75,
+      gcCountThreshold: 20,
+      gcDurationThresholdMs: 1000,
+      unreachableObjectsThreshold: 2000,
+    });
+  });
+
+  test("memory threshold weight updates the most recent valid package threshold", async function() {
+    const manager = new MemoryThresholdManager(db);
+    await db.insertInto("memory_thresholds").values([
+      {
+        device_id: "device-1",
+        package_name: "com.example.app",
+        heap_growth_threshold_mb: 10,
+        native_heap_growth_threshold_mb: 20,
+        gc_count_threshold: 1,
+        gc_duration_threshold_ms: 100,
+        unreachable_objects_threshold: 50,
+        weight: 1,
+        ttl_hours: 24,
+        created_at: hoursAgo(2),
+      },
+      {
+        device_id: "device-1",
+        package_name: "com.example.app",
+        heap_growth_threshold_mb: 30,
+        native_heap_growth_threshold_mb: 60,
+        gc_count_threshold: 4,
+        gc_duration_threshold_ms: 300,
+        unreachable_objects_threshold: 150,
+        weight: 1,
+        created_at: new Date().toISOString(),
+        ttl_hours: 24,
+      },
+    ]).execute();
+
+    await manager.updateThresholdWeight("device-1", "com.example.app", false);
+
+    const rows = await db
+      .selectFrom("memory_thresholds")
+      .select(["heap_growth_threshold_mb", "weight"])
+      .orderBy("created_at")
+      .execute();
+    expect(rows).toEqual([
+      { heap_growth_threshold_mb: 10, weight: 1 },
+      { heap_growth_threshold_mb: 30, weight: 0.9 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Refactors the duplicated performance and memory threshold managers around a shared descriptor-driven threshold manager while keeping the existing wrapper APIs intact. The descriptors capture each table's metric columns, rounding, mode handling, and scope so future threshold-column changes have one shared query/weighting path.

## Linked Issue

Closes #3448

## Validation

- `bun test test/features/shared/GenericThresholdManager.test.ts`
- `bun test test/features/shared/GenericThresholdManager.test.ts test/features/memory/MemoryAudit.test.ts test/features/memory/MemoryBaselineManager.test.ts test/features/performance/PerformanceMonitor.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`

## Follow-ups

None.

Made with [Cursor](https://cursor.com)