### PR TITLE
fix(ios): bound socket-path copy into sun_path to prevent overflow (#3625)

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -664,6 +664,27 @@ public enum DaemonManager {
         )
     }
 
+    /// Copy a Unix socket path into `addr.sun_path` without overflowing the fixed
+    /// buffer. `sun_path` is a fixed C array (104 bytes on Darwin); the previous
+    /// unbounded `strcpy` overflowed the stack `sockaddr_un` for env-supplied
+    /// paths longer than the buffer (issue #3625). Returns `false` (leaving `addr`
+    /// unchanged) when the path plus its NUL terminator does not fit.
+    static func setSocketPath(_ path: String, into addr: inout sockaddr_un) -> Bool {
+        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
+        let bytes = Array(path.utf8)
+        // Need room for the trailing NUL, so the path itself must be < capacity.
+        guard bytes.count < capacity else { return false }
+        withUnsafeMutablePointer(to: &addr.sun_path) { tuplePtr in
+            tuplePtr.withMemoryRebound(to: CChar.self, capacity: capacity) { dst in
+                for (i, byte) in bytes.enumerated() {
+                    dst[i] = CChar(bitPattern: byte)
+                }
+                dst[bytes.count] = 0
+            }
+        }
+        return true
+    }
+
     private static func sendDaemonRequest(_ request: String, timeoutSeconds: TimeInterval) -> [String: Any]? {
         let socketFd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard socketFd >= 0 else {
@@ -674,10 +695,9 @@ public enum DaemonManager {
 
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
-        socketPath.withCString { cString in
-            _ = withUnsafeMutablePointer(to: &addr.sun_path.0) { ptr in
-                strcpy(ptr, cString)
-            }
+        guard Self.setSocketPath(socketPath, into: &addr) else {
+            print("[AutoMobile] Daemon socket path too long (\(socketPath.utf8.count) bytes): \(socketPath)")
+            return nil
         }
 
         let connectResult = withUnsafePointer(to: &addr) { ptr in

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileEnvironmentSocketPathTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileEnvironmentSocketPathTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import XCTestRunner
+
+final class AutoMobileEnvironmentSocketPathTests: XCTestCase {
+    /// Read back the NUL-terminated C string currently stored in `sun_path`.
+    private func readSunPath(_ addr: sockaddr_un) -> String {
+        var addr = addr
+        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
+        return withUnsafePointer(to: &addr.sun_path) { tuplePtr in
+            tuplePtr.withMemoryRebound(to: CChar.self, capacity: capacity) { ptr in
+                String(cString: ptr)
+            }
+        }
+    }
+
+    private var sunPathCapacity: Int {
+        let addr = sockaddr_un()
+        return MemoryLayout.size(ofValue: addr.sun_path)
+    }
+
+    func testSetSocketPathCopiesShortPath() {
+        var addr = sockaddr_un()
+        let path = "/tmp/auto-mobile/daemon.sock"
+        XCTAssertTrue(DaemonManager.setSocketPath(path, into: &addr))
+        XCTAssertEqual(readSunPath(addr), path)
+    }
+
+    /// The longest path that still fits is `capacity - 1` bytes (room for NUL).
+    func testSetSocketPathAcceptsMaximumLengthPath() {
+        var addr = sockaddr_un()
+        let path = String(repeating: "a", count: sunPathCapacity - 1)
+        XCTAssertTrue(DaemonManager.setSocketPath(path, into: &addr))
+        XCTAssertEqual(readSunPath(addr), path)
+    }
+
+    /// A path exactly `capacity` bytes (no room for NUL) must be rejected — the
+    /// pre-fix `strcpy` would have overflowed the stack `sockaddr_un` (issue #3625).
+    func testSetSocketPathRejectsPathWithoutRoomForNul() {
+        var addr = sockaddr_un()
+        let path = String(repeating: "b", count: sunPathCapacity)
+        XCTAssertFalse(DaemonManager.setSocketPath(path, into: &addr))
+    }
+
+    func testSetSocketPathRejectsOverlongPath() {
+        var addr = sockaddr_un()
+        let path = String(repeating: "c", count: sunPathCapacity + 200)
+        XCTAssertFalse(DaemonManager.setSocketPath(path, into: &addr))
+    }
+}


### PR DESCRIPTION
## Summary
`DaemonManager.sendDaemonRequest` copied an env-var-supplied socket path (`AUTOMOBILE_DAEMON_SOCKET_PATH` / `AUTO_MOBILE_DAEMON_SOCKET_PATH`) into the fixed 104-byte `sockaddr_un.sun_path` using an **unbounded `strcpy`**. A path longer than the buffer overflowed the stack `sockaddr_un`, corrupting adjacent stack memory.

## Fix
Replace the `strcpy` with `DaemonManager.setSocketPath(_:into:)`, which:
- rejects paths whose UTF-8 length + NUL terminator don't fit (returns `false`, leaving `addr` untouched; the caller logs and bails), and
- otherwise copies the bytes and NUL-terminates strictly within `sun_path`'s capacity.

## Tests
- copies a normal path (roundtrip verified),
- accepts the maximum-length path (`capacity - 1` bytes),
- rejects a path exactly `capacity` bytes (no room for NUL) — the overflow case,
- rejects an over-long path.

Full XCTestRunner suite green.

Fixes #3625