### PR TITLE
perf(explore): index pending edges to remove O(E^2) SHA-256 hashing (#3425)

### DIFF
--- a/src/features/navigation/ExploreTypes.ts
+++ b/src/features/navigation/ExploreTypes.ts
@@ -152,7 +152,10 @@ export interface TrackedElement {
 export interface GraphTraversalState {
   visitedNodes: Set<string>;
   traversedEdges: Set<string>;
-  pendingEdges: NavigationEdge[];
+  /** Pending (untraversed) edges keyed by their edge key for O(1) removal. */
+  pendingEdges: Map<string, NavigationEdge>;
+  /** Pending edges indexed by their `from` screen for O(1)+O(deg) selection. */
+  pendingEdgesByFrom: Map<string, NavigationEdge[]>;
   edgeValidationResults: Map<string, EdgeValidationResult>;
   totalNodesInGraph: number;
   totalEdgesInGraph: number;

--- a/src/features/navigation/ExploreValidateMode.ts
+++ b/src/features/navigation/ExploreValidateMode.ts
@@ -26,17 +26,69 @@ export async function initializeGraphTraversal(
   const state: GraphTraversalState = {
     visitedNodes: new Set<string>(),
     traversedEdges: new Set<string>(),
-    pendingEdges: [...allEdges],
+    pendingEdges: new Map<string, NavigationEdge>(),
+    pendingEdgesByFrom: new Map<string, NavigationEdge[]>(),
     edgeValidationResults: new Map<string, EdgeValidationResult>(),
     totalNodesInGraph: graph.nodes.length,
     totalEdgesInGraph: allEdges.length
   };
+
+  // Hash each edge key exactly once here; markEdgeTraversed then removes by key
+  // (O(1)) instead of re-hashing every pending edge on every traversal (O(E^2)).
+  for (const edge of allEdges) {
+    addPendingEdge(state, edge);
+  }
 
   logger.info(
     `[Explore] Initialized graph traversal: ${graph.nodes.length} nodes, ${allEdges.length} edges`
   );
 
   return state;
+}
+
+/**
+ * Add an edge to the pending set, keeping the key map and the `from` index in
+ * sync. The edge key is computed once here; deduplicates by key.
+ */
+export function addPendingEdge(
+  state: GraphTraversalState,
+  edge: NavigationEdge
+): void {
+  const edgeKey = getEdgeKey(edge);
+  if (state.pendingEdges.has(edgeKey)) {
+    return;
+  }
+  state.pendingEdges.set(edgeKey, edge);
+
+  const fromBucket = state.pendingEdgesByFrom.get(edge.from);
+  if (fromBucket) {
+    fromBucket.push(edge);
+  } else {
+    state.pendingEdgesByFrom.set(edge.from, [edge]);
+  }
+}
+
+/**
+ * Remove a pending edge by key from both the key map (O(1)) and the `from`
+ * index (O(deg), by object identity so no re-hashing).
+ */
+function removePendingEdge(state: GraphTraversalState, edgeKey: string): void {
+  const stored = state.pendingEdges.get(edgeKey);
+  if (!stored) {
+    return;
+  }
+  state.pendingEdges.delete(edgeKey);
+
+  const fromBucket = state.pendingEdgesByFrom.get(stored.from);
+  if (fromBucket) {
+    const idx = fromBucket.indexOf(stored);
+    if (idx !== -1) {
+      fromBucket.splice(idx, 1);
+    }
+    if (fromBucket.length === 0) {
+      state.pendingEdgesByFrom.delete(stored.from);
+    }
+  }
 }
 
 /**
@@ -120,10 +172,8 @@ export function markEdgeTraversed(
 
   state.edgeValidationResults.set(edgeKey, validationResult);
 
-  // Remove from pending edges
-  state.pendingEdges = state.pendingEdges.filter(
-    e => getEdgeKey(e) !== edgeKey
-  );
+  // Remove from pending edges (O(1) map delete + O(deg) index splice)
+  removePendingEdge(state, edgeKey);
 
   logger.info(
     `[Explore] Edge ${edgeKey} validation: ${success ? "SUCCESS" : "FAILED"}` +
@@ -140,17 +190,10 @@ export function selectNextEdgeToTraverse(
   currentScreen: string
 ): NavigationEdge | null {
   // Only select untraversed edges from current screen
-  // Do not attempt to navigate to other screens, as this causes false divergence
-  const untraversedFromCurrent = state.pendingEdges.filter(
-    edge => edge.from === currentScreen
-  );
-
-  if (untraversedFromCurrent.length > 0) {
-    return untraversedFromCurrent[0];
-  }
-
-  // No edges from current screen - exploration is complete or stuck
-  return null;
+  // Do not attempt to navigate to other screens, as this causes false divergence.
+  // Empty buckets are pruned on removal, so a present bucket always has an edge.
+  const untraversedFromCurrent = state.pendingEdgesByFrom.get(currentScreen);
+  return untraversedFromCurrent ? untraversedFromCurrent[0] : null;
 }
 
 /**

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -482,8 +482,8 @@ describe("Explore", () => {
       const state = await initializeGraphTraversal(fakeGraph);
 
       // If there are any pending edges, selectNextEdgeToTraverse should return one
-      if (state.pendingEdges.length > 0) {
-        const firstEdge = state.pendingEdges[0];
+      if (state.pendingEdges.size > 0) {
+        const firstEdge = state.pendingEdges.values().next().value!;
         const edge = selectNextEdgeToTraverse(state, firstEdge.from);
         expect(edge).toBeDefined();
         expect(edge).toBe(firstEdge);

--- a/test/features/navigation/ExploreValidateMode.test.ts
+++ b/test/features/navigation/ExploreValidateMode.test.ts
@@ -10,7 +10,8 @@ import {
   markNodeVisited,
   markEdgeTraversed,
   selectNextEdgeToTraverse,
-  findElementMatchingEdge
+  findElementMatchingEdge,
+  addPendingEdge
 } from "../../../src/features/navigation/ExploreValidateMode";
 
 describe("ExploreValidateMode", () => {
@@ -59,7 +60,7 @@ describe("ExploreValidateMode", () => {
 
       expect(state.visitedNodes.size).toBe(0);
       expect(state.traversedEdges.size).toBe(0);
-      expect(state.pendingEdges.length).toBe(0);
+      expect(state.pendingEdges.size).toBe(0);
       expect(state.totalNodesInGraph).toBe(0);
       expect(state.totalEdgesInGraph).toBe(0);
     });
@@ -95,7 +96,7 @@ describe("ExploreValidateMode", () => {
 
       expect(state.totalNodesInGraph).toBeGreaterThan(0);
       expect(state.totalEdgesInGraph).toBeGreaterThan(0);
-      expect(state.pendingEdges.length).toBeGreaterThan(0);
+      expect(state.pendingEdges.size).toBeGreaterThan(0);
     });
   });
 
@@ -328,12 +329,14 @@ describe("ExploreValidateMode", () => {
         }
       });
 
-      state.pendingEdges.push(edge);
-      const initialLength = state.pendingEdges.length;
+      addPendingEdge(state, edge);
+      const initialLength = state.pendingEdges.size;
 
       markEdgeTraversed(state, edge, "B", true, fakeTimer);
 
-      expect(state.pendingEdges.length).toBeLessThan(initialLength);
+      expect(state.pendingEdges.size).toBeLessThan(initialLength);
+      // The `from` index must stay in sync with the key map.
+      expect(state.pendingEdgesByFrom.has("A")).toBe(false);
     });
   });
 
@@ -347,7 +350,7 @@ describe("ExploreValidateMode", () => {
           timestamp: 1000
         }
       });
-      state.pendingEdges.push(edge);
+      addPendingEdge(state, edge);
 
       const selected = selectNextEdgeToTraverse(state, "CurrentScreen");
 
@@ -357,7 +360,7 @@ describe("ExploreValidateMode", () => {
     test("should return null if no edges from current screen", async () => {
       const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
       const edge = createMockEdge("OtherScreen", "NextScreen");
-      state.pendingEdges.push(edge);
+      addPendingEdge(state, edge);
 
       const selected = selectNextEdgeToTraverse(state, "CurrentScreen");
 
@@ -376,11 +379,46 @@ describe("ExploreValidateMode", () => {
       const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
       const edge1 = createMockEdge("Current", "A");
       const edge2 = createMockEdge("Current", "B");
-      state.pendingEdges.push(edge1, edge2);
+      addPendingEdge(state, edge1);
+      addPendingEdge(state, edge2);
 
       const selected = selectNextEdgeToTraverse(state, "Current");
 
       expect(selected).toBe(edge1);
+    });
+
+    test("should keep the from-index in sync as edges are traversed", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge1 = createMockEdge("Current", "A", {
+        interaction: { toolName: "tapOn", args: { text: "A" }, timestamp: 1 }
+      });
+      const edge2 = createMockEdge("Current", "B", {
+        interaction: { toolName: "tapOn", args: { text: "B" }, timestamp: 2 }
+      });
+      addPendingEdge(state, edge1);
+      addPendingEdge(state, edge2);
+
+      // Traversing edge1 leaves edge2 as the next selection from "Current".
+      markEdgeTraversed(state, edge1, "A", true, fakeTimer);
+      expect(selectNextEdgeToTraverse(state, "Current")).toBe(edge2);
+
+      // Traversing edge2 empties the bucket, which must be dropped entirely.
+      markEdgeTraversed(state, edge2, "B", true, fakeTimer);
+      expect(selectNextEdgeToTraverse(state, "Current")).toBeNull();
+      expect(state.pendingEdgesByFrom.has("Current")).toBe(false);
+      expect(state.pendingEdges.size).toBe(0);
+    });
+
+    test("addPendingEdge deduplicates by edge key", async () => {
+      const state = await initializeGraphTraversal(fakeGraph as unknown as NavigationGraphManager);
+      const edge = createMockEdge("Current", "A", {
+        interaction: { toolName: "tapOn", args: { text: "A" }, timestamp: 1 }
+      });
+      addPendingEdge(state, edge);
+      addPendingEdge(state, edge);
+
+      expect(state.pendingEdges.size).toBe(1);
+      expect(state.pendingEdgesByFrom.get("Current")?.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #3425. `ExploreValidateMode` recomputed a SHA-256 edge key for **every** pending edge on **every** traversal, giving O(E²) hashing across a validate run, and `selectNextEdgeToTraverse` re-scanned all pending edges each call.

## Change

- `GraphTraversalState.pendingEdges` is now `Map<edgeKey, NavigationEdge>` — each edge is hashed exactly once at init; removal is an O(1) `delete` by key.
- Added `pendingEdgesByFrom: Map<from, NavigationEdge[]>` so `selectNextEdgeToTraverse` is O(1)+O(deg) instead of a full scan.
- New `addPendingEdge` / private `removePendingEdge` keep the two indexes in sync; removal splices the from-bucket **by object identity**, so no edge key is ever re-hashed after init.
- Net: O(E²) → O(E) hashing.

## Tests

- Updated `ExploreValidateMode.test.ts` / `Explore.test.ts` for the new `Map` shape.
- Added regression tests: from-index stays in sync as edges are traversed (empty buckets are dropped), and `addPendingEdge` deduplicates by edge key.
- `bun test` (47 pass), `bun run typecheck`, `bun run lint`, `bun run build` all green.

Ran `/simplify` — collapsed a dead `length > 0` guard; two-map design confirmed correct altitude with no external mutators.

Closes #3425