### PR TITLE
perf(interaction): compact advertised exclusive selectors (92% -> 90% tools budget)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1034,63 +1034,55 @@
       "type": "object",
       "properties": {
         "source": {
-          "anyOf": [
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Source ID"
+            },
+            "text": {
+              "type": "string",
+              "description": "Source text"
+            }
+          },
+          "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "Source ID"
-                }
-              },
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Source text"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             }
           ],
           "description": "Source element"
         },
         "target": {
-          "anyOf": [
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Target ID"
+            },
+            "text": {
+              "type": "string",
+              "description": "Target text"
+            }
+          },
+          "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "Target ID"
-                }
-              },
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Target text"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             }
           ],
           "description": "Target element"
@@ -4900,35 +4892,31 @@
           "type": "boolean"
         },
         "container": {
-          "description": "Scope search to a container",
-          "anyOf": [
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Container resource ID"
+            },
+            "text": {
+              "type": "string",
+              "description": "Container text"
+            }
+          },
+          "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
-                }
-              },
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Container text"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             }
-          ]
+          ],
+          "description": "Scope search to a container"
         },
         "autoTarget": {
           "description": "Auto-target pinchable containers",
@@ -6205,35 +6193,31 @@
           "type": "boolean"
         },
         "container": {
-          "description": "Scope search to a container",
-          "anyOf": [
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Container resource ID"
+            },
+            "text": {
+              "type": "string",
+              "description": "Container text"
+            }
+          },
+          "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
-                }
-              },
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Container text"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             }
-          ]
+          ],
+          "description": "Scope search to a container"
         },
         "autoTarget": {
           "description": "Auto-target scrollable containers (default: true)",
@@ -6258,35 +6242,31 @@
           ]
         },
         "lookFor": {
-          "description": "Element to look for during swipe",
-          "anyOf": [
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "ID of the element to look for"
+            },
+            "text": {
+              "type": "string",
+              "description": "Text to look for"
+            }
+          },
+          "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "ID of the element to look for"
-                }
-              },
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Text to look for"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             }
-          ]
+          ],
+          "description": "Element to look for during swipe"
         },
         "boomerang": {
           "description": "Return to start position after swipe apex",
@@ -6425,35 +6405,31 @@
       "type": "object",
       "properties": {
         "container": {
-          "description": "Scope search to a container",
-          "anyOf": [
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Container resource ID"
+            },
+            "text": {
+              "type": "string",
+              "description": "Container text"
+            }
+          },
+          "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
-                }
-              },
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Container text"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             }
-          ]
+          ],
+          "description": "Scope search to a container"
         },
         "selectionStrategy": {
           "description": "Element selection strategy: 'first' (default) or 'random'",
@@ -6531,52 +6507,44 @@
       "type": "object",
       "properties": {
         "selector": {
-          "anyOf": [
-            {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "Resource ID, e.g. com.app:id/btn_login"
-                }
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Resource ID, e.g. com.app:id/btn_login"
+            },
+            "text": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Text, content-desc, or placeholder"
+            },
+            "textAny": {
+              "minItems": 1,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
               },
+              "description": "Ordered text variants; first visible match wins"
+            }
+          },
+          "oneOf": [
+            {
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "Text, content-desc, or placeholder"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "textAny": {
-                  "minItems": 1,
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": "Ordered text variants; first visible match wins"
-                }
-              },
               "required": [
                 "textAny"
-              ],
-              "additionalProperties": false
+              ]
             }
           ],
           "description": "Element to tap: elementId, text, or ordered text variants"
@@ -6586,35 +6554,31 @@
           "type": "boolean"
         },
         "container": {
-          "description": "Scope search to a container",
-          "anyOf": [
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Container resource ID"
+            },
+            "text": {
+              "type": "string",
+              "description": "Container text"
+            }
+          },
+          "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
-                }
-              },
               "required": [
                 "elementId"
-              ],
-              "additionalProperties": false
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "text": {
-                  "type": "string",
-                  "description": "Container text"
-                }
-              },
               "required": [
                 "text"
-              ],
-              "additionalProperties": false
+              ]
             }
