### PR TITLE
fix(db): detect comment-/whitespace-prefixed mutations for change notifications (#3591)

### DIFF
--- a/src/server/databaseTools.ts
+++ b/src/server/databaseTools.ts
@@ -60,13 +60,43 @@ function extractAffectedTables(query: string): string[] {
 }
 
 /**
+ * Strip leading SQL comments and whitespace so keyword detection sees the first
+ * significant token.
+ *
+ * Handles line comments (`-- ...` to end of line) and block comments
+ * (`/* ... *\/`), including several stacked in sequence, e.g.
+ * `-- note\n/* x *\/  DELETE FROM t`. Without this, a mutation whose text does
+ * not literally start with the keyword is misclassified as a non-mutation.
+ */
+export function stripLeadingSqlNoise(query: string): string {
+  let text = query.trimStart();
+
+  for (;;) {
+    if (text.startsWith("--")) {
+      const newline = text.indexOf("\n");
+      text = newline === -1 ? "" : text.slice(newline + 1);
+    } else if (text.startsWith("/*")) {
+      const end = text.indexOf("*/");
+      text = end === -1 ? "" : text.slice(end + 2);
+    } else {
+      break;
+    }
+    text = text.trimStart();
+  }
+
+  return text;
+}
+
+/**
  * Determine if query is a mutation (modifies data)
  *
  * Handles CTE queries (WITH ... SELECT/INSERT/UPDATE/DELETE) by looking past
- * the CTE prefix to find the actual statement type.
+ * the CTE prefix to find the actual statement type. Leading comments and
+ * whitespace are stripped first so a commented-out preamble does not hide the
+ * statement keyword.
  */
-function isMutationQuery(query: string): boolean {
-  const upperQuery = query.trim().toUpperCase();
+export function isMutationQuery(query: string): boolean {
+  const upperQuery = stripLeadingSqlNoise(query).toUpperCase();
 
   // Direct mutations
   if (

--- a/test/server/isMutationQuery.test.ts
+++ b/test/server/isMutationQuery.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { isMutationQuery, stripLeadingSqlNoise } from "../../src/server/databaseTools";
+
+describe("isMutationQuery", () => {
+  test("classifies plain mutations", () => {
+    expect(isMutationQuery("DELETE FROM t")).toBe(true);
+    expect(isMutationQuery("insert into t values (1)")).toBe(true);
+    expect(isMutationQuery("UPDATE t SET a = 1")).toBe(true);
+    expect(isMutationQuery("ALTER TABLE t ADD COLUMN a")).toBe(true);
+    expect(isMutationQuery("DROP TABLE t")).toBe(true);
+  });
+
+  test("classifies reads as non-mutations", () => {
+    expect(isMutationQuery("SELECT * FROM t")).toBe(false);
+    expect(isMutationQuery("WITH cte AS (SELECT 1) SELECT * FROM cte")).toBe(false);
+  });
+
+  test("detects mutations behind a leading line comment", () => {
+    // Regression for #3591: the mutation keyword is not the literal prefix.
+    expect(isMutationQuery("-- purge stale rows\nDELETE FROM t")).toBe(true);
+    expect(isMutationQuery("  -- indented\n  UPDATE t SET a = 1")).toBe(true);
+  });
+
+  test("detects mutations behind a leading block comment", () => {
+    expect(isMutationQuery("/* migration */UPDATE t SET a = 1")).toBe(true);
+    expect(isMutationQuery("/* multi\nline */ INSERT INTO t VALUES (1)")).toBe(true);
+  });
+
+  test("detects mutations behind stacked comments and whitespace", () => {
+    expect(isMutationQuery("-- one\n/* two */\n\tDELETE FROM t")).toBe(true);
+  });
+
+  test("detects CTE mutations behind a leading comment", () => {
+    expect(
+      isMutationQuery("-- cte\nWITH d AS (SELECT id FROM t) DELETE FROM t WHERE id IN (SELECT id FROM d)")
+    ).toBe(true);
+  });
+
+  test("still treats a commented-out read as a non-mutation", () => {
+    expect(isMutationQuery("/* just looking */ SELECT * FROM t")).toBe(false);
+  });
+});
+
+describe("stripLeadingSqlNoise", () => {
+  test("removes leading whitespace, line, and block comments", () => {
+    expect(stripLeadingSqlNoise("  \n-- a\n/* b */ SELECT 1")).toBe("SELECT 1");
+  });
+
+  test("is a no-op for a bare statement", () => {
+    expect(stripLeadingSqlNoise("SELECT 1")).toBe("SELECT 1");
+  });
+
+  test("handles an unterminated block comment without hanging", () => {
+    expect(stripLeadingSqlNoise("/* never closed DELETE FROM t")).toBe("");
+  });
+});


### PR DESCRIPTION
Fixes #3591.

## Problem
`isMutationQuery` (`src/server/databaseTools.ts`) matched `INSERT`/`UPDATE`/`DELETE`/... against `query.trim().toUpperCase()`. A mutation whose text does not literally start with the keyword — a leading SQL comment (`-- x\nDELETE FROM t`, `/* */UPDATE t …`) or non-trivial leading whitespace stacked with comments — was classified as a **non-mutation**. The query still executed, but `notifyDatabaseChanged` never fired, so MCP resource subscribers (the dashboard) missed the change and showed stale data.

This is a change-notification gate only, not an auth gate, so impact is limited to subscriber staleness.

## Fix
Add `stripLeadingSqlNoise()` — removes leading whitespace, line comments (`-- …`), and block comments (`/* … */`), including several stacked in sequence and an unterminated block comment (without hanging) — and run it before keyword detection. Exported `isMutationQuery` for direct unit testing.

## Tests
New `test/server/isMutationQuery.test.ts`:
- plain mutations / reads still classified correctly;
- mutations behind leading line, block, and stacked comments now detected;
- a CTE mutation behind a comment detected;
- a commented-out `SELECT` stays a non-mutation;
- `stripLeadingSqlNoise` unit cases incl. unterminated block comment.

10 new tests pass; existing `databaseIos.test.ts` green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)