### PR TITLE
feat(observe): support richer waitFor predicates

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3152,6 +3152,60 @@
                           "description": "Foreground app bundle ID / package name",
                           "type": "string"
                         },
+                        "packageId": {
+                          "type": "string"
+                        },
+                        "package": {
+                          "type": "string"
+                        },
+                        "packageName": {
+                          "type": "string"
+                        },
+                        "appPackage": {
+                          "type": "string"
+                        },
+                        "appPackageId": {
+                          "type": "string"
+                        },
+                        "bundle": {
+                          "type": "string"
+                        },
+                        "bundleId": {
+                          "type": "string"
+                        },
+                        "bundleID": {
+                          "type": "string"
+                        },
+                        "bundleIdentifier": {
+                          "type": "string"
+                        },
+                        "application": {
+                          "type": "string"
+                        },
+                        "applicationId": {
+                          "type": "string"
+                        },
+                        "applicationIdentifier": {
+                          "type": "string"
+                        },
+                        "app": {
+                          "type": "string"
+                        },
+                        "appIdentifier": {
+                          "type": "string"
+                        },
+                        "package_id": {
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "type": "string"
+                        },
+                        "bundle_id": {
+                          "type": "string"
+                        },
+                        "application_id": {
+                          "type": "string"
+                        },
                         "activityName": {
                           "description": "Foreground Android activity name",
                           "type": "string"
@@ -3171,7 +3225,223 @@
                           "required": [
                             "appId"
                           ],
-                          "additionalProperties": false
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "packageId": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "packageId"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "package": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "package"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "packageName": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "packageName"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "appPackage": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "appPackage"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "appPackageId": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "appPackageId"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "bundle": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "bundle"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "bundleId": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "bundleId"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "bundleID": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "bundleID"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "bundleIdentifier": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "bundleIdentifier"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "application": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "application"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "applicationId": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "applicationId"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "applicationIdentifier": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "applicationIdentifier"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "app": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "app"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "appIdentifier": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "appIdentifier"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "package_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "package_id"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "package_name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "package_name"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "bundle_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "bundle_id"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "application_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "application_id"
+                          ],
+                          "additionalProperties": {}
                         },
                         {
                           "type": "object",
@@ -3183,7 +3453,7 @@
                           "required": [
                             "activityName"
                           ],
-                          "additionalProperties": false
+                          "additionalProperties": {}
                         }
                       ]
                     }
@@ -3256,7 +3526,7 @@
                   "required": [
                     "elementId"
                   ],
-                  "additionalProperties": false
+                  "additionalProperties": {}
                 },
                 {
                   "type": "object",
@@ -3268,7 +3538,7 @@
                   "required": [
                     "text"
                   ],
-                  "additionalProperties": false
+                  "additionalProperties": {}
                 },
                 {
                   "type": "object",
@@ -3285,7 +3555,7 @@
                   "required": [
                     "textAny"
                   ],
-                  "additionalProperties": false
+                  "additionalProperties": {}
                 },
                 {
                   "type": "object",
@@ -3297,7 +3567,7 @@
                   "required": [
                     "className"
                   ],
-                  "additionalProperties": false
+                  "additionalProperties": {}
                 },
                 {
                   "type": "object",
@@ -3309,7 +3579,7 @@
                   "required": [
                     "contentDescription"
                   ],
-                  "additionalProperties": false
+                  "additionalProperties": {}
                 },
                 {
                   "type": "object",
@@ -3321,6 +3591,60 @@
                           "properties": {
                             "appId": {
                               "description": "Foreground app bundle ID / package name",
+                              "type": "string"
+                            },
+                            "packageId": {
+                              "type": "string"
+                            },
+                            "package": {
+                              "type": "string"
+                            },
+                            "packageName": {
+                              "type": "string"
+                            },
+                            "appPackage": {
+                              "type": "string"
+                            },
+                            "appPackageId": {
+                              "type": "string"
+                            },
+                            "bundle": {
+                              "type": "string"
+                            },
+                            "bundleId": {
+                              "type": "string"
+                            },
+                            "bundleID": {
+                              "type": "string"
+                            },
+                            "bundleIdentifier": {
+                              "type": "string"
+                            },
+                            "application": {
+                              "type": "string"
+                            },
+                            "applicationId": {
+                              "type": "string"
+                            },
+                            "applicationIdentifier": {
+                              "type": "string"
+                            },
+                            "app": {
+                              "type": "string"
+                            },
+                            "appIdentifier": {
+                              "type": "string"
+                            },
+                            "package_id": {
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "type": "string"
+                            },
+                            "bundle_id": {
+                              "type": "string"
+                            },
+                            "application_id": {
                               "type": "string"
                             },
                             "activityName": {
@@ -3342,7 +3666,223 @@
                               "required": [
                                 "appId"
                               ],
-                              "additionalProperties": false
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "packageId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "packageId"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "package": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "package"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "packageName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "packageName"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "appPackage": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "appPackage"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "appPackageId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "appPackageId"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "bundle": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "bundle"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "bundleId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "bundleId"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "bundleID": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "bundleID"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "bundleIdentifier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "bundleIdentifier"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "application": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "application"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "applicationId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "applicationId"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "applicationIdentifier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "applicationIdentifier"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "app": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "app"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "appIdentifier": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "appIdentifier"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "package_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "package_id"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "package_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "package_name"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "bundle_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "bundle_id"
+                              ],
+                              "additionalProperties": {}
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "application_id": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "application_id"
+                              ],
+                              "additionalProperties": {}
                             },
                             {
                               "type": "object",
@@ -3354,7 +3894,7 @@
                               "required": [
                                 "activityName"
                               ],
-                              "additionalProperties": false
+                              "additionalProperties": {}
                             }
                           ]
                         }
@@ -3364,7 +3904,7 @@
                   "required": [
                     "activeWindow"
                   ],
-                  "additionalProperties": false
+                  "additionalProperties": {}
                 }
               ]
             }

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3113,157 +3113,102 @@
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
-          "anyOf": [
-            {
+          "type": "object",
+          "properties": {
+            "elementId": {
+              "description": "Element resource ID / accessibility identifier",
+              "type": "string"
+            },
+            "text": {
+              "description": "Element text",
+              "type": "string"
+            },
+            "textAny": {
+              "description": "Ordered text variants; first visible match wins",
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "className": {
+              "description": "Element class name",
+              "type": "string"
+            },
+            "contentDescription": {
+              "description": "Element content description / accessibility label",
+              "type": "string"
+            },
+            "activeWindow": {
+              "description": "Foreground app/window predicates",
               "type": "object",
               "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "Element resource ID / accessibility identifier"
+                "appId": {
+                  "description": "Foreground app bundle ID / package name",
+                  "type": "string"
                 },
-                "timeout": {
-                  "description": "Wait timeout ms (default: 5000)",
-                  "type": "number"
-                },
-                "container": {
-                  "description": "Scope match to a container",
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "elementId": {
-                          "type": "string",
-                          "description": "Container resource ID"
-                        }
-                      },
-                      "required": [
-                        "elementId"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "text": {
-                          "type": "string",
-                          "description": "Container text"
-                        }
-                      },
-                      "required": [
-                        "text"
-                      ],
-                      "additionalProperties": false
-                    }
-                  ]
+                "activityName": {
+                  "description": "Foreground Android activity name",
+                  "type": "string"
                 }
               },
-              "required": [
-                "elementId"
-              ],
               "additionalProperties": false
             },
-            {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Element text"
-                },
-                "timeout": {
-                  "description": "Wait timeout ms (default: 5000)",
-                  "type": "number"
-                },
-                "container": {
-                  "description": "Scope match to a container",
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "elementId": {
-                          "type": "string",
-                          "description": "Container resource ID"
-                        }
-                      },
-                      "required": [
-                        "elementId"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "text": {
-                          "type": "string",
-                          "description": "Container text"
-                        }
-                      },
-                      "required": [
-                        "text"
-                      ],
-                      "additionalProperties": false
+            "matchType": {
+              "description": "Whether element predicates must all match the same node or any one may match",
+              "type": "string",
+              "enum": [
+                "all",
+                "any"
+              ]
+            },
+            "textMatch": {
+              "description": "How to match text predicates",
+              "type": "string",
+              "enum": [
+                "exact",
+                "contains",
+                "regex"
+              ]
+            },
+            "timeout": {
+              "description": "Wait timeout ms (default: 5000)",
+              "type": "number"
+            },
+            "container": {
+              "description": "Scope match to a container",
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "elementId": {
+                      "type": "string",
+                      "description": "Container resource ID"
                     }
-                  ]
-                }
-              },
-              "required": [
-                "text"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "textAny": {
-                  "minItems": 1,
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "minLength": 1
                   },
-                  "description": "Ordered text variants; first visible match wins"
+                  "required": [
+                    "elementId"
+                  ],
+                  "additionalProperties": false
                 },
-                "timeout": {
-                  "description": "Wait timeout ms (default: 5000)",
-                  "type": "number"
-                },
-                "container": {
-                  "description": "Scope match to a container",
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "elementId": {
-                          "type": "string",
-                          "description": "Container resource ID"
-                        }
-                      },
-                      "required": [
-                        "elementId"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "text": {
-                          "type": "string",
-                          "description": "Container text"
-                        }
-                      },
-                      "required": [
-                        "text"
-                      ],
-                      "additionalProperties": false
+                {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "description": "Container text"
                     }
-                  ]
+                  },
+                  "required": [
+                    "text"
+                  ],
+                  "additionalProperties": false
                 }
-              },
-              "required": [
-                "textAny"
-              ],
-              "additionalProperties": false
+              ]
             }
