### PR TITLE
fix(scripts): guard empty device_args in start-emulator-wtf-session (#3651)

### DIFF
--- a/scripts/android/start-emulator-wtf-session.sh
+++ b/scripts/android/start-emulator-wtf-session.sh
@@ -106,9 +106,13 @@ if [[ -z "${EW_API_TOKEN:-}" ]]; then
   exit 1
 fi
 
-# Start session in background
+# Start session in background.
+# Use the `${arr[@]+"${arr[@]}"}` form so an empty device_args expands to
+# nothing under `set -u` on bash < 4.4 (macOS default 3.2), where a bare
+# "${device_args[@]}" would abort with "unbound variable" (#3651). The dry-run
+# path above is already guarded; this is the real invocation.
 log "Starting emulator.wtf session (max-time-limit: ${MAX_TIME_LIMIT})"
-ew-cli start-session --max-time-limit "$MAX_TIME_LIMIT" --adb "${device_args[@]}" \
+ew-cli start-session --max-time-limit "$MAX_TIME_LIMIT" --adb ${device_args[@]+"${device_args[@]}"} \
   >"$SESSION_LOG" 2>&1 &
 session_pid=$!
 

--- a/test/bats/start-emulator-wtf-session.bats
+++ b/test/bats/start-emulator-wtf-session.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/android/start-emulator-wtf-session.sh
+#
+# Regression guard for #3651: the real ew-cli invocation used
+#   --adb "${device_args[@]}"
+# which, with no --device (empty device_args) under `set -u` on bash < 4.4
+# (macOS default 3.2), aborts with "unbound variable" — while the dry-run path
+# is guarded. The invocation must expand an empty array to nothing.
+
+SCRIPT="scripts/android/start-emulator-wtf-session.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  STUB_DIR="$(mktemp -d)"
+  WORK_DIR="$(mktemp -d)"
+
+  # ew-cli: no-op session process.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_DIR/ew-cli"
+  # adb: report one connected device so the wait loop exits immediately.
+  cat > "$STUB_DIR/adb" <<'EOF'
+#!/usr/bin/env bash
+echo "List of devices attached"
+echo "emulator-5554	device"
+EOF
+  chmod +x "$STUB_DIR/ew-cli" "$STUB_DIR/adb"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$WORK_DIR"
+}
+
+@test "starts a session with no --device without an unbound-variable abort" {
+  # The bug only manifests on bash < 4.4; skip on newer bash (e.g. Linux CI).
+  local major minor
+  major="$(/bin/bash -c 'echo "${BASH_VERSINFO[0]}"')"
+  minor="$(/bin/bash -c 'echo "${BASH_VERSINFO[1]}"')"
+  if [[ "$major" -gt 4 || ( "$major" -eq 4 && "$minor" -ge 4 ) ]]; then
+    skip "/bin/bash $major.$minor handles empty arrays under set -u"
+  fi
+
+  run env PATH="$STUB_DIR:$PATH" EW_API_TOKEN="dummy" \
+    /bin/bash "$ABS_SCRIPT" --session-log "$WORK_DIR/session.log" --timeout 4 --poll-interval 1
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"adb device connected"* ]]
+  [[ "$output" != *"unbound variable"* ]]
+}


### PR DESCRIPTION
## Summary
The real ew-cli invocation was:
```bash
ew-cli start-session --max-time-limit "$MAX_TIME_LIMIT" --adb "${device_args[@]}" ...
```
With no `--device` (empty `device_args`) under `set -u` on **bash < 4.4** (macOS default 3.2), expanding `"${device_args[@]}"` aborts with "unbound variable". The dry-run path (line 94) is already guarded with `${device_args[*]:-}`, but the real invocation was not — so `--dry-run` worked while the actual run crashed.

## Change
- Expand with `${device_args[@]+"${device_args[@]}"}` so an empty array expands to nothing (no spurious empty arg).
- Add `test/bats/start-emulator-wtf-session.bats`: runs the script with no `--device` under `/bin/bash` (stubbed `ew-cli`/`adb`) and asserts no unbound-variable abort (skips on bash ≥ 4.4). Verified failing on the baseline under local bash 3.2.

Fixes #3651