### PR TITLE
Recover missing observation stream socket

### DIFF
--- a/src/daemon/ObservationStreamHealth.ts
+++ b/src/daemon/ObservationStreamHealth.ts
@@ -1,0 +1,33 @@
+export interface ObservationStreamHealth {
+  isHealthy(): boolean;
+  recover(): Promise<void>;
+}
+
+export interface ObservationStreamHealthServer {
+  isListening(): boolean;
+  hasActiveSocketPath(): boolean;
+}
+
+export interface ObservationStreamHealthDependencies {
+  getServer(): ObservationStreamHealthServer | null;
+  stopServer(): Promise<void>;
+  startServer(): Promise<void>;
+  configureCallbacks(): void;
+}
+
+export class DefaultObservationStreamHealth implements ObservationStreamHealth {
+  constructor(private readonly dependencies: ObservationStreamHealthDependencies) {}
+
+  isHealthy(): boolean {
+    const server = this.dependencies.getServer();
+    return server !== null &&
+      server.isListening() &&
+      server.hasActiveSocketPath();
+  }
+
+  async recover(): Promise<void> {
+    await this.dependencies.stopServer();
+    await this.dependencies.startServer();
+    this.dependencies.configureCallbacks();
+  }
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -17,7 +17,6 @@ import {
 } from "./constants";
 import { DaemonOptions, PidFileData } from "./types";
 import { mkdir, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
@@ -41,7 +40,7 @@ import { startDeviceSnapshotSocketServer, stopDeviceSnapshotSocketServer } from 
 import { startAppearanceSocketServer, stopAppearanceSocketServer } from "./appearanceSocketServer";
 import { startPerformanceStreamSocketServer, stopPerformanceStreamSocketServer } from "./performanceStreamSocketServer";
 import { startPerformancePushSocketServer, stopPerformancePushSocketServer } from "./performancePushSocketServer";
-import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer, getDeviceDataStreamSocketPath, type NavigationGraphStreamData } from "./deviceDataStreamSocketServer";
+import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer, type NavigationGraphStreamData } from "./deviceDataStreamSocketServer";
 import { startFailuresStreamSocketServer, stopFailuresStreamSocketServer } from "./failuresStreamSocketServer";
 import { startFailuresPushSocketServer, stopFailuresPushSocketServer } from "./failuresPushSocketServer";
 import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from "./telemetryPushSocketServer";
