### PR TITLE
fix(ci): verify-artifact-sha256 empty-checksum guard + sha256sum fallback (#3658)

### DIFF
--- a/scripts/ci/verify-artifact-sha256.sh
+++ b/scripts/ci/verify-artifact-sha256.sh
@@ -17,6 +17,16 @@ PLATFORM="${2:?Usage: verify-artifact-sha256.sh <artifact-path> <platform>}"
 
 RELEASE_TS="src/constants/release.ts"
 
+# sha256sum is GNU coreutils and absent on stock macOS; fall back to shasum
+# (matching verify-release-integrity.sh) so this works on any runner (#3658).
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
 if [ ! -f "$ARTIFACT_PATH" ]; then
   echo "ERROR: Artifact not found at $ARTIFACT_PATH"
   exit 1
@@ -27,7 +37,7 @@ if [ ! -f "$RELEASE_TS" ]; then
   exit 1
 fi
 
-BUILT_SHA256=$(sha256sum "$ARTIFACT_PATH" | cut -d' ' -f1)
+BUILT_SHA256=$(sha256_of "$ARTIFACT_PATH")
 echo "Built artifact SHA256: $BUILT_SHA256"
 
 if [ "$PLATFORM" = "android" ]; then
@@ -39,7 +49,11 @@ else
   exit 1
 fi
 
-SOURCE_SHA256=$(grep "$FIELD" "$RELEASE_TS" | head -1 | sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/')
+# `sed -n ... p` only prints on a real 64-hex match, so an empty or malformed
+# value (e.g. `ipaSha256: ""`) yields an empty SOURCE_SHA256 and the guard
+# below fires. The old unanchored `s///` passed the whole line through on no
+# match, making SOURCE_SHA256 non-empty and defeating the -z check (#3658).
+SOURCE_SHA256=$(grep "$FIELD" "$RELEASE_TS" | head -1 | sed -n 's/.*"\([a-f0-9]\{64\}\)".*/\1/p')
 echo "Source SHA256:         $SOURCE_SHA256"
 
 if [ -z "$SOURCE_SHA256" ]; then

--- a/scripts/ci/verify-transit-sha256.sh
+++ b/scripts/ci/verify-transit-sha256.sh
@@ -11,12 +11,22 @@ set -euo pipefail
 FILE_PATH="${1:?Usage: verify-transit-sha256.sh <file-path> <expected-sha256>}"
 EXPECTED="${2:?Usage: verify-transit-sha256.sh <file-path> <expected-sha256>}"
 
+# sha256sum is GNU coreutils and absent on stock macOS; fall back to shasum
+# (matching verify-release-integrity.sh) so this works on any runner (#3658).
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
 if [ ! -f "$FILE_PATH" ]; then
   echo "ERROR: File not found at $FILE_PATH"
   exit 1
 fi
 
-ACTUAL=$(sha256sum "$FILE_PATH" | cut -d' ' -f1)
+ACTUAL=$(sha256_of "$FILE_PATH")
 echo "Expected: $EXPECTED"
 echo "Actual:   $ACTUAL"
 

--- a/test/bats/verify-artifact-sha256.bats
+++ b/test/bats/verify-artifact-sha256.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/verify-artifact-sha256.sh
+#
+# Regression guards for #3658:
+#  1. An empty/malformed registry value (e.g. ipaSha256: "") must produce the
+#     actionable "No SHA256 checksum found" error, not a spurious "SHA256
+#     mismatch". The old unanchored `sed 's///'` passed the whole source line
+#     through on no match, making SOURCE_SHA256 non-empty and defeating the
+#     `[ -z ]` guard.
+#  2. sha256 must be computed via sha256sum-or-shasum so it works on macOS
+#     (stock macOS has no sha256sum).
+
+SCRIPT="scripts/ci/verify-artifact-sha256.sh"
+
+setup() {
+  ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  PROJECT="$(mktemp -d)"
+  mkdir -p "$PROJECT/src/constants"
+  ARTIFACT="$PROJECT/control-proxy.ipa"
+  printf 'dummy artifact contents\n' > "$ARTIFACT"
+  if command -v sha256sum >/dev/null 2>&1; then
+    ART_SHA="$(sha256sum "$ARTIFACT" | cut -d' ' -f1)"
+  else
+    ART_SHA="$(shasum -a 256 "$ARTIFACT" | cut -d' ' -f1)"
+  fi
+}
+
+teardown() {
+  rm -rf "$PROJECT"
+}
+
+# $1 = ipaSha256 value (may be empty)
+write_release_ts() {
+  cat > "$PROJECT/src/constants/release.ts" <<EOF
+export const RELEASE_CHECKSUM_REGISTRY = [
+  { version: "1.0.0", apkSha256: "", ipaSha256: "$1" },
+];
+EOF
+}
+
+@test "empty ipaSha256 reports 'no checksum', not a spurious mismatch" {
+  write_release_ts ""
+  cd "$PROJECT"
+  run bash "$ABS_SCRIPT" "$ARTIFACT" ios
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No SHA256 checksum found"* ]]
+  [[ "$output" != *"SHA256 mismatch"* ]]
+}
+
+@test "matching ipaSha256 verifies successfully" {
+  write_release_ts "$ART_SHA"
+  cd "$PROJECT"
+  run bash "$ABS_SCRIPT" "$ARTIFACT" ios
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"verified successfully"* ]]
+}
+
+@test "sha256_of falls back to shasum when sha256sum is absent" {
+  command -v shasum >/dev/null 2>&1 || skip "shasum not available"
+  local bin
+  bin="$(mktemp -d)"
+  ln -s "$(command -v bash)" "$bin/bash"
+  ln -s "$(command -v cut)" "$bin/cut"
+  ln -s "$(command -v shasum)" "$bin/shasum"   # shasum present, sha256sum absent
+
+  local fn="$PROJECT/sha256_of.sh"
+  awk '/^sha256_of\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$ABS_SCRIPT" > "$fn"
+
+  run env PATH="$bin" bash -c 'source "$1"; sha256_of "$2"' _ "$fn" "$ARTIFACT"
+  rm -rf "$bin"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$ART_SHA" ]
+}


### PR DESCRIPTION
## Summary
Two robustness bugs in `scripts/ci/verify-artifact-sha256.sh` (plus the sibling `verify-transit-sha256.sh`):

1. **Empty-checksum guard bypass** — a present-but-empty value (`ipaSha256: ""`) didn't match `sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/'`, so `sed` passed the whole source line through; `SOURCE_SHA256` became non-empty and the `[ -z ]` guard never fired — you got the confusing "SHA256 mismatch / source changed" error instead of the actionable "No SHA256 checksum found". Fixed by using `sed -n '…/p'` so a non-match yields empty.
2. **sha256sum portability** — both scripts called `sha256sum` unconditionally (absent on stock macOS). Added a `sha256_of` helper with a `shasum -a 256` fallback, matching `verify-release-integrity.sh`.

## Tests
`test/bats/verify-artifact-sha256.bats`: empty `ipaSha256` now reports "no checksum" (not a spurious mismatch), a matching checksum verifies, and `sha256_of` falls back to `shasum` when `sha256sum` is absent.

Fixes #3658