### PR TITLE
test(critical-section): pin error strings + daemon-only registration; doc nesting (#3572)

### DIFF
--- a/docs/design-docs/mcp/daemon/critical-section.md
+++ b/docs/design-docs/mcp/daemon/critical-section.md
@@ -169,8 +169,25 @@ Error: Nested critical sections are not supported.
 Found criticalSection step inside critical section "outer-lock".
 ```
 
+A nested `barrier` step is rejected the same way (it would deadlock — the device
+holding the section's mutex would wait for peers that cannot enter):
+
+```yaml
+Error: Nested critical sections are not supported.
+Found barrier step inside critical section "outer-lock".
+```
+
+There is also a second, lock-level guard: if the *same* device arrives at the
+*same* lock again before the barrier has passed (e.g. re-entry via a wrapped
+call), the coordinator rejects it:
+
+```yaml
+Error: Device <deviceId> already arrived at barrier for lock "outer-lock".
+Nested critical sections with the same lock are not supported.
+```
+
 **Resolution**:
-- Remove nested critical sections
+- Remove nested critical sections (or `barrier` steps inside them)
 - Use different lock names for sequential synchronization points
 
 ### Step Execution Failure

--- a/test/server/CriticalSectionCoordinator.test.ts
+++ b/test/server/CriticalSectionCoordinator.test.ts
@@ -154,6 +154,20 @@ describe("CriticalSectionCoordinator", () => {
     );
   });
 
+  test("timeout error reports arrived/expected count and the default 30000ms duration", async () => {
+    const lockName = "lock-timeout-body";
+    coordinator.registerExpectedDevices(lockName, 2);
+
+    // Only one of two devices arrives; use the default 30000ms barrier timeout so
+    // the documented message body (arrived count + duration + guidance) is pinned.
+    const promise = coordinator.enterCriticalSection(lockName, "device-1");
+    fakeTimer.advanceTime(30000);
+
+    await expect(promise).rejects.toThrow(
+      /Timeout waiting for critical section "lock-timeout-body"\. 1\/2 devices arrived after 30000ms\. Missing devices may have failed or not reached the critical section\./
+    );
+  });
+
   test("throws error if same device tries to enter twice before barrier passes", async () => {
     const lockName = "lock-5";
     coordinator.registerExpectedDevices(lockName, 2);

--- a/test/server/criticalSectionRegistration.test.ts
+++ b/test/server/criticalSectionRegistration.test.ts
@@ -1,0 +1,37 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { createMcpServer } from "../../src/server/index";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+/**
+ * `criticalSection` (and the `barrier` tool built on it) are registered ONLY in
+ * daemon mode — they rely on the daemon's cross-process lock coordinator and are
+ * meaningless over a single stdio connection. Pin that gate so it can't silently
+ * regress into the stdio tool surface.
+ */
+describe("criticalSection / barrier daemon-only registration", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  afterAll(() => {
+    // Leave a clean registry for any later suite in the same process.
+    ToolRegistry.clearTools();
+  });
+
+  test("stdio mode registers core tools but not criticalSection or barrier", () => {
+    createMcpServer({ daemonMode: false });
+
+    // Sanity: non-gated tools are present, so registration actually ran.
+    expect(ToolRegistry.getTool("observe")).toBeDefined();
+
+    expect(ToolRegistry.getTool("criticalSection")).toBeUndefined();
+    expect(ToolRegistry.getTool("barrier")).toBeUndefined();
+  });
+
+  test("daemon mode registers criticalSection and barrier", () => {
+    createMcpServer({ daemonMode: true });
+
+    expect(ToolRegistry.getTool("criticalSection")).toBeDefined();
+    expect(ToolRegistry.getTool("barrier")).toBeDefined();
+  });
+});

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -436,4 +436,41 @@ describe("criticalSection tool", () => {
     // Verify only first two steps executed
     expect(executionLog).toEqual(["step1", "failure"]);
   });
+
+  test("wraps a step failure with the documented device + step context", async () => {
+    const tool = ToolRegistry.getTool("criticalSection");
+    expect(tool).toBeDefined();
+
+    const fakeDevice: BootedDevice = {
+      platform: "android",
+      deviceId: "dev-wrap",
+      name: "Dev Wrap",
+    };
+
+    ToolRegistry.register("mockWrapOk", "ok", z.object({}), async () => ({
+      success: true,
+    }));
+    ToolRegistry.register("mockWrapBoom", "boom", z.object({}), async () => {
+      throw new Error("kaboom");
+    });
+
+    CriticalSectionCoordinator.getInstance().registerExpectedDevices("wrap-lock", 1);
+
+    const params = {
+      lock: "wrap-lock",
+      deviceCount: 1,
+      steps: [
+        { tool: "mockWrapOk", params: {} },
+        { tool: "mockWrapBoom", params: {} },
+      ],
+    };
+
+    // Both wrapper layers are documented verbatim: the outer "Critical section
+    // <lock> failed for device <id>" and the inner "Failed at step X/Y (<tool>)".
+    await expect(
+			tool!.deviceAwareHandler!(fakeDevice, params, undefined, undefined)
+    ).rejects.toThrow(
+      /Critical section "wrap-lock" failed for device dev-wrap: Failed at step 2\/2 \(mockWrapBoom\): kaboom/
+    );
+  });
 });


### PR DESCRIPTION
Pins the exact critical-section error strings and the daemon-only registration gate that were documented verbatim but only loosely tested, and documents the second nesting guard.

Fixes #3572.

## Tests
- **`CriticalSectionCoordinator.test.ts`** — assert the full timeout message body: `... 1/2 devices arrived after 30000ms. Missing devices may have failed or not reached the critical section.` (previously only the `Timeout waiting for critical section` prefix was matched, at a 100ms timeout — the `30000ms`/count/guidance fragments were unpinned).
- **`criticalSectionTools.test.ts`** — assert **both** documented wrapper layers on a step failure: outer `Critical section "<lock>" failed for device <id>:` and inner `Failed at step X/Y (<tool>): <msg>` (previously only the inner cause `/Simulated failure/` was matched).
- **`criticalSectionRegistration.test.ts`** (new) — assert `criticalSection` **and** `barrier` register only in daemon mode: absent over stdio (with core tools still present as a sanity anchor), present under `daemonMode: true`. Uses `createMcpServer({daemonMode})` with `ToolRegistry.clearTools()` isolation.

## Doc
Documented the second, lock-level re-entry guard in `critical-section.md`: `Device <id> already arrived at barrier for lock "<lock>". Nested critical sections with the same lock are not supported.`, and that a nested `barrier` step is rejected identically (it would deadlock).

## Testing
31 targeted tests pass; full `test/server/` (1036 tests) green — the new `clearTools()` isolation introduces no cross-file pollution.

Part of the design-doc accuracy audit (#3565).
