### PR TITLE
fix(scripts): hadolint installer uses curl --fail and maps Darwin/arm64 (#3641)

### DIFF
--- a/scripts/hadolint/install_hadolint.sh
+++ b/scripts/hadolint/install_hadolint.sh
@@ -109,6 +109,14 @@ install_manual() {
             ;;
     esac
 
+    # hadolint publishes no Darwin-arm64 asset (v2.12.0 ships only Darwin-x86_64);
+    # Apple Silicon runs the x86_64 build under Rosetta 2. Without this remap the
+    # download URL 404s on Apple Silicon. (#3641)
+    if [[ "$os_name" == "Darwin" && "$arch_name" == "arm64" ]]; then
+        echo -e "${YELLOW}No native Darwin-arm64 hadolint build; using x86_64 (Rosetta 2).${NC}"
+        arch_name="x86_64"
+    fi
+
     # Create installation directory
     install_dir="$HOME/.local/bin"
     mkdir -p "$install_dir"
@@ -126,7 +134,9 @@ install_manual() {
 
     # Download the binary
     if command_exists curl; then
-        if ! curl -sL -o "$temp_dir/hadolint" "$download_url"; then
+        # -f/--fail: treat HTTP errors (e.g. 404) as failures instead of
+        # silently saving the error page as the "binary". (#3641)
+        if ! curl -fsSL -o "$temp_dir/hadolint" "$download_url"; then
             echo -e "${RED}Failed to download hadolint binary${NC}"
             return 1
         fi

--- a/test/bats/install-hadolint.bats
+++ b/test/bats/install-hadolint.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/hadolint/install_hadolint.sh install_manual()
+#
+# Regression guards for #3641:
+#  1. curl must use --fail so an HTTP 404 is a download failure, not a
+#     404 error page saved and installed as the "binary".
+#  2. macOS/arm64 must map to the published Darwin-x86_64 asset (hadolint
+#     ships no Darwin-arm64 build), so the URL does not 404 on Apple Silicon.
+
+SCRIPT="scripts/hadolint/install_hadolint.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  STUB_DIR="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+# Run install_manual with stubbed detect_os/detect_arch/curl.
+# $1=os $2=arch ; $3="404" makes the stub curl simulate a 404.
+run_install_manual() {
+  local os="$1" arch="$2" mode="${3:-ok}"
+
+  # Stub curl: if --fail/-f is present, a 404 exits non-zero and writes
+  # nothing; otherwise it "succeeds" and saves an HTML error page.
+  cat > "$STUB_DIR/curl" <<EOF
+#!/usr/bin/env bash
+out=""; prev=""; has_fail=0
+for a in "\$@"; do
+  case "\$a" in -*f*) [[ "\$a" != --* || "\$a" == --fail ]] && has_fail=1 ;; esac
+  [ "\$prev" = "-o" ] && out="\$a"
+  prev="\$a"
+done
+if [ "$mode" = "404" ]; then
+  if [ "\$has_fail" = "1" ]; then echo "curl: (22) 404 Not Found" >&2; exit 22; fi
+  [ -n "\$out" ] && printf '<html>404: Not Found</html>' > "\$out"
+  exit 0
+fi
+[ -n "\$out" ] && printf '#!/bin/sh\necho fake-hadolint\n' > "\$out"
+exit 0
+EOF
+  chmod +x "$STUB_DIR/curl"
+
+  run env HOME="$WORK_DIR" PATH="$STUB_DIR:$PATH" bash -c '
+    eval "$(grep "^HADOLINT_VERSION=" "$1")"
+    eval "$(sed -n "/^install_manual() {/,/^}/p" "$1")"
+    detect_os() { echo "'"$os"'"; }
+    detect_arch() { echo "'"$arch"'"; }
+    command_exists() { [ "$1" = curl ]; }
+    RED=""; GREEN=""; YELLOW=""; NC=""
+    install_manual
+  ' _ "$ABS_SCRIPT"
+}
+
+@test "install_manual fails when the download 404s (curl --fail)" {
+  run_install_manual macos x86_64 404
+  [ "$status" -ne 0 ]
+  # The garbage payload must NOT be installed.
+  [ ! -f "$WORK_DIR/.local/bin/hadolint" ]
+}
+
+@test "install_manual succeeds on a real download" {
+  run_install_manual macos x86_64 ok
+  [ "$status" -eq 0 ]
+  [ -f "$WORK_DIR/.local/bin/hadolint" ]
+}
+
+@test "macOS arm64 maps to the published Darwin-x86_64 asset" {
+  run_install_manual macos arm64 ok
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hadolint-Darwin-x86_64"* ]]
+  # The download URL must not reference the nonexistent Darwin-arm64 asset.
+  [[ "$output" != *"hadolint-Darwin-arm64"* ]]
+}


### PR DESCRIPTION
## Summary
`scripts/hadolint/install_hadolint.sh` `install_manual` had two bugs:
1. **`curl -sL` without `--fail`**: curl returns 0 on an HTTP 404, so the error page was saved, `chmod +x`'d, and moved to `~/.local/bin/hadolint` — a bogus install reported as success (there's no extraction step to catch it).
2. **Darwin/arm64 404**: on Apple Silicon `detect_arch`→`arm64` built `hadolint-Darwin-arm64`, which hadolint has never published (v2.12.0 ships only `Darwin-x86_64`) → guaranteed 404 → combined with bug 1, a guaranteed bad install.

## Change
- Add `-f` (`curl -fsSL`) so HTTP errors are download failures.
- Remap `Darwin`+`arm64` → `x86_64` (runs under Rosetta 2); Linux arm64 is untouched (hadolint does publish `Linux-arm64`).
- Add `test/bats/install-hadolint.bats`: stubbed `curl` proves a 404 now fails the install (and doesn't install the garbage payload), and that macOS/arm64 resolves to `hadolint-Darwin-x86_64`.

Fixes #3641