### PR TITLE
feat(desktop): surface screenshot capture metadata in the layout inspector

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -83,6 +83,7 @@ import dev.jasonpearson.automobile.desktop.core.failures.StreamingFailuresDataSo
 import dev.jasonpearson.automobile.desktop.core.failures.TimeAggregation
 import dev.jasonpearson.automobile.desktop.core.layout.ConnectionStatus
 import dev.jasonpearson.automobile.desktop.core.layout.DeviceScreenView
+import dev.jasonpearson.automobile.desktop.core.layout.ScreenshotMetadataOverlay
 import dev.jasonpearson.automobile.desktop.core.layout.parseHierarchyFromJson
 import dev.jasonpearson.automobile.desktop.core.layout.rememberLayoutInspectorState
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
@@ -680,6 +681,10 @@ fun AutoMobileContent(
           width = update.screenWidth,
           height = update.screenHeight,
           timestamp = update.timestamp,
+          fallback = update.screenshotFallback ?: false,
+          fallbackReason = update.screenshotFallbackReason,
+          format = update.screenshotFormat,
+          captureSource = update.screenshotCaptureSource,
         )
       }
     }
@@ -1292,6 +1297,14 @@ fun AutoMobileContent(
               socketExists = true,
               elementMap = layoutInspectorState.currentElementMap.takeIf { it.isNotEmpty() },
               modifier = Modifier.fillMaxSize(),
+            )
+
+            ScreenshotMetadataOverlay(
+              fallback = layoutInspectorState.screenshotFallback,
+              fallbackReason = layoutInspectorState.screenshotFallbackReason,
+              format = layoutInspectorState.screenshotFormat,
+              captureSource = layoutInspectorState.screenshotCaptureSource,
+              modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
             )
           }
         } else {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -15,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
@@ -108,6 +110,10 @@ fun LayoutInspectorDashboard(
           width = update.screenWidth,
           height = update.screenHeight,
           timestamp = update.timestamp,
+          fallback = update.screenshotFallback ?: false,
+          fallbackReason = update.screenshotFallbackReason,
+          format = update.screenshotFormat,
+          captureSource = update.screenshotCaptureSource,
         )
         dashboardLog.info("Updated state with new screenshot")
       }
@@ -259,6 +265,14 @@ fun LayoutInspectorDashboard(
         elementMap = state.currentElementMap.takeIf { it.isNotEmpty() },
         modifier = Modifier.fillMaxSize(),
         refitTrigger = refitTrigger, // Trigger refit when panels toggle
+      )
+
+      ScreenshotMetadataOverlay(
+        fallback = state.screenshotFallback,
+        fallbackReason = state.screenshotFallbackReason,
+        format = state.screenshotFormat,
+        captureSource = state.screenshotCaptureSource,
+        modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
       )
     }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
