### PR TITLE
perf: fold observe element collection traversal

### DIFF
--- a/src/features/observe/ObserveElementCollector.ts
+++ b/src/features/observe/ObserveElementCollector.ts
@@ -1,6 +1,6 @@
 import type { ObserveResult, ViewHierarchyNode, ViewHierarchyResult } from "../../models";
 import type { Element } from "../../models/Element";
-import { hasAccessibilityAction } from "../../utils/elementProperties";
+import { isClickableElementProperties } from "../../utils/elementProperties";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../utility/ElementParser";
 import { FlattenedElementEntry, IdentifyMediaViews } from "./IdentifyMediaViews";
@@ -59,7 +59,7 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
       }
 
       const nodeProperties = this.parser.extractNodeProperties(node);
-      if (this.isClickableNode(nodeProperties)) {
+      if (isClickableElementProperties(nodeProperties)) {
         collections.clickable.push(parsedNode);
       }
       if (nodeProperties.scrollable === "true" || nodeProperties.scrollable === true) {
@@ -76,9 +76,4 @@ export class DefaultObserveElementCollector implements ObserveElementCollector {
     });
   }
 
-  private isClickableNode(props: Record<string, unknown>): boolean {
-    return props.clickable === "true" ||
-      props.clickable === true ||
-      hasAccessibilityAction(props.actions, "click");
-  }
 }

--- a/src/features/observe/ObserveElementCollector.ts
+++ b/src/features/observe/ObserveElementCollector.ts
@@ -1,0 +1,84 @@
+import type { ObserveResult, ViewHierarchyNode, ViewHierarchyResult } from "../../models";
+import type { Element } from "../../models/Element";
+import { hasAccessibilityAction } from "../../utils/elementProperties";
+import type { ElementParser } from "../../utils/interfaces/ElementParser";
+import { DefaultElementParser } from "../utility/ElementParser";
+import { FlattenedElementEntry, IdentifyMediaViews } from "./IdentifyMediaViews";
+
+export interface ObserveElementCollector {
+  collect(viewHierarchy: ViewHierarchyResult, platform: "android" | "ios"): ObserveResult["elements"];
+}
+
+export class DefaultObserveElementCollector implements ObserveElementCollector {
+  constructor(
+    private readonly parser: ElementParser = new DefaultElementParser(),
+    private readonly mediaClassifier: IdentifyMediaViews = new IdentifyMediaViews(parser)
+  ) {}
+
+  collect(viewHierarchy: ViewHierarchyResult, platform: "android" | "ios"): ObserveResult["elements"] {
+    const clickable: Element[] = [];
+    const scrollable: Element[] = [];
+    const flattenedEntries: FlattenedElementEntry[] = [];
+    let currentIndex = 0;
+
+    const rootNodes = [
+      ...this.parser.extractRootNodes(viewHierarchy),
+      ...this.parser.extractWindowRootNodes(viewHierarchy, "topmost-first")
+    ];
+
+    for (const rootNode of rootNodes) {
+      this.collectFromRoot(rootNode, {
+        clickable,
+        scrollable,
+        flattenedEntries,
+        nextIndex: () => currentIndex++
+      });
+    }
+
+    const text = flattenedEntries
+      .filter(entry => typeof entry.text === "string" && entry.text.trim().length > 0)
+      .map(entry => entry.element);
+    const media = this.mediaClassifier.classify(viewHierarchy, platform, flattenedEntries);
+
+    return { clickable, scrollable, text, media };
+  }
+
+  private collectFromRoot(
+    rootNode: ViewHierarchyNode,
+    collections: {
+      clickable: Element[];
+      scrollable: Element[];
+      flattenedEntries: FlattenedElementEntry[];
+      nextIndex: () => number;
+    }
+  ): void {
+    this.parser.traverseNode(rootNode, (node: ViewHierarchyNode, depth: number) => {
+      const parsedNode = this.parser.parseNodeBounds(node);
+      if (!parsedNode) {
+        return;
+      }
+
+      const nodeProperties = this.parser.extractNodeProperties(node);
+      if (this.isClickableNode(nodeProperties)) {
+        collections.clickable.push(parsedNode);
+      }
+      if (nodeProperties.scrollable === "true" || nodeProperties.scrollable === true) {
+        collections.scrollable.push(parsedNode);
+      }
+
+      const accessibilityText = nodeProperties.text || nodeProperties["content-desc"] || undefined;
+      collections.flattenedEntries.push({
+        element: parsedNode,
+        index: collections.nextIndex(),
+        depth,
+        text: accessibilityText
+      });
+    });
+  }
+
+  private isClickableNode(props: Record<string, unknown>): boolean {
+    return props.clickable === "true" ||
+      props.clickable === true ||
+      hasAccessibilityAction(props.actions, "click");
+  }
+}

