### PR TITLE
ci: shell-portability footgun lint (blocking) + fix 3 curl --fail bugs it found

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -590,7 +590,7 @@ jobs:
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \
-            --only yaml,xml,shellcheck,mkdocs-nav,ktfmt,claude-plugin,codex-skills \
+            --only yaml,xml,shellcheck,shell-portability,mkdocs-nav,ktfmt,claude-plugin,codex-skills \
             --max-parallel 4
 
       - name: "Run BATS Tests (Ubuntu)"

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -33,6 +33,7 @@ add_check() {
 add_check "yaml" "bun \"$PROJECT_ROOT/scripts/validate-yaml.ts\"" "config,yaml" "Validate test plan YAML files"
 add_check "xml" "\"$PROJECT_ROOT/scripts/xml/validate_xml.sh\"" "config,xml" "Validate XML files"
 add_check "shellcheck" "\"$PROJECT_ROOT/scripts/shellcheck/validate_shell_scripts.sh\"" "lint,shell" "Validate shell scripts with shellcheck"
+add_check "shell-portability" "\"$PROJECT_ROOT/scripts/shellcheck/validate_shell_portability.sh\"" "lint,shell" "Lint shell scripts for portability footguns"
 add_check "mkdocs-nav" "\"$PROJECT_ROOT/scripts/validate_mkdocs_nav.sh\"" "docs" "Validate MkDocs navigation"
 add_check "ktfmt" "ONLY_TOUCHED_FILES=${KTFMT_ONLY_TOUCHED_FILES:-true} \"$PROJECT_ROOT/scripts/ktfmt/validate_ktfmt.sh\"" "format,kotlin" "Validate Kotlin formatting"
 add_check "claude-plugin" "\"$PROJECT_ROOT/scripts/claude/validate_plugin.sh\"" "config" "Validate Claude plugin structure"

--- a/scripts/docker/validate_dockerfile.sh
+++ b/scripts/docker/validate_dockerfile.sh
@@ -39,7 +39,7 @@ if ! command -v hadolint &>/dev/null; then
   TMP_DIR=$(mktemp -d)
   trap 'rm -rf "${TMP_DIR}"' EXIT
 
-  if curl -sL "${DOWNLOAD_URL}" -o "${TMP_DIR}/hadolint"; then
+  if curl -fsSL "${DOWNLOAD_URL}" -o "${TMP_DIR}/hadolint"; then
     # Install to user bin
     mkdir -p "${HOME}/bin"
     mv "${TMP_DIR}/hadolint" "${HOME}/bin/hadolint"

--- a/scripts/lychee/install_lychee.sh
+++ b/scripts/lychee/install_lychee.sh
@@ -181,7 +181,7 @@ install_manual() {
 
     # Download the archive
     if command_exists curl; then
-        if ! curl -L -o "$temp_dir/$binary_name" "$download_url"; then
+        if ! curl -fL -o "$temp_dir/$binary_name" "$download_url"; then
             echo -e "${RED}Failed to download lychee binary${NC}"
             return 1
         fi

--- a/scripts/shellcheck/install_shfmt.sh
+++ b/scripts/shellcheck/install_shfmt.sh
@@ -105,7 +105,8 @@ install_binary() {
   fi
 
   if command_exists curl; then
-    curl -L -o "$target_file" "$download_url"
+    # -f: treat an HTTP error (e.g. 404) as a failure, not a saved error page.
+    curl -fL -o "$target_file" "$download_url"
   elif command_exists wget; then
     wget -O "$target_file" "$download_url"
   else

--- a/scripts/shellcheck/validate_shell_portability.sh
+++ b/scripts/shellcheck/validate_shell_portability.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Portability & footgun lint for scripts/**/*.sh.
+#
+# Catches a curated set of high-confidence shell bug classes that shellcheck
+# does not flag, most of them found during the bash bug hunt (issues
+# #3637–#3658). Each rule is deliberately low-false-positive; add
+# `# portability-ok` on a line to suppress a genuine exception.
+#
+# Rules:
+#   gnu-sed-bre        GNU BRE quantifiers (\+, \?) in a non -E/-r sed — literal
+#                      on BSD/macOS sed. Use ERE (sed -E). (#3646)
+#   command-v-negated  `$(! command -v X ...)` captures stdout (always empty),
+#                      so the guard is always false. Test the exit status. (#3642)
+#   command-v-multiarg `command -v X Y` treats Y as a second command name and
+#                      never checks the subcommand. (#3652)
+#   curl-no-fail       `curl … -o/-O/--output` without -f/--fail saves a 404
+#                      error page as the "download". (#3641, #3649)
+#   append-then-stderr `>> file >&2` sends output to stderr, not the file, because
+#                      the last redirect wins. (#3648)
+#   bare-python        A bare `python` invocation (not python3) — absent on
+#                      ubuntu-latest / modern macOS. (#3657)
+#
+# Usage: scripts/shellcheck/validate_shell_portability.sh [dir ...]
+set -uo pipefail
+
+ROOTS=("$@")
+[ "${#ROOTS[@]}" -eq 0 ] && ROOTS=("scripts")
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; NC=$'\033[0m'
+[ -t 1 ] || { RED=""; GREEN=""; YELLOW=""; NC=""; }
+
+violations=0
+
+# report LABEL FILE LINENO TEXT HINT
+report() {
+  printf '%s%s%s %s:%s\n    %s\n    %s→ %s%s\n' \
+    "$RED" "[$1]" "$NC" "$2" "$3" "$4" "$YELLOW" "$5" "$NC"
+  violations=$((violations + 1))
+}
+
+# scan LABEL PATTERN HINT [inverse_filter]
+# Emits a report for every non-comment, non-suppressed line matching PATTERN.
+# If inverse_filter is given, a line only counts when it does NOT match it.
+scan() {
+  local label="$1" pattern="$2" hint="$3" inverse="${4:-}"
+  local file lineno text
+  while IFS= read -r file; do
+    while IFS=: read -r lineno text; do
+      [ -z "$lineno" ] && continue
+      # skip comment-only lines and lines with an explicit suppression
+      printf '%s' "$text" | grep -qE '^[[:space:]]*#' && continue
+      printf '%s' "$text" | grep -q 'portability-ok' && continue
+      if [ -n "$inverse" ]; then
+        printf '%s' "$text" | grep -qE "$inverse" && continue
+      fi
+      report "$label" "$file" "$lineno" "$(printf '%s' "$text" | sed 's/^[[:space:]]*//')" "$hint"
+    done < <(grep -nE "$pattern" "$file" 2>/dev/null || true)
+    # Skip this linter itself — its rule definitions contain the very patterns
+    # it searches for.
+  done < <(find "${ROOTS[@]}" -name '*.sh' -type f ! -name 'validate_shell_portability.sh' 2>/dev/null | sort)
+}
+
+scan "gnu-sed-bre" \
+  "sed( -[nr]*| )[^|]*'[^']*\\\\[+?]" \
+  "GNU BRE \\+/\\? is literal on BSD sed — use ERE (sed -E)."
+
+scan "command-v-negated" \
+  '\$\([[:space:]]*![[:space:]]*command -v' \
+  'This captures stdout (always empty) so the guard is always false — test the exit status directly.'
+
+scan "command-v-multiarg" \
+  'command -v +[A-Za-z0-9_./-]+ +[A-Za-z0-9_./-]+' \
+  'command -v takes one name — probe the subcommand directly.'
+
+scan "curl-no-fail" \
+  'curl .*(-o |-O |--output|--remote-name)' \
+  'Add -f/--fail so an HTTP error is not saved as the download.' \
+  '(--fail|-[[:alnum:]]*f)'
+
+scan "append-then-stderr" \
+  '>>[^>|]*>&2' \
+  'Redirect order: this writes to stderr, not the file. Drop >&2 or use tee -a.'
+
+scan "bare-python" \
+  '(^|[;&|(]|\$\()[[:space:]]*python([[:space:]]|$)' \
+  'Use python3 — bare python is absent on ubuntu-latest / modern macOS.'
+
+echo ""
+if [ "$violations" -gt 0 ]; then
+  echo "${RED}Found ${violations} shell-portability issue(s).${NC}" >&2
+  echo "Fix them, or add '# portability-ok' on the line if it is a genuine exception." >&2
+  exit 1
+fi
+echo "${GREEN}No shell-portability issues found.${NC}"

--- a/test/bats/validate-shell-portability.bats
+++ b/test/bats/validate-shell-portability.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/shellcheck/validate_shell_portability.sh — the portability
+# footgun lint. Each rule must flag its bad pattern and the current tree must
+# be clean.
+
+SCRIPT="scripts/shellcheck/validate_shell_portability.sh"
+
+setup() {
+  ABS="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
+  FIX="$(mktemp -d)"
+}
+teardown() {
+  rm -rf "$FIX"
+}
+
+write() { printf '%s\n' "$2" > "$FIX/$1.sh"; }
+
+@test "passes on the repository's own scripts/ tree" {
+  run bash "$ABS" scripts
+  [ "$status" -eq 0 ]
+}
+
+@test "flags a GNU BRE sed quantifier" {
+  write bad "x=\$(echo y | sed -n 's/\\([0-9]\\+\\)/x/p')"
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"gnu-sed-bre"* ]]
+}
+
+@test "flags a negated command -v inside a substitution" {
+  write bad 'if [[ $(! command -v foo) ]]; then :; fi'
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"command-v-negated"* ]]
+}
+
+@test "does NOT flag a legitimate \$(command -v foo) path lookup" {
+  write ok 'p=$(command -v foo); echo "$p"'
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "flags a multi-arg command -v" {
+  write bad 'if command -v xcrun simctl; then :; fi'
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"command-v-multiarg"* ]]
+}
+
+@test "flags a curl download without --fail" {
+  write bad 'curl -sL "$u" -o out'
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"curl-no-fail"* ]]
+}
+
+@test "does NOT flag curl -fL -o (has --fail)" {
+  write ok 'curl -fL -o out "$u"'
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "flags an append-then-stderr redirect" {
+  write bad 'echo hi >> "$f" >&2'
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"append-then-stderr"* ]]
+}
+
+@test "flags a bare python invocation" {
+  write bad 'python script.py'
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"bare-python"* ]]
+}
+
+@test "does NOT flag python3" {
+  write ok 'python3 script.py'
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "respects a # portability-ok suppression" {
+  write bad 'curl -sL "$u" -o out # portability-ok'
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
Adds a **portability footgun lint** — `scripts/shellcheck/validate_shell_portability.sh` — that catches shell bug classes shellcheck does not, all drawn from the bash bug hunt (#3637–#3658). It's a low-false-positive `grep` scanner (verified clean on the whole `scripts/` tree) and runs everywhere (no BSD/GNU dependence).

**Rules:** GNU BRE sed quantifiers (`\+`,`\?`), negated `$(! command -v …)`, multi-arg `command -v`, `curl … -o` without `--fail`, append-then-`>&2` redirects, bare `python`. A `# portability-ok` comment suppresses a line.

**Wiring:** registered as the `shell-portability` check in `all_fast_validate_checks.sh` and added to the Fast Validation `--only` list — so it is **blocking** via the already-required "Fast Validation" status check (no ruleset change needed).

## It already found 3 live bugs
Running the lint surfaced 3 `curl … -o` without `--fail` downloads (same 404-as-binary class as #3641/#3649) that the manual audit missed — fixed here:
- `scripts/docker/validate_dockerfile.sh` (hadolint)
- `scripts/lychee/install_lychee.sh`
- `scripts/shellcheck/install_shfmt.sh`

## Tests
`test/bats/validate-shell-portability.bats` — 11 cases: the tree passes, each rule flags its pattern, legitimate forms are not flagged, and `# portability-ok` is honored.