### PR TITLE
Fix macOS development installer CI gating

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -400,6 +400,7 @@ jobs:
           lfs: false
 
       - name: "Run Installer (development)"
+        id: run-installer-development
         shell: bash
         continue-on-error: true
         run: |
@@ -410,14 +411,15 @@ jobs:
           install_status=${PIPESTATUS[0]}
           set -e
           echo "INSTALL_EXIT_CODE=${install_status}" >> "$GITHUB_ENV"
+          echo "install_exit_code=${install_status}" >> "$GITHUB_OUTPUT"
           exit 0
 
       - name: "Verify runtime dependencies"
-        if: env.INSTALL_EXIT_CODE == '0'
+        if: steps.run-installer-development.outputs.install_exit_code == '0'
         run: ./scripts/ci/verify-runtime-deps.sh
 
       - name: "Build from source"
-        if: env.INSTALL_EXIT_CODE == '0'
+        if: steps.run-installer-development.outputs.install_exit_code == '0'
         shell: bash
         run: |
           export PATH="${HOME}/.bun/bin:${PATH}"
@@ -425,11 +427,11 @@ jobs:
           bunx turbo run build --output-logs=errors-only
 
       - name: "Daemon lifecycle (start → health → doctor → stop)"
-        if: env.INSTALL_EXIT_CODE == '0'
+        if: steps.run-installer-development.outputs.install_exit_code == '0'
         run: ./scripts/ci/daemon-lifecycle.sh
 
       - name: "Upload Logs"
-        if: env.INSTALL_EXIT_CODE != '0' || failure()
+        if: steps.run-installer-development.outputs.install_exit_code != '0' || failure()
         uses: actions/upload-artifact@v6
         with:
           name: installer-development-${{ matrix.os }}-logs
@@ -437,10 +439,10 @@ jobs:
           retention-days: 7
 
       - name: "Fail on error"
-        if: env.INSTALL_EXIT_CODE != '0'
+        if: steps.run-installer-development.outputs.install_exit_code != '0'
         shell: bash
         run: |
-          echo "Installer exit code: ${INSTALL_EXIT_CODE:-0}"
+          echo "Installer exit code: ${{ steps.run-installer-development.outputs.install_exit_code }}"
           exit 1
 
   mcp-build-and-test:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -737,6 +737,7 @@ jobs:
           lfs: false
 
       - name: "Run Installer (development)"
+        id: run-installer-development
         if: env.RUN_INSTALLER == 'true'
         shell: bash
         continue-on-error: true
@@ -748,14 +749,15 @@ jobs:
           install_status=${PIPESTATUS[0]}
           set -e
           echo "INSTALL_EXIT_CODE=${install_status}" >> "$GITHUB_ENV"
+          echo "install_exit_code=${install_status}" >> "$GITHUB_OUTPUT"
           exit 0
 
       - name: "Verify runtime dependencies"
-        if: env.RUN_INSTALLER == 'true' && env.INSTALL_EXIT_CODE == '0'
+        if: env.RUN_INSTALLER == 'true' && steps.run-installer-development.outputs.install_exit_code == '0'
         run: ./scripts/ci/verify-runtime-deps.sh
 
       - name: "Build from source"
-        if: env.RUN_INSTALLER == 'true' && env.INSTALL_EXIT_CODE == '0'
+        if: env.RUN_INSTALLER == 'true' && steps.run-installer-development.outputs.install_exit_code == '0'
         shell: bash
         run: |
           export PATH="${HOME}/.bun/bin:${PATH}"
@@ -763,11 +765,11 @@ jobs:
           bunx turbo run build --output-logs=errors-only
 
       - name: "Daemon lifecycle (start → health → doctor → stop)"
-        if: env.RUN_INSTALLER == 'true' && env.INSTALL_EXIT_CODE == '0'
+        if: env.RUN_INSTALLER == 'true' && steps.run-installer-development.outputs.install_exit_code == '0'
         run: ./scripts/ci/daemon-lifecycle.sh
 
       - name: "Upload Logs"
-        if: env.RUN_INSTALLER == 'true' && (env.INSTALL_EXIT_CODE != '0' || failure())
+        if: env.RUN_INSTALLER == 'true' && (steps.run-installer-development.outputs.install_exit_code != '0' || failure())
         uses: actions/upload-artifact@v6
         with:
           name: installer-development-${{ matrix.os }}-logs
