### PR TITLE
fix(desktop-core): drain process output concurrently to avoid pipe-buffer deadlock (#3602)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDiscovery.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDiscovery.kt
@@ -219,20 +219,47 @@ class GitWorktreeLister : WorktreeLister {
           .directory(java.io.File(workingDir))
           .redirectErrorStream(true)
           .start()
-      val completed = process.waitFor(3, TimeUnit.SECONDS)
-      if (!completed) {
-        process.destroy()
-        return null
-      }
-      if (process.exitValue() != 0) {
-        return null
-      }
-      process.inputStream.bufferedReader().readText()
+      captureProcessOutput(process, 3, TimeUnit.SECONDS)
     } catch (_: Exception) {
       null
     }
   }
 }
+
+/**
+ * Runs [process] to completion, draining its (merged) output stream concurrently so a child that
+ * emits more than the OS pipe buffer (~64KB) can't block on write while the parent waits (#3602).
+ *
+ * Returns the fully captured output on a clean (exit 0) completion within [timeout], or null if the
+ * process times out (it is destroyed) or exits non-zero.
+ */
+internal fun captureProcessOutput(process: Process, timeout: Long, unit: TimeUnit): String? {
+  val output = StringBuilder()
+  val reader = Thread {
+    try {
+      process.inputStream.bufferedReader().use { output.append(it.readText()) }
+    } catch (_: Exception) {
+      // Stream closed early (e.g. the process was destroyed); a partial read is acceptable.
+    }
+  }
+    .apply {
+      isDaemon = true
+      start()
+    }
+  if (!process.waitFor(timeout, unit)) {
+    process.destroy()
+    reader.join(READER_JOIN_TIMEOUT_MS)
+    return null
+  }
+  // Process has exited; its stdout is closed, so the reader reaches EOF and finishes promptly.
+  reader.join()
+  if (process.exitValue() != 0) {
+    return null
+  }
+  return output.toString()
+}
+
+private const val READER_JOIN_TIMEOUT_MS = 500L
 
 interface PortCommandRunner {
   fun runCommand(command: List<String>): String?
@@ -242,15 +269,7 @@ class SystemPortCommandRunner : PortCommandRunner {
   override fun runCommand(command: List<String>): String? {
     return try {
       val process = ProcessBuilder(command).redirectErrorStream(true).start()
-      val completed = process.waitFor(2, TimeUnit.SECONDS)
-      if (!completed) {
-        process.destroy()
-        return null
-      }
-      if (process.exitValue() != 0) {
-        return null
-      }
-      process.inputStream.bufferedReader().readText()
+      captureProcessOutput(process, 2, TimeUnit.SECONDS)
     } catch (_: Exception) {
       null
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/CaptureProcessOutputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/CaptureProcessOutputTest.kt
@@ -1,0 +1,72 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Assume.assumeFalse
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression coverage for #3602: [captureProcessOutput] must drain the child's output concurrently
+ * so a command whose output exceeds the OS pipe buffer (~64KB) does not deadlock and get reported
+ * as a spurious failure.
+ */
+class CaptureProcessOutputTest {
+
+  @Before
+  fun onlyOnUnix() {
+    // These tests spawn `sh`; the desktop-core unit-test job runs on Linux.
+    assumeFalse(System.getProperty("os.name", "").lowercase().contains("windows"))
+  }
+
+  @Test
+  fun capturesOutputLargerThanPipeBuffer() {
+    // 200_000 lines of ~11 bytes ≈ 2MB, far beyond the ~64KB pipe buffer that used to deadlock the
+    // old read-after-waitFor implementation.
+    val lineCount = 200_000
+    val process =
+      ProcessBuilder("sh", "-c", "yes 'AUTOMOBILE' | head -n $lineCount")
+        .redirectErrorStream(true)
+        .start()
+
+    val output = captureProcessOutput(process, 30, TimeUnit.SECONDS)
+
+    assertTrue(output != null, "expected the large output to be captured, not a spurious null")
+    val lines = output!!.trim().split("\n")
+    assertEquals(lineCount, lines.size, "every emitted line should be captured")
+    assertTrue(lines.all { it == "AUTOMOBILE" }, "captured content should be intact")
+  }
+
+  @Test
+  fun capturesSmallOutput() {
+    val process =
+      ProcessBuilder("sh", "-c", "printf 'hello world'").redirectErrorStream(true).start()
+
+    val output = captureProcessOutput(process, 5, TimeUnit.SECONDS)
+
+    assertEquals("hello world", output)
+  }
+
+  @Test
+  fun returnsNullOnTimeout() {
+    val process = ProcessBuilder("sh", "-c", "sleep 10").redirectErrorStream(true).start()
+
+    val output = captureProcessOutput(process, 1, TimeUnit.SECONDS)
+
+    assertNull(output, "a command exceeding the timeout should be destroyed and yield null")
+    // The timed-out process should have been destroyed; give it a brief moment to die.
+    process.waitFor(2, TimeUnit.SECONDS)
+    assertTrue(!process.isAlive, "timed-out process should have been destroyed")
+  }
+
+  @Test
+  fun returnsNullOnNonZeroExit() {
+    val process = ProcessBuilder("sh", "-c", "echo oops; exit 3").redirectErrorStream(true).start()
+
+    val output = captureProcessOutput(process, 5, TimeUnit.SECONDS)
+
+    assertNull(output, "a non-zero exit should yield null")
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #3602. `McpDiscovery.runProcess` (and the identical `SystemPortCommandRunner.runCommand`) read the child's stdout **after** `waitFor`. A command whose merged stdout+stderr exceeds the OS pipe buffer (~64KB) blocks the child on write; the parent's timed `waitFor` then expires, the child is destroyed, and the call spuriously returns `null` — e.g. git worktree discovery silently returns empty for a large repo even though the command would have succeeded.

## Fix
Extract a shared `captureProcessOutput(process, timeout, unit)` helper that drains the (merged) output stream on a daemon thread **concurrently** with `waitFor`, so the child can never block on the pipe. Both call sites route through it; timeout/destroy and non-zero-exit semantics are preserved (still return `null`).

## Tests
`CaptureProcessOutputTest` spawns a process that emits ~2MB (200k lines, far beyond the ~64KB buffer that used to deadlock) and asserts full, intact capture, plus the timeout-destroy and non-zero-exit paths. Guarded to run only on Unix (the `desktop-core` unit-test job is `ubuntu-latest`).

Automated bug-hunt origin; verified locally via `:desktop-core:test`.