### PR TITLE
feat(multi-device): add barrier tool for non-serializing device sync (#3567)

### DIFF
--- a/docs/design-docs/mcp/multi-device.md
+++ b/docs/design-docs/mcp/multi-device.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** Fully implemented. Parallel device execution, `criticalSection` synchronization, per-device abort strategies, and YAML anchor support are all active. See the [Status Glossary](../status-glossary.md) for chip definitions.
+> **Current state:** Fully implemented. Parallel device execution, `criticalSection` synchronization, the `barrier` sync point, per-device abort strategies, and YAML anchor support are all active. See the [Status Glossary](../status-glossary.md) for chip definitions.
 
 ## Goal
 
@@ -103,14 +103,19 @@ Semantics:
 - Steps targeting different devices run concurrently by default.
 - `criticalSection` is a mutex; all devices must reach it, then steps execute
   one device at a time within the section. See [Critical Section](daemon/critical-section.md) for details.
-- Optional `barrier` tool can synchronize devices without serializing actions.
+- `barrier` synchronizes devices without serializing actions: every device
+  runs its own `barrier` step with a shared `lock` and `deviceCount`, blocks
+  until all `deviceCount` devices arrive, then all proceed concurrently (no
+  held section, no steps). Use it when tracks must line up at a point but
+  should then continue in parallel. Like `criticalSection`, `barrier` is
+  daemon-only and may not be nested inside a `criticalSection`.
 
 ## Implementation
 
 ### Plan Validation
 
 Plans are validated at parse time:
-- If `devices` field is present, all non-`criticalSection` steps must have a `device` parameter
+- If `devices` field is present, every step must have a `device` parameter — including `criticalSection` and `barrier` steps and each of their nested sub-steps (there is no device-agnostic exemption)
 - Device labels must be unique and non-empty strings
 - Steps cannot reference undeclared device labels
 - If any step uses device labels or criticalSection, the plan must declare `devices`
@@ -144,6 +149,6 @@ Debug mode or failures log per-device execution timing:
 
 ## Known Limitations
 
-- YAML anchors (`<<` merge keys) work but device labels must still be explicitly specified (not merged from anchors).
+- YAML anchors (`<<` merge keys) merge all keys, including `device`; a per-step `device` written after the merge simply overrides the merged value.
 - Parallel actions can cause ordering hazards without explicit locks - use critical sections to synchronize.
 - Each device's abort signal is checked between steps, not mid-step.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -335,6 +335,37 @@
     }
   },
   {
+    "name": "barrier",
+    "description": "Synchronize multiple devices at a barrier, then let all proceed concurrently (no serialized section).",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "lock": {
+          "type": "string",
+          "description": "Shared barrier name; all devices using the same name synchronize together"
+        },
+        "deviceCount": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "description": "Number of devices that must arrive before the barrier lifts"
+        },
+        "timeout": {
+          "description": "Barrier timeout ms (default 30000)",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        }
+      },
+      "required": [
+        "lock",
+        "deviceCount"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "biometricAuth",
     "description": "Simulate biometric auth: Android emulator/SDK hook or iOS Simulator.",
     "inputSchema": {

--- a/scripts/generate-tool-definitions.ts
+++ b/scripts/generate-tool-definitions.ts
@@ -20,6 +20,7 @@ import { registerNotificationTools } from "../src/server/notificationTools";
 import { registerPlanTools } from "../src/server/planTools";
 import { registerDoctorTools } from "../src/server/doctorTools";
 import { registerCriticalSectionTools } from "../src/server/criticalSectionTools";
+import { registerBarrierTools } from "../src/server/barrierTools";
 import { registerVideoRecordingTools } from "../src/server/videoRecordingTools";
 import { registerSnapshotTools } from "../src/server/snapshotTools";
 import { registerBiometricTools } from "../src/server/biometricTools";
@@ -49,6 +50,7 @@ function registerAllTools(): void {
   registerPlanTools();
   registerDoctorTools();
   registerCriticalSectionTools();
+  registerBarrierTools();
   registerVideoRecordingTools();
   registerSnapshotTools();
   registerBiometricTools();

--- a/src/server/CriticalSectionCoordinator.ts
+++ b/src/server/CriticalSectionCoordinator.ts
@@ -101,6 +101,28 @@ export class CriticalSectionCoordinator {
   }
 
   /**
+	 * Wait at a barrier until all expected devices arrive, then proceed
+	 * concurrently. Unlike {@link enterCriticalSection}, this acquires no mutex
+	 * and returns no release function: once the barrier lifts, every device
+	 * continues in parallel with no serialized section.
+	 *
+	 * Registers the expected device count (idempotently) before waiting, so each
+	 * participating device may call this with the same lock and deviceCount.
+	 * Schedules resource cleanup once the barrier lifts; on timeout the caller
+	 * should {@link forceCleanup} to release any devices still waiting.
+	 */
+  public async awaitBarrier(
+    lock: string,
+    deviceId: string,
+    deviceCount: number,
+    timeout: number = this.BARRIER_TIMEOUT_MS
+  ): Promise<void> {
+    this.registerExpectedDevices(lock, deviceCount);
+    await this.waitAtBarrier(lock, deviceId, timeout);
+    this.scheduleCleanup(lock);
+  }
+
+  /**
 	 * Wait at the barrier until all expected devices have arrived.
 	 */
   private async waitAtBarrier(

--- a/src/server/barrierTools.ts
+++ b/src/server/barrierTools.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import { ToolRegistry } from "./toolRegistry";
+import { ActionableError, BootedDevice } from "../models/index";
+import { logger } from "../utils/logger";
+import { createJSONToolResponse, throwIfAborted } from "../utils/toolUtils";
+import { CriticalSectionCoordinator } from "./CriticalSectionCoordinator";
+
+// Barrier tool schema. A barrier is a pure synchronization point: every
+// participating device arrives, and once all `deviceCount` devices have
+// arrived they all proceed concurrently. Unlike criticalSection there is no
+// serialized section and no steps — each device's own track continues in
+// parallel after the barrier lifts.
+const barrierSchema = z.object({
+  lock: z
+    .string()
+    .describe("Shared barrier name; all devices using the same name synchronize together"),
+  deviceCount: z
+    .number()
+    .int()
+    .positive()
+    .describe("Number of devices that must arrive before the barrier lifts"),
+  timeout: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Barrier timeout ms (default 30000)"),
+});
+
+type BarrierParams = z.infer<typeof barrierSchema>;
+
+/**
+ * Barrier tool handler. Blocks the calling device at a named synchronization
+ * point until `deviceCount` devices have arrived, then returns so every device
+ * continues concurrently.
+ */
+const barrierHandler = async (
+  device: BootedDevice,
+  params: BarrierParams,
+  _progress?: unknown,
+  signal?: AbortSignal
+): Promise<any> => {
+  const { lock, deviceCount, timeout } = params;
+  const coordinator = CriticalSectionCoordinator.getInstance();
+
+  logger.info(
+    `Device ${device.deviceId} arriving at barrier "${lock}" (expecting ${deviceCount} devices)`
+  );
+
+  throwIfAborted(signal);
+
+  try {
+    await coordinator.awaitBarrier(lock, device.deviceId, deviceCount, timeout);
+  } catch (error) {
+    // Release any devices still waiting so they fail fast instead of hanging
+    // until their own barrier timeout.
+    coordinator.forceCleanup(lock);
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(
+      `Device ${device.deviceId} error at barrier "${lock}": ${errorMessage}`
+    );
+    throw new ActionableError(
+      `Barrier "${lock}" failed for device ${device.deviceId}: ${errorMessage}`
+    );
+  }
+
+  logger.info(`Device ${device.deviceId} passed barrier "${lock}"`);
+
+  return createJSONToolResponse({
+    success: true,
+    lock,
+    deviceId: device.deviceId,
+    deviceCount,
+  });
+};
+
+/**
+ * Register the barrier tool.
+ */
+export function registerBarrierTools(): void {
+  ToolRegistry.registerDeviceAware(
+    "barrier",
+    "Synchronize multiple devices at a barrier, then let all proceed concurrently (no serialized section).",
+    barrierSchema,
+    barrierHandler
+  );
+
+  logger.info("Barrier tools registered");
+}

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -88,11 +88,13 @@ const criticalSectionHandler = async (
   // Check for abort before entering
   throwIfAborted(signal);
 
-  // Validate steps to prevent nesting
+  // Validate steps to prevent nesting. A nested criticalSection or barrier
+  // would deadlock: the device holding this section's mutex would wait for
+  // peers that cannot enter until it releases.
   for (const step of normalizedSteps) {
-    if (step.tool === "criticalSection") {
+    if (step.tool === "criticalSection" || step.tool === "barrier") {
       throw new ActionableError(
-        `Nested critical sections are not supported. Found criticalSection step inside critical section "${lock}".`
+        `Nested critical sections are not supported. Found ${step.tool} step inside critical section "${lock}".`
       );
     }
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,6 +31,7 @@ import { registerNotificationTools } from "./notificationTools";
 import { registerPlanTools } from "./planTools";
 import { registerDoctorTools } from "./doctorTools";
 import { registerCriticalSectionTools } from "./criticalSectionTools";
+import { registerBarrierTools } from "./barrierTools";
 import { registerVideoRecordingTools } from "./videoRecordingTools";
 import { registerSnapshotTools } from "./snapshotTools";
 import { registerBiometricTools } from "./biometricTools";
@@ -181,6 +182,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerPlanTools();
   if (daemonMode) {
     registerCriticalSectionTools();
+    registerBarrierTools();
   }
   registerDoctorTools();
   registerVideoRecordingTools();

--- a/test/server/barrierCoordinator.test.ts
+++ b/test/server/barrierCoordinator.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { CriticalSectionCoordinator } from "../../src/server/CriticalSectionCoordinator";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+
+/**
+ * Unit tests for the barrier path of CriticalSectionCoordinator
+ * (awaitBarrier): synchronize devices at a point, then proceed concurrently
+ * with NO serialized section (unlike enterCriticalSection).
+ */
+describe("CriticalSectionCoordinator.awaitBarrier", () => {
+  let coordinator: CriticalSectionCoordinator;
+  let fakeTimer: FakeTimer;
+  let originalSetTimeout: typeof global.setTimeout;
+  let originalClearTimeout: typeof global.clearTimeout;
+  let originalDateNow: typeof Date.now;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+    originalSetTimeout = global.setTimeout;
+    originalClearTimeout = global.clearTimeout;
+    originalDateNow = Date.now;
+
+    global.setTimeout = ((callback: (...args: any[]) => void, ms?: number, ...args: any[]) => {
+      return fakeTimer.setTimeout(() => callback(...args), ms ?? 0);
+    }) as typeof global.setTimeout;
+    global.clearTimeout = ((handle: NodeJS.Timeout) => {
+      fakeTimer.clearTimeout(handle);
+    }) as typeof global.clearTimeout;
+    Date.now = () => fakeTimer.now();
+
+    coordinator = CriticalSectionCoordinator.getInstance();
+    coordinator.reset();
+  });
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+    global.setTimeout = originalSetTimeout;
+    global.clearTimeout = originalClearTimeout;
+    fakeTimer.reset();
+  });
+
+  const wait = async (ms: number): Promise<void> => {
+    const promise = defaultTimer.sleep(ms);
+    fakeTimer.advanceTime(ms);
+    await promise;
+  };
+
+  test("single device with deviceCount 1 proceeds immediately", async () => {
+    const start = Date.now();
+    await coordinator.awaitBarrier("solo", "device-1", 1);
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+
+  test("all devices are released only after the last arrives", async () => {
+    const arrivals: Array<{ deviceId: string; at: number }> = [];
+    const passes: Array<{ deviceId: string; at: number }> = [];
+
+    const promises = ["device-1", "device-2", "device-3"].map(
+      async (deviceId, index) => {
+        await wait(index * 10); // stagger arrivals
+        arrivals.push({ deviceId, at: Date.now() });
+        await coordinator.awaitBarrier("sync", deviceId, 3);
+        passes.push({ deviceId, at: Date.now() });
+      }
+    );
+
+    await Promise.all(promises);
+
+    expect(passes.length).toBe(3);
+    const lastArrival = Math.max(...arrivals.map(a => a.at));
+    // No device passes the barrier before the last one arrives.
+    for (const p of passes) {
+      expect(p.at).toBeGreaterThanOrEqual(lastArrival);
+    }
+  });
+
+  test("does NOT serialize: device work overlaps after the barrier", async () => {
+    const log: Array<{ deviceId: string; event: string; time: number }> = [];
+
+    const deviceWork = async (deviceId: string) => {
+      await coordinator.awaitBarrier("no-serialize", deviceId, 2);
+      log.push({ deviceId, event: "start", time: Date.now() });
+      await wait(20);
+      log.push({ deviceId, event: "end", time: Date.now() });
+    };
+
+    await Promise.all([deviceWork("device-1"), deviceWork("device-2")]);
+
+    // Both start before either ends — proof there is no mutual exclusion.
+    const starts = log.filter(e => e.event === "start").map(e => e.time);
+    const ends = log.filter(e => e.event === "end").map(e => e.time);
+    expect(starts.length).toBe(2);
+    expect(Math.max(...starts)).toBeLessThanOrEqual(Math.min(...ends));
+  });
+
+  test("times out if not all devices arrive", async () => {
+    // Only device-1 arrives; device-2 never does.
+    const promise = coordinator.awaitBarrier("missing", "device-1", 2, 100);
+    fakeTimer.advanceTime(100);
+    await expect(promise).rejects.toThrow(
+      /Timeout waiting for critical section "missing"\. 1\/2 devices arrived after 100ms/
+    );
+  });
+});

--- a/test/server/barrierTools.test.ts
+++ b/test/server/barrierTools.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerBarrierTools } from "../../src/server/barrierTools";
+import { CriticalSectionCoordinator } from "../../src/server/CriticalSectionCoordinator";
+import type { BootedDevice } from "../../src/models";
+
+const makeDevice = (deviceId: string): BootedDevice => ({
+  platform: "android",
+  deviceId,
+  name: `Device ${deviceId}`,
+});
+
+const parseResponse = (response: any): any =>
+  JSON.parse(response.content[0].text);
+
+describe("barrier tool", () => {
+  beforeAll(() => {
+    if (!ToolRegistry.getTool("barrier")) {
+      registerBarrierTools();
+    }
+  });
+
+  beforeEach(() => {
+    CriticalSectionCoordinator.getInstance().reset();
+  });
+
+  test("tool is registered with correct schema", () => {
+    const tool = ToolRegistry.getTool("barrier");
+    expect(tool).toBeDefined();
+    expect(tool?.name).toBe("barrier");
+    expect(tool?.description).toContain("proceed concurrently");
+    expect(tool?.deviceAwareHandler).toBeDefined();
+  });
+
+  test("single device with deviceCount 1 passes the barrier", async () => {
+    const tool = ToolRegistry.getTool("barrier");
+    const response = await tool!.deviceAwareHandler!(
+      makeDevice("device-1"),
+      { lock: "solo", deviceCount: 1 },
+      undefined,
+      undefined
+    );
+    const parsed = parseResponse(response);
+    expect(parsed.success).toBe(true);
+    expect(parsed.lock).toBe("solo");
+    expect(parsed.deviceId).toBe("device-1");
+    expect(parsed.deviceCount).toBe(1);
+  });
+
+  test("two devices synchronize and both pass concurrently", async () => {
+    const tool = ToolRegistry.getTool("barrier");
+
+    const results = await Promise.all([
+      tool!.deviceAwareHandler!(
+        makeDevice("device-1"),
+        { lock: "pair", deviceCount: 2 },
+        undefined,
+        undefined
+      ),
+      tool!.deviceAwareHandler!(
+        makeDevice("device-2"),
+        { lock: "pair", deviceCount: 2 },
+        undefined,
+        undefined
+      ),
+    ]);
+
+    const parsed = results.map(parseResponse);
+    expect(parsed.every(r => r.success)).toBe(true);
+    expect(new Set(parsed.map(r => r.deviceId))).toEqual(
+      new Set(["device-1", "device-2"])
+    );
+  });
+
+  test("rejects with an actionable error on barrier timeout", async () => {
+    const tool = ToolRegistry.getTool("barrier");
+    // deviceCount 2 but only one device arrives; short timeout so the test is fast.
+    await expect(
+      tool!.deviceAwareHandler!(
+        makeDevice("device-1"),
+        { lock: "lonely", deviceCount: 2, timeout: 50 },
+        undefined,
+        undefined
+      )
+    ).rejects.toThrow(/Barrier "lonely" failed for device device-1/);
+  });
+});

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -158,6 +158,35 @@ describe("criticalSection tool", () => {
     ).rejects.toThrow(/Nested critical sections are not supported/);
   });
 
+  test("detects a barrier nested inside a critical section", async () => {
+    const tool = ToolRegistry.getTool("criticalSection");
+    expect(tool).toBeDefined();
+
+    const fakeDevice: BootedDevice = {
+      platform: "android",
+      deviceId: "test-device",
+      name: "Test Device",
+    };
+
+    const coordinator = CriticalSectionCoordinator.getInstance();
+    coordinator.registerExpectedDevices("outer-lock", 1);
+
+    const params = {
+      lock: "outer-lock",
+      deviceCount: 1,
+      steps: [
+        {
+          tool: "barrier", // Nested barrier would deadlock
+          params: { lock: "inner-barrier", deviceCount: 1 },
+        },
+      ],
+    };
+
+    await expect(
+			tool!.deviceAwareHandler!(fakeDevice, params, undefined, undefined)
+    ).rejects.toThrow(/Nested critical sections are not supported.*barrier/);
+  });
+
   test("executes steps in order for single device", async () => {
     const tool = ToolRegistry.getTool("criticalSection");
     expect(tool).toBeDefined();


### PR DESCRIPTION
Implements the `barrier` multi-device synchronization tool that `docs/design-docs/mcp/multi-device.md` described but that did not exist, and corrects the doc drift called out alongside it.

Fixes #3567.

## What is a barrier
A pure synchronization point: every participating device runs its own `barrier` step with a shared `lock` and `deviceCount`, blocks until all `deviceCount` devices arrive, then **all proceed concurrently** — no held section and no steps. This is `criticalSection` minus the mutual exclusion: use it when tracks must line up at a point but should then continue in parallel.

## Changes
- **`CriticalSectionCoordinator.awaitBarrier()`** — reuses the existing barrier machinery (`registerExpectedDevices` + `waitAtBarrier` + `scheduleCleanup`) without acquiring the mutex, so devices run in parallel after the barrier lifts.
- **`barrierTools.ts`** — daemon-only `barrier` tool (registered next to `criticalSection`); on timeout it `forceCleanup`s so peers fail fast instead of hanging to their own timeout.
- **Nesting guard** — `criticalSection` now rejects a nested `barrier` step (it would deadlock: the mutex holder would wait for peers that can't enter).
- **Generated schema** — `barrier` added to the tool-definitions generator; `schemas/tool-definitions.json` regenerated (71 tools).

## Doc corrections (also #3567)
- Every step requires a `device` — including `criticalSection`/`barrier` and nested sub-steps (no device-agnostic exemption).
- YAML merge keys DO merge `device`; a per-step value written after the merge simply overrides it.
- `barrier` bullet now describes the real tool.

## Testing
- `test/server/barrierCoordinator.test.ts` — single-device pass-through, release-only-after-last-arrives, **non-serializing overlap**, and timeout (FakeTimer).
- `test/server/barrierTools.test.ts` — schema, single device, two-device sync, actionable timeout error.
- `test/server/criticalSectionTools.test.ts` — new nested-`barrier` rejection guard.
- Full tool registration/schema suite (41 tests) green with the new tool; typecheck gate: no new errors.

Part of the design-doc accuracy audit (#3565).
