### PR TITLE
test(sdk-android): cover AutoMobileCrashes + AutoMobileAnr; fix DropReason doc (#3570)

### DIFF
--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/anr/AutoMobileAnrTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/anr/AutoMobileAnrTest.kt
@@ -1,0 +1,50 @@
+package dev.jasonpearson.automobile.sdk.anr
+
+import android.os.Build
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for [AutoMobileAnr] availability gating and safe initialization. ANR detection is
+ * documented (and chipped "🧪 Tested") as retrospective and available only on Android 11+ (API 30)
+ * via `ApplicationExitInfo`; pin that SDK-version boundary and that initialize is safe with no
+ * historical ANRs.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AutoMobileAnrTest {
+
+  private val context: android.content.Context = RuntimeEnvironment.getApplication()
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.R])
+  fun `isAvailable is true on API 30 and above`() {
+    assertTrue(AutoMobileAnr.isAvailable())
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.Q])
+  fun `isAvailable is false below API 30`() {
+    assertFalse(AutoMobileAnr.isAvailable())
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.Q])
+  fun `initialize is a safe no-op below API 30`() {
+    // Must not throw on a device where ApplicationExitInfo is unavailable.
+    AutoMobileAnr.initialize(context)
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.R])
+  fun `initialize on API 30 with no historical ANRs completes without error`() {
+    // Robolectric reports no historical process exit reasons by default, so the
+    // retrospective scan should find nothing and broadcast nothing.
+    AutoMobileAnr.initialize(context)
+    assertTrue(AutoMobileAnr.isAvailable())
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashesTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/crashes/AutoMobileCrashesTest.kt
@@ -1,0 +1,107 @@
+package dev.jasonpearson.automobile.sdk.crashes
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Unit tests for [AutoMobileCrashes] install/uninstall of the default uncaught exception handler.
+ * Crash detection carries a "🧪 Tested" chip in the design doc, so pin the handler capture/restore
+ * contract (the safety-critical part: we must chain to and later restore whatever handler was
+ * already installed).
+ */
+@RunWith(RobolectricTestRunner::class)
+class AutoMobileCrashesTest {
+
+  private val context: android.content.Context = RuntimeEnvironment.getApplication()
+  private var priorDefaultHandler: Thread.UncaughtExceptionHandler? = null
+
+  @Before
+  fun setup() {
+    // Ensure a clean, known baseline: AutoMobileCrashes is a singleton object, so
+    // a prior test could have left it installed.
+    AutoMobileCrashes.uninstall()
+    priorDefaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+  }
+
+  @After
+  fun tearDown() {
+    AutoMobileCrashes.uninstall()
+    Thread.setDefaultUncaughtExceptionHandler(priorDefaultHandler)
+  }
+
+  @Test
+  fun `initialize installs its own handler and marks initialized`() {
+    val original = Thread.getDefaultUncaughtExceptionHandler()
+
+    AutoMobileCrashes.initialize(context)
+
+    assertTrue(AutoMobileCrashes.isInitialized())
+    assertNotSame(
+      "initialize must replace the default uncaught handler",
+      original,
+      Thread.getDefaultUncaughtExceptionHandler(),
+    )
+  }
+
+  @Test
+  fun `uninstall restores the original handler and clears initialized`() {
+    val original = Thread.UncaughtExceptionHandler { _, _ -> }
+    Thread.setDefaultUncaughtExceptionHandler(original)
+
+    AutoMobileCrashes.initialize(context)
+    AutoMobileCrashes.uninstall()
+
+    assertFalse(AutoMobileCrashes.isInitialized())
+    assertSame(
+      "uninstall must restore the handler present before initialize",
+      original,
+      Thread.getDefaultUncaughtExceptionHandler(),
+    )
+  }
+
+  @Test
+  fun `initialize is idempotent - second call does not re-capture`() {
+    val original = Thread.UncaughtExceptionHandler { _, _ -> }
+    Thread.setDefaultUncaughtExceptionHandler(original)
+
+    AutoMobileCrashes.initialize(context)
+    val afterFirst = Thread.getDefaultUncaughtExceptionHandler()
+    // A second initialize must not treat AutoMobile's own handler as the
+    // "original" to restore later.
+    AutoMobileCrashes.initialize(context)
+
+    assertSame(afterFirst, Thread.getDefaultUncaughtExceptionHandler())
+
+    AutoMobileCrashes.uninstall()
+    assertSame(
+      "after the idempotent second init, uninstall still restores the true original",
+      original,
+      Thread.getDefaultUncaughtExceptionHandler(),
+    )
+  }
+
+  @Test
+  fun `uninstall does not clobber a foreign handler installed after us`() {
+    AutoMobileCrashes.initialize(context)
+
+    // Another crash reporter installs its handler after AutoMobile.
+    val foreign = Thread.UncaughtExceptionHandler { _, _ -> }
+    Thread.setDefaultUncaughtExceptionHandler(foreign)
+
+    AutoMobileCrashes.uninstall()
+
+    assertSame(
+      "uninstall must leave a later-installed foreign handler untouched",
+      foreign,
+      Thread.getDefaultUncaughtExceptionHandler(),
+    )
+  }
+}

--- a/docs/design-docs/mcp/sdk-event-pipeline.md
+++ b/docs/design-docs/mcp/sdk-event-pipeline.md
@@ -80,8 +80,20 @@ When either threshold is reached, the buffer drains into the broadcaster. The bu
 | Reason | Trigger |
 |--------|---------|
 | `DISABLED` | Event added while buffer is disabled |
-| `SHUTDOWN` | Event added after buffer shutdown (Android only) |
+| `SHUTDOWN` | Event dropped because the buffer was shut down (see note) |
 | `FLUSH_ERROR` | Delivery callback threw an exception |
+| `BUFFER_OVERFLOW` | Buffer at capacity when the event arrived |
+| `FILTERED` | Event removed by a filter/processor before delivery |
+| `DELIVERY_FAILED` | Delivery attempted but did not succeed |
+| `PROCESSOR_ERROR` | An event processor threw (Android only) |
+
+Android defines all seven reasons (`DropReason.kt`); iOS defines six — it has no
+`processorError` case (`DropCounter.swift`).
+
+**Note on `SHUTDOWN`:** the enum value exists on both platforms, but only Android
+*drops with* `SHUTDOWN` — its `SdkEventBuffer.add()` rejects post-shutdown events
+and records the drop. iOS `shutdown()` flushes instead of dropping, so the iOS
+`shutdown` case is defined but not emitted on that path.
 
 The counter provides `snapshot()` for diagnostics and `reset()` to clear counts. Android uses `ConcurrentHashMap<DropReason, AtomicLong>` for lock-free increments; iOS uses `NSLock` with a `[DropReason: Int]` dictionary.
 


### PR DESCRIPTION
Adds Android test coverage for crash/ANR detection and corrects the `DropReason` documentation.

Fixes #3570.

## Re-verification against current main
The audit flagged crash/ANR/hang as untested on both platforms, but the **iOS half is already closed** — `CrashesTests.swift` and `HangsTests.swift` landed via #3633 (substantive tests with injectable handler seams). This PR closes the remaining **Android** gap and the doc drift.

## Tests (Robolectric, JDK 21)
- **`AutoMobileCrashesTest`** — pins the safety-critical uncaught-handler contract:
  - `initialize` installs its own default handler and marks initialized
  - `uninstall` restores the handler present before init and clears initialized
  - `initialize` is idempotent (a second call does not re-capture AutoMobile's own handler as the "original")
  - `uninstall` does **not** clobber a foreign handler installed after us
- **`AutoMobileAnrTest`** — pins the `ApplicationExitInfo` availability boundary:
  - `isAvailable` is true on API 30+ and false below (via `@Config(sdk=...)`)
  - `initialize` is a safe no-op below API 30, and completes with no historical ANRs on API 30+

All 8 new tests pass (`:auto-mobile-sdk:testDebugUnitTest`).

## Doc fix
The `DropReason` table listed only 3 reasons. Corrected to the real enums: Android defines **7** (adds `BUFFER_OVERFLOW`, `FILTERED`, `DELIVERY_FAILED`, `PROCESSOR_ERROR`), iOS **6** (no `processorError`). Clarified that `SHUTDOWN` exists on both platforms but only Android *drops* with it — iOS `shutdown()` flushes instead.

With iOS covered (#3633) and Android covered here, the doc's "🧪 Tested" chip for crash/ANR/hang is now justified.

Part of the design-doc accuracy audit (#3565).
