### PR TITLE
Fix Homebrew tap trust warning in iOS IPA build

### DIFF
--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -41,7 +41,9 @@ jobs:
           key: homebrew-xcodegen-${{ runner.os }}
 
       - name: "Install XcodeGen"
-        run: brew install xcodegen
+        run: |
+          brew untap aws/tap || true
+          brew install xcodegen
 
       - name: "Cache Ruby gems"
         uses: actions/cache@v5

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -42,3 +42,16 @@
 @test "prepare-release.yml runs the release-integrity gate" {
   grep -q "verify-release-integrity.sh" ".github/workflows/prepare-release.yml"
 }
+
+@test "build-ctrl-proxy-ios-ipa.yml removes untrusted Homebrew aws tap before installing XcodeGen" {
+  workflow=".github/workflows/build-ctrl-proxy-ios-ipa.yml"
+
+  grep -Fq "brew untap aws/tap || true" "$workflow"
+  grep -Fq "brew install xcodegen" "$workflow"
+  ! grep -Fq "HOMEBREW_NO_REQUIRE_TAP_TRUST" "$workflow"
+
+  untap_line="$(grep -Fn "brew untap aws/tap || true" "$workflow" | cut -d: -f1 | head -n 1)"
+  install_line="$(grep -Fn "brew install xcodegen" "$workflow" | cut -d: -f1 | head -n 1)"
+
+  [[ "$untap_line" -lt "$install_line" ]]
+}


### PR DESCRIPTION
## Summary

Untaps the unused Homebrew `aws/tap` on the macOS runner before installing XcodeGen in the reusable CtrlProxy iOS IPA workflow. This keeps Homebrew tap-trust enforcement enabled while removing the warning emitted by the runner-provided tap.

## Linked Issue

Closes #3548

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** The `build-ctrl-proxy-ios-ipa / Build CtrlProxy iOS IPA` job emits a Homebrew tap-trust warning for the preinstalled `aws/tap` during `brew install xcodegen`.
- **Repro steps / conditions:** Run the iOS IPA build workflow on a GitHub-hosted macOS runner with the untrusted `aws/tap` present.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) - covered by `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: workflow-only change; targeted `bats test/bats/release-workflow-wiring.bats` passes
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms - N/A, workflow-only change
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
