### PR TITLE
fix(control-proxy): cap WebSocket maxFrameSize to prevent OOM (#3711)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -48,6 +48,14 @@ class WebSocketServer(
   companion object {
     private const val TAG = "WebSocketServer"
 
+    /**
+     * Maximum accepted inbound WebSocket frame (64 MiB). ktor caps frame size by default;
+     * `Long.MAX_VALUE` removed the ceiling so a single hostile frame advertising a multi-GB length
+     * would be buffered into memory -> OutOfMemoryError, downing the runner. Cap it above any
+     * legitimate command/hierarchy payload (issue #3711, the twin of iOS #3626).
+     */
+    internal const val MAX_FRAME_SIZE_BYTES: Long = 64L * 1024 * 1024
+
     /** Lenient parser for best-effort field extraction from a raw (possibly malformed) payload. */
     private val lenientJson = Json {
       ignoreUnknownKeys = true
@@ -146,7 +154,7 @@ class WebSocketServer(
             install(WebSockets) {
               pingPeriod = 15.seconds
               timeout = 60.seconds
-              maxFrameSize = Long.MAX_VALUE
+              maxFrameSize = MAX_FRAME_SIZE_BYTES
               masking = false
             }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerMaxFrameSizeTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerMaxFrameSizeTest.kt
@@ -1,0 +1,23 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WebSocketServerMaxFrameSizeTest {
+
+  /**
+   * The inbound frame-size cap must be bounded. `Long.MAX_VALUE` disabled ktor's default cap, so a
+   * single hostile frame advertising a multi-GB length would be buffered into memory ->
+   * OutOfMemoryError (issue #3711). It must be a sane maximum: above any legitimate payload, far
+   * below unbounded.
+   */
+  @Test
+  fun `max frame size is bounded, not Long MAX_VALUE`() {
+    assertNotEquals(Long.MAX_VALUE, WebSocketServer.MAX_FRAME_SIZE_BYTES)
+    assertTrue(
+      "cap should be a sane size (1 MiB..1 GiB), was ${WebSocketServer.MAX_FRAME_SIZE_BYTES}",
+      WebSocketServer.MAX_FRAME_SIZE_BYTES in (1L shl 20)..(1L shl 30),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
The Android CtrlProxy `install(WebSockets) { ... }` set `maxFrameSize = Long.MAX_VALUE`, disabling ktor's default inbound frame-size cap. A single hostile frame on the adb-forwarded port advertising a multi-GB length would be buffered fully into memory -> `OutOfMemoryError`, downing the runner process. Kotlin twin of iOS #3626 (PR #3685).

## Fix
Cap `maxFrameSize` at 64 MiB (`MAX_FRAME_SIZE_BYTES`) — above any legitimate command/hierarchy payload, so oversized frames are rejected by ktor instead of buffered.

## Tests
- `max frame size is bounded, not Long MAX_VALUE` — the cap is a sane bounded size (1 MiB..1 GiB), guarding against regression to the unbounded value.
- The existing `WebSocketServerIntegrationTest` (live server + client) still passes, confirming normal operation under the new cap.

`:control-proxy:testDebugUnitTest` green; ktfmt-clean.

Fixes #3711