### PR TITLE
fix(db): preserve created_at on snapshot/recording upsert conflict (#3498)

### DIFF
--- a/src/db/deviceSnapshotRepository.ts
+++ b/src/db/deviceSnapshotRepository.ts
@@ -127,6 +127,10 @@ export class DeviceSnapshotRepository {
       .insertInto("device_snapshots")
       .values(row)
       .onConflict(oc =>
+        // created_at is intentionally omitted: on overwrite the original creation
+        // time must survive (retention ordering / age display depend on it). The
+        // INSERT still sets it for new rows; last_accessed_at carries the "touched"
+        // time (#3498).
         oc.column("snapshot_name").doUpdateSet({
           device_id: row.device_id,
           device_name: row.device_name,
@@ -134,7 +138,6 @@ export class DeviceSnapshotRepository {
           snapshot_type: row.snapshot_type,
           include_app_data: row.include_app_data,
           include_settings: row.include_settings,
-          created_at: row.created_at,
           last_accessed_at: row.last_accessed_at,
           size_bytes: row.size_bytes,
           manifest_json: row.manifest_json,

--- a/src/db/videoRecordingRepository.ts
+++ b/src/db/videoRecordingRepository.ts
@@ -169,6 +169,10 @@ export class VideoRecordingRepository {
       .insertInto("video_recordings")
       .values(row)
       .onConflict(oc =>
+        // created_at is intentionally omitted: on overwrite the original creation
+        // time must survive (retention ordering / age display depend on it). The
+        // INSERT still sets it for new rows; last_accessed_at carries the "touched"
+        // time (#3498).
         oc.column("recording_id").doUpdateSet({
           device_id: row.device_id,
           platform: row.platform,
@@ -180,7 +184,6 @@ export class VideoRecordingRepository {
           size_bytes: row.size_bytes,
           duration_ms: row.duration_ms,
           codec: row.codec,
-          created_at: row.created_at,
           started_at: row.started_at,
           ended_at: row.ended_at,
           last_accessed_at: row.last_accessed_at,

--- a/test/db/deviceSnapshotRepository.test.ts
+++ b/test/db/deviceSnapshotRepository.test.ts
@@ -104,10 +104,30 @@ describe("DeviceSnapshotRepository", () => {
     expect(result!.snapshotType).toBe("adb");
     expect(result!.includeAppData).toBe(true);
     expect(result!.includeSettings).toBe(true);
-    expect(result!.createdAt).toBe("2024-02-01T00:00:00.000Z");
+    // created_at is preserved from the original insert on overwrite (#3498); the
+    // "touched" time is carried by last_accessed_at.
+    expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
     expect(result!.lastAccessedAt).toBe("2024-02-02T00:00:00.000Z");
     expect(result!.sizeBytes).toBe(2048);
     expect(result!.manifest.osVersion).toBe("17");
+  });
+
+  test("insertSnapshot overwrite preserves the original created_at (#3498)", async () => {
+    await repo.insertSnapshot(makeRecord({ createdAt: "2024-01-01T00:00:00.000Z" }));
+
+    await repo.insertSnapshot(
+      makeRecord({
+        createdAt: "2025-05-05T00:00:00.000Z",
+        lastAccessedAt: "2025-05-05T00:00:00.000Z",
+        sizeBytes: 4096,
+      })
+    );
+
+    const result = await repo.getSnapshot("snap-1");
+    // Original creation time survives; other fields still update.
+    expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(result!.lastAccessedAt).toBe("2025-05-05T00:00:00.000Z");
+    expect(result!.sizeBytes).toBe(4096);
   });
 
   test("getSnapshot returns null for unknown snapshot", async () => {

--- a/test/db/videoRecordingRepository.test.ts
+++ b/test/db/videoRecordingRepository.test.ts
@@ -109,7 +109,8 @@ describe("VideoRecordingRepository", () => {
     expect(result!.sizeBytes).toBe(4096);
     expect(result!.durationMs).toBe(6000);
     expect(result!.codec).toBe("h265");
-    expect(result!.createdAt).toBe("2024-02-01T00:00:00.000Z");
+    // created_at is preserved from the original insert on overwrite (#3498).
+    expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
     expect(result!.startedAt).toBe("2024-02-01T00:00:01.000Z");
     expect(result!.endedAt).toBe("2024-02-01T00:00:07.000Z");
     expect(result!.lastAccessedAt).toBe("2024-02-02T00:00:00.000Z");
@@ -117,6 +118,24 @@ describe("VideoRecordingRepository", () => {
     expect(result!.config.fps).toBe(30);
     expect(result!.highlights).toHaveLength(1);
     expect(result!.highlights![0].description).toBe("second insert highlight");
+  });
+
+  test("insertRecording overwrite preserves the original created_at (#3498)", async () => {
+    await repo.insertRecording(makeRecord({ createdAt: "2024-01-01T00:00:00.000Z" }));
+
+    await repo.insertRecording(
+      makeRecord({
+        createdAt: "2025-05-05T00:00:00.000Z",
+        sizeBytes: 8192,
+        lastAccessedAt: "2025-05-05T00:00:00.000Z",
+      })
+    );
+
+    const result = await repo.getRecording("rec-1");
+    // Original creation time survives; other fields still update.
+    expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(result!.sizeBytes).toBe(8192);
+    expect(result!.lastAccessedAt).toBe("2025-05-05T00:00:00.000Z");
   });
 
   test("insertRecording upsert clears stale optional fields", async () => {

--- a/test/fakes/FakeDeviceSnapshotRepository.ts
+++ b/test/fakes/FakeDeviceSnapshotRepository.ts
@@ -7,7 +7,12 @@ export class FakeDeviceSnapshotRepository {
   private readonly records = new Map<string, DeviceSnapshotRecord>();
 
   async insertSnapshot(record: DeviceSnapshotRecord): Promise<void> {
-    this.records.set(record.snapshotName, { ...record });
+    // Mirror the real upsert: an overwrite preserves the original created_at (#3498).
+    const existing = this.records.get(record.snapshotName);
+    this.records.set(record.snapshotName, {
+      ...record,
+      createdAt: existing?.createdAt ?? record.createdAt,
+    });
   }
 
   async updateSnapshot(

--- a/test/fakes/FakeVideoRecordingRepository.ts
+++ b/test/fakes/FakeVideoRecordingRepository.ts
@@ -7,7 +7,12 @@ export class FakeVideoRecordingRepository {
   private readonly records = new Map<string, VideoRecordingRecord>();
 
   async insertRecording(record: VideoRecordingRecord): Promise<void> {
-    this.records.set(record.recordingId, { ...record });
+    // Mirror the real upsert: an overwrite preserves the original created_at (#3498).
+    const existing = this.records.get(record.recordingId);
+    this.records.set(record.recordingId, {
+      ...record,
+      createdAt: existing?.createdAt ?? record.createdAt,
+    });
   }
 
   async updateRecording(


### PR DESCRIPTION
## Summary
Closes #3498. Decision: **preserve** the original creation time on overwrite.

The idempotent-insert upserts added in #3412/#3404 included `created_at` in `doUpdateSet`, so re-creating a snapshot/recording under an existing key overwrote the original creation timestamp with the new call's value. Consumers that treat `created_at` as the true creation time — `listSnapshots` orders by it, plus age display / retention ordering — silently and unrecoverably lost it.

## Change
- `deviceSnapshotRepository.insertSnapshot` and `videoRecordingRepository.insertRecording`: drop `created_at` from the `onConflict(...).doUpdateSet(...)` so the stored value stands on overwrite. The `INSERT` still sets it for new rows, and `last_accessed_at` continues to carry the "touched" time. Every other column still updates on conflict.
- The in-memory fakes (`FakeDeviceSnapshotRepository`, `FakeVideoRecordingRepository`) did a full-record replace (reset semantics); aligned them to preserve `created_at` on re-insert so fake and real behavior match.

## Tests
- The existing `upserts an existing …` tests now assert the **original** `created_at` survives while every other column updates.
- Added explicit `overwrite preserves the original created_at (#3498)` regression tests for both repositories.

## Audit
The only snapshot/recording `created_at` consumer is `listSnapshots` ordering (now correct). The `created_at`-based TTL logic in `GenericThresholdManager`/`ThresholdManager` operates on unrelated tables (`*_thresholds`) and is unaffected.

`bun test` (both repo suites, fakes, snapshot/video consumer suites), `bunx turbo run build lint`, and `bun run typecheck` all green.