### PR TITLE
fix: keep junit runner consumable on Kotlin 2.2

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -681,6 +681,32 @@ jobs:
           release-key-alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
+  junit-runner-kotlin-consumer-compatibility:
+    name: "JUnit Runner Kotlin Consumer Compatibility"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Install JDK"
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: "Validate Kotlin 2.2 consumer compatibility"
+        run: bash scripts/android/validate-junit-runner-kotlin-consumer.sh
+
+      - name: "Upload Compatibility Logs"
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: junit-runner-kotlin-consumer-compatibility-logs
+          path: scratch/junit-runner-kotlin-consumer/logs/
+          if-no-files-found: ignore
+
   # Test isolation issue resolved in #107 and #109
   # Re-enabled in #110
   junit-runner-emulator-tests:
@@ -919,6 +945,7 @@ jobs:
       - validate-mkdocs-nav
       - validate-documentation-links
       - mcp-build-and-test
+      - junit-runner-kotlin-consumer-compatibility
       - junit-runner-unit-tests
       - benchmark-context-thresholds
     env:
@@ -974,7 +1001,7 @@ jobs:
       - uses: ./.github/actions/gradle-task-run
         if: ${{ endsWith(steps.library-version.outputs.version, '-SNAPSHOT') }}
         with:
-          gradle-tasks: ":junit-runner:publish :auto-mobile-sdk:publish"
+          gradle-tasks: ":test-plan-validation:publish :junit-runner:publish :auto-mobile-sdk:publish"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1487,6 +1487,34 @@ jobs:
           path: heap-dump
           if-no-files-found: ignore
 
+  junit-runner-kotlin-consumer-compatibility:
+    name: "JUnit Runner Kotlin Consumer Compatibility"
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.android_should_run == 'true'
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Install JDK"
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: "Validate Kotlin 2.2 consumer compatibility"
+        run: bash scripts/android/validate-junit-runner-kotlin-consumer.sh
+
+      - name: "Upload Compatibility Logs"
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: junit-runner-kotlin-consumer-compatibility-logs
+          path: scratch/junit-runner-kotlin-consumer/logs/
+          if-no-files-found: ignore
+
   # Test isolation issue resolved in #107 and #109
   # Re-enabled in #110
   junit-runner-emulator-tests:
@@ -2249,6 +2277,7 @@ jobs:
       - build-android-control-proxy
       - build-junit-runner-library
       - build-playground-app
+      - junit-runner-kotlin-consumer-compatibility
       - junit-runner-unit-tests
       - junit-runner-emulator-tests
       - junit-runner-emulator-wtf-tests
@@ -2263,6 +2292,7 @@ jobs:
             "${{ needs.build-android-control-proxy.result }}" \
             "${{ needs.build-junit-runner-library.result }}" \
             "${{ needs.build-playground-app.result }}" \
+            "${{ needs.junit-runner-kotlin-consumer-compatibility.result }}" \
             "${{ needs.junit-runner-unit-tests.result }}" \
             "${{ needs.junit-runner-emulator-tests.result }}" \
             "${{ needs.junit-runner-emulator-wtf-tests.result }}" \

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ build-android-agp = "9.2.1"
 # Kotlin versions
 build-kotlin = "2.4.0"
 build-kotlin-language = "2.3"              # Used in all Kotlin modules
+build-kotlin-consumer = "2.2.21"           # Published runner/test-plan consumer floor
+build-kotlin-consumer-api = "2.2"          # API surface supported by older Kotlin consumers
 build-kotlin-coroutines = "1.11.0"
 
 # Java versions
@@ -88,6 +90,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter-api" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-vintage-engine" }
 kgp = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "build-kotlin" }
+kotlin-stdlib-consumer = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "build-kotlin-consumer" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "build-android-agp" }
 
 koog-agents = { module = "ai.koog:koog-agents", version.ref = "koog-agents" }

