### PR TITLE
fix(sdk): make SharedPreferencesDriverImpl outer maps thread-safe (#3601)

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImpl.kt
@@ -29,11 +29,15 @@ internal class SharedPreferencesDriverImpl(
   }
 
   private val listeners = CopyOnWriteArrayList<OnPreferenceChangeListener>()
+  // ConcurrentHashMap: the SharedPreferences change listener fires on arbitrary
+  // threads and reads changeQueues/valueSnapshots while startListening/stopListening
+  // structurally modify these maps on other threads (#3601). The values were already
+  // concurrent; only the outer maps were plain HashMaps.
   private val sharedPrefsListeners =
-    mutableMapOf<String, SharedPreferences.OnSharedPreferenceChangeListener>()
+    ConcurrentHashMap<String, SharedPreferences.OnSharedPreferenceChangeListener>()
 
   /** Per-file change queues for push-based notifications. */
-  private val changeQueues = mutableMapOf<String, CopyOnWriteArrayList<PreferenceChange>>()
+  private val changeQueues = ConcurrentHashMap<String, CopyOnWriteArrayList<PreferenceChange>>()
 
   /**
    * Per-file snapshot of the last-known values, keyed by preference key. Seeded on [startListening]
@@ -42,7 +46,7 @@ internal class SharedPreferencesDriverImpl(
    * [ConcurrentHashMap] because the SharedPreferences listener may fire off arbitrary threads; it
    * cannot store null, so an absent key naturally means "no prior value".
    */
-  private val valueSnapshots = mutableMapOf<String, ConcurrentHashMap<String, Any?>>()
+  private val valueSnapshots = ConcurrentHashMap<String, ConcurrentHashMap<String, Any?>>()
 
   /** Monotonically increasing sequence counter for ordering changes. */
   private val sequenceCounter = AtomicLong(0)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImplConcurrencyTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesDriverImplConcurrencyTest.kt
@@ -1,0 +1,53 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import android.content.Context
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class SharedPreferencesDriverImplConcurrencyTest {
+
+  @Test
+  fun `concurrent start stop and getQueuedChanges do not corrupt maps`() {
+    val context = RuntimeEnvironment.getApplication() as Context
+    val driver = SharedPreferencesDriverImpl(context)
+
+    val threadCount = 8
+    val perThread = 150
+    val errors = CopyOnWriteArrayList<Throwable>()
+    val latch = CountDownLatch(threadCount)
+
+    // Distinct file names per thread so the outer maps (sharedPrefsListeners,
+    // changeQueues, valueSnapshots) are structurally modified concurrently. Under
+    // plain HashMaps this trips ConcurrentModificationException / a corrupted map
+    // (#3601); with ConcurrentHashMap it stays consistent.
+    for (t in 0 until threadCount) {
+      Thread {
+        try {
+          for (i in 0 until perThread) {
+            val file = "prefs-$t-$i"
+            driver.startListening(file)
+            driver.isListening(file)
+            driver.getQueuedChanges(file, 0)
+            driver.stopListening(file)
+          }
+        } catch (e: Throwable) {
+          errors.add(e)
+        } finally {
+          latch.countDown()
+        }
+      }
+        .start()
+    }
+
+    assertTrue("concurrent access timed out", latch.await(30, TimeUnit.SECONDS))
+    assertTrue("concurrent access threw: ${errors.firstOrNull()}", errors.isEmpty())
+    driver.stopAllListening()
+  }
+}


### PR DESCRIPTION
## Summary
`sharedPrefsListeners`, `changeQueues`, and `valueSnapshots` were plain `HashMap`s, while the class's own listener fires on **arbitrary threads** and reads `changeQueues[fileName]` concurrently with `getOrPut` (`startListening`) / `remove` (`stopListening`) on the same map — unsafe under concurrent structural modification (rare CME / corrupted-map hang).

## Fix
Convert the three outer maps to `ConcurrentHashMap` (their values were already concurrent — `CopyOnWriteArrayList` / `ConcurrentHashMap`). No locking across the listener callback.

## Tests
- `concurrent start stop and getQueuedChanges do not corrupt maps` — 8 threads × 150 iterations toggling listeners for distinct files; asserts no exception. Trips CME under the old `HashMap`.

`:auto-mobile-sdk:testDebugUnitTest` green; ktfmt-clean.

Fixes #3601