### PR TITLE
lint(guard): flag traceless catch blocks (#3594 class)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,5 +1,43 @@
 {
+  "src/cli/index.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 4
+    }
+  },
+  "src/daemon/buildIdentity.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/daemon/daemon.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    }
+  },
+  "src/daemon/daemonFiles.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 4
+    }
+  },
+  "src/daemon/debugTools.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/daemon/directModeGuard.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    }
+  },
+  "src/daemon/socketServer/PushSubscriptionSocketServer.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 4
+    }
+  },
   "src/daemon/telemetryPushSocketServer.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    },
     "auto-mobile/no-unknown-cast": {
       "count": 2
     }
@@ -16,6 +54,11 @@
   },
   "src/db/logEventRepository.ts": {
     "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/db/migrationLock.ts": {
+    "auto-mobile/catch-convention": {
       "count": 1
     }
   },
@@ -39,8 +82,63 @@
       "count": 1
     }
   },
+  "src/features/accessibility/ContrastChecker.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
   "src/features/accessibility/WcagAudit.ts": {
     "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/features/action/AppPermissions.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/action/BaseVisualChange.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/action/CaptureSnapshot.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    }
+  },
+  "src/features/action/ClearAppData.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/action/HomeScreen.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/action/InstallApp.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 3
+    }
+  },
+  "src/features/action/LaunchApp.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    }
+  },
+  "src/features/action/PressButton.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/action/RecentApps.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/action/TerminateApp.ts": {
+    "auto-mobile/catch-convention": {
       "count": 1
     }
   },
@@ -49,8 +147,43 @@
       "count": 1
     }
   },
+  "src/features/navigation/DefaultUIStateSetup.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    }
+  },
+  "src/features/navigation/Explore.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    }
+  },
+  "src/features/navigation/NavigateTo.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/navigation/NavigationScreenshotManager.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 3
+    }
+  },
+  "src/features/observe/DeviceServiceClient.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/observe/TakeScreenshot.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
   "src/features/observe/ios/CtrlProxyHierarchy.ts": {
     "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/features/observe/ios/IOSCtrlProxyClient.ts": {
+    "auto-mobile/catch-convention": {
       "count": 1
     }
   },
@@ -59,9 +192,19 @@
       "count": 2
     }
   },
+  "src/features/observe/ios/IosSdkEventIngestor.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 4
+    }
+  },
   "src/features/observe/output/ObserveResultOutput.ts": {
     "auto-mobile/no-unknown-cast": {
       "count": 8
+    }
+  },
+  "src/features/record/android/AxisRanges.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
     }
   },
   "src/features/record/android/DualTrackRecorder.ts": {
@@ -69,9 +212,57 @@
       "count": 1
     }
   },
+  "src/features/utility/SystemConfigurationManager.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/utility/ios/IosNotificationAuthorizationReader.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/utility/system-configuration/IosLockdownLocaleClient.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/video/NoopVideoCaptureBackend.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/features/video/VideoRecorderService.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/server/appFileContract.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
   "src/server/finalizeToolResponse.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    },
     "auto-mobile/no-unknown-cast": {
       "count": 3
+    }
+  },
+  "src/server/networkGraph.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/server/observeTools.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/server/toolRegistry.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
     }
   },
   "src/server/toolSchemaHelpers.ts": {
@@ -79,8 +270,98 @@
       "count": 2
     }
   },
