### PR TITLE
ci(ios): fail on stale CtrlProxy XcodeGen output

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1221,8 +1221,8 @@ jobs:
       - name: "Install XcodeGen"
         run: brew install xcodegen
 
-      - name: "Generate Xcode Projects"
-        run: ./scripts/ios/xcodegen-generate.sh
+      - name: "Check XcodeGen Project Drift"
+        run: ./scripts/ios/xcodegen-drift-check.sh
 
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
@@ -1269,8 +1269,14 @@ jobs:
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
+      - name: "Install XcodeGen"
+        run: brew install xcodegen
+
       - name: "Install xcpretty"
         run: gem install xcpretty
+
+      - name: "Check XcodeGen Project Drift"
+        run: ./scripts/ios/xcodegen-drift-check.sh
 
       - name: "Build CtrlProxy iOS for Testing"
         run: ./scripts/ios/ctrl-proxy-build-for-testing.sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1222,7 +1222,7 @@ jobs:
         run: brew install xcodegen
 
       - name: "Check XcodeGen Project Drift"
-        run: ./scripts/ios/xcodegen-drift-check.sh
+        run: ./scripts/ios/xcodegen-drift-check.sh --all
 
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
@@ -1275,8 +1275,8 @@ jobs:
       - name: "Install xcpretty"
         run: gem install xcpretty
 
-      - name: "Check XcodeGen Project Drift"
-        run: ./scripts/ios/xcodegen-drift-check.sh
+      - name: "Check CtrlProxy XcodeGen Project Drift"
+        run: ./scripts/ios/xcodegen-drift-check.sh --ctrl-proxy
 
       - name: "Build CtrlProxy iOS for Testing"
         run: ./scripts/ios/ctrl-proxy-build-for-testing.sh

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -15,3 +15,4 @@ Quick reference for AI agents working in `ios/`. Run all commands from the repo 
 ## Notes
 - Use the scripts in `scripts/ios/` instead of invoking Xcode directly.
 - If you need XcodeGen, install it with `brew install xcodegen`.
+- When adding, removing, or renaming files under `ios/control-proxy`, run `scripts/ios/xcodegen-generate.sh` from the repository root and commit the updated `ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj`.

--- a/scripts/ios/xcodegen-drift-check.sh
+++ b/scripts/ios/xcodegen-drift-check.sh
@@ -14,12 +14,13 @@ cd "${PROJECT_ROOT}"
 
 "${SCRIPT_DIR}/xcodegen-generate.sh"
 
-if git diff --quiet -- "${CTRL_PROXY_PROJECT}"; then
+if [ -z "$(git status --porcelain -- "${CTRL_PROXY_PROJECT}")" ]; then
     echo "CtrlProxy.xcodeproj/project.pbxproj is in sync with ios/control-proxy/project.yml"
     exit 0
 fi
 
 echo "Error: CtrlProxy.xcodeproj/project.pbxproj is out of date after xcodegen generation." >&2
 echo "Run scripts/ios/xcodegen-generate.sh and commit the regenerated project file." >&2
+git status --short -- "${CTRL_PROXY_PROJECT}" >&2
 git diff -- "${CTRL_PROXY_PROJECT}" >&2
 exit 1

--- a/scripts/ios/xcodegen-drift-check.sh
+++ b/scripts/ios/xcodegen-drift-check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Regenerates XcodeGen projects and fails if the committed CtrlProxy project file
+# is stale. This catches missing pbxproj updates before Xcode reports confusing
+# compile errors from an out-of-date target file list.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CTRL_PROXY_PROJECT="ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
+
+cd "${PROJECT_ROOT}"
+
+"${SCRIPT_DIR}/xcodegen-generate.sh"
+
+if git diff --quiet -- "${CTRL_PROXY_PROJECT}"; then
+    echo "CtrlProxy.xcodeproj/project.pbxproj is in sync with ios/control-proxy/project.yml"
+    exit 0
+fi
+
+echo "Error: CtrlProxy.xcodeproj/project.pbxproj is out of date after xcodegen generation." >&2
+echo "Run scripts/ios/xcodegen-generate.sh and commit the regenerated project file." >&2
+git diff -- "${CTRL_PROXY_PROJECT}" >&2
+exit 1

--- a/scripts/ios/xcodegen-drift-check.sh
+++ b/scripts/ios/xcodegen-drift-check.sh
@@ -1,26 +1,27 @@
 #!/bin/bash
 #
