### PR TITLE
docs(observe): clarify waitFor textMatch scope

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3316,7 +3316,7 @@
                       ]
                     },
                     "textMatch": {
-                      "description": "How to match text predicates",
+                      "description": "How to match waitFor.text; does not affect contentDescription",
                       "type": "string",
                       "enum": [
                         "exact",

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -79,7 +79,7 @@ const waitForElementBaseSchema = z.object({
   className: z.string().optional().describe("Element class name"),
   contentDescription: z.string().optional().describe("Element content description / accessibility label"),
   matchType: z.enum(["all", "any"]).optional().describe("Whether element predicates must all match the same node or any one may match"),
-  textMatch: z.enum(["exact", "contains", "regex"]).optional().describe("How to match text predicates"),
+  textMatch: z.enum(["exact", "contains", "regex"]).optional().describe("How to match waitFor.text; does not affect contentDescription"),
   ...waitForCommonShape,
 }).strict().superRefine((value, ctx) => {
 

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -227,6 +227,46 @@ describe("published observe waitFor input schema", () => {
     };
   };
 
+  const collectTextMatchDescriptions = (schema: unknown): string[] => {
+    if (schema === null || typeof schema !== "object") {
+      return [];
+    }
+
+    const record = schema as Record<string, unknown>;
+    const descriptions: string[] = [];
+    const properties = record.properties;
+    if (properties !== null && typeof properties === "object") {
+      const textMatch = (properties as Record<string, unknown>).textMatch;
+      if (textMatch !== null && typeof textMatch === "object") {
+        const description = (textMatch as Record<string, unknown>).description;
+        if (typeof description === "string") {
+          descriptions.push(description);
+        }
+      }
+    }
+
+    for (const value of Object.values(record)) {
+      descriptions.push(...collectTextMatchDescriptions(value));
+    }
+
+    return descriptions;
+  };
+
+  test("documents textMatch as applying only to waitFor.text", () => {
+    (ToolRegistry as any).tools.clear();
+    registerObserveTools();
+    const observeTool = ToolRegistry.getToolDefinitions()
+      .find(tool => tool.name === "observe");
+    expect(observeTool).toBeDefined();
+
+    const descriptions = collectTextMatchDescriptions(observeTool!.inputSchema);
+
+    expect(descriptions.length).toBeGreaterThan(0);
+    expect(new Set(descriptions)).toEqual(new Set([
+      "How to match waitFor.text; does not affect contentDescription",
+    ]));
+  });
+
   test.each([
     {
       label: "legacy elementId with timeout",

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -1,5 +1,6 @@
 import Ajv2020 from "ajv/dist/2020";
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
 import { DefaultElementFinder } from "../../src/features/utility/ElementFinder";
 import type { ObserveResult, ViewHierarchyResult } from "../../src/models";
 import { findWaitForElement, observeSchema, registerObserveTools, waitForObservation } from "../../src/server/observeTools";
@@ -257,6 +258,22 @@ describe("published observe waitFor input schema", () => {
     registerObserveTools();
     const observeTool = ToolRegistry.getToolDefinitions()
       .find(tool => tool.name === "observe");
+    expect(observeTool).toBeDefined();
+
+    const descriptions = collectTextMatchDescriptions(observeTool!.inputSchema);
+
+    expect(descriptions.length).toBeGreaterThan(0);
+    expect(new Set(descriptions)).toEqual(new Set([
+      "How to match waitFor.text; does not affect contentDescription",
+    ]));
+  });
+
+  test("committed tool definitions document textMatch as applying only to waitFor.text", () => {
+    const toolDefinitions = JSON.parse(readFileSync(
+      new URL("../../schemas/tool-definitions.json", import.meta.url),
+      "utf8"
+    )) as Array<{ name: string; inputSchema: unknown }>;
+    const observeTool = toolDefinitions.find(tool => tool.name === "observe");
     expect(observeTool).toBeDefined();
 
     const descriptions = collectTextMatchDescriptions(observeTool!.inputSchema);
@@ -713,6 +730,17 @@ describe("findWaitForElement rich predicates", () => {
     expect(findWaitForElement(finder, { text: "Home", textMatch: "contains" } as any, hierarchy)?.text).toBe("Welcome Home");
     expect(findWaitForElement(finder, { text: "^Welcome\\s+Home$", textMatch: "regex" } as any, hierarchy)?.text).toBe("Welcome Home");
     expect(findWaitForElement(finder, { text: "Home", textMatch: "exact" } as any, hierarchy)).toBeNull();
+  });
+
+  test("keeps contentDescription exact-only when textMatch is non-exact", () => {
+    const finder = new DefaultElementFinder();
+    const hierarchy = makeHierarchy([
+      { $: { "content-desc": "Home tab", "bounds": bounds(10, 10, 180, 60) } },
+    ]);
+
+    expect(findWaitForElement(finder, { contentDescription: "Home tab", textMatch: "exact" } as any, hierarchy)?.["content-desc"]).toBe("Home tab");
+    expect(findWaitForElement(finder, { contentDescription: "Home", textMatch: "contains" } as any, hierarchy)).toBeNull();
+    expect(findWaitForElement(finder, { contentDescription: "^Home", textMatch: "regex" } as any, hierarchy)).toBeNull();
   });
 
   test("matches iOS accessibility labels exposed as text for contentDescription", () => {


### PR DESCRIPTION
## Summary

Clarifies the `observe.waitFor.textMatch` schema description so callers know it applies only to `waitFor.text` and does not change `contentDescription` matching semantics. The generated tool definitions are refreshed to publish the same wording.

## Linked Issue

Closes #3514

## Bug / Regression Context

- **Prior attempts:** PR #3489 added richer `observe.waitFor` predicates and left `textMatch` wording broader than the runtime behavior.
- **Observed symptom:** `{ contentDescription: "Home tab", textMatch: "contains" }` still performed exact-only content-description matching with no schema hint.
- **Repro steps / conditions:** Inspect the published `observe` input schema for `waitFor.textMatch`.

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Public tool definitions regenerated with `bun scripts/generate-tool-definitions.ts`
- [x] Acceptance test passes: `bun test test/server/observeWaitForSchema.test.ts`
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not run: documentation/schema-description-only change; no on-device behavior changed.

## Acceptance Criteria

- [x] `textMatch` documentation states it applies only to `waitFor.text`.
- [x] `contentDescription` runtime behavior remains exact-only.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)