### PR TITLE
Use CryptoKit for WebSocket SHA1

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -102,7 +102,7 @@ public final class AutoMobileNetwork: @unchecked Sendable {
     /// Check if a content type is text-based and eligible for body capture.
     public static func isTextContentType(_ contentType: String?) -> Bool {
         guard let ct = contentType else { return false }
-        let base = ct.components(separatedBy: ";").first?.trimmingCharacters(in: .whitespaces).lowercased() ?? ""
+        let base = ct.split(separator: ";", maxSplits: 1).first?.trimmingCharacters(in: .whitespaces).lowercased() ?? ""
         return textContentTypes.contains(base) || base.hasPrefix("text/")
     }
 

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 import Network
 
 /// Global buffer for SDK events received via HTTP POST.
@@ -806,16 +807,9 @@ class WebSocketConnection: WebSocketResponding {
 
 extension Data {
     func sha1() -> Data {
-        var digest = [UInt8](repeating: 0, count: 20)
-        _ = withUnsafeBytes { bytes in
-            CC_SHA1(bytes.baseAddress, CC_LONG(self.count), &digest)
-        }
-        return Data(digest)
+        Data(Insecure.SHA1.hash(data: self))
     }
 }
-
-// CommonCrypto import for SHA1
-import CommonCrypto
 
 // MARK: - AnyEncodable Helper
 


### PR DESCRIPTION
## Summary
- Replace the CommonCrypto-backed WebSocket SHA1 helper with CryptoKit's `Insecure.SHA1.hash(data:)`.
- Preserve the existing `Data.sha1()` return type used by the WebSocket handshake.

## Test plan
- `cd ios/control-proxy && swift test --filter WebSocketServerTests`


Made with [Cursor](https://cursor.com)