--- a/src/features/observe/ObserveElementsBuilder.ts
+++ b/src/features/observe/ObserveElementsBuilder.ts
@@ -1,37 +1,23 @@
 import { ObserveResult, ViewHierarchyResult } from "../../models";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
-import { DefaultElementFinder } from "../utility/ElementFinder";
 import { DefaultElementParser } from "../utility/ElementParser";
 import { IdentifyMediaViews } from "./IdentifyMediaViews";
+import { DefaultObserveElementCollector, ObserveElementCollector } from "./ObserveElementCollector";
 
 export class ObserveElementsBuilder {
-  private finder: ElementFinder;
-  private parser: ElementParser;
-  private mediaClassifier: IdentifyMediaViews;
+  private collector: ObserveElementCollector;
 
   constructor(
-    finder: ElementFinder = new DefaultElementFinder(),
+    _finder?: ElementFinder,
     parser: ElementParser = new DefaultElementParser(),
-    mediaClassifier: IdentifyMediaViews = new IdentifyMediaViews()
+    mediaClassifier: IdentifyMediaViews = new IdentifyMediaViews(parser),
+    collector: ObserveElementCollector = new DefaultObserveElementCollector(parser, mediaClassifier)
   ) {
-    this.finder = finder;
-    this.parser = parser;
-    this.mediaClassifier = mediaClassifier;
+    this.collector = collector;
   }
 
   build(viewHierarchy: ViewHierarchyResult, platform: "android" | "ios" = "android"): ObserveResult["elements"] {
-    const clickable = this.finder.findClickableElements(viewHierarchy);
-    const scrollable = this.finder.findScrollableElements(viewHierarchy);
-    const flattenedEntries = this.parser.flattenViewHierarchy(viewHierarchy, {
-      includeWindows: true,
-      windowOrder: "topmost-first"
-    });
-    const text = flattenedEntries
-      .filter(entry => typeof entry.text === "string" && entry.text.trim().length > 0)
-      .map(entry => entry.element);
-    const media = this.mediaClassifier.classify(viewHierarchy, platform, flattenedEntries);
-
-    return { clickable, scrollable, text, media };
+    return this.collector.collect(viewHierarchy, platform);
   }
 }

--- a/src/features/observe/ObserveElementsBuilder.ts
+++ b/src/features/observe/ObserveElementsBuilder.ts
@@ -1,18 +1,11 @@
 import { ObserveResult, ViewHierarchyResult } from "../../models";
