### PR TITLE
fix(scripts): xml/validate_xml.sh tool-presence guard now actually fires (#3642)

### DIFF
--- a/scripts/xml/validate_xml.sh
+++ b/scripts/xml/validate_xml.sh
@@ -9,8 +9,11 @@ validate_xml() {
   fi
 }
 
-# Check for required XML tools
-if [[ $(! command -v xml &>/dev/null) && $(! command -v xmlstarlet &>/dev/null) ]]; then
+# Check for required XML tools.
+# Note: `$(! command -v xml &>/dev/null)` captures the command's *stdout*
+# (redirected to /dev/null → always empty), so the old `[[ "" && "" ]]` guard
+# was always false and never fired. Test the exit status directly instead.
+if ! command -v xml &>/dev/null && ! command -v xmlstarlet &>/dev/null; then
   echo "xmlstarlet missing, please install."
   if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Try 'brew install xmlstarlet'"

--- a/test/bats/validate-xml.bats
+++ b/test/bats/validate-xml.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/xml/validate_xml.sh
+#
+# Regression guard for #3642: the tool-presence guard was
+#   if [[ $(! command -v xml &>/dev/null) && $(! command -v xmlstarlet &>/dev/null) ]]
+# which captures each command's stdout (redirected to /dev/null → empty), so
+# `[[ "" && "" ]]` was always false and the guard never fired. With no XML tool
+# installed the script must print the actionable "xmlstarlet missing" message
+# and exit 1, not fall through to run a nonexistent command.
+
+SCRIPT="scripts/xml/validate_xml.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  # A PATH containing only `bash` (needed to launch the script) so that
+  # neither `xml` nor `xmlstarlet` is resolvable, regardless of the runner.
+  # The fixed guard needs only shell builtins, so this is sufficient.
+  BIN_DIR="$(mktemp -d)"
+  ln -s "$(command -v bash)" "$BIN_DIR/bash"
+}
+
+teardown() {
+  rm -rf "$BIN_DIR"
+}
+
+@test "fails with an actionable message when no XML tool is installed" {
+  # Sanity: neither tool is resolvable on this PATH.
+  run env PATH="$BIN_DIR" bash -c 'command -v xml || command -v xmlstarlet'
+  [ "$status" -ne 0 ]
+
+  run env PATH="$BIN_DIR" bash "$ABS_SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"xmlstarlet missing"* ]]
+}


### PR DESCRIPTION
## Summary
The guard was:
```bash
if [[ $(! command -v xml &>/dev/null) && $(! command -v xmlstarlet &>/dev/null) ]]; then
```
Each `$(...)` captures the command's **stdout** (redirected to `/dev/null` → always empty), so `[[ "" && "" ]]` is always false and the guard never fires. Without xmlstarlet the clean "please install" message + `exit 1` was skipped, and every file was handed to a nonexistent `xml`/`xmlstarlet`, producing a cryptic "Errors in the following files" failure.

## Change
- `if ! command -v xml &>/dev/null && ! command -v xmlstarlet &>/dev/null; then` — test exit status directly.
- Add `test/bats/validate-xml.bats`: runs the script with a PATH lacking both tools and asserts it prints "xmlstarlet missing" and exits 1 (pre-fix it fell through).

Fixes #3642