### PR TITLE
fix(observe): preserve Android className output alias

### DIFF
--- a/src/features/observe/android/CtrlProxyFocus.ts
+++ b/src/features/observe/android/CtrlProxyFocus.ts
@@ -351,6 +351,7 @@ export class CtrlProxyFocus {
     }
     if (node.className) {
       converted.class = node.className;
+      converted.className = node.className;
     }
     if (node.packageName) {
       converted.packageName = node.packageName;

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -863,6 +863,7 @@ export class CtrlProxyHierarchy {
     }
     if (node.className) {
       converted.class = node.className;
+      converted.className = node.className;
     }
     if (node.packageName) {
       converted.packageName = node.packageName;

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { getDbWriteBarrier, resetDbWriteBarrier } from "../../../src/db/dbWriteBarrier";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { CtrlProxyFocus } from "../../../src/features/observe/android/CtrlProxyFocus";
 import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { AndroidCtrlProxyManager } from "../../../src/utils/CtrlProxyManager";
@@ -1109,7 +1110,7 @@ describe("AndroidCtrlProxyClient", function() {
       expect(result.hierarchy.text).toBe("6:43 AM");
       expect(result.hierarchy["content-desc"]).toBe("6:43 AM");
       expect(result.hierarchy.class).toBe("android.widget.TextClock");
-      expect(result.hierarchy.className).toBeUndefined();
+      expect(result.hierarchy.className).toBe("android.widget.TextClock");
       expect(result.hierarchy.bounds).toEqual({
         left: 175,
         top: 687,
@@ -1132,7 +1133,7 @@ describe("AndroidCtrlProxyClient", function() {
       expect(typeof result.hierarchy.node).toBe("object");
       expect(result.hierarchy.node.text).toBe("Child Node");
       expect(result.hierarchy.node.class).toBe("android.widget.TextView");
-      expect(result.hierarchy.node.className).toBeUndefined();
+      expect(result.hierarchy.node.className).toBe("android.widget.TextView");
       expect(result.hierarchy.node.bounds).toEqual({
         left: 0,
         top: 0,
@@ -1214,6 +1215,21 @@ describe("AndroidCtrlProxyClient", function() {
       expect(before.hierarchy["view-id"]).toBe("com.test.app:id/root");
     });
 
+  });
+
+  describe("focus element conversion", function() {
+    test("normalizes Android runner className while preserving the public compatibility alias", function() {
+      const focus = new CtrlProxyFocus({} as any);
+
+      const element = focus.convertAccessibilityNodeToElement({
+        text: "Focused",
+        className: "android.widget.Button",
+        bounds: { left: 10, top: 20, right: 110, bottom: 70 },
+      });
+
+      expect(element?.class).toBe("android.widget.Button");
+      expect(element?.className).toBe("android.widget.Button");
+    });
   });
 
   describe("getAccessibilityHierarchy", function() {


### PR DESCRIPTION
## Summary

Preserve Android `className` as a public observe output compatibility alias while still emitting canonical `class` for normalized hierarchy and focus elements. This follows up #3525 so `waitFor.className` keeps using canonical parsing without breaking clients that read `viewHierarchy` or focus elements by `className`.

## Linked Issue

Related to #3513 and follow-up to #3525

## Bug / Regression Context

- **Prior attempts:** #3525 normalized Android runner `className` to `class` while removing dead matcher fallbacks.
- **Observed symptom:** Review passes flagged that dropping serialized `className` could break existing consumers of Android observe/focus output.
- **Repro steps / conditions:** Convert an Android CtrlProxy node with `className`; before this follow-up, converted hierarchy and focus elements exposed `class` but no longer preserved the `className` alias.

## Validation

- [x] `bun run turbo:validate` passes (`turbo run lint build test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: TypeScript-only observe conversion change; no platform source changed
- [x] New code uses existing fakes/test helpers; focused conversion test runs in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

Additional targeted checks:
- [x] `bun test test/features/observe/CtrlProxyClient.test.ts test/features/observe/android/stableNodeIdentity.test.ts test/server/observeWaitForSchema.test.ts`

## Device Verification

Not run: compatibility alias is covered by unit tests; no real-device verification in this worktree.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)