### PR TITLE
Support app-scoped Android locale changes

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -131,7 +131,7 @@ cat "$APP_CONTAINER/Documents/fixtures/hello.txt"
 - 🌐 `openLink` launches URLs or deep links.
 - 🧰 `systemTray`, `homeScreen`, and `recentApps` control system surfaces.
 - 🔔 `postNotification` posts notifications from the app-under-test when SDK hooks are installed.
-- 🌍 `changeLocalization` sets locale, time zone, text direction, and time format in one call. Android system-wide locale changes require a root-capable device and are verified against the effective system configuration before success is reported.
+- 🌍 `changeLocalization` sets locale, time zone, text direction, and time format in one call. On Android, pass `appId` for non-root app-scoped locale changes on Android 13+; system-wide locale changes without `appId` require a root-capable device and are verified against the effective system configuration before success is reported.
 
 #### Navigation & Exploration
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -131,7 +131,7 @@ cat "$APP_CONTAINER/Documents/fixtures/hello.txt"
 - 🌐 `openLink` launches URLs or deep links.
 - 🧰 `systemTray`, `homeScreen`, and `recentApps` control system surfaces.
 - 🔔 `postNotification` posts notifications from the app-under-test when SDK hooks are installed.
-- 🌍 `changeLocalization` sets locale, time zone, text direction, and time format in one call. On Android, pass `appId` for non-root app-scoped locale changes on Android 13+; system-wide locale changes without `appId` require a root-capable device and are verified against the effective system configuration before success is reported.
+- 🌍 `changeLocalization` sets locale, time zone, text direction, and time format in one call. Android locale changes require `appId`; Android 13+ uses non-root app-scoped locales, while older Android versions automatically verify root-capable ADB before using the system locale fallback.
 
 #### Navigation & Exploration
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -450,7 +450,7 @@
           ]
         },
         "appId": {
-          "description": "Android app package for app-scoped locale changes",
+          "description": "Android app package for locale changes",
           "type": "string",
           "minLength": 1
         },

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -449,6 +449,11 @@
             "ios"
           ]
         },
