### PR TITLE
fix: add isEmpty to ConnectionRegistry (unbreak control-proxy build)

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -79,6 +79,12 @@ final class ConnectionRegistry<Value> {
         return storage.count
     }
 
+    var isEmpty: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage.isEmpty
+    }
+
     /// Atomically clears the registry, returning the values that were removed.
     func removeAll() -> [Value] {
         lock.lock()


### PR DESCRIPTION
## The break

PR [#3759](https://github.com/kaeawc/auto-mobile/pull/3759) changed `WebSocketServer.broadcastPerformanceUpdate`'s guard from `connections.count > 0` to `!connections.isEmpty` to satisfy SwiftLint's `empty_count` rule. But `connections` is a `ConnectionRegistry` — the lock-guarded wrapper introduced by [#3611](https://github.com/kaeawc/auto-mobile/pull/3611) — which exposes `count` but **not** `isEmpty`. Result on main:

```
WebSocketServer.swift:315:28: error: value of type 'ConnectionRegistry<WebSocketConnection>' has no member 'isEmpty'
```

control-proxy no longer compiles, so the **Swift Code Coverage** job on main fails.

### Why it slipped through
- SwiftLint doesn't type-check, so the new `.isEmpty` looked fine to the lint gate.
- I verified PR #3759 with SwiftLint + `bun test` but never ran `swift build` on control-proxy.
- The PR's automerge landed it despite a red `Swift Code Coverage` job (repo has no branch protection).

## The fix

Add a lock-guarded `isEmpty` to `ConnectionRegistry`, mirroring its existing `count` property. This makes the guard compile **and** keeps `empty_count` satisfied (the rule prefers `isEmpty` over comparing `count` to zero — so reverting to `count > 0` would just re-trip it).

```swift
var isEmpty: Bool {
    lock.lock()
    defer { lock.unlock() }
    return storage.isEmpty
}
```

## Verification

- `swift build` (control-proxy) succeeds.
- All **402** control-proxy tests pass.
- Full-tree `validate_swiftlint.sh` is error-clean (0 errors).

Fixes the main breakage introduced by #3759.