### PR TITLE
lint(guard): ban 'as unknown as T' in src to catch shape-masking casts (#3595 class)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,0 +1,87 @@
+{
+  "src/daemon/telemetryPushSocketServer.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 2
+    }
+  },
+  "src/db/eventRetention.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/db/layoutEventRepository.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/db/logEventRepository.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/db/navigationEventRepository.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/db/networkEventRepository.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/db/osEventRepository.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/db/storageEventRepository.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/features/accessibility/WcagAudit.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/features/action/swipeon/SwipeOn.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/features/observe/ios/CtrlProxyHierarchy.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/features/observe/ios/IosScreenIdentity.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 2
+    }
+  },
+  "src/features/observe/output/ObserveResultOutput.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 8
+    }
+  },
+  "src/features/record/android/DualTrackRecorder.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/server/finalizeToolResponse.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 3
+    }
+  },
+  "src/server/toolSchemaHelpers.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 2
+    }
+  },
+  "src/utils/image/loadSharp.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,9 +134,35 @@ function catchConventionRule() {
 	};
 }
 
+function noUnknownCastRule() {
+	return {
+		meta: {
+			type: "problem",
+			messages: {
+				unknownCast: "Avoid `as unknown as T`: it silences the type checker and can mask a real shape mismatch (e.g. a dropped required field). Use a proper type, a type guard, or a narrow assertion. If a library genuinely forces it, add an eslint-disable-next-line with a one-line justification.",
+			},
+		},
+		create(context) {
+			return {
+				// Match the double assertion `X as unknown as T`: an outer `as T`
+				// whose operand is itself `X as unknown`.
+				TSAsExpression(node) {
+					if (
+						node.expression?.type === "TSAsExpression" &&
+						node.expression.typeAnnotation?.type === "TSUnknownKeyword"
+					) {
+						context.report({ node, messageId: "unknownCast" });
+					}
+				},
+			};
+		},
+	};
+}
+
 const catchConventionPlugin = {
 	rules: {
 		"catch-convention": catchConventionRule(),
+		"no-unknown-cast": noUnknownCastRule(),
 	},
 };
 
@@ -359,6 +385,7 @@ export default [
 		languageOptions,
 		rules: {
 			"auto-mobile/catch-convention": 2,
+			"auto-mobile/no-unknown-cast": 2,
 		},
 	},
 	{

--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,8 @@
         "src/**",
         "test/**",
         "scripts/**/*.ts",
-        "eslint.config.mjs"
+        "eslint.config.mjs",
+        "eslint-suppressions.json"
       ],
       "outputs": [],
       "outputLogs": "new-only",


### PR DESCRIPTION
Proactive guard for the **#3595 bug class**: a required field silently dropped behind an `as unknown as T` cast, which defeats the type checker on the object shape.

## What
- New `auto-mobile/no-unknown-cast` ESLint rule (a sibling of the existing `auto-mobile/catch-convention` rule) that flags the double assertion `X as unknown as T` in `src/**`.
- Existing casts grandfathered via `eslint-suppressions.json` (ESLint 10 bulk suppressions) — a **ratchet**: only NEW casts fail CI, mirroring the typecheck-baseline philosophy.
- `eslint-suppressions.json` added to turbo's `lint` inputs so the cache invalidates when the ratchet changes.

## Why a ratchet, not a fix-all
The 29 existing `src/` casts are mostly legitimate library seams — `getDatabase() as unknown as Kysely<Database>`, zod schema helpers, the Sharp module load. Fixing those is out of scope and risky; the point of the guard is preventing *new* ones. Test files (429 legitimate mock casts) are exempt — the rule is `src`-only.

## Dedicated rule id (not `no-restricted-syntax`)
Bulk suppressions are per-rule-id. Piggybacking on `no-restricted-syntax` would also grandfather that rule's *other* selectors (import-extension checks) in those files. A dedicated rule id keeps the ratchet surgical.

## Verified
- Plain `eslint .` → clean (29 existing grandfathered).
- A new `x as unknown as T` in `src/` → **fails** with an actionable message.
- Test-file casts → not flagged.
- Escape hatch: a genuinely-required cast can add `// eslint-disable-next-line auto-mobile/no-unknown-cast` with a one-line justification.

Note: the repo has no RuleTester harness for its inline rules (`catch-convention` has none either), so the behavioral verification above + the `turbo lint` gate is the regression protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)