### PR TITLE
feat(playground): integrate Compose HotSwan hot reload into the app

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.compose.compiler) apply false
   alias(libs.plugins.compose.hot.reload) apply false
+  alias(libs.plugins.compose.hotswan) apply false
   alias(libs.plugins.mavenPublish) apply false
   alias(libs.plugins.metro) apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ mavenpublish = "0.37.0"
 dokka = "2.2.0"
 compose-multiplatform = "1.11.1"
 compose-hot-reload = "1.2.0-rc01"
+compose-hotswan = "1.3.7"
 metro = "1.3.0"
 
 [plugins]
@@ -82,6 +83,7 @@ mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenpublis
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 compose-hot-reload = { id = "org.jetbrains.compose.hot-reload", version.ref = "compose-hot-reload" }
+compose-hotswan = { id = "com.github.skydoves.compose.hotswan.compiler", version.ref = "compose-hotswan" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 
 [libraries]

--- a/android/playground/README.md
+++ b/android/playground/README.md
@@ -35,3 +35,28 @@ The app includes a Docs Demo Index screen (Home > Demos) with deterministic demo
 
 Demo screens use stable labels and Compose test tags for repeatable automation. Deep links are
 listed in `android/docs/playground-deep-links.md`.
+
+## Compose Hot Reload (HotSwan)
+
+The playground app applies [Compose HotSwan](https://hotswan.dev/) (`com.github.skydoves.compose.hotswan.compiler`),
+so Jetpack Compose UI edits apply instantly on a running emulator/device with navigation,
+scroll, and `remember`/ViewModel state preserved -- no rebuild or reinstall. This is the
+Android on-device counterpart to the Compose-Desktop hot reload used by `:desktop-app`.
+
+Setup:
+
+1. Install the **Compose HotSwan** plugin in Android Studio / IntelliJ
+   (Settings > Plugins > Marketplace). Keep it roughly in step with the Gradle plugin
+   version pinned as `compose-hotswan` in `android/gradle/libs.versions.toml`.
+2. Run the playground app normally (a debug build) on an emulator or device.
+3. Open the HotSwan tool window (View > Tool Windows > HotSwan), select the target, and Start.
+4. Edit a composable in the app or any feature module (`:playground:home`, `:playground:mediaplayer`, ...)
+   and save -- the change reflects on the running app.
+
+Notes:
+
+- The Gradle plugin self-scopes: it adds its client library as `debugImplementation` only,
+  so `release` builds carry zero overhead and CI release/build jobs are unaffected.
+- The pinned version (`1.3.7`) is the latest HotSwan release built against Kotlin 2.4.0, matching
+  this project's Kotlin version. HotSwan is a Kotlin compiler plugin, so its version is bound to
+  the compiler -- bump `compose-hotswan` only to a build that targets the project's Kotlin version.

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
+  // Compose HotSwan: instant Compose UI hot reload on a running device. The plugin
+  // self-scopes to debug builds (adds its client library as debugImplementation only),
+  // so release builds carry zero overhead. See android/playground/README.md.
+  alias(libs.plugins.compose.hotswan)
 }
 
 // Signing configuration: reads from environment variables (CI) or gradle.properties (local)


### PR DESCRIPTION
## Summary

Applies [Compose HotSwan](https://hotswan.dev/) (`com.github.skydoves.compose.hotswan.compiler`, v1.3.7) to `:playground:app` so Jetpack Compose UI edits apply instantly on a running emulator/device with navigation, scroll, and `remember`/ViewModel state preserved — no rebuild or reinstall. This is the Android on-device counterpart to the Compose-Desktop hot reload wired into `:desktop-app` in #3748.

Changes:
- `android/gradle/libs.versions.toml` — add `compose-hotswan` version (`1.3.7`) and the `[plugins]` alias for `com.github.skydoves.compose.hotswan.compiler`.
- `android/build.gradle.kts` — register the plugin as `apply false` in the root plugins block.
- `android/playground/app/build.gradle.kts` — apply the plugin.
- `android/playground/README.md` — document the HotSwan dev workflow.

**Debug-only gating:** HotSwan self-scopes — the Gradle plugin adds its client library as `debugImplementation` only, so `release` builds carry zero overhead. Applying the plugin unconditionally is the vendor-intended, release-safe usage (a Kotlin compiler plugin applies at the project level, not per-variant), so no manual `buildType` wiring is needed.

**Version choice — the important call:** HotSwan is a Kotlin compiler plugin, so its version is bound to the Kotlin compiler it was built against. This project is on **Kotlin 2.4.0**. Inspecting the published POMs on Maven Central: `1.3.7` pins `kotlin-stdlib 2.4.0` (matches this project), whereas the newer `2.0.0-beta03` still pins `kotlin-stdlib 2.3.21`. So `1.3.7` is the correct choice; the v2 beta (structural reload + live-AI-edit MCP) is deferred until it ships a Kotlin 2.4.0-compatible build. The plugin marker resolves from Maven Central, which is already in `settings.gradle.kts` `pluginManagement` repositories.

## Linked Issue

Closes #3744

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — N/A (Android-only change)
- [ ] `bun run typecheck` reports no new errors (baseline gate) — N/A
- [x] Android changes: version compatibility verified against published POMs (`1.3.7` → `kotlin-stdlib 2.4.0`, matching the project); plugin id and debug-only self-scoping confirmed against HotSwan's setup docs; plugin marker confirmed present on Maven Central.
- [ ] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms — N/A (build-config only)
- [ ] Rebased onto latest `main`, conflicts resolved — branch was restarted from `main` after #3748 merged.

> **Note:** A local Gradle build/ktfmt run could not be executed in this environment — the egress policy blocks `services.gradle.org` (Gradle distribution) and the ktfmt release JAR (403 via the agent proxy). CI (which has network) is the validation gate here — it exercises **Build Playground App** and the playground emulator tests, which will resolve and apply the HotSwan plugin. **If CI surfaces a resolution or Kotlin-compatibility failure, I'll diagnose and fix it.**

## Device Verification

Not run here (no attached device/emulator in this environment). The dev workflow — run the debug playground app, open the HotSwan tool window, edit a composable, observe live reload — is documented in `android/playground/README.md` and requires the matching HotSwan IDE plugin.

## Follow-ups

- [ ] Once HotSwan v2 ships a Kotlin 2.4.0-compatible build, evaluate upgrading `compose-hotswan` for structural/whole-screen reload and the live-AI-edit MCP server (and assess whether that MCP coexists with AutoMobile's own MCP server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQBX8AP5QnkYZQhMMDyiLs)_