### PR TITLE
Target Android app locale commands by user

### DIFF
--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -119,7 +119,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
 
     try {
       await this.adb.executeCommand(
-        `shell cmd locale set-app-locales --user ${targetUserId} ${quoteShellArg(appId)} --locales ${quoteShellArg(languageTag)}`
+        `shell cmd locale set-app-locales ${quoteShellArg(appId)} --user ${targetUserId} --locales ${quoteShellArg(languageTag)}`
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -165,8 +165,8 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     }
 
     try {
-      const runningUser = (await this.adb.listUsers()).find(user => user.running);
-      return runningUser?.userId ?? 0;
+      const workProfile = (await this.adb.listUsers()).find(user => user.userId > 0 && user.running);
+      return workProfile?.userId ?? 0;
     } catch (error) {
       logger.debug(`[SystemConfigurationManager] Failed to list Android users for ${appId}: ${error}`);
       return 0;
@@ -487,7 +487,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
   private async getAppLocaleTag(appId: string, userId: number): Promise<string | null> {
     try {
       const result = await this.adb.executeCommand(
-        `shell cmd locale get-app-locales --user ${userId} ${quoteShellArg(appId)}`,
+        `shell cmd locale get-app-locales ${quoteShellArg(appId)} --user ${userId}`,
         undefined,
         undefined,
         true

--- a/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/AndroidSystemConfigurationAdapter.ts
@@ -114,11 +114,12 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       return this.setSystemLocale(languageTag, options, "setprop persist.sys.locale + stop/start after adb root");
     }
 
-    const previousLanguageTag = await this.getAppLocaleTag(appId);
+    const targetUserId = await this.resolveTargetUserId(appId);
+    const previousLanguageTag = await this.getAppLocaleTag(appId, targetUserId);
 
     try {
       await this.adb.executeCommand(
-        `shell cmd locale set-app-locales ${quoteShellArg(appId)} --locales ${quoteShellArg(languageTag)}`
+        `shell cmd locale set-app-locales --user ${targetUserId} ${quoteShellArg(appId)} --locales ${quoteShellArg(languageTag)}`
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -130,7 +131,7 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       };
     }
 
-    const effectiveLanguageTag = await this.getAppLocaleTag(appId);
+    const effectiveLanguageTag = await this.getAppLocaleTag(appId, targetUserId);
     if (!this.localeTagsMatch(effectiveLanguageTag, languageTag)) {
       return {
         success: false,
@@ -148,9 +149,28 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
       success: true,
       languageTag,
       previousLanguageTag,
-      method: `cmd locale set-app-locales ${appId}`,
+      method: `cmd locale set-app-locales ${appId} --user ${targetUserId}`,
       broadcasted
     };
+  }
+
+  private async resolveTargetUserId(appId: string): Promise<number> {
+    try {
+      const foregroundApp = await this.adb.getForegroundApp();
+      if (foregroundApp?.packageName === appId) {
+        return foregroundApp.userId;
+      }
+    } catch (error) {
+      logger.debug(`[SystemConfigurationManager] Failed to resolve foreground Android app user for ${appId}: ${error}`);
+    }
+
+    try {
+      const runningUser = (await this.adb.listUsers()).find(user => user.running);
+      return runningUser?.userId ?? 0;
+    } catch (error) {
+      logger.debug(`[SystemConfigurationManager] Failed to list Android users for ${appId}: ${error}`);
+      return 0;
+    }
   }
 
   private async ensureRootForLegacyLocale(apiLevel: number): Promise<{ success: true } | { success: false; error: string }> {
@@ -464,10 +484,10 @@ export class AndroidSystemConfigurationAdapter implements SystemConfigurationAda
     return language;
   }
 
-  private async getAppLocaleTag(appId: string): Promise<string | null> {
+  private async getAppLocaleTag(appId: string, userId: number): Promise<string | null> {
     try {
       const result = await this.adb.executeCommand(
-        `shell cmd locale get-app-locales ${quoteShellArg(appId)}`,
+        `shell cmd locale get-app-locales --user ${userId} ${quoteShellArg(appId)}`,
         undefined,
         undefined,
         true

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -179,7 +179,7 @@ describe("SystemConfigurationAdapter", () => {
       ];
       const original = adb.executeCommand.bind(adb);
       adb.executeCommand = (async (command: string, ...rest: any[]) => {
-        if (command === "shell cmd locale get-app-locales 'com.example.app'") {
+        if (command === "shell cmd locale get-app-locales --user 0 'com.example.app'") {
           const stdout = appLocaleResponses.shift() ?? "Locales for com.example.app for user 0 are [ja-JP]\n";
           return {
             stdout,
@@ -196,11 +196,44 @@ describe("SystemConfigurationAdapter", () => {
       const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
 
       expect(result.success).toBe(true);
-      expect(result.method).toBe("cmd locale set-app-locales com.example.app");
+      expect(result.method).toBe("cmd locale set-app-locales com.example.app --user 0");
       expect(result.previousLanguageTag).toBeNull();
-      expect(adb.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --locales 'ja-JP'")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales --user 0 'com.example.app' --locales 'ja-JP'")).toBe(true);
       expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
       expect(adb.wasCommandExecuted("stop; start")).toBe(false);
+    });
+
+    it("targets the foreground Android work-profile user for app-scoped locale commands", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      adb.setForegroundApp({ packageName: "com.example.app", userId: 10 });
+      const appLocaleResponses = [
+        "Locales for com.example.app for user 10 are []\n",
+        "Locales for com.example.app for user 10 are [ja-JP]\n",
+      ];
+      const original = adb.executeCommand.bind(adb);
+      adb.executeCommand = (async (command: string, ...rest: any[]) => {
+        if (command === "shell cmd locale get-app-locales --user 10 'com.example.app'") {
+          const stdout = appLocaleResponses.shift() ?? "Locales for com.example.app for user 10 are [ja-JP]\n";
+          return {
+            stdout,
+            stderr: "",
+            toString: () => stdout,
+            trim: () => stdout.trim(),
+            includes: (s: string) => stdout.includes(s),
+          };
+        }
+        return original(command, ...rest);
+      }) as any;
+
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("cmd locale set-app-locales com.example.app --user 10");
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales --user 10 'com.example.app' --locales 'ja-JP'")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale get-app-locales --user 10 'com.example.app'")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale get-app-locales --user 0 'com.example.app'")).toBe(false);
     });
 
     it("uses root-backed system locale after adb root below Android 13", async () => {
@@ -254,7 +287,7 @@ describe("SystemConfigurationAdapter", () => {
     it("returns false when app-scoped locale read-back does not match", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [en-US]\n");
+      adb.setCommandResult("shell cmd locale get-app-locales --user 0 'com.example.app'", "Locales for com.example.app for user 0 are [en-US]\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
 
@@ -266,7 +299,7 @@ describe("SystemConfigurationAdapter", () => {
     it("returns false when app-scoped locale read-back has no locale list", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Unknown package com.example.app for userId 0\n");
+      adb.setCommandResult("shell cmd locale get-app-locales --user 0 'com.example.app'", "Unknown package com.example.app for userId 0\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
 
@@ -278,7 +311,7 @@ describe("SystemConfigurationAdapter", () => {
     it("uses the first locale when app-scoped read-back returns multiple locales", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP,en-US]\n");
+      adb.setCommandResult("shell cmd locale get-app-locales --user 0 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP,en-US]\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
 

--- a/test/features/utility/SystemConfigurationAdapter.test.ts
+++ b/test/features/utility/SystemConfigurationAdapter.test.ts
@@ -179,7 +179,7 @@ describe("SystemConfigurationAdapter", () => {
       ];
       const original = adb.executeCommand.bind(adb);
       adb.executeCommand = (async (command: string, ...rest: any[]) => {
-        if (command === "shell cmd locale get-app-locales --user 0 'com.example.app'") {
+        if (command === "shell cmd locale get-app-locales 'com.example.app' --user 0") {
           const stdout = appLocaleResponses.shift() ?? "Locales for com.example.app for user 0 are [ja-JP]\n";
           return {
             stdout,
@@ -198,7 +198,7 @@ describe("SystemConfigurationAdapter", () => {
       expect(result.success).toBe(true);
       expect(result.method).toBe("cmd locale set-app-locales com.example.app --user 0");
       expect(result.previousLanguageTag).toBeNull();
-      expect(adb.wasCommandExecuted("cmd locale set-app-locales --user 0 'com.example.app' --locales 'ja-JP'")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --user 0 --locales 'ja-JP'")).toBe(true);
       expect(adb.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
       expect(adb.wasCommandExecuted("stop; start")).toBe(false);
     });
@@ -213,7 +213,8 @@ describe("SystemConfigurationAdapter", () => {
       ];
       const original = adb.executeCommand.bind(adb);
       adb.executeCommand = (async (command: string, ...rest: any[]) => {
-        if (command === "shell cmd locale get-app-locales --user 10 'com.example.app'") {
+        if (command === "shell cmd locale get-app-locales 'com.example.app' --user 10") {
+          await original(command, ...rest);
           const stdout = appLocaleResponses.shift() ?? "Locales for com.example.app for user 10 are [ja-JP]\n";
           return {
             stdout,
@@ -231,9 +232,45 @@ describe("SystemConfigurationAdapter", () => {
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("cmd locale set-app-locales com.example.app --user 10");
-      expect(adb.wasCommandExecuted("cmd locale set-app-locales --user 10 'com.example.app' --locales 'ja-JP'")).toBe(true);
-      expect(adb.wasCommandExecuted("cmd locale get-app-locales --user 10 'com.example.app'")).toBe(true);
-      expect(adb.wasCommandExecuted("cmd locale get-app-locales --user 0 'com.example.app'")).toBe(false);
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --user 10 --locales 'ja-JP'")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale get-app-locales 'com.example.app' --user 10")).toBe(true);
+      expect(adb.wasCommandExecuted("cmd locale get-app-locales 'com.example.app' --user 0")).toBe(false);
+    });
+
+    it("falls back to a running Android work-profile user for app-scoped locale commands", async () => {
+      const adb = new FakeAdbClient();
+      adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
+      adb.setForegroundApp({ packageName: "com.other.app", userId: 0 });
+      adb.setUsers([
+        { userId: 0, name: "Owner", running: true },
+        { userId: 10, name: "Work", running: true },
+      ]);
+      const appLocaleResponses = [
+        "Locales for com.example.app for user 10 are []\n",
+        "Locales for com.example.app for user 10 are [ja-JP]\n",
+      ];
+      const original = adb.executeCommand.bind(adb);
+      adb.executeCommand = (async (command: string, ...rest: any[]) => {
+        if (command === "shell cmd locale get-app-locales 'com.example.app' --user 10") {
+          await original(command, ...rest);
+          const stdout = appLocaleResponses.shift() ?? "Locales for com.example.app for user 10 are [ja-JP]\n";
+          return {
+            stdout,
+            stderr: "",
+            toString: () => stdout,
+            trim: () => stdout.trim(),
+            includes: (s: string) => stdout.includes(s),
+          };
+        }
+        return original(command, ...rest);
+      }) as any;
+
+      const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
+      const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("cmd locale set-app-locales com.example.app --user 10");
+      expect(adb.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --user 10 --locales 'ja-JP'")).toBe(true);
     });
 
     it("uses root-backed system locale after adb root below Android 13", async () => {
@@ -287,7 +324,7 @@ describe("SystemConfigurationAdapter", () => {
     it("returns false when app-scoped locale read-back does not match", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      adb.setCommandResult("shell cmd locale get-app-locales --user 0 'com.example.app'", "Locales for com.example.app for user 0 are [en-US]\n");
+      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app' --user 0", "Locales for com.example.app for user 0 are [en-US]\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
 
@@ -299,7 +336,7 @@ describe("SystemConfigurationAdapter", () => {
     it("returns false when app-scoped locale read-back has no locale list", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      adb.setCommandResult("shell cmd locale get-app-locales --user 0 'com.example.app'", "Unknown package com.example.app for userId 0\n");
+      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app' --user 0", "Unknown package com.example.app for userId 0\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { appId: "com.example.app" });
 
@@ -311,7 +348,7 @@ describe("SystemConfigurationAdapter", () => {
     it("uses the first locale when app-scoped read-back returns multiple locales", async () => {
       const adb = new FakeAdbClient();
       adb.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      adb.setCommandResult("shell cmd locale get-app-locales --user 0 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP,en-US]\n");
+      adb.setCommandResult("shell cmd locale get-app-locales 'com.example.app' --user 0", "Locales for com.example.app for user 0 are [ja-JP,en-US]\n");
       const adapter = new AndroidSystemConfigurationAdapter(androidDevice, adb as any);
       const result = await adapter.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
 

--- a/test/features/utility/SystemConfigurationManager.test.ts
+++ b/test/features/utility/SystemConfigurationManager.test.ts
@@ -458,14 +458,14 @@ describe("SystemConfigurationManager", () => {
   describe("Android setLocale still works", () => {
     test("uses app-scoped locale commands when an Android appId is provided", async () => {
       fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP]\n");
+      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app' --user 0", "Locales for com.example.app for user 0 are [ja-JP]\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
       expect(result.success).toBe(true);
-      expect(result.method).toBe("cmd locale set-app-locales com.example.app");
+      expect(result.method).toBe("cmd locale set-app-locales com.example.app --user 0");
       expect(fakeExec.getExecutedCommands()).toHaveLength(0);
-      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --locales 'ja-JP'")).toBe(true);
+      expect(fakeAdbClient.wasCommandExecuted("cmd locale set-app-locales 'com.example.app' --user 0 --locales 'ja-JP'")).toBe(true);
       expect(fakeAdbClient.wasCommandExecuted("setprop persist.sys.locale")).toBe(false);
       expect(fakeAdbClient.wasCommandExecuted("stop; start")).toBe(false);
     });
@@ -835,7 +835,7 @@ describe("SystemConfigurationManager", () => {
 
     test("broadcasts locale change by default", async () => {
       fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP]\n");
+      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app' --user 0", "Locales for com.example.app for user 0 are [ja-JP]\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       await mgr.setLocale("ja-JP", { appId: "com.example.app" });
 
@@ -844,7 +844,7 @@ describe("SystemConfigurationManager", () => {
 
     test("skips broadcast when option is false", async () => {
       fakeAdbClient.setCommandResult("shell getprop ro.build.version.sdk", "36");
-      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app'", "Locales for com.example.app for user 0 are [ja-JP]\n");
+      fakeAdbClient.setCommandResult("shell cmd locale get-app-locales 'com.example.app' --user 0", "Locales for com.example.app for user 0 are [ja-JP]\n");
       const mgr = new SystemConfigurationManager(ANDROID_DEVICE, fakeAdbFactory, fakeExec);
       const result = await mgr.setLocale("ja-JP", { broadcast: false, appId: "com.example.app" });
 


### PR DESCRIPTION
## Summary
- Pass the resolved Android user to app-scoped locale set/get commands.
- Reuse existing foreground app and user-list detection so work-profile apps target the owning user.
- Add focused regression coverage for foreground and fallback work-profile targeting.

## Test plan
- bun test test/features/utility/SystemConfigurationAdapter.test.ts test/features/utility/SystemConfigurationManager.test.ts


Made with [Cursor](https://cursor.com)