### PR TITLE
feat(desktop): request live observation cadence on subscribe

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -194,12 +194,16 @@ private val ANDROID_LAUNCHERS =
 private const val IOS_SPRINGBOARD = "com.apple.springboard"
 private const val TIMELINE_EVENT_CACHE_LIMIT = 10_000
 
-// Live observation cadence requested by the desktop app while a device is connected. The desktop
-// mirrors the device screen and hierarchy in near real time, so it asks the daemon for a faster
-// screenshot cadence than the daemon's low-cost keepalive default. The daemon clamps these values
-// and resolves the fastest cadence across all subscribers. See issue #3333 / #3382.
+// Live screenshot cadence requested by the desktop app while a device is connected. The desktop
+// mirrors the device screen in near real time, so it asks the daemon for a faster screenshot
+// cadence than the daemon's 3s low-cost keepalive default (the daemon clamps and resolves the
+// fastest cadence across all subscribers). See issue #3333 / #3382.
+//
+// Hierarchy cadence is deliberately NOT requested here: the daemon already applies a fast
+// per-platform hierarchy default (Android CtrlProxy broadcasts at 250ms, iOS polls at 1000ms), and
+// the resolver takes the minimum of explicit requests. Sending a fixed 1000ms would slow Android's
+// live hierarchy 4x. Platform-/focus-aware hierarchy cadence is tracked in issue #3756.
 private const val LIVE_SCREENSHOT_INTERVAL_MS = 1_000L
-private const val LIVE_HIERARCHY_INTERVAL_MS = 1_000L
 
 /**
  * Select the default app to show in the navigation graph. Priority: foreground app >
@@ -757,7 +761,6 @@ fun AutoMobileContent(
       obsClient.connect(
         deviceId = deviceId,
         screenshotIntervalMs = LIVE_SCREENSHOT_INTERVAL_MS,
-        hierarchyIntervalMs = LIVE_HIERARCHY_INTERVAL_MS,
       )
       observationStreamClient = obsClient
 
@@ -807,7 +810,6 @@ fun AutoMobileContent(
           client.connect(
             deviceId = deviceId,
             screenshotIntervalMs = LIVE_SCREENSHOT_INTERVAL_MS,
-            hierarchyIntervalMs = LIVE_HIERARCHY_INTERVAL_MS,
           )
         }
       }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -194,6 +194,13 @@ private val ANDROID_LAUNCHERS =
 private const val IOS_SPRINGBOARD = "com.apple.springboard"
 private const val TIMELINE_EVENT_CACHE_LIMIT = 10_000
 
+// Live observation cadence requested by the desktop app while a device is connected. The desktop
+// mirrors the device screen and hierarchy in near real time, so it asks the daemon for a faster
+// screenshot cadence than the daemon's low-cost keepalive default. The daemon clamps these values
+// and resolves the fastest cadence across all subscribers. See issue #3333 / #3382.
+private const val LIVE_SCREENSHOT_INTERVAL_MS = 1_000L
+private const val LIVE_HIERARCHY_INTERVAL_MS = 1_000L
+
 /**
  * Select the default app to show in the navigation graph. Priority: foreground app >
  * launcher/springboard > first app in list
@@ -747,7 +754,11 @@ fun AutoMobileContent(
       LOG.info(
         "Connecting observation stream for device: $deviceId (client: ${obsClient.hashCode()})"
       )
-      obsClient.connect(deviceId)
+      obsClient.connect(
+        deviceId = deviceId,
+        screenshotIntervalMs = LIVE_SCREENSHOT_INTERVAL_MS,
+        hierarchyIntervalMs = LIVE_HIERARCHY_INTERVAL_MS,
+      )
       observationStreamClient = obsClient
 
       if (dataSourceMode == DataSourceMode.Real) {
@@ -793,7 +804,11 @@ fun AutoMobileContent(
           LOG.info("Observation stream socket missing, daemon appears down - skipping reconnect")
         } else {
           LOG.info("Observation stream disconnected, attempting reconnect for device: $deviceId")
-          client.connect(deviceId)
+          client.connect(
+            deviceId = deviceId,
+            screenshotIntervalMs = LIVE_SCREENSHOT_INTERVAL_MS,
+            hierarchyIntervalMs = LIVE_HIERARCHY_INTERVAL_MS,
+          )
         }
       }
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -89,8 +89,17 @@ class ObservationStreamClient {
    * Connect to the observation stream socket and subscribe to updates.
    *
    * @param deviceId Optional device ID to subscribe to. If null, subscribes to all devices.
+   * @param screenshotIntervalMs Optional requested screenshot cadence in milliseconds. When null,
+   *   the daemon applies its default low-cost keepalive cadence. The daemon clamps the value to its
+   *   supported range and resolves the fastest cadence across all subscribers for the device.
+   * @param hierarchyIntervalMs Optional requested view-hierarchy polling cadence in milliseconds.
+   *   When null, the daemon applies its default cadence.
    */
