### PR TITLE
docs(biometrics): document BiometricResult.Error.errorMessage (#3584)

### DIFF
--- a/docs/design-docs/plat/android/biometrics.md
+++ b/docs/design-docs/plat/android/biometrics.md
@@ -117,7 +117,10 @@ AutoMobileBiometrics.initialize(applicationContext)
 AutoMobileBiometrics.overrideResult(BiometricResult.Success, ttlMs = 5000L)
 AutoMobileBiometrics.overrideResult(BiometricResult.Failure)
 AutoMobileBiometrics.overrideResult(BiometricResult.Cancel)
+// Error carries an optional human-readable errorMessage (defaults to ""):
+//   data class Error(val errorCode: Int, val errorMessage: String = "")
 AutoMobileBiometrics.overrideResult(BiometricResult.Error(errorCode = 7))
+AutoMobileBiometrics.overrideResult(BiometricResult.Error(errorCode = 7, errorMessage = "Lockout"))
 
 // Clear a pending override (call in @Before test setup):
 AutoMobileBiometrics.clearOverride()


### PR DESCRIPTION
Part of #3584 (doc-clarity item). Docs-only.

`BiometricResult.Error` carries an optional `errorMessage` (`BiometricResult.kt:27-29` — `val errorMessage: String = ""`) that the integration pattern already uses (`override.errorMessage`), but the SDK-API example only showed `errorCode`. Added the field signature and an example override that sets it.

The doc is otherwise accurate. The remaining #3584 items — validate `biometricAuth` on an API 29 emulator and add an `emu finger` enrollment smoke test — require a **live Android emulator** and stay deferred (they can't be unit-tested).

Part of the design-doc accuracy audit (#3565).