### PR TITLE
fix(ios): bound WebSocket frame payload length before Int() (#3626)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -787,9 +787,30 @@ class WebSocketConnection: WebSocketResponding {
         }
     }
 
+    /// Maximum accepted WebSocket frame payload (64 MiB). Frames declaring a
+    /// larger payload are rejected rather than trapping the `Int(length)`
+    /// conversion (which crashes for `length > Int.max`) or attempting an
+    /// enormous allocation (issue #3626).
+    static let maxFramePayloadLength: UInt64 = 64 * 1024 * 1024
+
+    /// Validate a frame payload length and compute the total bytes to read
+    /// (payload + mask). Returns `nil` when the payload exceeds `maxPayload`, so
+    /// the caller closes the connection instead of trapping/over-allocating.
+    static func frameReadLength(
+        payloadLength: UInt64,
+        isMasked: Bool,
+        maxPayload: UInt64 = maxFramePayloadLength
+    ) -> Int? {
+        guard payloadLength <= maxPayload else { return nil }
+        return Int(payloadLength) + (isMasked ? 4 : 0)
+    }
+
     private func readPayload(length: UInt64, isMasked: Bool, opcode: UInt8) {
-        let maskLength = isMasked ? 4 : 0
-        let totalLength = Int(length) + maskLength
+        guard let totalLength = Self.frameReadLength(payloadLength: length, isMasked: isMasked) else {
+            print("[WebSocketConnection] Frame payload too large (\(length) bytes), closing connection")
+            onClose()
+            return
+        }
 
         guard totalLength > 0 else {
             receiveWebSocketFrame()

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -202,4 +202,29 @@ final class WebSocketServerTests: XCTestCase {
         XCTAssertEqual(registry.count, 0)
         XCTAssertTrue(registry.values().isEmpty)
     }
+
+    // MARK: - WebSocket frame length bounds (#3626)
+
+    func testFrameReadLengthNormalUnmasked() {
+        XCTAssertEqual(WebSocketConnection.frameReadLength(payloadLength: 10, isMasked: false), 10)
+    }
+
+    func testFrameReadLengthAddsMaskBytes() {
+        XCTAssertEqual(WebSocketConnection.frameReadLength(payloadLength: 10, isMasked: true), 14)
+    }
+
+    func testFrameReadLengthAtMaxIsAccepted() {
+        let max = WebSocketConnection.maxFramePayloadLength
+        XCTAssertEqual(WebSocketConnection.frameReadLength(payloadLength: max, isMasked: false), Int(max))
+    }
+
+    /// A frame declaring a payload beyond the cap — including one > Int.max that
+    /// would trap `Int(length)` in the pre-fix code — is rejected (nil), so the
+    /// caller closes the connection instead of crashing the runner (#3626).
+    func testFrameReadLengthRejectsOversizedAndOverflowing() {
+        let overCap = WebSocketConnection.maxFramePayloadLength + 1
+        XCTAssertNil(WebSocketConnection.frameReadLength(payloadLength: overCap, isMasked: false))
+        XCTAssertNil(WebSocketConnection.frameReadLength(payloadLength: UInt64(Int.max) + 1, isMasked: false))
+        XCTAssertNil(WebSocketConnection.frameReadLength(payloadLength: .max, isMasked: true))
+    }
 }


### PR DESCRIPTION
## Summary
`readPayload` computed `Int(length) + maskLength` on a wire-supplied 64-bit frame length. For a 127-length frame declaring a payload `> Int.max` (2^63), `Int(length)` traps and crashes the runner. Even below that, a huge declared length would attempt an enormous allocation.

## Fix
Add a 64 MiB max-frame cap and route the length through a testable static `frameReadLength(payloadLength:isMasked:)` helper that returns `nil` for oversized/overflowing payloads. `readPayload` then closes the connection instead of trapping or over-allocating.

## Tests
- normal unmasked / masked (+4) lengths;
- exactly-at-cap accepted;
- over-cap, `> Int.max`, and `UInt64.max` all rejected (the crash cases).

Full control-proxy suite (400 tests) green.

Fixes #3626