### PR TITLE
feat(tools): gate barrier + criticalSection as plan-only (hidden from MCP discovery)

### DIFF
--- a/src/server/barrierTools.ts
+++ b/src/server/barrierTools.ts
@@ -83,7 +83,11 @@ export function registerBarrierTools(): void {
     "barrier",
     "Synchronize multiple devices at a barrier, then let all proceed concurrently (no serialized section).",
     barrierSchema,
-    barrierHandler
+    barrierHandler,
+    // Plan-only: a multi-device coordination primitive that only makes sense as
+    // a plan step (a single direct call would just block). Hidden from tools/list
+    // discovery, still runnable in plans via getToolForPlan.
+    { planOnly: true, planExecutable: true }
   );
 
   logger.info("Barrier tools registered");

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -218,7 +218,16 @@ const criticalSectionHandler = async (
  * Register the criticalSection tool.
  */
 export function registerCriticalSectionTools(): void {
-  ToolRegistry.registerDeviceAware("criticalSection", "Synchronize multiple devices at a barrier, then run steps serially.", criticalSectionSchema, criticalSectionHandler);
+  ToolRegistry.registerDeviceAware(
+    "criticalSection",
+    "Synchronize multiple devices at a barrier, then run steps serially.",
+    criticalSectionSchema,
+    criticalSectionHandler,
+    // Plan-only: a multi-device coordination primitive that only makes sense as
+    // a plan step (a single direct call would just block). Hidden from tools/list
+    // discovery, still runnable in plans via getToolForPlan.
+    { planOnly: true, planExecutable: true }
+  );
 
   logger.info("Critical section tools registered");
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -65,6 +65,10 @@ interface DeviceAwareToolHandler<T = any> {
   (device: BootedDevice, args: T, progress?: ProgressCallback, signal?: AbortSignal): Promise<any>;
 }
 
+// Gate reason emitted for `planOnly` tools — hidden from discovery by design,
+// expected in plans (so getToolForPlan does not warn about it).
+const PLAN_ONLY_GATE_REASON = "plan-only tool";
+
 interface ToolRegistrationOptions {
   supportsProgress?: boolean;
   debugOnly?: boolean;
@@ -76,6 +80,10 @@ interface DeviceAwareToolOptions<T = any> extends ToolRegistrationOptions {
   nonDeviceHandler?: ToolHandler<T>;
   embeddedSdkOnly?: boolean;
   planExecutable?: boolean;
+  // Hide from normal MCP discovery (tools/list) unconditionally, but keep the
+  // tool runnable inside plans (pair with planExecutable). For coordination
+  // primitives an interactive agent can never sensibly call directly.
+  planOnly?: boolean;
 }
 
 interface ToolListingOptions {
@@ -99,6 +107,7 @@ export interface RegisteredTool {
   debugOnly?: boolean;
   embeddedSdkOnly?: boolean;
   planExecutable?: boolean;
+  planOnly?: boolean;
   outputSchema?: any;
 }
 
@@ -744,6 +753,9 @@ class ToolRegistryClass {
     if (tool.embeddedSdkOnly && !serverConfig.isEmbeddedSdkEnabled()) {
       reasons.push("embedded SDK mode is disabled");
     }
+    if (tool.planOnly) {
+      reasons.push(PLAN_ONLY_GATE_REASON);
+    }
     return reasons;
   }
 
@@ -871,6 +883,7 @@ class ToolRegistryClass {
       debugOnly: options.debugOnly ?? false,
       embeddedSdkOnly: options.embeddedSdkOnly ?? false,
       planExecutable: options.planExecutable ?? false,
+      planOnly: options.planOnly ?? false,
       outputSchema: options.outputSchema
     });
   }
@@ -959,9 +972,13 @@ class ToolRegistryClass {
     if (gateReasons.length > 0 && !tool.planExecutable) {
       return undefined;
     }
-    if (gateReasons.length > 0) {
+    // A `planOnly` tool is hidden from discovery by design and is expected in
+    // plans, so don't warn about that reason — only surface *other* gate reasons
+    // (e.g. a debug-only tool being used inside a plan), which are noteworthy.
+    const unexpectedReasons = gateReasons.filter(r => r !== PLAN_ONLY_GATE_REASON);
+    if (unexpectedReasons.length > 0) {
       logger.warn(
-        `[ToolRegistry] Plan execution is using gated tool "${name}" (${gateReasons.join(", ")}). Tool is hidden from normal MCP discovery but marked planExecutable.`
+        `[ToolRegistry] Plan execution is using gated tool "${name}" (${unexpectedReasons.join(", ")}). Tool is hidden from normal MCP discovery but marked planExecutable.`
       );
     }
     return tool;

--- a/test/server/barrierTools.test.ts
+++ b/test/server/barrierTools.test.ts
@@ -15,7 +15,7 @@ const parseResponse = (response: any): any =>
 
 describe("barrier tool", () => {
   beforeAll(() => {
-    if (!ToolRegistry.getTool("barrier")) {
+    if (!ToolRegistry.getToolForPlan("barrier")) {
       registerBarrierTools();
     }
   });
@@ -25,7 +25,7 @@ describe("barrier tool", () => {
   });
 
   test("tool is registered with correct schema", () => {
-    const tool = ToolRegistry.getTool("barrier");
+    const tool = ToolRegistry.getToolForPlan("barrier");
     expect(tool).toBeDefined();
     expect(tool?.name).toBe("barrier");
     expect(tool?.description).toContain("proceed concurrently");
@@ -33,7 +33,7 @@ describe("barrier tool", () => {
   });
 
   test("single device with deviceCount 1 passes the barrier", async () => {
-    const tool = ToolRegistry.getTool("barrier");
+    const tool = ToolRegistry.getToolForPlan("barrier");
     const response = await tool!.deviceAwareHandler!(
       makeDevice("device-1"),
       { lock: "solo", deviceCount: 1 },
@@ -48,7 +48,7 @@ describe("barrier tool", () => {
   });
 
   test("two devices synchronize and both pass concurrently", async () => {
-    const tool = ToolRegistry.getTool("barrier");
+    const tool = ToolRegistry.getToolForPlan("barrier");
 
     const results = await Promise.all([
       tool!.deviceAwareHandler!(
@@ -73,7 +73,7 @@ describe("barrier tool", () => {
   });
 
   test("rejects with an actionable error on barrier timeout", async () => {
-    const tool = ToolRegistry.getTool("barrier");
+    const tool = ToolRegistry.getToolForPlan("barrier");
     // deviceCount 2 but only one device arrives; short timeout so the test is fast.
     await expect(
       tool!.deviceAwareHandler!(

--- a/test/server/criticalSectionRegistration.test.ts
+++ b/test/server/criticalSectionRegistration.test.ts
@@ -3,12 +3,15 @@ import { createMcpServer } from "../../src/server/index";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 
 /**
- * `criticalSection` (and the `barrier` tool built on it) are registered ONLY in
- * daemon mode — they rely on the daemon's cross-process lock coordinator and are
- * meaningless over a single stdio connection. Pin that gate so it can't silently
- * regress into the stdio tool surface.
+ * `criticalSection` and `barrier` have two independent gates:
+ *  1. daemon-only registration — only registered in daemon mode (they rely on
+ *     the daemon's cross-process lock coordinator).
+ *  2. plan-only discovery gate — even in daemon mode they are hidden from normal
+ *     MCP discovery (`getTool` / `tools/list`) because a single direct call would
+ *     just block; they are runnable only as plan steps via `getToolForPlan`.
+ * Pin both so neither can silently regress into the interactive tool surface.
  */
-describe("criticalSection / barrier daemon-only registration", () => {
+describe("criticalSection / barrier registration + plan-only discovery gate", () => {
   beforeEach(() => {
     ToolRegistry.clearTools();
   });
@@ -18,20 +21,33 @@ describe("criticalSection / barrier daemon-only registration", () => {
     ToolRegistry.clearTools();
   });
 
-  test("stdio mode registers core tools but not criticalSection or barrier", () => {
+  test("stdio mode registers neither criticalSection nor barrier at all", () => {
     createMcpServer({ daemonMode: false });
 
     // Sanity: non-gated tools are present, so registration actually ran.
     expect(ToolRegistry.getTool("observe")).toBeDefined();
 
+    // Not registered in stdio mode — absent from both discovery and plan lookup.
     expect(ToolRegistry.getTool("criticalSection")).toBeUndefined();
     expect(ToolRegistry.getTool("barrier")).toBeUndefined();
+    expect(ToolRegistry.getToolForPlan("criticalSection")).toBeUndefined();
+    expect(ToolRegistry.getToolForPlan("barrier")).toBeUndefined();
   });
 
-  test("daemon mode registers criticalSection and barrier", () => {
+  test("daemon mode registers them plan-only: hidden from discovery, resolvable for plans", () => {
     createMcpServer({ daemonMode: true });
 
-    expect(ToolRegistry.getTool("criticalSection")).toBeDefined();
-    expect(ToolRegistry.getTool("barrier")).toBeDefined();
+    // Hidden from normal MCP discovery (getTool honors the plan-only gate)...
+    expect(ToolRegistry.getTool("criticalSection")).toBeUndefined();
+    expect(ToolRegistry.getTool("barrier")).toBeUndefined();
+
+    // ...and therefore absent from the advertised tools/list.
+    const advertised = ToolRegistry.getToolDefinitions().map(t => t.name);
+    expect(advertised).not.toContain("criticalSection");
+    expect(advertised).not.toContain("barrier");
+
+    // ...but still resolvable for plan execution (they are planExecutable).
+    expect(ToolRegistry.getToolForPlan("criticalSection")).toBeDefined();
+    expect(ToolRegistry.getToolForPlan("barrier")).toBeDefined();
   });
 });

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -11,7 +11,7 @@ import { serverConfig } from "../../src/utils/ServerConfig";
 describe("criticalSection tool", () => {
   beforeAll(() => {
     // Register the tool if not already registered
-    if (!ToolRegistry.getTool("criticalSection")) {
+    if (!ToolRegistry.getToolForPlan("criticalSection")) {
       registerCriticalSectionTools();
     }
   });
@@ -24,7 +24,7 @@ describe("criticalSection tool", () => {
   });
 
   test("tool is registered with correct schema", () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
 
     expect(tool).toBeDefined();
     expect(tool?.name).toBe("criticalSection");
@@ -33,7 +33,7 @@ describe("criticalSection tool", () => {
   });
 
   test("validates schema with valid parameters", () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const validParams = {
@@ -55,7 +55,7 @@ describe("criticalSection tool", () => {
   });
 
   test("rejects invalid schema - missing required fields", () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const invalidParams = {
@@ -67,7 +67,7 @@ describe("criticalSection tool", () => {
   });
 
   test("rejects invalid schema - empty steps array", () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const invalidParams = {
@@ -80,7 +80,7 @@ describe("criticalSection tool", () => {
   });
 
   test("rejects schema when a sub-step is missing the device parameter", () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const invalidParams = {
@@ -98,7 +98,7 @@ describe("criticalSection tool", () => {
   });
 
   test("rejects schema when a sub-step's device is an empty string", () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const invalidParams = {
@@ -113,7 +113,7 @@ describe("criticalSection tool", () => {
   });
 
   test("rejects invalid schema - non-positive device count", () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const invalidParams = {
@@ -126,7 +126,7 @@ describe("criticalSection tool", () => {
   });
 
   test("detects nested critical sections", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {
@@ -159,7 +159,7 @@ describe("criticalSection tool", () => {
   });
 
   test("detects a barrier nested inside a critical section", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {
@@ -188,7 +188,7 @@ describe("criticalSection tool", () => {
   });
 
   test("executes steps in order for single device", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {
@@ -240,7 +240,7 @@ describe("criticalSection tool", () => {
   });
 
   test("executes plan-executable debug-only steps hidden from MCP discovery", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {
@@ -297,7 +297,7 @@ describe("criticalSection tool", () => {
   });
 
   test("rejects debug-only steps that are not plan-executable", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {
@@ -328,7 +328,7 @@ describe("criticalSection tool", () => {
   });
 
   test("executes plan-executable steps gated by non-debug feature flags with a warning", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {
@@ -385,7 +385,7 @@ describe("criticalSection tool", () => {
 
 
   test("fails fast when a step fails", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {
@@ -438,7 +438,7 @@ describe("criticalSection tool", () => {
   });
 
   test("wraps a step failure with the documented device + step context", async () => {
-    const tool = ToolRegistry.getTool("criticalSection");
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
 
     const fakeDevice: BootedDevice = {

--- a/test/server/tools/daemonModeTools.test.ts
+++ b/test/server/tools/daemonModeTools.test.ts
@@ -23,12 +23,20 @@ describe("Daemon-only MCP tools", () => {
     expect(toolNames).not.toContain("criticalSection");
   });
 
-  test("registers criticalSection in daemon mode", () => {
+  test("registers criticalSection/barrier plan-only in daemon mode (hidden from discovery, usable in plans)", () => {
     createMcpServer({ daemonMode: true });
 
     const toolNames = ToolRegistry.getToolDefinitions().map(tool => tool.name);
     expect(toolNames).toContain("executePlan");
-    expect(toolNames).toContain("criticalSection");
+    // Plan-only coordination primitives are registered in daemon mode but hidden
+    // from normal discovery — a single direct call would just block.
+    expect(toolNames).not.toContain("criticalSection");
+    expect(toolNames).not.toContain("barrier");
+    expect(ToolRegistry.getTool("criticalSection")).toBeUndefined();
+    expect(ToolRegistry.getTool("barrier")).toBeUndefined();
+    // ...but resolvable for plan execution.
+    expect(ToolRegistry.getToolForPlan("criticalSection")).toBeDefined();
+    expect(ToolRegistry.getToolForPlan("barrier")).toBeDefined();
   });
 
   test("hides debug-only tools unless debug mode is enabled", () => {


### PR DESCRIPTION
Hides the `barrier` and `criticalSection` tools from the advertised MCP `tools/list` while keeping them runnable inside plans.

## Why
Both are multi-device coordination primitives — a single direct MCP call (`deviceCount: 2`) just blocks until a second device arrives. An interactive agent has no use for them standalone; they only appear as **plan steps**, which `PlanExecutor` resolves via `getToolForPlan`, not discovery.

## How
Reuses the existing `planExecutable` / `getToolForPlan` seam (the same one `setUIState` uses):
- New `planOnly` tool flag + `PLAN_ONLY_GATE_REASON` gate reason in `ToolRegistry`.
- `planOnly` tools are excluded from discovery (`getTool` / `getToolDefinitions` / `registerWithServer`) but returned by `getToolForPlan` when also `planExecutable`.
- `getToolForPlan` suppresses its "gated tool used in plan" warning for the plan-only reason (it's by design) while still warning for other reasons (e.g. a debug-only tool in a plan).
- `barrier` + `criticalSection` marked `{ planOnly: true, planExecutable: true }`.

## Audit result (the "are there others?" question)
Audited all 71 registered tools: **no other genuinely plan-only tools exist** — `barrier`/`criticalSection` are the only two. 50 are agent-facing, 16 already gated (`debugOnly`/`embeddedSdkOnly`), and 3 recording/authoring meta-tools (`startTestRecording`, `exportPlan`, `recordSteps`) are *agent-invoked entry points*, not plan steps — so the `planExecutable` mechanism can't reach them; hiding those would remove the interactive record/export workflow (a product decision, not done here).

## Honest scope on savings
The ~450-token reduction applies to the **runtime daemon-mode `tools/list`** an agent connected to the daemon actually sees. It does **not** move the context benchmark's 99% figure — the benchmark models the stdio surface and never registered these daemon-only tools in the first place. So this is a correctness/cleanliness win (these shouldn't be interactively callable) with a modest daemon-only context trim, not a big benchmark drop.

## Testing
- Full `test/server` (1036) and plan suites (217) pass; typecheck clean.
- Registration test reworked to pin the plan-only gate: absent from `getTool`/`getToolDefinitions`, present via `getToolForPlan`, plus daemon-only registration.
- `daemonModeTools.test` updated to the new behavior.
- Static `schemas/tool-definitions.json` unchanged (generated with `includeUnavailable: true`).
