### PR TITLE
fix(video): handle encoder pipe errors so mid-recording ffmpeg death can't crash daemon (#3588)

### DIFF
--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -185,6 +185,37 @@ export function containsIosRecordingStartMessage(stderr: string): boolean {
   return IOS_RECORDING_START_MESSAGES.some(message => stderr.includes(message));
 }
 
+/**
+ * Pipe the capture process's stdout into the encoder's stdin, attaching an
+ * error handler to both streams first.
+ *
+ * `.pipe()` alone routes destination write errors nowhere. If the ffmpeg
+ * encoder exits or crashes mid-recording (bad codec args, OOM), its stdin
+ * closes while the still-running `screenrecord` capture keeps writing into it,
+ * producing an unhandled stream `'error'` (EPIPE / ERR_STREAM_WRITE_AFTER_END)
+ * that can crash the daemon. A broken encoder pipe is expected on abnormal
+ * encoder exit, so we log at debug and swallow (error-handling strategy 3).
+ */
+export function pipeCaptureToEncoder(
+  source: NodeJS.ReadableStream | null,
+  dest: NodeJS.WritableStream | null
+): void {
+  if (!source || !dest) {
+    throw new ActionableError(
+      "Cannot pipe screenrecord output to ffmpeg: capture stdout or encoder stdin stream is unavailable"
+    );
+  }
+  dest.on("error", (error: Error) => {
+    // Encoder stdin closing (EPIPE) is expected when ffmpeg exits before capture stops.
+    logger.debug(`[FfmpegVideo] encoder stdin stream error (expected on encoder exit): ${error}`);
+  });
+  source.on("error", (error: Error) => {
+    // Capture stdout erroring after the encoder pipe closed is likewise expected.
+    logger.debug(`[FfmpegVideo] capture stdout stream error: ${error}`);
+  });
+  source.pipe(dest);
+}
+
 export async function waitForStderrMessage(
   tracker: ProcessTracker,
   messages: string | string[],
@@ -365,7 +396,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    captureProcess.stdout.pipe(ffmpegProcess.stdin);
+    pipeCaptureToEncoder(captureProcess.stdout, ffmpegProcess.stdin);
     logger.info(`[FfmpegVideo] Piped screenrecord stdout to ffmpeg stdin`);
 
     try {

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -4,11 +4,13 @@ import { EventEmitter } from "node:events";
 import { promises as fsPromises } from "node:fs";
 import os, { platform } from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import {
   containsIosRecordingStartMessage,
   FfmpegVideoProcessingBackend,
   IOS_RECORDING_FILE_READY_TIMEOUT_MS,
   IOS_RECORDING_STOP_TIMEOUT_MS,
+  pipeCaptureToEncoder,
   PROCESS_EXIT_TIMEOUT_MS,
   waitForExit,
   waitForRecordingFileReady,
@@ -742,5 +744,38 @@ describe("waitForRecordingFileReady - post-exit file finalization", function() {
   test("the readiness window is generous but not unbounded", function() {
     expect(IOS_RECORDING_FILE_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(5000);
     expect(IOS_RECORDING_FILE_READY_TIMEOUT_MS).toBeLessThanOrEqual(IOS_RECORDING_STOP_TIMEOUT_MS);
+  });
+});
+
+describe("pipeCaptureToEncoder", function() {
+  test("registers an error handler on the encoder stdin so EPIPE is not unhandled", function() {
+    const source = new PassThrough();
+    const dest = new PassThrough();
+    pipeCaptureToEncoder(source, dest);
+
+    // A Node stream/EventEmitter with no 'error' listener rethrows on emit.
+    // The helper must have attached one, so the mid-recording encoder-death
+    // EPIPE is swallowed instead of crashing the daemon.
+    expect(() => dest.emit("error", new Error("EPIPE"))).not.toThrow();
+    expect(() => source.emit("error", new Error("EPIPE"))).not.toThrow();
+  });
+
+  test("throws a clear error when either stream is unavailable", function() {
+    expect(() => pipeCaptureToEncoder(null, new PassThrough())).toThrow(/unavailable/);
+    expect(() => pipeCaptureToEncoder(new PassThrough(), null)).toThrow(/unavailable/);
+  });
+
+  test("still forwards capture bytes into the encoder", async function() {
+    const source = new PassThrough();
+    const dest = new PassThrough();
+    pipeCaptureToEncoder(source, dest);
+
+    const chunks: Buffer[] = [];
+    dest.on("data", chunk => chunks.push(chunk as Buffer));
+    source.write("frame-data");
+    source.end();
+    await new Promise<void>(resolve => dest.on("end", () => resolve()));
+
+    expect(Buffer.concat(chunks).toString()).toBe("frame-data");
   });
 });


### PR DESCRIPTION
Fixes #3588.

## Problem
`src/features/video/FfmpegVideoProcessingBackend.ts` piped capture output into the encoder with:

```ts
captureProcess.stdout.pipe(ffmpegProcess.stdin);
```

`.pipe()` routes destination write errors nowhere. If the ffmpeg encoder exits or crashes **mid-recording** (bad codec args, OOM), its stdin closes while the still-running `screenrecord` capture keeps writing into it, producing an unhandled stream `'error'` (`EPIPE` / `ERR_STREAM_WRITE_AFTER_END`). Nothing listens on `ffmpegProcess.stdin`, so it can propagate and crash the daemon. The normal stop path SIGINTs capture first (clean EOF), which is why only the abnormal ordering triggers it.

## Fix
Extract `pipeCaptureToEncoder(source, dest)` which:
- attaches an `'error'` handler to **both** streams — logs at debug and swallows, since a broken encoder pipe is expected on abnormal encoder exit (error-handling strategy 3);
- guards against an unavailable stream with a clear `ActionableError`;
- then pipes.

## Tests
Three new cases in `FfmpegVideoProcessingBackend.test.ts`:
- emitting `'error'` on the encoder stdin (and capture stdout) does **not** throw — proving a handler is attached (a Node stream with no `'error'` listener rethrows on emit);
- unavailable streams throw a clear error;
- capture bytes still forward through to the encoder.

All 32 backend tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)