### PR TITLE
fix(daemon): catch eviction rejection on emulator process exit (#3593)

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -925,7 +925,12 @@ export class DevicePool {
     }
 
     childProcess.once("exit", (code, signal) => {
-      void this.evictStartedDeviceAfterProcessExit(device.deviceId, code, signal);
+      void this.evictStartedDeviceAfterProcessExit(device.deviceId, code, signal).catch(error => {
+        logger.warn(
+          `[DevicePool] Failed to evict ${device.deviceId} after emulator process exit: ${error}`,
+          error
+        );
+      });
     });
   }
 

--- a/test/daemon/devicePool.evictionCatch.test.ts
+++ b/test/daemon/devicePool.evictionCatch.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { EventEmitter } from "node:events";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { logger } from "../../src/utils/logger";
+
+// Regression for #3593: the emulator-exit eviction was a fire-and-forget
+// `void this.evictStartedDeviceAfterProcessExit(...)` with no rejection handler.
+// If the eviction chain rejected, it surfaced as an unhandled promise rejection
+// fired from a ChildProcess "exit" listener. It must now be caught and logged.
+describe("DevicePool emulator-exit eviction rejection handling", () => {
+  let pool: DevicePool;
+  let sessionManager: SessionManager;
+  let timer: FakeTimer;
+  let fakeDeviceUtils: FakeDeviceUtils;
+  const androidDevice = { name: "Pixel 7", platform: "android" as const, deviceId: "emulator-5554" };
+
+  beforeEach(async () => {
+    timer = new FakeTimer();
+    sessionManager = new SessionManager(timer);
+    fakeDeviceUtils = new FakeDeviceUtils();
+    pool = new DevicePool(sessionManager, "daemon-session-1", timer, undefined, fakeDeviceUtils);
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    await pool.initializeWithDevices([androidDevice]);
+  });
+
+  afterEach(() => {
+    timer.clearAllTimers?.();
+  });
+
+  it("logs a warning and does not throw when eviction rejects on process exit", async () => {
+    const warnSpy = spyOn(logger, "warn");
+    const evictError = new Error("removeDevice failed");
+    // Force the eviction chain to reject.
+    const evictSpy = spyOn(pool as unknown as {
+      evictMissingPooledDevice: (...args: unknown[]) => Promise<void>;
+    }, "evictMissingPooledDevice").mockRejectedValue(evictError);
+
+    const child = new EventEmitter();
+    // Register the exit listener under test.
+    (pool as unknown as {
+      trackStartedDeviceProcess: (device: unknown, child: unknown) => void;
+    }).trackStartedDeviceProcess(androidDevice, child);
+
+    // Fire the process-exit event; the rejection must be caught, not unhandled.
+    child.emit("exit", 1, null);
+
+    // Let the rejected eviction promise settle through the .catch (microtasks only).
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+
+    expect(evictSpy).toHaveBeenCalledTimes(1);
+    const loggedEviction = warnSpy.mock.calls.some(
+      call => typeof call[0] === "string" && call[0].includes("Failed to evict emulator-5554")
+    );
+    expect(loggedEviction).toBe(true);
+
+    warnSpy.mockRestore();
+    evictSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #3593.

## Problem
`src/daemon/devicePool.ts` registered the emulator-exit eviction as fire-and-forget inside a `ChildProcess` `"exit"` listener:

```ts
childProcess.once("exit", (code, signal) => {
  void this.evictStartedDeviceAfterProcessExit(device.deviceId, code, signal);
});
```

`evictStartedDeviceAfterProcessExit` → `evictMissingPooledDevice` → `releaseSessionForDisconnectedDevice`/`removeDevice` is fully async with no internal try/catch. If any step rejects when an emulator process exits, it becomes an **unhandled promise rejection** fired from an event listener — inconsistent with every other `void this.…` chain in `sessionManager.ts`, which carry a `.catch(err => logger.warn(...))`.

(The eviction path itself was added in #3554; this is the missing rejection-handler follow-up.)

## Fix
Attach the same `.catch` → `logger.warn` handler at the callsite.

## Tests
New `test/daemon/devicePool.evictionCatch.test.ts`: stubs `evictMissingPooledDevice` to reject, fires the `"exit"` event, and asserts the rejection is caught and logged (via the exact warning message the handler emits) with no throw. Fails without the fix. Existing 82 devicePool tests remain green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)