### PR TITLE
fix(ios): use loadUnaligned in FrameProtocol.decodeHeader (#3627)

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
@@ -42,10 +42,14 @@ public enum FrameProtocol {
         guard data.count >= headerSize else { return nil }
         return data.withUnsafeBytes { ptr -> Header in
             let base = ptr.baseAddress!
-            let w = UInt32(littleEndian: base.load(as: UInt32.self))
-            let h = UInt32(littleEndian: base.advanced(by: 4).load(as: UInt32.self))
-            let r = UInt32(littleEndian: base.advanced(by: 8).load(as: UInt32.self))
-            let t = UInt32(littleEndian: base.advanced(by: 12).load(as: UInt32.self))
+            // `load(as:)` requires the address to be aligned to the loaded type;
+            // when `data` is a slice of a larger buffer, `base` may be unaligned,
+            // making the loads undefined behavior (traps in debug). `loadUnaligned`
+            // has no alignment requirement (issue #3627).
+            let w = UInt32(littleEndian: base.loadUnaligned(as: UInt32.self))
+            let h = UInt32(littleEndian: base.advanced(by: 4).loadUnaligned(as: UInt32.self))
+            let r = UInt32(littleEndian: base.advanced(by: 8).loadUnaligned(as: UInt32.self))
+            let t = UInt32(littleEndian: base.advanced(by: 12).loadUnaligned(as: UInt32.self))
             return Header(width: w, height: h, bytesPerRow: r, timestampMs: t)
         }
     }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
@@ -35,4 +35,41 @@ final class FrameProtocolTests: XCTestCase {
         let truncated = Data(repeating: 0, count: FrameProtocol.headerSize - 1)
         XCTAssertNil(FrameProtocol.decodeHeader(truncated))
     }
+
+    /// Decoding a header from an unaligned buffer must not trap. The pre-fix
+    /// `load(as:)` requires 4-byte alignment; feeding it a header at an odd
+    /// address traps in debug (issue #3627). `loadUnaligned` decodes correctly.
+    func testDecodeHeaderHandlesUnalignedBuffer() {
+        let header = FrameProtocol.Header(
+            width: 0x1122_3344,
+            height: 0x5566_7788,
+            bytesPerRow: 0x99AA_BBCC,
+            timestampMs: 0xDDEE_FF00
+        )
+        let encoded = FrameProtocol.encodeHeader(header)
+
+        // Place the 16 header bytes at an odd (unaligned) offset in a raw buffer.
+        let raw = UnsafeMutableRawPointer.allocate(
+            byteCount: FrameProtocol.headerSize + 1,
+            alignment: 1
+        )
+        defer { raw.deallocate() }
+        encoded.withUnsafeBytes { src in
+            raw.advanced(by: 1).copyMemory(from: src.baseAddress!, byteCount: FrameProtocol.headerSize)
+        }
+        let unaligned = Data(
+            bytesNoCopy: raw.advanced(by: 1),
+            count: FrameProtocol.headerSize,
+            deallocator: .none
+        )
+
+        XCTAssertEqual(FrameProtocol.decodeHeader(unaligned), header)
+    }
+
+    func testEncodeDecodeRoundTrip() {
+        let header = FrameProtocol.Header(
+            width: 1290, height: 2796, bytesPerRow: 5160, timestampMs: 123_456
+        )
+        XCTAssertEqual(FrameProtocol.decodeHeader(FrameProtocol.encodeHeader(header)), header)
+    }
 }


### PR DESCRIPTION
## Summary
`FrameProtocol.decodeHeader` read its `UInt32` fields with `UnsafeRawPointer.load(as:)`, which requires the address to be aligned to the type. When `data` is a slice of a larger received buffer, `baseAddress` is not guaranteed 4-byte aligned, making the loads undefined behavior (traps in debug / on strict-alignment paths). The `encodeHeader` side is safe (it writes into a fresh `Data(count: 16)`); only decode is exposed to arbitrary slices.

## Fix
Use `loadUnaligned(as:)` for all four fields — no alignment requirement.

## Tests
- `testDecodeHeaderHandlesUnalignedBuffer` — decodes a header placed at an odd address via `Data(bytesNoCopy:)`; traps under the old `load` in debug, passes now.
- encode/decode round-trip.

Full screen-capture suite (29 tests) green.

Fixes #3627