### PR TITLE
fix(ios): make Execute Plan command work by posting plan content (#3620)

### DIFF
--- a/ios/XcodeExtension/Sources/XcodeExtension/Commands/ExecutePlanCommand.swift
+++ b/ios/XcodeExtension/Sources/XcodeExtension/Commands/ExecutePlanCommand.swift
@@ -1,4 +1,28 @@
 import Foundation
+
+/// Pure, testable logic for the Execute Plan source-editor command.
+///
+/// Kept outside the `canImport(XcodeKit)` gate so it can be unit-tested without
+/// the Xcode extension host (issue #3620).
+enum ExecutePlanCommandLogic {
+    static let notificationName = "com.automobile.execute-plan"
+
+    /// Validate the editor buffer content that will be sent to the companion app.
+    /// Returns an error when there is no runnable plan (empty/whitespace-only),
+    /// otherwise `nil`.
+    static func planContentError(_ content: String) -> NSError? {
+        guard content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return NSError(
+            domain: "AutoMobile",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey:
+                "The active editor buffer is empty; open an AutoMobile plan file before running Execute Plan."]
+        )
+    }
+}
+
 #if canImport(XcodeKit)
     import XcodeKit
 
@@ -8,36 +32,22 @@ import Foundation
             with invocation: XCSourceEditorCommandInvocation,
             completionHandler: @escaping (Error?) -> Void
         ) {
-            let buffer = invocation.buffer
-
-            // Get the file path
-            guard let fileURL = buffer.contentUTI as? URL else {
-                completionHandler(NSError(
-                    domain: "AutoMobile",
-                    code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Could not determine file path"]
-                ))
+            // The source-editor buffer does not expose the file URL (the previous
+            // `buffer.contentUTI as? URL` cast was between unrelated types and
+            // always failed, so this command could never run — issue #3620). Send
+            // the plan *content* to the companion app instead.
+            let planContent = invocation.buffer.completeBuffer
+            if let error = ExecutePlanCommandLogic.planContentError(planContent) {
+                completionHandler(error)
                 return
             }
 
-            // Execute plan via companion app or MCP
-            executePlan(at: fileURL.path) { error in
-                completionHandler(error)
-            }
-        }
-
-        private func executePlan(at path: String, completion: @escaping (Error?) -> Void) {
-            // TODO: Communicate with companion app to execute plan
-            // For MVP, just log the action
-            print("Executing plan at: \(path)")
-
-            // Send notification to companion app
             DistributedNotificationCenter.default().post(
-                name: NSNotification.Name("com.automobile.execute-plan"),
-                object: path
+                name: NSNotification.Name(ExecutePlanCommandLogic.notificationName),
+                object: planContent
             )
-
-            completion(nil)
+            print("Executing AutoMobile plan (\(planContent.count) chars)")
+            completionHandler(nil)
         }
     }
 #endif

--- a/ios/XcodeExtension/Sources/XcodeExtensionTests/ExecutePlanCommandTests.swift
+++ b/ios/XcodeExtension/Sources/XcodeExtensionTests/ExecutePlanCommandTests.swift
@@ -1,0 +1,23 @@
+@testable import XcodeExtension
+import XCTest
+
+final class ExecutePlanCommandTests: XCTestCase {
+    func testPlanContentErrorNilForNonEmptyPlan() {
+        XCTAssertNil(ExecutePlanCommandLogic.planContentError("name: Test\nsteps:\n  - tool: observe"))
+    }
+
+    func testPlanContentErrorForEmptyBuffer() {
+        let error = ExecutePlanCommandLogic.planContentError("")
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error?.domain, "AutoMobile")
+    }
+
+    func testPlanContentErrorForWhitespaceOnlyBuffer() {
+        XCTAssertNotNil(ExecutePlanCommandLogic.planContentError("   \n\t  \n"))
+    }
+
+    func testNotificationNameIsStable() {
+        // The companion app subscribes to this exact name.
+        XCTAssertEqual(ExecutePlanCommandLogic.notificationName, "com.automobile.execute-plan")
+    }
+}


### PR DESCRIPTION
## Summary
`ExecutePlanCommand` guarded on `buffer.contentUTI as? URL`. `XCSourceTextBuffer.contentUTI` is a `String` (a UTI like `public.swift-source`), so the cross-cast to `URL` always returned nil — every invocation dead-ended at "Could not determine file path" and `executePlan` never ran.

## Fix
The source-editor buffer exposes no file URL, so post the plan **content** (`invocation.buffer.completeBuffer`) to the companion app via the existing `com.automobile.execute-plan` distributed notification, erroring only when the buffer is genuinely empty. The impossible cast is gone.

Validation logic is extracted into a non-gated `ExecutePlanCommandLogic` enum so it's unit-testable without the Xcode extension host (which `swift test` can't instantiate).

## Tests
- non-empty plan → no error; empty and whitespace-only → error; notification-name stability guard.
- Full XcodeExtension suite green.

Fixes #3620