### PR TITLE
fix(ios): serialize WebSocketServer connections to fix data race (#3611)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -36,6 +36,59 @@ protocol WebSocketResponding: AnyObject {
     func send(_ data: Data)
 }
 
+/// Thread-safe registry of active connections keyed by connection id.
+///
+/// Connect/disconnect run on the server `DispatchQueue`, but broadcasts iterate
+/// the connections on the **main** thread (hierarchy debouncer + `CADisplayLink`
+/// FPS callbacks). A plain `Dictionary` mutated on one thread while iterated on
+/// another is undefined behavior, so every access is serialized by an internal
+/// lock and iteration is done over a copied snapshot taken under that lock
+/// (issue #3611).
+final class ConnectionRegistry<Value> {
+    private let lock = NSLock()
+    private var storage: [Int: Value] = [:]
+
+    func set(_ value: Value, forId id: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage[id] = value
+    }
+
+    func removeValue(forId id: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage[id] = nil
+    }
+
+    func value(forId id: Int) -> Value? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage[id]
+    }
+
+    /// Snapshot copy of all current values, safe to iterate outside the lock.
+    func values() -> [Value] {
+        lock.lock()
+        defer { lock.unlock() }
+        return Array(storage.values)
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage.count
+    }
+
+    /// Atomically clears the registry, returning the values that were removed.
+    func removeAll() -> [Value] {
+        lock.lock()
+        defer { lock.unlock() }
+        let all = Array(storage.values)
+        storage.removeAll()
+        return all
+    }
+}
+
 /// WebSocket server for CtrlProxy iOS
 /// Implements RFC 6455 WebSocket protocol over TCP
 public class WebSocketServer: WebSocketServing {
@@ -46,7 +99,7 @@ public class WebSocketServer: WebSocketServing {
     }
 
     private var listener: NWListener?
-    private var connections: [Int: WebSocketConnection] = [:]
+    private let connections = ConnectionRegistry<WebSocketConnection>()
     private var nextConnectionId = 1
     private let port: UInt16
     private let commandHandler: CommandHandler
@@ -108,8 +161,7 @@ public class WebSocketServer: WebSocketServing {
 
     /// Stops the server
     public func stop() {
-        connections.values.forEach { $0.close() }
-        connections.removeAll()
+        connections.removeAll().forEach { $0.close() }
         listener?.cancel()
         listener = nil
     }
@@ -129,15 +181,15 @@ public class WebSocketServer: WebSocketServing {
         ) { [weak self] message in
             self?.handleMessage(message, connectionId: connectionId)
         } onClose: { [weak self] in
-            self?.connections.removeValue(forKey: connectionId)
+            self?.connections.removeValue(forId: connectionId)
         }
 
-        connections[connectionId] = connection
+        connections.set(connection, forId: connectionId)
         connection.start()
     }
 
     private func handleMessage(_ data: Data, connectionId: Int) {
-        guard let connection = connections[connectionId] else { return }
+        guard let connection = connections.value(forId: connectionId) else { return }
         handleMessage(data, responder: connection)
     }
 
@@ -234,7 +286,7 @@ public class WebSocketServer: WebSocketServing {
 
     /// Broadcast a message to all connected clients
     public func broadcast(_ data: Data) {
-        for connection in connections.values {
+        for connection in connections.values() {
             connection.send(data)
         }
     }
@@ -260,7 +312,7 @@ public class WebSocketServer: WebSocketServing {
 
     /// Broadcast a performance update to all connected clients (push notification)
     public func broadcastPerformanceUpdate(_ snapshot: PerformanceSnapshot) {
-        guard !connections.isEmpty else { return }
+        guard connections.count > 0 else { return }
 
         let response = PerformanceUpdateResponse(data: snapshot)
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -157,4 +157,49 @@ final class WebSocketServerTests: XCTestCase {
         let id = WebSocketServer.extractRequestId(from: Data(#"{"type":"x","requestId":}"#.utf8))
         XCTAssertNil(id)
     }
+
+    // MARK: - ConnectionRegistry thread safety (#3611)
+
+    /// Basic set/get/remove/count/snapshot semantics.
+    func testConnectionRegistryBasicOperations() {
+        let registry = ConnectionRegistry<String>()
+        XCTAssertEqual(registry.count, 0)
+        XCTAssertNil(registry.value(forId: 1))
+
+        registry.set("a", forId: 1)
+        registry.set("b", forId: 2)
+        XCTAssertEqual(registry.count, 2)
+        XCTAssertEqual(registry.value(forId: 1), "a")
+        XCTAssertEqual(Set(registry.values()), ["a", "b"])
+
+        registry.removeValue(forId: 1)
+        XCTAssertNil(registry.value(forId: 1))
+        XCTAssertEqual(registry.count, 1)
+
+        let removed = registry.removeAll()
+        XCTAssertEqual(removed, ["b"])
+        XCTAssertEqual(registry.count, 0)
+    }
+
+    /// Hammer the registry from many threads while snapshotting concurrently —
+    /// mirrors the real hazard where connect/disconnect on the server queue races
+    /// broadcast iteration on the main thread. Under the pre-fix code (a bare
+    /// `Dictionary` mutated while `Array(storage.values)` is read) this trips the
+    /// Swift runtime / corrupts; with the lock it completes cleanly. The assertion
+    /// is that it does not crash and ends empty after a balanced add/remove.
+    func testConnectionRegistryConcurrentAccessDoesNotCrash() {
+        let registry = ConnectionRegistry<Int>()
+        let iterations = 2_000
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            registry.set(i, forId: i)
+            _ = registry.values()   // snapshot iteration, concurrent with mutation
+            _ = registry.count
+            registry.removeValue(forId: i)
+        }
+
+        // Every id added was also removed, so the registry must be empty and intact.
+        XCTAssertEqual(registry.count, 0)
+        XCTAssertTrue(registry.values().isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
`WebSocketServer.connections` was a bare `Dictionary` mutated on the server `DispatchQueue` (connect/disconnect via `NWListener`/`NWConnection` callbacks) but **iterated on the main thread** during hierarchy broadcasts (`HierarchyDebouncer` → `SystemTimer.schedule` → `DispatchQueue.main`) and FPS broadcasts (`CADisplayLink` on `.main`). Concurrent mutate-while-iterate on a Swift `Dictionary` is undefined behavior → torn reads or a runner crash.

## Fix
Introduce a small thread-safe `ConnectionRegistry<Value>` (lock-guarded, iteration over a snapshot copy taken under the lock) and route every `connections` access — add/remove/lookup/broadcast/stop — through it. Kept in `WebSocketServer.swift` (no new file) to avoid xcodeproj/xcodegen churn.

## Tests
- `testConnectionRegistryBasicOperations` — set/get/remove/count/snapshot/removeAll semantics.
- `testConnectionRegistryConcurrentAccessDoesNotCrash` — 2,000-iteration `concurrentPerform` add/snapshot/remove stress; trips the runtime under the pre-fix bare-dictionary code, passes cleanly with the lock.

Full `swift test` (control-proxy) green.

Fixes #3611