### PR TITLE
fix(ios): tolerate duplicate daemon timing rows instead of trapping (#3618)

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunner/TestTimingCache.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/TestTimingCache.swift
@@ -136,12 +136,26 @@ final class TestTimingCache {
             }
             let parsed = try jsonDecoder.decode(TestTimingSummary.self, from: data)
             summary = parsed
-            timingMap = Dictionary(
-                uniqueKeysWithValues: parsed.testTimings.map {
-                    (TestTimingKey(testClass: $0.testClass, testMethod: $0.testMethod), $0)
-                }
-            )
-        } catch {}
+            timingMap = Self.buildTimingMap(from: parsed.testTimings)
+        } catch {
+            // Best-effort prefetch: timing data is an optimization, so a failure here
+            // must not abort the test run. Log it so there is a trace (issue #3618).
+            print("[TestTimingCache] Failed to load timing data from daemon: \(error)")
+        }
+    }
+
+    /// Build the (class, method) → entry lookup from daemon rows.
+    ///
+    /// The daemon does not guarantee one row per (class, method) — aggregation
+    /// bugs, parametrized-variant collisions, or lookback overlap can yield
+    /// duplicates. `Dictionary(uniqueKeysWithValues:)` would `fatalError` (an
+    /// uncatchable trap) on a duplicate and take down the whole test run, so we
+    /// tolerate duplicates and keep the last occurrence instead (issue #3618).
+    static func buildTimingMap(from entries: [TestTimingEntry]) -> [TestTimingKey: TestTimingEntry] {
+        Dictionary(
+            entries.map { (TestTimingKey(testClass: $0.testClass, testMethod: $0.testMethod), $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
     }
 
     private func buildRequestUri() -> String {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/TestTimingCacheTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/TestTimingCacheTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import XCTestRunner
+
+final class TestTimingCacheTests: XCTestCase {
+    private func entry(_ cls: String, _ method: String, avg: Int) -> TestTimingEntry {
+        TestTimingEntry(
+            testClass: cls,
+            testMethod: method,
+            averageDurationMs: avg,
+            sampleSize: 1,
+            lastRun: nil,
+            lastRunTimestampMs: nil,
+            successRate: nil,
+            failureRate: nil,
+            stdDevDurationMs: nil,
+            statusCounts: nil
+        )
+    }
+
+    func testBuildTimingMapUniqueEntries() {
+        let map = TestTimingCache.buildTimingMap(from: [
+            entry("SuiteA", "testFoo", avg: 10),
+            entry("SuiteA", "testBar", avg: 20),
+            entry("SuiteB", "testFoo", avg: 30),
+        ])
+        XCTAssertEqual(map.count, 3)
+        XCTAssertEqual(map[TestTimingKey(testClass: "SuiteA", testMethod: "testFoo")]?.averageDurationMs, 10)
+        XCTAssertEqual(map[TestTimingKey(testClass: "SuiteB", testMethod: "testFoo")]?.averageDurationMs, 30)
+    }
+
+    /// A duplicate (class, method) row must NOT crash the process. Pre-fix this
+    /// went through `Dictionary(uniqueKeysWithValues:)`, which `fatalError`s on a
+    /// duplicate key — an uncatchable trap that took down the whole test run
+    /// (issue #3618). The dedup keeps the last occurrence.
+    func testBuildTimingMapToleratesDuplicateKeysKeepingLast() {
+        let map = TestTimingCache.buildTimingMap(from: [
+            entry("SuiteA", "testFoo", avg: 10),
+            entry("SuiteA", "testFoo", avg: 99), // duplicate key
+            entry("SuiteA", "testBar", avg: 20),
+        ])
+        XCTAssertEqual(map.count, 2)
+        XCTAssertEqual(map[TestTimingKey(testClass: "SuiteA", testMethod: "testFoo")]?.averageDurationMs, 99)
+        XCTAssertEqual(map[TestTimingKey(testClass: "SuiteA", testMethod: "testBar")]?.averageDurationMs, 20)
+    }
+
+    func testBuildTimingMapEmpty() {
+        XCTAssertTrue(TestTimingCache.buildTimingMap(from: []).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
`TestTimingCache.loadFromDaemon` built its lookup with `Dictionary(uniqueKeysWithValues:)`, which `fatalError`s on a duplicate `(testClass, testMethod)` key. The daemon's `automobile:test-timings` resource has no wire-level dedup guarantee (aggregation bugs, parametrized-variant collisions, lookback overlap), and a `fatalError` is **not** catchable by the surrounding `do/catch` — so one duplicated row crashed the entire XCTest run during `defaultTestSuite` bring-up.

## Fix
- Build the map with `Dictionary(_, uniquingKeysWith:)` (keep the last occurrence) via a pure, testable `buildTimingMap(from:)` helper.
- Replace the empty `catch {}` with a log line so prefetch failures leave a trace (per the repo error-handling convention).

## Tests
- `testBuildTimingMapToleratesDuplicateKeysKeepingLast` — the regression guard: duplicates no longer trap, last wins.
- Unique-entries and empty-input cases.
- Full XCTestRunner suite (46 tests) green.

Fixes #3618