### PR TITLE
test(resources): add dedicated tests for test-timings/performance-results/localization

### DIFF
--- a/src/server/localizationResources.ts
+++ b/src/server/localizationResources.ts
@@ -8,6 +8,10 @@ const LOCALIZATION_RESOURCE_TEMPLATES = {
   DEVICE_LOCALIZATION: "automobile:devices/{deviceId}/localization"
 } as const;
 
+export interface LocalizationSettingsProvider {
+  getLocalizationSettings(): Promise<LocalizationSettingsResult>;
+}
+
 interface LocalizationResourceContent {
   deviceId: string;
   platform: BootedDevice["platform"];
@@ -56,7 +60,11 @@ function toLocalizationResourceContent(
   };
 }
 
-async function getLocalizationResource(deviceId: string): Promise<ResourceContent> {
+export async function getLocalizationResource(
+  deviceId: string,
+  createSettingsProvider: (device: BootedDevice) => LocalizationSettingsProvider =
+  device => new SystemConfigurationManager(device)
+): Promise<ResourceContent> {
   const uri = `automobile:devices/${deviceId}/localization`;
   const device = await findBootedDevice(deviceId);
   if (!device) {
@@ -69,8 +77,8 @@ async function getLocalizationResource(deviceId: string): Promise<ResourceConten
     };
   }
 
-  const manager = new SystemConfigurationManager(device);
-  const settings = await manager.getLocalizationSettings();
+  const provider = createSettingsProvider(device);
+  const settings = await provider.getLocalizationSettings();
   const content = toLocalizationResourceContent(device, settings);
 
   return {

--- a/src/server/performanceData.ts
+++ b/src/server/performanceData.ts
@@ -25,6 +25,11 @@ interface PerformanceAuditResponse {
 const auditRepository = new PerformanceAuditRepository();
 const toolCallRepository = new ToolCallRepository();
 
+export interface PerformanceAuditRepositories {
+  auditRepository: PerformanceAuditRepository;
+  toolCallRepository: ToolCallRepository;
+}
+
 function normalizeTimestamp(value?: string | number): string | undefined {
   if (value === undefined || value === null) {
     return undefined;
@@ -54,14 +59,15 @@ function getTimestampRange(timestamps: string[]): { start: string; end: string }
 }
 
 export async function buildPerformanceAuditResponse(
-  args: PerformanceAuditQueryArgs
+  args: PerformanceAuditQueryArgs,
+  repositories: PerformanceAuditRepositories = { auditRepository, toolCallRepository }
 ): Promise<PerformanceAuditResponse> {
   const startTime = normalizeTimestamp(args.startTime);
   const endTime = normalizeTimestamp(args.endTime);
   const limit = args.limit ?? DEFAULT_PERFORMANCE_RESULTS_LIMIT;
   const offset = args.offset ?? DEFAULT_PERFORMANCE_RESULTS_OFFSET;
 
-  const page = await auditRepository.listResults({
+  const page = await repositories.auditRepository.listResults({
     startTime,
     endTime,
     limit,
@@ -71,7 +77,7 @@ export async function buildPerformanceAuditResponse(
 
   const range = getTimestampRange(page.results.map(result => result.timestamp));
   const toolCalls = range
-    ? await toolCallRepository.listToolNamesBetween(range.start, range.end)
+    ? await repositories.toolCallRepository.listToolNamesBetween(range.start, range.end)
     : [];
 
   return {

--- a/src/server/testTimingData.ts
+++ b/src/server/testTimingData.ts
@@ -66,7 +66,10 @@ interface TestTimingResponse {
 
 const testExecutionRepository = new TestExecutionRepository();
 
-export async function buildTestTimingResponse(args: TestTimingQueryArgs): Promise<TestTimingResponse> {
+export async function buildTestTimingResponse(
+  args: TestTimingQueryArgs,
+  repository: TestExecutionRepository = testExecutionRepository
+): Promise<TestTimingResponse> {
   const lookbackDays = args.lookbackDays ?? DEFAULT_TEST_TIMING_LOOKBACK_DAYS;
   const limit = args.limit ?? DEFAULT_TEST_TIMING_LIMIT;
   const minSamples = args.minSamples ?? DEFAULT_TEST_TIMING_MIN_SAMPLES;
@@ -93,7 +96,7 @@ export async function buildTestTimingResponse(args: TestTimingQueryArgs): Promis
     sessionUuid: args.sessionUuid,
   };
 
-  const timings = await testExecutionRepository.getTimingStats(options);
+  const timings = await repository.getTimingStats(options);
   const totalSamples = timings.reduce((total, entry) => total + entry.sampleSize, 0);
 
   const filters: Record<string, unknown> = {};

--- a/test/server/localizationResources.test.ts
+++ b/test/server/localizationResources.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { BootedDevice, LocalizationSettingsResult } from "../../src/models";
+import {
+  getLocalizationResource,
+  registerLocalizationResources,
+  type LocalizationSettingsProvider,
+} from "../../src/server/localizationResources";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+
+function makeDevice(overrides: Partial<BootedDevice> = {}): BootedDevice {
+  return {
+    deviceId: "emulator-5554",
+    name: "Pixel 8",
+    platform: "android",
+    ...overrides,
+  } as BootedDevice;
+}
+
+function makeSettings(overrides: Partial<LocalizationSettingsResult> = {}): LocalizationSettingsResult {
+  return {
+    success: true,
+    locale: "en-US",
+    timeZone: "America/Los_Angeles",
+    textDirection: "ltr",
+    timeFormat: "12",
+    calendarSystem: "gregorian",
+    ...overrides,
+  };
+}
+
+class FakeLocalizationSettingsProvider implements LocalizationSettingsProvider {
+  constructor(private readonly result: LocalizationSettingsResult) {}
+
+  async getLocalizationSettings(): Promise<LocalizationSettingsResult> {
+    return this.result;
+  }
+}
+
+describe("localizationResources", () => {
+  afterEach(() => {
+    PlatformDeviceManagerFactory.reset();
+  });
+
+  describe("getLocalizationResource", () => {
+    test("returns localization settings for a booted device", async () => {
+      const device = makeDevice();
+      const fakeManager = new FakeDeviceManager([], [device]);
+      PlatformDeviceManagerFactory.setInstance(fakeManager);
+
+      const content = await getLocalizationResource(
+        device.deviceId,
+        () => new FakeLocalizationSettingsProvider(makeSettings())
+      );
+
+      const parsed = JSON.parse(content.text ?? "{}");
+      expect(parsed.deviceId).toBe(device.deviceId);
+      expect(parsed.locale).toBe("en-US");
+      expect(parsed.timeZone).toBe("America/Los_Angeles");
+      expect(parsed.textDirection).toBe("ltr");
+      expect(parsed.success).toBe(true);
+    });
+
+    test("returns an error payload when the device is not booted", async () => {
+      PlatformDeviceManagerFactory.setInstance(new FakeDeviceManager([], []));
+
+      const content = await getLocalizationResource(
+        "not-a-real-device",
+        () => new FakeLocalizationSettingsProvider(makeSettings())
+      );
+
+      const parsed = JSON.parse(content.text ?? "{}");
+      expect(parsed.error).toContain("not-a-real-device");
+    });
+
+    test("surfaces a failed settings read", async () => {
+      const device = makeDevice();
+      PlatformDeviceManagerFactory.setInstance(new FakeDeviceManager([], [device]));
+
+      const content = await getLocalizationResource(
+        device.deviceId,
+        () => new FakeLocalizationSettingsProvider(makeSettings({ success: false, error: "adb shell failed", locale: null }))
+      );
+
+      const parsed = JSON.parse(content.text ?? "{}");
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toBe("adb shell failed");
+      expect(parsed.locale).toBeNull();
+    });
+  });
+
+  describe("resource registration", () => {
+    afterEach(() => {
+      ResourceRegistry.clearResources();
+    });
+
+    test("registers the device localization template", () => {
+      registerLocalizationResources();
+
+      const templates = ResourceRegistry.getAllTemplates();
+      const template = templates.find(t => t.uriTemplate === "automobile:devices/{deviceId}/localization");
+      expect(template).toBeDefined();
+    });
+  });
+});

--- a/test/server/performanceResources.test.ts
+++ b/test/server/performanceResources.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "../db/testDbHelper";
+import { FakeTimer } from "../fakes/FakeTimer";
+import {
+  PerformanceAuditRepository,
+  type PerformanceAuditRecord,
+  type PerformanceAuditMetricsRecord,
+} from "../../src/db/performanceAuditRepository";
+import { ToolCallRepository } from "../../src/db/toolCallRepository";
+import { buildPerformanceAuditResponse } from "../../src/server/performanceData";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { registerPerformanceResources } from "../../src/server/performanceResources";
+
+function makeMetrics(overrides: Partial<PerformanceAuditMetricsRecord> = {}): PerformanceAuditMetricsRecord {
+  return {
+    p50Ms: 8,
+    p90Ms: 12,
+    p95Ms: 14,
+    p99Ms: 18,
+    jankCount: 2,
+    missedVsyncCount: 1,
+    slowUiThreadCount: 0,
+    frameDeadlineMissedCount: 3,
+    cpuUsagePercent: 45,
+    touchLatencyMs: 50,
+    ...overrides,
+  };
+}
+
+function makeRecord(overrides: Partial<PerformanceAuditRecord> = {}): PerformanceAuditRecord {
+  return {
+    deviceId: "device-1",
+    sessionId: "session-1",
+    packageName: "com.example.app",
+    timestamp: "2024-06-01T12:00:00.000Z",
+    passed: true,
+    metrics: makeMetrics(),
+    diagnostics: null,
+    ...overrides,
+  };
+}
+
+describe("performanceData", () => {
+  let db: Kysely<Database>;
+  let auditRepo: PerformanceAuditRepository;
+  let toolCallRepo: ToolCallRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    auditRepo = new PerformanceAuditRepository(new FakeTimer(), db);
+    toolCallRepo = new ToolCallRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  describe("buildPerformanceAuditResponse", () => {
+    test("returns recorded results with tool calls in the timestamp range", async () => {
+      await auditRepo.recordAudit(makeRecord());
+      await toolCallRepo.recordToolCall({
+        toolName: "swipeOn",
+        timestamp: "2024-06-01T12:00:00.000Z",
+      });
+
+      const response = await buildPerformanceAuditResponse(
+        {},
+        { auditRepository: auditRepo, toolCallRepository: toolCallRepo }
+      );
+
+      expect(response.results).toHaveLength(1);
+      expect(response.results[0].deviceId).toBe("device-1");
+      expect(response.toolCalls).toContain("swipeOn");
+      expect(response.range).not.toBeNull();
+    });
+
+    test("filters by deviceId", async () => {
+      await auditRepo.recordAudit(makeRecord({ deviceId: "device-1" }));
+      await auditRepo.recordAudit(makeRecord({ deviceId: "device-2" }));
+
+      const response = await buildPerformanceAuditResponse(
+        { deviceId: "device-2" },
+        { auditRepository: auditRepo, toolCallRepository: toolCallRepo }
+      );
+
+      expect(response.results).toHaveLength(1);
+      expect(response.results[0].deviceId).toBe("device-2");
+    });
+
+    test("returns empty results and a null range when nothing matches", async () => {
+      const response = await buildPerformanceAuditResponse(
+        { deviceId: "no-such-device" },
+        { auditRepository: auditRepo, toolCallRepository: toolCallRepo }
+      );
+
+      expect(response.results).toHaveLength(0);
+      expect(response.range).toBeNull();
+      expect(response.toolCalls).toHaveLength(0);
+    });
+
+    test("respects the limit option and reports hasMore/nextOffset", async () => {
+      await auditRepo.recordAudit(makeRecord({ sessionId: "session-1" }));
+      await auditRepo.recordAudit(makeRecord({ sessionId: "session-2" }));
+
+      const response = await buildPerformanceAuditResponse(
+        { limit: 1 },
+        { auditRepository: auditRepo, toolCallRepository: toolCallRepo }
+      );
+
+      expect(response.results).toHaveLength(1);
+      expect(response.hasMore).toBe(true);
+      expect(response.nextOffset).toBe(1);
+    });
+  });
+
+  describe("resource registration", () => {
+    afterEach(() => {
+      ResourceRegistry.clearResources();
+    });
+
+    test("registers the base URI and query-param templates", () => {
+      registerPerformanceResources();
+
+      expect(ResourceRegistry.getResource("automobile:performance-results")).toBeDefined();
+
+      const templates = ResourceRegistry.getAllTemplates();
+      const queryTemplates = templates.filter(t => t.uriTemplate.startsWith("automobile:performance-results?"));
+      expect(queryTemplates.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/test/server/testTimingResources.test.ts
+++ b/test/server/testTimingResources.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "../db/testDbHelper";
+import { FakeTimer } from "../fakes/FakeTimer";
+import {
+  TestExecutionRepository,
+  type TestExecutionRecord,
+} from "../../src/db/testExecutionRepository";
+import { buildTestTimingResponse } from "../../src/server/testTimingData";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { registerTestTimingResources } from "../../src/server/testTimingResources";
+
+function makeExecution(overrides: Partial<TestExecutionRecord> = {}): TestExecutionRecord {
+  return {
+    testClass: "com.example.LoginTest",
+    testMethod: "testLoginSuccess",
+    durationMs: 1500,
+    status: "passed",
+    timestamp: 1_000_000,
+    ...overrides,
+  };
+}
+
+describe("testTimingData", () => {
+  let db: Kysely<Database>;
+  let timer: FakeTimer;
+  let repo: TestExecutionRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    timer = new FakeTimer();
+    timer.setCurrentTime(2_000_000);
+    repo = new TestExecutionRepository(timer, db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  describe("buildTestTimingResponse", () => {
+    test("returns aggregated timing stats for recorded executions", async () => {
+      await repo.recordExecution(makeExecution());
+      await repo.recordExecution(makeExecution({ durationMs: 2500, timestamp: 1_100_000 }));
+
+      const response = await buildTestTimingResponse({}, repo);
+
+      expect(response.totalTests).toBe(1);
+      expect(response.totalSamples).toBe(2);
+      expect(response.testTimings).toHaveLength(1);
+      expect(response.testTimings[0].testClass).toBe("com.example.LoginTest");
+      expect(response.testTimings[0].sampleSize).toBe(2);
+      expect(response.testTimings[0].statusCounts.passed).toBe(2);
+    });
+
+    test("filters by testClass", async () => {
+      await repo.recordExecution(makeExecution());
+      await repo.recordExecution(makeExecution({ testClass: "com.example.SignupTest" }));
+
+      const response = await buildTestTimingResponse({ testClass: "com.example.SignupTest" }, repo);
+
+      expect(response.testTimings).toHaveLength(1);
+      expect(response.testTimings[0].testClass).toBe("com.example.SignupTest");
+      expect(response.filters.testClass).toBe("com.example.SignupTest");
+    });
+
+    test("returns empty results when no executions match", async () => {
+      const response = await buildTestTimingResponse({ testClass: "com.example.Nonexistent" }, repo);
+
+      expect(response.testTimings).toHaveLength(0);
+      expect(response.totalTests).toBe(0);
+      expect(response.totalSamples).toBe(0);
+    });
+
+    test("respects the limit option", async () => {
+      await repo.recordExecution(makeExecution({ testMethod: "testA" }));
+      await repo.recordExecution(makeExecution({ testMethod: "testB" }));
+
+      const response = await buildTestTimingResponse({ limit: 1 }, repo);
+
+      expect(response.testTimings).toHaveLength(1);
+      expect(response.aggregation.limit).toBe(1);
+    });
+  });
+
+  describe("resource registration", () => {
+    afterEach(() => {
+      ResourceRegistry.clearResources();
+    });
+
+    test("registers the base URI and a query-param template", () => {
+      registerTestTimingResources();
+
+      expect(ResourceRegistry.getResource("automobile:test-timings")).toBeDefined();
+
+      const templates = ResourceRegistry.getAllTemplates();
+      const queryTemplate = templates.find(t => t.uriTemplate.startsWith("automobile:test-timings?"));
+      expect(queryTemplate).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
#3576's doc-drift portion was already fixed in #3719 (which deliberately left the issue open for this follow-up: the add-tests item + query-param template verification).

- `buildTestTimingResponse` and `buildPerformanceAuditResponse` now accept an optional injectable repository/repositories param (default unchanged, matches the existing repository DI pattern), so they can be exercised against an in-memory DB in tests without tripping the unit-test real-DB guard.
- `getLocalizationResource` now accepts an optional `LocalizationSettingsProvider` factory (default unchanged), so it can be tested with a fake device manager + fake settings provider instead of real adb/simctl calls.
- Added `test/server/testTimingResources.test.ts`, `test/server/performanceResources.test.ts`, `test/server/localizationResources.test.ts` covering filtering, pagination, empty-result, and error paths, plus confirming each resource's query-param template is registered (not just the base URI) — closing the last two `#3576` checklist items.

## Test plan
- [x] `bun test` — 7711 pass, 0 fail
- [x] `turbo run lint build` — clean
- [x] `bun run typecheck` — no new errors

Fixes #3576