### PR TITLE
ci: raise iOS Xcode toolchain pin from 26.3 to 26.5

### DIFF
--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           lfs: false
 
-      - name: "Select Xcode 26.3"
+      - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.5"
 
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -626,7 +626,7 @@ jobs:
       matrix:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
-          - { name: "Xcode 26", runner: "macos-26", xcode: "26.3" }
+          - { name: "Xcode 26", runner: "macos-26", xcode: "26.5" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -216,7 +216,7 @@ jobs:
   # =============================================================================
   # Full iOS Xcode-version sweep
   # =============================================================================
-  # Pull requests build only the primary Xcode toolchain (26.3) to conserve the
+  # Pull requests build only the primary Xcode toolchain (26.5) to conserve the
   # scarce macOS runner pool. The full version matrix runs here nightly to catch
   # slow-moving Xcode-toolchain drift within a day.
   ios-swift-packages-sweep:
@@ -231,7 +231,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
-          - { name: "Xcode 26.3", runner: "macos-26", xcode: "26.3" }
+          - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -282,7 +282,7 @@ jobs:
       matrix:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
-          - { name: "Xcode 26.3", runner: "macos-26", xcode: "26.3" }
+          - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -414,10 +414,10 @@ jobs:
         with:
           lfs: false
 
-      - name: "Select Xcode 26.3"
+      - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.5"
 
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
@@ -477,29 +477,29 @@ jobs:
         if: always()
         run: xcrun simctl shutdown all || true
 
-      - name: "Select Xcode 26.3"
+      - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.5"
 
-      - name: "Ensure iOS Simulator runtime (Xcode 26.3)"
+      - name: "Ensure iOS Simulator runtime (Xcode 26.5)"
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
-      - name: "Boot iOS Simulator (Xcode 26.3)"
+      - name: "Boot iOS Simulator (Xcode 26.5)"
         run: ./scripts/ios/boot-simulator.sh
 
-      - name: "Ensure AutoMobile daemon ready (Xcode 26.3)"
+      - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
         run: ./scripts/ci/ensure-daemon-ready.sh
 
-      - name: "Warm up iOS CtrlProxy (Xcode 26.3)"
+      - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
-      - name: "Warm up Reminders target app (Xcode 26.3)"
+      - name: "Warm up Reminders target app (Xcode 26.5)"
         timeout-minutes: 5
         run: ./scripts/ci/warm-reminders-target-app.sh
 
-      - name: "Run Reminders integration tests (Xcode 26.3)"
+      - name: "Run Reminders integration tests (Xcode 26.5)"
         timeout-minutes: 10
         env:
           AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1163,10 +1163,10 @@ jobs:
       fail-fast: false
       matrix:
         # PR runs only the primary Xcode toolchain. The full version sweep
-        # (15.4 / 26.0 / 26.3) runs on nightly.yml — Xcode-toolchain drift is
+        # (15.4 / 26.0 / 26.5) runs on nightly.yml — Xcode-toolchain drift is
         # slow-moving and does not need per-PR macOS minutes.
         config:
-          - { name: "Xcode 26.3", runner: "macos-26", xcode: "26.3" }
+          - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -1219,7 +1219,7 @@ jobs:
       matrix:
         # PR runs only the primary Xcode toolchain; full sweep runs on nightly.yml.
         config:
-          - { name: "Xcode 26.3", runner: "macos-26", xcode: "26.3" }
+          - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -1278,10 +1278,10 @@ jobs:
         with:
           lfs: false
 
-      - name: "Select Xcode 26.3"
+      - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.5"
 
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
@@ -1313,11 +1313,11 @@ jobs:
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
           echo "xctestrun file: ${XCTESTRUN}"
 
-      - name: "Boot iOS Simulator for CtrlProxy UI tests (Xcode 26.3)"
+      - name: "Boot iOS Simulator for CtrlProxy UI tests (Xcode 26.5)"
         id: ctrlproxy-simulator
         run: ./scripts/ios/boot-simulator.sh
 
-      - name: "Run CtrlProxy privacy resource mapping UI test (Xcode 26.3)"
+      - name: "Run CtrlProxy privacy resource mapping UI test (Xcode 26.5)"
         timeout-minutes: 5
         run: |
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
@@ -1375,15 +1375,15 @@ jobs:
         if: always()
         run: xcrun simctl shutdown all || true
 
-      - name: "Select Xcode 26.3"
+      - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.5"
 
-      - name: "Ensure iOS Simulator runtime (Xcode 26.3)"
+      - name: "Ensure iOS Simulator runtime (Xcode 26.5)"
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
-      - name: "Boot iOS Simulator (Xcode 26.3)"
+      - name: "Boot iOS Simulator (Xcode 26.5)"
         run: ./scripts/ios/boot-simulator.sh
 
       - name: "Run videoRecording MP4 integration test"
@@ -1394,18 +1394,18 @@ jobs:
 
       # This is a freshly-booted sim, so re-confirm the daemon and warm CtrlProxy
       # again before the second Reminders run (same rationale as the 26.2 block).
-      - name: "Ensure AutoMobile daemon ready (Xcode 26.3)"
+      - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
         run: ./scripts/ci/ensure-daemon-ready.sh
 
-      - name: "Warm up iOS CtrlProxy (Xcode 26.3)"
+      - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
-      - name: "Warm up Reminders target app (Xcode 26.3)"
+      - name: "Warm up Reminders target app (Xcode 26.5)"
         timeout-minutes: 5
         run: ./scripts/ci/warm-reminders-target-app.sh
 
-      - name: "Run Reminders integration tests (Xcode 26.3)"
+      - name: "Run Reminders integration tests (Xcode 26.5)"
         timeout-minutes: 10
         env:
           AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -255,8 +255,8 @@ final class RemindersPlanContentTests: XCTestCase {
         )
         assertWorkflowWarmsTargetAppBeforeRemindersRun(
             workflow,
-            warmupStepName: "Warm up Reminders target app (Xcode 26.3)",
-            runStepName: "Run Reminders integration tests (Xcode 26.3)"
+            warmupStepName: "Warm up Reminders target app (Xcode 26.5)",
+            runStepName: "Run Reminders integration tests (Xcode 26.5)"
         )
     }
 
