### PR TITLE
perf(resources): precompile URI-template regexes at registration (#3427)

### DIFF
--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -37,6 +37,55 @@ interface RegisteredResourceTemplate {
   description?: string;
   mimeType?: string;
   handler: ResourceTemplateHandler;
+  // Precompiled at registration so matchTemplate never compiles a RegExp inside
+  // the per-request scan (issue #3427). Patterns are 100% static.
+  regex: RegExp;
+  paramNames: string[];
+}
+
+// Compile an RFC 6570 URI template into an anchored RegExp plus its ordered
+// parameter names. Pure and called once per template at registration.
+// E.g. "automobile:emulators/{id}" -> /^automobile:emulators\/([^/&]+)$/, ["id"]
+function compileUriTemplate(template: string): {
+  regex: RegExp;
+  paramNames: string[];
+} {
+  const paramNames: string[] = [];
+  const tokenizedTemplate = template.replace(/\{(\w+)\}/g, (_, paramName) => {
+    paramNames.push(paramName);
+    return `__PARAM_${paramNames.length - 1}__`;
+  });
+  const escapedTemplate = tokenizedTemplate.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  // Use [^/&]+ so query-string params stop at the & delimiter; a trailing
+  // {path} param is greedy so it can capture nested slashes.
+  const regexPattern = escapedTemplate.replace(/__PARAM_(\d+)__/g, (_placeholder, indexText) => {
+    const index = Number(indexText);
+    const isTrailingPathParam =
+      paramNames[index] === "path" &&
+      escapedTemplate.endsWith(`__PARAM_${index}__`);
+    return isTrailingPathParam ? "(.+)" : "([^/&]+)";
+  });
+
+  return { regex: new RegExp(`^${regexPattern}$`), paramNames };
+}
+
+// Run a precompiled template's regex against a URI and, on a match, extract the
+// named parameters. Returns null when the URI does not match the template.
+function extractTemplateParams(
+  template: RegisteredResourceTemplate,
+  uri: string
+): Record<string, string> | null {
+  const match = uri.match(template.regex);
+  if (!match) {
+    return null;
+  }
+
+  const params: Record<string, string> = {};
+  template.paramNames.forEach((name, index) => {
+    params[name] = match[index + 1];
+  });
+
+  return params;
 }
 
 // The registry that holds all resources
@@ -70,7 +119,8 @@ class ResourceRegistryClass {
     mimeType: string,
     handler: ResourceTemplateHandler
   ): void {
-    this.templates.set(uriTemplate, { uriTemplate, name, description, mimeType, handler });
+    const { regex, paramNames } = compileUriTemplate(uriTemplate);
+    this.templates.set(uriTemplate, { uriTemplate, name, description, mimeType, handler, regex, paramNames });
   }
 
   // Get all registered templates
@@ -85,49 +135,13 @@ class ResourceRegistryClass {
 
   // Match a URI against registered templates and return the template and extracted parameters
   matchTemplate(uri: string): { template: RegisteredResourceTemplate; params: Record<string, string> } | undefined {
-    for (const [uriTemplate, registeredTemplate] of this.templates) {
-      const params = this.extractTemplateParams(uriTemplate, uri);
+    for (const registeredTemplate of this.templates.values()) {
+      const params = extractTemplateParams(registeredTemplate, uri);
       if (params) {
         return { template: registeredTemplate, params };
       }
     }
     return undefined;
-  }
-
-  // Extract parameters from a URI using a URI template pattern
-  private extractTemplateParams(template: string, uri: string): Record<string, string> | null {
-    // Convert URI template to regex pattern
-    // E.g., "automobile:emulators/([^/]+)"
-    // For query params, we need to stop at '&' as well as '/'
-    const paramNames: string[] = [];
-    const tokenizedTemplate = template.replace(/\{(\w+)\}/g, (_, paramName) => {
-      paramNames.push(paramName);
-      return `__PARAM_${paramNames.length - 1}__`;
-    });
-    const escapedTemplate = tokenizedTemplate.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-    // Use [^/&]+ to properly handle query string parameters (stop at & delimiter)
-    const regexPattern = escapedTemplate.replace(/__PARAM_(\d+)__/g, (_placeholder, indexText) => {
-      const index = Number(indexText);
-      const isTrailingPathParam =
-        paramNames[index] === "path" &&
-        escapedTemplate.endsWith(`__PARAM_${index}__`);
-      return isTrailingPathParam ? "(.+)" : "([^/&]+)";
-    });
-
-    const regex = new RegExp(`^${regexPattern}$`);
-    const match = uri.match(regex);
-
-    if (!match) {
-      return null;
-    }
-
-    // Extract parameters from match groups
-    const params: Record<string, string> = {};
-    paramNames.forEach((name, index) => {
-      params[name] = match[index + 1];
-    });
-
-    return params;
   }
 
   // Get all registered resources

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -685,4 +685,70 @@ describe("ResourceRegistry Template Matching", () => {
       mimeType: "application/json"
     });
   });
+
+  test("precompiles the template regex once at registration and reuses it across reads (#3427)", () => {
+    ResourceRegistry.registerTemplate(
+      "test://items/{id}",
+      "Test Item",
+      "Test item description",
+      "application/json",
+      async params => ({ uri: `test://items/${params.id}`, text: "{}" })
+    );
+
+    const first = ResourceRegistry.matchTemplate("test://items/1");
+    const second = ResourceRegistry.matchTemplate("test://items/2");
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    // The compiled RegExp is stored on the template and the SAME instance is
+    // returned on every read — proof it is not recompiled per request.
+    const firstRegex = (first!.template as unknown as { regex: RegExp }).regex;
+    const secondRegex = (second!.template as unknown as { regex: RegExp }).regex;
+    expect(firstRegex).toBeInstanceOf(RegExp);
+    expect(firstRegex).toBe(secondRegex);
+  });
+
+  test("does not construct a new RegExp during matchTemplate (#3427)", () => {
+    ResourceRegistry.registerTemplate(
+      "test://items/{id}",
+      "Test Item",
+      "Test item description",
+      "application/json",
+      async params => ({ uri: `test://items/${params.id}`, text: "{}" })
+    );
+
+    // Count RegExp constructions while only reading, not registering.
+    const OriginalRegExp = globalThis.RegExp;
+    let constructions = 0;
+    class CountingRegExp extends OriginalRegExp {
+      constructor(...args: ConstructorParameters<typeof OriginalRegExp>) {
+        super(...args);
+        constructions++;
+      }
+    }
+    (globalThis as { RegExp: typeof RegExp }).RegExp = CountingRegExp as typeof RegExp;
+    try {
+      ResourceRegistry.matchTemplate("test://items/1");
+      ResourceRegistry.matchTemplate("test://items/2");
+      ResourceRegistry.matchTemplate("test://items/3");
+    } finally {
+      (globalThis as { RegExp: typeof RegExp }).RegExp = OriginalRegExp;
+    }
+
+    expect(constructions).toBe(0);
+  });
+
+  test("matches a trailing {path} param greedily across slashes", () => {
+    ResourceRegistry.registerTemplate(
+      "test://files/{id}/{path}",
+      "File",
+      "A nested file",
+      "application/json",
+      async params => ({ uri: `test://files/${params.id}/${params.path}`, text: "{}" })
+    );
+
+    const match = ResourceRegistry.matchTemplate("test://files/app1/dir/sub/file.txt");
+    expect(match).toBeDefined();
+    expect(match!.params).toEqual({ id: "app1", path: "dir/sub/file.txt" });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #3427. On a `ReadResource` exact-URI miss, `matchTemplate` iterated every registered template and, per template, called `extractTemplateParams`, which built a brand-new `RegExp` (plus tokenization + two `.replace` passes) **inside the per-request loop**. With ~180 combinatorially-registered templates, a single read compiled ~180 regexes. The patterns are 100% static.

## Change

- Precompile `{ regex, paramNames }` once at registration via a pure `compileUriTemplate()`, stored on `RegisteredResourceTemplate`.
- `matchTemplate` now just runs the stored regex against the URI (short-circuits at first match, unchanged).
- Extraction logic moved to a small pure `extractTemplateParams(template, uri)`.
- Public `registerTemplate` / `matchTemplate` signatures unchanged — purely internal. Also speeds `notifyResourceUpdated`, which shares the path.

## Tests

- Added regression tests (`bootedDevices.test.ts`): the compiled RegExp is stored and the **same instance** is reused across reads; `matchTemplate` constructs **zero** RegExps (counting-subclass probe); trailing `{path}` still captures greedily across slashes.
- All existing resource tests pass; `bun run typecheck` / `lint` / `build` green.

`/simplify`: confirmed the SDK's `UriTemplate.match()` is **not** a viable swap — it recompiles a RegExp per call (reintroducing this exact bug) and has different capture semantics. Hand-rolled precompile kept.

Closes #3427