### PR TITLE
Add tool output artifact startup config

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -190,8 +190,6 @@ src/index.ts: error TS2322: Type 'string | number | undefined' is not assignable
 src/index.ts: error TS2322: Type 'string | number | undefined' is not assignable to type 'number | undefined'.
 src/index.ts: error TS2322: Type 'string | number | undefined' is not assignable to type 'number | undefined'.
 src/index.ts: error TS2322: Type 'string | number | undefined' is not assignable to type 'number | undefined'.
-src/index.ts: error TS2339: Property 'networkMockable' does not exist on type '{ cliMode: boolean; cliArgs: string[]; daemonPort: number | undefined; daemonHost: string | undefined; debugPerf: boolean; debug: boolean; uiPerfMode: boolean; memPerfAuditMode: boolean; ... 23 more ...; outputReduction: OutputReductionFlags; }'.
-src/index.ts: error TS2353: Object literal may only specify known properties, and 'networkMockable' does not exist in type '{ cliMode: boolean; cliArgs: string[]; daemonPort: number | undefined; daemonHost: string | undefined; debugPerf: boolean; debug: boolean; uiPerfMode: boolean; memPerfAuditMode: boolean; ... 23 more ...; outputReduction: OutputReductionFlags; }'.
 src/server/appFileService.ts: error TS2345: Argument of type 'PutAppFileRequest' is not assignable to parameter of type 'PutAppFileArgs'.
 src/server/appFileService.ts: error TS2430: Interface 'PutAppFileRequest' incorrectly extends interface 'PutAppFileArgs'.
 src/server/appResources.ts: error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'readonly ("platform" | "type" | "search" | "deviceId" | "profile")[]'.
@@ -357,7 +355,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 48 :: src/db/migrator.ts: error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
 # swap-fp: 5 :: src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type '{ bounds: NormalizedHighlightBounds | undefined; type: "box"; style?: HighlightStyle | null; }' is not assignable to type 'HighlightShape'.
 # swap-fp: 5 :: src/features/observe/ios/CtrlProxyHighlights.ts: error TS2322: Type '{ bounds: { x: number; y: number; width: number; height: number; sourceWidth: number | null | undefined; sourceHeight: number | null | undefined; } | null | undefined; type: "box"; style?: HighlightStyle | null; }' is not assignable to type 'HighlightShape'.
-# swap-fp: 5 :: src/index.ts: error TS2353: Object literal may only specify known properties, and 'networkMockable' does not exist in type '{ cliMode: boolean; cliArgs: string[]; daemonPort: number | undefined; daemonHost: string | undefined; debugPerf: boolean; debug: boolean; uiPerfMode: boolean; memPerfAuditMode: boolean; ... 23 more ...; outputReduction: OutputReductionFlags; }'.
 # swap-fp: 5 :: src/server/bootedDeviceResources.ts: error TS2322: Type '"local" | "remote"' is not assignable to type '"local" | undefined'.
 # swap-fp: 5,21,76 :: src/db/migrator.ts: error TS7006: Parameter 'name' implicitly has an 'any' type.
 # swap-fp: 5,7,7 :: src/server/networkGraph.ts: error TS18048: 'group' is possibly 'undefined'.