-# Regenerates XcodeGen projects and fails if the committed CtrlProxy project file
-# is stale. This catches missing pbxproj updates before Xcode reports confusing
-# compile errors from an out-of-date target file list.
+# Regenerates the CtrlProxy XcodeGen project and fails if the committed project
+# file is stale. This catches missing pbxproj updates before Xcode reports
+# confusing compile errors from an out-of-date target file list.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CTRL_PROXY_DIR="${PROJECT_ROOT}/ios/control-proxy"
 CTRL_PROXY_PROJECT="ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
 
+cd "${CTRL_PROXY_DIR}"
+xcodegen generate
+
 cd "${PROJECT_ROOT}"
-
-"${SCRIPT_DIR}/xcodegen-generate.sh"
-
 if [ -z "$(git status --porcelain -- "${CTRL_PROXY_PROJECT}")" ]; then
     echo "CtrlProxy.xcodeproj/project.pbxproj is in sync with ios/control-proxy/project.yml"
     exit 0
 fi
 
 echo "Error: CtrlProxy.xcodeproj/project.pbxproj is out of date after xcodegen generation." >&2
-echo "Run scripts/ios/xcodegen-generate.sh and commit the regenerated project file." >&2
+echo "Run 'cd ios/control-proxy && xcodegen generate' and commit the regenerated project file." >&2
 git status --short -- "${CTRL_PROXY_PROJECT}" >&2
 git diff -- "${CTRL_PROXY_PROJECT}" >&2
 exit 1

--- a/scripts/ios/xcodegen-drift-check.sh
+++ b/scripts/ios/xcodegen-drift-check.sh
@@ -1,27 +1,70 @@
 #!/bin/bash
 #
-# Regenerates the CtrlProxy XcodeGen project and fails if the committed project
-# file is stale. This catches missing pbxproj updates before Xcode reports
-# confusing compile errors from an out-of-date target file list.
+# Regenerates XcodeGen projects and fails if committed project files are stale.
+# Use --ctrl-proxy for the TypeScript-triggered XCTestRunner integration job so
+# unrelated iOS project generation cannot block that narrower path.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+IOS_DIR="${PROJECT_ROOT}/ios"
 CTRL_PROXY_DIR="${PROJECT_ROOT}/ios/control-proxy"
 CTRL_PROXY_PROJECT="ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
+SCOPE="${1:---all}"
 
-cd "${CTRL_PROXY_DIR}"
-xcodegen generate
+usage() {
+    echo "Usage: $0 [--all|--ctrl-proxy]" >&2
+}
+
+collect_all_project_files() {
+    local path
+
+    while IFS= read -r path; do
+        DRIFT_PATHS+=("${path}")
+    done < <(git ls-files "ios/**/project.pbxproj")
+
+    while IFS= read -r path; do
+        path="${path#"${PROJECT_ROOT}"/}"
+        DRIFT_PATHS+=("${path}")
+    done < <(find "${IOS_DIR}" -path "*/project.pbxproj" -type f 2>/dev/null | sort)
+}
 
 cd "${PROJECT_ROOT}"
