### PR TITLE
fix(scripts): await_idle.sh parses mRotation with portable ERE sed (#3646)

### DIFF
--- a/scripts/await_idle.sh
+++ b/scripts/await_idle.sh
@@ -100,7 +100,11 @@ wait_for_rotation() {
         local rotation_output
         if rotation_output=$($ADB_CMD shell dumpsys window 2>/dev/null | grep -i "mRotation=" || true); then
             local current_rotation
-            if current_rotation=$(echo "$rotation_output" | sed -n 's/.*mRotation=\([0-9]\+\).*/\1/p'); then
+            # Use ERE (sed -E): the GNU BRE `\+` is a literal '+' on BSD/macOS
+            # sed, so `mRotation=0` never matched and wait_for_rotation always
+            # ran to timeout. This script targets macOS (gdate/bc), so it runs
+            # under BSD sed. (#3646)
+            if current_rotation=$(echo "$rotation_output" | sed -nE 's/.*mRotation=([0-9]+).*/\1/p'); then
                 if [[ -n "$current_rotation" ]]; then
                     log_info "Current rotation: $current_rotation, target: $target_rotation"
 

--- a/test/bats/await-idle-rotation.bats
+++ b/test/bats/await-idle-rotation.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+#
+# Tests for the mRotation parsing in scripts/await_idle.sh
+#
+# Regression guard for #3646: rotation was parsed with GNU BRE
+#   sed -n 's/.*mRotation=\([0-9]\+\).*/\1/p'
+# but this script targets macOS (it uses gdate/bc because BSD date lacks %3N),
+# where the default sed is BSD and treats `\+` as a literal '+'. So
+# `mRotation=0` never matched, current_rotation stayed empty, and
+# wait_for_rotation always ran to timeout. The fix uses ERE (sed -E).
+
+SCRIPT="scripts/await_idle.sh"
+
+@test "mRotation extraction works under BSD sed" {
+  # Pull the exact sed invocation the script uses for mRotation.
+  local sed_cmd
+  sed_cmd="$(grep -oE "sed -n?E? +'[^']*mRotation[^']*'" "$SCRIPT" | head -1)"
+  [ -n "$sed_cmd" ]
+
+  # Run that invocation under BSD sed (/usr/bin/sed on macOS; GNU on Linux —
+  # the fixed ERE form must work under both). The old `\+` form yields empty
+  # output under BSD sed.
+  run bash -c "printf '    mRotation=3 mDisplayRotation=3\n' | ${sed_cmd/sed //usr/bin/sed }"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+}


### PR DESCRIPTION
## Summary
`wait_for_rotation` parsed rotation with GNU BRE:
```bash
sed -n 's/.*mRotation=\([0-9]\+\).*/\1/p'
```
But this script targets macOS (it uses `gdate`/`bc` precisely because BSD `date` lacks `%3N`), where the default `sed` is BSD and treats `\+` as a **literal** `+`. So `mRotation=0` never matched, `current_rotation` stayed empty, and `wait_for_rotation` always ran to timeout and returned 1 even after a correct rotation.

## Change
- Use ERE: `sed -nE 's/.*mRotation=([0-9]+).*/\1/p'` (works under both BSD and GNU sed).
- Add `test/bats/await-idle-rotation.bats`: runs the script's actual sed invocation under `/usr/bin/sed` (BSD on macOS) against a sample and asserts it extracts the rotation (empty pre-fix under BSD).

Fixes #3646