### PR TITLE
fix(scripts): setup-ios-simulator honors documented --min-ios VERSION form (#3645)

### DIFF
--- a/scripts/ios/setup-ios-simulator.sh
+++ b/scripts/ios/setup-ios-simulator.sh
@@ -31,24 +31,37 @@ SKIP_DOWNLOAD=false
 VERBOSE=false
 MIN_IOS_VERSION=""
 
-for arg in "$@"; do
-    case "$arg" in
+# A `while … shift` loop (not `for arg in "$@"`) so `--min-ios VERSION` (the
+# space-separated form documented in the help) is honored, not just
+# `--min-ios=VERSION`. The old for-loop dropped the space form silently (#3645).
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --dry-run)
             DRY_RUN=true
+            shift
             ;;
         --force-download)
             FORCE_DOWNLOAD=true
+            shift
             ;;
         --skip-download)
             SKIP_DOWNLOAD=true
+            shift
             ;;
         --verbose)
             VERBOSE=true
+            shift
             ;;
         --min-ios=*)
-            MIN_IOS_VERSION="${arg#*=}"
+            MIN_IOS_VERSION="${1#*=}"
+            shift
+            ;;
+        --min-ios)
+            MIN_IOS_VERSION="${2:?--min-ios requires a VERSION argument}"
+            shift 2
             ;;
         *)
+            shift
             ;;
     esac
 done

--- a/test/bats/setup-ios-simulator-min-ios.bats
+++ b/test/bats/setup-ios-simulator-min-ios.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ios/setup-ios-simulator.sh argument parsing
+#
+# Regression guard for #3645: the help documents `--min-ios VERSION`
+# (space-separated), but the old `for arg in "$@"` loop only matched
+# `--min-ios=*`, so the documented space form was silently dropped and the
+# minimum was auto-detected instead. Both forms must be honored.
+
+SCRIPT="scripts/ios/setup-ios-simulator.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  STUB_DIR="$(mktemp -d)"
+  # Stub every tool the early gates require so the script reaches (and logs)
+  # the parsed min-ios value on any OS (Linux CI has no Xcode), then exits
+  # without touching real simulators.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_DIR/xcrun"   # no runtimes
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$STUB_DIR/rg"      # no detected versions
+  printf '#!/usr/bin/env bash\necho "/Applications/Xcode.app/Contents/Developer"\n' > "$STUB_DIR/xcode-select"
+  cat > "$STUB_DIR/xcodebuild" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  -version)  echo "Xcode 15.0"; echo "Build version 15A240d" ;;
+  -showsdks) echo "iOS Simulator SDKs:"; echo "        -sdk iphonesimulator17.0" ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_DIR/xcrun" "$STUB_DIR/rg" "$STUB_DIR/xcode-select" "$STUB_DIR/xcodebuild"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR"
+}
+
+@test "honors --min-ios VERSION (space-separated, as documented)" {
+  run env PATH="$STUB_DIR:$PATH" bash "$ABS_SCRIPT" --min-ios 16.0 --skip-download
+  [[ "$output" == *"Minimum iOS deployment target: 16.0"* ]]
+}
+
+@test "still honors --min-ios=VERSION" {
+  run env PATH="$STUB_DIR:$PATH" bash "$ABS_SCRIPT" --min-ios=17.2 --skip-download
+  [[ "$output" == *"Minimum iOS deployment target: 17.2"* ]]
+}


### PR DESCRIPTION
## Summary
The help documents `--min-ios VERSION` (space-separated), but the `for arg in "$@"` loop only matched `--min-ios=*`. Invoking `--min-ios 16.0` sent `--min-ios` and `16.0` to the no-op `*)` case, so `MIN_IOS_VERSION` stayed empty and was auto-detected instead — the user's explicit minimum silently ignored, no error.

## Change
- Convert the parser to a `while [[ $# -gt 0 ]]; do … shift` loop supporting **both** `--min-ios VERSION` and `--min-ios=VERSION` (`--min-ios` with no value errors clearly).
- Add `test/bats/setup-ios-simulator-min-ios.bats`: stubs the heavy tools and asserts the space form's value is honored (fails pre-fix) and the `=` form still works.

Fixes #3645