@@ -55,6 +55,20 @@ class LayoutInspectorState {
   var lastScreenshotTimestamp by mutableStateOf(0L)
     private set
 
+  // Screenshot capture metadata (from the observation stream's screenshot_update message). Absent
+  // (null/false) when the daemon predates this metadata or a field wasn't reported.
+  var screenshotFallback by mutableStateOf(false)
+    private set
+
+  var screenshotFallbackReason by mutableStateOf<String?>(null)
+    private set
+
+  var screenshotFormat by mutableStateOf<String?>(null)
+    private set
+
+  var screenshotCaptureSource by mutableStateOf<String?>(null)
+    private set
+
   // Hierarchy state — stores the full parsed hierarchy with prebuilt indexes
   private var currentParsedHierarchy by mutableStateOf<ParsedHierarchy?>(null)
 
@@ -151,11 +165,24 @@ class LayoutInspectorState {
   }
 
   /** Update screenshot data. Called when receiving screenshot frames from device. */
-  fun updateScreenshot(data: ByteArray, width: Int, height: Int, timestamp: Long) {
+  fun updateScreenshot(
+    data: ByteArray,
+    width: Int,
+    height: Int,
+    timestamp: Long,
+    fallback: Boolean = false,
+    fallbackReason: String? = null,
+    format: String? = null,
+    captureSource: String? = null,
+  ) {
     screenshotData = data
     screenWidth = width
     screenHeight = height
     lastScreenshotTimestamp = timestamp
+    screenshotFallback = fallback
+    screenshotFallbackReason = fallbackReason
+    screenshotFormat = format
+    screenshotCaptureSource = captureSource
   }
 
   /**
@@ -269,6 +296,10 @@ class LayoutInspectorState {
     connectionStatus = ConnectionStatus.Disconnected
     streamingMode = StreamingMode.Paused
     screenshotData = null
+    screenshotFallback = false
+    screenshotFallbackReason = null
+    screenshotFormat = null
+    screenshotCaptureSource = null
     currentParsedHierarchy = null
     rotation = 0
     selectedElementId = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/ScreenshotMetadataBadge.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/ScreenshotMetadataBadge.kt
@@ -1,0 +1,88 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Overlay showing screenshot capture metadata from the observation stream (issue #3757): a
+ * fallback-capture warning when the daemon fell back to a slower capture path, and a
+ * format/capture-source label. Renders nothing when no metadata is present (older daemons), so it
+ * never occupies space or clutters the device screen view.
+ */
+@Composable
+fun ScreenshotMetadataOverlay(
+  fallback: Boolean,
+  fallbackReason: String?,
+  format: String?,
+  captureSource: String?,
+  modifier: Modifier = Modifier,
+) {
+  val hasSourceLabel = format != null || captureSource != null
+  if (!fallback && !hasSourceLabel) return
+
+  Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    if (fallback) {
+      ScreenshotFallbackBadge(reason = fallbackReason)
+    }
+    if (hasSourceLabel) {
+      ScreenshotSourceLabel(format = format, captureSource = captureSource)
+    }
+  }
+}
+
+@Composable
+private fun ScreenshotFallbackBadge(reason: String?, modifier: Modifier = Modifier) {
+  Column(
+    modifier =
+      modifier
+        .background(Color(0xFFFF9800).copy(alpha = 0.85f), RoundedCornerShape(4.dp))
+        .padding(horizontal = 6.dp, vertical = 3.dp)
+  ) {
+    Text(
+      text = "Fallback capture",
+      color = Color.White,
+      fontSize = 10.sp,
+      maxLines = 1,
+    )
+    if (reason != null) {
+      Text(
+        text = reason,
+        color = Color.White.copy(alpha = 0.85f),
+        fontSize = 9.sp,
+        maxLines = 1,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ScreenshotSourceLabel(
+  format: String?,
+  captureSource: String?,
+  modifier: Modifier = Modifier,
+) {
+  val label = listOfNotNull(format, captureSource).joinToString(" · ")
+  Row(
+    modifier =
+      modifier
+        .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(4.dp))
+        .padding(horizontal = 6.dp, vertical = 3.dp)
+  ) {
+    Text(
+      text = label,
+      color = Color.White.copy(alpha = 0.8f),
+      fontSize = 9.sp,
+      maxLines = 1,
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateScreenshotMetadataTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateScreenshotMetadataTest.kt
@@ -1,0 +1,82 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LayoutInspectorStateScreenshotMetadataTest {
+
+  @Test
+  fun `updateScreenshot defaults metadata to absent when not provided`() {
+    val state = LayoutInspectorState()
+
+    state.updateScreenshot(data = byteArrayOf(1), width = 100, height = 200, timestamp = 1L)
+
+    assertFalse(state.screenshotFallback)
+    assertNull(state.screenshotFallbackReason)
+    assertNull(state.screenshotFormat)
+    assertNull(state.screenshotCaptureSource)
+  }
+
+  @Test
+  fun `updateScreenshot stores provided metadata`() {
+    val state = LayoutInspectorState()
+
+    state.updateScreenshot(
+      data = byteArrayOf(1),
+      width = 100,
+      height = 200,
+      timestamp = 1L,
+      fallback = true,
+      fallbackReason = "websocket_unavailable",
+      format = "png",
+      captureSource = "android_adb_screencap",
+    )
+
+    assertEquals(true, state.screenshotFallback)
+    assertEquals("websocket_unavailable", state.screenshotFallbackReason)
+    assertEquals("png", state.screenshotFormat)
+    assertEquals("android_adb_screencap", state.screenshotCaptureSource)
+  }
+
+  @Test
+  fun `a later update without fallback clears a previously reported fallback`() {
+    val state = LayoutInspectorState()
+    state.updateScreenshot(
+      data = byteArrayOf(1),
+      width = 100,
+      height = 200,
+      timestamp = 1L,
+      fallback = true,
+      fallbackReason = "websocket_unavailable",
+    )
+
+    state.updateScreenshot(data = byteArrayOf(2), width = 100, height = 200, timestamp = 2L)
+
+    assertFalse(state.screenshotFallback)
+    assertNull(state.screenshotFallbackReason)
+  }
+
+  @Test
+  fun `disconnect clears screenshot metadata`() {
+    val state = LayoutInspectorState()
+    state.updateScreenshot(
+      data = byteArrayOf(1),
+      width = 100,
+      height = 200,
+      timestamp = 1L,
+      fallback = true,
+      fallbackReason = "websocket_unavailable",
+      format = "png",
+      captureSource = "android_adb_screencap",
+    )
+
+    state.disconnect()
+
+    assertFalse(state.screenshotFallback)
+    assertNull(state.screenshotFallbackReason)
+    assertNull(state.screenshotFormat)
+    assertNull(state.screenshotCaptureSource)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/ScreenshotMetadataBadgeUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/ScreenshotMetadataBadgeUiTest.kt
@@ -1,0 +1,105 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ScreenshotMetadataBadgeUiTest {
+
+  @Test
+  fun `shows fallback badge and reason when fallback is true`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        ScreenshotMetadataOverlay(
+          fallback = true,
+          fallbackReason = "websocket_unavailable",
+          format = null,
+          captureSource = null,
+        )
+      }
+    }
+    onNodeWithText("Fallback capture").assertIsDisplayed()
+    onNodeWithText("websocket_unavailable").assertIsDisplayed()
+  }
+
+  @Test
+  fun `shows fallback badge without reason text when reason is absent`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        ScreenshotMetadataOverlay(
+          fallback = true,
+          fallbackReason = null,
+          format = null,
+          captureSource = null,
+        )
+      }
+    }
+    onNodeWithText("Fallback capture").assertIsDisplayed()
+  }
+
+  @Test
+  fun `hides fallback badge when fallback is false`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        ScreenshotMetadataOverlay(
+          fallback = false,
+          fallbackReason = "websocket_unavailable",
+          format = null,
+          captureSource = null,
+        )
+      }
+    }
+    onNodeWithText("Fallback capture").assertDoesNotExist()
+    // A stale reason from a previous fallback must not leak once fallback clears.
+    onNodeWithText("websocket_unavailable").assertDoesNotExist()
+  }
+
+  @Test
+  fun `shows combined format and capture source label`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        ScreenshotMetadataOverlay(
+          fallback = false,
+          fallbackReason = null,
+          format = "png",
+          captureSource = "android_adb_screencap",
+        )
+      }
+    }
+    onNodeWithText("png · android_adb_screencap").assertIsDisplayed()
+  }
+
+  @Test
+  fun `shows format only when capture source is absent`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        ScreenshotMetadataOverlay(
+          fallback = false,
+          fallbackReason = null,
+          format = "png",
+          captureSource = null,
+        )
+      }
+    }
+    onNodeWithText("png").assertIsDisplayed()
+  }
+
+  @Test
+  fun `renders nothing when no metadata is present`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        ScreenshotMetadataOverlay(
+          fallback = false,
+          fallbackReason = null,
+          format = null,
+          captureSource = null,
+        )
+      }
+    }
+    onNodeWithText("Fallback capture").assertDoesNotExist()
+  }
+}


