### PR TITLE
fix(daemon): keep singleton daemon alive on background fatal events (#3408)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -33,6 +33,7 @@ import { DatabaseHealthProbe, DefaultDatabaseHealthProbe } from "../db/DatabaseH
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
 import { handleFatalDatabaseStartupFailure } from "./daemonStartupGuard";
 import { runStartupPrologue } from "./startupPrologue";
+import { createDaemonFatalProcessHandler } from "./daemonFatalHandler";
 import { startupBenchmark } from "../utils/startupBenchmark";
 import { startVideoRecordingSocketServer, stopVideoRecordingSocketServer } from "./videoRecordingSocketServer";
 import { startTestRecordingSocketServer, stopTestRecordingSocketServer } from "./testRecordingSocketServer";
@@ -1421,24 +1422,14 @@ export class Daemon {
       await this.stop();
     };
 
-    const cleanupAndExit = (label: string, error: unknown) => {
-      logger.error(`${label}: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
-      cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
-      logger.close();
-      process.exit(1);
-    };
-
     setProcessShutdownHandler(shutdown);
     process.once("exit", () => {
       cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
     });
-    setFatalProcessHandler(event => {
-      if (event.type === "uncaughtException") {
-        cleanupAndExit("Uncaught exception in daemon", event.error);
-        return;
-      }
-      cleanupAndExit("Unhandled rejection in daemon", event.reason);
-    });
+    // Escaped throws in un-awaited callbacks/timers and floating rejections must
+    // NOT crash the shared singleton daemon and wedge every session (issue #3408).
+    // Log-then-continue; the offending tool call already failed on its own chain.
+    setFatalProcessHandler(createDaemonFatalProcessHandler(logger));
   }
 
   /**

--- a/src/daemon/daemonFatalHandler.ts
+++ b/src/daemon/daemonFatalHandler.ts
@@ -1,0 +1,39 @@
+import type { FatalProcessEvent, FatalProcessHandler } from "../processLifecycle";
+import { describeUnknownError } from "../utils/describeUnknownError";
+
+/** Minimal logger surface the daemon fatal handler needs (satisfied by `logger`). */
+export interface FatalHandlerLogger {
+  error(message: string, ...args: any[]): void;
+}
+
+/**
+ * Build the daemon's process-level fatal-event handler.
+ *
+ * The daemon is a long-lived singleton shared across every MCP client/session.
+ * A throw that escapes an un-awaited callback/timer (e.g. an emulator
+ * child-process `on("data"|"exit")` handler in `AndroidEmulatorClient`) or a
+ * floating promise rejection surfaces here as `uncaughtException` /
+ * `unhandledRejection` rather than on any awaited tool chain. The offending tool
+ * call has already failed on its own path, so tearing down the process would
+ * only wedge every OTHER connected session.
+ *
+ * We therefore log with full context and keep the daemon alive (issue #3408),
+ * following the repo's log-then-continue convention for genuinely-unexpected
+ * background failures. This is intentionally scoped to daemon mode; short-lived
+ * CLI/proxy processes keep their own fail-fast handler (`src/index.ts`).
+ */
+export function createDaemonFatalProcessHandler(logger: FatalHandlerLogger): FatalProcessHandler {
+  return (event: FatalProcessEvent) => {
+    if (event.type === "uncaughtException") {
+      logger.error(
+        `[daemon] uncaughtException in background task; keeping daemon alive: ${describeUnknownError(event.error)}`,
+        event.error
+      );
+      return;
+    }
+    logger.error(
+      `[daemon] unhandledRejection in background task; keeping daemon alive: ${describeUnknownError(event.reason)}`,
+      event.reason
+    );
+  };
+}

--- a/test/daemon/daemonFatalHandler.test.ts
+++ b/test/daemon/daemonFatalHandler.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { createDaemonFatalProcessHandler } from "../../src/daemon/daemonFatalHandler";
+import {
+  ProcessLifecycleHandlers,
+  type ProcessLifecycleEventMap,
+  type ProcessLifecycleProcess,
+} from "../../src/processLifecycle";
+
+interface LoggedError {
+  message: string;
+  args: unknown[];
+}
+
+function makeFakeLogger(): { errors: LoggedError[]; error: (message: string, ...args: unknown[]) => void } {
+  const errors: LoggedError[] = [];
+  return {
+    errors,
+    error: (message: string, ...args: unknown[]) => {
+      errors.push({ message, args });
+    },
+  };
+}
+
+class FakeProcess implements ProcessLifecycleProcess {
+  readonly listeners = new Map<keyof ProcessLifecycleEventMap, Array<(...args: any[]) => void>>();
+  readonly exitCodes: number[] = [];
+
+  on<K extends keyof ProcessLifecycleEventMap>(
+    event: K,
+    listener: (...args: ProcessLifecycleEventMap[K]) => void
+  ): unknown {
+    const eventListeners = this.listeners.get(event) ?? [];
+    eventListeners.push(listener);
+    this.listeners.set(event, eventListeners);
+    return this;
+  }
+
+  exit(code: number = 0): never {
+    this.exitCodes.push(code);
+    return undefined as never;
+  }
+
+  emit<K extends keyof ProcessLifecycleEventMap>(event: K, ...args: ProcessLifecycleEventMap[K]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("createDaemonFatalProcessHandler (unit)", () => {
+  test("logs an uncaughtException with the stack and does not exit", () => {
+    const logger = makeFakeLogger();
+    const handler = createDaemonFatalProcessHandler(logger);
+    const error = new Error("boom in child.on(data)");
+
+    handler({ type: "uncaughtException", error });
+
+    expect(logger.errors).toHaveLength(1);
+    expect(logger.errors[0].message).toContain("uncaughtException");
+    expect(logger.errors[0].message).toContain("keeping daemon alive");
+    expect(logger.errors[0].message).toContain("boom in child.on(data)");
+    // The caught error is forwarded as a structured arg for the log sink.
+    expect(logger.errors[0].args[0]).toBe(error);
+  });
+
+  test("logs an unhandledRejection reason and does not exit", () => {
+    const logger = makeFakeLogger();
+    const handler = createDaemonFatalProcessHandler(logger);
+
+    handler({ type: "unhandledRejection", reason: "floating rejection", promise: Promise.resolve() });
+
+    expect(logger.errors).toHaveLength(1);
+    expect(logger.errors[0].message).toContain("unhandledRejection");
+    expect(logger.errors[0].message).toContain("floating rejection");
+  });
+
+  test("handles a non-Error uncaughtException value without throwing", () => {
+    const logger = makeFakeLogger();
+    const handler = createDaemonFatalProcessHandler(logger);
+
+    // Node types this as Error, but a thrown non-Error can still reach here.
+    handler({ type: "uncaughtException", error: "not-an-error" as unknown as Error });
+
+    expect(logger.errors[0].message).toContain("not-an-error");
+  });
+});
+
+describe("daemon fatal handler wired through ProcessLifecycleHandlers (integration)", () => {
+  test("keeps the process alive on both fatal events once the daemon handler is bound", async () => {
+    const fakeProcess = new FakeProcess();
+    const logger = makeFakeLogger();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+
+    lifecycle.install();
+    lifecycle.setFatalProcessHandler(createDaemonFatalProcessHandler(logger));
+
+    fakeProcess.emit("uncaughtException", new Error("escaped throw"));
+    fakeProcess.emit("unhandledRejection", "bad", Promise.resolve());
+    await flushMicrotasks();
+
+    // The regression this guards (#3408): the daemon must NOT exit on background failures.
+    expect(fakeProcess.exitCodes).toEqual([]);
+    expect(logger.errors.map(e => e.message.includes("uncaughtException"))).toContain(true);
+    expect(logger.errors.map(e => e.message.includes("unhandledRejection"))).toContain(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #3408.

The daemon's process-level fatal-event handler (`setupShutdownHandlers` in `src/daemon/daemon.ts`) called `cleanupAndExit → process.exit(1)` on **both** `uncaughtException` and `unhandledRejection`. Because the daemon is a long-lived singleton shared across every MCP client/session, a throw escaping an un-awaited callback/timer — e.g. an emulator child-process `on("data"|"exit")` handler in `AndroidEmulatorClient` — or a floating promise rejection crashed the whole daemon and wedged every connected session, even though the offending tool call had already failed on its own awaited chain.

## Change
- New `src/daemon/daemonFatalHandler.ts` exports `createDaemonFatalProcessHandler(logger)`: logs each fatal background event with full context (via the shared `describeUnknownError` helper) and **keeps the daemon alive** — the repo's log-then-continue convention for genuinely-unexpected background failures.
- `daemon.ts` now wires that factory instead of the exit-on-fatal handler; the now-dead `cleanupAndExit` local is removed.
- Scoped to daemon mode only. Short-lived CLI/proxy processes keep their own fail-fast handler in `src/index.ts`.

## Tests
- **Unit** (`test/daemon/daemonFatalHandler.test.ts`): both event types logged (incl. non-Error throws), message content asserted.
- **Integration**: handler wired through the real `ProcessLifecycleHandlers` + a fake process; asserts `exitCodes === []` on both `uncaughtException` and `unhandledRejection` — the exact regression #3408 describes.

`bun test` green; `bunx turbo run build lint` clean. The 3 `adm-zip`/`ajv` typecheck-baseline errors are pre-existing environmental dependency-resolution noise (present with this change stashed, none in touched files).