### PR TITLE
docs(feature-flags): --ui-perf-mode is on-by-default, not an enable flag (#3583)

### DIFF
--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd>
 
-> **Current state:** Feature flags are implemented as CLI args (e.g., `--debug`, `--accessibility-audit`, `--ui-perf-mode`). IDE integration for runtime flag toggling is described in linked docs but is `<kbd>🚧 Design Only</kbd>` for Android Studio and Xcode. See the [Status Glossary](../status-glossary.md) for chip definitions.
+> **Current state:** Feature flags are implemented as CLI args (e.g., `--debug`, `--accessibility-audit`, `--mem-perf-audit`). IDE integration for runtime flag toggling is described in linked docs but is `<kbd>🚧 Design Only</kbd>` for Android Studio and Xcode. See the [Status Glossary](../status-glossary.md) for chip definitions.
 
 Runtime configuration system for experimental features, performance tuning, and debugging AutoMobile. At
 present these flags can only be set on MCP startup as CLI args. The plan is to have them configurable via IDE integrations for
@@ -16,7 +16,7 @@ present these flags can only be set on MCP startup as CLI args. The plan is to h
 
 ### Performance Flags
 
-**`--ui-perf-mode`** - Enable UI performance monitoring
+**`--no-ui-perf-mode`** - Disable UI performance monitoring. UI perf mode is **on by default** (`uiPerfMode = !args.includes("--no-ui-perf-mode")` in `src/index.ts`); there is no `--ui-perf-mode` enable flag — passing it has no effect since the mode is already on. Use `--no-ui-perf-mode` to turn off selection-state visual capture on taps and UI perf auditing.
 
 **`--mem-perf-audit`** - Memory performance auditing
 


### PR DESCRIPTION
Fixes #3583. Docs-only.

`src/index.ts:159` sets `uiPerfMode = !args.includes("--no-ui-perf-mode")` — UI perf mode is **on by default**, and only `--no-ui-perf-mode` has any effect; there is **no** `--ui-perf-mode` enable flag (passing it is a no-op). Replaced the 'Enable UI performance monitoring' entry with `--no-ui-perf-mode` (disable) and dropped `--ui-perf-mode` from the intro example.

Verified against `src/index.ts`.

Part of the design-doc accuracy audit (#3565).