### PR TITLE
docs+test(ios): fix simctl terminate/DND framing; add isIosSimulatorUdid test (#3580)

### DIFF
--- a/docs/design-docs/plat/ios/simctl.md
+++ b/docs/design-docs/plat/ios/simctl.md
@@ -40,7 +40,7 @@ For `launchApp` specifically:
 For `terminateApp` specifically:
 
 - **Simulator** — `xcrun simctl terminate <udid> <bundle-id>`; a "found nothing to terminate" error is treated as `wasRunning: false` rather than a failure.
-- **Physical device** — `devicectl` has no terminate-by-bundle-id verb, so termination is a **two-step** operation (`DeviceAppManager.terminateApp`):
+- **Physical device** — `devicectl` has no terminate-by-bundle-id verb, so termination is a **three-step** operation (`DeviceAppManager.terminateApp`): resolve the bundle path, find the running PID, then kill it —
   1. Resolve the on-device bundle path via `xcrun devicectl device info apps --device <udid> --bundle-id <id> --json-output <file> --quiet`. No matching bundle → `{ wasInstalled: false, wasRunning: false }` (no terminate issued).
   2. Enumerate running processes via `xcrun devicectl device info processes --device <udid> --json-output <file> --quiet` and match the process whose executable path lives **inside** the resolved bundle directory (the app's own main binary, a direct child of `<bundle>.app/` — nested `PlugIns/*.appex/*` extensions are excluded). No match → `{ wasInstalled: true, wasRunning: false }`.
   3. Force-kill the matched PID with the dedicated verb: `xcrun devicectl device process terminate --device <udid> --pid <pid> --kill --quiet` → `{ wasInstalled: true, wasRunning: true }`. `--kill` sends SIGKILL (uncatchable), matching Android `am force-stop` semantics; the bare verb would send a catchable SIGTERM.
@@ -326,7 +326,10 @@ fresh-process readback.
 
 1. **Binary toggle** — the only lever the simulator exposes is the
    `com.apple.donotdisturb.enabled` Darwin notification, driven via
-   `xcrun simctl spawn <udid> notifyutil`:
+   `xcrun simctl spawn <udid> notifyutil`. All four flags are passed in a
+   **single combined invocation** — `notifyutil -1 <key> -s <key> <0|1> -g <key> -p <key>`
+   (`iosNotifyutilRegisteredSetReadPostCommand` in `src/utils/ios-cmdline-tools/notifyutil.ts`),
+   not four separate shell calls:
    - `notifyutil -1 com.apple.donotdisturb.enabled ...` creates a temporary
      registration so the state variable exists even if no other process already
      owns the key.

--- a/test/utils/ios-cmdline-tools/iosDeviceType.test.ts
+++ b/test/utils/ios-cmdline-tools/iosDeviceType.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { isIosSimulatorUdid } from "../../../src/utils/ios-cmdline-tools/iosDeviceType";
+
+/**
+ * `isIosSimulatorUdid` is the routing predicate that decides simctl (simulator)
+ * vs devicectl (physical) across the iOS action layer. Pin the 8-4-4-4-12
+ * simulator-UUID shape and the physical-device forms it must reject.
+ */
+describe("isIosSimulatorUdid", () => {
+  test("accepts a standard 8-4-4-4-12 simulator UUID (either case)", () => {
+    expect(isIosSimulatorUdid("A1B2C3D4-E5F6-7890-ABCD-EF1234567890")).toBe(true);
+    expect(isIosSimulatorUdid("a1b2c3d4-e5f6-7890-abcd-ef1234567890")).toBe(true);
+  });
+
+  test("rejects a physical-device UDID (8-hex + 16-hex, no dashed groups)", () => {
+    // e.g. 00008110-000A4D3C1234801E
+    expect(isIosSimulatorUdid("00008110-000A4D3C1234801E")).toBe(false);
+  });
+
+  test("rejects a 40-char physical-device UDID", () => {
+    expect(isIosSimulatorUdid("a".repeat(40))).toBe(false);
+  });
+
+  test("rejects malformed / empty / non-hex input", () => {
+    expect(isIosSimulatorUdid("")).toBe(false);
+    expect(isIosSimulatorUdid("not-a-uuid")).toBe(false);
+    // Wrong group lengths (7-4-4-4-12) and non-hex chars must not match.
+    expect(isIosSimulatorUdid("A1B2C3D-E5F6-7890-ABCD-EF1234567890")).toBe(false);
+    expect(isIosSimulatorUdid("G1B2C3D4-E5F6-7890-ABCD-EF1234567890")).toBe(false);
+  });
+
+  test("rejects a UUID with surrounding whitespace (anchored match)", () => {
+    expect(isIosSimulatorUdid(" A1B2C3D4-E5F6-7890-ABCD-EF1234567890 ")).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3580.

- **Terminate label:** relabel the physical-device flow **three-step** (resolve bundle path → find PID → kill) — the doc called it 'two-step' but lists 3 numbered `devicectl` commands (and the code docstring was likewise off).
- **DND flags:** clarify that `notifyutil -1 -s -g -p` are passed in **one combined `spawn` invocation** (`iosNotifyutilRegisteredSetReadPostCommand` in `notifyutil.ts`), not four separate shell calls — the sub-bullets now read as flags within a single command.
- **Test:** add `test/utils/ios-cmdline-tools/iosDeviceType.test.ts` — a table test pinning the 8-4-4-4-12 simulator-UUID accept case and the physical-device (`00008110-…`, 40-hex) and malformed reject cases for `isIosSimulatorUdid`, the simctl-vs-devicectl routing predicate that was only exercised indirectly. 5 tests pass.

Verified against `DeviceAppManager.ts`, `notifyutil.ts`, `iosDeviceType.ts`.

Part of the design-doc accuracy audit (#3565).