### PR TITLE
fix(sdk): contain throwing EventPersistence so the flush timer survives (#3605)

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBuffer.kt
@@ -50,7 +50,10 @@ internal class SdkEventBuffer(
       if (flushTask == null && !isShutdown) {
         flushTask =
           executor.scheduleAtFixedRate(
-            { flush() },
+            // Backstop: any exception escaping the periodic task cancels all future
+            // runs (the scheduleAtFixedRate contract). Per-batch errors are already
+            // accounted inside deliverBatch; swallow here so the timer survives (#3605).
+            { runCatching { flush() } },
             flushIntervalMs,
             flushIntervalMs,
             TimeUnit.MILLISECONDS,
@@ -148,13 +151,17 @@ internal class SdkEventBuffer(
 
   private fun deliverBatch(events: List<SdkEvent>) {
     if (events.isEmpty()) return
-    val batchId = persistence?.persist(events) // persist to disk first
+    var batchId: String? = null
     try {
+      batchId = persistence?.persist(events) // persist to disk first
       onFlush(events)
       batchId?.let { persistence?.removeBatch(it) } // remove on success
     } catch (_: Exception) {
+      // A throwing custom EventPersistence.persist() must NOT escape here: this
+      // runs inside the scheduleAtFixedRate task, and an uncaught exception would
+      // silently cancel all future periodic flushes (#3605). Count the batch as a
+      // flush error; anything already persisted stays on disk for next-launch retry.
       repeat(events.size) { dropCounter?.increment(DropReason.FLUSH_ERROR) }
-      // Keep on disk for retry on next launch
     }
   }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/events/SdkEventBufferTest.kt
@@ -381,4 +381,66 @@ class SdkEventBufferTest {
     val snapshot = counter.snapshot()
     assertEquals(1L, snapshot[DropReason.BUFFER_OVERFLOW])
   }
+
+  // ================= Throwing persistence (#3605) =================
+
+  private class ThrowingPersistence(val shouldThrow: java.util.concurrent.atomic.AtomicBoolean) :
+    dev.jasonpearson.automobile.sdk.persistence.EventPersistence {
+    override fun persist(events: List<SdkEvent>): String? {
+      if (shouldThrow.get()) throw RuntimeException("boom")
+      return "batch-id"
+    }
+
+    override fun loadPending(): List<Pair<String, List<SdkEvent>>> = emptyList()
+
+    override fun removeBatch(batchId: String) {}
+
+    override fun cleanup(maxAgeDays: Int) {}
+  }
+
+  /**
+   * A throwing custom EventPersistence.persist() must not propagate out of flush() — it runs inside
+   * the scheduleAtFixedRate task, and an uncaught exception would cancel all future periodic
+   * flushes (#3605).
+   */
+  @Test
+  fun `flush does not propagate exception from throwing persistence`() {
+    val flushed = CopyOnWriteArrayList<List<SdkEvent>>()
+    val persistence = ThrowingPersistence(java.util.concurrent.atomic.AtomicBoolean(true))
+    val buffer =
+      SdkEventBuffer(
+        maxBufferSize = 1_000, // only flush() triggers delivery, never capacity
+        flushIntervalMs = 60_000,
+        onFlush = { flushed.add(it) },
+        persistence = persistence,
+      )
+
+    buffer.add(makeEvent(1))
+    buffer.flush() // pre-fix: throws out of flush() (and would cancel the periodic task)
+
+    assertEquals(0, flushed.size) // batch dropped on persist failure, not delivered
+  }
+
+  @Test
+  fun `buffer keeps delivering after a persist failure`() {
+    val flushed = CopyOnWriteArrayList<List<SdkEvent>>()
+    val shouldThrow = java.util.concurrent.atomic.AtomicBoolean(true)
+    val buffer =
+      SdkEventBuffer(
+        maxBufferSize = 1_000,
+        flushIntervalMs = 60_000,
+        onFlush = { flushed.add(it) },
+        persistence = ThrowingPersistence(shouldThrow),
+      )
+
+    buffer.add(makeEvent(1))
+    buffer.flush() // persist throws, contained
+    assertEquals(0, flushed.size)
+
+    shouldThrow.set(false)
+    buffer.add(makeEvent(2))
+    buffer.flush() // persist succeeds, delivers
+    assertEquals(1, flushed.size)
+    assertEquals(2L, flushed[0][0].timestamp)
+  }
 }


### PR DESCRIPTION
## Summary
`persistence?.persist(events)` was called **outside** `deliverBatch`'s `try`. A throwing custom `EventPersistence` therefore propagated out of the `scheduleAtFixedRate` task, which silently cancels all future periodic flushes — so low-volume events stop being delivered (only capacity-triggered flushes keep working). The default `FileEventPersistence` swallows its own exceptions, so this only bites custom implementations, but the periodic-task contract is still violated.

## Fix
- Move the `persist` call inside `deliverBatch`'s `try` (its throw is now caught and the batch counted as a flush error).
- Wrap the scheduled `{ flush() }` lambda in `runCatching` as a backstop, so no exception can ever escape the periodic task.

## Tests
- `flush does not propagate exception from throwing persistence` — `flush()` no longer throws when `persist()` does (the escape path that killed the timer);
- `buffer keeps delivering after a persist failure` — after a throwing flush, a later flush with a working persistence still delivers.

`:auto-mobile-sdk:testDebugUnitTest` green; ktfmt-clean.

Fixes #3605