### PR TITLE
fix(ios): bound ViewBodyTracker entries with LRU eviction (#3624)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewBody/ViewBodyTracker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewBody/ViewBodyTracker.swift
@@ -14,6 +14,14 @@ public final class ViewBodyTracker: @unchecked Sendable {
     private let snapshotIntervalMs: Int = 1000
     private var dateProvider: DateProvider = SystemDateProvider()
 
+    /// Upper bound on tracked entries. Apps may use per-instance ids (e.g.
+    /// `trackViewBody(id: item.uuid)` over a long/paginated feed), which would
+    /// otherwise grow `entries` without bound for the life of the process
+    /// (issue #3624). When the cap is exceeded we evict the least-recently-updated
+    /// entries in a batch so the O(n) eviction scan is amortized across inserts.
+    private let maxEntries = 512
+    private let evictionBatch = 64
+
     private init() {}
 
     func initialize(buffer: SdkEventBuffer, dateProvider: DateProvider = SystemDateProvider()) {
@@ -68,12 +76,30 @@ public final class ViewBodyTracker: @unchecked Sendable {
         var updated = entry
         updated.totalCount += 1
         let now = dateProvider.now().timeIntervalSince1970
+        updated.lastUpdated = now
         updated.recentTimestamps.append(now)
         // Keep only timestamps from the last second for rolling average
         let cutoff = now - 1.0
         updated.recentTimestamps.removeAll { $0 < cutoff }
         entries[id] = updated
+        enforceEntryCapLocked()
         lock.unlock()
+    }
+
+    /// Evict least-recently-updated entries once the cap is exceeded, down to a
+    /// low-water mark so this scan runs at most once per `evictionBatch` inserts.
+    /// Must be called with `lock` held.
+    private func enforceEntryCapLocked() {
+        guard entries.count > maxEntries else { return }
+        let target = maxEntries - evictionBatch
+        let removeCount = entries.count - target
+        let oldestKeys = entries
+            .sorted { $0.value.lastUpdated < $1.value.lastUpdated }
+            .prefix(removeCount)
+            .map { $0.key }
+        for key in oldestKeys {
+            entries.removeValue(forKey: key)
+        }
     }
 
     /// Record composition duration for a view.
@@ -151,6 +177,8 @@ extension ViewBodyTracker {
         var recentTimestamps: [TimeInterval] = []
         var totalDurationMs: Double = 0
         var durationCount: Int = 0
+        /// Timestamp of the most recent body evaluation, used for LRU eviction.
+        var lastUpdated: TimeInterval = 0
     }
 }
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ViewBodyTrackerTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ViewBodyTrackerTests.swift
@@ -60,4 +60,29 @@ final class ViewBodyTrackerTests: XCTestCase {
         XCTAssertEqual(viewA?.totalCount, 2)
         XCTAssertEqual(viewB?.totalCount, 1)
     }
+
+    /// Per-instance ids (e.g. a long feed keyed by item uuid) must not grow the
+    /// entries map without bound; the tracker caps it and evicts the
+    /// least-recently-updated entries (issue #3624).
+    func testEntriesAreBoundedAndEvictLeastRecentlyUpdated() {
+        let dateProvider = FakeDateProvider(initialDate: Date(timeIntervalSince1970: 0))
+        let buffer = SdkEventBuffer(maxBufferSize: 100, flushIntervalMs: 60000) { _ in }
+        ViewBodyTracker.shared.initialize(buffer: buffer, dateProvider: dateProvider)
+        ViewBodyTracker.shared.setEnabled(true, timerFactory: { FakeTimer() })
+
+        // Record 600 distinct ids, each at a strictly later time so LRU order is
+        // well defined. The cap is 512, so the map must stay bounded.
+        let total = 600
+        for i in 0..<total {
+            ViewBodyTracker.shared.recordBodyEvaluation(id: "view-\(i)", viewName: "V")
+            dateProvider.advance(by: 1.0)
+        }
+
+        let snapshots = ViewBodyTracker.shared.getSnapshots()
+        let ids = Set(snapshots.map(\.id))
+
+        XCTAssertLessThanOrEqual(snapshots.count, 512, "entries map must stay bounded")
+        XCTAssertTrue(ids.contains("view-\(total - 1)"), "the most recent id must survive")
+        XCTAssertFalse(ids.contains("view-0"), "the oldest id must have been evicted")
+    }
 }


### PR DESCRIPTION
## Summary
`ViewBodyTracker.entries` added one entry per unique `id` and **never evicted** any (only each entry's inner `recentTimestamps` was trimmed). Apps using per-instance ids — `trackViewBody(id: item.uuid)` / `MeasureViewBody(id:)` over a long or paginated feed — leaked memory monotonically for the process lifetime, and `getSnapshots()`/`broadcastSnapshot()` iterated an ever-growing set every second.

## Fix
Cap `entries` at 512 and, when exceeded, batch-evict the least-recently-updated entries down to a low-water mark (so the O(n) eviction scan is amortized across ~64 inserts rather than run on every insert). Entries gain a `lastUpdated` timestamp for LRU ordering.

## Tests
- `testEntriesAreBoundedAndEvictLeastRecentlyUpdated` — records 600 distinct ids at strictly increasing times; asserts the map stays ≤ 512, the newest id survives, and the oldest is evicted.
- Full auto-mobile-sdk suite (252 tests) green.

Fixes #3624