### PR TITLE
fix(errors): replace generic catch-block boilerplate with per-site reasoning

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -147,7 +147,8 @@ export class DaemonClient {
           return false;
         }
       } catch (error) {
-        // This probe is best-effort; callers can safely use the fallback value.
+        // statSync throws when the path doesn't exist (or is unreadable); either way
+        // there's no live daemon socket to connect to, so report unavailable.
         logger.debug(`src/daemon/client.ts fallback failed: ${error}`, error);
         return false;
       }

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -142,8 +142,9 @@ export function readPidFileDataSync(pidFilePath: string = PID_FILE_PATH): PidFil
   try {
     return JSON.parse(readFileSync(pidFilePath, "utf-8")) as PidFileData;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
-    logger.debug(`src/daemon/daemonFiles.ts fallback failed: ${error}`, error);
+    // A missing/malformed pidfile is expected when the daemon is stale or hasn't
+    // written it yet; treating it as "no daemon" is the correct degraded behavior.
+    logger.debug(`src/daemon/daemonFiles.ts pidfile parse failed: ${error}`, error);
     return null;
   }
 }
@@ -153,8 +154,9 @@ export function isProcessRunning(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
-    logger.debug(`src/daemon/daemonFiles.ts fallback failed: ${error}`, error);
+    // ESRCH (no such process) or EPERM both mean the pid is not a live process
+    // we own; reporting "not running" is the safe, correct answer here.
+    logger.debug(`src/daemon/daemonFiles.ts liveness check failed: ${error}`, error);
     return false;
   }
 }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -68,8 +68,9 @@ function resolvePackageRunner(): string | null {
     execSync("which bunx", { stdio: "ignore" });
     return "bunx";
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
-    logger.debug(`src/daemon/manager.ts fallback failed: ${error}`, error);
+    // `which bunx` throws when bunx isn't on PATH; that's a normal "not found"
+    // outcome, not a failure worth surfacing, so we report null and move on.
+    logger.debug(`src/daemon/manager.ts bunx lookup failed: ${error}`, error);
     return null;
   }
 }
@@ -1172,8 +1173,9 @@ export class DaemonManager implements DaemonManagerLike {
       const pidData: PidFileData = JSON.parse(pidFileContent);
       return pidData.pid;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/daemon/manager.ts fallback failed: ${error}`, error);
+      // A stale or partially-written lock file fails JSON.parse; treating that
+      // as "no pid on record" lets callers fall back to re-detecting the daemon.
+      logger.debug(`src/daemon/manager.ts pidfile parse failed: ${error}`, error);
       return null;
     }
   }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1655,7 +1655,8 @@ export class UnixSocketServer {
       const stats = statSync(this.socketPath);
       return { dev: stats.dev, ino: stats.ino };
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // statSync fails if the socket file was removed/replaced concurrently; callers
+      // treat a null identity as "can't confirm ownership" rather than a hard error.
       logger.debug(`src/daemon/socketServer.ts fallback failed: ${error}`, error);
       return null;
     }

--- a/src/daemon/socketServer/BaseSocketServer.ts
+++ b/src/daemon/socketServer/BaseSocketServer.ts
@@ -104,8 +104,9 @@ export abstract class BaseSocketServer {
       const stats = statSync(this.socketPath);
       return { dev: stats.dev, ino: stats.ino };
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/daemon/socketServer/BaseSocketServer.ts fallback failed: ${error}`, error);
+      // The socket file may already be gone (e.g. removed by another process);
+      // returning null lets ownership checks treat it as "not our socket".
+      logger.debug(`src/daemon/socketServer/BaseSocketServer.ts stat failed: ${error}`, error);
       return null;
     }
   }
