### PR TITLE
fix(ci): anchor run-ts-coverage WriteFailed guard to true zero-failure runs (#3639)

### DIFF
--- a/scripts/ci/run-ts-coverage.sh
+++ b/scripts/ci/run-ts-coverage.sh
@@ -22,7 +22,7 @@ if [[ "${status}" -eq 0 ]]; then
   exit 0
 fi
 
-if rg -q 'error: An internal error occurred \(WriteFailed\)' "${log_file}" && rg -q '0 fail' "${log_file}"; then
+if rg -q 'error: An internal error occurred \(WriteFailed\)' "${log_file}" && rg -q '(^|[^0-9])0 fail' "${log_file}"; then
   echo "::warning::Bun coverage ended with WriteFailed after tests passed; continuing to verify coverage output"
   tail -n 80 "${log_file}"
   exit 0

--- a/test/bats/run-ts-coverage.bats
+++ b/test/bats/run-ts-coverage.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/run-ts-coverage.sh
+#
+# Regression guard for #3639: the WriteFailed-recovery guard must only treat a
+# run as passing when it had ZERO failures. The old `rg -q '0 fail'` matched
+# `10 fail`, `20 fail`, etc. as a substring, turning a genuinely failing test
+# run (that also hit the known Bun WriteFailed crash) into a green CI step.
+
+SCRIPT="scripts/ci/run-ts-coverage.sh"
+
+setup() {
+  command -v rg >/dev/null 2>&1 || skip "ripgrep (rg) not installed"
+  STUB_DIR="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+# Stub `bun` to emit a canned coverage log ($STUB_LOG) and exit non-zero,
+# simulating the WriteFailed crash after tests ran.
+make_bun_stub() {
+  cat > "$STUB_DIR/bun" <<EOF
+#!/usr/bin/env bash
+cat "$STUB_LOG"
+exit 1
+EOF
+  chmod +x "$STUB_DIR/bun"
+}
+
+@test "recovers (exit 0) when WriteFailed follows a fully-passing run (0 fail)" {
+  STUB_LOG="$WORK_DIR/pass.log"
+  printf ' 42 pass\n 0 fail\nerror: An internal error occurred (WriteFailed)\n' > "$STUB_LOG"
+  make_bun_stub
+
+  run env PATH="$STUB_DIR:$PATH" bash "$SCRIPT" "$WORK_DIR/out.log"
+  [ "$status" -eq 0 ]
+}
+
+@test "does NOT recover (exit non-zero) when WriteFailed follows real failures (10 fail)" {
+  STUB_LOG="$WORK_DIR/fail.log"
+  printf ' 32 pass\n 10 fail\nerror: An internal error occurred (WriteFailed)\n' > "$STUB_LOG"
+  make_bun_stub
+
+  run env PATH="$STUB_DIR:$PATH" bash "$SCRIPT" "$WORK_DIR/out.log"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
`scripts/ci/run-ts-coverage.sh`'s WriteFailed-recovery guard used `rg -q '0 fail'`, but `0 fail` is a substring of `10 fail`, `20 fail`, `100 fail`, etc. A run that hit the known Bun coverage-table WriteFailed crash **and** had real test failures matched both `rg` checks, so the step printed a warning and `exit 0` — turning a genuinely failing test run into a green CI step.

## Change
- Anchor the match to `(^|[^0-9])0 fail` so `10 fail` no longer matches.
- Add `test/bats/run-ts-coverage.bats`: drives the script with a stubbed `bun` that emits a WriteFailed log with `0 fail` (must recover → exit 0) and with `10 fail` (must NOT recover → non-zero). Fails pre-fix, passes post-fix.

Fixes #3639