### PR TITLE
Inject IdGenerator for failure IDs

### DIFF
--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -10,6 +10,7 @@ import type {
 import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
+import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { type DbWriteBarrier, getDbWriteBarrier } from "./dbWriteBarrier";
 import { appendToBucket, chunkBySqliteParameterLimit } from "./sqliteBatch";
 import type {
@@ -162,6 +163,7 @@ export class FailureAnalyticsRepository {
   private timer: Timer;
   private db: Kysely<Database> | null;
   private getBarrier: () => DbWriteBarrier;
+  private idGenerator: IdGenerator;
 
   constructor(
     timer: Timer = defaultTimer,
@@ -170,10 +172,12 @@ export class FailureAnalyticsRepository {
     // same-process DB reopen (resetDbWriteBarrier swaps in a fresh barrier) is
     // seen instead of a pinned drained instance (issue #2912).
     getBarrier: () => DbWriteBarrier = getDbWriteBarrier,
+    idGenerator: IdGenerator = defaultIdGenerator,
   ) {
     this.timer = timer;
     this.db = db ?? null;
     this.getBarrier = getBarrier;
+    this.idGenerator = idGenerator;
   }
 
   private getDb(): Kysely<Database> {
@@ -189,7 +193,7 @@ export class FailureAnalyticsRepository {
   async recordFailure(input: RecordFailureInput): Promise<string> {
     const db = this.getDb();
     const now = this.timer.now();
-    const occurrenceId = crypto.randomUUID();
+    const occurrenceId = this.idGenerator.next();
 
     try {
       await db.transaction().execute(async trx => {
@@ -200,7 +204,7 @@ export class FailureAnalyticsRepository {
         // migration 2026_07_01_000) or both read a stale total_count and clobber
         // (lost increments). A single INSERT ... ON CONFLICT DO UPDATE makes the
         // count bump atomic. The candidate id is used only on the first-seen path.
-        const candidateGroupId = crypto.randomUUID();
+        const candidateGroupId = this.idGenerator.next();
         const nowIso = new Date().toISOString();
 
         const upserted = await trx
@@ -318,7 +322,7 @@ export class FailureAnalyticsRepository {
         // Insert capture if provided
         if (input.capture) {
           const capture: NewFailureCapture = {
-            id: crypto.randomUUID(),
+            id: this.idGenerator.next(),
             occurrence_id: occurrenceId,
             type: input.capture.type,
             path: input.capture.path,

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -12,6 +12,7 @@ import { runMigrations } from "../../src/db/migrator";
 import { createTestDatabase } from "./testDbHelper";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 
 describe("FailureAnalyticsRepository", () => {
   let db: Kysely<Database>;
@@ -76,6 +77,35 @@ describe("FailureAnalyticsRepository", () => {
       expect(notifications[0].type).toBe("crash");
       expect(notifications[0].severity).toBe("critical");
       expect(notifications[0].acknowledged).toBe(0);
+    });
+
+    test("uses injected IdGenerator for persisted IDs", async () => {
+      const idGenerator = new FakeIdGenerator(["occurrence-id", "group-id", "capture-id"]);
+      const deterministicRepo = new FailureAnalyticsRepository(
+        timer,
+        db,
+        () => new FakeDbWriteBarrier(),
+        idGenerator,
+      );
+
+      const occurrenceId = await deterministicRepo.recordFailure(
+        makeFailureInput({
+          capture: {
+            type: "screenshot",
+            path: "/tmp/screenshot.png",
+          },
+        })
+      );
+
+      const groups = await db.selectFrom("failure_groups").selectAll().execute();
+      const occurrences = await db.selectFrom("failure_occurrences").selectAll().execute();
+      const captures = await db.selectFrom("failure_captures").selectAll().execute();
+
+      expect(occurrenceId).toBe("occurrence-id");
+      expect(groups[0].id).toBe("group-id");
+      expect(occurrences[0].id).toBe("occurrence-id");
+      expect(captures[0].id).toBe("capture-id");
+      expect(idGenerator.pendingCount()).toBe(0);
     });
 
     test("updates group count on second occurrence with same signature", async () => {


### PR DESCRIPTION
## Summary
- Inject the shared IdGenerator primitive into FailureAnalyticsRepository.
- Route persisted occurrence, group, and capture IDs through the injected generator for deterministic tests.

## Test plan
- bun test test/db/failureAnalyticsRepository.test.ts
- bun run typecheck


Made with [Cursor](https://cursor.com)