### PR TITLE
fix: clear SIGKILL timer when exitPromise rejects in waitForExit (#3617)

### DIFF
--- a/src/utils/ChildProcessTracker.ts
+++ b/src/utils/ChildProcessTracker.ts
@@ -136,10 +136,17 @@ export async function waitForExit(
     }, timeoutMs);
   });
 
-  await Promise.race([exitPromise, timeoutPromise]);
-
-  if (timeoutId) {
-    timer.clearTimeout(timeoutId);
+  // Clear the SIGKILL timer in `finally`: `exitPromise` rejects on the child's
+  // 'error' event (see createExitTracker), which makes the race throw. Clearing
+  // only on the resolve path leaked the timer, so it later fired process.kill
+  // ("SIGKILL") on the already-failed process and kept the event loop alive up to
+  // `timeoutMs` (#3617).
+  try {
+    await Promise.race([exitPromise, timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      timer.clearTimeout(timeoutId);
+    }
   }
 
   await exitPromise;

--- a/test/utils/ChildProcessTracker.test.ts
+++ b/test/utils/ChildProcessTracker.test.ts
@@ -37,6 +37,14 @@ function createExitPromise(process: EventEmitter): Promise<void> {
   });
 }
 
+/** Mirrors createExitTracker: resolves on 'exit', rejects on the child 'error' event. */
+function createExitOrErrorPromise(process: EventEmitter): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    process.once("exit", () => resolve());
+    process.once("error", (error: Error) => reject(error));
+  });
+}
+
 describe("ChildProcessTracker", () => {
   describe("waitForExit", () => {
     test("sends SIGINT first and escalates to SIGKILL after the configured timeout", async () => {
@@ -84,6 +92,29 @@ describe("ChildProcessTracker", () => {
 
       expect(process.signals).toEqual([]);
       expect(timer.getPendingTimeoutCount()).toBe(0);
+    });
+
+    test("clears the SIGKILL timer when exitPromise rejects, leaving no stray kill (#3617)", async () => {
+      const timer = new FakeTimer();
+      const process = new FakeStoppableProcess();
+      const waitPromise = waitForExit(process, createExitOrErrorPromise(process), {
+        timeoutMs: 5000,
+        timer,
+      });
+
+      expect(process.signals).toEqual(["SIGINT"]);
+      expect(timer.getPendingTimeoutCount()).toBe(1);
+
+      // The child 'error' event rejects exitPromise and unwinds the race.
+      process.emit("error", new Error("spawn failed"));
+      await expect(waitPromise).rejects.toThrow("spawn failed");
+
+      // Regression (#3617): the timer must be cleared despite the reject path...
+      expect(timer.getPendingTimeoutCount()).toBe(0);
+
+      // ...so advancing past the timeout fires no stray SIGKILL.
+      timer.advanceTime(5000);
+      expect(process.signals).toEqual(["SIGINT"]);
     });
   });
 


### PR DESCRIPTION
## Summary
Closes #3617.

`waitForExit` (`src/utils/ChildProcessTracker.ts`) cleared the SIGINT→SIGKILL escalation timer only *after* `await Promise.race([exitPromise, timeoutPromise])` resolved:

```ts
await Promise.race([exitPromise, timeoutPromise]);
if (timeoutId) { timer.clearTimeout(timeoutId); }  // skipped when the race rejects
await exitPromise;
```

`exitPromise` rejects on the child's `'error'` event (`createExitTracker` registers `process.once("error", … rejectPromise)`). When it rejects, the race throws and unwinds **before** `clearTimeout`, leaking the timer. Its callback later fires `process.kill("SIGKILL")` on the already-failed process and keeps the event loop alive up to `timeoutMs`. Reachable via `FfmpegVideoProcessingBackend.stop()`, which awaits `waitForExit` with that same rejecting `exitPromise`.

Harm is bounded (Node's `kill()` on an exited process returns `false` without throwing), but it's a real cleanup defect.

## Change
Wrap the race in `try/finally` so `clearTimeout` runs on both the resolve and reject paths. The trailing `await exitPromise` still re-throws the rejection to the caller unchanged.

## Test
New unit test: `exitPromise` rejects (via the child `'error'` event) → asserts the timer is cleared (`getPendingTimeoutCount() === 0`) and that advancing a `FakeTimer` past the timeout fires **no** stray SIGKILL (`signals` stays `["SIGINT"]`). Fails against the pre-fix implementation.

`bun test` (ChildProcessTracker + FfmpegVideoProcessingBackend), `bunx turbo run build lint` all green.