### PR TITLE
fix: serialize gh-pages deploy-docs job to avoid overlapping deployments

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1137,6 +1137,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [kotlin-code-coverage, swift-code-coverage]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write

--- a/test/bats/merge-workflow-deploy-docs-concurrency.bats
+++ b/test/bats/merge-workflow-deploy-docs-concurrency.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+#
+# Guards issue #3578: overlapping `On Merge` runs (multiple PRs merging in
+# quick succession) each reach actions/deploy-pages@v4, and GitHub Pages
+# allows only one in-progress deployment per environment — the loser errors
+# out. The deploy-docs job must serialize via a job-scoped `concurrency`
+# block (group "pages", cancel-in-progress: false) so deploys queue instead
+# of racing, without serializing the rest of the workflow.
+
+WORKFLOW=".github/workflows/merge.yml"
+
+# Extract the deploy-docs job block: from its "  deploy-docs:" line up to
+# (but not including) the next top-level (2-space-indented) job key.
+deploy_docs_block() {
+  awk '
+    /^  deploy-docs:/ { capture=1 }
+    capture && /^  [A-Za-z0-9_-]+:/ && !/^  deploy-docs:/ { exit }
+    capture { print }
+  ' "$WORKFLOW"
+}
+
+@test "deploy-docs job has a job-scoped concurrency block" {
+  block="$(deploy_docs_block)"
+  [ -n "$block" ]
+  echo "$block" | grep -Eq '^    concurrency:'
+}
+
+@test "deploy-docs concurrency group is scoped to pages deploys" {
+  block="$(deploy_docs_block)"
+  echo "$block" | grep -Fq 'group: "pages"'
+}
+
+@test "deploy-docs concurrency does not cancel in-progress deploys" {
+  block="$(deploy_docs_block)"
+  echo "$block" | grep -Fq 'cancel-in-progress: false'
+}
+
+@test "top-level workflow concurrency is untouched (only deploy-docs job is scoped)" {
+  # The fix must not add a workflow-level concurrency block, which would
+  # serialize the entire On Merge workflow instead of just Pages deploys.
+  top_level_concurrency_count="$(awk '/^concurrency:/' "$WORKFLOW" | wc -l | tr -d ' ')"
+  [ "$top_level_concurrency_count" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

When multiple PRs merge into `main` in quick succession, each push triggers a separate `On Merge` run, and each run's `deploy-docs` job reaches `actions/deploy-pages@v4`. GitHub Pages allows only one in-progress deployment per environment, so overlapping runs race and the loser fails ("another deployment is in progress" / cancelled).

Adds a job-scoped `concurrency` block to `deploy-docs` (group `"pages"`, `cancel-in-progress: false`) so Pages deploys queue and run in order instead of racing. Scoped to the job (not the workflow) so the rest of `On Merge` stays fully parallel.

## Linked Issue

Closes #3578

## Bug / Regression Context

- **Prior attempts:** none
- **Observed symptom:** `deploy-docs` job fails on the losing side of overlapping `On Merge` runs when merges land close together
- **Repro steps / conditions:** two or more PRs merge to `main` within the same Pages-deploy window

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (14/14 checks OK)
- [x] `bun run typecheck` — not applicable (no TypeScript changed)
- [x] Android/iOS changes — not applicable (workflow YAML only)
- [x] New bats test `test/bats/merge-workflow-deploy-docs-concurrency.bats` pins the job-scoped concurrency block; confirmed red before the fix, green after
- [x] Rebased onto latest `main`, no conflicts

## Device Verification

N/A — CI workflow change only, no on-device behavior affected.

## Follow-ups

None filed yet; will triage after review per issue's "Alternatives considered" (dedicated `deploy-docs.yml` with path filter, merge queue) if raised in review.