### PR TITLE
Fix Android occlusion view-id links

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1601,14 +1601,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
         intersections.add(intersection)
 
-        val occluderViewId = occluder.element.viewId?.takeIf { it.isNotBlank() }
-        val shouldPreferOccluder =
-          overlapArea > maxOverlap ||
-            (overlapArea == maxOverlap && occludedByViewId == null && occluderViewId != null)
-        if (shouldPreferOccluder) {
+        if (overlapArea > maxOverlap) {
           maxOverlap = overlapArea
           occludedBy = resolveOccluderLabel(occluder)
-          occludedByViewId = occluderViewId
+          occludedByViewId =
+            resolveViewIdForOcclusionNode(
+              occluder.element,
+              occluder.key.windowKey,
+              occluder.key.path,
+            )
         }
       }
 
@@ -1716,6 +1717,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     val nodeToUse = filteredNodeElement
 
     return element.copy(
+      viewId = resolveViewIdForOcclusionNode(element, windowKey, path),
       node = nodeToUse,
       occlusionState = occlusionState,
       occludedBy = info?.occludedBy,
@@ -1841,6 +1843,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       ?: element.text?.takeIf { it.isNotBlank() }
       ?: element.className?.takeIf { it.isNotBlank() }
       ?: "unlabeled view"
+  }
+
+  private fun resolveViewIdForOcclusionNode(
+    element: UIElementInfo,
+    windowKey: Int,
+    path: String,
+  ): String {
+    return element.viewId?.takeIf { it.isNotBlank() }
+      ?: generateDeterministicUuid("occlusion/window:$windowKey/path:$path")
   }
 
   /** Extract information about a single focused element. Used for getCurrentFocus command. */

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1601,10 +1601,14 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
         intersections.add(intersection)
 
-        if (overlapArea > maxOverlap) {
+        val occluderViewId = occluder.element.viewId?.takeIf { it.isNotBlank() }
+        val shouldPreferOccluder =
+          overlapArea > maxOverlap ||
+            (overlapArea == maxOverlap && occludedByViewId == null && occluderViewId != null)
+        if (shouldPreferOccluder) {
           maxOverlap = overlapArea
           occludedBy = resolveOccluderLabel(occluder)
-          occludedByViewId = resolveOccluderViewId(occluder)
+          occludedByViewId = occluderViewId
         }
       }
 
@@ -1837,27 +1841,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       ?: element.text?.takeIf { it.isNotBlank() }
       ?: element.className?.takeIf { it.isNotBlank() }
       ?: "unlabeled view"
-  }
-
-  private fun resolveOccluderViewId(occluder: OcclusionNode): String? {
-    occluder.element.viewId?.takeIf { it.isNotBlank() }?.let { return it }
-    val label = resolveOccluderLabel(occluder).takeUnless { it == "unlabeled view" } ?: return null
-    return findDescendantViewIdMatchingLabel(occluder.element, label)
-  }
-
-  private fun findDescendantViewIdMatchingLabel(element: UIElementInfo, label: String): String? {
-    for (child in decodeChildrenFromNode(element.node)) {
-      val childViewId = child.viewId?.takeIf { it.isNotBlank() }
-      if (childViewId != null && child.hasSemanticOccluderLabel(label)) {
-        return childViewId
-      }
-      findDescendantViewIdMatchingLabel(child, label)?.let { return it }
-    }
-    return null
-  }
-
-  private fun UIElementInfo.hasSemanticOccluderLabel(label: String): Boolean {
-    return resourceId == label || contentDesc == label || text == label
   }
 
   /** Extract information about a single focused element. Used for getCurrentFocus command. */

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1604,7 +1604,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         if (overlapArea > maxOverlap) {
           maxOverlap = overlapArea
           occludedBy = resolveOccluderLabel(occluder)
-          occludedByViewId = occluder.element.viewId
+          occludedByViewId = resolveOccluderViewId(occluder)
         }
       }
 
@@ -1837,6 +1837,27 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       ?: element.text?.takeIf { it.isNotBlank() }
       ?: element.className?.takeIf { it.isNotBlank() }
       ?: "unlabeled view"