+        "appId": {
+          "description": "Android app package for app-scoped locale changes",
+          "type": "string",
+          "minLength": 1
+        },
         "locale": {
           "description": "Locale tag (e.g., ar-SA, ja-JP)",
           "type": "string",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -508,7 +508,23 @@
       "required": [
         "platform"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "platform": {
+            "const": "android"
+          }
+        },
+        "required": [
+          "platform",
+          "locale"
+        ]
+      },
+      "then": {
+        "required": [
+          "appId"
+        ]
+      }
     }
   },
   {

--- a/scripts/local-dev/probe-android-locale.sh
+++ b/scripts/local-dev/probe-android-locale.sh
@@ -9,7 +9,7 @@ APP_ID="${APP_ID:-com.android.settings}"
 ADB_SERIAL="${ADB_SERIAL:-}"
 BOOT_TIMEOUT_SECONDS="${BOOT_TIMEOUT_SECONDS:-180}"
 EMULATOR_PORT="${EMULATOR_PORT:-5554}"
-EMULATOR_ARGS="${EMULATOR_ARGS:--no-window -no-audio -no-snapshot}"
+EMULATOR_ARGS="${EMULATOR_ARGS:-}"
 KILL_ON_EXIT="${KILL_ON_EXIT:-false}"
 
 EMULATOR_PID=""
@@ -48,10 +48,8 @@ find_sdk_tool() {
 }
 
 ADB_BIN="$(find_sdk_tool "platform-tools/adb" "adb" || true)"
-EMULATOR_BIN="$(find_sdk_tool "emulator/emulator" "emulator" || true)"
 
 [[ -n "${ADB_BIN}" ]] || fail "adb not found. Set ANDROID_SDK_ROOT or ANDROID_HOME."
-[[ -n "${EMULATOR_BIN}" ]] || fail "emulator not found. Set ANDROID_SDK_ROOT or ANDROID_HOME."
 
 adb_cmd() {
   "${ADB_BIN}" -s "${ADB_SERIAL}" "$@"
@@ -183,8 +181,18 @@ fi
 
 if [[ -z "${ADB_SERIAL}" ]]; then
   log "Starting AVD ${AVD_NAME}"
-  # shellcheck disable=SC2206
-  emulator_args_array=(${EMULATOR_ARGS})
+  EMULATOR_BIN="$(find_sdk_tool "emulator/emulator" "emulator" || true)"
+  [[ -n "${EMULATOR_BIN}" ]] || fail "emulator not found. Set ANDROID_SDK_ROOT or ANDROID_HOME, or pass ADB_SERIAL for an already running emulator."
+
+  emulator_args_array=("-no-window" "-no-audio" "-no-snapshot")
+  if [[ -n "${EMULATOR_ARGS}" ]]; then
+    extra_emulator_args=()
+    while IFS= read -r arg; do
+      [[ -n "${arg}" ]] || continue
+      extra_emulator_args+=("${arg}")
+    done <<< "${EMULATOR_ARGS}"
+    emulator_args_array+=("${extra_emulator_args[@]}")
+  fi
   "${EMULATOR_BIN}" -avd "${AVD_NAME}" -port "${EMULATOR_PORT}" "${emulator_args_array[@]}" >/tmp/auto-mobile-locale-probe-emulator.log 2>&1 &
   EMULATOR_PID="$!"
   STARTED_EMULATOR="true"

--- a/scripts/local-dev/probe-android-locale.sh
+++ b/scripts/local-dev/probe-android-locale.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Boot an Android AVD and probe system-wide vs per-app locale commands.
+
+set -euo pipefail
+
+AVD_NAME="${AVD_NAME:-Pixel_9}"
+LOCALE="${LOCALE:-fr-FR}"
+APP_ID="${APP_ID:-com.android.settings}"
+ADB_SERIAL="${ADB_SERIAL:-}"
+BOOT_TIMEOUT_SECONDS="${BOOT_TIMEOUT_SECONDS:-180}"
+EMULATOR_PORT="${EMULATOR_PORT:-5554}"
+EMULATOR_ARGS="${EMULATOR_ARGS:--no-window -no-audio -no-snapshot}"
+KILL_ON_EXIT="${KILL_ON_EXIT:-false}"
+
+EMULATOR_PID=""
+STARTED_EMULATOR="false"
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+warn() {
+  printf 'WARN: %s\n' "$*" >&2
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+find_sdk_tool() {
+  local relative_path="$1"
+  local command_name="$2"
+
+  if [[ -n "${ANDROID_SDK_ROOT:-}" && -x "${ANDROID_SDK_ROOT}/${relative_path}" ]]; then
+    printf '%s\n' "${ANDROID_SDK_ROOT}/${relative_path}"
+    return 0
+  fi
+  if [[ -n "${ANDROID_HOME:-}" && -x "${ANDROID_HOME}/${relative_path}" ]]; then
+    printf '%s\n' "${ANDROID_HOME}/${relative_path}"
+    return 0
+  fi
+  if command -v "${command_name}" >/dev/null 2>&1; then
+    command -v "${command_name}"
+    return 0
+  fi
+  return 1
+}
+
+ADB_BIN="$(find_sdk_tool "platform-tools/adb" "adb" || true)"
+EMULATOR_BIN="$(find_sdk_tool "emulator/emulator" "emulator" || true)"
+
+[[ -n "${ADB_BIN}" ]] || fail "adb not found. Set ANDROID_SDK_ROOT or ANDROID_HOME."
+[[ -n "${EMULATOR_BIN}" ]] || fail "emulator not found. Set ANDROID_SDK_ROOT or ANDROID_HOME."
+
+adb_cmd() {
+  "${ADB_BIN}" -s "${ADB_SERIAL}" "$@"
+}
+
+cleanup() {
+  if [[ "${KILL_ON_EXIT}" == "true" && "${STARTED_EMULATOR}" == "true" && -n "${ADB_SERIAL}" ]]; then
+    warn "KILL_ON_EXIT=true, stopping ${ADB_SERIAL}"
+    adb_cmd emu kill >/dev/null 2>&1 || true
+  elif [[ -n "${EMULATOR_PID}" ]]; then
+    warn "Leaving emulator process running (pid ${EMULATOR_PID}). Set KILL_ON_EXIT=true to stop it."
+  fi
+}
+trap cleanup EXIT
+
+running_serial_for_avd() {
+  local serial
+  while read -r serial; do
+    [[ -n "${serial}" ]] || continue
+    local avd
+    avd="$("${ADB_BIN}" -s "${serial}" emu avd name 2>/dev/null | tr -d '\r' | awk 'NF {print; exit}' || true)"
+    if [[ "${avd}" == "${AVD_NAME}" ]]; then
+      printf '%s\n' "${serial}"
+      return 0
+    fi
+  done < <("${ADB_BIN}" devices | awk 'NR > 1 && $2 == "device" && $1 ~ /^emulator-/ {print $1}')
+  return 1
+}
+
+wait_for_boot() {
+  local deadline=$((SECONDS + BOOT_TIMEOUT_SECONDS))
+
+  adb_cmd wait-for-device
+  while (( SECONDS < deadline )); do
+    local boot_completed sys_boot_completed
+    boot_completed="$(adb_cmd shell getprop dev.bootcomplete 2>/dev/null | tr -d '\r' || true)"
+    sys_boot_completed="$(adb_cmd shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
+    if [[ "${boot_completed}" == "1" && "${sys_boot_completed}" == "1" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  return 1
+}
+
+read_locale_state() {
+  printf 'id: '
+  adb_cmd shell id || true
+  printf 'ro.debuggable: '
+  adb_cmd shell getprop ro.debuggable || true
+  printf 'ro.secure: '
+  adb_cmd shell getprop ro.secure || true
+  printf 'ro.build.tags: '
+  adb_cmd shell getprop ro.build.tags || true
+  printf 'sdk: '
+  adb_cmd shell getprop ro.build.version.sdk || true
+  printf 'persist.sys.locale: '
+  adb_cmd shell getprop persist.sys.locale || true
+  printf 'settings system_locales: '
+  adb_cmd shell settings get system system_locales || true
+  printf 'am get-config locale line: '
+  adb_cmd shell am get-config 2>/dev/null | tr -d '\r' | awk 'NR == 1 {print}'
+}
+
+try_system_locale_setprop() {
+  local label="$1"
+
+  log "Trying system locale via setprop (${label})"
+  set +e
+  local output
+  output="$(adb_cmd shell setprop persist.sys.locale "${LOCALE}" 2>&1)"
+  local status=$?
+  set -e
+
+  if (( status != 0 )); then
+    printf 'setprop failed (%s):\n%s\n' "${label}" "${output}"
+    return 1
+  fi
+
+  printf 'setprop succeeded (%s). Restarting Android framework for read-back...\n' "${label}"
+  adb_cmd shell stop
+  sleep 2
+  adb_cmd shell start
+  wait_for_boot || fail "device did not finish booting after framework restart"
+  read_locale_state
+  return 0
+}
+
+try_adb_root() {
+  log "Trying adb root"
+  set +e
+  local output
+  output="$("${ADB_BIN}" -s "${ADB_SERIAL}" root 2>&1)"
+  local status=$?
+  set -e
+  printf '%s\n' "${output}"
+  "${ADB_BIN}" -s "${ADB_SERIAL}" wait-for-device || true
+  sleep 1
+  read_locale_state
+  return "${status}"
+}
+
+try_app_locale() {
+  local sdk
+  sdk="$(adb_cmd shell getprop ro.build.version.sdk | tr -d '\r')"
+  if [[ ! "${sdk}" =~ ^[0-9]+$ || "${sdk}" -lt 33 ]]; then
+    warn "Skipping per-app locale probe: sdk=${sdk:-unknown}, requires Android 13/API 33+."
+    return 1
+  fi
+
+  log "Trying per-app locale for ${APP_ID}"
+  adb_cmd shell cmd locale get-app-locales "${APP_ID}" || true
+  adb_cmd shell cmd locale set-app-locales "${APP_ID}" --locales "${LOCALE}"
+  adb_cmd shell cmd locale get-app-locales "${APP_ID}"
+
+  log "Resetting per-app locale for ${APP_ID}"
+  adb_cmd shell cmd locale set-app-locales "${APP_ID}" --locales ""
+  adb_cmd shell cmd locale get-app-locales "${APP_ID}"
+}
+
+log "Probe configuration"
+printf 'AVD_NAME=%s\nLOCALE=%s\nAPP_ID=%s\nEMULATOR_PORT=%s\nEMULATOR_ARGS=%s\n' \
+  "${AVD_NAME}" "${LOCALE}" "${APP_ID}" "${EMULATOR_PORT}" "${EMULATOR_ARGS}"
+
+if [[ -z "${ADB_SERIAL}" ]]; then
+  ADB_SERIAL="$(running_serial_for_avd || true)"
+fi
+
+if [[ -z "${ADB_SERIAL}" ]]; then
+  log "Starting AVD ${AVD_NAME}"
+  # shellcheck disable=SC2206
+  emulator_args_array=(${EMULATOR_ARGS})
+  "${EMULATOR_BIN}" -avd "${AVD_NAME}" -port "${EMULATOR_PORT}" "${emulator_args_array[@]}" >/tmp/auto-mobile-locale-probe-emulator.log 2>&1 &
+  EMULATOR_PID="$!"
+  STARTED_EMULATOR="true"
+  ADB_SERIAL="emulator-${EMULATOR_PORT}"
+fi
+
+log "Waiting for ${ADB_SERIAL} to boot"
+wait_for_boot || fail "device ${ADB_SERIAL} did not boot within ${BOOT_TIMEOUT_SECONDS}s"
+
+log "Initial locale/root state"
+read_locale_state
+
+system_without_root="failed"
+if try_system_locale_setprop "before adb root"; then
+  system_without_root="succeeded"
+fi
+
+root_result="failed"
+if try_adb_root; then
+  root_result="succeeded"
+fi
+
+system_after_root="skipped"
+if adb_cmd shell id | grep -q 'uid=0(root)'; then
+  system_after_root="failed"
+  if try_system_locale_setprop "after adb root"; then
+    system_after_root="succeeded"
+  fi
+else
+  warn "adbd is not root after adb root; skipping second system setprop attempt."
+fi
+
+app_locale="failed"
+if try_app_locale; then
+  app_locale="succeeded"
+fi
+
+log "Summary"
+printf 'system setprop before adb root: %s\n' "${system_without_root}"
+printf 'adb root: %s\n' "${root_result}"
+printf 'system setprop after adb root: %s\n' "${system_after_root}"
+printf 'per-app cmd locale: %s\n' "${app_locale}"

--- a/src/features/utility/SystemConfigurationManager.ts
+++ b/src/features/utility/SystemConfigurationManager.ts
@@ -53,7 +53,7 @@ export class SystemConfigurationManager {
     );
   }
 
-  async setLocale(languageTag: string, options: { broadcast?: boolean } = {}): Promise<SetLocaleResult> {
+  async setLocale(languageTag: string, options: { broadcast?: boolean; appId?: string } = {}): Promise<SetLocaleResult> {
     const trimmedTag = languageTag.trim();
     if (!trimmedTag) {
       return {

--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -25,13 +25,15 @@ import {
 } from "./parsing";
 
 type TextDirectionSettingKey = "debug.force_rtl" | "force_rtl";
+const MIN_APP_LOCALE_API_LEVEL = 33;
 
 /**
  * Android implementation of {@link SystemConfigurationAdapter}. Uses
  * ADB shell commands (with an accessibility-service fast path for
- * `settings get`/`settings put`) and `getprop`/`setprop` to read and
- * write locale, time zone, RTL, 24-hour format, and calendar
- * settings.
+ * `settings get`/`settings put`) and ADB shell commands to read and
+ * write locale, time zone, RTL, 24-hour format, and calendar settings.
+ * App-scoped locale changes use Android 13+'s non-root LocaleManager shell
+ * command; system-wide locale changes keep the root-backed setprop path.
  */
 export class AndroidSystemConfigurationAdapter implements SystemConfigurationAdapter {
   readonly defaultCalendarSystem = "gregory";
@@ -42,6 +44,10 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
   ) {}
 
   async setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult> {
+    if (options.appId) {
+      return this.setAppLocale(languageTag, options.appId, options);
+    }
+
     const previousLanguageTag = await this.getCurrentLocaleTag();
 
     try {
@@ -76,6 +82,59 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       languageTag,
       previousLanguageTag,
       method: "setprop persist.sys.locale + stop/start",
+      broadcasted
+    };
+  }
+
+  private async setAppLocale(
+    languageTag: string,
+    appId: string,
+    options: BroadcastOptions
+  ): Promise<SetLocaleResult> {
+    const apiLevel = await this.getAndroidApiLevel();
+    if (apiLevel !== null && apiLevel < MIN_APP_LOCALE_API_LEVEL) {
+      return {
+        success: false,
+        languageTag,
+        error: `Android app-scoped locale changes require API ${MIN_APP_LOCALE_API_LEVEL}+; device is API ${apiLevel}`
+      };
+    }
+
+    const previousLanguageTag = await this.getAppLocaleTag(appId);
+
+    try {
+      await this.adb.executeCommand(
+        `shell cmd locale set-app-locales ${quoteShellArg(appId)} --locales ${quoteShellArg(languageTag)}`
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        languageTag,
+        previousLanguageTag,
+        error: `Failed to set app locale for ${appId}: ${errorMessage}`
+      };
+    }
+
+    const effectiveLanguageTag = await this.getAppLocaleTag(appId);
+    if (!this.localeTagsMatch(effectiveLanguageTag, languageTag)) {
+      return {
+        success: false,
+        languageTag,
+        previousLanguageTag,
+        error: `Read-back verification failed for ${appId}: expected "${languageTag}" but got "${effectiveLanguageTag ?? "null"}"`
+      };
+    }
+
+    const broadcasted = options.broadcast === false
+      ? false
+      : await this.broadcastLocaleChange();
+
+    return {
+      success: true,
+      languageTag,
+      previousLanguageTag,
+      method: `cmd locale set-app-locales ${appId}`,
       broadcasted
     };
   }
@@ -358,6 +417,41 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     }
 
     return language;
+  }
+
+  private async getAppLocaleTag(appId: string): Promise<string | null> {
+    try {
+      const result = await this.adb.executeCommand(
+        `shell cmd locale get-app-locales ${quoteShellArg(appId)}`,
+        undefined,
+        undefined,
+        true
+      );
+      return this.parseAppLocalesOutput(result.stdout);
+    } catch (error) {
+      logger.warn(`[SystemConfigurationManager] Failed to read Android app locale for ${appId}: ${error}`);
+      return null;
+    }
+  }
+
+  private async getAndroidApiLevel(): Promise<number | null> {
+    try {
+      const result = await this.adb.executeCommand("shell getprop ro.build.version.sdk", undefined, undefined, true);
+      const parsed = Number.parseInt(result.stdout.trim(), 10);
+      return Number.isNaN(parsed) ? null : parsed;
+    } catch (error) {
+      logger.warn(`[SystemConfigurationManager] Failed to read Android API level: ${error}`);
+      return null;
+    }
+  }
+
+  private parseAppLocalesOutput(output: string): string | null {
+    const normalized = normalizeSettingValue(output);
+    if (!normalized) {
+      return null;
+    }
+    const bracketedLocales = normalized.match(/\[([^\]]*)\]/)?.[1] ?? normalized;
+    return parseLocaleList(bracketedLocales);
   }
 
   private async getEffectiveLocaleTag(): Promise<string | null> {

--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -33,8 +33,9 @@ const MIN_APP_LOCALE_API_LEVEL = 33;
  * ADB shell commands (with an accessibility-service fast path for
  * `settings get`/`settings put`) and ADB shell commands to read and
  * write locale, time zone, RTL, 24-hour format, and calendar settings.
- * App-scoped locale changes use Android 13+'s non-root LocaleManager shell
- * command; system-wide locale changes keep the root-backed setprop path.
+ * Android locale changes require an app id. Android 13+ uses the app-scoped
+ * non-root LocaleManager shell command; older devices fall back to the
+ * root-backed system locale path after verifying `adb root` works.
  */
 export class AndroidSystemConfigurationAdapter implements SystemConfigurationAdapter {
   readonly defaultCalendarSystem = "gregory";
@@ -45,10 +46,18 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
   ) {}
 
   async setLocale(languageTag: string, options: BroadcastOptions): Promise<SetLocaleResult> {
-    if (options.appId) {
-      return this.setAppLocale(languageTag, options.appId, options);
+    if (!options.appId) {
+      return {
+        success: false,
+        languageTag,
+        error: "appId is required for Android locale changes. Provide the target app package so AutoMobile can choose the supported Android locale path."
+      };
     }
 
+    return this.setTargetAppLocale(languageTag, options.appId, options);
+  }
+
+  private async setSystemLocale(languageTag: string, options: BroadcastOptions, method: string): Promise<SetLocaleResult> {
     const previousLanguageTag = await this.getCurrentLocaleTag();
 
     try {
@@ -82,23 +91,27 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       success: true,
       languageTag,
       previousLanguageTag,
-      method: "setprop persist.sys.locale + stop/start",
+      method,
       broadcasted
     };
   }
 
-  private async setAppLocale(
+  private async setTargetAppLocale(
     languageTag: string,
     appId: string,
     options: BroadcastOptions
   ): Promise<SetLocaleResult> {
     const apiLevel = await readAndroidDeviceApiLevel(this.adb);
     if (apiLevel !== null && apiLevel < MIN_APP_LOCALE_API_LEVEL) {
-      return {
-        success: false,
-        languageTag,
-        error: `Android app-scoped locale changes require API ${MIN_APP_LOCALE_API_LEVEL}+; device is API ${apiLevel}`
-      };
+      const rootResult = await this.ensureRootForLegacyLocale(apiLevel);
+      if (!rootResult.success) {
+        return {
+          success: false,
+          languageTag,
+          error: rootResult.error,
+        };
+      }
+      return this.setSystemLocale(languageTag, options, "setprop persist.sys.locale + stop/start after adb root");
     }
 
     const previousLanguageTag = await this.getAppLocaleTag(appId);
@@ -138,6 +151,37 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       method: `cmd locale set-app-locales ${appId}`,
       broadcasted
     };
+  }
+
+  private async ensureRootForLegacyLocale(apiLevel: number): Promise<{ success: true } | { success: false; error: string }> {
+    try {
+      await this.adb.executeCommand("root", undefined, undefined, true);
+      await this.adb.executeCommand("wait-for-device", undefined, undefined, true);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Android API ${apiLevel} does not support app-scoped locale changes, so AutoMobile must use the root-backed system locale path. Failed to run adb root; the target emulator is not root-capable or does not allow root ADB. adb root error: ${errorMessage}`
+      };
+    }
+
+    try {
+      const idResult = await this.adb.executeCommand("shell id", undefined, undefined, true);
+      if (!idResult.stdout.includes("uid=0(root)")) {
+        return {
+          success: false,
+          error: `Android API ${apiLevel} does not support app-scoped locale changes, so AutoMobile must use the root-backed system locale path. adb root completed, but ADB shell is still not root; the target emulator is not root-capable. shell id: ${idResult.stdout.trim() || "unknown"}`
+        };
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Android API ${apiLevel} does not support app-scoped locale changes, so AutoMobile must verify root before changing the system locale. Failed to verify root shell after adb root: ${errorMessage}`
+      };
+    }
+
+    return { success: true };
   }
 
   async setTimeZone(zoneId: string): Promise<SetTimeZoneResult> {

--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -1,4 +1,5 @@
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { readAndroidDeviceApiLevel } from "../../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import { logger } from "../../../utils/logger";
 import { AndroidCtrlProxyClient } from "../../observe/android/AndroidCtrlProxyClient";
 import type { SettingsNamespace } from "../../observe/android";
@@ -91,7 +92,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     appId: string,
     options: BroadcastOptions
   ): Promise<SetLocaleResult> {
-    const apiLevel = await this.getAndroidApiLevel();
+    const apiLevel = await readAndroidDeviceApiLevel(this.adb);
     if (apiLevel !== null && apiLevel < MIN_APP_LOCALE_API_LEVEL) {
       return {
         success: false,
@@ -434,23 +435,15 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     }
   }
 
-  private async getAndroidApiLevel(): Promise<number | null> {
-    try {
-      const result = await this.adb.executeCommand("shell getprop ro.build.version.sdk", undefined, undefined, true);
-      const parsed = Number.parseInt(result.stdout.trim(), 10);
-      return Number.isNaN(parsed) ? null : parsed;
-    } catch (error) {
-      logger.warn(`[SystemConfigurationManager] Failed to read Android API level: ${error}`);
-      return null;
-    }
-  }
-
   private parseAppLocalesOutput(output: string): string | null {
     const normalized = normalizeSettingValue(output);
     if (!normalized) {
       return null;
     }
-    const bracketedLocales = normalized.match(/\[([^\]]*)\]/)?.[1] ?? normalized;
+    const bracketedLocales = normalized.match(/\bare\s+\[([^\]]*)\]\s*$/)?.[1];
+    if (bracketedLocales === undefined) {
+      return null;
+    }
     return parseLocaleList(bracketedLocales);
   }
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -29,6 +29,7 @@ import { finalizeToolResponse, type ObservationArtifactWriter, type ObservationB
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
 import { ListChangedBroadcaster } from "./listChangedBroadcast";
 import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
+import { applyJsonSchemaOverride } from "./toolSchemaHelpers";
 import {
   InternalToolName,
   InternalToolPayloads,
@@ -39,6 +40,14 @@ import { JsonToolOutputArtifactWriter } from "./toolOutputArtifactWriter";
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
 export { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
+
+function toAdvertisedJsonSchema(schema: any): Record<string, unknown> {
+  return flattenTopLevelUnion(toJSONSchema(schema, {
+    override: ({ zodSchema, jsonSchema }) => {
+      applyJsonSchemaOverride(zodSchema, jsonSchema);
+    },
+  }));
+}
 
 // Progress notification interface
 export interface ProgressCallback {
@@ -1091,7 +1100,7 @@ class ToolRegistryClass {
     let cached = this.toolDefinitionSchemaCache.get(tool.name);
     if (!cached) {
       cached = {
-        inputSchema: flattenTopLevelUnion(toJSONSchema(tool.schema)) as Record<string, unknown>,
+        inputSchema: toAdvertisedJsonSchema(tool.schema),
         outputSchemasByRuntimeFlags: new Map(),
       };
       this.toolDefinitionSchemaCache.set(tool.name, cached);
@@ -1101,7 +1110,7 @@ class ToolRegistryClass {
     if (!cached.outputSchemasByRuntimeFlags.has(outputSchemaCacheKey)) {
       const outputSchema = toolHasOutputSchema(tool) && !suppressOutputSchema
         ? advertiseBoundsForCompact(
-          flattenTopLevelUnion(toJSONSchema(tool.outputSchema)),
+          toAdvertisedJsonSchema(tool.outputSchema),
           compactBounds
         ) as Record<string, unknown>
         : undefined;

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -29,6 +29,22 @@ export const appIdFieldAliases = [
 
 export type FieldAliasMap = Record<string, readonly string[]>;
 
+export type JsonSchemaOverride = (jsonSchema: Record<string, unknown>) => void;
+
+const jsonSchemaOverrides = new WeakMap<object, JsonSchemaOverride>();
+
+export function withJsonSchemaOverride<T extends z.ZodTypeAny>(schema: T, override: JsonSchemaOverride): T {
+  jsonSchemaOverrides.set(schema, override);
+  return schema;
+}
+
+export function applyJsonSchemaOverride(
+  zodSchema: object,
+  jsonSchema: Record<string, unknown>
+): void {
+  jsonSchemaOverrides.get(zodSchema)?.(jsonSchema);
+}
+
 export function withFieldAliases<T extends z.ZodTypeAny>(schema: T, aliases: FieldAliasMap): T {
   return z.preprocess(input => normalizeFieldAliases(input, aliases), schema) as unknown as T;
 }

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -8,7 +8,7 @@ import { createJSONToolResponse } from "../utils/toolUtils";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { BootedDevice, Platform } from "../models";
-import { addDeviceTargetingToSchema, addSessionUuidToSchema, platformSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, addSessionUuidToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
 
 // Schema definitions
@@ -19,6 +19,7 @@ export const setActiveDeviceSchema = addSessionUuidToSchema(z.object({
 
 const changeLocalizationBaseSchema = z.object({
   platform: platformSchema,
+  appId: z.string().min(1).optional().describe("Android app package for app-scoped locale changes"),
   locale: z.string().min(1).optional().describe("Locale tag (e.g., ar-SA, ja-JP)"),
   timeZone: z.string().min(1).optional().describe("Zone ID (e.g., America/Los_Angeles)"),
   textDirection: z.enum(["ltr", "rtl"]).optional().describe("Text direction"),
@@ -27,7 +28,7 @@ const changeLocalizationBaseSchema = z.object({
   restartApp: z.string().min(1).optional().describe("iOS bundle ID to relaunch after locale change")
 });
 
-export const changeLocalizationSchema = addDeviceTargetingToSchema(changeLocalizationBaseSchema).refine(values =>
+export const changeLocalizationSchema = withAppIdAliases(addDeviceTargetingToSchema(changeLocalizationBaseSchema)).refine(values =>
   values.locale || values.timeZone || values.textDirection || values.timeFormat || values.calendarSystem, {
   message: "At least one of locale, timeZone, textDirection, timeFormat, or calendarSystem must be provided."
 });
@@ -61,6 +62,7 @@ export interface SetActiveDeviceArgs {
 
 export interface ChangeLocalizationArgs {
   platform: Platform;
+  appId?: string;
   locale?: string;
   timeZone?: string;
   textDirection?: "ltr" | "rtl";
@@ -154,7 +156,10 @@ export function registerUtilityTools() {
     const errors: string[] = [];
 
     if (args.locale !== undefined) {
-      const result = await manager.setLocale(args.locale, { broadcast: false });
+      const localeOptions = args.appId && device.platform === "android"
+        ? { broadcast: false, appId: args.appId }
+        : { broadcast: false };
+      const result = await manager.setLocale(args.locale, localeOptions);
       if (result.success) {
         changes.locale = result.languageTag;
       } else {

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -28,9 +28,27 @@ const changeLocalizationBaseSchema = z.object({
   restartApp: z.string().min(1).optional().describe("iOS bundle ID to relaunch after locale change")
 });
 
-export const changeLocalizationSchema = withAppIdAliases(addDeviceTargetingToSchema(changeLocalizationBaseSchema)).refine(values =>
-  values.locale || values.timeZone || values.textDirection || values.timeFormat || values.calendarSystem, {
-  message: "At least one of locale, timeZone, textDirection, timeFormat, or calendarSystem must be provided."
+export const changeLocalizationSchema = withAppIdAliases(addDeviceTargetingToSchema(changeLocalizationBaseSchema)).superRefine((values, ctx) => {
+  if (!values.locale && !values.timeZone && !values.textDirection && !values.timeFormat && !values.calendarSystem) {
+    ctx.addIssue({
+      code: "custom",
+      message: "At least one of locale, timeZone, textDirection, timeFormat, or calendarSystem must be provided.",
+    });
+  }
+  if (values.appId && values.platform !== "android") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["appId"],
+      message: "appId is only supported for Android locale changes.",
+    });
+  }
+  if (values.appId && !values.locale) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["appId"],
+      message: "appId only applies when locale is provided.",
+    });
+  }
 });
 
 const doNotDisturbStateInputSchema = z.object({
@@ -154,6 +172,11 @@ export function registerUtilityTools() {
       calendarSystem?: string;
     } = {};
     const errors: string[] = [];
+    let localeMetadata: {
+      localeScope?: "app" | "system";
+      localeAppId?: string;
+      localeMethod?: string;
+    } = {};
 
     if (args.locale !== undefined) {
       const localeOptions = args.appId && device.platform === "android"
@@ -162,6 +185,11 @@ export function registerUtilityTools() {
       const result = await manager.setLocale(args.locale, localeOptions);
       if (result.success) {
         changes.locale = result.languageTag;
+        localeMetadata = {
+          localeScope: args.appId && device.platform === "android" ? "app" : "system",
+          ...(args.appId && device.platform === "android" ? { localeAppId: args.appId } : {}),
+          ...(result.method ? { localeMethod: result.method } : {}),
+        };
       } else {
         errors.push(result.error ?? "Failed to set locale");
       }
@@ -221,6 +249,7 @@ export function registerUtilityTools() {
       success,
       changes,
       intentBroadcast,
+      ...localeMetadata,
       ...(liveChanges ? { iosLiveChanges: liveChanges } : {}),
       ...(success ? {} : { error: errors.join("; ") })
     });

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -8,7 +8,13 @@ import { createJSONToolResponse } from "../utils/toolUtils";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { BootedDevice, Platform } from "../models";
-import { addDeviceTargetingToSchema, addSessionUuidToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import {
+  addDeviceTargetingToSchema,
+  addSessionUuidToSchema,
+  platformSchema,
+  withAppIdAliases,
+  withJsonSchemaOverride,
+} from "./toolSchemaHelpers";
 import { DaemonState } from "../daemon/daemonState";
 
 // Schema definitions
@@ -28,35 +34,48 @@ const changeLocalizationBaseSchema = z.object({
   restartApp: z.string().min(1).optional().describe("iOS bundle ID to relaunch after locale change")
 });
 
-export const changeLocalizationSchema = withAppIdAliases(addDeviceTargetingToSchema(changeLocalizationBaseSchema)).superRefine((values, ctx) => {
-  if (!values.locale && !values.timeZone && !values.textDirection && !values.timeFormat && !values.calendarSystem) {
-    ctx.addIssue({
-      code: "custom",
-      message: "At least one of locale, timeZone, textDirection, timeFormat, or calendarSystem must be provided.",
-    });
+export const changeLocalizationSchema = withJsonSchemaOverride(
+  withAppIdAliases(addDeviceTargetingToSchema(changeLocalizationBaseSchema)).superRefine((values, ctx) => {
+    if (!values.locale && !values.timeZone && !values.textDirection && !values.timeFormat && !values.calendarSystem) {
+      ctx.addIssue({
+        code: "custom",
+        message: "At least one of locale, timeZone, textDirection, timeFormat, or calendarSystem must be provided.",
+      });
+    }
+    if (values.appId && values.platform !== "android") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["appId"],
+        message: "appId is only supported for Android locale changes.",
+      });
+    }
+    if (values.appId && !values.locale) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["appId"],
+        message: "appId only applies when locale is provided.",
+      });
+    }
+    if (values.platform === "android" && values.locale && !values.appId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["appId"],
+        message: "appId is required for Android locale changes.",
+      });
+    }
+  }),
+  jsonSchema => {
+    jsonSchema.if = {
+      properties: {
+        platform: { const: "android" },
+      },
+      required: ["platform", "locale"],
+    };
+    jsonSchema.then = {
+      required: ["appId"],
+    };
   }
-  if (values.appId && values.platform !== "android") {
-    ctx.addIssue({
-      code: "custom",
-      path: ["appId"],
-      message: "appId is only supported for Android locale changes.",
-    });
-  }
-  if (values.appId && !values.locale) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["appId"],
-      message: "appId only applies when locale is provided.",
-    });
-  }
-  if (values.platform === "android" && values.locale && !values.appId) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["appId"],
-      message: "appId is required for Android locale changes.",
-    });
-  }
-});
+);
 
 const doNotDisturbStateInputSchema = z.object({
   enabled: z.boolean().optional().describe("Enable or disable Do Not Disturb"),

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -19,7 +19,7 @@ export const setActiveDeviceSchema = addSessionUuidToSchema(z.object({
 
 const changeLocalizationBaseSchema = z.object({
   platform: platformSchema,
-  appId: z.string().min(1).optional().describe("Android app package for app-scoped locale changes"),
+  appId: z.string().min(1).optional().describe("Android app package for locale changes"),
   locale: z.string().min(1).optional().describe("Locale tag (e.g., ar-SA, ja-JP)"),
   timeZone: z.string().min(1).optional().describe("Zone ID (e.g., America/Los_Angeles)"),
   textDirection: z.enum(["ltr", "rtl"]).optional().describe("Text direction"),
@@ -47,6 +47,13 @@ export const changeLocalizationSchema = withAppIdAliases(addDeviceTargetingToSch
       code: "custom",
       path: ["appId"],
       message: "appId only applies when locale is provided.",
+    });
+  }
+  if (values.platform === "android" && values.locale && !values.appId) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["appId"],
+      message: "appId is required for Android locale changes.",
     });
   }
 });
@@ -186,7 +193,7 @@ export function registerUtilityTools() {
       if (result.success) {
         changes.locale = result.languageTag;
         localeMetadata = {
-          localeScope: args.appId && device.platform === "android" ? "app" : "system",
+          localeScope: result.method?.startsWith("cmd locale set-app-locales") ? "app" : "system",
           ...(args.appId && device.platform === "android" ? { localeAppId: args.appId } : {}),
           ...(result.method ? { localeMethod: result.method } : {}),
         };

--- a/src/utils/interfaces/SystemConfigurationAdapter.ts
+++ b/src/utils/interfaces/SystemConfigurationAdapter.ts
@@ -14,6 +14,7 @@ import type {
  */
 export interface BroadcastOptions {
   broadcast?: boolean;
+  appId?: string;
 }
 
 /**

--- a/test/bats/probe-android-locale.bats
+++ b/test/bats/probe-android-locale.bats
@@ -84,5 +84,8 @@ SCRIPT
   [[ "$output" == *"adb root: failed"* ]]
   [[ "$output" == *"system setprop after adb root: skipped"* ]]
   [[ "$output" == *"per-app cmd locale: succeeded"* ]]
-  ! grep -q "emu kill" "$INVOCATION_FILE"
+  if grep -q "emu kill" "$INVOCATION_FILE"; then
+    echo "script should not kill externally supplied ADB_SERIAL" >&2
+    return 1
+  fi
 }

--- a/test/bats/probe-android-locale.bats
+++ b/test/bats/probe-android-locale.bats
@@ -7,12 +7,26 @@ SCRIPT="scripts/local-dev/probe-android-locale.sh"
 setup() {
   MOCK_BIN="$(mktemp -d)"
   ORIG_PATH="$PATH"
+  ORIG_ANDROID_HOME="${ANDROID_HOME-}"
+  ORIG_ANDROID_HOME_SET="${ANDROID_HOME+x}"
+  ORIG_ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT-}"
+  ORIG_ANDROID_SDK_ROOT_SET="${ANDROID_SDK_ROOT+x}"
   export INVOCATION_FILE="${MOCK_BIN}/adb-invocations"
 }
 
 teardown() {
   rm -rf "$MOCK_BIN"
   export PATH="$ORIG_PATH"
+  if [ -n "$ORIG_ANDROID_HOME_SET" ]; then
+    export ANDROID_HOME="$ORIG_ANDROID_HOME"
+  else
+    unset ANDROID_HOME
+  fi
+  if [ -n "$ORIG_ANDROID_SDK_ROOT_SET" ]; then
+    export ANDROID_SDK_ROOT="$ORIG_ANDROID_SDK_ROOT"
+  else
+    unset ANDROID_SDK_ROOT
+  fi
 }
 
 make_mock_adb() {
@@ -62,6 +76,8 @@ esac
 exit 0
 SCRIPT
   chmod +x "${MOCK_BIN}/adb"
+  unset ANDROID_HOME
+  unset ANDROID_SDK_ROOT
   export PATH="${MOCK_BIN}:/usr/bin:/bin"
 }
 

--- a/test/bats/probe-android-locale.bats
+++ b/test/bats/probe-android-locale.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/local-dev/probe-android-locale.sh.
+
+SCRIPT="scripts/local-dev/probe-android-locale.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  export INVOCATION_FILE="${MOCK_BIN}/adb-invocations"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+  export PATH="$ORIG_PATH"
+}
+
+make_mock_adb() {
+  cat > "${MOCK_BIN}/adb" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "$1" = "-s" ]; then
+  serial="$2"
+  shift 2
+else
+  serial=""
+fi
+printf '%s %s\n' "${serial}" "$*" >> "${INVOCATION_FILE}"
+
+case "$*" in
+  "wait-for-device")
+    exit 0
+    ;;
+  "root")
+    echo "adbd cannot run as root in production builds"
+    exit 1
+    ;;
+  "shell id")
+    echo "uid=2000(shell) gid=2000(shell)"
+    exit 0
+    ;;
+  "shell getprop dev.bootcomplete"|"shell getprop sys.boot_completed")
+    echo "1"
+    exit 0
+    ;;
+  "shell getprop ro.build.version.sdk")
+    echo "36"
+    exit 0
+    ;;
+  "shell setprop persist.sys.locale fr-FR")
+    echo "Failed to set property 'persist.sys.locale' to 'fr-FR'." >&2
+    exit 1
+    ;;
+  "shell cmd locale get-app-locales com.android.settings")
+    echo "Locales for com.android.settings for user 0 are []"
+    exit 0
+    ;;
+  "shell cmd locale set-app-locales com.android.settings --locales fr-FR"|"shell cmd locale set-app-locales com.android.settings --locales ")
+    exit 0
+    ;;
+esac
+
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/adb"
+  export PATH="${MOCK_BIN}:/usr/bin:/bin"
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "script has bash shebang" {
+  head -1 "$SCRIPT" | grep -q "bash"
+}
+
+@test "uses supplied ADB_SERIAL without requiring emulator binary" {
+  make_mock_adb
+
+  run env ADB_SERIAL=emulator-5554 KILL_ON_EXIT=true BOOT_TIMEOUT_SECONDS=5 bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"emulator not found"* ]]
+  [[ "$output" == *"system setprop before adb root: failed"* ]]
+  [[ "$output" == *"adb root: failed"* ]]
+  [[ "$output" == *"system setprop after adb root: skipped"* ]]
+  [[ "$output" == *"per-app cmd locale: succeeded"* ]]
+  ! grep -q "emu kill" "$INVOCATION_FILE"
+}

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -203,15 +203,51 @@ describe("SystemConfigurationAdapter", () => {
       expect(adb.wasCommandExecuted("stop; start")).toBe(false);
     });
 
-    it("rejects app-scoped locale changes below Android 13", async () => {
+    it("uses root-backed system locale after adb root below Android 13", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      adb.setCommandResult("root", "restarting adbd as root\n");
+      adb.setCommandResult("wait-for-device", "");
+      adb.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
+      adb.setCommandResult("shell settings get system system_locales", "en-US");
+      adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("setprop persist.sys.locale + stop/start after adb root");
+      expect(adb.wasCommandExecuted("root")).toBe(true);
+      expect(adb.wasCommandExecuted("shell id")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
+      expect(adb.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
+    });
+
+    it("returns a root-capability error below Android 13 when adb root fails", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      adb.setCommandError("root", new Error("adbd cannot run as root in production builds"));
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe("Android app-scoped locale changes require API 33+; device is API 32");
-      expect(adb.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
+      expect(result.error).toContain("Android API 32 does not support app-scoped locale changes");
+      expect(result.error).toContain("target emulator is not root-capable");
+      expect(result.error).toContain("adbd cannot run as root in production builds");
+      expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
+    });
+
+    it("returns a root-capability error below Android 13 when shell remains non-root", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      adb.setCommandResult("root", "adbd cannot run as root in production builds\n");
+      adb.setCommandResult("wait-for-device", "");
+      adb.setCommandResult("shell id", "uid=2000(shell) gid=2000(shell)\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("ADB shell is still not root");
+      expect(result.error).toContain("uid=2000(shell)");
       expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
     });
 
@@ -250,28 +286,27 @@ describe("SystemConfigurationAdapter", () => {
       expect(result.previousLanguageTag).toBe("ja-JP");
     });
 
-    it("sets system locale with setprop, restarts Android, and verifies am get-config", async () => {
+    it("requires appId for Android locale changes", async () => {
       const adb = new FakeAdbClient();
-      adb.setCommandResult("shell settings get system system_locales", "en-US");
-      adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { broadcast: false });
 
-      expect(result.success).toBe(true);
-      expect(result.method).toBe("setprop persist.sys.locale + stop/start");
-      expect(result.previousLanguageTag).toBe("en-US");
-      expect(adb.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
-      expect(adb.wasCommandExecuted("stop; start")).toBe(true);
-      expect(adb.wasCommandExecuted("cmd locale set-locales ja-JP")).toBe(false);
-      expect(adb.wasCommandExecuted("settings put system user_locale ja-JP")).toBe(false);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("appId is required for Android locale changes");
+      expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
     });
 
-    it("returns false when Android locale verification reads the old effective locale", async () => {
+    it("returns false when legacy root-backed verification reads the old effective locale", async () => {
       const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      adb.setCommandResult("root", "restarting adbd as root\n");
+      adb.setCommandResult("wait-for-device", "");
+      adb.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
       adb.setCommandResult("shell settings get system system_locales", "en-US");
       adb.setCommandResult("shell am get-config", "config: mcc310-mnc260-en-rUS-sw411dp\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
-      const result = await adapter.setLocale("ja-JP", {});
+      const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Read-back verification failed: expected "ja-JP" but got "en-US"');

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -227,6 +227,29 @@ describe("SystemConfigurationAdapter", () => {
       expect(adb.wasCommandExecuted("am broadcast")).toBe(false);
     });
 
+    it("returns false when app-scoped locale read-back has no locale list", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Unknown package com.example.app for userId 0\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Read-back verification failed for com.example.app: expected "ja-JP" but got "null"');
+      expect(adb.wasCommandExecuted("am broadcast")).toBe(false);
+    });
+
+    it("uses the first locale when app-scoped read-back returns multiple locales", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP,en-US]\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
+
+      expect(result.success).toBe(true);
+      expect(result.previousLanguageTag).toBe("ja-JP");
+    });
+
     it("sets system locale with setprop, restarts Android, and verifies am get-config", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell settings get system system_locales", "en-US");

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -170,6 +170,63 @@ describe("SystemConfigurationAdapter", () => {
   }
 
   describe("AndroidSystemConfigurationAdapter behavior", () => {
+    it("sets an app-scoped locale with cmd locale when appId is provided", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      const appLocaleResponses = [
+        "Locales for com.example.app for user 0 are []\n",
+        "Locales for com.example.app for user 0 are [ja-JP]\n",
+      ];
+      const original = adb.executeCommand.bind(adb);
+      adb.executeCommand = (async (command: string, ...rest: any[]) => {
+        if (command === "shell cmd locale get-app-locales 'com.example.app'") {
+          const stdout = appLocaleResponses.shift() ?? "Locales for com.example.app for user 0 are [ja-JP]\n";
+          return {
+            stdout,
+            stderr: "",
+            toString: () => stdout,
+            trim: () => stdout.trim(),
+            includes: (s: string) => stdout.includes(s),
+          };
+        }
+        return original(command, ...rest);
+      }) as any;
+
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("cmd locale set-app-locales com.example.app");
+      expect(result.previousLanguageTag).toBeNull();
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --locales 'ja-JP'")).toBe(true);
+      expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
+      expect(adb.wasCommandExecuted("stop; start")).toBe(false);
+    });
+
+    it("rejects app-scoped locale changes below Android 13", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Android app-scoped locale changes require API 33+; device is API 32");
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
+      expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
+    });
+
+    it("returns false when app-scoped locale read-back does not match", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [en-US]\n");
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Read-back verification failed for com.example.app: expected "ja-JP" but got "en-US"');
+      expect(adb.wasCommandExecuted("am broadcast")).toBe(false);
+    });
+
     it("sets system locale with setprop, restarts Android, and verifies am get-config", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell settings get system system_locales", "en-US");

--- a/test/features/utility/SystemConfigurationManager.test.ts
+++ b/test/features/utility/SystemConfigurationManager.test.ts
@@ -470,14 +470,20 @@ describe("SystemConfigurationManager", () => {
       expect(fakeAdbClient.wasCommandExecuted("stop; start")).toBe(false);
     });
 
-    test("uses root-backed adb commands for Android and verifies the effective locale", async () => {
+    test("uses root-backed adb commands on Android 12 after adb root succeeds", async () => {
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
+      fakeAdbClient.setCommandResult("wait-for-device", "");
+      fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
       fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
       fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("ja-JP");
+      const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(true);
+      expect(result.method).toBe("setprop persist.sys.locale + stop/start after adb root");
       expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+      expect(fakeAdbClient.wasCommandExecuted("root")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("stop; start")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("cmd locale set-locales ja-JP")).toBe(false);
@@ -750,26 +756,45 @@ describe("SystemConfigurationManager", () => {
   // --- Android: setLocale verification paths ---
 
   describe("Android setLocale verification", () => {
-    test("sets system locale with persist.sys.locale, restarts Android, and verifies am get-config", async () => {
-      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
-      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
+    test("requires appId for Android locale changes", async () => {
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP");
 
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("appId is required for Android locale changes");
+      expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
+      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-app-locales")).toBe(false);
+    });
+
+    test("sets system locale with persist.sys.locale on Android 12 after adb root and verifies am get-config", async () => {
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
+      fakeAdbClient.setCommandResult("wait-for-device", "");
+      fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
+      fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
+      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
+      const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
+
       expect(result.success).toBe(true);
-      expect(result.method).toBe("setprop persist.sys.locale + stop/start");
+      expect(result.method).toBe("setprop persist.sys.locale + stop/start after adb root");
       expect(result.previousLanguageTag).toBe("en-US");
+      expect(fakeAdbClient.wasCommandExecuted("root")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale 'ja-JP'")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("stop; start")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("cmd locale set-locales ja-JP")).toBe(false);
       expect(fakeAdbClient.wasCommandExecuted("settings put system user_locale ja-JP")).toBe(false);
     });
 
-    test("returns false when the command succeeds but effective locale is unchanged", async () => {
+    test("returns false when legacy root-backed command succeeds but effective locale is unchanged", async () => {
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
+      fakeAdbClient.setCommandResult("wait-for-device", "");
+      fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
       fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
       fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-en-rUS-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("ja-JP");
+      const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(false);
       expect(result.languageTag).toBe("ja-JP");
@@ -778,10 +803,14 @@ describe("SystemConfigurationManager", () => {
     });
 
     test("returns command error when root-backed locale write is denied", async () => {
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
+      fakeAdbClient.setCommandResult("wait-for-device", "");
+      fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
       fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
       fakeAdbClient.setCommandError("shell setprop persist.sys.locale 'ja-JP'", new Error("permission denied"));
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("ja-JP");
+      const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("Failed to set locale");
@@ -789,11 +818,15 @@ describe("SystemConfigurationManager", () => {
     });
 
     test("reads previous locale from system_locales without consulting user_locale", async () => {
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "32");
+      fakeAdbClient.setCommandResult("root", "restarting adbd as root\n");
+      fakeAdbClient.setCommandResult("wait-for-device", "");
+      fakeAdbClient.setCommandResult("shell id", "uid=0(root) gid=0(root)\n");
       fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US,fr-FR");
       fakeAdbClient.setCommandResult("shell settings get system user_locale", "ja-JP");
       fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("ja-JP");
+      const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(true);
       expect(result.previousLanguageTag).toBe("en-US");
@@ -801,17 +834,19 @@ describe("SystemConfigurationManager", () => {
     });
 
     test("broadcasts locale change by default", async () => {
-      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP]\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      await mgr.setLocale("ja-JP");
+      await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(fakeAdbClient.wasCommandExecuted("am broadcast -a android.intent.action.LOCALE_CHANGED")).toBe(true);
     });
 
     test("skips broadcast when option is false", async () => {
-      fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP]\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
-      const result = await mgr.setLocale("ja-JP", { broadcast: false });
+      const result = await mgr.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
 
       expect(result.success).toBe(true);
       expect(result.broadcasted).toBe(false);

--- a/test/features/utility/SystemConfigurationManager.test.ts
+++ b/test/features/utility/SystemConfigurationManager.test.ts
@@ -456,6 +456,20 @@ describe("SystemConfigurationManager", () => {
   // --- Android: setLocale ---
 
   describe("Android setLocale still works", () => {
+    test("uses app-scoped locale commands when an Android appId is provided", async () => {
+      fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP]\n");
+      const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
+      const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("cmd locale set-app-locales com.example.app");
+      expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --locales 'ja-JP'")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
+      expect(fakeAdbClient.wasCommandExecuted("stop; start")).toBe(false);
+    });
+
     test("uses root-backed adb commands for Android and verifies the effective locale", async () => {
       fakeAdbClient.setCommandResult("shell settings get system system_locales", "en-US");
       fakeAdbClient.setCommandResult("shell am get-config", "config: mcc310-mnc260-ja-rJP-sw411dp\n");

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -304,14 +304,29 @@ describe("appId aliases on tool schemas", () => {
 });
 
 describe("generated tool definitions", () => {
-  test("changeLocalization generated schema includes appId", () => {
+  test("changeLocalization generated schema conditionally requires appId for Android locale changes", () => {
     const schemas = JSON.parse(readFileSync("schemas/tool-definitions.json", "utf8")) as Array<{
       name: string;
-      inputSchema?: { properties?: Record<string, unknown> };
+      inputSchema?: {
+        properties?: Record<string, unknown>;
+        if?: unknown;
+        then?: unknown;
+        required?: string[];
+      };
     }>;
     const changeLocalization = schemas.find(schema => schema.name === "changeLocalization");
 
     expect(changeLocalization?.inputSchema?.properties?.appId).toBeDefined();
+    expect(changeLocalization?.inputSchema?.if).toEqual({
+      properties: {
+        platform: { const: "android" },
+      },
+      required: ["platform", "locale"],
+    });
+    expect(changeLocalization?.inputSchema?.then).toEqual({
+      required: ["appId"],
+    });
+    expect(changeLocalization?.inputSchema?.required).toEqual(["platform"]);
   });
 });
 

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
 import { z } from "zod";
 import {
   addDeviceTargetingToSchema,
@@ -261,6 +262,44 @@ describe("appId aliases on tool schemas", () => {
       expect(result.data.appId).toBe("com.example.app");
       expect("packageName" in result.data).toBe(false);
     }
+  });
+
+  test("changeLocalizationSchema rejects appId for iOS locale changes", () => {
+    const result = changeLocalizationSchema.safeParse({
+      platform: "ios",
+      bundleId: "com.example.app",
+      locale: "fr-FR",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(issue => issue.message.includes("appId is only supported for Android"))).toBe(true);
+    }
+  });
+
+  test("changeLocalizationSchema rejects appId when locale is omitted", () => {
+    const result = changeLocalizationSchema.safeParse({
+      platform: "android",
+      appId: "com.example.app",
+      timeZone: "Europe/Paris",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(issue => issue.message.includes("appId only applies when locale is provided"))).toBe(true);
+    }
+  });
+});
+
+describe("generated tool definitions", () => {
+  test("changeLocalization generated schema includes appId", () => {
+    const schemas = JSON.parse(readFileSync("schemas/tool-definitions.json", "utf8")) as Array<{
+      name: string;
+      inputSchema?: { properties?: Record<string, unknown> };
+    }>;
+    const changeLocalization = schemas.find(schema => schema.name === "changeLocalization");
+
+    expect(changeLocalization?.inputSchema?.properties?.appId).toBeDefined();
   });
 });
 

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -289,6 +289,18 @@ describe("appId aliases on tool schemas", () => {
       expect(result.error.issues.some(issue => issue.message.includes("appId only applies when locale is provided"))).toBe(true);
     }
   });
+
+  test("changeLocalizationSchema requires appId for Android locale changes", () => {
+    const result = changeLocalizationSchema.safeParse({
+      platform: "android",
+      locale: "fr-FR",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(issue => issue.message.includes("appId is required for Android locale changes"))).toBe(true);
+    }
+  });
 });
 
 describe("generated tool definitions", () => {
@@ -325,7 +337,7 @@ describe("platform field accepted by all device-targeting tool schemas", () => {
     ["observeSchema", observeSchema, { platform: "ios" }],
     ["identifyInteractionsSchema", identifyInteractionsSchema, { platform: "ios" }],
     ["deviceSnapshotSchema", deviceSnapshotSchema, { action: "capture" }],
-    ["changeLocalizationSchema", changeLocalizationSchema, { platform: "ios", locale: "en_US" }],
+    ["changeLocalizationSchema", changeLocalizationSchema, { platform: "ios", timeZone: "Europe/Paris" }],
     ["getDeviceStateSchema", getDeviceStateSchema, {}],
     ["setDeviceStateSchema", setDeviceStateSchema, { doNotDisturb: { enabled: true } }],
     ["shakeSchema", shakeSchema, { platform: "ios" }],

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -248,6 +248,20 @@ describe("appId aliases on tool schemas", () => {
       expect("packageName" in (result.data.notification ?? {})).toBe(false);
     }
   });
+
+  test("changeLocalizationSchema accepts appId aliases for Android app-scoped locale changes", () => {
+    const result = changeLocalizationSchema.safeParse({
+      platform: "android",
+      packageName: "com.example.app",
+      locale: "fr-FR",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.appId).toBe("com.example.app");
+      expect("packageName" in result.data).toBe(false);
+    }
+  });
 });
 
 describe("platform field accepted by all device-targeting tool schemas", () => {


### PR DESCRIPTION
## Summary
- Fixes #3492 by making Android locale changes require an `appId`, so callers always provide the target app package instead of needing to understand Android's app-scoped vs system-scoped locale internals.
- Uses Android 13+ `cmd locale set-app-locales` for non-root app-scoped locale changes, with read-back verification and locale scope/method metadata in the tool response.
- Supports Android 12 and older by explicitly running `adb root`, waiting for the device, verifying `shell id` is root, then using the root-backed system locale path; non-root-capable emulator images now return a clear actionable error.
- Adds the EC2/emulator probe script, BATS coverage, regenerated public tool definitions, docs, and unit/schema coverage for the final Android locale contract.

## Test plan
- `bun test test/features/utility/SystemConfigurationAdapter.test.ts test/features/utility/SystemConfigurationManager.test.ts test/server/toolSchemaHelpers.test.ts test/cli/helpSchema.test.ts`
- `bats test/bats/probe-android-locale.bats`
- `shellcheck test/bats/probe-android-locale.bats scripts/local-dev/probe-android-locale.sh`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- Live CLI smoke: `bun dist/src/index.js --cli changeLocalization --platform android --locale ja-JP --appId com.android.settings --deviceId emulator-5554`
- Live CLI validation smoke: `bun dist/src/index.js --cli changeLocalization --platform android --locale ja-JP --deviceId emulator-5554` returns `appId is required for Android locale changes.`