### PR TITLE
ci: bump gradle task actions to Node 24

### DIFF
--- a/.github/actions/gradle-task-run/action.yml
+++ b/.github/actions/gradle-task-run/action.yml
@@ -177,7 +177,7 @@ runs:
         echo "ANDROID_HOME: $ANDROID_HOME"
 
     - name: "Setup Gradle"
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v5.0.2
       with:
         gradle-version: ${{ steps.eval_gradle.outputs.version }}
         cache-encryption-key: ${{ inputs.gradle-encryption-key }}

--- a/.github/actions/gradle-task-run/action.yml
+++ b/.github/actions/gradle-task-run/action.yml
@@ -152,11 +152,13 @@ runs:
         echo "GRADLE_FLAGS: $GRADLE_FLAGS"
 
     - name: "Hash Gradle Tasks"
-      uses: pplanel/hash-calculator-action@v1.3.2
       id: gradle-task-hash
-      with:
-        input: ${{ inputs.gradle-tasks }}
-        method: MD5
+      shell: ${{ inputs.shell }}
+      env:
+        GRADLE_TASKS: ${{ inputs.gradle-tasks }}
+      run: |
+        digest=$(printf '%s' "$GRADLE_TASKS" | openssl dgst -md5 -r | awk '{print $1}')
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
     - name: "Debug cache key inputs"
       shell: ${{ inputs.shell }}
@@ -175,7 +177,7 @@ runs:
         echo "ANDROID_HOME: $ANDROID_HOME"
 
     - name: "Setup Gradle"
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: ${{ steps.eval_gradle.outputs.version }}
         cache-encryption-key: ${{ inputs.gradle-encryption-key }}
@@ -188,7 +190,7 @@ runs:
 
     - name: "Restore Android SDK Cache"
       id: cache-android-sdk
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5.1.0
       with:
         path: |
           ~/.android
@@ -200,7 +202,7 @@ runs:
       uses: android-actions/setup-android@v3.2.2
 
     - name: "Save Android SDK Cache"
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5.1.0
       if: steps.cache-android-sdk.outputs.cache-hit != 'true'
       with:
         path: |
@@ -255,7 +257,7 @@ runs:
         fi
 
     - name: "Store Config Cache Report"
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v7.0.1
       if: success()
       with:
         name: config-cache-report-${{ steps.sanitize-name.outputs.sanitized_name }}-${{ runner.os }}

--- a/test/scripts/gradleTaskRunAction.test.ts
+++ b/test/scripts/gradleTaskRunAction.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../..");
+const actionPath = join(repoRoot, ".github/actions/gradle-task-run/action.yml");
+
+describe("gradle-task-run action", () => {
+  test("does not reference GitHub actions pinned to Node 20 runtimes", () => {
+    const action = readFileSync(actionPath, "utf8");
+
+    expect(action).not.toContain("pplanel/hash-calculator-action");
+    expect(action).not.toContain("actions/cache/restore@v4");
+    expect(action).not.toContain("actions/cache/save@v4");
+    expect(action).not.toContain("actions/upload-artifact@v4.4.0");
+    expect(action).not.toContain("gradle/actions/setup-gradle@v4");
+
+    expect(action).toContain("gradle/actions/setup-gradle@v6.2.0");
+    expect(action).toContain("actions/cache/restore@v5.1.0");
+    expect(action).toContain("actions/cache/save@v5.1.0");
+    expect(action).toContain("actions/upload-artifact@v7.0.1");
+    expect(action).toContain('echo "digest=$digest" >> "$GITHUB_OUTPUT"');
+  });
+});

--- a/test/scripts/gradleTaskRunAction.test.ts
+++ b/test/scripts/gradleTaskRunAction.test.ts
@@ -15,7 +15,7 @@ describe("gradle-task-run action", () => {
     expect(action).not.toContain("actions/upload-artifact@v4.4.0");
     expect(action).not.toContain("gradle/actions/setup-gradle@v4");
 
-    expect(action).toContain("gradle/actions/setup-gradle@v6.2.0");
+    expect(action).toContain("gradle/actions/setup-gradle@v5.0.2");
     expect(action).toContain("actions/cache/restore@v5.1.0");
     expect(action).toContain("actions/cache/save@v5.1.0");
     expect(action).toContain("actions/upload-artifact@v7.0.1");


### PR DESCRIPTION
## Summary
- remove the Node 20-only `pplanel/hash-calculator-action` dependency from `gradle-task-run`
- bump `gradle-task-run` action dependencies to Node 24-compatible releases
- add a focused guard test for the deprecated action references and replacement contract

Closes #3547

## Testing
- `bun test test/scripts/gradleTaskRunAction.test.ts`
- `bash scripts/all_fast_validate_checks.sh --only yaml`
- `git diff --check`
- `bun run turbo:validate`
- `bun run typecheck`

## Review
- Ran parallel AutoMobile review passes for shell/hash semantics and test adequacy; both found no actionable issues.
- The CI/runtime compatibility reviewer was interrupted before returning.
