### PR TITLE
ci(merge): fix README badge push race with concurrency group + conflict-free script

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1246,30 +1246,21 @@ jobs:
     name: "Update README Test Count Badges"
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Serialize badge pushes so two merges can't race to push a badge commit to
+    # main at once (issue #3590). cancel-in-progress:false lets a queued run wait
+    # rather than drop the update; the run recomputes counts from scratch anyway.
+    concurrency:
+      group: update-readme-badges
+      cancel-in-progress: false
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
         with:
           lfs: false
-          fetch-depth: 0  # Full history so rebase-on-race works before pushing to main
+          fetch-depth: 0  # Full history so the badge commit push to main isn't rejected as a shallow update
           token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
 
-      - name: "Update badge counts"
-        shell: bash
-        run: bash scripts/update-readme-badges.sh
-
-      - name: "Check for changes"
-        id: changes
-        shell: bash
-        run: |
-          if git diff --quiet README.md; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: "Commit and push badge update to main"
-        if: steps.changes.outputs.changed == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -1277,22 +1268,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # "[skip ci]" stops this cosmetic commit from re-triggering the merge
-          # workflow (and any other push-triggered CI).
-          git add README.md
-          git commit -m "chore: update README test count badges [skip ci]"
-
           # AUTO_MOBILE_PR_TOKEN is an admin actor and bypasses the green-main
-          # ruleset, so this pushes straight to main with no PR or status checks.
-          # Rebase-and-retry guards against losing a race with a concurrent push.
-          for attempt in 1 2 3; do
-            if git pull --rebase origin main && git push origin HEAD:main; then
-              echo "Pushed badge update to main"
-              exit 0
-            fi
-            echo "Push attempt ${attempt} failed; retrying..."
-            sleep 5
-          done
-
-          echo "Failed to push badge update to main after 3 attempts" >&2
-          exit 1
+          # ruleset, so the script pushes straight to main with no PR or status
+          # checks. It re-syncs to origin/main and regenerates the badge each
+          # attempt (exiting cleanly when counts are unchanged), so a concurrent
+          # push can never leave a conflicted rebase.
+          bash scripts/push-readme-badges.sh

--- a/scripts/push-readme-badges.sh
+++ b/scripts/push-readme-badges.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Regenerate the README test-count badges on top of the latest origin/main and
+# push the result, retrying if a concurrent push wins the race first.
+#
+# Why re-sync + regenerate instead of rebase-and-push:
+#   The old inline loop did `git pull --rebase origin main && git push`. When a
+#   concurrent merge had already pushed its own badge commit, the rebase hit a
+#   conflict on the same README badge region and left the tree with unmerged
+#   files. The next loop iteration then failed with "Pulling is not possible
+#   because you have unmerged files" — the failure cascaded instead of retrying
+#   cleanly (issue #3590).
+#
+#   This script is conflict-free by construction: each attempt hard-resets to the
+#   latest origin/main and regenerates the badge from scratch, so there is never
+#   anything to merge or rebase. CI also serializes this job with a concurrency
+#   group, but main can still advance between reset and push (a non-badge push),
+#   which the retry loop absorbs.
+set -euo pipefail
+
+attempts="${BADGE_PUSH_ATTEMPTS:-3}"
+retry_sleep="${BADGE_RETRY_SLEEP:-5}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+update_script="${BADGE_UPDATE_SCRIPT:-${script_dir}/update-readme-badges.sh}"
+
+for attempt in $(seq 1 "${attempts}"); do
+  git fetch origin main
+  git reset --hard origin/main
+
+  bash "${update_script}"
+
+  if git diff --quiet README.md; then
+    echo "Badge counts already up to date with origin/main"
+    exit 0
+  fi
+
+  git add README.md
+  # "[skip ci]" stops this cosmetic commit from re-triggering the merge workflow
+  # (and any other push-triggered CI).
+  git commit -m "chore: update README test count badges [skip ci]"
+
+  if git push origin HEAD:main; then
+    echo "Pushed badge update to main"
+    exit 0
+  fi
+
+  echo "Push attempt ${attempt} lost a race with origin/main; retrying..." >&2
+  sleep "${retry_sleep}"
+done
+
+echo "Failed to push badge update to main after ${attempts} attempts" >&2
+exit 1

