### PR TITLE
fix(scripts): deploy_website.sh deploys from the fresh clone, not the dirty tree (#3656)

### DIFF
--- a/scripts/deploy_website.sh
+++ b/scripts/deploy_website.sh
@@ -8,39 +8,33 @@
 
 if [[ "$1" = "--local" ]]; then local=true; fi
 
-if ! [[ ${local} ]]; then
+if [[ ${local} ]]; then
+  # Local preview: build and serve straight from the current working tree.
+  # Copy in special files that GitHub wants in the project root.
+  cp CHANGELOG.md docs/changelog.md
+  cp .github/CONTRIBUTING.md docs/contributing.md
+  mkdocs serve
+else
   set -ex
 
   export GIT_CLONE_PROTECTION_ACTIVE=false
   REPO="git@github.com:kaeawc/auto-mobile.git"
   DIR=temp-clone
 
-  # Delete any existing temporary website clone
+  # Deploy from a fresh clone so we never publish uncommitted local state.
+  # (Previously the clone was created then immediately deleted with nothing
+  # done inside it, so gh-deploy ran against the dirty working tree — #3656.)
   rm -rf "${DIR}"
-
-  # Clone the current repo into temp folder
   git clone "${REPO}" "${DIR}"
+  (
+    cd "${DIR}"
+    # Copy in special files that GitHub wants in the project root.
+    cp CHANGELOG.md docs/changelog.md
+    cp .github/CONTRIBUTING.md docs/contributing.md
+    # Build the site and push the new files up to GitHub.
+    mkdocs gh-deploy
+  )
 
-  # Move working directory into temp folder
-  cd "${DIR}"
-
-  cd ..
-  rm -rf "${DIR}"
-fi
-
-# Copy in special files that GitHub wants in the project root.
-cp CHANGELOG.md docs/changelog.md
-cp .github/CONTRIBUTING.md docs/contributing.md
-
-# Build the site and push the new files up to GitHub
-if ! [[ ${local} ]]; then
-  mkdocs gh-deploy
-else
-  mkdocs serve
-fi
-
-# Delete our temp folder
-if ! [[ ${local} ]]; then
-  cd ..
+  # Delete our temp folder.
   rm -rf "${DIR}"
 fi

--- a/test/bats/deploy-website.bats
+++ b/test/bats/deploy-website.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/deploy_website.sh
+#
+# Regression guard for #3656: the non-local deploy path must run
+# `mkdocs gh-deploy` from inside the fresh clone (temp-clone), not the
+# current (possibly dirty) working tree. Previously the clone was created
+# and immediately deleted with nothing done inside it, so gh-deploy
+# published whatever local state was in the working directory.
+
+SCRIPT="scripts/deploy_website.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  STUB_DIR="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
+
+  # The "working tree" the script is invoked from — give it the same files
+  # so a buggy (in-place) deploy would still succeed and be detectable only
+  # by *where* mkdocs runs.
+  mkdir -p "$WORK_DIR/docs" "$WORK_DIR/.github"
+  : > "$WORK_DIR/CHANGELOG.md"
+  : > "$WORK_DIR/.github/CONTRIBUTING.md"
+
+  # Stub git: `clone <repo> <dir>` materializes <dir> with the same layout.
+  cat > "$STUB_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "clone" ]; then
+  dir="${3:?clone target}"
+  mkdir -p "$dir/docs" "$dir/.github"
+  : > "$dir/CHANGELOG.md"
+  : > "$dir/.github/CONTRIBUTING.md"
+fi
+exit 0
+EOF
+
+  # Stub mkdocs: record the working directory gh-deploy runs from.
+  cat > "$STUB_DIR/mkdocs" <<'EOF'
+#!/usr/bin/env bash
+echo "$PWD" > "$MKDOCS_CWD_FILE"
+exit 0
+EOF
+  chmod +x "$STUB_DIR/git" "$STUB_DIR/mkdocs"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+@test "gh-deploy runs from inside the fresh clone, not the working tree" {
+  cd "$WORK_DIR"
+  run env PATH="$STUB_DIR:$PATH" MKDOCS_CWD_FILE="$WORK_DIR/mkdocs_cwd.txt" \
+    bash "$ABS_SCRIPT"
+  [ "$status" -eq 0 ]
+
+  [ -f "$WORK_DIR/mkdocs_cwd.txt" ]
+  local deploy_cwd
+  deploy_cwd="$(cat "$WORK_DIR/mkdocs_cwd.txt")"
+  # Must have deployed from within temp-clone.
+  [[ "$deploy_cwd" == *"/temp-clone" ]]
+  # And the temp clone must be cleaned up afterward.
+  [ ! -d "$WORK_DIR/temp-clone" ]
+}


### PR DESCRIPTION
## Summary
The non-local branch cloned into `temp-clone`, `cd`'d in, then immediately `cd ..` and `rm -rf`'d it — doing nothing inside. The `cp` + `mkdocs gh-deploy` then ran in the **original working tree**, so `gh-deploy` force-pushed whatever uncommitted local state was present to `gh-pages` — defeating the clean-clone isolation the clone step was meant to provide. (This is a manually-run maintainer script; not referenced by any workflow.)

## Change
- Run the `cp` + `mkdocs gh-deploy` **inside** the fresh clone (in a `( cd "${DIR}" ... )` subshell), then clean up.
- Local (`--local`) path is unchanged: copy into the working tree and `mkdocs serve`.
- Add `test/bats/deploy-website.bats`: stubs `git`/`mkdocs` and asserts `gh-deploy` runs with cwd inside `temp-clone` (fails pre-fix, where it ran from the working tree).

Fixes #3656