-          ]
+          ],
+          "description": "Scope search to a container"
         },
         "action": {
           "default": "tap",

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -27,7 +27,7 @@ import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { createJSONToolResponse, createStructuredToolResponse, StructuredToolResponse } from "../utils/toolUtils";
 import { resolveSwipeDirection } from "../utils/swipeOnUtils";
 import { RecompositionTracker } from "../features/performance/RecompositionTracker";
-import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases, withJsonSchemaOverride, compactExclusiveSelectorProperties } from "./toolSchemaHelpers";
 import { serverConfig } from "../utils/ServerConfig";
 import {
   createElementIdTextSelectorSchema,
@@ -137,7 +137,7 @@ const tapOnSelectorSchema = z.union([
   z.object({ textAny: z.array(z.string().min(1)).min(1).describe("Ordered text variants; first visible match wins") }).strict()
 ]).describe("Element to tap: elementId, text, or ordered text variants");
 
-export const tapOnSchema = addDeviceTargetingToSchema(z.object({
+export const tapOnSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   selector: tapOnSelectorSchema,
   sibling: z.boolean().optional().describe(
     "Tap a clickable sibling of the match, e.g. checkbox beside label"
@@ -168,9 +168,9 @@ export const tapOnSchema = addDeviceTargetingToSchema(z.object({
     "Enable preTapStability and retryIfNoChange"
   ),
   platform: platformSchema
-}).strict());
+}).strict()), js => compactExclusiveSelectorProperties(js, ["selector", "container"]));
 
-export const tapAnySchema = addDeviceTargetingToSchema(z.object({
+export const tapAnySchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   container: elementContainerSchema.optional().describe(
     "Scope search to a container"
   ),
@@ -186,7 +186,7 @@ export const tapAnySchema = addDeviceTargetingToSchema(z.object({
     duration: z.number().min(100).max(12000).optional().describe("Polling duration (ms, default: 500)"),
   }).optional().describe("Poll for clickable element before tapping"),
   platform: platformSchema
-}).strict());
+}).strict()), js => compactExclusiveSelectorProperties(js, ["container"]));
 
 const dragAndDropSelectorSchema = (label: "Source" | "Target") =>
   createElementIdTextSelectorSchema({
@@ -199,7 +199,7 @@ const swipeOnLookForSchema = createElementIdTextSelectorSchema({
   text: "Text to look for"
 });
 
-export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
+export const dragAndDropSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   source: dragAndDropSelectorSchema("Source"),
   target: dragAndDropSelectorSchema("Target"),
   pressDurationMs: z.number().min(600).max(3000).optional().describe(
@@ -212,9 +212,9 @@ export const dragAndDropSchema = addDeviceTargetingToSchema(z.object({
     "Hold duration ms (min: 100, max: 3000, default: 100)"
   ),
   platform: platformSchema
-}));
+})), js => compactExclusiveSelectorProperties(js, ["source", "target"]));
 
-export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
+export const swipeOnSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   includeSystemInsets: z.boolean().optional().describe("Use full screen including status/nav bars"),
   container: elementContainerSchema.optional().describe(
     "Scope search to a container"
@@ -229,9 +229,9 @@ export const swipeOnSchema = addDeviceTargetingToSchema(z.object({
   returnSpeed: z.number().min(0.1).max(3.0).optional().describe("Speed multiplier for return swipe (0.1-3.0)"),
   speed: z.enum(["slow", "normal", "fast"]).optional().describe("Swipe speed preset"),
   platform: platformSchema
-}));
+})), js => compactExclusiveSelectorProperties(js, ["container", "lookFor"]));
 
-export const pinchOnSchema = addDeviceTargetingToSchema(z.object({
+export const pinchOnSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   direction: z.enum(["in", "out"]).describe("Pinch direction"),
   distanceStart: z.number().optional().describe("Initial finger distance (px, default: 400)"),
   distanceEnd: z.number().optional().describe("Final finger distance (px, default: 100)"),
@@ -246,7 +246,7 @@ export const pinchOnSchema = addDeviceTargetingToSchema(z.object({
   ),
   autoTarget: z.boolean().optional().describe("Auto-target pinchable containers"),
   platform: platformSchema
-}));
+})), js => compactExclusiveSelectorProperties(js, ["container"]));
 
 export const clearTextSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -45,6 +45,71 @@ export function applyJsonSchemaOverride(
   jsonSchemaOverrides.get(zodSchema)?.(jsonSchema);
 }
 
