### PR TITLE
fix(ios): snapshot timingData under lock in export/summary (#3629)

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunner/XCTestObservationIntegration.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/XCTestObservationIntegration.swift
@@ -71,11 +71,17 @@ public class AutoMobileTestObserver: NSObject, XCTestObservation {
             passed: testCase.testRun?.totalFailureCount == 0
         )
 
+        recordTiming(timing)
+
+        print("Test case finished: \(testCase.name) - Duration: \(duration)s - Passed: \(timing.passed)")
+    }
+
+    /// Append a timing entry under the lock. Single write path so all mutations
+    /// of `timingData` stay synchronized (issue #3629).
+    func recordTiming(_ timing: TimingData) {
         timingLock.lock()
         timingData.append(timing)
         timingLock.unlock()
-
-        print("Test case finished: \(testCase.name) - Duration: \(duration)s - Passed: \(timing.passed)")
     }
 
     /// Called when a test suite starts
@@ -99,29 +105,34 @@ public class AutoMobileTestObserver: NSObject, XCTestObservation {
 
     /// Exports timing data to JSON
     public func exportTimingData(to path: String) throws {
-        let jsonData = try JSONEncoder().encode(timingData)
+        // Snapshot under the lock; testCaseDidFinish may append concurrently under
+        // parallel testing (issue #3629).
+        let data = getTimingData()
+        let jsonData = try JSONEncoder().encode(data)
         try jsonData.write(to: URL(fileURLWithPath: path))
     }
 
     /// Prints a summary of timing data
     private func printSummary() {
-        guard !timingData.isEmpty else {
+        // Snapshot under the lock before reading repeatedly (issue #3629).
+        let data = getTimingData()
+        guard !data.isEmpty else {
             return
         }
 
         print("\n=== Test Timing Summary ===")
-        print("Total tests: \(timingData.count)")
-        print("Passed: \(timingData.filter { $0.passed }.count)")
-        print("Failed: \(timingData.filter { !$0.passed }.count)")
+        print("Total tests: \(data.count)")
+        print("Passed: \(data.filter { $0.passed }.count)")
+        print("Failed: \(data.filter { !$0.passed }.count)")
 
-        let totalDuration = timingData.reduce(0) { $0 + $1.duration }
+        let totalDuration = data.reduce(0) { $0 + $1.duration }
         print("Total duration: \(String(format: "%.2f", totalDuration))s")
 
-        if let slowest = timingData.max(by: { $0.duration < $1.duration }) {
+        if let slowest = data.max(by: { $0.duration < $1.duration }) {
             print("Slowest test: \(slowest.testName) (\(String(format: "%.2f", slowest.duration))s)")
         }
 
-        if let fastest = timingData.min(by: { $0.duration < $1.duration }) {
+        if let fastest = data.min(by: { $0.duration < $1.duration }) {
             print("Fastest test: \(fastest.testName) (\(String(format: "%.2f", fastest.duration))s)")
         }
 

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestObservationIntegrationTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestObservationIntegrationTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+@testable import XCTestRunner
+import XCTest
+
+final class XCTestObservationIntegrationTests: XCTestCase {
+    private func timing(_ name: String, duration: TimeInterval = 1, passed: Bool = true) -> AutoMobileTestObserver.TimingData {
+        let start = Date(timeIntervalSince1970: 0)
+        return AutoMobileTestObserver.TimingData(
+            testName: name,
+            duration: duration,
+            startTime: start,
+            endTime: start.addingTimeInterval(duration),
+            passed: passed
+        )
+    }
+
+    func testRecordAndGetTimingData() {
+        let observer = AutoMobileTestObserver()
+        observer.recordTiming(timing("a"))
+        observer.recordTiming(timing("b"))
+        let data = observer.getTimingData()
+        XCTAssertEqual(data.map(\.testName), ["a", "b"])
+    }
+
+    func testExportTimingDataWritesJSONArray() throws {
+        let observer = AutoMobileTestObserver()
+        observer.recordTiming(timing("a"))
+        observer.recordTiming(timing("b"))
+        observer.recordTiming(timing("c"))
+
+        let path = NSTemporaryDirectory() + "am-timing-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try observer.exportTimingData(to: path)
+
+        let raw = try Data(contentsOf: URL(fileURLWithPath: path))
+        let array = try JSONSerialization.jsonObject(with: raw) as? [[String: Any]]
+        XCTAssertEqual(array?.count, 3)
+    }
+
+    /// Concurrent appends and snapshot reads must not race. exportTimingData and
+    /// printSummary previously read `timingData` without the lock while
+    /// testCaseDidFinish appended under it (issue #3629). Both now go through the
+    /// lock-guarded getTimingData() snapshot, exercised here via getTimingData().
+    func testConcurrentRecordAndReadDoNotCrash() {
+        let observer = AutoMobileTestObserver()
+
+        DispatchQueue.concurrentPerform(iterations: 2_000) { i in
+            observer.recordTiming(timing("t\(i)"))
+            _ = observer.getTimingData() // snapshot read concurrent with appends
+        }
+
+        XCTAssertEqual(observer.getTimingData().count, 2_000)
+    }
+}


### PR DESCRIPTION
## Summary
`AutoMobileTestObserver.exportTimingData` (`JSONEncoder().encode(timingData)`) and `printSummary` (`guard !timingData.isEmpty` + repeated reads) accessed the shared `timingData` array **without** `timingLock`, while `testCaseDidFinish` appends to it under the lock. Under `-parallel-testing-worker-count` that's a data race (torn read / crash under TSan).

## Fix
Route both readers through the existing lock-guarded `getTimingData()` snapshot, and funnel appends through a single `recordTiming` write path.

## Tests
- record → getTimingData; exportTimingData writes a JSON array of the right length;
- concurrent record + snapshot-read stress (2,000 iterations) ends with a consistent count and no crash.

Full XCTestRunner suite (53 tests) green.

Fixes #3629