### PR TITLE
fix(scripts): apply_shfmt.sh checks shfmt exit status, not just keywords (#3643)

### DIFF
--- a/scripts/shellcheck/apply_shfmt.sh
+++ b/scripts/shellcheck/apply_shfmt.sh
@@ -115,12 +115,16 @@ printf '%s\n' "${files_to_process[@]}" > "$temp_file"
 echo -e "${YELLOW}Applying shfmt formatting...${NC}"
 
 if [[ -s "$temp_file" ]]; then
-  # Apply shfmt formatting and capture output
+  # Apply shfmt formatting and capture output + exit status.
   shfmt_output=$(xargs shfmt -i 2 -bn -ci -sr -w 2>&1 < "$temp_file")
+  shfmt_status=$?
 
-  # Check if the output contains actual errors
-  if echo "$shfmt_output" | grep -E "(error|Error|ERROR|failed|Failed|FAILED)" > /dev/null 2>&1; then
-    errors="$shfmt_output"
+  # A non-zero shfmt exit (e.g. an unparseable file → "reached EOF without
+  # matching ...") is a failure even when the diagnostic lacks the keywords
+  # below. The old keyword-only check silently skipped such files and still
+  # git-added + reported success (#3643). Flag either signal.
+  if [[ $shfmt_status -ne 0 ]] || echo "$shfmt_output" | grep -E "(error|Error|ERROR|failed|Failed|FAILED)" > /dev/null 2>&1; then
+    errors="${shfmt_output:-shfmt exited with status $shfmt_status}"
   fi
 fi
 

--- a/test/bats/apply-shfmt.bats
+++ b/test/bats/apply-shfmt.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/shellcheck/apply_shfmt.sh
+#
+# Regression guard for #3643: shfmt's exit status must be checked. The old code
+# inferred failure only by grepping shfmt's output for keywords
+# (error|Error|…|FAILED); shfmt parse errors ("reached EOF without matching …")
+# contain none of them, so an unparseable file was silently skipped, the files
+# were still git-added, and the script reported success — the same silent-failure
+# class apply_ktfmt.sh fixed via PIPESTATUS.
+#
+# Source-scan assertions (a behavioral run needs a git repo + file-selection lib
+# + shfmt; the fix is a small, self-contained status check).
+
+SCRIPT="scripts/shellcheck/apply_shfmt.sh"
+
+# Non-comment source lines only.
+code() { grep -vE '^\s*#' "$SCRIPT"; }
+
+@test "shfmt exit status is captured" {
+  code | grep -qE 'shfmt_status=\$\?'
+}
+
+@test "a non-zero shfmt exit is treated as an error (not just keyword matches)" {
+  code | grep -qE 'shfmt_status[[:space:]]*-ne[[:space:]]*0'
+}


### PR DESCRIPTION
## Summary
`shfmt`'s exit status was discarded; failure was detected only by grepping its output for `error|Error|…|FAILED`. shfmt's parse diagnostics (e.g. `file.sh:3:1: reached EOF without matching …`) contain none of those keywords, so a file shfmt cannot parse was silently skipped, the files were still `git add`ed, and the script reported success — the exact silent-failure class `apply_ktfmt.sh` fixed via `PIPESTATUS`.

## Change
- Capture the `xargs shfmt` exit status (`shfmt_status=$?`) and treat non-zero as an error even when the diagnostic lacks the keywords (falling back to a synthetic message if shfmt produced no output).
- Add `test/bats/apply-shfmt.bats`: source-scan asserting the status is captured and drives the error path (fails on the keyword-only baseline).

Fixes #3643