### PR TITLE
docs(android): correct pre-tap stability drift — opt-in guard, real options, budget model (#3575)

### DIFF
--- a/docs/design-docs/plat/android/tapOn-pre-tap-stability-and-search-flakes.md
+++ b/docs/design-docs/plat/android/tapOn-pre-tap-stability-and-search-flakes.md
@@ -1,4 +1,4 @@
-# Android `tapOn` flakes after `observe` (search lists, `tapClickableParent`)
+# Android `tapOn` flakes after `observe` (search lists, sibling/row taps)
 
 <kbd>✅ Implemented</kbd>
 
@@ -12,25 +12,39 @@ The flake was **not** primarily “wrong tap coordinates” or “semantic click
 
 **The fix that stuck** is two parts in the MCP server (Android **`tapOn`** path in `TapOnElement`):
 
-1. **Pre-tap stable re-find (hard guard)**  
-   After the initial element resolution, **refresh the hierarchy** several times, **re-find** the same target each time, and require **two consecutive** re-finds whose **bounds match within a small ε** (`boundsNearlyEqual`). **If that never happens, abort the tap** with a clear error instead of tapping pre-observe coordinates.  
+1. **Pre-tap stable re-find (opt-in guard)**  
+   The guard is **opt-in**, not the default `tapOn` behavior: it runs only when
+   `preTapStability: true` is passed (and is enabled implicitly by
+   `ensureTap: true`), gated by `AndroidTapStrategy.shouldRunPreTapStability`.
+   When active, after the initial element resolution it **refreshes the
+   hierarchy** several times, **re-finds** the same target each time, and requires
+   the target's **bounds to match within a small ε** (`boundsNearlyEqual`) — **one**
+   stable re-find by default, or **two consecutive** when `sibling: true` (see the
+   policy note). **If that never happens, it aborts the tap** with a clear error
+   instead of tapping pre-observe coordinates.  
    - Code: `resolveAndroidStableTapTargetAfterRefreshes` in `src/features/action/TapOnElement.ts`  
    - Utility: `boundsNearlyEqual` in `src/utils/bounds.ts`
 
 2. **Loading-aware patience (so the guard can succeed)**  
-   If the current tree **looks like a blocking loading state** (progress indicators, common loading view classes / resource ids), **extend** the pre-tap refresh budget (default **8** attempts → up to **32**), with a short delay between attempts, so the list can **come back** before we give up.  
+   If the current tree **looks like a blocking loading state** (progress indicators, common loading view classes / resource ids), **extend** the pre-tap refresh budget — a wall-clock budget (default **2500ms → 10000ms**) plus a minimum-productive-poll floor (**8 → 32**) — with a short delay between polls, so the list can **come back** before we give up.  
    - Code: `androidViewHierarchyIndicatesLikelyBlockingLoading` in `src/utils/androidTransientLoading.ts`
 
 Together: **don’t tap on ghosts**, and **wait long enough through real loading** for the row to reappear in the a11y tree. After this landed, the same plan **passed repeatedly** (e.g. four consecutive runs) where step 28 had previously been flaky.
 
-**Policy note:** The **two consecutive** ε-stable re-finds apply to **churn-prone selector paths** (`tapClickableParent`, `siblingOfText`, `clickable`, `scrollableContainer`). Plain **`text`** or **`elementId`-only** taps still require a **live re-find** after refresh but only **one** successful stable match, so static labels are not held to the same double-stability bar as search list rows.
+**Policy note:** The stricter **two consecutive** ε-stable re-finds apply only
+when the tap targets an adjacent control via **`sibling: true`** (the churn-prone
+case — see `resolveAndroidPreTapConsecutiveStableMatchesRequired` in
+`src/features/action/androidPreTapStablePolicy.ts`, which returns 2 for
+`sibling`, else 1). Plain **`text`** or **resource-id** taps still require a
+**live re-find** after refresh but only **one** successful stable match, so they
+are not held to the same double-stability bar as sibling taps.
 
 ---
 
 ## Symptom
 
 - **`observe`** with **`waitFor`** on the row text (often scoped with **`container`**) **succeeds**.
-- Immediately after, **`tapOn`** with **`tapClickableParent: true`** on the same text **either**:
+- Immediately after, **`tapOn`** on the same text (which resolves the clickable row) **either**:
   - reported **success** but the screen **did not change**, and a later **`observe`** timed out, **or**
   - failed with an error about **not re-finding** the target after refreshes (after the guard was added).
 
@@ -58,7 +72,7 @@ These changes **improved** robustness or diagnostics and are worth keeping in mi
 | Area | What we tried | Why it wasn’t sufficient alone |
 |------|----------------|----------------------------------|
 | **CtrlProxy / semantic tap** | **`ACTION_CLICK`** with bounds disambiguation, multi-window search, hit-test ordering, framework id handling (`android:id/*` vs app ids) | Still need a **real node** matching the row; semantic success doesn’t help if the tree **dropped** the row. |
-| **Coordinates** | **`tapClickableParent`**: label∩row overlap, clamped centers, ADB-before-gesture for search+IME | Wrong if bounds refer to a **row that no longer exists** in the current tree. |
+| **Coordinates** | Clickable-row resolution: label∩row overlap, clamped centers, ADB-before-gesture for search+IME | Wrong if bounds refer to a **row that no longer exists** in the current tree. |
 | **Snapshot consistency** | Ensure tap target and geometry come from the **same** refreshed hierarchy | Necessary but not enough if the next refresh **still** has no row. |
 | **Diagnostics** | **`tapDebug`**, focus/hit-test around tap, plan **`failureObservation`** on observe timeout | Great for proving **loading / missing row**; doesn’t fix timing. |
 | **Plans** | **`waitFor.container`**, tighter waits | Reduces false positives; doesn’t remove the **gap** between end of observe and start of tap. |
@@ -83,7 +97,7 @@ Typical **success** log line:
 When loading extension applies:
 
 ```text
-[TapOnElement] Android pre-tap: loading/progress indicators present; extending refind attempts to 32
+[TapOnElement] Android pre-tap: loading/progress indicators present; extending refind budget to 10000ms / 32 polls
 ```
 
 Failure (guard working, UI still churning):
@@ -111,7 +125,7 @@ When reading **daemon** logs, you may see issues that **do not** change the abov
 - **`NAV_SCREENSHOT` … Unsupported platform: undefined** — screenshot path missing **`platform`**; unrelated to tap re-find logic.
 - **`CTRL_PROXY` Timeout waiting for fresh data** — hierarchy may be slightly stale; the pre-tap loop is meant to cope by **re-fetching** right before tap.
 
-If logs show **`pre-tap refresh attempt …/8`** with **no** “extending refind attempts” line, the running server may be **older** than the loading-extension change, or the app’s loader **does not** match the [loading heuristic](../../../../src/utils/androidTransientLoading.ts) (extend patterns there if needed).
+If logs show repeated **`Android pre-tap refresh attempt N did not re-find tap target`** with **no** “extending refind budget” line, the running server may be **older** than the loading-extension change, or the app’s loader **does not** match the [loading heuristic](../../../../src/utils/androidTransientLoading.ts) (extend patterns there if needed).
 
 ---
 


### PR DESCRIPTION
Fixes #3575. Docs-only.

- **Opt-in, not default:** the pre-tap stable re-find runs only when `preTapStability: true` (or implicitly `ensureTap: true`), gated by `AndroidTapStrategy.shouldRunPreTapStability` — the doc framed it as an always-on "hard guard" on the `tapOn` path.
- **Real options only:** the policy note's two-consecutive stability bar applies only to `sibling: true` taps (`androidPreTapStablePolicy` returns 2 for `sibling`, else 1). The doc listed selector names that **don't exist** (`tapClickableParent`, `siblingOfText`) or belong to another tool (`scrollableContainer` is a `tapAny` option). Default text/resource-id taps require **one** stable match.
- **Budget model:** it's a wall-clock budget (2500ms → 10000ms) **plus** a min-productive-poll floor (8 → 32), not "8 attempts → 32". Corrected the log examples to the real strings (`extending refind budget to 10000ms / 32 polls`; `Android pre-tap refresh attempt N did not re-find tap target` — dropped the fabricated `…/8`).
- Retitled and reworked the fabricated `tapClickableParent` references.

Verified against `TapOnElement.ts`, `androidPreTapStablePolicy.ts`, `AndroidTapStrategy.ts`.

Part of the design-doc accuracy audit (#3565).