@@ -1243,7 +1242,7 @@ export class Daemon {
     const server = getDeviceDataStreamServer();
     return server !== null &&
       server.isListening() &&
-      existsSync(getDeviceDataStreamSocketPath());
+      server.hasActiveSocketPath();
   }
 
   /**

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -17,6 +17,7 @@ import {
 } from "./constants";
 import { DaemonOptions, PidFileData } from "./types";
 import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
@@ -40,7 +41,7 @@ import { startDeviceSnapshotSocketServer, stopDeviceSnapshotSocketServer } from 
 import { startAppearanceSocketServer, stopAppearanceSocketServer } from "./appearanceSocketServer";
 import { startPerformanceStreamSocketServer, stopPerformanceStreamSocketServer } from "./performanceStreamSocketServer";
 import { startPerformancePushSocketServer, stopPerformancePushSocketServer } from "./performancePushSocketServer";
-import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer, type NavigationGraphStreamData } from "./deviceDataStreamSocketServer";
+import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer, getDeviceDataStreamSocketPath, type NavigationGraphStreamData } from "./deviceDataStreamSocketServer";
 import { startFailuresStreamSocketServer, stopFailuresStreamSocketServer } from "./failuresStreamSocketServer";
 import { startFailuresPushSocketServer, stopFailuresPushSocketServer } from "./failuresPushSocketServer";
 import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from "./telemetryPushSocketServer";
@@ -98,6 +99,10 @@ const MIGRATION_SETTLE_TIMEOUT_MS = 5_000;
 
 type HealthFailureKind = "http" | "socket" | "database" | "unknown";
 type DatabaseHealthFailureRecovery = (code: number) => void;
+interface ObservationStreamHealth {
+  isHealthy(): boolean;
+  recover(): Promise<void>;
+}
 
 /**
  * Main daemon process
@@ -133,6 +138,7 @@ export class Daemon {
   private databaseHealthProbe: DatabaseHealthProbe;
   private startupFailureTracker: StartupFailureTracker;
   private recoverFromDatabaseHealthFailure: DatabaseHealthFailureRecovery;
+  private observationStreamHealth: ObservationStreamHealth;
   private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
@@ -165,6 +171,14 @@ export class Daemon {
       logger.close();
       process.exit(code);
     });
+    this.observationStreamHealth = {
+      isHealthy: () => this.isObservationStreamSocketHealthy(),
+      recover: async () => {
+        await stopDeviceDataStreamSocketServer();
+        await startDeviceDataStreamSocketServer(this.timer);
+        this.setupDeviceDataStreamCallback();
+      },
+    };
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
     // Register centralized cleanup for session-scoped state
@@ -967,9 +981,13 @@ export class Daemon {
           logger.warn("Health check failed: HTTP server not listening");
           recordHealthCheckFailure("http");
         } else {
-          // Check if socket server is active before probing shared dependencies.
+          // Check socket servers before probing shared dependencies; clients
+          // can only subscribe to advertised streams while their socket paths exist.
           if (!this.socketServer || !this.socketServer.isListening()) {
             logger.warn("Health check failed: Socket server not listening");
+            recordHealthCheckFailure("socket");
+          } else if (!this.observationStreamHealth.isHealthy()) {
+            logger.warn("Health check failed: Observation stream socket unavailable");
             recordHealthCheckFailure("socket");
           } else {
             try {
@@ -1206,9 +1224,26 @@ export class Daemon {
           logger.error(`Failed to restart socket server: ${error}`);
         }
       }
+
+      if (!this.observationStreamHealth.isHealthy()) {
+        logger.info("Restarting observation stream socket server...");
+        try {
+          await this.observationStreamHealth.recover();
+          logger.info("Observation stream socket server restarted successfully");
+        } catch (error) {
+          logger.error(`Failed to restart observation stream socket server: ${error}`);
+        }
+      }
     } catch (error) {
       logger.error(`Recovery attempt failed: ${error}`);
     }
+  }
+
+  private isObservationStreamSocketHealthy(): boolean {
+    const server = getDeviceDataStreamServer();
+    return server !== null &&
+      server.isListening() &&
+      existsSync(getDeviceDataStreamSocketPath());
   }
 
   /**

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -80,6 +80,10 @@ import {
   resolveStableDaemonWorkingDirectory,
 } from "../utils/workingDirectory";
 import { resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
+import {
+  DefaultObservationStreamHealth,
+  type ObservationStreamHealth,
+} from "./ObservationStreamHealth";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
@@ -98,10 +102,6 @@ const MIGRATION_SETTLE_TIMEOUT_MS = 5_000;
 
 type HealthFailureKind = "http" | "socket" | "database" | "unknown";
 type DatabaseHealthFailureRecovery = (code: number) => void;
-interface ObservationStreamHealth {
-  isHealthy(): boolean;
-  recover(): Promise<void>;
-}
 
 /**
  * Main daemon process
@@ -170,14 +170,14 @@ export class Daemon {
       logger.close();
       process.exit(code);
     });
-    this.observationStreamHealth = {
-      isHealthy: () => this.isObservationStreamSocketHealthy(),
-      recover: async () => {
-        await stopDeviceDataStreamSocketServer();
+    this.observationStreamHealth = new DefaultObservationStreamHealth({
+      getServer: getDeviceDataStreamServer,
+      stopServer: stopDeviceDataStreamSocketServer,
+      startServer: async () => {
         await startDeviceDataStreamSocketServer(this.timer);
-        this.setupDeviceDataStreamCallback();
       },
-    };
+      configureCallbacks: () => this.setupDeviceDataStreamCallback(),
+    });
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
     // Register centralized cleanup for session-scoped state
@@ -1236,13 +1236,6 @@ export class Daemon {
     } catch (error) {
       logger.error(`Recovery attempt failed: ${error}`);
     }
-  }
-
-  private isObservationStreamSocketHealthy(): boolean {
-    const server = getDeviceDataStreamServer();
-    return server !== null &&
-      server.isListening() &&
-      server.hasActiveSocketPath();
   }
 
   /**

--- a/src/daemon/socketServer/BaseSocketServer.ts
+++ b/src/daemon/socketServer/BaseSocketServer.ts
@@ -134,6 +134,15 @@ export abstract class BaseSocketServer {
   }
 
   /**
+   * Return true only while this server is listening through the same socket file
+   * it created. A listening Unix server whose path was unlinked or replaced is
+   * still alive for existing connections, but new clients cannot reach it there.
+   */
+  hasActiveSocketPath(): boolean {
+    return this.isOwnedSocketFile();
+  }
+
+  /**
    * Handle a new connection. Sets up line-based protocol.
    */
   protected handleConnection(socket: Socket): void {

--- a/test/daemon/ObservationStreamHealth.test.ts
+++ b/test/daemon/ObservationStreamHealth.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { DefaultObservationStreamHealth } from "../../src/daemon/ObservationStreamHealth";
+
+describe("DefaultObservationStreamHealth", () => {
+  test("is healthy only when the stream server is listening at its active socket path", () => {
+    const server = {
+      listening: true,
+      activeSocketPath: true,
+      isListening() {
+        return this.listening;
+      },
+      hasActiveSocketPath() {
+        return this.activeSocketPath;
+      },
+    };
+    const health = new DefaultObservationStreamHealth({
+      getServer: () => server,
+      stopServer: async () => {},
+      startServer: async () => {},
+      configureCallbacks: () => {},
+    });
+
+    expect(health.isHealthy()).toBe(true);
+
+    server.activeSocketPath = false;
+    expect(health.isHealthy()).toBe(false);
+
+    server.activeSocketPath = true;
+    server.listening = false;
+    expect(health.isHealthy()).toBe(false);
+  });
+
+  test("is unhealthy when no stream server is available", () => {
+    const health = new DefaultObservationStreamHealth({
+      getServer: () => null,
+      stopServer: async () => {},
+      startServer: async () => {},
+      configureCallbacks: () => {},
+    });
+
+    expect(health.isHealthy()).toBe(false);
+  });
+
+  test("recovers by stopping, starting, then restoring callbacks", async () => {
+    const calls: string[] = [];
+    const health = new DefaultObservationStreamHealth({
+      getServer: () => null,
+      stopServer: async () => {
+        calls.push("stop");
+      },
+      startServer: async () => {
+        calls.push("start");
+      },
+      configureCallbacks: () => {
+        calls.push("configure");
+      },
+    });
+
+    await health.recover();
+
+    expect(calls).toEqual(["stop", "start", "configure"]);
+  });
+});

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -199,6 +199,78 @@ describe("Daemon database health check", () => {
     expect(exitCodes).toEqual([1]);
   });
 
+  test("counts repeated HTTP failures as HTTP recovery without probing socket or database health", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    const daemon = buildDaemon(timer, databaseHealthProbe);
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+    const recoveryCalls: Array<{ at: number; failureKind?: string }> = [];
+    let observationHealthChecks = 0;
+
+    internals.httpServer = { listening: false };
+    internals.socketServer = { isListening: () => true };
+    internals.observationStreamHealth = {
+      isHealthy: () => {
+        observationHealthChecks += 1;
+        return true;
+      },
+      recover: async () => {},
+    };
+    internals.attemptRecovery = async failureKind => {
+      recoveryCalls.push({ at: timer.now(), failureKind });
+    };
+
+    internals.startHealthCheckTimer();
+
+    for (let i = 0; i < MAX_FAILED_CHECKS; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    expect(observationHealthChecks).toBe(0);
+    expect(databaseHealthProbe.checkCalls).toBe(0);
+    expect(recoveryCalls).toEqual([{
+      at: HEALTH_CHECK_INTERVAL_MS * MAX_FAILED_CHECKS,
+      failureKind: "http",
+    }]);
+  });
+
+  test("counts repeated control socket failures as socket recovery before observation and database checks", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    const daemon = buildDaemon(timer, databaseHealthProbe);
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+    const recoveryCalls: Array<{ at: number; failureKind?: string }> = [];
+    let observationHealthChecks = 0;
+
+    internals.httpServer = { listening: true };
+    internals.socketServer = { isListening: () => false };
+    internals.observationStreamHealth = {
+      isHealthy: () => {
+        observationHealthChecks += 1;
+        return true;
+      },
+      recover: async () => {},
+    };
+    internals.attemptRecovery = async failureKind => {
+      recoveryCalls.push({ at: timer.now(), failureKind });
+    };
+
+    internals.startHealthCheckTimer();
+
+    for (let i = 0; i < MAX_FAILED_CHECKS; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    expect(observationHealthChecks).toBe(0);
+    expect(databaseHealthProbe.checkCalls).toBe(0);
+    expect(recoveryCalls).toEqual([{
+      at: HEALTH_CHECK_INTERVAL_MS * MAX_FAILED_CHECKS,
+      failureKind: "socket",
+    }]);
+  });
+
   test("counts a missing observation stream socket as a socket health failure", async () => {
     const timer = new FakeTimer();
     const databaseHealthProbe = new FakeDatabaseHealthProbe();

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -14,9 +14,15 @@ interface FakeSocketServer {
   isListening(): boolean;
 }
 
+interface FakeObservationStreamHealth {
+  isHealthy(): boolean;
+  recover(): Promise<void>;
+}
+
 interface DaemonHealthInternals {
   httpServer: { listening: boolean } | null;
   socketServer: FakeSocketServer | null;
+  observationStreamHealth: FakeObservationStreamHealth;
   healthCheckTimer: NodeJS.Timeout | null;
   startHealthCheckTimer(): void;
   stopHealthCheckTimer(): void;
@@ -44,7 +50,7 @@ function buildDaemon(
   databaseHealthProbe: FakeDatabaseHealthProbe,
   exitProcess: (code: number) => void = () => {}
 ): Daemon {
-  return new Daemon(
+  const daemon = new Daemon(
     {},
     new FakeInstalledAppsRepository(),
     timer,
@@ -55,6 +61,11 @@ function buildDaemon(
     databaseHealthProbe,
     exitProcess
   );
+  (daemon as unknown as DaemonHealthInternals).observationStreamHealth = {
+    isHealthy: () => true,
+    recover: async () => {},
+  };
+  return daemon;
 }
 
 describe("Daemon database health check", () => {
@@ -186,6 +197,57 @@ describe("Daemon database health check", () => {
 
     expect(databaseHealthProbe.checkCalls).toBe(MAX_FAILED_CHECKS);
     expect(exitCodes).toEqual([1]);
+  });
+
+  test("counts a missing observation stream socket as a socket health failure", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    const daemon = buildDaemon(timer, databaseHealthProbe);
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+    const recoveryCalls: Array<{ at: number; failureKind?: string }> = [];
+
+    internals.httpServer = { listening: true };
+    internals.socketServer = { isListening: () => true };
+    internals.observationStreamHealth = {
+      isHealthy: () => false,
+      recover: async () => {},
+    };
+    internals.attemptRecovery = async failureKind => {
+      recoveryCalls.push({ at: timer.now(), failureKind });
+    };
+
+    internals.startHealthCheckTimer();
+
+    for (let i = 0; i < MAX_FAILED_CHECKS; i += 1) {
+      await timer.advanceTimersByTimeAsync(HEALTH_CHECK_INTERVAL_MS);
+    }
+
+    expect(databaseHealthProbe.checkCalls).toBe(0);
+    expect(recoveryCalls).toEqual([{
+      at: HEALTH_CHECK_INTERVAL_MS * MAX_FAILED_CHECKS,
+      failureKind: "socket",
+    }]);
+  });
+
+  test("recovers the observation stream socket on socket health recovery", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    const daemon = buildDaemon(timer, databaseHealthProbe);
+    const internals = daemon as unknown as DaemonHealthInternals;
+    cleanup = { internals, timer };
+    const recoverCalls: number[] = [];
+
+    internals.observationStreamHealth = {
+      isHealthy: () => false,
+      recover: async () => {
+        recoverCalls.push(timer.now());
+      },
+    };
+
+    await internals.attemptRecovery("socket");
+
+    expect(recoverCalls).toEqual([0]);
   });
 
   test("clears the health interval through the injected timer", () => {

--- a/test/daemon/socketServer/BaseSocketServerOwnership.test.ts
+++ b/test/daemon/socketServer/BaseSocketServerOwnership.test.ts
@@ -57,10 +57,12 @@ describe("BaseSocketServer close ownership", () => {
     server = new TestServer(socketPath, new FakeTimer());
     await server.start();
     expect(existsSync(socketPath)).toBe(true);
+    expect(server.hasActiveSocketPath()).toBe(true);
 
     await server.close();
 
     expect(existsSync(socketPath)).toBe(false);
+    expect(server.hasActiveSocketPath()).toBe(false);
   });
 
   (isWindows ? test.skip : test)("does NOT remove a replacement socket rebound at the same path", async () => {
@@ -71,7 +73,9 @@ describe("BaseSocketServer close ownership", () => {
     // Simulate a fast restart: our socket is replaced by a successor process
     // binding the same path before our close() runs.
     await unlink(socketPath);
+    expect(server.hasActiveSocketPath()).toBe(false);
     const replacement = await listenOnSocket(socketPath);
+    expect(server.hasActiveSocketPath()).toBe(false);
 
     try {
       await server.close();


### PR DESCRIPTION
## Summary

Treat the advertised `observation-stream` socket as part of daemon health. If the stream server is still in memory but its Unix socket path disappears or is replaced, the daemon now classifies that as a socket health failure and recovers by restarting the observation stream server and re-wiring its callbacks.

## Linked Issue

Closes #3556

## Bug / Regression Context

- **Prior attempts:** None found in the issue timeline.
- **Observed symptom:** The daemon control socket remained reachable while clients could not subscribe to the advertised `observation-stream` socket because the socket path no longer existed.
- **Repro steps / conditions:** Daemon PID/state advertises `observation-stream`, startup logs show it initially listening, then the socket path disappears while daemon/control socket stay alive.

## Acceptance Criteria

- The daemon detects when the advertised `observation-stream` socket is unavailable even though control socket and DB health are otherwise OK.
- Socket recovery restarts the observation stream server and restores its subscriber/cadence/observation/navigation callbacks.
- Existing HTTP, control socket, and database health recovery behavior remains unchanged.

## Validation

- [x] `bun test test/daemon/ObservationStreamHealth.test.ts test/daemon/daemonDatabaseHealthCheck.test.ts test/daemon/socketServer/BaseSocketServerOwnership.test.ts test/daemon/deviceDataStreamSocketServer.test.ts test/daemon/socketPaths.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] New code uses fakes + `FakeTimer`; focused unit tests run in <100ms.
- [ ] Rebased onto latest `main`, conflicts resolved

## Follow-ups

None.