@@ -393,7 +390,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["predictive-ui", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["raw-element-search", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
-# swap-fp: 7 :: src/index.ts: error TS2339: Property 'networkMockable' does not exist on type '{ cliMode: boolean; cliArgs: string[]; daemonPort: number | undefined; daemonHost: string | undefined; debugPerf: boolean; debug: boolean; uiPerfMode: boolean; memPerfAuditMode: boolean; ... 23 more ...; outputReduction: OutputReductionFlags; }'.
 # swap-fp: 7 :: src/server/deviceTools.ts: error TS2322: Type 'TimingData | null' is not assignable to type 'Record<string, number>'.
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
 # swap-fp: 7,7 :: src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -243,6 +243,9 @@ export class Daemon {
     if (options.toolResultsCompactJson) {
       serverConfig.setToolResultsCompactJsonEnabled(true);
     }
+    if (options.toolOutputsDir) {
+      serverConfig.setToolOutputsDir(options.toolOutputsDir);
+    }
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -220,6 +220,10 @@ const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
   ...OUTPUT_REDUCTION_FLAG_SPECS.map(spec => spec.field),
 ];
 
+const REUSE_CRITICAL_STRING_OPTION_KEYS: (keyof DaemonOptions)[] = [
+  "toolOutputsDir",
+];
+
 /**
  * Boolean-valued startup options that differ between the requested MCP config
  * and the running daemon. Each option is compared as a strict boolean
@@ -237,6 +241,13 @@ function startupOptionMismatches(
     const have = running?.[key] === true;
     if (want !== have) {
       mismatches.push(`${key} (requested=${want}, running=${have})`);
+    }
+  }
+  for (const key of REUSE_CRITICAL_STRING_OPTION_KEYS) {
+    const want = typeof requested?.[key] === "string" ? requested[key] : undefined;
+    const have = typeof running?.[key] === "string" ? running[key] : undefined;
+    if (want !== have) {
+      mismatches.push(`${key} (requested=${want ?? "unset"}, running=${have ?? "unset"})`);
     }
   }
   return mismatches;

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -56,6 +56,7 @@ import {
   parseToolOutputsDirConfig,
   TOOL_OUTPUTS_DIR_FLAG,
   TOOL_OUTPUT_DIR_FLAG_ALIAS,
+  TOOL_OUTPUTS_DIR_ENV,
 } from "../utils/toolOutputArtifacts";
 
 /**
@@ -636,6 +637,9 @@ export class DaemonManager implements DaemonManagerLike {
     if (this.socketPath !== SOCKET_PATH) {
       childEnv.AUTOMOBILE_DAEMON_SOCKET_PATH = this.socketPath;
     }
+    if (options.toolOutputsDir) {
+      childEnv[TOOL_OUTPUTS_DIR_ENV] = options.toolOutputsDir;
+    }
 
     try {
       let retriedIncompleteExtraction = false;
@@ -723,9 +727,6 @@ export class DaemonManager implements DaemonManagerLike {
     }
     if (options.videoMaxArchiveSizeMb !== undefined) {
       args.push("--video-archive-size-mb", options.videoMaxArchiveSizeMb.toString());
-    }
-    if (options.toolOutputsDir) {
-      args.push(TOOL_OUTPUTS_DIR_FLAG, options.toolOutputsDir);
     }
     if (options.networkMockable) {
       args.push("--network-mockable");

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -52,6 +52,11 @@ import {
   resolvePathFromDaemonLaunchWorkingDirectory,
   resolveStableDaemonWorkingDirectory,
 } from "../utils/workingDirectory";
+import {
+  parseToolOutputsDirConfig,
+  TOOL_OUTPUTS_DIR_FLAG,
+  TOOL_OUTPUT_DIR_FLAG_ALIAS,
+} from "../utils/toolOutputArtifacts";
 
 /**
  * Check that bunx is available on PATH.
@@ -719,6 +724,9 @@ export class DaemonManager implements DaemonManagerLike {
     if (options.videoMaxArchiveSizeMb !== undefined) {
       args.push("--video-archive-size-mb", options.videoMaxArchiveSizeMb.toString());
     }
+    if (options.toolOutputsDir) {
+      args.push(TOOL_OUTPUTS_DIR_FLAG, options.toolOutputsDir);
+    }
     if (options.networkMockable) {
       args.push("--network-mockable");
     }
@@ -1170,6 +1178,11 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
   const options: DaemonOptions = shouldSkipCtrlProxyDownload(args, env)
     ? { skipCtrlProxyDownload: true }
     : {};
+  options.toolOutputsDir = parseToolOutputsDirConfig(
+    [],
+    env,
+    resolveDaemonLaunchWorkingDirectory()
+  );
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--port") {
       options.port = parseInt(args[i + 1], 10);
@@ -1207,6 +1220,12 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
       i++;
     } else if (args[i] === "--video-archive-size-mb") {
       options.videoMaxArchiveSizeMb = Number(args[i + 1]);
+      i++;
+    } else if (args[i] === TOOL_OUTPUTS_DIR_FLAG || args[i] === TOOL_OUTPUT_DIR_FLAG_ALIAS) {
+      const toolOutputsDir = args[i + 1];
+      if (toolOutputsDir && !toolOutputsDir.startsWith("--")) {
+        options.toolOutputsDir = toolOutputsDir;
+      }
       i++;
     } else if (args[i] === "--network-mockable") {
       options.networkMockable = true;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -172,6 +172,8 @@ export interface DaemonOptions {
   videoFormat?: string;
   /** Default video archive size limit in MB */
   videoMaxArchiveSizeMb?: number;
+  /** Absolute host-local directory for tool output artifacts */
+  toolOutputsDir?: string;
   /** Enable network mocking */
   networkMockable?: boolean;
   /** Expose tools that require the target app to embed the AutoMobile SDK */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env bun
 import { bootstrapEnvironment } from "./utils/envBootstrap";
-import { DAEMON_LAUNCH_CWD_ENV, safeProcessCwd } from "./utils/workingDirectory";
+import {
+  DAEMON_LAUNCH_CWD_ENV,
+  resolveDaemonLaunchWorkingDirectory,
+  safeProcessCwd,
+} from "./utils/workingDirectory";
 
 // Run before any other imports that may resolve tool paths at module load time.
 bootstrapEnvironment();
@@ -32,6 +36,7 @@ import {
   SKIP_CTRL_PROXY_DOWNLOAD_FLAG,
   shouldSkipCtrlProxyDownload,
 } from "./utils/ctrlProxyDownloadControl";
+import { parseToolOutputsDirConfig } from "./utils/toolOutputArtifacts";
 import {
   installProcessLifecycleHandlers,
   setFatalProcessHandler,
@@ -100,6 +105,7 @@ function parseArgs(log: ParseLogger): {
   daemonArgs: string[];
   skipCtrlProxyDownload: boolean;
   embeddedSdk: boolean;
+  networkMockable: boolean;
   dismissKeyboardAfterInput: boolean;
   mcpRecording: boolean;
   navigationScreenshots: boolean;
@@ -110,6 +116,7 @@ function parseArgs(log: ParseLogger): {
   noA11yReportViewIds: boolean;
   noA11yRetrieveInteractiveWindows: boolean;
   outputReduction: OutputReductionFlags;
+  toolOutputsDir: string | undefined;
   } {
   const args = process.argv.slice(2);
 
@@ -175,6 +182,11 @@ function parseArgs(log: ParseLogger): {
   // Output-size reduction flags (issue #2756): each parses from CLI OR its
   // AUTOMOBILE_* env var, CLI winning via ||.
   const outputReduction = parseOutputReductionFlags(args, process.env);
+  const toolOutputsDir = parseToolOutputsDirConfig(
+    args,
+    process.env,
+    resolveDaemonLaunchWorkingDirectory()
+  );
   let planExecutionLockScope: PlanExecutionLockScope = "session";
   const videoRecordingDefaults: VideoRecordingConfigInput = {};
 
@@ -377,6 +389,7 @@ function parseArgs(log: ParseLogger): {
     noA11yReportViewIds,
     noA11yRetrieveInteractiveWindows,
     outputReduction,
+    toolOutputsDir,
   };
 }
 
@@ -460,10 +473,12 @@ async function main() {
       noA11yReportViewIds,
       noA11yRetrieveInteractiveWindows,
       outputReduction,
+      toolOutputsDir,
     } = parseArgs(logger);
 
     serverConfig.setPlanExecutionLockScope(planExecutionLockScope);
     serverConfig.setVideoRecordingDefaults(videoRecordingDefaults);
+    serverConfig.setToolOutputsDir(toolOutputsDir);
     serverConfig.setSkipCtrlProxyDownload(skipCtrlProxyDownload);
     serverConfig.setEmbeddedSdkEnabled(embeddedSdk);
     serverConfig.setNetworkMockableEnabled(networkMockable);
@@ -604,6 +619,7 @@ async function main() {
         videoFps: videoRecordingDefaults.fps,
         videoFormat: videoRecordingDefaults.format,
         videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
+        toolOutputsDir,
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,
@@ -665,6 +681,7 @@ async function main() {
         videoFps: videoRecordingDefaults.fps,
         videoFormat: videoRecordingDefaults.format,
         videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
+        toolOutputsDir,
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -41,6 +41,7 @@ class ServerConfig {
   private _actionsDiffObserve: boolean = false;
   private _actionsNoObserve: boolean = false;
   private _toolResultsCompactJson: boolean = false;
+  private _toolOutputsDir: string | undefined;
 
   private constructor() {}
 
@@ -125,6 +126,18 @@ class ServerConfig {
 
   getAppearanceDefaults(): AppearanceConfigInput {
     return { ...this._appearanceDefaults };
+  }
+
+  setToolOutputsDir(dir: string | undefined): void {
+    this._toolOutputsDir = dir;
+  }
+
+  getToolOutputsDir(): string | undefined {
+    return this._toolOutputsDir;
+  }
+
+  isToolOutputArtifactModeEnabled(): boolean {
+    return this._toolOutputsDir !== undefined;
   }
 
   setSkipCtrlProxyDownload(skip: boolean): void {

--- a/src/utils/toolOutputArtifacts.ts
+++ b/src/utils/toolOutputArtifacts.ts
@@ -1,0 +1,98 @@
+import { promises as fsPromises, constants as fsConstants } from "node:fs";
+import path from "node:path";
+import { ActionableError } from "../models";
+
+export const TOOL_OUTPUTS_DIR_FLAG = "--tool-outputs-dir";
+export const TOOL_OUTPUT_DIR_FLAG_ALIAS = "--tool-output-dir";
+export const TOOL_OUTPUTS_DIR_ENV = "AUTOMOBILE_TOOL_OUTPUTS_DIR";
+
+export interface ToolOutputsDirFileSystem {
+  ensureDir(dirPath: string): Promise<void>;
+  stat(dirPath: string): Promise<{ isDirectory(): boolean }>;
+  access(dirPath: string): Promise<void>;
+}
+
+const nodeToolOutputsDirFileSystem: ToolOutputsDirFileSystem = {
+  async ensureDir(dirPath: string): Promise<void> {
+    await fsPromises.mkdir(dirPath, { recursive: true });
+  },
+
+  async stat(dirPath: string): Promise<{ isDirectory(): boolean }> {
+    return await fsPromises.stat(dirPath);
+  },
+
+  async access(dirPath: string): Promise<void> {
+    await fsPromises.access(dirPath, fsConstants.W_OK);
+  },
+};
+
+function firstFlagValue(args: string[], flags: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (!flags.includes(args[i])) {
+      continue;
+    }
+    const value = args[i + 1];
+    if (!value || value.startsWith("--")) {
+      return undefined;
+    }
+    return value;
+  }
+  return undefined;
+}
+
+function normalizeConfiguredPath(value: string | undefined, launchCwd: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return path.isAbsolute(trimmed) ? trimmed : path.resolve(launchCwd, trimmed);
+}
+
+export function parseToolOutputsDirConfig(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  launchCwd: string
+): string | undefined {
+  const cliValue = firstFlagValue(args, [TOOL_OUTPUTS_DIR_FLAG, TOOL_OUTPUT_DIR_FLAG_ALIAS]);
+  return normalizeConfiguredPath(cliValue ?? env[TOOL_OUTPUTS_DIR_ENV], launchCwd);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function validateToolOutputsDirForWrite(
+  dirPath: string,
+  fileSystem: ToolOutputsDirFileSystem = nodeToolOutputsDirFileSystem
+): Promise<string> {
+  try {
+    await fileSystem.ensureDir(dirPath);
+  } catch (error) {
+    throw new ActionableError(
+      `Failed to create tool outputs directory "${dirPath}": ${errorMessage(error)}`
+    );
+  }
+
+  let stats: { isDirectory(): boolean };
+  try {
+    stats = await fileSystem.stat(dirPath);
+  } catch (error) {
+    throw new ActionableError(
+      `Failed to inspect tool outputs directory "${dirPath}": ${errorMessage(error)}`
+    );
+  }
+
+  if (!stats.isDirectory()) {
+    throw new ActionableError(`Configured tool outputs path "${dirPath}" is not a directory`);
+  }
+
+  try {
+    await fileSystem.access(dirPath);
+  } catch (error) {
+    throw new ActionableError(
+      `Configured tool outputs directory "${dirPath}" is not writable: ${errorMessage(error)}`
+    );
+  }
+
+  return dirPath;
+}

--- a/src/utils/toolOutputArtifacts.ts
+++ b/src/utils/toolOutputArtifacts.ts
@@ -1,6 +1,7 @@
 import { promises as fsPromises, constants as fsConstants } from "node:fs";
 import path from "node:path";
 import { ActionableError } from "../models";
+import { serverConfig } from "./ServerConfig";
 
 export const TOOL_OUTPUTS_DIR_FLAG = "--tool-outputs-dir";
 export const TOOL_OUTPUT_DIR_FLAG_ALIAS = "--tool-output-dir";
@@ -95,4 +96,15 @@ export async function validateToolOutputsDirForWrite(
   }
 
   return dirPath;
+}
+
+export async function getValidatedToolOutputsDirForWrite(
+  fileSystem: ToolOutputsDirFileSystem = nodeToolOutputsDirFileSystem
+): Promise<string | undefined> {
+  const configuredDir = serverConfig.getToolOutputsDir();
+  if (!configuredDir) {
+    return undefined;
+  }
+
+  return await validateToolOutputsDirForWrite(configuredDir, fileSystem);
 }

--- a/src/utils/toolOutputArtifacts.ts
+++ b/src/utils/toolOutputArtifacts.ts
@@ -1,19 +1,20 @@
 import { promises as fsPromises, constants as fsConstants } from "node:fs";
 import path from "node:path";
 import { ActionableError } from "../models";
+import type { FileSystem } from "./filesystem/DefaultFileSystem";
 import { serverConfig } from "./ServerConfig";
 
 export const TOOL_OUTPUTS_DIR_FLAG = "--tool-outputs-dir";
 export const TOOL_OUTPUT_DIR_FLAG_ALIAS = "--tool-output-dir";
 export const TOOL_OUTPUTS_DIR_ENV = "AUTOMOBILE_TOOL_OUTPUTS_DIR";
+export const TOOL_OUTPUTS_DIR_ENV_ALIAS = "AUTO_MOBILE_TOOL_OUTPUTS_DIR";
 
-export interface ToolOutputsDirFileSystem {
-  ensureDir(dirPath: string): Promise<void>;
+export interface ToolOutputsDirValidationDeps extends Pick<FileSystem, "ensureDir"> {
   stat(dirPath: string): Promise<{ isDirectory(): boolean }>;
   access(dirPath: string): Promise<void>;
 }
 
-const nodeToolOutputsDirFileSystem: ToolOutputsDirFileSystem = {
+const nodeToolOutputsDirValidationDeps: ToolOutputsDirValidationDeps = {
   async ensureDir(dirPath: string): Promise<void> {
     await fsPromises.mkdir(dirPath, { recursive: true });
   },
@@ -55,7 +56,10 @@ export function parseToolOutputsDirConfig(
   launchCwd: string
 ): string | undefined {
   const cliValue = firstFlagValue(args, [TOOL_OUTPUTS_DIR_FLAG, TOOL_OUTPUT_DIR_FLAG_ALIAS]);
-  return normalizeConfiguredPath(cliValue ?? env[TOOL_OUTPUTS_DIR_ENV], launchCwd);
+  return normalizeConfiguredPath(
+    cliValue ?? env[TOOL_OUTPUTS_DIR_ENV] ?? env[TOOL_OUTPUTS_DIR_ENV_ALIAS],
+    launchCwd
+  );
 }
 
 function errorMessage(error: unknown): string {
@@ -64,7 +68,7 @@ function errorMessage(error: unknown): string {
 
 export async function validateToolOutputsDirForWrite(
   dirPath: string,
-  fileSystem: ToolOutputsDirFileSystem = nodeToolOutputsDirFileSystem
+  fileSystem: ToolOutputsDirValidationDeps = nodeToolOutputsDirValidationDeps
 ): Promise<string> {
   try {
     await fileSystem.ensureDir(dirPath);
@@ -99,7 +103,7 @@ export async function validateToolOutputsDirForWrite(
 }
 
 export async function getValidatedToolOutputsDirForWrite(
-  fileSystem: ToolOutputsDirFileSystem = nodeToolOutputsDirFileSystem
+  fileSystem: ToolOutputsDirValidationDeps = nodeToolOutputsDirValidationDeps
 ): Promise<string | undefined> {
   const configuredDir = serverConfig.getToolOutputsDir();
   if (!configuredDir) {

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -6,6 +6,7 @@ import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { DaemonManager, type DaemonProcessSpawner } from "../../src/daemon/manager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { TOOL_OUTPUTS_DIR_ENV, TOOL_OUTPUTS_DIR_FLAG } from "../../src/utils/toolOutputArtifacts";
 
 describe("DaemonManager launch", () => {
   const tempDirs: string[] = [];
@@ -177,14 +178,16 @@ describe("DaemonManager launch", () => {
     expect(realpathSync(capturedEnv![DAEMON_LAUNCH_CWD_ENV]!)).toBe(realpathSync(spawnerCwd));
   });
 
-  test("passes tool outputs directory option to the daemon child args", async () => {
+  test("passes tool outputs directory option to the daemon child env to preserve spaces", async () => {
     const stateDir = createTempDir("daemon-launch-state-");
     process.env.AUTOMOBILE_DATA_DIR = stateDir;
 
     let capturedArgs: string[] | undefined;
+    let capturedEnv: NodeJS.ProcessEnv | undefined;
     const processSpawner: DaemonProcessSpawner = {
-      spawn: (_command: string, args: string[], _options: SpawnOptions) => {
+      spawn: (_command: string, args: string[], options: SpawnOptions) => {
         capturedArgs = args;
+        capturedEnv = options.env;
         return {
           unref() {},
           once() { return this; },
@@ -218,10 +221,11 @@ describe("DaemonManager launch", () => {
       processSpawner
     );
 
-    await manager.start({ toolOutputsDir: "/tmp/auto-mobile-artifacts" });
+    const toolOutputsDir = "/tmp/auto mobile artifacts";
+    await manager.start({ toolOutputsDir });
 
-    expect(capturedArgs).toContain("--tool-outputs-dir");
-    expect(capturedArgs).toContain("/tmp/auto-mobile-artifacts");
+    expect(capturedArgs).not.toContain(TOOL_OUTPUTS_DIR_FLAG);
+    expect(capturedEnv![TOOL_OUTPUTS_DIR_ENV]).toBe(toolOutputsDir);
   });
 
   test("resolves relative daemon state paths before changing daemon cwd", async () => {

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -177,6 +177,53 @@ describe("DaemonManager launch", () => {
     expect(realpathSync(capturedEnv![DAEMON_LAUNCH_CWD_ENV]!)).toBe(realpathSync(spawnerCwd));
   });
 
+  test("passes tool outputs directory option to the daemon child args", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    process.env.AUTOMOBILE_DATA_DIR = stateDir;
+
+    let capturedArgs: string[] | undefined;
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, args: string[], _options: SpawnOptions) => {
+        capturedArgs = args;
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start({ toolOutputsDir: "/tmp/auto-mobile-artifacts" });
+
+    expect(capturedArgs).toContain("--tool-outputs-dir");
+    expect(capturedArgs).toContain("/tmp/auto-mobile-artifacts");
+  });
+
   test("resolves relative daemon state paths before changing daemon cwd", async () => {
     const spawnerCwd = createTempDir("daemon-spawner-cwd-");
     process.chdir(spawnerCwd);

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -430,7 +430,7 @@ describe("DaemonMcpProxy", () => {
     });
 
     describe("startup option mismatch handling", () => {
-      function runningStatus(options: { embeddedSdk?: boolean; toolResultsNoStructuredContent?: boolean }) {
+      function runningStatus(options: { embeddedSdk?: boolean; toolResultsNoStructuredContent?: boolean; toolOutputsDir?: string }) {
         return {
           running: true,
           pid: 1234,
@@ -492,6 +492,34 @@ describe("DaemonMcpProxy", () => {
           await proxy.listTools();
           expect(fakeManager.restartCalled).toBe(true);
           expect(fakeManager.restartOptions).toEqual({ toolResultsNoStructuredContent: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts daemon when tool outputs directory differs", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ toolOutputsDir: "/tmp/old-artifacts" }), // ensureVersionMatches
+          runningStatus({ toolOutputsDir: "/tmp/old-artifacts" }), // ensureBuildMatches
+          runningStatus({ toolOutputsDir: "/tmp/old-artifacts" }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ toolOutputsDir: "/tmp/new-artifacts" }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { toolOutputsDir: "/tmp/new-artifacts" },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ toolOutputsDir: "/tmp/new-artifacts" });
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/daemon/managerOutputReductionArgs.test.ts
+++ b/test/daemon/managerOutputReductionArgs.test.ts
@@ -96,6 +96,11 @@ describe("tool outputs directory daemon arg relay", () => {
       .toBe("/tmp/artifacts");
   });
 
+  test("legacy AUTO_MOBILE_TOOL_OUTPUTS_DIR env alias parses into DaemonOptions", () => {
+    expect(parseDaemonArgs([], { AUTO_MOBILE_TOOL_OUTPUTS_DIR: "/tmp/legacy-artifacts" }).toolOutputsDir)
+      .toBe("/tmp/legacy-artifacts");
+  });
+
   test("ignores missing or flag-shaped values", () => {
     expect(parseDaemonArgs(["--tool-outputs-dir"]).toolOutputsDir).toBeUndefined();
     expect(parseDaemonArgs(["--tool-outputs-dir", "--debug"]).toolOutputsDir).toBeUndefined();

--- a/test/daemon/managerOutputReductionArgs.test.ts
+++ b/test/daemon/managerOutputReductionArgs.test.ts
@@ -84,3 +84,20 @@ describe("output-reduction daemon-arg round trip", () => {
     }
   });
 });
+
+describe("tool outputs directory daemon arg relay", () => {
+  test("--tool-outputs-dir parses into DaemonOptions", () => {
+    expect(parseDaemonArgs(["--tool-outputs-dir", "/tmp/artifacts"]).toolOutputsDir)
+      .toBe("/tmp/artifacts");
+  });
+
+  test("--tool-output-dir alias parses into DaemonOptions", () => {
+    expect(parseDaemonArgs(["--tool-output-dir", "/tmp/artifacts"]).toolOutputsDir)
+      .toBe("/tmp/artifacts");
+  });
+
+  test("ignores missing or flag-shaped values", () => {
+    expect(parseDaemonArgs(["--tool-outputs-dir"]).toolOutputsDir).toBeUndefined();
+    expect(parseDaemonArgs(["--tool-outputs-dir", "--debug"]).toolOutputsDir).toBeUndefined();
+  });
+});

--- a/test/utils/ServerConfig.test.ts
+++ b/test/utils/ServerConfig.test.ts
@@ -2,6 +2,34 @@ import { describe, expect, test, beforeEach } from "bun:test";
 import { serverConfig } from "../../src/utils/ServerConfig";
 
 describe("ServerConfig", () => {
+  describe("tool output artifacts", () => {
+    beforeEach(() => {
+      serverConfig.setToolOutputsDir(undefined);
+    });
+
+    test("defaults to artifact mode disabled", () => {
+      expect(serverConfig.getToolOutputsDir()).toBeUndefined();
+      expect(serverConfig.isToolOutputArtifactModeEnabled()).toBe(false);
+    });
+
+    test("enables artifact mode when a directory is configured", () => {
+      serverConfig.setToolOutputsDir("/tmp/auto-mobile-artifacts");
+
+      expect(serverConfig.getToolOutputsDir()).toBe("/tmp/auto-mobile-artifacts");
+      expect(serverConfig.isToolOutputArtifactModeEnabled()).toBe(true);
+    });
+
+    test("copies the configured directory value out of config", () => {
+      const dir = "/tmp/auto-mobile-artifacts";
+      serverConfig.setToolOutputsDir(dir);
+      const configured = serverConfig.getToolOutputsDir();
+
+      expect(configured).toBe(dir);
+      serverConfig.setToolOutputsDir(undefined);
+      expect(configured).toBe(dir);
+    });
+  });
+
   describe("dismissKeyboardAfterInput", () => {
     beforeEach(() => {
       serverConfig.setDismissKeyboardAfterInputEnabled(false);

--- a/test/utils/toolOutputArtifacts.test.ts
+++ b/test/utils/toolOutputArtifacts.test.ts
@@ -8,10 +8,10 @@ import {
   getValidatedToolOutputsDirForWrite,
   parseToolOutputsDirConfig,
   validateToolOutputsDirForWrite,
-  type ToolOutputsDirFileSystem,
+  type ToolOutputsDirValidationDeps,
 } from "../../src/utils/toolOutputArtifacts";
 
-class FakeToolOutputsDirFileSystem implements ToolOutputsDirFileSystem {
+class FakeToolOutputsDirFileSystem implements ToolOutputsDirValidationDeps {
   ensureDirCalls: string[] = [];
   statCalls: string[] = [];
   accessCalls: string[] = [];
@@ -82,6 +82,27 @@ describe("parseToolOutputsDirConfig", () => {
       { AUTOMOBILE_TOOL_OUTPUTS_DIR: "env-artifacts" },
       launchCwd
     )).toBe(path.resolve(launchCwd, "env-artifacts"));
+  });
+
+  test("supports the legacy AUTO_MOBILE environment variable alias", () => {
+    const launchCwd = path.resolve("launch-root");
+    expect(parseToolOutputsDirConfig(
+      [],
+      { AUTO_MOBILE_TOOL_OUTPUTS_DIR: "legacy-artifacts" },
+      launchCwd
+    )).toBe(path.resolve(launchCwd, "legacy-artifacts"));
+  });
+
+  test("primary environment variable wins over the legacy alias", () => {
+    const launchCwd = path.resolve("launch-root");
+    expect(parseToolOutputsDirConfig(
+      [],
+      {
+        AUTOMOBILE_TOOL_OUTPUTS_DIR: "primary-artifacts",
+        AUTO_MOBILE_TOOL_OUTPUTS_DIR: "legacy-artifacts",
+      },
+      launchCwd
+    )).toBe(path.resolve(launchCwd, "primary-artifacts"));
   });
 
   test("ignores blank configured values", () => {

--- a/test/utils/toolOutputArtifacts.test.ts
+++ b/test/utils/toolOutputArtifacts.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { ActionableError } from "../../src/models";
+import { serverConfig } from "../../src/utils/ServerConfig";
 import {
+  getValidatedToolOutputsDirForWrite,
   parseToolOutputsDirConfig,
   validateToolOutputsDirForWrite,
   type ToolOutputsDirFileSystem,
@@ -96,6 +100,17 @@ describe("validateToolOutputsDirForWrite", () => {
     expect(fs.accessCalls).toEqual(["/artifacts"]);
   });
 
+  test("creates missing directories with the default filesystem adapter", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "tool-output-artifacts-"));
+    const artifactsDir = path.join(tempDir, "missing", "outputs");
+    try {
+      await expect(validateToolOutputsDirForWrite(artifactsDir)).resolves.toBe(artifactsDir);
+      expect(existsSync(artifactsDir)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("throws an actionable error when the path is not a directory", async () => {
     const fs = new FakeToolOutputsDirFileSystem();
     fs.isDirectory = false;
@@ -135,5 +150,31 @@ describe("validateToolOutputsDirForWrite", () => {
     expect(fs.ensureDirCalls).toEqual(["/artifacts", "/artifacts"]);
     expect(fs.statCalls).toEqual(["/artifacts", "/artifacts"]);
     expect(fs.accessCalls).toEqual(["/artifacts", "/artifacts"]);
+  });
+
+  test("validates the configured directory on every write attempt", async () => {
+    const fs = new FakeToolOutputsDirFileSystem();
+    serverConfig.setToolOutputsDir("/configured-artifacts");
+    try {
+      await expect(getValidatedToolOutputsDirForWrite(fs)).resolves.toBe("/configured-artifacts");
+      await expect(getValidatedToolOutputsDirForWrite(fs)).resolves.toBe("/configured-artifacts");
+    } finally {
+      serverConfig.setToolOutputsDir(undefined);
+    }
+
+    expect(fs.ensureDirCalls).toEqual(["/configured-artifacts", "/configured-artifacts"]);
+    expect(fs.statCalls).toEqual(["/configured-artifacts", "/configured-artifacts"]);
+    expect(fs.accessCalls).toEqual(["/configured-artifacts", "/configured-artifacts"]);
+  });
+
+  test("returns undefined without validation when artifact mode is disabled", async () => {
+    const fs = new FakeToolOutputsDirFileSystem();
+    serverConfig.setToolOutputsDir(undefined);
+
+    await expect(getValidatedToolOutputsDirForWrite(fs)).resolves.toBeUndefined();
+
+    expect(fs.ensureDirCalls).toEqual([]);
+    expect(fs.statCalls).toEqual([]);
+    expect(fs.accessCalls).toEqual([]);
   });
 });

--- a/test/utils/toolOutputArtifacts.test.ts
+++ b/test/utils/toolOutputArtifacts.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import { ActionableError } from "../../src/models";
+import {
+  parseToolOutputsDirConfig,
+  validateToolOutputsDirForWrite,
+  type ToolOutputsDirFileSystem,
+} from "../../src/utils/toolOutputArtifacts";
+
+class FakeToolOutputsDirFileSystem implements ToolOutputsDirFileSystem {
+  ensureDirCalls: string[] = [];
+  statCalls: string[] = [];
+  accessCalls: string[] = [];
+  ensureDirError: Error | undefined;
+  statError: Error | undefined;
+  accessError: Error | undefined;
+  isDirectory = true;
+
+  async ensureDir(dirPath: string): Promise<void> {
+    this.ensureDirCalls.push(dirPath);
+    if (this.ensureDirError) {
+      throw this.ensureDirError;
+    }
+  }
+
+  async stat(dirPath: string): Promise<{ isDirectory(): boolean }> {
+    this.statCalls.push(dirPath);
+    if (this.statError) {
+      throw this.statError;
+    }
+    return { isDirectory: () => this.isDirectory };
+  }
+
+  async access(dirPath: string): Promise<void> {
+    this.accessCalls.push(dirPath);
+    if (this.accessError) {
+      throw this.accessError;
+    }
+  }
+}
+
+describe("parseToolOutputsDirConfig", () => {
+  test("returns undefined when no CLI flag or environment variable is configured", () => {
+    expect(parseToolOutputsDirConfig([], {}, "/launch")).toBeUndefined();
+  });
+
+  test("resolves CLI paths to absolute paths from the launch working directory", () => {
+    expect(parseToolOutputsDirConfig(
+      ["--tool-outputs-dir", "artifacts"],
+      {},
+      "/launch"
+    )).toBe(path.join("/launch", "artifacts"));
+  });
+
+  test("supports the singular CLI alias", () => {
+    expect(parseToolOutputsDirConfig(
+      ["--tool-output-dir", "artifacts"],
+      {},
+      "/launch"
+    )).toBe(path.join("/launch", "artifacts"));
+  });
+
+  test("CLI flag wins over environment variable", () => {
+    expect(parseToolOutputsDirConfig(
+      ["--tool-outputs-dir", "cli-artifacts"],
+      { AUTOMOBILE_TOOL_OUTPUTS_DIR: "env-artifacts" },
+      "/launch"
+    )).toBe(path.join("/launch", "cli-artifacts"));
+  });
+
+  test("resolves environment variable paths to absolute paths from the launch working directory", () => {
+    expect(parseToolOutputsDirConfig(
+      [],
+      { AUTOMOBILE_TOOL_OUTPUTS_DIR: "env-artifacts" },
+      "/launch"
+    )).toBe(path.join("/launch", "env-artifacts"));
+  });
+
+  test("ignores blank configured values", () => {
+    expect(parseToolOutputsDirConfig(
+      ["--tool-outputs-dir", "   "],
+      { AUTOMOBILE_TOOL_OUTPUTS_DIR: "   " },
+      "/launch"
+    )).toBeUndefined();
+  });
+});
+
+describe("validateToolOutputsDirForWrite", () => {
+  test("creates missing directories and verifies writability", async () => {
+    const fs = new FakeToolOutputsDirFileSystem();
+
+    await expect(validateToolOutputsDirForWrite("/artifacts", fs)).resolves.toBe("/artifacts");
+
+    expect(fs.ensureDirCalls).toEqual(["/artifacts"]);
+    expect(fs.statCalls).toEqual(["/artifacts"]);
+    expect(fs.accessCalls).toEqual(["/artifacts"]);
+  });
+
+  test("throws an actionable error when the path is not a directory", async () => {
+    const fs = new FakeToolOutputsDirFileSystem();
+    fs.isDirectory = false;
+
+    await expect(validateToolOutputsDirForWrite("/artifact-file", fs))
+      .rejects.toThrow(ActionableError);
+    await expect(validateToolOutputsDirForWrite("/artifact-file", fs))
+      .rejects.toThrow("not a directory");
+  });
+
+  test("throws an actionable error when the directory cannot be created", async () => {
+    const fs = new FakeToolOutputsDirFileSystem();
+    fs.ensureDirError = new Error("permission denied");
+
+    await expect(validateToolOutputsDirForWrite("/locked", fs))
+      .rejects.toThrow(ActionableError);
+    await expect(validateToolOutputsDirForWrite("/locked", fs))
+      .rejects.toThrow("Failed to create tool outputs directory");
+  });
+
+  test("throws an actionable error when the directory is not writable", async () => {
+    const fs = new FakeToolOutputsDirFileSystem();
+    fs.accessError = new Error("EACCES");
+
+    await expect(validateToolOutputsDirForWrite("/readonly", fs))
+      .rejects.toThrow(ActionableError);
+    await expect(validateToolOutputsDirForWrite("/readonly", fs))
+      .rejects.toThrow("not writable");
+  });
+
+  test("revalidates on every write attempt", async () => {
+    const fs = new FakeToolOutputsDirFileSystem();
+
+    await validateToolOutputsDirForWrite("/artifacts", fs);
+    await validateToolOutputsDirForWrite("/artifacts", fs);
+
+    expect(fs.ensureDirCalls).toEqual(["/artifacts", "/artifacts"]);
+    expect(fs.statCalls).toEqual(["/artifacts", "/artifacts"]);
+    expect(fs.accessCalls).toEqual(["/artifacts", "/artifacts"]);
+  });
+});

--- a/test/utils/toolOutputArtifacts.test.ts
+++ b/test/utils/toolOutputArtifacts.test.ts
@@ -49,42 +49,46 @@ describe("parseToolOutputsDirConfig", () => {
   });
 
   test("resolves CLI paths to absolute paths from the launch working directory", () => {
+    const launchCwd = path.resolve("launch-root");
     expect(parseToolOutputsDirConfig(
       ["--tool-outputs-dir", "artifacts"],
       {},
-      "/launch"
-    )).toBe(path.join("/launch", "artifacts"));
+      launchCwd
+    )).toBe(path.resolve(launchCwd, "artifacts"));
   });
 
   test("supports the singular CLI alias", () => {
+    const launchCwd = path.resolve("launch-root");
     expect(parseToolOutputsDirConfig(
       ["--tool-output-dir", "artifacts"],
       {},
-      "/launch"
-    )).toBe(path.join("/launch", "artifacts"));
+      launchCwd
+    )).toBe(path.resolve(launchCwd, "artifacts"));
   });
 
   test("CLI flag wins over environment variable", () => {
+    const launchCwd = path.resolve("launch-root");
     expect(parseToolOutputsDirConfig(
       ["--tool-outputs-dir", "cli-artifacts"],
       { AUTOMOBILE_TOOL_OUTPUTS_DIR: "env-artifacts" },
-      "/launch"
-    )).toBe(path.join("/launch", "cli-artifacts"));
+      launchCwd
+    )).toBe(path.resolve(launchCwd, "cli-artifacts"));
   });
 
   test("resolves environment variable paths to absolute paths from the launch working directory", () => {
+    const launchCwd = path.resolve("launch-root");
     expect(parseToolOutputsDirConfig(
       [],
       { AUTOMOBILE_TOOL_OUTPUTS_DIR: "env-artifacts" },
-      "/launch"
-    )).toBe(path.join("/launch", "env-artifacts"));
+      launchCwd
+    )).toBe(path.resolve(launchCwd, "env-artifacts"));
   });
 
   test("ignores blank configured values", () => {
     expect(parseToolOutputsDirConfig(
       ["--tool-outputs-dir", "   "],
       { AUTOMOBILE_TOOL_OUTPUTS_DIR: "   " },
-      "/launch"
+      path.resolve("launch-root")
     )).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds process-startup configuration for tool output artifacts without changing any tool response payloads yet. The configured directory is resolved to an absolute host path, stored in process-wide config, relayed through proxy-to-daemon startup, and validated at write time through a shared helper for follow-on artifact writer work.

## Linked Issue

Closes #3482

## Validation

- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses focused fakes for directory validation and daemon relay tests
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A: startup/config plumbing only; no on-device tool behavior changed.

## Follow-ups

Issues #3480 and #3481 are intentionally left for their in-progress payload artifact behavior. This PR provides the startup config and write-time validation helper they can use.

Made with [Cursor](https://cursor.com)