### PR TITLE
Fix junit runner JSON request escaping

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -433,20 +433,19 @@ open class AutoMobileAgent(
       }
     }
 
-    private fun buildJsonParameters(parameters: Map<String, Any>): JsonObject =
-      buildJsonObject {
-        parameters.forEach { (key, value) ->
-          put(
-            key,
-            when (value) {
-              is String -> JsonPrimitive(value)
-              is Number -> JsonPrimitive(value)
-              is Boolean -> JsonPrimitive(value)
-              else -> JsonPrimitive(value.toString())
-            },
-          )
-        }
+    private fun buildJsonParameters(parameters: Map<String, Any>): JsonObject = buildJsonObject {
+      parameters.forEach { (key, value) ->
+        put(
+          key,
+          when (value) {
+            is String -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            is Boolean -> JsonPrimitive(value)
+            else -> JsonPrimitive(value.toString())
+          },
+        )
       }
+    }
 
     private fun testConnection(): Boolean {
       val url = serverUrl ?: return false

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -17,9 +17,12 @@ import java.time.Duration
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 
 /**
  * Handles AI agent loop functionality for AutoMobile test execution using Koog framework.
@@ -346,22 +349,19 @@ open class AutoMobileAgent(
       val url = serverUrl ?: throw RuntimeException("MCP client not connected")
 
       try {
-        // Create the JSON request manually by building the JSON string
-        val paramsJsonBuilder = StringBuilder("{")
-        parameters.entries.forEachIndexed { index, (key, value) ->
-          if (index > 0) paramsJsonBuilder.append(", ")
-          paramsJsonBuilder.append("\"$key\": ")
-          when (value) {
-            is String -> paramsJsonBuilder.append("\"$value\"")
-            is Number -> paramsJsonBuilder.append(value.toString())
-            is Boolean -> paramsJsonBuilder.append(value.toString())
-            else -> paramsJsonBuilder.append("\"$value\"")
-          }
-        }
-        paramsJsonBuilder.append("}")
-
         val requestJson =
-          """{"method":"tools/call","params":{"name":"$toolName","arguments":${paramsJsonBuilder}}}"""
+          koogJson.encodeToString(
+            buildJsonObject {
+              put("method", JsonPrimitive("tools/call"))
+              put(
+                "params",
+                buildJsonObject {
+                  put("name", JsonPrimitive(toolName))
+                  put("arguments", buildJsonParameters(parameters))
+                },
+              )
+            }
+          )
 
         val request =
           HttpRequest.newBuilder()
@@ -395,7 +395,13 @@ open class AutoMobileAgent(
       val url = serverUrl ?: throw RuntimeException("MCP client not connected")
 
       try {
-        val requestJson = """{"method":"tools/list","params":{}}"""
+        val requestJson =
+          koogJson.encodeToString(
+            buildJsonObject {
+              put("method", JsonPrimitive("tools/list"))
+              put("params", JsonObject(emptyMap()))
+            }
+          )
 
         val request =
           HttpRequest.newBuilder()
@@ -426,6 +432,21 @@ open class AutoMobileAgent(
         throw RuntimeException("Failed to list MCP tools: ${e.message}", e)
       }
     }
+
+    private fun buildJsonParameters(parameters: Map<String, Any>): JsonObject =
+      buildJsonObject {
+        parameters.forEach { (key, value) ->
+          put(
+            key,
+            when (value) {
+              is String -> JsonPrimitive(value)
+              is Number -> JsonPrimitive(value)
+              is Boolean -> JsonPrimitive(value)
+              else -> JsonPrimitive(value.toString())
+            },
+          )
+        }
+      }
 
     private fun testConnection(): Boolean {
       val url = serverUrl ?: return false

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonHeartbeat.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonHeartbeat.kt
@@ -8,7 +8,10 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -166,7 +169,8 @@ internal object DaemonHeartbeat {
     connection.readTimeout = 2000
     connection.doOutput = true
 
-    val payload = """{"sessionId":"$sessionId"}"""
+    val payload =
+      json.encodeToString(buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) })
     connection.outputStream.use { it.write(payload.toByteArray()) }
 
     connection.inputStream.use { it.readBytes() }


### PR DESCRIPTION
## Summary
- Replace hand-built junit-runner MCP and heartbeat JSON request strings with kotlinx.serialization JSON builders.
- Preserve existing request object shapes and primitive handling while letting kotlinx.serialization escape string values correctly.

## Test plan
- `./gradlew :junit-runner:test --no-daemon` from `android/`
