### PR TITLE
Expose occluding view ids in observe hierarchies

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1425,7 +1425,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     val subtreeEnd: Int,
   )
 
-  private data class OcclusionInfo(val coverage: Double, val occludedBy: String?)
+  private data class OcclusionInfo(
+    val coverage: Double,
+    val occludedBy: String?,
+    val occludedByViewId: String?,
+  )
 
   /** Represents the relationship between two nodes in a tree hierarchy. */
   enum class NodeRelationship {
@@ -1545,6 +1549,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val intersections = mutableListOf<ElementBounds>()
       var maxOverlap = 0
       var occludedBy: String? = null
+      var occludedByViewId: String? = null
 
       // Debug: Track occlusion for text nodes
       val isDebugNode = node.element.text == "Tap" || node.element.text == "Discover"
@@ -1609,6 +1614,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         if (overlapArea > maxOverlap) {
           maxOverlap = overlapArea
           occludedBy = resolveOccluderLabel(occluder)
+          occludedByViewId = occluder.element.viewId
         }
       }
 
@@ -1623,7 +1629,12 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           )
         }
         if (coverage > 0.0) {
-          occlusionInfo[node.key] = OcclusionInfo(coverage = coverage, occludedBy = occludedBy)
+          occlusionInfo[node.key] =
+            OcclusionInfo(
+              coverage = coverage,
+              occludedBy = occludedBy,
+              occludedByViewId = occludedByViewId,
+            )
         }
       }
     }
@@ -1714,6 +1725,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       node = nodeToUse,
       occlusionState = occlusionState,
       occludedBy = info?.occludedBy,
