### PR TITLE
test(vision): cover VisionFallback orchestrator/cache + calculateCost; fix doc drift (#3571)

### DIFF
--- a/docs/design-docs/mcp/observe/vision-fallback.md
+++ b/docs/design-docs/mcp/observe/vision-fallback.md
@@ -15,7 +15,10 @@ Vision fallback is an **internal feature** that is:
 - **Disabled by default** to avoid unexpected API costs
 - Only available when constructing `TapOnElement` with custom vision configuration
 - Not exposed via MCP server or CLI by default
-- Currently integrated into `tapOn` only (invoked after polling times out)
+- Integrated into `tapOn`, `swipeOn`, `pinchOn`, and `dragAndDrop` — each
+  invokes vision fallback via the shared `getVisionEnrichedError` after its own
+  retries/timeout (gating conditions differ per tool: e.g. swipe requires
+  `lookFor`/`container`; pinch/drag require `container`)
 - Android screenshots only (iOS not yet implemented)
 
 ### How It Works
@@ -26,33 +29,37 @@ When element finding fails after retries, `TapOnElement` follows this flow:
 flowchart LR
     A["Element finding retries<br/>exhausted"] --> B["Screenshot capture<br/>(~100-200ms)"];
     B --> C["Claude vision analysis<br/>(~2-5s)"];
-    C --> D{"Confidence high?"};
-    D -->|"yes"| E["Return alternative selectors<br/>or navigation instructions"];
-    D -->|"no"| F["Return detailed error<br/>with screen context"];
+    C --> D{"High-confidence<br/>navigation steps?"};
+    D -->|"yes"| E["Return navigation<br/>instructions"];
+    D -->|"no"| F{"Alternative<br/>selectors?"};
+    F -->|"yes"| G["Return alternative selectors<br/>(any confidence)"];
+    F -->|"no"| H["Return detailed error<br/>with screen context"];
     classDef decision fill:#CC2200,stroke-width:0px,color:white;
     classDef logic fill:#525FE1,stroke-width:0px,color:white;
     classDef result stroke-width:0px;
-    class A,E,F result;
+    class A,E,G,H result;
     class B,C logic;
-    class D decision;
+    class D,F decision;
 ```
+
+Only navigation instructions are gated on high confidence; alternative
+selectors are returned regardless of confidence when present.
 
 ### Configuration
 
 ```typescript
-const tapTool = new TapOnElement(
-  device,
-  adb,
-  axe,
-  {
+// Vision config is passed via the third `options` argument (options.visionConfig),
+// not as a positional argument.
+const tapTool = new TapOnElement(device, adb, {
+  visionConfig: {
     enabled: true,              // Enable vision fallback
     provider: 'claude',         // Only Claude supported currently
     confidenceThreshold: 'high', // Reserved for future gating
     maxCostUsd: 1.0,            // Warning threshold (does not block)
     cacheResults: true,         // Cache to avoid repeated calls
     cacheTtlMinutes: 60         // Cache for 60 minutes
-  }
-);
+  },
+});
 ```
 
 **Note**: MCP server constructs `TapOnElement` with default config (enabled: false), so vision fallback is not available through MCP unless you modify the server code.
@@ -124,7 +131,7 @@ Get an API key at: https://console.anthropic.com/
 ### Limitations
 
 **Current Limitations**:
-1. **tapOn only**: Not integrated into other tools (swipeOn, scrollUntil, etc.)
+1. **Not universal**: Integrated into `tapOn`, `swipeOn`, `pinchOn`, and `dragAndDrop`, but not yet other tools (e.g. `scrollUntil`)
 2. **Android only**: iOS screenshot capture not implemented
 3. **No auto-retry**: Suggestions are informational - user must manually retry with suggested selectors
 4. **Not in MCP**: Requires custom TapOnElement construction, not available via MCP server by default
@@ -213,7 +220,7 @@ export interface VisionFallbackConfig {
 Planned improvements:
 
 1. **Auto-retry**: Automatically retry with suggested selectors
-2. **More tools**: Integrate into `swipeOn`, `scrollUntil`, etc.
+2. **More tools**: Integrate into remaining tools (e.g. `scrollUntil`) beyond the current `tapOn`/`swipeOn`/`pinchOn`/`dragAndDrop`
 3. **Set-of-Mark**: Enhanced spatial understanding with visual markers
 4. **Learning**: Track corrections to improve suggestions over time
 5. **Multi-screenshot analysis**: Compare before/after states

--- a/test/vision/ClaudeVisionClient.test.ts
+++ b/test/vision/ClaudeVisionClient.test.ts
@@ -3,6 +3,12 @@ import { ClaudeVisionClient } from "../../src/vision/ClaudeVisionClient";
 
 const makeClient = () => new ClaudeVisionClient("test-key-not-used");
 
+const callCalculateCost = (
+  client: ClaudeVisionClient,
+  inputTokens: number,
+  outputTokens: number
+): number => (client as any).calculateCost(inputTokens, outputTokens);
+
 const makeResponse = (text: string) =>
   ({ content: [{ type: "text", text }] } as any);
 
@@ -48,5 +54,21 @@ describe("ClaudeVisionClient.parseClaudeResponse", () => {
     expect(parsed.elementFound).toBe(true);
     expect(parsed.confidence).toBe(0.95);
     expect(parsed.reasoning).toBe("ok");
+  });
+});
+
+describe("ClaudeVisionClient.calculateCost", () => {
+  // Sonnet pricing: $3 / Mtok input, $15 / Mtok output.
+  test("prices input and output tokens at $3 and $15 per million", () => {
+    const client = makeClient();
+    // 1M input = $3, 1M output = $15 → $18 total.
+    expect(callCalculateCost(client, 1_000_000, 1_000_000)).toBeCloseTo(18.0, 6);
+  });
+
+  test("is zero for zero tokens and scales linearly", () => {
+    const client = makeClient();
+    expect(callCalculateCost(client, 0, 0)).toBe(0);
+    // 500k input ($1.50) + 100k output ($1.50) = $3.00.
+    expect(callCalculateCost(client, 500_000, 100_000)).toBeCloseTo(3.0, 6);
   });
 });

--- a/test/vision/VisionFallback.test.ts
+++ b/test/vision/VisionFallback.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { VisionFallback } from "../../src/vision/VisionFallback";
+import type {
+  VisionFallbackConfig,
+  VisionFallbackResult,
+  ElementSearchCriteria,
+} from "../../src/vision/VisionTypes";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+// VisionFallback constructs a ClaudeVisionClient internally (provider "claude"),
+// whose Anthropic client needs *some* key at construction. A dummy is fine — we
+// override the client with a counting stub before any call, so no request is
+// ever made.
+process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || "test-key-not-used";
+
+const config = (overrides: Partial<VisionFallbackConfig> = {}): VisionFallbackConfig => ({
+  enabled: true,
+  provider: "claude",
+  confidenceThreshold: "high",
+  maxCostUsd: 1.0,
+  cacheResults: true,
+  cacheTtlMinutes: 60,
+  ...overrides,
+});
+
+const result = (overrides: Partial<VisionFallbackResult> = {}): VisionFallbackResult => ({
+  found: true,
+  confidence: "high",
+  costUsd: 0.02,
+  durationMs: 100,
+  screenshotPath: "/s.png",
+  provider: "claude",
+  ...overrides,
+});
+
+const criteria = (text: string): ElementSearchCriteria => ({ text });
+const HIERARCHY = {} as any;
+
+/**
+ * Replace the internal Claude client with a stub that counts calls and returns
+ * a fixed result, so we exercise the orchestrator's cache/cost logic without a
+ * network call. Returns a getter for the call count.
+ */
+function stubAnalyzer(fallback: VisionFallback, canned: VisionFallbackResult): () => number {
+  let calls = 0;
+  (fallback as any).claudeClient = {
+    analyzeUIElement: async () => {
+      calls += 1;
+      return canned;
+    },
+  };
+  return () => calls;
+}
+
+describe("VisionFallback orchestrator", () => {
+  let timer: FakeTimer;
+
+  beforeEach(() => {
+    timer = new FakeTimer();
+  });
+
+  test("throws when vision fallback is disabled", async () => {
+    const fb = new VisionFallback(config({ enabled: false }), timer);
+    await expect(
+      fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"))
+    ).rejects.toThrow(/not enabled/);
+  });
+
+  test("caches a result: an identical query hits the analyzer only once", async () => {
+    const fb = new VisionFallback(config(), timer);
+    const count = stubAnalyzer(fb, result());
+
+    const first = await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    const second = await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+
+    expect(count()).toBe(1);
+    expect(second).toEqual(first);
+    expect(fb.getCacheStats().size).toBe(1);
+  });
+
+  test("re-analyzes after the cache entry passes cacheTtlMinutes", async () => {
+    const fb = new VisionFallback(config({ cacheTtlMinutes: 60 }), timer);
+    const count = stubAnalyzer(fb, result());
+
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    // Just under the TTL: still cached.
+    timer.advanceTime(59 * 60 * 1000);
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    expect(count()).toBe(1);
+
+    // Past the TTL: the stale entry is evicted and the analyzer runs again.
+    timer.advanceTime(2 * 60 * 1000);
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    expect(count()).toBe(2);
+  });
+
+  test("caches distinct search criteria separately", async () => {
+    const fb = new VisionFallback(config(), timer);
+    const count = stubAnalyzer(fb, result());
+
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Signup"));
+    expect(count()).toBe(2);
+    expect(fb.getCacheStats().size).toBe(2);
+
+    // Repeating the first is still a cache hit.
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    expect(count()).toBe(2);
+  });
+
+  test("clearCache forces re-analysis", async () => {
+    const fb = new VisionFallback(config(), timer);
+    const count = stubAnalyzer(fb, result());
+
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    fb.clearCache();
+    expect(fb.getCacheStats().size).toBe(0);
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    expect(count()).toBe(2);
+  });
+
+  test("does not cache when cacheResults is false", async () => {
+    const fb = new VisionFallback(config({ cacheResults: false }), timer);
+    const count = stubAnalyzer(fb, result());
+
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    expect(count()).toBe(2);
+    expect(fb.getCacheStats().size).toBe(0);
+  });
+
+  test("a cost above maxCostUsd is a warning, not a failure — the result is still returned", async () => {
+    const fb = new VisionFallback(config({ maxCostUsd: 0.01 }), timer);
+    stubAnalyzer(fb, result({ costUsd: 5.0 }));
+
+    const res = await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    expect(res.found).toBe(true);
+    expect(res.costUsd).toBe(5.0);
+  });
+});


### PR DESCRIPTION
Adds test coverage for the vision-fallback orchestrator and corrects doc drift.

Fixes #3571.

## Re-verification against current main
Per-tool `*.visionFallback.test.ts` for tapOn/swipeOn/pinchOn/dragAndDrop and `applyVisionFallback.test.ts` already exist, but the **`VisionFallback` orchestrator/cache still had no test** and the doc still claimed "tapOn only".

## Tests
- **`test/vision/VisionFallback.test.ts`** (new) — exercises the orchestrator the doc chips as covered:
  - throws when disabled
  - cache hit: an identical query calls the analyzer once
  - TTL expiry via injected `FakeTimer` (re-analyzes past `cacheTtlMinutes`)
  - distinct search criteria cached separately
  - `clearCache` forces re-analysis; `cacheResults: false` never caches
  - a cost above `maxCostUsd` is a warning, not a failure (result still returned)
  - Stubs the internal Claude client so no network request is made.
- **`test/vision/ClaudeVisionClient.test.ts`** — add `calculateCost` tests ($3/Mtok input, $15/Mtok output; zero and linear scaling).

## Doc fixes
- Vision fallback is integrated into **tapOn, swipeOn, pinchOn, dragAndDrop** (via shared `getVisionEnrichedError`), not tapOn-only — corrected the intro, limitations, and future-work bullets.
- Fix the stale `TapOnElement` constructor example: config goes through the third `options` arg (`options.visionConfig`), not a positional argument.
- Fix the flow diagram: only **navigation steps** are high-confidence-gated; **alternative selectors** are returned at any confidence.

## Testing
21 vision tests pass (`bun test test/vision/`). Verified against `VisionFallback.ts`, `ClaudeVisionClient.ts`, `applyVisionFallback.ts`, `TapOnElement.ts`.

Part of the design-doc accuracy audit (#3565).