@@ -775,10 +777,10 @@ jobs:
           retention-days: 7
 
       - name: "Fail on error"
-        if: env.RUN_INSTALLER == 'true' && env.INSTALL_EXIT_CODE != '0'
+        if: env.RUN_INSTALLER == 'true' && steps.run-installer-development.outputs.install_exit_code != '0'
         shell: bash
         run: |
-          echo "Installer exit code: ${INSTALL_EXIT_CODE:-0}"
+          echo "Installer exit code: ${{ steps.run-installer-development.outputs.install_exit_code }}"
           exit 1
 
   # =============================================================================

--- a/scripts/ci/verify-runtime-deps.sh
+++ b/scripts/ci/verify-runtime-deps.sh
@@ -11,7 +11,24 @@
 set -euo pipefail
 
 # Refresh PATH — installer may have added ~/.bun/bin or Homebrew paths
-export PATH="${HOME}/.bun/bin:${PATH}"
+prepend_path_if_dir() {
+  local candidate="$1"
+  if [[ -d "${candidate}" && ":${PATH}:" != *":${candidate}:"* ]]; then
+    export PATH="${candidate}:${PATH}"
+  fi
+}
+
+prepend_path_if_dir "${HOME}/.bun/bin"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  if command -v brew >/dev/null 2>&1; then
+    homebrew_prefix="$(brew --prefix 2>/dev/null || true)"
+    if [[ -n "${homebrew_prefix}" ]]; then
+      prepend_path_if_dir "${homebrew_prefix}/bin"
+    fi
+  fi
+  prepend_path_if_dir "/opt/homebrew/bin"
+  prepend_path_if_dir "/usr/local/bin"
+fi
 # shellcheck disable=SC1091
 if [[ -f "${HOME}/.bashrc" ]]; then source "${HOME}/.bashrc" 2>/dev/null || true; fi
 hash -r 2>/dev/null || true

--- a/scripts/ci/verify-runtime-deps.sh
+++ b/scripts/ci/verify-runtime-deps.sh
@@ -18,17 +18,18 @@ prepend_path_if_dir() {
   fi
 }
 
-prepend_path_if_dir "${HOME}/.bun/bin"
 if [[ "$(uname -s)" == "Darwin" ]]; then
+  homebrew_prefix=""
   if command -v brew >/dev/null 2>&1; then
     homebrew_prefix="$(brew --prefix 2>/dev/null || true)"
-    if [[ -n "${homebrew_prefix}" ]]; then
-      prepend_path_if_dir "${homebrew_prefix}/bin"
-    fi
   fi
-  prepend_path_if_dir "/opt/homebrew/bin"
   prepend_path_if_dir "/usr/local/bin"
+  prepend_path_if_dir "/opt/homebrew/bin"
+  if [[ -n "${homebrew_prefix}" ]]; then
+    prepend_path_if_dir "${homebrew_prefix}/bin"
+  fi
 fi
+prepend_path_if_dir "${HOME}/.bun/bin"
 # shellcheck disable=SC1091
 if [[ -f "${HOME}/.bashrc" ]]; then source "${HOME}/.bashrc" 2>/dev/null || true; fi
 hash -r 2>/dev/null || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2886,6 +2886,7 @@ _install_dev_tools_brew() {
 
     if [[ ${missing} -gt 0 ]]; then
         log_warn "${missing} dev tool(s) could not be installed"
+        return 1
     else
         log_info "Development tools ready."
     fi
@@ -2941,6 +2942,7 @@ _install_dev_tools_apt() {
 
     if [[ ${missing} -gt 0 ]]; then
         log_warn "${missing} dev tool(s) could not be installed"
+        return 1
     else
         log_info "Development tools ready."
     fi

--- a/test/bats/install-dev-tools.bats
+++ b/test/bats/install-dev-tools.bats
@@ -51,3 +51,34 @@ STUB
   [ "$status" -ne 0 ]
   [[ "$output" == *"dev tool(s) could not be installed"* ]]
 }
+
+@test "Linux development tool installer fails when any apt package install fails" {
+  cat > "${STUB_BIN}/apt-get" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  "$CHMOD" +x "${STUB_BIN}/apt-get"
+
+  cat > "${STUB_BIN}/dpkg" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  "$CHMOD" +x "${STUB_BIN}/dpkg"
+
+  cat > "${STUB_BIN}/sudo" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "apt-get" && "${2:-}" == "install" && "${5:-}" == "shellcheck" ]]; then
+  exit 1
+fi
+
+exit 0
+STUB
+  "$CHMOD" +x "${STUB_BIN}/sudo"
+
+  run _install_dev_tools_apt
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"dev tool(s) could not be installed"* ]]
+}

