### PR TITLE
fix(control-proxy): atomic sequence + guarded trim in NavigationEventAccumulator (#3604)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.ctrlproxy
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,8 +36,14 @@ data class TimestampedNavigationEvent(
  */
 class NavigationEventAccumulator {
   private val events = CopyOnWriteArrayList<TimestampedNavigationEvent>()
-  private var sequenceNumber = 0L
+  // Incremented from two paths (addEvent + the navigation listener callback);
+  // AtomicLong so concurrent events can't collide on a sequence number (#3604).
+  private val sequenceNumber = AtomicLong(0L)
   private val maxEvents = 100 // Keep last 100 events
+
+  // Guards the non-atomic add+trim compound and the size/subList read so the
+  // buffer can't be trimmed mid-read (IndexOutOfBoundsException, #3604).
+  private val bufferLock = Any()
 
   // StateFlow for reactive consumption - emits latest event
   private val _latestEvent = MutableStateFlow<TimestampedNavigationEvent?>(null)
@@ -60,7 +67,7 @@ class NavigationEventAccumulator {
     applicationId: String? = null,
   ) {
     val timestamp = System.currentTimeMillis()
-    val sequence = sequenceNumber++
+    val sequence = sequenceNumber.getAndIncrement()
 
     val timestampedEvent =
       TimestampedNavigationEvent(
@@ -73,19 +80,13 @@ class NavigationEventAccumulator {
         applicationId = applicationId,
       )
 
-    events.add(timestampedEvent)
-    if (events.size > maxEvents) {
-      events.removeAt(0)
-    }
-
-    _latestEvent.value = timestampedEvent
-    _eventCount.value = events.size
+    appendEvent(timestampedEvent)
   }
 
   /** Handle incoming navigation event from AutoMobileSDK. */
   private fun onNavigationEvent(event: NavigationEvent) {
     val timestamp = System.currentTimeMillis()
-    val sequence = sequenceNumber++
+    val sequence = sequenceNumber.getAndIncrement()
 
     // Convert NavigationEvent to TimestampedNavigationEvent
     // Convert arguments map to String-keyed map (serialize non-string values)
@@ -110,16 +111,18 @@ class NavigationEventAccumulator {
         sequenceNumber = sequence,
       )
 
-    // Add to events list
-    events.add(timestampedEvent)
+    appendEvent(timestampedEvent)
+  }
 
-    // Maintain circular buffer - remove oldest if exceeds max
-    if (events.size > maxEvents) {
-      events.removeAt(0)
+  /** Append an event and trim the circular buffer atomically, then emit updates. */
+  private fun appendEvent(event: TimestampedNavigationEvent) {
+    synchronized(bufferLock) {
+      events.add(event)
+      if (events.size > maxEvents) {
+        events.removeAt(0)
+      }
     }
-
-    // Emit latest event
-    _latestEvent.value = timestampedEvent
+    _latestEvent.value = event
     _eventCount.value = events.size
   }
 
@@ -140,11 +143,13 @@ class NavigationEventAccumulator {
 
   /** Get the most recent N events. */
   fun getRecentEvents(count: Int): List<TimestampedNavigationEvent> {
-    val size = events.size
-    return if (size <= count) {
-      events.toList()
-    } else {
-      events.subList(size - count, size).toList()
+    synchronized(bufferLock) {
+      val size = events.size
+      return if (size <= count) {
+        events.toList()
+      } else {
+        events.subList(size - count, size).toList()
+      }
     }
   }
 
@@ -161,7 +166,7 @@ class NavigationEventAccumulator {
       totalEvents = events.size,
       oldestTimestamp = events.firstOrNull()?.timestamp,
       newestTimestamp = events.lastOrNull()?.timestamp,
-      currentSequence = sequenceNumber,
+      currentSequence = sequenceNumber.get(),
     )
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulatorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulatorTest.kt
@@ -1,0 +1,77 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavigationEventAccumulatorTest {
+
+  @Test
+  fun `single-threaded add assigns monotonic sequences and bounds the buffer`() {
+    val acc = NavigationEventAccumulator()
+    repeat(150) { acc.addEvent("dest-$it", "src", emptyMap(), emptyMap()) }
+
+    val all = acc.getAllEvents()
+    assertEquals(100, all.size) // trimmed to maxEvents
+    // Retained events keep their original increasing sequence numbers (50..149).
+    assertEquals((50L..149L).toList(), all.map { it.sequenceNumber })
+    assertEquals(150L, acc.getStats().currentSequence)
+  }
+
+  /**
+   * Concurrent producers must not collide on sequence numbers, and a reader hammering
+   * getRecentEvents/getAllEvents must never see an IndexOutOfBoundsException from a trim between
+   * size and subList (#3604).
+   */
+  @Test
+  fun `concurrent addEvent produces no lost sequences and no IOOBE`() {
+    val acc = NavigationEventAccumulator()
+    val threadCount = 6
+    val perThread = 500
+    val errors = CopyOnWriteArrayList<Throwable>()
+    val latch = CountDownLatch(threadCount)
+
+    val readerRunning = AtomicBoolean(true)
+    val reader = Thread {
+      while (readerRunning.get()) {
+        try {
+          acc.getRecentEvents(50)
+          acc.getAllEvents()
+        } catch (e: Throwable) {
+          errors.add(e)
+        }
+      }
+    }
+    reader.start()
+
+    for (t in 0 until threadCount) {
+      Thread {
+        try {
+          repeat(perThread) { acc.addEvent("dest", "src", emptyMap(), emptyMap()) }
+        } catch (e: Throwable) {
+          errors.add(e)
+        } finally {
+          latch.countDown()
+        }
+      }
+        .start()
+    }
+
+    assertTrue("producers timed out", latch.await(30, TimeUnit.SECONDS))
+    readerRunning.set(false)
+    reader.join(5_000)
+
+    assertTrue("concurrent access threw: ${errors.firstOrNull()}", errors.isEmpty())
+    // The counter advanced exactly once per event — no lost/duplicate increments
+    // (a plain `var++` would lose some under contention, giving < total).
+    assertEquals((threadCount * perThread).toLong(), acc.getStats().currentSequence)
+    // Buffer stayed bounded and its retained sequence numbers are unique.
+    val retained = acc.getAllEvents().map { it.sequenceNumber }
+    assertTrue(retained.size <= 100)
+    assertEquals(retained.size, retained.toSet().size)
+  }
+}


### PR DESCRIPTION
## Summary
`sequenceNumber` was a plain `var Long` incremented from two paths (`addEvent` and the `onNavigationEvent` listener callback), so two concurrent events could receive the **same** sequence number (or an increment is lost). Since `getEventsSinceSequence` filters `> sinceSequence`, a duplicate-sequence event is then silently dropped by the daemon. The `size > maxEvents { removeAt(0) }` trim and `getRecentEvents`' `size`/`subList` read were also non-atomic compounds, risking `IndexOutOfBoundsException` when the buffer is trimmed mid-read.

## Fix
- `AtomicLong` for the sequence (both paths use `getAndIncrement()`).
- A lock around the add+trim compound (extracted to `appendEvent`) and around `getRecentEvents`' `size`/`subList`.

## Tests
- single-threaded: monotonic sequences + buffer trimmed to 100;
- `concurrent addEvent produces no lost sequences and no IOOBE` — 6 producers × 500 events + a reader hammering `getRecentEvents`/`getAllEvents`; asserts the counter advanced exactly once per event (a plain `var++` loses some under contention), unique retained sequences, and no exception.

`:control-proxy:testDebugUnitTest` green; ktfmt-clean.

Fixes #3604