### PR TITLE
Use structuredClone for internal deep copies

### DIFF
--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -242,7 +242,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     }
 
     if (isRootNode) {
-      const rootCopy = JSON.parse(JSON.stringify(node));
+      const rootCopy = structuredClone(node);
 
       if (node.node) {
         const processedChildren = this.processNodeChildren(node, child => this.filterSingleNode(child));
@@ -291,7 +291,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       return viewHierarchy;
     }
 
-    const result = JSON.parse(JSON.stringify(viewHierarchy));
+    const result = structuredClone(viewHierarchy);
     result.hierarchy = this.filterSingleNode(viewHierarchy.hierarchy, true);
     return result;
   }

--- a/src/utils/PerformanceTracker.ts
+++ b/src/utils/PerformanceTracker.ts
@@ -495,7 +495,7 @@ function removeTimingEntry(parent: TimingData, key: string | number): void {
  */
 function truncateTimingData(timings: TimingData, maxSizeBytes: number): ProcessedTimingData {
   // Make a deep copy to avoid mutating the original
-  const workingCopy = JSON.parse(JSON.stringify(timings)) as TimingData;
+  const workingCopy = structuredClone(timings) as TimingData;
 
   let currentSize = estimateTimingDataSize(workingCopy);
   if (currentSize <= maxSizeBytes) {

--- a/test/features/observe/ViewHierarchy.filter.test.ts
+++ b/test/features/observe/ViewHierarchy.filter.test.ts
@@ -37,4 +37,36 @@ describe("ViewHierarchy filtering", () => {
       "actions": ["click"],
     });
   });
+
+  test("filters a cloned hierarchy without mutating the source", () => {
+    const viewHierarchy = new ViewHierarchy(device, new FakeAdbClientFactory());
+    const source = {
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 1920 },
+          node: [
+            {
+              text: "Keep me",
+              bounds: { left: 10, top: 10, right: 100, bottom: 80 },
+            },
+            {
+              bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+            },
+          ],
+        },
+      },
+    };
+    const originalChildren = source.hierarchy.node.node;
+
+    const result = viewHierarchy.filterViewHierarchy(source);
+
+    expect(result).not.toBe(source);
+    expect(result.hierarchy).not.toBe(source.hierarchy);
+    expect(result.hierarchy.node).toEqual({
+      text: "Keep me",
+      bounds: { left: 10, top: 10, right: 100, bottom: 80 },
+    });
+    expect(source.hierarchy.node.node).toBe(originalChildren);
+    expect(source.hierarchy.node.node).toHaveLength(2);
+  });
 });

--- a/test/utils/PerformanceTracker.test.ts
+++ b/test/utils/PerformanceTracker.test.ts
@@ -397,6 +397,26 @@ describe("PerformanceTracker", function() {
       expect(Math.max(...remainingDurations)).toBeGreaterThan(50);
     });
 
+    test("should truncate a cloned copy without mutating source timings", function() {
+      setMaxPerfTimingSizeBytes(200);
+      const timings: TimingEntry[] = [
+        { name: "large1", durationMs: 100 },
+        { name: "large2", durationMs: 90 },
+        { name: "medium", durationMs: 50 },
+        { name: "small1", durationMs: 10 },
+        { name: "small2", durationMs: 5 },
+        { name: "small3", durationMs: 1 }
+      ];
+      const originalNames = timings.map(entry => entry.name);
+
+      const result = processTimingData(timings);
+
+      expect(result).not.toBeNull();
+      expect(result!.truncated).toBe(true);
+      expect(result!.data).not.toBe(timings);
+      expect(timings.map(entry => entry.name)).toEqual(originalNames);
+    });
+
     test("should set truncated flag when truncation occurs", function() {
       setMaxPerfTimingSizeBytes(100);
 


### PR DESCRIPTION
## Summary
- Replace internal JSON round-trip deep copies with `structuredClone` in view hierarchy filtering and performance timing truncation.
- Add focused tests that filtering/truncation clone their working data without mutating callers' source objects.

## Test plan
- `bun test test/features/observe/ViewHierarchy.filter.test.ts test/utils/PerformanceTracker.test.ts`
- `bun run typecheck`
