### PR TITLE
Fix iOS CtrlProxy runner tree teardown

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -2112,7 +2112,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // The runner env is ALSO set on the host xcodebuild process env so the daemon
     // can later discover/own/recover this process by reading its env via `ps eww`.
     // Routed through the injected processExecutor so tests can observe/control the process.
-    const child = this.processExecutor.spawn(command, [], { shell: true, env: { ...process.env, ...runnerEnv }, stdio: ["ignore", "pipe", "pipe"] });
+    // Match the simulator path's detached shell group so stop()/forceRestart() can
+    // terminate the shell and xcodebuild child through terminateProcessTree().
+    const child = this.processExecutor.spawn(command, [], { shell: true, detached: true, env: { ...process.env, ...runnerEnv }, stdio: ["ignore", "pipe", "pipe"] });
 
     child.on("error", error => {
       logger.warn(`[IOSCtrlProxy] xcodebuild test error: ${error.message}`);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1912,12 +1912,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   /**
-   * Terminate a runner process TREE rooted at `pid` (TERM → wait → KILL), signaling the
-   * process group first and falling back to the single PID. Under `spawn(..., {shell:
-   * true, detached: true})` the tracked PID is a /bin/sh group leader whose xcodebuild
-   * child does NOT die when only the shell is signaled (#2834 review) — the group signal
-   * (`kill -- -pid`) reaches both. The single-PID fallback covers processes that predate
-   * detachment (not group leaders) or whose group is already gone. Scoped to this tree —
+   * Terminate a runner process TREE rooted at `pid` (TERM → wait → KILL). The process
+   * group signal handles current detached launches; the descendant fallback handles
+   * legacy/orphaned shell roots that are not process-group leaders. Scoped to this tree —
    * deliberately NOT a machine-wide pkill sweep, which would hit other devices' runners.
    */
   private static async terminateProcessTree(
@@ -1925,19 +1922,76 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     timer: Timer,
     pid: number
   ): Promise<void> {
-    try {
-      await processExecutor.exec(`kill -TERM -- -${pid} 2>/dev/null || kill -TERM ${pid} 2>/dev/null`);
-    } catch {
-      // Process/group may have already exited.
-    }
+    const processTreePids = await IOSCtrlProxyManager.findDescendantProcessIds(processExecutor, pid);
+    const descendantFirstPids = [...processTreePids].reverse();
 
-    if (!await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid)) {
+    try {
+      await processExecutor.exec(`kill -TERM -- -${pid} 2>/dev/null`);
+    } catch {
+      // Process group may not exist when pid is not a group leader.
+    }
+    await IOSCtrlProxyManager.signalProcessIds(processExecutor, [...descendantFirstPids, pid], "TERM");
+
+    if (!await IOSCtrlProxyManager.waitForProcessesExit(processExecutor, timer, [pid, ...processTreePids])) {
       try {
-        await processExecutor.exec(`kill -KILL -- -${pid} 2>/dev/null || kill -KILL ${pid} 2>/dev/null`);
+        await processExecutor.exec(`kill -KILL -- -${pid} 2>/dev/null`);
       } catch {
-        // Process/group may have exited between liveness check and kill.
+        // Process group may not exist when pid is not a group leader.
       }
-      await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid);
+      await IOSCtrlProxyManager.signalProcessIds(processExecutor, [...descendantFirstPids, pid], "KILL");
+      await IOSCtrlProxyManager.waitForProcessesExit(processExecutor, timer, [pid, ...processTreePids]);
+    }
+  }
+
+  private static async findDescendantProcessIds(
+    processExecutor: ProcessExecutor,
+    rootPid: number
+  ): Promise<number[]> {
+    try {
+      const { stdout } = await processExecutor.exec("ps -axo pid=,ppid=");
+      const childrenByParent = new Map<number, number[]>();
+      for (const line of stdout.trim().split("\n")) {
+        const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+        if (!match) {
+          continue;
+        }
+        const pid = Number(match[1]);
+        const ppid = Number(match[2]);
+        const siblings = childrenByParent.get(ppid) ?? [];
+        siblings.push(pid);
+        childrenByParent.set(ppid, siblings);
+      }
+
+      const descendants: number[] = [];
+      const queue = [...(childrenByParent.get(rootPid) ?? [])];
+      const visited = new Set<number>();
+      while (queue.length > 0) {
+        const pid = queue.shift()!;
+        if (visited.has(pid)) {
+          continue;
+        }
+        visited.add(pid);
+        descendants.push(pid);
+        queue.push(...(childrenByParent.get(pid) ?? []));
+      }
+      return descendants;
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to enumerate descendants for PID ${rootPid}: ${error}`);
+      return [];
+    }
+  }
+
+  private static async signalProcessIds(
+    processExecutor: ProcessExecutor,
+    pids: number[],
+    signal: "TERM" | "KILL"
+  ): Promise<void> {
+    for (const pid of pids) {
+      try {
+        await processExecutor.exec(`kill -${signal} ${pid} 2>/dev/null`);
+      } catch {
+        // Process may have already exited.
+      }
     }
   }
 
@@ -1960,6 +2014,32 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
       await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid);
     }
+  }
+
+  private static async waitForProcessesExit(
+    processExecutor: ProcessExecutor,
+    timer: Timer,
+    pids: number[]
+  ): Promise<boolean> {
+    for (let attempt = 0; attempt < IOSCtrlProxyManager.PORT_RELEASE_ATTEMPTS; attempt++) {
+      if (await IOSCtrlProxyManager.haveProcessesExited(processExecutor, pids)) {
+        return true;
+      }
+      await timer.sleep(IOSCtrlProxyManager.PORT_RELEASE_GRACE_MS);
+    }
+    return IOSCtrlProxyManager.haveProcessesExited(processExecutor, pids);
+  }
+
+  private static async haveProcessesExited(
+    processExecutor: ProcessExecutor,
+    pids: number[]
+  ): Promise<boolean> {
+    for (const pid of pids) {
+      if (await IOSCtrlProxyManager.isProcessRunningWithExecutor(processExecutor, pid)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static async waitForProcessExit(

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -370,11 +370,21 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     for (const pid of pids) {
       try {
         const processInfo = await IOSCtrlProxyManager.getProcessInfo(processExecutor, pid);
-        if (!processInfo || processInfo.ppid !== 1 || !IOSCtrlProxyManager.isCtrlProxyRunnerCommand(processInfo.command)) {
+        if (!processInfo || !IOSCtrlProxyManager.isCtrlProxyRunnerCommand(processInfo.command)) {
           continue;
         }
-        logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process ${pid}`);
-        await IOSCtrlProxyManager.terminateProcess(processExecutor, timer, pid);
+        const rootPid = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(processExecutor, {
+          pid,
+          port: IOSCtrlProxyManager.DEFAULT_PORT,
+          command: processInfo.command,
+          environment: processInfo.environment,
+          ppid: processInfo.ppid,
+        });
+        if (rootPid === null) {
+          continue;
+        }
+        logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process tree rooted at ${rootPid}`);
+        await IOSCtrlProxyManager.terminateProcessTree(processExecutor, timer, rootPid);
       } catch (error) {
         logger.debug(`[IOSCtrlProxy] Failed to reap orphaned CtrlProxy iOS process ${pid}: ${error}`);
       }
@@ -872,26 +882,22 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     if (this.xcTestProcessId) {
       try {
-        process.kill(this.xcTestProcessId);
-      } catch {
-        // Process may have already exited
+        if (await this.isOwnRunnerProcessAlive()) {
+          await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, this.xcTestProcessId);
+        } else {
+          logger.debug(
+            `[IOSCtrlProxy] Tracked runner PID ${this.xcTestProcessId} is not an owned CtrlProxy runner; ` +
+            `clearing without terminating`
+          );
+        }
+      } catch (error) {
+        logger.warn(
+          `[IOSCtrlProxy] Failed to terminate tracked CtrlProxy runner ${this.xcTestProcessId}: ` +
+          `${error instanceof Error ? error.message : String(error)}`
+        );
       }
       this.xcTestProcessId = null;
       this.xcTestProcess = null;
-    }
-
-    // Kill any lingering simulator runner processes (legacy simctl spawn path)
-    try {
-      await this.processExecutor.exec("pkill -f 'CtrlProxyUITests-Runner'");
-    } catch {
-      // Ignore errors if no process found
-    }
-
-    // Kill any lingering xcodebuild test processes (simulator and physical device)
-    try {
-      await this.processExecutor.exec("pkill -f 'xcodebuild.*CtrlProxyUITests'");
-    } catch {
-      // Ignore errors if no process found
     }
 
     this.clearCaches();
@@ -1558,6 +1564,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         if (!IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(process.command)) {
           continue;
         }
+        // A direct in-simulator runner with a daemon-managed xcodebuild/shell ancestor is
+        // stale daemon state, not an external hot-reload runner. Let port cleanup reap
+        // the owning tree instead of adopting a runner whose health endpoint is down.
+        const daemonManagedRoot = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
+          this.processExecutor,
+          process
+        );
+        if (daemonManagedRoot !== null && daemonManagedRoot !== process.pid) {
+          continue;
+        }
         if (!await this.processAncestryContainsDeviceId(process)) {
           continue;
         }
@@ -1596,20 +1612,39 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       );
       if (ownedProcesses.length > 0) {
         for (const process of ownedProcesses) {
+          const rootPid = await this.findDaemonManagedRunnerTreeRoot(process);
           logger.warn(
-            `[IOSCtrlProxy] Terminating stale CtrlProxy process ${process.pid} on port ${this.servicePort}`
+            `[IOSCtrlProxy] Terminating stale CtrlProxy process tree rooted at ${rootPid} ` +
+            `for listener ${process.pid} on port ${this.servicePort}`
           );
-          await IOSCtrlProxyManager.terminateProcess(this.processExecutor, this.timer, process.pid);
+          await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, rootPid);
         }
 
         const remainingProcesses = await this.findListeningProcessesOnPort(this.servicePort);
         if (remainingProcesses.length === 0) {
           return;
         }
-        if (remainingProcesses.some(process => this.isOwnedCtrlProxyRunnerProcess(process))) {
+        const remainingOwnedProcesses = remainingProcesses.filter(process =>
+          this.isOwnedCtrlProxyRunnerProcess(process)
+        );
+        if (remainingOwnedProcesses.length > 0) {
+          for (const process of remainingOwnedProcesses) {
+            logger.warn(
+              `[IOSCtrlProxy] CtrlProxy listener ${process.pid} still holds port ${this.servicePort}; ` +
+              `force-terminating remaining owned process tree`
+            );
+            await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, process.pid);
+          }
+        }
+
+        const afterForceCleanup = await this.findListeningProcessesOnPort(this.servicePort);
+        if (afterForceCleanup.length === 0) {
+          return;
+        }
+        if (afterForceCleanup.some(process => this.isOwnedCtrlProxyRunnerProcess(process))) {
           throw new Error(
             `CtrlProxy recovery failed, port ${this.servicePort} still held by ` +
-            this.formatListeningProcesses(remainingProcesses)
+            this.formatListeningProcesses(afterForceCleanup)
           );
         }
       }
@@ -1675,6 +1710,51 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     return false;
+  }
+
+  private async findDaemonManagedRunnerTreeRoot(process: ListeningProcess): Promise<number> {
+    return (await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(this.processExecutor, process)) ??
+      process.pid;
+  }
+
+  private static async findDaemonManagedRunnerTreeRoot(
+    processExecutor: ProcessExecutor,
+    process: ListeningProcess
+  ): Promise<number | null> {
+    if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
+      return null;
+    }
+
+    let rootPid: number | null = process.ppid === 1 ? process.pid : null;
+    let parentPid = process.ppid;
+    const visitedPids = new Set<number>([process.pid]);
+
+    if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)) {
+      rootPid = process.pid;
+    }
+
+    while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
+      visitedPids.add(parentPid);
+      const parentInfo = await IOSCtrlProxyManager.getProcessInfo(processExecutor, parentPid);
+      if (!parentInfo) {
+        break;
+      }
+
+      if (
+        IOSCtrlProxyManager.isShellCommand(parentInfo.command) &&
+        IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)
+      ) {
+        return parentPid;
+      }
+
+      if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)) {
+        rootPid = parentPid;
+      }
+
+      parentPid = parentInfo.ppid;
+    }
+
+    return rootPid;
   }
 
   private formatListeningProcesses(processes: ListeningProcess[]): string {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -373,13 +373,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         if (!processInfo || !IOSCtrlProxyManager.isCtrlProxyRunnerCommand(processInfo.command)) {
           continue;
         }
-        const rootPid = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(processExecutor, {
-          pid,
-          port: IOSCtrlProxyManager.DEFAULT_PORT,
-          command: processInfo.command,
-          environment: processInfo.environment,
-          ppid: processInfo.ppid,
-        });
+        const rootPid = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
+          processExecutor,
+          {
+            pid,
+            port: IOSCtrlProxyManager.DEFAULT_PORT,
+            command: processInfo.command,
+            environment: processInfo.environment,
+            ppid: processInfo.ppid,
+          },
+          { requireOrphanedRoot: true }
+        );
         if (rootPid === null) {
           continue;
         }
@@ -1719,7 +1723,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   private static async findDaemonManagedRunnerTreeRoot(
     processExecutor: ProcessExecutor,
-    process: ListeningProcess
+    process: ListeningProcess,
+    options: { requireOrphanedRoot?: boolean } = {}
   ): Promise<number | null> {
     if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
       return null;
@@ -1730,7 +1735,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const visitedPids = new Set<number>([process.pid]);
 
     if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)) {
-      rootPid = process.pid;
+      rootPid = options.requireOrphanedRoot && process.ppid !== 1 ? null : process.pid;
     }
 
     while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
@@ -1744,11 +1749,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         IOSCtrlProxyManager.isShellCommand(parentInfo.command) &&
         IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)
       ) {
-        return parentPid;
+        return options.requireOrphanedRoot && parentInfo.ppid !== 1 ? null : parentPid;
       }
 
       if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)) {
-        rootPid = parentPid;
+        rootPid = options.requireOrphanedRoot && parentInfo.ppid !== 1 ? null : parentPid;
       }
 
       parentPid = parentInfo.ppid;

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -56,6 +56,25 @@ function installListeningProcessFakes(
   fakeExecutor: FakeProcessExecutor,
   processes: FakeListeningProcess[]
 ): void {
+  const markProcessTreeDead = (rootPid: number, signal: "TERM" | "KILL") => {
+    const queue = [rootPid];
+    const visited = new Set<number>();
+    while (queue.length > 0) {
+      const pid = queue.shift()!;
+      if (visited.has(pid)) {
+        continue;
+      }
+      visited.add(pid);
+      const process = processes.find(candidate => candidate.pid === pid);
+      if (process && !(signal === "TERM" ? process.ignoreTerm : process.ignoreKill)) {
+        process.alive = false;
+      }
+      for (const child of processes.filter(candidate => candidate.ppid === pid)) {
+        queue.push(child.pid);
+      }
+    }
+  };
+
   fakeExecutor.setCommandHandler("lsof -nP -iTCP:", command => {
     const port = Number(command.match(/-iTCP:(\d+)/)?.[1]);
     const stdout = processes
@@ -81,6 +100,11 @@ function installListeningProcessFakes(
     );
   });
   fakeExecutor.setCommandHandler("kill -TERM", command => {
+    const groupPid = Number(command.match(/kill -TERM -- -(\d+)/)?.[1]);
+    if (!Number.isNaN(groupPid)) {
+      markProcessTreeDead(groupPid, "TERM");
+      return createExecResult("", "");
+    }
     const pid = Number(command.match(/kill -TERM\s+(\d+)/)?.[1]);
     const process = processes.find(candidate => candidate.pid === pid);
     if (process && !process.ignoreTerm) {
@@ -89,6 +113,11 @@ function installListeningProcessFakes(
     return createExecResult("", "");
   });
   fakeExecutor.setCommandHandler("kill -KILL", command => {
+    const groupPid = Number(command.match(/kill -KILL -- -(\d+)/)?.[1]);
+    if (!Number.isNaN(groupPid)) {
+      markProcessTreeDead(groupPid, "KILL");
+      return createExecResult("", "");
+    }
     const pid = Number(command.match(/kill -KILL\s+(\d+)/)?.[1]);
     const process = processes.find(candidate => candidate.pid === pid);
     if (process && !process.ignoreKill) {
@@ -583,6 +612,77 @@ describe("IOSCtrlProxyManager", function() {
         }
       }
     }
+
+    test("stop() tears down only the tracked owned runner tree without global pkill (#2847)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912345;
+
+      const ownedRunner = ownRunnerProcess(912345);
+      const otherDeviceRunner: FakeListeningProcess = {
+        pid: 912346,
+        port: 8766,
+        command: "xcodebuild test-without-building " +
+          "-xctestrun /tmp/automobile-ctrl-proxy/automobile-runner-OTHER.xctestrun " +
+          "-destination \"platform=iOS Simulator,id=OTHER-SIMULATOR\" " +
+          "-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService",
+        environment: "CTRL_PROXY_IOS_PORT=8766 AUTOMOBILE_DEVICE_ID=OTHER-SIMULATOR",
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      const externalHotReloadRunner: FakeListeningProcess = {
+        pid: 912347,
+        port: 8767,
+        command: `xcodebuild test-without-building ` +
+          `-xctestrun /Users/me/hot-reload/CtrlProxy.xctestrun ` +
+          `-destination "platform=iOS Simulator,id=${testDevice.deviceId}" ` +
+          `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8767 AUTOMOBILE_EXTERNAL_RUNNER=1 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [ownedRunner, otherDeviceRunner, externalHotReloadRunner]);
+
+      await manager.stop();
+
+      expect(fakeExecutor.wasCommandExecuted("pkill -f 'CtrlProxyUITests-Runner'")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("pkill -f 'xcodebuild.*CtrlProxyUITests'")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912345")).toBe(true);
+      expect(ownedRunner.alive).toBe(false);
+      expect(otherDeviceRunner.alive).toBe(true);
+      expect(externalHotReloadRunner.alive).toBe(true);
+    });
+
+    test("stop() does not kill a recycled tracked PID that is no longer our runner (#2847)", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 912348;
+      const recycledProcess: FakeListeningProcess = {
+        pid: 912348,
+        port: 8999,
+        command: "/usr/sbin/some-unrelated-daemon --serve",
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [recycledProcess]);
+
+      await manager.stop();
+
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912348")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 912348")).toBe(false);
+      expect(recycledProcess.alive).toBe(true);
+    });
 
     test("start() waits for an own runner then terminates it if it never becomes healthy (#2834)", async function() {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1686,6 +1786,56 @@ describe("IOSCtrlProxyManager", function() {
       });
     });
 
