### PR TITLE
fix(ios): classify UserDefaults NSNumber values by underlying type (#3628)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -429,7 +429,7 @@ final class DefaultUserDefaultsDriver: UserDefaultsDriver, @unchecked Sendable {
     func getValues(suiteName: String?) -> [KeyValuePair] {
         guard let defaults = resolveDefaults(suiteName: suiteName) else { return [] }
         return defaults.dictionaryRepresentation().map { key, value in
-            let type = typeOf(value)
+            let type = Self.typeOf(value)
             return KeyValuePair(key: key, value: Self.encode(value, as: type), type: type)
         }.sorted { $0.key < $1.key }
     }
@@ -437,7 +437,7 @@ final class DefaultUserDefaultsDriver: UserDefaultsDriver, @unchecked Sendable {
     func getValue(suiteName: String?, key: String) -> KeyValuePair? {
         guard let defaults = resolveDefaults(suiteName: suiteName) else { return nil }
         guard let value = defaults.object(forKey: key) else { return nil }
-        let type = typeOf(value)
+        let type = Self.typeOf(value)
         return KeyValuePair(key: key, value: Self.encode(value, as: type), type: type)
     }
 
@@ -513,12 +513,22 @@ final class DefaultUserDefaultsDriver: UserDefaultsDriver, @unchecked Sendable {
         }
     }
 
-    private func typeOf(_ value: Any) -> KeyValueType {
+    /// Classify a UserDefaults value.
+    ///
+    /// Values from `UserDefaults` are NSNumber-bridged, so a plain `is Int` check
+    /// (ordered before `is Bool`/`is Double`) misclassifies `Bool` (backed by
+    /// `__NSCFBoolean`) and whole-number `Double` (e.g. `3.0`) as `.int`
+    /// (issue #3628). Inspect the NSNumber's underlying representation instead:
+    /// detect CFBoolean explicitly, then use `CFNumberIsFloatType` to split
+    /// floating-point from integer.
+    static func typeOf(_ value: Any) -> KeyValueType {
         switch value {
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool
+            }
+            return CFNumberIsFloatType(number) ? .double : .int
         case is String: return .string
-        case is Int: return .int
-        case is Double, is Float: return .double
-        case is Bool: return .bool
         case is Data: return .data
         case is Date: return .date
         case is [Any]: return .array

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -887,4 +887,37 @@ final class UserDefaultsValueEncodingTests: XCTestCase {
         let encoded = DefaultUserDefaultsDriver.encode(array, as: .array)
         XCTAssertFalse(encoded.isEmpty)
     }
+
+    // MARK: - typeOf NSNumber classification (#3628)
+
+    func testTypeOfDistinguishesBoolIntDoubleNSNumbers() {
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(NSNumber(value: true)), .bool)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(NSNumber(value: false)), .bool)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(NSNumber(value: 42)), .int)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(NSNumber(value: 3.0)), .double) // whole-number double
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(NSNumber(value: 3.5)), .double)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf("hello"), .string)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(Data([1, 2, 3])), .data)
+    }
+
+    /// Values round-tripped through a real UserDefaults suite are NSNumber-bridged;
+    /// the pre-fix `is Int`-first switch reported bool and whole-number double as
+    /// `.int` (issue #3628).
+    func testTypeOfClassifiesUserDefaultsBridgedValues() {
+        let suiteName = "dev.jasonpearson.automobile.tests.typeof-3628"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: "flag")
+        defaults.set(42, forKey: "count")
+        defaults.set(3.0, forKey: "whole")
+        defaults.set(3.5, forKey: "frac")
+        defaults.set("name", forKey: "label")
+
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(defaults.object(forKey: "flag")!), .bool)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(defaults.object(forKey: "count")!), .int)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(defaults.object(forKey: "whole")!), .double)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(defaults.object(forKey: "frac")!), .double)
+        XCTAssertEqual(DefaultUserDefaultsDriver.typeOf(defaults.object(forKey: "label")!), .string)
+    }
 }


### PR DESCRIPTION
## Summary
`DefaultUserDefaultsDriver.typeOf` checked `is Int` before `is Bool`/`is Double`. Values from `UserDefaults` are NSNumber-bridged, so `Bool` (backed by `__NSCFBoolean`) and whole-number `Double` (e.g. `3.0`) matched `is Int` first and were reported as `.int` in `storage_changed` telemetry.

## Fix
Inspect the NSNumber's underlying representation: detect `CFBoolean` explicitly via `CFGetTypeID == CFBooleanGetTypeID()`, then use `CFNumberIsFloatType` to split floating-point from integer. `typeOf` is now a `static` helper so it can be unit-tested directly.

## Tests
- direct NSNumber classification (bool/int/whole-double/frac-double/string/data);
- round-trip through a real `UserDefaults` suite (the exact bridging path that exhibited the bug).

Full auto-mobile-sdk suite (254 tests) green.

Fixes #3628