### PR TITLE
fix(observe): populate updatedAt on ViewHierarchy error results, drop unsafe cast (#3594)

### DIFF
--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -133,8 +133,9 @@ export class ViewHierarchy implements ViewHierarchyInterface {
         return {
           hierarchy: {
             error: "Failed to retrieve iOS view hierarchy from CtrlProxy iOS"
-          }
-        } as unknown as ViewHierarchyResult;
+          },
+          updatedAt: this.timer.now()
+        };
       }
 
       // Convert XCTestHierarchy to ViewHierarchyResult format
@@ -207,8 +208,9 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       return {
         hierarchy: {
           error: "Failed to retrieve view hierarchy from accessibility service"
-        }
-      } as unknown as ViewHierarchyResult;
+        },
+        updatedAt: this.timer.now()
+      };
     } catch (err) {
       perf.end();
       const duration = this.timer.now() - startTime;
@@ -216,8 +218,9 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       return {
         hierarchy: {
           error: "Failed to retrieve view hierarchy"
-        }
-      } as unknown as ViewHierarchyResult;
+        },
+        updatedAt: this.timer.now()
+      };
     }
   }
 

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -1105,4 +1105,34 @@ describe("Offscreen Node Filtering", function() {
       expect(result?.["accessibility-focused"]).toBe(true);
     });
   });
+
+  describe("error-result shape (#3594)", function() {
+    const device: BootedDevice = { deviceId: "test-device", name: "Test Device", platform: "android" };
+
+    test("populates updatedAt when the accessibility service returns null", async function() {
+      const nullClient = {
+        getAccessibilityHierarchy: async () => null
+      } as unknown as AndroidCtrlProxyClient;
+      const vh = new ViewHierarchy(device, new FakeAdbClientFactory(), nullClient);
+
+      const result = await vh.getAndroidViewHierarchy();
+
+      expect(result.hierarchy.error).toBeDefined();
+      expect(typeof result.updatedAt).toBe("number");
+    });
+
+    test("populates updatedAt when the accessibility service throws", async function() {
+      const throwingClient = {
+        getAccessibilityHierarchy: async () => {
+          throw new Error("ctrlproxy offline");
+        }
+      } as unknown as AndroidCtrlProxyClient;
+      const vh = new ViewHierarchy(device, new FakeAdbClientFactory(), throwingClient);
+
+      const result = await vh.getAndroidViewHierarchy();
+
+      expect(result.hierarchy.error).toBeDefined();
+      expect(typeof result.updatedAt).toBe("number");
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3594.

## Problem
Three error-path returns in `src/features/observe/ViewHierarchy.ts` used `as unknown as ViewHierarchyResult` and omitted `updatedAt`, so any consumer reading `.updatedAt` on an error result got `undefined` — inconsistent with the reconnect branch, which sets it. The double cast was also masking the object shape.

## Fix
`Hierarchy.error` and `ViewHierarchyResult.updatedAt` are both optional, so `{ hierarchy: { error } }` already conforms — the `as unknown as` cast was unnecessary. Populate `updatedAt: this.timer.now()` on all three paths (iOS failure; Android null-hierarchy; Android catch) and drop the cast so TypeScript checks the shape.

## Tests
New `error-result shape (#3594)` block in `ViewHierarchy.test.ts`: drives `getAndroidViewHierarchy` down the null-return and throw paths and asserts each result carries both `hierarchy.error` and a numeric `updatedAt`.

50 tests pass (2 new); lint clean; no new type errors (casts removed cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)