--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -34,6 +34,7 @@ val npmPackageVersion =
 dependencies {
   // Shared validation module
   api(project(":test-plan-validation"))
+  api(libs.kotlin.stdlib.consumer)
 
   // JUnit dependencies
   implementation(libs.junit)
@@ -63,6 +64,7 @@ tasks.withType<KotlinCompile>().configureEach {
     languageVersion.set(
       KotlinVersion.valueOf("KOTLIN_${libs.versions.build.kotlin.language.get().replace(".", "_")}")
     )
+    apiVersion.set(KotlinVersion.fromVersion(libs.versions.build.kotlin.consumer.api.get()))
   }
 }
 

--- a/android/junit-runner/gradle.properties
+++ b/android/junit-runner/gradle.properties
@@ -1,3 +1,4 @@
 POM_ARTIFACT_ID=auto-mobile-junit-runner
 POM_NAME=AutoMobile JUnit Runner
 POM_DESCRIPTION=Runs AutoMobile JUnit tests with AutoMobile CLI.
+kotlin.stdlib.default.dependency=false

--- a/android/test-plan-validation/build.gradle.kts
+++ b/android/test-plan-validation/build.gradle.kts
@@ -13,6 +13,8 @@ java {
 }
 
 dependencies {
+  api(libs.kotlin.stdlib.consumer)
+
   // YAML processing and schema validation
   implementation(libs.snakeyaml)
   implementation(libs.json.schema.validator)
@@ -69,5 +71,6 @@ tasks.withType<KotlinCompile>().configureEach {
     languageVersion.set(
       KotlinVersion.valueOf("KOTLIN_${libs.versions.build.kotlin.language.get().replace(".", "_")}")
     )
+    apiVersion.set(KotlinVersion.fromVersion(libs.versions.build.kotlin.consumer.api.get()))
   }
 }

--- a/android/test-plan-validation/gradle.properties
+++ b/android/test-plan-validation/gradle.properties
@@ -1,3 +1,4 @@
 POM_ARTIFACT_ID=auto-mobile-test-plan-validation
 POM_NAME=AutoMobile Test Plan Validation
 POM_DESCRIPTION=YAML test plan parsing and JSON schema validation for AutoMobile.
+kotlin.stdlib.default.dependency=false