+  "src/utils/DebugContextBuilder.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/DeepLinkManager.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/IOSCtrlProxyBuilder.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 4
+    }
+  },
+  "src/utils/IOSCtrlProxyManager.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 10
+    }
+  },
+  "src/utils/android-cmdline-tools/AndroidBuildToolsLocator.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/describeUnknownError.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/deviceUtils.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/envBootstrap.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/fileLock.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 2
+    }
+  },
   "src/utils/image/loadSharp.ts": {
     "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
+  "src/utils/ios-cmdline-tools/DeviceAppManager.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/ios-cmdline-tools/SimCtlClient.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/ios-cmdline-tools/XcodeSigning.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/logPruner.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/mcpVersion.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 3
+    }
+  },
+  "src/utils/plan/PlanExecutor.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/requireBootedDevice.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/truncateBodyText.ts": {
+    "auto-mobile/catch-convention": {
+      "count": 1
+    }
+  },
+  "src/utils/workingDirectory.ts": {
+    "auto-mobile/catch-convention": {
       "count": 1
     }
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -186,16 +186,19 @@ function catchConventionRule() {
 			return {
 				CatchClause(node) {
 					const statements = node.body.body;
-					// A catch that swallows the error with no trace at all — it does
-					// not log, does not throw, and never even references the caught
-					// binding — is the root cause of the #3594-class bugs (empty iOS
-					// SDK-event catches; the Idle rotation-check whose `err` was
-					// unused). Catches that forward the error elsewhere (e.g. reject(e),
-					// handleError(e)) reference the binding and are left alone.
-					if (!hasAnyLoggerCall(node.body) && !hasThrowStatement(node.body) && !referencesCaughtError(node)) {
-						context.report({ node, messageId: "tracelessCatch" });
-					} else if (statements.length === 1 && statements[0].type === "ReturnStatement" && isFallbackReturn(statements[0].argument) && !hasAnyLoggerCall(node.body)) {
+					if (statements.length === 1 && statements[0].type === "ReturnStatement" && isFallbackReturn(statements[0].argument) && !hasAnyLoggerCall(node.body)) {
+						// A single fallback return without logging keeps its specific
+						// message — checked precedence-first so it is not reclassified.
 						context.report({ node: statements[0], messageId: "fallbackReturn" });
+					} else if (!hasAnyLoggerCall(node.body) && !hasThrowStatement(node.body) && !referencesCaughtError(node)) {
+						// Otherwise, a catch that swallows the error with no trace at all
+						// — no log, no throw, and never even references the caught binding
+						// — is the root cause of the #3594-class bugs (comment-only iOS
+						// SDK-event catches that core no-empty ignores; the Idle
+						// rotation-check whose `err` was unused and returned a non-fallback
+						// object). Catches that forward the error (reject(e), handleError(e))
+						// reference the binding and are intentionally left alone.
+						context.report({ node, messageId: "tracelessCatch" });
 					}
 					reportStatusReturnsWithoutWarn(statements, false);
 				},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,67 @@ function isFallbackReturn(argument) {
 	return !argument || argument.type === "Literal" && argument.value === null || isUndefinedReturn(argument) || isBooleanReturn(argument) || isStatusObjectReturn(argument);
 }
 
+function hasThrowStatement(node, seen = new WeakSet()) {
+	if (!node || typeof node.type !== "string" || seen.has(node)) {
+		return false;
+	}
+	seen.add(node);
+	if (node.type === "ThrowStatement") {
+		return true;
+	}
+	// Do not descend into nested function bodies: a throw inside a callback
+	// defined in the catch does not satisfy the catch's own error contract.
+	if (node.type === "FunctionDeclaration" || node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression") {
+		return false;
+	}
+	for (const [key, value] of Object.entries(node)) {
+		if (key === "parent") {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			if (value.some(child => hasThrowStatement(child, seen))) {
+				return true;
+			}
+		} else if (value && typeof value === "object" && typeof value.type === "string" && hasThrowStatement(value, seen)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function identifierIsReferenced(node, name, seen = new WeakSet()) {
+	if (!node || typeof node.type !== "string" || seen.has(node)) {
+		return false;
+	}
+	seen.add(node);
+	if (node.type === "Identifier" && node.name === name) {
+		return true;
+	}
+	for (const [key, value] of Object.entries(node)) {
+		if (key === "parent") {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			if (value.some(child => identifierIsReferenced(child, name, seen))) {
+				return true;
+			}
+		} else if (value && typeof value === "object" && typeof value.type === "string" && identifierIsReferenced(value, name, seen)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// True if the catch body uses its caught error binding anywhere (forwarding it
+// to a helper, rejector, etc.). A catch with no binding (`catch { }`) or an
+// unused binding counts as NOT referencing it.
+function referencesCaughtError(catchNode) {
+	if (!catchNode.param || catchNode.param.type !== "Identifier") {
+		return false;
+	}
+	return identifierIsReferenced(catchNode.body, catchNode.param.name);
+}
+
 function catchConventionRule() {
 	return {
 		meta: {
@@ -95,6 +156,7 @@ function catchConventionRule() {
 			messages: {
 				fallbackReturn: "Catch blocks that return a fallback must log the caught error before returning.",
 				statusReturn: "Catch blocks that return a typed failure/status object must log at warn, not debug.",
+				tracelessCatch: "Catch block swallows the error with no trace: it does not log, does not throw, and never references the caught error. Per the error-handling convention, log it (logger.debug/warn/error) or throw a structured error (see CLAUDE.md).",
 			},
 		},
 		create(context) {
@@ -124,7 +186,15 @@ function catchConventionRule() {
 			return {
 				CatchClause(node) {
 					const statements = node.body.body;
-					if (statements.length === 1 && statements[0].type === "ReturnStatement" && isFallbackReturn(statements[0].argument) && !hasAnyLoggerCall(node.body)) {
+					// A catch that swallows the error with no trace at all — it does
+					// not log, does not throw, and never even references the caught
+					// binding — is the root cause of the #3594-class bugs (empty iOS
+					// SDK-event catches; the Idle rotation-check whose `err` was
+					// unused). Catches that forward the error elsewhere (e.g. reject(e),
+					// handleError(e)) reference the binding and are left alone.
+					if (!hasAnyLoggerCall(node.body) && !hasThrowStatement(node.body) && !referencesCaughtError(node)) {
+						context.report({ node, messageId: "tracelessCatch" });
+					} else if (statements.length === 1 && statements[0].type === "ReturnStatement" && isFallbackReturn(statements[0].argument) && !hasAnyLoggerCall(node.body)) {
 						context.report({ node: statements[0], messageId: "fallbackReturn" });
 					}
 					reportStatusReturnsWithoutWarn(statements, false);

--- a/test/lint/errorHandlingConvention.test.ts
+++ b/test/lint/errorHandlingConvention.test.ts
@@ -90,6 +90,52 @@ export function probe(): boolean {
     expect(messages).toContain("Catch blocks that return a fallback must log the caught error before returning.");
   });
 
+  test("rejects comment-only catch bodies that core no-empty ignores (#3594)", async () => {
+    // no-empty skips blocks containing a comment, so this shape shipped
+    // undetected in IOSCtrlProxyClient. tracelessCatch must still flag it.
+    const messages = await lintSnippet(`
+export function poll(): void {
+  try {
+    throw new Error("boom");
+  } catch {
+    // non-fatal, skip
+  }
+}
+`);
+
+    expect(messages).toContain("Catch block swallows the error with no trace: it does not log, does not throw, and never references the caught error. Per the error-handling convention, log it (logger.debug/warn/error) or throw a structured error (see CLAUDE.md).");
+  });
+
+  test("rejects an unused-error catch returning a non-fallback object (#3594 Idle case)", async () => {
+    const messages = await lintSnippet(`
+export function status(): { done: boolean; value: number | null } {
+  try {
+    return { done: true, value: 1 };
+  } catch (err) {
+    return { done: false, value: null };
+  }
+}
+`);
+
+    expect(messages).toContain("Catch block swallows the error with no trace: it does not log, does not throw, and never references the caught error. Per the error-handling convention, log it (logger.debug/warn/error) or throw a structured error (see CLAUDE.md).");
+  });
+
+  test("allows catches that forward the error without logging", async () => {
+    // Forwarding the caught error to a handler/rejector references the binding,
+    // so it is not a silent swallow and must not be flagged.
+    const messages = await lintSnippet(`
+export function run(reject: (error: unknown) => void): void {
+  try {
+    throw new Error("boom");
+  } catch (error) {
+    reject(error);
+  }
+}
+`);
+
+    expect(messages).not.toContain("Catch block swallows the error with no trace: it does not log, does not throw, and never references the caught error. Per the error-handling convention, log it (logger.debug/warn/error) or throw a structured error (see CLAUDE.md).");
+  });
+
   test("allows non-fallback recovery returns", async () => {
     const messages = await lintSnippet(`
 function recover(error: unknown): string {


### PR DESCRIPTION
Proactive guard for the **#3594 bug class**: a `catch` that swallows the error with no trace. The existing `auto-mobile/catch-convention` rule only checked single fallback-returns and status objects, so the empty iOS SDK-event catches and the Idle rotation-check (unused `err`) passed lint.

## What
Add a `tracelessCatch` check to the existing rule: flag a catch that **does not log, does not throw, and never references the caught error binding**. That's the "error vanishes silently" signature.

Deliberately exempt (high signal, low noise):
- **Forwarding** — `catch (e) { reject(e) }`, `catch (e) { handleError(e) }` — references `e`, so it's not silent.
- **Rethrow** — `catch (e) { throw e }` — has a throw.
- Catches that log at any level.

## Ratchet
96 existing traceless catches — mostly expected-failure swallows that per convention strategy 3 still owe a `logger.debug` — are grandfathered via `eslint-suppressions.json` (the same mechanism the `no-unknown-cast` guard introduced). Only **new** traceless catches fail CI.

## Verified
- Empty catch (`catch { }`) and unused-`err` catch → **fail**.
- `reject(e)` / `handleError(e)` forwarding and `throw e` rethrow → pass.
- Plain `eslint .` → clean (96 grandfathered).
- A newly-added `catch { }` in `src/` → fails.

## Follow-up
The 96 grandfathered catches are tracked debt — some may be genuine silent-swallow bugs like the ones this class produced. They should be burned down by adding the missing `logger.debug(...)` traces and pruning the suppressions, which will also shrink the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)