### PR TITLE
Fix optional step recording parity

### DIFF
--- a/src/db/testExecutionRepository.ts
+++ b/src/db/testExecutionRepository.ts
@@ -96,6 +96,7 @@ interface TestRunStep {
   screenName: string | null;
   screenshotPath: string | null;
   errorMessage: string | null;
+  details: unknown;
 }
 
 export interface TestRun {
@@ -121,6 +122,18 @@ export interface TestRunQueryOptions {
   lookbackDays?: number;
   limit?: number;
   orderDirection?: "asc" | "desc";
+}
+
+function parseStepDetailsJson(detailsJson: string | null, stepId: number): unknown {
+  if (!detailsJson) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(detailsJson) as unknown;
+  } catch (error) {
+    logger.warn(`[TestExecutionRepository] Failed to parse details_json for step ${stepId}: ${error}`);
+    return undefined;
+  }
 }
 
 export class TestExecutionRepository {
@@ -267,6 +280,7 @@ export class TestExecutionRepository {
       screenName: string | null;
       screenshotPath: string | null;
       errorMessage: string | null;
+      details: unknown;
     }>>();
     const screensByExecutionId = new Map<number, string[]>();
 
@@ -284,6 +298,7 @@ export class TestExecutionRepository {
           "screen_name as screenName",
           "screenshot_path as screenshotPath",
           "error_message as errorMessage",
+          "details_json as detailsJson",
         ])
         .where("execution_id", "in", chunk)
         .orderBy("execution_id", "asc")