--- a/scripts/android/validate-junit-runner-kotlin-consumer.sh
+++ b/scripts/android/validate-junit-runner-kotlin-consumer.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+ANDROID_DIR="${PROJECT_ROOT}/android"
+SCRATCH_DIR="${PROJECT_ROOT}/scratch/junit-runner-kotlin-consumer"
+CONSUMER_DIR="${SCRATCH_DIR}/consumer"
+LOG_DIR="${SCRATCH_DIR}/logs"
+
+KOTLIN_CONSUMER_VERSION="${KOTLIN_CONSUMER_VERSION:-2.2.21}"
+RUNNER_VERSION=$(
+  sed -n 's/^VERSION_NAME=//p' "${ANDROID_DIR}/gradle.properties" | head -n 1
+)
+GROUP_ID=$(
+  sed -n 's/^GROUP=//p' "${ANDROID_DIR}/gradle.properties" | head -n 1
+)
+
+if [[ -z "${RUNNER_VERSION}" || -z "${GROUP_ID}" ]]; then
+  echo "Could not read GROUP and VERSION_NAME from android/gradle.properties" >&2
+  exit 1
+fi
+
+rm -rf "${SCRATCH_DIR}"
+mkdir -p "${CONSUMER_DIR}/src/test/kotlin/dev/jasonpearson/automobile/compat" "${LOG_DIR}"
+
+(
+  cd "${ANDROID_DIR}"
+  ./gradlew \
+    :test-plan-validation:publishToMavenLocal \
+    :junit-runner:publishToMavenLocal \
+    --stacktrace
+) >"${LOG_DIR}/publish.log" 2>&1
+
+cat >"${CONSUMER_DIR}/settings.gradle.kts" <<'GRADLE_SETTINGS'
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    mavenLocal()
+    mavenCentral()
+  }
+}
+
+rootProject.name = "junit-runner-kotlin-consumer"
+GRADLE_SETTINGS
+
+cat >"${CONSUMER_DIR}/build.gradle.kts" <<GRADLE_BUILD
+plugins {
+  kotlin("jvm") version "${KOTLIN_CONSUMER_VERSION}"
+}
+
+dependencies {
+  testImplementation("${GROUP_ID}:auto-mobile-junit-runner:${RUNNER_VERSION}")
+  testImplementation(kotlin("test"))
+}
+
+tasks.test {
+  useJUnitPlatform()
+}
+GRADLE_BUILD
+
+cat >"${CONSUMER_DIR}/src/test/kotlin/dev/jasonpearson/automobile/compat/RunnerConsumerCompatibilityTest.kt" <<'KOTLIN'
+package dev.jasonpearson.automobile.compat
+
+import dev.jasonpearson.automobile.junit.AutoMobileRunner
+import dev.jasonpearson.automobile.validation.TestPlanValidator
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class RunnerConsumerCompatibilityTest {
+  @Test
+  fun canReferenceRunnerAndValidationApis() {
+    assertNotNull(AutoMobileRunner::class.qualifiedName)
+    assertNotNull(TestPlanValidator.validateYaml("name: compat\nsteps: []\n"))
+  }
+}
+KOTLIN
+
+(
+  cd "${ANDROID_DIR}"
+  ./gradlew -p "${CONSUMER_DIR}" dependencyInsight \
+    --dependency org.jetbrains.kotlin:kotlin-stdlib \
+    --configuration testRuntimeClasspath \
+    --stacktrace
+) >"${LOG_DIR}/dependencyInsight.log" 2>&1
+
+if grep -q 'org.jetbrains.kotlin:kotlin-stdlib:2\.4\.0' "${LOG_DIR}/dependencyInsight.log"; then
+  echo "Kotlin ${KOTLIN_CONSUMER_VERSION} consumer resolved kotlin-stdlib 2.4.0 from auto-mobile-junit-runner." >&2
+  echo "See ${LOG_DIR}/dependencyInsight.log" >&2
+  exit 1
+fi
+
+(
+  cd "${ANDROID_DIR}"
+  ./gradlew -p "${CONSUMER_DIR}" test --stacktrace
+) >"${LOG_DIR}/test.log" 2>&1
+
+echo "Kotlin ${KOTLIN_CONSUMER_VERSION} consumer compiled and tested against auto-mobile-junit-runner ${RUNNER_VERSION}."


### PR DESCRIPTION
## Summary

Keep `auto-mobile-junit-runner` consumable by Kotlin 2.2.x projects by preventing the published runner and test-plan-validation artifacts from forcing `kotlin-stdlib` 2.4.0. The runner/test-plan modules now publish an explicit Kotlin 2.2.21 stdlib API dependency, set an API-version floor, and CI verifies a Kotlin 2.2.21 consumer can compile against both the runner and transitive validation APIs.

## Linked Issue

Closes #3558

## Bug / Regression Context

- **Prior attempts:** The runner already set `languageVersion = 2.3`, but the Kotlin plugin still published `kotlin-stdlib:2.4.0` as a transitive dependency.
- **Observed symptom:** Consumers on Kotlin 2.2.x failed during Kotlin compilation / kapt stub generation with incompatible Kotlin metadata from `kotlin-stdlib` 2.4.0.
- **Repro steps / conditions:** Add `auto-mobile-junit-runner >= 0.0.36` to a Kotlin 2.2.x consumer and inspect/compile the dependency graph; the published runner forced Kotlin stdlib 2.4.0.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
  - Covered by `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran the matching `scripts/` validation
  - `bash scripts/android/validate-junit-runner-kotlin-consumer.sh`
  - `cd android && ./gradlew :junit-runner:test :test-plan-validation:test --stacktrace`
  - `scripts/shellcheck/validate_shell_scripts.sh`
  - `bun scripts/validate-yaml.ts`
  - `scripts/ktfmt/validate_ktfmt.sh`
  - `git diff --check`
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
  - N/A: this adds Gradle publication config plus a shell compatibility fixture.
- [x] Rebased onto latest `main`, conflicts resolved
  - Branch is based on current `origin/main` at creation time and `git fetch origin main` was run before review.

## Device Verification

N/A: publication metadata and CI compatibility check only.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
