### PR TITLE
fix(scripts): guard gfxinfo capture so adb failure doesn't abort run (#3647)

### DIFF
--- a/scripts/launch_app_perf_test.sh
+++ b/scripts/launch_app_perf_test.sh
@@ -224,10 +224,16 @@ launch_and_collect_metrics() {
             break
         fi
 
-        # Get gfxinfo output
-        local gfx_output
-        gfx_output=$($ADB_CMD shell dumpsys gfxinfo "$PACKAGE_NAME" 2>&1)
-        local gfx_exit=$?
+        # Get gfxinfo output. Capture adb's exit status via an `if` so a
+        # non-zero result does not trip `set -e` and abort the whole run
+        # (this function is captured via result=$(...), and the retry/continue
+        # logic below depends on gfx_exit being reachable) — #3647.
+        local gfx_output gfx_exit
+        if gfx_output=$($ADB_CMD shell dumpsys gfxinfo "$PACKAGE_NAME" 2>&1); then
+            gfx_exit=0
+        else
+            gfx_exit=$?
+        fi
 
         if [[ $gfx_exit -ne 0 ]]; then
             log_debug "Poll $poll_count: gfxinfo failed (exit $gfx_exit): $gfx_output"

--- a/test/bats/launch-app-perf-gfx-capture.bats
+++ b/test/bats/launch-app-perf-gfx-capture.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+#
+# Tests for the gfxinfo capture in scripts/launch_app_perf_test.sh
+#
+# Regression guard for #3647: under `set -euo pipefail`, the assignment
+#   gfx_output=$($ADB_CMD shell dumpsys gfxinfo "$PACKAGE_NAME" 2>&1)
+# takes the substitution's exit status, so a single non-zero adb call aborted
+# the whole run (the function is captured via result=$(...)), and the
+# gfx_exit-based retry/continue below was unreachable. The capture must be
+# guarded so adb failure does not trip `set -e`.
+
+SCRIPT="scripts/launch_app_perf_test.sh"
+
+code() { grep -vE '^\s*#' "$SCRIPT"; }
+
+@test "gfxinfo capture is guarded by an if so adb failure cannot trip set -e" {
+  code | grep -qE 'if +gfx_output=\$\('
+}
+
+@test "no bare gfxinfo assignment relying on a following gfx_exit=\$?" {
+  # The buggy form assigned gfx_output on its own line, then read gfx_exit=$?
+  # on the next — unreachable under set -e. Ensure gfx_output is only assigned
+  # inside the if-condition now.
+  local bare
+  bare="$(code | grep -nE '^[[:space:]]*gfx_output=\$\(' || true)"
+  [ -z "$bare" ]
+}


### PR DESCRIPTION
## Summary
Under `set -euo pipefail`:
```bash
gfx_output=$($ADB_CMD shell dumpsys gfxinfo "$PACKAGE_NAME" 2>&1)
local gfx_exit=$?
```
The assignment takes the substitution's exit status, so a single non-zero adb call aborts the whole script before `gfx_exit` is ever checked. Since the function is captured via `result=$(launch_and_collect_metrics …)`, one transient adb failure exits the entire run, and the `gfx_exit`-based retry/`continue` is unreachable.

## Change
- Capture the status via `if gfx_output=$(…); then gfx_exit=0; else gfx_exit=$?; fi` so a non-zero adb result doesn't trip `set -e`.
- Add `test/bats/launch-app-perf-gfx-capture.bats`: source-scan asserting the capture is `if`-guarded and no bare `gfx_output=$(…)` remains (fails on the baseline).

Fixes #3647