### PR TITLE
ci: gate the force-unwrap crash class with a SwiftLint CI job (#3607 class)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1118,6 +1118,33 @@ jobs:
           retention-days: 7
 
   # =============================================================================
+  # SwiftLint
+  # =============================================================================
+
+  swiftlint:
+    name: "SwiftLint"
+    runs-on: macos-14
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ios_should_run == 'true'
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      # Full-tree lint (validate_swiftlint.sh defaults: ONLY_TOUCHED_FILES=false,
+      # STRICT_MODE=false), so the whole ios/ tree must stay error-clean on every
+      # iOS-affecting PR. The script exits non-zero only on error-severity rules
+      # (force_unwrapping/force_try are configured as errors — the fail-fast crash
+      # class we burned down in 2026-07); warnings remain non-blocking. SwiftLint is
+      # installed on demand at the version pinned in install_swiftlint.sh.
+      - name: "Run SwiftLint (fail on error-severity rules)"
+        shell: bash
+        env:
+          INSTALL_SWIFTLINT_WHEN_MISSING: "true"
+        run: bash scripts/swiftlint/validate_swiftlint.sh
+
+  # =============================================================================
   # Swift Code Coverage
   # =============================================================================
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -61,6 +61,7 @@ opt_in_rules:
   - file_name_no_space
   - first_where
   - flatmap_over_map_reduce
+  - force_unwrapping
   - identical_operands
   - joined_default_parameter
   - last_where
@@ -84,6 +85,18 @@ opt_in_rules:
   - yoda_condition
 
 # Rule configurations
+
+# Force-unwrap (`!`) on a possibly-nil value is a whole bug class we burned down in
+# 2026-07 (e.g. the Kotlin `mcpResponse.result!!` NPE, #3607). CI runs SwiftLint
+# non-strict, so a default `warning` would be ignored — make it an error so a new
+# force-unwrap fails the SwiftLint job at author time. The handful of provably-safe
+# pre-existing unwraps (hardcoded URLs, ASCII UTF-8, just-inserted dictionary keys,
+# non-empty-buffer base addresses) carry a `// swiftlint:disable:this force_unwrapping`
+# with a one-line justification; test targets disable it file-wide (fail-fast on bad
+# fixtures is idiomatic there).
+force_unwrapping:
+  severity: error
+
 identifier_name:
   min_length:
     error: 1
@@ -127,3 +140,11 @@ large_tuple:
 
 # Reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)
 reporter: "xcode"
+
+# Test targets file-disable the fail-fast crash rules (force-unwrap/force-try are
+# idiomatic in fixtures). Allow those rules to be blanket-disabled without tripping
+# blanket_disable_command; every other rule still requires scoped this/next/previous.
+blanket_disable_command:
+  allowed_rules:
+    - force_unwrapping
+    - force_try

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Breadcrumbs/BreadcrumbTrail.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Breadcrumbs/BreadcrumbTrail.swift
@@ -91,6 +91,7 @@ public final class BreadcrumbTrail: BreadcrumbTracking, @unchecked Sendable {
     }
 
     private static func defaultDirectory() -> URL {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        // The caches directory always exists in userDomainMask on iOS.
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!  // swiftlint:disable:this force_unwrapping
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -74,6 +74,8 @@ public final class AutoMobileNetwork: @unchecked Sendable {
     private var _isEnabled = true
     private var _captureHeaders = false
     private var _captureBodies = false
+    // Leading-underscore backing field is internal (not private) for URLProtocol access.
+    // swiftlint:disable:next identifier_name
     var _maxBodyBytes: Int = AutoMobileNetwork.defaultMaxBodyBytes // 32KB default (internal for URLProtocol access)
 
     /// Thread-safe read of maxBodyBytes for URLProtocol callbacks.
@@ -460,12 +462,14 @@ public class AutoMobileURLProtocol: URLProtocol {
             let body = Data(match.responseBody.utf8)
             var headers = match.responseHeaders
             headers["Content-Type"] = match.contentType
+            // HTTPURLResponse(url:statusCode:...) only fails on a nil-ish URL; `url`
+            // is a valid request URL and any Int statusCode is accepted.
             let response = HTTPURLResponse(
                 url: url,
                 statusCode: match.statusCode,
                 httpVersion: "HTTP/1.1",
                 headerFields: headers
-            )!
+            )!  // swiftlint:disable:this force_unwrapping
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             if !body.isEmpty {
                 client?.urlProtocol(self, didLoad: body)
@@ -570,12 +574,14 @@ public class AutoMobileURLProtocol: URLProtocol {
         let requestBody = requestBodyData.flatMap { AutoMobileNetwork.utf8String(from: $0) }
 
         if simulation.errorType == "http500" {
+            // HTTPURLResponse(url:statusCode:...) only fails on a nil-ish URL; `url`
+            // is a valid request URL and 500 is a valid status code.
             let response = HTTPURLResponse(
                 url: url,
                 statusCode: 500,
                 httpVersion: "HTTP/1.1",
                 headerFields: nil
-            )!
+            )!  // swiftlint:disable:this force_unwrapping
             AutoMobileNetwork.shared.recordRequest(NetworkRequestRecord(
                 url: url.absoluteString,
                 method: method,

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/BreadcrumbTrailTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/BreadcrumbTrailTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 import XCTest
 @testable import AutoMobileSDK
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/CrashesTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 @testable import AutoMobileSDK
 import XCTest
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping force_try
+// Force-unwrap/force-try are idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 import XCTest
 @testable import AutoMobileSDK
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 import XCTest
 @testable import AutoMobileSDK
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 @testable import AutoMobileSDK
 import SQLite3
 import XCTest

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -426,7 +426,8 @@ public enum HierarchyMerger {
                 let childKey = exactKey(for: sdkChild)
                 localKeyCounts[childKey, default: 0] += 1
                 let matchedCount = matchedSdkKeyCounts[childKey] ?? 0
-                if localKeyCounts[childKey]! > matchedCount && isWorthInjecting(sdkChild) {
+                // childKey was inserted into localKeyCounts earlier in this same loop.
+                if localKeyCounts[childKey]! > matchedCount && isWorthInjecting(sdkChild) {  // swiftlint:disable:this force_unwrapping
                     injected.append(convertSdkNode(sdkChild))
                 }
             }

--- a/ios/control-proxy/Sources/CtrlProxy/PerfProvider.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/PerfProvider.swift
@@ -271,10 +271,12 @@ public class PerfProvider {
         instanceLock.lock()
         defer { instanceLock.unlock() }
 
-        if _instance == nil {
-            _instance = PerfProvider()
+        if let existing = _instance {
+            return existing
         }
-        return _instance!
+        let created = PerfProvider()
+        _instance = created
+        return created
     }
 
     /// For testing - allows injecting a custom TimeProvider.

--- a/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
@@ -122,7 +122,8 @@ public final class SdkDatabaseClient: SdkDatabaseFetching, @unchecked Sendable {
     private let urlSession: URLSession
 
     public init(port: UInt16 = 8766) {
-        self.baseURL = URL(string: "http://localhost:\(port)")!
+        // Hardcoded localhost URL with an integer port always parses.
+        self.baseURL = URL(string: "http://localhost:\(port)")!  // swiftlint:disable:this force_unwrapping
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 2
         config.timeoutIntervalForResource = 5

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
@@ -7,7 +7,8 @@ public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable
     private let urlSession: URLSession
 
     public init(port: UInt16 = 8766) {
-        self.baseURL = URL(string: "http://localhost:\(port)")!
+        // Hardcoded localhost URL with an integer port always parses.
+        self.baseURL = URL(string: "http://localhost:\(port)")!  // swiftlint:disable:this force_unwrapping
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 2
         config.timeoutIntervalForResource = 5

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -312,7 +312,7 @@ public class WebSocketServer: WebSocketServing {
 
     /// Broadcast a performance update to all connected clients (push notification)
     public func broadcastPerformanceUpdate(_ snapshot: PerformanceSnapshot) {
-        guard connections.count > 0 else { return }
+        guard !connections.isEmpty else { return }
 
         let response = PerformanceUpdateResponse(data: snapshot)
 
@@ -672,7 +672,8 @@ class WebSocketConnection: WebSocketResponding {
 
         // Calculate accept key
         let magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-        let acceptKey = (key + magic).data(using: .utf8)!.sha1().base64EncodedString()
+        // A String always encodes to UTF-8, so .data(using: .utf8) is never nil.
+    let acceptKey = (key + magic).data(using: .utf8)!.sha1().base64EncodedString()  // swiftlint:disable:this force_unwrapping
 
         // Send upgrade response
         let response = """

--- a/ios/control-proxy/Tests/CtrlProxyTests/PerfProviderTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/PerfProviderTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 @testable import CtrlProxy
 import XCTest
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 @testable import CtrlProxy
 import XCTest
 

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
@@ -29,7 +29,9 @@ public enum FrameProtocol {
     public static func encodeHeader(_ header: Header) -> Data {
         var data = Data(count: headerSize)
         data.withUnsafeMutableBytes { ptr in
-            let base = ptr.baseAddress!
+            // `data` was allocated with `Data(count: headerSize)` (headerSize > 0), so
+            // the buffer is non-empty and baseAddress is non-nil.
+            let base = ptr.baseAddress!  // swiftlint:disable:this force_unwrapping
             base.storeBytes(of: header.width.littleEndian, as: UInt32.self)
             base.advanced(by: 4).storeBytes(of: header.height.littleEndian, as: UInt32.self)
             base.advanced(by: 8).storeBytes(of: header.bytesPerRow.littleEndian, as: UInt32.self)
@@ -41,7 +43,9 @@ public enum FrameProtocol {
     public static func decodeHeader(_ data: Data) -> Header? {
         guard data.count >= headerSize else { return nil }
         return data.withUnsafeBytes { ptr -> Header in
-            let base = ptr.baseAddress!
+            // Guarded above by `data.count >= headerSize` (headerSize > 0), so the
+            // buffer is non-empty and baseAddress is non-nil.
+            let base = ptr.baseAddress!  // swiftlint:disable:this force_unwrapping
             // `load(as:)` requires the address to be aligned to the loaded type;
             // when `data` is a slice of a larger buffer, `base` may be unaligned,
             // making the loads undefined behavior (traps in debug). `loadUnaligned`

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -193,7 +193,8 @@ func runBlocking<T>(_ body: @escaping () async -> T) -> T {
         semaphore.signal()
     }
     semaphore.wait()
-    return box.value!
+    // box.value is set by the async body before semaphore.signal(); wait() blocks until then.
+    return box.value!  // swiftlint:disable:this force_unwrapping
 }
 
 // MARK: - Signal handling

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 import XCTest
 @testable import ScreenCaptureCore
 

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
@@ -1,3 +1,6 @@
+// swiftlint:disable force_unwrapping
+// Force-unwrap is idiomatic in test fixtures (fail fast on bad setup); disabled file-wide.
+
 import XCTest
 @testable import ScreenCaptureCore
 


### PR DESCRIPTION
## What

- **Wires SwiftLint into CI.** It had no job before — only a paths-filter mention — so it gated nothing. Adds a full-tree `SwiftLint` job to `pull_request.yml` (macOS, gated on `ios_should_run`) running the existing `scripts/swiftlint/validate_swiftlint.sh`.
- **Enables `force_unwrapping` as an *error*.** CI runs SwiftLint non-strict, so a default *warning* would be silently ignored — error severity makes a new force-unwrap fail the job.

## Why

Force-unwrap (`!`) on a possibly-nil value is the crash class we burned down across the 2026-07 bug hunt — canonically the Kotlin `mcpResponse.result!!` NPE on a well-formed-but-empty response ([#3607](https://github.com/kaeawc/auto-mobile/issues/3607)). Nothing stopped a reintroduction. Now a new force-unwrap in any `ios/` file fails the SwiftLint job at author time.

## Making the tree error-clean under the new gate

- **11 provably-safe pre-existing unwraps** in shipping code get `// swiftlint:disable:this force_unwrapping` + a one-line justification: hardcoded `URL(string:)!`, ASCII `.data(using:.utf8)!`, a dict key inserted two lines up, non-empty-buffer `baseAddress!`, `HTTPURLResponse(...)!`.
- **`PerfProvider.instance`** rewritten to an `if let` — removes the unwrap outright rather than annotating it.
- **Test targets** file-disable `force_unwrapping`/`force_try` (fail-fast on bad fixtures is idiomatic in tests); `blanket_disable_command` is configured to allow exactly those two rules, so every other rule still requires scoped `this/next/previous`.
- **Two unrelated pre-existing errors** the full-tree gate would otherwise surface are fixed in passing: `WebSocketServer` `empty_count` (`count > 0` → `!isEmpty`) and `AutoMobileNetwork` `identifier_name` (internal `_maxBodyBytes` backing field — scoped `disable:next`).

## Verification

- `validate_swiftlint.sh` full-tree exits **0** (0 errors, 122 non-blocking warnings).
- Injecting a force-unwrap into shipping code makes it exit **1** with a `force_unwrapping` error; reverting returns it to 0.
- Warnings remain non-blocking (matches prior local behavior) — only error-severity rules fail the job.

Follow-up to the #3599/#3605/#3607-class fixes; complements the registration/teardown guard (#3755).