### PR TITLE
feat(desktop): focus-aware observation stream cadence

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -806,7 +806,8 @@ fun AutoMobileContent(
           LOG.info("Observation stream socket missing, daemon appears down - skipping reconnect")
         } else {
           LOG.info("Observation stream disconnected, attempting reconnect for device: $deviceId")
-          // connect() re-applies the cadence last set via setCadence, preserving it across reconnects.
+          // connect() re-applies the cadence last set via setCadence, preserving it across
+          // reconnects.
           client.connect(deviceId = deviceId)
         }
       }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -194,15 +194,15 @@ private val ANDROID_LAUNCHERS =
 private const val IOS_SPRINGBOARD = "com.apple.springboard"
 private const val TIMELINE_EVENT_CACHE_LIMIT = 10_000
 
-// Live screenshot cadence requested by the desktop app while a device is connected. The desktop
-// mirrors the device screen in near real time, so it asks the daemon for a faster screenshot
-// cadence than the daemon's 3s low-cost keepalive default (the daemon clamps and resolves the
-// fastest cadence across all subscribers). See issue #3333 / #3382.
+// Screenshot cadence requested while the live layout inspector is active, so the device mirror
+// refreshes in near real time instead of at the daemon's 3s low-cost keepalive default (the daemon
+// clamps and resolves the fastest cadence across all subscribers). When the inspector is not active
+// the desktop relaxes back to the daemon default, avoiding frequent captures the user can't see.
+// See issue #3333 / #3382 / #3756.
 //
-// Hierarchy cadence is deliberately NOT requested here: the daemon already applies a fast
-// per-platform hierarchy default (Android CtrlProxy broadcasts at 250ms, iOS polls at 1000ms), and
-// the resolver takes the minimum of explicit requests. Sending a fixed 1000ms would slow Android's
-// live hierarchy 4x. Platform-/focus-aware hierarchy cadence is tracked in issue #3756.
+// Hierarchy cadence is deliberately left unset: the daemon already applies a fast per-platform
+// hierarchy default (Android CtrlProxy broadcasts at 250ms, iOS polls at 1000ms) and the resolver
+// takes the minimum of explicit requests, so requesting a fixed value would only risk slowing it.
 private const val LIVE_SCREENSHOT_INTERVAL_MS = 1_000L
 
 /**
@@ -758,10 +758,9 @@ fun AutoMobileContent(
       LOG.info(
         "Connecting observation stream for device: $deviceId (client: ${obsClient.hashCode()})"
       )
-      obsClient.connect(
-        deviceId = deviceId,
-        screenshotIntervalMs = LIVE_SCREENSHOT_INTERVAL_MS,
-      )
+      // Cadence starts at the daemon default; the focus-aware effect below raises it while the
+      // live layout inspector is active and relaxes it otherwise.
+      obsClient.connect(deviceId = deviceId)
       observationStreamClient = obsClient
 
       if (dataSourceMode == DataSourceMode.Real) {
@@ -807,13 +806,22 @@ fun AutoMobileContent(
           LOG.info("Observation stream socket missing, daemon appears down - skipping reconnect")
         } else {
           LOG.info("Observation stream disconnected, attempting reconnect for device: $deviceId")
-          client.connect(
-            deviceId = deviceId,
-            screenshotIntervalMs = LIVE_SCREENSHOT_INTERVAL_MS,
-          )
+          // connect() re-applies the cadence last set via setCadence, preserving it across reconnects.
+          client.connect(deviceId = deviceId)
         }
       }
     }
+  }
+
+  // Focus-aware observation cadence: request a fast screenshot cadence only while the live layout
+  // inspector is active, and relax to the daemon default otherwise, so the daemon isn't driving
+  // frequent screenshot captures when the mirror isn't on screen. setCadence is a no-op when the
+  // value is unchanged, so re-firing on unrelated recompositions is cheap.
+  LaunchedEffect(observationStreamClient, isLiveLayoutMode) {
+    val client = observationStreamClient ?: return@LaunchedEffect
+    client.setCadence(
+      screenshotIntervalMs = if (isLiveLayoutMode) LIVE_SCREENSHOT_INTERVAL_MS else null
+    )
   }
 
   // Periodic connection health check for failures push - reconnect if dropped

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -85,21 +85,19 @@ class ObservationStreamClient {
   private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
   val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
+  // Requested observation cadence, remembered so it is re-applied on every (re)subscribe (so the
+  // cadence survives reconnects). Managed via setCadence(); null means "use the daemon's default".
+  private var subscribedDeviceId: String? = null
+  private var requestedScreenshotIntervalMs: Long? = null
+  private var requestedHierarchyIntervalMs: Long? = null
+
   /**
-   * Connect to the observation stream socket and subscribe to updates.
+   * Connect to the observation stream socket and subscribe to updates. Any cadence configured via
+   * [setCadence] is sent on the subscribe request and re-applied automatically on reconnect.
    *
    * @param deviceId Optional device ID to subscribe to. If null, subscribes to all devices.
-   * @param screenshotIntervalMs Optional requested screenshot cadence in milliseconds. When null,
-   *   the daemon applies its default low-cost keepalive cadence. The daemon clamps the value to its
-   *   supported range and resolves the fastest cadence across all subscribers for the device.
-   * @param hierarchyIntervalMs Optional requested view-hierarchy polling cadence in milliseconds.
-   *   When null, the daemon applies its default cadence.
    */
