### PR TITLE
fix(sdk): bound RecompositionTracker entries with LRU eviction (#3708)

### DIFF
--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
@@ -11,6 +11,7 @@ import android.os.Looper
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -18,7 +19,18 @@ internal object RecompositionTracker {
   private const val WINDOW_MS = 1000L
   private const val BROADCAST_INTERVAL_MS = 1000L
 
+  // Upper bound on tracked entries. Apps may key tracking per instance (e.g.
+  // autoMobileRecomposition("row-$itemId") over a long/paginated feed), which
+  // would otherwise grow `entries` without bound for the life of the process
+  // (issue #3708, the twin of iOS #3624). When exceeded we evict the
+  // least-recently-touched entries in a batch to amortize the eviction scan.
+  private const val MAX_ENTRIES = 512
+  private const val EVICTION_BATCH = 64
+
   private val entries = ConcurrentHashMap<String, Entry>()
+
+  // Monotonic tick stamped on every record; used as the LRU key for eviction.
+  private val touchSequence = AtomicLong(0)
   private val enabled = AtomicBoolean(false)
   private val handler = Handler(Looper.getMainLooper())
   private var context: Context? = null
@@ -66,6 +78,7 @@ internal object RecompositionTracker {
       rememberedCount,
       likelyCause,
     )
+    enforceEntryCap()
   }
 
   fun recordDuration(id: String, durationMs: Double) {
@@ -74,6 +87,23 @@ internal object RecompositionTracker {
     }
     val entry = entries.computeIfAbsent(id) { Entry(id) }
     entry.recordDuration(durationMs)
+    enforceEntryCap()
+  }
+
+  /**
+   * Evict least-recently-touched entries once the cap is exceeded, down to a low-water mark so the
+   * O(n) scan runs at most once per [EVICTION_BATCH] inserts (issue #3708).
+   */
+  private fun enforceEntryCap() {
+    if (entries.size <= MAX_ENTRIES) return
+    synchronized(entries) {
+      if (entries.size <= MAX_ENTRIES) return
+      val removeCount = entries.size - (MAX_ENTRIES - EVICTION_BATCH)
+      entries.entries
+        .sortedBy { it.value.lastTouch }
+        .take(removeCount)
+        .forEach { entries.remove(it.key) }
+    }
   }
 
   internal fun isEnabled(): Boolean = enabled.get()
@@ -162,6 +192,9 @@ internal object RecompositionTracker {
     }
 
   private class Entry(val id: String) {
+    /** LRU tick of the last record; read during eviction without the entry lock. */
+    @Volatile var lastTouch: Long = 0
+
     private val rollingAverage = RollingAverage(WINDOW_MS)
     private var totalCount = 0
     private var skipCount = 0
@@ -186,6 +219,7 @@ internal object RecompositionTracker {
       likelyCause: String?,
     ) {
       totalCount += 1
+      lastTouch = touchSequence.incrementAndGet()
       rollingAverage.record()
       if (composableName != null) this.composableName = composableName
       if (resourceId != null) this.resourceId = resourceId
@@ -199,6 +233,7 @@ internal object RecompositionTracker {
     @Synchronized
     fun recordDuration(durationMs: Double) {
       if (durationMs <= 0) return
+      lastTouch = touchSequence.incrementAndGet()
       durationTotalMs += durationMs
       durationSamples += 1
     }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTrackerEvictionTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTrackerEvictionTest.kt
@@ -1,0 +1,42 @@
+package dev.jasonpearson.automobile.sdk
+
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RecompositionTrackerEvictionTest {
+
+  @After
+  fun tearDown() {
+    RecompositionTracker.setEnabled(false) // clears entries
+  }
+
+  /**
+   * Per-instance ids (e.g. a long feed keyed by item id) must not grow the entries map without
+   * bound; the tracker caps it and evicts the least-recently-touched entries (issue #3708).
+   */
+  @Test
+  fun `entries are bounded and evict the least recently touched`() {
+    RecompositionTracker.setEnabled(true)
+
+    val total = 600
+    for (i in 0 until total) {
+      RecompositionTracker.recordRecomposition("view-$i")
+    }
+
+    val entries = JSONObject(RecompositionTracker.buildSnapshotJson("test")).getJSONArray("entries")
+    val ids = mutableSetOf<String>()
+    for (i in 0 until entries.length()) {
+      ids.add(entries.getJSONObject(i).getString("id"))
+    }
+
+    assertTrue("entries map must stay bounded, was ${entries.length()}", entries.length() <= 512)
+    assertTrue("the most recently recorded id must survive", ids.contains("view-${total - 1}"))
+    assertFalse("the oldest id must have been evicted", ids.contains("view-0"))
+  }
+}


### PR DESCRIPTION
## Summary
`RecompositionTracker.entries` added one `Entry` per unique `id` (`computeIfAbsent`) and was only ever cleared on disable — never LRU/size-capped. Apps that key tracking per instance (e.g. `autoMobileRecomposition("row-$itemId")` / `MeasureViewBody` over a long or paginated feed) leaked memory for the process lifetime, and the periodic snapshot iterated an ever-growing set. Kotlin twin of iOS #3624 (PR #3683); #3613 fixed a separate read-race in this class, not the growth.

## Fix
Cap `entries` at 512 and, when exceeded, batch-evict the least-recently-touched entries down to a low-water mark (so the O(n) scan runs at most once per ~64 inserts). LRU order uses a monotonic `touchSequence` tick stamped on each record (deterministic, collision-free).

## Tests
- `entries are bounded and evict the least recently touched` — records 600 distinct ids; asserts the map stays ≤ 512, the newest id survives, and the oldest is evicted.

`:auto-mobile-sdk:testDebugUnitTest` green; ktfmt-clean.

Fixes #3708