### PR TITLE
perf(ios): only persist event batches when an async sink exists (#3636)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEventBroadcaster.swift
@@ -76,10 +76,16 @@ final class SdkEventBroadcaster: EventBroadcasting, @unchecked Sendable {
 
     func broadcastBatch(bundleId: String?, events: [any SdkEvent]) {
         guard !events.isEmpty else { return }
-        InternalLogger.debug("broadcastBatch called with \(events.count) events, ctrlProxyUrl=\(ctrlProxyUrl?.absoluteString ?? "nil")")
+        let sink = ctrlProxyUrl
+        InternalLogger.debug("broadcastBatch called with \(events.count) events, ctrlProxyUrl=\(sink?.absoluteString ?? "nil")")
 
-        // Persist to disk first for crash resilience
-        let batchId = persistence?.persist(events)
+        // Persist to disk only when there is an asynchronous delivery sink whose
+        // failure we must survive across a crash. Without a CtrlProxy URL the only
+        // delivery is the synchronous in-process NotificationCenter post below, so
+        // persisting would be a write-then-immediate-delete every flush — pure I/O
+        // churn (issue #3636). CtrlProxy forwarding is DEBUG-only, so release builds
+        // never persist.
+        let batchId = sink != nil ? persistence?.persist(events) : nil
 
         deliverBatch(bundleId: bundleId, events: events, batchId: batchId)
     }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkEventBroadcasterTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SdkEventBroadcasterTests.swift
@@ -22,4 +22,33 @@ final class SdkEventBroadcasterTests: XCTestCase {
         XCTAssertEqual(broadcaster.ctrlProxyUrl, url)
         #endif
     }
+
+    // MARK: - persist-only-when-a-sink-exists (#3636)
+
+    /// With no async delivery sink, the batch must NOT be written to disk (delivery
+    /// is a synchronous NotificationCenter post), avoiding a write-then-delete churn.
+    func testDoesNotPersistWhenNoSink() {
+        let broadcaster = SdkEventBroadcaster.makeTestInstance()
+        let persistence = FakeEventPersistence()
+        broadcaster.persistence = persistence
+        broadcaster.ctrlProxyUrl = nil
+
+        broadcaster.broadcastBatch(bundleId: "com.example", events: [SdkInteractionEvent(interactionType: "e1")])
+
+        XCTAssertEqual(persistence.persistCallCount, 0)
+        XCTAssertEqual(persistence.removeCallCount, 0)
+    }
+
+    /// With a sink configured, the batch is persisted (so an async-delivery failure
+    /// can be replayed after a crash).
+    func testPersistsWhenSinkConfigured() {
+        let broadcaster = SdkEventBroadcaster.makeTestInstance()
+        let persistence = FakeEventPersistence()
+        broadcaster.persistence = persistence
+        broadcaster.ctrlProxyUrl = URL(string: "http://localhost:1/sdk-events") // unused port; delivery fails fast
+
+        broadcaster.broadcastBatch(bundleId: "com.example", events: [SdkInteractionEvent(interactionType: "e1")])
+
+        XCTAssertEqual(persistence.persistCallCount, 1)
+    }
 }


### PR DESCRIPTION
## Summary
`SdkEventBroadcaster.broadcastBatch` always wrote each batch to disk (`persistence.persist`, a synchronous atomic file write) and then `deliverBatch` immediately deleted it whenever there was no CtrlProxy URL. Since CtrlProxy forwarding is `#if DEBUG` only, **release builds never have that URL**, and the sole delivery path is a synchronous in-process `NotificationCenter` post — so every flush (default every 500ms or 50 events) did a write-then-immediate-delete to Caches for no crash-resilience benefit.

## Fix
Persist only when a CtrlProxy sink (`ctrlProxyUrl`) is configured — the only path whose asynchronous delivery failure needs to survive a crash for next-launch replay. Without a sink, no batch id is created, so `deliverBatch` neither writes nor deletes.

## Tests
- `testDoesNotPersistWhenNoSink` — no sink → `persist` and `removeBatch` are never called;
- `testPersistsWhenSinkConfigured` — sink set → batch is persisted.

Full auto-mobile-sdk suite (260 tests) green.

Fixes #3636