### PR TITLE
fix(sdk): synchronize RecompositionTracker.Entry.toJson (#3613)

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
@@ -115,7 +115,7 @@ internal object RecompositionTracker {
     ctx.sendBroadcast(intent)
   }
 
-  private fun buildSnapshotJson(applicationId: String): String {
+  internal fun buildSnapshotJson(applicationId: String): String {
     val entriesArray = JSONArray()
     for (entry in entries.values) {
       entriesArray.put(entry.toJson())
@@ -203,6 +203,10 @@ internal object RecompositionTracker {
       durationSamples += 1
     }
 
+    // Reads the same mutable counters that record()/recordDuration() write under
+    // @Synchronized; without it, a snapshot on the handler thread can observe torn
+    // or stale counters (e.g. durationTotalMs updated but durationSamples not, #3613).
+    @Synchronized
     fun toJson(): JSONObject {
       val json =
         JSONObject()

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTrackerConcurrencyTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTrackerConcurrencyTest.kt
@@ -1,0 +1,93 @@
+package dev.jasonpearson.automobile.sdk
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RecompositionTrackerConcurrencyTest {
+
+  @After
+  fun tearDown() {
+    RecompositionTracker.setEnabled(false) // clears entries
+  }
+
+  private fun durationOf(snapshotJson: String, id: String): Double? {
+    val entries = JSONObject(snapshotJson).getJSONArray("entries")
+    for (i in 0 until entries.length()) {
+      val e = entries.getJSONObject(i)
+      if (e.getString("id") == id && e.has("durationMs")) return e.getDouble("durationMs")
+    }
+    return null
+  }
+
+  /**
+   * Every recorded duration is exactly 2.0, so the average reported by a snapshot must always be
+   * 2.0. Without synchronizing toJson (#3613), a snapshot taken between `durationTotalMs += 2.0`
+   * and `durationSamples += 1` in recordDuration reads a torn pair and reports an average > 2.0.
+   */
+  @Test
+  fun `concurrent snapshot never observes a torn duration average`() {
+    RecompositionTracker.setEnabled(true)
+    val id = "screen-home"
+    val threadCount = 6
+    val perThread = 1_000
+    val errors = CopyOnWriteArrayList<Throwable>()
+    val tornAverages = CopyOnWriteArrayList<Double>()
+    val latch = CountDownLatch(threadCount)
+
+    val readerRunning = AtomicBoolean(true)
+    val reader = Thread {
+      while (readerRunning.get()) {
+        try {
+          val avg = durationOf(RecompositionTracker.buildSnapshotJson("test"), id)
+          if (avg != null && kotlin.math.abs(avg - 2.0) > 1e-9) tornAverages.add(avg)
+        } catch (e: Throwable) {
+          errors.add(e)
+        }
+      }
+    }
+    reader.start()
+
+    for (t in 0 until threadCount) {
+      Thread {
+        try {
+          repeat(perThread) {
+            RecompositionTracker.recordRecomposition(id)
+            RecompositionTracker.recordDuration(id, 2.0)
+          }
+        } catch (e: Throwable) {
+          errors.add(e)
+        } finally {
+          latch.countDown()
+        }
+      }
+        .start()
+    }
+
+    assertTrue("producers timed out", latch.await(30, TimeUnit.SECONDS))
+    readerRunning.set(false)
+    reader.join(5_000)
+
+    assertTrue("concurrent access threw: ${errors.firstOrNull()}", errors.isEmpty())
+    assertTrue("snapshot observed torn duration averages: $tornAverages", tornAverages.isEmpty())
+    // Final quiescent snapshot: total == every record, average is exactly 2.0.
+    val finalJson = JSONObject(RecompositionTracker.buildSnapshotJson("test"))
+    val entries = finalJson.getJSONArray("entries")
+    var total = -1
+    for (i in 0 until entries.length()) {
+      val e = entries.getJSONObject(i)
+      if (e.getString("id") == id) total = e.getInt("total")
+    }
+    assertEquals(threadCount * perThread, total)
+    assertEquals(2.0, durationOf(finalJson.toString(), id)!!, 1e-9)
+  }
+}


### PR DESCRIPTION
## Summary
`RecompositionTracker.Entry.toJson()` read the mutable counters (`totalCount`, `durationTotalMs`/`durationSamples`) **without** synchronization, while `record()`/`recordDuration()` mutate them under `@Synchronized` from other threads. A snapshot taken on the handler thread during `broadcastSnapshot` could observe a torn/stale pair (e.g. `durationTotalMs` bumped but `durationSamples` not yet) and emit a wrong average. No crash — inaccurate diagnostics.

## Fix
Mark `toJson()` `@Synchronized` so it reads the counters under the same monitor as the writers.

## Tests
- `concurrent snapshot never observes a torn duration average` — 6 threads × 1,000 records where every duration is `2.0` (so the average must always be exactly `2.0`), with a reader hammering `buildSnapshotJson`; asserts no snapshot ever reports a torn average ≠ 2.0, plus exact final total. (`buildSnapshotJson` made `internal` for the test.)

`:auto-mobile-sdk:testDebugUnitTest` green; ktfmt-clean.

Fixes #3613