### PR TITLE
fix(ios): report one event per hang with full duration (#3622)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Hangs/AutoMobileHangs.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Hangs/AutoMobileHangs.swift
@@ -13,13 +13,42 @@ public final class AutoMobileHangs: @unchecked Sendable {
     private var _isMonitoring = false
     private var monitorGeneration: UInt64 = 0
 
+    private var _hangThresholdMs: Double = 2000
+    private var _pollIntervalMs: Double = 500
+
     /// Threshold in milliseconds before a hang is reported. Default: 2000ms.
-    public var hangThresholdMs: Double = 2000
+    public var hangThresholdMs: Double {
+        get { lock.lock(); defer { lock.unlock() }; return _hangThresholdMs }
+        set { lock.lock(); defer { lock.unlock() }; _hangThresholdMs = newValue }
+    }
 
     /// Polling interval in milliseconds. Default: 500ms.
-    public var pollIntervalMs: Double = 500
+    public var pollIntervalMs: Double {
+        get { lock.lock(); defer { lock.unlock() }; return _pollIntervalMs }
+        set { lock.lock(); defer { lock.unlock() }; _pollIntervalMs = newValue }
+    }
+
+    // MARK: - Injectable seams (deterministic testing, #3622)
+
+    /// Monotonic clock in milliseconds. Overridden in tests.
+    var monotonicNowMs: () -> Double = { CFAbsoluteTimeGetCurrent() * 1000 }
+
+    /// Probe the monitored thread: dispatch to it and return `true` if it services
+    /// the probe within `timeoutMs`, `false` if it is blocked. Overridden in tests.
+    var probeMainThread: (_ timeoutMs: Double) -> Bool = { timeoutMs in
+        let semaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.main.async { semaphore.signal() }
+        return semaphore.wait(timeout: .now() + .milliseconds(Int(timeoutMs))) == .success
+    }
+
+    /// Sleep for the given milliseconds. Overridden in tests.
+    var sleepMs: (Double) -> Void = { Thread.sleep(forTimeInterval: $0 / 1000.0) }
 
     private init() {}
+
+    /// Test-only instance so the watchdog logic can be exercised in isolation
+    /// without touching the shared singleton.
+    static func makeTestInstance() -> AutoMobileHangs { AutoMobileHangs() }
 
     func initialize(bundleId: String?, buffer: SdkEventBuffer) {
         lock.lock()
@@ -68,6 +97,12 @@ public final class AutoMobileHangs: @unchecked Sendable {
         return _isMonitoring
     }
 
+    private func isMonitoring(generation: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isMonitoring && monitorGeneration == generation
+    }
+
     /// Enable or disable hang detection.
     /// When disabled, the watchdog thread is stopped. When re-enabled, it restarts.
     public func setEnabled(_ enabled: Bool) {
@@ -79,31 +114,38 @@ public final class AutoMobileHangs: @unchecked Sendable {
     }
 
     private func watchdogLoop(generation: UInt64) {
-        while true {
-            lock.lock()
-            let monitoring = _isMonitoring && monitorGeneration == generation
-            lock.unlock()
-            guard monitoring else { break }
-
-            let semaphore = DispatchSemaphore(value: 0)
-            let checkStart = CFAbsoluteTimeGetCurrent()
-
-            DispatchQueue.main.async {
-                semaphore.signal()
+        while isMonitoring(generation: generation) {
+            if let durationMs = runWatchdogCycle(shouldContinue: { [weak self] in
+                self?.isMonitoring(generation: generation) ?? false
+            }) {
+                reportHang(durationMs: durationMs, stackTrace: captureMainThreadStack())
             }
-
-            let timeoutMs = hangThresholdMs
-            let result = semaphore.wait(timeout: .now() + .milliseconds(Int(timeoutMs)))
-
-            if result == .timedOut {
-                // Main thread is still blocked — measure actual duration
-                let actualDurationMs = (CFAbsoluteTimeGetCurrent() - checkStart) * 1000
-                let mainThreadStack = captureMainThreadStack()
-                reportHang(durationMs: actualDurationMs, stackTrace: mainThreadStack)
-            }
-
-            Thread.sleep(forTimeInterval: pollIntervalMs / 1000.0)
+            sleepMs(pollIntervalMs)
         }
+    }
+
+    /// Run a single watchdog cycle: probe the monitored thread once, and if it is
+    /// hung, wait for it to recover and return the duration of the **whole** hang.
+    ///
+    /// This is the latch that fixes #3622: a single cycle consumes an entire hang
+    /// episode (probe → wait-for-recovery → one report), so a sustained hang yields
+    /// exactly one event whose duration spans first detection to recovery — instead
+    /// of one event per poll interval, each mis-reporting only ~`hangThresholdMs`.
+    /// Returns `nil` when the thread is responsive, or when `shouldContinue` goes
+    /// false before recovery (e.g. monitoring stopped / permanent hang until crash).
+    func runWatchdogCycle(shouldContinue: () -> Bool) -> Double? {
+        let threshold = hangThresholdMs
+        let probeStart = monotonicNowMs()
+        guard !probeMainThread(threshold) else {
+            return nil // responsive within threshold — no hang
+        }
+        // Hang in progress. Keep probing until the thread recovers, then report once.
+        while shouldContinue() {
+            if probeMainThread(threshold) {
+                return monotonicNowMs() - probeStart
+            }
+        }
+        return nil
     }
 
     /// Capture stack trace context during a hang.

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/HangsTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/HangsTests.swift
@@ -1,0 +1,70 @@
+@testable import AutoMobileSDK
+import XCTest
+
+final class HangsTests: XCTestCase {
+    /// A responsive main thread (probe succeeds within threshold) reports no hang.
+    func testResponsiveThreadReportsNoHang() {
+        let hangs = AutoMobileHangs.makeTestInstance()
+        var probeCalls = 0
+        hangs.probeMainThread = { _ in probeCalls += 1; return true }
+
+        let duration = hangs.runWatchdogCycle(shouldContinue: { true })
+
+        XCTAssertNil(duration)
+        XCTAssertEqual(probeCalls, 1)
+    }
+
+    /// A sustained hang across several probes yields exactly ONE report whose
+    /// duration spans first detection to recovery — not one report per poll each
+    /// mis-reporting ~hangThresholdMs (the #3622 regression).
+    func testSustainedHangReportsOnceWithFullDuration() {
+        let hangs = AutoMobileHangs.makeTestInstance()
+
+        // Monotonic clock advances 1000ms per read. probeStart reads once, the
+        // recovery report reads once → duration is deterministic regardless of
+        // how many probes the hang spans.
+        var clock = 0.0
+        hangs.monotonicNowMs = { let v = clock; clock += 1000; return v }
+
+        // hung, hung, hung, then recovered.
+        let results = [false, false, false, true]
+        var idx = 0
+        var probeCalls = 0
+        hangs.probeMainThread = { _ in
+            probeCalls += 1
+            defer { idx += 1 }
+            return results[idx]
+        }
+
+        let duration = hangs.runWatchdogCycle(shouldContinue: { true })
+
+        XCTAssertEqual(duration, 1000) // single event spanning the whole hang
+        XCTAssertEqual(probeCalls, 4)  // 1 detection probe + 3 recovery probes
+    }
+
+    /// If monitoring stops (or the app is being torn down) before the thread
+    /// recovers, no hang event is emitted.
+    func testHangWithoutRecoveryReportsNothingWhenMonitoringStops() {
+        let hangs = AutoMobileHangs.makeTestInstance()
+        hangs.probeMainThread = { _ in false } // never recovers
+        var remaining = 3
+        let duration = hangs.runWatchdogCycle(shouldContinue: {
+            remaining -= 1
+            return remaining > 0
+        })
+        XCTAssertNil(duration)
+    }
+
+    /// Threshold/poll accessors are lock-guarded; concurrent read/write must not
+    /// crash (they were unsynchronized `public var`s read on the watchdog thread).
+    func testThresholdAccessorsAreThreadSafe() {
+        let hangs = AutoMobileHangs.makeTestInstance()
+        DispatchQueue.concurrentPerform(iterations: 1_000) { i in
+            hangs.hangThresholdMs = Double(i)
+            _ = hangs.hangThresholdMs
+            hangs.pollIntervalMs = Double(i)
+            _ = hangs.pollIntervalMs
+        }
+        XCTAssertGreaterThanOrEqual(hangs.hangThresholdMs, 0)
+    }
+}


### PR DESCRIPTION
## Summary
The SDK hang watchdog had no "already reported" latch. While the main thread stayed blocked, each poll iteration re-timed-out and called `reportHang` again, each time measuring `actualDurationMs` from a **per-iteration** start (≈`hangThresholdMs`) rather than the true hang length. A single 30s hang produced ~12 duplicate `SdkHangEvent`s with wrong durations. Separately, `hangThresholdMs`/`pollIntervalMs` were unsynchronized `public var`s read on the watchdog thread — a data race.

## Fix
- Restructure the loop around `runWatchdogCycle(shouldContinue:)`, which consumes an **entire** hang episode: probe → wait for the thread to recover → return one duration spanning first detection to recovery. So a sustained hang yields exactly one event with the correct duration.
- Lock-guard the `hangThresholdMs`/`pollIntervalMs` accessors.
- Injectable clock / main-thread-probe / sleep seams make the behavior deterministically testable (the loop was previously pure real-time `DispatchSemaphore`/`CFAbsoluteTimeGetCurrent`).

## Tests
- responsive thread → no report;
- sustained multi-probe hang → **exactly one** report with full duration (the regression guard);
- hang with no recovery before monitoring stops → no report;
- concurrent threshold/poll accessor stress.

Full auto-mobile-sdk suite (251 tests) green.

Fixes #3622