-  fun connect(deviceId: String? = null) {
+  fun connect(
+    deviceId: String? = null,
+    screenshotIntervalMs: Long? = null,
+    hierarchyIntervalMs: Long? = null,
+  ) {
     if (_connectionState.value.isConnected) {
       log.info("Already connected to observation stream")
       return
@@ -124,7 +133,7 @@ class ObservationStreamClient {
       log.info("Connected to observation stream")
 
       // Send subscribe request
-      subscribe(deviceId)
+      subscribe(deviceId, screenshotIntervalMs, hierarchyIntervalMs)
 
       // Start reading messages
       scope.launch {
@@ -174,12 +183,18 @@ class ObservationStreamClient {
     scope.coroutineContext[Job]?.cancel()
   }
 
-  private fun subscribe(deviceId: String?) {
+  private fun subscribe(
+    deviceId: String?,
+    screenshotIntervalMs: Long? = null,
+    hierarchyIntervalMs: Long? = null,
+  ) {
     val request =
       StreamRequest(
         id = UUID.randomUUID().toString(),
         command = "subscribe",
         deviceId = deviceId,
+        screenshotIntervalMs = screenshotIntervalMs,
+        hierarchyIntervalMs = hierarchyIntervalMs,
       )
 
     if (sendRequest(request)) {
@@ -422,6 +437,8 @@ data class StreamRequest(
   val command: String,
   val deviceId: String? = null,
   val appId: String? = null,
+  val screenshotIntervalMs: Long? = null,
+  val hierarchyIntervalMs: Long? = null,
 )
 
 @Serializable

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -3,9 +3,50 @@ package dev.jasonpearson.automobile.desktop.core.daemon
 import app.cash.turbine.test
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 
 class ObservationStreamClientTest {
+  // Mirrors the Json config used by ObservationStreamClient.sendRequest so the serialized subscribe
+  // payload asserted here matches what is written to the socket.
+  private val wireJson = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `subscribe request carries requested cadence when provided`() {
+    val request =
+      StreamRequest(
+        id = "req-1",
+        command = "subscribe",
+        deviceId = "emulator-5554",
+        screenshotIntervalMs = 1000L,
+        hierarchyIntervalMs = 500L,
+      )
+
+    val encoded = wireJson.encodeToString(StreamRequest.serializer(), request)
+
+    assertTrue(encoded.contains("\"screenshotIntervalMs\":1000"), encoded)
+    assertTrue(encoded.contains("\"hierarchyIntervalMs\":500"), encoded)
+  }
+
+  @Test
+  fun `subscribe request omits cadence fields when not requested`() {
+    // Older daemons predate cadence support; omitting the keys keeps the request backward
+    // compatible and lets the daemon apply its default cadence.
+    val request =
+      StreamRequest(
+        id = "req-2",
+        command = "subscribe",
+        deviceId = "emulator-5554",
+      )
+
+    val encoded = wireJson.encodeToString(StreamRequest.serializer(), request)
+
+    assertFalse(encoded.contains("screenshotIntervalMs"), encoded)
+    assertFalse(encoded.contains("hierarchyIntervalMs"), encoded)
+  }
+
   @Test
   fun `emits screenshot metadata when provided by stream`() = runTest {
     val client = ObservationStreamClient()

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -146,7 +146,7 @@ Real-time data flows over Unix domain sockets, separate from the request/respons
 
 ### ObservationStreamClient
 
-Maintains a persistent connection with subscribe/unsubscribe semantics. `connect()` accepts optional `screenshotIntervalMs` / `hierarchyIntervalMs` cadence hints that are sent on the `subscribe` request; the desktop app requests a faster live cadence than the daemon's low-cost keepalive default while a device is connected. Omitting them (older daemons) falls back to the daemon default. Exposes Kotlin `SharedFlow` instances:
+Maintains a persistent connection with subscribe/unsubscribe semantics. `connect()` accepts optional `screenshotIntervalMs` / `hierarchyIntervalMs` cadence hints that are sent on the `subscribe` request. The desktop app requests a faster screenshot cadence than the daemon's 3s keepalive default while a device is connected; it deliberately leaves the hierarchy cadence unset so each platform keeps its faster hierarchy default (Android 250ms, iOS 1000ms) instead of being slowed to a fixed value. Omitting a field (or an older daemon) falls back to the daemon default. Exposes Kotlin `SharedFlow` instances:
 
 - `hierarchyUpdates: SharedFlow<HierarchyStreamUpdate>`
 - `screenshotUpdates: SharedFlow<ScreenshotStreamUpdate>`

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -146,7 +146,7 @@ Real-time data flows over Unix domain sockets, separate from the request/respons
 
 ### ObservationStreamClient
 
-Maintains a persistent connection with subscribe/unsubscribe semantics. Exposes Kotlin `SharedFlow` instances:
+Maintains a persistent connection with subscribe/unsubscribe semantics. `connect()` accepts optional `screenshotIntervalMs` / `hierarchyIntervalMs` cadence hints that are sent on the `subscribe` request; the desktop app requests a faster live cadence than the daemon's low-cost keepalive default while a device is connected. Omitting them (older daemons) falls back to the daemon default. Exposes Kotlin `SharedFlow` instances:
 
 - `hierarchyUpdates: SharedFlow<HierarchyStreamUpdate>`
 - `screenshotUpdates: SharedFlow<ScreenshotStreamUpdate>`


### PR DESCRIPTION
## Summary

The daemon's observation stream lets a subscriber request a screenshot and view-hierarchy polling cadence — `screenshotIntervalMs` / `hierarchyIntervalMs` are parsed straight off the `subscribe` request (`src/daemon/deviceDataStreamSocketServer.ts:582-583`) and the daemon resolves the fastest cadence across all subscribers. The desktop app's `ObservationStreamClient` never sent these fields, so it always ran at the daemon's default low-cost keepalive cadence (3s screenshots) even while actively mirroring a device.

This wires the client to request cadence:
- `ObservationStreamClient.connect()`/`subscribe()` take optional `screenshotIntervalMs` / `hierarchyIntervalMs`, carried on `StreamRequest`. When omitted the fields are dropped from the JSON (`encodeDefaults` is off), so older daemons are unaffected and apply their default cadence.
- `AutoMobileContent` requests a faster live cadence (1s) at both the initial connect and the reconnect health-check while a device is connected, so the live screen mirror and hierarchy tree refresh in near real time instead of at the 3s keepalive default.

This is the first slice of an enumeration of desktop gaps against the past week's observation-stream work (screenshot metadata #3387/#3398, hierarchy cadence #3382/#3384/#3333, socket recovery #3557). It closes the "cadence control is entirely unused" gap; see Follow-ups for the rest.

## Linked Issue

Relates to #3333 and #3382 (daemon-side subscriber-controlled cadence). No dedicated desktop issue exists yet.

## Validation

- [x] `Run Desktop Core Unit Tests` and `Fast Validation` (ktfmt) pass in CI. These could not be run locally — the sandbox egress policy returns 403 for `services.gradle.org` (Gradle distribution) and `github.com` release assets (ktfmt jar), so I confirmed them via CI instead.
- [x] Added wire-contract unit tests (`ObservationStreamClientTest`): cadence fields serialize when present and are omitted when absent (back-compat).
- [x] `bun run typecheck` — N/A, no TypeScript changed.

## Device Verification

- [ ] Not verified on-device in this environment. This changes on-device observe cadence (more frequent screenshot/hierarchy capture while a device is connected); worth a manual check that the live layout mirror refreshes faster without excess device load.

## Follow-ups

Filed as separate issues to keep this PR focused (from the enumeration):
- [ ] **Focus-aware cadence** — #3756. Escalate cadence when the layout inspector is focused, relax/drop it when backgrounded. Needs a safe live-update path: re-sending `subscribe` on the same socket currently leaks a duplicate subscriber (`handleSubscribe` keys by a new id, not by socket), so this requires unsubscribe+subscribe or a new daemon "update cadence" command.
- [ ] **Surface screenshot metadata** (#3387/#3398) — #3757. The client already parses `screenshotFallback`/`format`/`captureSource`/timings into `ScreenshotStreamUpdate`, but no UI consumer reads them; add a fallback badge / format label in the layout inspector.
- [ ] **Model observation diff metadata** (#3338) — #3758. Expose diff metadata carried in the hierarchy payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144zCBppELsVDcXmsMJHsbc)_