### PR TITLE
Fix DB RMW concurrency follow-ups

### DIFF
--- a/docs/design-docs/db-concurrency-rmw-audit.md
+++ b/docs/design-docs/db-concurrency-rmw-audit.md
@@ -1,6 +1,6 @@
 # DB Concurrency RMW Audit
 
-Issue: #3405
+Issues: #3405, #3415
 
 ## Context
 
@@ -43,35 +43,33 @@ upsert.
 | `AppearanceConfigRepository.setConfig` | Atomic upsert on the singleton `key`. | Existing config tests. |
 | `DeviceSnapshotConfigRepository.setConfig` | Atomic upsert on the singleton `key`. | Existing config tests. |
 | `VideoRecordingConfigRepository.setConfig` | Atomic upsert on the singleton `key`. | Existing config tests. |
+| `SqliteFeatureFlagRepository.ensureFlags` | Atomic insert with `ON CONFLICT(key) DO NOTHING`, so concurrent default initialization ignores rows another caller already inserted. | `DB RMW follow-up fixes (#3415)`. |
+| `SqliteFeatureFlagRepository.upsertFlag` | Atomic upsert on `feature_flags.key`; omitted config preserves the current config on the conflict path. | `DB RMW follow-up fixes (#3415)`. |
+| `recordStorageEvent` | Caller-supplied `previousValue` stays on the zero-lookup fast path; omitted previous-value lookup plus insert runs in one transaction so same-key concurrent inserts observe a serialized prior value. | Existing storage tests and `DB RMW follow-up fixes (#3415)`. |
+| `NavigationRepository.promoteSuggestion` | Direct repository calls open a transaction unless already bound to one, so suggestion lookup, fingerprint upsert, and suggestion link update roll back together. | Existing manager rollback tests and `DB RMW follow-up fixes (#3415)`. |
+
+## Guarded Adjacent Paths
+
+These paths are DB-backed feature-manager methods rather than repositories. #3415
+guards the same read-modify-write shapes because they were found during the
+follow-up review.
+
+| Path | Strategy | Regression coverage |
+| --- | --- | --- |
+| `ThresholdManager.getOrCreateThresholds` | The get-valid-then-store initial threshold path runs in a short transaction, preserving one append-only threshold sample for concurrent first callers. | `DB RMW follow-up fixes (#3415)`. |
+| `MemoryThresholdManager.getOrCreateThresholds` | The get-valid-then-store initial threshold path runs in a short transaction, preserving one append-only threshold sample for concurrent first callers. | `DB RMW follow-up fixes (#3415)`. |
+| `BaselineManager.saveBaseline` | Atomic upsert on the unique `screen_id`. | `DB RMW follow-up fixes (#3415)`. |
+| `MemoryBaselineManager.updateBaseline` | Atomic upsert on `(device_id, package_name, tool_name)`; sample count increments and EMA calculations happen in SQL on the conflict path. | `DB RMW follow-up fixes (#3415)`. |
+| `ThresholdManager.updateThresholdWeight` | Atomic SQL update of the latest `(device_id, session_id)` threshold row; the multiplier applies to the current stored weight. | `DB RMW follow-up fixes (#3415)`. |
+| `MemoryThresholdManager.updateThresholdWeight` | Atomic SQL update of the latest `(device_id, package_name)` threshold row; the multiplier applies to the current stored weight. | `DB RMW follow-up fixes (#3415)`. |
 
 ## Follow-Up Candidates
 
-These paths still perform separate awaited reads and writes without a local
-transaction or atomic upsert. They were not fixed as part of #3405 because the
-acceptance criteria ask for follow-up fixes for any unguarded path found.
-
-| Path | Current behavior | Follow-up direction |
-| --- | --- | --- |
-| `SqliteFeatureFlagRepository.ensureFlags` | Reads all existing flag keys, computes missing definitions in JS, then inserts the missing rows. Concurrent first initialization can race on the primary key. | Convert to `INSERT ... ON CONFLICT DO NOTHING` or a transaction. |
-| `SqliteFeatureFlagRepository.upsertFlag` | SELECTs by key, then UPDATEs or INSERTs. Concurrent first writes can race on the primary key. | Replace with `insertInto(...).onConflict(...doUpdateSet(...))`. |
-| `recordStorageEvent` | When `previousValue` is omitted, SELECTs the latest same device/file/key value, then inserts a new event with that value. Concurrent inserts can observe the same prior value. | Decide whether previous-value derivation is best-effort telemetry or must be serialized per key; then either document best-effort semantics or guard the lookup+insert. |
-| `NavigationRepository.promoteSuggestion` | Direct raw repository callers SELECT a suggestion, upsert a fingerprint, then update the suggestion outside a transaction. The public `NavigationGraphManager.promoteSuggestion` path already wraps this in `runInTransaction`/`withExecutor`, but the repository method itself does not enforce that contract. | Either make the repository method transaction-safe for direct use or narrow its visibility/contract so callers cannot bypass the manager-owned transaction. |
+No unguarded repository RMW follow-up candidates remain from #3415.
 
 ## Adjacent Follow-Up Candidates
 
-These paths are DB-backed feature-manager methods rather than repositories, so
-they are outside the strict repository-method acceptance criterion. They still
-have the same awaited read-then-write shape and should be tracked with the
-follow-up fixes if their current best-effort/history semantics are not intended.
-
-| Path | Current behavior | Follow-up direction |
-| --- | --- | --- |
-| `ThresholdManager.getOrCreateThresholds` | Reads valid threshold rows, then stores a new append-only threshold row when none exist. Concurrent callers can insert duplicate threshold samples. | Decide whether duplicate threshold history is acceptable; if not, add a transaction or atomic key. |
-| `MemoryThresholdManager.getOrCreateThresholds` | Reads valid threshold rows, then stores a new append-only threshold row when no weighted/adaptive threshold exists. Concurrent callers can insert duplicate threshold samples. | Decide whether duplicate threshold history is acceptable; if not, add a transaction or atomic key. |
-| `BaselineManager.saveBaseline` | SELECTs by unique `screen_id`, then UPDATEs or INSERTs the accessibility baseline. Concurrent first saves can race on the unique key. | Replace with `INSERT ... ON CONFLICT(screen_id) DO UPDATE`. |
-| `MemoryBaselineManager.updateBaseline` | Reads the current `(device_id, package_name, tool_name)` baseline, computes EMA and `sample_count + 1` in JS, then UPDATEs or INSERTs. Concurrent updates can lose samples/averages and concurrent first writes can race on the unique key. | Convert to a transaction or an atomic upsert/update strategy that preserves read-derived calculations. |
-| `ThresholdManager.updateThresholdWeight` | Reads the latest performance threshold weight, computes the next weight in JS, then UPDATEs that row. Concurrent updates can lose weight adjustments. | Move the weight adjustment into SQL or serialize the read-derived update. |
-| `MemoryThresholdManager.updateThresholdWeight` | Reads the latest memory threshold weight, computes the next weight in JS, then UPDATEs that row. Concurrent updates can lose weight adjustments. | Move the weight adjustment into SQL or serialize the read-derived update. |
+No unguarded adjacent manager RMW follow-up candidates remain from #3415.
 
 `SessionManager.getOrCreateSession` is an in-memory session-map operation; its
 persistence path goes through `DeviceSessionRepository.upsertActiveSession`,

