### PR TITLE
Fix app lifecycle probe failure handling

### DIFF
--- a/src/utils/AppLifecycleMonitor.ts
+++ b/src/utils/AppLifecycleMonitor.ts
@@ -131,7 +131,7 @@ export class DefaultAppLifecycleMonitor extends EventEmitter implements AppLifec
     try {
       // Create ADB client for this device
       const adb = this.adbFactory.create(device);
-      const result = await adb.executeCommand(`shell pidof ${packageName}`);
+      const result = await adb.executeCommand(`shell pidof ${packageName} || true`);
 
       // pidof returns empty stdout if package is not running
       return result.stdout.trim().length > 0;

--- a/src/utils/AppLifecycleMonitor.ts
+++ b/src/utils/AppLifecycleMonitor.ts
@@ -124,6 +124,10 @@ export class DefaultAppLifecycleMonitor extends EventEmitter implements AppLifec
    * Check if a specific package is currently running
    */
   public async isPackageRunning(device: BootedDevice, packageName: string): Promise<boolean> {
+    return (await this.probePackageRunning(device, packageName)) ?? false;
+  }
+
+  private async probePackageRunning(device: BootedDevice, packageName: string): Promise<boolean | undefined> {
     try {
       // Create ADB client for this device
       const adb = this.adbFactory.create(device);
@@ -132,7 +136,8 @@ export class DefaultAppLifecycleMonitor extends EventEmitter implements AppLifec
       // pidof returns empty stdout if package is not running
       return result.stdout.trim().length > 0;
     } catch (error) {
-      return false;
+      logger.warn(`Failed to check whether ${packageName} is running on ${device.deviceId}`, error);
+      return undefined;
     }
   }
 
@@ -185,7 +190,11 @@ export class DefaultAppLifecycleMonitor extends EventEmitter implements AppLifec
    */
   private async updateRunningPackages(device: BootedDevice) {
     for (const packageName of this.trackedPackages) {
-      if (await this.isPackageRunning(device, packageName)) {
+      const isRunning = await this.probePackageRunning(device, packageName);
+      if (isRunning === undefined) {
+        continue;
+      }
+      if (isRunning) {
         this.runningPackages.add(packageName);
       } else {
         this.runningPackages.delete(packageName);

--- a/test/utils/AppLifecycleMonitor.test.ts
+++ b/test/utils/AppLifecycleMonitor.test.ts
@@ -1,9 +1,10 @@
-import { expect, describe, test, beforeEach, afterEach } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { AppLifecycleMonitor, DefaultAppLifecycleMonitor, AppLifecycleEvent } from "../../src/utils/AppLifecycleMonitor";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { AppLifecycleMonitorFactory } from "../../src/utils/factories/AppLifecycleMonitorFactory";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import type { BootedDevice } from "../../src/models";
+import { logger } from "../../src/utils/logger";
 
 describe("AppLifecycleMonitor", () => {
   let monitor: DefaultAppLifecycleMonitor;
@@ -215,6 +216,33 @@ describe("AppLifecycleMonitor", () => {
   });
 
   describe("error handling", () => {
+    test("preserves running package state and suppresses terminate event when pidof probe fails", async () => {
+      const terminateEvents: AppLifecycleEvent[] = [];
+      const probeError = new Error("adb transport closed");
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+      try {
+        monitor.addEventListener("terminate", async event => {
+          terminateEvents.push(event);
+        });
+
+        fakeAdb.setCommandResponse("shell pidof com.example.app", { stdout: "12345", stderr: "" });
+        await monitor.trackPackage(testDevice, "com.example.app");
+        expect(monitor.getRunningPackages()).toEqual(["com.example.app"]);
+
+        fakeAdb.setCommandError("shell pidof com.example.app", probeError);
+        await monitor.checkForChanges(testDevice);
+
+        expect(monitor.getRunningPackages()).toEqual(["com.example.app"]);
+        expect(terminateEvents).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toContain("Failed to check whether com.example.app is running");
+        expect(warnSpy.mock.calls[0]?.[1]).toBe(probeError);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     test("should handle event emission errors gracefully", async () => {
       fakeAdb.setCommandResponse("shell pidof com.example.app", { stdout: "12345", stderr: "" });
 


### PR DESCRIPTION
## Summary

Preserve AppLifecycleMonitor running-package state when an ADB `pidof` probe throws, so transient ADB errors are logged without producing phantom terminate lifecycle events.

## Linked Issue

Closes #3515

## Bug / Regression Context

- **Prior attempts:** None known; related broader convention sweep is #3508.
- **Observed symptom:** `isPackageRunning` collapsed ADB execution errors to `false`, causing `updateRunningPackages` to delete still-running packages.
- **Repro steps / conditions:** Track a running package, then hit a transient `adb shell pidof <package>` error on the next lifecycle poll.

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + build + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: not applicable
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A - covered by focused unit regression test using the existing fake ADB executor.

## Follow-ups

None.

## Acceptance Criteria

- [x] A transient ADB error during `isPackageRunning` does not remove a still-tracked package from `runningPackages`.
- [x] No phantom "terminate" event is emitted on probe failure.
- [x] The catch logs per the CLAUDE.md convention.

Made with [Cursor](https://cursor.com)