@@ -239,8 +240,9 @@ export abstract class BaseSocketServer {
     try {
       return JSON.parse(line) as T;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/daemon/socketServer/BaseSocketServer.ts fallback failed: ${error}`, error);
+      // A malformed or partial line (e.g. from a client disconnecting mid-write)
+      // is not actionable here; the caller drops it and waits for the next line.
+      logger.debug(`src/daemon/socketServer/BaseSocketServer.ts line parse failed: ${error}`, error);
       return null;
     }
   }

--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -134,7 +134,8 @@ export class InstallApp {
           const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true, signal);
           return parseInt(isInstalledOutput.trim(), 10) > 0;
         } catch (error) {
-          // This probe is best-effort; callers can safely use the fallback value.
+          // Both the a11y check and this pm/grep fallback failed; treat the package as
+          // not installed rather than blocking the install flow on a query error.
           logger.debug(`src/features/action/InstallApp.ts fallback failed: ${error}`, error);
           return false;
         }

--- a/src/features/action/TapAnyElement.ts
+++ b/src/features/action/TapAnyElement.ts
@@ -135,7 +135,8 @@ export class TapAnyElement extends BaseVisualChange {
     try {
       return NodeCryptoService.generateCacheKey(JSON.stringify(viewHierarchy.hierarchy));
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Hashing is only used to key an optional cache lookup; if JSON.stringify or the
+      // hash fails on a malformed hierarchy, skip the cache instead of failing the tap.
       logger.debug(`src/features/action/TapAnyElement.ts fallback failed: ${error}`, error);
       return null;
     }

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -108,8 +108,9 @@ export class TerminateApp extends BaseVisualChange {
           const isInstalledOutput = await this.adb.executeCommand(isInstalledCmd, undefined, undefined, true);
           return parseInt(isInstalledOutput.trim(), 10) > 0;
         } catch (error) {
-          // This probe is best-effort; callers can safely use the fallback value.
-          logger.debug(`src/features/action/TerminateApp.ts fallback failed: ${error}`, error);
+          // Both the CtrlProxy call and this shell fallback failed; treating the
+          // app as not installed is the safe default for a terminate/uninstall flow.
+          logger.debug(`src/features/action/TerminateApp.ts install check failed: ${error}`, error);
           return false;
         }
       });

--- a/src/features/observe/android/AndroidSdkEventIngestor.ts
+++ b/src/features/observe/android/AndroidSdkEventIngestor.ts
@@ -343,8 +343,9 @@ export class DefaultAndroidSdkEventIngestor implements AndroidSdkEventIngestor {
     try {
       return this.getNavigationScreenSource().getCurrentScreen() ?? undefined;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/features/observe/android/AndroidSdkEventIngestor.ts fallback failed: ${error}`, error);
+      // The navigation session may not be bound yet when an ANR/crash event
+      // arrives; omitting currentScreen is fine, it's supplementary context.
+      logger.debug(`src/features/observe/android/AndroidSdkEventIngestor.ts screen resolution failed: ${error}`, error);
       return undefined;
     }
   }

--- a/src/features/preferences/AppPreferences.ts
+++ b/src/features/preferences/AppPreferences.ts
@@ -243,8 +243,9 @@ export class AppPreferences {
       ], IOS_DEFAULTS_TIMEOUT_MS);
       return parseIosDefaultsType(result.stdout);
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/features/preferences/AppPreferences.ts fallback failed: ${error}`, error);
+      // `defaults read-type` fails when the key doesn't exist yet, which is a
+      // normal "no preference set" state; undefined lets callers fall back.
+      logger.debug(`src/features/preferences/AppPreferences.ts defaults type parse failed: ${error}`, error);
       return undefined;
     }
   }

--- a/src/features/utility/system-configuration/IosLockdownLocaleClient.ts
+++ b/src/features/utility/system-configuration/IosLockdownLocaleClient.ts
@@ -93,8 +93,9 @@ export class CommandLineLockdownLocaleClient implements LockdownLocaleClient {
         .filter(Boolean);
       return values.length > 0 ? values : undefined;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/features/utility/system-configuration/IosLockdownLocaleClient.ts fallback failed: ${error}`, error);