+    test("start() reclaims a stale listener by terminating the daemon-managed shell root (#2847)", async function() {
+      const staleListener: FakeListeningProcess = {
+        pid: 2227,
+        port: 8765,
+        ppid: 2226,
+        command: `/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner`,
+        environment: `AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+      const daemonXcodebuild: FakeListeningProcess = {
+        pid: 2226,
+        port: 0,
+        ppid: 2225,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun ` +
+          `-destination platform=iOS Simulator,id=${testDevice.deviceId} ` +
+          `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+      const daemonShell: FakeListeningProcess = {
+        pid: 2225,
+        port: 0,
+        ppid: 1,
+        command: `/bin/sh -c ${daemonXcodebuild.command} 2>&1`,
+        environment: daemonXcodebuild.environment,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [staleListener, daemonXcodebuild, daemonShell]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      await manager.start();
+
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -2225")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2227")).toBe(false);
+      expect(daemonShell.alive).toBe(false);
+      expect(daemonXcodebuild.alive).toBe(false);
+      expect(staleListener.alive).toBe(false);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+    });
+
     test("start() reallocates when the intended port is held by a foreign process", async function() {
       const foreignProcess: FakeListeningProcess = {
         pid: 3333,
@@ -1892,6 +2042,46 @@ describe("IOSCtrlProxyManager", function() {
 
       expect(orphanProcess.alive).toBe(false);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 4445")).toBe(true);
+    });
+
+    test("startup orphan reaping terminates daemon-managed shell-rooted runner trees (#2847)", async function() {
+      const orphanedRunner: FakeListeningProcess = {
+        pid: 4448,
+        port: 8765,
+        ppid: 4447,
+        command: `/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner`,
+        environment: `AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+      const orphanedXcodebuild: FakeListeningProcess = {
+        pid: 4447,
+        port: 0,
+        ppid: 4446,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun ` +
+          `-destination platform=iOS Simulator,id=${testDevice.deviceId} ` +
+          `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+      const orphanedShell: FakeListeningProcess = {
+        pid: 4446,
+        port: 0,
+        ppid: 1,
+        command: `/bin/sh -c ${orphanedXcodebuild.command} 2>&1`,
+        environment: orphanedXcodebuild.environment,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [orphanedRunner, orphanedXcodebuild, orphanedShell]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("4447\n", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("4448\n", ""));
+      fakeTimer.enableAutoAdvance();
+
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -4446")).toBe(true);
+      expect(orphanedShell.alive).toBe(false);
+      expect(orphanedXcodebuild.alive).toBe(false);
+      expect(orphanedRunner.alive).toBe(false);
     });
 
     test("start() reports the bound PID and command when owned port cleanup cannot free the port", async function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -14,6 +14,18 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import os from "os";
 
+interface FakeListeningProcess {
+  pid: number;
+  port: number;
+  command: string;
+  alive: boolean;
+  ppid?: number;
+  pgid?: number;
+  environment?: string;
+  ignoreTerm?: boolean;
+  ignoreKill?: boolean;
+}
+
 /**
  * A minimal format-version-1 xctestrun with a single UI-test bundle, used by the
  * boundary test to model what the in-simulator runner actually reads.
@@ -56,22 +68,10 @@ function installListeningProcessFakes(
   fakeExecutor: FakeProcessExecutor,
   processes: FakeListeningProcess[]
 ): void {
-  const markProcessTreeDead = (rootPid: number, signal: "TERM" | "KILL") => {
-    const queue = [rootPid];
-    const visited = new Set<number>();
-    while (queue.length > 0) {
-      const pid = queue.shift()!;
-      if (visited.has(pid)) {
-        continue;
-      }
-      visited.add(pid);
-      const process = processes.find(candidate => candidate.pid === pid);
-      if (process && !(signal === "TERM" ? process.ignoreTerm : process.ignoreKill)) {
-        process.alive = false;
-      }
-      for (const child of processes.filter(candidate => candidate.ppid === pid)) {
-        queue.push(child.pid);
-      }
+  const markProcessDead = (pid: number, signal: "TERM" | "KILL") => {
+    const process = processes.find(candidate => candidate.pid === pid);
+    if (process && !(signal === "TERM" ? process.ignoreTerm : process.ignoreKill)) {
+      process.alive = false;
     }
   };
 
@@ -99,30 +99,37 @@ function installListeningProcessFakes(
       ""
     );
   });
+  fakeExecutor.setCommandHandler("ps -axo pid=,ppid=", () =>
+    createExecResult(
+      processes
+        .filter(process => process.alive)
+        .map(process => `${process.pid} ${process.ppid ?? 1}`)
+        .join("\n"),
+      ""
+    )
+  );
   fakeExecutor.setCommandHandler("kill -TERM", command => {
     const groupPid = Number(command.match(/kill -TERM -- -(\d+)/)?.[1]);
     if (!Number.isNaN(groupPid)) {
-      markProcessTreeDead(groupPid, "TERM");
+      for (const process of processes.filter(candidate => candidate.alive && (candidate.pgid ?? candidate.pid) === groupPid)) {
+        markProcessDead(process.pid, "TERM");
+      }
       return createExecResult("", "");
     }
     const pid = Number(command.match(/kill -TERM\s+(\d+)/)?.[1]);
-    const process = processes.find(candidate => candidate.pid === pid);
-    if (process && !process.ignoreTerm) {
-      process.alive = false;
-    }
+    markProcessDead(pid, "TERM");
     return createExecResult("", "");
   });
   fakeExecutor.setCommandHandler("kill -KILL", command => {
     const groupPid = Number(command.match(/kill -KILL -- -(\d+)/)?.[1]);
     if (!Number.isNaN(groupPid)) {
-      markProcessTreeDead(groupPid, "KILL");
+      for (const process of processes.filter(candidate => candidate.alive && (candidate.pgid ?? candidate.pid) === groupPid)) {
+        markProcessDead(process.pid, "KILL");
+      }
       return createExecResult("", "");
     }
     const pid = Number(command.match(/kill -KILL\s+(\d+)/)?.[1]);
-    const process = processes.find(candidate => candidate.pid === pid);
-    if (process && !process.ignoreKill) {
-      process.alive = false;
-    }
+    markProcessDead(pid, "KILL");
     return createExecResult("", "");
   });
   fakeExecutor.setCommandHandler("kill -0", command => {
@@ -1840,7 +1847,8 @@ describe("IOSCtrlProxyManager", function() {
       await manager.start();
 
       expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -2225")).toBe(true);
-      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2227")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2226")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 2227")).toBe(true);
       expect(daemonShell.alive).toBe(false);
       expect(daemonXcodebuild.alive).toBe(false);
       expect(staleListener.alive).toBe(false);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -654,6 +654,10 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.wasCommandExecuted("pkill -f 'CtrlProxyUITests-Runner'")).toBe(false);
       expect(fakeExecutor.wasCommandExecuted("pkill -f 'xcodebuild.*CtrlProxyUITests'")).toBe(false);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912345")).toBe(true);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912346")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL -- -912346")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -912347")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -KILL -- -912347")).toBe(false);
       expect(ownedRunner.alive).toBe(false);
       expect(otherDeviceRunner.alive).toBe(true);
       expect(externalHotReloadRunner.alive).toBe(true);
@@ -1825,6 +1829,12 @@ describe("IOSCtrlProxyManager", function() {
         createFakeBuilder(),
         fakeExecutor
       );
+      const originalSpawn = fakeExecutor.spawn.bind(fakeExecutor);
+      let portWasFreeAtSpawn = false;
+      fakeExecutor.spawn = (command, args, options) => {
+        portWasFreeAtSpawn = !staleListener.alive;
+        return originalSpawn(command, args, options);
+      };
 
       await manager.start();
 
@@ -1833,6 +1843,7 @@ describe("IOSCtrlProxyManager", function() {
       expect(daemonShell.alive).toBe(false);
       expect(daemonXcodebuild.alive).toBe(false);
       expect(staleListener.alive).toBe(false);
+      expect(portWasFreeAtSpawn).toBe(true);
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
     });
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -2084,6 +2084,38 @@ describe("IOSCtrlProxyManager", function() {
       expect(orphanedRunner.alive).toBe(false);
     });
 
+    test("startup orphan reaping preserves CtrlProxy xcodebuild with a live non-orphan parent (#2847)", async function() {
+      const liveParent: FakeListeningProcess = {
+        pid: 4450,
+        port: 0,
+        ppid: 4400,
+        command: "node dist/src/index.js --daemon-mode",
+        alive: true,
+      };
+      const liveXcodebuild: FakeListeningProcess = {
+        pid: 4451,
+        port: 0,
+        ppid: 4450,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun ` +
+          `-destination platform=iOS Simulator,id=${testDevice.deviceId} ` +
+          `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+        ignoreTerm: true,
+        ignoreKill: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [liveParent, liveXcodebuild]);
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("4451\n", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("", ""));
+      fakeTimer.enableAutoAdvance();
+
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -4451")).toBe(false);
+      expect(fakeExecutor.wasCommandExecuted("kill -TERM 4451")).toBe(false);
+      expect(liveXcodebuild.alive).toBe(true);
+    });
+
     test("start() reports the bound PID and command when owned port cleanup cannot free the port", async function() {
       const stuckProcess: FakeListeningProcess = {
         pid: 5555,

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1620,6 +1620,7 @@ describe("IOSCtrlProxyManager", function() {
         // xcodebuild points at the per-launch copy; the bare build-setting token is gone.
         expect(spawn.command).toContain("-xctestrun \"/tmp/automobile-runner-DEV.xctestrun\"");
         expect(spawn.command).not.toMatch(/(?:^|\s)CTRL_PROXY_IOS_PORT=/);
+        expect(spawn.options?.detached).toBe(true);
 
         // Host env still carries identity vars for daemon-side process discovery.
         expect(spawn.options?.env).toMatchObject({


### PR DESCRIPTION
## Summary

Fixes local iOS CtrlProxy runner lifecycle cleanup so teardown is scoped to the tracked/device-owned runner tree instead of machine-wide process patterns. Startup orphan reaping and port-reclaim cleanup now root termination at daemon-managed shell/xcodebuild trees before spawning replacements.

## Linked Issue

Closes #2847

## Bug / Regression Context

- **Prior attempts:** #2834 stabilized CtrlProxy startup but intentionally left broader local lifecycle cleanup for a follow-up.
- **Observed symptom:** `stop()` used bare `process.kill` plus global `pkill`, startup orphan reaping missed shell-rooted trees, and port cleanup could kill only the listening leaf while ancestors survived.
- **Repro steps / conditions:** Modeled with fake process trees in `test/utils/IOSCtrlProxyManager.test.ts`: other-device runners, external hot-reload runners, orphaned shell -> xcodebuild -> runner trees, stale listeners with daemon-managed ancestors, and live non-orphan parents that must be preserved.

## Validation

- [x] `bun run turbo:validate` passes (`7391 pass`, `2 skip`, `0 fail`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: covered by focused iOS CtrlProxy unit tests; no live-device validation required for fake process lifecycle logic
- [x] New code uses interfaces + fakes + FakeTimer; targeted unit suite runs in ~205ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A — this is process lifecycle logic covered by injected executor/fake process-tree tests. No live simulator was required.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: timeout-policy items remain intentionally out of scope from #2847.

Made with [Cursor](https://cursor.com)