### PR TITLE
docs(test-plan): correct CI job + tool-name claims; add .github validation reminders (#3566)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,22 @@
+# .github — agent guidance
+
+CI runs a **Fast Validation** job (`.github/workflows/pull_request.yml` →
+`scripts/all_fast_validate_checks.sh`) that gates merges. When you modify any of
+the files it checks, run the matching validation locally *before* pushing so the
+PR check does not fail:
+
+| If you change… | Run locally |
+| --- | --- |
+| Test plan YAML (`**/test-plans/**/*.yaml`) | `bun run validate:yaml` |
+| Any CI workflow or files under `.github/` | `scripts/all_fast_validate_checks.sh` |
+| XML resources | `scripts/all_fast_validate_checks.sh --only xml` |
+| Shell scripts under `scripts/` | `scripts/all_fast_validate_checks.sh --only shellcheck` (or `shellcheck`) |
+| MkDocs nav / docs structure | `scripts/all_fast_validate_checks.sh --only mkdocs-nav` |
+| Kotlin sources | `scripts/all_fast_validate_checks.sh --only ktfmt` |
+
+Run the whole suite at once with `scripts/all_fast_validate_checks.sh` (it mirrors
+the CI job's `--only yaml,xml,shellcheck,mkdocs-nav,ktfmt,claude-plugin,codex-skills`).
+
+Do not add a new standalone validation workflow for something the fast-validation
+aggregator already covers — extend `all_fast_validate_checks.sh` and let the
+existing Fast Validation job pick it up.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,22 @@
+# .github — agent guidance
+
+CI runs a **Fast Validation** job (`.github/workflows/pull_request.yml` →
+`scripts/all_fast_validate_checks.sh`) that gates merges. When you modify any of
+the files it checks, run the matching validation locally *before* pushing so the
+PR check does not fail:
+
+| If you change… | Run locally |
+| --- | --- |
+| Test plan YAML (`**/test-plans/**/*.yaml`) | `bun run validate:yaml` |
+| Any CI workflow or files under `.github/` | `scripts/all_fast_validate_checks.sh` |
+| XML resources | `scripts/all_fast_validate_checks.sh --only xml` |
+| Shell scripts under `scripts/` | `scripts/all_fast_validate_checks.sh --only shellcheck` (or `shellcheck`) |
+| MkDocs nav / docs structure | `scripts/all_fast_validate_checks.sh --only mkdocs-nav` |
+| Kotlin sources | `scripts/all_fast_validate_checks.sh --only ktfmt` |
+
+Run the whole suite at once with `scripts/all_fast_validate_checks.sh` (it mirrors
+the CI job's `--only yaml,xml,shellcheck,mkdocs-nav,ktfmt,claude-plugin,codex-skills`).
+
+Do not add a new standalone validation workflow for something the fast-validation
+aggregator already covers — extend `all_fast_validate_checks.sh` and let the
+existing Fast Validation job pick it up.

--- a/docs/design-docs/mcp/test-plan-validation.md
+++ b/docs/design-docs/mcp/test-plan-validation.md
@@ -101,7 +101,7 @@ Invalid files: 0
 ```text
 ✗ test/resources/test-plans/my-plan.yaml
   root: Missing required property 'name'
-  steps[0].tool: Must be one of: observe, tapOn, swipeOn, launchApp, ...
+  steps[0]: Missing required property 'tool'
   steps[2]: Unknown property 'invalidField'. This might be a legacy field - check the migration guide.
 
 ❌ Validation failed - see errors above
@@ -111,11 +111,14 @@ Invalid files: 0
 
 YAML validation runs automatically in GitHub Actions on every pull request:
 
-- Job name: **Validate YAML Test Plans**
-- Workflow: `.github/workflows/pull_request.yml`
-- Runs alongside other validation steps (XML, shell scripts, MkDocs navigation)
+- Job: **Fast Validation** in `.github/workflows/pull_request.yml`, which runs
+  `scripts/all_fast_validate_checks.sh --only yaml,...`.
+- The `yaml` check invokes `bun scripts/validate-yaml.ts` ("Validate test plan
+  YAML files") alongside the other fast checks (XML, shell scripts, MkDocs
+  navigation) in the same aggregator.
+- Run it locally the same way with `bun run validate:yaml`.
 
-If validation fails, the PR check will fail and block merging.
+If validation fails, the Fast Validation check fails and blocks merging.
 
 ## Test Plan Schema
 
@@ -189,24 +192,18 @@ steps:
           testTag: welcome_message
 ```
 
-### Supported Tools
+### Tool names and per-tool constraints
 
-The schema validates the following tool names:
+The schema does **not** restrict which tool names are allowed: `tool` is any
+non-empty string (`{ "type": "string", "minLength": 1 }`) and steps use
+`additionalProperties: true`, so an unknown or misspelled tool name **passes**
+schema validation. It is caught later at execution time when the tool is not
+found in the registry.
 
-- `observe`
-- `tapOn`
-- `swipeOn`
-- `launchApp`
-- `terminateApp`
-- `installApp`
-- `inputText`
-- `clearText`
-- `pressButton`
-- `highlight`
-- `auditAccessibility`
-- `openLink`
-- `postNotification`
-- `criticalSection`
+What the schema *does* enforce is tool-specific **parameter** shapes via
+`if`/`then` blocks keyed on `tool` (e.g. `dragAndDrop`, `highlight`). Adding a
+new tool does not require a schema change unless it needs such a parameter
+constraint.
 
 ### Parameter Formats
 
@@ -385,8 +382,8 @@ Validation is automatic when using the `executePlan` MCP tool. If a plan fails v
 
 ```text
 Plan YAML validation failed:
-steps[0].tool: Must be one of: observe, tapOn, swipeOn, ... (line 5)
-steps[2]: Missing required property 'tool' (line 12)
+steps[0]: Missing required property 'tool' (line 5)
+steps[2].params: dragAndDrop requires 'startX', 'startY', 'endX', 'endY' (line 12)
 
 The plan does not conform to the AutoMobile test plan schema.
 Check the schema at schemas/test-plan.schema.json for details.
@@ -403,17 +400,16 @@ steps[0]: Unknown property 'auditType'. This might be a legacy field - check the
 
 This means the property should be inside the `params` object or is a tool-specific parameter. Since `additionalProperties: true` is set for steps, this shouldn't fail validation, but indicates the field might be better placed in `params`.
 
-### "Must be one of" tool name errors
+### Unknown tool names
 
-If you see:
-```text
-steps[0].tool: Must be one of: observe, tapOn, swipeOn, ...
-```
-
-The tool name is not recognized. Check:
+Note that the schema does **not** reject unknown tool names — any non-empty
+`tool` string passes validation (see [Tool names and per-tool
+constraints](#tool-names-and-per-tool-constraints)). A misspelled or
+nonexistent tool therefore surfaces later, at execution time, as a
+"tool not found in registry" error rather than a schema error. If a plan runs
+but a step fails with a registry error, check:
 1. Is the tool name spelled correctly?
-2. Is it a custom/legacy tool that needs to be added to the schema?
-3. Has the tool been deprecated or renamed?
+2. Has the tool been deprecated or renamed?
 
 ### YAML parsing errors
 


### PR DESCRIPTION
Corrects the test-plan-validation doc and adds `.github` validation reminders for agents.

Fixes #3566.

## Key finding: the CI claim was actually true
The audit flagged "CI runs validation on every PR" as false, but that was a false negative — the earlier check grepped only `.github/` and missed that the invocation lives in `scripts/all_fast_validate_checks.sh`. `validate-yaml.ts` has run in the **Fast Validation** job (`pull_request.yml`, `--only yaml,...` → "Validate test plan YAML files") since #2303 (May 2026), and it passes clean today (27/27 plans). So **no CI change was needed** — this PR fixes the doc's accuracy and adds the requested agent reminders.

## Changes
- **CI Integration section:** fix the job name — validation is the `yaml` check inside the **Fast Validation** job (`bun scripts/validate-yaml.ts` via `all_fast_validate_checks.sh`), not a standalone "Validate YAML Test Plans" job. It runs alongside XML/shell/MkDocs in the same aggregator and blocks merge.
- **Tool-name claims (de-doc):** the schema does **not** enforce a tool-name allowlist. `tool` is any non-empty string with `additionalProperties: true`, so unknown/misspelled tools **pass** schema validation and fail later at execution ("tool not found in registry"). Replaced the misleading "Must be one of: observe, tapOn, ..." examples and troubleshooting with accurate errors, and added a "Tool names and per-tool constraints" section explaining the real `if`/`then` per-tool **parameter** constraints.
- **New `.github/CLAUDE.md` + `.github/AGENTS.md`:** remind agents to run the matching local validation (`bun run validate:yaml`, `scripts/all_fast_validate_checks.sh`) before pushing changes that the Fast Validation job gates, and not to add redundant standalone validation workflows.

## Testing
`scripts/all_fast_validate_checks.sh --only yaml,mkdocs-nav` passes. No test pins the doc content. No workflow files changed.

Part of the design-doc accuracy audit (#3565).
