### PR TITLE
perf(observe): compact the advertised waitFor input schema (99% -> 92% tools budget)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3176,447 +3176,182 @@
           ]
         },
         "waitFor": {
-          "description": "Wait for element to appear before returning observation",
-          "anyOf": [
-            {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Wait for a predicate before returning the observation. Provide at least one of: elementId, text, textAny, className, contentDescription, or activeWindow. textAny is mutually exclusive with the element predicates.",
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Element resource ID / accessibility identifier"
+            },
+            "text": {
+              "type": "string",
+              "description": "Element text"
+            },
+            "textAny": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Ordered text variants; first visible match wins"
+            },
+            "className": {
+              "type": "string",
+              "description": "Element class name"
+            },
+            "contentDescription": {
+              "type": "string",
+              "description": "Element content description / accessibility label"
+            },
+            "matchType": {
+              "type": "string",
+              "enum": [
+                "all",
+                "any"
+              ],
+              "description": "Whether element predicates must all match one node, or any one may match"
+            },
+            "textMatch": {
+              "type": "string",
+              "enum": [
+                "exact",
+                "contains",
+                "regex"
+              ],
+              "description": "How to match waitFor.text; does not affect contentDescription"
+            },
+            "activeWindow": {
               "type": "object",
+              "additionalProperties": false,
+              "description": "Foreground app/window predicates (provide an app id or activityName)",
               "properties": {
-                "textAny": {
-                  "minItems": 1,
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": "Ordered text variants; first visible match wins"
+                "appId": {
+                  "type": "string",
+                  "description": "Foreground app bundle ID / package name"
                 },
-                "elementId": {
-                  "not": {}
+                "packageName": {
+                  "type": "string",
+                  "description": "Alias for appId (Android package name)"
                 },
-                "text": {
-                  "not": {}
+                "bundleId": {
+                  "type": "string",
+                  "description": "Alias for appId (iOS bundle ID)"
                 },
-                "className": {
-                  "not": {}
-                },
-                "contentDescription": {
-                  "not": {}
-                },
-                "matchType": {
-                  "not": {}
-                },
-                "textMatch": {
-                  "not": {}
-                },
-                "activeWindow": {
-                  "description": "Foreground app/window predicates",
-                  "allOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "appId": {
-                          "description": "Foreground app bundle ID / package name",
-                          "type": "string"
-                        },
-                        "packageName": {
-                          "type": "string"
-                        },
-                        "bundleId": {
-                          "type": "string"
-                        },
-                        "activityName": {
-                          "description": "Foreground Android activity name",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "appId": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "appId"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "packageName": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "packageName"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "bundleId": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "bundleId"
-                          ],
-                          "additionalProperties": {}
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "activityName": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "activityName"
-                          ],
-                          "additionalProperties": {}
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "timeout": {
-                  "description": "Wait timeout ms (default: 5000)",
-                  "type": "number"
-                },
-                "container": {
-                  "description": "Scope match to a container",
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "elementId": {
-                          "type": "string",
-                          "description": "Container resource ID"
-                        }
-                      },
-                      "required": [
-                        "elementId"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "text": {
-                          "type": "string",
-                          "description": "Container text"
-                        }
-                      },
-                      "required": [
-                        "text"
-                      ],
-                      "additionalProperties": false
-                    }
-                  ]
+                "activityName": {
+                  "type": "string",
+                  "description": "Foreground Android activity name (Android-only)"
                 }
               },
+              "anyOf": [
+                {
+                  "required": [
+                    "appId"
+                  ]
+                },
+                {
+                  "required": [
+                    "packageName"
+                  ]
+                },
+                {
+                  "required": [
+                    "bundleId"
+                  ]
+                },
+                {
+                  "required": [
+                    "activityName"
+                  ]
+                }
+              ]
+            },
+            "container": {
+              "type": "object",
+              "description": "Scope the match to a container element (by elementId or text)",
+              "properties": {
+                "elementId": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Wait timeout ms (default 5000)"
+            }
+          },
+          "anyOf": [
+            {
               "required": [
                 "textAny"
               ],
-              "additionalProperties": false
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "elementId"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "text"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "className"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "contentDescription"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "matchType"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "textMatch"
+                    ]
+                  }
+                ]
+              }
             },
             {
-              "allOf": [
+              "not": {
+                "required": [
+                  "textAny"
+                ]
+              },
+              "anyOf": [
                 {
-                  "type": "object",
-                  "properties": {
-                    "elementId": {
-                      "description": "Element resource ID / accessibility identifier",
-                      "type": "string"
-                    },
-                    "text": {
-                      "description": "Element text",
-                      "type": "string"
-                    },
-                    "textAny": {
-                      "not": {}
-                    },
-                    "className": {
-                      "description": "Element class name",
-                      "type": "string"
-                    },
-                    "contentDescription": {
-                      "description": "Element content description / accessibility label",
-                      "type": "string"
-                    },
-                    "matchType": {
-                      "description": "Whether element predicates must all match the same node or any one may match",
-                      "type": "string",
-                      "enum": [
-                        "all",
-                        "any"
-                      ]
-                    },
-                    "textMatch": {
-                      "description": "How to match waitFor.text; does not affect contentDescription",
-                      "type": "string",
-                      "enum": [
-                        "exact",
-                        "contains",
-                        "regex"
-                      ]
-                    },
-                    "activeWindow": {
-                      "description": "Foreground app/window predicates",
-                      "allOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "appId": {
-                              "description": "Foreground app bundle ID / package name",
-                              "type": "string"
-                            },
-                            "packageName": {
-                              "type": "string"
-                            },
-                            "bundleId": {
-                              "type": "string"
-                            },
-                            "activityName": {
-                              "description": "Foreground Android activity name",
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "appId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "appId"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "packageName": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "packageName"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "bundleId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "bundleId"
-                              ],
-                              "additionalProperties": {}
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "activityName": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "activityName"
-                              ],
-                              "additionalProperties": {}
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "timeout": {
-                      "description": "Wait timeout ms (default: 5000)",
-                      "type": "number"
-                    },
-                    "container": {
-                      "description": "Scope match to a container",
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "elementId": {
-                              "type": "string",
-                              "description": "Container resource ID"
-                            }
-                          },
-                          "required": [
-                            "elementId"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "text": {
-                              "type": "string",
-                              "description": "Container text"
-                            }
-                          },
-                          "required": [
-                            "text"
-                          ],
-                          "additionalProperties": false
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
+                  "required": [
+                    "elementId"
+                  ]
                 },
                 {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "elementId": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "elementId"
-                      ],
-                      "additionalProperties": {}
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "text": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "text"
-                      ],
-                      "additionalProperties": {}
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "className": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "className"
-                      ],
-                      "additionalProperties": {}
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "contentDescription": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "contentDescription"
-                      ],
-                      "additionalProperties": {}
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "activeWindow": {
-                          "allOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "appId": {
-                                  "description": "Foreground app bundle ID / package name",
-                                  "type": "string"
-                                },
-                                "packageName": {
-                                  "type": "string"
-                                },
-                                "bundleId": {
-                                  "type": "string"
-                                },
-                                "activityName": {
-                                  "description": "Foreground Android activity name",
-                                  "type": "string"
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            {
-                              "anyOf": [
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "appId": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "appId"
-                                  ],
-                                  "additionalProperties": {}
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "packageName": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "packageName"
-                                  ],
-                                  "additionalProperties": {}
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "bundleId": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "bundleId"
-                                  ],
-                                  "additionalProperties": {}
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "activityName": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "activityName"
-                                  ],
-                                  "additionalProperties": {}
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "activeWindow"
-                      ],
-                      "additionalProperties": {}
-                    }
+                  "required": [
+                    "text"
+                  ]
+                },
+                {
+                  "required": [
+                    "className"
+                  ]
+                },
+                {
+                  "required": [
+                    "contentDescription"
+                  ]
+                },
+                {
+                  "required": [
+                    "activeWindow"
                   ]
                 }
               ]

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -110,6 +110,92 @@ const waitForSchema = z.union([
   waitForElementSchema,
 ]);
 