-import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
-import type { ElementParser } from "../../utils/interfaces/ElementParser";
-import { DefaultElementParser } from "../utility/ElementParser";
-import { IdentifyMediaViews } from "./IdentifyMediaViews";
 import { DefaultObserveElementCollector, ObserveElementCollector } from "./ObserveElementCollector";
 
 export class ObserveElementsBuilder {
   private collector: ObserveElementCollector;
 
   constructor(
-    _finder?: ElementFinder,
-    parser: ElementParser = new DefaultElementParser(),
-    mediaClassifier: IdentifyMediaViews = new IdentifyMediaViews(parser),
-    collector: ObserveElementCollector = new DefaultObserveElementCollector(parser, mediaClassifier)
+    collector: ObserveElementCollector = new DefaultObserveElementCollector()
   ) {
     this.collector = collector;
   }

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -6,7 +6,7 @@ import type { TextMatcher } from "../../utils/interfaces/TextMatcher";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import { DefaultElementParser } from "./ElementParser";
 import { DefaultTextMatcher, normalizeQuotes } from "./TextMatcher";
-import { ANDROID_INPUT_CLASSES, hasAccessibilityAction } from "../../utils/elementProperties";
+import { ANDROID_INPUT_CLASSES, isClickableElementProperties } from "../../utils/elementProperties";
 
 /**
  * Handles searching and selection of elements in view hierarchy
@@ -287,9 +287,7 @@ export class DefaultElementFinder implements ElementFinder {
   }
 
   private isClickableNode(props: Record<string, unknown>): boolean {
-    return props.clickable === "true" ||
-      props.clickable === true ||
-      hasAccessibilityAction(props.actions, "click");
+    return isClickableElementProperties(props);
   }
 
   /**

--- a/src/utils/elementProperties.ts
+++ b/src/utils/elementProperties.ts
@@ -11,6 +11,10 @@ export function hasAccessibilityAction(
   return Array.isArray(value) && value.some(item => item === action);
 }
 
+export function isClickableElementProperties(props: Record<string, unknown>): boolean {
+  return isTruthyFlag(props.clickable) || hasAccessibilityAction(props.actions, "click");
+}
+
 export function buildContainerFromElement(element: Element): { elementId?: string; text?: string } | null {
   if (element["resource-id"]) {
     return { elementId: element["resource-id"] };

--- a/test/features/observe/ObserveElementsBuilder.test.ts
+++ b/test/features/observe/ObserveElementsBuilder.test.ts
@@ -2,11 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { ObserveElementsBuilder } from "../../../src/features/observe/ObserveElementsBuilder";
 import { Element, ViewHierarchyNode, ViewHierarchyResult } from "../../../src/models";
 import { IdentifyMediaViews } from "../../../src/features/observe/IdentifyMediaViews";
-import type { ObserveElementCollector } from "../../../src/features/observe/ObserveElementCollector";
+import { DefaultObserveElementCollector, ObserveElementCollector } from "../../../src/features/observe/ObserveElementCollector";
 import { DefaultElementParser } from "../../../src/features/utility/ElementParser";
 import { DefaultElementFinder } from "../../../src/features/utility/ElementFinder";
-import { FakeElementFinder } from "../../fakes/FakeElementFinder";
-import { FakeElementParser } from "../../fakes/FakeElementParser";
 import { loadAndroidHomeObserve, loadIosFractionalObserve } from "../../fixtures/observe/observeFixture";
 
 const createElement = (bounds: Element["bounds"]): Element => ({
@@ -21,16 +19,6 @@ class TraversalCountingParser extends DefaultElementParser {
       this.rootTraversalStarts++;
     }
     super.traverseNode(node, callback, depth);
-  }
-}
-
-class ThrowingObserveFinder extends FakeElementFinder {
-  override findClickableElements(): Element[] {
-    throw new Error("ObserveElementsBuilder should collect clickable elements from the shared traversal");
-  }
-
-  override findScrollableElements(): Element[] {
-    throw new Error("ObserveElementsBuilder should collect scrollable elements from the shared traversal");
   }
 }
 
@@ -91,7 +79,6 @@ describe("ObserveElementsBuilder", () => {
       bounds: { left: 20, top: 20, right: 30, bottom: 30 }
     };
     const viewHierarchy = { hierarchy: { node: {} } } as ViewHierarchyResult;
-    const fakeParser = new FakeElementParser();
     const fakeCollector = new FakeObserveElementCollector();
     fakeCollector.nextElements = {
       clickable: [clickable],
@@ -100,12 +87,7 @@ describe("ObserveElementsBuilder", () => {
       media: [mediaElement]
     };
 
-    const builder = new ObserveElementsBuilder(
-      new FakeElementFinder(),
-      fakeParser,
-      new IdentifyMediaViews(fakeParser),
-      fakeCollector
-    );
+    const builder = new ObserveElementsBuilder(fakeCollector);
     const elements = builder.build(viewHierarchy, "ios");
 
     expect(fakeCollector.lastViewHierarchy).toBe(viewHierarchy);
@@ -175,9 +157,7 @@ describe("ObserveElementsBuilder", () => {
 
     const parser = new TraversalCountingParser();
     const builder = new ObserveElementsBuilder(
-      new ThrowingObserveFinder(),
-      parser,
-      new IdentifyMediaViews(parser)
+      new DefaultObserveElementCollector(parser, new IdentifyMediaViews(parser))
     );
 
     const elements = builder.build(viewHierarchy, "android");
@@ -239,9 +219,7 @@ describe("ObserveElementsBuilder", () => {
 
     const parser = new TraversalCountingParser();
     const builder = new ObserveElementsBuilder(
-      new ThrowingObserveFinder(),
-      parser,
-      new IdentifyMediaViews(parser)
+      new DefaultObserveElementCollector(parser, new IdentifyMediaViews(parser))
     );
 
     const elements = builder.build(viewHierarchy, "ios");

--- a/test/features/observe/ObserveElementsBuilder.test.ts
+++ b/test/features/observe/ObserveElementsBuilder.test.ts
@@ -1,84 +1,279 @@
 import { describe, expect, test } from "bun:test";
 import { ObserveElementsBuilder } from "../../../src/features/observe/ObserveElementsBuilder";
-import { Element, ViewHierarchyResult } from "../../../src/models";
+import { Element, ViewHierarchyNode, ViewHierarchyResult } from "../../../src/models";
 import { IdentifyMediaViews } from "../../../src/features/observe/IdentifyMediaViews";
+import type { ObserveElementCollector } from "../../../src/features/observe/ObserveElementCollector";
+import { DefaultElementParser } from "../../../src/features/utility/ElementParser";
+import { DefaultElementFinder } from "../../../src/features/utility/ElementFinder";
 import { FakeElementFinder } from "../../fakes/FakeElementFinder";
 import { FakeElementParser } from "../../fakes/FakeElementParser";
+import { loadAndroidHomeObserve, loadIosFractionalObserve } from "../../fixtures/observe/observeFixture";
 
 const createElement = (bounds: Element["bounds"]): Element => ({
   bounds
 });
 
-class CountingElementParser extends FakeElementParser {
-  flattenCallCount = 0;
+class TraversalCountingParser extends DefaultElementParser {
+  rootTraversalStarts = 0;
 
-  override flattenViewHierarchy(
-    viewHierarchy: ViewHierarchyResult,
-    options?: { includeWindows?: boolean; windowOrder?: "topmost-first" | "bottommost-first" }
-  ): Array<{ element: Element; index: number; depth: number; text?: string }> {
-    this.flattenCallCount++;
-    return super.flattenViewHierarchy(viewHierarchy, options);
+  override traverseNode(node: any, callback: (node: any, depth: number) => void, depth: number = 0): void {
+    if (depth === 0) {
+      this.rootTraversalStarts++;
+    }
+    super.traverseNode(node, callback, depth);
   }
 }
 
+class ThrowingObserveFinder extends FakeElementFinder {
+  override findClickableElements(): Element[] {
+    throw new Error("ObserveElementsBuilder should collect clickable elements from the shared traversal");
+  }
+
+  override findScrollableElements(): Element[] {
+    throw new Error("ObserveElementsBuilder should collect scrollable elements from the shared traversal");
+  }
+}
+
+class FakeObserveElementCollector implements ObserveElementCollector {
+  nextElements: ReturnType<ObserveElementCollector["collect"]> = {
+    clickable: [],
+    scrollable: [],
+    text: [],
+    media: []
+  };
+  lastViewHierarchy?: ViewHierarchyResult;
+  lastPlatform?: "android" | "ios";
+
+  collect(viewHierarchy: ViewHierarchyResult, platform: "android" | "ios"): ReturnType<ObserveElementCollector["collect"]> {
+    this.lastViewHierarchy = viewHierarchy;
+    this.lastPlatform = platform;
+    return this.nextElements;
+  }
+}
+
+const node = (attrs: Record<string, unknown>, children?: ViewHierarchyNode[]): ViewHierarchyNode => ({
+  $: attrs,
+  bounds: attrs.bounds as Element["bounds"],
+  ...(children ? { node: children } : {})
+});
+
+const expectBuilderPreservesLegacyFixtureElements = (
+  viewHierarchy: ViewHierarchyResult,
+  platform: "android" | "ios"
+): void => {
+  const parser = new DefaultElementParser();
+  const finder = new DefaultElementFinder(parser);
+  const mediaClassifier = new IdentifyMediaViews(parser);
+  const flattenedEntries = parser.flattenViewHierarchy(viewHierarchy, {
+    includeWindows: true,
+    windowOrder: "topmost-first"
+  });
+  const expected = {
+    clickable: finder.findClickableElements(viewHierarchy),
+    scrollable: finder.findScrollableElements(viewHierarchy),
+    text: flattenedEntries
+      .filter(entry => typeof entry.text === "string" && entry.text.trim().length > 0)
+      .map(entry => entry.element),
+    media: mediaClassifier.classify(viewHierarchy, platform, flattenedEntries)
+  };
+
+  expect(new ObserveElementsBuilder().build(viewHierarchy, platform)).toEqual(expected);
+};
+
 describe("ObserveElementsBuilder", () => {
-  test("builds clickable, scrollable, and text elements with filtering", () => {
+  test("returns the collector output for the requested platform", () => {
     const clickable = createElement({ left: 0, top: 0, right: 10, bottom: 10 });
     const scrollable = createElement({ left: 5, top: 5, right: 15, bottom: 15 });
     const textElement = createElement({ left: 10, top: 10, right: 20, bottom: 20 });
-    const blankTextElement = createElement({ left: 20, top: 20, right: 30, bottom: 30 });
-
-    const fakeFinder = new FakeElementFinder();
-    fakeFinder.nextClickableElements = [clickable];
-    fakeFinder.nextScrollableElements = [scrollable];
-
+    const mediaElement = {
+      className: "UIImageView",
+      mediaType: "image" as const,
+      bounds: { left: 20, top: 20, right: 30, bottom: 30 }
+    };
+    const viewHierarchy = { hierarchy: { node: {} } } as ViewHierarchyResult;
     const fakeParser = new FakeElementParser();
-    fakeParser.nextFlattenedElements = [
-      { element: textElement, index: 0, depth: 0, text: "Hello" },
-      { element: blankTextElement, index: 1, depth: 0, text: "   " },
-      { element: clickable, index: 2, depth: 0 }
-    ];
+    const fakeCollector = new FakeObserveElementCollector();
+    fakeCollector.nextElements = {
+      clickable: [clickable],
+      scrollable: [scrollable],
+      text: [textElement],
+      media: [mediaElement]
+    };
 
-    const builder = new ObserveElementsBuilder(fakeFinder, fakeParser);
-    const elements = builder.build({ hierarchy: { node: {} } } as ViewHierarchyResult);
+    const builder = new ObserveElementsBuilder(
+      new FakeElementFinder(),
+      fakeParser,
+      new IdentifyMediaViews(fakeParser),
+      fakeCollector
+    );
+    const elements = builder.build(viewHierarchy, "ios");
 
+    expect(fakeCollector.lastViewHierarchy).toBe(viewHierarchy);
+    expect(fakeCollector.lastPlatform).toBe("ios");
     expect(elements.clickable).toEqual([clickable]);
     expect(elements.scrollable).toEqual([scrollable]);
     expect(elements.text).toEqual([textElement]);
+    expect(elements.media).toEqual([mediaElement]);
   });
 
-  test("reuses one flattened hierarchy for text and media elements", () => {
-    const clickable = createElement({ left: 0, top: 0, right: 10, bottom: 10 });
-    const scrollable = createElement({ left: 5, top: 5, right: 15, bottom: 15 });
-    const textElement = createElement({ left: 10, top: 10, right: 20, bottom: 20 });
-    const imageElement: Element = {
-      "bounds": { left: 20, top: 20, right: 30, bottom: 30 },
-      "class": "android.widget.ImageView"
+  test("collects Android clickable, scrollable, text, and media elements from one traversal", () => {
+    const clickableButton = node({
+      "bounds": { left: 0, top: 0, right: 40, bottom: 40 },
+      "class": "android.widget.Button",
+      "clickable": "true",
+      "text": "Tap me"
+    });
+    const scrollableList = node({
+      "bounds": { left: 0, top: 45, right: 120, bottom: 200 },
+      "class": "androidx.recyclerview.widget.RecyclerView",
+      "scrollable": true
+    });
+    const blankText = node({
+      "bounds": { left: 0, top: 205, right: 120, bottom: 230 },
+      "class": "android.widget.TextView",
+      "text": "   "
+    });
+    const mainImage = node({
+      "bounds": { left: 50, top: 0, right: 100, bottom: 50 },
+      "class": "android.widget.ImageView",
+      "content-desc": "Hero image",
+      "resource-id": "hero"
+    });
+    const topWindowText = node({
+      "bounds": { left: 0, top: 0, right: 80, bottom: 30 },
+      "class": "android.widget.TextView",
+      "text": "Overlay"
+    });
+    const bottomWindowVideo = node({
+      "bounds": { left: 0, top: 30, right: 80, bottom: 90 },
+      "class": "android.widget.VideoView"
+    });
+    const viewHierarchy: ViewHierarchyResult = {
+      hierarchy: {
+        node: node(
+          { "bounds": { left: 0, top: 0, right: 200, bottom: 300 }, "class": "root" },
+          [clickableButton, scrollableList, blankText, mainImage]
+        )
+      },
+      windows: [
+        {
+          windowLayer: 1,
+          hierarchy: node(
+            { "bounds": { left: 0, top: 0, right: 100, bottom: 100 }, "class": "bottomWindow" },
+            [bottomWindowVideo]
+          )
+        },
+        {
+          windowLayer: 2,
+          hierarchy: node(
+            { "bounds": { left: 0, top: 0, right: 100, bottom: 100 }, "class": "topWindow" },
+            [topWindowText]
+          )
+        }
+      ]
     };
 
-    const fakeFinder = new FakeElementFinder();
-    fakeFinder.nextClickableElements = [clickable];
-    fakeFinder.nextScrollableElements = [scrollable];
-
-    const fakeParser = new CountingElementParser();
-    fakeParser.nextFlattenedElements = [
-      { element: textElement, index: 0, depth: 0, text: "Hello" },
-      { element: imageElement, index: 1, depth: 0 }
-    ];
-
+    const parser = new TraversalCountingParser();
     const builder = new ObserveElementsBuilder(
-      fakeFinder,
-      fakeParser,
-      new IdentifyMediaViews(fakeParser)
+      new ThrowingObserveFinder(),
+      parser,
+      new IdentifyMediaViews(parser)
     );
-    const elements = builder.build({ hierarchy: { node: {} } } as ViewHierarchyResult);
 
-    expect(fakeParser.flattenCallCount).toBe(1);
-    expect(elements.text).toEqual([textElement]);
-    expect(elements.media).toEqual([{
-      className: "android.widget.ImageView",
-      mediaType: "image",
-      bounds: imageElement.bounds
+    const elements = builder.build(viewHierarchy, "android");
+
+    expect(parser.rootTraversalStarts).toBe(3);
+    expect(elements.clickable).toEqual([{
+      ...clickableButton.$,
+      bounds: clickableButton.bounds
     }]);
+    expect(elements.scrollable).toEqual([{
+      ...scrollableList.$,
+      bounds: scrollableList.bounds
+    }]);
+    expect(elements.text).toEqual([
+      { ...clickableButton.$, bounds: clickableButton.bounds },
+      { ...mainImage.$, bounds: mainImage.bounds },
+      { ...topWindowText.$, bounds: topWindowText.bounds }
+    ]);
+    expect(elements.media).toEqual([
+      {
+        className: "android.widget.ImageView",
+        mediaType: "image",
+        bounds: mainImage.bounds,
+        contentDescription: "Hero image",
+        resourceId: "hero"
+      },
+      {
+        className: "android.widget.VideoView",
+        mediaType: "video",
+        bounds: bottomWindowVideo.bounds
+      }
+    ]);
+  });
+
+  test("collects iOS text and media from the shared traversal without adding accessibility-label text", () => {
+    const labelOnlyImage = node({
+      "bounds": { left: 0, top: 0, right: 50, bottom: 50 },
+      "className": "CustomImageWidget",
+      "ios-accessibility-label": "VoiceOver label",
+      "role": "image"
+    });
+    const explicitText = node({
+      "bounds": { left: 0, top: 60, right: 100, bottom: 90 },
+      "className": "UILabel",
+      "text": "Visible label"
+    });
+    const spinner = node({
+      "bounds": { left: 0, top: 100, right: 20, bottom: 120 },
+      "className": "UIActivityIndicatorView"
+    });
+    const viewHierarchy: ViewHierarchyResult = {
+      hierarchy: {
+        node: node(
+          { "bounds": { left: 0, top: 0, right: 200, bottom: 300 }, "className": "root" },
+          [labelOnlyImage, explicitText, spinner]
+        )
+      }
+    };
+
+    const parser = new TraversalCountingParser();
+    const builder = new ObserveElementsBuilder(
+      new ThrowingObserveFinder(),
+      parser,
+      new IdentifyMediaViews(parser)
+    );
+
+    const elements = builder.build(viewHierarchy, "ios");
+
+    expect(parser.rootTraversalStarts).toBe(1);
+    expect(elements.text).toEqual([{ ...explicitText.$, bounds: explicitText.bounds }]);
+    expect(elements.media).toEqual([
+      {
+        className: "CustomImageWidget",
+        mediaType: "image",
+        bounds: labelOnlyImage.bounds
+      },
+      {
+        className: "UIActivityIndicatorView",
+        mediaType: "loading",
+        bounds: spinner.bounds,
+        isLoading: true
+      }
+    ]);
+  });
+
+  test("preserves Android observe fixture element output", () => {
+    const { observe } = loadAndroidHomeObserve();
+    expect(observe.viewHierarchy).toBeDefined();
+
+    expectBuilderPreservesLegacyFixtureElements(observe.viewHierarchy!, "android");
+  });
+
+  test("preserves iOS observe fixture element output", () => {
+    const observe = loadIosFractionalObserve();
+    expect(observe.viewHierarchy).toBeDefined();
+
+    expectBuilderPreservesLegacyFixtureElements(observe.viewHierarchy!, "ios");
   });
 });


### PR DESCRIPTION
## Summary

Fold observe element derivation into a narrow shared collector so clickable, scrollable, text, and media outputs are derived from one parser traversal while preserving the existing output shapes and ordering.

## Linked Issue

Closes #3456

## Bug / Regression Context

- **Prior attempts:** #3452 reused the already-flattened text entries for media, but intentionally left clickable/scrollable traversal folding for this follow-up.
- **Observed symptom:** `ObserveElementsBuilder` still walked the same hierarchy separately for clickable, scrollable, and text/media element derivation.
- **Repro steps / conditions:** Any `observe` call that builds categorized elements from a view hierarchy.

## Validation

- [x] `bun run turbo:validate` passes (`lint` + `build` + full `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, TypeScript observe derivation only
- [x] New code uses interfaces + fakes + FakeTimer; focused unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Acceptance Criteria

- [x] Preserve current `elements.clickable`, `elements.scrollable`, `elements.text`, and `elements.media` outputs for Android and iOS fixtures.
- [x] Add focused tests that prove the builder performs one traversal for all four element collections.
- [x] Keep the existing finder/parser APIs stable by introducing a narrow observe collector interface with fakes.

## Follow-ups

- [ ] None currently identified.

Made with [Cursor](https://cursor.com)