+/**
+ * Compacts advertised "exactly one of" selector properties. `z.union([...strict
+ * objects])` (the elementId/text/textAny selectors, `container`, etc.) expands to
+ * an `anyOf` where every branch re-inlines a full object schema — costly in
+ * `tools/list`. When a named property matches that pattern (each branch a strict
+ * object requiring exactly one key), rewrite it to a single flat object that
+ * lists all keys once with `oneOf: [{required:[k]}, ...]` — same accepted shape
+ * and the same "exactly one" hint at roughly half the tokens.
+ *
+ * Runtime validation is unaffected: this only mutates the advertised JSON schema
+ * (via `withJsonSchemaOverride`); the source-of-truth zod union is untouched.
+ * Non-matching properties are left as-is.
+ */
+export function compactExclusiveSelectorProperties(
+  jsonSchema: Record<string, unknown>,
+  propNames: readonly string[]
+): void {
+  const props = jsonSchema.properties as Record<string, any> | undefined;
+  if (!props) {
+    return;
+  }
+  for (const name of propNames) {
+    const prop = props[name];
+    const branches: unknown = prop?.anyOf ?? prop?.oneOf;
+    if (!Array.isArray(branches) || branches.length < 2) {
+      continue;
+    }
+    const merged: Record<string, unknown> = {};
+    const oneOf: Array<{ required: string[] }> = [];
+    let matchesPattern = true;
+    for (const branch of branches) {
+      const b = branch as Record<string, any>;
+      if (
+        b?.type !== "object" ||
+        typeof b.properties !== "object" ||
+        !Array.isArray(b.required) ||
+        b.required.length !== 1
+      ) {
+        matchesPattern = false;
+        break;
+      }
+      const key = b.required[0] as string;
+      if (!(key in b.properties)) {
+        matchesPattern = false;
+        break;
+      }
+      merged[key] = b.properties[key];
+      oneOf.push({ required: [key] });
+    }
+    if (!matchesPattern) {
+      continue;
+    }
+    const compact: Record<string, unknown> = {
+      type: "object",
+      additionalProperties: false,
+      properties: merged,
+      oneOf,
+    };
+    if (typeof prop.description === "string") {
+      compact.description = prop.description;
+    }
+    props[name] = compact;
+  }
+}
+
 export function withFieldAliases<T extends z.ZodTypeAny>(schema: T, aliases: FieldAliasMap): T {
   return z.preprocess(input => normalizeFieldAliases(input, aliases), schema) as unknown as T;
 }


### PR DESCRIPTION
Follow-up to the observe `waitFor` trim (#3750).

## What
The `selector`/`container`/`source`/`target`/`lookFor` params on `tapOn`/`tapAny`/`swipeOn`/`dragAndDrop`/`pinchOn` are `z.union([...strict objects])`, which expands in `tools/list` to an `anyOf` that re-inlines a full object schema per branch.

Adds a reusable `compactExclusiveSelectorProperties()` json-schema override helper that rewrites that pattern to a **single flat object** listing all keys once with `oneOf: [{required:[k]}, ...]` — same accepted shape, same 'exactly one' constraint, minus the per-branch structural duplication. Applied via `withJsonSchemaOverride` on the five interaction tools. **Runtime zod validation is unchanged** (source of truth); only the advertised hint shrinks.

## Result
- Benchmark **Tools 13,725 → 13,536 (92% → 90%)**, TOTAL 79%.
- 1,794 server + action tests pass (action tests exercise real selectors); typecheck + lint clean.

## Honest scope
Modest (~189 tokens) vs the observe change (~1,185) — these selectors are mostly **functional descriptions**, not structural bloat, so after the observe fix the budget is spread thin across genuinely-needed descriptions. This is the tail of the input-schema optimization; there's no further big structural lever without trimming guidance the agent actually uses. The helper is reusable for future tools.

Context: the tracked budget is the right target because — per the Claude Agent SDK — only input schemas + descriptions reach the model; output schemas / structuredContent do not.