### PR TITLE
Fix release constants import with malformed mirror config

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -365,14 +365,14 @@ export function resolveDaemonInstallSpecifier(env: EnvLike = process.env): strin
   return `${DAEMON_PACKAGE_NAME}@${resolveAssetVersion(resolvePinnedVersion(env))}`;
 }
 
-export const APK_URL: string = resolveApkUrl();
-export const APK_SHA256_CHECKSUM: string = resolveApkChecksum();
+export const APK_URL: string = resolveApkUrl({});
+export const APK_SHA256_CHECKSUM: string = resolveApkChecksum({});
 
 export const IOS_CTRL_PROXY_RELEASE_VERSION: string = RELEASE_VERSION;
-export const IOS_CTRL_PROXY_IPA_URL: string = resolveIpaUrl();
-export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveIpaChecksum();
+export const IOS_CTRL_PROXY_IPA_URL: string = resolveIpaUrl({});
+export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveIpaChecksum({});
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
 // SHA256 of the simulator runner binary (CtrlProxyUITests-Runner), empty = skip
 // verification. Resolved through RELEASE_CHECKSUM_REGISTRY so pinned iOS
 // downloads verify against the runner hash recorded for the same release entry.
-export const IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM: string = resolveRunnerChecksum();
+export const IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM: string = resolveRunnerChecksum({});

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -117,6 +117,23 @@ describe("module-level URL and checksum exports", function() {
   test("iOS runner checksum matches the newest registered entry", function() {
     expect(IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM).toBe(newest.runnerSha256);
   });
+
+  test("malformed mirror config does not prevent importing release constants (#3491)", async function() {
+    const prevBaseUrl = process.env.AUTOMOBILE_ASSET_BASE_URL;
+    process.env.AUTOMOBILE_ASSET_BASE_URL = "https://mirror.test/am?";
+    try {
+      const module = await import(`../../src/constants/release.ts?malformed-mirror-import-${Date.now()}`);
+
+      expect(module.RELEASE_VERSION).toBe("latest");
+      expect(module.APK_URL).toContain("/releases/download/");
+    } finally {
+      if (prevBaseUrl === undefined) {
+        delete process.env.AUTOMOBILE_ASSET_BASE_URL;
+      } else {
+        process.env.AUTOMOBILE_ASSET_BASE_URL = prevBaseUrl;
+      }
+    }
+  });
 });
 
 // --- Issue #2746: hermetic single-version pinning knobs ---


### PR DESCRIPTION
## Summary

Keep backward-compatible release constants import-safe when `AUTOMOBILE_ASSET_BASE_URL` is malformed by resolving their default values without reading `process.env` at module evaluation time. Runtime mirror validation remains at resolver and doctor call boundaries.

## Linked Issue

Closes #3491

## Bug / Regression Context

- **Prior attempts:** PR #3484 hardened malformed mirror validation but left compatibility constants evaluating env-dependent URL resolvers at import time.
- **Observed symptom:** `AUTOMOBILE_ASSET_BASE_URL='https://mirror.test/am?' bun -e 'import("./src/constants/release.ts")'` aborted during module import before doctor could report a scoped actionable failure.
- **Repro steps / conditions:** Set `AUTOMOBILE_ASSET_BASE_URL` to a URL with a query or fragment before importing `src/constants/release.ts`.

## Validation

- [x] `bun test test/constants/release.test.ts test/doctor/automobile.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New unit test runs in <100ms

## Device Verification

N/A — release constants and doctor configuration validation only.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)