### PR TITLE
fix(junit-runner): pace WaitForTool between attempts on error (#3606)

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -645,11 +645,16 @@ open class AutoMobileAgent(
           if (args.elementId != null && observeResult.contains(args.elementId)) {
             return "Element with ID '${args.elementId}' found"
           }
-
-          Thread.sleep(500) // Wait 500ms before checking again
         } catch (e: Exception) {
-          // Continue waiting if there's an error
+          // Log instead of swallowing; keep polling after a transient observe failure.
+          println("Warning: waitFor observe failed, will retry: ${e.message}")
         }
+
+        // Pace between attempts on BOTH the no-match and error paths. Previously the
+        // sleep sat inside the try above the throw, so a throwing observe skipped it
+        // and the loop busy-spun the daemon for the whole timeout window (#3606).
+        // A successful match returns from inside the try and never reaches here.
+        Thread.sleep(500)
       }
 
       val target = args.text ?: args.elementId ?: "unknown"

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolBackoffTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/WaitForToolBackoffTest.kt
@@ -1,0 +1,49 @@
+package dev.jasonpearson.automobile.junit
+
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class WaitForToolBackoffTest {
+
+  private class ThrowingClient(val calls: AtomicInteger) : AutoMobileAgent.MCPClient {
+    override fun isConnected(): Boolean = true
+
+    override fun connect(serverUrl: String) {}
+
+    override fun disconnect() {}
+
+    override fun callTool(toolName: String, parameters: Map<String, Any>): String {
+      calls.incrementAndGet()
+      throw RuntimeException("observe failed")
+    }
+
+    override fun listAvailableTools(): List<AutoMobileAgent.MCPToolDefinition> = emptyList()
+  }
+
+  /**
+   * When observe throws, the loop must still pace between attempts. Pre-fix the Thread.sleep sat
+   * inside the try above the throw, so a throwing observe skipped it and the loop busy-spun the
+   * daemon for the whole timeout window (#3606).
+   */
+  @Test
+  fun `throwing observe does not busy-spin the daemon`() = runBlocking {
+    val calls = AtomicInteger(0)
+    val tool = AutoMobileAgent.WaitForTool(ThrowingClient(calls))
+
+    val start = System.currentTimeMillis()
+    try {
+      tool.execute(AutoMobileAgent.WaitForTool.Args(text = "hello", timeout = 1100))
+      fail("expected a timeout")
+    } catch (e: RuntimeException) {
+      assertTrue(e.message!!.contains("Timeout"))
+    }
+    val elapsed = System.currentTimeMillis() - start
+
+    // With ~500ms pacing over an ~1100ms window this is a handful of attempts; a
+    // busy-spin would be thousands.
+    assertTrue("busy-spun: ${calls.get()} calls in ${elapsed}ms", calls.get() in 1..8)
+  }
+}


### PR DESCRIPTION
## Summary
`WaitForTool.execute` polled `observe` in a loop with `Thread.sleep(500)` **inside the try, above the throw**. When `callTool("observe", ...)` threw, control jumped to the empty `catch` and skipped the sleep, so the `while` loop re-hammered `callTool` with zero delay for the whole timeout window — a tight spin against the daemon during exactly the failure it should back off from. The catch was also silent.

## Fix
Move `Thread.sleep(500)` below the try/catch so it paces between attempts on both the no-match and error paths (a successful match still `return`s from inside the try, so it isn't delayed). Log the previously-silent catch (`println("Warning: ...")`, matching the class's logging idiom).

## Tests (JUnit 4)
- `throwing observe does not busy-spin the daemon` — a client whose `observe` always throws; over a ~1100ms window the loop makes only a handful of attempts (1..8) instead of thousands, and still throws the timeout at the end.

`:junit-runner:test` runs it (PASSED); the 2 unrelated failures are device suites needing an emulator.

Fixes #3606