-if [ -z "$(git status --porcelain -- "${CTRL_PROXY_PROJECT}")" ]; then
-    echo "CtrlProxy.xcodeproj/project.pbxproj is in sync with ios/control-proxy/project.yml"
+
+DRIFT_PATHS=()
+case "${SCOPE}" in
+    --all)
+        "${SCRIPT_DIR}/xcodegen-generate.sh"
+        collect_all_project_files
+        ;;
+    --ctrl-proxy)
+        (cd "${CTRL_PROXY_DIR}" && xcodegen generate)
+        DRIFT_PATHS=("${CTRL_PROXY_PROJECT}")
+        ;;
+    *)
+        usage
+        exit 2
+        ;;
+esac
+
+if [ ${#DRIFT_PATHS[@]} -eq 0 ]; then
+    echo "No XcodeGen project files found to check"
     exit 0
 fi
 
-echo "Error: CtrlProxy.xcodeproj/project.pbxproj is out of date after xcodegen generation." >&2
-echo "Run 'cd ios/control-proxy && xcodegen generate' and commit the regenerated project file." >&2
-git status --short -- "${CTRL_PROXY_PROJECT}" >&2
-git diff -- "${CTRL_PROXY_PROJECT}" >&2
+STATUS_OUTPUT="$(git status --porcelain -- "${DRIFT_PATHS[@]}")"
+if [ -z "${STATUS_OUTPUT}" ]; then
+    echo "XcodeGen project files are in sync"
+    exit 0
+fi
+
+echo "Error: XcodeGen project files are out of date after generation." >&2
+if [ "${SCOPE}" = "--ctrl-proxy" ]; then
+    echo "Run 'cd ios/control-proxy && xcodegen generate' and commit the regenerated project file." >&2
+else
+    echo "Run scripts/ios/xcodegen-generate.sh and commit the regenerated project files." >&2
+fi
+git status --short -- "${DRIFT_PATHS[@]}" >&2
+git diff -- "${DRIFT_PATHS[@]}" >&2
 exit 1

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = join(import.meta.dir, "../..");
+const driftCheckScript = join(repoRoot, "scripts/ios/xcodegen-drift-check.sh");
+const workflowPath = join(repoRoot, ".github/workflows/pull_request.yml");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const tempDir = tempDirs.pop();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+});
+
+function createTempGitRepo(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-xcodegen-drift-"));
+  tempDirs.push(tempDir);
+
+  mkdirSync(join(tempDir, "scripts/ios"), { recursive: true });
+  mkdirSync(join(tempDir, "ios/control-proxy/CtrlProxy.xcodeproj"), { recursive: true });
+  writeFileSync(
+    join(tempDir, "ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"),
+    "committed project\n"
+  );
+  cpSync(driftCheckScript, join(tempDir, "scripts/ios/xcodegen-drift-check.sh"));
+  chmodSync(join(tempDir, "scripts/ios/xcodegen-drift-check.sh"), 0o755);
+
+  expect(spawnSync("git", ["init"], { cwd: tempDir }).status).toBe(0);
+  expect(spawnSync("git", ["add", "ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"], { cwd: tempDir }).status).toBe(0);
+
+  return tempDir;
+}
+
+function writeFakeGenerator(repoDir: string, body: string): void {
+  const generatorPath = join(repoDir, "scripts/ios/xcodegen-generate.sh");
+  writeFileSync(generatorPath, `#!/bin/bash\nset -euo pipefail\n${body}\n`);
+  chmodSync(generatorPath, 0o755);
+}
+
+describe("xcodegen drift check", () => {
+  test("script exists for CI and local validation", () => {
+    expect(existsSync(driftCheckScript)).toBe(true);
+  });
+
+  test("fails when xcodegen generation changes the committed CtrlProxy project", () => {
+    const repoDir = createTempGitRepo();
+    writeFakeGenerator(
+      repoDir,
+      "printf 'regenerated project\\n' > ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
+    );
+
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
+      cwd: repoDir,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is out of date");
+  });
+
+  test("passes when xcodegen generation leaves the committed CtrlProxy project unchanged", () => {
+    const repoDir = createTempGitRepo();
+    writeFakeGenerator(repoDir, "true");
+
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
+      cwd: repoDir,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is in sync");
+  });
+
+  test("pull request workflow gates both Xcode project jobs on the drift check", () => {
+    const workflow = readFileSync(workflowPath, "utf8");
+    const xcodeBuildJob = workflow.indexOf("ios-xcode-build:");
+    const xctestRunnerJob = workflow.indexOf("ios-xctest-runner-simulator-tests:");
+    const xcodeBuildDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh", xcodeBuildJob);
+    const xctestRunnerDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh", xctestRunnerJob);
+    const xctestRunnerBuild = workflow.indexOf("./scripts/ios/ctrl-proxy-build-for-testing.sh", xctestRunnerJob);
+
+    expect(xcodeBuildJob).toBeGreaterThan(-1);
+    expect(xctestRunnerJob).toBeGreaterThan(-1);
+    expect(xcodeBuildDriftCheck).toBeGreaterThan(xcodeBuildJob);
+    expect(xcodeBuildDriftCheck).toBeLessThan(xctestRunnerJob);
+    expect(xctestRunnerDriftCheck).toBeGreaterThan(xctestRunnerJob);
+    expect(xctestRunnerDriftCheck).toBeLessThan(xctestRunnerBuild);
+  });
+});

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -39,13 +39,29 @@ function createTempRepo(): string {
 set -euo pipefail
 project="\${FAKE_REPO_ROOT}/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
 baseline="\${FAKE_REPO_ROOT}/baseline/project.pbxproj"
+tracked_path="ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
 
-if [[ "$1" == "diff" && "\${2:-}" == "--quiet" ]]; then
-    cmp -s "\${baseline}" "\${project}"
-    exit $?
+if [[ "$1" == "status" && "\${2:-}" == "--porcelain" && "\${3:-}" == "--" && "\${4:-}" == "\${tracked_path}" ]]; then
+    if [[ -n "\${FAKE_GIT_STATUS_OUTPUT:-}" ]]; then
+        printf "%s" "\${FAKE_GIT_STATUS_OUTPUT}"
+    elif cmp -s "\${baseline}" "\${project}"; then
+        exit 0
+    else
+        printf " M %s\\n" "\${tracked_path}"
+    fi
+    exit 0
 fi
 
-if [[ "$1" == "diff" ]]; then
+if [[ "$1" == "status" && "\${2:-}" == "--short" && "\${3:-}" == "--" && "\${4:-}" == "\${tracked_path}" ]]; then
+    if [[ -n "\${FAKE_GIT_STATUS_OUTPUT:-}" ]]; then
+        printf "%s" "\${FAKE_GIT_STATUS_OUTPUT}"
+    elif ! cmp -s "\${baseline}" "\${project}"; then
+        printf " M %s\\n" "\${tracked_path}"
+    fi
+    exit 0
+fi
+
+if [[ "$1" == "diff" && "\${2:-}" == "--" && "\${3:-}" == "\${tracked_path}" ]]; then
     if cmp -s "\${baseline}" "\${project}"; then
         exit 0
     fi
@@ -94,6 +110,29 @@ describe("xcodegen drift check", () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is out of date");
+  });
+
+  test("fails when the regenerated CtrlProxy project is untracked after deletion", () => {
+    const repoDir = createTempRepo();
+    writeFakeGenerator(
+      repoDir,
+      "rm -f ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj\nprintf 'committed project\\n' > ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
+    );
+
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
+      cwd: repoDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_REPO_ROOT: repoDir,
+        FAKE_GIT_STATUS_OUTPUT: "?? ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj\n",
+        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is out of date");
+    expect(result.stdout + result.stderr).toContain("?? ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj");
   });
 
   test("passes when xcodegen generation leaves the committed CtrlProxy project unchanged", () => {

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -41,7 +41,25 @@ function createTempRepo(): string {
   chmodSync(join(tempDir, "scripts/ios/xcodegen-drift-check.sh"), 0o755);
   writeFileSync(
     join(tempDir, "scripts/ios/xcodegen-generate.sh"),
-    "#!/bin/bash\necho 'repo-wide xcodegen-generate.sh should not be called' >&2\nexit 2\n"
+    `#!/bin/bash
+set -euo pipefail
+
+case "\${FAKE_REPO_WIDE_GENERATOR_BEHAVIOR:-fail}" in
+    unchanged)
+        ;;
+    modify)
+        printf 'regenerated project\\n' > ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+        ;;
+    fail)
+        echo 'repo-wide xcodegen-generate.sh should not be called' >&2
+        exit 2
+        ;;
+    *)
+        echo "unexpected repo-wide generator behavior: \${FAKE_REPO_WIDE_GENERATOR_BEHAVIOR}" >&2
+        exit 2
+        ;;
+esac
+`
   );
   chmodSync(join(tempDir, "scripts/ios/xcodegen-generate.sh"), 0o755);
   writeFileSync(
@@ -130,10 +148,10 @@ describe("xcodegen drift check", () => {
     expect(existsSync(driftCheckScript)).toBe(true);
   });
 
-  test("fails when xcodegen generation changes the committed CtrlProxy project", () => {
+  test("ctrl-proxy scope fails when xcodegen generation changes the committed CtrlProxy project", () => {
     const repoDir = createTempRepo();
 
-    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
       env: {
@@ -145,13 +163,13 @@ describe("xcodegen drift check", () => {
     });
 
     expectExitStatus(result, 1);
-    expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is out of date");
+    expect(result.stdout + result.stderr).toContain("XcodeGen project files are out of date");
   });
 
-  test("fails when the regenerated CtrlProxy project is untracked after deletion", () => {
+  test("ctrl-proxy scope fails when the regenerated CtrlProxy project is untracked after deletion", () => {
     const repoDir = createTempRepo();
 
-    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
       env: {
@@ -164,14 +182,14 @@ describe("xcodegen drift check", () => {
     });
 
     expectExitStatus(result, 1);
-    expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is out of date");
+    expect(result.stdout + result.stderr).toContain("XcodeGen project files are out of date");
     expect(result.stdout + result.stderr).toContain("?? ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj");
   });
 
-  test("passes when xcodegen generation leaves the committed CtrlProxy project unchanged", () => {
+  test("ctrl-proxy scope passes when xcodegen generation leaves the committed CtrlProxy project unchanged", () => {
     const repoDir = createTempRepo();
 
-    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
       env: {
@@ -182,16 +200,51 @@ describe("xcodegen drift check", () => {
     });
 
     expectExitStatus(result, 0);
-    expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is in sync");
+    expect(result.stdout + result.stderr).toContain("XcodeGen project files are in sync");
+  });
+
+  test("all scope uses the repo-wide generator for wider iOS build gates", () => {
+    const repoDir = createTempRepo();
+
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--all"], {
+      cwd: repoDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_REPO_ROOT: repoDir,
+        FAKE_REPO_WIDE_GENERATOR_BEHAVIOR: "modify",
+        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expectExitStatus(result, 1);
+    expect(result.stdout + result.stderr).toContain("Run scripts/ios/xcodegen-generate.sh");
+  });
+
+  test("all scope fails when repo-wide generation fails", () => {
+    const repoDir = createTempRepo();
+
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--all"], {
+      cwd: repoDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_REPO_ROOT: repoDir,
+        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expectExitStatus(result, 2);
+    expect(result.stdout + result.stderr).toContain("repo-wide xcodegen-generate.sh should not be called");
   });
 
   test("pull request workflow gates both Xcode project jobs on the drift check", () => {
     const workflow = readFileSync(workflowPath, "utf8");
     const xcodeBuildJob = workflow.indexOf("ios-xcode-build:");
     const xctestRunnerJob = workflow.indexOf("ios-xctest-runner-simulator-tests:");
-    const xcodeBuildDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh", xcodeBuildJob);
+    const xcodeBuildDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh --all", xcodeBuildJob);
     const xcodeBuild = workflow.indexOf("./scripts/ios/xcode-build.sh", xcodeBuildJob);
-    const xctestRunnerDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh", xctestRunnerJob);
+    const xctestRunnerDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh --ctrl-proxy", xctestRunnerJob);
     const xctestRunnerBuild = workflow.indexOf("./scripts/ios/ctrl-proxy-build-for-testing.sh", xctestRunnerJob);
 
     expect(xcodeBuildJob).toBeGreaterThan(-1);

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -119,13 +119,14 @@ describe("xcodegen drift check", () => {
     const xcodeBuildJob = workflow.indexOf("ios-xcode-build:");
     const xctestRunnerJob = workflow.indexOf("ios-xctest-runner-simulator-tests:");
     const xcodeBuildDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh", xcodeBuildJob);
+    const xcodeBuild = workflow.indexOf("./scripts/ios/xcode-build.sh", xcodeBuildJob);
     const xctestRunnerDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh", xctestRunnerJob);
     const xctestRunnerBuild = workflow.indexOf("./scripts/ios/ctrl-proxy-build-for-testing.sh", xctestRunnerJob);
 
     expect(xcodeBuildJob).toBeGreaterThan(-1);
     expect(xctestRunnerJob).toBeGreaterThan(-1);
     expect(xcodeBuildDriftCheck).toBeGreaterThan(xcodeBuildJob);
-    expect(xcodeBuildDriftCheck).toBeLessThan(xctestRunnerJob);
+    expect(xcodeBuildDriftCheck).toBeLessThan(xcodeBuild);
     expect(xctestRunnerDriftCheck).toBeGreaterThan(xctestRunnerJob);
     expect(xctestRunnerDriftCheck).toBeLessThan(xctestRunnerBuild);
   });

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -9,6 +9,12 @@ const driftCheckScript = join(repoRoot, "scripts/ios/xcodegen-drift-check.sh");
 const workflowPath = join(repoRoot, ".github/workflows/pull_request.yml");
 const tempDirs: string[] = [];
 
+function expectExitStatus(result: ReturnType<typeof spawnSync>, expectedStatus: number): void {
+  if (result.status !== expectedStatus) {
+    throw new Error(`Expected exit ${expectedStatus}, got ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+}
+
 afterEach(() => {
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop();
@@ -33,6 +39,45 @@ function createTempRepo(): string {
   writeFileSync(join(tempDir, "baseline/project.pbxproj"), "committed project\n");
   cpSync(driftCheckScript, join(tempDir, "scripts/ios/xcodegen-drift-check.sh"));
   chmodSync(join(tempDir, "scripts/ios/xcodegen-drift-check.sh"), 0o755);
+  writeFileSync(
+    join(tempDir, "scripts/ios/xcodegen-generate.sh"),
+    "#!/bin/bash\necho 'repo-wide xcodegen-generate.sh should not be called' >&2\nexit 2\n"
+  );
+  chmodSync(join(tempDir, "scripts/ios/xcodegen-generate.sh"), 0o755);
+  writeFileSync(
+    join(tempDir, "bin/xcodegen"),
+    `#!/bin/bash
+set -euo pipefail
+
+if [[ "$*" != "generate" ]]; then
+    echo "unexpected xcodegen invocation: $*" >&2
+    exit 2
+fi
+
+expected_cwd="$(cd "\${FAKE_REPO_ROOT}/ios/control-proxy" && pwd -P)"
+if [[ "$(pwd -P)" != "\${expected_cwd}" ]]; then
+    echo "xcodegen ran outside CtrlProxy project: $(pwd -P)" >&2
+    exit 2
+fi
+
+case "\${FAKE_XCODEGEN_BEHAVIOR:-unchanged}" in
+    unchanged)
+        ;;
+    modify)
+        printf 'regenerated project\\n' > CtrlProxy.xcodeproj/project.pbxproj
+        ;;
+    recreate)
+        rm -f CtrlProxy.xcodeproj/project.pbxproj
+        printf 'committed project\\n' > CtrlProxy.xcodeproj/project.pbxproj
+        ;;
+    *)
+        echo "unexpected fake xcodegen behavior: \${FAKE_XCODEGEN_BEHAVIOR}" >&2
+        exit 2
+        ;;
+esac
+`
+  );
+  chmodSync(join(tempDir, "bin/xcodegen"), 0o755);
   writeFileSync(
     join(tempDir, "bin/git"),
     `#!/bin/bash
@@ -80,12 +125,6 @@ exit 2
   return tempDir;
 }
 
-function writeFakeGenerator(repoDir: string, body: string): void {
-  const generatorPath = join(repoDir, "scripts/ios/xcodegen-generate.sh");
-  writeFileSync(generatorPath, `#!/bin/bash\nset -euo pipefail\n${body}\n`);
-  chmodSync(generatorPath, 0o755);
-}
-
 describe("xcodegen drift check", () => {
   test("script exists for CI and local validation", () => {
     expect(existsSync(driftCheckScript)).toBe(true);
@@ -93,10 +132,6 @@ describe("xcodegen drift check", () => {
 
   test("fails when xcodegen generation changes the committed CtrlProxy project", () => {
     const repoDir = createTempRepo();
-    writeFakeGenerator(
-      repoDir,
-      "printf 'regenerated project\\n' > ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
-    );
 
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
       cwd: repoDir,
@@ -104,20 +139,17 @@ describe("xcodegen drift check", () => {
       env: {
         ...process.env,
         FAKE_REPO_ROOT: repoDir,
+        FAKE_XCODEGEN_BEHAVIOR: "modify",
         PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
       },
     });
 
-    expect(result.status).toBe(1);
+    expectExitStatus(result, 1);
     expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is out of date");
   });
 
   test("fails when the regenerated CtrlProxy project is untracked after deletion", () => {
     const repoDir = createTempRepo();
-    writeFakeGenerator(
-      repoDir,
-      "rm -f ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj\nprintf 'committed project\\n' > ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
-    );
 
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
       cwd: repoDir,
@@ -125,19 +157,19 @@ describe("xcodegen drift check", () => {
       env: {
         ...process.env,
         FAKE_REPO_ROOT: repoDir,
+        FAKE_XCODEGEN_BEHAVIOR: "recreate",
         FAKE_GIT_STATUS_OUTPUT: "?? ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj\n",
         PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
       },
     });
 
-    expect(result.status).toBe(1);
+    expectExitStatus(result, 1);
     expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is out of date");
     expect(result.stdout + result.stderr).toContain("?? ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj");
   });
 
   test("passes when xcodegen generation leaves the committed CtrlProxy project unchanged", () => {
     const repoDir = createTempRepo();
-    writeFakeGenerator(repoDir, "true");
 
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
       cwd: repoDir,
@@ -149,7 +181,7 @@ describe("xcodegen drift check", () => {
       },
     });
 
-    expect(result.status).toBe(0);
+    expectExitStatus(result, 0);
     expect(result.stdout + result.stderr).toContain("CtrlProxy.xcodeproj/project.pbxproj is in sync");
   });
 

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -18,21 +18,48 @@ afterEach(() => {
   }
 });
 
-function createTempGitRepo(): string {
+function createTempRepo(): string {
   const tempDir = mkdtempSync(join(tmpdir(), "auto-mobile-xcodegen-drift-"));
   tempDirs.push(tempDir);
 
   mkdirSync(join(tempDir, "scripts/ios"), { recursive: true });
   mkdirSync(join(tempDir, "ios/control-proxy/CtrlProxy.xcodeproj"), { recursive: true });
+  mkdirSync(join(tempDir, "baseline"), { recursive: true });
+  mkdirSync(join(tempDir, "bin"), { recursive: true });
   writeFileSync(
     join(tempDir, "ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"),
     "committed project\n"
   );
+  writeFileSync(join(tempDir, "baseline/project.pbxproj"), "committed project\n");
   cpSync(driftCheckScript, join(tempDir, "scripts/ios/xcodegen-drift-check.sh"));
   chmodSync(join(tempDir, "scripts/ios/xcodegen-drift-check.sh"), 0o755);
+  writeFileSync(
+    join(tempDir, "bin/git"),
+    `#!/bin/bash
+set -euo pipefail
+project="\${FAKE_REPO_ROOT}/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
+baseline="\${FAKE_REPO_ROOT}/baseline/project.pbxproj"
 
-  expect(spawnSync("git", ["init"], { cwd: tempDir }).status).toBe(0);
-  expect(spawnSync("git", ["add", "ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"], { cwd: tempDir }).status).toBe(0);
+if [[ "$1" == "diff" && "\${2:-}" == "--quiet" ]]; then
+    cmp -s "\${baseline}" "\${project}"
+    exit $?
+fi
+
+if [[ "$1" == "diff" ]]; then
+    if cmp -s "\${baseline}" "\${project}"; then
+        exit 0
+    fi
+    echo "diff --git a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
+    echo "-committed project"
+    echo "+regenerated project"
+    exit 0
+fi
+
+echo "unexpected git invocation: $*" >&2
+exit 2
+`
+  );
+  chmodSync(join(tempDir, "bin/git"), 0o755);
 
   return tempDir;
 }
@@ -49,7 +76,7 @@ describe("xcodegen drift check", () => {
   });
 
   test("fails when xcodegen generation changes the committed CtrlProxy project", () => {
-    const repoDir = createTempGitRepo();
+    const repoDir = createTempRepo();
     writeFakeGenerator(
       repoDir,
       "printf 'regenerated project\\n' > ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
@@ -58,6 +85,11 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
       cwd: repoDir,
       encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_REPO_ROOT: repoDir,
+        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
+      },
     });
 
     expect(result.status).toBe(1);
@@ -65,12 +97,17 @@ describe("xcodegen drift check", () => {
   });
 
   test("passes when xcodegen generation leaves the committed CtrlProxy project unchanged", () => {
-    const repoDir = createTempGitRepo();
+    const repoDir = createTempRepo();
     writeFakeGenerator(repoDir, "true");
 
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh"], {
       cwd: repoDir,
       encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_REPO_ROOT: repoDir,
+        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
+      },
     });
 
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary

- Adds an iOS XcodeGen drift guard that regenerates projects and fails when the committed CtrlProxy `project.pbxproj` changes.
- Runs the guard in both the Build Xcode Projects job and the XCTestRunner Simulator Tests job before Xcode builds.
- Documents the control-proxy file-addition regeneration requirement.

## Acceptance Criteria

- Drift guard runs `xcodegen generate` and fails on stale `ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj` output.
- CI catches the stale-project footgun before the XCTestRunner job reports confusing missing-symbol build errors.
- Contributors get local guidance to regenerate and commit the pbxproj after control-proxy file changes.

## Testing

- `bun test test/scripts/xcodegenDriftCheck.test.ts`
- `shellcheck scripts/ios/xcodegen-drift-check.sh`
- `bun run turbo:validate`
- `bun run typecheck`

Closes #2858

Made with [Cursor](https://cursor.com)