### PR TITLE
test: guard flush timer surviving a throwing scheduled flush (#3605)

### DIFF
--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventBufferTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventBufferTests.swift
@@ -100,6 +100,45 @@ final class SdkEventBufferTests: XCTestCase {
         buffer.shutdown()
         XCTAssertTrue(fakeTimer.isCancelled)
     }
+
+    // Regression guard for issue #3605 (and its Android twin #3710): a throw from a
+    // *timer-scheduled* flush must not tear down the repeating flush timer. The
+    // existing flush-error tests only drive the throw through a direct `flush()` /
+    // `shutdown()` call; this one drives it through the timer, then fires the timer
+    // again to prove it is still live and still flushing.
+    func testTimerSurvivesThrowingFlush() {
+        struct FlushError: Error {}
+        let fakeTimer = FakeTimer()
+        let dropCounter = FakeDropCounter()
+
+        let buffer = SdkEventBuffer(
+            maxBufferSize: 100,
+            flushIntervalMs: 500,
+            timerFactory: { fakeTimer },
+            dropCounter: dropCounter
+        ) { _ in
+            throw FlushError()
+        }
+
+        buffer.start()
+
+        // First scheduled flush throws — must be swallowed and counted, not crash.
+        buffer.add(SdkInteractionEvent(interactionType: "e1"))
+        buffer.add(SdkInteractionEvent(interactionType: "e2"))
+        fakeTimer.fire()
+        XCTAssertEqual(dropCounter.snapshot()[.flushError], 2)
+
+        // The throw must not have cancelled the repeating timer (the #3605 bug).
+        XCTAssertFalse(fakeTimer.isCancelled)
+
+        // A subsequent tick must still flush — proving the timer kept firing after
+        // the earlier throw. Cumulative flushError count reflects both rounds.
+        buffer.add(SdkInteractionEvent(interactionType: "e3"))
+        buffer.add(SdkInteractionEvent(interactionType: "e4"))
+        buffer.add(SdkInteractionEvent(interactionType: "e5"))
+        fakeTimer.fire()
+        XCTAssertEqual(dropCounter.snapshot()[.flushError], 5)
+    }
 }
 
 // MARK: - Event Processor Tests


### PR DESCRIPTION
## What

Adds `SdkEventBufferTests.testTimerSurvivesThrowingFlush` — a regression guard that a throw from a **timer-scheduled** flush does not tear down the repeating flush timer.

## Why

The 2026-07 bug hunt fixed a class where a throwing periodic task killed its own timer — canonically [#3605](https://github.com/kaeawc/auto-mobile/issues/3605) (iOS `SdkEventBuffer`) and its Android twin [#3710](https://github.com/kaeawc/auto-mobile/issues/3710).

Swift already covered the *swallow-and-count* behavior, but only through **direct** `flush()`/`shutdown()` calls (`testFlushErrorCountedPerEvent`). Nothing drove the throw through the **timer** — which is exactly the code path that bit on Android. This closes that parity gap.

## The test

Fires the `FakeTimer` with a throwing `onFlush`, then asserts:
1. the throw is swallowed and counted (`.flushError`), not crashed;
2. `fakeTimer.isCancelled == false` — the timer was **not** torn down by the throw (the #3605 bug);
3. a second `fire()` still flushes (cumulative `.flushError` count) — proving the timer kept firing.

## Verification

- Passes as-is.
- **Negatively verified**: injecting the #3605 bug (cancel the timer in the flush catch block) fails both assertion 2 and assertion 3; reverting makes it pass — so it is a real guard, not a vacuous test.

Third of three proactive follow-ups to the #3599/#3605/#3607-class fixes, alongside the registration/teardown guard (#3755) and the SwiftLint force-unwrap CI gate (#3759).

### Follow-up noted (not in this PR)

A direct `DaemonSocketClient` pending-drain / typed-`DaemonUnavailableException` test (#3598) would need a production transport seam — the client uses raw `SocketChannel` per-thread with only a whole-client override hook — so it is out of scope for a test-only change.