### PR TITLE
fix(ios): capture previousExceptionHandler under the lock (#3633)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Crashes/AutoMobileCrashes.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Crashes/AutoMobileCrashes.swift
@@ -23,7 +23,26 @@ public final class AutoMobileCrashes: @unchecked Sendable {
     /// Provide a closure that returns the current screen name for crash context.
     public var currentScreenProvider: (@Sendable () -> String?)?
 
+    /// The process-global uncaught-exception handler that routes to this class.
+    private static let uncaughtExceptionHandler: @convention(c) (NSException) -> Void = { exception in
+        AutoMobileCrashes.shared.handleException(exception)
+    }
+
+    /// Injectable accessors for the process-global uncaught-exception handler
+    /// (testing seam, #3633). Default to the real Foundation APIs; tests override
+    /// them so they don't clobber the test runner's own handler.
+    var captureUncaughtHandler: () -> (@convention(c) (NSException) -> Void)? = {
+        NSGetUncaughtExceptionHandler()
+    }
+
+    var installUncaughtHandler: (( @convention(c) (NSException) -> Void)?) -> Void = {
+        NSSetUncaughtExceptionHandler($0)
+    }
+
     private init() {}
+
+    /// Test-only instance to exercise initialize/reset in isolation.
+    static func makeTestInstance() -> AutoMobileCrashes { AutoMobileCrashes() }
 
     func initialize(bundleId: String?, buffer: SdkEventBuffer) {
         lock.lock()
@@ -34,14 +53,12 @@ public final class AutoMobileCrashes: @unchecked Sendable {
         _isInitialized = true
         self.bundleId = bundleId
         self.buffer = buffer
+        // Capture the previous handler under the lock so the locked reads in
+        // handleException/reset can't observe a stale nil (issue #3633).
+        previousExceptionHandler = captureUncaughtHandler()
         lock.unlock()
 
-        // Save the previous handler so we can chain to it
-        previousExceptionHandler = NSGetUncaughtExceptionHandler()
-
-        NSSetUncaughtExceptionHandler { exception in
-            AutoMobileCrashes.shared.handleException(exception)
-        }
+        installUncaughtHandler(Self.uncaughtExceptionHandler)
 
         // Signal handlers are opt-in via enableSignalHandlers() because they
         // interfere with debuggers and test frameworks. NSSetUncaughtExceptionHandler
@@ -151,11 +168,7 @@ public final class AutoMobileCrashes: @unchecked Sendable {
         lock.unlock()
 
         // Restore process-level handler outside the lock
-        if let prevHandler = prevHandler {
-            NSSetUncaughtExceptionHandler(prevHandler)
-        } else {
-            NSSetUncaughtExceptionHandler(nil)
-        }
+        installUncaughtHandler(prevHandler)
     }
 }
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
@@ -1,0 +1,51 @@
+@testable import AutoMobileSDK
+import XCTest
+
+/// A stable C-convention handler used as a stand-in "previous" handler.
+private let knownPreviousHandler: @convention(c) (NSException) -> Void = { _ in }
+
+private func rawPointer(_ handler: (@convention(c) (NSException) -> Void)?) -> UnsafeRawPointer? {
+    handler.map { unsafeBitCast($0, to: UnsafeRawPointer.self) }
+}
+
+final class CrashesTests: XCTestCase {
+    private func makeBuffer() -> SdkEventBuffer {
+        SdkEventBuffer(maxBufferSize: 10, flushIntervalMs: 60000) { _ in }
+    }
+
+    /// initialize must capture the previous handler and reset must restore it —
+    /// exercising the capture that #3633 moved under the lock.
+    func testInitializeCapturesPreviousHandlerAndResetRestoresIt() {
+        let crashes = AutoMobileCrashes.makeTestInstance()
+        var installed: [(@convention(c) (NSException) -> Void)?] = []
+        crashes.captureUncaughtHandler = { knownPreviousHandler }
+        crashes.installUncaughtHandler = { installed.append($0) }
+
+        crashes.initialize(bundleId: "com.example", buffer: makeBuffer())
+        XCTAssertTrue(crashes.isInitialized)
+        XCTAssertEqual(installed.count, 1) // installed our routing handler
+
+        crashes.reset()
+        XCTAssertFalse(crashes.isInitialized)
+        XCTAssertEqual(installed.count, 2)
+        // reset restored exactly the handler initialize captured.
+        XCTAssertEqual(rawPointer(installed.last!), rawPointer(knownPreviousHandler))
+    }
+
+    /// Concurrent initialize calls are idempotent and thread-safe (the capture is
+    /// now synchronized with the locked reads).
+    func testConcurrentInitializeIsThreadSafe() {
+        let crashes = AutoMobileCrashes.makeTestInstance()
+        crashes.captureUncaughtHandler = { nil }
+        crashes.installUncaughtHandler = { _ in }
+        let buffer = makeBuffer()
+
+        DispatchQueue.concurrentPerform(iterations: 1_000) { _ in
+            crashes.initialize(bundleId: "com.example", buffer: buffer)
+            _ = crashes.isInitialized
+        }
+
+        XCTAssertTrue(crashes.isInitialized)
+        crashes.reset()
+    }
+}


### PR DESCRIPTION
## Summary
`AutoMobileCrashes.initialize` assigned `previousExceptionHandler = NSGetUncaughtExceptionHandler()` **outside** the lock, while `handleException` and `reset` read it **under** the lock. A lock on the read side only provides a memory barrier if the write side also takes the lock, so a racing read (or a compiler/CPU reordering relative to `NSSetUncaughtExceptionHandler`) could observe a stale `nil` and fail to chain to the host app's crash reporter.

## Fix
Capture the previous handler inside the lock (before unlock). Added injectable get/install seams for the process-global handler so the initialize→reset chain-of-custody is unit-testable **without** clobbering the test runner's own uncaught-exception handler.

## Tests
- `testInitializeCapturesPreviousHandlerAndResetRestoresIt` — initialize captures the previous handler; reset restores exactly that handler (compared by function-pointer identity);
- concurrent initialize is idempotent + thread-safe.

Full auto-mobile-sdk suite (258 tests) green.

Fixes #3633