### PR TITLE
fix(scripts): iOS shell-script polish (#3652)

### DIFF
--- a/scripts/ios/ctrl-proxy-run.sh
+++ b/scripts/ios/ctrl-proxy-run.sh
@@ -59,7 +59,9 @@ if [ -z "${SIMULATOR_ID}" ]; then
     exit 1
 fi
 
-SIMULATOR_NAME=$(xcrun simctl list devices booted | grep "${SIMULATOR_ID}" | sed 's/.*(\(.*\)) (.*/\1/' | head -1)
+# Extract the device name (everything before the first " (UDID)"). The old
+# greedy `s/.*(\(.*\)) (.*/\1/` captured the UDID, not the name (#3652).
+SIMULATOR_NAME=$(xcrun simctl list devices booted | grep "${SIMULATOR_ID}" | head -1 | sed 's/^[[:space:]]*//; s/ *(.*//')
 echo -e "${BLUE}Simulator:${NC} ${SIMULATOR_NAME:-${SIMULATOR_ID}}"
 echo -e "${BLUE}Port:${NC} ${PORT}"
 echo ""

--- a/scripts/ios/ensure-simulator-runtime.sh
+++ b/scripts/ios/ensure-simulator-runtime.sh
@@ -26,7 +26,7 @@ CHECK_ONLY=false
 for arg in "$@"; do
   case "$arg" in
     --check-only) CHECK_ONLY=true ;;
-    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
 

