### PR TITLE
fix(control-proxy): make PerfProvider entry stack thread-local (#3709)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/perf/PerfProvider.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/perf/PerfProvider.kt
@@ -2,7 +2,6 @@ package dev.jasonpearson.automobile.ctrlproxy.perf
 
 import android.util.Log
 import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.atomic.AtomicReference
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -75,31 +74,41 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
 
   private val json = Json { prettyPrint = false }
 
-  // Stack of active timing entries (for nested operations)
-  private val entryStack = ConcurrentLinkedDeque<MutablePerfEntry>()
+  // Per-thread active-entry state. The entry stack and current root are kept
+  // per-thread so an operation on one thread (e.g. hierarchy polling) never nests
+  // under an in-flight operation on another (e.g. command handling), and end()/
+  // flush()/independentRoot() can't close/steal another thread's open entries
+  // (issue #3709, the twin of iOS #3635). Completed roots are still moved into the
+  // shared completedEntries pool below, so flush() reports all threads' timings.
+  private class LocalState {
+    val entryStack = java.util.ArrayDeque<MutablePerfEntry>()
+    var currentRoot: MutablePerfEntry? = null
+  }
 
-  // Root entries that have been completed
+  private val threadState = ThreadLocal.withInitial { LocalState() }
+
+  private fun local(): LocalState = threadState.get()
+
+  // Root entries that have been completed. Shared across threads.
   private val completedEntries = ConcurrentLinkedDeque<MutablePerfEntry>()
 
-  // Current active root entry
-  private val currentRoot = AtomicReference<MutablePerfEntry?>(null)
-
-  // Debounce tracking
+  // Debounce tracking (shared)
   private var debounceCount = 0
   private var lastDebounceTime: Long? = null
 
   /** Start a serial block (operations run sequentially). */
   fun serial(name: String) {
+    val state = local()
     val now = timeProvider.currentTimeMillis()
     val entry = MutablePerfEntry(name = name, startTime = now, isParallel = false)
 
-    val parent = entryStack.peekLast()
+    val parent = state.entryStack.peekLast()
     if (parent != null) {
       parent.children.add(entry)
     } else {
-      currentRoot.set(entry)
+      state.currentRoot = entry
     }
-    entryStack.addLast(entry)
+    state.entryStack.addLast(entry)
 
     Log.d(TAG, "Started serial block: $name")
   }
@@ -113,8 +122,9 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
    * inclusion in the next flush().
    */
   fun independentRoot(name: String) {
-    // End all open entries - they become completed entries (parallel siblings)
-    while (entryStack.isNotEmpty()) {
+    // End all open entries on THIS thread - they become completed siblings
+    val state = local()
+    while (state.entryStack.isNotEmpty()) {
       end()
     }
 
@@ -124,33 +134,35 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
 
   /** Start a parallel block (operations run concurrently). */
   fun parallel(name: String) {
+    val state = local()
     val now = timeProvider.currentTimeMillis()
     val entry = MutablePerfEntry(name = name, startTime = now, isParallel = true)
 
-    val parent = entryStack.peekLast()
+    val parent = state.entryStack.peekLast()
     if (parent != null) {
       parent.children.add(entry)
     } else {
-      currentRoot.set(entry)
+      state.currentRoot = entry
     }
-    entryStack.addLast(entry)
+    state.entryStack.addLast(entry)
 
     Log.d(TAG, "Started parallel block: $name")
   }
 
   /** End the current block. */
   fun end() {
+    val state = local()
     val now = timeProvider.currentTimeMillis()
-    val entry = entryStack.pollLast()
+    val entry = state.entryStack.pollLast()
 
     if (entry != null) {
       entry.endTime = now
       Log.d(TAG, "Ended block: ${entry.name} (${now - entry.startTime}ms)")
 
-      // If this was the root entry, move it to completed
-      if (entryStack.isEmpty() && currentRoot.get() == entry) {
+      // If this was the root entry, move it to the shared completed pool
+      if (state.entryStack.isEmpty() && state.currentRoot == entry) {
         completedEntries.add(entry)
-        currentRoot.set(null)
+        state.currentRoot = null
       }
     } else {
       Log.w(TAG, "end() called with no active block")
@@ -179,17 +191,18 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
 
   /** Start tracking an operation manually. */
   fun startOperation(name: String) {
+    val state = local()
     val now = timeProvider.currentTimeMillis()
     val entry = MutablePerfEntry(name = name, startTime = now)
 
-    val parent = entryStack.peekLast()
+    val parent = state.entryStack.peekLast()
     if (parent != null) {
       parent.children.add(entry)
-      entryStack.addLast(entry)
+      state.entryStack.addLast(entry)
     } else {
       // No active block, this becomes a root entry
-      currentRoot.set(entry)
-      entryStack.addLast(entry)
+      state.currentRoot = entry
+      state.entryStack.addLast(entry)
     }
 
     Log.d(TAG, "Started operation: $name")
@@ -197,19 +210,20 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
 
   /** End tracking an operation manually. */
   fun endOperation(name: String) {
+    val state = local()
     val now = timeProvider.currentTimeMillis()
 
-    // Find the matching entry in the stack
-    val entry = entryStack.peekLast()
+    // Find the matching entry in this thread's stack
+    val entry = state.entryStack.peekLast()
     if (entry != null && entry.name == name) {
       entry.endTime = now
-      entryStack.pollLast()
+      state.entryStack.pollLast()
       Log.d(TAG, "Ended operation: $name (${now - entry.startTime}ms)")
 
-      // If this was the root entry, move it to completed
-      if (entryStack.isEmpty() && currentRoot.get() == entry) {
+      // If this was the root entry, move it to the shared completed pool
+      if (state.entryStack.isEmpty() && state.currentRoot == entry) {
         completedEntries.add(entry)
-        currentRoot.set(null)
+        state.currentRoot = null
       }
     } else {
       Log.w(TAG, "endOperation($name) called but current entry is ${entry?.name}")
@@ -228,8 +242,9 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
    * inclusion in WebSocket messages.
    */
   fun flush(): JsonElement? {
-    // End any incomplete entries
-    while (entryStack.isNotEmpty()) {
+    // End any incomplete entries on this thread (moves their roots into the pool)
+    val state = local()
+    while (state.entryStack.isNotEmpty()) {
       end()
     }
 
@@ -277,10 +292,10 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
   fun peek(): List<PerfTiming> {
     val entries = mutableListOf<PerfTiming>()
 
-    // Include current root if any
-    currentRoot.get()?.let { entries.add(it.toTiming()) }
+    // Include this thread's current root if any
+    local().currentRoot?.let { entries.add(it.toTiming()) }
 
-    // Include completed entries
+    // Include shared completed entries
     completedEntries.forEach { entries.add(it.toTiming()) }
 
     return entries
@@ -288,14 +303,15 @@ private constructor(private val timeProvider: TimeProvider = SystemTimeProvider(
 
   /** Check if there's any accumulated timing data. */
   fun hasData(): Boolean {
-    return completedEntries.isNotEmpty() || currentRoot.get() != null || debounceCount > 0
+    return completedEntries.isNotEmpty() || local().currentRoot != null || debounceCount > 0
   }
 
   /** Clear all timing data without returning it. */
   fun clear() {
-    entryStack.clear()
+    val state = local()
+    state.entryStack.clear()
+    state.currentRoot = null
     completedEntries.clear()
-    currentRoot.set(null)
     debounceCount = 0
     lastDebounceTime = null
   }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/perf/PerfProviderThreadLocalTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/perf/PerfProviderThreadLocalTest.kt
@@ -1,0 +1,69 @@
+package dev.jasonpearson.automobile.ctrlproxy.perf
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PerfProviderThreadLocalTest {
+
+  private fun topLevelNames(json: kotlinx.serialization.json.JsonElement?): List<String> {
+    val array = json as? JsonArray ?: return emptyList()
+    return array.mapNotNull { it.jsonObject["name"]?.jsonPrimitive?.content }
+  }
+
+  @Test
+  fun `single-thread nesting still works`() {
+    val provider = PerfProvider.createForTesting(SystemTimeProvider())
+    provider.serial("root")
+    provider.startOperation("child")
+    provider.endOperation("child")
+    provider.end()
+
+    val names = topLevelNames(provider.flush())
+    assertTrue("root should be a top-level entry", names.contains("root"))
+  }
+
+  /**
+   * An operation left open on another thread must NOT become the parent of an operation started on
+   * this thread. Pre-fix the entry stack was shared, so "B" nested under the still-open "A"
+   * (issue #3709). Now the stack is per-thread, so "B" is its own top-level root.
+   */
+  @Test
+  fun `entries from different threads do not nest`() {
+    val provider = PerfProvider.createForTesting(SystemTimeProvider())
+    val aOpened = CountDownLatch(1)
+    val releaseA = CountDownLatch(1)
+
+    val threadA = Thread {
+      provider.serial("A") // leave "A" open on thread A
+      aOpened.countDown()
+      releaseA.await()
+      provider.end()
+    }
+    threadA.start()
+    assertTrue(aOpened.await(5, TimeUnit.SECONDS))
+
+    // Start and finish "B" on this thread while "A" is still open elsewhere.
+    provider.serial("B")
+    provider.end()
+
+    val names = topLevelNames(provider.flush())
+    assertNotNull(names)
+    assertTrue("B should be a top-level completed root", names.contains("B"))
+    // Under the old shared stack, B would have been nested inside the still-open A
+    // and A (not B) would surface here once flush closed it.
+    assertFalse("A must not be flushed by this thread (it's open on thread A)", names.contains("A"))
+
+    releaseA.countDown()
+    threadA.join(2_000)
+  }
+}


### PR DESCRIPTION
## Summary
The `PerfProvider.instance` singleton shared one `entryStack`/`currentRoot` across all threads. Command handling (server coroutines) and background hierarchy polling (`HierarchyDebouncer`'s own coroutine) interleaved on that single stack, so an operation started on one nested under an in-flight entry from another (`entryStack.peekLast()` picks the last-pushed regardless of thread), and `end()`/`flush()`/`independentRoot()` closed/stole entries other coroutines still had open. The result is a corrupted timing tree. (No crash — `ConcurrentLinkedDeque` kept it memory-safe.) Kotlin twin of iOS #3635 (PR #3688).

## Fix
Make the active-entry state (`entryStack` + `currentRoot`) **thread-local**, so nesting is per-thread-correct and a thread can only end its own entries. Completed roots are still moved into a **shared** `completedEntries` pool, so `flush()` keeps reporting all threads' timings together.

## Tests
- `single-thread nesting still works` — serial → startOperation → end → flush yields the root;
- `entries from different threads do not nest` — an operation left open on another thread does not become the parent of an operation on this thread (fails under the old shared stack).

`:control-proxy:testDebugUnitTest` fully green; ktfmt-clean.

Fixes #3709