+      occludedByViewId = info?.occludedByViewId,
     )
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
@@ -52,6 +52,8 @@ data class UIElementInfo(
   @SerialName("extras") val extras: Map<String, String>? = null, // Custom extras from semantics
   val occlusionState: String? = null, // visible | partial | hidden
   val occludedBy: String? = null, // Resource ID or label of the occluding view
+  @SerialName("occludedByViewId")
+  val occludedByViewId: String? = null, // Stable view-id of the occluding view
   val recomposition: RecompositionEntry? = null,
 
   // Use JsonElement to allow flexible structure matching test expectations

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -445,7 +445,12 @@ class ViewHierarchyExtractorTest {
   fun `occlusion filter keeps partial overlap and annotates metadata`() {
     val target = elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
     val targetParent = elementWithBounds(resourceId = "partial-parent", children = listOf(target))
-    val occluder = elementWithBounds(resourceId = "partial-occluder", bounds = bounds(0, 0, 50, 50))
+    val occluder =
+      elementWithBounds(
+        resourceId = "partial-occluder",
+        viewId = "stable-partial-occluder",
+        bounds = bounds(0, 0, 50, 50),
+      )
     val occluderParent =
       elementWithBounds(resourceId = "occluder-parent", children = listOf(occluder))
     val root = elementWithBounds(children = listOf(targetParent, occluderParent))
@@ -457,6 +462,31 @@ class ViewHierarchyExtractorTest {
     assertNotNull(targetResult)
     assertEquals("partial", targetResult!!.occlusionState)
     assertEquals("partial-occluder", targetResult.occludedBy)
+    assertEquals("stable-partial-occluder", targetResult.occludedByViewId)
+  }
+
+  @Test
+  fun `occlusion filter annotates unlabeled occluder with view id`() {
+    val target =
+      elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
+    val targetParent = elementWithBounds(resourceId = "partial-parent", children = listOf(target))
+    val occluder =
+      elementWithBounds(
+        viewId = "stable-unlabeled-occluder",
+        bounds = bounds(0, 0, 50, 50),
+      )
+    val occluderParent =
+      elementWithBounds(resourceId = "occluder-parent", children = listOf(occluder))
+    val root = elementWithBounds(children = listOf(targetParent, occluderParent))
+
+    val filtered = extractor.applyOcclusionFilteringSingleWindowForTest(root)
+
+    assertNotNull(filtered)
+    val targetResult = findElementByResourceId(filtered!!, "partial-target")
+    assertNotNull(targetResult)
+    assertEquals("partial", targetResult!!.occlusionState)
+    assertEquals("unlabeled view", targetResult.occludedBy)
+    assertEquals("stable-unlabeled-occluder", targetResult.occludedByViewId)
   }
 
   @Test
@@ -487,6 +517,7 @@ class ViewHierarchyExtractorTest {
     assertNotNull(filtered)
     assertEquals("hidden", filtered!!.occlusionState)
     assertEquals("occluding-root", filtered.occludedBy)
+    assertEquals("occluding-root", filtered.occludedByViewId)
     assertNotNull(findElementByResourceId(filtered, "root-child"))
   }
 
@@ -983,6 +1014,22 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `occludedByViewId field is serialized to JSON with correct key`() {
+    val element =
+      UIElementInfo(
+        text = "Covered",
+        occlusionState = "partial",
+        occludedBy = "unlabeled view",
+        occludedByViewId = "stable-unlabeled-occluder",
+      )
+    val jsonString = json.encodeToString(UIElementInfo.serializer(), element)
+    assertTrue(
+      "JSON should contain occludedByViewId field",
+      jsonString.contains("\"occludedByViewId\""),
+    )
+  }
+
+  @Test
   fun `detectContentHiddenRegions finds large empty non-interactive Compose descendant with sparse child coverage`() {
     val visibleToolbar =
       elementWithBounds(
@@ -1188,6 +1235,7 @@ class ViewHierarchyExtractorTest {
 
   private fun elementWithBounds(
     resourceId: String? = null,
+    viewId: String? = resourceId,
     bounds: ElementBounds? = null,
     className: String? = null,
     text: String? = null,
@@ -1203,6 +1251,7 @@ class ViewHierarchyExtractorTest {
       }
     return UIElementInfo(
       resourceId = resourceId,
+      viewId = viewId,
       bounds = bounds,
       className = className,
       text = text,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -409,6 +409,7 @@ class ViewHierarchyExtractorTest {
     assertNull(targetResult.occludedBy)
   }
 
+  @Test
   fun `same-window occlusion skip rescues an asymmetric-depth cousin that fix 3 cannot`() {
     // Faithful reproduction of the channel-header shape AND the justification for the full
     // same-window skip (Option B) over the narrower determineNodeRelationship patch (Option A).
@@ -525,8 +526,7 @@ class ViewHierarchyExtractorTest {
 
   @Test
   fun `cross-window occlusion annotates unlabeled occluder with view id`() {
-    val target =
-      elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
+    val target = elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
     val appRoot =
       elementWithBounds(
         resourceId = "app-root",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -168,6 +168,15 @@
             "content-desc": {
               "type": "string"
             },
+            "occlusionState": {
+              "type": "string"
+            },
+            "occludedBy": {
+              "type": "string"
+            },
+            "occludedByViewId": {
+              "type": "string"
+            },
             "class": {
               "type": "string"
             },
@@ -4118,6 +4127,15 @@
             "content-desc": {
               "type": "string"
             },
+            "occlusionState": {
+              "type": "string"
+            },
+            "occludedBy": {
+              "type": "string"
+            },
+            "occludedByViewId": {
+              "type": "string"
+            },
             "class": {
               "type": "string"
             },
@@ -4308,6 +4326,15 @@
             "content-desc": {
               "type": "string"
             },
+            "occlusionState": {
+              "type": "string"
+            },
+            "occludedBy": {
+              "type": "string"
+            },
+            "occludedByViewId": {
+              "type": "string"
+            },
             "class": {
               "type": "string"
             },
@@ -4496,6 +4523,15 @@
               "type": "string"
             },
             "content-desc": {
+              "type": "string"
+            },
+            "occlusionState": {
+              "type": "string"
+            },
+            "occludedBy": {
+              "type": "string"
+            },
+            "occludedByViewId": {
               "type": "string"
             },
             "class": {
@@ -6831,6 +6867,15 @@
             "content-desc": {
               "type": "string"
             },
+            "occlusionState": {
+              "type": "string"
+            },
+            "occludedBy": {
+              "type": "string"
+            },
+            "occludedByViewId": {
+              "type": "string"
+            },
             "class": {
               "type": "string"
             },
@@ -7111,6 +7156,15 @@
                     "content-desc": {
                       "type": "string"
                     },
+                    "occlusionState": {
+                      "type": "string"
+                    },
+                    "occludedBy": {
+                      "type": "string"
+                    },
+                    "occludedByViewId": {
+                      "type": "string"
+                    },
                     "class": {
                       "type": "string"
                     },
@@ -7299,6 +7353,15 @@
                       "type": "string"
                     },
                     "content-desc": {
+                      "type": "string"
+                    },
+                    "occlusionState": {
+                      "type": "string"
+                    },
+                    "occludedBy": {
+                      "type": "string"
+                    },
+                    "occludedByViewId": {
                       "type": "string"
                     },
                     "class": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -165,6 +165,9 @@
             "resource-id": {
               "type": "string"
             },
+            "view-id": {
+              "type": "string"
+            },
             "content-desc": {
               "type": "string"
             },
@@ -4124,6 +4127,9 @@
             "resource-id": {
               "type": "string"
             },
+            "view-id": {
+              "type": "string"
+            },
             "content-desc": {
               "type": "string"
             },
@@ -4323,6 +4329,9 @@
             "resource-id": {
               "type": "string"
             },
+            "view-id": {
+              "type": "string"
+            },
             "content-desc": {
               "type": "string"
             },
@@ -4520,6 +4529,9 @@
               "type": "string"
             },
             "resource-id": {
+              "type": "string"
+            },
+            "view-id": {
               "type": "string"
             },
             "content-desc": {
@@ -6864,6 +6876,9 @@
             "resource-id": {
               "type": "string"
             },
+            "view-id": {
+              "type": "string"
+            },
             "content-desc": {
               "type": "string"
             },
@@ -7153,6 +7168,9 @@
                     "resource-id": {
                       "type": "string"
                     },
+                    "view-id": {
+                      "type": "string"
+                    },
                     "content-desc": {
                       "type": "string"
                     },
@@ -7350,6 +7368,9 @@
                       "type": "string"
                     },
                     "resource-id": {
+                      "type": "string"
+                    },
+                    "view-id": {
                       "type": "string"
                     },
                     "content-desc": {

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -662,6 +662,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       "extras",
       "occlusionState",
       "occludedBy",
+      "occludedByViewId",
       "recomposition",
       "recompositionMetrics"
     ];

--- a/src/features/observe/android/CtrlProxyFocus.ts
+++ b/src/features/observe/android/CtrlProxyFocus.ts
@@ -392,6 +392,9 @@ export class CtrlProxyFocus {
     if (node.occludedBy) {
       converted.occludedBy = node.occludedBy;
     }
+    if (node.occludedByViewId) {
+      converted.occludedByViewId = node.occludedByViewId;
+    }
     if (node.extras) {
       converted.extras = node.extras;
     }

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -24,7 +24,7 @@ import type {
 } from "./types";
 import { generateSecureId } from "./types";
 import { ctrlProxyRequests, serializeCtrlProxyRequest } from "./ctrlProxyProtocol";
-import { assignStableViewIds } from "./StableNodeIdentity";
+import { applyStableViewIdRewrites, assignStableViewIds } from "./StableNodeIdentity";
 
 /** Cooldown after a WebSocket timeout before retrying fresh-data waits.
  *  Keep short: a long cooldown (e.g. 5s) turns a single slow response into
@@ -491,15 +491,17 @@ export class CtrlProxyHierarchy {
       // positional (path-derived UUID) view-ids into content-derived stable ids
       // so id-less rows keep their identity across a scroll and the diff
       // layer's content-identity re-pair can collapse scroll churn.
-      assignStableViewIds(convertedHierarchy);
+      const hierarchyViewIdRewrites = assignStableViewIds(convertedHierarchy);
 
       // Convert accessibility-focused element if present
       const accessibilityFocusedElement = accessibilityHierarchy["accessibility-focused-element"]
         ? this.convertAccessibilityNode(accessibilityHierarchy["accessibility-focused-element"])
         : undefined;
-      // Same rewrite for the focus mirror so its view-id matches the hierarchy
-      // node's (the mirror is the same node content, so the content hash
-      // agrees; only a content-identical duplicate's ordinal suffix can differ).
+      // Reuse the hierarchy rewrite map first so mirror links point at the exact
+      // ids emitted in the hierarchy, including occluders outside the mirror.
+      applyStableViewIdRewrites(accessibilityFocusedElement, hierarchyViewIdRewrites);
+      // Fallback for mirrors that contain generated ids absent from the hierarchy
+      // map; resource-id-backed and already-rewritten ids are left untouched.
       assignStableViewIds(accessibilityFocusedElement);
 
       const result: ViewHierarchyResult = {

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -904,6 +904,9 @@ export class CtrlProxyHierarchy {
     if (node.occludedBy) {
       converted.occludedBy = node.occludedBy;
     }
+    if (node.occludedByViewId) {
+      converted.occludedByViewId = node.occludedByViewId;
+    }
     if (node.extras) {
       converted.extras = node.extras;
     }

--- a/src/features/observe/android/StableNodeIdentity.ts
+++ b/src/features/observe/android/StableNodeIdentity.ts
@@ -91,9 +91,9 @@ function toChildArray(node: Record<string, unknown>): Record<string, unknown>[] 
  * own output. Accepts the converted hierarchy root (or any node-like object);
  * a non-object input is ignored.
  */
-export function assignStableViewIds(root: unknown): void {
+export function assignStableViewIds(root: unknown): Map<string, string> {
   if (!root || typeof root !== "object") {
-    return;
+    return new Map();
   }
   if (Array.isArray(root)) {
     // A multi-root capture: each root is an independent tree, but duplicates
@@ -102,7 +102,7 @@ export function assignStableViewIds(root: unknown): void {
     for (const item of root) {
       assignStableViewIds(item);
     }
-    return;
+    return new Map();
   }
   const rootNode = root as Record<string, unknown>;
 
@@ -149,19 +149,44 @@ export function assignStableViewIds(root: unknown): void {
   // runner fills occludedByViewId from the occluding node's pre-ingest view-id;
   // generated UUID ids are rewritten above, so references to those ids must
   // follow the same rewrite.
-  if (rewrittenViewIds.size > 0) {
-    const remapOcclusionReferences = (node: Record<string, unknown>): void => {
-      const occludedByViewId = node.occludedByViewId;
-      if (typeof occludedByViewId === "string") {
-        const stableViewId = rewrittenViewIds.get(occludedByViewId);
-        if (stableViewId) {
-          node.occludedByViewId = stableViewId;
-        }
-      }
-      for (const child of toChildArray(node)) {
-        remapOcclusionReferences(child);
-      }
-    };
-    remapOcclusionReferences(rootNode);
+  applyStableViewIdRewrites(rootNode, rewrittenViewIds);
+  return rewrittenViewIds;
+}
+
+/**
+ * Apply a view-id rewrite map produced from a related hierarchy tree. This keeps
+ * mirror nodes (for example `accessibility-focused-element`) linked to the exact
+ * ids emitted in the full hierarchy rather than recomputing them in isolation.
+ */
+export function applyStableViewIdRewrites(
+  root: unknown,
+  rewrittenViewIds: ReadonlyMap<string, string>
+): void {
+  if (!root || typeof root !== "object" || rewrittenViewIds.size === 0) {
+    return;
+  }
+  if (Array.isArray(root)) {
+    for (const item of root) {
+      applyStableViewIdRewrites(item, rewrittenViewIds);
+    }
+    return;
+  }
+  const node = root as Record<string, unknown>;
+  const viewId = node["view-id"];
+  if (typeof viewId === "string") {
+    const stableViewId = rewrittenViewIds.get(viewId);
+    if (stableViewId) {
+      node["view-id"] = stableViewId;
+    }
+  }
+  const occludedByViewId = node.occludedByViewId;
+  if (typeof occludedByViewId === "string") {
+    const stableViewId = rewrittenViewIds.get(occludedByViewId);
+    if (stableViewId) {
+      node.occludedByViewId = stableViewId;
+    }
+  }
+  for (const child of toChildArray(node)) {
+    applyStableViewIdRewrites(child, rewrittenViewIds);
   }
 }

--- a/src/features/observe/android/StableNodeIdentity.ts
+++ b/src/features/observe/android/StableNodeIdentity.ts
@@ -60,8 +60,8 @@ export const STABLE_VIEW_ID_PREFIX = "s-";
  * `bounds` and sibling order shift on scroll; `focused` / `checked` /
  * `selected` / `enabled` flip on interaction (a toggle should surface as a
  * `changed` delta, not an identity change); `extras` and
- * `occlusionState`/`occludedBy` churn nondeterministically between captures
- * (#3051).
+ * `occlusionState`/`occludedBy`/`occludedByViewId` churn nondeterministically
+ * between captures (#3051, #3519).
  */
 const CONTENT_FIELDS: readonly string[] = [
   "className",
@@ -127,18 +127,41 @@ export function assignStableViewIds(root: unknown): void {
   // Pass 2 (pre-order): assign ids, suffixing content-identical duplicates by
   // document-order occurrence so ids stay unique within the capture.
   const occurrences = new Map<string, number>();
+  const rewrittenViewIds = new Map<string, string>();
   const assign = (node: Record<string, unknown>): void => {
     const viewId = node["view-id"];
     if (typeof viewId === "string" && GENERATED_VIEW_ID_PATTERN.test(viewId)) {
       const hash = contentHash.get(node)!;
       const seen = (occurrences.get(hash) ?? 0) + 1;
       occurrences.set(hash, seen);
-      node["view-id"] =
+      const stableViewId =
         seen === 1 ? `${STABLE_VIEW_ID_PREFIX}${hash}` : `${STABLE_VIEW_ID_PREFIX}${hash}-${seen}`;
+      node["view-id"] = stableViewId;
+      rewrittenViewIds.set(viewId, stableViewId);
     }
     for (const child of toChildArray(node)) {
       assign(child);
     }
   };
   assign(rootNode);
+
+  // Keep occlusion links pointing at the final emitted hierarchy ids. The
+  // runner fills occludedByViewId from the occluding node's pre-ingest view-id;
+  // generated UUID ids are rewritten above, so references to those ids must
+  // follow the same rewrite.
+  if (rewrittenViewIds.size > 0) {
+    const remapOcclusionReferences = (node: Record<string, unknown>): void => {
+      const occludedByViewId = node.occludedByViewId;
+      if (typeof occludedByViewId === "string") {
+        const stableViewId = rewrittenViewIds.get(occludedByViewId);
+        if (stableViewId) {
+          node.occludedByViewId = stableViewId;
+        }
+      }
+      for (const child of toChildArray(node)) {
+        remapOcclusionReferences(child);
+      }
+    };
+    remapOcclusionReferences(rootNode);
+  }
 }

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -69,6 +69,7 @@ export interface AccessibilityNode {
   "long-clickable"?: string;
   occlusionState?: string;
   occludedBy?: string;
+  occludedByViewId?: string;
   extras?: Record<string, string>;
   recomposition?: RecompositionNodeInfo;
   node?: AccessibilityNode | AccessibilityNode[];

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -98,8 +98,10 @@ export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveCo
   reduceTopLevelDebugPerfTelemetry(out);
 
   if (cfg.trimNodes !== false) {
-    for (const root of toNodeArray(out.viewHierarchy?.hierarchy?.node)) {
-      trimHierarchyNodes(root);
+    const roots = toNodeArray(out.viewHierarchy?.hierarchy?.node);
+    const referencedOccluderViewIds = collectOccludedByViewIds(roots);
+    for (const root of roots) {
+      trimHierarchyNodes(root, referencedOccluderViewIds);
     }
   }
 
@@ -199,7 +201,30 @@ function toNodeArray(
  * `view-id` when it duplicates `resource-id`, omit default-false booleans, and
  * omit empty-string fields. Lossless for decision-making.
  */
-function trimHierarchyNodes(node: ViewHierarchyNode | undefined): void {
+function collectOccludedByViewIds(nodes: ViewHierarchyNode[]): Set<string> {
+  const referencedViewIds = new Set<string>();
+  const visit = (node: ViewHierarchyNode | undefined): void => {
+    if (!node) {
+      return;
+    }
+    const occludedByViewId = (node as unknown as Record<string, unknown>).occludedByViewId;
+    if (typeof occludedByViewId === "string" && occludedByViewId !== "") {
+      referencedViewIds.add(occludedByViewId);
+    }
+    for (const child of toNodeArray(node.node)) {
+      visit(child);
+    }
+  };
+  for (const node of nodes) {
+    visit(node);
+  }
+  return referencedViewIds;
+}
+
+function trimHierarchyNodes(
+  node: ViewHierarchyNode | undefined,
+  referencedOccluderViewIds: ReadonlySet<string>
+): void {
   if (!node) {
     return;
   }
@@ -207,7 +232,11 @@ function trimHierarchyNodes(node: ViewHierarchyNode | undefined): void {
   const attrs = node as unknown as Record<string, unknown>;
 
   // Drop view-id when it is identical to resource-id (redundant duplicate).
-  if (attrs["view-id"] !== undefined && attrs["view-id"] === attrs["resource-id"]) {
+  if (
+    typeof attrs["view-id"] === "string"
+    && attrs["view-id"] === attrs["resource-id"]
+    && !referencedOccluderViewIds.has(attrs["view-id"])
+  ) {
     delete attrs["view-id"];
   }
 
@@ -231,7 +260,7 @@ function trimHierarchyNodes(node: ViewHierarchyNode | undefined): void {
   }
 
   for (const child of toNodeArray(node.node)) {
-    trimHierarchyNodes(child);
+    trimHierarchyNodes(child, referencedOccluderViewIds);
   }
 }
 

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -106,6 +106,7 @@ export interface ViewHierarchyNode {
   recompositionMetrics?: RecompositionMetrics;
   occlusionState?: string;
   occludedBy?: string;
+  occludedByViewId?: string;
   "test-tag"?: string;
   "view-id"?: string;
   extras?: Record<string, string>;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -63,6 +63,9 @@ export const elementSchema = z.object({
   "text": z.string().optional(),
   "resource-id": z.string().optional(),
   "content-desc": z.string().optional(),
+  "occlusionState": z.string().optional(),
+  "occludedBy": z.string().optional(),
+  "occludedByViewId": z.string().optional(),
   "class": z.string().optional(),
   "package": z.string().optional(),
   "checkable": booleanOrString,
@@ -271,6 +274,9 @@ export const accessibilityFocusResultSchema = z.object({
 export const viewHierarchyNodeSchema: z.ZodType = z.lazy(() =>
   z.object({
     bounds: elementBoundsSchema.optional(),
+    occlusionState: z.string().optional(),
+    occludedBy: z.string().optional(),
+    occludedByViewId: z.string().optional(),
     node: z.union([viewHierarchyNodeSchema, z.array(viewHierarchyNodeSchema)]).optional()
   }).passthrough()
 );

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -62,6 +62,7 @@ export const elementSchema = z.object({
   "bounds": elementBoundsSchema,
   "text": z.string().optional(),
   "resource-id": z.string().optional(),
+  "view-id": z.string().optional(),
   "content-desc": z.string().optional(),
   "occlusionState": z.string().optional(),
   "occludedBy": z.string().optional(),

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1077,6 +1077,9 @@ describe("AndroidCtrlProxyClient", function() {
           "text": "6:43 AM",
           "content-desc": "6:43 AM",
           "resource-id": "com.google.android.deskclock:id/digital_clock",
+          "occlusionState": "partial",
+          "occludedBy": "Debug menu",
+          "occludedByViewId": "stable-debug-menu",
           "bounds": {
             left: 175,
             top: 687,
@@ -1114,6 +1117,9 @@ describe("AndroidCtrlProxyClient", function() {
       });
       expect(result.hierarchy.clickable).toBeUndefined();
       expect(result.hierarchy.enabled).toBe("true");
+      expect(result.hierarchy.occlusionState).toBe("partial");
+      expect(result.hierarchy.occludedBy).toBe("Debug menu");
+      expect(result.hierarchy.occludedByViewId).toBe("stable-debug-menu");
       expect(result.intentChooserDetected).toBe(true);
       expect(result.notificationPermissionDetected).toBe(true);
       expect(result.contentHiddenRegions).toEqual([

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1214,6 +1214,52 @@ describe("AndroidCtrlProxyClient", function() {
       expect(before.hierarchy["view-id"]).toBe("com.test.app:id/root");
     });
 
+    test("rewrites accessibility-focused mirror occlusion links against the emitted hierarchy ids", function() {
+      const focusedUuid = "11111111-1111-4111-8111-111111111111";
+      const occluderUuid = "22222222-2222-4222-8222-222222222222";
+      const accessibilityHierarchy = {
+        "updatedAt": 1750934583218,
+        "packageName": "com.test.app",
+        "hierarchy": {
+          "resource-id": "com.test.app:id/root",
+          "view-id": "com.test.app:id/root",
+          "node": [
+            {
+              "view-id": focusedUuid,
+              "text": "Covered",
+              "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+              "occlusionState": "partial",
+              "occludedBy": "unlabeled view",
+              "occludedByViewId": occluderUuid,
+            },
+            {
+              "view-id": occluderUuid,
+              "bounds": { left: 0, top: 0, right: 50, bottom: 50 },
+            },
+          ],
+        },
+        "accessibility-focused-element": {
+          "view-id": focusedUuid,
+          "text": "Covered",
+          "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+          "occlusionState": "partial",
+          "occludedBy": "unlabeled view",
+          "occludedByViewId": occluderUuid,
+        },
+      };
+
+      const result = accessibilityServiceClient.convertToViewHierarchyResult(accessibilityHierarchy);
+      const hierarchyChildren = result.hierarchy.node as any[];
+      const focusedNode = hierarchyChildren[0];
+      const occluderNode = hierarchyChildren[1];
+      const focusedMirror = result["accessibility-focused-element"] as any;
+
+      expect(focusedNode.occludedByViewId).toBe(occluderNode["view-id"]);
+      expect(focusedMirror["view-id"]).toBe(focusedNode["view-id"]);
+      expect(focusedMirror.occludedByViewId).toBe(occluderNode["view-id"]);
+      expect(focusedMirror.occludedByViewId).not.toBe(occluderUuid);
+    });
+
   });
 
   describe("getAccessibilityHierarchy", function() {

--- a/test/features/observe/ViewHierarchy.filter.test.ts
+++ b/test/features/observe/ViewHierarchy.filter.test.ts
@@ -38,6 +38,36 @@ describe("ViewHierarchy filtering", () => {
     });
   });
 
+  test("preserves occlusion metadata when filtering retained nodes", () => {
+    const viewHierarchy = new ViewHierarchy(device, new FakeAdbClientFactory());
+    const result = viewHierarchy.filterViewHierarchy({
+      hierarchy: {
+        node: {
+          bounds: { left: 0, top: 0, right: 1080, bottom: 1920 },
+          node: [
+            {
+              "resource-id": "com.example:id/title",
+              "view-id": "com.example:id/title",
+              "bounds": { left: 0, top: 100, right: 800, bottom: 180 },
+              "occlusionState": "partial",
+              "occludedBy": "unlabeled view",
+              "occludedByViewId": "stable-occluder",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.hierarchy.node).toEqual({
+      "resource-id": "com.example:id/title",
+      "view-id": "com.example:id/title",
+      "bounds": { left: 0, top: 100, right: 800, bottom: 180 },
+      "occlusionState": "partial",
+      "occludedBy": "unlabeled view",
+      "occludedByViewId": "stable-occluder",
+    });
+  });
+
   test("filters a cloned hierarchy without mutating the source", () => {
     const viewHierarchy = new ViewHierarchy(device, new FakeAdbClientFactory());
     const source = {

--- a/test/features/observe/android/stableNodeIdentity.test.ts
+++ b/test/features/observe/android/stableNodeIdentity.test.ts
@@ -110,6 +110,28 @@ describe("assignStableViewIds (#3228)", () => {
     expect(root).toEqual(snapshot);
   });
 
+  test("rewrites occludedByViewId references when generated occluder ids are stabilized", () => {
+    const occluderUuid = generatedUuid("overlay");
+    const occluded = node({
+      "view-id": generatedUuid("covered"),
+      "text": "Covered",
+      "occlusionState": "partial",
+      "occludedBy": "unlabeled view",
+      "occludedByViewId": occluderUuid,
+    });
+    const occluder = node({
+      "view-id": occluderUuid,
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+    });
+    const root = node({ "view-id": generatedUuid("root") }, [occluded, occluder]);
+
+    assignStableViewIds(root);
+
+    const children = root.node as Record<string, unknown>[];
+    expect(children[0].occludedByViewId).toBe(children[1]["view-id"]);
+    expect(GENERATED_VIEW_ID_PATTERN.test(children[0].occludedByViewId as string)).toBe(false);
+  });
+
   test("handles single-object and array child slots plus non-object input", () => {
     const single = node({ "view-id": generatedUuid("p") }, [node({ "view-id": generatedUuid("c"), "text": "only" })]);
     expect(Array.isArray(single.node)).toBe(false); // single child is an object, not an array

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -340,6 +340,49 @@ describe("sanitizeObserveResult", () => {
       expect(out.viewHierarchy!.hierarchy!.node!["view-id"]).toBe("distinct-uuid");
     });
 
+    test("preserves duplicate view-id when referenced by occludedByViewId", () => {
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: {
+          hierarchy: {
+            node: [
+              {
+                "resource-id": "id/covered",
+                "view-id": "id/covered",
+                "occludedByViewId": "id/overlay",
+                "node": [],
+                "$": {},
+              },
+              {
+                "resource-id": "id/overlay",
+                "view-id": "id/overlay",
+                "node": [],
+                "$": {},
+              },
+              {
+                "resource-id": "id/unreferenced",
+                "view-id": "id/unreferenced",
+                "node": [],
+                "$": {},
+              },
+            ] as any,
+          },
+        },
+      };
+
+      const out = sanitizeObserveResult(obs, DROP_NONE);
+      const [covered, overlay, unreferenced] = out.viewHierarchy!.hierarchy!.node as unknown as Array<
+        Record<string, unknown>
+      >;
+
+      expect(covered.occludedByViewId).toBe("id/overlay");
+      expect(covered["view-id"]).toBeUndefined();
+      expect(overlay["view-id"]).toBe("id/overlay");
+      expect(unreferenced["view-id"]).toBeUndefined();
+    });
+
     test("omits default-false booleans and empty-string fields (synthetic)", () => {
       const obs: ObserveResult = {
         updatedAt: 0,

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -137,10 +137,19 @@ describe("viewHierarchyNodeSchema: polymorphic node + bounds union (#3025)", () 
   });
 
   test("keeps the polymorphic `$` attribute bag and per-node metadata", () => {
-    const node = { "$": { class: "android.widget.TextView" }, "view-id": "id/foo", "occlusionState": "none" };
+    const node = {
+      "$": { class: "android.widget.TextView" },
+      "view-id": "id/foo",
+      "occlusionState": "partial",
+      "occludedBy": "unlabeled view",
+      "occludedByViewId": "id/occluder",
+    };
     const parsed = viewHierarchyNodeSchema.parse(node) as Record<string, unknown>;
     expect(parsed["$"]).toEqual({ class: "android.widget.TextView" });
     expect(parsed["view-id"]).toBe("id/foo");
+    expect(parsed.occlusionState).toBe("partial");
+    expect(parsed.occludedBy).toBe("unlabeled view");
+    expect(parsed.occludedByViewId).toBe("id/occluder");
   });
 });
 

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -151,6 +151,19 @@ describe("viewHierarchyNodeSchema: polymorphic node + bounds union (#3025)", () 
     expect(parsed.occludedBy).toBe("unlabeled view");
     expect(parsed.occludedByViewId).toBe("id/occluder");
   });
+
+  test("advertises occlusion metadata as typed node properties", () => {
+    const schemaJson = JSON.stringify(toJSONSchema(viewHierarchyNodeSchema));
+    expect(schemaJson).toContain("\"occlusionState\"");
+    expect(schemaJson).toContain("\"occludedBy\"");
+    expect(schemaJson).toContain("\"occludedByViewId\"");
+    expect(() =>
+      viewHierarchyNodeSchema.parse({
+        bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+        occludedByViewId: 123,
+      })
+    ).toThrow();
+  });
 });
 
 describe("observeResultSchema: every bounds site is the advertised union (#3025)", () => {

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { toJSONSchema } from "zod";
 import {
+  elementSchema,
   observeResultSchema,
   observeToolResultSchema,
   viewHierarchyNodeSchema,
@@ -161,6 +162,27 @@ describe("viewHierarchyNodeSchema: polymorphic node + bounds union (#3025)", () 
       viewHierarchyNodeSchema.parse({
         bounds: { left: 0, top: 0, right: 10, bottom: 10 },
         occludedByViewId: 123,
+      })
+    ).toThrow();
+  });
+});
+
+describe("elementSchema: occlusion link fields", () => {
+  test("advertises both view-id targets and occludedByViewId references", () => {
+    const schemaJson = JSON.stringify(toJSONSchema(elementSchema));
+    expect(schemaJson).toContain("\"view-id\"");
+    expect(schemaJson).toContain("\"occludedByViewId\"");
+    expect(() =>
+      elementSchema.parse({
+        bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+        "view-id": "id/target",
+        occludedByViewId: "id/occluder",
+      })
+    ).not.toThrow();
+    expect(() =>
+      elementSchema.parse({
+        bounds: { left: 0, top: 0, right: 10, bottom: 10 },
+        "view-id": 123,
       })
     ).toThrow();
   });


### PR DESCRIPTION
## Summary

Adds `occludedByViewId` to Android observe hierarchy nodes that already carry `occlusionState`, preserving the existing human-readable `occludedBy` field while giving consumers a stable machine-readable link to the occluding node.

## Linked Issue

Closes #3519

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** Occluded nodes could identify an occluder only by display-ish label/resource text, which is not enough for consumers to select or highlight the responsible hierarchy row when the occluder is unlabeled.
- **Repro steps / conditions:** Android observe hierarchy contains a partially or fully occluded node and the responsible occluding node has a `view-id`.

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran the matching validation (`./gradlew :control-proxy:testDebugUnitTest`)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

Additional targeted checks:
- [x] `./gradlew :control-proxy:testDebugUnitTest --tests 'dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest'`
- [x] `bun test test/features/observe/CtrlProxyClient.test.ts test/server/observeOutputSchema.test.ts test/features/observe/android/stableNodeIdentity.test.ts`

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Not run; covered with control-proxy and TS conversion/schema unit tests.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A

Made with [Cursor](https://cursor.com)