### PR TITLE
feat(output-artifacts): artifact observation payloads

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4809,7 +4809,10 @@
             },
             "payload": {
               "type": "string",
-              "const": "ObserveResult"
+              "enum": [
+                "ObserveResult",
+                "ObserveDiff"
+              ]
             },
             "bytes": {
               "type": "integer",
@@ -7531,7 +7534,10 @@
                     },
                     "payload": {
                       "type": "string",
-                      "const": "ObserveResult"
+                      "enum": [
+                        "ObserveResult",
+                        "ObserveDiff"
+                      ]
                     },
                     "bytes": {
                       "type": "integer",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4796,58 +4796,37 @@
             "service"
           ],
           "additionalProperties": {}
-        }
-      },
-      "additionalProperties": {},
-      "$defs": {
-        "__schema0": {
+        },
+        "artifact": {
           "type": "object",
           "properties": {
-            "bounds": {
-              "type": "object",
-              "properties": {
-                "left": {
-                  "type": "number"
-                },
-                "top": {
-                  "type": "number"
-                },
-                "right": {
-                  "type": "number"
-                },
-                "bottom": {
-                  "type": "number"
-                },
-                "centerX": {
-                  "type": "number"
-                },
-                "centerY": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "left",
-                "top",
-                "right",
-                "bottom"
-              ],
-              "additionalProperties": false,
-              "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
+            "path": {
+              "type": "string"
             },
-            "node": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/__schema0"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/__schema0"
-                  }
-                }
-              ]
+            "format": {
+              "type": "string",
+              "const": "json"
+            },
+            "payload": {
+              "type": "string",
+              "const": "ObserveResult"
+            },
+            "bytes": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "tool": {
+              "type": "string"
             }
           },
+          "required": [
+            "path",
+            "format",
+            "payload",
+            "bytes",
+            "tool"
+          ],
           "additionalProperties": {}
         }
       }
