### PR TITLE
fix(scripts): macOS/BSD portability & cosmetic cleanups (#3653)

### DIFF
--- a/scripts/detect-dead-code-ts.sh
+++ b/scripts/detect-dead-code-ts.sh
@@ -297,7 +297,21 @@ jq --argjson allow "$ALLOWLIST_JSON" --argjson bashUsed "$BASH_USED_JSON" '
 # Generate report
 # ============================================================================
 
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+# %3N (milliseconds) is GNU-only; BSD/macOS `date` emits a literal "%3N",
+# producing a malformed timestamp. Use GNU date's %3N when supported, else
+# gdate (Homebrew coreutils), else fall back to second precision (#3653).
+iso_now_ms() {
+  # GNU date renders %3N as a 3-digit number; BSD date renders it as "3N"
+  # (garbage), so only trust %3N when it comes back all-digits.
+  if [[ "$(date -u +%3N 2>/dev/null)" =~ ^[0-9]{1,3}$ ]]; then
+    date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  elif command -v gdate >/dev/null 2>&1; then
+    gdate -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  else
+    date -u +"%Y-%m-%dT%H:%M:%S.000Z"
+  fi
+}
+TIMESTAMP=$(iso_now_ms)
 TOTAL_ISSUES=$(jq 'length' "$ISSUES_JSON")
 
 # Count by tool

--- a/scripts/shellcheck/validate_shell_scripts.sh
+++ b/scripts/shellcheck/validate_shell_scripts.sh
@@ -14,11 +14,15 @@ fi
 # Start the timer
 start_time=$(bash -c "$(pwd)/scripts/utils/get_timestamp.sh")
 
+# Portable CPU count: nproc (GNU) is absent on stock macOS, where an empty
+# `$(nproc)` made `xargs -P ""` fail. Fall back to sysctl/getconf (#3653).
+NPROC="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
 # Find shell scripts and validate in parallel
 # shellcheck disable=SC2016
 errors=$(git ls-files --cached --others --exclude-standard -z |
   grep -z '\.sh$' |
-  xargs -0 -n 1 -P "$(nproc)" bash -c 'shellcheck "$0"' 2>&1)
+  xargs -0 -n 1 -P "$NPROC" bash -c 'shellcheck "$0"' 2>&1)
 
 # Calculate total elapsed time
 end_time=$(bash -c "$(pwd)/scripts/utils/get_timestamp.sh")

--- a/scripts/validate_mkdocs_nav.sh
+++ b/scripts/validate_mkdocs_nav.sh
@@ -71,6 +71,16 @@ extract_nav_files() {
         uniq
 }
 
