### PR TITLE
fix(scripts): start-simulator.sh falls back when GNU timeout is absent (#3644)

### DIFF
--- a/scripts/ios/start-simulator.sh
+++ b/scripts/ios/start-simulator.sh
@@ -160,9 +160,34 @@ xcrun simctl boot "${UDID}"
 
 echo "Waiting for boot to complete (timeout: ${TIMEOUT_SECS}s)..." >&2
 
+# Run a command with a wall-clock timeout. Prefer GNU coreutils `timeout`,
+# then `gtimeout` (Homebrew coreutils on macOS); fall back to a pure-bash
+# implementation because stock macOS ships neither — without this, `timeout`
+# resolved to 127 (command not found) and the boot was falsely reported as
+# failed even when the simulator booted fine (#3644).
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${secs}" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "${secs}" "$@"
+  else
+    "$@" &
+    local cmd_pid=$!
+    ( sleep "${secs}"; kill -0 "${cmd_pid}" 2>/dev/null && kill "${cmd_pid}" 2>/dev/null ) &
+    local watcher_pid=$!
+    local status=0
+    wait "${cmd_pid}" 2>/dev/null || status=$?
+    kill "${watcher_pid}" 2>/dev/null || true
+    wait "${watcher_pid}" 2>/dev/null || true
+    return "${status}"
+  fi
+}
+
 # bootstatus -b blocks until the device is fully booted.
 # It exits 0 on success, non-zero on failure/timeout.
-if ! timeout "${TIMEOUT_SECS}" xcrun simctl bootstatus "${UDID}" -b >&2; then
+if ! run_with_timeout "${TIMEOUT_SECS}" xcrun simctl bootstatus "${UDID}" -b >&2; then
   echo "error: simulator boot did not complete within ${TIMEOUT_SECS}s" >&2
   echo "Current state:" >&2
   xcrun simctl list devices --json | jq --arg udid "${UDID}" '

--- a/test/bats/start-simulator-timeout.bats
+++ b/test/bats/start-simulator-timeout.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ios/start-simulator.sh timeout handling
+#
+# Regression guard for #3644: the boot wait used GNU `timeout`, which is absent
+# on stock macOS (only `gtimeout` when coreutils is brew-installed). Inside
+# `if ! timeout ...` the resulting 127 read as "boot failed", so the script
+# reported failure even when the simulator booted — on the local-macOS path its
+# header advertises. The fix resolves timeout/gtimeout with a pure-bash fallback.
+
+SCRIPT="scripts/ios/start-simulator.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  WORK_DIR="$(mktemp -d)"
+  # A PATH with only bash + sleep (no `timeout`/`gtimeout`), to force the
+  # pure-bash fallback path deterministically. The fallback needs no other
+  # external tools (command/kill/wait are builtins).
+  BIN_DIR="$(mktemp -d)"
+  ln -s "$(command -v bash)" "$BIN_DIR/bash"
+  ln -s "$(command -v sleep)" "$BIN_DIR/sleep"
+
+  # Extract run_with_timeout now (full PATH → awk available); run it later
+  # under the restricted PATH by sourcing this file.
+  FN_FILE="$WORK_DIR/run_with_timeout.sh"
+  awk '/^run_with_timeout\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$ABS_SCRIPT" > "$FN_FILE"
+}
+
+teardown() {
+  rm -rf "$BIN_DIR" "$WORK_DIR"
+}
+
+# $1 = snippet to eval after sourcing run_with_timeout, under the restricted PATH.
+run_helper() {
+  run env PATH="$BIN_DIR" bash -c 'source "$1"; eval "$2"' _ "$FN_FILE" "$1"
+}
+
+@test "boot wait no longer calls bare GNU timeout (uses run_with_timeout)" {
+  local hits
+  hits="$(grep -vE '^\s*#' "$SCRIPT" | grep -E '(^|[^_])timeout .*bootstatus' || true)"
+  [ -z "$hits" ]
+}
+
+@test "run_with_timeout succeeds via bash fallback when timeout/gtimeout absent" {
+  # Sanity: neither timeout nor gtimeout resolvable here.
+  run env PATH="$BIN_DIR" bash -c 'command -v timeout || command -v gtimeout'
+  [ "$status" -ne 0 ]
+
+  run_helper 'run_with_timeout 5 true; echo "rc=$?"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rc=0"* ]]
+}
+
+@test "run_with_timeout reports failure when the command exceeds the limit" {
+  run_helper 'run_with_timeout 1 sleep 5; echo "rc=$?"'
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"rc=0"* ]]
+}


### PR DESCRIPTION
## Summary
The boot wait used:
```bash
if ! timeout "${TIMEOUT_SECS}" xcrun simctl bootstatus "${UDID}" -b >&2; then
```
`timeout` is GNU coreutils and is **not** present on stock macOS (only `gtimeout` when coreutils is brew-installed). On a normal Mac `timeout` exits 127; inside `if ! timeout ...` that reads as "boot failed", so the script reports `simulator boot did not complete` and exits 1 even when the simulator booted — on the very local-macOS path the header advertises.

## Change
- Add a `run_with_timeout` helper: prefer `timeout`, then `gtimeout`, then a pure-bash background-and-kill fallback.
- Use it for the `bootstatus` wait.
- Add `test/bats/start-simulator-timeout.bats`: forces the fallback (PATH with neither `timeout` nor `gtimeout`) and asserts a fast command returns 0 and a slow one is killed; plus a source-scan guard against the bare `timeout … bootstatus`.

Fixes #3644