### PR TITLE
tapOn: target a specific control among repeated rows (nested-label sibling + instance)

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -8,7 +8,7 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 
 #### Interactions
 
-- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match).
+- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match). When multiple elements match, `instance` (0-based) taps the Nth on-screen match instead of applying `selectionStrategy`.
 - 👉 `swipeOn` handles directional swipes and scrolling within container bounds.
 - ↔️ `dragAndDrop` for element-to-element moves.
 - 🔍 `pinchOn` for zoom in/out gestures.

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -8,7 +8,7 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 
 #### Interactions
 
-- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selector strategies include `text`, `elementId`, `clickable` (first clickable element), `siblingOfText` (clickable sibling of a text element), and `tapClickableParent` (nearest clickable ancestor of a text match). When multiple elements match, `instance` (0-based) taps the Nth on-screen match instead of applying `selectionStrategy`.
+- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selectors include `selector.text`, `selector.textAny`, and `selector.elementId`; `sibling: true` taps a clickable sibling of the selector match. When multiple elements match, `index` (0-based) taps the Nth on-screen match instead of applying `selectionStrategy`.
 - 👉 `swipeOn` handles directional swipes and scrolling within container bounds.
 - ↔️ `dragAndDrop` for element-to-element moves.
 - 🔍 `pinchOn` for zoom in/out gestures.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6721,6 +6721,12 @@
             "random"
           ]
         },
+        "index": {
+          "description": "0-based index to tap the Nth on-screen match (in hierarchy order, i.e. top-to-bottom for a vertical list) instead of applying selectionStrategy — for repeated controls with no unique text. Out of range → no match.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
         "duration": {
           "description": "Long press duration (ms)",
           "type": "number"

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -314,7 +314,7 @@ export class TapOnElement extends BaseVisualChange {
             fuzzyMatch: true,
             caseSensitive: false,
             strategy: options.selectionStrategy,
-            index: options.instance
+            index: options.index
           }),
           containerFound
         };
@@ -326,7 +326,7 @@ export class TapOnElement extends BaseVisualChange {
           partialMatch: true,
           caseSensitive: false,
           strategy: options.selectionStrategy,
-          index: options.instance
+          index: options.index
         }),
         containerFound
       };
@@ -343,14 +343,14 @@ export class TapOnElement extends BaseVisualChange {
             fuzzyMatch: true,
             caseSensitive: false,
             strategy: options.selectionStrategy,
-            index: options.instance
+            index: options.index
           })
           : this.elementSelector.selectByText(viewHierarchy, text, {
             container: options.container,
             partialMatch: true,
             caseSensitive: false,
             strategy: options.selectionStrategy,
-            index: options.instance
+            index: options.index
           });
         lastSelection = selection;
         if (selection.element) {
@@ -381,7 +381,7 @@ export class TapOnElement extends BaseVisualChange {
             container: options.container,
             partialMatch: false,
             strategy: options.selectionStrategy,
-            index: options.instance
+            index: options.index
           }),
           containerFound
         };
@@ -392,7 +392,7 @@ export class TapOnElement extends BaseVisualChange {
           container: options.container,
           partialMatch: false,
           strategy: options.selectionStrategy,
-          index: options.instance
+          index: options.index
         }),
         containerFound
       };

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -313,7 +313,8 @@ export class TapOnElement extends BaseVisualChange {
             container: options.container,
             fuzzyMatch: true,
             caseSensitive: false,
-            strategy: options.selectionStrategy
+            strategy: options.selectionStrategy,
+            index: options.instance
           }),
           containerFound
         };
@@ -324,7 +325,8 @@ export class TapOnElement extends BaseVisualChange {
           container: options.container,
           partialMatch: true,
           caseSensitive: false,
-          strategy: options.selectionStrategy
+          strategy: options.selectionStrategy,
+          index: options.instance
         }),
         containerFound
       };
@@ -340,13 +342,15 @@ export class TapOnElement extends BaseVisualChange {
             container: options.container,
             fuzzyMatch: true,
             caseSensitive: false,
-            strategy: options.selectionStrategy
+            strategy: options.selectionStrategy,
+            index: options.instance
           })
           : this.elementSelector.selectByText(viewHierarchy, text, {
             container: options.container,
             partialMatch: true,
             caseSensitive: false,
-            strategy: options.selectionStrategy
+            strategy: options.selectionStrategy,
+            index: options.instance
           });
         lastSelection = selection;
         if (selection.element) {
@@ -376,7 +380,8 @@ export class TapOnElement extends BaseVisualChange {
           selection: this.elementSelector.selectClickableSiblingOfResourceId(viewHierarchy, options.elementId, {
             container: options.container,
             partialMatch: false,
-            strategy: options.selectionStrategy
+            strategy: options.selectionStrategy,
+            index: options.instance
           }),
           containerFound
         };
@@ -386,7 +391,8 @@ export class TapOnElement extends BaseVisualChange {
         selection: this.elementSelector.selectByResourceId(viewHierarchy, options.elementId, {
           container: options.container,
           partialMatch: false,
-          strategy: options.selectionStrategy
+          strategy: options.selectionStrategy,
+          index: options.instance
         }),
         containerFound
       };

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -35,7 +35,8 @@ export class DefaultElementSelector implements ElementSelector {
       text,
       options?.container ?? null,
       options?.partialMatch ?? true,
-      options?.caseSensitive ?? false
+      options?.caseSensitive ?? false,
+      options?.index !== undefined
     );
     return this.pickMatch(matches, strategy, viewHierarchy, options?.index);
   }
