### PR TITLE
perf(a11y): hoist TextView filter out of WcagAudit.hasNearbyLabel (#3429)

### DIFF
--- a/src/features/accessibility/WcagAudit.ts
+++ b/src/features/accessibility/WcagAudit.ts
@@ -324,12 +324,16 @@ export class WcagAudit {
         e.class?.includes("RadioButton")
     );
 
+    // Compute the candidate label TextViews once, not once per input
+    // (hasNearbyLabel was O(inputs * elements) just rebuilding this list).
+    const textViews = elements.filter(e => e.class?.includes("TextView") && e.text);
+
     for (const input of inputElements) {
       // Check if input has a label via text, content-desc, or nearby TextView
       const hasLabel =
         input.text ||
         input["content-desc"] ||
-        this.hasNearbyLabel(input, elements);
+        this.hasNearbyLabel(input, textViews);
 
       if (!hasLabel) {
         violations.push({
@@ -351,18 +355,20 @@ export class WcagAudit {
   }
 
   /**
-   * Check if an element has a nearby TextView that could serve as a label
+   * Check if an element has a nearby TextView that could serve as a label.
+   * `textViews` is precomputed by the caller (see checkFormInputLabels) so this
+   * is O(textViews) per input rather than re-filtering all elements each call.
    */
-  private hasNearbyLabel(input: Element, allElements: Element[]): boolean {
-    const textViews = allElements.filter(e => e.class?.includes("TextView") && e.text);
+  private hasNearbyLabel(input: Element, textViews: Element[]): boolean {
+    // Input centers are loop-invariant; compute them once.
+    const inputCenterY = (input.bounds.top + input.bounds.bottom) / 2;
+    const inputCenterX = (input.bounds.left + input.bounds.right) / 2;
 
     for (const textView of textViews) {
       // Check if TextView is close to the input (within 50dp vertically or horizontally)
-      const inputCenterY = (input.bounds.top + input.bounds.bottom) / 2;
       const textCenterY = (textView.bounds.top + textView.bounds.bottom) / 2;
       const verticalDistance = Math.abs(inputCenterY - textCenterY);
 
-      const inputCenterX = (input.bounds.left + input.bounds.right) / 2;
       const textCenterX = (textView.bounds.left + textView.bounds.right) / 2;
       const horizontalDistance = Math.abs(inputCenterX - textCenterX);
 

--- a/test/features/accessibility/WcagAudit.test.ts
+++ b/test/features/accessibility/WcagAudit.test.ts
@@ -285,4 +285,52 @@ describe("WcagAudit", function() {
       expect(contrastViolations).toHaveLength(0);
     });
   });
+
+  describe("Form Input Labels", function() {
+    const config: AccessibilityAuditConfig = {
+      level: "AA",
+      failureMode: "report",
+      useBaseline: false,
+    };
+    const hierarchy: ViewHierarchyNode = { class: "View", children: [] };
+
+    async function formInputViolations(elements: Element[]) {
+      const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
+      return result.violations.filter(v => v.type === "unlabeled-form-input");
+    }
+
+    it("flags an EditText with no text, content-desc, or nearby TextView", async function() {
+      const elements: Element[] = [
+        { class: "android.widget.EditText", bounds: { left: 0, top: 0, right: 200, bottom: 60 } },
+      ];
+      expect(await formInputViolations(elements)).toHaveLength(1);
+    });
+
+    it("does NOT flag an EditText with a TextView within 50dp", async function() {
+      const elements: Element[] = [
+        { class: "android.widget.EditText", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+        // Horizontally aligned label just above the input (centers within 50dp on X).
+        { class: "android.widget.TextView", text: "Name", bounds: { left: 0, top: 40, right: 200, bottom: 80 } },
+      ];
+      expect(await formInputViolations(elements)).toHaveLength(0);
+    });
+
+    it("flags an EditText whose only TextView is far away on both axes", async function() {
+      const elements: Element[] = [
+        { class: "android.widget.EditText", bounds: { left: 0, top: 0, right: 100, bottom: 60 } },
+        // Label >50dp away in both X and Y from the input center.
+        { class: "android.widget.TextView", text: "Far", bounds: { left: 500, top: 500, right: 600, bottom: 560 } },
+      ];
+      expect(await formInputViolations(elements)).toHaveLength(1);
+    });
+
+    it("ignores TextViews with no text when resolving labels", async function() {
+      const elements: Element[] = [
+        { class: "android.widget.EditText", bounds: { left: 0, top: 100, right: 200, bottom: 160 } },
+        // Empty-text TextView must not count as a label even though it is adjacent.
+        { class: "android.widget.TextView", bounds: { left: 0, top: 40, right: 200, bottom: 80 } },
+      ];
+      expect(await formInputViolations(elements)).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #3429. `hasNearbyLabel` rebuilt `allElements.filter(e => e.class?.includes("TextView") && e.text)` on **every** call — once per form input — making the label check O(inputs × allElements) just to reconstruct the same list, then an inner proximity scan.

## Change

- Compute the candidate label TextViews **once** in `checkFormInputLabels` and pass them into `hasNearbyLabel`.
- Also hoist the loop-invariant input center coordinates out of the per-TextView loop.
- Pure hoist — matching behavior is unchanged.

## Tests

- Added a `Form Input Labels` suite (this path had no prior coverage): unlabeled EditText with no nearby TextView → violation; EditText with a TextView within 50dp → no violation; EditText whose only TextView is far on both axes → violation; empty-text TextViews are not treated as labels.
- `typecheck` / `lint` / `build` green.

Closes #3429