### PR TITLE
fix(junit-runner): surface DaemonUnavailableException on daemon disconnect (#3598)

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -15,6 +15,7 @@ import java.security.MessageDigest
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
@@ -979,12 +980,7 @@ internal class DaemonSocketClient(
 
     sendRequest(request)
 
-    return try {
-      responseFuture.get(timeoutMs, TimeUnit.MILLISECONDS)
-    } catch (e: TimeoutException) {
-      pending.remove(requestId)
-      throw DaemonUnavailableException("Daemon request timeout after ${timeoutMs}ms")
-    }
+    return awaitResponse(requestId, responseFuture, timeoutMs)
   }
 
   override fun readResource(uri: String, timeoutMs: Long): DaemonResponse {
@@ -1010,12 +1006,7 @@ internal class DaemonSocketClient(
 
     sendRequest(request)
 
-    return try {
-      responseFuture.get(timeoutMs, TimeUnit.MILLISECONDS)
-    } catch (e: TimeoutException) {
-      pending.remove(requestId)
-      throw DaemonUnavailableException("Daemon request timeout after ${timeoutMs}ms")
-    }
+    return awaitResponse(requestId, responseFuture, timeoutMs)
   }
 
   fun callDaemonMethod(
@@ -1044,11 +1035,33 @@ internal class DaemonSocketClient(
 
     sendRequest(request)
 
+    return awaitResponse(requestId, responseFuture, timeoutMs)
+  }
+
+  /**
+   * Await a pending daemon response, translating failure modes into [DaemonUnavailableException] so
+   * callers' retry/fallback can catch them, and always removing the pending entry (#3598).
+   *
+   * `failPendingRequests` completes the future with a [DaemonUnavailableException] when the read
+   * loop dies; `future.get` then rethrows it wrapped in an [ExecutionException], so we unwrap it
+   * here.
+   */
+  private fun awaitResponse(
+    requestId: String,
+    responseFuture: CompletableFuture<DaemonResponse>,
+    timeoutMs: Long,
+  ): DaemonResponse {
     return try {
       responseFuture.get(timeoutMs, TimeUnit.MILLISECONDS)
     } catch (e: TimeoutException) {
+      throw mapAwaitFailure(e, timeoutMs)
+    } catch (e: ExecutionException) {
+      throw mapAwaitFailure(e, timeoutMs)
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+      throw mapAwaitFailure(e, timeoutMs)
+    } finally {
       pending.remove(requestId)
-      throw DaemonUnavailableException("Daemon request timeout after ${timeoutMs}ms")
     }
   }
 
@@ -1132,6 +1145,28 @@ internal class DaemonSocketClient(
   }
 
   companion object {
+    /**
+     * Translate a [responseFuture.get] failure into a [DaemonUnavailableException] so callers'
+     * retry/fallback (which catch that type) work. A disconnect surfaces as an [ExecutionException]
+     * wrapping the [DaemonUnavailableException] that `failPendingRequests` set — unwrap it rather
+     * than leaking the opaque wrapper (#3598).
+     */
+    internal fun mapAwaitFailure(e: Throwable, timeoutMs: Long): DaemonUnavailableException =
+      when (e) {
+        is TimeoutException ->
+          DaemonUnavailableException("Daemon request timeout after ${timeoutMs}ms")
+        is ExecutionException -> {
+          val cause = e.cause
+          (cause as? DaemonUnavailableException)
+            ?: DaemonUnavailableException(
+              "Daemon request failed: ${cause?.message ?: e.message}",
+              cause,
+            )
+        }
+        is InterruptedException -> DaemonUnavailableException("Daemon request interrupted")
+        else -> DaemonUnavailableException("Daemon request failed: ${e.message}", e)
+      }
+
     fun isAvailable(socketPath: String): Boolean {
       return try {
         val client = DaemonSocketClient(socketPath)
@@ -1189,7 +1224,8 @@ internal interface DaemonToolClient {
   var sessionUuid: String
 }
 
-internal class DaemonUnavailableException(message: String) : Exception(message)
+internal class DaemonUnavailableException(message: String, cause: Throwable? = null) :
+  Exception(message, cause)
 
 /** Interface for checking daemon connectivity. Allows for easy testing with fakes. */
 internal interface DaemonConnectivityChecker {

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClientMapAwaitFailureTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClientMapAwaitFailureTest.kt
@@ -1,0 +1,45 @@
+package dev.jasonpearson.automobile.junit
+
+import java.io.IOException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DaemonSocketClientMapAwaitFailureTest {
+
+  @Test
+  fun `timeout maps to a DaemonUnavailableException`() {
+    val mapped = DaemonSocketClient.mapAwaitFailure(TimeoutException(), 1500)
+    assertTrue(mapped.message!!.contains("timeout"))
+    assertTrue(mapped.message!!.contains("1500"))
+  }
+
+  /**
+   * A daemon disconnect completes the future with a DaemonUnavailableException, which future.get
+   * rethrows wrapped in an ExecutionException. It must be unwrapped so callers that catch
+   * DaemonUnavailableException see it (#3598) — pre-fix only TimeoutException was caught.
+   */
+  @Test
+  fun `execution exception wrapping DaemonUnavailableException is unwrapped`() {
+    val original = DaemonUnavailableException("read loop died")
+    val mapped = DaemonSocketClient.mapAwaitFailure(ExecutionException(original), 1000)
+    assertSame(original, mapped) // same instance, not a new opaque wrapper
+  }
+
+  @Test
+  fun `execution exception with another cause becomes DaemonUnavailableException with that cause`() {
+    val cause = IOException("socket closed")
+    val mapped = DaemonSocketClient.mapAwaitFailure(ExecutionException(cause), 1000)
+    assertSame(cause, mapped.cause)
+    assertTrue(mapped.message!!.contains("socket closed"))
+  }
+
+  @Test
+  fun `interruption maps to a DaemonUnavailableException`() {
+    val mapped = DaemonSocketClient.mapAwaitFailure(InterruptedException(), 1000)
+    assertEquals("Daemon request interrupted", mapped.message)
+  }
+}


### PR DESCRIPTION
## Summary
`callTool`/`readResource`/`callDaemonMethod` caught only `TimeoutException` around `responseFuture.get(...)`. When the read loop dies (socket closed / daemon crash mid-request), `failPendingRequests` completes the future via `completeExceptionally(DaemonUnavailableException)`, and `get()` rethrows that wrapped in a `java.util.concurrent.ExecutionException` — so callers that catch `DaemonUnavailableException` (the whole reason the type exists) miss it and retry/fallback breaks.

## Fix
Route all three call sites through a shared `awaitResponse` that:
- unwraps `ExecutionException` (rethrows the `DaemonUnavailableException` cause, or wraps other causes),
- handles `InterruptedException` (restores the interrupt),
- always removes the `pending` entry in a `finally`.

Adds a `(message, cause)` overload to `DaemonUnavailableException`. The exception-mapping logic is extracted to a pure `mapAwaitFailure` so it's unit-testable without a live socket.

## Tests (JUnit 4, matching the module's other runnable tests)
- timeout → `DaemonUnavailableException`;
- `ExecutionException` wrapping a `DaemonUnavailableException` → **same instance** unwrapped;
- `ExecutionException` with another cause → `DaemonUnavailableException` preserving that cause;
- interruption → `DaemonUnavailableException`.

`:junit-runner:test` runs them (the 2 unrelated failures are `@RunWith(AutoMobileRunner)` device suites needing an emulator).

Fixes #3598