### PR TITLE
feat(output-artifacts): artifact non-observation outputs

### DIFF
--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -43,6 +43,43 @@ Part of the MCP output-context reduction effort. Each flag can be set either as 
 | **`--actions-no-observe`** | `AUTOMOBILE_ACTIONS_NO_OBSERVE` | Strip the embedded `observation` from non-observe tool results entirely (deleted from **both** `structuredContent` and the serialized `content[0].text`). Output-only — `BaseVisualChange` still computes the observation internally for its own success detection, so visual-change behavior is unchanged; the `observe` tool's own observation is never stripped. Applied at `finalizeToolResponse`. **Precedence:** when both `--actions-no-observe` and `--actions-diff-observe` are set, no-observe wins — the observation is removed, so there is nothing to diff. |
 | **`--tool-results-compact-json`** | `AUTOMOBILE_TOOL_RESULTS_COMPACT_JSON` | Serialize tool results as compact (non-pretty-printed) JSON — drops the 2-space indentation in `stringifyToolResponse`. Same data (parses back identically, no effect on `tapOn`/text matching); ~35% fewer characters on element-heavy payloads. Composes with the other flags. |
 
+### Tool Output Artifact Mode
+
+`--tool-outputs-dir <path>` (alias `--tool-output-dir`; env
+`AUTOMOBILE_TOOL_OUTPUTS_DIR` or legacy `AUTO_MOBILE_TOOL_OUTPUTS_DIR`) enables
+artifact mode for large MCP tool-output subtrees. The directory is resolved to a
+host-local path at startup and validated again at write time. Artifact write
+failures are tool failures; AutoMobile does not fall back to inlining the large
+payload.
+
+Every artifact replacement uses the shared metadata shape:
+
+```json
+{
+  "artifact": {
+    "path": "/absolute/host/path/to/file.json",
+    "format": "json",
+    "payload": "NetworkGraph",
+    "bytes": 123456,
+    "tool": "getNetworkGraph"
+  }
+}
+```
+
+Artifact mode currently applies to:
+
+- `observe`: the final agent-facing `ObserveResult` or `ObserveDiff` payload is written to an artifact after existing observe output transforms.
+- Action tools with embedded `observation`: the embedded final agent-facing observation or diff is replaced with artifact metadata; internal tool-to-tool calls still receive full in-memory observations.
+- `executePlan`: large `viewHierarchy` and `rawViewHierarchy` subtrees inside `failedStep.failureObservation` and captured debug observations are artifacted. Small fields such as success/counts/errors, device metadata, video paths, and observation samples remain inline.
+- `bugReport`: `viewHierarchy.rawXml`, `logcat`, and long `windowState.windows` lists are artifacted. Report identity, device/screen state, hierarchy counts, clickable-element summary, saved report path, errors, and log counts remain inline.
+- `getNetworkGraph`: the aggregate `graph` tree is artifacted, with `graphSummary.hostCount` left inline.
+
+Evaluated but not selected for the first non-observation pass: `debugSearch`
+returns bounded summaries rather than raw hierarchies; `exportPlan` and
+`recordSteps` can return long YAML but that content is the primary result agents
+usually need immediately. Revisit them if size tests or real-world traces show
+they dominate context.
+
 `--actions-diff-observe` chooses the full-vs-diff policy by action class before
 calling the shared diff implementation. Navigation-prone actions (`tapOn`,
 `tapAny`, `homeScreen`, `recentApps`, `openLink`, and `pressButton` for

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4808,11 +4808,7 @@
               "const": "json"
             },
             "payload": {
-              "type": "string",
-              "enum": [
-                "ObserveResult",
-                "ObserveDiff"
-              ]
+              "type": "string"
             },
             "bytes": {
               "type": "integer",
@@ -7533,11 +7529,7 @@
                       "const": "json"
                     },
                     "payload": {
-                      "type": "string",
-                      "enum": [
-                        "ObserveResult",
-                        "ObserveDiff"
-                      ]
+                      "type": "string"
                     },
                     "bytes": {
                       "type": "integer",

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -22,7 +22,7 @@ export interface ObservationBaselineStore {
   set(sessionUuid: string, observation: ObserveResult): void;
 }
 
-export type ObservationArtifactPayload = "ObserveResult" | "ObserveDiff";
+export type ObservationArtifactPayload = string;
 
 export interface ObservationArtifactMetadata {
   artifact: {
@@ -299,11 +299,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     }
   }
 
-  if (!sanitizedPayload) {
-    return response;
-  }
-
-  if (ctx.artifactWriter && !ctx.internal && hasArtifactableObservation) {
+  if (ctx.artifactWriter && !ctx.internal && hasArtifactableObservation && sanitizedPayload) {
     if (isObserveTool) {
       sanitizedPayload = writeObservationArtifact(ctx, sanitizedPayload) as unknown as Record<string, unknown>;
     } else {
@@ -312,6 +308,12 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         observation: writeObservationArtifact(ctx, sanitizedPayload.observation),
       };
     }
+  }
+
+  sanitizedPayload ??= artifactNonObservationPayload(ctx, payload);
+
+  if (!sanitizedPayload) {
+    return response;
   }
 
   // Rewrite both representations from the same object so they cannot diverge.
@@ -330,11 +332,7 @@ function writeObservationArtifact(
   ctx: FinalizeToolResponseContext,
   observationPayload: unknown
 ): ObservationArtifactMetadata {
-  return ctx.artifactWriter!.writeJsonArtifact({
-    tool: ctx.name,
-    payload: getObservationArtifactPayload(observationPayload),
-    data: observationPayload,
-  });
+  return writeJsonArtifact(ctx, getObservationArtifactPayload(observationPayload), observationPayload);
 }
 
 function getObservationArtifactPayload(observationPayload: unknown): ObservationArtifactPayload {
@@ -346,6 +344,185 @@ function getObservationArtifactPayload(observationPayload: unknown): Observation
     return "ObserveDiff";
   }
   return "ObserveResult";
+}
+
+function writeJsonArtifact(
+  ctx: FinalizeToolResponseContext,
+  payload: ObservationArtifactPayload,
+  data: unknown
+): ObservationArtifactMetadata {
+  return ctx.artifactWriter!.writeJsonArtifact({
+    tool: ctx.name,
+    payload,
+    data,
+  });
+}
+
+function artifactNonObservationPayload(
+  ctx: FinalizeToolResponseContext,
+  payload: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!ctx.artifactWriter || ctx.internal) {
+    return undefined;
+  }
+
+  switch (ctx.name) {
+    case "executePlan":
+      return artifactExecutePlanPayload(ctx, payload);
+    case "bugReport":
+      return artifactBugReportPayload(ctx, payload);
+    case "getNetworkGraph":
+      return artifactNetworkGraphPayload(ctx, payload);
+    default:
+      return undefined;
+  }
+}
+
+function artifactExecutePlanPayload(
+  ctx: FinalizeToolResponseContext,
+  payload: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  let changed = false;
+  const nextPayload: Record<string, unknown> = { ...payload };
+  if (isRecord(payload.failedStep)) {
+    const failureObservation = artifactPlanObservation(
+      ctx,
+      payload.failedStep.failureObservation,
+      "ExecutePlanFailureObservation"
+    );
+    if (failureObservation) {
+      nextPayload.failedStep = { ...payload.failedStep, failureObservation };
+      changed = true;
+    }
+  }
+
+  if (isRecord(payload.debug) && Array.isArray(payload.debug.steps)) {
+    let debugChanged = false;
+    const steps = payload.debug.steps.map(step => {
+      if (!isRecord(step) || !isRecord(step.details)) {
+        return step;
+      }
+
+      let detailsChanged = false;
+      let details = step.details;
+      const stepObservation = artifactPlanObservation(
+        ctx,
+        details.stepObservation,
+        "ExecutePlanDebugStepObservation"
+      );
+      if (stepObservation) {
+        details = { ...details, stepObservation };
+        detailsChanged = true;
+      }
+
+      const failureObservation = artifactPlanObservation(
+        ctx,
+        details.failureObservation,
+        "ExecutePlanDebugFailureObservation"
+      );
+      if (failureObservation) {
+        details = { ...details, failureObservation };
+        detailsChanged = true;
+      }
+
+      if (!detailsChanged) {
+        return step;
+      }
+      debugChanged = true;
+      return { ...step, details };
+    });
+
+    if (debugChanged) {
+      nextPayload.debug = { ...payload.debug, steps };
+      changed = true;
+    }
+  }
+
+  return changed ? nextPayload : undefined;
+}
+
+function artifactPlanObservation(
+  ctx: FinalizeToolResponseContext,
+  observation: unknown,
+  payloadPrefix: string
+): Record<string, unknown> | undefined {
+  if (!isRecord(observation)) {
+    return undefined;
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = { ...observation };
+  if (observation.viewHierarchy !== undefined) {
+    next.viewHierarchy = writeJsonArtifact(ctx, `${payloadPrefix}ViewHierarchy`, observation.viewHierarchy);
+    changed = true;
+  }
+  if (observation.rawViewHierarchy !== undefined) {
+    next.rawViewHierarchy = writeJsonArtifact(ctx, `${payloadPrefix}RawViewHierarchy`, observation.rawViewHierarchy);
+    changed = true;
+  }
+
+  return changed ? next : undefined;
+}
+
+function artifactBugReportPayload(
+  ctx: FinalizeToolResponseContext,
+  payload: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  let changed = false;
+  const next: Record<string, unknown> = { ...payload };
+
+  if (isRecord(payload.viewHierarchy) && payload.viewHierarchy.rawXml !== undefined) {
+    next.viewHierarchy = {
+      ...payload.viewHierarchy,
+      rawXml: writeJsonArtifact(ctx, "BugReportViewHierarchyRawXml", payload.viewHierarchy.rawXml),
+    };
+    changed = true;
+  }
+
+  if (isRecord(payload.logcat)) {
+    next.logcatSummary = {
+      errorCount: arrayLength(payload.logcat.errors),
+      warningCount: arrayLength(payload.logcat.warnings),
+      appLogCount: arrayLength(payload.logcat.appLogs),
+    };
+    next.logcat = writeJsonArtifact(ctx, "BugReportLogcat", payload.logcat);
+    changed = true;
+  }
+
+  if (isRecord(payload.windowState) && Array.isArray(payload.windowState.windows)) {
+    next.windowState = {
+      ...payload.windowState,
+      windows: writeJsonArtifact(ctx, "BugReportWindowList", payload.windowState.windows),
+    };
+    changed = true;
+  }
+
+  return changed ? next : undefined;
+}
+
+function artifactNetworkGraphPayload(
+  ctx: FinalizeToolResponseContext,
+  payload: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!Array.isArray(payload.graph)) {
+    return undefined;
+  }
+
+  return {
+    ...payload,
+    graph: writeJsonArtifact(ctx, "NetworkGraph", payload.graph),
+    graphSummary: {
+      hostCount: payload.graph.length,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function arrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
 }
 
 /**

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -148,7 +148,7 @@ const observationDiffMetadataSchema = z.object({
 const toolOutputArtifactDetailsSchema = z.object({
   path: z.string(),
   format: z.literal("json"),
-  payload: z.enum(["ObserveResult", "ObserveDiff"]),
+  payload: z.string(),
   bytes: z.number().int().nonnegative(),
   tool: z.string()
 }).passthrough();

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1235,6 +1235,12 @@ describe("finalizeToolResponse", () => {
         viewHierarchy: { hierarchy: { node: { "resource-id": "step-root" } } },
         visibleTextsSample: ["Step"],
       };
+      const debugFailureObservation = {
+        capturedAtMs: 789,
+        viewHierarchy: { hierarchy: { node: { "resource-id": "debug-failure-root" } } },
+        rawViewHierarchy: "<hierarchy><node text=\"debug failure\" /></hierarchy>",
+        visibleTextsSample: ["Debug failure"],
+      };
       const payload = {
         success: false,
         executedSteps: 1,
@@ -1252,7 +1258,7 @@ describe("finalizeToolResponse", () => {
               step: "1: observe",
               status: "completed",
               durationMs: 10,
-              details: { stepObservation },
+              details: { stepObservation, failureObservation: debugFailureObservation },
             },
           ],
         },
@@ -1289,14 +1295,22 @@ describe("finalizeToolResponse", () => {
       const finalizedStepObservation = (finalized.structuredContent as any).debug.steps[0].details.stepObservation;
       expect(finalizedStepObservation.visibleTextsSample).toEqual(["Step"]);
       expect(finalizedStepObservation.viewHierarchy.artifact.payload).toBe("ExecutePlanDebugStepObservationViewHierarchy");
+      const finalizedDebugFailureObservation = (finalized.structuredContent as any).debug.steps[0].details.failureObservation;
+      expect(finalizedDebugFailureObservation.visibleTextsSample).toEqual(["Debug failure"]);
+      expect(finalizedDebugFailureObservation.viewHierarchy.artifact.payload).toBe("ExecutePlanDebugFailureObservationViewHierarchy");
+      expect(finalizedDebugFailureObservation.rawViewHierarchy.artifact.payload).toBe("ExecutePlanDebugFailureObservationRawViewHierarchy");
       expect(writer.writes.map(write => write.payload)).toEqual([
         "ExecutePlanFailureObservationViewHierarchy",
         "ExecutePlanFailureObservationRawViewHierarchy",
         "ExecutePlanDebugStepObservationViewHierarchy",
+        "ExecutePlanDebugFailureObservationViewHierarchy",
+        "ExecutePlanDebugFailureObservationRawViewHierarchy",
       ]);
       expect(writer.writes[0].data).toEqual(failureObservation.viewHierarchy);
       expect(writer.writes[1].data).toBe(failureObservation.rawViewHierarchy);
       expect(writer.writes[2].data).toEqual(stepObservation.viewHierarchy);
+      expect(writer.writes[3].data).toEqual(debugFailureObservation.viewHierarchy);
+      expect(writer.writes[4].data).toBe(debugFailureObservation.rawViewHierarchy);
       expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
     });
 

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1219,6 +1219,216 @@ describe("finalizeToolResponse", () => {
     });
   });
 
+  describe("non-observation artifact mode (#3481)", () => {
+    test("executePlan artifacts large failure/debug observation subtrees and keeps summaries inline", () => {
+      const writer = new FakeObservationArtifactWriter();
+      const failureObservation = {
+        capturedAtMs: 123,
+        activeWindow: { appId: "com.example" },
+        viewHierarchy: { hierarchy: { node: { "resource-id": "root" } } },
+        rawViewHierarchy: "<hierarchy><node text=\"large\" /></hierarchy>",
+        visibleTextsSample: ["Submit"],
+        resourceIdsSample: ["com.example:id/submit"],
+      };
+      const stepObservation = {
+        capturedAtMs: 456,
+        viewHierarchy: { hierarchy: { node: { "resource-id": "step-root" } } },
+        visibleTextsSample: ["Step"],
+      };
+      const payload = {
+        success: false,
+        executedSteps: 1,
+        totalSteps: 2,
+        failedStep: {
+          stepIndex: 1,
+          tool: "tapOn",
+          error: "Button missing",
+          failureObservation,
+        },
+        debug: {
+          executionTimeMs: 50,
+          steps: [
+            {
+              step: "1: observe",
+              status: "completed",
+              durationMs: 10,
+              details: { stepObservation },
+            },
+          ],
+        },
+      };
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(payload),
+        { name: "executePlan", artifactWriter: writer } as any
+      );
+
+      const failedObservation = (finalized.structuredContent as any).failedStep.failureObservation;
+      expect(failedObservation.capturedAtMs).toBe(123);
+      expect(failedObservation.visibleTextsSample).toEqual(["Submit"]);
+      expect(failedObservation.resourceIdsSample).toEqual(["com.example:id/submit"]);
+      expect(failedObservation.viewHierarchy).toEqual({
+        artifact: {
+          path: "/tmp/auto-mobile/executePlan-1.json",
+          format: "json",
+          payload: "ExecutePlanFailureObservationViewHierarchy",
+          bytes: 123,
+          tool: "executePlan",
+        },
+      });
+      expect(failedObservation.rawViewHierarchy).toEqual({
+        artifact: {
+          path: "/tmp/auto-mobile/executePlan-2.json",
+          format: "json",
+          payload: "ExecutePlanFailureObservationRawViewHierarchy",
+          bytes: 123,
+          tool: "executePlan",
+        },
+      });
+
+      const finalizedStepObservation = (finalized.structuredContent as any).debug.steps[0].details.stepObservation;
+      expect(finalizedStepObservation.visibleTextsSample).toEqual(["Step"]);
+      expect(finalizedStepObservation.viewHierarchy.artifact.payload).toBe("ExecutePlanDebugStepObservationViewHierarchy");
+      expect(writer.writes.map(write => write.payload)).toEqual([
+        "ExecutePlanFailureObservationViewHierarchy",
+        "ExecutePlanFailureObservationRawViewHierarchy",
+        "ExecutePlanDebugStepObservationViewHierarchy",
+      ]);
+      expect(writer.writes[0].data).toEqual(failureObservation.viewHierarchy);
+      expect(writer.writes[1].data).toBe(failureObservation.rawViewHierarchy);
+      expect(writer.writes[2].data).toEqual(stepObservation.viewHierarchy);
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
+    test("bugReport artifacts raw report details and keeps status summaries inline", () => {
+      const writer = new FakeObservationArtifactWriter();
+      const payload = {
+        reportId: "bug-1",
+        timestamp: 123,
+        device: { deviceId: "emulator-5554", platform: "android" },
+        screenState: { currentPackage: "com.example" },
+        viewHierarchy: {
+          rawXml: "<hierarchy><node text=\"large\" /></hierarchy>",
+          elementCount: 42,
+          filteredNodeCount: 3,
+          clickableElements: [{ text: "Submit", bounds: { left: 0, top: 0, right: 1, bottom: 1 } }],
+        },
+        logcat: {
+          errors: ["E/Example: one", "E/Example: two"],
+          warnings: ["W/Example: warn"],
+          appLogs: ["I/Example: app"],
+        },
+        windowState: {
+          focusedWindow: "com.example/.Main",
+          windows: ["Window #1", "Window #2"],
+        },
+        savedTo: "/tmp/bug-report.json",
+        errors: [],
+      };
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(payload),
+        { name: "bugReport", artifactWriter: writer } as any
+      );
+
+      const report = finalized.structuredContent as any;
+      expect(report.reportId).toBe("bug-1");
+      expect(report.device.deviceId).toBe("emulator-5554");
+      expect(report.viewHierarchy.elementCount).toBe(42);
+      expect(report.viewHierarchy.clickableElements).toHaveLength(1);
+      expect(report.viewHierarchy.rawXml.artifact.payload).toBe("BugReportViewHierarchyRawXml");
+      expect(report.logcatSummary).toEqual({ errorCount: 2, warningCount: 1, appLogCount: 1 });
+      expect(report.logcat).toEqual({
+        artifact: {
+          path: "/tmp/auto-mobile/bugReport-2.json",
+          format: "json",
+          payload: "BugReportLogcat",
+          bytes: 123,
+          tool: "bugReport",
+        },
+      });
+      expect(report.windowState.focusedWindow).toBe("com.example/.Main");
+      expect(report.windowState.windows.artifact.payload).toBe("BugReportWindowList");
+      expect(writer.writes.map(write => write.payload)).toEqual([
+        "BugReportViewHierarchyRawXml",
+        "BugReportLogcat",
+        "BugReportWindowList",
+      ]);
+      expect(writer.writes[0].data).toBe(payload.viewHierarchy.rawXml);
+      expect(writer.writes[1].data).toEqual(payload.logcat);
+      expect(writer.writes[2].data).toEqual(payload.windowState.windows);
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
+    test("getNetworkGraph artifacts aggregate graph and keeps host count inline", () => {
+      const writer = new FakeObservationArtifactWriter();
+      const payload = {
+        graph: [
+          {
+            scheme: "https",
+            host: "api.example.com",
+            paths: {
+              v1: {
+                paths: {
+                  "users[GET]": { method: "GET", success: 10, errors: 1, p50: 100, p95: 200 },
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(payload),
+        { name: "getNetworkGraph", artifactWriter: writer } as any
+      );
+
+      expect(finalized.structuredContent).toEqual({
+        graph: {
+          artifact: {
+            path: "/tmp/auto-mobile/getNetworkGraph-1.json",
+            format: "json",
+            payload: "NetworkGraph",
+            bytes: 123,
+            tool: "getNetworkGraph",
+          },
+        },
+        graphSummary: { hostCount: 1 },
+      });
+      expect(writer.writes).toEqual([
+        { tool: "getNetworkGraph", payload: "NetworkGraph", data: payload.graph },
+      ]);
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+    });
+
+    test("internal executePlan calls do not artifact non-observation payloads", () => {
+      const writer = new FakeObservationArtifactWriter();
+      const payload = {
+        success: false,
+        executedSteps: 1,
+        totalSteps: 2,
+        failedStep: {
+          stepIndex: 1,
+          tool: "tapOn",
+          error: "Button missing",
+          failureObservation: {
+            capturedAtMs: 123,
+            viewHierarchy: { hierarchy: { node: { text: "keep inline" } } },
+          },
+        },
+      };
+
+      const finalized = finalizeToolResponse(
+        createStructuredToolResponse(payload),
+        { name: "executePlan", internal: true, artifactWriter: writer } as any
+      );
+
+      expect(writer.writes).toHaveLength(0);
+      expect(finalized.structuredContent).toEqual(payload);
+      expect(finalized.content[0].text).toBe(stringifyToolResponse(payload));
+    });
+  });
+
   // --actions-no-observe (#2762, folded into #3026): strip the embedded
   // observation from non-observe tool results entirely. Precedence over
   // --actions-diff-observe — nothing to diff once stripped.

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -208,7 +208,7 @@ describe("observe tool registration advertises the schema (#3025)", () => {
     withFreshRegistry(() => {
       const observe = ToolRegistry.getToolDefinitions().find(t => t.name === "observe");
       expect(JSON.stringify((observe as Record<string, unknown>).outputSchema)).toContain("\"artifact\"");
-      expect(JSON.stringify((observe as Record<string, unknown>).outputSchema)).toContain("\"ObserveResult\"");
+      expect(JSON.stringify((observe as Record<string, unknown>).outputSchema)).toContain("\"payload\"");
     });
   });
 

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -63,7 +63,7 @@ describe("tool output artifact metadata schema (#3480)", () => {
     },
   };
 
-  test("accepts the shared observation artifact metadata shape", () => {
+  test("accepts the shared artifact metadata shape", () => {
     expect(toolOutputArtifactMetadataSchema.parse(metadata)).toEqual(metadata);
   });
 
@@ -81,6 +81,16 @@ describe("tool output artifact metadata schema (#3480)", () => {
         payload: "ObserveDiff",
       },
     }).artifact.payload).toBe("ObserveDiff");
+  });
+
+  test("accepts non-observation artifact payload labels", () => {
+    expect(toolOutputArtifactMetadataSchema.parse({
+      artifact: {
+        ...metadata.artifact,
+        payload: "NetworkGraph",
+        tool: "getNetworkGraph",
+      },
+    }).artifact.payload).toBe("NetworkGraph");
   });
 });
 


### PR DESCRIPTION
## Summary

Extends tool output artifact mode to selected large non-observation payloads: `executePlan` observation subtrees, `bugReport` raw/log details, and `getNetworkGraph` aggregate graphs. Small status and summary fields remain inline so agents can decide whether to read the artifact.

## Linked Issue

Closes #3481

## Validation

- [x] `bun run turbo:validate` passes (`lint`, `build`, `test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Focused artifact tests pass: `bun test test/server/finalizeToolResponse.test.ts test/server/toolOutputSchemas.test.ts test/server/observeOutputSchema.test.ts`
- [x] New code uses the existing injectable artifact writer fake; focused unit tests run in <100ms
- [x] Rebased onto latest `origin/main`, conflicts resolved

## Device Verification

N/A. This changes response serialization and schema metadata only; no device-side behavior changed.

## Acceptance Criteria

- Identifies selected non-observation outputs in docs: `executePlan`, `bugReport`, and `getNetworkGraph`; documents evaluated non-selected outputs.
- Applies artifact metadata to selected large payload subtrees using the shared `{ artifact: { path, format, payload, bytes, tool } }` shape.
- Keeps small status/summary fields inline, including plan status/errors/samples, bug report counts/status, and network graph host count.
- Adds focused tests for each newly artifacted payload shape.
- Updates user-facing artifact-mode docs.

## Follow-ups

- [x] No deferred follow-up issues from this implementation.

Made with [Cursor](https://cursor.com)