### PR TITLE
docs(resources): correct the listDevices 'removed' claim + scope the catalog (#3576)

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -16,6 +16,12 @@ MCP Resources provide read-only access to:
 
 ## Available Resources
 
+> This page documents the primary resources. It is **not** an exhaustive list of
+> every registered resource — the server also registers observation, device
+> images, test runs, video recording, device snapshots, databases, failures,
+> storage, app files, feature flags, and network resources (see the
+> `register*Resources()` calls in `src/server/index.ts`).
+
 ### Navigation Graph
 
 **URI**: `automobile:navigation/graph`
@@ -40,7 +46,7 @@ Returns booted device inventory across Android and iOS, including:
 
 **URI Template**: `automobile:devices/booted/{platform}`
 
-This resource replaces the removed `listDevices` and `daemon_available_devices` tools.
+This resource supersedes the device data that the `listDevices` tool used to return. `listDevices` still exists as an MCP tool, but now returns **resource guidance** — a message pointing callers at these resource URIs — rather than device data (see `listDevicesHandler` in `src/server/deviceTools.ts`). The separate `daemon_available_devices` tool was removed.
 
 ### Installed Apps
 


### PR DESCRIPTION
Part of #3576 (doc-drift portion; the add-tests item is left as a follow-up — see below).

## Changes
- **`listDevices` is not removed.** The booted-devices resource supersedes the device *data* `listDevices` used to return, but the tool still exists as a **guidance shim** (`listDevicesHandler` returns a message pointing at the resource URIs — `src/server/deviceTools.ts`). Only the separate `daemon_available_devices` tool was removed. Corrected the line-43 claim.
- **Catalog scope note.** Added a note that this page documents the *primary* resources, not every registered one — the server also registers observation, device-image, test-run, video, snapshot, database, failures, storage, app-file, feature-flag, and network resources (`register*Resources()` in `src/server/index.ts`).

## Deferred follow-up (keeps #3576 open)
Dedicated read/list tests for the `localization`, `test-timings`, and `performance-results` resources. These are DB-backed and need in-memory DB injection to respect the unit-test DB guard (CLAUDE.md) — a careful, separate change rather than a rushed brittle add. The resources are registered and functional today.

Part of the design-doc accuracy audit (#3565).