### PR TITLE
chore(observe): remove dead waitFor fallbacks

### DIFF
--- a/src/features/observe/android/CtrlProxyFocus.ts
+++ b/src/features/observe/android/CtrlProxyFocus.ts
@@ -350,7 +350,7 @@ export class CtrlProxyFocus {
       converted["view-id"] = node["view-id"];
     }
     if (node.className) {
-      converted.className = node.className;
+      converted.class = node.className;
     }
     if (node.packageName) {
       converted.packageName = node.packageName;

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -862,7 +862,7 @@ export class CtrlProxyHierarchy {
       converted["view-id"] = node["view-id"];
     }
     if (node.className) {
-      converted.className = node.className;
+      converted.class = node.className;
     }
     if (node.packageName) {
       converted.packageName = node.packageName;

--- a/src/features/observe/android/StableNodeIdentity.ts
+++ b/src/features/observe/android/StableNodeIdentity.ts
@@ -64,7 +64,6 @@ export const STABLE_VIEW_ID_PREFIX = "s-";
  * (#3051).
  */
 const CONTENT_FIELDS: readonly string[] = [
-  "className",
   "resource-id",
   "content-desc",
   "text",
@@ -115,6 +114,7 @@ export function assignStableViewIds(root: unknown): void {
     // JSON-encoding the field array keeps values from straddling separator
     // boundaries (text can contain any delimiter we might pick by hand).
     const canonical = JSON.stringify([
+      node["class"] ?? node.className ?? "",
       ...CONTENT_FIELDS.map(field => node[field] ?? ""),
       childHashes,
     ]);

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -265,22 +265,16 @@ const collectCandidateElements = (
 const getClassName = (element: Element): string | undefined =>
   typeof element.class === "string"
     ? element.class
-    : typeof element.className === "string"
-      ? element.className
-      : undefined;
+    : undefined;
 
 const getContentDescription = (element: Element, platform?: BootedDevice["platform"]): string | undefined =>
   typeof element["content-desc"] === "string"
     ? element["content-desc"]
     : typeof element["ios-accessibility-label"] === "string"
       ? element["ios-accessibility-label"]
-      : typeof element.contentDescription === "string"
-        ? element.contentDescription
-        : typeof element.accessibilityLabel === "string"
-          ? element.accessibilityLabel
-          : platform === "ios" && typeof element.text === "string"
-            ? element.text
-            : undefined;
+      : platform === "ios" && typeof element.text === "string"
+        ? element.text
+        : undefined;
 
 const textFieldsForElement = (element: Element): string[] => [
   element.text,

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1077,6 +1077,7 @@ describe("AndroidCtrlProxyClient", function() {
           "text": "6:43 AM",
           "content-desc": "6:43 AM",
           "resource-id": "com.google.android.deskclock:id/digital_clock",
+          "className": "android.widget.TextClock",
           "bounds": {
             left: 175,
             top: 687,
@@ -1088,6 +1089,7 @@ describe("AndroidCtrlProxyClient", function() {
           "node": [
             {
               text: "Child Node",
+              className: "android.widget.TextView",
               bounds: {
                 left: 0,
                 top: 0,
@@ -1106,6 +1108,8 @@ describe("AndroidCtrlProxyClient", function() {
       expect(result.hierarchy).toBeDefined();
       expect(result.hierarchy.text).toBe("6:43 AM");
       expect(result.hierarchy["content-desc"]).toBe("6:43 AM");
+      expect(result.hierarchy.class).toBe("android.widget.TextClock");
+      expect(result.hierarchy.className).toBeUndefined();
       expect(result.hierarchy.bounds).toEqual({
         left: 175,
         top: 687,
@@ -1127,6 +1131,8 @@ describe("AndroidCtrlProxyClient", function() {
       // Check child node conversion
       expect(typeof result.hierarchy.node).toBe("object");
       expect(result.hierarchy.node.text).toBe("Child Node");
+      expect(result.hierarchy.node.class).toBe("android.widget.TextView");
+      expect(result.hierarchy.node.className).toBeUndefined();
       expect(result.hierarchy.node.bounds).toEqual({
         left: 0,
         top: 0,

--- a/test/features/observe/android/stableNodeIdentity.test.ts
+++ b/test/features/observe/android/stableNodeIdentity.test.ts
@@ -79,6 +79,19 @@ describe("assignStableViewIds (#3228)", () => {
     expect(rowA["view-id"]).not.toEqual(rowB["view-id"]);
   });
 
+  test("canonical class and legacy className participate equivalently in identity", () => {
+    const canonical = node({ "view-id": generatedUuid("canonical"), "class": "android.widget.ImageView" });
+    const legacy = node({ "view-id": generatedUuid("legacy"), "className": "android.widget.ImageView" });
+    const different = node({ "view-id": generatedUuid("different"), "class": "android.widget.TextView" });
+
+    assignStableViewIds(canonical);
+    assignStableViewIds(legacy);
+    assignStableViewIds(different);
+
+    expect(canonical["view-id"]).toEqual(legacy["view-id"]);
+    expect(canonical["view-id"]).not.toEqual(different["view-id"]);
+  });
+
   test("interaction-state flips (checked/focused) do not change identity", () => {
     const off = node({ "view-id": generatedUuid("t"), "content-desc": "Wifi toggle", "checked": "false" });
     const on = node({ "view-id": generatedUuid("t"), "content-desc": "Wifi toggle", "checked": "true", "focused": "true" });

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -469,6 +469,59 @@ describe("findWaitForElement rich predicates", () => {
     expect(element?.class).toBe("android.widget.BottomNavigationView");
   });
 
+  test("ignores camelCase className attributes on parsed elements", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          className: "android.widget.BottomNavigationView",
+          bounds: bounds(10, 80, 190, 140),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        className: "android.widget.BottomNavigationView",
+      } as any,
+      hierarchy
+    );
+
+    expect(element).toBeNull();
+  });
+
+  test.each([
+    {
+      label: "contentDescription",
+      attributes: { contentDescription: "Home tab" },
+    },
+    {
+      label: "accessibilityLabel",
+      attributes: { accessibilityLabel: "Home tab" },
+    },
+  ])("ignores camelCase $label attributes on parsed elements", ({ attributes }) => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          ...attributes,
+          bounds: bounds(10, 80, 190, 140),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        contentDescription: "Home tab",
+      } as any,
+      hierarchy
+    );
+
+    expect(element).toBeNull();
+  });
+
   test("requires elementId and text to match the same node", () => {
     const finder = new DefaultElementFinder();
     const hierarchy = makeHierarchy([

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -752,6 +752,30 @@ describe("findWaitForElement rich predicates", () => {
     expect(element?.text).toBe("Home");
   });
 
+  test("matches canonical iOS accessibility labels for contentDescription", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      {
+        $: {
+          "ios-accessibility-label": "Home",
+          "class": "XCUIElementTypeButton",
+          "bounds": bounds(10, 10, 180, 60),
+        },
+      },
+    ]);
+
+    const element = findWaitForElement(
+      finder,
+      {
+        contentDescription: "Home",
+      } as any,
+      hierarchy,
+      "ios"
+    );
+
+    expect(element?.["ios-accessibility-label"]).toBe("Home");
+  });
+
   test("does not match Android text-only nodes for contentDescription", () => {
     const finder = new DefaultElementFinder();
     const hierarchy = makeHierarchy([


### PR DESCRIPTION
## Summary

Remove dead camelCase parsed-Element fallback branches from the observe `waitFor` matcher. Parsed hierarchy elements now use canonical attribute keys (`class`, `content-desc`, `ios-accessibility-label`), so matcher output lookup no longer treats `className`, `contentDescription`, or `accessibilityLabel` as parsed `Element` attributes.

The Android CtrlProxy conversion path now normalizes runner `className` into canonical `class` before matcher parsing, preserving real Android `waitFor.className` behavior without keeping the matcher fallback.

## Linked Issue

Closes #3513

## Bug / Regression Context

- **Prior attempts:** Follow-up cleanup from #3489.
- **Observed symptom:** Matcher helpers carried fallback branches for camelCase keys that parsed `Element` values should not canonically expose.
- **Repro steps / conditions:** A hierarchy node with only camelCase `className`, `contentDescription`, or `accessibilityLabel` could satisfy rich `waitFor` predicates before this cleanup. Android runner `className` output is normalized at ingest so production Android class matching still works.

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: no platform source changes touched
- [x] New code uses existing fakes/test helpers; focused matcher tests run in <100ms each
- [x] Rebased onto latest `main`, conflicts resolved

Additional targeted checks:
- [x] `bun test test/server/observeWaitForSchema.test.ts`
- [x] `bun test test/features/observe/CtrlProxyClient.test.ts test/features/observe/android/stableNodeIdentity.test.ts test/server/observeWaitForSchema.test.ts`

## Device Verification

Not run: matcher and hierarchy conversion cleanup covered by unit tests; no real-device verification in this worktree.

## Acceptance Criteria

- [x] Remove the dead `element.className` fallback from `getClassName`.
- [x] Remove the dead `element.contentDescription` fallback from `getContentDescription`.
- [x] Remove the dead `element.accessibilityLabel` fallback from `getContentDescription`.
- [x] Keep canonical keys working: `class`, `content-desc`, `ios-accessibility-label`, plus the iOS `text` fallback.
- [x] Preserve behavior for real parsed `Element` values, including Android runner `className` normalized to canonical `class` at ingest.

## Follow-ups

None.