### PR TITLE
fix(scripts): log_debug writes to the debug log file, not stderr (#3648)

### DIFF
--- a/scripts/launch_app_perf_test.sh
+++ b/scripts/launch_app_perf_test.sh
@@ -115,7 +115,7 @@ log_info() {
 log_debug() {
     local msg
     msg="[$(date '+%Y-%m-%d %H:%M:%S')] [DEBUG] $*"
-    echo "$msg" >> "$DEBUG_LOG" >&2
+    echo "$msg" >> "$DEBUG_LOG"
 }
 
 log_error() {

--- a/test/bats/launch-app-perf-test-logging.bats
+++ b/test/bats/launch-app-perf-test-logging.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# Tests for the logging helpers in scripts/launch_app_perf_test.sh
+#
+# Regression guard for #3648: log_debug used `echo "$msg" >> "$DEBUG_LOG" >&2`,
+# where the trailing `>&2` repoints stdout to stderr *after* the file redirect,
+# so debug lines went to stderr and never reached the log file. This test
+# extracts the log_debug function from the script and exercises it in isolation.
+
+SCRIPT="scripts/launch_app_perf_test.sh"
+
+setup() {
+  WORK_DIR="$(mktemp -d)"
+  # Load only the log_debug function definition (no side effects / no main).
+  eval "$(sed -n '/^log_debug() {/,/^}/p' "$SCRIPT")"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+@test "log_debug writes the message to the debug log file" {
+  DEBUG_LOG="$WORK_DIR/debug.log"
+  log_debug "sentinel-debug-line"
+  [ -f "$DEBUG_LOG" ]
+  grep -q 'sentinel-debug-line' "$DEBUG_LOG"
+  grep -q '\[DEBUG\]' "$DEBUG_LOG"
+}


### PR DESCRIPTION
## Summary
In `scripts/launch_app_perf_test.sh`, `log_debug` used:
```bash
echo "$msg" >> "$DEBUG_LOG" >&2
```
Redirections apply left-to-right, so `>&2` repoints stdout to stderr *after* the file redirect — the file redirect is overridden and every debug line goes to stderr, never reaching `$DEBUG_LOG`. All debug diagnostics were lost from the log file.

## Change
- Drop the trailing `>&2` so DEBUG goes to the log file only. INFO/ERROR keep their `tee -a "$DEBUG_LOG" >&2` (both file and stderr); DEBUG is the verbose level, so keeping it out of stderr avoids terminal noise while ensuring it lands in the debug log.
- Add `test/bats/launch-app-perf-test-logging.bats`: extracts `log_debug` and asserts the message reaches the file. Fails pre-fix, passes post-fix.

Fixes #3648