### PR TITLE
test+docs(loading-awareness): enumerate loading-detector hints; note constants are compile-time (#3585)

### DIFF
--- a/docs/design-docs/mcp/loading-awareness.md
+++ b/docs/design-docs/mcp/loading-awareness.md
@@ -51,6 +51,10 @@ bounds, because neither alone is correct — this was the key finding from adver
   8. The floor guarantees we never poll fewer times than the previous implementation, so the
   change is **never less patient** than before, in any fetch-speed regime.
 
+These are compile-time `private static readonly` fields on `TapOnElement` — they
+are **not** environment-tunable at runtime (there is no `process.env` override
+path; the `ANDROID_PRE_TAP_*` names are constant identifiers, not env vars).
+
 | | base | when loading detected |
 |---|---|---|
 | `ANDROID_PRE_TAP_REFIND_BUDGET_MS` | 2500 ms | 10000 ms |

--- a/test/utils/androidTransientLoading.test.ts
+++ b/test/utils/androidTransientLoading.test.ts
@@ -38,4 +38,56 @@ describe("androidViewHierarchyIndicatesLikelyBlockingLoading", () => {
     });
     expect(androidViewHierarchyIndicatesLikelyBlockingLoading(h, parser)).toBe(false);
   });
+
+  // Enumerate every resource-id hint the detector matches
+  // (RESOURCE_ID_LOADING_HINT), so the surface can't silently narrow.
+  const RESOURCE_ID_HINTS = [
+    "progress_bar",
+    "loading_indicator",
+    "progress_indicator",
+    "shimmer",
+    "content_loading",
+  ];
+  test.each(RESOURCE_ID_HINTS)("true when resource-id contains %s", hint => {
+    const h = hierarchyWithNode({
+      "resource-id": `com.app:id/${hint}`,
+      "class": "android.view.View",
+      "bounds": { left: 0, top: 0, right: 10, bottom: 10 }
+    });
+    expect(androidViewHierarchyIndicatesLikelyBlockingLoading(h, parser)).toBe(true);
+  });
+
+  // Enumerate every class hint (CLASS_LOADING_HINT).
+  const CLASS_HINTS = [
+    "android.widget.ProgressBar",
+    "com.google.android.material.progressindicator.CircularProgressIndicator",
+    "com.facebook.shimmer.ShimmerFrameLayout",
+    "androidx.core.widget.ContentLoadingProgressBar",
+  ];
+  test.each(CLASS_HINTS)("true for loading class %s", className => {
+    const h = hierarchyWithNode({
+      class: className,
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 }
+    });
+    expect(androidViewHierarchyIndicatesLikelyBlockingLoading(h, parser)).toBe(true);
+  });
+
+  test("hints are case-insensitive", () => {
+    const h = hierarchyWithNode({
+      "resource-id": "com.app:id/LOADING_INDICATOR",
+      "class": "android.view.View",
+      "bounds": { left: 0, top: 0, right: 10, bottom: 10 }
+    });
+    expect(androidViewHierarchyIndicatesLikelyBlockingLoading(h, parser)).toBe(true);
+  });
+
+  test("ProgressBar class hint is anchored - a mid-string match does not trip it", () => {
+    // CLASS_LOADING_HINT uses `ProgressBar$`, so a class that merely contains
+    // "ProgressBar" but does not end with it (and matches no other hint) is false.
+    const h = hierarchyWithNode({
+      class: "com.app.ProgressBarWidget",
+      bounds: { left: 0, top: 0, right: 10, bottom: 10 }
+    });
+    expect(androidViewHierarchyIndicatesLikelyBlockingLoading(h, parser)).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes #3585. The doc was accurate — these are the minor follow-ups.

- **`androidTransientLoading.test.ts`:** the detector matches 5 resource-id hints (`progress_bar`/`loading_indicator`/`progress_indicator`/`shimmer`/`content_loading`) and 4 class hints (`ProgressBar$`/`ProgressIndicator`/`ShimmerFrameLayout`/`ContentLoadingProgressBar`), but only 1 of each was tested. Added table tests for **every** hint, a case-insensitivity check, and a guard that the anchored `ProgressBar$` class hint doesn't trip on a mid-string match (`ProgressBarWidget` → false). **14 tests pass.**
- **`loading-awareness.md`:** noted the `ANDROID_PRE_TAP_*` budgets are compile-time `private static readonly` constants, **not** env-tunable — preempts readers expecting a runtime override.

Verified against `androidTransientLoading.ts`, `TapOnElement.ts`.

Part of the design-doc accuracy audit (#3565).