### PR TITLE
feat(desktop-app): wire in JetBrains Compose Hot Reload

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.compose.compiler) apply false
+  alias(libs.plugins.compose.hot.reload) apply false
   alias(libs.plugins.mavenPublish) apply false
   alias(libs.plugins.metro) apply false
 }

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.compose.reload.gradle.ComposeHotRun
 
 plugins {
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
   kotlin("plugin.compose")
   alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.hot.reload)
   alias(libs.plugins.metro)
 }
 
@@ -57,4 +59,11 @@ compose.desktop {
       windows { iconFile.set(project.file("src/main/resources/icons/app-icon.ico")) }
     }
   }
+}
+
+// Compose Hot Reload: `./gradlew :desktop-app:hotRun --autoReload` launches the desktop
+// dashboard with live UI reloading. Composables live in :desktop-core (an implementation
+// dependency), so edits there reload into the running window without a restart.
+tasks.withType<ComposeHotRun>().configureEach {
+  mainClass.set("dev.jasonpearson.automobile.desktop.MainKt")
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ okhttp = "5.4.0"
 mavenpublish = "0.37.0"
 dokka = "2.2.0"
 compose-multiplatform = "1.11.1"
+compose-hot-reload = "1.2.0-rc01"
 metro = "1.3.0"
 
 [plugins]
@@ -80,6 +81,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenpublish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+compose-hot-reload = { id = "org.jetbrains.compose.hot-reload", version.ref = "compose-hot-reload" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 
 [libraries]

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -46,6 +46,24 @@ The entry point module is intentionally small:
 2. **`AutoMobileDesktopApp.kt`** -- wraps `AutoMobileContent` (from desktop-core) with an `AutoMobileTheme` and an `ObservableSettingsProvider` that bridges `SettingsProvider` changes into Compose snapshot state.
 3. **`AutoMobileTheme.kt`** -- Material 3 color scheme with light and dark variants. Resolves `themeMode` strings (`"dark"`, `"light"`, `"system"`) to the appropriate scheme. Defaults to dark to match the IDE plugin.
 
+## Hot Reload (Development)
+
+The `:desktop-app` module applies [JetBrains Compose Hot Reload](https://github.com/JetBrains/compose-hot-reload) (`org.jetbrains.compose.hot-reload`) so UI changes reflect on the running window without a full restart. This is the Compose-Desktop/JVM-native hot reload path -- distinct from Compose HotSwan, which targets on-device Android apps.
+
+Launch the dashboard in hot-reload mode:
+
+```bash
+./gradlew -p android :desktop-app:hotRun --autoReload
+```
+
+- The plugin auto-registers `hotRun` (blocking) and `hotDev` (async) tasks for this Kotlin/JVM module.
+- `ComposeHotRun.mainClass` is pinned to `dev.jasonpearson.automobile.desktop.MainKt` in `desktop-app/build.gradle.kts`.
+- Most composables live in `:desktop-core` (an `implementation` dependency of `:desktop-app`), so editing a dashboard panel there reloads into the running window.
+- Requires the JetBrains Runtime (JBR) for enhanced class redefinition; the foojay toolchain resolver in `settings.gradle.kts` provisions a compatible JDK. Java target stays at 21.
+- The single-instance file lock in `Main.kt` (`automobile-desktop.lock`) is released on process exit, so hot-reload relaunches do not deadlock.
+
+Normal `:desktop-app:run` and the packaged `nativeDistributions` builds are unaffected -- the plugin only adds the dev-time run tasks.
+
 ## DI System
 
 The app uses [Metro](https://github.com/ZacSweers/metro) for compile-time dependency injection.


### PR DESCRIPTION
## Summary

Adds [JetBrains Compose Hot Reload](https://github.com/JetBrains/compose-hot-reload) (`org.jetbrains.compose.hot-reload`, v1.2.0-rc01) to the standalone Compose **Desktop** dashboard (`:desktop-app`) so UI changes reflect on the running window without a full restart. This is the Compose-Desktop/JVM-native hot reload path — distinct from Compose HotSwan, which targets on-device Android apps (tracked separately in #3744).

Changes:
- `android/gradle/libs.versions.toml` — add `compose-hot-reload` version (`1.2.0-rc01`) and the `[plugins]` alias for `org.jetbrains.compose.hot-reload`.
- `android/build.gradle.kts` — register the plugin as `apply false` in the root plugins block.
- `android/desktop-app/build.gradle.kts` — apply the plugin and pin `ComposeHotRun.mainClass` to `dev.jasonpearson.automobile.desktop.MainKt`.
- `docs/design-docs/plat/android/desktop-app.md` — document the `:desktop-app:hotRun --autoReload` dev workflow.

Version choice: the project is on Kotlin 2.4.0 / Compose Multiplatform 1.11.1 (both recent), so the newest CHR `1.2.0-rc01` is the compatible release (the 1.2.0 line requires CMP ≥ 1.10.0). Java target stays at 21, within CHR's ≤21 requirement, and the foojay resolver already in `settings.gradle.kts` provisions a compatible JBR.

The `ComposeHotRun` FQN and the auto-registered `hotRun`/`hotDev` JVM task names were verified against the plugin's source (`JetBrains/compose-hot-reload`) since a local Gradle build couldn't run in this environment (see Validation).

## Linked Issue

Closes #3743

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
- [ ] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android changes: verified the CHR setup against the plugin source — `org.jetbrains.compose.reload.gradle.ComposeHotRun` is the non-deprecated class (the bare `org.jetbrains.compose.reload.ComposeHotRun` is `@Deprecated` with `ReplaceWith` pointing at the `.gradle.` one), and JVM projects auto-register `hotRun` + `hotDev`.
- [ ] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms — N/A (build-config only)
- [ ] Rebased onto latest `main`, conflicts resolved

> **Note:** A local Gradle build/format could not be run in this environment — the egress policy blocks `services.gradle.org` (Gradle distribution download) and the ktfmt release JAR (both return 403 through the agent proxy). The build-script edits follow ktfmt google-style (2-space indent, alphabetical imports). **A reviewer should run `./gradlew -p android :desktop-app:hotRun --autoReload` (and a normal `:desktop-app:build`) to confirm plugin resolution and live reload.**

## Device Verification

N/A — no on-device behavior change; this only adds a dev-time run task to the desktop app.

## Follow-ups

- [ ] #3744 — Compose HotSwan integration for the Android playground app (`:playground:app`).
- [ ] Once CHR 1.2.0 goes stable, bump `compose-hot-reload` off the `-rc01` release candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQBX8AP5QnkYZQhMMDyiLs)_