+# Same as extract_nav_files but WITHOUT deduping — needed for the duplicate
+# check, which was previously fed the already-deduped output (so `uniq -d`
+# could never report anything) (#3653).
+extract_nav_files_raw() {
+    awk '/^nav:$/,0' "$MKDOCS_YML" | \
+        grep -oE "['\"]?[a-zA-Z0-9/_-]+\.md['\"]?" | \
+        tr -d "'" | \
+        tr -d '"'
+}
+
 # List all .md files in docs/ directory relative to docs/
 list_actual_files() {
     (
@@ -196,7 +206,7 @@ fi
 # Check for duplicate entries in mkdocs.yml
 print_status "Checking for duplicate entries in mkdocs.yml..."
 DUPLICATES=$(mktemp)
-extract_nav_files | sort | uniq -d > "$DUPLICATES"
+extract_nav_files_raw | sort | uniq -d > "$DUPLICATES"
 if [[ -s "$DUPLICATES" ]]; then
     print_error "Duplicate entries found in mkdocs.yml:"
     while IFS= read -r file; do

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -30,7 +30,10 @@ fi
 # Validate the version shape up front, before any file is written. The iOS
 # generator (invoked late, below) rejects non-semver; validating here avoids
 # aborting mid-bump with a half-updated tree on operator error.
-if ! [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
+# Restrict the optional pre-release/build segment to valid semver characters
+# ([0-9A-Za-z.-]); the old `([-+].*)?` allowed `/`, `\`, `&` etc. which then
+# broke the downstream sed/re.sub substitutions (#3653).
+if ! [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
   echo "Invalid --new-version '${new_version}': expected MAJOR.MINOR.PATCH semver." >&2
   exit 1
 fi

--- a/scripts/xml/format_xml.sh
+++ b/scripts/xml/format_xml.sh
@@ -27,10 +27,14 @@ echo "PROJECT_ROOT: $PROJECT_ROOT"
 # Cross-platform XML formatting using xmlstarlet or xml command
 format_xml() {
   local file="$1"
+  # Do NOT merge stderr into the formatted output (2>&1): if the formatter
+  # exits 0 while emitting a warning to stderr, that text would be written into
+  # $file.formatted and then mv'd over the original, corrupting the XML. Let
+  # stderr flow to the script's stderr instead (#3653).
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    xml fo -s 2 "$file" > "$file.formatted" 2>&1
+    xml fo -s 2 "$file" > "$file.formatted"
   else
-    xmlstarlet fo -s 2 "$file" > "$file.formatted" 2>&1
+    xmlstarlet fo -s 2 "$file" > "$file.formatted"
   fi
 
   local exit_code=$?

--- a/scripts/xml/validate_xml.sh
+++ b/scripts/xml/validate_xml.sh
@@ -29,11 +29,15 @@ start_time=$(bash -c "$(pwd)/scripts/utils/get_timestamp.sh")
 # Need to export this function for xargs bash to see it
 export -f validate_xml
 
+# Portable CPU count: nproc (GNU) is absent on stock macOS, where an empty
+# `$(nproc)` made `xargs -P ""` fail. Fall back to sysctl/getconf (#3653).
+NPROC="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
 # Find XML files, excluding files ignored by .gitignore
 # shellcheck disable=SC2016
 errors=$(git ls-files --cached --others --exclude-standard -z |
   grep -z '\.xml$' |
-  xargs -0 -n 1 -P "$(nproc)" bash -c 'validate_xml val -w -b -e "$0"' 2>&1)
+  xargs -0 -n 1 -P "$NPROC" bash -c 'validate_xml val -w -b -e "$0"' 2>&1)
 
 # Calculate total elapsed time
 end_time=$(bash -c "$(pwd)/scripts/utils/get_timestamp.sh")

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -129,3 +129,16 @@ run_bump() {
   [[ "$output" == *"Package/runtime version -> ${VERSION}"* ]]
   [[ "$output" == *"Android dev/Maven coordinate -> ${VERSION}-SNAPSHOT"* ]]
 }
+
+@test "rejects a semver whose pre-release/build has invalid characters (#3653)" {
+  # A '/' (or '\', '&') in the build segment would break the downstream
+  # sed/re.sub substitutions; the old `([-+].*)?` allowed it.
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --new-version '1.2.3+a/b'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid --new-version"* ]]
+}
+
+@test "accepts a valid semver pre-release (#3653)" {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --new-version '1.2.3-beta.1' --dry-run"
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/portability-cosmetic.bats
+++ b/test/bats/portability-cosmetic.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+#
+# Tests for the portability/cosmetic fixes in #3653:
+#  A) detect-dead-code-ts.sh: timestamp must not emit a literal "%3N" on BSD date
+#  B) validate_shell_scripts.sh / xml/validate_xml.sh: portable CPU count (no bare nproc)
+#  C) xml/format_xml.sh: formatter stderr must not be merged into the output file
+#  D) validate_mkdocs_nav.sh: duplicate nav entries must be detectable
+
+setup() {
+  WORK_DIR="$(mktemp -d)"
+}
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+# --- A ---------------------------------------------------------------------
+@test "iso_now_ms produces a valid ISO timestamp (no literal %3N)" {
+  local abs
+  abs="$(cd scripts && pwd)/detect-dead-code-ts.sh"
+  local fn="$WORK_DIR/iso.sh"
+  awk '/^iso_now_ms\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$abs" > "$fn"
+
+  run bash -c 'source "$1"; iso_now_ms' _ "$fn"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"%3N"* ]]
+  [[ "$output" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z$ ]]
+}
+
+# --- B ---------------------------------------------------------------------
+@test "shell/xml validators do not use a bare -P \"\$(nproc)\"" {
+  for s in scripts/shellcheck/validate_shell_scripts.sh scripts/xml/validate_xml.sh; do
+    local hits
+    hits="$(grep -vE '^\s*#' "$s" | grep -F '$(nproc)' || true)"
+    [ -z "$hits" ]
+  done
+}
+
+@test "the CPU-count fallback yields a positive integer without nproc" {
+  local bin
+  bin="$(mktemp -d)"
+  for t in bash sysctl getconf; do
+    [ -e "$(command -v "$t" 2>/dev/null)" ] && ln -s "$(command -v "$t")" "$bin/$t"
+  done
+  # No `nproc` in $bin — exercise the fallback chain used by the scripts.
+  run env PATH="$bin" bash -c 'echo "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"'
+  rm -rf "$bin"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+$ ]]
+  [ "$output" -ge 1 ]
+}
+
+# --- C ---------------------------------------------------------------------
+@test "format_xml does not write the formatter's stderr into the file" {
+  local abs
+  abs="$(cd scripts/xml && pwd)/format_xml.sh"
+  local fn="$WORK_DIR/format_xml.sh"
+  awk '/^format_xml\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$abs" > "$fn"
+
+  local bin="$WORK_DIR/bin"
+  mkdir -p "$bin"
+  # Both tools: valid XML to stdout, a warning to stderr, exit 0.
+  for tool in xml xmlstarlet; do
+    cat > "$bin/$tool" <<'EOF'
+#!/usr/bin/env bash
+echo "<root/>"
+echo "warning: deprecated option" >&2
+exit 0
+EOF
+    chmod +x "$bin/$tool"
+  done
+
+  local target="$WORK_DIR/doc.xml"
+  printf '<root></root>\n' > "$target"
+  run env PATH="$bin:$PATH" bash -c 'source "$1"; format_xml "$2"' _ "$fn" "$target"
+  [ "$status" -eq 0 ]
+  # The formatted file must contain the valid output, NOT the stderr warning.
+  run cat "$target"
+  [[ "$output" == *"<root/>"* ]]
+  [[ "$output" != *"deprecated option"* ]]
+}
+
+# --- D ---------------------------------------------------------------------
+@test "duplicate nav entries are detected" {
+  local abs
+  abs="$(cd scripts && pwd)/validate_mkdocs_nav.sh"
+  local fn="$WORK_DIR/extract_raw.sh"
+  awk '/^extract_nav_files_raw\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$abs" > "$fn"
+
+  cat > "$WORK_DIR/mkdocs.yml" <<'YML'
+nav:
+  - Home: index.md
+  - Guide: guide.md
+  - Also home: index.md
+YML
+
+  run env MKDOCS_YML="$WORK_DIR/mkdocs.yml" bash -c '
+    source "$1"
+    extract_nav_files_raw | sort | uniq -d
+  ' _ "$fn"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"index.md"* ]]
+}


### PR DESCRIPTION
## Summary
Batch of low-severity, verified fixes in validation/tooling scripts:
- **detect-dead-code-ts.sh** — `date +%3N` is GNU-only; BSD/macOS `date` emitted a malformed timestamp. Added an `iso_now_ms` helper (trust `%3N` only when all-digits → else `gdate` → else second precision).
- **validate_shell_scripts.sh / xml/validate_xml.sh** — `xargs -P "$(nproc)"` failed on stock macOS (empty `nproc` → `xargs -P ""`); compute a portable `NPROC` via `sysctl -n hw.ncpu` / `getconf` fallback.
- **xml/format_xml.sh** — dropped `2>&1` so a formatter warning on stderr can't be written into `$file.formatted` and `mv`'d over the original.
- **validate_mkdocs_nav.sh** — the duplicate-entry check ran on already-deduped output (`extract_nav_files` ends in `sort | uniq`), so `uniq -d` never fired; added `extract_nav_files_raw`.
- **versioning/bump-versions.sh** — tightened the semver regex's optional segment to `[0-9A-Za-z.-]` so `/`, `\\`, `&` are rejected before breaking downstream `sed`/`re.sub`.

## Tests
`test/bats/portability-cosmetic.bats` (A–D) + two cases added to `test/bats/bump-versions.bats` (E). Each fails on the pre-fix baseline.

Fixes #3653