### PR TITLE
fix(sdk): register two filters so scheme-less broadcasts aren't dropped (#3597)

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileBroadcastInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileBroadcastInterceptor.kt
@@ -17,6 +17,12 @@ import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 internal object AutoMobileBroadcastInterceptor {
 
   /** Curated system broadcasts to intercept (avoids noise). */
+  // Package actions carry a `package:` data URI, so they must be matched by a
+  // filter that declares addDataScheme("package"). The other actions carry no
+  // data and must be matched by a scheme-less filter — a single filter with a
+  // data scheme fails the data test for them (#3597).
+  private val PACKAGE_ACTIONS = setOf(Intent.ACTION_PACKAGE_ADDED, Intent.ACTION_PACKAGE_REMOVED)
+
   private val MONITORED_ACTIONS =
     listOf(
       Intent.ACTION_LOCALE_CHANGED,
@@ -62,18 +68,37 @@ internal object AutoMobileBroadcastInterceptor {
 
     receiver = broadcastReceiver
 
-    val filter =
+    buildFilters().forEach { filter -> registerReceiver(context, broadcastReceiver, filter) }
+  }
+
+  /**
+   * Build the intent filters the interceptor registers. Two are needed: a scheme-less filter for
+   * the plain system actions and a `package`-scheme filter for the package add/remove actions,
+   * because a single filter declaring a data scheme fails the data test for scheme-less broadcasts
+   * (#3597).
+   */
+  internal fun buildFilters(): List<IntentFilter> {
+    val plainFilter =
       IntentFilter().apply {
-        MONITORED_ACTIONS.forEach { addAction(it) }
-        // Package events need data scheme
+        MONITORED_ACTIONS.filterNot { it in PACKAGE_ACTIONS }.forEach { addAction(it) }
+      }
+    val packageFilter =
+      IntentFilter().apply {
+        PACKAGE_ACTIONS.forEach { addAction(it) }
         addDataScheme("package")
       }
+    return listOf(plainFilter, packageFilter)
+  }
 
+  private fun registerReceiver(
+    context: Context,
+    receiver: BroadcastReceiver,
+    filter: IntentFilter,
+  ) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      context.registerReceiver(broadcastReceiver, filter, Context.RECEIVER_EXPORTED)
+      context.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
     } else {
-      @Suppress("UnspecifiedRegisterReceiverFlag")
-      context.registerReceiver(broadcastReceiver, filter)
+      @Suppress("UnspecifiedRegisterReceiverFlag") context.registerReceiver(receiver, filter)
     }
   }
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileBroadcastInterceptorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileBroadcastInterceptorTest.kt
@@ -1,0 +1,64 @@
+package dev.jasonpearson.automobile.sdk.os
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+class AutoMobileBroadcastInterceptorTest {
+
+  private val plainActions =
+    listOf(
+      Intent.ACTION_LOCALE_CHANGED,
+      Intent.ACTION_TIMEZONE_CHANGED,
+      Intent.ACTION_SCREEN_ON,
+      Intent.ACTION_SCREEN_OFF,
+      Intent.ACTION_USER_PRESENT,
+    )
+
+  private val packageActions = listOf(Intent.ACTION_PACKAGE_ADDED, Intent.ACTION_PACKAGE_REMOVED)
+
+  /**
+   * All seven monitored actions must be matched by a registered filter. Pre-fix a single filter
+   * declared addDataScheme("package"), so the five scheme-less actions failed the IntentFilter data
+   * test and were silently dropped (#3597).
+   */
+  @Test
+  fun `all seven monitored actions match a registered filter`() {
+    val filters = AutoMobileBroadcastInterceptor.buildFilters()
+    val resolver = RuntimeEnvironment.getApplication().contentResolver
+
+    for (action in plainActions) {
+      val intent = Intent(action) // scheme-less, as the real system broadcasts are
+      assertTrue(
+        "scheme-less action $action should match a registered filter",
+        filters.any { it.match(resolver, intent, false, "test") >= 0 },
+      )
+    }
+
+    for (action in packageActions) {
+      val intent = Intent(action).apply { data = Uri.parse("package:com.example.app") }
+      assertTrue(
+        "package action $action should match a registered filter",
+        filters.any { it.match(resolver, intent, false, "test") >= 0 },
+      )
+    }
+  }
+
+  /**
+   * The plain-action filter must declare no data scheme, or the scheme-less actions won't match.
+   */
+  @Test
+  fun `plain action filter has no data scheme`() {
+    val filters = AutoMobileBroadcastInterceptor.buildFilters()
+    val plainFilter = filters.first { !it.hasAction(Intent.ACTION_PACKAGE_ADDED) }
+    assertTrue("plain filter must not require a data scheme", plainFilter.countDataSchemes() == 0)
+  }
+}


### PR DESCRIPTION
## Summary
`AutoMobileBroadcastInterceptor` registered a single `IntentFilter` with `addDataScheme("package")`. Once a filter declares any data scheme, Android's data-test excludes intents that carry no data URI — so of the 7 `MONITORED_ACTIONS`, only `PACKAGE_ADDED`/`PACKAGE_REMOVED` (which carry a `package:` URI) ever matched. `LOCALE_CHANGED`, `TIMEZONE_CHANGED`, `SCREEN_ON`, `SCREEN_OFF`, and `USER_PRESENT` were silently dropped.

## Fix
Register **two** filters on the same receiver: a scheme-less filter for the plain system actions and a `package`-scheme filter for the package add/remove actions (`buildFilters()`). One `unregisterReceiver` still tears both down.

## Tests
- `all seven monitored actions match a registered filter` — verifies each of the 7 actions matches a filter via `IntentFilter.match` (scheme-less intents for the 5 plain actions, `package:` URI for the 2 package actions);
- `plain action filter has no data scheme`.

`:auto-mobile-sdk:testDebugUnitTest` green; ktfmt-clean.

Fixes #3597