### PR TITLE
test(hadolint): fix macOS BATS via portable awk extraction (follow-up #3641)

### DIFF
--- a/test/bats/install-hadolint.bats
+++ b/test/bats/install-hadolint.bats
@@ -47,7 +47,7 @@ EOF
 
   run env HOME="$WORK_DIR" PATH="$STUB_DIR:$PATH" bash -c '
     eval "$(grep "^HADOLINT_VERSION=" "$1")"
-    eval "$(sed -n "/^install_manual() {/,/^}/p" "$1")"
+    eval "$(awk "/^install_manual\\(\\) \\{/{f=1} f{print} f&&/^\\}/{exit}" "$1")"
     detect_os() { echo "'"$os"'"; }
     detect_arch() { echo "'"$arch"'"; }
     command_exists() { [ "$1" = curl ]; }


### PR DESCRIPTION
## Summary
`test/bats/install-hadolint.bats` (merged in #3677) extracts `install_manual` with `sed -n "/^install_manual() {/,/^}/p"`. **BSD sed** on `macos-latest` runners mishandles the `{` in that double-quoted address inside `bash -c`, so `install_manual` is never defined and tests 'succeeds on a real download' / 'macOS arm64 maps…' exit 127.

The awk-based fix was authored on the #3677 branch but did not make it into the squash-merge, so **main's macOS BATS job is currently red** and blocks all PRs. This re-applies the portable `awk` extraction (verified under a BSD-only PATH).

No production code change — test-only.