### PR TITLE
Fix hermetic CtrlProxy pin hardening

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -305,7 +305,7 @@ export function resolveAssetBaseUrl(env: EnvLike = process.env): string {
         `use a path-only base URL such as ${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}.`
       );
     }
-    return trimmed.replace(/\/+$/, "");
+    return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, "");
   }
   return DEFAULT_ASSET_BASE_URL;
 }

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -12,6 +12,8 @@
  * scripts/generate-release-constants.sh
  */
 
+import { ActionableError } from "../models/ActionableError";
+
 export const LATEST_RELEASE_VERSION = "latest";
 
 export interface ReleaseChecksumEntry {
@@ -289,6 +291,20 @@ export function isPinnedVersionKnown(
 export function resolveAssetBaseUrl(env: EnvLike = process.env): string {
   const trimmed = env[AUTOMOBILE_ASSET_BASE_URL_ENV]?.trim();
   if (trimmed && trimmed.length > 0) {
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      throw new ActionableError(
+        `${AUTOMOBILE_ASSET_BASE_URL_ENV} must be an absolute URL, for example https://mirror.example/auto-mobile.`
+      );
+    }
+    if (parsed.search || parsed.hash) {
+      throw new ActionableError(
+        `${AUTOMOBILE_ASSET_BASE_URL_ENV} must not include a query string or fragment; ` +
+        `use a path-only base URL such as ${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}.`
+      );
+    }
     return trimmed.replace(/\/+$/, "");
   }
   return DEFAULT_ASSET_BASE_URL;

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -299,7 +299,7 @@ export function resolveAssetBaseUrl(env: EnvLike = process.env): string {
         `${AUTOMOBILE_ASSET_BASE_URL_ENV} must be an absolute URL, for example https://mirror.example/auto-mobile.`
       );
     }
-    if (parsed.search || parsed.hash) {
+    if (trimmed.includes("?") || trimmed.includes("#")) {
       throw new ActionableError(
         `${AUTOMOBILE_ASSET_BASE_URL_ENV} must not include a query string or fragment; ` +
         `use a path-only base URL such as ${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}.`

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -18,9 +18,12 @@ import {
 } from "../../daemon/buildIdentity";
 import type { BuildIdentity } from "../../daemon/buildIdentity";
 import {
+  isExplicitPin,
   LATEST_RELEASE_VERSION,
+  resolveApkUrl,
   resolveAssetVersion,
   resolveDaemonInstallSpecifier,
+  resolveIpaUrl,
   resolvePinnedVersion,
 } from "../../constants/release";
 import { getMcpServerVersion } from "../../utils/mcpVersion";
@@ -323,6 +326,10 @@ export async function checkCtrlProxy(
 ): Promise<CheckResult> {
   try {
     const adb = adbFactory.create();
+    // Validate hermetic asset configuration before device-dependent shortcuts so
+    // a malformed mirror fails the doctor gate even on hosts with no Android device.
+    resolveApkUrl();
+    resolveIpaUrl();
     const devices = await adb.getBootedAndroidDevices();
 
     if (devices.length === 0) {
@@ -389,6 +396,15 @@ export async function checkCtrlProxy(
 
     if (versionResult.acceptedPreinstalled) {
       diagnostics.push("acceptedPreinstalled=true");
+    }
+
+    if (versionResult.status === "failed" && isExplicitPin()) {
+      return {
+        name: "CtrlProxy",
+        status: "fail",
+        message: diagnostics.join("; "),
+        recommendation: "CtrlProxy APK provisioning failed for an explicit AutoMobile version pin. Fix the pinned asset source, checksum, or mirror configuration and re-run doctor."
+      };
     }
 
     if (downloadUnavailable) {

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -30,6 +30,7 @@ import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
 import { loadSharp, type SharpFactory } from "../../utils/image/loadSharp";
 import { WebpBinaryResolver, type ResolvedWebpBinaries } from "../../utils/image/webp/WebpBinaryResolver";
 import { logger } from "../../utils/logger";
+import { ActionableError } from "../../models/ActionableError";
 
 const RELEASES_URL = "https://github.com/kaeawc/auto-mobile/releases";
 
@@ -448,6 +449,13 @@ export async function checkCtrlProxy(
         : "Review CtrlProxy installation status",
     };
   } catch (error) {
+    if (error instanceof ActionableError) {
+      return {
+        name: "CtrlProxy",
+        status: "fail",
+        message: error.message,
+      };
+    }
     logger.debug(`CtrlProxy check failed: ${error}`);
     return {
       name: "CtrlProxy",

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -659,6 +659,15 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
           return this.cacheVersionCheckResult(prefetchedUpgradeResult);
         }
 
+        if (AndroidCtrlProxyManager.isKnownExplicitPinConfigured()) {
+          throw new ActionableError(
+            `Installed CtrlProxy APK SHA differs from expected release checksum for ` +
+            `AUTOMOBILE_VERSION=${resolvePinnedVersion()}. Expected: ${expectedSha}, Got: ${installedSha}. ` +
+            `Install the pinned CtrlProxy APK, restart with a matching daemon, or set ` +
+            `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1 to override.`
+          );
+        }
+
         logger.warn("[CTRL_PROXY] Installed APK SHA differs from expected release; accepting preinstalled CtrlProxy for nonblocking readiness", {
           expected: expectedSha,
           actual: installedSha
@@ -1633,6 +1642,13 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       return false;
     }
     return isExplicitPin() && !isPinnedVersionKnown();
+  }
+
+  private static isKnownExplicitPinConfigured(): boolean {
+    if (AndroidCtrlProxyManager.isChecksumSkipConfigured()) {
+      return false;
+    }
+    return isExplicitPin() && isPinnedVersionKnown();
   }
 
   private shouldSkipDownloadIfInstalled(): boolean {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -617,7 +617,12 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     const isInstalled = await this.isInstalled();
     perf.endOperation("checkInstalled");
 
-    if (isInstalled && this.shouldSkipDownloadIfInstalled() && !options.allowDownloadWhenInstalled) {
+    if (
+      isInstalled &&
+      this.shouldSkipDownloadIfInstalled() &&
+      !AndroidCtrlProxyManager.isKnownExplicitPinConfigured() &&
+      !options.allowDownloadWhenInstalled
+    ) {
       logger.warn("[CTRL_PROXY] Skipping APK download/version check (preinstalled APK allowed)");
       return this.cacheVersionCheckResult({
         status: "skipped",

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -660,12 +660,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         }
 
         if (AndroidCtrlProxyManager.isKnownExplicitPinConfigured()) {
-          throw new ActionableError(
-            `Installed CtrlProxy APK SHA differs from expected release checksum for ` +
-            `AUTOMOBILE_VERSION=${resolvePinnedVersion()}. Expected: ${expectedSha}, Got: ${installedSha}. ` +
-            `Install the pinned CtrlProxy APK, restart with a matching daemon, or set ` +
-            `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1 to override.`
-          );
+          throw AndroidCtrlProxyManager.createKnownPinMismatchError(expectedSha, installedSha);
         }
 
         logger.warn("[CTRL_PROXY] Installed APK SHA differs from expected release; accepting preinstalled CtrlProxy for nonblocking readiness", {
@@ -760,6 +755,12 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       logger.warn("[CTRL_PROXY] Completed prefetched APK install failed; verified existing CtrlProxy remains installed for readiness", {
         error: upgradeResult.error || upgradeResult.upgradeError || upgradeResult.reinstallError
       });
+      if (AndroidCtrlProxyManager.isKnownExplicitPinConfigured()) {
+        throw AndroidCtrlProxyManager.createKnownPinMismatchError(
+          result.expectedSha256 ?? "",
+          result.installedSha256
+        );
+      }
       return {
         ...upgradeResult,
         status: "skipped",
@@ -1649,6 +1650,15 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       return false;
     }
     return isExplicitPin() && isPinnedVersionKnown();
+  }
+
+  private static createKnownPinMismatchError(expectedSha: string, installedSha: string | null | undefined): ActionableError {
+    return new ActionableError(
+      `Installed CtrlProxy APK SHA differs from expected release checksum for ` +
+      `AUTOMOBILE_VERSION=${resolvePinnedVersion()}. Expected: ${expectedSha}, Got: ${installedSha ?? "unknown"}. ` +
+      `Install the pinned CtrlProxy APK, restart with a matching daemon, or set ` +
+      `AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1 to override.`
+    );
   }
 
   private shouldSkipDownloadIfInstalled(): boolean {

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -151,6 +151,16 @@ describe("resolveAssetBaseUrl (AUTOMOBILE_ASSET_BASE_URL mirror knob)", function
   test("ignores a blank mirror base", function() {
     expect(resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "  " })).toBe(DEFAULT_ASSET_BASE_URL);
   });
+
+  test("rejects mirror bases with query strings", function() {
+    expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am?token=abc" }))
+      .toThrow("AUTOMOBILE_ASSET_BASE_URL must not include a query string or fragment");
+  });
+
+  test("rejects mirror bases with fragments", function() {
+    expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am#release" }))
+      .toThrow("AUTOMOBILE_ASSET_BASE_URL must not include a query string or fragment");
+  });
 });
 
 describe("resolveApkUrl / resolveIpaUrl (EC1, EC2, EC3)", function() {

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -148,6 +148,13 @@ describe("resolveAssetBaseUrl (AUTOMOBILE_ASSET_BASE_URL mirror knob)", function
       .toBe("https://mirror.test/am");
   });
 
+  test("normalizes parser-accepted mirror bases before URL composition", function() {
+    expect(resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https:mirror.test/am/" }))
+      .toBe("https://mirror.test/am");
+    expect(resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test\\am" }))
+      .toBe("https://mirror.test/am");
+  });
+
   test("ignores a blank mirror base", function() {
     expect(resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "  " })).toBe(DEFAULT_ASSET_BASE_URL);
   });

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -162,6 +162,13 @@ describe("resolveAssetBaseUrl (AUTOMOBILE_ASSET_BASE_URL mirror knob)", function
       .toThrow("AUTOMOBILE_ASSET_BASE_URL must not include a query string or fragment");
   });
 
+  test("rejects mirror bases with empty query or fragment delimiters", function() {
+    expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am?" }))
+      .toThrow("AUTOMOBILE_ASSET_BASE_URL must not include a query string or fragment");
+    expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am#" }))
+      .toThrow("AUTOMOBILE_ASSET_BASE_URL must not include a query string or fragment");
+  });
+
   test("rejects non-absolute mirror bases", function() {
     expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "/mirror/am" }))
       .toThrow("AUTOMOBILE_ASSET_BASE_URL must be an absolute URL");

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -161,6 +161,11 @@ describe("resolveAssetBaseUrl (AUTOMOBILE_ASSET_BASE_URL mirror knob)", function
     expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am#release" }))
       .toThrow("AUTOMOBILE_ASSET_BASE_URL must not include a query string or fragment");
   });
+
+  test("rejects non-absolute mirror bases", function() {
+    expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "/mirror/am" }))
+      .toThrow("AUTOMOBILE_ASSET_BASE_URL must be an absolute URL");
+  });
 });
 
 describe("resolveApkUrl / resolveIpaUrl (EC1, EC2, EC3)", function() {

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -379,6 +379,43 @@ describe("checkCtrlProxy", () => {
     }
   });
 
+  test("fails (not skips) when a known pinned CtrlProxy APK SHA mismatches (#2815)", async () => {
+    const prevVersion = process.env.AUTOMOBILE_VERSION;
+    process.env.AUTOMOBILE_VERSION = "0.0.18";
+    try {
+      fakeAdb.setDevices([{
+        deviceId: "emulator-5554",
+        platform: "android",
+        isEmulator: true,
+        name: "Pixel"
+      }]);
+      fakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell sha256sum", {
+        stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+        stderr: ""
+      });
+
+      const result = await checkCtrlProxy(fakeFactory);
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("Installed CtrlProxy APK SHA differs from expected release checksum");
+      expect(result.message).toContain("AUTOMOBILE_VERSION=0.0.18");
+    } finally {
+      if (prevVersion === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = prevVersion;
+      }
+    }
+  });
+
   test("warns when installed and enabled CtrlProxy is stale but accepted for readiness", async () => {
     AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
     const originalDefaultDownloader = (AndroidCtrlProxyManager as any).defaultFileDownloader;

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -19,6 +19,10 @@ import { getMcpServerVersion } from "../../src/utils/mcpVersion";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import * as fs from "fs/promises";
+import * as path from "path";
+import AdmZip from "adm-zip";
+import crypto from "crypto";
 
 describe("checkDaemonVersion", () => {
   test("returns pass status", () => {
@@ -352,6 +356,26 @@ describe("checkCtrlProxy", () => {
     expect(result.message).toBe("No Android devices connected");
   });
 
+  test("fails malformed mirror configuration even when no devices are connected (#2815)", async () => {
+    const prevBaseUrl = process.env.AUTOMOBILE_ASSET_BASE_URL;
+    process.env.AUTOMOBILE_ASSET_BASE_URL = "https://mirror.test/am?";
+    try {
+      fakeAdb.setDevices([]);
+
+      const result = await checkCtrlProxy(fakeFactory);
+
+      expect(result.name).toBe("CtrlProxy");
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("AUTOMOBILE_ASSET_BASE_URL must not include a query string or fragment");
+    } finally {
+      if (prevBaseUrl === undefined) {
+        delete process.env.AUTOMOBILE_ASSET_BASE_URL;
+      } else {
+        process.env.AUTOMOBILE_ASSET_BASE_URL = prevBaseUrl;
+      }
+    }
+  });
+
   test("fails (not skips) when AUTOMOBILE_VERSION pins an unverifiable version (#2746)", async () => {
     const prevVersion = process.env.AUTOMOBILE_VERSION;
     process.env.AUTOMOBILE_VERSION = "99.99.99";
@@ -408,6 +432,46 @@ describe("checkCtrlProxy", () => {
       expect(result.message).toContain("Installed CtrlProxy APK SHA differs from expected release checksum");
       expect(result.message).toContain("AUTOMOBILE_VERSION=0.0.18");
     } finally {
+      if (prevVersion === undefined) {
+        delete process.env.AUTOMOBILE_VERSION;
+      } else {
+        process.env.AUTOMOBILE_VERSION = prevVersion;
+      }
+    }
+  });
+
+  test("fails (not warns) when a known pinned CtrlProxy APK download fails checksum verification (#2815)", async () => {
+    const prevVersion = process.env.AUTOMOBILE_VERSION;
+    const originalDefaultDownloader = (AndroidCtrlProxyManager as any).defaultFileDownloader;
+    process.env.AUTOMOBILE_VERSION = "0.0.18";
+    try {
+      (AndroidCtrlProxyManager as any).defaultFileDownloader = {
+        download: async (_url: string, destination: string) => {
+          const zip = new AdmZip();
+          zip.addFile("AndroidManifest.xml", Buffer.from('<?xml version="1.0" encoding="utf-8"?><manifest></manifest>', "utf8"));
+          zip.addFile("classes.dex", crypto.randomBytes(15000));
+          await fs.mkdir(path.dirname(destination), { recursive: true });
+          zip.writeZip(destination);
+        }
+      };
+      fakeAdb.setDevices([{
+        deviceId: "emulator-5554",
+        platform: "android",
+        isEmulator: true,
+        name: "Pixel"
+      }]);
+      fakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+        stdout: "",
+        stderr: ""
+      });
+
+      const result = await checkCtrlProxy(fakeFactory);
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("versionStatus=failed");
+      expect(result.message).toContain("APK checksum verification failed");
+    } finally {
+      (AndroidCtrlProxyManager as any).defaultFileDownloader = originalDefaultDownloader;
       if (prevVersion === undefined) {
         delete process.env.AUTOMOBILE_VERSION;
       } else {

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -373,6 +373,52 @@ describe("CtrlProxyManager", function() {
       expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(false);
     });
 
+    test("fails closed on an installed APK SHA mismatch when a concrete version is pinned (#2815)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "0.0.18";
+      try {
+        const localFakeAdb = new FakeAdbExecutor();
+        localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+          stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+          stderr: ""
+        });
+        localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+          stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+          stderr: ""
+        });
+        localFakeAdb.setCommandResponse("shell sha256sum", {
+          stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+          stderr: ""
+        });
+
+        let downloadCalls = 0;
+        AndroidCtrlProxyManager.resetInstances();
+        const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          localFakeAdb,
+          new FakeTimer(),
+          {
+            download: async () => {
+              downloadCalls++;
+              throw new Error("download should not be called for a hermetic mismatch");
+            }
+          }
+        );
+
+        await expect(manager.ensureCompatibleVersion()).rejects.toThrow(
+          "Installed CtrlProxy APK SHA differs from expected release checksum"
+        );
+        expect(downloadCalls).toBe(0);
+        expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(false);
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
     test("should upgrade when installed SHA mismatches expected and installed download is explicitly allowed", async function() {
       AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
       const localFakeAdb = new FakeAdbExecutor();

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -419,6 +419,57 @@ describe("CtrlProxyManager", function() {
       }
     });
 
+    test("fails closed on a pinned mismatch even when preinstalled download skip is set (#2815)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      const prevSkipDownload = process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED;
+      process.env.AUTOMOBILE_VERSION = "0.0.18";
+      process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED = "true";
+      try {
+        const localFakeAdb = new FakeAdbExecutor();
+        localFakeAdb.setCommandResponse(`shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`, {
+          stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
+          stderr: ""
+        });
+        localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+          stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+          stderr: ""
+        });
+        localFakeAdb.setCommandResponse("shell sha256sum", {
+          stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+          stderr: ""
+        });
+
+        AndroidCtrlProxyManager.resetInstances();
+        const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          localFakeAdb,
+          new FakeTimer(),
+          {
+            download: async () => {
+              throw new Error("download should not be called for a hermetic mismatch");
+            }
+          }
+        );
+
+        await expect(manager.ensureCompatibleVersion()).rejects.toThrow(
+          "Installed CtrlProxy APK SHA differs from expected release checksum"
+        );
+        expect(localFakeAdb.wasCommandExecuted("shell sha256sum")).toBe(true);
+        expect(localFakeAdb.wasCommandExecuted("install -r -d")).toBe(false);
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+        if (prevSkipDownload === undefined) {
+          delete process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED;
+        } else {
+          process.env.AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED = prevSkipDownload;
+        }
+      }
+    });
+
     test("should upgrade when installed SHA mismatches expected and installed download is explicitly allowed", async function() {
       AndroidCtrlProxyManager.setExpectedChecksumForTesting("expected-sha");
       const localFakeAdb = new FakeAdbExecutor();

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -573,6 +573,56 @@ describe("CtrlProxyManager", function() {
       expect(localFakeAdb.wasCommandExecuted(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`)).toBe(true);
     });
 
+    test("fails closed on a pinned mismatch when completed prefetch install fails and old APK remains (#2815)", async function() {
+      const prevVersion = process.env.AUTOMOBILE_VERSION;
+      process.env.AUTOMOBILE_VERSION = "0.0.18";
+      try {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-prefetch-source-"));
+        const prefetchedApkPath = path.join(tempDir, "control-proxy.apk");
+        await fs.writeFile(prefetchedApkPath, Buffer.from("prefetched-apk"));
+        (AndroidCtrlProxyManager as any).prefetchedApkPath = prefetchedApkPath;
+
+        const packageCheckCommand = `shell pm list packages | grep ${AndroidCtrlProxyManager.PACKAGE}`;
+        const localFakeAdb = new FakeAdbExecutor();
+        localFakeAdb.setCommandResponseSequence(packageCheckCommand, [
+          createExecResult(`package:${AndroidCtrlProxyManager.PACKAGE}\n`, ""),
+          createExecResult(`package:${AndroidCtrlProxyManager.PACKAGE}\n`, "")
+        ]);
+        localFakeAdb.setCommandResponse(`shell pm path ${AndroidCtrlProxyManager.PACKAGE}`, {
+          stdout: "package:/data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+          stderr: ""
+        });
+        localFakeAdb.setCommandResponse("shell sha256sum", {
+          stdout: "different-sha /data/app/dev.jasonpearson.automobile.ctrlproxy/base.apk\n",
+          stderr: ""
+        });
+        localFakeAdb.setCommandError("install -r -d", new Error("INSTALL_FAILED_UPDATE_INCOMPATIBLE"));
+        localFakeAdb.setCommandResponse(`shell pm uninstall ${AndroidCtrlProxyManager.PACKAGE}`, createExecResult("Success", ""));
+        localFakeAdb.setCommandError("install \"", new Error("INSTALL_FAILED_ABORTED"));
+
+        const manager = AndroidCtrlProxyManager.createForTestingWithDeps(
+          testDevice,
+          localFakeAdb,
+          new FakeTimer(),
+          {
+            download: async () => {
+              throw new Error("download should not be called for completed prefetch");
+            }
+          }
+        );
+
+        await expect(manager.ensureCompatibleVersion()).rejects.toThrow(
+          "Installed CtrlProxy APK SHA differs from expected release checksum"
+        );
+      } finally {
+        if (prevVersion === undefined) {
+          delete process.env.AUTOMOBILE_VERSION;
+        } else {
+          process.env.AUTOMOBILE_VERSION = prevVersion;
+        }
+      }
+    });
+
     test("prefetch is skipped (no network) for an unknown pin (#2746)", async function() {
       const prevVersion = process.env.AUTOMOBILE_VERSION;
       process.env.AUTOMOBILE_VERSION = "99.99.99";


### PR DESCRIPTION
## Summary

Harden the hermetic pinning trust boundary by failing closed when a concrete `AUTOMOBILE_VERSION` points to a registry-known CtrlProxy APK but the already-installed APK has a different SHA. Also reject `AUTOMOBILE_ASSET_BASE_URL` values with query strings or fragments before they compose malformed asset URLs.

## Linked Issue

Closes #2815

## Bug / Regression Context

- **Prior attempts:** #2748 added daemon-side hermetic pinning and fail-closed behavior for unknown pins, but intentionally left these two pre-existing edges as follow-ups.
- **Observed symptom:** A known checksum mismatch on a preinstalled Android CtrlProxy APK could still be accepted non-blocking, and mirror bases like `https://mirror/am?token=abc` composed to malformed asset paths.
- **Repro steps / conditions:** Set a concrete known `AUTOMOBILE_VERSION` with a mismatched installed APK SHA, or set `AUTOMOBILE_ASSET_BASE_URL` to a value containing `?` or `#`.

## Validation

- [x] `bun test test/constants/release.test.ts test/utils/CtrlProxyManager.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses existing fakes + `FakeTimer`; unit tests run in <100ms

## Follow-ups

None.

Made with [Cursor](https://cursor.com)