### PR TITLE
fix(observe): fail fast on iOS activity waits

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3606,6 +3606,49 @@
       "required": [
         "platform"
       ],
+      "if": {
+        "required": [
+          "platform",
+          "waitFor"
+        ],
+        "properties": {
+          "platform": {
+            "const": "ios"
+          },
+          "waitFor": {
+            "required": [
+              "activeWindow"
+            ],
+            "properties": {
+              "activeWindow": {
+                "required": [
+                  "activityName"
+                ],
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "appId"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "bundleId"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "packageName"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": false,
       "additionalProperties": false
     },
     "outputSchema": {

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -10,7 +10,7 @@ import { BootedDevice, Element, ObserveResult, ObserveToolPayload, ViewHierarchy
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
-import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases, withJsonSchemaOverride } from "./toolSchemaHelpers";
 import { elementContainerSchema } from "./elementSelectorSchemas";
 import { observeToolResultSchema } from "./toolOutputSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
@@ -110,7 +110,7 @@ const waitForSchema = z.union([
   waitForElementSchema,
 ]);
 
-const observeBaseSchema = addDeviceTargetingToSchema(z.object({
+const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
   raw: z.boolean().optional().describe("Include raw view hierarchy"),
@@ -128,6 +128,29 @@ const observeBaseSchema = addDeviceTargetingToSchema(z.object({
       message: "activityName is Android-only; use appId/bundleId on iOS"
     });
   }
+}), jsonSchema => {
+  jsonSchema.if = {
+    required: ["platform", "waitFor"],
+    properties: {
+      platform: { const: "ios" },
+      waitFor: {
+        required: ["activeWindow"],
+        properties: {
+          activeWindow: {
+            required: ["activityName"],
+            not: {
+              anyOf: [
+                { required: ["appId"] },
+                { required: ["bundleId"] },
+                { required: ["packageName"] }
+              ]
+            }
+          }
+        }
+      }
+    }
+  };
+  jsonSchema.then = false;
 });
 
 export const observeSchema = withAppIdAliases(observeBaseSchema);

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -110,12 +110,27 @@ const waitForSchema = z.union([
   waitForElementSchema,
 ]);
 
-export const observeSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
+const observeBaseSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
   raw: z.boolean().optional().describe("Include raw view hierarchy"),
   skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling")
-})));
+})).superRefine((value, ctx) => {
+  const activeWindow = value.waitFor?.activeWindow;
+  if (
+    value.platform === "ios" &&
+    activeWindow?.activityName !== undefined &&
+    activeWindow.appId === undefined
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["waitFor", "activeWindow", "activityName"],
+      message: "activityName is Android-only; use appId/bundleId on iOS"
+    });
+  }
+});
+
+export const observeSchema = withAppIdAliases(observeBaseSchema);
 
 export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema,

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -370,6 +370,17 @@ describe("published observe waitFor input schema", () => {
         },
       },
     },
+    {
+      label: "iOS activeWindow has activityName without app id",
+      input: {
+        platform: "ios",
+        waitFor: {
+          activeWindow: {
+            activityName: "com.example.ios.IgnoredActivity",
+          },
+        },
+      },
+    },
   ])("rejects runtime-invalid waitFor input: $label", ({ input }) => {
     expect(observeSchema.safeParse(input).success).toBe(false);
 

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -846,28 +846,18 @@ describe("waitForObservation activeWindow", () => {
     expect(observeScreen.getExecuteCallCount()).toBe(1);
   });
 
-  test("does not satisfy iOS activeWindow with only Android activityName", async () => {
-    const timer = new FakeTimer();
-    timer.enableAutoAdvance();
-    const observeScreen = new FakeObserveScreen();
-    observeScreen.setObserveResult(() => makeObservation("com.example.ios", ""));
-
-    const outcome = await waitForObservation(
-      observeScreen,
-      {
-        activeWindow: {
-          activityName: "com.example.ios.IgnoredActivity",
+  test("rejects iOS activeWindow with only Android activityName", () => {
+    expect(() =>
+      observeSchema.parse({
+        platform: "ios",
+        waitFor: {
+          activeWindow: {
+            activityName: "com.example.ios.IgnoredActivity",
+          },
+          timeout: 250,
         },
-        timeout: 250,
-      } as any,
-      undefined,
-      false,
-      timer,
-      "ios"
-    );
-
-    expect(outcome.awaitTimeout).toBe(true);
-    expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(1);
+      })
+    ).toThrow("activityName is Android-only; use appId/bundleId on iOS");
   });
 
   test("times out when only the element predicate matches", async () => {


### PR DESCRIPTION
## Summary

Reject impossible iOS `observe.waitFor` predicates that provide only Android `activityName`, so callers get an immediate actionable validation error instead of waiting for a timeout.

## Linked Issue

Closes #3512

## Bug / Regression Context

- **Prior attempts:** Follow-up from PR #3489, which added richer `observe.waitFor` predicates.
- **Observed symptom:** `platform: "ios"` with `waitFor.activeWindow.activityName` and no app/bundle identifier could never match, so `observe` burned the full timeout and returned `awaitTimeout: true`.
- **Repro steps / conditions:** Call `observe` on iOS with `waitFor: { activeWindow: { activityName: "..." } }` and no `appId`/`bundleId`.

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: no platform source changes touched
- [x] New code uses existing schema validation and FakeTimer-backed unit coverage; targeted unit tests run in <100ms each
- [ ] Rebased onto latest `main`, conflicts resolved

Additional targeted checks:
- [x] `bun test test/server/observeWaitForSchema.test.ts`

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Not run: no real-device verification in this worktree; the change is covered by schema/unit tests.

## Acceptance Criteria

- [x] iOS `activeWindow.activityName` without an app/bundle identifier fails fast during validation.
- [x] The failure message is actionable: `activityName is Android-only; use appId/bundleId on iOS`.
- [x] Android `activityName` waits and iOS app-id waits remain covered by existing tests.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: none

Made with [Cursor](https://cursor.com)