### PR TITLE
test+docs(fs-contract): pin 0o700 base-dir mode; fix uncited #2453 reference (#3586)

### DIFF
--- a/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
+++ b/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
@@ -139,7 +139,9 @@ run **one daemon per user** (each gets its own `<uid>` paths automatically).
   one client wins the start, the rest `waitForReady`.
 - The daemon is spawned via the resolved entry script, falling back to
   `bunx -y @kaeawc/auto-mobile@<pinned-version>` (`resolveDaemonLaunchCommand`).
-  The version is **pinned**, not `@latest` (fixed in #2453), so parallel
+  The version is **pinned**, not `@latest` (see `resolveDaemonLaunchCommand` in
+  `src/daemon/manager.ts` — `@kaeawc/auto-mobile@<version>`; the comment there
+  notes `@latest` is not an installable npm tag, so `bunx` must pin), so parallel
   bunx-spawned starts resolve to the same package and the bun install cache is
   not raced across versions. The lock means at most one bunx spawn happens
   anyway. For fully deterministic prod, install the package globally / ship the

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -71,7 +71,9 @@ describe("getTempDir", () => {
 });
 
 describe("ensureSecureTempDirSync", () => {
-  test("creates the directory with restrictive 0o700 permissions", () => {
+  // POSIX-only: Windows does not honor Unix permission bits, so mkdir's `mode`
+  // is ignored and `fs.statSync().mode` does not report 0o700 there.
+  test.skipIf(process.platform === "win32")("creates the directory with restrictive 0o700 permissions", () => {
     // The single-user isolation guarantee in the multi-agent filesystem contract
     // rests on the base dir being mode 0o700; pin it.
     const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-mode-test-"));

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { resolveAutoMobileBaseDir, getTempDir, TEMP_SUBDIRS } from "../../src/utils/tempDir";
+import {
+  resolveAutoMobileBaseDir,
+  getTempDir,
+  ensureSecureTempDirSync,
+  TEMP_SUBDIRS,
+} from "../../src/utils/tempDir";
 
 describe("resolveAutoMobileBaseDir", () => {
   const home = "/home/tester";
@@ -61,5 +67,29 @@ describe("getTempDir", () => {
     const logs = getTempDir(TEMP_SUBDIRS.LOGS);
     const base = resolveAutoMobileBaseDir();
     expect(logs).toBe(path.join(base, TEMP_SUBDIRS.LOGS));
+  });
+});
+
+describe("ensureSecureTempDirSync", () => {
+  test("creates the directory with restrictive 0o700 permissions", () => {
+    // The single-user isolation guarantee in the multi-agent filesystem contract
+    // rests on the base dir being mode 0o700; pin it.
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-mode-test-"));
+    const prev = process.env.AUTOMOBILE_DATA_DIR;
+    process.env.AUTOMOBILE_DATA_DIR = tmpBase;
+    try {
+      const dir = ensureSecureTempDirSync("mode-check");
+      // On POSIX, 0o700 survives a typical umask (022) because it sets no
+      // group/other bits; assert the created dir's permission bits are exactly 0o700.
+      const mode = fs.statSync(dir).mode & 0o777;
+      expect(mode).toBe(0o700);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AUTOMOBILE_DATA_DIR;
+      } else {
+        process.env.AUTOMOBILE_DATA_DIR = prev;
+      }
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #3586. The doc was accurate — these are the minor follow-ups.

- **`dataDir.test.ts`:** assert `ensureSecureTempDirSync` creates the directory with exactly **0o700** permissions (`SECURE_DIR_MODE`). The single-user isolation guarantee in the multi-agent filesystem contract rests on this, and only path resolution was previously tested. Uses an `AUTOMOBILE_DATA_DIR` temp override, restored in `finally`. **10 tests pass.**
- **`multi-agent-filesystem-contract.md`:** the bunx version-pin was cited as 'fixed in #2453', but #2453 is *'Fix daemon version mismatch handling'* — not clearly the pin fix, and uncited in code. Replaced the citation with a pointer to `resolveDaemonLaunchCommand` in `src/daemon/manager.ts` (which carries the explanatory comment that `@latest` is not an installable npm tag).

Verified against `tempDir.ts`, `manager.ts`, issue #2453.

Part of the design-doc accuracy audit (#3565).