### PR TITLE
fix(scripts): exact PID exclusion, bash 3.2 mapfile, independent idle flags (#3654)

### DIFF
--- a/scripts/avd_experiments.sh
+++ b/scripts/avd_experiments.sh
@@ -34,9 +34,12 @@ create_log="${scratch_dir}/avdmanager-create-${start_api}-${end_api}.log"
 echo "Listing system images..." | tee "$list_log"
 "$sdkmanager" --list | tee -a "$list_log"
 
-mapfile -t available_packages < <(
-  rg -o "system-images;android-[0-9]+;${tag};${abi}" "$list_log" | sort -u
-)
+# `mapfile` is a bash 4+ builtin absent from macOS's default bash 3.2; use a
+# portable while-read loop so this doesn't abort under `set -e` (#3654).
+available_packages=()
+while IFS= read -r pkg_line; do
+  available_packages+=("$pkg_line")
+done < <(rg -o "system-images;android-[0-9]+;${tag};${abi}" "$list_log" | sort -u)
 
 declare -a requested_packages=()
 for api in $(seq "$start_api" "$end_api"); do

--- a/scripts/await_idle.sh
+++ b/scripts/await_idle.sh
@@ -266,11 +266,16 @@ wait_for_process_idle() {
             return 1
         fi
 
-        # Check if device is process idle
-        local idle_output
-        idle_output=$($ADB_CMD shell dumpsys activity | grep -cE "mSleeping=false|mBooted=true|mBooting=false")
+        # Check if device is process idle. Test each flag independently: a single
+        # `grep -c` counts matching LINES, not distinct conditions (all three flags
+        # can share one line -> 1, or repeat -> >3), and a zero-match `grep -c`
+        # exits 1 which aborts the script under `set -euo pipefail` (#3654).
+        local dumpsys_output
+        dumpsys_output=$($ADB_CMD shell dumpsys activity)
 
-        if [ "$idle_output" -eq 3 ]; then
+        if echo "$dumpsys_output" | grep -q "mSleeping=false" &&
+            echo "$dumpsys_output" | grep -q "mBooted=true" &&
+            echo "$dumpsys_output" | grep -q "mBooting=false"; then
             echo "Device is process idle"
             return 0
         fi

--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -204,13 +204,13 @@ kill_previous() {
   fi
 
   local pids
-  pids=$(pgrep -f "hot-reload.sh" 2>/dev/null | grep -v "$$" || true)
+  pids=$(pgrep -f "hot-reload.sh" 2>/dev/null | grep -vxF "$$" || true)
   if [[ -n "${pids}" ]]; then
     log_info "Killing orphaned hot-reload processes..."
     echo "${pids}" | xargs kill 2>/dev/null || true
     sleep 1
     # Force kill if still running
-    pids=$(pgrep -f "hot-reload.sh" 2>/dev/null | grep -v "$$" || true)
+    pids=$(pgrep -f "hot-reload.sh" 2>/dev/null | grep -vxF "$$" || true)
     if [[ -n "${pids}" ]]; then
       log_warn "Force killing orphaned hot-reload processes..."
       echo "${pids}" | xargs kill -9 2>/dev/null || true

--- a/test/bats/shell-latent-fixes-3654.bats
+++ b/test/bats/shell-latent-fixes-3654.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+#
+# Regression guards for the latent shell bugs fixed in #3654:
+#   - hot-reload.sh excluded the current PID by substring (grep -v) instead of
+#     exact match, sparing orphans whose PID contained the self PID's digits.
+#   - avd_experiments.sh used the bash-4 `mapfile` builtin, aborting under the
+#     macOS default bash 3.2.
+#   - await_idle.sh gated process-idle on `grep -c ... -eq 3`, which counts
+#     matching LINES (not distinct flags) and aborts under set -e on zero match.
+
+HOT_RELOAD="scripts/local-dev/hot-reload.sh"
+AVD="scripts/avd_experiments.sh"
+AWAIT_IDLE="scripts/await_idle.sh"
+
+# --- hot-reload.sh: exact PID exclusion -------------------------------------
+
+@test "hot-reload self-PID exclusion is exact, not substring" {
+  # The fix uses `grep -vxF "\$\$"`; the old `grep -v "\$\$"` matched substrings.
+  grep -q 'grep -vxF "\$\$"' "$HOT_RELOAD"
+  ! grep -qE 'pgrep -f "hot-reload.sh"[^|]*\| *grep -v "\$\$"' "$HOT_RELOAD"
+}
+
+@test "grep -vxF excludes only the exact self PID" {
+  # self=456: orphans 4560 and 3456 must NOT be excluded.
+  run bash -c 'printf "456\n4560\n3456\n" | grep -vxF 456'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf "4560\n3456")" ]
+}
+
+# --- avd_experiments.sh: no bash-4 mapfile ----------------------------------
+
+@test "avd_experiments does not use the bash-4 mapfile builtin" {
+  ! grep -qE '^\s*mapfile\b' "$AVD"
+}
+
+@test "avd_experiments parses under macOS default bash 3.2" {
+  # The array-populating loop must run under bash 3.2 (/bin/bash on macOS).
+  run /bin/bash -c 'a=(); while IFS= read -r x; do a+=("$x"); done < <(printf "p1\np2\n"); echo "${#a[@]}:${a[0]}"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "2:p1" ]
+}
+
+# --- await_idle.sh: independent flag checks ---------------------------------
+
+@test "await_idle no longer uses grep -c for the idle flags" {
+  ! grep -q 'grep -cE "mSleeping=false' "$AWAIT_IDLE"
+}
+
+@test "await_idle checks each idle flag independently" {
+  grep -q 'grep -q "mSleeping=false"' "$AWAIT_IDLE"
+  grep -q 'grep -q "mBooted=true"' "$AWAIT_IDLE"
+  grep -q 'grep -q "mBooting=false"' "$AWAIT_IDLE"
+}
+
+@test "idle requires all three flags; missing one is not idle" {
+  check() {
+    echo "$1" | grep -q "mSleeping=false" &&
+      echo "$1" | grep -q "mBooted=true" &&
+      echo "$1" | grep -q "mBooting=false"
+  }
+  all=$'mSleeping=false\nmBooted=true\nmBooting=false'
+  run check "$all"
+  [ "$status" -eq 0 ]
+
+  booting=$'mSleeping=false\nmBooted=true\nmBooting=true'
+  run check "$booting"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
Three latent shell bugs, grouped into one cleanup pass:

- **`hot-reload.sh`** — `pgrep -f "hot-reload.sh" | grep -v "$$"` excluded the current PID by **substring**, so an orphan watcher whose PID merely contained the self PID's digits (e.g. self=`456`, orphan=`4560`/`3456`) was wrongly spared. → `grep -vxF` (exact, whole-line).
- **`avd_experiments.sh`** — used `mapfile`, a bash 4+ builtin absent from macOS's default bash 3.2; under `set -e` the script aborted immediately. → portable `while IFS= read -r` loop.
- **`await_idle.sh`** — `wait_for_process_idle` required `grep -cE "..." -eq 3`, but `grep -c` counts matching **lines** not distinct conditions (flags can share a line → 1, or repeat → >3), and a zero-match `grep -c` exits 1 which aborts under `set -euo pipefail`. → test each flag independently with `grep -q`.

## Tests
- New `test/bats/shell-latent-fixes-3654.bats` (7 tests): exact-PID exclusion behavior + source guard; no-`mapfile` guard + bash-3.2 while-read run; no-`grep -c` guard + independent-flag logic (all-three → idle, missing one → not idle).
- `shellcheck` clean on all three scripts; `bash -n` OK.

Fixes #3654