--- a/test/bats/install-dev-tools.bats
+++ b/test/bats/install-dev-tools.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC2329
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  STUB_BIN="${TEST_DIR}/bin"
+  mkdir -p "${STUB_BIN}"
+
+  ORIG_PATH="${PATH}"
+  CHMOD="$(command -v chmod)"
+  RM="$(command -v rm)"
+
+  export PATH="${STUB_BIN}:/usr/bin:/bin"
+  export INSTALL_SH_SOURCE_ONLY=true
+  # shellcheck source=/dev/null
+  source scripts/install.sh
+
+  log_info() { printf '[INFO] %s\n' "$1"; }
+  log_warn() { printf '[WARN] %s\n' "$1"; }
+  run_spinner() {
+    shift
+    "$@"
+  }
+}
+
+teardown() {
+  export PATH="${ORIG_PATH}"
+  "$RM" -rf "${TEST_DIR}"
+}
+
+@test "macOS development tool installer fails when any Homebrew package install fails" {
+  cat > "${STUB_BIN}/brew" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "list" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "install" && "${2:-}" == "shellcheck" ]]; then
+  exit 1
+fi
+
+exit 0
+STUB
+  "$CHMOD" +x "${STUB_BIN}/brew"
+
+  run _install_dev_tools_brew
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"dev tool(s) could not be installed"* ]]
+}

--- a/test/bats/installer-workflow-status.bats
+++ b/test/bats/installer-workflow-status.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+workflow_files=(
+  ".github/workflows/pull_request.yml"
+  ".github/workflows/merge.yml"
+)
+
+@test "installer development workflows gate follow-up steps on installer step output" {
+  for workflow_file in "${workflow_files[@]}"; do
+    run grep -q "id: run-installer-development" "${workflow_file}"
+    [ "$status" -eq 0 ]
+
+    run grep -q "steps.run-installer-development.outputs.install_exit_code == '0'" "${workflow_file}"
+    [ "$status" -eq 0 ]
+
+    run grep -q "env.INSTALL_EXIT_CODE == '0'" "${workflow_file}"
+    [ "$status" -eq 1 ]
+  done
+}

--- a/test/bats/installer-workflow-status.bats
+++ b/test/bats/installer-workflow-status.bats
@@ -5,7 +5,7 @@ workflow_files=(
   ".github/workflows/merge.yml"
 )
 