@@ -270,8 +270,8 @@ final class RemindersPlanContentTests: XCTestCase {
         )
         assertWorkflowWarmsTargetAppBeforeRemindersRun(
             workflow,
-            warmupStepName: "Warm up Reminders target app (Xcode 26.3)",
-            runStepName: "Run Reminders integration tests (Xcode 26.3)"
+            warmupStepName: "Warm up Reminders target app (Xcode 26.5)",
+            runStepName: "Run Reminders integration tests (Xcode 26.5)"
         )
     }
 


### PR DESCRIPTION
## What

Bump the primary/top Xcode toolchain from **26.3 → 26.5** across all four iOS CI workflows:

- `.github/workflows/pull_request.yml` — PR primary toolchain matrix + CtrlProxy/videoRecording/Reminders blocks
- `.github/workflows/nightly.yml` — sweep matrix (now `15.4 / 26.0 / 26.5`) + build sweep + Reminders blocks
- `.github/workflows/merge.yml` — `Xcode 26` merge matrix top entry
- `.github/workflows/build-ctrl-proxy-ios-ipa.yml` — CtrlProxy release IPA build

## Why

**26.5 is the current default Xcode on GitHub's `macos-26` runner image** (ships the iOS 26.5 simulator runtime). We were pinned to 26.3, one release behind the runner default. Raising the pin lifts the effective max iOS runtime AutoMobile exercises in CI.

No TypeScript/scripts changes are needed: the max iOS simulator runtime is derived dynamically from the active Xcode SDK (`scripts/ios/setup-ios-simulator.sh`), so bumping the toolchain is sufficient. `MIN_XCODE_VERSION = "15.0"` is untouched.

## Reviewer notes

- The deliberate **lower sweep points (15.4 / 26.0 / 26.2) are intentionally left as-is** for backward-compat / drift coverage — this PR only raises the ceiling.
- Comments in `src/` and `scripts/ios/*.sh` that mention `26.3` are illustrative examples, not pins, and were left unchanged.
- Not CI-validated locally (can't run these workflows here) — the nightly sweep is where 26.5 gets its first real exercise.
- Follow-up to also add the newest **26.6** to the nightly sweep is tracked in #3630.