### PR TITLE
fix(ios): lock-guard SdkEventBroadcaster.ctrlProxyUrl (#3632)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
@@ -20,7 +20,26 @@ final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
 
     /// CtrlProxy HTTP endpoint for SDK event forwarding.
     /// Set by the SDK during initialization if CtrlProxy is detected.
-    private var ctrlProxyUrl: URL?
+    ///
+    /// Read on the event buffer's flush thread (`broadcastBatch`/`deliverBatch`)
+    /// and written from arbitrary threads (`setCtrlProxyUrl`), so all access is
+    /// serialized by a lock — Optional/reference assignment is not atomic in
+    /// Swift's memory model (issue #3632).
+    private let ctrlProxyUrlLock = NSLock()
+    private var _ctrlProxyUrl: URL?
+    var ctrlProxyUrl: URL? {
+        get {
+            ctrlProxyUrlLock.lock()
+            defer { ctrlProxyUrlLock.unlock() }
+            return _ctrlProxyUrl
+        }
+        set {
+            ctrlProxyUrlLock.lock()
+            defer { ctrlProxyUrlLock.unlock() }
+            _ctrlProxyUrl = newValue
+        }
+    }
+
     private let urlSession: URLSession
 
     /// Disk-first event persistence for reliable delivery.
@@ -38,11 +57,14 @@ final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
 
         #if DEBUG
         // Default CtrlProxy port — only in debug builds
-        self.ctrlProxyUrl = URL(string: "http://localhost:8765/sdk-events")
+        _ctrlProxyUrl = URL(string: "http://localhost:8765/sdk-events")
         #else
-        self.ctrlProxyUrl = nil
+        _ctrlProxyUrl = nil
         #endif
     }
+
+    /// Test-only instance to exercise the broadcaster in isolation.
+    static func makeTestInstance() -> SdkEventBroadcaster { SdkEventBroadcaster() }
 
     /// Configure the CtrlProxy endpoint URL. Pass nil to disable HTTP forwarding.
     /// No-op in release builds.

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkEventBroadcasterTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkEventBroadcasterTests.swift
@@ -1,0 +1,25 @@
+@testable import AutoMobileSDK
+import XCTest
+
+final class SdkEventBroadcasterTests: XCTestCase {
+    /// Concurrent get/set of the CtrlProxy URL must not race. It was a plain
+    /// `var` read on the flush thread while written from other threads (#3632).
+    func testCtrlProxyUrlConcurrentAccessDoesNotCrash() {
+        let broadcaster = SdkEventBroadcaster.makeTestInstance()
+        DispatchQueue.concurrentPerform(iterations: 2_000) { i in
+            broadcaster.ctrlProxyUrl = URL(string: "http://localhost:\(8000 + i % 100)/sdk-events")
+            _ = broadcaster.ctrlProxyUrl
+        }
+        // Final value is one of the concurrently-set URLs; the point is no crash.
+        XCTAssertNotNil(broadcaster.ctrlProxyUrl)
+    }
+
+    func testSetCtrlProxyUrlUpdatesValue() {
+        let broadcaster = SdkEventBroadcaster.makeTestInstance()
+        let url = URL(string: "http://localhost:9999/sdk-events")
+        broadcaster.setCtrlProxyUrl(url)
+        #if DEBUG
+        XCTAssertEqual(broadcaster.ctrlProxyUrl, url)
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
`SdkEventBroadcaster.ctrlProxyUrl` was a plain `private var URL?` read on the event buffer's GCD flush thread (`broadcastBatch`/`deliverBatch`) while written from arbitrary threads (`setCtrlProxyUrl`), with no synchronization — a data race on a non-atomic Optional/reference. Every other cross-thread field in the SDK uses an `NSLock`. (Both the meaningful read and the writes are `#if DEBUG`, so the blast radius is debug builds.)

## Fix
Back `ctrlProxyUrl` with lock-guarded storage via a computed accessor, matching the SDK's convention.

## Tests
- concurrent get/set stress (2,000 iterations) — no crash;
- `setCtrlProxyUrl` updates the value (DEBUG).

Full auto-mobile-sdk suite (256 tests) green.

Fixes #3632