### PR TITLE
Add screenshot testing for desktop-core Compose UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,8 @@
 
 # Image assets under 100KB are committed directly to git — no LFS budget needed in CI
 test/fixtures/**/*.png -filter -diff -merge -text
+# Desktop screenshot-test baselines: small, frequently reviewed, and diffed in PRs — keep in git
+android/desktop-core/src/test/resources/screenshots/**/*.png -filter -diff -merge -text
 android/control-proxy/src/**/*.png -filter -diff -merge -text
 android/playground/app/src/main/res/drawable/auto_mobile_big.png -filter -diff -merge -text
 android/playground/app/src/main/res/drawable/automobile_wordmark.png -filter -diff -merge -text

--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -52,3 +52,20 @@ dependencies {
   testImplementation(compose.desktop.uiTestJUnit4)
   testImplementation(compose.desktop.currentOs)
 }
+
+// Forward screenshot-testing switches from the Gradle invocation to the forked test JVM so
+// `-Dscreenshot.record=true` (and friends) reach the tests. See
+// desktop-core/src/test/kotlin/.../screenshot/ScreenshotEnvironment.kt for the supported flags.
+val screenshotProperties =
+  listOf(
+    "screenshot.record",
+    "screenshot.reference.os",
+    "screenshot.golden.dir",
+    "screenshot.report.dir",
+  )
+
+tasks.withType<Test>().configureEach {
+  screenshotProperties.forEach { key ->
+    System.getProperty(key)?.let { value -> systemProperty(key, value) }
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
@@ -1,0 +1,90 @@
+package dev.jasonpearson.automobile.desktop.core.screenshot
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.components.ErrorCard
+import dev.jasonpearson.automobile.desktop.core.components.SearchBar
+import dev.jasonpearson.automobile.desktop.core.shell.StatusBarBadge
+import org.junit.Test
+
+/**
+ * Screenshot baselines for representative desktop components, captured in both light and dark
+ * Material themes. This is a starter set that proves the [screenshotTest] pattern; extend it with
+ * more components and dashboard states as coverage grows.
+ *
+ * Record the baselines (on the reference OS / CI) with:
+ * ```
+ * ./gradlew -p android :desktop-core:test --tests '*ComponentScreenshotTest' -Dscreenshot.record=true
+ * ```
+ */
+class ComponentScreenshotTest {
+
+  /** Wraps content in a themed, fixed-width surface so captures are deterministic. */
+  @Composable
+  private fun ThemedSurface(dark: Boolean, content: @Composable () -> Unit) {
+    MaterialTheme(colorScheme = if (dark) darkColorScheme() else lightColorScheme()) {
+      Surface(modifier = Modifier.width(360.dp)) {
+        Surface(modifier = Modifier.padding(12.dp), content = content)
+      }
+    }
+  }
+
+  @Test
+  fun errorCardLight() = screenshotTest("error_card_light") {
+    ThemedSurface(dark = false) {
+      ErrorCard(title = "Something went wrong", message = "Please try again later.")
+    }
+  }
+
+  @Test
+  fun errorCardDark() = screenshotTest("error_card_dark") {
+    ThemedSurface(dark = true) {
+      ErrorCard(title = "Something went wrong", message = "Please try again later.")
+    }
+  }
+
+  @Test
+  fun errorCardWithActions() = screenshotTest("error_card_with_actions") {
+    ThemedSurface(dark = true) {
+      ErrorCard(
+        title = "Connection lost",
+        message = "The daemon is unreachable.",
+        onRetry = {},
+        onDismiss = {},
+      )
+    }
+  }
+
+  @Test
+  fun searchBarEmpty() = screenshotTest("search_bar_empty") {
+    ThemedSurface(dark = true) { SearchBar(query = "", onQueryChange = {}) }
+  }
+
+  @Test
+  fun searchBarWithQuery() = screenshotTest("search_bar_with_query") {
+    ThemedSurface(dark = true) {
+      SearchBar(
+        query = "MainActivity",
+        onQueryChange = {},
+        showRegexToggle = true,
+        isRegexEnabled = true,
+        onRegexToggle = {},
+      )
+    }
+  }
+
+  @Test
+  fun statusBarBadge() = screenshotTest("status_bar_badge") {
+    ThemedSurface(dark = true) {
+      StatusBarBadge(count = 12, label = "Crashes", color = Color(0xFFF28B82))
+    }
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
@@ -38,53 +38,59 @@ class ComponentScreenshotTest {
   }
 
   @Test
-  fun errorCardLight() = screenshotTest("error_card_light") {
-    ThemedSurface(dark = false) {
-      ErrorCard(title = "Something went wrong", message = "Please try again later.")
+  fun errorCardLight() =
+    screenshotTest("error_card_light") {
+      ThemedSurface(dark = false) {
+        ErrorCard(title = "Something went wrong", message = "Please try again later.")
+      }
     }
-  }
 
   @Test
-  fun errorCardDark() = screenshotTest("error_card_dark") {
-    ThemedSurface(dark = true) {
-      ErrorCard(title = "Something went wrong", message = "Please try again later.")
+  fun errorCardDark() =
+    screenshotTest("error_card_dark") {
+      ThemedSurface(dark = true) {
+        ErrorCard(title = "Something went wrong", message = "Please try again later.")
+      }
     }
-  }
 
   @Test
-  fun errorCardWithActions() = screenshotTest("error_card_with_actions") {
-    ThemedSurface(dark = true) {
-      ErrorCard(
-        title = "Connection lost",
-        message = "The daemon is unreachable.",
-        onRetry = {},
-        onDismiss = {},
-      )
+  fun errorCardWithActions() =
+    screenshotTest("error_card_with_actions") {
+      ThemedSurface(dark = true) {
+        ErrorCard(
+          title = "Connection lost",
+          message = "The daemon is unreachable.",
+          onRetry = {},
+          onDismiss = {},
+        )
+      }
     }
-  }
 
   @Test
-  fun searchBarEmpty() = screenshotTest("search_bar_empty") {
-    ThemedSurface(dark = true) { SearchBar(query = "", onQueryChange = {}) }
-  }
+  fun searchBarEmpty() =
+    screenshotTest("search_bar_empty") {
+      ThemedSurface(dark = true) { SearchBar(query = "", onQueryChange = {}) }
+    }
 
   @Test
-  fun searchBarWithQuery() = screenshotTest("search_bar_with_query") {
-    ThemedSurface(dark = true) {
-      SearchBar(
-        query = "MainActivity",
-        onQueryChange = {},
-        showRegexToggle = true,
-        isRegexEnabled = true,
-        onRegexToggle = {},
-      )
+  fun searchBarWithQuery() =
+    screenshotTest("search_bar_with_query") {
+      ThemedSurface(dark = true) {
+        SearchBar(
+          query = "MainActivity",
+          onQueryChange = {},
+          showRegexToggle = true,
+          isRegexEnabled = true,
+          onRegexToggle = {},
+        )
+      }
     }
-  }
 
   @Test
-  fun statusBarBadge() = screenshotTest("status_bar_badge") {
-    ThemedSurface(dark = true) {
-      StatusBarBadge(count = 12, label = "Crashes", color = Color(0xFFF28B82))
+  fun statusBarBadge() =
+    screenshotTest("status_bar_badge") {
+      ThemedSurface(dark = true) {
+        StatusBarBadge(count = 12, label = "Crashes", color = Color(0xFFF28B82))
+      }
     }
-  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.components.ErrorCard
 import dev.jasonpearson.automobile.desktop.core.components.SearchBar
 import dev.jasonpearson.automobile.desktop.core.shell.StatusBarBadge
+import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -20,11 +21,15 @@ import org.junit.Test
  * Material themes. This is a starter set that proves the [screenshotTest] pattern; extend it with
  * more components and dashboard states as coverage grows.
  *
- * Record the baselines (on the reference OS / CI) with:
+ * `@Ignore`d until the baseline PNGs are recorded and committed alongside these tests — the harness
+ * fails (does not skip) on a missing baseline, so these must not run until their baselines exist.
+ * To enable: record and commit the baselines, then remove the `@Ignore`.
+ *
  * ```
  * ./gradlew -p android :desktop-core:test --tests '*ComponentScreenshotTest' -Dscreenshot.record=true
  * ```
  */
+@Ignore("Enable once baseline PNGs are recorded and committed (see class KDoc).")
 class ComponentScreenshotTest {
 
   /** Wraps content in a themed, fixed-width surface so captures are deterministic. */

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ComponentScreenshotTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.components.ErrorCard
 import dev.jasonpearson.automobile.desktop.core.components.SearchBar
 import dev.jasonpearson.automobile.desktop.core.shell.StatusBarBadge
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -21,15 +20,13 @@ import org.junit.Test
  * Material themes. This is a starter set that proves the [screenshotTest] pattern; extend it with
  * more components and dashboard states as coverage grows.
  *
- * `@Ignore`d until the baseline PNGs are recorded and committed alongside these tests — the harness
- * fails (does not skip) on a missing baseline, so these must not run until their baselines exist.
- * To enable: record and commit the baselines, then remove the `@Ignore`.
- *
+ * Each case is marked `pending = true` because its baseline PNG is not committed yet: pending tests
+ * are skipped in verify mode (so CI can't fail on the missing baseline) but still run in record
+ * mode. To turn them into active checks, record and commit the baselines, then drop `pending`:
  * ```
  * ./gradlew -p android :desktop-core:test --tests '*ComponentScreenshotTest' -Dscreenshot.record=true
  * ```
  */
-@Ignore("Enable once baseline PNGs are recorded and committed (see class KDoc).")
 class ComponentScreenshotTest {
 
   /** Wraps content in a themed, fixed-width surface so captures are deterministic. */
@@ -44,7 +41,7 @@ class ComponentScreenshotTest {
 
   @Test
   fun errorCardLight() =
-    screenshotTest("error_card_light") {
+    screenshotTest("error_card_light", pending = true) {
       ThemedSurface(dark = false) {
         ErrorCard(title = "Something went wrong", message = "Please try again later.")
       }
@@ -52,7 +49,7 @@ class ComponentScreenshotTest {
 
   @Test
   fun errorCardDark() =
-    screenshotTest("error_card_dark") {
+    screenshotTest("error_card_dark", pending = true) {
       ThemedSurface(dark = true) {
         ErrorCard(title = "Something went wrong", message = "Please try again later.")
       }
@@ -60,7 +57,7 @@ class ComponentScreenshotTest {
 
   @Test
   fun errorCardWithActions() =
-    screenshotTest("error_card_with_actions") {
+    screenshotTest("error_card_with_actions", pending = true) {
       ThemedSurface(dark = true) {
         ErrorCard(
           title = "Connection lost",
@@ -73,13 +70,13 @@ class ComponentScreenshotTest {
 
   @Test
   fun searchBarEmpty() =
-    screenshotTest("search_bar_empty") {
+    screenshotTest("search_bar_empty", pending = true) {
       ThemedSurface(dark = true) { SearchBar(query = "", onQueryChange = {}) }
     }
 
   @Test
   fun searchBarWithQuery() =
-    screenshotTest("search_bar_with_query") {
+    screenshotTest("search_bar_with_query", pending = true) {
       ThemedSurface(dark = true) {
         SearchBar(
           query = "MainActivity",
@@ -93,7 +90,7 @@ class ComponentScreenshotTest {
 
   @Test
   fun statusBarBadge() =
-    screenshotTest("status_bar_badge") {
+    screenshotTest("status_bar_badge", pending = true) {
       ThemedSurface(dark = true) {
         StatusBarBadge(count = 12, label = "Crashes", color = Color(0xFFF28B82))
       }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparator.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparator.kt
@@ -1,0 +1,139 @@
+package dev.jasonpearson.automobile.desktop.core.screenshot
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.abs
+
+/**
+ * Pure image record/compare logic for desktop screenshot tests. Deliberately free of any Compose
+ * dependency so it is fast to unit test on its own (see `ScreenshotComparatorTest`).
+ *
+ * Comparison is tolerant of tiny anti-aliasing differences via [Options.channelTolerance] and
+ * [Options.maxDifferentPixelRatio]; see the defaults for the rationale. Font rasterization still
+ * differs across operating systems, so baselines are pinned to a single reference OS — that gating
+ * lives in [ScreenshotEnvironment], not here.
+ */
+object ScreenshotComparator {
+
+  /**
+   * @param channelTolerance Per-channel (ARGB) absolute difference, 0-255, below which two pixels
+   *   are considered equal. A small value absorbs sub-pixel anti-aliasing jitter without hiding
+   *   real color changes.
+   * @param maxDifferentPixelRatio Fraction of differing pixels (0.0-1.0) tolerated before the
+   *   comparison fails. Kept very small so genuine layout/content changes are still caught.
+   */
+  data class Options(
+    val channelTolerance: Int = 4,
+    val maxDifferentPixelRatio: Double = 0.001,
+  )
+
+  sealed interface Result {
+    /** The baseline was (re)written; nothing was compared. */
+    data object Recorded : Result
+
+    /** Actual image matched the baseline within tolerance. */
+    data object Match : Result
+
+    /** No baseline exists yet; record one before it can be verified. */
+    data class MissingBaseline(val baseline: File) : Result
+
+    /** Actual and baseline dimensions differ; a full pixel diff is not meaningful. */
+    data class SizeMismatch(
+      val expectedWidth: Int,
+      val expectedHeight: Int,
+      val actualWidth: Int,
+      val actualHeight: Int,
+      val actualFile: File,
+    ) : Result
+
+    /** Dimensions matched but too many pixels differ. */
+    data class Mismatch(
+      val differentPixelRatio: Double,
+      val differentPixelCount: Int,
+      val diffFile: File,
+      val actualFile: File,
+    ) : Result
+  }
+
+  /** Writes [actual] to [baseline], creating parent directories as needed. */
+  fun record(baseline: File, actual: BufferedImage): Result {
+    baseline.parentFile?.mkdirs()
+    ImageIO.write(actual, "png", baseline)
+    return Result.Recorded
+  }
+
+  /**
+   * Compares [actual] against the PNG at [baseline]. On mismatch, writes the rejected image and a
+   * red-highlighted diff into [reportDir] so failures are inspectable.
+   */
+  fun compare(
+    baseline: File,
+    actual: BufferedImage,
+    reportDir: File,
+    name: String,
+    options: Options = Options(),
+  ): Result {
+    if (!baseline.exists()) return Result.MissingBaseline(baseline)
+    val expected = ImageIO.read(baseline) ?: return Result.MissingBaseline(baseline)
+
+    if (expected.width != actual.width || expected.height != actual.height) {
+      return Result.SizeMismatch(
+        expectedWidth = expected.width,
+        expectedHeight = expected.height,
+        actualWidth = actual.width,
+        actualHeight = actual.height,
+        actualFile = writeReport(reportDir, "$name.actual.png", actual),
+      )
+    }
+
+    val diff = BufferedImage(expected.width, expected.height, BufferedImage.TYPE_INT_ARGB)
+    var differing = 0
+    for (y in 0 until expected.height) {
+      for (x in 0 until expected.width) {
+        val e = Color(expected.getRGB(x, y), true)
+        val a = Color(actual.getRGB(x, y), true)
+        if (pixelsDiffer(e, a, options.channelTolerance)) {
+          differing++
+          diff.setRGB(x, y, HIGHLIGHT)
+        } else {
+          diff.setRGB(x, y, dim(a))
+        }
+      }
+    }
+
+    val total = expected.width.toLong() * expected.height.toLong()
+    val ratio = if (total == 0L) 0.0 else differing.toDouble() / total.toDouble()
+    if (ratio > options.maxDifferentPixelRatio) {
+      return Result.Mismatch(
+        differentPixelRatio = ratio,
+        differentPixelCount = differing,
+        diffFile = writeReport(reportDir, "$name.diff.png", diff),
+        actualFile = writeReport(reportDir, "$name.actual.png", actual),
+      )
+    }
+    return Result.Match
+  }
+
+  private fun pixelsDiffer(a: Color, b: Color, tolerance: Int): Boolean =
+    abs(a.red - b.red) > tolerance ||
+      abs(a.green - b.green) > tolerance ||
+      abs(a.blue - b.blue) > tolerance ||
+      abs(a.alpha - b.alpha) > tolerance
+
+  /** Desaturated, dimmed version of a matching pixel so the red diff stands out. */
+  private fun dim(c: Color): Int {
+    val gray = ((c.red + c.green + c.blue) / 3 * 0.35).toInt().coerceIn(0, 255)
+    return Color(gray, gray, gray, 255).rgb
+  }
+
+  private fun writeReport(reportDir: File, fileName: String, image: BufferedImage): File {
+    reportDir.mkdirs()
+    val file = File(reportDir, fileName)
+    ImageIO.write(image, "png", file)
+    return file
+  }
+
+  private val HIGHLIGHT = Color(255, 0, 0, 255).rgb
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparatorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparatorTest.kt
@@ -42,8 +42,7 @@ class ScreenshotComparatorTest {
   fun `identical images match`() {
     val baseline = File(tempDir, "match.png")
     ScreenshotComparator.record(baseline, solid(8, 8, Color.GREEN))
-    val result =
-      ScreenshotComparator.compare(baseline, solid(8, 8, Color.GREEN), tempDir, "match")
+    val result = ScreenshotComparator.compare(baseline, solid(8, 8, Color.GREEN), tempDir, "match")
     assertEquals(ScreenshotComparator.Result.Match, result)
   }
 
@@ -61,8 +60,7 @@ class ScreenshotComparatorTest {
   fun `large color change fails and writes diff plus rejected image`() {
     val baseline = File(tempDir, "diff.png")
     ScreenshotComparator.record(baseline, solid(8, 8, Color.WHITE))
-    val result =
-      ScreenshotComparator.compare(baseline, solid(8, 8, Color.BLACK), tempDir, "diff")
+    val result = ScreenshotComparator.compare(baseline, solid(8, 8, Color.BLACK), tempDir, "diff")
     assertTrue(result is ScreenshotComparator.Result.Mismatch, "expected a mismatch")
     result as ScreenshotComparator.Result.Mismatch
     assertEquals(1.0, result.differentPixelRatio, "all pixels differ")
@@ -86,8 +84,7 @@ class ScreenshotComparatorTest {
   fun `dimension change is reported as size mismatch`() {
     val baseline = File(tempDir, "size.png")
     ScreenshotComparator.record(baseline, solid(8, 8, Color.GRAY))
-    val result =
-      ScreenshotComparator.compare(baseline, solid(16, 8, Color.GRAY), tempDir, "size")
+    val result = ScreenshotComparator.compare(baseline, solid(16, 8, Color.GRAY), tempDir, "size")
     assertTrue(result is ScreenshotComparator.Result.SizeMismatch)
     result as ScreenshotComparator.Result.SizeMismatch
     assertEquals(8, result.expectedWidth)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparatorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparatorTest.kt
@@ -1,0 +1,97 @@
+package dev.jasonpearson.automobile.desktop.core.screenshot
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pure-logic tests for [ScreenshotComparator]. No Compose, no rendering — these run in well under
+ * the module's fast-test budget and never touch a display.
+ */
+class ScreenshotComparatorTest {
+
+  private val tempDir: File = Files.createTempDirectory("screenshot-comparator").toFile()
+
+  @AfterTest
+  fun cleanUp() {
+    tempDir.deleteRecursively()
+  }
+
+  private fun solid(width: Int, height: Int, color: Color): BufferedImage {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) for (x in 0 until width) image.setRGB(x, y, color.rgb)
+    return image
+  }
+
+  @Test
+  fun `record writes baseline and creates parent dirs`() {
+    val baseline = File(tempDir, "nested/dir/badge.png")
+    val result = ScreenshotComparator.record(baseline, solid(4, 4, Color.BLUE))
+    assertEquals(ScreenshotComparator.Result.Recorded, result)
+    assertTrue(baseline.exists(), "baseline PNG should be written")
+    assertEquals(4, ImageIO.read(baseline).width)
+  }
+
+  @Test
+  fun `identical images match`() {
+    val baseline = File(tempDir, "match.png")
+    ScreenshotComparator.record(baseline, solid(8, 8, Color.GREEN))
+    val result =
+      ScreenshotComparator.compare(baseline, solid(8, 8, Color.GREEN), tempDir, "match")
+    assertEquals(ScreenshotComparator.Result.Match, result)
+  }
+
+  @Test
+  fun `small anti-aliasing jitter is tolerated`() {
+    val baseline = File(tempDir, "jitter.png")
+    ScreenshotComparator.record(baseline, solid(8, 8, Color(100, 100, 100)))
+    // Every pixel off by 3 (< default channelTolerance of 4).
+    val result =
+      ScreenshotComparator.compare(baseline, solid(8, 8, Color(103, 103, 103)), tempDir, "jitter")
+    assertEquals(ScreenshotComparator.Result.Match, result)
+  }
+
+  @Test
+  fun `large color change fails and writes diff plus rejected image`() {
+    val baseline = File(tempDir, "diff.png")
+    ScreenshotComparator.record(baseline, solid(8, 8, Color.WHITE))
+    val result =
+      ScreenshotComparator.compare(baseline, solid(8, 8, Color.BLACK), tempDir, "diff")
+    assertTrue(result is ScreenshotComparator.Result.Mismatch, "expected a mismatch")
+    result as ScreenshotComparator.Result.Mismatch
+    assertEquals(1.0, result.differentPixelRatio, "all pixels differ")
+    assertTrue(result.diffFile.exists(), "diff image should be written")
+    assertTrue(result.actualFile.exists(), "rejected image should be written")
+  }
+
+  @Test
+  fun `missing baseline is reported`() {
+    val result =
+      ScreenshotComparator.compare(
+        File(tempDir, "does-not-exist.png"),
+        solid(2, 2, Color.RED),
+        tempDir,
+        "missing",
+      )
+    assertTrue(result is ScreenshotComparator.Result.MissingBaseline)
+  }
+
+  @Test
+  fun `dimension change is reported as size mismatch`() {
+    val baseline = File(tempDir, "size.png")
+    ScreenshotComparator.record(baseline, solid(8, 8, Color.GRAY))
+    val result =
+      ScreenshotComparator.compare(baseline, solid(16, 8, Color.GRAY), tempDir, "size")
+    assertTrue(result is ScreenshotComparator.Result.SizeMismatch)
+    result as ScreenshotComparator.Result.SizeMismatch
+    assertEquals(8, result.expectedWidth)
+    assertEquals(16, result.actualWidth)
+    assertTrue(result.actualFile.exists())
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
@@ -1,0 +1,90 @@
+package dev.jasonpearson.automobile.desktop.core.screenshot
+
+import java.awt.image.BufferedImage
+import java.io.File
+import kotlin.test.fail
+import org.junit.Assume
+
+/**
+ * Reads the system properties that configure a screenshot-test run and turns a captured image into
+ * a pass/fail/record outcome.
+ *
+ * Supported `-D` properties (forwarded to the test JVM by `desktop-core/build.gradle.kts`):
+ * - `screenshot.record` (`true`/`false`, default `false`) — write baselines instead of comparing.
+ * - `screenshot.reference.os` (default `linux`, or `any` to disable OS gating) — baselines are
+ *   pixel-identical only on one OS because font rasterization differs; tests are skipped (not
+ *   failed) elsewhere so `./gradlew test` stays green on any developer machine.
+ * - `screenshot.golden.dir` (default `src/test/resources/screenshots`) — where baseline PNGs live.
+ * - `screenshot.report.dir` (default `build/reports/screenshots`) — where rejected/diff images go.
+ */
+object ScreenshotEnvironment {
+
+  private const val RECORD_PROPERTY = "screenshot.record"
+  private const val REFERENCE_OS_PROPERTY = "screenshot.reference.os"
+  private const val GOLDEN_DIR_PROPERTY = "screenshot.golden.dir"
+  private const val REPORT_DIR_PROPERTY = "screenshot.report.dir"
+
+  private const val DEFAULT_REFERENCE_OS = "linux"
+  private const val DEFAULT_GOLDEN_DIR = "src/test/resources/screenshots"
+  private const val DEFAULT_REPORT_DIR = "build/reports/screenshots"
+
+  val recordEnabled: Boolean
+    get() = System.getProperty(RECORD_PROPERTY)?.toBooleanStrictOrNull() == true
+
+  private val goldenDir: File
+    get() = File(System.getProperty(GOLDEN_DIR_PROPERTY) ?: DEFAULT_GOLDEN_DIR)
+
+  private val reportDir: File
+    get() = File(System.getProperty(REPORT_DIR_PROPERTY) ?: DEFAULT_REPORT_DIR)
+
+  /**
+   * Skips the calling test (via a JUnit assumption) unless it is running on the reference OS. This
+   * keeps OS-specific pixel differences from turning into false failures on developer machines while
+   * still enforcing the baseline on the reference CI platform.
+   */
+  fun assumeReferencePlatform() {
+    val referenceOs =
+      (System.getProperty(REFERENCE_OS_PROPERTY) ?: DEFAULT_REFERENCE_OS).lowercase()
+    if (referenceOs == "any") return
+    val currentOs = System.getProperty("os.name", "").lowercase()
+    Assume.assumeTrue(
+      "Screenshot tests only run on the reference OS '$referenceOs' (current: '$currentOs'). " +
+        "Record on CI, or override locally with -D$REFERENCE_OS_PROPERTY=any.",
+      currentOs.contains(referenceOs),
+    )
+  }
+
+  /** Records or verifies [image] for [name], failing the test with an actionable message. */
+  fun handleResult(
+    name: String,
+    image: BufferedImage,
+    options: ScreenshotComparator.Options,
+  ) {
+    val baseline = File(goldenDir, "$name.png")
+    if (recordEnabled) {
+      ScreenshotComparator.record(baseline, image)
+      return
+    }
+    when (val result = ScreenshotComparator.compare(baseline, image, reportDir, name, options)) {
+      ScreenshotComparator.Result.Match -> Unit
+      ScreenshotComparator.Result.Recorded -> Unit
+      is ScreenshotComparator.Result.MissingBaseline ->
+        fail(
+          "No screenshot baseline for '$name' at ${result.baseline.path}. " +
+            "Record it with: ./gradlew :desktop-core:test -D$RECORD_PROPERTY=true"
+        )
+      is ScreenshotComparator.Result.SizeMismatch ->
+        fail(
+          "Screenshot '$name' size changed: baseline ${result.expectedWidth}x${result.expectedHeight}, " +
+            "actual ${result.actualWidth}x${result.actualHeight}. Rejected image: ${result.actualFile.path}"
+        )
+      is ScreenshotComparator.Result.Mismatch ->
+        fail(
+          "Screenshot '$name' differs: ${result.differentPixelCount} pixels " +
+            "(${"%.4f".format(result.differentPixelRatio * 100)}%) exceed tolerance. " +
+            "Diff: ${result.diffFile.path}, rejected: ${result.actualFile.path}. " +
+            "If intentional, re-record with -D$RECORD_PROPERTY=true."
+        )
+    }
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
@@ -69,13 +69,14 @@ object ScreenshotEnvironment {
       ScreenshotComparator.Result.Match -> Unit
       ScreenshotComparator.Result.Recorded -> Unit
       is ScreenshotComparator.Result.MissingBaseline ->
-        // Treat a not-yet-recorded baseline as pending (skipped), not failed, so adding a
-        // screenshot test before its baseline exists doesn't break the build. Record with
-        // -Dscreenshot.record=true, then the test actively verifies.
-        Assume.assumeTrue(
-          "No screenshot baseline for '$name' yet at ${result.baseline.path}. " +
-            "Record it with: ./gradlew -p android :desktop-core:test -D$RECORD_PROPERTY=true",
-          false,
+        // A missing baseline is a failure, not a skip: verification must not silently pass when a
+        // baseline is absent or has been deleted. Commit baselines together with their tests
+        // (record them with -Dscreenshot.record=true). Tests whose baselines are not yet recorded
+        // should be @Ignore'd until they are, rather than relaxing this into a skip.
+        fail(
+          "No screenshot baseline for '$name' at ${result.baseline.path}. " +
+            "Record it with: ./gradlew -p android :desktop-core:test -D$RECORD_PROPERTY=true, " +
+            "then commit the PNG alongside the test."
         )
       is ScreenshotComparator.Result.SizeMismatch ->
         fail(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
@@ -39,8 +39,8 @@ object ScreenshotEnvironment {
 
   /**
    * Skips the calling test (via a JUnit assumption) unless it is running on the reference OS. This
-   * keeps OS-specific pixel differences from turning into false failures on developer machines while
-   * still enforcing the baseline on the reference CI platform.
+   * keeps OS-specific pixel differences from turning into false failures on developer machines
+   * while still enforcing the baseline on the reference CI platform.
    */
   fun assumeReferencePlatform() {
     val referenceOs =
@@ -69,9 +69,13 @@ object ScreenshotEnvironment {
       ScreenshotComparator.Result.Match -> Unit
       ScreenshotComparator.Result.Recorded -> Unit
       is ScreenshotComparator.Result.MissingBaseline ->
-        fail(
-          "No screenshot baseline for '$name' at ${result.baseline.path}. " +
-            "Record it with: ./gradlew :desktop-core:test -D$RECORD_PROPERTY=true"
+        // Treat a not-yet-recorded baseline as pending (skipped), not failed, so adding a
+        // screenshot test before its baseline exists doesn't break the build. Record with
+        // -Dscreenshot.record=true, then the test actively verifies.
+        Assume.assumeTrue(
+          "No screenshot baseline for '$name' yet at ${result.baseline.path}. " +
+            "Record it with: ./gradlew -p android :desktop-core:test -D$RECORD_PROPERTY=true",
+          false,
         )
       is ScreenshotComparator.Result.SizeMismatch ->
         fail(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotEnvironment.kt
@@ -54,6 +54,21 @@ object ScreenshotEnvironment {
     )
   }
 
+  /**
+   * Skips a [pending] test (one whose baseline is not recorded yet) in verify mode, so it can't
+   * fail on a missing baseline — but lets it run in record mode so `-Dscreenshot.record=true` still
+   * produces the baseline. Non-pending tests are unaffected and fail on a missing baseline.
+   */
+  fun skipIfPending(name: String, pending: Boolean) {
+    if (pending && !recordEnabled) {
+      Assume.assumeTrue(
+        "Screenshot '$name' is pending — its baseline is not recorded yet. " +
+          "Record it with -D$RECORD_PROPERTY=true, commit the PNG, then drop pending = true.",
+        false,
+      )
+    }
+  }
+
   /** Records or verifies [image] for [name], failing the test with an actionable message. */
   fun handleResult(
     name: String,
@@ -71,8 +86,8 @@ object ScreenshotEnvironment {
       is ScreenshotComparator.Result.MissingBaseline ->
         // A missing baseline is a failure, not a skip: verification must not silently pass when a
         // baseline is absent or has been deleted. Commit baselines together with their tests
-        // (record them with -Dscreenshot.record=true). Tests whose baselines are not yet recorded
-        // should be @Ignore'd until they are, rather than relaxing this into a skip.
+        // (record them with -Dscreenshot.record=true). A test whose baseline is not recorded yet
+        // should pass pending = true (see skipIfPending) rather than relaxing this into a skip.
         fail(
           "No screenshot baseline for '$name' at ${result.baseline.path}. " +
             "Record it with: ./gradlew -p android :desktop-core:test -D$RECORD_PROPERTY=true, " +

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotTester.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotTester.kt
@@ -1,0 +1,48 @@
+package dev.jasonpearson.automobile.desktop.core.screenshot
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toAwtImage
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+
+/** Test tag applied to the captured root so we snapshot exactly the content bounds. */
+private const val ROOT_TAG = "automobile_screenshot_root"
+
+/**
+ * Renders [content] in an isolated Compose Desktop test host, captures it to a PNG, and either
+ * records a new baseline or compares against the committed one — depending on the `screenshot.*`
+ * system properties documented on [ScreenshotEnvironment].
+ *
+ * Usage mirrors the existing `*UiTest` files in this module:
+ * ```
+ * @Test fun errorCard() = screenshotTest("error_card_light") {
+ *   MaterialTheme { Surface { ErrorCard(title = "Oops", message = "Try again") } }
+ * }
+ * ```
+ *
+ * Wrap [content] in the theme/`Surface` you want captured — the harness adds only an invisible
+ * tagged wrapper so the snapshot is sized to the content, not the whole test window. Keep the
+ * captured surface small and deterministic: avoid animations, time-based state, and random data.
+ *
+ * @param name Stable baseline name (also the PNG file name). Use lowercase_snake_case.
+ * @param options Pixel-comparison tolerances; the defaults suit anti-aliased Compose UI.
+ */
+@OptIn(ExperimentalTestApi::class)
+fun screenshotTest(
+  name: String,
+  options: ScreenshotComparator.Options = ScreenshotComparator.Options(),
+  content: @Composable () -> Unit,
+) {
+  ScreenshotEnvironment.assumeReferencePlatform()
+  runComposeUiTest {
+    setContent { Box(Modifier.testTag(ROOT_TAG)) { content() } }
+    waitForIdle()
+    val image = onNodeWithTag(ROOT_TAG).captureToImage().toAwtImage()
+    ScreenshotEnvironment.handleResult(name, image, options)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotTester.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotTester.kt
@@ -31,14 +31,20 @@ private const val ROOT_TAG = "automobile_screenshot_root"
  *
  * @param name Stable baseline name (also the PNG file name). Use lowercase_snake_case.
  * @param options Pixel-comparison tolerances; the defaults suit anti-aliased Compose UI.
+ * @param pending Set `true` for a test whose baseline has not been recorded and committed yet. A
+ *   pending test is skipped in verify mode (so it can't fail on a missing baseline) but still runs
+ *   in record mode (`-Dscreenshot.record=true`), so the documented recording path produces its PNG.
+ *   Once the baseline is committed, drop `pending` so the test actively verifies.
  */
 @OptIn(ExperimentalTestApi::class)
 fun screenshotTest(
   name: String,
   options: ScreenshotComparator.Options = ScreenshotComparator.Options(),
+  pending: Boolean = false,
   content: @Composable () -> Unit,
 ) {
   ScreenshotEnvironment.assumeReferencePlatform()
+  ScreenshotEnvironment.skipIfPending(name, pending)
   runComposeUiTest {
     setContent { Box(Modifier.testTag(ROOT_TAG)) { content() } }
     waitForIdle()

--- a/android/desktop-core/src/test/resources/screenshots/README.md
+++ b/android/desktop-core/src/test/resources/screenshots/README.md
@@ -1,0 +1,32 @@
+# Desktop screenshot baselines
+
+This directory holds the committed baseline PNGs for `desktop-core` screenshot tests
+(see `src/test/kotlin/.../core/screenshot/`). Each `*.png` here is the reference image a
+`screenshotTest("name") { … }` compares against.
+
+## Recording / updating baselines
+
+Baselines are pixel-identical only on the **reference OS** (Linux by default), because font
+rasterization differs across platforms. Record them on that OS (or in CI):
+
+```bash
+# Record every screenshot baseline
+./gradlew -p android :desktop-core:test --tests '*ScreenshotTest' -Dscreenshot.record=true
+
+# Record a single test's baselines
+./gradlew -p android :desktop-core:test \
+  --tests '*ComponentScreenshotTest' -Dscreenshot.record=true
+```
+
+Then review the generated/updated PNGs in this folder and commit them alongside the code change.
+
+## Verifying
+
+Plain `./gradlew -p android :desktop-core:test` compares against these baselines. On a non-reference
+OS the screenshot tests are **skipped** (a JUnit assumption), so they never produce false failures
+on developer machines — override with `-Dscreenshot.reference.os=any` to force them locally.
+
+On a mismatch, the rejected image and a red-highlighted diff are written under
+`build/reports/screenshots/` for inspection.
+
+See `android/docs/screenshot-testing.md` for the full guide.

--- a/android/desktop-core/src/test/resources/screenshots/README.md
+++ b/android/desktop-core/src/test/resources/screenshots/README.md
@@ -24,7 +24,8 @@ Then review the generated/updated PNGs in this folder and commit them alongside 
 
 Plain `./gradlew -p android :desktop-core:test` compares against these baselines. On a non-reference
 OS the screenshot tests are **skipped** (a JUnit assumption), so they never produce false failures
-on developer machines — override with `-Dscreenshot.reference.os=any` to force them locally.
+on developer machines — override with `-Dscreenshot.reference.os=any` to force them locally. A test
+whose baseline has not been recorded yet is likewise **skipped (pending)** rather than failed.
 
 On a mismatch, the rejected image and a red-highlighted diff are written under
 `build/reports/screenshots/` for inspection.

--- a/android/desktop-core/src/test/resources/screenshots/README.md
+++ b/android/desktop-core/src/test/resources/screenshots/README.md
@@ -26,7 +26,8 @@ Plain `./gradlew -p android :desktop-core:test` compares against these baselines
 OS the screenshot tests are **skipped** (a JUnit assumption), so they never produce false failures
 on developer machines — override with `-Dscreenshot.reference.os=any` to force them locally. A
 **missing baseline fails** verification (it is never silently skipped), so commit baselines together
-with their tests and `@Ignore` any test whose baseline has not been recorded yet.
+with their tests; mark a test whose baseline is not recorded yet with `pending = true` (skipped in
+verify mode, still records) instead.
 
 On a mismatch, the rejected image and a red-highlighted diff are written under
 `build/reports/screenshots/` for inspection.

--- a/android/desktop-core/src/test/resources/screenshots/README.md
+++ b/android/desktop-core/src/test/resources/screenshots/README.md
@@ -24,8 +24,9 @@ Then review the generated/updated PNGs in this folder and commit them alongside 
 
 Plain `./gradlew -p android :desktop-core:test` compares against these baselines. On a non-reference
 OS the screenshot tests are **skipped** (a JUnit assumption), so they never produce false failures
-on developer machines — override with `-Dscreenshot.reference.os=any` to force them locally. A test
-whose baseline has not been recorded yet is likewise **skipped (pending)** rather than failed.
+on developer machines — override with `-Dscreenshot.reference.os=any` to force them locally. A
+**missing baseline fails** verification (it is never silently skipped), so commit baselines together
+with their tests and `@Ignore` any test whose baseline has not been recorded yet.
 
 On a mismatch, the rejected image and a red-highlighted diff are written under
 `build/reports/screenshots/` for inspection.

--- a/android/docs/screenshot-testing.md
+++ b/android/docs/screenshot-testing.md
@@ -1,0 +1,96 @@
+# Desktop screenshot testing
+
+The `desktop-core` module supports **screenshot (golden-image) tests** for its Compose UI on top of
+the existing Compose Desktop UI-test setup (`compose.desktop.uiTestJUnit4` + `runComposeUiTest`).
+A test renders a composable, captures it to a PNG, and compares it against a committed baseline so
+unintended visual changes fail the build.
+
+No third-party screenshot library is used — the harness is a thin wrapper around Compose Desktop's
+own `captureToImage()`, which keeps it dependency-free and resilient to Compose/Kotlin upgrades.
+
+## Writing a test
+
+Add a test that calls `screenshotTest(name) { … }` (mirrors the module's existing `*UiTest` style):
+
+```kotlin
+class ComponentScreenshotTest {
+  @Test
+  fun errorCardLight() = screenshotTest("error_card_light") {
+    MaterialTheme(colorScheme = lightColorScheme()) {
+      Surface(Modifier.width(360.dp)) {
+        ErrorCard(title = "Something went wrong", message = "Please try again later.")
+      }
+    }
+  }
+}
+```
+
+Guidelines:
+
+- **Wrap content in the theme/`Surface` you want captured.** The harness only adds an invisible
+  tagged wrapper so the snapshot is sized to your content, not the whole test window.
+- **Keep it deterministic.** Avoid animations, `Date`/time-based state, randomness, and network or
+  daemon data. Feed fixed inputs and fakes (the module already provides `FakeAutoMobileClient`).
+- **Constrain width** for components that `fillMaxWidth()` (e.g. `ErrorCard`) so the image stays
+  small and stable.
+- Use `lowercase_snake_case` names; the name is also the PNG file name.
+
+## Recording baselines
+
+Baselines live in `desktop-core/src/test/resources/screenshots/` and are committed to git (excluded
+from Git LFS in `.gitattributes`). Record or update them with `-Dscreenshot.record=true`:
+
+```bash
+# All screenshot baselines
+./gradlew -p android :desktop-core:test --tests '*ScreenshotTest' -Dscreenshot.record=true
+
+# One test class
+./gradlew -p android :desktop-core:test \
+  --tests '*ComponentScreenshotTest' -Dscreenshot.record=true
+```
+
+Review the resulting PNGs and commit them with your change.
+
+## Verifying
+
+A normal test run compares against the baselines:
+
+```bash
+./gradlew -p android :desktop-core:test --tests '*ScreenshotTest'
+```
+
+On a mismatch the test fails and writes the rejected image plus a red-highlighted diff to
+`build/reports/screenshots/`.
+
+## Cross-platform note (important)
+
+Font rasterization differs across operating systems, so a baseline recorded on Linux will not be
+pixel-identical on macOS or Windows. To avoid false failures:
+
+- Screenshot tests **only run on the reference OS** (Linux by default). On other platforms they are
+  **skipped** via a JUnit assumption, so `./gradlew … test` stays green everywhere.
+- **Record and verify baselines on the same OS** — do it on CI/Linux, not a developer Mac.
+- Override the gate locally (at your own risk) with `-Dscreenshot.reference.os=any`.
+
+## Configuration flags
+
+All are JVM system properties, forwarded to the test JVM by `desktop-core/build.gradle.kts`:
+
+| Property                    | Default                          | Purpose                                            |
+| --------------------------- | -------------------------------- | -------------------------------------------------- |
+| `screenshot.record`         | `false`                          | Write baselines instead of comparing.              |
+| `screenshot.reference.os`   | `linux`                          | Reference OS substring; `any` disables OS gating.  |
+| `screenshot.golden.dir`     | `src/test/resources/screenshots` | Where baseline PNGs are read/written.              |
+| `screenshot.report.dir`     | `build/reports/screenshots`      | Where rejected/diff images are written on failure. |
+
+Pixel tolerances (per-channel and max differing-pixel ratio) are set per test via
+`ScreenshotComparator.Options`; the defaults suit anti-aliased Compose UI.
+
+## How it fits together
+
+| File                        | Role                                                                    |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `ScreenshotTester.kt`       | `screenshotTest(...)` — renders, captures to a `BufferedImage`.         |
+| `ScreenshotEnvironment.kt`  | Reads flags, applies OS gating, records or delegates comparison.        |
+| `ScreenshotComparator.kt`   | Pure record/compare/diff logic (no Compose; unit-tested for speed).     |
+| `ComponentScreenshotTest.kt`| Starter baselines for representative components (light + dark).         |

--- a/android/docs/screenshot-testing.md
+++ b/android/docs/screenshot-testing.md
@@ -62,8 +62,13 @@ A normal test run compares against the baselines:
 On a mismatch the test **fails** and writes the rejected image plus a red-highlighted diff to
 `build/reports/screenshots/`. A **missing baseline is also a failure** — verification never silently
 passes when a baseline is absent or has been deleted. Always commit a baseline together with its
-test. A test whose baseline is not recorded yet should be `@Ignore`d until it is (see
-`ComponentScreenshotTest` for the pattern), not left to fail.
+test.
+
+For a test whose baseline is not recorded yet, pass `pending = true` (see `ComponentScreenshotTest`
+for the pattern). A pending test is **skipped in verify mode** (so it can't fail on the missing
+baseline) but **still runs in record mode**, so `-Dscreenshot.record=true` produces its PNG. Once the
+baseline is committed, drop `pending` so the test actively verifies. Do not use `@Ignore` for this —
+`@Ignore` also blocks recording.
 
 ## Cross-platform note (important)
 

--- a/android/docs/screenshot-testing.md
+++ b/android/docs/screenshot-testing.md
@@ -59,8 +59,10 @@ A normal test run compares against the baselines:
 ./gradlew -p android :desktop-core:test --tests '*ScreenshotTest'
 ```
 
-On a mismatch the test fails and writes the rejected image plus a red-highlighted diff to
-`build/reports/screenshots/`.
+On a mismatch the test **fails** and writes the rejected image plus a red-highlighted diff to
+`build/reports/screenshots/`. If a baseline has **not been recorded yet**, the test is reported as
+**skipped (pending)** rather than failed — so adding a screenshot test before recording its baseline
+never breaks the build. Record the baseline to turn the pending test into an active check.
 
 ## Cross-platform note (important)
 

--- a/android/docs/screenshot-testing.md
+++ b/android/docs/screenshot-testing.md
@@ -60,9 +60,10 @@ A normal test run compares against the baselines:
 ```
 
 On a mismatch the test **fails** and writes the rejected image plus a red-highlighted diff to
-`build/reports/screenshots/`. If a baseline has **not been recorded yet**, the test is reported as
-**skipped (pending)** rather than failed — so adding a screenshot test before recording its baseline
-never breaks the build. Record the baseline to turn the pending test into an active check.
+`build/reports/screenshots/`. A **missing baseline is also a failure** — verification never silently
+passes when a baseline is absent or has been deleted. Always commit a baseline together with its
+test. A test whose baseline is not recorded yet should be `@Ignore`d until it is (see
+`ComponentScreenshotTest` for the pattern), not left to fail.
 
 ## Cross-platform note (important)
 


### PR DESCRIPTION
## Summary

Adds **screenshot (golden-image) testing** for the AutoMobile desktop app's shared Compose UI in `desktop-core`. It builds on the module's existing Compose Desktop UI-test setup (`compose.desktop.uiTestJUnit4` + `runComposeUiTest`, already used by 12 `*UiTest` files) and adds **no third-party screenshot library** — the harness is a thin wrapper over Compose Desktop's own `captureToImage()`, so it stays dependency-free and doesn't couple us to a Roborazzi/Paparazzi version against the bleeding-edge Compose Multiplatform 1.11.1 / Kotlin 2.4.0 toolchain.

What a test looks like:

```kotlin
@Test fun errorCardLight() = screenshotTest("error_card_light") {
  MaterialTheme(colorScheme = lightColorScheme()) {
    Surface(Modifier.width(360.dp)) {
      ErrorCard(title = "Something went wrong", message = "Please try again later.")
    }
  }
}
```

New files (all under `desktop-core/src/test/.../core/screenshot/`):

- **`ScreenshotComparator.kt`** — pure record/compare/diff logic, no Compose dependency, with per-channel + pixel-ratio tolerances for anti-aliasing. Writes a red-highlighted diff and the rejected image on mismatch.
- **`ScreenshotEnvironment.kt`** — reads the `screenshot.*` system properties, gates tests to a reference OS (skipped elsewhere via a JUnit assumption so `test` stays green on any dev machine), records or verifies, and treats a not-yet-recorded baseline as pending (skipped) rather than failed.
- **`ScreenshotTester.kt`** — `screenshotTest("name") { … }` renders, captures via `captureToImage()`, delegates to the environment.
- **`ScreenshotComparatorTest.kt`** — fast unit tests for the comparator (no rendering).
- **`ComponentScreenshotTest.kt`** — starter baselines for `ErrorCard`, `SearchBar`, `StatusBarBadge` in light + dark themes.

Supporting changes:

- `desktop-core/build.gradle.kts` forwards `screenshot.*` flags to the forked test JVM.
- `.gitattributes` keeps baseline PNGs in git (out of LFS), matching the existing `test/fixtures/**/*.png` convention.
- `android/docs/screenshot-testing.md` documents recording, verifying, tolerances, and the cross-platform caveat.

Recording baselines (on the reference OS / CI):

```bash
./gradlew -p android :desktop-core:test --tests '*ScreenshotTest' -Dscreenshot.record=true
```

## Linked Issue

N/A — no tracking issue; setup requested directly.

## Validation

> ⚠️ **Could not run the Android Gradle build in the authoring sandbox.** That session's egress policy returns 403 for both Google's Maven repo (`dl.google.com`) and the pinned Gradle distribution (`services.gradle.org`), so AGP/Compose artifacts don't resolve there. I did not route around the policy. Instead I fetched the pinned ktfmt from Maven Central and formatted every changed file, and compiled + ran the pure-JVM pieces (`ScreenshotComparator` + `ScreenshotEnvironment`) with the Kotlin compiler — the comparator's 6 unit tests pass. The two Compose-dependent files (`ScreenshotTester`, `ComponentScreenshotTest`) are exercised by the `desktop-core` CI jobs below.

- [ ] `Run Desktop Core Unit Tests` (CI) compiles and runs the screenshot tests — the real check for the Compose-dependent files
- [x] `ScreenshotComparatorTest` passes (verified locally, pure-logic)
- [x] ktfmt `--google-style` applied with the pinned formatter (idempotent)
- [ ] Record the initial baselines with `-Dscreenshot.record=true`, review the PNGs, and commit them (none committed yet — screenshot tests report as pending until then)

## Follow-ups

- [ ] Record and commit the initial baseline PNGs on the reference OS / CI
- [ ] Add a reference-OS (Linux) screenshot verification step; the existing `desktop-core` jobs in `.github/workflows/pull_request.yml` already run `:desktop-core:test` on ubuntu, so the baselines will be enforced there once recorded
- [ ] Expand coverage beyond the starter components to more of the desktop composables / dashboard states

🤖 Generated with [Claude Code](https://claude.com/claude-code)