### PR TITLE
fix(screenshot): reconcile extractHashFromFilename name/doc/behavior

### DIFF
--- a/src/utils/ScreenshotUtilsAdapter.ts
+++ b/src/utils/ScreenshotUtilsAdapter.ts
@@ -170,10 +170,11 @@ class ScreenshotUtilsAdapter implements ScreenshotUtils {
    * Extract timestamp from screenshot filename
    * Assumes filename format: screenshot_timestamp.extension or hierarchy_timestamp.json
    * @param filePath Path to screenshot file
-   * @returns Timestamp portion of filename or null if not extractable
+   * @returns Timestamp portion of filename
+   * @throws Error if no timestamp is extractable from the filename
    */
-  extractHashFromFilename(filePath: string): string {
-    return ScreenshotUtilsImpl.extractHashFromFilename(filePath);
+  extractTimestampFromFilename(filePath: string): string {
+    return ScreenshotUtilsImpl.extractTimestampFromFilename(filePath);
   }
 
   /**

--- a/src/utils/interfaces/ScreenshotUtils.ts
+++ b/src/utils/interfaces/ScreenshotUtils.ts
@@ -138,9 +138,10 @@ export interface ScreenshotUtils {
    * Extract timestamp from screenshot filename
    * Assumes filename format: screenshot_timestamp.extension or hierarchy_timestamp.json
    * @param filePath Path to screenshot file
-   * @returns Timestamp portion of filename or null if not extractable
+   * @returns Timestamp portion of filename
+   * @throws Error if no timestamp is extractable from the filename
    */
-  extractHashFromFilename(filePath: string): string;
+  extractTimestampFromFilename(filePath: string): string;
 
   /**
    * Generate a simple hash from image buffer for fallback cache key

--- a/src/utils/screenshot/ScreenshotUtils.ts
+++ b/src/utils/screenshot/ScreenshotUtils.ts
@@ -195,9 +195,10 @@ export class ScreenshotUtils {
    * Extract timestamp from screenshot filename
    * Assumes filename format: screenshot_timestamp.extension or hierarchy_timestamp.json
    * @param filePath Path to screenshot file
-   * @returns Timestamp portion of filename or null if not extractable
+   * @returns Timestamp portion of filename
+   * @throws Error if no timestamp is extractable from the filename
    */
-  static extractHashFromFilename(filePath: string): string {
+  static extractTimestampFromFilename(filePath: string): string {
     const filename = path.basename(filePath, path.extname(filePath));
 
     // Handle screenshot_timestamp format

--- a/test/fakes/FakeScreenshotUtils.ts
+++ b/test/fakes/FakeScreenshotUtils.ts
@@ -25,7 +25,7 @@ export class FakeScreenshotUtils implements ScreenshotUtils {
     similarity: 0,
     matchFound: false
   };
-  private extractHashResult: string = "1234567890";
+  private extractTimestampResult: string = "1234567890";
   private generateImageHashResult: string = "abcdef0123456789abcdef0123456789";
 
   // Call tracking
@@ -109,10 +109,10 @@ export class FakeScreenshotUtils implements ScreenshotUtils {
   }
 
   /**
-   * Configure extract hash result
+   * Configure extract timestamp result
    */
-  setExtractHashResult(hash: string): void {
-    this.extractHashResult = hash;
+  setExtractTimestampResult(timestamp: string): void {
+    this.extractTimestampResult = timestamp;
   }
 
   /**
@@ -303,9 +303,9 @@ export class FakeScreenshotUtils implements ScreenshotUtils {
     return this.findSimilarScreenshotsResult;
   }
 
-  extractHashFromFilename(filePath: string): string {
-    this.recordCall("extractHashFromFilename", { filePath });
-    return this.extractHashResult;
+  extractTimestampFromFilename(filePath: string): string {
+    this.recordCall("extractTimestampFromFilename", { filePath });
+    return this.extractTimestampResult;
   }
 
   generateImageHash(buffer: Buffer): string {

--- a/test/utils/screenshot-utils.test.ts
+++ b/test/utils/screenshot-utils.test.ts
@@ -149,18 +149,18 @@ describe("ScreenshotUtils", function() {
       expect(files).toHaveLength(0);
     });
 
-    test("should extract hash from filename correctly", function() {
-      const timestamp1 = ScreenshotUtils.extractHashFromFilename("/path/to/screenshot_1234567890.png");
-      const timestamp2 = ScreenshotUtils.extractHashFromFilename("hierarchy_9876543210.json");
-      const legacyHash = ScreenshotUtils.extractHashFromFilename("old_format_hash_789.webp");
+    test("should extract timestamp from filename correctly", function() {
+      const timestamp1 = ScreenshotUtils.extractTimestampFromFilename("/path/to/screenshot_1234567890.png");
+      const timestamp2 = ScreenshotUtils.extractTimestampFromFilename("hierarchy_9876543210.json");
+      const legacyTimestamp = ScreenshotUtils.extractTimestampFromFilename("old_format_hash_789.webp");
 
       expect(timestamp1).toBe("1234567890");
       expect(timestamp2).toBe("9876543210");
-      expect(legacyHash).toBe("789");
+      expect(legacyTimestamp).toBe("789");
 
       // Test invalid filename
       expect(() => {
-        ScreenshotUtils.extractHashFromFilename("notimestamp.png");
+        ScreenshotUtils.extractTimestampFromFilename("notimestamp.png");
       }).toThrow("Unable to extract timestamp from filename");
     });
 


### PR DESCRIPTION
## Summary
- `extractHashFromFilename` had a three-way disagreement between name ("hash"), JSDoc (claims timestamp-or-null), and actual behavior (returns a timestamp string, throws when not extractable).
- Renamed to `extractTimestampFromFilename` across the interface, adapter, impl, fake, and test; corrected the JSDoc `@returns`/`@throws` to match real behavior.

## Test plan
- [x] `bun test test/utils/screenshot-utils.test.ts` — 20 pass
- [x] `turbo run lint build` — clean

Fixes #3562