### PR TITLE
fix(ios): clamp get_table_data offset to avoid Int() trap (#3616)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -1408,7 +1408,7 @@ public class CommandHandler: CommandHandling {
                 databasePath: databasePath,
                 table: table,
                 limit: request.limit ?? 50,
-                offset: Int(request.offset ?? 0)
+                offset: Self.sanitizedTableOffset(request.offset)
             )
             return TableDataResponse(
                 requestId: request.requestId,
@@ -1426,6 +1426,18 @@ public class CommandHandler: CommandHandling {
                 totalTimeMs: totalTimeMs(from: startTime)
             )
         }
+    }
+
+    /// Convert a wire-supplied table `offset` into a safe non-negative `Int`.
+    ///
+    /// `offset` is decoded as a `Double` (see `Models.swift`) and is untrusted:
+    /// a non-finite value (`NaN`/`±Inf`) or a magnitude beyond `Int64` would trap
+    /// `Int(_:)` and crash the runner (issue #3616). Non-finite or negative values
+    /// clamp to 0; values at/above `Int.max` clamp to `Int.max`.
+    static func sanitizedTableOffset(_ value: Double?) -> Int {
+        guard let value = value, value.isFinite, value >= 0 else { return 0 }
+        if value >= Double(Int.max) { return Int.max }
+        return Int(value)
     }
 
     private func handleGetTableStructure(

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -2146,4 +2146,27 @@ final class DatabaseCommandHandlerTests: XCTestCase {
         XCTAssertTrue(response.error?.contains("does not match requested appId") ?? false)
         XCTAssertEqual(fakeDatabase.executeSqlCalls.count, 0)
     }
+
+    // MARK: - get_table_data offset sanitization (#3616)
+
+    func testSanitizedTableOffsetNormalValues() {
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(nil), 0)
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(0), 0)
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(42), 42)
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(42.9), 42) // truncates
+    }
+
+    func testSanitizedTableOffsetNegativeClampsToZero() {
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(-1), 0)
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(-1e18), 0)
+    }
+
+    /// These inputs would trap `Int(_:)` in the pre-fix code and crash the runner
+    /// (issue #3616): a magnitude beyond Int64, and the non-finite values.
+    func testSanitizedTableOffsetOutOfRangeAndNonFiniteDoNotTrap() {
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(1e19), Int.max)
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(.infinity), 0)
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(-.infinity), 0)
+        XCTAssertEqual(CommandHandler.sanitizedTableOffset(.nan), 0)
+    }
 }


### PR DESCRIPTION
## Summary
`handleGetTableData` did `Int(request.offset ?? 0)` where `offset` is decoded as an untrusted `Double` (`Models.swift`). `Int(_:)` traps — crashing the whole runner process — on a non-finite value (`NaN`/`±Inf`) or any magnitude beyond `Int64`'s range (e.g. `{"offset": 1e19}`). Unlike gesture coordinates, there was no `requireFinite` guard here.

## Fix
Route the offset through `CommandHandler.sanitizedTableOffset(_:)`, which clamps non-finite/negative inputs to `0` and values at/above `Int.max` to `Int.max` before converting.

## Tests
- `testSanitizedTableOffsetOutOfRangeAndNonFiniteDoNotTrap` — the regression guard: `1e19`, `±Inf`, `NaN` no longer trap.
- Normal, truncation, and negative-clamp cases.

Fixes #3616