@@ -309,6 +324,7 @@ export class TestExecutionRepository {
           screenName: step.screenName,
           screenshotPath: step.screenshotPath,
           errorMessage: step.errorMessage,
+          details: parseStepDetailsJson(step.detailsJson, step.id),
         });
       }
 

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -80,6 +80,7 @@ export interface DeviceSkippedStepResult {
   trackIndex: number; // Index in device track
   tool: string;
   error: string;
+  durationMs: number;
   details?: Record<string, unknown>;
 }
 

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -65,6 +65,7 @@ export interface DeviceExecutionResult {
   executedSteps: number;
   totalSteps: number;
   executionTimeMs?: number;
+  skippedSteps?: DeviceSkippedStepResult[];
   failedStep?: {
     stepIndex: number; // Index in plan
     trackIndex: number; // Index in device track
@@ -72,6 +73,14 @@ export interface DeviceExecutionResult {
     error: string;
     failureObservation?: FailureObservationSummary;
   };
+}
+
+export interface DeviceSkippedStepResult {
+  stepIndex: number; // Index in plan
+  trackIndex: number; // Index in device track
+  tool: string;
+  error: string;
+  details?: Record<string, unknown>;
 }
 
 export type AbortStrategy = "immediate" | "finish-current-step";

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -129,22 +129,11 @@ export function convertDebugStepsToRecords(
     const action = toolMatch ? toolMatch[1] : step.step;
 
     const details = step.details as { params?: Record<string, unknown>; error?: string } | undefined;
-    const params = details?.params;
-    let target: string | null = null;
-    if (params) {
-      if (params.text) {
-        target = `text="${params.text}"`;
-      } else if (params.elementId) {
-        target = `id="${params.elementId}"`;
-      } else if (params.direction) {
-        target = `direction=${params.direction}`;
-      }
-    }
 
     return {
       stepIndex: index,
       action,
-      target,
+      target: buildStepRecordTarget(details?.params),
       status: step.status,
       durationMs: step.durationMs,
       screenName: null,
@@ -153,6 +142,54 @@ export function convertDebugStepsToRecords(
       details: step.details,
     };
   });
+}
+
+function buildStepRecordTarget(params: Record<string, unknown> | undefined): string | null {
+  if (!params) {
+    return null;
+  }
+  if (params.text) {
+    return `text="${params.text}"`;
+  }
+  if (params.elementId) {
+    return `id="${params.elementId}"`;
+  }
+  if (params.direction) {
+    return `direction=${params.direction}`;
+  }
+  return null;
+}
+
+export function convertPerDeviceSkippedStepsToRecords(
+  perDeviceResults: PlanExecutionResult["perDeviceResults"] | undefined
+): TestStepRecord[] {
+  if (!perDeviceResults) {
+    return [];
+  }
+
+  const skippedRecords: TestStepRecord[] = [];
+  for (const deviceResult of perDeviceResults.values()) {
+    for (const skippedStep of deviceResult.skippedSteps ?? []) {
+      const details = skippedStep.details as { params?: Record<string, unknown>; error?: string } | undefined;
+      skippedRecords.push({
+        stepIndex: skippedStep.stepIndex,
+        action: skippedStep.tool,
+        target: buildStepRecordTarget(details?.params),
+        status: "skipped",
+        durationMs: 0,
+        screenName: null,
+        screenshotPath: null,
+        errorMessage: skippedStep.error,
+        details: {
+          device: deviceResult.device,
+          trackIndex: skippedStep.trackIndex,
+          ...(skippedStep.details ?? {}),
+        },
+      });
+    }
+  }
+
+  return skippedRecords.sort((a, b) => a.stepIndex - b.stepIndex || a.action.localeCompare(b.action));
 }
 
 /**
@@ -248,8 +285,12 @@ export class PlanExecutionOrchestrator {
         throw new Error("Plan execution failed without producing a result");
       }
 
+      const recordedSteps = [
+        ...convertDebugStepsToRecords(result.debug?.steps),
+        ...convertPerDeviceSkippedStepsToRecords(result.perDeviceResults),
+      ];
       await this.recordExecution(result.success ? "passed" : "failed", startTime, {
-        steps: convertDebugStepsToRecords(result.debug?.steps),
+        steps: recordedSteps,
         errorMessage: result.failedStep?.error ?? undefined,
         videoPath: finalizedVideo.videoFilePaths[0],
       });

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -176,7 +176,7 @@ export function convertPerDeviceSkippedStepsToRecords(
         action: skippedStep.tool,
         target: buildStepRecordTarget(details?.params),
         status: "skipped",
-        durationMs: 0,
+        durationMs: skippedStep.durationMs,
         screenName: null,
         screenshotPath: null,
         errorMessage: skippedStep.error,

--- a/src/server/testRunResources.ts
+++ b/src/server/testRunResources.ts
@@ -39,6 +39,7 @@ interface TestRunResponseStep {
   durationMs: number;
   status: "completed" | "failed" | "skipped";
   errorMessage: string | null;
+  details?: unknown;
 }
 
 interface TestRunResponseEntry {
@@ -189,7 +190,7 @@ function buildTestRunUri(options: TestRunQueryArgs): string {
   return queryString ? `${TEST_RUN_RESOURCE_URIS.BASE}?${queryString}` : TEST_RUN_RESOURCE_URIS.BASE;
 }
 
-function convertToResponseEntry(run: TestRun, sampleSize: number): TestRunResponseEntry {
+export function convertToResponseEntry(run: TestRun, sampleSize: number): TestRunResponseEntry {
   // Derive test name from class + method
   const classSimpleName = run.testClass.split(".").pop() || run.testClass;
   const testName = `${classSimpleName}.${run.testMethod}`;
@@ -218,6 +219,7 @@ function convertToResponseEntry(run: TestRun, sampleSize: number): TestRunRespon
       durationMs: step.durationMs,
       status: step.status,
       errorMessage: step.errorMessage,
+      ...(step.details !== undefined ? { details: step.details } : {}),
     })),
     screensVisited: run.screensVisited,
     sampleSize,

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -965,6 +965,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           `[PARALLEL_EXEC][${device}] Step ${trackIndex + 1}/${track.length} (plan step ${planIndex}): ${step.tool}, Label: ${stepLabel}`
         );
 
+        const stepStartTime = this.timer.now();
         const stepResult = await this.executeStep(step, {
           platform,
           deviceId,
@@ -983,6 +984,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
             trackIndex,
             tool: step.tool,
             error: stepResult.error ?? "Unknown error",
+            durationMs: this.timer.now() - stepStartTime,
             details: stepResult.details,
           });
           continue;

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -3,6 +3,7 @@ import {
   PlanStep,
   PlanExecutionResult,
   DeviceExecutionResult,
+  DeviceSkippedStepResult,
   AbortStrategy,
   DEFAULT_ABORT_STRATEGY,
 } from "../../models/Plan";
@@ -781,6 +782,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           success: result.success,
           executedSteps: result.executedSteps,
           totalSteps: track.length,
+          skippedSteps: result.skippedSteps.length > 0 ? result.skippedSteps : undefined,
           executionTimeMs: debugMode ? this.timer.now() - deviceStartTime : undefined,
           failedStep: result.failedStep
             ? {
@@ -865,6 +867,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
             tool: "unknown",
             error: errorMessage,
           },
+          skippedSteps: [],
         };
       }
     });
@@ -937,8 +940,10 @@ export class DefaultPlanExecutor implements PlanExecutor {
       error: string;
       failureObservation?: FailureObservationSummary;
     };
+    skippedSteps: DeviceSkippedStepResult[];
   }> {
     let executedSteps = 0;
+    const skippedSteps: DeviceSkippedStepResult[] = [];
 
     try {
       for (let trackIndex = 0; trackIndex < track.length; trackIndex++) {
@@ -970,11 +975,16 @@ export class DefaultPlanExecutor implements PlanExecutor {
         });
 
         if (stepResult.status === "skipped") {
-          // Parallel tracks do not emit the unified debug-step array (see the captureObserveSteps
-          // warning in executeParallel), so a skipped optional step is logged rather than recorded.
           logger.warn(
             `[PARALLEL_EXEC][${device}] optional step ${step.tool} failed; skipping and continuing: ${stepResult.error}`
           );
+          skippedSteps.push({
+            stepIndex: planIndex,
+            trackIndex,
+            tool: step.tool,
+            error: stepResult.error ?? "Unknown error",
+            details: stepResult.details,
+          });
           continue;
         }
 
@@ -991,6 +1001,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
               error: stepResult.error ?? "Unknown error",
               ...(stepResult.failureObservation ? { failureObservation: stepResult.failureObservation } : {}),
             },
+            skippedSteps,
           };
         }
 
@@ -1008,6 +1019,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
         success: true,
         executedSteps,
         totalSteps: track.length,
+        skippedSteps,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -1023,6 +1035,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           tool: "unknown",
           error: errorMessage,
         },
+        skippedSteps,
       };
     }
   }

--- a/src/utils/plan/PlanSerializer.ts
+++ b/src/utils/plan/PlanSerializer.ts
@@ -106,6 +106,7 @@ export class YamlPlanSerializer implements PlanSerializer {
         timestamp: string;
         tool: string;
         params: Record<string, any>;
+        optional?: boolean;
         result: { success: boolean; data?: any; error?: string };
       }> = [];
 
@@ -158,7 +159,8 @@ export class YamlPlanSerializer implements PlanSerializer {
         if (YamlPlanSerializer.shouldIncludeInPlan(toolCall.tool, isLastObserve)) {
           planSteps.push({
             tool: toolCall.tool,
-            params: toolCall.params
+            params: toolCall.params,
+            ...(toolCall.optional === true ? { optional: true } : {})
           });
         }
       }

--- a/test/db/testExecutionRepository.test.ts
+++ b/test/db/testExecutionRepository.test.ts
@@ -132,6 +132,33 @@ describe("TestExecutionRepository", () => {
       expect(runs[0].steps[1].errorMessage).toBe("Element not visible");
     });
 
+    test("roundtrips step details through getTestRuns", async () => {
+      await repo.recordExecution(
+        makeExecution({
+          steps: [
+            makeStep({
+              status: "skipped",
+              details: {
+                device: "device-a",
+                trackIndex: 0,
+                optional: true,
+                error: "element not found",
+              },
+            }),
+          ],
+        })
+      );
+
+      const runs = await repo.getTestRuns();
+
+      expect((runs[0].steps[0] as any).details).toEqual({
+        device: "device-a",
+        trackIndex: 0,
+        optional: true,
+        error: "element not found",
+      });
+    });
+
     test("records execution with screens visited", async () => {
       await repo.recordExecution(
         makeExecution({

--- a/test/plan/planExecutorOptionalStep.test.ts
+++ b/test/plan/planExecutorOptionalStep.test.ts
@@ -5,6 +5,7 @@ import { ToolRegistry } from "../../src/server/toolRegistry";
 import { registerObserveTools } from "../../src/server/observeTools";
 import { z } from "zod";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 /**
  * Optional (best-effort) plan steps. A step marked `optional: true` whose tool fails must NOT abort
@@ -193,6 +194,7 @@ describe("PlanExecutor — optional steps", () => {
         trackIndex: 0,
         tool: "optionalStepFail",
         error: "element not found",
+        durationMs: expect.any(Number),
         details: {
           params: { device: "device-a" },
           error: "element not found",
@@ -200,5 +202,37 @@ describe("PlanExecutor — optional steps", () => {
         },
       },
     ]);
+  });
+
+  test("records elapsed duration for skipped optional steps in multi-device results", async () => {
+    const fakeTimer = new FakeTimer();
+    const timedExecutor = new DefaultPlanExecutor(fakeTimer);
+    ToolRegistry.register(
+      "optionalStepTimedFail",
+      "fails after time passes",
+      z.object({
+        platform: z.string().optional(),
+        device: z.string().optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      mock(async () => {
+        fakeTimer.advanceTime(250);
+        return createStructuredToolResponse({ success: false, error: "timed out" });
+      })
+    );
+    (ToolRegistry.getTool("optionalStepTimedFail") as { requiresDevice: boolean }).requiresDevice = true;
+
+    const plan: Plan = {
+      name: "parallel-optional-timed-fail",
+      devices: ["device-a"],
+      steps: [
+        { tool: "optionalStepTimedFail", params: { device: "device-a" }, optional: true },
+      ],
+    };
+
+    const result = await timedExecutor.executePlan(plan, 0, "ios", "sim-1", "session-1");
+
+    expect(result.success).toBe(true);
+    expect(result.perDeviceResults?.get("device-a")?.skippedSteps?.[0].durationMs).toBe(250);
   });
 });

--- a/test/plan/planExecutorOptionalStep.test.ts
+++ b/test/plan/planExecutorOptionalStep.test.ts
@@ -169,4 +169,36 @@ describe("PlanExecutor — optional steps", () => {
     expect(result.success).toBe(false);
     expect(result.failedStep?.tool).toBe("optionalStepFail");
   });
+
+  test("records skipped optional steps in multi-device per-device results", async () => {
+    const plan: Plan = {
+      name: "parallel-optional-fail-then-ok",
+      devices: ["device-a"],
+      steps: [
+        { tool: "optionalStepFail", params: { device: "device-a" }, optional: true },
+        { tool: "optionalStepOk", params: { device: "device-a" } },
+      ],
+    };
+
+    const result = await planExecutor.executePlan(plan, 0, "ios", "sim-1", "session-1");
+    const deviceResult = result.perDeviceResults?.get("device-a");
+
+    expect(result.success).toBe(true);
+    expect(result.executedSteps).toBe(1);
+    expect(deviceResult?.success).toBe(true);
+    expect(deviceResult?.executedSteps).toBe(1);
+    expect(deviceResult?.skippedSteps).toEqual([
+      {
+        stepIndex: 0,
+        trackIndex: 0,
+        tool: "optionalStepFail",
+        error: "element not found",
+        details: {
+          params: { device: "device-a" },
+          error: "element not found",
+          optional: true,
+        },
+      },
+    ]);
+  });
 });

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -296,6 +296,7 @@ steps:
                 trackIndex: 0,
                 tool: "tapOn",
                 error: "element not found",
+                durationMs: 250,
                 details: {
                   params: { text: "Not Now", device: "device-a" },
                   error: "element not found",
@@ -328,7 +329,7 @@ steps:
         action: "tapOn",
         target: 'text="Not Now"',
         status: "skipped",
-        durationMs: 0,
+        durationMs: 250,
         screenName: null,
         screenshotPath: null,
         errorMessage: "element not found",

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -278,6 +278,71 @@ steps:
     expect(fakeRepo.recorded[0].errorMessage).toBe("element not found");
   });
 
+  test("execute() records skipped optional steps from multi-device per-device results", async () => {
+    executePlanMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        success: true,
+        executedSteps: 1,
+        totalSteps: 2,
+        perDeviceResults: new Map([
+          ["device-a", {
+            device: "device-a",
+            success: true,
+            executedSteps: 1,
+            totalSteps: 2,
+            skippedSteps: [
+              {
+                stepIndex: 0,
+                trackIndex: 0,
+                tool: "tapOn",
+                error: "element not found",
+                details: {
+                  params: { text: "Not Now", device: "device-a" },
+                  error: "element not found",
+                  optional: true,
+                },
+              },
+            ],
+          }],
+        ]),
+      })
+    );
+    const fakeRepo = new FakeTestExecutionRepository();
+    const orchestrator = new PlanExecutionOrchestrator(
+      {
+        device: iosDevice,
+        request: {
+          ...baseRequest,
+          testMetadata: { testClass: "FooTest", testMethod: "parallelOptional" },
+        },
+      },
+      { ...baseDeps(), testExecutionRepository: fakeRepo as unknown as TestExecutionRepository }
+    );
+
+    const result = await orchestrator.execute();
+
+    expect(result.success).toBe(true);
+    expect(fakeRepo.recorded[0].steps).toEqual([
+      {
+        stepIndex: 0,
+        action: "tapOn",
+        target: 'text="Not Now"',
+        status: "skipped",
+        durationMs: 0,
+        screenName: null,
+        screenshotPath: null,
+        errorMessage: "element not found",
+        details: {
+          device: "device-a",
+          trackIndex: 0,
+          params: { text: "Not Now", device: "device-a" },
+          error: "element not found",
+          optional: true,
+        },
+      },
+    ]);
+  });
+
   test("repository write errors are logged and do not crash the run", async () => {
     const exploding = {
       recordExecution: () => Promise.reject(new Error("db down")),

--- a/test/server/testRunResources.test.ts
+++ b/test/server/testRunResources.test.ts
@@ -1,9 +1,55 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { convertToResponseEntry } from "../../src/server/testRunResources";
+import type { TestRun } from "../../src/db/testExecutionRepository";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import type { Database as DatabaseSchema, NewTestExecution, NewTestExecutionStep, NewTestExecutionScreen } from "../../src/db/types";
 import { runMigrations } from "../../src/db/migrator";
+
+describe("testRunResources", () => {
+  test("exposes step details in test run resource entries", () => {
+    const entry = convertToResponseEntry({
+      id: 1,
+      testClass: "com.example.LoginTest",
+      testMethod: "testLogin",
+      status: "passed",
+      startTime: 1000,
+      durationMs: 500,
+      deviceId: "sim-1",
+      deviceName: "iPhone",
+      platform: "ios",
+      errorMessage: null,
+      videoPath: null,
+      snapshotPath: null,
+      screensVisited: [],
+      steps: [
+        {
+          id: 10,
+          stepIndex: 0,
+          action: "tapOn",
+          target: 'text="Not Now"',
+          status: "skipped",
+          durationMs: 250,
+          screenName: null,
+          screenshotPath: null,
+          errorMessage: "element not found",
+          details: {
+            device: "device-a",
+            trackIndex: 0,
+            optional: true,
+          },
+        },
+      ],
+    } as TestRun, 1);
+
+    expect(entry.steps[0].details).toEqual({
+      device: "device-a",
+      trackIndex: 0,
+      optional: true,
+    });
+  });
+});
 
 describe("TestRunResources - Database Schema", () => {
   let db: Kysely<DatabaseSchema>;

--- a/test/utils/plan/PlanSerializer.test.ts
+++ b/test/utils/plan/PlanSerializer.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import fs from "fs/promises";
 import * as yaml from "js-yaml";
+import os from "os";
+import path from "path";
 import { YamlPlanSerializer } from "../../../src/utils/plan/PlanSerializer";
 import type { Plan } from "../../../src/models/Plan";
 
@@ -11,6 +14,39 @@ import type { Plan } from "../../../src/models/Plan";
  */
 describe("YamlPlanSerializer", () => {
   const serializer = new YamlPlanSerializer();
+
+  describe("exportPlanFromLogs", () => {
+    test("preserves step-level optional flag when present in logged tool calls", async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-serializer-"));
+      const outputPath = path.join(tempDir, "exported.yaml");
+      try {
+        await fs.writeFile(
+          path.join(tempDir, "tool-calls.json"),
+          JSON.stringify({
+            timestamp: "2026-07-09T00:00:00.000Z",
+            tool: "tapOn",
+            params: { text: "Not Now" },
+            optional: true,
+            result: { success: true },
+          }) + "\n",
+          "utf-8"
+        );
+
+        const result = await serializer.exportPlanFromLogs(tempDir, "Optional Export", outputPath);
+
+        expect(result.success).toBe(true);
+        const exported = yaml.load(result.planContent ?? "") as Plan;
+        expect(exported.steps[0]).toMatchObject({
+          tool: "tapOn",
+          params: { text: "Not Now" },
+          optional: true,
+        });
+        expect(exported.steps[0].params.optional).toBeUndefined();
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
 
   describe("importPlanFromYaml", () => {
     test("imports a valid plan with name and steps", () => {


### PR DESCRIPTION
## Summary

Multi-device optional plan steps now surface skipped failures in per-device executor results and test-execution recording, matching the single-device observability path. Log-derived plan export also preserves `optional: true` when that step-level field is present in logged tool calls.

## Linked Issue

Closes #2863

## Bug / Regression Context

- **Prior attempts:** PR #2853 introduced `optional: true` and intentionally deferred multi-device recording parity plus log-export round-trip behavior.
- **Observed symptom:** skipped optional steps in parallel device tracks were only logged, so recorded runs had no skipped step entry; `exportPlanFromLogs` emitted `{ tool, params }` only.
- **Repro steps / conditions:** execute a multi-device plan with an optional failing step, or export a logged tool call that carries a step-level `optional: true` field.

## Validation

- [x] `bun run turbo:validate` passes (`lint` + `build` + `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, TypeScript-only change
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional targeted validation:

- [x] `bun test test/plan/planExecutorOptionalStep.test.ts test/server/planExecutionOrchestrator.test.ts test/utils/plan/PlanSerializer.test.ts`

## Device Verification

N/A, internal TypeScript executor/recording/export behavior covered by unit tests.

## Follow-ups

No follow-ups deferred.

Made with [Cursor](https://cursor.com)