--- a/test/bats/push-readme-badges.bats
+++ b/test/bats/push-readme-badges.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/push-readme-badges.sh (issue #3590).
+#
+# The script must push a regenerated README badge to main without ever using a
+# rebase, so a concurrent badge push can never leave a conflicted tree that
+# cascades into "Pulling is not possible because you have unmerged files".
+
+SCRIPT="scripts/push-readme-badges.sh"
+WORKFLOW=".github/workflows/merge.yml"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  BIN_DIR="${TEST_ROOT}/bin"
+  mkdir -p "$BIN_DIR"
+  GIT_LOG="${TEST_ROOT}/git.log"
+  GIT_STATE="${TEST_ROOT}/push.state"
+
+  # Fake `git` shadowing the real one; other coreutils stay real.
+  cat > "${BIN_DIR}/git" <<'FAKE'
+#!/usr/bin/env bash
+echo "$*" >> "${FAKE_GIT_LOG}"
+case "$1" in
+  diff)  exit "${FAKE_GIT_DIFF_RC:-1}" ;;  # `git diff --quiet README.md`
+  push)
+    state="${FAKE_GIT_STATE}"
+    n="$(cat "$state" 2>/dev/null || echo 0)"; n=$((n + 1)); echo "$n" > "$state"
+    [ "${FAKE_GIT_PUSH_ALWAYS_FAIL:-0}" = "1" ] && exit 1
+    [ "$n" -le "${FAKE_GIT_PUSH_FAIL_UNTIL:-0}" ] && exit 1
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+FAKE
+  chmod +x "${BIN_DIR}/git"
+
+  # Fake badge updater: the fake `git diff` decides whether a change exists, so
+  # this only needs to succeed.
+  UPDATE_SCRIPT="${TEST_ROOT}/fake-update.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$UPDATE_SCRIPT"
+  chmod +x "$UPDATE_SCRIPT"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+run_push() {
+  run env PATH="${BIN_DIR}:${PATH}" \
+    FAKE_GIT_LOG="$GIT_LOG" FAKE_GIT_STATE="$GIT_STATE" \
+    BADGE_UPDATE_SCRIPT="$UPDATE_SCRIPT" BADGE_RETRY_SLEEP=0 "$@" \
+    bash "$SCRIPT"
+}
+
+@test "pushes on the first attempt when the badge changed" {
+  run_push FAKE_GIT_DIFF_RC=1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Pushed badge update to main"* ]]
+  grep -q "reset --hard origin/main" "$GIT_LOG"
+  grep -q "push origin HEAD:main" "$GIT_LOG"
+  ! grep -q "rebase" "$GIT_LOG"
+}
+
+@test "no-op (no push) when badge counts already match main" {
+  run_push FAKE_GIT_DIFF_RC=0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already up to date"* ]]
+  ! grep -q "push origin" "$GIT_LOG"
+}
+
+@test "retries after losing a race, then succeeds — without rebasing" {
+  run_push FAKE_GIT_DIFF_RC=1 FAKE_GIT_PUSH_FAIL_UNTIL=1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"lost a race"* ]]
+  [[ "$output" == *"Pushed badge update to main"* ]]
+  # Two push attempts, each preceded by a fresh reset (no lingering rebase state).
+  [ "$(grep -c 'push origin HEAD:main' "$GIT_LOG")" -eq 2 ]
+  [ "$(grep -c 'reset --hard origin/main' "$GIT_LOG")" -eq 2 ]
+  ! grep -q "rebase" "$GIT_LOG"
+}
+
+@test "fails cleanly after exhausting all attempts" {
+  run_push FAKE_GIT_DIFF_RC=1 FAKE_GIT_PUSH_ALWAYS_FAIL=1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Failed to push badge update to main after 3 attempts"* ]]
+  [ "$(grep -c 'push origin HEAD:main' "$GIT_LOG")" -eq 3 ]
+  ! grep -q "rebase" "$GIT_LOG"
+}
+
+@test "merge.yml serializes the badge job and calls the script" {
+  # Regression guard for the wiring: concurrency group + script invocation.
+  grep -q "group: update-readme-badges" "$WORKFLOW"
+  grep -q "cancel-in-progress: false" "$WORKFLOW"
+  grep -q "bash scripts/push-readme-badges.sh" "$WORKFLOW"
+  # The fragile rebase-and-push loop must not come back.
+  ! grep -q "git pull --rebase origin main" "$WORKFLOW"
+}


### PR DESCRIPTION
## What

Fixes the `Update README Test Count Badges` job push race — **58 On Merge failures in the past week** (issue #3590).

## Root cause

The job pushed a badge commit straight to `main` via `git pull --rebase origin main && git push`. Two merges landing close together each generated a badge commit touching the same README region; the rebase conflicted and left **unmerged files**, so the retry loop cascaded into `Pulling is not possible because you have unmerged files` and failed after 3 attempts:

```
Failed to push badge update to main after 3 attempts
error: could not apply b488d04d... chore: update README test count badges [skip ci]
error: Pulling is not possible because you have unmerged files.
```

## Fix

- **Serialize** the job with a concurrency group (`update-readme-badges`, `cancel-in-progress: false`) so two badge pushes can't run at once.
- **Conflict-free push** — new `scripts/push-readme-badges.sh` re-syncs to `origin/main` and regenerates the badge from scratch each attempt. No rebase → nothing to conflict; a concurrent non-badge push just triggers a clean retry instead of a poisoned tree.
- Collapse the now-redundant `Update badge counts` + `Check for changes` steps into the script's own idempotent no-op detection.

## Tests

`test/bats/push-readme-badges.bats` (fake `git` on PATH): first-try push, no-op when unchanged, retry-then-succeed after losing a race, clean exhaustion after N attempts, and a **regression guard that rebase never returns**. shellcheck clean; `merge.yml` YAML validated.

## Validation note

This is a `merge.yml` change, so it only fully exercises **post-merge**; PR checks don't run the merge workflow. Behavior is covered by the BATS suite.

Closes #3590