### PR TITLE
fix(sdk): unregister network-mock/biometric receivers on shutdown (#3599)

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -405,6 +405,8 @@ object AutoMobileSDK {
         AutoMobileOsEvents.shutdown(ctx)
         AutoMobileBroadcastInterceptor.shutdown(ctx)
         AutoMobileClickTracker.shutdown(ctx)
+        NetworkMockRuleStore.shutdown(ctx)
+        AutoMobileBiometrics.shutdown()
         sessionLifecycleObserver?.let {
           ProcessLifecycleOwner.get().lifecycle.removeObserver(it)
         }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/biometrics/AutoMobileBiometrics.kt
@@ -199,6 +199,18 @@ object AutoMobileBiometrics {
     }
   }
 
+  /** Unregister the override receiver so it doesn't leak across init/shutdown cycles (#3599). */
+  @Synchronized
+  fun shutdown() {
+    if (!receiverRegistered) return
+    context?.let {
+      try {
+        it.unregisterReceiver(broadcastReceiver)
+      } catch (_: Exception) {}
+    }
+    receiverRegistered = false
+  }
+
   /**
    * Process an incoming biometric override broadcast intent.
    *

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
@@ -43,7 +43,16 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
     fun initialize(context: Context) {
       getInstance().registerReceiver(context)
     }
+
+    fun shutdown(context: Context) {
+      getInstance().unregisterReceiver(context)
+    }
   }
+
+  // Guards against double-registration on re-init and ensures unregister runs at
+  // most once — the receiver is a process singleton, so a leaked/duplicate
+  // registration would double-handle every broadcast (#3599).
+  private var receiverRegistered = false
 
   /** Interface for the interceptor to query rules without depending on the full store. */
   interface RuleMatcher {
@@ -195,7 +204,9 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
 
   fun getRuleCount(): Int = rules.size
 
+  @Synchronized
   fun registerReceiver(context: Context) {
+    if (receiverRegistered) return
     val filter =
       IntentFilter().apply {
         addAction(ACTION_NETWORK_MOCK_RULES)
@@ -212,15 +223,19 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
     } else {
       context.registerReceiver(receiver, filter, PERMISSION_NETWORK_CONTROL, null)
     }
+    receiverRegistered = true
     AutoMobileSDK.logger.d(TAG) {
       "Registered broadcast receiver for network mock rules (permission-gated)"
     }
   }
 
+  @Synchronized
   fun unregisterReceiver(context: Context) {
+    if (!receiverRegistered) return
     try {
       context.unregisterReceiver(receiver)
     } catch (_: Exception) {}
+    receiverRegistered = false
   }
 
   private val receiver =

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
@@ -1,0 +1,76 @@
+package dev.jasonpearson.automobile.sdk.network
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.IntentFilter
+import android.os.Build
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+class NetworkMockRuleStoreReceiverTest {
+
+  /**
+   * The receiver must register at most once and unregister must allow a later re-register — without
+   * the idempotency guard, re-init leaked/double-registered it so every broadcast was handled twice
+   * (#3599).
+   */
+  @Test
+  fun `registerReceiver is idempotent and unregister allows re-register`() {
+    val store = NetworkMockRuleStore()
+    val context = mockk<Context>(relaxed = true)
+    every {
+      context.registerReceiver(
+        any<BroadcastReceiver>(),
+        any<IntentFilter>(),
+        any<String>(),
+        any(),
+        any<Int>(),
+      )
+    } returns null
+
+    store.registerReceiver(context)
+    store.registerReceiver(context) // guarded no-op
+
+    verify(exactly = 1) {
+      context.registerReceiver(
+        any<BroadcastReceiver>(),
+        any<IntentFilter>(),
+        any<String>(),
+        any(),
+        any<Int>(),
+      )
+    }
+
+    store.unregisterReceiver(context)
+    verify(exactly = 1) { context.unregisterReceiver(any<BroadcastReceiver>()) }
+
+    // After unregister, register works again (total of two registrations).
+    store.registerReceiver(context)
+    verify(exactly = 2) {
+      context.registerReceiver(
+        any<BroadcastReceiver>(),
+        any<IntentFilter>(),
+        any<String>(),
+        any(),
+        any<Int>(),
+      )
+    }
+  }
+
+  @Test
+  fun `unregister without register is a no-op`() {
+    val store = NetworkMockRuleStore()
+    val context = mockk<Context>(relaxed = true)
+
+    store.unregisterReceiver(context)
+
+    verify(exactly = 0) { context.unregisterReceiver(any<BroadcastReceiver>()) }
+  }
+}


### PR DESCRIPTION
## Summary
`NetworkMockRuleStore.unregisterReceiver` had **zero callers**, so the network-mock `BroadcastReceiver` stayed registered after `AutoMobileSDK.shutdown()`. Because the store is a process singleton with no idempotency guard, a second `initialize()` re-registered the **same** receiver, so each incoming rules/error-sim broadcast ran `setRules` twice, and every init→shutdown→init cycle leaked another registration.

## Fix
- Add a `receiverRegistered` guard so `registerReceiver`/`unregisterReceiver` are idempotent.
- Add `NetworkMockRuleStore.shutdown(ctx)` and call it from `AutoMobileSDK.shutdown()`.
- Add `AutoMobileBiometrics.shutdown()` (its `BroadcastReceiver` was also never torn down; its guard bounded it to a single leak) and wire it into shutdown too.

## Tests
- `registerReceiver is idempotent and unregister allows re-register` — double register → one OS registration; unregister → one OS unregistration; re-register → two total.
- `unregister without register is a no-op`.

`:auto-mobile-sdk:testDebugUnitTest` fully green; ktfmt-clean.

Fixes #3599