### PR DESCRIPTION
## Summary

Implements #3757. The observation stream carries per-screenshot metadata added by #3387 (format/capture-source/fallback) and #3398 (capture/encode timings, byte sizes), and `ObservationStreamClient` already parses all of it into `ScreenshotStreamUpdate`. But no UI consumer read it — `LayoutInspectorDashboard`'s screenshot collector only used `screenshotBase64`/`screenWidth`/`screenHeight`, so the metadata was received and dropped on the floor.

- `LayoutInspectorState` gains `screenshotFallback`/`screenshotFallbackReason`/`screenshotFormat`/`screenshotCaptureSource`, set via `updateScreenshot(...)` and cleared on `disconnect()`. Each update resets them (not sticky), so a later non-fallback frame doesn't leave a stale fallback badge on screen.
- `LayoutInspectorDashboard`'s screenshot collector threads the fields from the stream update into state.
- New `ScreenshotMetadataOverlay` composable (`ScreenshotMetadataBadge.kt`) renders an orange "Fallback capture" badge + reason when the daemon fell back to a slower capture path, and a `format · captureSource` label otherwise. Renders nothing when no metadata is present (older daemons) — no empty box, no wasted space.
- Overlaid top-start on the device screen `Box` in `LayoutInspectorDashboard`, alongside `DeviceScreenView`.

No daemon changes — purely consuming data the transport already delivers.

## Linked Issue

Closes #3757. Builds on #3747, #3387, #3398.

## Validation

- [x] Added `LayoutInspectorStateScreenshotMetadataTest`: defaults, storage, reset-on-next-update, clear-on-disconnect.
- [x] Added `ScreenshotMetadataBadgeUiTest` (Compose UI test, same pattern as `FailuresBadgeUiTest`/`StatusBarBadgeUiTest`): fallback badge + reason shown/hidden, format/source label combinations, renders-nothing case.
- [x] Ran the local ktfmt 0.64 jar (pulled from Maven Central — the pinned installer's GitHub release URL and the Gradle distribution are both blocked by this sandbox's egress policy) against every touched/created file; all clean and idempotent.
- [ ] Could not run the actual Gradle test task locally (same egress block). Relying on CI's `Run Desktop Core Unit Tests` + `Fast Validation` (ktfmt), as in #3747/#3767.

## Device Verification

- [ ] Not verified on-device here. Worth confirming the badge appears when a real fallback capture occurs (e.g. kill the Android WebSocket mid-session) and disappears on the next healthy frame.

## Follow-ups

- [ ] **Model observation diff metadata** — #3758 (last remaining item from the enumeration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0144zCBppELsVDcXmsMJHsbc)_