### PR TITLE
Fix oversized observe output spillover

### DIFF
--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -44,6 +44,10 @@ export interface ObservationArtifactWriter {
   writeJsonArtifact(input: ObservationArtifactWriteInput): ObservationArtifactMetadata;
 }
 
+export type ObservationArtifactMode = "always" | "oversized";
+
+export const DEFAULT_OBSERVATION_INLINE_MAX_BYTES = 64 * 1024;
+
 type ObservationActionClass = "navigation" | "inPlace" | "scroll" | "unknown";
 
 function classifyObservationAction(
@@ -115,6 +119,13 @@ export interface FinalizeToolResponseContext {
    * this writer so in-process consumers still receive full observations.
    */
   artifactWriter?: ObservationArtifactWriter;
+  /**
+   * Configured artifact mode keeps the historical "always artifact" behavior.
+   * The automatic fallback only spills observations whose finalized inline JSON
+   * is large enough to risk client-side truncation.
+   */
+  artifactMode?: ObservationArtifactMode;
+  artifactInlineMaxBytes?: number;
 }
 
 type ObservationDiffMode = "diff" | "full";
@@ -299,7 +310,13 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     }
   }
 
-  if (ctx.artifactWriter && !ctx.internal && hasArtifactableObservation && sanitizedPayload) {
+  if (
+    ctx.artifactWriter
+    && !ctx.internal
+    && hasArtifactableObservation
+    && sanitizedPayload
+    && shouldArtifactObservationPayload(ctx, sanitizedPayload)
+  ) {
     if (isObserveTool) {
       sanitizedPayload = writeObservationArtifact(ctx, sanitizedPayload) as unknown as Record<string, unknown>;
     } else {
@@ -310,7 +327,9 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     }
   }
 
-  sanitizedPayload ??= artifactNonObservationPayload(ctx, payload);
+  if (artifactMode(ctx) === "always") {
+    sanitizedPayload ??= artifactNonObservationPayload(ctx, payload);
+  }
 
   if (!sanitizedPayload) {
     return response;
@@ -326,6 +345,22 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
   pendingBaselineUpdate && ctx.baselineStore!.set(pendingBaselineUpdate.sessionUuid, pendingBaselineUpdate.observation);
 
   return response;
+}
+
+function artifactMode(ctx: FinalizeToolResponseContext): ObservationArtifactMode {
+  return ctx.artifactMode ?? "always";
+}
+
+function shouldArtifactObservationPayload(
+  ctx: FinalizeToolResponseContext,
+  payload: Record<string, unknown>
+): boolean {
+  if (artifactMode(ctx) === "always") {
+    return true;
+  }
+
+  const inlineMaxBytes = ctx.artifactInlineMaxBytes ?? DEFAULT_OBSERVATION_INLINE_MAX_BYTES;
+  return Buffer.byteLength(stringifyToolResponse(payload), "utf8") > inlineMaxBytes;
 }
 
 function writeObservationArtifact(

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -125,7 +125,6 @@ export interface FinalizeToolResponseContext {
    * is large enough to risk client-side truncation.
    */
   artifactMode?: ObservationArtifactMode;
-  artifactInlineMaxBytes?: number;
 }
 
 type ObservationDiffMode = "diff" | "full";
@@ -359,8 +358,7 @@ function shouldArtifactObservationPayload(
     return true;
   }
 
-  const inlineMaxBytes = ctx.artifactInlineMaxBytes ?? DEFAULT_OBSERVATION_INLINE_MAX_BYTES;
-  return Buffer.byteLength(stringifyToolResponse(payload), "utf8") > inlineMaxBytes;
+  return Buffer.byteLength(stringifyToolResponse(payload), "utf8") > DEFAULT_OBSERVATION_INLINE_MAX_BYTES;
 }
 
 function writeObservationArtifact(

--- a/src/server/toolOutputArtifactWriter.ts
+++ b/src/server/toolOutputArtifactWriter.ts
@@ -6,21 +6,33 @@ import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { stringifyToolResponse } from "../utils/toolUtils";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
+import { logger } from "../utils/logger";
 import type {
   ObservationArtifactMetadata,
   ObservationArtifactWriter,
   ObservationArtifactWriteInput,
 } from "./finalizeToolResponse";
 
+const SECURE_TOOL_OUTPUT_DIR_MODE = 0o700;
+
 export interface ToolOutputArtifactFileSystem {
   ensureDirectory(dirPath: string): void;
   assertWritableDirectory(dirPath: string): void;
   writeFileExclusive(filePath: string, content: string, mode: number): void;
+  listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[];
+  deleteFile(filePath: string): void;
+}
+
+export interface ToolOutputArtifactDirectoryEntry {
+  path: string;
+  name: string;
+  isFile: boolean;
+  mtimeMs: number;
 }
 
 export class NodeToolOutputArtifactFileSystem implements ToolOutputArtifactFileSystem {
   ensureDirectory(dirPath: string): void {
-    fs.mkdirSync(dirPath, { recursive: true });
+    fs.mkdirSync(dirPath, { recursive: true, mode: SECURE_TOOL_OUTPUT_DIR_MODE });
   }
 
   assertWritableDirectory(dirPath: string): void {
@@ -34,6 +46,29 @@ export class NodeToolOutputArtifactFileSystem implements ToolOutputArtifactFileS
   writeFileExclusive(filePath: string, content: string, mode: number): void {
     fs.writeFileSync(filePath, content, { encoding: "utf8", flag: "wx", mode });
   }
+
+  listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[] {
+    return fs.readdirSync(dirPath, { withFileTypes: true }).map(entry => {
+      const entryPath = path.join(dirPath, entry.name);
+      const stats = fs.statSync(entryPath);
+      return {
+        path: entryPath,
+        name: entry.name,
+        isFile: entry.isFile(),
+        mtimeMs: stats.mtimeMs,
+      };
+    });
+  }
+
+  deleteFile(filePath: string): void {
+    fs.unlinkSync(filePath);
+  }
+}
+
+export interface ToolOutputArtifactRetention {
+  maxAgeMs: number;
+  maxFiles: number;
+  overflowMinAgeMs: number;
 }
 
 export interface JsonToolOutputArtifactWriterOptions {
@@ -41,6 +76,7 @@ export interface JsonToolOutputArtifactWriterOptions {
   fileSystem?: ToolOutputArtifactFileSystem;
   idGenerator?: IdGenerator;
   timer?: Timer;
+  retention?: ToolOutputArtifactRetention;
 }
 
 export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
@@ -48,18 +84,21 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
   private readonly fileSystem: ToolOutputArtifactFileSystem;
   private readonly idGenerator: IdGenerator;
   private readonly timer: Timer;
+  private readonly retention: ToolOutputArtifactRetention | undefined;
 
   constructor(options: JsonToolOutputArtifactWriterOptions) {
     this.outputDirectory = resolvePathFromDaemonLaunchWorkingDirectory(options.outputDirectory);
     this.fileSystem = options.fileSystem ?? new NodeToolOutputArtifactFileSystem();
     this.idGenerator = options.idGenerator ?? defaultIdGenerator;
     this.timer = options.timer ?? defaultTimer;
+    this.retention = options.retention;
   }
 
   writeJsonArtifact(input: ObservationArtifactWriteInput): ObservationArtifactMetadata {
     try {
       this.fileSystem.ensureDirectory(this.outputDirectory);
       this.fileSystem.assertWritableDirectory(this.outputDirectory);
+      this.pruneOldArtifacts();
 
       const content = stringifyToolResponse(input.data);
       const filename = `${Math.trunc(this.timer.now())}-${safeFilenameSegment(input.tool)}-${safeFilenameSegment(this.idGenerator.next())}.json`;
@@ -77,6 +116,35 @@ export class JsonToolOutputArtifactWriter implements ObservationArtifactWriter {
       };
     } catch (error) {
       throw toActionableError(error, `Failed to write ${input.payload} artifact for ${input.tool}`);
+    }
+  }
+
+  private pruneOldArtifacts(): void {
+    const retention = this.retention;
+    if (!retention) {
+      return;
+    }
+
+    try {
+      const nowMs = this.timer.now();
+      const candidates = this.fileSystem.listFiles(this.outputDirectory)
+        .filter(entry => entry.isFile && entry.name.endsWith(".json"))
+        .sort((a, b) => a.mtimeMs - b.mtimeMs);
+      const expired = candidates.filter(entry => nowMs - entry.mtimeMs > retention.maxAgeMs);
+      const expiredPaths = new Set(expired.map(entry => entry.path));
+      const remainingCount = candidates.length - expiredPaths.size;
+      const overflowCount = Math.max(0, remainingCount - retention.maxFiles);
+      const overflow = candidates
+        .filter(entry => !expiredPaths.has(entry.path))
+        .filter(entry => nowMs - entry.mtimeMs > retention.overflowMinAgeMs)
+        .slice(0, overflowCount);
+      const filesToDelete = new Set([...expired, ...overflow].map(entry => entry.path));
+
+      for (const filePath of filesToDelete) {
+        this.fileSystem.deleteFile(filePath);
+      }
+    } catch (error) {
+      logger.warn(`Failed to prune old tool output artifacts: ${error}`, error);
     }
   }
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -36,6 +36,7 @@ import {
   narrowInternalToolEnvelope,
 } from "./internalToolPayloads";
 import { JsonToolOutputArtifactWriter } from "./toolOutputArtifactWriter";
+import { getDefaultToolOutputsDir } from "../utils/toolOutputArtifacts";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -616,8 +617,10 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
           set: (uuid, observation) => DaemonState.getInstance().getSessionManager().setLastRenderedObservation(uuid, observation),
         }
         : undefined;
-    const artifactDirectory = serverConfig.getToolOutputArtifactDirectory();
-    const artifactWriter = artifactDirectory && !internalCall
+    const configuredArtifactDirectory = serverConfig.getToolOutputArtifactDirectory();
+    const artifactMode = configuredArtifactDirectory ? "always" : "oversized";
+    const artifactDirectory = configuredArtifactDirectory ?? getDefaultToolOutputsDir();
+    const artifactWriter = !internalCall
       ? this.createArtifactWriter(artifactDirectory, timer)
       : undefined;
 
@@ -628,6 +631,7 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
       baselineStore,
       internal: internalCall,
       artifactWriter,
+      artifactMode,
     });
 
     TelemetryRecorder.getInstance().recordToolCallEvent({

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -35,7 +35,7 @@ import {
   InternalToolPayloads,
   narrowInternalToolEnvelope,
 } from "./internalToolPayloads";
-import { JsonToolOutputArtifactWriter } from "./toolOutputArtifactWriter";
+import { JsonToolOutputArtifactWriter, type ToolOutputArtifactRetention } from "./toolOutputArtifactWriter";
 import { getDefaultToolOutputsDir } from "../utils/toolOutputArtifacts";
 
 // Re-exported for backward compatibility; the implementation now lives in
@@ -173,7 +173,17 @@ interface AfterToolCallHandler {
   handle(input: AfterToolCallInput): Promise<AfterToolCallResult>;
 }
 
-type ObservationArtifactWriterFactory = (outputDirectory: string, timer: Timer) => ObservationArtifactWriter;
+type ObservationArtifactWriterFactory = (
+  outputDirectory: string,
+  timer: Timer,
+  retention?: ToolOutputArtifactRetention
+) => ObservationArtifactWriter;
+
+const AUTOMATIC_TOOL_OUTPUT_RETENTION: ToolOutputArtifactRetention = {
+  maxAgeMs: 24 * 60 * 60 * 1000,
+  maxFiles: 500,
+  overflowMinAgeMs: 60 * 60 * 1000,
+};
 
 export interface PlanLifecycleInput {
   name: string;
@@ -530,7 +540,7 @@ class DefaultNavigationToolCallRecorder implements NavigationToolCallRecorder {
 export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
   constructor(
     private readonly createArtifactWriter: ObservationArtifactWriterFactory =
-    (outputDirectory, timer) => new JsonToolOutputArtifactWriter({ outputDirectory, timer })
+    (outputDirectory, timer, retention) => new JsonToolOutputArtifactWriter({ outputDirectory, timer, retention })
   ) {}
 
   async handle(input: AfterToolCallInput): Promise<AfterToolCallResult> {
@@ -621,7 +631,9 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
     const artifactMode = configuredArtifactDirectory ? "always" : "oversized";
     const artifactDirectory = configuredArtifactDirectory ?? getDefaultToolOutputsDir();
     const artifactWriter = !internalCall
-      ? this.createArtifactWriter(artifactDirectory, timer)
+      ? configuredArtifactDirectory
+        ? this.createArtifactWriter(artifactDirectory, timer)
+        : this.createArtifactWriter(artifactDirectory, timer, AUTOMATIC_TOOL_OUTPUT_RETENTION)
       : undefined;
 
     const finalizedResponse = finalizeToolResponse(response, {

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -91,6 +91,7 @@ export const TEMP_SUBDIRS = {
   NAVIGATION_SCREENSHOTS: "navigation-screenshots",
   VIEW_HIERARCHY: "view_hierarchy",
   OBSERVE_RESULTS: "observe_results",
+  TOOL_OUTPUTS: "tool_outputs",
   WINDOW: "window",
   CACHE: "cache",
   STATE: "state",

--- a/src/utils/toolOutputArtifacts.ts
+++ b/src/utils/toolOutputArtifacts.ts
@@ -1,18 +1,14 @@
 import { promises as fsPromises, constants as fsConstants } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { ActionableError } from "../models";
 import type { FileSystem } from "./filesystem/DefaultFileSystem";
 import { serverConfig } from "./ServerConfig";
+import { getTempDir, TEMP_SUBDIRS } from "./tempDir";
 
 export const TOOL_OUTPUTS_DIR_FLAG = "--tool-outputs-dir";
 export const TOOL_OUTPUT_DIR_FLAG_ALIAS = "--tool-output-dir";
 export const TOOL_OUTPUTS_DIR_ENV = "AUTOMOBILE_TOOL_OUTPUTS_DIR";
 export const TOOL_OUTPUTS_DIR_ENV_ALIAS = "AUTO_MOBILE_TOOL_OUTPUTS_DIR";
-
-function currentUserId(): string {
-  return process.getuid?.()?.toString() ?? process.env.USERNAME ?? "default";
-}
 
 export interface ToolOutputsDirValidationDeps extends Pick<FileSystem, "ensureDir"> {
   stat(dirPath: string): Promise<{ isDirectory(): boolean }>;
@@ -68,7 +64,7 @@ export function parseToolOutputsDirConfig(
 }
 
 export function getDefaultToolOutputsDir(): string {
-  return path.join(tmpdir(), `auto-mobile-tool-outputs-${currentUserId()}`);
+  return getTempDir(TEMP_SUBDIRS.TOOL_OUTPUTS);
 }
 
 function errorMessage(error: unknown): string {

--- a/src/utils/toolOutputArtifacts.ts
+++ b/src/utils/toolOutputArtifacts.ts
@@ -1,4 +1,5 @@
 import { promises as fsPromises, constants as fsConstants } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { ActionableError } from "../models";
 import type { FileSystem } from "./filesystem/DefaultFileSystem";
@@ -8,6 +9,10 @@ export const TOOL_OUTPUTS_DIR_FLAG = "--tool-outputs-dir";
 export const TOOL_OUTPUT_DIR_FLAG_ALIAS = "--tool-output-dir";
 export const TOOL_OUTPUTS_DIR_ENV = "AUTOMOBILE_TOOL_OUTPUTS_DIR";
 export const TOOL_OUTPUTS_DIR_ENV_ALIAS = "AUTO_MOBILE_TOOL_OUTPUTS_DIR";
+
+function currentUserId(): string {
+  return process.getuid?.()?.toString() ?? process.env.USERNAME ?? "default";
+}
 
 export interface ToolOutputsDirValidationDeps extends Pick<FileSystem, "ensureDir"> {
   stat(dirPath: string): Promise<{ isDirectory(): boolean }>;
@@ -60,6 +65,10 @@ export function parseToolOutputsDirConfig(
     cliValue ?? env[TOOL_OUTPUTS_DIR_ENV] ?? env[TOOL_OUTPUTS_DIR_ENV_ALIAS],
     launchCwd
   );
+}
+
+export function getDefaultToolOutputsDir(): string {
+  return path.join(tmpdir(), `auto-mobile-tool-outputs-${currentUserId()}`);
 }
 
 function errorMessage(error: unknown): string {

--- a/test/server/toolOutputArtifactWriter.test.ts
+++ b/test/server/toolOutputArtifactWriter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import {
   JsonToolOutputArtifactWriter,
+  type ToolOutputArtifactDirectoryEntry,
   type ToolOutputArtifactFileSystem,
 } from "../../src/server/toolOutputArtifactWriter";
 import { stringifyToolResponse } from "../../src/utils/toolUtils";
@@ -13,6 +14,9 @@ class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
   ensureCalls: string[] = [];
   assertWritableCalls: string[] = [];
   writes: Array<{ path: string; content: string; mode: number }> = [];
+  entries: ToolOutputArtifactDirectoryEntry[] = [];
+  listCalls: string[] = [];
+  deleteCalls: string[] = [];
   writeError: Error | undefined;
 
   ensureDirectory(dirPath: string): void {
@@ -28,6 +32,15 @@ class FakeArtifactFileSystem implements ToolOutputArtifactFileSystem {
       throw this.writeError;
     }
     this.writes.push({ path: filePath, content, mode });
+  }
+
+  listFiles(dirPath: string): ToolOutputArtifactDirectoryEntry[] {
+    this.listCalls.push(dirPath);
+    return this.entries;
+  }
+
+  deleteFile(filePath: string): void {
+    this.deleteCalls.push(filePath);
   }
 }
 
@@ -75,6 +88,94 @@ describe("JsonToolOutputArtifactWriter", () => {
       },
     });
     expect(second.artifact.path).toBe(secondPath);
+    expect(fileSystem.listCalls).toEqual([]);
+    expect(fileSystem.deleteCalls).toEqual([]);
+  });
+
+  test("prunes stale JSON artifacts when retention is configured", () => {
+    const fileSystem = new FakeArtifactFileSystem();
+    const outputDirectory = path.resolve("/tmp/auto-mobile artifacts");
+    fileSystem.entries = [
+      {
+        path: path.join(outputDirectory, "old-observe.json"),
+        name: "old-observe.json",
+        isFile: true,
+        mtimeMs: 1_000,
+      },
+      {
+        path: path.join(outputDirectory, "recent-observe.json"),
+        name: "recent-observe.json",
+        isFile: true,
+        mtimeMs: 9_500,
+      },
+      {
+        path: path.join(outputDirectory, "old-note.txt"),
+        name: "old-note.txt",
+        isFile: true,
+        mtimeMs: 1_000,
+      },
+      {
+        path: path.join(outputDirectory, "nested"),
+        name: "nested",
+        isFile: false,
+        mtimeMs: 1_000,
+      },
+    ];
+    const timer = new FakeTimer();
+    timer.setCurrentTime(10_000);
+    const writer = new JsonToolOutputArtifactWriter({
+      outputDirectory,
+      fileSystem,
+      idGenerator: new FakeIdGenerator(["id"]),
+      timer,
+      retention: { maxAgeMs: 1_000, maxFiles: 500, overflowMinAgeMs: 500 },
+    });
+
+    writer.writeJsonArtifact({
+      tool: "observe",
+      payload: "ObserveResult",
+      data: { updatedAt: 1 },
+    });
+
+    expect(fileSystem.listCalls).toEqual([outputDirectory]);
+    expect(fileSystem.deleteCalls).toEqual([path.join(outputDirectory, "old-observe.json")]);
+    expect(fileSystem.writes).toHaveLength(1);
+  });
+
+  test("prunes file-count overflow only after the overflow age gate", () => {
+    const fileSystem = new FakeArtifactFileSystem();
+    const outputDirectory = path.resolve("/tmp/auto-mobile artifacts");
+    fileSystem.entries = [
+      {
+        path: path.join(outputDirectory, "older-observe.json"),
+        name: "older-observe.json",
+        isFile: true,
+        mtimeMs: 1_000,
+      },
+      {
+        path: path.join(outputDirectory, "fresh-observe.json"),
+        name: "fresh-observe.json",
+        isFile: true,
+        mtimeMs: 9_900,
+      },
+    ];
+    const timer = new FakeTimer();
+    timer.setCurrentTime(10_000);
+    const writer = new JsonToolOutputArtifactWriter({
+      outputDirectory,
+      fileSystem,
+      idGenerator: new FakeIdGenerator(["id"]),
+      timer,
+      retention: { maxAgeMs: 20_000, maxFiles: 1, overflowMinAgeMs: 5_000 },
+    });
+
+    writer.writeJsonArtifact({
+      tool: "observe",
+      payload: "ObserveResult",
+      data: { updatedAt: 1 },
+    });
+
+    expect(fileSystem.deleteCalls).toEqual([path.join(outputDirectory, "older-observe.json")]);
   });
 
   test("resolves relative artifact directories from the daemon launch cwd", () => {

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -15,6 +15,7 @@ import {
   stripToolResultStructuredContent,
   structuredContentOmissionReason,
 } from "../../src/server/stripToolResultStructuredContent";
+import type { ToolOutputArtifactRetention } from "../../src/server/toolOutputArtifactWriter";
 
 describe("ToolRegistry device-aware pipeline", () => {
   const device: BootedDevice = {
@@ -272,8 +273,10 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
   test("configured artifact directory creates a writer and replaces observe output metadata", async () => {
     const writer = new FakeObservationArtifactWriter();
     const requestedDirectories: string[] = [];
-    const handler = new DefaultAfterToolCallHandler(outputDirectory => {
+    const requestedRetentions: Array<ToolOutputArtifactRetention | undefined> = [];
+    const handler = new DefaultAfterToolCallHandler((outputDirectory, _timer, retention) => {
       requestedDirectories.push(outputDirectory);
+      requestedRetentions.push(retention);
       return writer;
     });
     const timer = new FakeTimer();
@@ -294,6 +297,7 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
 
     expect(result.durationMs).toBe(5);
     expect(requestedDirectories).toEqual(["/tmp/artifacts"]);
+    expect(requestedRetentions).toEqual([undefined]);
     expect(writer.writes).toHaveLength(1);
     expect((writer.writes[0].data as any).viewHierarchy.hierarchy.node["view-id"]).toBeUndefined();
     expect(result.finalizedResponse.structuredContent).toEqual({
@@ -314,8 +318,10 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
     const originalNoStructuredContent = serverConfig.isToolResultsNoStructuredContentEnabled();
     const writer = new FakeObservationArtifactWriter();
     const requestedDirectories: string[] = [];
-    const handler = new DefaultAfterToolCallHandler(outputDirectory => {
+    const requestedRetentions: Array<ToolOutputArtifactRetention | undefined> = [];
+    const handler = new DefaultAfterToolCallHandler((outputDirectory, _timer, retention) => {
       requestedDirectories.push(outputDirectory);
+      requestedRetentions.push(retention);
       return writer;
     });
     const timer = new FakeTimer();
@@ -342,7 +348,14 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
         structuredContentOmissionReason(true)
       );
 
-      expect(requestedDirectories).toEqual([expect.stringContaining("auto-mobile-tool-outputs")]);
+      expect(requestedDirectories).toEqual([expect.stringContaining("tool_outputs")]);
+      expect(requestedRetentions).toEqual([
+        {
+          maxAgeMs: 24 * 60 * 60 * 1000,
+          maxFiles: 500,
+          overflowMinAgeMs: 60 * 60 * 1000,
+        },
+      ]);
       expect(writer.writes).toHaveLength(1);
       const writtenRoot = (writer.writes[0].data as any).viewHierarchy.hierarchy.node;
       expect(writtenRoot["view-id"]).toBeUndefined();

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -226,6 +226,40 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
     },
   });
 
+  const makeLargeOcclusionHeavyObservePayload = () => {
+    const overlayId = "com.example:id/floating_overlay";
+    return {
+      updatedAt: 1,
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      viewHierarchy: {
+        hierarchy: {
+          node: {
+            "resource-id": "com.example:id/root",
+            "view-id": "com.example:id/root",
+            "node": [
+              {
+                "resource-id": overlayId,
+                "view-id": overlayId,
+                "bounds": { left: 850, top: 1500, right: 1030, bottom: 1680 },
+                "content-desc": "Compose floating action button",
+              },
+              ...Array.from({ length: 900 }, (_, index) => ({
+                "resource-id": `com.example:id/card_${index}`,
+                "view-id": `com.example:id/card_${index}`,
+                "text": `Occlusion-heavy card row ${index} ${"detail ".repeat(12)}`,
+                "bounds": { left: 24, top: index * 4, right: 1056, bottom: index * 4 + 120 },
+                "occlusionState": "partial",
+                "occludedBy": "Compose floating action button",
+                "occludedByViewId": overlayId,
+              })),
+            ],
+          },
+        },
+      },
+    };
+  };
+
   afterEach(() => {
     serverConfig.setToolOutputArtifactDirectory(undefined);
     resetMcpRecordingState();
@@ -267,6 +301,81 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
         tool: "observe",
       },
     });
+    expect(result.finalizedResponse.content[0].text).toBe(stringifyToolResponse(result.finalizedResponse.structuredContent));
+  });
+
+  test("oversized occlusion-heavy observe auto-spills to an artifact when no directory is configured", async () => {
+    const originalObserveCompact = serverConfig.isObserveResultCompactEnabled();
+    const originalCompactJson = serverConfig.isToolResultsCompactJsonEnabled();
+    const writer = new FakeObservationArtifactWriter();
+    const requestedDirectories: string[] = [];
+    const handler = new DefaultAfterToolCallHandler(outputDirectory => {
+      requestedDirectories.push(outputDirectory);
+      return writer;
+    });
+    const timer = new FakeTimer();
+    timer.setCurrentTime(25);
+    serverConfig.setToolOutputArtifactDirectory(undefined);
+    serverConfig.setObserveResultCompactEnabled(true);
+    serverConfig.setToolResultsCompactJsonEnabled(true);
+
+    try {
+      const result = await handler.handle({
+        name: "observe",
+        args: {},
+        device: undefined,
+        internalCall: false,
+        response: createStructuredToolResponse(makeLargeOcclusionHeavyObservePayload()),
+        sessionUuid: "session-1",
+        shouldResolveDevice: false,
+        timer,
+        toolStartMs: 20,
+      });
+
+      expect(requestedDirectories).toEqual([expect.stringContaining("auto-mobile-tool-outputs")]);
+      expect(writer.writes).toHaveLength(1);
+      const writtenRoot = (writer.writes[0].data as any).viewHierarchy.hierarchy.node;
+      expect(writtenRoot["view-id"]).toBeUndefined();
+      expect(writtenRoot.node[0]["view-id"]).toBe("com.example:id/floating_overlay");
+      expect(writtenRoot.node[1].occludedByViewId).toBe("com.example:id/floating_overlay");
+      expect(writtenRoot.node[1].bounds).toEqual([24, 0, 1056, 120]);
+      expect(result.finalizedResponse.structuredContent).toEqual({
+        artifact: {
+          path: "/tmp/artifacts/observe-1.json",
+          format: "json",
+          payload: "ObserveResult",
+          bytes: 123,
+          tool: "observe",
+        },
+      });
+      expect(() => JSON.parse(result.finalizedResponse.content[0].text)).not.toThrow();
+      expect(result.finalizedResponse.content[0].text).toBe(stringifyToolResponse(result.finalizedResponse.structuredContent));
+    } finally {
+      serverConfig.setObserveResultCompactEnabled(originalObserveCompact);
+      serverConfig.setToolResultsCompactJsonEnabled(originalCompactJson);
+    }
+  });
+
+  test("small observe results remain inline when no artifact directory is configured", async () => {
+    const writer = new FakeObservationArtifactWriter();
+    const handler = new DefaultAfterToolCallHandler(() => writer);
+    serverConfig.setToolOutputArtifactDirectory(undefined);
+
+    const result = await handler.handle({
+      name: "observe",
+      args: {},
+      device: undefined,
+      internalCall: false,
+      response: createStructuredToolResponse(makeObservePayload()),
+      sessionUuid: "session-1",
+      shouldResolveDevice: false,
+      timer: new FakeTimer(),
+      toolStartMs: 0,
+    });
+
+    expect(writer.writes).toHaveLength(0);
+    expect((result.finalizedResponse.structuredContent as any).viewHierarchy).toBeDefined();
+    expect((result.finalizedResponse.structuredContent as any).artifact).toBeUndefined();
     expect(result.finalizedResponse.content[0].text).toBe(stringifyToolResponse(result.finalizedResponse.structuredContent));
   });
 

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -11,6 +11,10 @@ import { serverConfig } from "../../src/utils/ServerConfig";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { TelemetryRecorder } from "../../src/features/telemetry/TelemetryRecorder";
 import { getMcpRecordingStatus, resetMcpRecordingState, startMcpRecording } from "../../src/server/mcpRecordingManager";
+import {
+  stripToolResultStructuredContent,
+  structuredContentOmissionReason,
+} from "../../src/server/stripToolResultStructuredContent";
 
 describe("ToolRegistry device-aware pipeline", () => {
   const device: BootedDevice = {
@@ -307,6 +311,7 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
   test("oversized occlusion-heavy observe auto-spills to an artifact when no directory is configured", async () => {
     const originalObserveCompact = serverConfig.isObserveResultCompactEnabled();
     const originalCompactJson = serverConfig.isToolResultsCompactJsonEnabled();
+    const originalNoStructuredContent = serverConfig.isToolResultsNoStructuredContentEnabled();
     const writer = new FakeObservationArtifactWriter();
     const requestedDirectories: string[] = [];
     const handler = new DefaultAfterToolCallHandler(outputDirectory => {
@@ -318,6 +323,7 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
     serverConfig.setToolOutputArtifactDirectory(undefined);
     serverConfig.setObserveResultCompactEnabled(true);
     serverConfig.setToolResultsCompactJsonEnabled(true);
+    serverConfig.setToolResultsNoStructuredContentEnabled(true);
 
     try {
       const result = await handler.handle({
@@ -331,6 +337,10 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
         timer,
         toolStartMs: 20,
       });
+      const wireResult = stripToolResultStructuredContent(
+        result.finalizedResponse,
+        structuredContentOmissionReason(true)
+      );
 
       expect(requestedDirectories).toEqual([expect.stringContaining("auto-mobile-tool-outputs")]);
       expect(writer.writes).toHaveLength(1);
@@ -339,7 +349,8 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
       expect(writtenRoot.node[0]["view-id"]).toBe("com.example:id/floating_overlay");
       expect(writtenRoot.node[1].occludedByViewId).toBe("com.example:id/floating_overlay");
       expect(writtenRoot.node[1].bounds).toEqual([24, 0, 1056, 120]);
-      expect(result.finalizedResponse.structuredContent).toEqual({
+      expect(wireResult.structuredContent).toBeUndefined();
+      expect(JSON.parse(wireResult.content[0].text)).toEqual({
         artifact: {
           path: "/tmp/artifacts/observe-1.json",
           format: "json",
@@ -348,11 +359,11 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
           tool: "observe",
         },
       });
-      expect(() => JSON.parse(result.finalizedResponse.content[0].text)).not.toThrow();
-      expect(result.finalizedResponse.content[0].text).toBe(stringifyToolResponse(result.finalizedResponse.structuredContent));
+      expect(wireResult.content[0].text).not.toContain("\n");
     } finally {
       serverConfig.setObserveResultCompactEnabled(originalObserveCompact);
       serverConfig.setToolResultsCompactJsonEnabled(originalCompactJson);
+      serverConfig.setToolResultsNoStructuredContentEnabled(originalNoStructuredContent);
     }
   });
 

--- a/test/utils/toolOutputArtifacts.test.ts
+++ b/test/utils/toolOutputArtifacts.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { ActionableError } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import {
+  getDefaultToolOutputsDir,
   getValidatedToolOutputsDirForWrite,
   parseToolOutputsDirConfig,
   validateToolOutputsDirForWrite,
@@ -111,6 +112,39 @@ describe("parseToolOutputsDirConfig", () => {
       { AUTOMOBILE_TOOL_OUTPUTS_DIR: "   " },
       path.resolve("launch-root")
     )).toBeUndefined();
+  });
+});
+
+describe("getDefaultToolOutputsDir", () => {
+  test("uses the stable AutoMobile data directory instead of TMPDIR", () => {
+    const originalDataDir = process.env.AUTOMOBILE_DATA_DIR;
+    const originalLegacyDataDir = process.env.AUTO_MOBILE_DATA_DIR;
+    const originalTmpDir = process.env.TMPDIR;
+    const dataDir = path.join(tmpdir(), "auto-mobile-data-dir-test");
+    const ephemeralTmpDir = path.join(tmpdir(), "bunx-ephemeral-test");
+
+    process.env.AUTOMOBILE_DATA_DIR = dataDir;
+    delete process.env.AUTO_MOBILE_DATA_DIR;
+    process.env.TMPDIR = ephemeralTmpDir;
+    try {
+      expect(getDefaultToolOutputsDir()).toBe(path.join(dataDir, "tool_outputs"));
+    } finally {
+      if (originalDataDir === undefined) {
+        delete process.env.AUTOMOBILE_DATA_DIR;
+      } else {
+        process.env.AUTOMOBILE_DATA_DIR = originalDataDir;
+      }
+      if (originalLegacyDataDir === undefined) {
+        delete process.env.AUTO_MOBILE_DATA_DIR;
+      } else {
+        process.env.AUTO_MOBILE_DATA_DIR = originalLegacyDataDir;
+      }
+      if (originalTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = originalTmpDir;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Automatically spills oversized agent-facing observe payloads to JSON artifact metadata when no explicit tool output directory is configured, so occlusion-heavy screens return small parseable tool JSON instead of risking client-side truncation. Existing configured artifact mode still artifacts observations unconditionally, and small observations remain inline.

## Linked Issue

Closes #3539

## Bug / Regression Context

- **Prior attempts:** PR #3537 fixed Android occlusion view-id links; this handles the remaining oversized observe output failure mode.
- **Observed symptom:** `observe` on occlusion-heavy Android screens could return a malformed/truncated escaped JSON payload.
- **Repro steps / conditions:** Large Android hierarchies with occlusion metadata under compact observe/compact JSON/no structured-content style output.

## Validation

- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: N/A, TypeScript output pipeline only
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Not run: device verification was not performed; this is covered by synthetic output-pipeline regression tests.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A

Risk class: higher-risk because this changes public observe/tool-output behavior.

Made with [Cursor](https://cursor.com)