-  fun connect(
-    deviceId: String? = null,
-    screenshotIntervalMs: Long? = null,
-    hierarchyIntervalMs: Long? = null,
-  ) {
+  fun connect(deviceId: String? = null) {
     if (_connectionState.value.isConnected) {
       log.info("Already connected to observation stream")
       return
@@ -132,8 +130,9 @@ class ObservationStreamClient {
       _connectionState.update { ConnectionState.Connected() }
       log.info("Connected to observation stream")
 
-      // Send subscribe request
-      subscribe(deviceId, screenshotIntervalMs, hierarchyIntervalMs)
+      // Send subscribe request (carries any cadence configured via setCadence)
+      subscribedDeviceId = deviceId
+      subscribe(deviceId)
 
       // Start reading messages
       scope.launch {
@@ -183,18 +182,14 @@ class ObservationStreamClient {
     scope.coroutineContext[Job]?.cancel()
   }
 
-  private fun subscribe(
-    deviceId: String?,
-    screenshotIntervalMs: Long? = null,
-    hierarchyIntervalMs: Long? = null,
-  ) {
+  private fun subscribe(deviceId: String?) {
     val request =
       StreamRequest(
         id = UUID.randomUUID().toString(),
         command = "subscribe",
         deviceId = deviceId,
-        screenshotIntervalMs = screenshotIntervalMs,
-        hierarchyIntervalMs = hierarchyIntervalMs,
+        screenshotIntervalMs = requestedScreenshotIntervalMs,
+        hierarchyIntervalMs = requestedHierarchyIntervalMs,
       )
 
     if (sendRequest(request)) {
@@ -206,6 +201,40 @@ class ObservationStreamClient {
         }
       }
       log.info("Subscribed to observation stream (device: ${deviceId ?: "all"})")
+    }
+  }
+
+  /**
+   * Update the requested observation cadence. When connected, sends an `update_cadence` command so
+   * the daemon reconfigures capture in place (no resubscribe, no backfill); the values are also
+   * remembered and re-applied on the next (re)subscribe, so the cadence survives reconnects. Pass
+   * null for a field to fall back to the daemon's per-platform default. No-op when the cadence is
+   * unchanged, so callers can invoke this on every focus change without spamming the socket.
+   */
+  fun setCadence(screenshotIntervalMs: Long? = null, hierarchyIntervalMs: Long? = null) {
+    if (
+      requestedScreenshotIntervalMs == screenshotIntervalMs &&
+        requestedHierarchyIntervalMs == hierarchyIntervalMs
+    ) {
+      return
+    }
+    requestedScreenshotIntervalMs = screenshotIntervalMs
+    requestedHierarchyIntervalMs = hierarchyIntervalMs
+
+    if (!_connectionState.value.isConnected) return
+
+    val request =
+      StreamRequest(
+        id = UUID.randomUUID().toString(),
+        command = "update_cadence",
+        deviceId = subscribedDeviceId,
+        screenshotIntervalMs = screenshotIntervalMs,
+        hierarchyIntervalMs = hierarchyIntervalMs,
+      )
+    if (sendRequest(request)) {
+      log.info(
+        "Requested observation cadence update (screenshot=$screenshotIntervalMs, hierarchy=$hierarchyIntervalMs)"
+      )
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -48,6 +48,25 @@ class ObservationStreamClientTest {
   }
 
   @Test
+  fun `update_cadence request carries the changed cadence and omits unset fields`() {
+    // setCadence(screenshotIntervalMs = X) sends an update_cadence command; the hierarchy field is
+    // omitted so the daemon relaxes it back to its per-platform default.
+    val request =
+      StreamRequest(
+        id = "req-3",
+        command = "update_cadence",
+        deviceId = "emulator-5554",
+        screenshotIntervalMs = 500L,
+      )
+
+    val encoded = wireJson.encodeToString(StreamRequest.serializer(), request)
+
+    assertTrue(encoded.contains("\"command\":\"update_cadence\""), encoded)
+    assertTrue(encoded.contains("\"screenshotIntervalMs\":500"), encoded)
+    assertFalse(encoded.contains("hierarchyIntervalMs"), encoded)
+  }
+
+  @Test
   fun `emits screenshot metadata when provided by stream`() = runTest {
     val client = ObservationStreamClient()
 

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -164,7 +164,7 @@ Real-time data flows over Unix domain sockets, separate from the request/respons
 
 ### ObservationStreamClient
 
-Maintains a persistent connection with subscribe/unsubscribe semantics. `connect()` accepts optional `screenshotIntervalMs` / `hierarchyIntervalMs` cadence hints that are sent on the `subscribe` request. The desktop app requests a faster screenshot cadence than the daemon's 3s keepalive default while a device is connected; it deliberately leaves the hierarchy cadence unset so each platform keeps its faster hierarchy default (Android 250ms, iOS 1000ms) instead of being slowed to a fixed value. Omitting a field (or an older daemon) falls back to the daemon default. Exposes Kotlin `SharedFlow` instances:
+Maintains a persistent connection with subscribe/unsubscribe semantics. Cadence is managed through `setCadence(screenshotIntervalMs, hierarchyIntervalMs)`: when connected it sends an `update_cadence` command so the daemon reconfigures capture in place (no resubscribe, no backfill), and the values are remembered so they are re-applied on the `subscribe` request after any reconnect. The desktop requests a faster screenshot cadence only while the live layout inspector is active (`isLiveLayoutMode`) and relaxes to the daemon default otherwise, avoiding frequent captures the user can't see. The hierarchy cadence is deliberately left unset so each platform keeps its faster hierarchy default (Android 250ms, iOS 1000ms) instead of being slowed to a fixed value. Omitting a field (or an older daemon, which replies with a benign "unknown command" error) falls back to the daemon default. Exposes Kotlin `SharedFlow` instances:
 
 - `hierarchyUpdates: SharedFlow<HierarchyStreamUpdate>`
 - `screenshotUpdates: SharedFlow<ScreenshotStreamUpdate>`

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -455,7 +455,14 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * Override processLine to handle additional commands and the onSubscriberConnected callback.
    */
   protected async processLine(socket: Socket, line: string): Promise<void> {
-    const request = this.parseJson<{ id?: string; command: string; deviceId?: string; appId?: string }>(line);
+    const request = this.parseJson<{
+      id?: string;
+      command: string;
+      deviceId?: string;
+      appId?: string;
+      screenshotIntervalMs?: unknown;
+      hierarchyIntervalMs?: unknown;
+    }>(line);
 
     if (!request) {
       const errorResponse: SubscriptionResponse = {
@@ -538,6 +545,29 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     if (request.command === "unsubscribe") {
       const filter = this.findFilterForSocket(socket);
       await super.processLine(socket, line);
+      if (filter) {
+        this.notifyScreenshotCadenceChanged(filter.deviceId);
+        this.notifyHierarchyCadenceChanged(filter.deviceId);
+      }
+      return;
+    }
+
+    // Update the requested cadence for an existing subscription in place, without a
+    // resubscribe (which would leak a duplicate subscriber and re-trigger backfill). Lets a
+    // subscriber raise the cadence while it is actively viewing the device and relax it when
+    // backgrounded. Unknown to older daemons, which reply with a benign "unknown command" error.
+    if (request.command === "update_cadence") {
+      const filter = this.findFilterForSocket(socket);
+      if (filter) {
+        filter.screenshotIntervalMs = this.parseScreenshotIntervalMs(request.screenshotIntervalMs);
+        filter.hierarchyIntervalMs = this.parseHierarchyIntervalMs(request.hierarchyIntervalMs);
+      }
+      const response: SubscriptionResponse = {
+        id: request.id,
+        type: "subscription_response",
+        success: true,
+      };
+      this.sendJson(socket, response);
       if (filter) {
         this.notifyScreenshotCadenceChanged(filter.deviceId);
         this.notifyHierarchyCadenceChanged(filter.deviceId);

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -863,6 +863,130 @@ describe("DeviceDataStreamSocketServer", () => {
     });
   });
 
+  describe("update_cadence", () => {
+    it("raises the screenshot cadence for an existing subscription in place", async () => {
+      const socket = new FakeSocket();
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub",
+        command: "subscribe",
+        deviceId: "device-1",
+      }));
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "upd",
+        command: "update_cadence",
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      }));
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
+    });
+
+    it("does not add a second subscriber when updating cadence", async () => {
+      const socket = new FakeSocket();
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub",
+        command: "subscribe",
+        deviceId: "device-1",
+      }));
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "upd",
+        command: "update_cadence",
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      }));
+
+      expect((server as any).subscribers.size).toBe(1);
+    });
+
+    it("relaxes cadence back to the default when the field is omitted", async () => {
+      const socket = new FakeSocket();
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub",
+        command: "subscribe",
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      }));
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "upd",
+        command: "update_cadence",
+        deviceId: "device-1",
+      }));
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+    });
+
+    it("clamps the updated hierarchy cadence and notifies both cadence listeners", async () => {
+      const changedScreenshot: Array<string | null> = [];
+      const changedHierarchy: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged(deviceId => changedScreenshot.push(deviceId));
+      server.setOnHierarchyCadenceChanged(deviceId => changedHierarchy.push(deviceId));
+      const socket = new FakeSocket();
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub",
+        command: "subscribe",
+        deviceId: "device-1",
+      }));
+      changedScreenshot.length = 0;
+      changedHierarchy.length = 0;
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "upd",
+        command: "update_cadence",
+        deviceId: "device-1",
+        hierarchyIntervalMs: 50,
+      }));
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(250);
+      expect(changedScreenshot).toEqual(["device-1"]);
+      expect(changedHierarchy).toEqual(["device-1"]);
+    });
+
+    it("acknowledges update_cadence with a subscription_response", async () => {
+      const socket = new FakeSocket();
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "sub",
+        command: "subscribe",
+        deviceId: "device-1",
+      }));
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "upd-ack",
+        command: "update_cadence",
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      }));
+
+      const ack = socket
+        .getWrittenMessages<{ id?: string; type: string; success?: boolean }>()
+        .find(message => message.id === "upd-ack");
+      expect(ack?.type).toBe("subscription_response");
+      expect(ack?.success).toBe(true);
+    });
+
+    it("acknowledges update_cadence even when the socket has no active subscription", async () => {
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "upd-no-sub",
+        command: "update_cadence",
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      }));
+
+      const ack = socket
+        .getWrittenMessages<{ id?: string; type: string; success?: boolean }>()
+        .find(message => message.id === "upd-no-sub");
+      expect(ack?.type).toBe("subscription_response");
+      expect(ack?.success).toBe(true);
+      expect((server as any).subscribers.size).toBe(0);
+    });
+  });
+
   describe("onDeviceConnectionLost", () => {
     it("pushes a device-scoped error to subscribers for that device", () => {
       const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });


### PR DESCRIPTION
## Summary

Implements #3756, the follow-up to the observation-stream cadence plumbing (#3747).

After #3747 the desktop requested a fixed live screenshot cadence for the whole session — driving frequent captures even when the device mirror wasn't on screen — and there was no safe way to change cadence on a live subscription (re-`subscribe` on the same socket leaks a duplicate subscriber, since `handleSubscribe` keys by a fresh id, not by socket).

- **Daemon** (`deviceDataStreamSocketServer.ts`): new `update_cadence` command that mutates the subscribing socket's filter in place and fires the existing cadence-change callbacks, which already reconfigure Android/iOS CtrlProxy capture live. No resubscribe, no backfill, no duplicate subscriber. Unknown to older daemons, which reply with a benign "unknown command" error — so the client degrades gracefully.
- **Client** (`ObservationStreamClient.kt`): cadence is now managed via `setCadence()`. It sends `update_cadence` when connected and remembers the value so it is re-applied on the `subscribe` request after any reconnect. `connect()` no longer takes cadence params. `setCadence` is a no-op when the value is unchanged.
- **UI** (`AutoMobileContent.kt`): requests the fast screenshot cadence only while the live layout inspector is active (`isLiveLayoutMode`) and relaxes to the daemon default otherwise. Hierarchy cadence stays unset so each platform keeps its fast default (Android 250ms, iOS 1000ms).

## Linked Issue

Closes #3756. Builds on #3747, #3382, #3333.

## Validation

- [x] `bun test test/daemon/deviceDataStreamSocketServer.test.ts` — 56 pass (6 new `update_cadence` tests: in-place mutation, no duplicate subscriber, relax-to-default, clamp + notify both listeners, ack, ack-without-subscription).
- [x] `bun run typecheck` — no new type errors (baseline gate).
- [x] `eslint` clean on the changed TS.
- [x] Added a Kotlin wire-contract test for the `update_cadence` command payload. The `desktop-core` Gradle build/tests could not be run locally (sandbox egress policy 403s `services.gradle.org` and the ktfmt jar); relying on CI's `Run Desktop Core Unit Tests` + `Fast Validation` (ktfmt), as in #3747.

## Device Verification

- [ ] Not verified on-device here. Worth confirming the mirror refreshes fast when the layout inspector is open and that cadence relaxes (fewer captures) when switching away, on both Android and iOS.

## Follow-ups

- [ ] **Surface screenshot metadata** — #3757
- [ ] **Model observation diff metadata** — #3758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144zCBppELsVDcXmsMJHsbc)_