### PR TITLE
chore: bump versions to v0.0.43

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "auto-mobile",
       "source": "./.claude-plugin",
       "description": "Mobile device automation for Android and iOS - control devices with natural language",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "author": {
         "name": "AutoMobile Contributors",
         "email": "jason.d.pearson@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-mobile",
   "description": "Mobile device automation for Android and iOS - control devices with natural language",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "author": {
     "name": "AutoMobile Contributors",
     "email": "jason.d.pearson@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.0.43] - 2026-07-10
+### Other
+- Invalid observe outputSchema breaks strict MCP tools/list clients ([#3542](https://github.com/kaeawc/auto-mobile/issues/3542))
+- observe returns malformed/truncated JSON on occlusion-heavy screens (regression in current main) ([#3539](https://github.com/kaeawc/auto-mobile/issues/3539))
+
 ## [v0.0.42] - 2026-07-10
 ### Added
 - docs/observe: contentDescription waitFor predicate silently ignores textMatch ([#3514](https://github.com/kaeawc/auto-mobile/issues/3514)) (documentation)

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -34,7 +34,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.42-SNAPSHOT"
+    versionName = "0.0.43-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -140,7 +140,7 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 # Maven Central Publishing
 
 # Library versions (single source of truth)
-VERSION_NAME=0.0.42-SNAPSHOT
+VERSION_NAME=0.0.43-SNAPSHOT
 GROUP=dev.jasonpearson.auto-mobile
 
 # POM metadata

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
     minSdk = libs.versions.build.android.minSdk.get().toInt()
     targetSdk = libs.versions.build.android.targetSdk.get().toInt()
     versionCode = 1
-    versionName = "0.0.42-SNAPSHOT"
+    versionName = "0.0.43-SNAPSHOT"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift
@@ -19,5 +19,5 @@ import Foundation
 /// matches a source-checkout daemon carrying a `+g<sha>` dev stamp at the same release.
 public enum AutoMobileVersion {
     /// The current AutoMobile release version. Generated — do not edit by hand.
-    public static let current = "0.0.42"
+    public static let current = "0.0.43"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaeawc/auto-mobile",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.jasonpearson/auto-mobile",
   "title": "AutoMobile",
   "description": "Mobile device interaction automation via MCP",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "websiteUrl": "https://kaeawc.github.io/auto-mobile/",
   "repository": {
     "url": "https://github.com/kaeawc/auto-mobile",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@kaeawc/auto-mobile",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "runtimeHint": "bunx",
       "transport": {
         "type": "stdio"

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -29,6 +29,12 @@ export interface ReleaseChecksumEntry {
  */
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
   {
+    version: "0.0.43",
+    apkSha256: "7e4e2ce3c19b7473d171433186dbc7487df60ff6045dba66da7a320d31e63cd3",
+    ipaSha256: "db0e3c4c172681068ae7ae24182f5569519b5fab034fbcf0e85abdc952b398dd",
+    runnerSha256: "b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982",
+  },
+  {
     version: "0.0.42",
     apkSha256: "cb00a835f58ce2d0344483f27b7c35036bb6faa973aa3fcc66fe67e75428abb0",
     ipaSha256: "de55b77ee0e821b4f08b7cd1b84f9a2706f69279422901546e2dc6fdd4cc3f0f",


### PR DESCRIPTION
## Summary
- Bump versions to v0.0.43
- Update CHANGELOG.md from closed issues since the last tag
- Refresh CtrlProxy APK SHA256 checksum
- Refresh CtrlProxy iOS IPA SHA256 checksum

## Automation
- Generated by `prepare-release` workflow