### PR TITLE
fix(daemon): reject non-finite tap coordinates, matching swipe (#3615)

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1158,10 +1158,17 @@ export class UnixSocketServer {
     if (args.platform !== "android" && args.platform !== "ios") {
       throw new Error("input/tap requires platform 'android' or 'ios'");
     }
-    if (typeof args.x !== "number" || Number.isNaN(args.x) || typeof args.y !== "number" || Number.isNaN(args.y)) {
+    // Reject NaN AND ±Infinity (finiteness), matching parseInputSwipeParams. Number.isNaN
+    // alone lets ±Infinity through, violating the "numeric x and y" contract (#3615).
+    if (
+      typeof args.x !== "number" ||
+      !Number.isFinite(args.x) ||
+      typeof args.y !== "number" ||
+      !Number.isFinite(args.y)
+    ) {
       throw new Error("input/tap requires numeric x and y params");
     }
-    if (args.duration !== undefined && (typeof args.duration !== "number" || Number.isNaN(args.duration))) {
+    if (args.duration !== undefined && (typeof args.duration !== "number" || !Number.isFinite(args.duration))) {
       throw new Error("input/tap duration must be numeric when provided");
     }
     if (args.deviceId !== undefined && typeof args.deviceId !== "string") {

--- a/test/daemon/socketServerInputTap.test.ts
+++ b/test/daemon/socketServerInputTap.test.ts
@@ -433,4 +433,33 @@ describe("UnixSocketServer input/tap", () => {
     expect(nonNumeric.success).toBe(false);
     expect(nonNumeric.error).toBe("input/tap requires numeric x and y params");
   });
+
+  test("parseInputTapParams rejects non-finite x/y/duration, matching swipe (#3615)", () => {
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    // ±Infinity cannot survive a JSON round-trip (stringify -> null, parse rejects the
+    // literal), so it only reaches the parser from a non-JSON in-process caller. Exercise
+    // parseInputTapParams directly with the raw floats the parser is responsible for.
+    const parseTap = (args: Record<string, unknown>): unknown =>
+      (server as unknown as { parseInputTapParams(params: unknown): unknown }).parseInputTapParams(args);
+
+    for (const bad of [Infinity, -Infinity, NaN]) {
+      expect(() => parseTap({ platform: "android", x: bad, y: 10 })).toThrow(
+        "input/tap requires numeric x and y params"
+      );
+      expect(() => parseTap({ platform: "android", x: 5, y: bad })).toThrow(
+        "input/tap requires numeric x and y params"
+      );
+    }
+    expect(() => parseTap({ platform: "android", x: 5, y: 10, duration: Infinity })).toThrow(
+      "input/tap duration must be numeric when provided"
+    );
+
+    // Finite values still parse successfully (no over-rejection regression).
+    expect(parseTap({ platform: "android", x: 5, y: 10, duration: 200 })).toMatchObject({
+      platform: "android",
+      x: 5,
+      y: 10,
+      duration: 200,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Closes #3615.

`parseInputTapParams` (`src/daemon/socketServer.ts`) validated `x`/`y`/`duration` with `Number.isNaN`. Because `Number.isNaN(Infinity) === false` and `typeof Infinity === "number"`, `input/tap` **accepted `±Infinity`**, while the sibling `parseInputSwipeParams` deliberately rejects non-finite values via `!Number.isFinite`. Classic intra-change copy-paste drift; the parser violated its own `"requires numeric x and y"` contract.

## Change
Switch the tap checks to `!Number.isFinite` for `x`, `y`, and `duration`, so tap and swipe use the same finiteness validation.

Impact is bounded (a JSON client stringifies `Infinity` → `null`, and downstream runners carry their own non-finite guards per #2964), so this is contract-correctness/anti-drift hardening.

## Test
`parseInputTapParams` is exercised **directly** rather than over the socket: `±Infinity`/`NaN` cannot survive a JSON round-trip (`JSON.stringify` → `null`, `JSON.parse` rejects the literal), so the non-finite value only reaches the parser from a non-JSON in-process caller. The test asserts `Infinity`/`-Infinity`/`NaN` are rejected for `x`/`y`/`duration` and that finite values still parse — a guard that fails against the old `Number.isNaN` implementation.

`bun test` (tap + swipe), `bunx turbo run build lint`, and `bun run typecheck` all green.