### PR TITLE
chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -32,7 +32,7 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     version: "0.0.44",
     apkSha256: "e95f2b14e218bc51e92a44680cf38ceca9c9143014b2f74b803f47650614cf39",
     ipaSha256: "73dd4551ef7226d67a46423f6925775fc10d68198913b5b23bc1cbdceb50b663",
-    runnerSha256: "b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982",
+    runnerSha256: "ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a",
   },
   {
     version: "0.0.43",


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `  apkSha256: string;` | `1be224f4f5e5a21087a6552a9567290da64ad7deea6de6239a38324a8d91b0cc` | ✅ Yes |
| **IPA** | `  ipaSha256: string;` | `bfceb921d0d55088f9a209f0519f332ed731025d8e0fe802f53eab62a7272996` | ✅ Yes |
| **iOS Runner** | `b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982` | `ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow