### PR TITLE
docs+refactor(nav): remove vestigial 5th fingerprint tier; soften unsubstantiated stats (#3574)

### DIFF
--- a/docs/design-docs/mcp/nav/fingerprinting.md
+++ b/docs/design-docs/mcp/nav/fingerprinting.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** 4-tier fingerprinting strategy fully implemented and benchmarked. 100% success rate for non-keyboard scenarios. See the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Current state:** 4-tier fingerprinting strategy fully implemented and unit-tested. Designed to reliably identify non-keyboard screens; there is no committed end-to-end benchmark backing a specific success-rate figure. See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Screen Fingerprinting
 
@@ -10,16 +10,19 @@ Screen fingerprinting generates stable identifiers for UI screens that remain co
 
 This strategy is critical for reliably identifying screens and building accurate navigation graphs across diverse scenarios.
 
-### Research Foundation
+### Design Foundation
 
-The implementation is based on extensive research testing multiple strategies across real-world scenarios:
+The tiered strategy came out of a design exploration over representative screen
+types (e.g. discover-tap, discover-swipe, discover-chat, discover-text) and
+several candidate fingerprinting approaches, from which the shallow-scrollable
+markers emerged as the most robust for non-keyboard scenarios.
 
-- **4 screen types** tested (discover-tap, discover-swipe, discover-chat, discover-text)
-- **11 observations** captured with varying states
-- **6 strategies** evaluated
-- **100% success rate** for non-keyboard scenarios achieved with shallow scrollable markers
-
-The tiered strategy was validated across 4 screen types and 11 observations with a 100% success rate for non-keyboard scenarios.
+> Note: the specific figures previously quoted here ("11 observations",
+> "6 strategies", "100% success rate") described that original exploration and
+> are **not** reproduced by a committed benchmark or dataset in this repo. The
+> mechanics are covered by unit tests (`test/features/navigation/ScreenFingerprint.test.ts`),
+> not a measured cross-scenario success rate. Treat the tiers below as design
+> intent rather than benchmarked results.
 
 ---
 
@@ -170,7 +173,8 @@ After scroll:  filter_chip_1, icon_button_delete, slider_control
 Both fingerprint to: hash(scrollable container metadata)
 ```
 
-**Impact**: 100% success for scrolling scenarios
+**Impact**: stable fingerprints across scrolling scenarios (the container
+metadata stays constant as content scrolls)
 
 ---
 

--- a/docs/design-docs/mcp/nav/performance.md
+++ b/docs/design-docs/mcp/nav/performance.md
@@ -12,18 +12,22 @@
 
 ---
 
-### Success Rates by Scenario
+### Expected Reliability by Scenario
 
-| Scenario | Strategy | Success Rate | Notes |
-|----------|----------|--------------|-------|
-| SDK app, no keyboard | Navigation ID | **100%** | Perfect identifier |
-| SDK app, with keyboard | Cached Nav ID | **100%** | Keyboard occlusion handled |
-| Scrolling content | Shallow Scrollable | **100%** | Container stays stable |
-| Tab navigation | Shallow Scrollable | **100%** | Selected state preserved |
-| Non-SDK app | Shallow Scrollable | **75-85%** | Depends on hierarchy distinctiveness |
+These are the strategy's *design expectations*, not figures from a committed
+benchmark (no such dataset exists in the repo — see the note in
+[Fingerprinting](fingerprinting.md#design-foundation)):
 
-#### Overall Performance
+| Scenario | Strategy | Expected reliability | Notes |
+|----------|----------|----------------------|-------|
+| SDK app, no keyboard | Navigation ID | High | Explicit navigation identifier |
+| SDK app, with keyboard | Cached Nav ID | High | Keyboard occlusion handled via cache |
+| Scrolling content | Shallow Scrollable | High | Container metadata stays stable |
+| Tab navigation | Shallow Scrollable | High | Selected state preserved |
+| Non-SDK app | Shallow Scrollable | Moderate | Depends on hierarchy distinctiveness |
 
-- **Non-keyboard scenarios**: 100% success
-- **Keyboard scenarios**: Depends on cache availability
-- **No false positives**: Collision prevention through selected state
+#### Overall Design Expectations
+
+- **Non-keyboard scenarios**: high reliability by design (explicit or structural IDs)
+- **Keyboard scenarios**: depends on cache availability
+- **Collision avoidance**: selected-state disambiguation (unit-tested)

--- a/src/features/navigation/ScreenFingerprint.ts
+++ b/src/features/navigation/ScreenFingerprint.ts
@@ -49,8 +49,6 @@ export enum FingerprintConfidence {
   MEDIUM = 75,
   /** Keyboard detected, filtered hierarchy */
   LOW_MEDIUM = 60,
-  /** Package + structure only */
-  LOW = 50,
 }
 
 /**
@@ -61,7 +59,6 @@ export enum FingerprintMethod {
   CACHED_NAVIGATION_ID = "cached-navigation-id",
   SHALLOW_SCROLLABLE = "shallow-scrollable",
   SHALLOW_SCROLLABLE_WITH_KEYBOARD = "shallow-scrollable-keyboard",
-  PACKAGE_STRUCTURE = "package-structure",
 }
 
 /**
@@ -113,7 +110,6 @@ const PERCENT_PATTERN = /^\d+%$/;
  * 2. Cached Navigation ID (85% confidence) - Use cached ID when keyboard detected
  * 3. Shallow Scrollable (75% confidence) - Filtered hierarchy with shallow scrollable markers
  * 4. Shallow Scrollable + Keyboard (60% confidence) - Filtered hierarchy with keyboard detected
- * 5. Package + Structure (50% confidence) - Last resort fallback
  *
  * Key features:
  * - Shallow scrollable markers: Keep container, drop children (handles scrolling)


### PR DESCRIPTION
Fixes #3574. Reconciles code and docs to one honest story.

## Remove the vestigial 5th tier
`FingerprintConfidence.LOW` (50) and `FingerprintMethod.PACKAGE_STRUCTURE` were defined but **never returned** by `compute()` (referenced only at their own definitions), and a JSDoc line described a "5. Package + Structure" tier that doesn't exist at runtime. The strategy is genuinely **4-tier** — the code now says so. No behavior change (the values were unreachable); 46 `ScreenFingerprint` tests pass, typecheck clean.

## Soften unsubstantiated benchmark claims
The "100% success rate", "6 strategies evaluated", and "11 observations" figures have **no committed benchmark or dataset** backing them. Reframed the fingerprinting "Design Foundation" and the performance "Expected Reliability" table as design intent — with an explicit note that the mechanics are unit-tested, not a measured cross-scenario success rate.

Part of the design-doc accuracy audit (#3565).