### PR TITLE
fix(desktop-core): run screenshot action on composition scope, not GlobalScope (#3603)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -482,22 +483,32 @@ fun AutoMobileContent(
       }
     }
 
-  // Register the screenshot callback on the shared MenuBarActions bridge so the
-  // native menu bar "Take Screenshot" item can trigger it.
-  DisposableEffect(clientProvider) {
-    actions.onTakeScreenshot = {
-      val provider = clientProvider
-      if (provider != null) {
-        kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO) {
+  // Take-screenshot is driven from both the native menu bar and the in-app menu.
+  // Run it on a composition-scoped coroutine (not GlobalScope) so the call and its
+  // MCP client are cancelled when this composable leaves composition instead of
+  // leaking a hung coroutine + client if the daemon is unresponsive (#3603).
+  val screenshotScope = rememberCoroutineScope()
+  val takeScreenshot: () -> Unit =
+    remember(clientProvider, screenshotScope) {
+      takeScreenshot@{
+        val provider = clientProvider ?: return@takeScreenshot
+        screenshotScope.launch(Dispatchers.IO) {
           val client = provider()
           try {
             client.callTool("screenshot", buildJsonObject {})
-          } catch (_: Exception) {} finally {
+          } catch (e: Exception) {
+            LOG.warn("Screenshot request failed: ${e.message}")
+          } finally {
             client.close()
           }
         }
       }
     }
+
+  // Register the screenshot callback on the shared MenuBarActions bridge so the
+  // native menu bar "Take Screenshot" item can trigger it.
+  DisposableEffect(takeScreenshot) {
+    actions.onTakeScreenshot = takeScreenshot
     onDispose { actions.onTakeScreenshot = null }
   }
 
@@ -1068,19 +1079,7 @@ fun AutoMobileContent(
         onSwitchToDarkMode = { isDarkMode = true },
         onSwitchToLightMode = { isDarkMode = false },
         onOpenSettings = { showSettings = true },
-        onTakeScreenshot = {
-          val provider = clientProvider
-          if (provider != null) {
-            kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO) {
-              val client = provider()
-              try {
-                client.callTool("screenshot", buildJsonObject {})
-              } catch (_: Exception) {} finally {
-                client.close()
-              }
-            }
-          }
-        },
+        onTakeScreenshot = takeScreenshot,
         onToggleLiveLayout = { showNavigationView = !showNavigationView },
       )
     )

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/ScreenshotActionScopeTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/ScreenshotActionScopeTest.kt
@@ -1,0 +1,72 @@
+package dev.jasonpearson.automobile.desktop.core
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for #3603: the take-screenshot action must run on a composition-scoped coroutine
+ * (`rememberCoroutineScope`) rather than `GlobalScope`, so the call and its MCP client are
+ * cancelled when the composable leaves composition instead of leaking a hung coroutine + client.
+ *
+ * Compose interaction is impractical to unit test here, so this asserts the invariant at the source
+ * level (per the issue's suggested source-scan strategy).
+ */
+class ScreenshotActionScopeTest {
+  private val source =
+    Path.of("src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt").let {
+      assertTrue(Files.exists(it), "$it should exist")
+      Files.readString(it)
+    }
+
+  @Test
+  fun `screenshot action is launched on the composition scope, not GlobalScope`() {
+    val marker = "callTool(\"screenshot\""
+    val occurrences = source.indicesOf(marker)
+    assertTrue(occurrences.isNotEmpty(), "the screenshot handler should still exist")
+
+    occurrences.forEach { idx ->
+      val preceding = source.substring(maxOf(0, idx - 400), idx)
+      assertTrue(
+        preceding.contains("screenshotScope.launch"),
+        "the screenshot callTool must be launched on the composition-scoped screenshotScope (#3603)",
+      )
+      assertFalse(
+        preceding.contains("GlobalScope"),
+        "the screenshot callTool must not run on GlobalScope (#3603)",
+      )
+    }
+  }
+
+  @Test
+  fun `screenshot scope is bound to rememberCoroutineScope`() {
+    assertTrue(
+      source.contains("val screenshotScope = rememberCoroutineScope()"),
+      "screenshot work must be tied to a composition-scoped coroutine (#3603)",
+    )
+  }
+
+  @Test
+  fun `screenshot handler is defined once and shared by both menus`() {
+    // Both the native menu bar and the in-app menu route through the single shared lambda, so the
+    // screenshot callTool appears exactly once.
+    assertEquals(
+      1,
+      source.indicesOf("callTool(\"screenshot\"").size,
+      "the two screenshot entry points should share one handler",
+    )
+  }
+
+  private fun String.indicesOf(needle: String): List<Int> {
+    val result = mutableListOf<Int>()
+    var from = indexOf(needle)
+    while (from >= 0) {
+      result.add(from)
+      from = indexOf(needle, from + needle.length)
+    }
+    return result
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #3603. The take-screenshot action — reachable from both the native menu bar and the in-app menu — launched `client.callTool("screenshot")` on `GlobalScope`. Because it is unstructured it isn't cancelled when the composable leaves composition; if `callTool` hangs (MCP unresponsive) the coroutine and its client leak until the network layer times out, and rapid clicks spawn unbounded concurrent screenshot calls.

## Fix
Extract a single composition-scoped `takeScreenshot` handler bound to `rememberCoroutineScope()`. Both entry points now share it, so the work (and its client) is cancelled when the composable leaves composition. The previously-swallowed exception is now logged (`LOG.warn`) per the repo error-handling convention.

The handler is `remember`ed on `clientProvider` so the `DisposableEffect` menu-bar registration keeps its original re-registration cadence (keyed to the provider, not every recomposition).

## Tests
`ScreenshotActionScopeTest` — a source-scan guard (per the issue's suggested strategy, since Compose interaction is impractical to unit test) asserting the screenshot `callTool` is launched on `screenshotScope` and never `GlobalScope`, that the scope is a `rememberCoroutineScope()`, and that both menus share one handler.

Scope note: three unrelated `GlobalScope.launch` sites remain in this file (kill-device, and the two start-device handlers tracked by #3609); this PR is deliberately limited to the screenshot action.

Automated bug-hunt origin; verified locally via `:desktop-core:test`.