### PR TITLE
fix(ci): fail daemon-lifecycle when daemon start/health fail (#3640)

### DIFF
--- a/scripts/ci/daemon-lifecycle.sh
+++ b/scripts/ci/daemon-lifecycle.sh
@@ -13,11 +13,35 @@ set -uo pipefail
 export PATH="${HOME}/.bun/bin:${PATH}"
 mkdir -p ci-logs
 
-bun dist/src/index.js --daemon start  2>&1 | tee ci-logs/daemon-start.log
-bun dist/src/index.js --daemon health 2>&1 | tee ci-logs/daemon-health.log
+# Run a daemon command, tee its output to a log, and return the *bun* exit
+# status rather than tee's. Without this (and with no `set -e`), a failing
+# `start`/`health` was silently ignored and the script's exit status only
+# reflected the final `stop` — so the lifecycle step passed green even when
+# the daemon never started (#3640).
+run_step() {
+  local log="$1"
+  shift
+  bun dist/src/index.js "$@" 2>&1 | tee "${log}"
+  return "${PIPESTATUS[0]}"
+}
+
+if ! run_step ci-logs/daemon-start.log --daemon start; then
+  echo "error: daemon start failed" >&2
+  exit 1
+fi
+
+if ! run_step ci-logs/daemon-health.log --daemon health; then
+  echo "error: daemon health check failed" >&2
+  # Best-effort stop so we don't leak a daemon on the runner.
+  run_step ci-logs/daemon-stop.log --daemon stop || true
+  exit 1
+fi
 
 # Doctor exits non-zero when checks fail (expected on CI without devices).
 # We just verify the daemon responds to the request.
-bun dist/src/index.js --cli doctor --json 2>&1 | tee ci-logs/daemon-doctor.log || true
+run_step ci-logs/daemon-doctor.log --cli doctor --json || true
 
-bun dist/src/index.js --daemon stop   2>&1 | tee ci-logs/daemon-stop.log
+if ! run_step ci-logs/daemon-stop.log --daemon stop; then
+  echo "error: daemon stop failed" >&2
+  exit 1
+fi

--- a/test/bats/daemon-lifecycle.bats
+++ b/test/bats/daemon-lifecycle.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/daemon-lifecycle.sh
+#
+# Regression guard for #3640: the lifecycle script must fail when `--daemon
+# start` or `--daemon health` fails. Previously (no `set -e`, no PIPESTATUS
+# check) those failures were swallowed and the script's exit status reflected
+# only the final `stop`, so the CI step passed green even when the daemon
+# never started.
+
+SCRIPT="scripts/ci/daemon-lifecycle.sh"
+
+setup() {
+  # Resolve absolute script path before we cd elsewhere (bats cwd = repo root).
+  SCRIPT_ABS="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  STUB_DIR="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
+
+  # Stub `bun`: fails the subcommand named in $FAIL_ON (e.g. "start"),
+  # returns 7 for `--cli doctor` (normal on device-less CI), else succeeds.
+  cat > "$STUB_DIR/bun" <<'EOF'
+#!/usr/bin/env bash
+if [ -n "${FAIL_ON:-}" ] && [[ "$*" == *"--daemon ${FAIL_ON}"* ]]; then
+  echo "stub bun: failing ${FAIL_ON}" >&2
+  exit 1
+fi
+if [[ "$*" == *"--cli doctor"* ]]; then
+  echo "stub bun: doctor found no devices" >&2
+  exit 7
+fi
+echo "stub bun: ok $*"
+exit 0
+EOF
+  chmod +x "$STUB_DIR/bun"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+# HOME points at an empty dir so the script's `${HOME}/.bun/bin` PATH prefix
+# is a no-op and our stub `bun` wins.
+run_lifecycle() {
+  cd "$WORK_DIR"
+  run env HOME="$WORK_DIR" PATH="$STUB_DIR:/usr/bin:/bin" "$@" bash "$SCRIPT_ABS"
+}
+
+@test "succeeds when start, health, and stop all succeed (doctor non-zero tolerated)" {
+  run_lifecycle
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when daemon start fails" {
+  run_lifecycle FAIL_ON=start
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"daemon start failed"* ]]
+}
+
+@test "fails when daemon health fails" {
+  run_lifecycle FAIL_ON=health
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"daemon health check failed"* ]]
+}


### PR DESCRIPTION
## Summary
`scripts/ci/daemon-lifecycle.sh` used `set -uo pipefail` with **no `-e`** and never checked the status of `--daemon start` or `--daemon health`. The script's exit status was only that of the final `daemon stop`, so if start failed but stop returned 0, the lifecycle CI step passed green despite the daemon never having started.

## Change
- Route each step through a `run_step` helper that tees output to `ci-logs/` and returns bun's `PIPESTATUS[0]` (not tee's).
- Fail the script if `start`, `health`, or `stop` fail; `doctor` stays best-effort (`|| true`) since it exits non-zero on device-less CI by design. On health failure we best-effort `stop` so the runner doesn't leak a daemon.
- Add `test/bats/daemon-lifecycle.bats`: stubbed `bun` fails `start`/`health`; asserts the script now exits non-zero (it passed pre-fix).

Fixes #3640