### PR TITLE
Use bare semver release tags

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1239,53 +1239,6 @@ jobs:
           echo "::notice::MCP context threshold benchmark passed - all thresholds satisfied"
 
   # =============================================================================
-  # Tag Release (triggers release.yml workflow)
-  # =============================================================================
-
-  tag-release:
-    name: "Create Release Tag"
-    runs-on: ubuntu-latest
-    if: |
-      github.ref == 'refs/heads/main' &&
-      github.event_name == 'push' &&
-      startsWith(github.event.head_commit.message, 'chore: bump versions to v')
-    steps:
-      - name: "Git Checkout"
-        uses: actions/checkout@v6
-        with:
-          lfs: false
-          fetch-depth: 0
-
-      - name: "Extract version and create tag"
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          # Extract version from commit message
-          VERSION=$(echo "$COMMIT_MESSAGE" | sed -n 's/chore: bump versions to v\([0-9.]*\).*/\1/p')
-
-          if [ -z "$VERSION" ]; then
-            echo "Could not extract version from commit message: $COMMIT_MESSAGE"
-            exit 1
-          fi
-
-          TAG="v${VERSION}"
-          echo "Creating tag: $TAG"
-
-          # Check if tag already exists
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists. Skipping."
-            exit 0
-          fi
-
-          # Create and push tag
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG"
-          git push origin "$TAG"
-
-          echo "Successfully created and pushed tag: $TAG"
-
-  # =============================================================================
   # Auto-update README Test Count Badges
   # =============================================================================
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          TAG="v${{ inputs.version }}"
+          TAG="${{ inputs.version }}"
 
           git fetch --tags origin
           if git rev-parse "$TAG" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           TAG: ${{ github.event.ref }}
         run: |
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
+          if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
             echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
@@ -81,7 +81,7 @@ jobs:
         env:
           TAG: ${{ github.event.ref }}
         run: |
-          VERSION=${TAG#v}
+          VERSION="$TAG"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

- create release tags as bare semver values like `0.0.45` from `prepare-release.yml`
- make `release.yml` accept only bare semver tags and use the tag value directly as the release version
- remove the stale `merge.yml` tag-release job so the PAT-backed prepare-release workflow is the single tag producer

## Validation

- YAML parse for `.github/workflows/prepare-release.yml`, `.github/workflows/release.yml`, and `.github/workflows/merge.yml`
- `git diff --check -- .github/workflows/prepare-release.yml .github/workflows/release.yml .github/workflows/merge.yml`
- `actionlint -shellcheck= .github/workflows/prepare-release.yml .github/workflows/release.yml`
- `actionlint -shellcheck= -ignore 'constant expression "false" in condition' -ignore 'could not parse action metadata' .github/workflows/merge.yml`
- local release-tag regex simulation: `0.0.45` accepted, `v0.0.45` ignored

## Review

- ran three `/auto-mobile-code-review` subagent passes with separate focus areas
- addressed the release-trigger finding by removing the legacy `merge.yml` tag producer that used `GITHUB_TOKEN`