+// Compact advertised JSON schema for `waitFor` (issue: observe input schema
+// bloat). The runtime zod `waitForSchema` above stays the source of truth for
+// validation — its union/intersection/presence machinery expands to ~2k tokens
+// in `tools/list`, which the agent does not need. This flat object advertises
+// the same fields + guidance at ~1/4 the token cost; it is swapped in via the
+// observe json-schema override below and never used for validation.
+// Presence options shared by the two branches below.
+const ELEMENT_PREDICATE_REQUIRED = [
+  { required: ["elementId"] },
+  { required: ["text"] },
+  { required: ["className"] },
+  { required: ["contentDescription"] },
+];
+const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  description:
+    "Wait for a predicate before returning the observation. Provide at least one of: " +
+    "elementId, text, textAny, className, contentDescription, or activeWindow. " +
+    "textAny is mutually exclusive with the element predicates.",
+  properties: {
+    elementId: { type: "string", description: "Element resource ID / accessibility identifier" },
+    text: { type: "string", description: "Element text" },
+    textAny: {
+      type: "array",
+      items: { type: "string" },
+      description: "Ordered text variants; first visible match wins",
+    },
+    className: { type: "string", description: "Element class name" },
+    contentDescription: {
+      type: "string",
+      description: "Element content description / accessibility label",
+    },
+    matchType: {
+      type: "string",
+      enum: ["all", "any"],
+      description: "Whether element predicates must all match one node, or any one may match",
+    },
+    textMatch: {
+      type: "string",
+      enum: ["exact", "contains", "regex"],
+      description: "How to match waitFor.text; does not affect contentDescription",
+    },
+    activeWindow: {
+      type: "object",
+      additionalProperties: false,
+      description: "Foreground app/window predicates (provide an app id or activityName)",
+      properties: {
+        appId: { type: "string", description: "Foreground app bundle ID / package name" },
+        packageName: { type: "string", description: "Alias for appId (Android package name)" },
+        bundleId: { type: "string", description: "Alias for appId (iOS bundle ID)" },
+        activityName: {
+          type: "string",
+          description: "Foreground Android activity name (Android-only)",
+        },
+      },
+      anyOf: [
+        { required: ["appId"] },
+        { required: ["packageName"] },
+        { required: ["bundleId"] },
+        { required: ["activityName"] },
+      ],
+    },
+    container: {
+      type: "object",
+      description: "Scope the match to a container element (by elementId or text)",
+      properties: { elementId: { type: "string" }, text: { type: "string" } },
+    },
+    timeout: { type: "number", description: "Wait timeout ms (default 5000)" },
+  },
+  // Enforce the same shape the runtime does: at least one predicate, and textAny
+  // mutually exclusive with the element predicates / matchType / textMatch.
+  anyOf: [
+    {
+      required: ["textAny"],
+      not: {
+        anyOf: [...ELEMENT_PREDICATE_REQUIRED, { required: ["matchType"] }, { required: ["textMatch"] }],
+      },
+    },
+    {
+      not: { required: ["textAny"] },
+      anyOf: [...ELEMENT_PREDICATE_REQUIRED, { required: ["activeWindow"] }],
+    },
+  ],
+};
+
 const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
