### PR TITLE
fix(junit-runner): read the correct system property for the MCP server URL (#3596)

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -891,7 +891,10 @@ open class AutoMobileAgent(
     }
 
     override fun getMcpServerUrl(): String {
-      return System.getProperty("automobile:localhost:3000")
+      // The URL was mistakenly passed as the property NAME (1-arg getProperty),
+      // which is never set, so this returned null and AI recovery could never
+      // connect to the MCP server (#3596). Use the 2-arg form with the URL default.
+      return System.getProperty("automobile.mcp.server.url", "http://localhost:3000")
     }
   }
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DefaultConfigProviderTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DefaultConfigProviderTest.kt
@@ -1,0 +1,36 @@
+package dev.jasonpearson.automobile.junit
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class DefaultConfigProviderTest {
+
+  @AfterEach
+  fun tearDown() {
+    System.clearProperty("automobile.mcp.server.url")
+  }
+
+  /**
+   * Pre-fix, getMcpServerUrl() passed the URL as the property NAME (1-arg getProperty), so it
+   * returned null and AI recovery could never connect (#3596). It must return the default URL when
+   * the property is unset.
+   */
+  @Test
+  fun `getMcpServerUrl returns the default url when the property is unset`() {
+    System.clearProperty("automobile.mcp.server.url")
+    assertEquals(
+      "http://localhost:3000",
+      AutoMobileAgent.DefaultConfigProvider().getMcpServerUrl(),
+    )
+  }
+
+  @Test
+  fun `getMcpServerUrl returns the override when the property is set`() {
+    System.setProperty("automobile.mcp.server.url", "http://10.0.0.5:9000")
+    assertEquals(
+      "http://10.0.0.5:9000",
+      AutoMobileAgent.DefaultConfigProvider().getMcpServerUrl(),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
`AutoMobileAgent.DefaultConfigProvider.getMcpServerUrl()` called `System.getProperty("automobile:localhost:3000")` — the intended default URL was passed as the property **name** (1-arg `getProperty`), which is never set, so it returned `null`. `attemptAiRecovery` then handed `null` to `mcpClient.connect(...)`, failing every AI-recovery connect with "Failed to connect ... at null". (This is item 2 of #541, which was closed but the defect is still present.)

## Fix
Use the 2-arg form with the URL as the default, matching every sibling getter in the class:
```kotlin
System.getProperty("automobile.mcp.server.url", "http://localhost:3000")
```

## Tests
Added `DefaultConfigProviderTest` asserting the default URL when the property is unset and the override when it's set.

**Note on local execution:** this module's `:junit-runner:test` does not execute `AutoMobileAgent`-scoped test classes in a plain local checkout (the pre-existing `AutoMobileAgentTest` is likewise not run locally — both load `AutoMobileAgent`, whose `ai.koog` deps don't resolve for class-loading here). The new test compiles cleanly (`compileTestKotlin` passes) and runs where `ai.koog` resolves (CI). The fix itself is a one-line correctness change verifiable by inspection.

Fixes #3596