### PR TITLE
docs(image-backend): correct drift + drop unimplemented backend-override claim (#3568)

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -25,7 +25,7 @@ const result = await Bun.build({
   target: "bun",
   format: "esm",
   // Keep native/asset-backed image dependencies external so sharp's @img
-  // packages and @jimp/wasm-webp resolve their runtime assets from node_modules.
+  // packages and jimp resolve their runtime assets from node_modules.
   external: ["sharp", "@img/sharp-*", "jimp", "@jimp/*"],
   sourcemap: "external",
   minify: true,

--- a/docs/design-docs/image-backend.md
+++ b/docs/design-docs/image-backend.md
@@ -63,12 +63,15 @@ the active backend executes.
 
 ```ts
 // src/utils/image/backend/ImageBackend.ts
+export type ImageOperation =
+  | { type: "resize"; width: number; height?: number; maintainAspectRatio: boolean; mode?: "nearest" }
+  | { type: "crop"; x: number; y: number; width: number; height: number };
+export interface ImageEncoding { mime: "image/png" | "image/webp"; options?: Record<string, unknown>; }
 export interface ImagePipeline {
-  resize?: { w: number; h?: number; mode: "cover" | "fill" | "width" };
-  crop?:   { x: number; y: number; w: number; h: number };
-  output:  { format: "png" | "webp"; quality?: number; lossless?: boolean; nearLossless?: boolean };
+  operations: ImageOperation[];
+  encoding: ImageEncoding | null; // null = re-encode in the decoded input format
 }
-export interface RawImage { width: number; height: number; data: Buffer; } // RGBA
+export interface RawImage { width: number; height: number; data: Buffer; } // RGBA, length === w*h*4
 
 export interface ImageBackend {
   execute(source: Buffer, pipeline: ImagePipeline): Promise<Buffer>;
@@ -92,10 +95,10 @@ Implementations:
 Selection (one injectable resolver, fake-able):
 
 ```ts
-resolveImageBackend(platform, env, executor, provisioner): ImageBackend
+resolveImageBackend(options?: { platform?: NodeJS.Platform; sharpLoader?: SharpLoader }): ImageBackend
 // win32 → JimpCliBackend
-// else  → SharpBackend, falling back to JimpBackend if sharp import throws
-// AUTOMOBILE_IMAGE_BACKEND=sharp|jimp|jimp-cli overrides (test any backend off-platform)
+// darwin/linux → SharpBackend, falling back to JimpBackend if sharp import throws
+// other → JimpBackend
 ```
 
 ## Seam — existing code changes
@@ -131,14 +134,14 @@ which we reject).
 - **Failure is a surfaced error, never PNG**: a cwebp/dwebp spawn/exit failure
   throws `ActionableError` (CLAUDE.md strategy 1) pointing at
   `AUTOMOBILE_CWEBP_PATH`. On-disk format stays uniformly `.webp` everywhere.
-- A macOS `cwebp` build for `AUTOMOBILE_IMAGE_BACKEND=jimp-cli` off-platform
-  testing stays download-on-demand (dev-only, no offline guarantee needed).
+- A macOS `cwebp` build for exercising the `JimpCliBackend` WebP path off-platform
+  (dev-only) stays download-on-demand — no offline guarantee needed there.
 
 ## Dependency & build management — the anti-treadmill work
 
 Freezing sharp is part of the deliverable (this is what #2920 lacked):
 
-- `package.json`: add `sharp@0.34.5` + the 25 `@img/*` optionalDependencies
+- `package.json`: add `sharp@0.34.5` + the 24 `@img/*` optionalDependencies
   pinned exactly to `0.34.5`/`1.2.4`. Keep `jimp`/`@jimp/core`. Remove
   `@jimp/wasm-webp`.
 - **Dependabot ignore** rules for `sharp` and every `@img/*` (comment linking
@@ -194,8 +197,7 @@ resolution (Windows).
    no code path uses jimp for WebP, so removing it can't leave any path without a
    codec. (The wasm removal and cwebp introduction must land together — never
    drop the plugin before cwebp exists.)
-4. **doctor check + docs** — cache-portability contract, backend override env,
-   close #2974.
+4. **doctor check + docs** — cache-portability contract, close #2974.
 
 ## Contribution track (non-blocking)
 


### PR DESCRIPTION
Corrects documentation drift in the image-backend design doc and removes a claim for an unimplemented feature.

Fixes #3568.

## Changes
- **Drop the unimplemented `AUTOMOBILE_IMAGE_BACKEND` override.** The doc promised `AUTOMOBILE_IMAGE_BACKEND=sharp|jimp|jimp-cli` to force a backend off-platform, but it has zero references in `src/`. Removed the claim and reworded the two dependent mentions to describe the off-platform `cwebp` path without the env var.
- **Fix `resolveImageBackend` signature.** Doc showed `(platform, env, executor, provisioner)`; actual is `resolveImageBackend({ platform?, sharpLoader? })` (`resolveImageBackend.ts`).
- **Fix the `ImagePipeline` interface block.** Doc's `{resize?, crop?, output}` illustration diverged from the shipped `{ operations: ImageOperation[]; encoding: ImageEncoding | null }` (`ImageBackend.ts`).
- **`@img/*` count 25 → 24** to match `package.json`.
- **`build.ts`:** drop the stale `@jimp/wasm-webp` reference in the externals comment (that dependency was removed).

Decision: the override was de-doc'd rather than implemented — the capability wasn't offered anywhere and criticalSection-style off-platform backend testing isn't currently needed. If it's wanted later, it's a small feature (read env in `resolveImageBackend`, wrap Sharp with a Jimp fallback).

## Testing
`test/docs/imageBackendCacheContract.test.ts` passes (it pins the cache-contract strings, none of which changed). Remaining `@jimp/wasm-webp` mentions are the legitimate historical/phasing references. `build.ts` change is comment-only.

Part of the design-doc accuracy audit (#3565).