+  }
+
+  private fun resolveOccluderViewId(occluder: OcclusionNode): String? {
+    occluder.element.viewId?.takeIf { it.isNotBlank() }?.let { return it }
+    val label = resolveOccluderLabel(occluder).takeUnless { it == "unlabeled view" } ?: return null
+    return findDescendantViewIdMatchingLabel(occluder.element, label)
+  }
+
+  private fun findDescendantViewIdMatchingLabel(element: UIElementInfo, label: String): String? {
+    for (child in decodeChildrenFromNode(element.node)) {
+      val childViewId = child.viewId?.takeIf { it.isNotBlank() }
+      if (childViewId != null && child.hasOccluderLabel(label)) {
+        return childViewId
+      }
+      findDescendantViewIdMatchingLabel(child, label)?.let { return it }
+    }
+    return null
+  }
+
+  private fun UIElementInfo.hasOccluderLabel(label: String): Boolean {
+    return resourceId == label || contentDesc == label || text == label || className == label
   }
 
   /** Extract information about a single focused element. Used for getCurrentFocus command. */

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1848,7 +1848,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   private fun findDescendantViewIdMatchingLabel(element: UIElementInfo, label: String): String? {
     for (child in decodeChildrenFromNode(element.node)) {
       val childViewId = child.viewId?.takeIf { it.isNotBlank() }
-      if (childViewId != null && child.hasOccluderLabel(label)) {
+      if (childViewId != null && child.hasSemanticOccluderLabel(label)) {
         return childViewId
       }
       findDescendantViewIdMatchingLabel(child, label)?.let { return it }
@@ -1856,8 +1856,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     return null
   }
 
-  private fun UIElementInfo.hasOccluderLabel(label: String): Boolean {
-    return resourceId == label || contentDesc == label || text == label || className == label
+  private fun UIElementInfo.hasSemanticOccluderLabel(label: String): Boolean {
+    return resourceId == label || contentDesc == label || text == label
   }
 
   /** Extract information about a single focused element. Used for getCurrentFocus command. */

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -600,6 +600,85 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `cross-window occlusion does not link matching descendant that does not overlap`() {
+    val target = elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
+    val appRoot =
+      elementWithBounds(
+        resourceId = "app-root",
+        bounds = bounds(0, 0, 200, 200),
+        children = listOf(target),
+      )
+    val nonOverlappingChild =
+      elementWithBounds(text = "Demos", viewId = "stable-demos", bounds = bounds(150, 150, 190, 190))
+    val labelledWrapper =
+      elementWithBounds(
+        contentDesc = "Demos",
+        bounds = bounds(0, 0, 50, 50),
+        children = listOf(nonOverlappingChild),
+      )
+
+    val appEntry = extractor.createWindowEntry(windowId = 1, windowLayer = 0, hierarchy = appRoot)
+    val overlayEntry =
+      extractor.createWindowEntry(windowId = 2, windowLayer = 1, hierarchy = labelledWrapper)
+    val occlusionInfo = extractor.buildOcclusionInfoForTest(listOf(appEntry, overlayEntry))
+    val filtered =
+      extractor.filterOccludedHierarchyForTest(
+        element = appRoot,
+        occlusionInfo = occlusionInfo,
+        windowKey = 1,
+        path = "",
+        isRoot = true,
+      )
+
+    assertNotNull(filtered)
+    val targetResult = findElementByResourceId(filtered!!, "partial-target")
+    assertNotNull(targetResult)
+    assertEquals("partial", targetResult!!.occlusionState)
+    assertEquals("Demos", targetResult.occludedBy)
+    assertNull(targetResult.occludedByViewId)
+  }
+
+  @Test
+  fun `cross-window occlusion prefers direct wrapper view id over equal-overlap child`() {
+    val target = elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
+    val appRoot =
+      elementWithBounds(
+        resourceId = "app-root",
+        bounds = bounds(0, 0, 200, 200),
+        children = listOf(target),
+      )
+    val labelledChild =
+      elementWithBounds(text = "Demos", viewId = "stable-demos-child", bounds = bounds(0, 0, 50, 50))
+    val labelledWrapper =
+      elementWithBounds(
+        contentDesc = "Demos",
+        viewId = "stable-demos-wrapper",
+        bounds = bounds(0, 0, 50, 50),
+        children = listOf(labelledChild),
+      )
+
+    val appEntry = extractor.createWindowEntry(windowId = 1, windowLayer = 0, hierarchy = appRoot)
+    val overlayEntry =
+      extractor.createWindowEntry(windowId = 2, windowLayer = 1, hierarchy = labelledWrapper)
+    val occlusionInfo = extractor.buildOcclusionInfoForTest(listOf(appEntry, overlayEntry))
+    val filtered =
+      extractor.filterOccludedHierarchyForTest(
+        element = appRoot,
+        occlusionInfo = occlusionInfo,
+        windowKey = 1,
+        path = "",
+        isRoot = true,
+      )
+
+    assertNotNull(filtered)
+    val targetResult = findElementByResourceId(filtered!!, "partial-target")
+    assertNotNull(targetResult)
+    assertEquals("partial", targetResult!!.occlusionState)
+    assertEquals("Demos", targetResult.occludedBy)
+    assertEquals("stable-demos-wrapper", targetResult.occludedByViewId)
+  }
+
+  @Test
   fun `hidden root occlusion retains children`() {
     val child = elementWithBounds(resourceId = "root-child", bounds = bounds(98, 98, 100, 100))
     val root =

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -596,11 +596,21 @@ class ViewHierarchyExtractorTest {
     assertNotNull(targetResult)
     assertEquals("partial", targetResult!!.occlusionState)
     assertEquals("Demos", targetResult.occludedBy)
-    assertEquals("stable-demos", targetResult.occludedByViewId)
+    val overlayResult =
+      extractor.filterOccludedHierarchyForTest(
+        element = labelledWrapper,
+        occlusionInfo = occlusionInfo,
+        windowKey = 2,
+        path = "",
+        isRoot = true,
+      )
+    assertNotNull(overlayResult)
+    assertEquals(overlayResult!!.viewId, targetResult.occludedByViewId)
+    assertNotNull(targetResult.occludedByViewId)
   }
 
   @Test
-  fun `cross-window occlusion does not link matching descendant that does not overlap`() {
+  fun `cross-window occlusion links id-less container to its emitted fallback view id`() {
     val target = elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
     val appRoot =
       elementWithBounds(
@@ -608,18 +618,12 @@ class ViewHierarchyExtractorTest {
         bounds = bounds(0, 0, 200, 200),
         children = listOf(target),
       )
-    val nonOverlappingChild =
-      elementWithBounds(text = "Demos", viewId = "stable-demos", bounds = bounds(150, 150, 190, 190))
-    val labelledWrapper =
-      elementWithBounds(
-        contentDesc = "Demos",
-        bounds = bounds(0, 0, 50, 50),
-        children = listOf(nonOverlappingChild),
-      )
+    val statusBarRoot =
+      elementWithBounds(className = "android.view.ViewGroup", bounds = bounds(0, 0, 100, 50))
 
     val appEntry = extractor.createWindowEntry(windowId = 1, windowLayer = 0, hierarchy = appRoot)
     val overlayEntry =
-      extractor.createWindowEntry(windowId = 2, windowLayer = 1, hierarchy = labelledWrapper)
+      extractor.createWindowEntry(windowId = 2, windowLayer = 1, hierarchy = statusBarRoot)
     val occlusionInfo = extractor.buildOcclusionInfoForTest(listOf(appEntry, overlayEntry))
     val filtered =
       extractor.filterOccludedHierarchyForTest(
@@ -634,12 +638,22 @@ class ViewHierarchyExtractorTest {
     val targetResult = findElementByResourceId(filtered!!, "partial-target")
     assertNotNull(targetResult)
     assertEquals("partial", targetResult!!.occlusionState)
-    assertEquals("Demos", targetResult.occludedBy)
-    assertNull(targetResult.occludedByViewId)
+    assertEquals("android.view.ViewGroup", targetResult.occludedBy)
+    val overlayResult =
+      extractor.filterOccludedHierarchyForTest(
+        element = statusBarRoot,
+        occlusionInfo = occlusionInfo,
+        windowKey = 2,
+        path = "",
+        isRoot = true,
+      )
+    assertNotNull(overlayResult)
+    assertEquals(overlayResult!!.viewId, targetResult.occludedByViewId)
+    assertNotNull(targetResult.occludedByViewId)
   }
 
   @Test
-  fun `cross-window occlusion prefers direct wrapper view id over equal-overlap child`() {
+  fun `cross-window occlusion prefers direct wrapper view id over generated fallback`() {
     val target = elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
     val appRoot =
       elementWithBounds(
@@ -647,14 +661,11 @@ class ViewHierarchyExtractorTest {
         bounds = bounds(0, 0, 200, 200),
         children = listOf(target),
       )
-    val labelledChild =
-      elementWithBounds(text = "Demos", viewId = "stable-demos-child", bounds = bounds(0, 0, 50, 50))
     val labelledWrapper =
       elementWithBounds(
         contentDesc = "Demos",
         viewId = "stable-demos-wrapper",
         bounds = bounds(0, 0, 50, 50),
-        children = listOf(labelledChild),
       )
 
     val appEntry = extractor.createWindowEntry(windowId = 1, windowLayer = 0, hierarchy = appRoot)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -561,6 +561,45 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `cross-window occlusion links labelled wrapper to matching descendant view id`() {
+    val target = elementWithBounds(resourceId = "partial-target", bounds = bounds(0, 0, 100, 100))
+    val appRoot =
+      elementWithBounds(
+        resourceId = "app-root",
+        bounds = bounds(0, 0, 200, 200),
+        children = listOf(target),
+      )
+    val labelledChild =
+      elementWithBounds(text = "Demos", viewId = "stable-demos", bounds = bounds(0, 0, 50, 50))
+    val labelledWrapper =
+      elementWithBounds(
+        contentDesc = "Demos",
+        bounds = bounds(0, 0, 50, 50),
+        children = listOf(labelledChild),
+      )
+
+    val appEntry = extractor.createWindowEntry(windowId = 1, windowLayer = 0, hierarchy = appRoot)
+    val overlayEntry =
+      extractor.createWindowEntry(windowId = 2, windowLayer = 1, hierarchy = labelledWrapper)
+    val occlusionInfo = extractor.buildOcclusionInfoForTest(listOf(appEntry, overlayEntry))
+    val filtered =
+      extractor.filterOccludedHierarchyForTest(
+        element = appRoot,
+        occlusionInfo = occlusionInfo,
+        windowKey = 1,
+        path = "",
+        isRoot = true,
+      )
+
+    assertNotNull(filtered)
+    val targetResult = findElementByResourceId(filtered!!, "partial-target")
+    assertNotNull(targetResult)
+    assertEquals("partial", targetResult!!.occlusionState)
+    assertEquals("Demos", targetResult.occludedBy)
+    assertEquals("stable-demos", targetResult.occludedByViewId)
+  }
+
+  @Test
   fun `hidden root occlusion retains children`() {
     val child = elementWithBounds(resourceId = "root-child", bounds = bounds(98, 98, 100, 100))
     val root =


### PR DESCRIPTION
## Summary
- Fix Android runner occlusion metadata so cross-window occluder candidates without a direct `viewId` still receive a deterministic emitted `view-id`.
- Link `occludedByViewId` to the same emitted occlusion-candidate id, while preserving existing `occludedBy` label behavior and same-window occlusion skip behavior from #3521.

## Changes
- Resolve `occludedByViewId` from the actual max-overlap occlusion candidate, generating a UUID-shaped fallback id when the candidate has no direct `viewId`.
- Copy that same fallback id into the emitted filtered hierarchy so TS stable-id rewriting can remap the link.
- Add regressions for labelled wrappers, id-less cross-window containers/window roots, and direct `viewId` precedence.

## Testing
- Red first: `./gradlew :control-proxy:testDebugUnitTest --tests 'dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest.cross-window occlusion links labelled wrapper to matching descendant view id'` failed before the fix at the `occludedByViewId` assertion.
- `./gradlew :control-proxy:testDebugUnitTest --tests 'dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest.cross-window occlusion links labelled wrapper to matching descendant view id'`
- `./gradlew :control-proxy:testDebugUnitTest --tests 'dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest'`
- `./gradlew :control-proxy:testDebugUnitTest`
- Rerun after review fixes: `./gradlew :control-proxy:testDebugUnitTest --tests 'dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest'`
- Rerun after review fixes: `./gradlew :control-proxy:testDebugUnitTest` (first rerun hit a transient `WebSocketServerIntegrationTest` socket close; the isolated failing test and full module rerun both passed)
- Rerun after issue comment correction: `./gradlew :control-proxy:testDebugUnitTest --tests 'dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest'`
- Rerun after issue comment correction: `./gradlew :control-proxy:testDebugUnitTest`
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`

## Acceptance Criteria
- [x] `occludedByViewId` is populated for cross-window occlusion candidates, including id-less containers/window roots that need generated emitted ids.
- [x] The emitted value is the runner-side occluding node id that the existing TS stable-id rewrite can remap.
- [x] Existing `occludedBy` label behavior remains unchanged.
- [x] Same-window occlusion skip behavior remains intact.

Risk class: higher-risk because this changes Android runner observe output semantics for a public field.

Closes #3536