### PR TITLE
fix(control-proxy): make StorageSubscriptionManager maps thread-safe (#3600)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
@@ -9,6 +9,7 @@ import android.os.Looper
 import android.util.Log
 import dev.jasonpearson.automobile.protocol.StorageProtocolSerializer
 import dev.jasonpearson.automobile.protocol.StorageResponse
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -36,12 +37,19 @@ class StorageSubscriptionManager(private val context: Context) {
   /** State for a package being observed. */
   private data class PackageObserverState(
     val observer: ContentObserver,
-    val subscriptions: MutableSet<String> = mutableSetOf(), // file names
+    // Thread-safe: mutated on IO (subscribe/unsubscribe) and read on the main
+    // looper (ContentObserver.onChange -> fetchChangesForPackage). See #3600.
+    val subscriptions: MutableSet<String> = ConcurrentHashMap.newKeySet(), // file names
   )
 
-  private val subscriptions = mutableMapOf<String, SubscriptionState>() // subscriptionId -> state
+  // Mutated from Dispatchers.IO (subscribe/unsubscribe) and the main looper
+  // (ContentObserver.onChange, destroy). ConcurrentHashMap avoids the
+  // resize-under-concurrent-put corruption / ConcurrentModificationException a
+  // plain HashMap would hit here (#3600).
+  private val subscriptions =
+    ConcurrentHashMap<String, SubscriptionState>() // subscriptionId -> state
   private val packageObservers =
-    mutableMapOf<String, PackageObserverState>() // packageName -> state
+    ConcurrentHashMap<String, PackageObserverState>() // packageName -> state
 
   private val _changeEvents = MutableSharedFlow<PreferenceChangeEvent>(extraBufferCapacity = 64)
   val changeEvents: SharedFlow<PreferenceChangeEvent> = _changeEvents.asSharedFlow()
@@ -511,7 +519,11 @@ class StorageSubscriptionManager(private val context: Context) {
 
     try {
       context.contentResolver.registerContentObserver(changesUri, false, observer)
-      packageObservers[packageName] = PackageObserverState(observer, mutableSetOf(fileName))
+      packageObservers[packageName] =
+        PackageObserverState(
+          observer,
+          ConcurrentHashMap.newKeySet<String>().apply { add(fileName) },
+        )
       Log.d(TAG, "Registered ContentObserver for $packageName")
     } catch (e: Exception) {
       Log.e(TAG, "Failed to register ContentObserver for $packageName", e)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManagerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManagerTest.kt
@@ -311,4 +311,51 @@ class StorageSubscriptionManagerTest {
 
     assertTrue(manager.getActiveSubscriptions().isEmpty())
   }
+
+  // ================= Concurrency (#3600) =================
+
+  @Test
+  fun `concurrent subscribe unsubscribe and iteration do not corrupt state`() {
+    val bundle =
+      Bundle().apply {
+        putBoolean("success", true)
+        putString("result", """{"subscribed":true}""")
+      }
+    every { contentResolver.call(any<Uri>(), any(), any(), any()) } returns bundle
+
+    val threadCount = 8
+    val perThread = 200
+    val errors = java.util.concurrent.CopyOnWriteArrayList<Throwable>()
+    val latch = java.util.concurrent.CountDownLatch(threadCount)
+
+    // All threads target the same package (shared packageObservers entry + nested
+    // file set) with unique file names, hammering the maps concurrently. Under a
+    // plain HashMap this trips ConcurrentModificationException / a corrupted map
+    // (#3600); with ConcurrentHashMap it stays consistent.
+    for (t in 0 until threadCount) {
+      Thread {
+        try {
+          for (i in 0 until perThread) {
+            val file = "file-$t-$i"
+            manager.subscribe("com.example.app", file)
+            manager.getActiveSubscriptions() // iterate while others mutate
+            manager.unsubscribe("com.example.app", file)
+          }
+        } catch (e: Throwable) {
+          errors.add(e)
+        } finally {
+          latch.countDown()
+        }
+      }
+        .start()
+    }
+
+    assertTrue(
+      "concurrent access timed out",
+      latch.await(30, java.util.concurrent.TimeUnit.SECONDS),
+    )
+    assertTrue("concurrent access threw: ${errors.firstOrNull()}", errors.isEmpty())
+    // Every subscribe (unique id) was matched by an unsubscribe.
+    assertTrue(manager.getActiveSubscriptions().isEmpty())
+  }
 }


### PR DESCRIPTION
## Summary
`StorageSubscriptionManager.subscriptions` and `packageObservers` were plain `HashMap`s (and a nested `HashSet`) mutated from `Dispatchers.IO` (`subscribe`/`unsubscribe`) and the main looper (`ContentObserver.onChange` → `fetchChangesForPackage`, plus `destroy`). Concurrent mutate/iterate on a plain `HashMap` risks `ConcurrentModificationException` or resize-under-put corruption, which surfaces as lost storage-change events or a spinning map.

## Fix
Use `ConcurrentHashMap` for both maps and `ConcurrentHashMap.newKeySet()` for the nested per-package file set — weakly-consistent iteration and safe concurrent puts, no locking across the blocking `contentResolver.call` IPC.

## Tests
- `concurrent subscribe unsubscribe and iteration do not corrupt state` — 8 threads × 200 iterations hammering subscribe/`getActiveSubscriptions`/unsubscribe on a shared package; asserts no exception and a consistent empty final state. Trips CME under the old `HashMap`.

`:control-proxy:testDebugUnitTest` green; ktfmt-clean.

Fixes #3600