### PR TITLE
fix(scripts): uninstall.sh jq-less sed fallback no longer reverts its edit (#3638)

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -319,12 +319,18 @@ remove_from_json_config() {
     local backup="${path}.bak"
     cp "${path}" "${backup}"
 
-    # Remove lines containing auto-mobile (case insensitive)
-    # and clean up any resulting empty objects or trailing commas
-    sed -i.tmp -E '/"[^"]*[aA]uto-?[mM]obile[^"]*"/d' "${path}" 2>/dev/null || \
-    sed -E '/"[^"]*[aA]uto-?[mM]obile[^"]*"/d' "${path}" > "${tmp_file}" && mv "${tmp_file}" "${path}"
+    # Remove lines containing auto-mobile (case insensitive).
+    # Prefer an in-place edit; fall back to a temp-file rewrite only when the
+    # platform's sed lacks `-i` support. `${tmp_file}` is `${path}.tmp`, which
+    # is also the backup suffix `sed -i.tmp` writes — so the in-place branch
+    # must NOT then `mv` that backup back over the edited file, which reverted
+    # the edit and left auto-mobile entries in place on jq-less machines (#3638).
+    if sed -i.tmp -E '/"[^"]*[aA]uto-?[mM]obile[^"]*"/d' "${path}" 2>/dev/null; then
+        rm -f "${path}.tmp" 2>/dev/null || true
+    else
+        sed -E '/"[^"]*[aA]uto-?[mM]obile[^"]*"/d' "${path}" > "${tmp_file}" && mv "${tmp_file}" "${path}"
+    fi
 
-    rm -f "${path}.tmp" 2>/dev/null || true
     return 0
 }
 

--- a/test/bats/uninstall-remove-from-json-config.bats
+++ b/test/bats/uninstall-remove-from-json-config.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# Tests for the jq-less JSON fallback in scripts/uninstall.sh
+#
+# Regression guard for #3638: the fallback reverted its own edit.
+# `tmp_file="${path}.tmp"` is exactly the backup `sed -i.tmp` writes, and the
+# `A || B && C` precedence ran `mv "${tmp_file}" "${path}"` after a *successful*
+# in-place edit, restoring the original. So on machines without jq the
+# uninstaller silently left auto-mobile entries in the MCP config.
+#
+# The fix guards the in-place edit with `if sed -i.tmp ...; then`. These are
+# source-scan assertions (portable + deterministic across sed variants).
+
+SCRIPT="scripts/uninstall.sh"
+
+@test "in-place sed edit is not chained with '||' (the revert-prone form)" {
+  # The buggy fallback was:
+  #   sed -i.tmp -E '...' "${path}" || \
+  #   sed -E '...' "${path}" > "${tmp_file}" && mv "${tmp_file}" "${path}"
+  # i.e. an in-place `sed -i.tmp` followed by `||`. Fail if that reappears.
+  run grep -nE 'sed +-i\.tmp.*\|\|' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "in-place sed edit is guarded by 'if ... then'" {
+  grep -qE 'if +sed +-i\.tmp' "$SCRIPT"
+}
+
+@test "the fallback still has a non-in-place sed branch (for seds lacking -i)" {
+  # The else branch writes to a temp file then moves it into place.
+  grep -qE 'mv +"\$\{tmp_file\}" +"\$\{path\}"' "$SCRIPT"
+}


### PR DESCRIPTION
## Summary
In `remove_from_json_config`, `tmp_file="${path}.tmp"` is exactly the backup that `sed -i.tmp` writes. The old fallback:
```bash
sed -i.tmp -E '...' "${path}" 2>/dev/null || \
sed -E '...' "${path}" > "${tmp_file}" && mv "${tmp_file}" "${path}"
```
parses as `(A || B) && C`. When `sed -i.tmp` (A) succeeds, `&& mv "${tmp_file}" "${path}"` runs and restores the original over the edited file. On any machine **without jq**, removing auto-mobile entries from a JSON MCP config silently did nothing.

## Change
- Guard the in-place edit with `if sed -i.tmp ...; then rm -f "${path}.tmp"; else <rewrite-then-mv>; fi`, so the in-place branch never `mv`s its own backup back. The temp-file rewrite is kept as the `else` branch for seds lacking `-i`.
- Add `test/bats/uninstall-remove-from-json-config.bats`: a source-scan guard that fails if the revert-prone `sed -i.tmp … ||` form reappears and asserts the in-place edit is `if`-guarded. (Portable/deterministic across sed variants; behavioral correctness verified manually — buggy form reverts, fixed form removes.)

Fixes #3638