### PR TITLE
Use stdlib hex parsing for SDK highlights

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHighlightOverlayManager.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHighlightOverlayManager.swift
@@ -146,9 +146,7 @@ struct SdkHighlightColorComponents: Equatable {
 
     static func parse(hex: String) -> SdkHighlightColorComponents {
         let trimmed = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
-        let scanner = Scanner(string: trimmed)
-        var value: UInt64 = 0
-        guard scanner.scanHexInt64(&value) else {
+        guard let value = UInt64(trimmed, radix: 16) else {
             return SdkHighlightColorComponents(red: 0, green: 0, blue: 0, alpha: 1)
         }
 


### PR DESCRIPTION
## Summary
- Replace Scanner-based SDK highlight color parsing with `UInt64(trimmed, radix: 16)`.
- Preserve existing fallback color and ARGB/RGB component handling.

## Test plan
- `cd ios/auto-mobile-sdk && swift test`


Made with [Cursor](https://cursor.com)