+      // ideviceinfo can fail transiently (device asleep, USB hiccup) for a
+      // list that's supplementary locale data; undefined lets the caller skip it.
+      logger.debug(`src/features/utility/system-configuration/IosLockdownLocaleClient.ts international list read failed: ${error}`, error);
       return undefined;
     }
   }

--- a/src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts
+++ b/src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts
@@ -291,8 +291,9 @@ export class IosSystemConfigurationAdapter implements SystemConfigurationAdapter
       );
       return normalizeSettingValue(result.stdout);
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts fallback failed: ${error}`, error);
+      // `defaults read` fails when the domain/key has never been set on this
+      // simulator; null correctly signals "no value configured" to the caller.
+      logger.debug(`src/features/utility/system-configuration/IosSystemConfigurationAdapter.ts defaults read failed: ${error}`, error);
       return null;
     }
   }

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -101,8 +101,9 @@ const defaultRecordingFileProbe: RecordingFileProbe = {
       const stats = await fsPromises.stat(filePath);
       return stats.size;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
-      logger.debug(`src/features/video/FfmpegVideoProcessingBackend.ts fallback failed: ${error}`, error);
+      // ENOENT is expected while ffmpeg hasn't created the output file yet;
+      // null lets the readiness poll keep waiting instead of erroring out.
+      logger.debug(`src/features/video/FfmpegVideoProcessingBackend.ts recording file stat failed: ${error}`, error);
       return null;
     }
   },

--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -776,8 +776,9 @@ function decodeUtf8Text(buffer: Buffer): string | undefined {
     const text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
     return text.includes("\u0000") ? undefined : text;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
-    logger.debug(`src/server/appFileService.ts fallback failed: ${error}`, error);
+    // Strict UTF-8 decoding throws on binary/invalid-encoding data; undefined
+    // tells the caller to treat the file as binary instead of as text.
+    logger.debug(`src/server/appFileService.ts utf8 decode failed: ${error}`, error);
     return undefined;
   }
 }

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -278,8 +278,9 @@ export const resolveAppLabel = async (device: BootedDevice, appId: string): Prom
     const result = await adb.executeCommand(`shell dumpsys package ${appId}`, undefined, undefined, true);
     return parseAppLabelFromDumpsys(result.stdout);
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
-    logger.debug(`src/server/systemTrayHelpers.ts fallback failed: ${error}`, error);
+    // Both the CtrlProxy fast path and this dumpsys fallback failed (e.g. app
+    // uninstalled mid-check); null lets the caller fall back to the package name.
+    logger.debug(`src/server/systemTrayHelpers.ts dumpsys label lookup failed: ${error}`, error);
     return null;
   }
 };

--- a/src/utils/ChildProcessTracker.ts
+++ b/src/utils/ChildProcessTracker.ts
@@ -157,8 +157,9 @@ export async function getFileSize(filePath: string): Promise<number | undefined>
     const stats = await fsPromises.stat(filePath);
     return stats.size;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
-    logger.debug(`src/utils/ChildProcessTracker.ts fallback failed: ${error}`, error);
+    // The file may have been removed or never created by the tracked process;
+    // undefined signals "size unknown" rather than treating it as fatal.
+    logger.debug(`src/utils/ChildProcessTracker.ts file size stat failed: ${error}`, error);
     return undefined;
   }
 }

--- a/src/utils/DeviceSnapshotStore.ts
+++ b/src/utils/DeviceSnapshotStore.ts
@@ -63,7 +63,8 @@ export class DeviceSnapshotStore {
       await fs.access(this.getSnapshotPathWithOptions(snapshotName, options));
       return true;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // fs.access throws when the snapshot directory doesn't exist yet, which is a
+      // normal "no snapshot taken" state, not an error — report false.
       logger.debug(`src/utils/DeviceSnapshotStore.ts fallback failed: ${error}`, error);
       return false;
     }

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -205,7 +205,8 @@ export class IOSCtrlProxyBuilder {
       this.cachedBuildProductsPath.set(platform, buildDir);
       return buildDir;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Build products directory doesn't exist yet (no build has run); null tells the
+      // caller to trigger a build rather than treating this as a hard failure.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -266,7 +267,8 @@ export class IOSCtrlProxyBuilder {
       this.cachedXctestrunPath.set(cacheKey, fullPath);
       return fullPath;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Products directory listing/stat failed (e.g. not built yet); reporting no
+      // xctestrun path lets the caller fall back to triggering a build.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -568,7 +570,8 @@ export class IOSCtrlProxyBuilder {
       await IOSCtrlProxyBuilder.prefetchPromise;
       return IOSCtrlProxyBuilder.prefetchResult;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Background prefetch already failed and recorded its error via getPrefetchError();
+      // returning null here just means "no prefetched result", callers build on demand.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -620,7 +623,8 @@ export class IOSCtrlProxyBuilder {
       await fs.access(appPath);
       return appPath;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // App bundle isn't present in the build products dir; null signals "not built"
+      // so callers can decide to (re)build instead of treating this as fatal.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -640,7 +644,8 @@ export class IOSCtrlProxyBuilder {
       this.cachedAppBundleHash.set(platform, hash);
       return hash;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Hashing the app bundle failed (e.g. bundle missing/unreadable); hash is only
+      // used for compat checks, so null just skips that optimization.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -660,7 +665,8 @@ export class IOSCtrlProxyBuilder {
       await fs.access(runnerBinaryPath);
       return runnerBinaryPath;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Runner binary not present in the build products dir; null tells the caller
+      // the UI test runner hasn't been built yet rather than throwing.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -774,7 +780,8 @@ export class IOSCtrlProxyBuilder {
         return false;
       }
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // fs.stat failed because the cached bundle file doesn't exist (or isn't
+      // readable); treat it as invalid so the caller re-downloads it.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return false;
     }
@@ -862,7 +869,8 @@ export class IOSCtrlProxyBuilder {
       const raw = await fs.readFile(this.getMetadataPath(), "utf-8");
       return JSON.parse(raw) as IOSCtrlProxyBundleMetadata;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Metadata file is missing or its JSON is malformed/stale; null just means
+      // "no cached metadata", so the caller recomputes it from the bundle.
       logger.debug(`src/utils/IOSCtrlProxyBuilder.ts fallback failed: ${error}`, error);
       return null;
     }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1379,7 +1379,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       await this.processExecutor.exec(`kill -0 ${pid} 2>/dev/null`);
       return true;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // `kill -0` exits non-zero (throwing) when the PID is gone or unreachable;
+      // treat that as "not running" rather than failing the liveness check.
       logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
       return false;
     }
@@ -1409,7 +1410,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           (status.data?.running ?? false) &&
           status.data?.pid === this.xcTestProcessId;
       } catch (error) {
-        // This probe is best-effort; callers can safely use the fallback value.
+        // A failed remote status call (network/daemon error) is treated the same as
+        // "not our tracked runner": returning false here is safe because the caller
+        // falls back to local isProcessRunning/re-adoption rather than crashing.
         logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
         return false;
       }
@@ -1484,7 +1487,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           (status.data?.running ?? false) &&
           status.data?.pid === this.xcTestProcessId;
       } catch (error) {
-        // This probe is best-effort; callers can safely use the fallback value.
+        // Remote status call failed; report not-alive so the caller respawns rather
+        // than trusting a stale in-memory pid across a daemon error.
         logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
         return false;
       }
@@ -1557,7 +1561,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
       return null;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // pgrep exits non-zero (throwing) when no xcodebuild process matches; that
+      // just means there's no external runner to adopt, not a real failure.
       logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -1832,7 +1837,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         environment,
       };
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // `ps -p <pid>` exits non-zero (throwing) if the process exited between
+      // discovery and this lookup; treat it as "no info available", not an error.
       logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -1847,7 +1853,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       const output = stdout.trim();
       return output.length > 0 ? output : undefined;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Same-pid race as getProcessInfo: the process may be gone by the time we
+      // read its full command line, so an absent environment string is expected.
       logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
       return undefined;
     }
@@ -2075,7 +2082,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       await processExecutor.exec(`kill -0 ${pid} 2>/dev/null`);
       return true;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // `kill -0` throws once the pid has exited, which is exactly the "not
+      // running" case the port-release / exit-wait callers are polling for.
       logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
       return false;
     }
@@ -2095,7 +2103,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         const status = await this.remoteRunner.getIproxyStatus({ pid: this.iproxyProcessId });
         return status.success && (status.data?.running ?? false);
       } catch (error) {
-        // This probe is best-effort; callers can safely use the fallback value.
+        // Remote status call failed; the supervisor should treat iproxy as down
+        // and attempt a restart rather than assume the tunnel is still healthy.
         logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
         return false;
       }
@@ -2534,7 +2543,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         const { stdout } = await this.processExecutor.exec("xcrun simctl list devices");
         return stdout.includes(this.device.deviceId);
       } catch (error) {
-        // This probe is best-effort; callers can safely use the fallback value.
+        // `xcrun simctl list devices` failing (Xcode tooling missing/misconfigured)
+        // means we can't confirm the simulator is present; treat it as undetected.
         logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
         return false;
       }
@@ -2552,7 +2562,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       const { stdout } = await this.processExecutor.exec("idevice_id -l");
       return stdout.split("\n").some(line => line.trim() === this.device.deviceId);
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // `idevice_id -l` failing (libimobiledevice missing, or no physical device
+      // attached) means we can't enumerate physical devices; report undetected.
       logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
       return false;
     }

--- a/src/utils/android-cmdline-tools/detection.ts
+++ b/src/utils/android-cmdline-tools/detection.ts
@@ -203,7 +203,7 @@ export async function isToolInPath(toolName: string, systemDetection = createDef
     await systemDetection.exec(`${command} ${toolName}`);
     return true;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // which/where exits non-zero when the tool isn't on PATH; that's a normal "not found", not a fault.
     logger.debug(`src/utils/android-cmdline-tools/detection.ts fallback failed: ${error}`, error);
     return false;
   }
@@ -219,7 +219,7 @@ export async function getToolPathFromPath(toolName: string, systemDetection = cr
     const path = result.stdout.trim().split("\n")[0]; // Take first result if multiple
     return path || null;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // which/where exits non-zero when the tool isn't on PATH; null tells the caller to keep searching.
     logger.debug(`src/utils/android-cmdline-tools/detection.ts fallback failed: ${error}`, error);
     return null;
   }

--- a/src/utils/android-cmdline-tools/readAndroidDeviceApiLevel.ts
+++ b/src/utils/android-cmdline-tools/readAndroidDeviceApiLevel.ts
@@ -19,7 +19,7 @@ export async function readAndroidDeviceApiLevel(adb: AdbExecutor): Promise<numbe
     const n = parseInt(r.stdout.trim(), 10);
     return Number.isFinite(n) ? n : null;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // getprop can fail if the device disconnects mid-command; null lets the caller fall back to another detection path.
     logger.debug(`src/utils/android-cmdline-tools/readAndroidDeviceApiLevel.ts fallback failed: ${error}`, error);
     return null;
   }

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -111,7 +111,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     try {
       return await this.simctl.isAvailable();
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // simctl.isAvailable() throws on non-macOS hosts/missing Xcode tools; treat as "no local iOS discovery".
       logger.debug(`src/utils/deviceUtils.ts fallback failed: ${error}`, error);
       return false;
     }

--- a/src/utils/dockerEnv.ts
+++ b/src/utils/dockerEnv.ts
@@ -10,7 +10,7 @@ export function isRunningInDocker(): boolean {
     const cgroup = fs.readFileSync("/proc/1/cgroup", "utf8");
     return cgroup.includes("docker") || cgroup.includes("containerd");
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // /proc/1/cgroup is Linux-only and may not exist (e.g. macOS/Windows); assume non-Docker rather than fail.
     logger.debug(`src/utils/dockerEnv.ts fallback failed: ${error}`, error);
     return false;
   }

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -125,7 +125,8 @@ export function tryAcquireExclusiveLock(
   try {
     content = readFileSync(lockFilePath, "utf-8").trim();
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // The lock file vanished between the failed `wx` create and this read (holder
+    // released it); treat as still-held so the caller retries rather than racing.
     logger.debug(`src/utils/fileLock.ts fallback failed: ${error}`, error);
     return false;
   }
@@ -179,7 +180,8 @@ export function tryAcquireExclusiveLock(
   try {
     renameSync(lockFilePath, reclaimMarker);
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // A racing opener already renamed/claimed this exact stale lock instance (see
+    // comment above); losing the race means we don't own it, so report not-acquired.
     logger.debug(`src/utils/fileLock.ts fallback failed: ${error}`, error);
     return false;
   }
@@ -214,7 +216,8 @@ export function releaseExclusiveLock(
   try {
     content = readFileSync(lockFilePath, "utf-8").trim();
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // Lock file is already gone (released concurrently, or never existed); there is
+    // nothing left to release, so returning is a no-op, not a failure.
     logger.debug(`src/utils/fileLock.ts fallback failed: ${error}`, error);
     return;
   }
@@ -253,7 +256,8 @@ function writeExclusiveLockFile(lockFilePath: string, pid: number, ownerToken?: 
     closeSync(fd);
     return true;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // `wx` create fails when the lock file already exists (another holder got there
+    // first); false tells the caller to fall through to the read/reclaim path.
     logger.debug(`src/utils/fileLock.ts fallback failed: ${error}`, error);
     return false;
   }

--- a/src/utils/filesystem/DefaultFileSystem.ts
+++ b/src/utils/filesystem/DefaultFileSystem.ts
@@ -8,7 +8,7 @@ export async function pathExists(filePath: string): Promise<boolean> {
     await fsPromises.access(filePath);
     return true;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // fs.access rejects for a missing path (and other stat errors); either way the path is not usable.
     logger.debug(`src/utils/filesystem/DefaultFileSystem.ts fallback failed: ${error}`, error);
     return false;
   }

--- a/src/utils/hostAppearance.ts
+++ b/src/utils/hostAppearance.ts
@@ -18,7 +18,9 @@ async function runCommand(command: string, args: string[]): Promise<CommandResul
       stderr: result.stderr ? result.stderr.toString() : "",
     };
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // Command may not exist on this host, or the queried key/scheme may be unset
+    // (e.g. no AppleInterfaceStyle default in light mode); null just means "unknown",
+    // so callers fall through to the next detection method or a light-mode default.
     logger.debug(`src/utils/hostAppearance.ts fallback failed: ${error}`, error);
     return null;
   }

--- a/src/utils/image/webp/WebpBinaryResolver.ts
+++ b/src/utils/image/webp/WebpBinaryResolver.ts
@@ -256,7 +256,7 @@ async function isExecutableFile(filePath: string, platform: NodeJS.Platform): Pr
     await fs.access(filePath, fsConstants.X_OK);
     return true;
   } catch (error) {
-    // This probe is best-effort; callers can safely use the fallback value.
+    // Missing file or lacking the execute bit both mean this binary can't be used; treat either as "not executable".
     logger.debug(`src/utils/image/webp/WebpBinaryResolver.ts fallback failed: ${error}`, error);
     return false;
   }

--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -414,7 +414,7 @@ export class DeviceAppManager implements DeviceUrlLauncher {
       await this.deps.exec("xcrun devicectl --version");
       return true;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // `devicectl --version` fails when Xcode 15+ isn't installed; that just means physical-device URL launch is unavailable.
       logger.debug(`src/utils/ios-cmdline-tools/DeviceAppManager.ts fallback failed: ${error}`, error);
       return false;
     }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -489,7 +489,7 @@ export class SimCtlClient implements SimCtl {
       await this.ensureLocalSimctlAvailable();
       return true;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // ensureLocalSimctlAvailable already logged the underlying reason; here we only need the boolean result.
       logger.debug(`src/utils/ios-cmdline-tools/SimCtlClient.ts fallback failed: ${error}`, error);
       return false;
     }

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -92,7 +92,7 @@ export class XcodebuildClient implements Xcodebuild {
       await this.execAsync("xcodebuild", ["-version"]);
       return true;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // `xcodebuild -version` fails when Xcode/command-line tools aren't installed; that just means it's unavailable.
       logger.debug(`src/utils/ios-cmdline-tools/XcodebuildClient.ts fallback failed: ${error}`, error);
       return false;
     }

--- a/src/utils/ios/IOSCtrlProxyHealthClient.ts
+++ b/src/utils/ios/IOSCtrlProxyHealthClient.ts
@@ -66,7 +66,7 @@ export class IOSCtrlProxyHealthClient {
       const health = JSON.parse(body) as { status?: unknown; deviceId?: unknown };
       return health.status === "ok" && health.deviceId === deviceId;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Malformed/non-JSON health body means we can't trust this runner's identity; treat it as not matching.
       logger.debug(`src/utils/ios/IOSCtrlProxyHealthClient.ts fallback failed: ${error}`, error);
       return false;
     }
@@ -92,7 +92,7 @@ export class IOSCtrlProxyHealthClient {
       }
       return isValidCtrlProxyPort(health.port) ? health.port : null;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // Malformed/non-JSON health body means we can't confirm the reported port belongs to this device; null it out.
       logger.debug(`src/utils/ios/IOSCtrlProxyHealthClient.ts fallback failed: ${error}`, error);
       return null;
     }
@@ -128,7 +128,7 @@ export class IOSCtrlProxyHealthClient {
       );
       return stdout;
     } catch (error) {
-      // This probe is best-effort; callers can safely use the fallback value.
+      // No runner listening on this port (connection refused/timeout) is the expected case; null means "not up yet".
       logger.debug(`src/utils/ios/IOSCtrlProxyHealthClient.ts fallback failed: ${error}`, error);
       return null;
     }

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -147,7 +147,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
             return parsed as Record<string, unknown>;
           }
         } catch (error) {
-          // This probe is best-effort; callers can safely use the fallback value.
+          // Tool response text that isn't valid JSON has no structured payload to extract; null signals "no payload".
           logger.debug(`src/utils/plan/PlanExecutor.ts fallback failed: ${error}`, error);
           return null;
         }


### PR DESCRIPTION
## Summary
- The catch-convention sweep (#3508/#3529) left one verbatim comment (`This probe is best-effort; callers can safely use the fallback value.`) stamped across 57 catch sites in 32 files — it restated that a fallback exists instead of explaining *why* swallowing is safe there.
- Several sites also mislabeled JSON/pidfile/`defaults`-output parses as "probes" (they're not probing anything, they're parsing).
- Replaced each occurrence with a comment specific to that call site's real failure mode. Corrected "probe" wording at the parse sites (`daemonFiles.ts` pidfile parse, `AppPreferences.ts` defaults parse, `IOSCtrlProxyHealthClient.ts` health-body JSON parses, `PlanExecutor.ts` tool-response JSON parse, `IOSCtrlProxyBuilder.ts` metadata JSON parse).
- No log levels, log message *meaning*, or control flow changed — only comment text and, where wrong, the word "probe" in the adjacent log message.

## Test plan
- [x] `bun test` — 7612 pass, 0 fail
- [x] `turbo run lint build` — clean
- [x] `grep -rc "This probe is best-effort..." src/` → 0

Fixes #3563