--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -979,7 +979,21 @@ export class NavigationRepository {
     timestamp: number
   ): Promise<NavigationNodeFingerprint> {
     const db = this.getDb();
+    if (db.isTransaction) {
+      return this.promoteSuggestionWithin(db, suggestionId, nodeId, timestamp);
+    }
 
+    return db.transaction().execute(trx =>
+      this.withExecutor(trx).promoteSuggestionWithin(trx, suggestionId, nodeId, timestamp)
+    );
+  }
+
+  private async promoteSuggestionWithin(
+    db: Kysely<Database>,
+    suggestionId: number,
+    nodeId: number,
+    timestamp: number
+  ): Promise<NavigationNodeFingerprint> {
     // Get the suggestion
     const suggestion = await db
       .selectFrom("navigation_suggestions")
@@ -992,7 +1006,7 @@ export class NavigationRepository {
     }
 
     // Create fingerprint record (using app_id from suggestion)
-    const fingerprint = await this.getOrCreateFingerprint(
+    const fingerprint = await this.withExecutor(db).getOrCreateFingerprint(
       suggestion.app_id,
       nodeId,
       suggestion.fingerprint_hash,

--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -80,6 +80,24 @@ export async function recordStorageEvent(
   // through here, so neither can reintroduce divergent casing/defaults.
   const input = normalizeStorageEvent(rawInput);
 
+  const previousValueSupplied = input.previousValue !== undefined;
+  const shouldLookupPreviousValue =
+    !previousValueSupplied && input.key !== null && input.deviceId !== null;
+
+  if (shouldLookupPreviousValue && !d.isTransaction) {
+    await d.transaction().execute(trx => insertStorageEventWithPreviousValue(input, trx, true));
+  } else {
+    await insertStorageEventWithPreviousValue(input, d, shouldLookupPreviousValue);
+  }
+
+  cleanupIfNeeded(db);
+}
+
+async function insertStorageEventWithPreviousValue(
+  input: RecordStorageEventInput,
+  d: Kysely<Database>,
+  shouldLookupPreviousValue: boolean
+): Promise<void> {
   // Look up the previous value for this key only when the caller did not supply
   // one. `!== undefined` (not `?? null`) is deliberate: a caller that passes an
   // explicit `previousValue: null` is asserting "there is no prior value" and
@@ -93,8 +111,7 @@ export async function recordStorageEvent(
   // RecordStorageEventInput, so it never binds NULL here (a NULL bind would make
   // `file_name = ?` match nothing regardless of the index).
   let previousValue: string | null = input.previousValue ?? null;
-  const previousValueSupplied = input.previousValue !== undefined;
-  if (!previousValueSupplied && input.key !== null && input.deviceId !== null) {
+  if (shouldLookupPreviousValue) {
     try {
       const q = d
         .selectFrom("storage_events")
@@ -130,8 +147,6 @@ export async function recordStorageEvent(
       previous_value: previousValue,
     })
     .execute();
-
-  cleanupIfNeeded(db);
 }
 
 export async function getStorageEvents(

--- a/src/features/accessibility/BaselineManager.ts
+++ b/src/features/accessibility/BaselineManager.ts
@@ -61,35 +61,22 @@ export class BaselineManager {
   async saveBaseline(screenId: string, violations: WcagViolation[]): Promise<void> {
     const db = this.db;
     const now = new Date().toISOString();
+    const violationsJson = JSON.stringify(violations);
 
-    // Upsert baseline
-    const existing = await db
-      .selectFrom("accessibility_baselines")
-      .select("id")
-      .where("screen_id", "=", screenId)
-      .executeTakeFirst();
-
-    if (existing) {
-      // Update existing baseline
-      await db
-        .updateTable("accessibility_baselines")
-        .set({
-          violations_json: JSON.stringify(violations),
+    await db
+      .insertInto("accessibility_baselines")
+      .values({
+        screen_id: screenId,
+        violations_json: violationsJson,
+        updated_at: now,
+      })
+      .onConflict(oc =>
+        oc.column("screen_id").doUpdateSet({
+          violations_json: violationsJson,
           updated_at: now,
         })
-        .where("screen_id", "=", screenId)
-        .execute();
-    } else {
-      // Insert new baseline
-      await db
-        .insertInto("accessibility_baselines")
-        .values({
-          screen_id: screenId,
-          violations_json: JSON.stringify(violations),
-          updated_at: now,
-        })
-        .execute();
-    }
+      )
+      .execute();
   }
 
   /**

--- a/src/features/featureFlags/FeatureFlagRepository.ts
+++ b/src/features/featureFlags/FeatureFlagRepository.ts
@@ -1,4 +1,6 @@
+import type { Kysely } from "kysely";
 import { ensureMigrations, getDatabase } from "../../db/database";
+import type { Database } from "../../db/types";
 import type { FeatureFlagConfig, FeatureFlagDefinition, FeatureFlagKey } from "./FeatureFlagDefinitions";
 
 export interface FeatureFlagRecord {
@@ -15,38 +17,47 @@ export interface FeatureFlagRepository {
 }
 
 export class SqliteFeatureFlagRepository implements FeatureFlagRepository {
+  private readonly injectedDb: Kysely<Database> | null;
+
+  constructor(db?: Kysely<Database>) {
+    this.injectedDb = db ?? null;
+  }
+
+  private async ensureReady(): Promise<void> {
+    if (!this.injectedDb) {
+      await ensureMigrations();
+    }
+  }
+
+  private getDb(): Kysely<Database> {
+    return this.injectedDb ?? getDatabase();
+  }
+
   async ensureFlags(definitions: FeatureFlagDefinition[]): Promise<void> {
-    await ensureMigrations();
-    const db = getDatabase();
-    const existing = await db
-      .selectFrom("feature_flags")
-      .select(["key"])
-      .execute();
-
-    const existingKeys = new Set(existing.map(row => row.key));
-    const now = new Date().toISOString();
-    const missing = definitions.filter(definition => !existingKeys.has(definition.key));
-
-    if (missing.length === 0) {
+    await this.ensureReady();
+    if (definitions.length === 0) {
       return;
     }
+    const db = this.getDb();
+    const now = new Date().toISOString();
 
     await db
       .insertInto("feature_flags")
       .values(
-        missing.map(definition => ({
+        definitions.map(definition => ({
           key: definition.key,
           enabled: definition.defaultValue ? 1 : 0,
           config_json: definition.defaultConfig ? JSON.stringify(definition.defaultConfig) : null,
           updated_at: now,
         }))
       )
+      .onConflict(oc => oc.column("key").doNothing())
       .execute();
   }
 
   async listFlags(): Promise<FeatureFlagRecord[]> {
-    await ensureMigrations();
-    const db = getDatabase();
+    await this.ensureReady();
+    const db = this.getDb();
     const rows = await db
       .selectFrom("feature_flags")
       .select(["key", "enabled", "config_json", "updated_at"])
@@ -61,39 +72,26 @@ export class SqliteFeatureFlagRepository implements FeatureFlagRepository {
   }
 
   async upsertFlag(key: FeatureFlagKey, enabled: boolean, config?: FeatureFlagConfig | null): Promise<void> {
-    await ensureMigrations();
-    const db = getDatabase();
+    await this.ensureReady();
+    const db = this.getDb();
     const now = new Date().toISOString();
-    const existing = await db
-      .selectFrom("feature_flags")
-      .select(["key"])
-      .where("key", "=", key)
-      .executeTakeFirst();
-
-    if (existing) {
-      const updatePayload: Record<string, unknown> = {
-        enabled: enabled ? 1 : 0,
-        updated_at: now,
-      };
-      if (config !== undefined) {
-        updatePayload.config_json = config ? JSON.stringify(config) : null;
-      }
-      await db
-        .updateTable("feature_flags")
-        .set(updatePayload)
-        .where("key", "=", key)
-        .execute();
-      return;
-    }
+    const configJson = config ? JSON.stringify(config) : null;
 
     await db
       .insertInto("feature_flags")
       .values({
         key,
         enabled: enabled ? 1 : 0,
-        config_json: config ? JSON.stringify(config) : null,
+        config_json: configJson,
         updated_at: now,
       })
+      .onConflict(oc =>
+        oc.column("key").doUpdateSet(eb => ({
+          enabled: enabled ? 1 : 0,
+          config_json: config === undefined ? eb.ref("feature_flags.config_json") : configJson,
+          updated_at: now,
+        }))
+      )
       .execute();
   }
 }

--- a/src/features/memory/MemoryBaselineManager.ts
+++ b/src/features/memory/MemoryBaselineManager.ts
@@ -1,10 +1,9 @@
 import { sql, type Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
-import { Database, MemoryBaseline, NewMemoryBaseline, MemoryBaselineUpdate } from "../../db/types";
+import { Database, MemoryBaseline } from "../../db/types";
 import { logger } from "../../utils/logger";
 import { MemoryMetrics } from "./MemoryMetricsCollector";
 import {
-  exponentialMovingAverage,
   safeDivide,
   getCutoffDate,
   DEFAULT_EMA_ALPHA,
@@ -69,52 +68,12 @@ export class MemoryBaselineManager {
     alpha: number = DEFAULT_EMA_ALPHA
   ): Promise<void> {
     try {
-      const existingBaseline = await this.getBaseline(deviceId, packageName, toolName);
+      const now = new Date().toISOString();
+      const unreachableObjects = metrics.unreachableObjects?.count || 0;
 
-      if (existingBaseline) {
-        // Update existing baseline with exponential moving average
-        const updated: MemoryBaselineUpdate = {
-          java_heap_baseline_mb: exponentialMovingAverage(
-            existingBaseline.java_heap_baseline_mb,
-            metrics.postSnapshot.javaHeapMb,
-            alpha
-          ),
-          native_heap_baseline_mb: exponentialMovingAverage(
-            existingBaseline.native_heap_baseline_mb,
-            metrics.postSnapshot.nativeHeapMb,
-            alpha
-          ),
-          gc_count_baseline: exponentialMovingAverage(
-            existingBaseline.gc_count_baseline,
-            metrics.gcCount,
-            alpha
-          ),
-          gc_duration_baseline_ms: exponentialMovingAverage(
-            existingBaseline.gc_duration_baseline_ms,
-            metrics.gcTotalDurationMs,
-            alpha
-          ),
-          unreachable_objects_baseline: exponentialMovingAverage(
-            existingBaseline.unreachable_objects_baseline,
-            metrics.unreachableObjects?.count || 0,
-            alpha
-          ),
-          sample_count: existingBaseline.sample_count + 1,
-          last_updated: new Date().toISOString(),
-        };
-
-        await this.db
-          .updateTable("memory_baselines")
-          .set(updated)
-          .where("id", "=", existingBaseline.id)
-          .execute();
-
-        logger.info(
-          `[MemoryBaselineManager] Updated baseline for ${packageName}/${toolName} (sample ${updated.sample_count})`
-        );
-      } else {
-        // Create new baseline
-        const newBaseline: NewMemoryBaseline = {
+      await this.db
+        .insertInto("memory_baselines")
+        .values({
           device_id: deviceId,
           package_name: packageName,
           tool_name: toolName,
@@ -122,20 +81,26 @@ export class MemoryBaselineManager {
           native_heap_baseline_mb: metrics.postSnapshot.nativeHeapMb,
           gc_count_baseline: metrics.gcCount,
           gc_duration_baseline_ms: metrics.gcTotalDurationMs,
-          unreachable_objects_baseline: metrics.unreachableObjects?.count || 0,
+          unreachable_objects_baseline: unreachableObjects,
           sample_count: 1,
-          last_updated: new Date().toISOString(),
-        };
+          last_updated: now,
+        })
+        .onConflict(oc =>
+          oc.columns(["device_id", "package_name", "tool_name"]).doUpdateSet({
+            java_heap_baseline_mb: sql<number>`${alpha} * ${metrics.postSnapshot.javaHeapMb} + (1 - ${alpha}) * java_heap_baseline_mb`,
+            native_heap_baseline_mb: sql<number>`${alpha} * ${metrics.postSnapshot.nativeHeapMb} + (1 - ${alpha}) * native_heap_baseline_mb`,
+            gc_count_baseline: sql<number>`${alpha} * ${metrics.gcCount} + (1 - ${alpha}) * gc_count_baseline`,
+            gc_duration_baseline_ms: sql<number>`${alpha} * ${metrics.gcTotalDurationMs} + (1 - ${alpha}) * gc_duration_baseline_ms`,
+            unreachable_objects_baseline: sql<number>`${alpha} * ${unreachableObjects} + (1 - ${alpha}) * unreachable_objects_baseline`,
+            sample_count: sql<number>`sample_count + 1`,
+            last_updated: now,
+          })
+        )
+        .execute();
 
-        await this.db
-          .insertInto("memory_baselines")
-          .values(newBaseline)
-          .execute();
-
-        logger.info(
-          `[MemoryBaselineManager] Created new baseline for ${packageName}/${toolName}`
-        );
-      }
+      logger.info(
+        `[MemoryBaselineManager] Upserted baseline for ${packageName}/${toolName}`
+      );
     } catch (error) {
       logger.error(`[MemoryBaselineManager] Failed to update baseline: ${error}`);
       throw error;

--- a/src/features/memory/MemoryThresholdManager.ts
+++ b/src/features/memory/MemoryThresholdManager.ts
@@ -336,6 +336,7 @@ export class MemoryThresholdManager {
     passed: boolean
   ): Promise<void> {
     try {
+      await this.cleanupExpiredThresholds(deviceId);
       const adjustedWeight = passed
         ? sql<number>`min(weight * ${WEIGHT_BOUNDS.successMultiplier}, ${WEIGHT_BOUNDS.max})`
         : sql<number>`max(weight * ${WEIGHT_BOUNDS.failureMultiplier}, ${WEIGHT_BOUNDS.min})`;
@@ -345,6 +346,7 @@ export class MemoryThresholdManager {
         .where("id", "=", sql<number>`(
           select id from memory_thresholds
           where device_id = ${deviceId} and package_name = ${packageName}
+            and datetime(created_at, '+' || ttl_hours || ' hours') >= datetime('now')
           order by created_at desc
           limit 1
         )`)

--- a/src/features/memory/MemoryThresholdManager.ts
+++ b/src/features/memory/MemoryThresholdManager.ts
@@ -5,7 +5,6 @@ import { logger } from "../../utils/logger";
 import { sql } from "kysely";
 import { MemoryBaseline } from "../../db/types";
 import {
-  adjustWeight,
   calculateWeightedAverage,
   WEIGHT_BOUNDS,
   DEFAULT_TTL,
@@ -66,8 +65,15 @@ export class MemoryThresholdManager {
    * Clean up expired thresholds based on TTL
    */
   async cleanupExpiredThresholds(deviceId: string): Promise<void> {
+    await this.cleanupExpiredThresholdsWith(this.db, deviceId);
+  }
+
+  private async cleanupExpiredThresholdsWith(
+    db: Kysely<Database>,
+    deviceId: string
+  ): Promise<void> {
     try {
-      const deleted = await this.db
+      const deleted = await db
         .deleteFrom("memory_thresholds")
         .where("device_id", "=", deviceId)
         .where(
@@ -94,9 +100,17 @@ export class MemoryThresholdManager {
     deviceId: string,
     packageName: string
   ): Promise<MemoryThresholds[]> {
-    await this.cleanupExpiredThresholds(deviceId);
+    return this.getValidThresholdsWith(this.db, deviceId, packageName);
+  }
 
-    const thresholds = await this.db
+  private async getValidThresholdsWith(
+    db: Kysely<Database>,
+    deviceId: string,
+    packageName: string
+  ): Promise<MemoryThresholds[]> {
+    await this.cleanupExpiredThresholdsWith(db, deviceId);
+
+    const thresholds = await db
       .selectFrom("memory_thresholds")
       .selectAll()
       .where("device_id", "=", deviceId)
@@ -200,54 +214,79 @@ export class MemoryThresholdManager {
     gcDurationThresholdMs: number;
     unreachableObjectsThreshold: number;
   }> {
+    const db = this.db;
+    const run = async (executor: Kysely<Database>) => {
     // Try to get existing weighted thresholds
-    const existingThresholds = await this.getValidThresholds(deviceId, packageName);
+      const existingThresholds = await this.getValidThresholdsWith(executor, deviceId, packageName);
 
-    if (existingThresholds.length > 0) {
-      const weighted = this.calculateWeightedAverageThresholds(existingThresholds);
-      if (weighted) {
-        logger.info(
-          `[MemoryThresholdManager] Using weighted average of ${existingThresholds.length} threshold entries for ${packageName}`
-        );
-        return {
-          heapGrowthThresholdMb: weighted.heap_growth_threshold_mb,
-          nativeHeapGrowthThresholdMb: weighted.native_heap_growth_threshold_mb,
-          gcCountThreshold: weighted.gc_count_threshold,
-          gcDurationThresholdMs: weighted.gc_duration_threshold_ms,
-          unreachableObjectsThreshold: weighted.unreachable_objects_threshold,
-        };
+      if (existingThresholds.length > 0) {
+        const weighted = this.calculateWeightedAverageThresholds(existingThresholds);
+        if (weighted) {
+          logger.info(
+            `[MemoryThresholdManager] Using weighted average of ${existingThresholds.length} threshold entries for ${packageName}`
+          );
+          return {
+            heapGrowthThresholdMb: weighted.heap_growth_threshold_mb,
+            nativeHeapGrowthThresholdMb: weighted.native_heap_growth_threshold_mb,
+            gcCountThreshold: weighted.gc_count_threshold,
+            gcDurationThresholdMs: weighted.gc_duration_threshold_ms,
+            unreachableObjectsThreshold: weighted.unreachable_objects_threshold,
+          };
+        }
       }
-    }
 
-    // Try to create adaptive thresholds from baseline
-    if (baseline && baseline.sample_count >= 3) {
+      // Try to create adaptive thresholds from baseline
+      if (baseline && baseline.sample_count >= 3) {
+        logger.info(
+          `[MemoryThresholdManager] Creating adaptive thresholds from baseline for ${packageName} (${baseline.sample_count} samples)`
+        );
+        const adaptiveThresholds = this.createThresholdsFromBaseline(baseline);
+
+        // Store these thresholds for future use
+        await this.storeThresholdsWith(executor, deviceId, packageName, adaptiveThresholds);
+
+        return adaptiveThresholds;
+      }
+
+      // Fall back to default profile
       logger.info(
-        `[MemoryThresholdManager] Creating adaptive thresholds from baseline for ${packageName} (${baseline.sample_count} samples)`
+        `[MemoryThresholdManager] Using default '${profile}' profile for ${packageName}`
       );
-      const adaptiveThresholds = this.createThresholdsFromBaseline(baseline);
+      const defaultThresholds = DEFAULT_THRESHOLDS[profile];
 
-      // Store these thresholds for future use
-      await this.storeThresholds(deviceId, packageName, adaptiveThresholds);
+      // Store defaults for future weight adjustment
+      await this.storeThresholdsWith(executor, deviceId, packageName, defaultThresholds);
 
-      return adaptiveThresholds;
+      return defaultThresholds;
+    };
+
+    if (db.isTransaction) {
+      return run(db);
     }
-
-    // Fall back to default profile
-    logger.info(
-      `[MemoryThresholdManager] Using default '${profile}' profile for ${packageName}`
-    );
-    const defaultThresholds = DEFAULT_THRESHOLDS[profile];
-
-    // Store defaults for future weight adjustment
-    await this.storeThresholds(deviceId, packageName, defaultThresholds);
-
-    return defaultThresholds;
+    return db.transaction().execute(run);
   }
 
   /**
    * Store new thresholds for a device/package
    */
   async storeThresholds(
+    deviceId: string,
+    packageName: string,
+    thresholds: {
+      heapGrowthThresholdMb: number;
+      nativeHeapGrowthThresholdMb: number;
+      gcCountThreshold: number;
+      gcDurationThresholdMs: number;
+      unreachableObjectsThreshold: number;
+    },
+    weight: number = 1.0,
+    ttlHours: number = 24
+  ): Promise<void> {
+    await this.storeThresholdsWith(this.db, deviceId, packageName, thresholds, weight, ttlHours);
+  }
+
+  private async storeThresholdsWith(
+    db: Kysely<Database>,
     deviceId: string,
     packageName: string,
     thresholds: {
@@ -273,7 +312,7 @@ export class MemoryThresholdManager {
     };
 
     try {
-      await this.db
+      await db
         .insertInto("memory_thresholds")
         .values(newThresholds)
         .execute();
@@ -297,28 +336,29 @@ export class MemoryThresholdManager {
     passed: boolean
   ): Promise<void> {
     try {
-      const thresholds = await this.getValidThresholds(deviceId, packageName);
+      const adjustedWeight = passed
+        ? sql<number>`min(weight * ${WEIGHT_BOUNDS.successMultiplier}, ${WEIGHT_BOUNDS.max})`
+        : sql<number>`max(weight * ${WEIGHT_BOUNDS.failureMultiplier}, ${WEIGHT_BOUNDS.min})`;
+      const result = await this.db
+        .updateTable("memory_thresholds")
+        .set({ weight: adjustedWeight })
+        .where("id", "=", sql<number>`(
+          select id from memory_thresholds
+          where device_id = ${deviceId} and package_name = ${packageName}
+          order by created_at desc
+          limit 1
+        )`)
+        .executeTakeFirst();
 
-      if (thresholds.length === 0) {
+      if (Number(result.numUpdatedRows) === 0) {
         logger.warn(
           `[MemoryThresholdManager] No thresholds found for ${packageName} on device ${deviceId}`
         );
         return;
       }
 
-      // Update the most recent threshold
-      const mostRecent = thresholds[0];
-      const currentWeight = mostRecent.weight;
-      const newWeight = adjustWeight(currentWeight, passed);
-
-      await this.db
-        .updateTable("memory_thresholds")
-        .set({ weight: newWeight })
-        .where("id", "=", mostRecent.id)
-        .execute();
-
       logger.debug(
-        `[MemoryThresholdManager] Updated threshold weight from ${currentWeight.toFixed(2)} to ${newWeight.toFixed(2)} for ${packageName} (${passed ? "passed" : "failed"})`
+        `[MemoryThresholdManager] Updated threshold weight for ${packageName} (${passed ? "passed" : "failed"})`
       );
     } catch (error) {
       logger.warn(`[MemoryThresholdManager] Failed to update threshold weight: ${error}`);

--- a/src/features/performance/ThresholdManager.ts
+++ b/src/features/performance/ThresholdManager.ts
@@ -290,6 +290,7 @@ export class ThresholdManager {
     passed: boolean
   ): Promise<void> {
     try {
+      await this.cleanupExpiredThresholds(deviceId);
       const adjustedWeight = passed
         ? sql<number>`min(weight * ${WEIGHT_BOUNDS.successMultiplier}, ${WEIGHT_BOUNDS.max})`
         : sql<number>`max(weight * ${WEIGHT_BOUNDS.failureMultiplier}, ${WEIGHT_BOUNDS.min})`;
@@ -299,6 +300,7 @@ export class ThresholdManager {
         .where("id", "=", sql<number>`(
           select id from performance_thresholds
           where device_id = ${deviceId} and session_id = ${sessionId}
+            and datetime(created_at, '+' || ttl_hours || ' hours') >= datetime('now')
           order by created_at desc
           limit 1
         )`)

--- a/src/features/performance/ThresholdManager.ts
+++ b/src/features/performance/ThresholdManager.ts
@@ -5,7 +5,6 @@ import { logger } from "../../utils/logger";
 import { DeviceCapabilities, DeviceCapabilitiesDetector } from "../../utils/DeviceCapabilities";
 import { sql } from "kysely";
 import {
-  adjustWeight,
   calculateWeightedAverage,
   calculateMode,
   WEIGHT_BOUNDS,
@@ -48,9 +47,16 @@ export class ThresholdManager {
    * Clean up expired thresholds based on TTL
    */
   async cleanupExpiredThresholds(deviceId: string): Promise<void> {
+    await this.cleanupExpiredThresholdsWith(this.db, deviceId);
+  }
+
+  private async cleanupExpiredThresholdsWith(
+    db: Kysely<Database>,
+    deviceId: string
+  ): Promise<void> {
     try {
       // Delete thresholds where created_at + ttl_hours < now
-      const deleted = await this.db
+      const deleted = await db
         .deleteFrom("performance_thresholds")
         .where("device_id", "=", deviceId)
         .where(
@@ -72,11 +78,18 @@ export class ThresholdManager {
    * Get valid (non-expired) thresholds for a device
    */
   async getValidThresholds(deviceId: string): Promise<PerformanceThresholds[]> {
+    return this.getValidThresholdsWith(this.db, deviceId);
+  }
+
+  private async getValidThresholdsWith(
+    db: Kysely<Database>,
+    deviceId: string
+  ): Promise<PerformanceThresholds[]> {
     // First cleanup expired thresholds
-    await this.cleanupExpiredThresholds(deviceId);
+    await this.cleanupExpiredThresholdsWith(db, deviceId);
 
     // Get all valid thresholds
-    const thresholds = await this.db
+    const thresholds = await db
       .selectFrom("performance_thresholds")
       .selectAll()
       .where("device_id", "=", deviceId)
@@ -156,43 +169,71 @@ export class ThresholdManager {
     cpuUsageThresholdPercent: number;
     touchLatencyThresholdMs: number;
   }> {
+    const db = this.db;
+    const run = async (executor: Kysely<Database>) => {
     // Get existing valid thresholds
-    const existingThresholds = await this.getValidThresholds(deviceId);
+      const existingThresholds = await this.getValidThresholdsWith(executor, deviceId);
 
-    // If we have existing thresholds, calculate weighted average
-    if (existingThresholds.length > 0) {
-      const weighted = this.calculateWeightedAverageThresholds(existingThresholds);
-      if (weighted) {
-        logger.info(
-          `[ThresholdManager] Using weighted average of ${existingThresholds.length} threshold entries for device ${deviceId}`
-        );
-        return {
-          frameTimeThresholdMs: weighted.frame_time_threshold_ms,
-          p50ThresholdMs: weighted.p50_threshold_ms,
-          p90ThresholdMs: weighted.p90_threshold_ms,
-          p95ThresholdMs: weighted.p95_threshold_ms,
-          p99ThresholdMs: weighted.p99_threshold_ms,
-          jankCountThreshold: weighted.jank_count_threshold,
-          cpuUsageThresholdPercent: weighted.cpu_usage_threshold_percent,
-          touchLatencyThresholdMs: weighted.touch_latency_threshold_ms,
-        };
+      // If we have existing thresholds, calculate weighted average
+      if (existingThresholds.length > 0) {
+        const weighted = this.calculateWeightedAverageThresholds(existingThresholds);
+        if (weighted) {
+          logger.info(
+            `[ThresholdManager] Using weighted average of ${existingThresholds.length} threshold entries for device ${deviceId}`
+          );
+          return {
+            frameTimeThresholdMs: weighted.frame_time_threshold_ms,
+            p50ThresholdMs: weighted.p50_threshold_ms,
+            p90ThresholdMs: weighted.p90_threshold_ms,
+            p95ThresholdMs: weighted.p95_threshold_ms,
+            p99ThresholdMs: weighted.p99_threshold_ms,
+            jankCountThreshold: weighted.jank_count_threshold,
+            cpuUsageThresholdPercent: weighted.cpu_usage_threshold_percent,
+            touchLatencyThresholdMs: weighted.touch_latency_threshold_ms,
+          };
+        }
       }
+
+      // No existing thresholds, create new ones based on device capabilities
+      logger.info(`[ThresholdManager] Creating new thresholds for device ${deviceId}`);
+      const defaultThresholds = DeviceCapabilitiesDetector.calculateDefaultThresholds(capabilities);
+
+      // Store the new thresholds
+      await this.storeThresholdsWith(executor, deviceId, capabilities, defaultThresholds);
+
+      return defaultThresholds;
+    };
+
+    if (db.isTransaction) {
+      return run(db);
     }
-
-    // No existing thresholds, create new ones based on device capabilities
-    logger.info(`[ThresholdManager] Creating new thresholds for device ${deviceId}`);
-    const defaultThresholds = DeviceCapabilitiesDetector.calculateDefaultThresholds(capabilities);
-
-    // Store the new thresholds
-    await this.storeThresholds(deviceId, capabilities, defaultThresholds);
-
-    return defaultThresholds;
+    return db.transaction().execute(run);
   }
 
   /**
    * Store new thresholds for a device
    */
   async storeThresholds(
+    deviceId: string,
+    capabilities: DeviceCapabilities,
+    thresholds: {
+      frameTimeThresholdMs: number;
+      p50ThresholdMs: number;
+      p90ThresholdMs: number;
+      p95ThresholdMs: number;
+      p99ThresholdMs: number;
+      jankCountThreshold: number;
+      cpuUsageThresholdPercent: number;
+      touchLatencyThresholdMs: number;
+    },
+    weight: number = 1.0,
+    ttlHours: number = 24
+  ): Promise<void> {
+    await this.storeThresholdsWith(this.db, deviceId, capabilities, thresholds, weight, ttlHours);
+  }
+
+  private async storeThresholdsWith(
+    db: Kysely<Database>,
     deviceId: string,
     capabilities: DeviceCapabilities,
     thresholds: {
@@ -227,7 +268,7 @@ export class ThresholdManager {
     };
 
     try {
-      await this.db
+      await db
         .insertInto("performance_thresholds")
         .values(newThresholds)
         .execute();
@@ -249,33 +290,27 @@ export class ThresholdManager {
     passed: boolean
   ): Promise<void> {
     try {
-      // Get current thresholds for this session
-      const threshold = await this.db
-        .selectFrom("performance_thresholds")
-        .selectAll()
-        .where("device_id", "=", deviceId)
-        .where("session_id", "=", sessionId)
-        .orderBy("created_at", "desc")
-        .limit(1)
+      const adjustedWeight = passed
+        ? sql<number>`min(weight * ${WEIGHT_BOUNDS.successMultiplier}, ${WEIGHT_BOUNDS.max})`
+        : sql<number>`max(weight * ${WEIGHT_BOUNDS.failureMultiplier}, ${WEIGHT_BOUNDS.min})`;
+      const result = await this.db
+        .updateTable("performance_thresholds")
+        .set({ weight: adjustedWeight })
+        .where("id", "=", sql<number>`(
+          select id from performance_thresholds
+          where device_id = ${deviceId} and session_id = ${sessionId}
+          order by created_at desc
+          limit 1
+        )`)
         .executeTakeFirst();
 
-      if (!threshold) {
+      if (Number(result.numUpdatedRows) === 0) {
         logger.warn(`[ThresholdManager] No threshold found for device ${deviceId} session ${sessionId}`);
         return;
       }
 
-      // Adjust weight based on result using shared utility
-      const currentWeight = threshold.weight;
-      const newWeight = adjustWeight(currentWeight, passed);
-
-      await this.db
-        .updateTable("performance_thresholds")
-        .set({ weight: newWeight })
-        .where("id", "=", threshold.id)
-        .execute();
-
       logger.debug(
-        `[ThresholdManager] Updated threshold weight from ${currentWeight.toFixed(2)} to ${newWeight.toFixed(2)} (${passed ? "passed" : "failed"})`
+        `[ThresholdManager] Updated threshold weight (${passed ? "passed" : "failed"})`
       );
     } catch (error) {
       logger.warn(`[ThresholdManager] Failed to update threshold weight: ${error}`);

--- a/test/db/dbConcurrencyAudit.test.ts
+++ b/test/db/dbConcurrencyAudit.test.ts
@@ -78,6 +78,10 @@ describe("DB concurrency RMW audit", () => {
       ["AppearanceConfigRepository.setConfig", "Atomic upsert on the singleton `key`"],
       ["DeviceSnapshotConfigRepository.setConfig", "Atomic upsert on the singleton `key`"],
       ["VideoRecordingConfigRepository.setConfig", "Atomic upsert on the singleton `key`"],
+      ["SqliteFeatureFlagRepository.ensureFlags", "Atomic insert with `ON CONFLICT(key) DO NOTHING`"],
+      ["SqliteFeatureFlagRepository.upsertFlag", "Atomic upsert on `feature_flags.key`"],
+      ["recordStorageEvent", "omitted previous-value lookup plus insert runs in one transaction"],
+      ["NavigationRepository.promoteSuggestion", "Direct repository calls open a transaction"],
     ] as const;
 
     expect(tablePathsInSection(audit, "Guarded Paths")).toEqual(
@@ -88,37 +92,28 @@ describe("DB concurrency RMW audit", () => {
       expect(audit).toContain(strategy);
     }
 
-    const followUpPaths = [
-      ["SqliteFeatureFlagRepository.ensureFlags", "Concurrent first initialization can race"],
-      ["SqliteFeatureFlagRepository.upsertFlag", "Concurrent first writes can race"],
-      ["recordStorageEvent", "Concurrent inserts can observe the same prior value"],
-      ["NavigationRepository.promoteSuggestion", "the repository method itself does not enforce that contract"],
+    expect(tablePathsInSection(audit, "Follow-Up Candidates")).toEqual([]);
+    expect(audit).toContain("No unguarded repository RMW follow-up candidates remain from #3415.");
+
+    const guardedAdjacentPaths = [
+      ["ThresholdManager.getOrCreateThresholds", "runs in a short transaction"],
+      ["MemoryThresholdManager.getOrCreateThresholds", "runs in a short transaction"],
+      ["BaselineManager.saveBaseline", "Atomic upsert on the unique `screen_id`"],
+      ["MemoryBaselineManager.updateBaseline", "sample count increments and EMA calculations happen in SQL"],
+      ["ThresholdManager.updateThresholdWeight", "Atomic SQL update of the latest `(device_id, session_id)`"],
+      ["MemoryThresholdManager.updateThresholdWeight", "Atomic SQL update of the latest `(device_id, package_name)`"],
     ] as const;
 
-    expect(tablePathsInSection(audit, "Follow-Up Candidates")).toEqual(
-      followUpPaths.map(([path]) => path)
+    expect(tablePathsInSection(audit, "Guarded Adjacent Paths")).toEqual(
+      guardedAdjacentPaths.map(([path]) => path)
     );
-    for (const [path, status] of followUpPaths) {
+    for (const [path, status] of guardedAdjacentPaths) {
       expect(audit).toContain(`| \`${path}\` |`);
       expect(audit).toContain(status);
     }
 
-    const adjacentFollowUpPaths = [
-      ["ThresholdManager.getOrCreateThresholds", "Concurrent callers can insert duplicate threshold samples"],
-      ["MemoryThresholdManager.getOrCreateThresholds", "Concurrent callers can insert duplicate threshold samples"],
-      ["BaselineManager.saveBaseline", "Concurrent first saves can race on the unique key"],
-      ["MemoryBaselineManager.updateBaseline", "Concurrent updates can lose samples/averages"],
-      ["ThresholdManager.updateThresholdWeight", "Concurrent updates can lose weight adjustments"],
-      ["MemoryThresholdManager.updateThresholdWeight", "Concurrent updates can lose weight adjustments"],
-    ] as const;
-
-    expect(tablePathsInSection(audit, "Adjacent Follow-Up Candidates")).toEqual(
-      adjacentFollowUpPaths.map(([path]) => path)
-    );
-    for (const [path, status] of adjacentFollowUpPaths) {
-      expect(audit).toContain(`| \`${path}\` |`);
-      expect(audit).toContain(status);
-    }
+    expect(tablePathsInSection(audit, "Adjacent Follow-Up Candidates")).toEqual([]);
+    expect(audit).toContain("No unguarded adjacent manager RMW follow-up candidates remain from #3415.");
   });
 
   test("stresses guarded get-or-create and increment paths through the real dialect mutex", async () => {

--- a/test/db/dbRmwFollowups.test.ts
+++ b/test/db/dbRmwFollowups.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { sql, type Kysely } from "kysely";
+import { BaselineManager } from "../../src/features/accessibility/BaselineManager";
+import { SqliteFeatureFlagRepository } from "../../src/features/featureFlags/FeatureFlagRepository";
+import type { FeatureFlagDefinition } from "../../src/features/featureFlags/FeatureFlagDefinitions";
+import { MemoryBaselineManager } from "../../src/features/memory/MemoryBaselineManager";
+import type { MemoryMetrics } from "../../src/features/memory/MemoryMetricsCollector";
+import { MemoryThresholdManager } from "../../src/features/memory/MemoryThresholdManager";
+import { ThresholdManager } from "../../src/features/performance/ThresholdManager";
+import type { DeviceCapabilities } from "../../src/utils/DeviceCapabilities";
+import { NavigationRepository } from "../../src/db/navigationRepository";
+import { getStorageEvents, recordStorageEvent } from "../../src/db/storageEventRepository";
+import type { Database } from "../../src/db/types";
+import type { WcagViolation } from "../../src/models/AccessibilityAudit";
+import { runConcurrentSameKeyStress } from "./concurrencyStressHelper";
+import { createTestDatabase } from "./testDbHelper";
+
+describe("DB RMW follow-up fixes (#3415)", () => {
+  const N = 8;
+  const openDbs: Kysely<Database>[] = [];
+
+  afterEach(async () => {
+    await Promise.all(openDbs.splice(0).map(db => db.destroy()));
+  });
+
+  async function openDb(): Promise<Kysely<Database>> {
+    const db = await createTestDatabase();
+    openDbs.push(db);
+    return db;
+  }
+
+  const featureDefinitions: FeatureFlagDefinition[] = [
+    {
+      key: "debug",
+      label: "Debug",
+      description: "debug flag",
+      defaultValue: false,
+    },
+    {
+      key: "accessibility-audit",
+      label: "Accessibility",
+      description: "accessibility flag",
+      defaultValue: true,
+      defaultConfig: { level: "AA" },
+    },
+  ];
+
+  function violation(fingerprint: string): WcagViolation {
+    return {
+      type: "missing-content-description",
+      severity: "error",
+      criterion: "1.1.1",
+      message: "Missing content description",
+      element: { bounds: { left: 0, top: 0, right: 10, bottom: 10 } },
+      fingerprint,
+    };
+  }
+
+  function memoryMetrics(value: number): MemoryMetrics {
+    return {
+      preSnapshot: {
+        javaHeapMb: value,
+        nativeHeapMb: value,
+        totalPssMb: value,
+        timestamp: 1000,
+        raw: "",
+      },
+      postSnapshot: {
+        javaHeapMb: value,
+        nativeHeapMb: value,
+        totalPssMb: value,
+        timestamp: 2000,
+        raw: "",
+      },
+      javaHeapGrowthMb: 0,
+      nativeHeapGrowthMb: 0,
+      totalPssGrowthMb: 0,
+      gcEvents: [],
+      gcCount: value,
+      gcTotalDurationMs: value,
+      unreachableObjects: { count: value, sizeKb: value, raw: "" },
+    };
+  }
+
+  const capabilities: DeviceCapabilities = {
+    refreshRate: 60,
+    frameTimeMs: 1000 / 60,
+  };
+
+  test("feature flag initialization is idempotent under concurrent first initialization", async () => {
+    const db = await openDb();
+    const repository = new SqliteFeatureFlagRepository(db);
+
+    await runConcurrentSameKeyStress({
+      count: N,
+      act: () => repository.ensureFlags(featureDefinitions),
+    });
+
+    const flags = await repository.listFlags();
+    expect(flags.map(flag => flag.key).sort()).toEqual(["accessibility-audit", "debug"]);
+    expect(flags.find(flag => flag.key === "accessibility-audit")?.config).toEqual({
+      level: "AA",
+    });
+  });
+
+  test("feature flag upsert is atomic under concurrent first writes", async () => {
+    const db = await openDb();
+    const repository = new SqliteFeatureFlagRepository(db);
+
+    await runConcurrentSameKeyStress({
+      count: N,
+      act: index =>
+        repository.upsertFlag("debug", index % 2 === 0, { writer: index }),
+    });
+
+    const flags = await repository.listFlags();
+    expect(flags).toHaveLength(1);
+    expect(flags[0].key).toBe("debug");
+    expect(flags[0].config).toHaveProperty("writer");
+  });
+
+  test("storage previous-value auto-lookup serializes lookup and insert", async () => {
+    const db = await openDb();
+    await recordStorageEvent(
+      {
+        deviceId: "device-1",
+        timestamp: 1000,
+        applicationId: null,
+        sessionId: null,
+        fileName: "prefs.xml",
+        key: "theme",
+        value: "seed",
+        valueType: null,
+        changeType: "add",
+      },
+      db
+    );
+
+    await runConcurrentSameKeyStress({
+      count: N,
+      act: index =>
+        recordStorageEvent(
+          {
+            deviceId: "device-1",
+            timestamp: 2000 + index,
+            applicationId: null,
+            sessionId: null,
+            fileName: "prefs.xml",
+            key: "theme",
+            value: `value-${index}`,
+            valueType: null,
+            changeType: "modify",
+          },
+          db
+        ),
+    });
+
+    const events = await getStorageEvents({ deviceId: "device-1", limit: N + 1 }, db);
+    const concurrentEvents = events.filter(event => event.value !== "seed");
+    expect(concurrentEvents).toHaveLength(N);
+    expect(concurrentEvents.filter(event => event.previousValue === "seed")).toHaveLength(1);
+  });
+
+  test("direct suggestion promotion rolls back the fingerprint when linking fails", async () => {
+    const db = await openDb();
+    const repository = new NavigationRepository(db);
+    await repository.getOrCreateApp("com.example.app");
+    const node = await repository.getOrCreateNode("com.example.app", "Settings", 1000);
+    const suggestion = await repository.addOrUpdateSuggestion(
+      "com.example.app",
+      "settings-fingerprint",
+      "{}",
+      2000
+    );
+    await sql`
+      CREATE TRIGGER fail_promote_update
+      BEFORE UPDATE OF promoted_to_fingerprint_id ON navigation_suggestions
+      WHEN NEW.promoted_to_fingerprint_id IS NOT NULL
+      BEGIN
+        SELECT RAISE(ABORT, 'injected promote failure');
+      END
+    `.execute(db);
+
+    await expect(repository.promoteSuggestion(suggestion.id, node.id, 3000)).rejects.toThrow(
+      /injected promote failure/
+    );
+
+    const fingerprints = await db
+      .selectFrom("navigation_node_fingerprints")
+      .selectAll()
+      .execute();
+    expect(fingerprints).toHaveLength(0);
+  });
+
+  test("accessibility baseline saves use one row under concurrent first saves", async () => {
+    const db = await openDb();
+    const manager = new BaselineManager(db);
+
+    await runConcurrentSameKeyStress({
+      count: N,
+      act: index => manager.saveBaseline("screen-1", [violation(`fp-${index}`)]),
+    });
+
+    const rows = await db.selectFrom("accessibility_baselines").selectAll().execute();
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0].violations_json)).toHaveLength(1);
+  });
+
+  test("memory baseline updates do not lose samples under concurrency", async () => {
+    const db = await openDb();
+    const manager = new MemoryBaselineManager(db);
+
+    await runConcurrentSameKeyStress({
+      count: N,
+      act: () => manager.updateBaseline("device-1", "com.example.app", "tapOn", memoryMetrics(10)),
+    });
+
+    const baseline = await manager.getBaseline("device-1", "com.example.app", "tapOn");
+    expect(baseline?.sample_count).toBe(N);
+    expect(baseline?.java_heap_baseline_mb).toBe(10);
+  });
+
+  test("performance thresholds get-or-create stores one initial threshold under concurrency", async () => {
+    const db = await openDb();
+    const manager = new ThresholdManager(db);
+
+    await runConcurrentSameKeyStress({
+      count: N,
+      act: () => manager.getOrCreateThresholds("device-1", capabilities),
+    });
+
+    const rows = await db.selectFrom("performance_thresholds").selectAll().execute();
+    expect(rows).toHaveLength(1);
+  });
+
+  test("performance threshold weight updates do not lose concurrent adjustments", async () => {
+    const db = await openDb();
+    const manager = new ThresholdManager(db);
+    await manager.storeThresholds("device-1", capabilities, {
+      frameTimeThresholdMs: 16,
+      p50ThresholdMs: 12,
+      p90ThresholdMs: 16,
+      p95ThresholdMs: 20,
+      p99ThresholdMs: 25,
+      jankCountThreshold: 5,
+      cpuUsageThresholdPercent: 80,
+      touchLatencyThresholdMs: 32,
+    });
+
+    await runConcurrentSameKeyStress({
+      count: 3,
+      act: () => manager.updateThresholdWeight("device-1", new Date().toISOString().split("T")[0], true),
+    });
+
+    const row = await db.selectFrom("performance_thresholds").selectAll().executeTakeFirstOrThrow();
+    expect(row.weight).toBeCloseTo(1.331);
+  });
+
+  test("memory thresholds get-or-create stores one initial threshold under concurrency", async () => {
+    const db = await openDb();
+    const manager = new MemoryThresholdManager(db);
+
+    await runConcurrentSameKeyStress({
+      count: N,
+      act: () => manager.getOrCreateThresholds("device-1", "com.example.app"),
+    });
+
+    const rows = await db.selectFrom("memory_thresholds").selectAll().execute();
+    expect(rows).toHaveLength(1);
+  });
+
+  test("memory threshold weight updates do not lose concurrent adjustments", async () => {
+    const db = await openDb();
+    const manager = new MemoryThresholdManager(db);
+    await manager.storeThresholds("device-1", "com.example.app", {
+      heapGrowthThresholdMb: 50,
+      nativeHeapGrowthThresholdMb: 30,
+      gcCountThreshold: 10,
+      gcDurationThresholdMs: 500,
+      unreachableObjectsThreshold: 1000,
+    });
+
+    await runConcurrentSameKeyStress({
+      count: 3,
+      act: () => manager.updateThresholdWeight("device-1", "com.example.app", true),
+    });
+
+    const row = await db.selectFrom("memory_thresholds").selectAll().executeTakeFirstOrThrow();
+    expect(row.weight).toBeCloseTo(1.331);
+  });
+});

--- a/test/db/dbRmwFollowups.test.ts
+++ b/test/db/dbRmwFollowups.test.ts
@@ -274,6 +274,35 @@ describe("DB RMW follow-up fixes (#3415)", () => {
     expect(row.weight).toBeCloseTo(1.331);
   });
 
+  test("performance threshold weight update ignores expired threshold rows", async () => {
+    const db = await openDb();
+    const manager = new ThresholdManager(db);
+    await db
+      .insertInto("performance_thresholds")
+      .values({
+        device_id: "device-1",
+        session_id: "expired-session",
+        refresh_rate: 60,
+        frame_time_threshold_ms: 16,
+        p50_threshold_ms: 12,
+        p90_threshold_ms: 16,
+        p95_threshold_ms: 20,
+        p99_threshold_ms: 25,
+        jank_count_threshold: 5,
+        cpu_usage_threshold_percent: 80,
+        touch_latency_threshold_ms: 32,
+        weight: 1,
+        ttl_hours: 1,
+        created_at: "2000-01-01T00:00:00.000Z",
+      })
+      .execute();
+
+    await manager.updateThresholdWeight("device-1", "expired-session", true);
+
+    const rows = await db.selectFrom("performance_thresholds").selectAll().execute();
+    expect(rows).toHaveLength(0);
+  });
+
   test("memory thresholds get-or-create stores one initial threshold under concurrency", async () => {
     const db = await openDb();
     const manager = new MemoryThresholdManager(db);
@@ -305,5 +334,30 @@ describe("DB RMW follow-up fixes (#3415)", () => {
 
     const row = await db.selectFrom("memory_thresholds").selectAll().executeTakeFirstOrThrow();
     expect(row.weight).toBeCloseTo(1.331);
+  });
+
+  test("memory threshold weight update ignores expired threshold rows", async () => {
+    const db = await openDb();
+    const manager = new MemoryThresholdManager(db);
+    await db
+      .insertInto("memory_thresholds")
+      .values({
+        device_id: "device-1",
+        package_name: "com.example.app",
+        heap_growth_threshold_mb: 50,
+        native_heap_growth_threshold_mb: 30,
+        gc_count_threshold: 10,
+        gc_duration_threshold_ms: 500,
+        unreachable_objects_threshold: 1000,
+        weight: 1,
+        ttl_hours: 1,
+        created_at: "2000-01-01T00:00:00.000Z",
+      })
+      .execute();
+
+    await manager.updateThresholdWeight("device-1", "com.example.app", true);
+
+    const rows = await db.selectFrom("memory_thresholds").selectAll().execute();
+    expect(rows).toHaveLength(0);
   });
 });

--- a/test/db/dbRmwFollowups.test.ts
+++ b/test/db/dbRmwFollowups.test.ts
@@ -119,6 +119,24 @@ describe("DB RMW follow-up fixes (#3415)", () => {
     expect(flags[0].config).toHaveProperty("writer");
   });
 
+  test("feature flag upsert preserves existing config when config is omitted", async () => {
+    const db = await openDb();
+    const repository = new SqliteFeatureFlagRepository(db);
+
+    await repository.upsertFlag("debug", true, { writer: "initial" });
+    await repository.upsertFlag("debug", false);
+
+    const flags = await repository.listFlags();
+    expect(flags).toEqual([
+      {
+        key: "debug",
+        enabled: false,
+        config: { writer: "initial" },
+        updatedAt: expect.any(String),
+      },
+    ]);
+  });
+
   test("storage previous-value auto-lookup serializes lookup and insert", async () => {
     const db = await openDb();
     await recordStorageEvent(

--- a/test/db/dbRmwFollowups.test.ts
+++ b/test/db/dbRmwFollowups.test.ts
@@ -177,6 +177,12 @@ describe("DB RMW follow-up fixes (#3415)", () => {
     const concurrentEvents = events.filter(event => event.value !== "seed");
     expect(concurrentEvents).toHaveLength(N);
     expect(concurrentEvents.filter(event => event.previousValue === "seed")).toHaveLength(1);
+    expect(concurrentEvents.every(event => event.previousValue !== null)).toBe(true);
+    expect(
+      concurrentEvents
+        .filter(event => event.previousValue !== "seed")
+        .every(event => event.previousValue?.startsWith("value-"))
+    ).toBe(true);
   });
 
   test("direct suggestion promotion rolls back the fingerprint when linking fails", async () => {


### PR DESCRIPTION
## Summary

Fixes the remaining DB-backed read-modify-write paths found by the #3405 concurrency audit. The changes replace same-key first-write races with atomic upserts where unique keys exist, and use short DB-only transactions where a read-derived insert/update must be serialized.

## Linked Issue

Closes #3415

## Bug / Regression Context

- **Prior attempts:** #3405 / PR #3413 audited these paths and intentionally filed follow-ups instead of fixing them in the audit PR.
- **Observed symptom:** Concurrent same-key callers could race first inserts, duplicate initial threshold samples, leave partial navigation promotion writes, or lose weight/sample updates.
- **Repro steps / conditions:** Parallel in-process tool/session calls share the Bun SQLite connection mutex, which serializes individual statements but releases across awaited SELECT-then-write sequences.

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun test test/db/dbRmwFollowups.test.ts test/db/dbConcurrencyAudit.test.ts`
- [x] New code uses injected in-memory DB tests; unit tests run in <100ms per case
- [x] Merged latest `origin/main`, conflicts resolved

## Device Verification

N/A; DB concurrency hardening with in-memory database regression coverage.

## Follow-ups

No follow-up gaps identified.