### PR TITLE
fix(scripts): guard empty-array reassignment in all_fast_validate_checks (#3650)

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -310,8 +310,16 @@ prune_finished_jobs() {
       wait "$pid" || true
     fi
   done
-  pids=("${new_pids[@]}")
-  pid_names=("${new_names[@]}")
+  # Guard the reassignment: on bash < 4.4 (macOS default 3.2), expanding an
+  # empty `"${new_pids[@]}"` under `set -u` throws "unbound variable" once all
+  # in-flight jobs drain (#3650).
+  if [[ ${#new_pids[@]} -gt 0 ]]; then
+    pids=("${new_pids[@]}")
+    pid_names=("${new_names[@]}")
+  else
+    pids=()
+    pid_names=()
+  fi
 }
 
 wait_for_slot() {

--- a/test/bats/all-fast-validate-prune.bats
+++ b/test/bats/all-fast-validate-prune.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+#
+# Tests for prune_finished_jobs in scripts/all_fast_validate_checks.sh
+#
+# Regression guard for #3650: reassigning `pids=("${new_pids[@]}")` with an
+# empty new_pids under `set -u` on bash < 4.4 (macOS default 3.2) throws
+# "unbound variable" once all in-flight jobs drain. The empty case must be
+# guarded.
+
+SCRIPT="scripts/all_fast_validate_checks.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+}
+
+@test "prune_finished_jobs handles an empty job list under set -u" {
+  # The bug only manifests on bash < 4.4; skip on newer bash (e.g. Linux CI).
+  local major minor
+  major="$(/bin/bash -c 'echo "${BASH_VERSINFO[0]}"')"
+  minor="$(/bin/bash -c 'echo "${BASH_VERSINFO[1]}"')"
+  if [[ "$major" -gt 4 || ( "$major" -eq 4 && "$minor" -ge 4 ) ]]; then
+    skip "/bin/bash $major.$minor handles empty arrays under set -u"
+  fi
+
+  run /bin/bash -c '
+    set -euo pipefail
+    eval "$(awk "/^prune_finished_jobs\\(\\) \\{/{f=1} f{print} f&&/^\\}/{exit}" "$1")"
+    pids=(); pid_names=()
+    prune_finished_jobs
+    echo DONE
+  ' _ "$ABS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DONE"* ]]
+}


### PR DESCRIPTION
## Summary
`prune_finished_jobs` ends with:
```bash
pids=("${new_pids[@]}")
pid_names=("${new_names[@]}")
```
Under `set -u` (the script sets `set -euo pipefail`) on **bash < 4.4** (macOS default 3.2), expanding an empty `"${new_pids[@]}"` throws "unbound variable" once all in-flight jobs drain. The script guards its other arrays (`${only_list[*]-}` etc.) but not these two.

## Change
- Guard the reassignment: only expand when the array is non-empty, else assign `()`.
- Add `test/bats/all-fast-validate-prune.bats`: runs `prune_finished_jobs` with empty arrays under `/bin/bash` and asserts no unbound-variable abort (skips on bash ≥ 4.4, where the bug can't reproduce). Verified failing on the baseline under local bash 3.2.

Fixes #3650