### PR TITLE
Pin lifecycle pidof no-match probe command

### DIFF
--- a/test/utils/AppLifecycleMonitor.test.ts
+++ b/test/utils/AppLifecycleMonitor.test.ts
@@ -156,6 +156,7 @@ describe("AppLifecycleMonitor", () => {
 
       // Clear events from the launch
       launchEvents.length = 0;
+      fakeAdb.clearHistory();
 
       // Simulate package termination
       fakeAdb.setCommandResponse("shell pidof com.example.app", { stdout: "", stderr: "" });
@@ -163,6 +164,7 @@ describe("AppLifecycleMonitor", () => {
       // Check for changes to detect termination
       await monitor.checkForChanges(testDevice);
 
+      expect(fakeAdb.getExecutedCommands()).toContain("shell pidof com.example.app || true");
       expect(terminateEvents).toHaveLength(1);
       expect(terminateEvents[0].type).toBe("terminate");
       expect(terminateEvents[0].appId).toBe("com.example.app");


### PR DESCRIPTION
## Summary

Adds a focused regression assertion for the AppLifecycleMonitor termination path so the test suite pins the `pidof ... || true` command added in #3531.

## Linked Issue

Follow-up to #3515 and #3531.

## Bug / Regression Context

- **Prior attempts:** #3531 fixed transient ADB probe failures and addressed review feedback about real `pidof` no-match exits.
- **Observed symptom:** The fake ADB executor matches command substrings, so tests would still pass if `|| true` were accidentally removed.
- **Repro steps / conditions:** Remove `|| true` from the lifecycle `pidof` probe command; this assertion should fail.

## Validation

- [x] `bun test test/utils/AppLifecycleMonitor.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: not applicable
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A - test-only follow-up.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)