### PR TITLE
perf(observe): pre-normalize edges into a lookup index in PredictiveUIState (#3428)

### DIFF
--- a/src/features/observe/PredictiveUIState.ts
+++ b/src/features/observe/PredictiveUIState.ts
@@ -7,9 +7,9 @@ import {
   PredictionTarget,
   Predictions
 } from "../../models";
-import { NavigationEdge, NavigationGraphManager, UIState } from "../navigation/NavigationGraphManager";
+import { NavigationEdge, NavigationGraphManager } from "../navigation/NavigationGraphManager";
 import { PredictionHistoryRepository } from "../../db/predictionHistoryRepository";
-import { normalizeToolArgs } from "../../utils/predictionUtils";
+import { normalizeToolArgs, normalizeIdentifier } from "../../utils/predictionUtils";
 import type { PredictiveUIState as PredictiveUIStateInterface } from "./interfaces/PredictiveUIState";
 
 interface InteractableElement {
@@ -19,6 +19,115 @@ interface InteractableElement {
   resourceId?: string;
   clickable: boolean;
   scrollable: boolean;
+}
+
+interface IndexedEdge {
+  edge: NavigationEdge;
+  index: number;
+}
+
+/**
+ * Pre-normalized lookup index over a screen's actionable edges (issue #3428).
+ *
+ * The old `findMatchingEdge` re-ran `.trim().toLowerCase()` on every edge's args
+ * for every interactable (O(interactables x edges) normalizations) and linearly
+ * scanned all edges per interactable. This normalizes each edge exactly once at
+ * construction and resolves each interactable via a constant number of Map
+ * lookups: O(I x E) -> O(I + E).
+ *
+ * `findMatch` returns the edge with the lowest original index among all matching
+ * paths, which is identical to the previous "first edge in edge order that
+ * matches by any path" behavior.
+ */
+export class EdgeMatchIndex {
+  // tapOn: keyed by normalized args.text / element id.
+  private readonly tapByText = new Map<string, IndexedEdge>();
+  private readonly tapById = new Map<string, IndexedEdge>();
+  // swipeOn: keyed by normalized container text / id / content-desc.
+  private readonly swipeByText = new Map<string, IndexedEdge>();
+  private readonly swipeById = new Map<string, IndexedEdge>();
+  private readonly swipeByDesc = new Map<string, IndexedEdge>();
+
+  constructor(edges: NavigationEdge[]) {
+    edges.forEach((edge, index) => {
+      const toolName = edge.interaction?.toolName;
+      if (toolName === "tapOn") {
+        this.indexTapEdge(edge, index);
+      } else if (toolName === "swipeOn") {
+        this.indexSwipeEdge(edge, index);
+      }
+    });
+  }
+
+  private indexTapEdge(edge: NavigationEdge, index: number): void {
+    const args = edge.interaction?.args;
+    this.addKey(this.tapByText, normalizeIdentifier(args?.text), edge, index);
+    this.addKey(this.tapById, normalizeIdentifier(args?.elementId ?? args?.id), edge, index);
+  }
+
+  private indexSwipeEdge(edge: NavigationEdge, index: number): void {
+    const args = edge.interaction?.args;
+    const container = args?.container || edge.interaction?.uiState?.scrollPosition?.container;
+    if (!container) {
+      return;
+    }
+    this.addKey(this.swipeByText, normalizeIdentifier(container.text), edge, index);
+    this.addKey(this.swipeById, normalizeIdentifier(container.elementId || container.resourceId), edge, index);
+    this.addKey(this.swipeByDesc, normalizeIdentifier(container.contentDesc), edge, index);
+  }
+
+  // First edge wins for a given key (preserves edge-order tie-breaking); empty
+  // keys are skipped, matching the old `if (!normalized) return false` guards.
+  private addKey(map: Map<string, IndexedEdge>, key: string | undefined, edge: NavigationEdge, index: number): void {
+    if (!key || map.has(key)) {
+      return;
+    }
+    map.set(key, { edge, index });
+  }
+
+  findMatch(interactable: InteractableElement): NavigationEdge | undefined {
+    const text = normalizeIdentifier(interactable.text);
+    const contentDesc = normalizeIdentifier(interactable.contentDesc);
+    const resourceId = normalizeIdentifier(interactable.resourceId);
+
+    let best: IndexedEdge | undefined;
+    const consider = (candidate?: IndexedEdge): void => {
+      if (candidate && (!best || candidate.index < best.index)) {
+        best = candidate;
+      }
+    };
+
+    if (interactable.clickable) {
+      // tapOn: args.text matches the interactable's text or content-desc; an
+      // element id matches its resource id.
+      if (text) {
+        consider(this.tapByText.get(text));
+      }
+      if (contentDesc) {
+        consider(this.tapByText.get(contentDesc));
+      }
+      if (resourceId) {
+        consider(this.tapById.get(resourceId));
+      }
+    }
+
+    if (interactable.scrollable) {
+      // swipeOn: container text matches text/content-desc; container id matches
+      // resource id; container content-desc matches content-desc.
+      if (text) {
+        consider(this.swipeByText.get(text));
+      }
+      if (contentDesc) {
+        consider(this.swipeByText.get(contentDesc));
+        consider(this.swipeByDesc.get(contentDesc));
+      }
+      if (resourceId) {
+        consider(this.swipeById.get(resourceId));
+      }
+    }
+
+    return best?.edge;
+  }
 }
 
 export class PredictiveUIState implements PredictiveUIStateInterface {
@@ -68,8 +177,10 @@ export class PredictiveUIState implements PredictiveUIStateInterface {
       transitionStatsByKey.set(key, stat);
     }
 
+    const edgeIndex = new EdgeMatchIndex(actionableEdges);
+
     for (const interactable of interactables) {
-      const match = this.findMatchingEdge(interactable, actionableEdges);
+      const match = edgeIndex.findMatch(interactable);
       if (!match || !match.interaction) {
         continue;
       }
@@ -151,93 +262,6 @@ export class PredictiveUIState implements PredictiveUIStateInterface {
     }
 
     return interactables;
-  }
-
-  private findMatchingEdge(
-    interactable: InteractableElement,
-    edges: NavigationEdge[]
-  ): NavigationEdge | undefined {
-    for (const edge of edges) {
-      const toolName = edge.interaction?.toolName;
-      const args = edge.interaction?.args;
-      const uiState = edge.interaction?.uiState;
-
-      if (toolName === "tapOn" && interactable.clickable) {
-        if (this.matchesTapOn(interactable, args)) {
-          return edge;
-        }
-      }
-
-      if (toolName === "swipeOn" && interactable.scrollable) {
-        if (this.matchesSwipeOn(interactable, args, uiState)) {
-          return edge;
-        }
-      }
-    }
-
-    return undefined;
-  }
-
-  private matchesTapOn(interactable: InteractableElement, args?: Record<string, any>): boolean {
-    if (!args) {
-      return false;
-    }
-
-    const hasTextMatch = this.matchesText(args.text, interactable);
-    const elementId = args.elementId ?? args.id;
-    const hasIdMatch = this.matchesResourceId(elementId, interactable);
-
-    return (args.text && hasTextMatch) || (elementId && hasIdMatch);
-  }
-
-  private matchesSwipeOn(
-    interactable: InteractableElement,
-    args?: Record<string, any>,
-    uiState?: UIState
-  ): boolean {
-    const container = args?.container || uiState?.scrollPosition?.container;
-    if (!container) {
-      return false;
-    }
-
-    const containerText = container.text;
-    const containerId = container.elementId || container.resourceId;
-    const containerDesc = container.contentDesc;
-
-    return (
-      this.matchesText(containerText, interactable) ||
-      this.matchesResourceId(containerId, interactable) ||
-      this.matchesContentDesc(containerDesc, interactable)
-    );
-  }
-
-  private matchesText(text: string | undefined, interactable: InteractableElement): boolean {
-    const normalized = this.normalizeValue(text);
-    if (!normalized) {
-      return false;
-    }
-    return normalized === this.normalizeValue(interactable.text)
-      || normalized === this.normalizeValue(interactable.contentDesc);
-  }
-
-  private matchesResourceId(resourceId: string | undefined, interactable: InteractableElement): boolean {
-    const normalized = this.normalizeValue(resourceId);
-    if (!normalized) {
-      return false;
-    }
-    return normalized === this.normalizeValue(interactable.resourceId);
-  }
-
-  private matchesContentDesc(contentDesc: string | undefined, interactable: InteractableElement): boolean {
-    const normalized = this.normalizeValue(contentDesc);
-    if (!normalized) {
-      return false;
-    }
-    return normalized === this.normalizeValue(interactable.contentDesc);
-  }
-
-  private normalizeValue(value: string | undefined): string | undefined {
-    return value?.trim().toLowerCase();
   }
 
   private buildTarget(edge: NavigationEdge, interactable: InteractableElement): PredictionTarget | null {

--- a/test/features/observe/EdgeMatchIndex.test.ts
+++ b/test/features/observe/EdgeMatchIndex.test.ts
@@ -1,0 +1,173 @@
+import { expect, describe, test } from "bun:test";
+import { EdgeMatchIndex } from "../../../src/features/observe/PredictiveUIState";
+import type { NavigationEdge } from "../../../src/features/navigation/NavigationGraphManager";
+import type { Element } from "../../../src/models";
+
+// Reuse the exact parameter type of findMatch without exporting the private
+// InteractableElement interface.
+type Interactable = Parameters<EdgeMatchIndex["findMatch"]>[0];
+
+function tapEdge(args: Record<string, any>, to = "B"): NavigationEdge {
+  return {
+    from: "A",
+    to,
+    timestamp: 1,
+    edgeType: "tool",
+    interaction: { toolName: "tapOn", args, timestamp: 1 }
+  };
+}
+
+function swipeEdge(args: Record<string, any>, to = "B"): NavigationEdge {
+  return {
+    from: "A",
+    to,
+    timestamp: 1,
+    edgeType: "tool",
+    interaction: { toolName: "swipeOn", args, timestamp: 1 }
+  };
+}
+
+function interactable(overrides: Partial<Interactable>): Interactable {
+  return {
+    element: {} as Element,
+    clickable: false,
+    scrollable: false,
+    ...overrides
+  };
+}
+
+describe("EdgeMatchIndex", () => {
+  describe("tapOn", () => {
+    test("matches a clickable interactable by text", () => {
+      const edge = tapEdge({ text: "Submit" });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ text: "Submit", clickable: true }))).toBe(edge);
+    });
+
+    test("matches when the edge text equals the interactable content-desc", () => {
+      const edge = tapEdge({ text: "Close" });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ contentDesc: "Close", clickable: true }))).toBe(edge);
+    });
+
+    test("matches by element id against the interactable resource id", () => {
+      const edge = tapEdge({ elementId: "com.app:id/ok" });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ resourceId: "com.app:id/ok", clickable: true }))).toBe(edge);
+    });
+
+    test("supports the legacy `id` arg alias", () => {
+      const edge = tapEdge({ id: "com.app:id/ok" });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ resourceId: "com.app:id/ok", clickable: true }))).toBe(edge);
+    });
+
+    test("does not match a tapOn edge when the interactable is not clickable", () => {
+      const edge = tapEdge({ text: "Submit" });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ text: "Submit", scrollable: true }))).toBeUndefined();
+    });
+  });
+
+  describe("swipeOn", () => {
+    test("matches a scrollable interactable by container text", () => {
+      const edge = swipeEdge({ container: { text: "List" } });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ text: "List", scrollable: true }))).toBe(edge);
+    });
+
+    test("matches container text against the interactable content-desc", () => {
+      const edge = swipeEdge({ container: { text: "Feed" } });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ contentDesc: "Feed", scrollable: true }))).toBe(edge);
+    });
+
+    test("matches by container resource id", () => {
+      const edge = swipeEdge({ container: { resourceId: "com.app:id/list" } });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ resourceId: "com.app:id/list", scrollable: true }))).toBe(edge);
+    });
+
+    test("matches by container content-desc", () => {
+      const edge = swipeEdge({ container: { contentDesc: "Scrollable feed" } });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ contentDesc: "Scrollable feed", scrollable: true }))).toBe(edge);
+    });
+
+    test("reads the container from uiState.scrollPosition when args.container is absent", () => {
+      const edge: NavigationEdge = {
+        from: "A",
+        to: "B",
+        timestamp: 1,
+        edgeType: "tool",
+        interaction: {
+          toolName: "swipeOn",
+          args: {},
+          timestamp: 1,
+          uiState: { scrollPosition: { container: { text: "List" } } } as any
+        }
+      };
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ text: "List", scrollable: true }))).toBe(edge);
+    });
+
+    test("does not match a swipeOn edge when the interactable is not scrollable", () => {
+      const edge = swipeEdge({ container: { text: "List" } });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ text: "List", clickable: true }))).toBeUndefined();
+    });
+  });
+
+  describe("normalization", () => {
+    test("matching is case-insensitive and trims whitespace", () => {
+      const edge = tapEdge({ text: "submit" });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ text: "  SUBMIT  ", clickable: true }))).toBe(edge);
+    });
+
+    test("whitespace-only edge text is not indexed", () => {
+      const edge = tapEdge({ text: "   " });
+      const index = new EdgeMatchIndex([edge]);
+      expect(index.findMatch(interactable({ text: "   ", clickable: true }))).toBeUndefined();
+    });
+  });
+
+  describe("edge-order tie-breaking", () => {
+    test("returns the earliest edge when several paths match (min index wins)", () => {
+      // edge0 matches by resource id; edge1 matches by text. Both apply to the
+      // same interactable, so the earlier edge (edge0) must win.
+      const edge0 = tapEdge({ elementId: "com.app:id/ok" }, "First");
+      const edge1 = tapEdge({ text: "OK" }, "Second");
+      const index = new EdgeMatchIndex([edge0, edge1]);
+      const match = index.findMatch(
+        interactable({ text: "OK", resourceId: "com.app:id/ok", clickable: true })
+      );
+      expect(match).toBe(edge0);
+    });
+
+    test("first edge wins for a shared normalized key", () => {
+      const edge0 = tapEdge({ text: "Go" }, "First");
+      const edge1 = tapEdge({ text: "go" }, "Second");
+      const index = new EdgeMatchIndex([edge0, edge1]);
+      expect(index.findMatch(interactable({ text: "GO", clickable: true }))).toBe(edge0);
+    });
+  });
+
+  test("returns undefined when nothing matches", () => {
+    const index = new EdgeMatchIndex([tapEdge({ text: "Submit" })]);
+    expect(index.findMatch(interactable({ text: "Cancel", clickable: true }))).toBeUndefined();
+    expect(index.findMatch(interactable({ clickable: true }))).toBeUndefined();
+  });
+
+  test("ignores non-actionable tool names", () => {
+    const edge: NavigationEdge = {
+      from: "A",
+      to: "B",
+      timestamp: 1,
+      edgeType: "tool",
+      interaction: { toolName: "inputText", args: { text: "Submit" }, timestamp: 1 }
+    };
+    const index = new EdgeMatchIndex([edge]);
+    expect(index.findMatch(interactable({ text: "Submit", clickable: true }))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3428. `findMatchingEdge` linearly scanned `actionableEdges` for every interactable and re-ran `normalizeValue` (`.trim().toLowerCase()`) on each edge's args on **every** iteration — loop-invariant normalization recomputed O(interactables × edges) times, on the observe path when predictive UI is enabled.

## Change

- Extracted matching into a testable, exported `EdgeMatchIndex`:
  - Normalizes each edge **once** at construction into keyed lookup Maps (tap/swipe × text/id/content-desc).
  - Resolves each interactable via a constant number of `Map.get` lookups, returning the edge with the **lowest original index** among matching paths.
  - This min-index rule is provably identical to the old "first edge in edge order that matches by any path" behavior.
- Net: **O(I × E) → O(I + E)**, normalization done once.
- Reuses the existing `normalizeIdentifier` helper (`predictionUtils.ts`) instead of a new local normalizer.

## Tests

- New `EdgeMatchIndex.test.ts` (17 cases): tap/swipe matching by text/content-desc/id, clickable/scrollable gating, `uiState.scrollPosition` container fallback, case-insensitive + whitespace normalization, whitespace-only keys ignored, and **edge-order tie-breaking (min index wins)**. There were no prior tests for this matcher.
- `typecheck` / `lint` / `build` green.

`/simplify`: reused `normalizeIdentifier`; the 5-map structure, min-index closure, and standalone-class altitude were all confirmed clean by review.

Closes #3428