### PR TITLE
perf(db): amortize per-insert offset-probe retention (#3435/#3436/#3440)

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -7,8 +7,8 @@ src/daemon/manager.ts: error TS18048: 'signal' is possibly 'undefined'.
 src/daemon/performanceStreamSocketServer.ts: error TS2559: Type 'PerformanceStreamSocketRequest' has no properties in common with type 'SocketRequest'.
 src/daemon/socketServer.ts: error TS2322: Type 'unknown' is not assignable to type '{ [x: string]: unknown; } | undefined'.
 src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.
-src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not exist on type '{ type: "crash" | "anr" | "tool_failure"; title: string; severity: "critical" | "high" | "medium" | "low"; stack_trace_json: string | null; timestamp: number; occurrenceId: string; groupId: string; deviceId: string | null; screen: string | null; }'.
-src/daemon/telemetryPushSocketServer.ts: error TS2345: Argument of type '"crash" | "anr" | "nonfatal"' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_groups" | "failure_occurrences", "failure_groups.type">'.
+src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not exist on type '{ timestamp: number; type: "crash" | "anr" | "tool_failure"; title: string; severity: "critical" | "high" | "medium" | "low"; stack_trace_json: string | null; occurrenceId: string; groupId: string; deviceId: string | null; screen: string | null; }'.
+src/daemon/telemetryPushSocketServer.ts: error TS2345: Argument of type '"crash" | "anr" | "nonfatal"' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_occurrences" | "failure_groups", "failure_groups.type">'.
 src/daemon/testRecordingSocketServer.ts: error TS2322: Type 'string' is not assignable to type 'Platform | undefined'.
 src/daemon/testRecordingSocketServer.ts: error TS2322: Type 'string' is not assignable to type 'Platform | undefined'.
 src/daemon/testRecordingSocketServer.ts: error TS2559: Type 'TestRecordingCommand' has no properties in common with type 'SocketRequest'.
@@ -278,7 +278,7 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 24,28,49 :: src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 # swap-fp: 25 :: src/daemon/client.ts: error TS2345: Argument of type 'string | NonSharedBuffer' is not assignable to parameter of type 'Buffer<ArrayBufferLike>'.
 # swap-fp: 25,27 :: src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
-# swap-fp: 26 :: src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not exist on type '{ type: "crash" | "anr" | "tool_failure"; title: string; severity: "critical" | "high" | "medium" | "low"; stack_trace_json: string | null; timestamp: number; occurrenceId: string; groupId: string; deviceId: string | null; screen: string | null; }'.
+# swap-fp: 26 :: src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not exist on type '{ timestamp: number; type: "crash" | "anr" | "tool_failure"; title: string; severity: "critical" | "high" | "medium" | "low"; stack_trace_json: string | null; occurrenceId: string; groupId: string; deviceId: string | null; screen: string | null; }'.
 # swap-fp: 27 :: src/db/migrator.ts: error TS7006: Parameter 'index' implicitly has an 'any' type.
 # swap-fp: 27,45 :: src/db/database.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
 # swap-fp: 28 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.
@@ -330,7 +330,7 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 45,46,46 :: src/features/accessibility/ContrastChecker.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 # swap-fp: 45,47 :: src/features/video/PlatformVideoCaptureBackend.ts: error TS2339: Property 'getBaseCommandParts' does not exist on type 'AdbExecutor'.
 # swap-fp: 45,47,53 :: src/features/observe/GetScreenSize.ts: error TS2345: Argument of type 'import("src/models/ScreenSize").ScreenSize' is not assignable to parameter of type 'import("src/features/observe/interfaces/ScreenSize").ScreenSize'.
-# swap-fp: 46 :: src/daemon/telemetryPushSocketServer.ts: error TS2345: Argument of type '"crash" | "anr" | "nonfatal"' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_groups" | "failure_occurrences", "failure_groups.type">'.
+# swap-fp: 46 :: src/daemon/telemetryPushSocketServer.ts: error TS2345: Argument of type '"crash" | "anr" | "nonfatal"' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_occurrences" | "failure_groups", "failure_groups.type">'.
 # swap-fp: 46 :: src/db/bunSqliteDialect.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
 # swap-fp: 46 :: src/server/observeTools.ts: error TS2488: Type 'TimingData' must have a '[Symbol.iterator]()' method that returns an iterator.
 # swap-fp: 46,63 :: src/features/action/InstallApp.ts: error TS2554: Expected 0 arguments, but got 1.

--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -13,6 +13,7 @@ import { defaultTimer } from "../utils/SystemTimer";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { type DbWriteBarrier, getDbWriteBarrier } from "./dbWriteBarrier";
 import { appendToBucket, chunkBySqliteParameterLimit } from "./sqliteBatch";
+import { createRowCapRetentionState, pruneTableByRowCap, runAmortizedRetention } from "./rowCapRetention";
 import type {
   FailureType,
   FailureSeverity,
@@ -29,7 +30,7 @@ import type {
 } from "../server/failuresResources";
 
 const RETENTION_MAX_ROWS = 10_000;
-let cleanupInProgress = false;
+const retentionState = createRowCapRetentionState();
 
 interface FailureScreenCountRow {
   screenName: string;
@@ -1126,54 +1127,42 @@ export class FailureAnalyticsRepository {
   }
 
   private async cleanupRetention(): Promise<void> {
-    if (cleanupInProgress) {
-      return;
-    }
+    // Amortize the offset probe and orphan sweep: fire at most once per
+    // CLEANUP_CHECK_INTERVAL failures and gate the index walk on a cheap
+    // count(*), instead of running both full-table operations on every ingest
+    // (#3436).
+    await runAmortizedRetention(retentionState, () => this.pruneToRowCap());
+  }
 
-    cleanupInProgress = true;
+  // `maxRows` is injectable so tests can exercise trimming at a small cap without
+  // inserting 10k rows.
+  private async pruneToRowCap(maxRows: number = RETENTION_MAX_ROWS): Promise<void> {
     try {
       const db = this.getDb();
 
-      // Find threshold occurrence
-      const threshold = await db
-        .selectFrom("failure_occurrences")
-        .select(["id", "timestamp"])
-        .orderBy("timestamp", "desc")
-        .limit(1)
-        .offset(RETENTION_MAX_ROWS - 1)
-        .executeTakeFirst();
+      // Delete old occurrences (cascades to screens, captures, notifications).
+      const deleted = await pruneTableByRowCap(db, "failure_occurrences", maxRows);
 
-      if (!threshold) {
-        return;
+      // Only sweep orphan groups when occurrences were actually removed, and
+      // use a correlated NOT EXISTS (index-served, early-exit) rather than
+      // materializing the full DISTINCT set for a NOT IN scan.
+      if (deleted > 0) {
+        await db
+          .deleteFrom("failure_groups")
+          .where(eb =>
+            eb.not(
+              eb.exists(
+                eb
+                  .selectFrom("failure_occurrences")
+                  .select(sql`1`.as("one"))
+                  .whereRef("failure_occurrences.group_id", "=", "failure_groups.id")
+              )
+            )
+          )
+          .execute();
       }
-
-      // Delete old occurrences (cascades to screens, captures, notifications)
-      await db
-        .deleteFrom("failure_occurrences")
-        .where(eb =>
-          eb.or([
-            eb("timestamp", "<", threshold.timestamp),
-            eb.and([
-              eb("timestamp", "=", threshold.timestamp),
-              eb("id", "<", threshold.id),
-            ]),
-          ])
-        )
-        .execute();
-
-      // Clean up groups with no occurrences
-      await db
-        .deleteFrom("failure_groups")
-        .where(
-          "id",
-          "not in",
-          db.selectFrom("failure_occurrences").select("group_id").distinct()
-        )
-        .execute();
     } catch (error) {
       logger.warn(`[FailureAnalyticsRepository] Retention cleanup failed: ${error}`);
-    } finally {
-      cleanupInProgress = false;
     }
   }
 }

--- a/src/db/performanceAuditRepository.ts
+++ b/src/db/performanceAuditRepository.ts
@@ -4,11 +4,12 @@ import type { Database, NewPerformanceAuditResult } from "./types";
 import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
+import { createRowCapRetentionState, pruneTableByRowCap, runAmortizedRetention } from "./rowCapRetention";
 
 const RETENTION_MAX_ROWS = 10_000;
 const RETENTION_MAX_AGE_HOURS = 24;
 const PRUNING_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-let cleanupInProgress = false;
+const retentionState = createRowCapRetentionState();
 let pruningTimer: NodeJS.Timeout | null = null;
 
 export interface PerformanceAuditMetricsRecord {
@@ -302,41 +303,19 @@ export class PerformanceAuditRepository {
   }
 
   private async cleanupRetention(): Promise<void> {
-    if (cleanupInProgress) {
-      return;
-    }
+    // Amortize the offset-probe: fire at most once per CLEANUP_CHECK_INTERVAL
+    // inserts and only walk the index when a cheap count(*) confirms we're over
+    // cap, instead of running LIMIT 1 OFFSET 9999 on every insert (#3435).
+    await runAmortizedRetention(retentionState, () => this.pruneToRowCap());
+  }
 
-    cleanupInProgress = true;
+  // `maxRows` is injectable so tests can exercise trimming at a small cap without
+  // inserting 10k rows.
+  private async pruneToRowCap(maxRows: number = RETENTION_MAX_ROWS): Promise<void> {
     try {
-      const db = this.getDb();
-
-      const threshold = await db
-        .selectFrom("performance_audit_results")
-        .select(["id", "timestamp"])
-        .orderBy("timestamp", "desc")
-        .orderBy("id", "desc")
-        .limit(1)
-        .offset(RETENTION_MAX_ROWS - 1)
-        .executeTakeFirst();
-
-      if (!threshold) {
-        return;
-      }
-
-      await db
-        .deleteFrom("performance_audit_results")
-        .where(eb => eb.or([
-          eb("timestamp", "<", threshold.timestamp),
-          eb.and([
-            eb("timestamp", "=", threshold.timestamp),
-            eb("id", "<", threshold.id),
-          ]),
-        ]))
-        .execute();
+      await pruneTableByRowCap(this.getDb(), "performance_audit_results", maxRows);
     } catch (error) {
       logger.warn(`[PerformanceAuditRepository] Retention cleanup failed: ${error}`);
-    } finally {
-      cleanupInProgress = false;
     }
   }
 

--- a/src/db/rowCapRetention.ts
+++ b/src/db/rowCapRetention.ts
@@ -1,0 +1,124 @@
+// Amortized row-cap retention (#3435/#3436/#3440).
+//
+// The event tables share `pruneEventTableByCount` (see `eventRetention.ts`),
+// but the audit / failure-analytics / test-execution repositories each have a
+// bespoke cleanup body (orphan-group sweep, age-based delete) that does not fit
+// that generic helper. What they DO share is two concerns this module owns:
+//   1. an offset-probe cleanup must not run on every insert, and
+//   2. the "keep the newest N rows" trim itself.
+// Historically each repo ran an unconditional `LIMIT 1 OFFSET 9999` index walk
+// on the hot write path — the exact offset-probe pattern known to be ~57x
+// slower than a `count(*)` gate (#2799). `runAmortizedRetention` amortizes the
+// cleanup so the scan fires at most once per `checkInterval` inserts, and
+// `pruneTableByRowCap` centralizes the trim (including the #3137 id-tiebreak
+// invariant) so it is not hand-copied per repo.
+
+import type { Kysely } from "kysely";
+import type { Database } from "./types";
+
+// Run the cleanup body at most once per this many inserts. Worst-case overshoot
+// is bounded (cap + CLEANUP_CHECK_INTERVAL rows) and negligible against a 10k
+// cap. Mirrors `eventRetention.CLEANUP_CHECK_INTERVAL`.
+export const CLEANUP_CHECK_INTERVAL = 256;
+
+// Tables this module can trim by row count. All have an `id` and a `timestamp`
+// column (the trim's ordering keys). Kept as an explicit union — rather than a
+// broad `keyof Database` — so `.select(["id", "timestamp"])` stays type-checked
+// and callers can't point the helper at a table that lacks those columns.
+export type RowCapTable = "performance_audit_results" | "test_executions" | "failure_occurrences";
+
+/**
+ * Trim `table` to at most `maxRows` rows, keeping the newest by
+ * (`timestamp` desc, `id` desc) and returning the number of rows deleted.
+ *
+ * A cheap `count(*)` gates the expensive `LIMIT 1 OFFSET maxRows-1` threshold
+ * probe, so the index walk only runs when actually over cap. The delete breaks
+ * cutoff-timestamp ties on the monotonic `id` (#3137), trimming to *exactly*
+ * `maxRows` rows and deterministically pruning same-timestamp rows — a burst of
+ * same-instant rows at the cutoff can never retain more than `maxRows`.
+ */
+export async function pruneTableByRowCap(
+  db: Kysely<Database>,
+  table: RowCapTable,
+  maxRows: number
+): Promise<number> {
+  const count = await db
+    .selectFrom(table)
+    .select(db.fn.countAll().as("count"))
+    .executeTakeFirstOrThrow();
+
+  if (Number(count.count) <= maxRows) {
+    return 0;
+  }
+
+  const threshold = await db
+    .selectFrom(table)
+    .select(["id", "timestamp"])
+    .orderBy("timestamp", "desc")
+    .orderBy("id", "desc")
+    .limit(1)
+    .offset(maxRows - 1)
+    .executeTakeFirst();
+
+  if (!threshold) {
+    return 0;
+  }
+
+  const deleted = await db
+    .deleteFrom(table)
+    .where(eb => eb.or([
+      eb("timestamp", "<", threshold.timestamp),
+      eb.and([
+        eb("timestamp", "=", threshold.timestamp),
+        eb("id", "<", threshold.id),
+      ]),
+    ]))
+    .executeTakeFirst();
+
+  return Number(deleted.numDeletedRows ?? 0);
+}
+
+export interface RowCapRetentionState {
+  cleanupInProgress: boolean;
+  insertsSinceCleanup: number;
+}
+
+export function createRowCapRetentionState(): RowCapRetentionState {
+  return { cleanupInProgress: false, insertsSinceCleanup: 0 };
+}
+
+/**
+ * Amortize a retention cleanup body across inserts.
+ *
+ * The counter is bumped synchronously on every call so cleanup still fires
+ * deterministically every `checkInterval` inserts without putting the scan on
+ * the hot path. When the gate trips, `runCleanup` runs behind an in-progress
+ * guard that drops overlapping calls (the next insert will re-arm the gate).
+ * `runCleanup` is expected to swallow its own errors; this wrapper only manages
+ * the amortization counter and the guard.
+ *
+ * `checkInterval` is injectable so unit tests can trip the gate without 256
+ * calls. (These repos insert one capped row per call, so — unlike the batched
+ * event repositories — there is no per-batch insert count to thread through.)
+ */
+export async function runAmortizedRetention(
+  state: RowCapRetentionState,
+  runCleanup: () => Promise<void>,
+  checkInterval: number = CLEANUP_CHECK_INTERVAL
+): Promise<void> {
+  state.insertsSinceCleanup += 1;
+  if (state.insertsSinceCleanup < checkInterval) {
+    return;
+  }
+  state.insertsSinceCleanup = 0;
+
+  if (state.cleanupInProgress) {
+    return;
+  }
+  state.cleanupInProgress = true;
+  try {
+    await runCleanup();
+  } finally {
+    state.cleanupInProgress = false;
+  }
+}

--- a/src/db/testExecutionRepository.ts
+++ b/src/db/testExecutionRepository.ts
@@ -6,12 +6,13 @@ import { logger } from "../utils/logger";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { appendToBucket, chunkBySqliteParameterLimit } from "./sqliteBatch";
+import { createRowCapRetentionState, pruneTableByRowCap, runAmortizedRetention } from "./rowCapRetention";
 
 const TEST_EXECUTION_RETENTION_MAX_ROWS = 10_000;
 export const TEST_EXECUTION_RETENTION_MAX_DAYS = 90;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-let cleanupInProgress = false;
+const retentionState = createRowCapRetentionState();
 
 export type TestExecutionStatus = "passed" | "failed" | "skipped";
 
@@ -356,11 +357,9 @@ export class TestExecutionRepository {
   }
 
   private async cleanupRetention(): Promise<void> {
-    if (cleanupInProgress) {
-      return;
-    }
-
-    cleanupInProgress = true;
+    // The age-based delete is a cheap indexed/sargable range delete, so it runs
+    // on every insert. The row-cap offset probe (LIMIT 1 OFFSET 9999) is the
+    // expensive index walk, so it is amortized behind a count(*) gate (#3440).
     try {
       const db = this.getDb();
       const cutoff = this.timer.now() - TEST_EXECUTION_RETENTION_MAX_DAYS * MS_PER_DAY;
@@ -369,34 +368,20 @@ export class TestExecutionRepository {
         .deleteFrom("test_executions")
         .where("timestamp", "<", cutoff)
         .execute();
-
-      const threshold = await db
-        .selectFrom("test_executions")
-        .select(["id", "timestamp"])
-        .orderBy("timestamp", "desc")
-        .orderBy("id", "desc")
-        .limit(1)
-        .offset(TEST_EXECUTION_RETENTION_MAX_ROWS - 1)
-        .executeTakeFirst();
-
-      if (!threshold) {
-        return;
-      }
-
-      await db
-        .deleteFrom("test_executions")
-        .where(eb => eb.or([
-          eb("timestamp", "<", threshold.timestamp),
-          eb.and([
-            eb("timestamp", "=", threshold.timestamp),
-            eb("id", "<", threshold.id),
-          ]),
-        ]))
-        .execute();
     } catch (error) {
-      logger.warn(`[TestExecutionRepository] Retention cleanup failed: ${error}`);
-    } finally {
-      cleanupInProgress = false;
+      logger.warn(`[TestExecutionRepository] Age-based retention cleanup failed: ${error}`);
+    }
+
+    await runAmortizedRetention(retentionState, () => this.pruneToRowCap());
+  }
+
+  // `maxRows` is injectable so tests can exercise trimming at a small cap without
+  // inserting 10k rows.
+  private async pruneToRowCap(maxRows: number = TEST_EXECUTION_RETENTION_MAX_ROWS): Promise<void> {
+    try {
+      await pruneTableByRowCap(this.getDb(), "test_executions", maxRows);
+    } catch (error) {
+      logger.warn(`[TestExecutionRepository] Row-cap retention cleanup failed: ${error}`);
     }
   }
 

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -921,3 +921,79 @@ async function seedFailureOccurrence(
     })
     .execute();
 }
+
+describe("FailureAnalyticsRepository row-cap retention (#3436)", () => {
+  let db: Kysely<Database>;
+  let timer: FakeTimer;
+  let repo: FailureAnalyticsRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    timer = new FakeTimer();
+    timer.setCurrentTime(1000);
+    repo = new FailureAnalyticsRepository(timer, db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  function input(signature: string): RecordFailureInput {
+    return {
+      type: "crash",
+      signature,
+      title: `title ${signature}`,
+      message: "m",
+      severity: "critical",
+      occurrence: { deviceModel: "Pixel 7", os: "Android 14", appVersion: "1.0.0", sessionId: "s" },
+    };
+  }
+
+  test("pruneToRowCap trims to the cap and sweeps groups left with no occurrences", async () => {
+    // Group "old" gets the two earliest occurrences; group "new" the two latest.
+    timer.setCurrentTime(1000); await repo.recordFailure(input("old"));
+    timer.setCurrentTime(2000); await repo.recordFailure(input("old"));
+    timer.setCurrentTime(3000); await repo.recordFailure(input("new"));
+    timer.setCurrentTime(4000); await repo.recordFailure(input("new"));
+
+    expect(await db.selectFrom("failure_occurrences").selectAll().execute()).toHaveLength(4);
+    expect(await db.selectFrom("failure_groups").selectAll().execute()).toHaveLength(2);
+
+    // Keep only the 2 newest occurrences -> both belong to "new".
+    await (repo as any).pruneToRowCap(2);
+
+    const occurrences = await db
+      .selectFrom("failure_occurrences")
+      .select("timestamp")
+      .orderBy("timestamp", "asc")
+      .execute();
+    expect(occurrences.map(o => Number(o.timestamp))).toEqual([3000, 4000]);
+
+    // "old" is now orphaned and swept; "new" still has occurrences and survives.
+    const groups = await db.selectFrom("failure_groups").select("signature").execute();
+    expect(groups.map(g => g.signature)).toEqual(["new"]);
+  });
+
+  test("a group that keeps at least one occurrence is NOT swept", async () => {
+    timer.setCurrentTime(1000); await repo.recordFailure(input("keep"));
+    timer.setCurrentTime(2000); await repo.recordFailure(input("keep"));
+    timer.setCurrentTime(3000); await repo.recordFailure(input("keep"));
+
+    // Cap of 2 prunes the single oldest occurrence but the group retains two.
+    await (repo as any).pruneToRowCap(2);
+
+    expect(await db.selectFrom("failure_occurrences").selectAll().execute()).toHaveLength(2);
+    const groups = await db.selectFrom("failure_groups").select("signature").execute();
+    expect(groups.map(g => g.signature)).toEqual(["keep"]);
+  });
+
+  test("under the cap, pruneToRowCap deletes nothing and sweeps no groups", async () => {
+    timer.setCurrentTime(1000); await repo.recordFailure(input("a"));
+    timer.setCurrentTime(2000); await repo.recordFailure(input("b"));
+
+    await (repo as any).pruneToRowCap(10);
+
+    expect(await db.selectFrom("failure_occurrences").selectAll().execute()).toHaveLength(2);
+    expect(await db.selectFrom("failure_groups").selectAll().execute()).toHaveLength(2);
+  });
+});

--- a/test/db/performanceAuditRepository.test.ts
+++ b/test/db/performanceAuditRepository.test.ts
@@ -409,3 +409,53 @@ describe("PerformanceAuditRepository", () => {
     });
   });
 });