-          ]
+          },
+          "additionalProperties": false
         },
         "raw": {
           "description": "Include raw view hierarchy",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3113,34 +3113,36 @@
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
-          "allOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {
-                "elementId": {
-                  "description": "Element resource ID / accessibility identifier",
-                  "type": "string"
-                },
-                "text": {
-                  "description": "Element text",
-                  "type": "string"
-                },
                 "textAny": {
-                  "description": "Ordered text variants; first visible match wins",
                   "minItems": 1,
                   "type": "array",
                   "items": {
                     "type": "string",
                     "minLength": 1
-                  }
+                  },
+                  "description": "Ordered text variants; first visible match wins"
+                },
+                "elementId": {
+                  "not": {}
+                },
+                "text": {
+                  "not": {}
                 },
                 "className": {
-                  "description": "Element class name",
-                  "type": "string"
+                  "not": {}
                 },
                 "contentDescription": {
-                  "description": "Element content description / accessibility label",
-                  "type": "string"
+                  "not": {}
+                },
+                "matchType": {
+                  "not": {}
+                },
+                "textMatch": {
+                  "not": {}
                 },
                 "activeWindow": {
                   "description": "Foreground app/window predicates",
@@ -3219,23 +3221,6 @@
                     }
                   ]
                 },
-                "matchType": {
-                  "description": "Whether element predicates must all match the same node or any one may match",
-                  "type": "string",
-                  "enum": [
-                    "all",
-                    "any"
-                  ]
-                },
-                "textMatch": {
-                  "description": "How to match text predicates",
-                  "type": "string",
-                  "enum": [
-                    "exact",
-                    "contains",
-                    "regex"
-                  ]
-                },
                 "timeout": {
                   "description": "Wait timeout ms (default: 5000)",
                   "type": "number"
@@ -3272,79 +3257,54 @@
                   ]
                 }
               },
