### PR TITLE
perf(db): getFailureCounts uses COUNT(*) instead of fetching full rows (#3437)

### DIFF
--- a/src/db/failureEventRepository.ts
+++ b/src/db/failureEventRepository.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import type { Kysely, SelectQueryBuilder } from "kysely";
 import { getDatabase } from "./database";
 import type {
   Database,
@@ -207,37 +207,94 @@ export class FailureEventRepository {
     return result.id;
   }
 
+  // Crash and ANR filters. The two tables carry identical filterable columns,
+  // but Kysely's table type parameter is invariant, so a single generic helper
+  // would need `as unknown as` casts (which the repo lints against). Two
+  // concrete helpers keep the row getters and the COUNT(*) queries filtering on
+  // exactly the same predicates without casts. `limit`/`orderBy` are applied by
+  // the caller (a count must not be capped by `limit`).
+  private applyCrashFilters<O>(
+    query: SelectQueryBuilder<Database, "crashes", O>,
+    options: FailureQueryOptions
+  ): SelectQueryBuilder<Database, "crashes", O> {
+    if (options.deviceId) {
+      query = query.where("device_id", "=", options.deviceId);
+    }
+    if (options.packageName) {
+      query = query.where("package_name", "=", options.packageName);
+    }
+    if (options.sessionUuid) {
+      query = query.where("session_uuid", "=", options.sessionUuid);
+    }
+    if (options.navigationNodeId) {
+      query = query.where("navigation_node_id", "=", options.navigationNodeId);
+    }
+    if (options.testExecutionId) {
+      query = query.where("test_execution_id", "=", options.testExecutionId);
+    }
+    if (options.since) {
+      query = query.where("timestamp", ">=", options.since);
+    }
+    return query;
+  }
+
+  private applyAnrFilters<O>(
+    query: SelectQueryBuilder<Database, "anrs", O>,
+    options: FailureQueryOptions
+  ): SelectQueryBuilder<Database, "anrs", O> {
+    if (options.deviceId) {
+      query = query.where("device_id", "=", options.deviceId);
+    }
+    if (options.packageName) {
+      query = query.where("package_name", "=", options.packageName);
+    }
+    if (options.sessionUuid) {
+      query = query.where("session_uuid", "=", options.sessionUuid);
+    }
+    if (options.navigationNodeId) {
+      query = query.where("navigation_node_id", "=", options.navigationNodeId);
+    }
+    if (options.testExecutionId) {
+      query = query.where("test_execution_id", "=", options.testExecutionId);
+    }
+    if (options.since) {
+      query = query.where("timestamp", ">=", options.since);
+    }
+    return query;
+  }
+
+  // Tool-call filters differ from crash/ANR: no navigation/test-execution
+  // columns, and `timestamp` is an ISO string. The `status = 'failure'` gate is
+  // applied by the caller so this helper can serve both selects and counts.
+  private applyToolCallFilters<O>(
+    query: SelectQueryBuilder<Database, "tool_calls", O>,
+    options: FailureQueryOptions
+  ): SelectQueryBuilder<Database, "tool_calls", O> {
+    if (options.deviceId) {
+      query = query.where("device_id", "=", options.deviceId);
+    }
+    if (options.packageName) {
+      query = query.where("package_name", "=", options.packageName);
+    }
+    if (options.sessionUuid) {
+      query = query.where("session_uuid", "=", options.sessionUuid);
+    }
+    if (options.since) {
+      query = query.where("timestamp", ">=", new Date(options.since).toISOString());
+    }
+    return query;
+  }
+
   /**
    * Get crashes matching the query options
    */
   async getCrashes(options: FailureQueryOptions = {}): Promise<Crash[]> {
     const db = this.getDb();
 
-    let query = db.selectFrom("crashes").selectAll().orderBy("timestamp", "desc");
-
-    if (options.deviceId) {
-      query = query.where("device_id", "=", options.deviceId);
-    }
-
-    if (options.packageName) {
-      query = query.where("package_name", "=", options.packageName);
-    }
-
-    if (options.sessionUuid) {
-      query = query.where("session_uuid", "=", options.sessionUuid);
-    }
-
-    if (options.navigationNodeId) {
-      query = query.where("navigation_node_id", "=", options.navigationNodeId);
-    }
-
-    if (options.testExecutionId) {
-      query = query.where("test_execution_id", "=", options.testExecutionId);
-    }
-
-    if (options.since) {
-      query = query.where("timestamp", ">=", options.since);
-    }
+    let query = this.applyCrashFilters(
+      db.selectFrom("crashes").selectAll().orderBy("timestamp", "desc"),
+      options
+    );
 
     if (options.limit) {
       query = query.limit(options.limit);
@@ -252,31 +309,10 @@ export class FailureEventRepository {
   async getAnrs(options: FailureQueryOptions = {}): Promise<Anr[]> {
     const db = this.getDb();
 
-    let query = db.selectFrom("anrs").selectAll().orderBy("timestamp", "desc");
-
-    if (options.deviceId) {
-      query = query.where("device_id", "=", options.deviceId);
-    }
-
-    if (options.packageName) {
-      query = query.where("package_name", "=", options.packageName);
-    }
-
-    if (options.sessionUuid) {
-      query = query.where("session_uuid", "=", options.sessionUuid);
-    }
-
-    if (options.navigationNodeId) {
-      query = query.where("navigation_node_id", "=", options.navigationNodeId);
-    }
-
-    if (options.testExecutionId) {
-      query = query.where("test_execution_id", "=", options.testExecutionId);
-    }
-
-    if (options.since) {
-      query = query.where("timestamp", ">=", options.since);
-    }
+    let query = this.applyAnrFilters(
+      db.selectFrom("anrs").selectAll().orderBy("timestamp", "desc"),
+      options
+    );
 
     if (options.limit) {
       query = query.limit(options.limit);
@@ -291,27 +327,14 @@ export class FailureEventRepository {
   async getToolCallFailures(options: FailureQueryOptions = {}): Promise<ToolCall[]> {
     const db = this.getDb();
 
-    let query = db
-      .selectFrom("tool_calls")
-      .selectAll()
-      .where("status", "=", "failure")
-      .orderBy("timestamp", "desc");
-
-    if (options.deviceId) {
-      query = query.where("device_id", "=", options.deviceId);
-    }
-
-    if (options.packageName) {
-      query = query.where("package_name", "=", options.packageName);
-    }
-
-    if (options.sessionUuid) {
-      query = query.where("session_uuid", "=", options.sessionUuid);
-    }
-
-    if (options.since) {
-      query = query.where("timestamp", ">=", new Date(options.since).toISOString());
-    }
+    let query = this.applyToolCallFilters(
+      db
+        .selectFrom("tool_calls")
+        .selectAll()
+        .where("status", "=", "failure")
+        .orderBy("timestamp", "desc"),
+      options
+    );
 
     if (options.limit) {
       query = query.limit(options.limit);
@@ -460,22 +483,44 @@ export class FailureEventRepository {
   }
 
   /**
-   * Get failure counts by type for a given query
+   * Get failure counts by type for a given query.
+   *
+   * Uses `COUNT(*)` rather than fetching every matching row (with its large
+   * stacktrace/raw_log columns) just to read `.length` (#3437). Counts the full
+   * matching set: `limit` intentionally does not apply here — it would silently
+   * cap the count.
    */
   async getFailureCounts(
     options: FailureQueryOptions = {}
   ): Promise<{ crashes: number; anrs: number; toolCallFailures: number }> {
-    const crashes = await this.getCrashes(options);
-    const anrs = await this.getAnrs(options);
-    const toolCallFailures =
-      options.includeToolCallFailures !== false
-        ? await this.getToolCallFailures(options)
-        : [];
+    const db = this.getDb();
+
+    const crashes = await this.applyCrashFilters(
+      db.selectFrom("crashes").select(db.fn.countAll<number>().as("count")),
+      options
+    ).executeTakeFirstOrThrow();
+
+    const anrs = await this.applyAnrFilters(
+      db.selectFrom("anrs").select(db.fn.countAll<number>().as("count")),
+      options
+    ).executeTakeFirstOrThrow();
+
+    let toolCallFailures = 0;
+    if (options.includeToolCallFailures !== false) {
+      const row = await this.applyToolCallFilters(
+        db
+          .selectFrom("tool_calls")
+          .select(db.fn.countAll<number>().as("count"))
+          .where("status", "=", "failure"),
+        options
+      ).executeTakeFirstOrThrow();
+      toolCallFailures = Number(row.count);
+    }
 
     return {
-      crashes: crashes.length,
-      anrs: anrs.length,
-      toolCallFailures: toolCallFailures.length,
+      crashes: Number(crashes.count),
+      anrs: Number(anrs.count),
+      toolCallFailures,
     };
   }
 }

--- a/test/db/failureEventRepository.test.ts
+++ b/test/db/failureEventRepository.test.ts
@@ -570,5 +570,54 @@ describe("FailureEventRepository", () => {
       expect(counts.crashes).toBe(1);
       expect(counts.toolCallFailures).toBe(0);
     });
+
+    // Regression for #3437: the count must reflect the full matching set. The
+    // old implementation fetched rows via the getters (which honor `limit`) and
+    // returned `.length`, so `limit` silently capped the count. A real COUNT(*)
+    // ignores `limit`.
+    test("limit does not cap the count", async () => {
+      for (let i = 0; i < 5; i++) {
+        await repo.saveCrash(makeCrashEvent({ timestamp: 1000 + i }));
+      }
+      for (let i = 0; i < 3; i++) {
+        await repo.saveAnr(makeAnrEvent({ timestamp: 2000 + i }));
+      }
+      for (let i = 0; i < 4; i++) {
+        await repo.saveToolCall(`tool-${i}`, { status: "failure", errorMessage: "e" });
+      }
+
+      const counts = await repo.getFailureCounts({ limit: 2 });
+      expect(counts).toEqual({ crashes: 5, anrs: 3, toolCallFailures: 4 });
+    });
+
+    // The counts share their filter predicates with the row getters, so they
+    // must agree under the same options (guards against filter drift between the
+    // COUNT(*) queries and getCrashes/getAnrs/getToolCallFailures).
+    test("counts match the filtered row getters under the same options", async () => {
+      await repo.saveCrash(makeCrashEvent({ deviceId: "d-1", packageName: "com.a", timestamp: 1000 }));
+      await repo.saveCrash(makeCrashEvent({ deviceId: "d-1", packageName: "com.b", timestamp: 2000 }));
+      await repo.saveCrash(makeCrashEvent({ deviceId: "d-2", packageName: "com.a", timestamp: 3000 }));
+      await repo.saveAnr(makeAnrEvent({ deviceId: "d-1", timestamp: 1500 }));
+      await repo.saveToolCall("tapOn", { status: "failure", deviceId: "d-1", packageName: "com.a" });
+      await repo.saveToolCall("observe", { status: "failure", deviceId: "d-2", packageName: "com.a" });
+
+      const opts = { deviceId: "d-1", packageName: "com.a" };
+      const counts = await repo.getFailureCounts(opts);
+      const crashes = await repo.getCrashes(opts);
+      const anrs = await repo.getAnrs(opts);
+      const toolCallFailures = await repo.getToolCallFailures(opts);
+
+      expect(counts.crashes).toBe(crashes.length);
+      expect(counts.anrs).toBe(anrs.length);
+      expect(counts.toolCallFailures).toBe(toolCallFailures.length);
+    });
+
+    test("applies tool-call-only filters (packageName) to the tool-call count", async () => {
+      await repo.saveToolCall("tapOn", { status: "failure", packageName: "com.a" });
+      await repo.saveToolCall("observe", { status: "failure", packageName: "com.b" });
+
+      const counts = await repo.getFailureCounts({ packageName: "com.a" });
+      expect(counts.toolCallFailures).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`getFailureCounts` called `getCrashes` / `getAnrs` / `getToolCallFailures` — each a `selectAll()` that pulls **every column** (including the large `stacktrace` / `raw_log` text) of every matching row — only to read `.length`. Replaced with three `SELECT COUNT(*)` queries carrying the same filters. Transfer drops from O(matching-rows × row-size) to O(1) per table.

### Also fixes a latent bug
The old path routed through the getters, which honor `options.limit`, so a caller passing `limit` **silently capped the count** (returned `min(actual, limit)`). `COUNT(*)` counts the full matching set — `limit` intentionally does not apply.

### Filter consistency
Filter predicates are extracted into `applyCrashFilters` / `applyAnrFilters` / `applyToolCallFilters`, shared by both the row getters and the count queries, so the counts filter on exactly the same conditions (no drift). Two concrete crash/ANR helpers (rather than one generic) keep this cast-free and lint-clean — Kysely's table type parameter is invariant, and the repo lints against `as unknown as`.

## Tests
- `limit does not cap the count` — regression for the latent bug (fails on the old `.length` implementation).
- `counts match the filtered row getters under the same options` — guards against predicate drift between the COUNT(*) queries and the getters.
- `applies tool-call-only filters (packageName) to the tool-call count`.
- Existing `getFailureCounts` coverage (zero counts, per-type counts, filters, `includeToolCallFailures:false`) still green. Full `test/db` suite: 820 tests.

## Notes
Reviewed via `/simplify` (4 agents). Efficiency confirmed the COUNT(*) win and that sequential awaits are correct (single-connection synchronous `bun:sqlite` — `Promise.all` gives no gain). Out of scope / informational: `tool_calls` has no index on `device_id`/`package_name`, so those count filters full-scan — pre-existing, not introduced here.

Closes #3437.