+
+describe("PerformanceAuditRepository row-cap retention (#3435)", () => {
+  let db: Kysely<Database>;
+  let repo: PerformanceAuditRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new PerformanceAuditRepository(new FakeTimer(), db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  const at = (n: number): string => new Date(Date.UTC(2024, 5, 1, 0, 0, 0, n)).toISOString();
+
+  test("pruneToRowCap trims to exactly the cap, keeping the newest rows", async () => {
+    for (let i = 1; i <= 12; i++) {
+      await repo.recordAudit(makeRecord({ timestamp: at(i) }));
+    }
+
+    await (repo as any).pruneToRowCap(5);
+
+    const rows = await db
+      .selectFrom("performance_audit_results")
+      .select("timestamp")
+      .orderBy("timestamp", "asc")
+      .execute();
+    expect(rows.map(r => r.timestamp)).toEqual([at(8), at(9), at(10), at(11), at(12)]);
+  });
+
+  test("pruneToRowCap under the cap deletes nothing (count(*) gate short-circuits)", async () => {
+    for (let i = 1; i <= 3; i++) {
+      await repo.recordAudit(makeRecord({ timestamp: at(i) }));
+    }
+
+    await (repo as any).pruneToRowCap(10);
+
+    const rows = await db.selectFrom("performance_audit_results").selectAll().execute();
+    expect(rows).toHaveLength(3);
+  });
+
+  test("a single recordAudit does not trip the amortized offset probe", async () => {
+    // One insert must not trigger a trim (the gate fires only every N inserts);
+    // the public path stays output-preserving under the cap.
+    await repo.recordAudit(makeRecord({ timestamp: at(1) }));
+    const rows = await db.selectFrom("performance_audit_results").selectAll().execute();
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/test/db/rowCapRetention.test.ts
+++ b/test/db/rowCapRetention.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createRowCapRetentionState,
+  runAmortizedRetention,
+} from "../../src/db/rowCapRetention";
+
+/**
+ * Unit coverage for the amortized row-cap retention wrapper shared by the
+ * audit / failure-analytics / test-execution repositories (#3435/#3436/#3440).
+ *
+ * The wrapper owns exactly one concern: an offset-probe cleanup must not run on
+ * every insert. These tests pin:
+ *   1. amortization — the cleanup body fires at most once per `checkInterval`
+ *      calls; the other N-1 calls are synchronous no-ops,
+ *   2. the in-progress guard drops overlapping runs,
+ *   3. the guard is released even when the cleanup body throws.
+ */
+describe("runAmortizedRetention (#3435/#3436/#3440)", () => {
+  test("fires the cleanup body at most once per checkInterval calls", async () => {
+    const state = createRowCapRetentionState();
+    let runs = 0;
+    const interval = 5;
+
+    // interval-1 calls are pure no-ops.
+    for (let i = 0; i < interval - 1; i++) {
+      await runAmortizedRetention(state, async () => { runs++; }, interval);
+    }
+    expect(runs).toBe(0);
+
+    // The interval-th call fires exactly once and resets the counter.
+    await runAmortizedRetention(state, async () => { runs++; }, interval);
+    expect(runs).toBe(1);
+
+    // The cycle repeats: another interval-1 no-ops, then one fire.
+    for (let i = 0; i < interval - 1; i++) {
+      await runAmortizedRetention(state, async () => { runs++; }, interval);
+    }
+    expect(runs).toBe(1);
+    await runAmortizedRetention(state, async () => { runs++; }, interval);
+    expect(runs).toBe(2);
+  });
+
+  test("the in-progress guard drops an overlapping run", async () => {
+    const state = createRowCapRetentionState();
+    let running = 0;
+    let maxConcurrent = 0;
+    let release: () => void = () => {};
+    const gate = new Promise<void>(resolve => { release = resolve; });
+
+    const body = async (): Promise<void> => {
+      running++;
+      maxConcurrent = Math.max(maxConcurrent, running);
+      await gate;
+      running--;
+    };
+
+    // First call arms and enters the body (and parks on `gate`).
+    const first = runAmortizedRetention(state, body, 1);
+    // Second call arms again but must be dropped by the in-progress guard.
+    const second = runAmortizedRetention(state, body, 1);
+
+    release();
+    await Promise.all([first, second]);
+
+    expect(maxConcurrent).toBe(1);
+  });
+
+  test("releases the guard even when the cleanup body throws", async () => {
+    const state = createRowCapRetentionState();
+
+    await expect(
+      runAmortizedRetention(state, async () => { throw new Error("boom"); }, 1)
+    ).rejects.toThrow("boom");
+
+    // The guard is released, so a subsequent gated call can still run.
+    let ran = false;
+    await runAmortizedRetention(state, async () => { ran = true; }, 1);
+    expect(ran).toBe(true);
+  });
+});

--- a/test/db/testExecutionRepository.test.ts
+++ b/test/db/testExecutionRepository.test.ts
@@ -705,3 +705,70 @@ function chunkArray<T>(values: readonly T[], size: number): T[][] {
   }
   return chunks;
 }
+
+describe("TestExecutionRepository retention (#3440)", () => {
+  let db: Kysely<Database>;
+  let repo: TestExecutionRepository;
+  let timer: FakeTimer;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    timer = new FakeTimer();
+    timer.setCurrentTime(10_000_000_000);
+    repo = new TestExecutionRepository(timer, db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("pruneToRowCap trims to exactly the cap, keeping the newest rows", async () => {
+    const base = timer.now();
+    for (let i = 1; i <= 12; i++) {
+      await repo.recordExecution(makeExecution({ timestamp: base + i }));
+    }
+
+    await (repo as any).pruneToRowCap(5);
+
+    const rows = await db
+      .selectFrom("test_executions")
+      .select("timestamp")
+      .orderBy("timestamp", "asc")
+      .execute();
+    expect(rows.map(r => Number(r.timestamp))).toEqual([base + 8, base + 9, base + 10, base + 11, base + 12]);
+  });
+
+  test("pruneToRowCap under the cap deletes nothing (count(*) gate short-circuits)", async () => {
+    const base = timer.now();
+    for (let i = 1; i <= 3; i++) {
+      await repo.recordExecution(makeExecution({ timestamp: base + i }));
+    }
+
+    await (repo as any).pruneToRowCap(10);
+
+    const rows = await db.selectFrom("test_executions").selectAll().execute();
+    expect(rows).toHaveLength(3);
+  });
+
+  test("cleanupRetention still runs the age-based delete on every insert", async () => {
+    // A row older than the retention window must be pruned by the cheap,
+    // sargable age-delete that fires on every insert, independent of the
+    // amortized row-cap probe (#3440). Seed the stale row directly so it isn't
+    // removed by the age-delete on its own insert.
+    const MS_PER_DAY = 24 * 60 * 60 * 1000;
+    const stale = timer.now() - 200 * MS_PER_DAY;
+    await db
+      .insertInto("test_executions")
+      .values({ test_class: "C", test_method: "m", duration_ms: 1, status: "passed", timestamp: stale })
+      .execute();
+    expect(await db.selectFrom("test_executions").selectAll().execute()).toHaveLength(1);
+
+    // A fresh insert triggers cleanupRetention, whose age-delete removes the
+    // stale row even though the row-cap probe is amortized away.
+    const fresh = timer.now();
+    await repo.recordExecution(makeExecution({ timestamp: fresh }));
+
+    const rows = await db.selectFrom("test_executions").select("timestamp").execute();
+    expect(rows.map(r => Number(r.timestamp))).toEqual([fresh]);
+  });
+});


### PR DESCRIPTION
## Summary

`recordAudit` / `recordFailure` / `recordExecution` each ran an unconditional `LIMIT 1 OFFSET 9999` row-cap probe on **every** insert — the offset-probe pattern known to be ~57x slower than a `count(*)` gate (#2799). This puts a 10k-row index walk on the hot write path, at live-metric cadence for audits/failures.

Introduces `src/db/rowCapRetention.ts` with two small primitives:

- **`runAmortizedRetention`** — fires the cleanup body at most once per `CLEANUP_CHECK_INTERVAL` (256) inserts behind an in-progress guard, so the scan leaves the hot path ~255/256 of the time. Mirrors the existing `eventRetention.pruneEventTableByCount` amortization idiom.
- **`pruneTableByRowCap`** — centralizes the `count(*)`-gated trim (threshold offset probe + tie-broken delete, including the #3137 id-tiebreak invariant) so it is **not** hand-copied per repo. The cheap `count(*)` gates the expensive offset walk, which now runs only when actually over cap.

### Per-repo specifics
- **performanceAudit (#3435):** pure row-cap trim via the shared helper.
- **failureAnalytics (#3436):** row-cap trim, then only sweeps orphan groups **when the delete removed rows**, via a correlated `NOT EXISTS` (served by `idx_failure_occurrences_group`, early-exit) instead of `NOT IN (SELECT group_id ... DISTINCT)`.
- **testExecution (#3440):** keeps the cheap sargable age-based delete on **every** insert; only the offset probe is amortized.

## Tests
- `test/db/rowCapRetention.test.ts` — amortization gate (fires 1/N), in-progress guard drops overlap, guard released on throw.
- Per-repo regression tests: trims to exactly the cap keeping the newest rows; under-cap `count(*)` gate short-circuits (no delete); failureAnalytics orphan-group sweep vs. retention of groups that keep an occurrence; testExecution age-delete still runs every insert.
- Full `test/db` suite green (817 tests).

## Notes
Reviewed via `/simplify` (4 cleanup agents): extracted the row-cap *body* (not just the amortization shell) into the shared helper so the correctness-sensitive tie-break invariant lives in one place; dropped an unused batch-count parameter (YAGNI).

Closes #3435, closes #3436, closes #3440.