--- a/scripts/ios/setup-ios-simulator.sh
+++ b/scripts/ios/setup-ios-simulator.sh
@@ -249,12 +249,15 @@ find_simulator_device() {
     log_debug "Available devices for iOS ${ios_version}:"
     log_debug "$devices"
 
-    # Prefer iPhone 16, then iPhone 15, then any iPhone
+    # Prefer iPhone 16, then iPhone 15, then any iPhone.
+    # Require a non-alphanumeric after the number (or end of line) so
+    # "iPhone 16" does not also match "iPhone 16e" — the old `[^0-9]` matched
+    # the 'e' and could select the 16e, defeating the preference order (#3652).
     local device_name=""
-    if echo "$devices" | grep -q "iPhone 16[^0-9]"; then
-        device_name=$(echo "$devices" | grep "iPhone 16[^0-9]" | head -1 | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | sed 's/[[:space:]]*$//')
-    elif echo "$devices" | grep -q "iPhone 15[^0-9]"; then
-        device_name=$(echo "$devices" | grep "iPhone 15[^0-9]" | head -1 | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | sed 's/[[:space:]]*$//')
+    if echo "$devices" | grep -qE "iPhone 16([^0-9A-Za-z]|$)"; then
+        device_name=$(echo "$devices" | grep -E "iPhone 16([^0-9A-Za-z]|$)" | head -1 | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | sed 's/[[:space:]]*$//')
+    elif echo "$devices" | grep -qE "iPhone 15([^0-9A-Za-z]|$)"; then
+        device_name=$(echo "$devices" | grep -E "iPhone 15([^0-9A-Za-z]|$)" | head -1 | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | sed 's/[[:space:]]*$//')
     elif echo "$devices" | grep -q "iPhone"; then
         device_name=$(echo "$devices" | grep "iPhone" | head -1 | sed 's/^[[:space:]]*//' | cut -d'(' -f1 | sed 's/[[:space:]]*$//')
     fi

--- a/scripts/local/validate-ios.sh
+++ b/scripts/local/validate-ios.sh
@@ -53,8 +53,10 @@ fi
 echo "✓ Bun version: $(bun --version)"
 echo ""
 
-# Check for simctl
-if ! command -v xcrun simctl &>/dev/null; then
+# Check for simctl. `command -v xcrun simctl` treats `simctl` as a second
+# command name (not a PATH binary), so it always failed regardless of whether
+# `xcrun simctl` actually works — probe the subcommand directly instead (#3652).
+if ! xcrun simctl help &>/dev/null; then
   echo "⚠️  Warning: simctl not found"
   echo "   Some functionality may not work"
 else

--- a/test/bats/ios-shell-polish.bats
+++ b/test/bats/ios-shell-polish.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+#
+# Tests for the iOS shell-script polish fixes in #3652:
+#  A) setup-ios-simulator.sh: "iPhone 16" preference must not match "iPhone 16e"
+#  B) ctrl-proxy-run.sh: SIMULATOR_NAME must be the device name, not the UDID
+#  C) ensure-simulator-runtime.sh: unknown-arg message must name the bad arg
+#  D) local/validate-ios.sh: simctl check must not use `command -v xcrun simctl`
+
+setup() {
+  WORK_DIR="$(mktemp -d)"
+  STUB_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR" "$STUB_DIR"
+}
+
+# --- A ---------------------------------------------------------------------
+@test "find_simulator_device prefers 'iPhone 16', not 'iPhone 16e'" {
+  local script="scripts/ios/setup-ios-simulator.sh"
+  local abs
+  abs="$(cd "$(dirname "$script")" && pwd)/$(basename "$script")"
+
+  # Stub xcrun to list both an iPhone 16e and an iPhone 16.
+  cat > "$STUB_DIR/xcrun" <<'EOF'
+#!/usr/bin/env bash
+cat <<'DEVS'
+    iPhone 16e (AAAA-0001) (Shutdown)
+    iPhone 16 (BBBB-0002) (Shutdown)
+DEVS
+EOF
+  chmod +x "$STUB_DIR/xcrun"
+
+  local fn="$WORK_DIR/find_simulator_device.sh"
+  awk '/^find_simulator_device\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$abs" > "$fn"
+
+  run env PATH="$STUB_DIR:$PATH" bash -c '
+    source "$1"
+    log_debug() { :; }
+    find_simulator_device "17.0"
+  ' _ "$fn"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "iPhone 16" ]
+}
+
+# --- B ---------------------------------------------------------------------
+@test "ctrl-proxy-run extracts the device name, not the UDID" {
+  # Pull the sed program the SIMULATOR_NAME line actually uses and run it on a
+  # booted-device line; the old greedy sed captured the UDID.
+  local sed_cmd
+  sed_cmd="$(grep 'SIMULATOR_NAME=' scripts/ios/ctrl-proxy-run.sh | grep -oE "sed '[^']*'")"
+  [ -n "$sed_cmd" ]
+  run bash -c "printf '    iPhone 16 (1234-ABCD) (Booted)\n' | $sed_cmd"
+  [ "$output" = "iPhone 16" ]
+}
+
+# --- C ---------------------------------------------------------------------
+@test "ensure-simulator-runtime names the offending unknown argument" {
+  local script="scripts/ios/ensure-simulator-runtime.sh"
+  run bash "$script" --check-only --bogus-flag
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown argument: --bogus-flag"* ]]
+}
+
+# --- D ---------------------------------------------------------------------
+@test "validate-ios does not probe simctl via 'command -v xcrun simctl'" {
+  # Ignore comment lines (the fix documents the old broken form in a comment).
+  local hits
+  hits="$(grep -vE '^\s*#' scripts/local/validate-ios.sh | grep -n 'command -v xcrun simctl' || true)"
+  [ -z "$hits" ]
+}


### PR DESCRIPTION
## Summary
Batch of low-severity, verified fixes in iOS helper scripts:
- **setup-ios-simulator.sh** — the "prefer iPhone 16" grep `iPhone 16[^0-9]` matched `iPhone 16e` (the `e` is non-digit), so a runner with a 16e could select it, defeating the preference order. Now requires a non-alphanumeric char (or EOL) after the number.
- **ctrl-proxy-run.sh** — greedy `sed 's/.*(\(.*\)) (.*/\1/'` on `iPhone 16 (UDID) (Booted)` captured the **UDID**, not the name; the "Simulator:" line printed the UDID. Now extracts the name before the first ` (`.
- **ensure-simulator-runtime.sh** — the unknown-argument branch printed `$1` (first arg) instead of `$arg` (the offending one).
- **local/validate-ios.sh** — `command -v xcrun simctl` treats `simctl` as a second command name and always failed, so the simctl check always warned; now probes `xcrun simctl help`.

## Tests
`test/bats/ios-shell-polish.bats` covers all four (each fails on the pre-fix baseline).

Fixes #3652