### PR TITLE
Use timers promises for system sleep

### DIFF
--- a/src/utils/SystemTimer.ts
+++ b/src/utils/SystemTimer.ts
@@ -1,3 +1,5 @@
+import { setTimeout as sleep } from "node:timers/promises";
+
 /**
  * Interface for timer utilities
  * Provides sleep/delay functionality and timeout/interval management
@@ -50,7 +52,7 @@ export interface Timer {
  */
 export class SystemTimer implements Timer {
   async sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return sleep(ms);
   }
 
   setTimeout(callback: () => void, ms: number): NodeJS.Timeout {


### PR DESCRIPTION
## Summary
- Replace the hand-written `SystemTimer.sleep` Promise wrapper with `node:timers/promises`.
- Keep the existing `Timer` interface and injected timer call sites intact.

## Test plan
- `bun test test/contracts/runAll.test.ts`
- `bun run typecheck`

Made with [Cursor](https://cursor.com)