### PR TITLE
fix(control-proxy): emit HierarchyResult.Error on extraction failure (#3608)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncer.kt
@@ -302,55 +302,57 @@ class HierarchyDebouncer(
       perfProvider.endOperation("extractHierarchy")
 
       if (hierarchy == null) {
+        // Set the Error and fall through to the emit below. A `return` here would
+        // unwind through `finally` and exit the function, skipping the emit block
+        // so consumers never saw the Error (#3608).
         resultToEmit = HierarchyResult.Error("Failed to extract hierarchy")
-        return
-      }
-
-      val extractionTime = timeProvider.currentTimeMillis() - startTime
-
-      perfProvider.startOperation("computeHash")
-      val structuralHash = StructuralHasher.computeHash(hierarchy)
-      perfProvider.endOperation("computeHash")
-
-      if (structuralHash == lastStructuralHash) {
-        // Structure unchanged - likely animation
-        // Enter animation mode to skip subsequent events
-        inAnimationMode = true
-        animationModeEndTime = timeProvider.currentTimeMillis() + animationSkipWindowMs
-
-        resultToEmit =
-          HierarchyResult.Unchanged(
-            hierarchy = hierarchy,
-            hash = structuralHash,
-            extractionTimeMs = extractionTime,
-            skippedEventCount = skippedEventCount,
-          )
-        hierarchyToCache = hierarchy
-
-        Log.d(
-          TAG,
-          "Structure unchanged (hash=$structuralHash), entering animation mode for ${animationSkipWindowMs}ms",
-        )
-
-        // Reset skipped count
-        skippedEventCount = 0
       } else {
-        // Structure changed - this is a real content change
-        val oldHash = lastStructuralHash
-        inAnimationMode = false
-        lastStructuralHash = structuralHash
+        val extractionTime = timeProvider.currentTimeMillis() - startTime
 
-        resultToEmit =
-          HierarchyResult.Changed(
-            hierarchy = hierarchy,
-            hash = structuralHash,
-            extractionTimeMs = extractionTime,
+        perfProvider.startOperation("computeHash")
+        val structuralHash = StructuralHasher.computeHash(hierarchy)
+        perfProvider.endOperation("computeHash")
+
+        if (structuralHash == lastStructuralHash) {
+          // Structure unchanged - likely animation
+          // Enter animation mode to skip subsequent events
+          inAnimationMode = true
+          animationModeEndTime = timeProvider.currentTimeMillis() + animationSkipWindowMs
+
+          resultToEmit =
+            HierarchyResult.Unchanged(
+              hierarchy = hierarchy,
+              hash = structuralHash,
+              extractionTimeMs = extractionTime,
+              skippedEventCount = skippedEventCount,
+            )
+          hierarchyToCache = hierarchy
+
+          Log.d(
+            TAG,
+            "Structure unchanged (hash=$structuralHash), entering animation mode for ${animationSkipWindowMs}ms",
           )
-        hierarchyToCache = hierarchy
 
-        Log.d(TAG, "Structure changed (oldHash=$oldHash, newHash=$structuralHash)")
+          // Reset skipped count
+          skippedEventCount = 0
+        } else {
+          // Structure changed - this is a real content change
+          val oldHash = lastStructuralHash
+          inAnimationMode = false
+          lastStructuralHash = structuralHash
 
-        skippedEventCount = 0
+          resultToEmit =
+            HierarchyResult.Changed(
+              hierarchy = hierarchy,
+              hash = structuralHash,
+              extractionTimeMs = extractionTime,
+            )
+          hierarchyToCache = hierarchy
+
+          Log.d(TAG, "Structure changed (oldHash=$oldHash, newHash=$structuralHash)")
+
+          skippedEventCount = 0
+        }
       }
     } finally {
       // End perf block BEFORE emit to prevent nesting if emit suspends

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncerErrorEmitTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncerErrorEmitTest.kt
@@ -1,0 +1,33 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HierarchyDebouncerErrorEmitTest {
+
+  /**
+   * When extraction fails (returns null), a HierarchyResult.Error must be emitted on the flow.
+   * Pre-fix an early `return` inside the try skipped the post-finally emit, so consumers never saw
+   * the Error (#3608).
+   */
+  @Test
+  fun `extraction failure emits an Error on the flow`() {
+    val debouncer =
+      HierarchyDebouncer(
+        scope = CoroutineScope(Dispatchers.Unconfined),
+        extractHierarchy = { _: Boolean -> null as ViewHierarchy? }, // force failure
+      )
+
+    debouncer.extractNowBlocking()
+
+    val last = debouncer.hierarchyFlow.replayCache.lastOrNull()
+    assertTrue("expected a HierarchyResult.Error, got $last", last is HierarchyResult.Error)
+    assertTrue((last as HierarchyResult.Error).message.contains("Failed to extract"))
+  }
+}


### PR DESCRIPTION
## Summary
In `HierarchyDebouncer.extractAndCompare`, when `extractHierarchy` returns null the code built `resultToEmit = HierarchyResult.Error(...)` and then `return`ed **inside the try**. The `return` unwinds through `finally` and exits the function, skipping the post-`finally` emit block — so consumers on `hierarchyFlow` never see the `Error`. (Impact is a lost diagnostic: the sole consumer only logs a warning, and the request_hierarchy failure path is separately covered by error frames.)

## Fix
Wrap the success path in an `else` so the null case sets the `Error` and **falls through** to the emit instead of returning.

## Tests
- `extraction failure emits an Error on the flow` — injects `extractHierarchy = { null }`, runs `extractNowBlocking()`, and asserts `hierarchyFlow`'s replay cache holds a `HierarchyResult.Error`.

`:control-proxy:testDebugUnitTest` fully green; ktfmt-clean.

Fixes #3608