### PR TITLE
fix(observe): restore debug trace on swallowed catches (iOS SDK events, Idle) (#3595)

### DIFF
--- a/src/features/observe/Idle.ts
+++ b/src/features/observe/Idle.ts
@@ -125,7 +125,9 @@ export class Idle {
         shouldContinue
       };
     } catch (err) {
-      // Just continue polling on error
+      // Continue polling on error, but trace it — otherwise a real ADB failure
+      // is indistinguishable from a genuine "not idle" reading.
+      logger.debug(`Rotation idle check failed, treating as not-yet-idle: ${err}`);
       return {
         rotationComplete: false,
         currentRotation: null,

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -913,11 +913,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
                 { type: envelope.eventType, timestamp, payload },
                 batch.bundleId ?? null,
               );
-            } catch { /* skip malformed */ }
+            } catch (error) {
+              // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
+              logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
+            }
           }
         }
-      } catch {
-        // Polling failure is non-fatal
+      } catch (error) {
+        // Polling failure is non-fatal (endpoint down, timeout) — trace at debug.
+        logger.debug(`[IOSCtrlProxy] SDK event poll failed: ${error}`);
       }
     }, 2000);
   }

--- a/test/features/observe/Idle.test.ts
+++ b/test/features/observe/Idle.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Idle } from "../../../src/features/observe/Idle";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { BootedDevice } from "../../../src/models";
+import { logger } from "../../../src/utils/logger";
 
 describe("Idle - Unit Tests", function() {
   let idle: Idle;
@@ -573,6 +574,32 @@ describe("Idle - Unit Tests", function() {
         const result = (idle as any).isSystemLauncher(packageName);
         expect(result, `Expected ${packageName} to NOT be identified as system package`).toBe(false);
       });
+    });
+  });
+
+  describe("getRotationStatus error handling", function() {
+    // Regression for #3595: an ADB failure during the rotation check was
+    // swallowed with no trace, making it indistinguishable from a genuine
+    // "not yet idle" reading. It must now leave a debug trace.
+    test("logs a debug trace and returns not-idle when the ADB check throws", async function() {
+      const device: BootedDevice = { deviceId: "test-device", name: "Test Device", platform: "android" };
+      const throwingAdb = new FakeAdbExecutor();
+      throwingAdb.setDefaultError(new Error("adb: device offline"));
+      const throwingIdle = new Idle(device, new FakeAdbClientFactory(throwingAdb));
+
+      const debugSpy = spyOn(logger, "debug");
+
+      const result = await throwingIdle.getRotationStatus(90, 0, 10_000);
+
+      expect(result.rotationComplete).toBe(false);
+      expect(result.currentRotation).toBeNull();
+
+      const traced = debugSpy.mock.calls.some(
+        call => typeof call[0] === "string" && call[0].includes("Rotation idle check failed")
+      );
+      expect(traced).toBe(true);
+
+      debugSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
Fixes #3595.

## Problem
Three catch blocks swallowed errors with only a justifying comment and **no** log, leaving zero trace even at debug level — undiagnosable failures (violating CLAUDE.md error-handling strategy 3, which requires `logger.debug` with a why-comment):

- `IOSCtrlProxyClient.ts` — malformed SDK-event envelope skip (`catch { /* skip malformed */ }`);
- `IOSCtrlProxyClient.ts` — `/sdk-events` poll failure (`catch { /* Polling failure is non-fatal */ }`);
- `Idle.ts` `getRotationStatus` — returned a "not idle" result on a caught error with no log, making a real ADB failure indistinguishable from a genuine non-idle reading.

## Fix
Add `logger.debug(...)` in each catch, keeping the swallow and the original why-comments.

## Tests
New case in `Idle.test.ts`: makes the ADB rotation check throw and asserts `getRotationStatus` returns the not-idle result **and** emits the debug trace. The two iOS paths are interval-driven ingest/poll callbacks; the fix is a pure logging addition and the existing observe suites remain green. Lint clean; no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)