### PR TITLE
fix(junit-runner): actionable error for null tools/list result (#3607)

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -420,17 +420,23 @@ open class AutoMobileAgent(
         }
 
         val mcpResponse = koogJson.decodeFromString<MCPResponse>(response.body())
-
-        if (mcpResponse.error != null) {
-          throw RuntimeException("MCP server error: ${mcpResponse.error}")
-        }
-
-        val listResponse =
-          koogJson.decodeFromString<MCPListToolsResponse>(mcpResponse.result!!.toString())
-        return listResponse.tools
+        return parseListToolsResponse(mcpResponse)
       } catch (e: Exception) {
         throw RuntimeException("Failed to list MCP tools: ${e.message}", e)
       }
+    }
+
+    /**
+     * Parse a tools/list MCP response. A well-formed response with no `error` but a null/absent
+     * `result` previously hit `result!!` and produced a misleading `... null` NPE; report an
+     * actionable message instead (#3607).
+     */
+    internal fun parseListToolsResponse(mcpResponse: MCPResponse): List<MCPToolDefinition> {
+      if (mcpResponse.error != null) {
+        throw RuntimeException("MCP server error: ${mcpResponse.error}")
+      }
+      val result = mcpResponse.result ?: throw RuntimeException("MCP tools/list returned no result")
+      return koogJson.decodeFromString<MCPListToolsResponse>(result.toString()).tools
     }
 
     private fun buildJsonParameters(parameters: Map<String, Any>): JsonObject = buildJsonObject {

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/ParseListToolsResponseTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/ParseListToolsResponseTest.kt
@@ -1,0 +1,43 @@
+package dev.jasonpearson.automobile.junit
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ParseListToolsResponseTest {
+
+  private val client = AutoMobileAgent.DefaultMCPClient()
+
+  /**
+   * A well-formed response with no error but a null result must produce an actionable message, not
+   * a misleading NPE from `result!!` (#3607).
+   */
+  @Test
+  fun `null result throws an actionable error`() {
+    try {
+      client.parseListToolsResponse(AutoMobileAgent.MCPResponse(result = null, error = null))
+      fail("expected an exception")
+    } catch (e: RuntimeException) {
+      assertTrue("message was: ${e.message}", e.message!!.contains("no result"))
+    }
+  }
+
+  @Test
+  fun `an error field is surfaced`() {
+    try {
+      client.parseListToolsResponse(AutoMobileAgent.MCPResponse(error = JsonPrimitive("boom")))
+      fail("expected an exception")
+    } catch (e: RuntimeException) {
+      assertTrue("message was: ${e.message}", e.message!!.contains("boom"))
+    }
+  }
+
+  @Test
+  fun `a valid result parses to the tools list`() {
+    val result = Json.parseToJsonElement("""{"tools":[]}""")
+    val tools = client.parseListToolsResponse(AutoMobileAgent.MCPResponse(result = result))
+    assertTrue(tools.isEmpty())
+  }
+}


### PR DESCRIPTION
## Summary
`DefaultMCPClient.listAvailableTools` force-unwrapped `mcpResponse.result!!`. A well-formed `tools/list` response with no `error` but a null/absent `result` therefore threw an NPE, which the surrounding catch rewrapped to `Failed to list MCP tools: null` — no actionable detail.

## Fix
Extract `parseListToolsResponse(mcpResponse)`, which surfaces an `error` field, then uses an elvis (`?: throw RuntimeException("MCP tools/list returned no result")`) instead of `!!`, then decodes the tools.

## Tests (JUnit 4)
- null result → "...no result" (not an NPE);
- `error` field is surfaced;
- a valid `{"tools":[]}` result parses.

`:junit-runner:test` runs them (PASSED); the 2 unrelated failures are device suites needing an emulator.

Fixes #3607