@@ -6980,560 +6959,605 @@
           "additionalProperties": {}
         },
         "observation": {
-          "type": "object",
-          "properties": {
-            "selectedElements": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "text": {
-                    "type": "string"
-                  },
-                  "resourceId": {
-                    "type": "string"
-                  },
-                  "contentDesc": {
-                    "type": "string"
-                  },
-                  "bounds": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "selectedElements": {
+                  "type": "array",
+                  "items": {
                     "type": "object",
                     "properties": {
-                      "left": {
-                        "type": "number"
-                      },
-                      "top": {
-                        "type": "number"
-                      },
-                      "right": {
-                        "type": "number"
-                      },
-                      "bottom": {
-                        "type": "number"
-                      },
-                      "centerX": {
-                        "type": "number"
-                      },
-                      "centerY": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "left",
-                      "top",
-                      "right",
-                      "bottom"
-                    ],
-                    "additionalProperties": false,
-                    "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
-                  },
-                  "indexInMatches": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
-                  },
-                  "totalMatches": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
-                  },
-                  "selectionStrategy": {
-                    "type": "string"
-                  },
-                  "selectedState": {
-                    "type": "object",
-                    "properties": {
-                      "method": {
-                        "type": "string",
-                        "enum": [
-                          "accessibility",
-                          "visual"
-                        ]
-                      },
-                      "confidence": {
-                        "type": "number"
-                      },
-                      "reason": {
+                      "text": {
                         "type": "string"
+                      },
+                      "resourceId": {
+                        "type": "string"
+                      },
+                      "contentDesc": {
+                        "type": "string"
+                      },
+                      "bounds": {
+                        "type": "object",
+                        "properties": {
+                          "left": {
+                            "type": "number"
+                          },
+                          "top": {
+                            "type": "number"
+                          },
+                          "right": {
+                            "type": "number"
+                          },
+                          "bottom": {
+                            "type": "number"
+                          },
+                          "centerX": {
+                            "type": "number"
+                          },
+                          "centerY": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "left",
+                          "top",
+                          "right",
+                          "bottom"
+                        ],
+                        "additionalProperties": false,
+                        "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
+                      },
+                      "indexInMatches": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "totalMatches": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "selectionStrategy": {
+                        "type": "string"
+                      },
+                      "selectedState": {
+                        "type": "object",
+                        "properties": {
+                          "method": {
+                            "type": "string",
+                            "enum": [
+                              "accessibility",
+                              "visual"
+                            ]
+                          },
+                          "confidence": {
+                            "type": "number"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "method",
+                          "confidence"
+                        ],
+                        "additionalProperties": false
                       }
                     },
-                    "required": [
-                      "method",
-                      "confidence"
-                    ],
-                    "additionalProperties": false
+                    "additionalProperties": {}
                   }
                 },
-                "additionalProperties": {}
-              }
-            },
-            "focusedElement": {
-              "type": "object",
-              "properties": {
-                "bounds": {
+                "focusedElement": {
                   "type": "object",
                   "properties": {
-                    "left": {
-                      "type": "number"
+                    "bounds": {
+                      "type": "object",
+                      "properties": {
+                        "left": {
+                          "type": "number"
+                        },
+                        "top": {
+                          "type": "number"
+                        },
+                        "right": {
+                          "type": "number"
+                        },
+                        "bottom": {
+                          "type": "number"
+                        },
+                        "centerX": {
+                          "type": "number"
+                        },
+                        "centerY": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "left",
+                        "top",
+                        "right",
+                        "bottom"
+                      ],
+                      "additionalProperties": false,
+                      "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
                     },
-                    "top": {
-                      "type": "number"
+                    "text": {
+                      "type": "string"
                     },
-                    "right": {
-                      "type": "number"
+                    "resource-id": {
+                      "type": "string"
                     },
-                    "bottom": {
-                      "type": "number"
+                    "content-desc": {
+                      "type": "string"
                     },
-                    "centerX": {
-                      "type": "number"
+                    "class": {
+                      "type": "string"
                     },
-                    "centerY": {
-                      "type": "number"
+                    "package": {
+                      "type": "string"
+                    },
+                    "checkable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "checked": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "clickable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "enabled": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "focusable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "focused": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "accessibility-focused": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "scrollable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "selected": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
                     }
                   },
                   "required": [
-                    "left",
-                    "top",
-                    "right",
-                    "bottom"
+                    "bounds"
                   ],
-                  "additionalProperties": false,
-                  "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
+                  "additionalProperties": {}
                 },
-                "text": {
-                  "type": "string"
-                },
-                "resource-id": {
-                  "type": "string"
-                },
-                "content-desc": {
-                  "type": "string"
-                },
-                "class": {
-                  "type": "string"
-                },
-                "package": {
-                  "type": "string"
-                },
-                "checkable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "checked": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "clickable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "enabled": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "focusable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "focused": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "accessibility-focused": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "scrollable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "selected": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "bounds"
-              ],
-              "additionalProperties": {}
-            },
-            "accessibilityFocusedElement": {
-              "type": "object",
-              "properties": {
-                "bounds": {
+                "accessibilityFocusedElement": {
                   "type": "object",
                   "properties": {
-                    "left": {
-                      "type": "number"
+                    "bounds": {
+                      "type": "object",
+                      "properties": {
+                        "left": {
+                          "type": "number"
+                        },
+                        "top": {
+                          "type": "number"
+                        },
+                        "right": {
+                          "type": "number"
+                        },
+                        "bottom": {
+                          "type": "number"
+                        },
+                        "centerX": {
+                          "type": "number"
+                        },
+                        "centerY": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "left",
+                        "top",
+                        "right",
+                        "bottom"
+                      ],
+                      "additionalProperties": false,
+                      "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
                     },
-                    "top": {
-                      "type": "number"
+                    "text": {
+                      "type": "string"
                     },
-                    "right": {
-                      "type": "number"
+                    "resource-id": {
+                      "type": "string"
                     },
-                    "bottom": {
-                      "type": "number"
+                    "content-desc": {
+                      "type": "string"
                     },
-                    "centerX": {
-                      "type": "number"
+                    "class": {
+                      "type": "string"
                     },
-                    "centerY": {
-                      "type": "number"
+                    "package": {
+                      "type": "string"
+                    },
+                    "checkable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "checked": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "clickable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "enabled": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "focusable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "focused": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "accessibility-focused": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "scrollable": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
+                    },
+                    "selected": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string",
+                          "const": "true"
+                        },
+                        {
+                          "type": "string",
+                          "const": "false"
+                        }
+                      ]
                     }
                   },
                   "required": [
-                    "left",
-                    "top",
-                    "right",
-                    "bottom"
+                    "bounds"
                   ],
-                  "additionalProperties": false,
-                  "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
+                  "additionalProperties": {}
                 },
-                "text": {
-                  "type": "string"
-                },
-                "resource-id": {
-                  "type": "string"
-                },
-                "content-desc": {
-                  "type": "string"
-                },
-                "class": {
-                  "type": "string"
-                },
-                "package": {
-                  "type": "string"
-                },
-                "checkable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "checked": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "clickable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "enabled": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "focusable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "focused": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "accessibility-focused": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "scrollable": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                },
-                "selected": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string",
-                      "const": "true"
-                    },
-                    {
-                      "type": "string",
-                      "const": "false"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "bounds"
-              ],
-              "additionalProperties": {}
-            },
-            "activeWindow": {
-              "type": "object",
-              "properties": {
-                "appId": {
-                  "type": "string"
-                },
-                "activityName": {
-                  "type": "string"
-                },
-                "layoutSeqSum": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "type": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": {}
-            },
-            "screenIdentity": {
-              "type": "object",
-              "properties": {
-                "platform": {
-                  "type": "string",
-                  "enum": [
-                    "ios",
-                    "android"
-                  ]
-                },
-                "source": {
-                  "type": "string",
-                  "enum": [
-                    "heuristic",
-                    "sdk"
-                  ]
-                },
-                "confidence": {
-                  "type": "string",
-                  "enum": [
-                    "high",
-                    "medium",
-                    "low"
-                  ]
-                },
-                "key": {
-                  "type": "string"
-                },
-                "components": {
+                "activeWindow": {
                   "type": "object",
                   "properties": {
-                    "bundleId": {
+                    "appId": {
                       "type": "string"
                     },
-                    "navigationTitle": {
+                    "activityName": {
                       "type": "string"
                     },
-                    "selectedTab": {
-                      "type": "string"
+                    "layoutSeqSum": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
                     },
-                    "modalClass": {
+                    "type": {
                       "type": "string"
-                    },
-                    "modalTitle": {
-                      "type": "string"
-                    },
-                    "focusedElementId": {
-                      "type": "string"
-                    },
-                    "keyboardVisible": {
-                      "type": "boolean"
                     }
                   },
+                  "additionalProperties": {}
+                },
+                "screenIdentity": {
+                  "type": "object",
+                  "properties": {
+                    "platform": {
+                      "type": "string",
+                      "enum": [
+                        "ios",
+                        "android"
+                      ]
+                    },
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "heuristic",
+                        "sdk"
+                      ]
+                    },
+                    "confidence": {
+                      "type": "string",
+                      "enum": [
+                        "high",
+                        "medium",
+                        "low"
+                      ]
+                    },
+                    "key": {
+                      "type": "string"
+                    },
+                    "components": {
+                      "type": "object",
+                      "properties": {
+                        "bundleId": {
+                          "type": "string"
+                        },
+                        "navigationTitle": {
+                          "type": "string"
+                        },
+                        "selectedTab": {
+                          "type": "string"
+                        },
+                        "modalClass": {
+                          "type": "string"
+                        },
+                        "modalTitle": {
+                          "type": "string"
+                        },
+                        "focusedElementId": {
+                          "type": "string"
+                        },
+                        "keyboardVisible": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "platform",
+                    "source",
+                    "confidence",
+                    "key",
+                    "components"
+                  ],
+                  "additionalProperties": {}
+                }
+              },
+              "additionalProperties": {}
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifact": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "format": {
+                      "type": "string",
+                      "const": "json"
+                    },
+                    "payload": {
+                      "type": "string",
+                      "const": "ObserveResult"
+                    },
+                    "bytes": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "tool": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "format",
+                    "payload",
+                    "bytes",
+                    "tool"
+                  ],
                   "additionalProperties": {}
                 }
               },
               "required": [
-                "platform",
-                "source",
-                "confidence",
-                "key",
-                "components"
+                "artifact"
               ],
               "additionalProperties": {}
             }
-          },
-          "additionalProperties": {}
+          ]
         },
         "observationDiff": {
           "type": "object",

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -22,6 +22,26 @@ export interface ObservationBaselineStore {
   set(sessionUuid: string, observation: ObserveResult): void;
 }
 
+export interface ObservationArtifactMetadata {
+  artifact: {
+    path: string;
+    format: "json";
+    payload: "ObserveResult";
+    bytes: number;
+    tool: string;
+  };
+}
+
+export interface ObservationArtifactWriteInput {
+  tool: string;
+  payload: "ObserveResult";
+  data: unknown;
+}
+
+export interface ObservationArtifactWriter {
+  writeJsonArtifact(input: ObservationArtifactWriteInput): ObservationArtifactMetadata;
+}
+
 type ObservationActionClass = "navigation" | "inPlace" | "scroll" | "unknown";
 
 function classifyObservationAction(
@@ -86,6 +106,13 @@ export interface FinalizeToolResponseContext {
    * (#2758) still applies; only the agent-facing diff/strip is suppressed.
    */
   internal?: boolean;
+  /**
+   * External-response artifact writer (issue #3480). When supplied for an
+   * agent-facing call, the final post-transform observation payload is written
+   * out-of-band and replaced with rich artifact metadata. Internal calls ignore
+   * this writer so in-process consumers still receive full observations.
+   */
+  artifactWriter?: ObservationArtifactWriter;
 }
 
 type ObservationDiffMode = "diff" | "full";
@@ -183,6 +210,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
 
   // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
   let sanitizedPayload: Record<string, unknown> | undefined;
+  let hasArtifactableObservation = false;
   if (isObserveTool && isObserveResult(payload)) {
     // `observe` always emits the full sanitized observation (no-observe never
     // strips the observe tool itself) and resets the diff baseline to it (#2761).
@@ -191,6 +219,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
       ctx.baselineStore!.set(ctx.sessionUuid!, sanitized);
     }
     sanitizedPayload = sanitized as unknown as Record<string, unknown>;
+    hasArtifactableObservation = true;
   } else if (!isObserveTool && payload.observation !== undefined) {
     if (noObserveEnabled) {
       // `--actions-no-observe` (#2762/#3026): drop the embedded observation from
@@ -263,11 +292,23 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
       if (observationDiff) {
         sanitizedPayload.observationDiff = observationDiff;
       }
+      hasArtifactableObservation = true;
     }
   }
 
   if (!sanitizedPayload) {
     return response;
+  }
+
+  if (ctx.artifactWriter && !ctx.internal && hasArtifactableObservation) {
+    if (isObserveTool) {
+      sanitizedPayload = writeObservationArtifact(ctx, sanitizedPayload) as unknown as Record<string, unknown>;
+    } else {
+      sanitizedPayload = {
+        ...sanitizedPayload,
+        observation: writeObservationArtifact(ctx, sanitizedPayload.observation),
+      };
+    }
   }
 
   // Rewrite both representations from the same object so they cannot diverge.
@@ -279,6 +320,17 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
   }
 
   return response;
+}
+
+function writeObservationArtifact(
+  ctx: FinalizeToolResponseContext,
+  observationPayload: unknown
+): ObservationArtifactMetadata {
+  return ctx.artifactWriter!.writeJsonArtifact({
+    tool: ctx.name,
+    payload: "ObserveResult",
+    data: observationPayload,
+  });
 }
 
 /**

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -22,11 +22,13 @@ export interface ObservationBaselineStore {
   set(sessionUuid: string, observation: ObserveResult): void;
 }
 
+export type ObservationArtifactPayload = "ObserveResult" | "ObserveDiff";
+
 export interface ObservationArtifactMetadata {
   artifact: {
     path: string;
     format: "json";
-    payload: "ObserveResult";
+    payload: ObservationArtifactPayload;
     bytes: number;
     tool: string;
   };
@@ -34,7 +36,7 @@ export interface ObservationArtifactMetadata {
 
 export interface ObservationArtifactWriteInput {
   tool: string;
-  payload: "ObserveResult";
+  payload: ObservationArtifactPayload;
   data: unknown;
 }
 
@@ -328,9 +330,20 @@ function writeObservationArtifact(
 ): ObservationArtifactMetadata {
   return ctx.artifactWriter!.writeJsonArtifact({
     tool: ctx.name,
-    payload: "ObserveResult",
+    payload: getObservationArtifactPayload(observationPayload),
     data: observationPayload,
   });
+}
+
+function getObservationArtifactPayload(observationPayload: unknown): ObservationArtifactPayload {
+  if (
+    observationPayload &&
+    typeof observationPayload === "object" &&
+    (observationPayload as Record<string, unknown>).isDiff === true
+  ) {
+    return "ObserveDiff";
+  }
+  return "ObserveResult";
 }
 
 /**

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -213,12 +213,13 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
   // Locate the ObserveResult: the payload itself for `observe`, else `.observation`.
   let sanitizedPayload: Record<string, unknown> | undefined;
   let hasArtifactableObservation = false;
+  let pendingBaselineUpdate: { sessionUuid: string; observation: ObserveResult } | undefined;
   if (isObserveTool && isObserveResult(payload)) {
     // `observe` always emits the full sanitized observation (no-observe never
     // strips the observe tool itself) and resets the diff baseline to it (#2761).
     const sanitized = sanitizeObserveResult(payload as unknown as ObserveResult, cfg);
     if (canDiff) {
-      ctx.baselineStore!.set(ctx.sessionUuid!, sanitized);
+      pendingBaselineUpdate = { sessionUuid: ctx.sessionUuid!, observation: sanitized };
     }
     sanitizedPayload = sanitized as unknown as Record<string, unknown>;
     hasArtifactableObservation = true;
@@ -285,7 +286,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
             toScreen: observationScreenIdentity(sanitized),
           };
         }
-        ctx.baselineStore!.set(ctx.sessionUuid!, sanitized);
+        pendingBaselineUpdate = { sessionUuid: ctx.sessionUuid!, observation: sanitized };
       }
       sanitizedPayload = {
         ...payload,
@@ -320,6 +321,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
   if (textPart) {
     textPart.text = stringifyToolResponse(sanitizedPayload);
   }
+  pendingBaselineUpdate && ctx.baselineStore!.set(pendingBaselineUpdate.sessionUuid, pendingBaselineUpdate.observation);
 
   return response;
 }

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -12,7 +12,7 @@ import { NavigationGraphManager } from "../features/navigation/NavigationGraphMa
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
 import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
 import { elementContainerSchema } from "./elementSelectorSchemas";
-import { observeResultSchema } from "./toolOutputSchemas";
+import { observeToolResultSchema } from "./toolOutputSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import { DefaultElementParser } from "../features/utility/ElementParser";
 import { normalizeQuotes } from "../features/utility/TextMatcher";
@@ -618,7 +618,7 @@ export function registerObserveTools() {
     "Get screen view hierarchy",
     observeSchema,
     observeHandler,
-    { outputSchema: observeResultSchema }
+    { outputSchema: observeToolResultSchema }
   );
 
   ToolRegistry.registerDeviceAware("identifyInteractions", "Suggest likely interactions", identifyInteractionsSchema, identifyInteractionsHandler, { debugOnly: true });

--- a/src/server/toolOutputArtifactWriter.ts
+++ b/src/server/toolOutputArtifactWriter.ts
@@ -5,6 +5,7 @@ import { toActionableError } from "../models/ActionableError";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { stringifyToolResponse } from "../utils/toolUtils";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import type {
   ObservationArtifactMetadata,
   ObservationArtifactWriter,
@@ -49,7 +50,7 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
   private readonly timer: Timer;
 
   constructor(options: JsonToolOutputArtifactWriterOptions) {
-    this.outputDirectory = path.resolve(options.outputDirectory);
+    this.outputDirectory = resolvePathFromDaemonLaunchWorkingDirectory(options.outputDirectory);
     this.fileSystem = options.fileSystem ?? new NodeToolOutputArtifactFileSystem();
     this.idGenerator = options.idGenerator ?? defaultIdGenerator;
     this.timer = options.timer ?? defaultTimer;

--- a/src/server/toolOutputArtifactWriter.ts
+++ b/src/server/toolOutputArtifactWriter.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+import { constants as fsConstants } from "node:fs";
+import { toActionableError } from "../models/ActionableError";
+import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { stringifyToolResponse } from "../utils/toolUtils";
+import type {
+  ObservationArtifactMetadata,
+  ObservationArtifactWriter,
+  ObservationArtifactWriteInput,
+} from "./finalizeToolResponse";
+
+export interface ToolOutputArtifactFileSystem {
+  ensureDirectory(dirPath: string): void;
+  assertWritableDirectory(dirPath: string): void;
+  writeFileExclusive(filePath: string, content: string, mode: number): void;
+}
+
+export class NodeToolOutputArtifactFileSystem implements ToolOutputArtifactFileSystem {
+  ensureDirectory(dirPath: string): void {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+
+  assertWritableDirectory(dirPath: string): void {
+    const stats = fs.statSync(dirPath);
+    if (!stats.isDirectory()) {
+      throw new Error(`Artifact output path is not a directory: ${dirPath}`);
+    }
+    fs.accessSync(dirPath, fsConstants.W_OK);
+  }
+
+  writeFileExclusive(filePath: string, content: string, mode: number): void {
+    fs.writeFileSync(filePath, content, { encoding: "utf8", flag: "wx", mode });
+  }
+}
+
+export interface JsonToolOutputArtifactWriterOptions {
+  outputDirectory: string;
+  fileSystem?: ToolOutputArtifactFileSystem;
+  idGenerator?: IdGenerator;
+  timer?: Timer;
+}
+
+export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
+  private readonly outputDirectory: string;
+  private readonly fileSystem: ToolOutputArtifactFileSystem;
+  private readonly idGenerator: IdGenerator;
+  private readonly timer: Timer;
+
+  constructor(options: JsonToolOutputArtifactWriterOptions) {
+    this.outputDirectory = path.resolve(options.outputDirectory);
+    this.fileSystem = options.fileSystem ?? new NodeToolOutputArtifactFileSystem();
+    this.idGenerator = options.idGenerator ?? defaultIdGenerator;
+    this.timer = options.timer ?? defaultTimer;
+  }
+
+  writeJsonArtifact(input: ObservationArtifactWriteInput): ObservationArtifactMetadata {
+    try {
+      this.fileSystem.ensureDirectory(this.outputDirectory);
+      this.fileSystem.assertWritableDirectory(this.outputDirectory);
+
+      const content = stringifyToolResponse(input.data);
+      const filename = `${Math.trunc(this.timer.now())}-${safeFilenameSegment(input.tool)}-${safeFilenameSegment(this.idGenerator.next())}.json`;
+      const artifactPath = path.join(this.outputDirectory, filename);
+      this.fileSystem.writeFileExclusive(artifactPath, content, 0o600);
+
+      return {
+        artifact: {
+          path: artifactPath,
+          format: "json",
+          payload: input.payload,
+          bytes: Buffer.byteLength(content, "utf8"),
+          tool: input.tool,
+        },
+      };
+    } catch (error) {
+      throw toActionableError(error, `Failed to write ${input.payload} artifact for ${input.tool}`);
+    }
+  }
+}
+
+function safeFilenameSegment(value: string): string {
+  const safe = value.replace(/[^A-Za-z0-9._-]/g, "_");
+  return safe.length > 0 ? safe : "artifact";
+}

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -148,7 +148,7 @@ const observationDiffMetadataSchema = z.object({
 const toolOutputArtifactDetailsSchema = z.object({
   path: z.string(),
   format: z.literal("json"),
-  payload: z.literal("ObserveResult"),
+  payload: z.enum(["ObserveResult", "ObserveDiff"]),
   bytes: z.number().int().nonnegative(),
   tool: z.string()
 }).passthrough();

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -145,6 +145,18 @@ const observationDiffMetadataSchema = z.object({
   toScreen: observationDiffScreenIdentitySchema.optional()
 }).passthrough();
 
+const toolOutputArtifactDetailsSchema = z.object({
+  path: z.string(),
+  format: z.literal("json"),
+  payload: z.literal("ObserveResult"),
+  bytes: z.number().int().nonnegative(),
+  tool: z.string()
+}).passthrough();
+
+export const toolOutputArtifactMetadataSchema = z.object({
+  artifact: toolOutputArtifactDetailsSchema
+}).passthrough();
+
 const tapOnSearchUntilSchema = z.object({
   durationMs: z.number().int(),
   requestCount: z.number().int(),
@@ -156,7 +168,7 @@ export const tapOnResultSchema = z.object({
   action: z.string().optional(),
   message: z.string().optional(),
   element: elementSchema.optional(),
-  observation: observationSummarySchema.optional(),
+  observation: z.union([observationSummarySchema, toolOutputArtifactMetadataSchema]).optional(),
   observationDiff: observationDiffMetadataSchema.optional(),
   selectedElement: selectedElementSchema.optional(),
   selectedElements: z.array(selectedElementSchema).optional(),
@@ -360,3 +372,8 @@ export const observeResultSchema = z.object({
   predictions: predictionsSchema.optional(),
   accessibilityState: accessibilityStateSchema.optional()
 }).passthrough();
+
+export const observeToolResultSchema = z.union([
+  observeResultSchema,
+  toolOutputArtifactMetadataSchema,
+]);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -563,18 +563,6 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
     }
 
     const durationMs = timer.now() - toolStartMs;
-    TelemetryRecorder.getInstance().recordToolCallEvent({
-      timestamp: toolStartMs,
-      toolName: name,
-      durationMs,
-      success: toolSuccess,
-      error: toolError,
-      args: typeof args === "object" ? args : null,
-    });
-
-    if (toolSuccess) {
-      getMcpRecorder()?.record(name, args);
-    }
 
     // Typed envelope views (issues #2932 / #3222): the heterogeneous pipeline
     // hands back `any`, so narrow to the concrete tool payload via
@@ -624,16 +612,31 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
       ? this.createArtifactWriter(artifactDirectory, timer)
       : undefined;
 
+    const finalizedResponse = finalizeToolResponse(response, {
+      name,
+      args,
+      sessionUuid,
+      baselineStore,
+      internal: internalCall,
+      artifactWriter,
+    });
+
+    TelemetryRecorder.getInstance().recordToolCallEvent({
+      timestamp: toolStartMs,
+      toolName: name,
+      durationMs,
+      success: toolSuccess,
+      error: toolError,
+      args: typeof args === "object" ? args : null,
+    });
+
+    if (toolSuccess) {
+      getMcpRecorder()?.record(name, args);
+    }
+
     return {
       durationMs,
-      finalizedResponse: finalizeToolResponse(response, {
-        name,
-        args,
-        sessionUuid,
-        baselineStore,
-        internal: internalCall,
-        artifactWriter,
-      }),
+      finalizedResponse,
     };
   }
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -34,6 +34,7 @@ import {
   InternalToolPayloads,
   narrowInternalToolEnvelope,
 } from "./internalToolPayloads";
+import { JsonToolOutputArtifactWriter } from "./toolOutputArtifactWriter";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -611,6 +612,10 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
           set: (uuid, observation) => DaemonState.getInstance().getSessionManager().setLastRenderedObservation(uuid, observation),
         }
         : undefined;
+    const artifactDirectory = serverConfig.getToolOutputArtifactDirectory();
+    const artifactWriter = artifactDirectory && !internalCall
+      ? new JsonToolOutputArtifactWriter({ outputDirectory: artifactDirectory, timer })
+      : undefined;
 
     return {
       durationMs,
@@ -620,6 +625,7 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
         sessionUuid,
         baselineStore,
         internal: internalCall,
+        artifactWriter,
       }),
     };
   }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -25,7 +25,7 @@ import { getMcpRecorder } from "./mcpRecordingManager";
 import { formatToolResultLog } from "./toolResultLog";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
-import { finalizeToolResponse, type ObservationBaselineStore } from "./finalizeToolResponse";
+import { finalizeToolResponse, type ObservationArtifactWriter, type ObservationBaselineStore } from "./finalizeToolResponse";
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
 import { ListChangedBroadcaster } from "./listChangedBroadcast";
 import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
@@ -162,6 +162,8 @@ interface AfterToolCallResult {
 interface AfterToolCallHandler {
   handle(input: AfterToolCallInput): Promise<AfterToolCallResult>;
 }
+
+type ObservationArtifactWriterFactory = (outputDirectory: string, timer: Timer) => ObservationArtifactWriter;
 
 export interface PlanLifecycleInput {
   name: string;
@@ -515,7 +517,12 @@ class DefaultNavigationToolCallRecorder implements NavigationToolCallRecorder {
   }
 }
 
-class DefaultAfterToolCallHandler implements AfterToolCallHandler {
+export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
+  constructor(
+    private readonly createArtifactWriter: ObservationArtifactWriterFactory =
+    (outputDirectory, timer) => new JsonToolOutputArtifactWriter({ outputDirectory, timer })
+  ) {}
+
   async handle(input: AfterToolCallInput): Promise<AfterToolCallResult> {
     const { name, args, internalCall, response, sessionUuid, shouldResolveDevice, signal, timer, toolStartMs } = input;
 
@@ -614,7 +621,7 @@ class DefaultAfterToolCallHandler implements AfterToolCallHandler {
         : undefined;
     const artifactDirectory = serverConfig.getToolOutputArtifactDirectory();
     const artifactWriter = artifactDirectory && !internalCall
-      ? new JsonToolOutputArtifactWriter({ outputDirectory: artifactDirectory, timer })
+      ? this.createArtifactWriter(artifactDirectory, timer)
       : undefined;
 
     return {

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -274,6 +274,14 @@ class ServerConfig {
     return this._toolResultsCompactJson;
   }
 
+  setToolOutputArtifactDirectory(directory: string | undefined): void {
+    this.setToolOutputsDir(directory);
+  }
+
+  getToolOutputArtifactDirectory(): string | undefined {
+    return this.getToolOutputsDir();
+  }
+
 }
 
 export const serverConfig = ServerConfig.getInstance();

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -66,6 +66,27 @@ function makeObserveResultWithBounds(): ObserveResult {
   } as ObserveResult;
 }
 
+class FakeObservationArtifactWriter {
+  writes: Array<{ tool: string; payload: string; data: unknown }> = [];
+  throwOnWrite: Error | undefined;
+
+  writeJsonArtifact(input: { tool: string; payload: string; data: unknown }): unknown {
+    if (this.throwOnWrite) {
+      throw this.throwOnWrite;
+    }
+    this.writes.push(input);
+    return {
+      artifact: {
+        path: `/tmp/auto-mobile/${input.tool}-${this.writes.length}.json`,
+        format: "json",
+        payload: input.payload,
+        bytes: 123,
+        tool: input.tool,
+      },
+    };
+  }
+}
+
 describe("finalizeToolResponse", () => {
   let originalDropElements: boolean;
   let originalCompact: boolean;
@@ -1024,6 +1045,153 @@ describe("finalizeToolResponse", () => {
       expect(obsSc.added).toHaveLength(1);
       expect(obsSc.added[0].attributes.bounds).toEqual([5, 6, 7, 8]);
       expectObservationDiff(finalized, { mode: "diff", reason: "diff_emitted" });
+    });
+  });
+
+  describe("observation artifact mode (#3480)", () => {
+    let originalDiff: boolean;
+    let originalNoObserve: boolean;
+
+    function sameScreenObserve(): ObserveResult {
+      return {
+        ...makeObserveResultWithBounds(),
+        activeWindow: { appId: "com.example", activityName: ".Main", layoutSeqSum: 1 },
+        viewHierarchy: {
+          packageName: "com.example",
+          hierarchy: {
+            node: {
+              "resource-id": "com.example:id/root",
+              "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+              "node": [{ "resource-id": "com.example:id/child", "text": "Hello" } as any],
+            } as any,
+          },
+        },
+      } as ObserveResult;
+    }
+
+    function makeStore(): { store: { get: (u: string) => ObserveResult | undefined; set: (u: string, o: ObserveResult) => void }; map: Map<string, ObserveResult> } {
+      const map = new Map<string, ObserveResult>();
+      return {
+        map,
+        store: {
+          get: (u: string) => map.get(u),
+          set: (u: string, o: ObserveResult) => { map.set(u, o); },
+        },
+      };
+    }
+
+    beforeEach(() => {
+      originalDiff = serverConfig.isActionsDiffObserveEnabled();
+      originalNoObserve = serverConfig.isActionsNoObserveEnabled();
+      serverConfig.setActionsDiffObserveEnabled(false);
+      serverConfig.setActionsNoObserveEnabled(false);
+    });
+
+    afterEach(() => {
+      serverConfig.setActionsDiffObserveEnabled(originalDiff);
+      serverConfig.setActionsNoObserveEnabled(originalNoObserve);
+    });
+
+    test("observe returns artifact metadata instead of an inline ObserveResult", () => {
+      const writer = new FakeObservationArtifactWriter();
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(makeObserveResult()),
+        { name: "observe", sessionUuid: "s1", artifactWriter: writer } as any
+      );
+
+      expect(finalized.structuredContent).toEqual({
+        artifact: {
+          path: "/tmp/auto-mobile/observe-1.json",
+          format: "json",
+          payload: "ObserveResult",
+          bytes: 123,
+          tool: "observe",
+        },
+      });
+      expect((finalized.structuredContent as any).viewHierarchy).toBeUndefined();
+      expect(writer.writes).toHaveLength(1);
+      expect((writer.writes[0].data as any).viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
+    test("action observation fields are replaced with artifact metadata", () => {
+      const writer = new FakeObservationArtifactWriter();
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: makeObserveResult() }),
+        { name: "tapOn", sessionUuid: "s1", artifactWriter: writer } as any
+      );
+
+      expect((finalized.structuredContent as any).success).toBe(true);
+      expect((finalized.structuredContent as any).observation).toEqual({
+        artifact: {
+          path: "/tmp/auto-mobile/tapOn-1.json",
+          format: "json",
+          payload: "ObserveResult",
+          bytes: 123,
+          tool: "tapOn",
+        },
+      });
+      expect((finalized.structuredContent as any).observation.viewHierarchy).toBeUndefined();
+      expect((writer.writes[0].data as any).viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+      expect(JSON.parse(finalized.content[0].text)).toEqual(finalized.structuredContent);
+    });
+
+    test("artifact writer receives the compacted diff after existing output transforms", () => {
+      serverConfig.setObserveResultCompactEnabled(true);
+      serverConfig.setActionsDiffObserveEnabled(true);
+      const { store } = makeStore();
+      finalizeToolResponse(
+        createStructuredToolResponse(sameScreenObserve()),
+        { name: "observe", sessionUuid: "s1", baselineStore: store }
+      );
+
+      const next = sameScreenObserve();
+      (next.viewHierarchy!.hierarchy.node as any).node = [
+        { "resource-id": "com.example:id/added", "bounds": { left: 5, top: 6, right: 7, bottom: 8 } },
+      ];
+      const writer = new FakeObservationArtifactWriter();
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store, artifactWriter: writer } as any
+      );
+
+      expect((writer.writes[0].data as any).isDiff).toBe(true);
+      expect((writer.writes[0].data as any).added[0].attributes.bounds).toEqual([5, 6, 7, 8]);
+      expect((finalized.structuredContent as any).observation.artifact.path).toBe("/tmp/auto-mobile/tapOn-1.json");
+      expect((finalized.structuredContent as any).observationDiff).toMatchObject({
+        mode: "diff",
+        reason: "diff_emitted",
+      });
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
+    test("internal calls receive full observations and do not write artifacts", () => {
+      serverConfig.setActionsNoObserveEnabled(true);
+      const writer = new FakeObservationArtifactWriter();
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: makeObserveResult() }),
+        { name: "tapOn", sessionUuid: "s1", internal: true, artifactWriter: writer } as any
+      );
+
+      expect(writer.writes).toHaveLength(0);
+      expect((finalized.structuredContent as any).observation.viewHierarchy).toBeDefined();
+      expect((finalized.structuredContent as any).observation.artifact).toBeUndefined();
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
+    test("artifact write failures are loud and do not produce inline fallback output", () => {
+      const writer = new FakeObservationArtifactWriter();
+      writer.throwOnWrite = new Error("artifact disk is full");
+      const response = createStructuredToolResponse(makeObserveResult());
+
+      expect(() => finalizeToolResponse(
+        response,
+        { name: "observe", sessionUuid: "s1", artifactWriter: writer } as any
+      )).toThrow("artifact disk is full");
+      expect((response.structuredContent as any).viewHierarchy).toBeDefined();
+      expect((response.structuredContent as any).artifact).toBeUndefined();
     });
   });
 

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1195,6 +1195,28 @@ describe("finalizeToolResponse", () => {
       expect((response.structuredContent as any).viewHierarchy).toBeDefined();
       expect((response.structuredContent as any).artifact).toBeUndefined();
     });
+
+    test("artifact write failures do not advance the diff baseline", () => {
+      serverConfig.setActionsDiffObserveEnabled(true);
+      const { store, map } = makeStore();
+      finalizeToolResponse(
+        createStructuredToolResponse(sameScreenObserve()),
+        { name: "observe", sessionUuid: "s1", baselineStore: store }
+      );
+      const renderedBaseline = map.get("s1");
+      const next = sameScreenObserve();
+      (next.viewHierarchy!.hierarchy.node as any).node = [
+        { "resource-id": "com.example:id/not-rendered", "bounds": { left: 1, top: 2, right: 3, bottom: 4 } },
+      ];
+      const writer = new FakeObservationArtifactWriter();
+      writer.throwOnWrite = new Error("artifact disk is full");
+
+      expect(() => finalizeToolResponse(
+        createStructuredToolResponse({ success: true, observation: next }),
+        { name: "tapOn", sessionUuid: "s1", baselineStore: store, artifactWriter: writer } as any
+      )).toThrow("artifact disk is full");
+      expect(map.get("s1")).toBe(renderedBaseline);
+    });
   });
 
   // --actions-no-observe (#2762, folded into #3026): strip the embedded

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1157,8 +1157,10 @@ describe("finalizeToolResponse", () => {
       );
 
       expect((writer.writes[0].data as any).isDiff).toBe(true);
+      expect(writer.writes[0].payload).toBe("ObserveDiff");
       expect((writer.writes[0].data as any).added[0].attributes.bounds).toEqual([5, 6, 7, 8]);
       expect((finalized.structuredContent as any).observation.artifact.path).toBe("/tmp/auto-mobile/tapOn-1.json");
+      expect((finalized.structuredContent as any).observation.artifact.payload).toBe("ObserveDiff");
       expect((finalized.structuredContent as any).observationDiff).toMatchObject({
         mode: "diff",
         reason: "diff_emitted",

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { toJSONSchema } from "zod";
 import {
   observeResultSchema,
+  observeToolResultSchema,
   viewHierarchyNodeSchema,
 } from "../../src/server/toolOutputSchemas";
 import {
@@ -107,6 +108,20 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
   });
 });
 
+describe("observeToolResultSchema: artifact metadata (#3480)", () => {
+  test("accepts artifact metadata in place of an inline ObserveResult", () => {
+    expect(() => observeToolResultSchema.parse({
+      artifact: {
+        path: "/tmp/auto-mobile/123-observe-id.json",
+        format: "json",
+        payload: "ObserveResult",
+        bytes: 123,
+        tool: "observe",
+      },
+    })).not.toThrow();
+  });
+});
+
 describe("viewHierarchyNodeSchema: polymorphic node + bounds union (#3025)", () => {
   test("accepts a node whose `node` child is a single object", () => {
     const node = { bounds: { left: 0, top: 0, right: 10, bottom: 10 }, node: { bounds: [1, 2, 3, 4] } };
@@ -187,6 +202,14 @@ describe("observe tool registration advertises the schema (#3025)", () => {
     } finally {
       serverConfig.setToolResultsNoStructuredContentEnabled(original);
     }
+  });
+
+  test("tools/list advertises observe artifact metadata shape", () => {
+    withFreshRegistry(() => {
+      const observe = ToolRegistry.getToolDefinitions().find(t => t.name === "observe");
+      expect(JSON.stringify((observe as Record<string, unknown>).outputSchema)).toContain("\"artifact\"");
+      expect(JSON.stringify((observe as Record<string, unknown>).outputSchema)).toContain("\"ObserveResult\"");
+    });
   });
 
   test("composes with --tool-results-no-structured-content: outputSchema suppressed", () => {

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -6,6 +6,7 @@ import {
 import { stringifyToolResponse } from "../../src/utils/toolUtils";
 import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 
 class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
   ensureCalls: string[] = [];
@@ -70,6 +71,35 @@ describe("JsonToolOutputArtifactWriter", () => {
       },
     });
     expect(second.artifact.path).toBe("/tmp/auto-mobile artifacts/1234-tapOn-id_2.json");
+  });
+
+  test("resolves relative artifact directories from the daemon launch cwd", () => {
+    const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+    process.env[DAEMON_LAUNCH_CWD_ENV] = "/workspace/project";
+    try {
+      const fileSystem = new FakeArtifactFileSystem();
+      const writer = new JsonToolOutputArtifactWriter({
+        outputDirectory: "scratch/artifacts",
+        fileSystem,
+        idGenerator: new FakeIdGenerator(["id"]),
+        timer: new FakeTimer(),
+      });
+
+      const metadata = writer.writeJsonArtifact({
+        tool: "observe",
+        payload: "ObserveResult",
+        data: { updatedAt: 1 },
+      });
+
+      expect(fileSystem.ensureCalls).toEqual(["/workspace/project/scratch/artifacts"]);
+      expect(metadata.artifact.path).toBe("/workspace/project/scratch/artifacts/0-observe-id.json");
+    } finally {
+      if (originalLaunchCwd === undefined) {
+        delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      } else {
+        process.env[DAEMON_LAUNCH_CWD_ENV] = originalLaunchCwd;
+      }
+    }
   });
 
   test("write failures surface as actionable artifact failures", () => {

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
 import {
   JsonToolOutputArtifactWriter,
   type ToolOutputArtifactFileSystem,
@@ -36,8 +37,9 @@ describe("JsonToolOutputArtifactWriter", () => {
     const idGenerator = new FakeIdGenerator(["id/1", "id/2"]);
     const timer = new FakeTimer();
     timer.setCurrentTime(1234);
+    const outputDirectory = path.resolve("/tmp/auto-mobile artifacts");
     const writer = new JsonToolOutputArtifactWriter({
-      outputDirectory: "/tmp/auto-mobile artifacts",
+      outputDirectory,
       fileSystem,
       idGenerator,
       timer,
@@ -54,28 +56,32 @@ describe("JsonToolOutputArtifactWriter", () => {
       data: { isDiff: true, changed: [] },
     });
 
-    expect(fileSystem.ensureCalls).toEqual(["/tmp/auto-mobile artifacts", "/tmp/auto-mobile artifacts"]);
-    expect(fileSystem.assertWritableCalls).toEqual(["/tmp/auto-mobile artifacts", "/tmp/auto-mobile artifacts"]);
+    const firstPath = path.join(outputDirectory, "1234-tapOn-id_1.json");
+    const secondPath = path.join(outputDirectory, "1234-tapOn-id_2.json");
+    expect(fileSystem.ensureCalls).toEqual([outputDirectory, outputDirectory]);
+    expect(fileSystem.assertWritableCalls).toEqual([outputDirectory, outputDirectory]);
     expect(fileSystem.writes[0]).toEqual({
-      path: "/tmp/auto-mobile artifacts/1234-tapOn-id_1.json",
+      path: firstPath,
       content: stringifyToolResponse({ viewHierarchy: { hierarchy: { node: { text: "Hello" } } } }),
       mode: 0o600,
     });
     expect(first).toEqual({
       artifact: {
-        path: "/tmp/auto-mobile artifacts/1234-tapOn-id_1.json",
+        path: firstPath,
         format: "json",
         payload: "ObserveResult",
         bytes: Buffer.byteLength(fileSystem.writes[0].content, "utf8"),
         tool: "tapOn",
       },
     });
-    expect(second.artifact.path).toBe("/tmp/auto-mobile artifacts/1234-tapOn-id_2.json");
+    expect(second.artifact.path).toBe(secondPath);
   });
 
   test("resolves relative artifact directories from the daemon launch cwd", () => {
     const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
-    process.env[DAEMON_LAUNCH_CWD_ENV] = "/workspace/project";
+    const launchCwd = path.resolve("workspace/project");
+    const expectedDir = path.join(launchCwd, "scratch/artifacts");
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
     try {
       const fileSystem = new FakeArtifactFileSystem();
       const writer = new JsonToolOutputArtifactWriter({
@@ -91,8 +97,8 @@ describe("JsonToolOutputArtifactWriter", () => {
         data: { updatedAt: 1 },
       });
 
-      expect(fileSystem.ensureCalls).toEqual(["/workspace/project/scratch/artifacts"]);
-      expect(metadata.artifact.path).toBe("/workspace/project/scratch/artifacts/0-observe-id.json");
+      expect(fileSystem.ensureCalls).toEqual([expectedDir]);
+      expect(metadata.artifact.path).toBe(path.join(expectedDir, "0-observe-id.json"));
     } finally {
       if (originalLaunchCwd === undefined) {
         delete process.env[DAEMON_LAUNCH_CWD_ENV];

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import {
+  JsonToolOutputArtifactWriter,
+  type ToolOutputArtifactFileSystem,
+} from "../../src/server/toolOutputArtifactWriter";
+import { stringifyToolResponse } from "../../src/utils/toolUtils";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
+  ensureCalls: string[] = [];
+  assertWritableCalls: string[] = [];
+  writes: Array<{ path: string; content: string; mode: number }> = [];
+  writeError: Error | undefined;
+
+  ensureDirectory(dirPath: string): void {
+    this.ensureCalls.push(dirPath);
+  }
+
+  assertWritableDirectory(dirPath: string): void {
+    this.assertWritableCalls.push(dirPath);
+  }
+
+  writeFileExclusive(filePath: string, content: string, mode: number): void {
+    if (this.writeError) {
+      throw this.writeError;
+    }
+    this.writes.push({ path: filePath, content, mode });
+  }
+}
+
+describe("JsonToolOutputArtifactWriter", () => {
+  test("writes JSON artifacts with deterministic metadata and validates per call", () => {
+    const fileSystem = new FakeArtifactFileSystem();
+    const idGenerator = new FakeIdGenerator(["id/1", "id/2"]);
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1234);
+    const writer = new JsonToolOutputArtifactWriter({
+      outputDirectory: "/tmp/auto-mobile artifacts",
+      fileSystem,
+      idGenerator,
+      timer,
+    });
+
+    const first = writer.writeJsonArtifact({
+      tool: "tapOn",
+      payload: "ObserveResult",
+      data: { viewHierarchy: { hierarchy: { node: { text: "Hello" } } } },
+    });
+    const second = writer.writeJsonArtifact({
+      tool: "tapOn",
+      payload: "ObserveResult",
+      data: { isDiff: true, changed: [] },
+    });
+
+    expect(fileSystem.ensureCalls).toEqual(["/tmp/auto-mobile artifacts", "/tmp/auto-mobile artifacts"]);
+    expect(fileSystem.assertWritableCalls).toEqual(["/tmp/auto-mobile artifacts", "/tmp/auto-mobile artifacts"]);
+    expect(fileSystem.writes[0]).toEqual({
+      path: "/tmp/auto-mobile artifacts/1234-tapOn-id_1.json",
+      content: stringifyToolResponse({ viewHierarchy: { hierarchy: { node: { text: "Hello" } } } }),
+      mode: 0o600,
+    });
+    expect(first).toEqual({
+      artifact: {
+        path: "/tmp/auto-mobile artifacts/1234-tapOn-id_1.json",
+        format: "json",
+        payload: "ObserveResult",
+        bytes: Buffer.byteLength(fileSystem.writes[0].content, "utf8"),
+        tool: "tapOn",
+      },
+    });
+    expect(second.artifact.path).toBe("/tmp/auto-mobile artifacts/1234-tapOn-id_2.json");
+  });
+
+  test("write failures surface as actionable artifact failures", () => {
+    const fileSystem = new FakeArtifactFileSystem();
+    fileSystem.writeError = new Error("disk full");
+    const writer = new JsonToolOutputArtifactWriter({
+      outputDirectory: "/tmp/artifacts",
+      fileSystem,
+      idGenerator: new FakeIdGenerator(["id"]),
+      timer: new FakeTimer(),
+    });
+
+    expect(() => writer.writeJsonArtifact({
+      tool: "observe",
+      payload: "ObserveResult",
+      data: { updatedAt: 1 },
+    })).toThrow("Failed to write ObserveResult artifact for observe: disk full");
+  });
+});

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -73,6 +73,15 @@ describe("tool output artifact metadata schema (#3480)", () => {
       observation: metadata,
     })).not.toThrow();
   });
+
+  test("accepts ObserveDiff artifact metadata for diffed observations", () => {
+    expect(toolOutputArtifactMetadataSchema.parse({
+      artifact: {
+        ...metadata.artifact,
+        payload: "ObserveDiff",
+      },
+    }).artifact.payload).toBe("ObserveDiff");
+  });
 });
 
 /**

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { toJSONSchema } from "zod";
-import { elementBoundsSchema, elementSchema, tapOnResultSchema } from "../../src/server/toolOutputSchemas";
+import { elementBoundsSchema, elementSchema, tapOnResultSchema, toolOutputArtifactMetadataSchema } from "../../src/server/toolOutputSchemas";
 
 /**
  * Wire-schema coverage for the `--observe-result-compact` tuple form (issue #2990,
@@ -49,6 +49,29 @@ describe("elementBoundsSchema: object + compact tuple (#2990)", () => {
     // so an external client can decode [l,t,r,b] from the wire schema alone.
     expect(json).toContain("left, top, right, bottom");
     expect(json.toLowerCase()).toContain("observe-result-compact");
+  });
+});
+
+describe("tool output artifact metadata schema (#3480)", () => {
+  const metadata = {
+    artifact: {
+      path: "/tmp/auto-mobile/123-tapOn-id.json",
+      format: "json",
+      payload: "ObserveResult",
+      bytes: 123,
+      tool: "tapOn",
+    },
+  };
+
+  test("accepts the shared observation artifact metadata shape", () => {
+    expect(toolOutputArtifactMetadataSchema.parse(metadata)).toEqual(metadata);
+  });
+
+  test("tapOn results accept artifact metadata in the embedded observation field", () => {
+    expect(() => tapOnResultSchema.parse({
+      success: true,
+      observation: metadata,
+    })).not.toThrow();
   });
 });
 

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -5,7 +5,7 @@ import type { BootedDevice } from "../../src/models";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { logger } from "../../src/utils/logger";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
-import type { ObservationArtifactWriter } from "../../src/server/finalizeToolResponse";
+import type { ObservationArtifactPayload, ObservationArtifactWriter } from "../../src/server/finalizeToolResponse";
 import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -192,7 +192,7 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
   class FakeObservationArtifactWriter implements ObservationArtifactWriter {
     writes: Array<{ tool: string; payload: string; data: unknown }> = [];
 
-    writeJsonArtifact(input: { tool: string; payload: "ObserveResult"; data: unknown }) {
+    writeJsonArtifact(input: { tool: string; payload: ObservationArtifactPayload; data: unknown }) {
       this.writes.push(input);
       return {
         artifact: {

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
-import { ToolRegistry } from "../../src/server/toolRegistry";
+import { DefaultAfterToolCallHandler, ToolRegistry } from "../../src/server/toolRegistry";
 import type { BootedDevice } from "../../src/models";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { logger } from "../../src/utils/logger";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+import type { ObservationArtifactWriter } from "../../src/server/finalizeToolResponse";
+import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
+import { serverConfig } from "../../src/utils/ServerConfig";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("ToolRegistry device-aware pipeline", () => {
   const device: BootedDevice = {
@@ -25,6 +29,7 @@ describe("ToolRegistry device-aware pipeline", () => {
     restorePipelineOverrides?.();
     restorePipelineOverrides = undefined;
     (ToolRegistry as any).toolCallRepository = originalToolCallRepository;
+    serverConfig.setToolOutputArtifactDirectory(undefined);
     ToolRegistry.clearTools();
   });
 
@@ -180,5 +185,107 @@ describe("ToolRegistry device-aware pipeline", () => {
       (AndroidCtrlProxyClient as any).getInstance = originalGetInstance;
       logger.debug = originalDebug;
     }
+  });
+});
+
+describe("DefaultAfterToolCallHandler observation artifact config path", () => {
+  class FakeObservationArtifactWriter implements ObservationArtifactWriter {
+    writes: Array<{ tool: string; payload: string; data: unknown }> = [];
+
+    writeJsonArtifact(input: { tool: string; payload: "ObserveResult"; data: unknown }) {
+      this.writes.push(input);
+      return {
+        artifact: {
+          path: `/tmp/artifacts/${input.tool}-1.json`,
+          format: "json" as const,
+          payload: input.payload,
+          bytes: 123,
+          tool: input.tool,
+        },
+      };
+    }
+  }
+
+  const makeObservePayload = () => ({
+    updatedAt: 1,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    viewHierarchy: {
+      hierarchy: {
+        node: {
+          "resource-id": "com.example:id/root",
+          "view-id": "com.example:id/root",
+        },
+      },
+    },
+  });
+
+  afterEach(() => {
+    serverConfig.setToolOutputArtifactDirectory(undefined);
+  });
+
+  test("configured artifact directory creates a writer and replaces observe output metadata", async () => {
+    const writer = new FakeObservationArtifactWriter();
+    const requestedDirectories: string[] = [];
+    const handler = new DefaultAfterToolCallHandler(outputDirectory => {
+      requestedDirectories.push(outputDirectory);
+      return writer;
+    });
+    const timer = new FakeTimer();
+    timer.setCurrentTime(25);
+    serverConfig.setToolOutputArtifactDirectory("/tmp/artifacts");
+
+    const result = await handler.handle({
+      name: "observe",
+      args: {},
+      device: undefined,
+      internalCall: false,
+      response: createStructuredToolResponse(makeObservePayload()),
+      sessionUuid: "session-1",
+      shouldResolveDevice: false,
+      timer,
+      toolStartMs: 20,
+    });
+
+    expect(result.durationMs).toBe(5);
+    expect(requestedDirectories).toEqual(["/tmp/artifacts"]);
+    expect(writer.writes).toHaveLength(1);
+    expect((writer.writes[0].data as any).viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
+    expect(result.finalizedResponse.structuredContent).toEqual({
+      artifact: {
+        path: "/tmp/artifacts/observe-1.json",
+        format: "json",
+        payload: "ObserveResult",
+        bytes: 123,
+        tool: "observe",
+      },
+    });
+    expect(result.finalizedResponse.content[0].text).toBe(stringifyToolResponse(result.finalizedResponse.structuredContent));
+  });
+
+  test("internal calls bypass configured artifact writers", async () => {
+    const writer = new FakeObservationArtifactWriter();
+    const requestedDirectories: string[] = [];
+    const handler = new DefaultAfterToolCallHandler(outputDirectory => {
+      requestedDirectories.push(outputDirectory);
+      return writer;
+    });
+    serverConfig.setToolOutputArtifactDirectory("/tmp/artifacts");
+
+    const result = await handler.handle({
+      name: "observe",
+      args: {},
+      device: undefined,
+      internalCall: true,
+      response: createStructuredToolResponse(makeObservePayload()),
+      sessionUuid: "session-1",
+      shouldResolveDevice: false,
+      timer: new FakeTimer(),
+      toolStartMs: 0,
+    });
+
+    expect(requestedDirectories).toEqual([]);
+    expect(writer.writes).toHaveLength(0);
+    expect((result.finalizedResponse.structuredContent as any).viewHierarchy).toBeDefined();
   });
 });

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -9,6 +9,8 @@ import type { ObservationArtifactPayload, ObservationArtifactWriter } from "../.
 import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { TelemetryRecorder } from "../../src/features/telemetry/TelemetryRecorder";
+import { getMcpRecordingStatus, resetMcpRecordingState, startMcpRecording } from "../../src/server/mcpRecordingManager";
 
 describe("ToolRegistry device-aware pipeline", () => {
   const device: BootedDevice = {
@@ -191,8 +193,12 @@ describe("ToolRegistry device-aware pipeline", () => {
 describe("DefaultAfterToolCallHandler observation artifact config path", () => {
   class FakeObservationArtifactWriter implements ObservationArtifactWriter {
     writes: Array<{ tool: string; payload: string; data: unknown }> = [];
+    throwOnWrite: Error | undefined;
 
     writeJsonArtifact(input: { tool: string; payload: ObservationArtifactPayload; data: unknown }) {
+      if (this.throwOnWrite) {
+        throw this.throwOnWrite;
+      }
       this.writes.push(input);
       return {
         artifact: {
@@ -222,6 +228,7 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
 
   afterEach(() => {
     serverConfig.setToolOutputArtifactDirectory(undefined);
+    resetMcpRecordingState();
   });
 
   test("configured artifact directory creates a writer and replaces observe output metadata", async () => {
@@ -287,5 +294,42 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
     expect(requestedDirectories).toEqual([]);
     expect(writer.writes).toHaveLength(0);
     expect((result.finalizedResponse.structuredContent as any).viewHierarchy).toBeDefined();
+  });
+
+  test("artifact finalization failures are not recorded as successful tool calls", async () => {
+    const writer = new FakeObservationArtifactWriter();
+    writer.throwOnWrite = new Error("artifact disk is full");
+    const telemetryEvents: unknown[] = [];
+    const originalGetInstance = (TelemetryRecorder as any).getInstance;
+    (TelemetryRecorder as any).getInstance = () => ({
+      recordToolCallEvent(event: unknown) {
+        telemetryEvents.push(event);
+      },
+    });
+    const timer = new FakeTimer();
+    timer.setCurrentTime(25);
+    startMcpRecording(timer);
+    serverConfig.setToolOutputArtifactDirectory("/tmp/artifacts");
+
+    try {
+      const handler = new DefaultAfterToolCallHandler(() => writer);
+
+      await expect(handler.handle({
+        name: "observe",
+        args: {},
+        device: undefined,
+        internalCall: false,
+        response: createStructuredToolResponse(makeObservePayload()),
+        sessionUuid: "session-1",
+        shouldResolveDevice: false,
+        timer,
+        toolStartMs: 20,
+      })).rejects.toThrow("artifact disk is full");
+
+      expect(telemetryEvents).toHaveLength(0);
+      expect(getMcpRecordingStatus(timer)?.stepCount).toBe(0);
+    } finally {
+      (TelemetryRecorder as any).getInstance = originalGetInstance;
+    }
   });
 });

--- a/test/utils/ServerConfig.outputReduction.test.ts
+++ b/test/utils/ServerConfig.outputReduction.test.ts
@@ -13,6 +13,7 @@ describe("ServerConfig output-reduction flags", () => {
     serverConfig.setActionsDiffObserveEnabled(false);
     serverConfig.setActionsNoObserveEnabled(false);
     serverConfig.setToolResultsCompactJsonEnabled(false);
+    serverConfig.setToolOutputArtifactDirectory(undefined);
   });
 
   test("observe-result-drop-elements defaults off and toggles", () => {
@@ -49,5 +50,15 @@ describe("ServerConfig output-reduction flags", () => {
     expect(serverConfig.isToolResultsCompactJsonEnabled()).toBe(false);
     serverConfig.setToolResultsCompactJsonEnabled(true);
     expect(serverConfig.isToolResultsCompactJsonEnabled()).toBe(true);
+  });
+
+  test("tool-output artifact directory defaults off and toggles", () => {
+    expect(serverConfig.isToolOutputArtifactModeEnabled()).toBe(false);
+    expect(serverConfig.getToolOutputArtifactDirectory()).toBeUndefined();
+
+    serverConfig.setToolOutputArtifactDirectory("/tmp/artifacts");
+
+    expect(serverConfig.isToolOutputArtifactModeEnabled()).toBe(true);
+    expect(serverConfig.getToolOutputArtifactDirectory()).toBe("/tmp/artifacts");
   });
 });


### PR DESCRIPTION
## Summary

Adds observation artifacting at the final tool-response boundary so agent-facing `ObserveResult` payloads are written out-of-band and replaced with rich metadata. The rewrite happens after existing sanitize/compact/drop/diff transforms, while internal tool-to-tool calls keep full observations.

## Linked Issue

Closes #3480

## Validation

- [x] `bun run turbo:validate` passes (`lint`, `build`, `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Focused acceptance tests pass: `bun test test/server/finalizeToolResponse.test.ts test/server/toolOutputArtifactWriter.test.ts test/server/observeOutputSchema.test.ts test/server/toolOutputSchemas.test.ts test/utils/ServerConfig.outputReduction.test.ts`
- [x] New code uses interfaces + fakes + FakeTimer; focused unit tests run in under 100ms each

## Device Verification

N/A. This changes response serialization and schema metadata; no device-side behavior changed.

## Follow-ups

- Startup config / daemon option relay remains tracked by #3482.
- Non-observation heavy output artifacting remains tracked by #3481.