+              "required": [
+                "textAny"
+              ],
               "additionalProperties": false
             },
             {
-              "anyOf": [
+              "allOf": [
                 {
                   "type": "object",
                   "properties": {
                     "elementId": {
+                      "description": "Element resource ID / accessibility identifier",
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "elementId"
-                  ],
-                  "additionalProperties": {}
-                },
-                {
-                  "type": "object",
-                  "properties": {
+                    },
                     "text": {
+                      "description": "Element text",
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "text"
-                  ],
-                  "additionalProperties": {}
-                },
-                {
-                  "type": "object",
-                  "properties": {
+                    },
                     "textAny": {
-                      "minItems": 1,
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
-                      }
-                    }
-                  },
-                  "required": [
-                    "textAny"
-                  ],
-                  "additionalProperties": {}
-                },
-                {
-                  "type": "object",
-                  "properties": {
+                      "not": {}
+                    },
                     "className": {
+                      "description": "Element class name",
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "className"
-                  ],
-                  "additionalProperties": {}
-                },
-                {
-                  "type": "object",
-                  "properties": {
+                    },
                     "contentDescription": {
+                      "description": "Element content description / accessibility label",
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "contentDescription"
-                  ],
-                  "additionalProperties": {}
-                },
-                {
-                  "type": "object",
-                  "properties": {
+                    },
+                    "matchType": {
+                      "description": "Whether element predicates must all match the same node or any one may match",
+                      "type": "string",
+                      "enum": [
+                        "all",
+                        "any"
+                      ]
+                    },
+                    "textMatch": {
+                      "description": "How to match text predicates",
+                      "type": "string",
+                      "enum": [
+                        "exact",
+                        "contains",
+                        "regex"
+                      ]
+                    },
                     "activeWindow": {
+                      "description": "Foreground app/window predicates",
                       "allOf": [
                         {
                           "type": "object",
@@ -3419,12 +3379,181 @@
                           ]
                         }
                       ]
+                    },
+                    "timeout": {
+                      "description": "Wait timeout ms (default: 5000)",
+                      "type": "number"
+                    },
+                    "container": {
+                      "description": "Scope match to a container",
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "elementId": {
+                              "type": "string",
+                              "description": "Container resource ID"
+                            }
+                          },
+                          "required": [
+                            "elementId"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "text": {
+                              "type": "string",
+                              "description": "Container text"
+                            }
+                          },
+                          "required": [
+                            "text"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
                     }
                   },
-                  "required": [
-                    "activeWindow"
-                  ],
-                  "additionalProperties": {}
+                  "additionalProperties": false
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "elementId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "elementId"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "text"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "className": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "className"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contentDescription": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "contentDescription"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "activeWindow": {
+                          "allOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "appId": {
+                                  "description": "Foreground app bundle ID / package name",
+                                  "type": "string"
+                                },
+                                "packageName": {
+                                  "type": "string"
+                                },
+                                "bundleId": {
+                                  "type": "string"
+                                },
+                                "activityName": {
+                                  "description": "Foreground Android activity name",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "appId": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "appId"
+                                  ],
+                                  "additionalProperties": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "packageName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "packageName"
+                                  ],
+                                  "additionalProperties": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "bundleId": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "bundleId"
+                                  ],
+                                  "additionalProperties": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "activityName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "activityName"
+                                  ],
+                                  "additionalProperties": {}
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "activeWindow"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  ]
                 }
               ]
             }

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3113,78 +3113,144 @@
         },
         "waitFor": {
           "description": "Wait for element to appear before returning observation",
-          "type": "object",
-          "properties": {
-            "elementId": {
-              "description": "Element resource ID / accessibility identifier",
-              "type": "string"
-            },
-            "text": {
-              "description": "Element text",
-              "type": "string"
-            },
-            "textAny": {
-              "description": "Ordered text variants; first visible match wins",
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "className": {
-              "description": "Element class name",
-              "type": "string"
-            },
-            "contentDescription": {
-              "description": "Element content description / accessibility label",
-              "type": "string"
-            },
-            "activeWindow": {
-              "description": "Foreground app/window predicates",
+          "allOf": [
+            {
               "type": "object",
               "properties": {
-                "appId": {
-                  "description": "Foreground app bundle ID / package name",
+                "elementId": {
+                  "description": "Element resource ID / accessibility identifier",
                   "type": "string"
                 },
-                "activityName": {
-                  "description": "Foreground Android activity name",
+                "text": {
+                  "description": "Element text",
                   "type": "string"
+                },
+                "textAny": {
+                  "description": "Ordered text variants; first visible match wins",
+                  "minItems": 1,
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "className": {
+                  "description": "Element class name",
+                  "type": "string"
+                },
+                "contentDescription": {
+                  "description": "Element content description / accessibility label",
+                  "type": "string"
+                },
+                "activeWindow": {
+                  "description": "Foreground app/window predicates",
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "appId": {
+                          "description": "Foreground app bundle ID / package name",
+                          "type": "string"
+                        },
+                        "activityName": {
+                          "description": "Foreground Android activity name",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "appId": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "appId"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "activityName": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "activityName"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "matchType": {
+                  "description": "Whether element predicates must all match the same node or any one may match",
+                  "type": "string",
+                  "enum": [
+                    "all",
+                    "any"
+                  ]
+                },
+                "textMatch": {
+                  "description": "How to match text predicates",
+                  "type": "string",
+                  "enum": [
+                    "exact",
+                    "contains",
+                    "regex"
+                  ]
+                },
+                "timeout": {
+                  "description": "Wait timeout ms (default: 5000)",
+                  "type": "number"
+                },
+                "container": {
+                  "description": "Scope match to a container",
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "elementId": {
+                          "type": "string",
+                          "description": "Container resource ID"
+                        }
+                      },
+                      "required": [
+                        "elementId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "text": {
+                          "type": "string",
+                          "description": "Container text"
+                        }
+                      },
+                      "required": [
+                        "text"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
                 }
               },
               "additionalProperties": false
             },
-            "matchType": {
-              "description": "Whether element predicates must all match the same node or any one may match",
-              "type": "string",
-              "enum": [
-                "all",
-                "any"
-              ]
-            },
-            "textMatch": {
-              "description": "How to match text predicates",
-              "type": "string",
-              "enum": [
-                "exact",
-                "contains",
-                "regex"
-              ]
-            },
-            "timeout": {
-              "description": "Wait timeout ms (default: 5000)",
-              "type": "number"
-            },
-            "container": {
-              "description": "Scope match to a container",
+            {
               "anyOf": [
                 {
                   "type": "object",
                   "properties": {
                     "elementId": {
-                      "type": "string",
-                      "description": "Container resource ID"
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3196,19 +3262,113 @@
                   "type": "object",
                   "properties": {
                     "text": {
-                      "type": "string",
-                      "description": "Container text"
+                      "type": "string"
                     }
                   },
                   "required": [
                     "text"
                   ],
                   "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "textAny": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "required": [
+                    "textAny"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "className": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "className"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "contentDescription": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "contentDescription"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "activeWindow": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "appId": {
+                              "description": "Foreground app bundle ID / package name",
+                              "type": "string"
+                            },
+                            "activityName": {
+                              "description": "Foreground Android activity name",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "appId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "appId"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "activityName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "activityName"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "activeWindow"
+                  ],
+                  "additionalProperties": false
                 }
               ]
             }
-          },
-          "additionalProperties": false
+          ]
         },
         "raw": {
           "description": "Include raw view hierarchy",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3152,58 +3152,10 @@
                           "description": "Foreground app bundle ID / package name",
                           "type": "string"
                         },
-                        "packageId": {
-                          "type": "string"
-                        },
-                        "package": {
-                          "type": "string"
-                        },
                         "packageName": {
                           "type": "string"
                         },
-                        "appPackage": {
-                          "type": "string"
-                        },
-                        "appPackageId": {
-                          "type": "string"
-                        },
-                        "bundle": {
-                          "type": "string"
-                        },
                         "bundleId": {
-                          "type": "string"
-                        },
-                        "bundleID": {
-                          "type": "string"
-                        },
-                        "bundleIdentifier": {
-                          "type": "string"
-                        },
-                        "application": {
-                          "type": "string"
-                        },
-                        "applicationId": {
-                          "type": "string"
-                        },
-                        "applicationIdentifier": {
-                          "type": "string"
-                        },
-                        "app": {
-                          "type": "string"
-                        },
-                        "appIdentifier": {
-                          "type": "string"
-                        },
-                        "package_id": {
-                          "type": "string"
-                        },
-                        "package_name": {
-                          "type": "string"
-                        },
-                        "bundle_id": {
-                          "type": "string"
-                        },
-                        "application_id": {
                           "type": "string"
                         },
                         "activityName": {
@@ -3230,30 +3182,6 @@
                         {
                           "type": "object",
                           "properties": {
-                            "packageId": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "packageId"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "package": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "package"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
                             "packageName": {
                               "type": "string"
                             }
@@ -3266,180 +3194,12 @@
                         {
                           "type": "object",
                           "properties": {
-                            "appPackage": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "appPackage"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "appPackageId": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "appPackageId"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "bundle": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "bundle"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
                             "bundleId": {
                               "type": "string"
                             }
                           },
                           "required": [
                             "bundleId"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "bundleID": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "bundleID"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "bundleIdentifier": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "bundleIdentifier"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "application": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "application"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "applicationId": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "applicationId"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "applicationIdentifier": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "applicationIdentifier"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "app": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "app"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "appIdentifier": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "appIdentifier"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "package_id": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "package_id"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "package_name": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "package_name"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "bundle_id": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "bundle_id"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "application_id": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "application_id"
                           ],
                           "additionalProperties": {}
                         },
@@ -3593,58 +3353,10 @@
                               "description": "Foreground app bundle ID / package name",
                               "type": "string"
                             },
-                            "packageId": {
-                              "type": "string"
-                            },
-                            "package": {
-                              "type": "string"
-                            },
                             "packageName": {
                               "type": "string"
                             },
-                            "appPackage": {
-                              "type": "string"
-                            },
-                            "appPackageId": {
-                              "type": "string"
-                            },
-                            "bundle": {
-                              "type": "string"
-                            },
                             "bundleId": {
-                              "type": "string"
-                            },
-                            "bundleID": {
-                              "type": "string"
-                            },
-                            "bundleIdentifier": {
-                              "type": "string"
-                            },
-                            "application": {
-                              "type": "string"
-                            },
-                            "applicationId": {
-                              "type": "string"
-                            },
-                            "applicationIdentifier": {
-                              "type": "string"
-                            },
-                            "app": {
-                              "type": "string"
-                            },
-                            "appIdentifier": {
-                              "type": "string"
-                            },
-                            "package_id": {
-                              "type": "string"
-                            },
-                            "package_name": {
-                              "type": "string"
-                            },
-                            "bundle_id": {
-                              "type": "string"
-                            },
-                            "application_id": {
                               "type": "string"
                             },
                             "activityName": {
@@ -3671,30 +3383,6 @@
                             {
                               "type": "object",
                               "properties": {
-                                "packageId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "packageId"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "package": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "package"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
                                 "packageName": {
                                   "type": "string"
                                 }
@@ -3707,180 +3395,12 @@
                             {
                               "type": "object",
                               "properties": {
-                                "appPackage": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "appPackage"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "appPackageId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "appPackageId"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "bundle": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "bundle"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
                                 "bundleId": {
                                   "type": "string"
                                 }
                               },
                               "required": [
                                 "bundleId"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "bundleID": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "bundleID"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "bundleIdentifier": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "bundleIdentifier"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "application": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "application"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "applicationId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "applicationId"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "applicationIdentifier": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "applicationIdentifier"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "app": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "app"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "appIdentifier": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "appIdentifier"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "package_id": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "package_id"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "package_name": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "package_name"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "bundle_id": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "bundle_id"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "application_id": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "application_id"
                               ],
                               "additionalProperties": {}
                             },

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -10,7 +10,7 @@ import { BootedDevice, Element, ObserveResult, ObserveToolPayload, ViewHierarchy
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
-import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { elementContainerSchema } from "./elementSelectorSchemas";
 import { observeResultSchema } from "./toolOutputSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
@@ -107,12 +107,12 @@ const waitForPredicatePresenceSchema = z.union([
 
 const waitForSchema = waitForBaseSchema.and(waitForPredicatePresenceSchema);
 
-export const observeSchema = addDeviceTargetingToSchema(z.object({
+export const observeSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
   raw: z.boolean().optional().describe("Include raw view hierarchy"),
   skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling")
-}));
+})));
 
 export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema,

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -10,7 +10,7 @@ import { BootedDevice, Element, ObserveResult, ObserveToolPayload, ViewHierarchy
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
-import { addDeviceTargetingToSchema, appIdFieldAliases, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { elementContainerSchema } from "./elementSelectorSchemas";
 import { observeResultSchema } from "./toolOutputSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
@@ -32,13 +32,16 @@ const waitForContainerField = elementContainerSchema
     "Scope match to a container"
   );
 
-const appIdAliasShape = Object.fromEntries(
-  appIdFieldAliases.map(alias => [alias, z.string().optional()])
-) as Record<typeof appIdFieldAliases[number], z.ZodOptional<z.ZodString>>;
+const publicActiveWindowAppIdAliases = ["packageName", "bundleId"] as const;
+
+const appIdAliasShape = {
+  packageName: z.string().optional(),
+  bundleId: z.string().optional(),
+};
 
 const appIdPresenceBranches = [
   z.object({ appId: z.string() }).passthrough(),
-  ...appIdFieldAliases.map(alias => z.object({ [alias]: z.string() }).passthrough())
+  ...publicActiveWindowAppIdAliases.map(alias => z.object({ [alias]: z.string() }).passthrough())
 ];
 
 const activeWindowWaitForBaseSchema = z.object({

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -166,7 +166,8 @@ const isElementCenterOffScreen = (
 export const findWaitForElement = (
   finder: ElementFinder,
   waitFor: ObserveWaitForOptions,
-  viewHierarchy: ViewHierarchyResult
+  viewHierarchy: ViewHierarchyResult,
+  platform?: BootedDevice["platform"]
 ): Element | null => {
   const container = waitForContainerForFinder(waitFor);
 
@@ -208,7 +209,7 @@ export const findWaitForElement = (
     return null;
   }
 
-  return findRichWaitForElement(finder, waitFor, viewHierarchy);
+  return findRichWaitForElement(finder, waitFor, viewHierarchy, platform);
 };
 
 const hasElementPredicate = (waitFor: ObserveWaitForOptions): boolean =>
@@ -268,7 +269,7 @@ const getClassName = (element: Element): string | undefined =>
       ? element.className
       : undefined;
 
-const getContentDescription = (element: Element): string | undefined =>
+const getContentDescription = (element: Element, platform?: BootedDevice["platform"]): string | undefined =>
   typeof element["content-desc"] === "string"
     ? element["content-desc"]
     : typeof element["ios-accessibility-label"] === "string"
@@ -277,7 +278,7 @@ const getContentDescription = (element: Element): string | undefined =>
         ? element.contentDescription
         : typeof element.accessibilityLabel === "string"
           ? element.accessibilityLabel
-          : typeof element.text === "string"
+          : platform === "ios" && typeof element.text === "string"
             ? element.text
             : undefined;
 
@@ -316,7 +317,8 @@ const matchesTextPredicate = (element: Element, waitFor: ObserveWaitForOptions):
 
 const elementPredicateResults = (
   element: Element,
-  waitFor: ObserveWaitForOptions
+  waitFor: ObserveWaitForOptions,
+  platform?: BootedDevice["platform"]
 ): boolean[] => {
   const results: boolean[] = [];
   if (waitFor.elementId !== undefined) {
@@ -329,7 +331,7 @@ const elementPredicateResults = (
     results.push(getClassName(element) === waitFor.className);
   }
   if (waitFor.contentDescription !== undefined) {
-    results.push(matchesString(getContentDescription(element), waitFor.contentDescription, "exact"));
+    results.push(matchesString(getContentDescription(element, platform), waitFor.contentDescription, "exact"));
   }
   return results;
 };
@@ -337,14 +339,15 @@ const elementPredicateResults = (
 const findRichWaitForElement = (
   finder: ElementFinder,
   waitFor: ObserveWaitForOptions,
-  viewHierarchy: ViewHierarchyResult
+  viewHierarchy: ViewHierarchyResult,
+  platform?: BootedDevice["platform"]
 ): Element | null => {
   const candidates = collectCandidateElements(finder, waitFor, viewHierarchy)
     .filter(candidate => !isElementCenterOffScreen(candidate, viewHierarchy));
   const matchType = waitFor.matchType ?? "all";
 
   for (const candidate of candidates) {
-    const results = elementPredicateResults(candidate, waitFor);
+    const results = elementPredicateResults(candidate, waitFor, platform);
     if (results.length === 0) {
       continue;
     }
@@ -378,6 +381,14 @@ const matchesActiveWindow = (
   }
 
   if (
+    platform === "ios" &&
+    waitFor.activeWindow.activityName !== undefined &&
+    waitFor.activeWindow.appId === undefined
+  ) {
+    return false;
+  }
+
+  if (
     platform !== "ios" &&
     waitFor.activeWindow.activityName !== undefined &&
     activeWindow.activityName !== waitFor.activeWindow.activityName
@@ -397,7 +408,7 @@ const evaluateWaitForObservation = (
   const activeWindowMatched = matchesActiveWindow(observation, waitFor, platform);
   const needsElementMatch = hasElementPredicate(waitFor);
   const awaitedElement = needsElementMatch && observation.viewHierarchy
-    ? findWaitForElement(finder, waitFor, observation.viewHierarchy)
+    ? findWaitForElement(finder, waitFor, observation.viewHierarchy, platform)
     : null;
 
   return {

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -55,47 +55,33 @@ const activeWindowWaitForSchema = activeWindowWaitForBaseSchema.and(z.union([
   z.object({ activityName: z.string() }).passthrough(),
 ]));
 
-const waitForBaseSchema = z.object({
-  elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
-  text: z.string().optional().describe("Element text"),
-  textAny: z.array(z.string().min(1)).min(1).optional().describe("Ordered text variants; first visible match wins"),
-  className: z.string().optional().describe("Element class name"),
-  contentDescription: z.string().optional().describe("Element content description / accessibility label"),
+const waitForCommonShape = {
   activeWindow: activeWindowWaitForSchema.optional().describe("Foreground app/window predicates"),
-  matchType: z.enum(["all", "any"]).optional().describe("Whether element predicates must all match the same node or any one may match"),
-  textMatch: z.enum(["exact", "contains", "regex"]).optional().describe("How to match text predicates"),
   timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
   container: waitForContainerField
-}).strict().superRefine((value, ctx) => {
-  const hasElementPredicate =
-    value.elementId !== undefined ||
-    value.text !== undefined ||
-    value.textAny !== undefined ||
-    value.className !== undefined ||
-    value.contentDescription !== undefined;
-  if (!hasElementPredicate && value.activeWindow === undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide at least one waitFor predicate"
-    });
-  }
+};
 
-  if (
-    value.textAny !== undefined &&
-    (
-      value.elementId !== undefined ||
-      value.text !== undefined ||
-      value.className !== undefined ||
-      value.contentDescription !== undefined ||
-      value.textMatch !== undefined ||
-      value.matchType !== undefined
-    )
-  ) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "textAny cannot be combined with element field predicates"
-    });
-  }
+const waitForTextAnySchema = z.object({
+  textAny: z.array(z.string().min(1)).min(1).describe("Ordered text variants; first visible match wins"),
+  elementId: z.never().optional(),
+  text: z.never().optional(),
+  className: z.never().optional(),
+  contentDescription: z.never().optional(),
+  matchType: z.never().optional(),
+  textMatch: z.never().optional(),
+  ...waitForCommonShape,
+}).strict();
+
+const waitForElementBaseSchema = z.object({
+  elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
+  text: z.string().optional().describe("Element text"),
+  textAny: z.never().optional(),
+  className: z.string().optional().describe("Element class name"),
+  contentDescription: z.string().optional().describe("Element content description / accessibility label"),
+  matchType: z.enum(["all", "any"]).optional().describe("Whether element predicates must all match the same node or any one may match"),
+  textMatch: z.enum(["exact", "contains", "regex"]).optional().describe("How to match text predicates"),
+  ...waitForCommonShape,
+}).strict().superRefine((value, ctx) => {
 
   if (value.textMatch === "regex" && value.text !== undefined) {
     try {
@@ -112,13 +98,17 @@ const waitForBaseSchema = z.object({
 const waitForPredicatePresenceSchema = z.union([
   z.object({ elementId: z.string() }).passthrough(),
   z.object({ text: z.string() }).passthrough(),
-  z.object({ textAny: z.array(z.string().min(1)).min(1) }).passthrough(),
   z.object({ className: z.string() }).passthrough(),
   z.object({ contentDescription: z.string() }).passthrough(),
   z.object({ activeWindow: activeWindowWaitForSchema }).passthrough(),
 ]);
 
-const waitForSchema = waitForBaseSchema.and(waitForPredicatePresenceSchema);
+const waitForElementSchema = waitForElementBaseSchema.and(waitForPredicatePresenceSchema);
+
+const waitForSchema = z.union([
+  waitForTextAnySchema,
+  waitForElementSchema,
+]);
 
 export const observeSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
@@ -287,7 +277,9 @@ const getContentDescription = (element: Element): string | undefined =>
         ? element.contentDescription
         : typeof element.accessibilityLabel === "string"
           ? element.accessibilityLabel
-          : undefined;
+          : typeof element.text === "string"
+            ? element.text
+            : undefined;
 
 const textFieldsForElement = (element: Element): string[] => [
   element.text,

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -10,7 +10,7 @@ import { BootedDevice, Element, ObserveResult, ObserveToolPayload, ViewHierarchy
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
-import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, appIdFieldAliases, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { elementContainerSchema } from "./elementSelectorSchemas";
 import { observeResultSchema } from "./toolOutputSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
@@ -32,14 +32,24 @@ const waitForContainerField = elementContainerSchema
     "Scope match to a container"
   );
 
+const appIdAliasShape = Object.fromEntries(
+  appIdFieldAliases.map(alias => [alias, z.string().optional()])
+) as Record<typeof appIdFieldAliases[number], z.ZodOptional<z.ZodString>>;
+
+const appIdPresenceBranches = [
+  z.object({ appId: z.string() }).passthrough(),
+  ...appIdFieldAliases.map(alias => z.object({ [alias]: z.string() }).passthrough())
+];
+
 const activeWindowWaitForBaseSchema = z.object({
   appId: z.string().optional().describe("Foreground app bundle ID / package name"),
+  ...appIdAliasShape,
   activityName: z.string().optional().describe("Foreground Android activity name")
 }).strict();
 
 const activeWindowWaitForSchema = activeWindowWaitForBaseSchema.and(z.union([
-  z.object({ appId: z.string() }),
-  z.object({ activityName: z.string() }),
+  ...appIdPresenceBranches,
+  z.object({ activityName: z.string() }).passthrough(),
 ]));
 
 const waitForBaseSchema = z.object({
@@ -97,12 +107,12 @@ const waitForBaseSchema = z.object({
 });
 
 const waitForPredicatePresenceSchema = z.union([
-  z.object({ elementId: z.string() }),
-  z.object({ text: z.string() }),
-  z.object({ textAny: z.array(z.string().min(1)).min(1) }),
-  z.object({ className: z.string() }),
-  z.object({ contentDescription: z.string() }),
-  z.object({ activeWindow: activeWindowWaitForSchema }),
+  z.object({ elementId: z.string() }).passthrough(),
+  z.object({ text: z.string() }).passthrough(),
+  z.object({ textAny: z.array(z.string().min(1)).min(1) }).passthrough(),
+  z.object({ className: z.string() }).passthrough(),
+  z.object({ contentDescription: z.string() }).passthrough(),
+  z.object({ activeWindow: activeWindowWaitForSchema }).passthrough(),
 ]);
 
 const waitForSchema = waitForBaseSchema.and(waitForPredicatePresenceSchema);
@@ -356,7 +366,8 @@ const findRichWaitForElement = (
 
 const matchesActiveWindow = (
   observation: ObserveResult,
-  waitFor: ObserveWaitForOptions
+  waitFor: ObserveWaitForOptions,
+  platform?: BootedDevice["platform"]
 ): boolean => {
   if (!waitFor.activeWindow) {
     return true;
@@ -371,7 +382,11 @@ const matchesActiveWindow = (
     return false;
   }
 
-  if (waitFor.activeWindow.activityName !== undefined && activeWindow.activityName !== waitFor.activeWindow.activityName) {
+  if (
+    platform !== "ios" &&
+    waitFor.activeWindow.activityName !== undefined &&
+    activeWindow.activityName !== waitFor.activeWindow.activityName
+  ) {
     return false;
   }
 
@@ -381,9 +396,10 @@ const matchesActiveWindow = (
 const evaluateWaitForObservation = (
   finder: ElementFinder,
   waitFor: ObserveWaitForOptions,
-  observation: ObserveResult
+  observation: ObserveResult,
+  platform?: BootedDevice["platform"]
 ): { matched: boolean; awaitedElement?: Element } => {
-  const activeWindowMatched = matchesActiveWindow(observation, waitFor);
+  const activeWindowMatched = matchesActiveWindow(observation, waitFor, platform);
   const needsElementMatch = hasElementPredicate(waitFor);
   const awaitedElement = needsElementMatch && observation.viewHierarchy
     ? findWaitForElement(finder, waitFor, observation.viewHierarchy)
@@ -400,7 +416,8 @@ export const waitForObservation = async (
   waitFor: ObserveWaitForOptions,
   signal?: AbortSignal,
   skipBackStack: boolean = false,
-  timer: Timer = defaultTimer
+  timer: Timer = defaultTimer,
+  platform?: BootedDevice["platform"]
 ): Promise<{
   observation: ObserveResult;
   awaitedElement?: Element;
@@ -432,7 +449,7 @@ export const waitForObservation = async (
     skipBackStack: skipPollingOverhead || skipBackStack,
     skipScreenshot: skipPollingOverhead,
   });
-  let waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation);
+  let waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation, platform);
 
   if (waitEvaluation.matched) {
     return {
@@ -464,7 +481,7 @@ export const waitForObservation = async (
       skipBackStack: skipPollingOverhead || skipBackStack,
       skipScreenshot: skipPollingOverhead,
     });
-    waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation);
+    waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation, platform);
 
     if (waitEvaluation.matched) {
       return {
@@ -494,7 +511,7 @@ export function registerObserveTools() {
       // source, so every observation reaching here is already platform-validated
       // (raw-mode append below is likewise gated on a validated primary hierarchy).
       const waitOutcome = waitFor
-        ? await waitForObservation(observeScreen, waitFor, signal, args.skipBackStack ?? false)
+        ? await waitForObservation(observeScreen, waitFor, signal, args.skipBackStack ?? false, defaultTimer, device.platform)
         : null;
       const result = waitOutcome
         ? waitOutcome.observation

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -32,19 +32,17 @@ const waitForContainerField = elementContainerSchema
     "Scope match to a container"
   );
 
-const activeWindowWaitForSchema = z.object({
+const activeWindowWaitForBaseSchema = z.object({
   appId: z.string().optional().describe("Foreground app bundle ID / package name"),
   activityName: z.string().optional().describe("Foreground Android activity name")
-}).strict().superRefine((value, ctx) => {
-  if (value.appId === undefined && value.activityName === undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide at least one activeWindow predicate"
-    });
-  }
-});
+}).strict();
 
-const waitForSchema = z.object({
+const activeWindowWaitForSchema = activeWindowWaitForBaseSchema.and(z.union([
+  z.object({ appId: z.string() }),
+  z.object({ activityName: z.string() }),
+]));
+
+const waitForBaseSchema = z.object({
   elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
   text: z.string().optional().describe("Element text"),
   textAny: z.array(z.string().min(1)).min(1).optional().describe("Ordered text variants; first visible match wins"),
@@ -97,6 +95,17 @@ const waitForSchema = z.object({
     }
   }
 });
+
+const waitForPredicatePresenceSchema = z.union([
+  z.object({ elementId: z.string() }),
+  z.object({ text: z.string() }),
+  z.object({ textAny: z.array(z.string().min(1)).min(1) }),
+  z.object({ className: z.string() }),
+  z.object({ contentDescription: z.string() }),
+  z.object({ activeWindow: activeWindowWaitForSchema }),
+]);
+
+const waitForSchema = waitForBaseSchema.and(waitForPredicatePresenceSchema);
 
 export const observeSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema,

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -14,38 +14,89 @@ import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers"
 import { elementContainerSchema } from "./elementSelectorSchemas";
 import { observeResultSchema } from "./toolOutputSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
+import { DefaultElementParser } from "../features/utility/ElementParser";
+import { normalizeQuotes } from "../features/utility/TextMatcher";
 import type { ElementFinder } from "../utils/interfaces/ElementFinder";
-import { defaultTimer } from "../utils/SystemTimer";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { consumeSetupTiming } from "./ToolExecutionContext";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { logger } from "../utils/logger";
 import { serverConfig } from "../utils/ServerConfig";
 
 // Schema definitions
-// waitFor accepts elementId OR text directly (oneOf), plus optional timeout and optional container (same shape as tapOn)
+// waitFor accepts legacy selectors plus richer predicates. Element predicates are
+// evaluated against the same node unless matchType is explicitly "any".
 const waitForContainerField = elementContainerSchema
   .optional()
   .describe(
     "Scope match to a container"
   );
 
-const waitForSchema = z.union([
-  z.object({
-    elementId: z.string().describe("Element resource ID / accessibility identifier"),
-    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
-    container: waitForContainerField
-  }).strict(),
-  z.object({
-    text: z.string().describe("Element text"),
-    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
-    container: waitForContainerField
-  }).strict(),
-  z.object({
-    textAny: z.array(z.string().min(1)).min(1).describe("Ordered text variants; first visible match wins"),
-    timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
-    container: waitForContainerField
-  }).strict()
-]);
+const activeWindowWaitForSchema = z.object({
+  appId: z.string().optional().describe("Foreground app bundle ID / package name"),
+  activityName: z.string().optional().describe("Foreground Android activity name")
+}).strict().superRefine((value, ctx) => {
+  if (value.appId === undefined && value.activityName === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Provide at least one activeWindow predicate"
+    });
+  }
+});
+
+const waitForSchema = z.object({
+  elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
+  text: z.string().optional().describe("Element text"),
+  textAny: z.array(z.string().min(1)).min(1).optional().describe("Ordered text variants; first visible match wins"),
+  className: z.string().optional().describe("Element class name"),
+  contentDescription: z.string().optional().describe("Element content description / accessibility label"),
+  activeWindow: activeWindowWaitForSchema.optional().describe("Foreground app/window predicates"),
+  matchType: z.enum(["all", "any"]).optional().describe("Whether element predicates must all match the same node or any one may match"),
+  textMatch: z.enum(["exact", "contains", "regex"]).optional().describe("How to match text predicates"),
+  timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
+  container: waitForContainerField
+}).strict().superRefine((value, ctx) => {
+  const hasElementPredicate =
+    value.elementId !== undefined ||
+    value.text !== undefined ||
+    value.textAny !== undefined ||
+    value.className !== undefined ||
+    value.contentDescription !== undefined;
+  if (!hasElementPredicate && value.activeWindow === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Provide at least one waitFor predicate"
+    });
+  }
+
+  if (
+    value.textAny !== undefined &&
+    (
+      value.elementId !== undefined ||
+      value.text !== undefined ||
+      value.className !== undefined ||
+      value.contentDescription !== undefined ||
+      value.textMatch !== undefined ||
+      value.matchType !== undefined
+    )
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "textAny cannot be combined with element field predicates"
+    });
+  }
+
+  if (value.textMatch === "regex" && value.text !== undefined) {
+    try {
+      new RegExp(value.text);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "text must be a valid regular expression when textMatch is regex"
+      });
+    }
+  }
+});
 
 export const observeSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
@@ -107,7 +158,7 @@ export const findWaitForElement = (
 ): Element | null => {
   const container = waitForContainerForFinder(waitFor);
 
-  if ("elementId" in waitFor) {
+  if (waitFor.elementId !== undefined && !hasRichElementPredicate(waitFor)) {
     return finder.findElementByResourceId(
       viewHierarchy,
       waitFor.elementId,
@@ -115,7 +166,7 @@ export const findWaitForElement = (
     );
   }
 
-  if ("text" in waitFor) {
+  if (waitFor.text !== undefined && !hasRichElementPredicate(waitFor)) {
     return finder.findElementByText(
       viewHierarchy,
       waitFor.text,
@@ -125,7 +176,7 @@ export const findWaitForElement = (
     );
   }
 
-  if ("textAny" in waitFor) {
+  if (waitFor.textAny !== undefined) {
     for (const text of waitFor.textAny) {
       const elements = finder.findElementsByText(
         viewHierarchy,
@@ -141,26 +192,218 @@ export const findWaitForElement = (
     }
   }
 
+  if (!hasElementPredicate(waitFor)) {
+    return null;
+  }
+
+  return findRichWaitForElement(finder, waitFor, viewHierarchy);
+};
+
+const hasElementPredicate = (waitFor: ObserveWaitForOptions): boolean =>
+  waitFor.elementId !== undefined ||
+  waitFor.text !== undefined ||
+  waitFor.textAny !== undefined ||
+  waitFor.className !== undefined ||
+  waitFor.contentDescription !== undefined;
+
+const hasRichElementPredicate = (waitFor: ObserveWaitForOptions): boolean =>
+  waitFor.className !== undefined ||
+  waitFor.contentDescription !== undefined ||
+  waitFor.matchType !== undefined ||
+  waitFor.textMatch !== undefined ||
+  (
+    waitFor.elementId !== undefined &&
+    waitFor.text !== undefined
+  );
+
+const parser = new DefaultElementParser();
+
+const collectCandidateElements = (
+  finder: ElementFinder,
+  waitFor: ObserveWaitForOptions,
+  viewHierarchy: ViewHierarchyResult
+): Element[] => {
+  const container = waitForContainerForFinder(waitFor);
+  const containerNode = container
+    ? finder.findContainerNode(viewHierarchy, container)
+    : null;
+  if (container && !containerNode) {
+    return [];
+  }
+
+  const roots = containerNode
+    ? [containerNode]
+    : [
+      ...parser.extractRootNodes(viewHierarchy),
+      ...parser.extractWindowRootNodes(viewHierarchy, "topmost-first")
+    ];
+  const elements: Element[] = [];
+  for (const root of roots) {
+    parser.traverseNode(root, node => {
+      const element = parser.parseNodeBounds(node);
+      if (element) {
+        elements.push(element);
+      }
+    });
+  }
+  return elements;
+};
+
+const getClassName = (element: Element): string | undefined =>
+  typeof element.class === "string"
+    ? element.class
+    : typeof element.className === "string"
+      ? element.className
+      : undefined;
+
+const getContentDescription = (element: Element): string | undefined =>
+  typeof element["content-desc"] === "string"
+    ? element["content-desc"]
+    : typeof element["ios-accessibility-label"] === "string"
+      ? element["ios-accessibility-label"]
+      : typeof element.contentDescription === "string"
+        ? element.contentDescription
+        : typeof element.accessibilityLabel === "string"
+          ? element.accessibilityLabel
+          : undefined;
+
+const textFieldsForElement = (element: Element): string[] => [
+  element.text,
+  element["content-desc"],
+  element["ios-accessibility-label"],
+].filter((value): value is string => typeof value === "string");
+
+const matchesString = (
+  actual: string | undefined,
+  expected: string,
+  matchMode: "exact" | "contains" | "regex" = "contains"
+): boolean => {
+  if (actual === undefined) {
+    return false;
+  }
+
+  if (matchMode === "regex") {
+    return new RegExp(expected, "i").test(actual);
+  }
+
+  const normalizedActual = normalizeQuotes(actual).toLowerCase();
+  const normalizedExpected = normalizeQuotes(expected).toLowerCase();
+  return matchMode === "exact"
+    ? normalizedActual === normalizedExpected
+    : normalizedActual.includes(normalizedExpected);
+};
+
+const matchesTextPredicate = (element: Element, waitFor: ObserveWaitForOptions): boolean => {
+  if (waitFor.text === undefined) {
+    return false;
+  }
+  return textFieldsForElement(element).some(text => matchesString(text, waitFor.text!, waitFor.textMatch ?? "contains"));
+};
+
+const elementPredicateResults = (
+  element: Element,
+  waitFor: ObserveWaitForOptions
+): boolean[] => {
+  const results: boolean[] = [];
+  if (waitFor.elementId !== undefined) {
+    results.push(element["resource-id"] === waitFor.elementId);
+  }
+  if (waitFor.text !== undefined) {
+    results.push(matchesTextPredicate(element, waitFor));
+  }
+  if (waitFor.className !== undefined) {
+    results.push(getClassName(element) === waitFor.className);
+  }
+  if (waitFor.contentDescription !== undefined) {
+    results.push(matchesString(getContentDescription(element), waitFor.contentDescription, "exact"));
+  }
+  return results;
+};
+
+const findRichWaitForElement = (
+  finder: ElementFinder,
+  waitFor: ObserveWaitForOptions,
+  viewHierarchy: ViewHierarchyResult
+): Element | null => {
+  const candidates = collectCandidateElements(finder, waitFor, viewHierarchy)
+    .filter(candidate => !isElementCenterOffScreen(candidate, viewHierarchy));
+  const matchType = waitFor.matchType ?? "all";
+
+  for (const candidate of candidates) {
+    const results = elementPredicateResults(candidate, waitFor);
+    if (results.length === 0) {
+      continue;
+    }
+    const matched = matchType === "any"
+      ? results.some(Boolean)
+      : results.every(Boolean);
+    if (matched) {
+      return candidate;
+    }
+  }
+
   return null;
 };
 
-const waitForObservation = async (
+const matchesActiveWindow = (
+  observation: ObserveResult,
+  waitFor: ObserveWaitForOptions
+): boolean => {
+  if (!waitFor.activeWindow) {
+    return true;
+  }
+
+  const activeWindow = observation.activeWindow;
+  if (!activeWindow) {
+    return false;
+  }
+
+  if (waitFor.activeWindow.appId !== undefined && activeWindow.appId !== waitFor.activeWindow.appId) {
+    return false;
+  }
+
+  if (waitFor.activeWindow.activityName !== undefined && activeWindow.activityName !== waitFor.activeWindow.activityName) {
+    return false;
+  }
+
+  return true;
+};
+
+const evaluateWaitForObservation = (
+  finder: ElementFinder,
+  waitFor: ObserveWaitForOptions,
+  observation: ObserveResult
+): { matched: boolean; awaitedElement?: Element } => {
+  const activeWindowMatched = matchesActiveWindow(observation, waitFor);
+  const needsElementMatch = hasElementPredicate(waitFor);
+  const awaitedElement = needsElementMatch && observation.viewHierarchy
+    ? findWaitForElement(finder, waitFor, observation.viewHierarchy)
+    : null;
+
+  return {
+    matched: activeWindowMatched && (!needsElementMatch || awaitedElement !== null),
+    awaitedElement: awaitedElement ?? undefined
+  };
+};
+
+export const waitForObservation = async (
   observeScreen: ObserveScreen,
   waitFor: ObserveWaitForOptions,
   signal?: AbortSignal,
-  skipBackStack: boolean = false
+  skipBackStack: boolean = false,
+  timer: Timer = defaultTimer
 ): Promise<{
   observation: ObserveResult;
   awaitedElement?: Element;
   awaitDuration: number;
   awaitTimeout: boolean;
 }> => {
-  const startTime = defaultTimer.now();
+  const startTime = timer.now();
   const timeoutMs = waitFor.timeout ?? 5000;
   const finder = new DefaultElementFinder();
   const queryOptions = {
-    text: "text" in waitFor ? waitFor.text : ("textAny" in waitFor ? waitFor.textAny[0] : undefined),
-    elementId: "elementId" in waitFor ? waitFor.elementId : undefined
+    text: waitFor.text ?? waitFor.textAny?.[0] ?? waitFor.contentDescription,
+    elementId: waitFor.elementId
   };
 
   // When overhead is disabled, skip screenshots and back stack during ALL waitFor
@@ -180,29 +423,27 @@ const waitForObservation = async (
     skipBackStack: skipPollingOverhead || skipBackStack,
     skipScreenshot: skipPollingOverhead,
   });
-  let awaitedElement = observation.viewHierarchy
-    ? findWaitForElement(finder, waitFor, observation.viewHierarchy)
-    : null;
+  let waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation);
 
-  if (awaitedElement) {
+  if (waitEvaluation.matched) {
     return {
       observation,
-      awaitedElement,
-      awaitDuration: defaultTimer.now() - startTime,
+      awaitedElement: waitEvaluation.awaitedElement,
+      awaitDuration: timer.now() - startTime,
       awaitTimeout: false
     };
   }
 
-  if (defaultTimer.now() - startTime >= timeoutMs) {
+  if (timer.now() - startTime >= timeoutMs) {
     return {
       observation,
-      awaitDuration: defaultTimer.now() - startTime,
+      awaitDuration: timer.now() - startTime,
       awaitTimeout: true
     };
   }
 
-  while (defaultTimer.now() - startTime < timeoutMs) {
-    await defaultTimer.sleep(WAIT_FOR_POLL_INTERVAL_MS);
+  while (timer.now() - startTime < timeoutMs) {
+    await timer.sleep(WAIT_FOR_POLL_INTERVAL_MS);
     throwIfAborted(signal);
 
     observation = await observeScreen.execute({
@@ -214,15 +455,13 @@ const waitForObservation = async (
       skipBackStack: skipPollingOverhead || skipBackStack,
       skipScreenshot: skipPollingOverhead,
     });
-    awaitedElement = observation.viewHierarchy
-      ? findWaitForElement(finder, waitFor, observation.viewHierarchy)
-      : null;
+    waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation);
 
-    if (awaitedElement) {
+    if (waitEvaluation.matched) {
       return {
         observation,
-        awaitedElement,
-        awaitDuration: defaultTimer.now() - startTime,
+        awaitedElement: waitEvaluation.awaitedElement,
+        awaitDuration: timer.now() - startTime,
         awaitTimeout: false
       };
     }
@@ -230,7 +469,7 @@ const waitForObservation = async (
 
   return {
     observation,
-    awaitDuration: defaultTimer.now() - startTime,
+    awaitDuration: timer.now() - startTime,
     awaitTimeout: true
   };
 };

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -1,7 +1,9 @@
+import Ajv2020 from "ajv/dist/2020";
 import { describe, expect, test } from "bun:test";
 import { DefaultElementFinder } from "../../src/features/utility/ElementFinder";
 import type { ObserveResult, ViewHierarchyResult } from "../../src/models";
-import { findWaitForElement, observeSchema, waitForObservation } from "../../src/server/observeTools";
+import { findWaitForElement, observeSchema, registerObserveTools, waitForObservation } from "../../src/server/observeTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
 import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -209,6 +211,124 @@ describe("observeSchema rich waitFor predicates", () => {
   });
 });
 
+describe("published observe waitFor input schema", () => {
+  const validatePublishedObserveInput = (input: unknown) => {
+    (ToolRegistry as any).tools.clear();
+    registerObserveTools();
+    const observeTool = ToolRegistry.getToolDefinitions()
+      .find(tool => tool.name === "observe");
+    expect(observeTool).toBeDefined();
+
+    const ajv = new Ajv2020({ strict: false, allErrors: true });
+    const validate = ajv.compile(observeTool!.inputSchema);
+    return {
+      valid: validate(input),
+      errors: validate.errors,
+    };
+  };
+
+  test.each([
+    {
+      label: "legacy elementId with timeout",
+      input: {
+        platform: "android",
+        waitFor: { elementId: "com.app:id/name", timeout: 5000 },
+      },
+    },
+    {
+      label: "legacy elementId with container",
+      input: {
+        platform: "android",
+        waitFor: {
+          elementId: "com.app:id/name",
+          container: { text: "People" },
+        },
+      },
+    },
+    {
+      label: "text with textMatch",
+      input: {
+        platform: "ios",
+        waitFor: { text: "Home", textMatch: "contains", timeout: 5000 },
+      },
+    },
+    {
+      label: "combined rich predicates",
+      input: {
+        platform: "ios",
+        waitFor: {
+          elementId: "home_tab_bar",
+          text: "Home",
+          className: "UITabBar",
+          contentDescription: "Home tab",
+          textMatch: "exact",
+          matchType: "all",
+        },
+      },
+    },
+    {
+      label: "activeWindow appId and activityName",
+      input: {
+        platform: "android",
+        waitFor: {
+          activeWindow: {
+            appId: "com.example.app",
+            activityName: "com.example.app.HomeActivity",
+          },
+          timeout: 5000,
+        },
+      },
+    },
+    {
+      label: "activeWindow packageName alias",
+      input: {
+        platform: "android",
+        waitFor: {
+          activeWindow: { packageName: "com.example.app" },
+        },
+      },
+    },
+    {
+      label: "activeWindow bundleId alias",
+      input: {
+        platform: "ios",
+        waitFor: {
+          activeWindow: { bundleId: "com.example.app" },
+        },
+      },
+    },
+  ])("accepts runtime-valid waitFor input: $label", ({ input }) => {
+    expect(observeSchema.safeParse(input).success).toBe(true);
+
+    const result = validatePublishedObserveInput(input);
+
+    expect(result.valid).toBe(true);
+  });
+
+  test.each([
+    {
+      label: "waitFor has only timeout",
+      input: {
+        platform: "android",
+        waitFor: { timeout: 5000 },
+      },
+    },
+    {
+      label: "activeWindow is empty",
+      input: {
+        platform: "android",
+        waitFor: { activeWindow: {} },
+      },
+    },
+  ])("rejects runtime-invalid waitFor input: $label", ({ input }) => {
+    expect(observeSchema.safeParse(input).success).toBe(false);
+
+    const result = validatePublishedObserveInput(input);
+
+    expect(result.valid).toBe(false);
+  });
+});
+
 describe("findWaitForElement textAny", () => {
   test("skips off-screen earlier variants when a later variant is visible", () => {
     const finder = new DefaultElementFinder();
@@ -361,6 +481,81 @@ describe("findWaitForElement rich predicates", () => {
       {
         elementId: "home_tab",
         text: "Home",
+      } as any,
+      hierarchy
+    );
+
+    expect(element).toBeNull();
+  });
+
+  test("scopes rich predicates to the requested container", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          "resource-id": "outside_container",
+          "bounds": bounds(0, 0, 200, 80),
+        },
+        node: [
+          {
+            $: {
+              "resource-id": "home_tab",
+              "class": "UITabBar",
+              "content-desc": "Home tab",
+              "bounds": bounds(10, 10, 190, 60),
+            },
+          },
+        ],
+      },
+      {
+        $: {
+          "resource-id": "target_container",
+          "bounds": bounds(0, 90, 200, 190),
+        },
+        node: [
+          {
+            $: {
+              "resource-id": "settings_tab",
+              "class": "UITabBar",
+              "content-desc": "Settings tab",
+              "bounds": bounds(10, 110, 190, 160),
+            },
+          },
+        ],
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        className: "UITabBar",
+        contentDescription: "Settings tab",
+        container: { elementId: "target_container" },
+      } as any,
+      hierarchy
+    );
+
+    expect(element?.["resource-id"]).toBe("settings_tab");
+  });
+
+  test("returns null for rich predicates when the requested container is missing", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          "class": "UITabBar",
+          "content-desc": "Home tab",
+          "bounds": bounds(10, 10, 190, 60),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        className: "UITabBar",
+        contentDescription: "Home tab",
+        container: { elementId: "missing_container" },
       } as any,
       hierarchy
     );
@@ -526,6 +721,31 @@ describe("waitForObservation activeWindow", () => {
 
     expect(outcome.awaitTimeout).toBe(true);
     expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(1);
+  });
+
+  test("ignores Android-only activityName on iOS", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult(() => makeObservation("com.example.ios", ""));
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: {
+          appId: "com.example.ios",
+          activityName: "com.example.ios.IgnoredActivity",
+        },
+        timeout: 250,
+      } as any,
+      undefined,
+      false,
+      timer,
+      "ios"
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(observeScreen.getExecuteCallCount()).toBe(1);
   });
 
   test("times out when only the element predicate matches", async () => {

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -163,6 +163,28 @@ describe("observeSchema rich waitFor predicates", () => {
     });
   });
 
+  test("accepts activeWindow appId aliases", () => {
+    const androidParsed = observeSchema.parse({
+      platform: "android",
+      waitFor: {
+        activeWindow: {
+          packageName: "com.example.android",
+        },
+      },
+    });
+    const iosParsed = observeSchema.parse({
+      platform: "ios",
+      waitFor: {
+        activeWindow: {
+          bundleId: "com.example.ios",
+        },
+      },
+    });
+
+    expect(androidParsed.waitFor?.activeWindow?.appId).toBe("com.example.android");
+    expect(iosParsed.waitFor?.activeWindow?.appId).toBe("com.example.ios");
+  });
+
   test("rejects a rich waitFor with no predicate fields", () => {
     expect(() =>
       observeSchema.parse({

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -277,6 +277,75 @@ describe("findWaitForElement rich predicates", () => {
     expect(element?.class).toBe("android.widget.BottomNavigationView");
   });
 
+  test("requires elementId and text to match the same node", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          "text": "Profile",
+          "resource-id": "home_tab",
+          "bounds": bounds(10, 10, 110, 60),
+        },
+      },
+      {
+        $: {
+          "text": "Home",
+          "resource-id": "other_tab",
+          "bounds": bounds(10, 80, 190, 140),
+        },
+      },
+      {
+        $: {
+          "text": "Home",
+          "resource-id": "home_tab",
+          "bounds": bounds(10, 150, 190, 190),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        elementId: "home_tab",
+        text: "Home",
+      } as any,
+      hierarchy
+    );
+
+    expect(element?.bounds).toEqual(bounds(10, 150, 190, 190));
+  });
+
+  test("does not satisfy elementId and text across different nodes", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          "text": "Profile",
+          "resource-id": "home_tab",
+          "bounds": bounds(10, 10, 110, 60),
+        },
+      },
+      {
+        $: {
+          "text": "Home",
+          "resource-id": "other_tab",
+          "bounds": bounds(10, 80, 190, 140),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        elementId: "home_tab",
+        text: "Home",
+      } as any,
+      hierarchy
+    );
+
+    expect(element).toBeNull();
+  });
+
   test("does not satisfy matchType all across different nodes", () => {
     const finder = new DefaultElementFinder();
     const hierarchy = makeHierarchy([
@@ -382,6 +451,59 @@ describe("waitForObservation activeWindow", () => {
     expect(outcome.awaitTimeout).toBe(false);
     expect(outcome.observation.activeWindow?.appId).toBe("com.example.app");
     expect(observeScreen.getExecuteCallCount()).toBe(2);
+  });
+
+  test("keeps polling until Android activityName matches", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const observations = [
+      makeObservation("com.example.app", "com.example.app.SplashActivity"),
+      makeObservation("com.example.app", "com.example.app.HomeActivity"),
+    ];
+    observeScreen.setObserveResult(() => observations.shift() ?? observations[0]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: {
+          appId: "com.example.app",
+          activityName: "com.example.app.HomeActivity",
+        },
+        timeout: 500,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(outcome.observation.activeWindow?.activityName).toBe("com.example.app.HomeActivity");
+    expect(observeScreen.getExecuteCallCount()).toBe(2);
+  });
+
+  test("times out when only activeWindow appId matches but activityName does not", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult(() => makeObservation("com.example.app", "com.example.app.SplashActivity"));
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: {
+          appId: "com.example.app",
+          activityName: "com.example.app.HomeActivity",
+        },
+        timeout: 250,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(true);
+    expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(1);
   });
 
   test("times out when only the element predicate matches", async () => {

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { DefaultElementFinder } from "../../src/features/utility/ElementFinder";
-import type { ViewHierarchyResult } from "../../src/models";
-import { findWaitForElement, observeSchema } from "../../src/server/observeTools";
+import type { ObserveResult, ViewHierarchyResult } from "../../src/models";
+import { findWaitForElement, observeSchema, waitForObservation } from "../../src/server/observeTools";
+import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 const bounds = (left: number, top: number, right: number, bottom: number) => ({
   left,
@@ -81,10 +83,6 @@ describe("observeSchema waitFor.container", () => {
 
   test.each([
     {
-      waitFor: { elementId: "com.app:id/name", text: "Name" },
-      label: "elementId and text",
-    },
-    {
       waitFor: { elementId: "com.app:id/name", textAny: ["Name", "Label"] },
       label: "elementId and textAny",
     },
@@ -96,7 +94,7 @@ describe("observeSchema waitFor.container", () => {
       waitFor: { elementId: "com.app:id/name", text: "Name", textAny: ["Name", "Label"] },
       label: "elementId, text, and textAny",
     },
-  ])("rejects waitFor with mixed selectors: $label", ({ waitFor }) => {
+  ])("rejects waitFor with textAny mixed with element fields: $label", ({ waitFor }) => {
     expect(() =>
       observeSchema.parse({
         platform: "ios",
@@ -112,6 +110,77 @@ describe("observeSchema waitFor.container", () => {
         waitFor: {
           elementId: "com.app:id/name",
           container: { elementId: "com.app:id/list", text: "extra" },
+        },
+      })
+    ).toThrow();
+  });
+});
+
+describe("observeSchema rich waitFor predicates", () => {
+  test("accepts element predicates combined on the same node", () => {
+    const parsed = observeSchema.parse({
+      platform: "ios",
+      waitFor: {
+        elementId: "home_tab_bar",
+        className: "UITabBar",
+        contentDescription: "Home tab",
+        text: "Home",
+        textMatch: "exact",
+        matchType: "all",
+        timeout: 25000,
+      },
+    });
+
+    expect(parsed.waitFor).toMatchObject({
+      elementId: "home_tab_bar",
+      className: "UITabBar",
+      contentDescription: "Home tab",
+      text: "Home",
+      textMatch: "exact",
+      matchType: "all",
+    });
+  });
+
+  test("accepts activeWindow predicates with an element predicate", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: {
+        activeWindow: {
+          appId: "com.example.app",
+          activityName: "com.example.app.HomeActivity",
+        },
+        className: "android.widget.FrameLayout",
+        timeout: 10000,
+      },
+    });
+
+    expect(parsed.waitFor).toMatchObject({
+      activeWindow: {
+        appId: "com.example.app",
+        activityName: "com.example.app.HomeActivity",
+      },
+      className: "android.widget.FrameLayout",
+    });
+  });
+
+  test("rejects a rich waitFor with no predicate fields", () => {
+    expect(() =>
+      observeSchema.parse({
+        platform: "android",
+        waitFor: {
+          matchType: "all",
+        },
+      })
+    ).toThrow();
+  });
+
+  test("rejects invalid waitFor regex text", () => {
+    expect(() =>
+      observeSchema.parse({
+        platform: "android",
+        waitFor: {
+          text: "[",
+          textMatch: "regex",
         },
       })
     ).toThrow();
@@ -168,5 +237,175 @@ describe("findWaitForElement textAny", () => {
 
     expect(element?.text).toBe("Done");
     expect(element?.bounds).toEqual(bounds(20, 20, 120, 70));
+  });
+});
+
+describe("findWaitForElement rich predicates", () => {
+  test("matches all specified element fields on the same node by default", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          "text": "Home",
+          "resource-id": "home_label",
+          "class": "android.widget.TextView",
+          "bounds": bounds(10, 10, 110, 60),
+        },
+      },
+      {
+        $: {
+          "text": "Settings",
+          "resource-id": "home_tab",
+          "class": "android.widget.BottomNavigationView",
+          "content-desc": "Home tab",
+          "bounds": bounds(10, 80, 190, 140),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        elementId: "home_tab",
+        className: "android.widget.BottomNavigationView",
+        contentDescription: "Home tab",
+      } as any,
+      hierarchy
+    );
+
+    expect(element?.["resource-id"]).toBe("home_tab");
+    expect(element?.class).toBe("android.widget.BottomNavigationView");
+  });
+
+  test("does not satisfy matchType all across different nodes", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      { $: { text: "Home", bounds: bounds(10, 10, 110, 60) } },
+      {
+        $: {
+          "class": "UITabBar",
+          "resource-id": "home_tab_bar",
+          "bounds": bounds(10, 80, 190, 140),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        text: "Home",
+        className: "UITabBar",
+        matchType: "all",
+      } as any,
+      hierarchy
+    );
+
+    expect(element).toBeNull();
+  });
+
+  test("matches any specified element field when matchType is any", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          "class": "UITabBar",
+          "resource-id": "home_tab_bar",
+          "bounds": bounds(10, 80, 190, 140),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        text: "Home",
+        className: "UITabBar",
+        matchType: "any",
+      } as any,
+      hierarchy
+    );
+
+    expect(element?.class).toBe("UITabBar");
+  });
+
+  test("honors exact, contains, and regex text matching modes", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      { $: { text: "Welcome Home", bounds: bounds(10, 10, 180, 60) } },
+    ]);
+
+    expect(findWaitForElement(finder, { text: "Home", textMatch: "contains" } as any, hierarchy)?.text).toBe("Welcome Home");
+    expect(findWaitForElement(finder, { text: "^Welcome\\s+Home$", textMatch: "regex" } as any, hierarchy)?.text).toBe("Welcome Home");
+    expect(findWaitForElement(finder, { text: "Home", textMatch: "exact" } as any, hierarchy)).toBeNull();
+  });
+});
+
+describe("waitForObservation activeWindow", () => {
+  const makeObservation = (
+    appId: string,
+    activityName: string,
+    nodes: unknown[] = []
+  ): ObserveResult => ({
+    updatedAt: 0,
+    screenSize: { width: 200, height: 200 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    activeWindow: { appId, activityName, layoutSeqSum: 0 },
+    viewHierarchy: makeHierarchy(nodes),
+  });
+
+  test("keeps polling until activeWindow and element predicates are both true", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const observations = [
+      makeObservation("com.browser", "", [
+        { $: { class: "UITabBar", bounds: bounds(10, 10, 100, 60) } },
+      ]),
+      makeObservation("com.example.app", "com.example.app.HomeActivity", [
+        { $: { class: "UITabBar", bounds: bounds(10, 10, 100, 60) } },
+      ]),
+    ];
+    observeScreen.setObserveResult(() => observations.shift() ?? observations[0]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: { appId: "com.example.app" },
+        className: "UITabBar",
+        timeout: 500,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(outcome.observation.activeWindow?.appId).toBe("com.example.app");
+    expect(observeScreen.getExecuteCallCount()).toBe(2);
+  });
+
+  test("times out when only the element predicate matches", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult(() => makeObservation("com.browser", "", [
+      { $: { class: "UITabBar", bounds: bounds(10, 10, 100, 60) } },
+    ]));
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: { appId: "com.example.app" },
+        className: "UITabBar",
+        timeout: 250,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(true);
+    expect(outcome.awaitedElement).toBeUndefined();
+    expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(1);
   });
 });

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -320,6 +320,26 @@ describe("published observe waitFor input schema", () => {
         waitFor: { activeWindow: {} },
       },
     },
+    {
+      label: "textAny mixed with elementId",
+      input: {
+        platform: "android",
+        waitFor: {
+          elementId: "com.app:id/name",
+          textAny: ["Name"],
+        },
+      },
+    },
+    {
+      label: "textAny mixed with matchType",
+      input: {
+        platform: "android",
+        waitFor: {
+          textAny: ["Name"],
+          matchType: "any",
+        },
+      },
+    },
   ])("rejects runtime-invalid waitFor input: $label", ({ input }) => {
     expect(observeSchema.safeParse(input).success).toBe(false);
 
@@ -623,6 +643,29 @@ describe("findWaitForElement rich predicates", () => {
     expect(findWaitForElement(finder, { text: "Home", textMatch: "contains" } as any, hierarchy)?.text).toBe("Welcome Home");
     expect(findWaitForElement(finder, { text: "^Welcome\\s+Home$", textMatch: "regex" } as any, hierarchy)?.text).toBe("Welcome Home");
     expect(findWaitForElement(finder, { text: "Home", textMatch: "exact" } as any, hierarchy)).toBeNull();
+  });
+
+  test("matches iOS accessibility labels exposed as text for contentDescription", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          text: "Home",
+          class: "XCUIElementTypeButton",
+          bounds: bounds(10, 10, 180, 60),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        contentDescription: "Home",
+      } as any,
+      hierarchy
+    );
+
+    expect(element?.text).toBe("Home");
   });
 });
 

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -340,6 +340,36 @@ describe("published observe waitFor input schema", () => {
         },
       },
     },
+    {
+      label: "textAny mixed with className",
+      input: {
+        platform: "android",
+        waitFor: {
+          textAny: ["Name"],
+          className: "android.widget.TextView",
+        },
+      },
+    },
+    {
+      label: "textAny mixed with contentDescription",
+      input: {
+        platform: "android",
+        waitFor: {
+          textAny: ["Name"],
+          contentDescription: "Name",
+        },
+      },
+    },
+    {
+      label: "textAny mixed with textMatch",
+      input: {
+        platform: "android",
+        waitFor: {
+          textAny: ["Name"],
+          textMatch: "exact",
+        },
+      },
+    },
   ])("rejects runtime-invalid waitFor input: $label", ({ input }) => {
     expect(observeSchema.safeParse(input).success).toBe(false);
 
@@ -662,10 +692,35 @@ describe("findWaitForElement rich predicates", () => {
       {
         contentDescription: "Home",
       } as any,
-      hierarchy
+      hierarchy,
+      "ios"
     );
 
     expect(element?.text).toBe("Home");
+  });
+
+  test("does not match Android text-only nodes for contentDescription", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          text: "Home",
+          class: "android.widget.TextView",
+          bounds: bounds(10, 10, 180, 60),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        contentDescription: "Home",
+      } as any,
+      hierarchy,
+      "android"
+    );
+
+    expect(element).toBeNull();
   });
 });
 
@@ -789,6 +844,30 @@ describe("waitForObservation activeWindow", () => {
 
     expect(outcome.awaitTimeout).toBe(false);
     expect(observeScreen.getExecuteCallCount()).toBe(1);
+  });
+
+  test("does not satisfy iOS activeWindow with only Android activityName", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult(() => makeObservation("com.example.ios", ""));
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        activeWindow: {
+          activityName: "com.example.ios.IgnoredActivity",
+        },
+        timeout: 250,
+      } as any,
+      undefined,
+      false,
+      timer,
+      "ios"
+    );
+
+    expect(outcome.awaitTimeout).toBe(true);
+    expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(1);
   });
 
   test("times out when only the element predicate matches", async () => {


### PR DESCRIPTION
## Summary

Adds richer `observe.waitFor` predicates so callers can wait on active-window state plus same-element hierarchy attributes like `className` and `contentDescription`. Existing `elementId`, `text`, `textAny`, `timeout`, and `container` behavior remains supported, and `schemas/tool-definitions.json` is regenerated for the public schema surface.

## Linked Issue

Closes #2845

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: no platform source changes touched
- [x] New code uses interfaces + fakes + FakeTimer; acceptance unit tests run in <100ms each
- [ ] Rebased onto latest `main`, conflicts resolved

Additional targeted checks:
- [x] `bun test test/server/observeWaitForSchema.test.ts`
- [x] `bun test test/server/observeWaitForSchema.test.ts test/server/toolSchemaHelpers.test.ts test/server/observeTools.raw.test.ts test/server/observeOutputSchema.test.ts test/server/internalToolPayloads.test.ts test/server/finalizeToolResponse.test.ts test/features/observe/ObserveScreen.test.ts`

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Not run: no real-device verification in this worktree; behavior is covered by fake `ObserveScreen` polling tests and pure hierarchy matcher tests.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: #3490

Deferred from #2845 to keep this PR focused: stability / settled gate, absence predicates, and `openLink` integrated `waitFor` convenience.