@@ -55,7 +56,8 @@ export class DefaultElementSelector implements ElementSelector {
       viewHierarchy,
       resourceId,
       options?.container ?? null,
-      options?.partialMatch ?? false
+      options?.partialMatch ?? false,
+      options?.index !== undefined
     );
     return this.pickMatch(matches, strategy, viewHierarchy, options?.index);
   }

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -26,6 +26,7 @@ export class DefaultElementSelector implements ElementSelector {
       partialMatch?: boolean;
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     const strategy = options?.strategy ?? "first";
@@ -36,7 +37,7 @@ export class DefaultElementSelector implements ElementSelector {
       options?.partialMatch ?? true,
       options?.caseSensitive ?? false
     );
-    return this.pickMatch(matches, strategy, viewHierarchy);
+    return this.pickMatch(matches, strategy, viewHierarchy, options?.index);
   }
 
   selectByResourceId(
@@ -46,6 +47,7 @@ export class DefaultElementSelector implements ElementSelector {
       container?: { elementId?: string; text?: string } | null;
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     const strategy = options?.strategy ?? "first";
@@ -55,7 +57,7 @@ export class DefaultElementSelector implements ElementSelector {
       options?.container ?? null,
       options?.partialMatch ?? false
     );
-    return this.pickMatch(matches, strategy, viewHierarchy);
+    return this.pickMatch(matches, strategy, viewHierarchy, options?.index);
   }
 
   selectClickableParentByText(
@@ -104,6 +106,7 @@ export class DefaultElementSelector implements ElementSelector {
       fuzzyMatch?: boolean;
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     const strategy = options?.strategy ?? "first";
@@ -114,7 +117,7 @@ export class DefaultElementSelector implements ElementSelector {
       options?.fuzzyMatch ?? true,
       options?.caseSensitive ?? false
     );
-    return this.pickMatch(matches, strategy, viewHierarchy);
+    return this.pickMatch(matches, strategy, viewHierarchy, options?.index);
   }
 
   selectClickableSiblingOfResourceId(
@@ -124,6 +127,7 @@ export class DefaultElementSelector implements ElementSelector {
       container?: { elementId?: string; text?: string } | null;
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     const strategy = options?.strategy ?? "first";
@@ -133,7 +137,7 @@ export class DefaultElementSelector implements ElementSelector {
       options?.container ?? null,
       options?.partialMatch ?? false
     );
-    return this.pickMatch(matches, strategy, viewHierarchy);
+    return this.pickMatch(matches, strategy, viewHierarchy, options?.index);
   }
 
   private isElementCenterOffScreen(element: Element, viewHierarchy: ViewHierarchyResult): boolean {
@@ -150,7 +154,8 @@ export class DefaultElementSelector implements ElementSelector {
   private pickMatch(
     matches: Element[],
     strategy: ElementSelectionStrategy,
-    viewHierarchy: ViewHierarchyResult
+    viewHierarchy: ViewHierarchyResult,
+    index?: number
   ): ElementSelectionResult {
     const totalMatches = matches.length;
     if (totalMatches === 0) {
@@ -158,11 +163,22 @@ export class DefaultElementSelector implements ElementSelector {
     }
 
     const visibleMatches = matches
-      .map((element, index) => ({ element, index }))
+      .map((element, matchIndex) => ({ element, index: matchIndex }))
       .filter(match => !this.isElementCenterOffScreen(match.element, viewHierarchy));
 
     if (visibleMatches.length === 0) {
       return { element: null, indexInMatches: -1, totalMatches, strategy };
+    }
+
+    // Explicit 0-based index overrides strategy: pick the Nth on-screen match, or return
+    // no match if out of range (so a caller asking for "the 3rd" of 2 fails, not silently
+    // grabbing another element).
+    if (index !== undefined) {
+      if (index < 0 || index >= visibleMatches.length) {
+        return { element: null, indexInMatches: -1, totalMatches, strategy };
+      }
+      const chosen = visibleMatches[index];
+      return { element: chosen.element, indexInMatches: chosen.index, totalMatches, strategy };
     }
 
     let selectedVisibleIndex = 0;

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -124,7 +124,8 @@ export class DefaultElementFinder implements ElementFinder {
   private collectTextMatchesInRoots(
     rootNodes: ViewHierarchyNode[],
     text: string,
-    matchesText: (input?: string) => boolean
+    matchesText: (input?: string) => boolean,
+    sortByArea: boolean = true
   ): { exactMatches: Element[]; partialMatches: Element[] } {
     const partialMatches: Element[] = [];
     const exactMatches: Element[] = [];
@@ -198,10 +199,10 @@ export class DefaultElementFinder implements ElementFinder {
       });
     }
 
-    if (exactMatches.length > 0) {
+    if (sortByArea && exactMatches.length > 0) {
       this.sortElementsByArea(exactMatches);
     }
-    if (partialMatches.length > 0) {
+    if (sortByArea && partialMatches.length > 0) {
       this.sortElementsByArea(partialMatches);
     }
 
@@ -211,7 +212,8 @@ export class DefaultElementFinder implements ElementFinder {
   private collectResourceIdMatchesInRoots(
     rootNodes: ViewHierarchyNode[],
     resourceId: string,
-    partialMatch: boolean
+    partialMatch: boolean,
+    sortByArea: boolean = true
   ): Element[] {
     const matches: Element[] = [];
 
@@ -233,7 +235,7 @@ export class DefaultElementFinder implements ElementFinder {
       });
     }
 
-    if (matches.length > 0) {
+    if (sortByArea && matches.length > 0) {
       this.sortElementsByArea(matches);
     }
 
@@ -290,6 +292,17 @@ export class DefaultElementFinder implements ElementFinder {
     return isClickableElementProperties(props);
   }
 
+  private isCollectionNode(props: Record<string, unknown>): boolean {
+    const className = typeof props.class === "string" ? props.class : "";
+    const scrollable = props.scrollable === "true" || props.scrollable === true;
+    return scrollable ||
+      className.includes("RecyclerView") ||
+      className.includes("ListView") ||
+      className.includes("ScrollView") ||
+      className.includes("CollectionView") ||
+      className.includes("TableView");
+  }
+
   /**
    * Find elements in the view hierarchy that match the specified text
    * @param viewHierarchy - The view hierarchy to search
@@ -304,7 +317,8 @@ export class DefaultElementFinder implements ElementFinder {
     text: string,
     container: { elementId?: string; text?: string } | null = null,
     partialMatch: boolean = true,
-    caseSensitive: boolean = false
+    caseSensitive: boolean = false,
+    preserveTraversalOrder: boolean = false
   ): Element[] {
     if (!viewHierarchy || !text) {
       return [];
@@ -324,18 +338,33 @@ export class DefaultElementFinder implements ElementFinder {
     };
 
     if (containerNode) {
-      return selectMatches(this.collectTextMatchesInRoots([containerNode], text, matchesText));
+      return selectMatches(this.collectTextMatchesInRoots(
+        [containerNode],
+        text,
+        matchesText,
+        !preserveTraversalOrder
+      ));
     }
 
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-    const mainMatches = selectMatches(this.collectTextMatchesInRoots(rootNodes, text, matchesText));
+    const mainMatches = selectMatches(this.collectTextMatchesInRoots(
+      rootNodes,
+      text,
+      matchesText,
+      !preserveTraversalOrder
+    ));
     if (mainMatches.length > 0) {
       return mainMatches;
     }
 
     const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
     for (const windowRoots of windowRootGroups) {
-      const windowMatches = selectMatches(this.collectTextMatchesInRoots(windowRoots, text, matchesText));
+      const windowMatches = selectMatches(this.collectTextMatchesInRoots(
+        windowRoots,
+        text,
+        matchesText,
+        !preserveTraversalOrder
+      ));
       if (windowMatches.length > 0) {
         return windowMatches;
       }
@@ -376,7 +405,8 @@ export class DefaultElementFinder implements ElementFinder {
     viewHierarchy: ViewHierarchyResult,
     resourceId: string,
     container: { elementId?: string; text?: string } | null = null,
-    partialMatch: boolean = false
+    partialMatch: boolean = false,
+    preserveTraversalOrder: boolean = false
   ): Element[] {
     if (!viewHierarchy || !resourceId) {
       return [];
@@ -391,18 +421,33 @@ export class DefaultElementFinder implements ElementFinder {
     }
 
     if (containerNode) {
-      return this.collectResourceIdMatchesInRoots([containerNode], resourceId, partialMatch);
+      return this.collectResourceIdMatchesInRoots(
+        [containerNode],
+        resourceId,
+        partialMatch,
+        !preserveTraversalOrder
+      );
     }
 
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-    const mainMatches = this.collectResourceIdMatchesInRoots(rootNodes, resourceId, partialMatch);
+    const mainMatches = this.collectResourceIdMatchesInRoots(
+      rootNodes,
+      resourceId,
+      partialMatch,
+      !preserveTraversalOrder
+    );
     if (mainMatches.length > 0) {
       return mainMatches;
     }
 
     const windowRootGroups = this.parser.extractWindowRootGroups(viewHierarchy, "topmost-first");
     for (const windowRoots of windowRootGroups) {
-      const windowMatches = this.collectResourceIdMatchesInRoots(windowRoots, resourceId, partialMatch);
+      const windowMatches = this.collectResourceIdMatchesInRoots(
+        windowRoots,
+        resourceId,
+        partialMatch,
+        !preserveTraversalOrder
+      );
       if (windowMatches.length > 0) {
         return windowMatches;
       }
@@ -1108,12 +1153,14 @@ export class DefaultElementFinder implements ElementFinder {
       return;
     }
 
-    // If that text-bearing child is ITSELF clickable, it is a row/list-item and THIS node
-    // is the list — collecting here would grab a sibling ROW's control (i.e. act on a
-    // different row). The real row is deeper; stop. This also means a matched row with
-    // no clickable control resolves to no match (a clean "not found") rather than silently
-    // hitting another row's control.
-    if (this.isClickableNode(this.parser.extractNodeProperties(textChild))) {
+    // If that text-bearing child is ITSELF clickable under a collection node, it is a
+    // row/list-item and THIS node is the list. Collecting here would grab a sibling
+    // ROW's control. A non-collection parent can still be an actual row with a
+    // clickable content group plus a trailing action, so let that case collect below.
+    if (
+      this.isClickableNode(this.parser.extractNodeProperties(textChild)) &&
+      this.isCollectionNode(this.parser.extractNodeProperties(node))
+    ) {
       return;
     }
 

--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -1050,14 +1050,29 @@ export class DefaultElementFinder implements ElementFinder {
   }
 
   /**
-   * Recursively search for clickable siblings of text-matching elements.
-   * When a node has children where one directly matches text and another is clickable,
-   * we return the clickable sibling.
+   * Recursively find the clickable control that shares a ROW with a text-matching
+   * element — the control a user taps "next to" that text (a remove button, a row
+   * checkbox, etc.).
    *
-   * Uses nodeHasText (shallow) instead of nodeOrDescendantHasText (deep) to avoid
-   * false positives: a parent whose deeply-nested descendant has the text should not
-   * cause its other children to be collected as "siblings." The recursion naturally
-   * finds the correct level.
+   * The text is frequently NOT a direct sibling of the control. List rows commonly nest
+   * the label under an intermediate container (e.g. a name/email pair inside an avatar
+   * group) while the action sits as a sibling of that container. So we match on a child
+   * whose SUBTREE contains the text (deep), and collect the clickable, non-text children
+   * at the DEEPEST qualifying node — the row.
+   *
+   * Two rules keep the deep match precise, addressing the false-positive the previous
+   * shallow (`nodeHasText`) version guarded against — i.e. stopping a list/recycler
+   * ancestor from collecting every sibling row's control at once:
+   *   - Recurse FIRST and bail if a descendant level already matched, so the nearest
+   *     (deepest) row wins when the matching row yields a control.
+   *   - Only collect at a node whose text-bearing child is NOT itself clickable. A
+   *     clickable text-bearing child means that child is the row/list-item and THIS node
+   *     is the list, so its other clickable children are sibling rows, not this row's
+   *     control. This is essential when the matching row has NO control of its own:
+   *     without it, recursion would unwind to the list and return a different row's
+   *     control (a silent wrong tap); with it, the result is a clean "not found".
+   * This keeps the old direct-sibling case working (the text's parent is the row) while
+   * also reaching a nested label, which previously returned "no clickable sibling".
    */
   private findClickableSiblingsInNode(
     node: ViewHierarchyNode,
@@ -1073,25 +1088,46 @@ export class DefaultElementFinder implements ElementFinder {
       ? children
       : [children];
 
-    // Check if any direct child has matching text (shallow — not descendants)
-    const hasTextMatch = childArray.some(child => this.nodeHasText(child, matchesText));
-
-    if (hasTextMatch) {
-      for (const child of childArray) {
-        const childProps = this.parser.extractNodeProperties(child);
-        const isClickable = this.isClickableNode(childProps);
-
-        if (isClickable && !this.nodeHasText(child, matchesText)) {
-          const parsedNode = this.parser.parseNodeBounds(child);
-          if (parsedNode) {
-            results.push(parsedNode);
-          }
-        }
-      }
-    }
-
+    // Recurse first so the DEEPEST (nearest-to-text) row wins. If a descendant level
+    // already produced matches, don't also collect at this (ancestor) level — that is
+    // what would pull sibling rows' controls in from a shared list container.
+    const before = results.length;
     for (const child of childArray) {
       this.findClickableSiblingsInNode(child, matchesText, results);
+    }
+    if (results.length > before) {
+      return;
+    }
+
+    // At this level, which child's SUBTREE contains the text (deep, so a label nested
+    // under an avatar/content group still counts)?
+    const textChild = childArray.find(child =>
+      this.nodeOrDescendantHasText(child, matchesText)
+    );
+    if (!textChild) {
+      return;
+    }
+
+    // If that text-bearing child is ITSELF clickable, it is a row/list-item and THIS node
+    // is the list — collecting here would grab a sibling ROW's control (i.e. act on a
+    // different row). The real row is deeper; stop. This also means a matched row with
+    // no clickable control resolves to no match (a clean "not found") rather than silently
+    // hitting another row's control.
+    if (this.isClickableNode(this.parser.extractNodeProperties(textChild))) {
+      return;
+    }
+
+    // THIS node is the row: its clickable, non-text children are the action control(s).
+    for (const child of childArray) {
+      const childProps = this.parser.extractNodeProperties(child);
+      const isClickable = this.isClickableNode(childProps);
+
+      if (isClickable && !this.nodeOrDescendantHasText(child, matchesText)) {
+        const parsedNode = this.parser.parseNodeBounds(child);
+        if (parsedNode) {
+          results.push(parsedNode);
+        }
+      }
     }
   }
 

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -12,6 +12,12 @@ export interface TapOnElementOptions {
   // Works with both text and elementId selectors.
   sibling?: boolean;
 
+  // When multiple elements match the selector, tap the one at this 0-based position among
+  // the on-screen matches (in hierarchy order, i.e. top-to-bottom for a vertical list)
+  // instead of applying selectionStrategy. Use for repeated controls with no unique text
+  // (e.g. the 2nd identical row action). Out of range → no match.
+  instance?: number;
+
   // Container to restrict search
   container?: {
     elementId?: string;

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -16,7 +16,7 @@ export interface TapOnElementOptions {
   // the on-screen matches (in hierarchy order, i.e. top-to-bottom for a vertical list)
   // instead of applying selectionStrategy. Use for repeated controls with no unique text
   // (e.g. the 2nd identical row action). Out of range → no match.
-  instance?: number;
+  index?: number;
 
   // Container to restrict search
   container?: {

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -60,6 +60,7 @@ export interface TapOnArgs {
     text?: string;
   };
   selectionStrategy?: ElementSelectionStrategy;
+  instance?: number;
   action: "tap" | "doubleTap" | "longPress" | "focus";
   duration?: number;
   searchUntil?: {

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -60,7 +60,7 @@ export interface TapOnArgs {
     text?: string;
   };
   selectionStrategy?: ElementSelectionStrategy;
-  instance?: number;
+  index?: number;
   action: "tap" | "doubleTap" | "longPress" | "focus";
   duration?: number;
   searchUntil?: {

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -149,6 +149,11 @@ export const tapOnSchema = addDeviceTargetingToSchema(z.object({
   selectionStrategy: elementSelectionStrategySchema.optional().describe(
     "Selection strategy when multiple match (default: first)"
   ),
+  instance: z.number().int().nonnegative().optional().describe(
+    "0-based index to tap the Nth on-screen match (in hierarchy order, i.e. top-to-bottom "
+    + "for a vertical list) instead of applying "
+    + "selectionStrategy — for repeated controls with no unique text. Out of range → no match."
+  ),
   duration: z.number().optional().describe("Long press duration (ms)"),
   searchUntil: z.object({
     duration: z.number().min(100).max(12000).optional().describe("Polling duration (ms, default: 500)"),
@@ -420,6 +425,7 @@ export function registerInteractionTools() {
       elementId: args.selector.elementId,
       sibling: args.sibling,
       selectionStrategy: args.selectionStrategy,
+      instance: args.instance,
       action: args.action,
       duration: args.duration,
       searchUntil: args.searchUntil,

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -149,7 +149,7 @@ export const tapOnSchema = addDeviceTargetingToSchema(z.object({
   selectionStrategy: elementSelectionStrategySchema.optional().describe(
     "Selection strategy when multiple match (default: first)"
   ),
-  instance: z.number().int().nonnegative().optional().describe(
+  index: z.number().int().nonnegative().optional().describe(
     "0-based index to tap the Nth on-screen match (in hierarchy order, i.e. top-to-bottom "
     + "for a vertical list) instead of applying "
     + "selectionStrategy — for repeated controls with no unique text. Out of range → no match."
@@ -425,7 +425,7 @@ export function registerInteractionTools() {
       elementId: args.selector.elementId,
       sibling: args.sibling,
       selectionStrategy: args.selectionStrategy,
-      instance: args.instance,
+      index: args.index,
       action: args.action,
       duration: args.duration,
       searchUntil: args.searchUntil,

--- a/src/utils/interfaces/ElementFinder.ts
+++ b/src/utils/interfaces/ElementFinder.ts
@@ -7,7 +7,8 @@ export interface ElementFinder {
     text: string,
     container?: { elementId?: string; text?: string } | null,
     partialMatch?: boolean,
-    caseSensitive?: boolean
+    caseSensitive?: boolean,
+    preserveTraversalOrder?: boolean
   ): Element[];
 
   findElementByText(
@@ -22,7 +23,8 @@ export interface ElementFinder {
     viewHierarchy: ViewHierarchyResult,
     resourceId: string,
     container?: { elementId?: string; text?: string } | null,
-    partialMatch?: boolean
+    partialMatch?: boolean,
+    preserveTraversalOrder?: boolean
   ): Element[];
 
   findElementByResourceId(

--- a/src/utils/interfaces/ElementSelector.ts
+++ b/src/utils/interfaces/ElementSelector.ts
@@ -11,6 +11,8 @@ export interface ElementSelector {
       partialMatch?: boolean;
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
+      /** 0-based position among on-screen matches; overrides strategy. Out of range → null. */
+      index?: number;
     }
   ): ElementSelectionResult;
 
@@ -21,6 +23,8 @@ export interface ElementSelector {
       container?: { elementId?: string; text?: string } | null;
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
+      /** 0-based position among on-screen matches; overrides strategy. Out of range → null. */
+      index?: number;
     }
   ): ElementSelectionResult;
 
@@ -32,6 +36,8 @@ export interface ElementSelector {
       fuzzyMatch?: boolean;
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
+      /** 0-based position among on-screen matches; overrides strategy. Out of range → null. */
+      index?: number;
     }
   ): ElementSelectionResult;
 
@@ -42,6 +48,8 @@ export interface ElementSelector {
       container?: { elementId?: string; text?: string } | null;
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
+      /** 0-based position among on-screen matches; overrides strategy. Out of range → null. */
+      index?: number;
     }
   ): ElementSelectionResult;
 }

--- a/test/fakes/FakeElementSelector.ts
+++ b/test/fakes/FakeElementSelector.ts
@@ -13,6 +13,7 @@ import type { ElementSelector } from "../../src/utils/interfaces/ElementSelector
  */
 export class FakeElementSelector implements ElementSelector {
   lastStrategy?: ElementSelectionStrategy;
+  lastIndex?: number;
   lastText?: string;
   textCalls: string[] = [];
   lastResourceId?: string;
@@ -58,10 +59,12 @@ export class FakeElementSelector implements ElementSelector {
       partialMatch?: boolean;
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
+    this.lastIndex = options?.index;
     this.lastText = text;
     this.textCalls.push(text);
     return this.buildSelectionResult(options?.strategy);
@@ -74,10 +77,12 @@ export class FakeElementSelector implements ElementSelector {
       container?: { elementId?: string; text?: string } | null;
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
+    this.lastIndex = options?.index;
     this.lastResourceId = resourceId;
     return this.buildSelectionResult(options?.strategy);
   }
@@ -120,10 +125,12 @@ export class FakeElementSelector implements ElementSelector {
       fuzzyMatch?: boolean;
       caseSensitive?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
+    this.lastIndex = options?.index;
     this.lastText = text;
     this.textCalls.push(text);
     return this.buildSelectionResult(options?.strategy);
@@ -136,10 +143,12 @@ export class FakeElementSelector implements ElementSelector {
       container?: { elementId?: string; text?: string } | null;
       partialMatch?: boolean;
       strategy?: ElementSelectionStrategy;
+      index?: number;
     }
   ): ElementSelectionResult {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
+    this.lastIndex = options?.index;
     this.lastResourceId = resourceId;
     return this.buildSelectionResult(options?.strategy);
   }

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -134,3 +134,126 @@ describe("DefaultElementSelector", () => {
     expect(match.totalMatches).toBe(1);
   });
 });
+
+describe("selectClickableSiblingOfText — nested label rows", () => {
+
+  const node = (attrs: Record<string, any>, children?: any[]): any => ({
+    $: attrs,
+    ...(children ? { node: children } : {})
+  });
+
+  // A list row that nests its label under a leading container (e.g. an avatar): the NAME
+  // is a descendant of that container, while the row's action button is a SIBLING of the
+  // container (a "cousin" of the name text), NOT a direct sibling of the text. Both rows
+  // share the removeButton resource-id.
+  const row = (name: string, top: number) =>
+    node(
+      { "bounds": { left: 0, top, right: 100, bottom: top + 20 }, "class": "android.view.ViewGroup", "resource-id": "app:id/row", "clickable": "true" },
+      [
+        node(
+          { "bounds": { left: 5, top: top + 2, right: 80, bottom: top + 18 }, "class": "android.view.ViewGroup", "resource-id": "app:id/avatar" },
+          [node({ "bounds": { left: 10, top: top + 2, right: 80, bottom: top + 10 }, "class": "android.widget.TextView", "resource-id": "app:id/nameLabel", "text": name })]
+        ),
+        node({ "bounds": { left: 85, top: top + 2, right: 98, bottom: top + 18 }, "class": "android.widget.ImageButton", "resource-id": "app:id/removeButton", "clickable": "true" })
+      ]
+    );
+
+  const rowsHierarchy = {
+    hierarchy: {
+      node: node({ bounds: { left: 0, top: 0, right: 100, bottom: 100 }, class: "android.widget.FrameLayout" }, [
+        node({ "bounds": { left: 0, top: 0, right: 100, bottom: 60 }, "class": "androidx.recyclerview.widget.RecyclerView", "resource-id": "app:id/list" }, [
+          row("Alice Adams", 0),
+          row("Bob Brown", 20)
+        ])
+      ])
+    },
+    screenWidth: 100,
+    screenHeight: 100
+  } as unknown as ViewHierarchyResult;
+
+  test("finds the remove button in the SAME row as the named row", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+
+    const alice = selector.selectClickableSiblingOfText(rowsHierarchy, "Alice Adams", { strategy: "first" });
+    const bob = selector.selectClickableSiblingOfText(rowsHierarchy, "Bob Brown", { strategy: "first" });
+
+    // Both resolve (before the fix, the nested name returned no clickable sibling)...
+    expect(alice.element?.["resource-id"]).toBe("app:id/removeButton");
+    expect(bob.element?.["resource-id"]).toBe("app:id/removeButton");
+    // ...and each targets ITS OWN row's button (the shared id no longer collapses to row 1).
+    expect(alice.element?.bounds.top).toBeLessThan(bob.element!.bounds.top);
+  });
+
+  test("a matched row with no control resolves to null, not a sibling row's control", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+    // Alice's row has NO remove button; Bob's row does. Searching Alice must NOT bubble up to
+    // the list and return Bob's control (a silent wrong tap) — it must be a clean null.
+    const aliceNoButton = {
+      hierarchy: {
+        node: node({ bounds: { left: 0, top: 0, right: 100, bottom: 100 }, class: "android.widget.FrameLayout" }, [
+          node({ "bounds": { left: 0, top: 0, right: 100, bottom: 60 }, "class": "androidx.recyclerview.widget.RecyclerView", "resource-id": "app:id/list" }, [
+            node({ "bounds": { left: 0, top: 0, right: 100, bottom: 20 }, "class": "android.view.ViewGroup", "resource-id": "app:id/row", "clickable": "true" }, [
+              node({ "bounds": { left: 5, top: 2, right: 80, bottom: 18 }, "class": "android.view.ViewGroup", "resource-id": "app:id/avatar" }, [
+                node({ "bounds": { left: 10, top: 2, right: 80, bottom: 10 }, "class": "android.widget.TextView", "resource-id": "app:id/nameLabel", "text": "Alice Adams" })
+              ])
+            ]),
+            row("Bob Brown", 20)
+          ])
+        ])
+      },
+      screenWidth: 100,
+      screenHeight: 100
+    } as unknown as ViewHierarchyResult;
+
+    const alice = selector.selectClickableSiblingOfText(aliceNoButton, "Alice Adams", { strategy: "first" });
+    expect(alice.element).toBeNull();
+  });
+
+  test("still finds a clickable DIRECT sibling of the text (regression)", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+    const flatRow = {
+      hierarchy: {
+        node: node({ bounds: { left: 0, top: 0, right: 100, bottom: 20 }, class: "android.view.ViewGroup" }, [
+          node({ bounds: { left: 0, top: 0, right: 50, bottom: 10 }, class: "android.widget.TextView", text: "Accept Terms" }),
+          node({ "bounds": { left: 50, top: 0, right: 60, bottom: 10 }, "class": "android.widget.CheckBox", "resource-id": "app:id/cb", "clickable": "true" })
+        ])
+      },
+      screenWidth: 100,
+      screenHeight: 100
+    } as unknown as ViewHierarchyResult;
+
+    const match = selector.selectClickableSiblingOfText(flatRow, "Accept Terms", { strategy: "first" });
+    expect(match.element?.["resource-id"]).toBe("app:id/cb");
+  });
+});
+
+describe("selectByResourceId — instance index", () => {
+  const node = (attrs: Record<string, any>, children?: any[]): any => ({
+    $: attrs,
+    ...(children ? { node: children } : {})
+  });
+
+  // Two controls sharing one resource-id (a repeated per-row action), stacked
+  // top-to-bottom. `index` picks the Nth on-screen match in hierarchy order.
+  const repeated = {
+    hierarchy: {
+      node: node({ bounds: { left: 0, top: 0, right: 100, bottom: 100 }, class: "android.widget.FrameLayout" }, [
+        node({ "bounds": { left: 0, top: 0, right: 100, bottom: 20 }, "class": "android.widget.ImageButton", "resource-id": "app:id/remove", "clickable": "true" }),
+        node({ "bounds": { left: 0, top: 20, right: 100, bottom: 40 }, "class": "android.widget.ImageButton", "resource-id": "app:id/remove", "clickable": "true" })
+      ])
+    },
+    screenWidth: 100,
+    screenHeight: 100
+  } as unknown as ViewHierarchyResult;
+
+  test("index selects the Nth match and is out-of-range safe", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+
+    expect(selector.selectByResourceId(repeated, "app:id/remove", { index: 0 }).element?.bounds.top).toBe(0);
+    expect(selector.selectByResourceId(repeated, "app:id/remove", { index: 1 }).element?.bounds.top).toBe(20);
+    // Out of range → no match, rather than silently grabbing another element.
+    expect(selector.selectByResourceId(repeated, "app:id/remove", { index: 2 }).element).toBeNull();
+    // No index → strategy default (first) still applies.
+    expect(selector.selectByResourceId(repeated, "app:id/remove", { strategy: "first" }).element?.bounds.top).toBe(0);
+  });
+});

--- a/test/features/utility/DefaultElementSelector.test.ts
+++ b/test/features/utility/DefaultElementSelector.test.ts
@@ -158,6 +158,18 @@ describe("selectClickableSiblingOfText — nested label rows", () => {
       ]
     );
 
+  const rowWithClickableContent = (name: string, top: number) =>
+    node(
+      { "bounds": { left: 0, top, right: 100, bottom: top + 20 }, "class": "android.view.ViewGroup", "resource-id": "app:id/row", "clickable": "true" },
+      [
+        node(
+          { "bounds": { left: 5, top: top + 2, right: 80, bottom: top + 18 }, "class": "android.view.ViewGroup", "resource-id": "app:id/content", "clickable": "true" },
+          [node({ "bounds": { left: 10, top: top + 2, right: 80, bottom: top + 10 }, "class": "android.widget.TextView", "resource-id": "app:id/nameLabel", "text": name })]
+        ),
+        node({ "bounds": { left: 85, top: top + 2, right: 98, bottom: top + 18 }, "class": "android.widget.ImageButton", "resource-id": "app:id/removeButton", "clickable": "true" })
+      ]
+    );
+
   const rowsHierarchy = {
     hierarchy: {
       node: node({ bounds: { left: 0, top: 0, right: 100, bottom: 100 }, class: "android.widget.FrameLayout" }, [
@@ -209,6 +221,26 @@ describe("selectClickableSiblingOfText — nested label rows", () => {
     expect(alice.element).toBeNull();
   });
 
+  test("finds the row action when the nested label container is clickable", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+    const clickableContentRows = {
+      hierarchy: {
+        node: node({ bounds: { left: 0, top: 0, right: 100, bottom: 100 }, class: "android.widget.FrameLayout" }, [
+          node({ "bounds": { left: 0, top: 0, right: 100, bottom: 60 }, "class": "androidx.recyclerview.widget.RecyclerView", "resource-id": "app:id/list" }, [
+            rowWithClickableContent("Alice Adams", 0),
+            rowWithClickableContent("Bob Brown", 20)
+          ])
+        ])
+      },
+      screenWidth: 100,
+      screenHeight: 100
+    } as unknown as ViewHierarchyResult;
+
+    const bob = selector.selectClickableSiblingOfText(clickableContentRows, "Bob Brown", { strategy: "first" });
+    expect(bob.element?.["resource-id"]).toBe("app:id/removeButton");
+    expect(bob.element?.bounds.top).toBe(22);
+  });
+
   test("still finds a clickable DIRECT sibling of the text (regression)", () => {
     const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
     const flatRow = {
@@ -227,7 +259,7 @@ describe("selectClickableSiblingOfText — nested label rows", () => {
   });
 });
 
-describe("selectByResourceId — instance index", () => {
+describe("selectByResourceId — index", () => {
   const node = (attrs: Record<string, any>, children?: any[]): any => ({
     $: attrs,
     ...(children ? { node: children } : {})
@@ -239,7 +271,7 @@ describe("selectByResourceId — instance index", () => {
     hierarchy: {
       node: node({ bounds: { left: 0, top: 0, right: 100, bottom: 100 }, class: "android.widget.FrameLayout" }, [
         node({ "bounds": { left: 0, top: 0, right: 100, bottom: 20 }, "class": "android.widget.ImageButton", "resource-id": "app:id/remove", "clickable": "true" }),
-        node({ "bounds": { left: 0, top: 20, right: 100, bottom: 40 }, "class": "android.widget.ImageButton", "resource-id": "app:id/remove", "clickable": "true" })
+        node({ "bounds": { left: 0, top: 20, right: 20, bottom: 30 }, "class": "android.widget.ImageButton", "resource-id": "app:id/remove", "clickable": "true" })
       ])
     },
     screenWidth: 100,
@@ -253,7 +285,29 @@ describe("selectByResourceId — instance index", () => {
     expect(selector.selectByResourceId(repeated, "app:id/remove", { index: 1 }).element?.bounds.top).toBe(20);
     // Out of range → no match, rather than silently grabbing another element.
     expect(selector.selectByResourceId(repeated, "app:id/remove", { index: 2 }).element).toBeNull();
-    // No index → strategy default (first) still applies.
-    expect(selector.selectByResourceId(repeated, "app:id/remove", { strategy: "first" }).element?.bounds.top).toBe(0);
+    // No index → strategy default (first/smallest exact match) still applies.
+    expect(selector.selectByResourceId(repeated, "app:id/remove", { strategy: "first" }).element?.bounds.top).toBe(20);
+  });
+
+  test("index uses hierarchy order even when area sorting would pick a later smaller match", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+
+    expect(selector.selectByResourceId(repeated, "app:id/remove", { index: 0 }).element?.bounds.top).toBe(0);
+    expect(selector.selectByResourceId(repeated, "app:id/remove", { index: 1 }).element?.bounds.top).toBe(20);
+  });
+});
+
+describe("selectByText — index", () => {
+  test("index uses hierarchy order even when area sorting would pick a later smaller match", () => {
+    const selector = new DefaultElementSelector(new DefaultElementFinder(), () => 0);
+    const viewHierarchy = createViewHierarchy([
+      { bounds: { left: 0, top: 0, right: 100, bottom: 20 }, text: "Match" },
+      { bounds: { left: 0, top: 20, right: 20, bottom: 30 }, text: "Match" }
+    ]);
+
+    expect(selector.selectByText(viewHierarchy, "Match", { index: 0 }).element?.bounds.top).toBe(0);
+    expect(selector.selectByText(viewHierarchy, "Match", { index: 1 }).element?.bounds.top).toBe(20);
+    // No index → strategy default (first/smallest exact match) still applies.
+    expect(selector.selectByText(viewHierarchy, "Match", { strategy: "first" }).element?.bounds.top).toBe(20);
   });
 });

--- a/test/server/tools/tapOnTapAnySchema.test.ts
+++ b/test/server/tools/tapOnTapAnySchema.test.ts
@@ -97,6 +97,7 @@ describe("tapOn schema", () => {
       action: "longPress",
       duration: 2000,
       selectionStrategy: "random",
+      index: 1,
       searchUntil: { duration: 3000 },
       preTapStability: true,
       retryIfNoChange: true,
@@ -104,6 +105,7 @@ describe("tapOn schema", () => {
     });
     expect(result.action).toBe("longPress");
     expect(result.duration).toBe(2000);
+    expect(result.index).toBe(1);
     expect(result.preTapStability).toBe(true);
   });
 


### PR DESCRIPTION
## What

Two related improvements for reliably tapping the right control when a list has many repeated controls (a remove button / checkbox per row):

1. **`selectClickableSiblingOfText` now reaches a row's control when the label is nested.** Common list rows nest the label under a leading container (e.g. a name/subtitle pair inside an avatar/content group) while the per-row action sits as a *sibling of that container* — a "cousin" of the text, not a direct sibling. Previously `tapOn --sibling` returned `No clickable sibling found` on such rows, and there was no other reliable way to target that row's control (the control's `resource-id` is shared across rows → an id tap hits the first row; `--container` by the label scopes to the label's narrow subtree and excludes the control).

2. **New `instance` field on `tapOn`.** When a selector matches multiple elements, tap the Nth on-screen match (0-based, in hierarchy order) instead of applying `selectionStrategy` — the general way to target a repeated control that has no unique text to anchor on. Out of range returns no match.

Fixes #3522 (reaching a nested-label row's control). Closes #3524 (the `instance` selector).

## Implementation

- `ElementFinder.findClickableSiblingsInNode`: match on a child whose **subtree** contains the text (deep), and collect the clickable, non-text children at the **deepest** qualifying node. To keep a list/recycler ancestor from collecting a *sibling row's* control, only collect at a node whose text-bearing child is **not itself clickable** (a clickable text-bearing child means that child is the row and this node is the list). A matched row with no control of its own therefore resolves to a clean `null` rather than silently hitting another row's control. The prior shallow (direct-text-child) behavior is preserved.
- `instance`: added to `tapOnSchema` + `TapOnElementOptions`/`TapOnArgs`, threaded through `selectByText`/`selectByResourceId` and the sibling selectors into `pickMatch` (0-based index into the on-screen matches; overrides `selectionStrategy`; out of range → no match).

## Tests

- New unit coverage: nested-label rows resolve **each row's own** control; a control-less matched row returns `null` (regression for the wrong-tap case); the direct-sibling case still works; `instance` selects the Nth match and is out-of-range safe.
- Full selector/finder/tapOn/interaction suite green (351 tests, 0 fail).
- `typecheck` gate clean (no new errors), `eslint` clean.
- Documented `instance` in `docs/design-docs/mcp/tools.md`.

## Notes

- Empirically validated on a real device: `--sibling` removes the named row's control (not the first row's), and `--instance N` removes the Nth.
- Open question for reviewers: the external field is named `instance`; happy to rename to `index` (matching the internal param / Maestro's equivalent) if that's preferred.