@@ -151,6 +237,16 @@ const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.ob
     }
   };
   jsonSchema.then = false;
+
+  // Replace the verbose generated `waitFor` schema with the compact advertised
+  // form. Runtime validation still uses the full zod `waitForSchema`; this only
+  // shrinks what `tools/list` carries (~2064 -> ~473 tokens). The `if`/`then`
+  // above evaluates against the request data, not this schema, so it is
+  // unaffected.
+  const props = jsonSchema.properties as Record<string, unknown> | undefined;
+  if (props && props.waitFor) {
+    props.waitFor = COMPACT_WAITFOR_ADVERTISED_SCHEMA;
+  }
 });
 
 export const observeSchema = withAppIdAliases(observeBaseSchema);


### PR DESCRIPTION
Cuts the biggest single consumer of the MCP `tools/list` context budget.

## Profiling first (the "which 50 tools" answer)
I profiled all 42 advertised tools. Two facts drove this change:
1. The tracked context budget (`benchmark-context-thresholds.ts`) **strips output schemas before counting**, so the 99% figure is input-schemas + descriptions only.
2. In that view, **`observe` is the #1 consumer at 2,433 tokens — and 2,064 of those are the single `waitFor` param.** Everything else is a long, even tail.

`waitFor`'s cost is pure JSON-schema *expansion* of the runtime zod union/intersection/alias machinery, which the agent doesn't need in `tools/list`.

## The change
Swap in a hand-authored **compact advertised schema** for `waitFor`, via observe's existing `withJsonSchemaOverride` seam. **Runtime validation is unchanged** — the full zod `waitForSchema` stays the source of truth; only the advertised hint shrinks:
- `waitFor`: 2,064 → **879** tokens
- `observe` inputSchema: 2,433 → **1,248** tokens

It preserves the published/runtime **reject-contract** that `observeWaitForSchema.test.ts` pins (and which I verified): at least one predicate required, `textAny` mutually exclusive with the element predicates / `matchType` / `textMatch`, `activeWindow` must carry an app id or `activityName` (incl. `packageName`/`bundleId` aliases), and the exact `textMatch` description string.

## Result
- **Context benchmark: Tools 14,910 → 13,725 (99% → 92%)**, TOTAL 86% → 80%.
- 2,075 server + observe tests pass; typecheck clean; lint clean.
- `schemas/tool-definitions.json` regenerated.

## Follow-up (not in this PR)
`tapOn`'s `selector`/`container` (~410 tokens) and the shared interaction targeting params are smaller, more-even candidates for the same treatment — a modest additional trim if wanted.
