### PR TITLE
Use Map for Android tools dedupe

### DIFF
--- a/src/utils/android-cmdline-tools/detection.ts
+++ b/src/utils/android-cmdline-tools/detection.ts
@@ -448,10 +448,14 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
     logger.warn(`Error detecting Android tools in PATH: ${(error as Error).message}`);
   }
 
-  // Remove duplicates based on path
-  const uniqueLocations = locations.filter((location, index, self) =>
-    index === self.findIndex(l => l.path === location.path)
-  );
+  // Remove duplicates based on path while preserving first-seen ordering.
+  const uniqueLocationsByPath = new Map<string, AndroidToolsLocation>();
+  for (const location of locations) {
+    if (!uniqueLocationsByPath.has(location.path)) {
+      uniqueLocationsByPath.set(location.path, location);
+    }
+  }
+  const uniqueLocations = Array.from(uniqueLocationsByPath.values());
 
   logger.debug(`Detection complete. Found ${uniqueLocations.length} unique Android tools installations.`);
 

--- a/test/utils/android-cmdline-tools/detection.test.ts
+++ b/test/utils/android-cmdline-tools/detection.test.ts
@@ -431,6 +431,33 @@ describe("Android Command Line Tools - Detection", () => {
   });
 
   describe("detectAndroidCommandLineTools", () => {
+    test("should preserve first-seen order when deduplicating by path", async () => {
+      systemDetection.setPlatform("darwin");
+      systemDetection.setEnvVar("ANDROID_SDK_ROOT", "/android/sdk");
+
+      const homebrewPath = "/opt/homebrew/share/android-commandlinetools/cmdline-tools/latest";
+      systemDetection.addExistingFile(homebrewPath);
+      systemDetection.addExistingFile(`${homebrewPath}/bin`);
+      systemDetection.addExistingFile(`${homebrewPath}/bin/sdkmanager`);
+      systemDetection.setExecResponse(`${homebrewPath}/bin/sdkmanager --version`, "1.0\n");
+      systemDetection.setExecResponse("which sdkmanager", `${homebrewPath}/bin/sdkmanager\n`);
+
+      const sdkPath = "/android/sdk/cmdline-tools/latest";
+      systemDetection.addExistingFile("/android/sdk");
+      systemDetection.addExistingFile(sdkPath);
+      systemDetection.addExistingFile(`${sdkPath}/bin`);
+      systemDetection.addExistingFile(`${sdkPath}/bin/sdkmanager`);
+      systemDetection.setExecResponse(`${sdkPath}/bin/sdkmanager --version`, "2.0\n");
+
+      const result = await detectAndroidCommandLineTools(systemDetection);
+
+      expect(result.map(location => normalizePath(location.path))).toEqual([
+        homebrewPath,
+        sdkPath
+      ]);
+      expect(result.map(location => location.source)).toEqual(["homebrew", "android_sdk_root"]);
+    });
+
     test("should handle errors gracefully and continue detection", async () => {
       systemDetection.setPlatform("darwin");
       systemDetection.setHomeDir("/Users/test");


### PR DESCRIPTION
## Summary
- Replace the Android command line tools duplicate-path filter with a first-seen Map pass.
- Add a focused regression test covering duplicate detection paths while preserving discovery order.

## Test plan
- bun run bootstrap:worktree
- bun test test/utils/android-cmdline-tools/detection.test.ts
- bun run typecheck

Made with [Cursor](https://cursor.com)