### PR TITLE
Use Object.fromEntries for stable object copies

### DIFF
--- a/src/features/navigation/ExploreValidateMode.ts
+++ b/src/features/navigation/ExploreValidateMode.ts
@@ -66,16 +66,12 @@ export function hashEdgeAction(edge: NavigationEdge): string {
   const stableData = {
     toolName: edge.interaction.toolName,
     // Sort args keys for stability, exclude any timestamp-like fields
-    args: Object.keys(edge.interaction.args)
-      .filter(k => !k.toLowerCase().includes("timestamp"))
-      .sort()
-      .reduce(
-        (acc, key) => {
-          acc[key] = edge.interaction!.args[key];
-          return acc;
-        },
-        {} as Record<string, any>
-      ),
+    args: Object.fromEntries(
+      Object.keys(edge.interaction.args)
+        .filter(k => !k.toLowerCase().includes("timestamp"))
+        .sort()
+        .map(key => [key, edge.interaction!.args[key]])
+    ),
     // Include edge type for additional uniqueness
     edgeType: edge.edgeType
   };

--- a/src/utils/predictionUtils.ts
+++ b/src/utils/predictionUtils.ts
@@ -20,12 +20,11 @@ function sortValue(value: unknown): unknown {
   }
   if (value && typeof value === "object") {
     const record = value as Record<string, unknown>;
-    const sortedKeys = Object.keys(record).sort();
-    const sorted: Record<string, unknown> = {};
-    for (const key of sortedKeys) {
-      sorted[key] = sortValue(record[key]);
-    }
-    return sorted;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map(key => [key, sortValue(record[key])])
+    );
   }
   return value;
 }

--- a/test/features/navigation/ExploreValidateMode.test.ts
+++ b/test/features/navigation/ExploreValidateMode.test.ts
@@ -219,6 +219,26 @@ describe("ExploreValidateMode", () => {
 
       expect(hashEdgeAction(edge1)).toBe(hashEdgeAction(edge2));
     });
+
+    test("should hash reordered interaction args identically", () => {
+      const edge1 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Button", enabled: true },
+          timestamp: 1000
+        }
+      });
+
+      const edge2 = createMockEdge("A", "B", {
+        interaction: {
+          toolName: "tapOn",
+          args: { enabled: true, text: "Button" },
+          timestamp: 1000
+        }
+      });
+
+      expect(hashEdgeAction(edge1)).toBe(hashEdgeAction(edge2));
+    });
   });
 
   describe("markNodeVisited", () => {

--- a/test/utils/predictionUtils.test.ts
+++ b/test/utils/predictionUtils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeToolArgs } from "../../src/utils/predictionUtils";
+
+describe("predictionUtils", () => {
+  test("normalizes tool args with stable nested key ordering", () => {
+    const first = normalizeToolArgs({
+      z: 1,
+      nested: { beta: true, alpha: false },
+      a: 2
+    });
+    const second = normalizeToolArgs({
+      a: 2,
+      nested: { alpha: false, beta: true },
+      z: 1
+    });
+
+    expect(first).toBe(second);
+    expect(first).toBe(
+      '{"a":2,"nested":{"alpha":false,"beta":true},"z":1}'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replace manual stable object-copy reductions with `Object.fromEntries` while preserving sorted key insertion order.
- Add focused coverage for reordered navigation args and nested prediction arg normalization.

## Test plan
- `bun run bootstrap:worktree`
- `bun test test/features/navigation/ExploreValidateMode.test.ts test/utils/predictionUtils.test.ts`
- `bun run typecheck`


Made with [Cursor](https://cursor.com)