### PR TITLE
fix(scripts): swiftformat/swiftlint install_manual fails on failed download (#3649)

### DIFF
--- a/scripts/swiftformat/install_swiftformat.sh
+++ b/scripts/swiftformat/install_swiftformat.sh
@@ -40,18 +40,34 @@ install_manual() {
 
         echo -e "${GREEN}Downloading SwiftFormat from GitHub...${NC}"
 
+        # -f/--fail: an HTTP error (e.g. 404) must fail, not save the error
+        # page as the "archive". Each install step is checked so a failed
+        # download/extract/move returns non-zero instead of reporting success
+        # from the unconditional `return 0` below (#3649).
         if command_exists curl; then
-            curl -L -o "$temp_dir/swiftformat.zip" "$download_url"
+            if ! curl -fL -o "$temp_dir/swiftformat.zip" "$download_url"; then
+                echo -e "${RED}Failed to download SwiftFormat${NC}"
+                return 1
+            fi
         elif command_exists wget; then
-            wget -O "$temp_dir/swiftformat.zip" "$download_url"
+            if ! wget -O "$temp_dir/swiftformat.zip" "$download_url"; then
+                echo -e "${RED}Failed to download SwiftFormat${NC}"
+                return 1
+            fi
         else
             echo -e "${RED}Neither curl nor wget found. Please install one of them.${NC}"
             return 1
         fi
 
         # Extract and install
-        unzip -o "$temp_dir/swiftformat.zip" -d "$temp_dir"
-        mv "$temp_dir/swiftformat" "$install_dir/swiftformat"
+        if ! unzip -o "$temp_dir/swiftformat.zip" -d "$temp_dir"; then
+            echo -e "${RED}Failed to extract SwiftFormat archive${NC}"
+            return 1
+        fi
+        if ! mv "$temp_dir/swiftformat" "$install_dir/swiftformat"; then
+            echo -e "${RED}Failed to install SwiftFormat binary${NC}"
+            return 1
+        fi
         chmod +x "$install_dir/swiftformat"
 
         echo -e "${GREEN}SwiftFormat installed successfully to $install_dir${NC}"

--- a/scripts/swiftlint/install_swiftlint.sh
+++ b/scripts/swiftlint/install_swiftlint.sh
@@ -40,18 +40,34 @@ install_manual() {
 
         echo -e "${GREEN}Downloading SwiftLint from GitHub...${NC}"
 
+        # -f/--fail: an HTTP error (e.g. 404) must fail, not save the error
+        # page as the "archive". Each install step is checked so a failed
+        # download/extract/move returns non-zero instead of reporting success
+        # from the unconditional `return 0` below (#3649).
         if command_exists curl; then
-            curl -L -o "$temp_dir/swiftlint.zip" "$download_url"
+            if ! curl -fL -o "$temp_dir/swiftlint.zip" "$download_url"; then
+                echo -e "${RED}Failed to download SwiftLint${NC}"
+                return 1
+            fi
         elif command_exists wget; then
-            wget -O "$temp_dir/swiftlint.zip" "$download_url"
+            if ! wget -O "$temp_dir/swiftlint.zip" "$download_url"; then
+                echo -e "${RED}Failed to download SwiftLint${NC}"
+                return 1
+            fi
         else
             echo -e "${RED}Neither curl nor wget found. Please install one of them.${NC}"
             return 1
         fi
 
         # Extract and install
-        unzip -o "$temp_dir/swiftlint.zip" -d "$temp_dir"
-        mv "$temp_dir/swiftlint" "$install_dir/swiftlint"
+        if ! unzip -o "$temp_dir/swiftlint.zip" -d "$temp_dir"; then
+            echo -e "${RED}Failed to extract SwiftLint archive${NC}"
+            return 1
+        fi
+        if ! mv "$temp_dir/swiftlint" "$install_dir/swiftlint"; then
+            echo -e "${RED}Failed to install SwiftLint binary${NC}"
+            return 1
+        fi
         chmod +x "$install_dir/swiftlint"
 
         echo -e "${GREEN}SwiftLint installed successfully to $install_dir${NC}"

--- a/test/bats/install-swift-tools.bats
+++ b/test/bats/install-swift-tools.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+#
+# Tests for install_manual() in scripts/swiftformat/install_swiftformat.sh
+# and scripts/swiftlint/install_swiftlint.sh
+#
+# Regression guard for #3649: install_manual ran unzip/mv/chmod with no error
+# checks and then `return 0` unconditionally, so a failed/404 download still
+# reported "Installation completed successfully!". The download must use
+# --fail and each step must be checked so a failure returns non-zero.
+
+setup() {
+  STUB_DIR="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
+
+  # Stub curl: with --fail/-f a 404 exits non-zero and writes nothing;
+  # otherwise it "succeeds" and saves a bogus (non-zip) payload.
+  cat > "$STUB_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+out=""; prev=""; has_fail=0
+for a in "$@"; do
+  case "$a" in -*f*) [[ "$a" != --* || "$a" == --fail ]] && has_fail=1 ;; esac
+  [ "$prev" = "-o" ] && out="$a"
+  prev="$a"
+done
+if [ "$has_fail" = "1" ]; then echo "curl: (22) 404 Not Found" >&2; exit 22; fi
+[ -n "$out" ] && printf 'not a real zip' > "$out"
+exit 0
+EOF
+  chmod +x "$STUB_DIR/curl"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+# $1 = script path, $2 = version-var name
+assert_manual_fails_on_404() {
+  local script="$1" ver_var="$2"
+  local abs
+  abs="$(cd "$(dirname "$script")" && pwd)/$(basename "$script")"
+
+  run env HOME="$WORK_DIR" PATH="$STUB_DIR:$PATH" bash -c '
+    eval "$(grep "^'"$ver_var"'=" "$1" || true)"
+    eval "$(awk "/^install_manual\\(\\) \\{/{f=1} f{print} f&&/^\\}/{exit}" "$1")"
+    detect_os() { echo macos; }
+    command_exists() { [ "$1" = curl ]; }
+    RED=""; GREEN=""; YELLOW=""; NC=""
+    install_manual
+  ' _ "$abs"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "swiftformat install_manual fails when the download 404s" {
+  assert_manual_fails_on_404 scripts/swiftformat/install_swiftformat.sh SWIFTFORMAT_VERSION
+}
+
+@test "swiftlint install_manual fails when the download 404s" {
+  assert_manual_fails_on_404 scripts/swiftlint/install_swiftlint.sh SWIFTLINT_VERSION
+}


### PR DESCRIPTION
## Summary
`install_manual` in both `scripts/swiftformat/install_swiftformat.sh` and `scripts/swiftlint/install_swiftlint.sh` ran `curl -L` (no `--fail`) then `unzip`/`mv`/`chmod` with **no error checks**, and ended with an unconditional `return 0`. A failed or 404 download therefore still printed "Installation completed successfully!"; the bad install was only caught later by the caller's `ensure_tool` re-probe.

## Change
- `curl -fL` (fail on HTTP errors) and check the download, extract, and move steps — return non-zero on any failure.
- Add `test/bats/install-swift-tools.bats`: stubbed `curl` 404 for both tools asserts `install_manual` now returns non-zero (it returned 0 pre-fix).

Fixes #3649