-assert_step_contains() {
+assert_step_if_equals() {
   local workflow_file="$1"
   local step_name="$2"
   local expected="$3"
@@ -21,7 +21,30 @@ assert_step_contains() {
     in_step && /^      - name:/ {
       exit(found ? 0 : 1)
     }
-    in_step && index($0, expected) {
+    in_step && $0 ~ /^[[:space:]]*if:/ && index($0, expected) {
+      found = 1
+    }
+    END {
+      if (in_step && found) {
+        exit 0
+      }
+      exit 1
+    }
+  ' "${workflow_file}"
+}
+
+assert_development_installer_writes_output() {
+  local workflow_file="$1"
+
+  awk '
+    index($0, "id: run-installer-development") {
+      in_step = 1
+      next
+    }
+    in_step && /^      - name:/ {
+      exit(found ? 0 : 1)
+    }
+    in_step && index($0, "echo \"install_exit_code=${install_status}\" >> \"$GITHUB_OUTPUT\"") {
       found = 1
     }
     END {
@@ -38,10 +61,11 @@ assert_step_contains() {
     run grep -q "id: run-installer-development" "${workflow_file}"
     [ "$status" -eq 0 ]
 
-    assert_step_contains "${workflow_file}" "Verify runtime dependencies" "steps.run-installer-development.outputs.install_exit_code == '0'"
-    assert_step_contains "${workflow_file}" "Build from source" "steps.run-installer-development.outputs.install_exit_code == '0'"
-    assert_step_contains "${workflow_file}" "Daemon lifecycle (start → health → doctor → stop)" "steps.run-installer-development.outputs.install_exit_code == '0'"
-    assert_step_contains "${workflow_file}" "Upload Logs" "steps.run-installer-development.outputs.install_exit_code != '0'"
-    assert_step_contains "${workflow_file}" "Fail on error" "steps.run-installer-development.outputs.install_exit_code != '0'"
+    assert_development_installer_writes_output "${workflow_file}"
+    assert_step_if_equals "${workflow_file}" "Verify runtime dependencies" "steps.run-installer-development.outputs.install_exit_code == '0'"
+    assert_step_if_equals "${workflow_file}" "Build from source" "steps.run-installer-development.outputs.install_exit_code == '0'"
+    assert_step_if_equals "${workflow_file}" "Daemon lifecycle (start → health → doctor → stop)" "steps.run-installer-development.outputs.install_exit_code == '0'"
+    assert_step_if_equals "${workflow_file}" "Upload Logs" "steps.run-installer-development.outputs.install_exit_code != '0'"
+    assert_step_if_equals "${workflow_file}" "Fail on error" "steps.run-installer-development.outputs.install_exit_code != '0'"
   done
 }

--- a/test/bats/installer-workflow-status.bats
+++ b/test/bats/installer-workflow-status.bats
@@ -5,15 +5,43 @@ workflow_files=(
   ".github/workflows/merge.yml"
 )
 
+assert_step_contains() {
+  local workflow_file="$1"
+  local step_name="$2"
+  local expected="$3"
+
+  awk -v step_name="${step_name}" -v expected="${expected}" '
+    index($0, "id: run-installer-development") {
+      seen_development_installer = 1
+    }
+    seen_development_installer && index($0, "name: \"" step_name "\"") {
+      in_step = 1
+      next
+    }
+    in_step && /^      - name:/ {
+      exit(found ? 0 : 1)
+    }
+    in_step && index($0, expected) {
+      found = 1
+    }
+    END {
+      if (in_step && found) {
+        exit 0
+      }
+      exit 1
+    }
+  ' "${workflow_file}"
+}
+
 @test "installer development workflows gate follow-up steps on installer step output" {
   for workflow_file in "${workflow_files[@]}"; do
     run grep -q "id: run-installer-development" "${workflow_file}"
     [ "$status" -eq 0 ]
 
-    run grep -q "steps.run-installer-development.outputs.install_exit_code == '0'" "${workflow_file}"
-    [ "$status" -eq 0 ]
-
-    run grep -q "env.INSTALL_EXIT_CODE == '0'" "${workflow_file}"
-    [ "$status" -eq 1 ]
+    assert_step_contains "${workflow_file}" "Verify runtime dependencies" "steps.run-installer-development.outputs.install_exit_code == '0'"
+    assert_step_contains "${workflow_file}" "Build from source" "steps.run-installer-development.outputs.install_exit_code == '0'"
+    assert_step_contains "${workflow_file}" "Daemon lifecycle (start → health → doctor → stop)" "steps.run-installer-development.outputs.install_exit_code == '0'"
+    assert_step_contains "${workflow_file}" "Upload Logs" "steps.run-installer-development.outputs.install_exit_code != '0'"
+    assert_step_contains "${workflow_file}" "Fail on error" "steps.run-installer-development.outputs.install_exit_code != '0'"
   done
 }

--- a/test/bats/verify-runtime-deps.bats
+++ b/test/bats/verify-runtime-deps.bats
@@ -93,6 +93,14 @@ STUB
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"All runtime dependencies verified."* ]]
+
+  resolved_bun=$(
+    PATH="${MOCK_BIN}:/usr/bin:/bin" \
+      HOME="${TEST_HOME}" \
+      FAKE_HOMEBREW_PREFIX="${homebrew_prefix}" \
+      bash -c 'source scripts/ci/verify-runtime-deps.sh >/dev/null; command -v bun'
+  )
+  [ "${resolved_bun}" = "${homebrew_prefix}/bin/bun" ]
 }
 
 @test "script is executable" {

--- a/test/bats/verify-runtime-deps.bats
+++ b/test/bats/verify-runtime-deps.bats
@@ -2,18 +2,23 @@
 #
 # Tests for scripts/ci/verify-runtime-deps.sh
 
+# shellcheck disable=SC2030,SC2031
+
 SCRIPT="scripts/ci/verify-runtime-deps.sh"
 
 setup() {
   MOCK_BIN="$(mktemp -d)"
+  TEST_HOME="$(mktemp -d)"
   ORIG_PATH="$PATH"
   # Resolve absolute paths for tools we need inside PATH-restricted tests
   CHMOD="$(command -v chmod)"
+  MKDIR="$(command -v mkdir)"
   RM="$(command -v rm)"
 }
 
 teardown() {
   "$RM" -rf "$MOCK_BIN"
+  "$RM" -rf "$TEST_HOME"
   export PATH="$ORIG_PATH"
 }
 
@@ -38,6 +43,8 @@ create_mock_command() {
   for cmd in bunx ffmpeg shellcheck jq rg; do
     create_mock_command "$cmd"
   done
+  printf '#!/bin/sh\nprintf "Linux\\n"\n' > "${MOCK_BIN}/uname"
+  "$CHMOD" +x "${MOCK_BIN}/uname"
   export PATH="${MOCK_BIN}:/usr/bin:/bin"
   export HOME="/nonexistent"
 
@@ -51,6 +58,8 @@ create_mock_command() {
   # Only provide bun and bunx
   create_mock_command "bun"
   create_mock_command "bunx"
+  printf '#!/bin/sh\nprintf "Linux\\n"\n' > "${MOCK_BIN}/uname"
+  "$CHMOD" +x "${MOCK_BIN}/uname"
   export PATH="${MOCK_BIN}:/usr/bin:/bin"
   export HOME="/nonexistent"
 
@@ -58,6 +67,32 @@ create_mock_command() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"Missing runtime dependencies"* ]]
   [[ "$output" == *"ffmpeg"* ]]
+}
+
+@test "macOS refreshes PATH from Homebrew prefix before verifying dependencies" {
+  homebrew_prefix="${TEST_HOME}/homebrew"
+  "$MKDIR" -p "${homebrew_prefix}/bin"
+
+  printf '#!/bin/sh\nprintf "Darwin\\n"\n' > "${MOCK_BIN}/uname"
+  "$CHMOD" +x "${MOCK_BIN}/uname"
+  cat > "${MOCK_BIN}/brew" <<'STUB'
+#!/bin/sh
+printf '%s\n' "${FAKE_HOMEBREW_PREFIX:?}"
+STUB
+  "$CHMOD" +x "${MOCK_BIN}/brew"
+
+  for cmd in bun bunx ffmpeg shellcheck jq rg yq swiftformat swiftlint iproxy; do
+    printf '#!/bin/sh\nexit 0\n' > "${homebrew_prefix}/bin/${cmd}"
+    "$CHMOD" +x "${homebrew_prefix}/bin/${cmd}"
+  done
+
+  export PATH="${MOCK_BIN}:/usr/bin:/bin"
+  export HOME="${TEST_HOME}"
+  export FAKE_HOMEBREW_PREFIX="${homebrew_prefix}"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All runtime dependencies verified."* ]]
 }
 
 @test "script is executable" {


### PR DESCRIPTION
## Summary

Fixes the macOS development installer CI path so follow-up dependency/build/daemon checks are gated on the captured installer step output, not a dynamic env flag. Also refreshes Homebrew binary paths before runtime dependency verification and makes development-tool package install failures fail the installer itself, so CI reports the real installer failure instead of a later missing-dependency symptom.

## Linked Issue

Closes #3500

## Bug / Regression Context

- **Prior attempts:** The failure was observed on PR #3499, where code validation passed but `Installer Development (macos-latest)` failed independently.
- **Observed symptom:** A failed installer run uploaded `installer.log` showing bundled `gum` download failed with a GitHub 504, but the job surfaced as `Missing runtime dependencies: bun bunx ffmpeg shellcheck ripgrep swiftlint iproxy` in the verify step.
- **Repro steps / conditions:** macOS development installer exits before completing dependency setup, or a development-tool package install fails, then the workflow reaches the dependency verifier and reports missing tools instead of the installer failure.

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + `bun run build` + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Shell/YAML changes: `bats test/bats/`, `shellcheck scripts/install.sh scripts/ci/verify-runtime-deps.sh test/bats/install-dev-tools.bats test/bats/installer-workflow-status.bats test/bats/verify-runtime-deps.bats`, `bun run validate:yaml`
- [x] Acceptance tests: `bats test/bats/install-dev-tools.bats test/bats/installer-workflow-status.bats test/bats/verify-runtime-deps.bats`
- [x] New code uses fast shell fakes; no DB/device/runtime dependencies

## Device Verification

Not applicable. This is CI installer/workflow behavior covered by shell tests.

## Follow-ups

None.