### PR TITLE
fix(desktop-core): stop swallowing start-device and file-save failures (#3609)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -1074,7 +1074,12 @@ fun AutoMobileContent(
               )
             }
           }
-          SwingFileSaver.save("telemetry_events.json", jsonArray.toString()) {}
+          SwingFileSaver.save(
+            "telemetry_events.json",
+            jsonArray.toString(),
+            onSuccess = {},
+            onError = { LOG.warn("Failed to export telemetry events: ${it.message}") },
+          )
         },
         onSwitchToDarkMode = { isDarkMode = true },
         onSwitchToLightMode = { isDarkMode = false },
@@ -1660,7 +1665,9 @@ fun AutoMobileContent(
                                       image.platform,
                                       image.deviceId,
                                     )
-                                } catch (_: Exception) {}
+                                } catch (e: Exception) {
+                                  LOG.warn("Failed to start device ${image.name}: ${e.message}")
+                                }
                               }
                             }
                             .pointerHoverIcon(PointerIcon.Hand)
@@ -1859,7 +1866,9 @@ fun AutoMobileContent(
                                         image.platform,
                                         image.deviceId,
                                       )
-                                  } catch (_: Exception) {}
+                                  } catch (e: Exception) {
+                                    LOG.warn("Failed to start device ${image.name}: ${e.message}")
+                                  }
                                 }
                               }
                               .pointerHoverIcon(PointerIcon.Hand)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/FileSaver.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/FileSaver.kt
@@ -1,5 +1,9 @@
 package dev.jasonpearson.automobile.desktop.core.platform
 
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+
+private val LOG = LoggerFactory.getLogger("FileSaver")
+
 /**
  * Platform-agnostic file save operation. The IDE plugin provides an IntelliJ implementation; the
  * desktop app can use a Swing/AWT file dialog.
@@ -7,30 +11,63 @@ package dev.jasonpearson.automobile.desktop.core.platform
 fun interface FileSaver {
   /**
    * Present a save dialog for the given file name and content. Calls [onSuccess] with the saved
-   * file path on success.
+   * file path on success, or [onError] with the failure so a caller can surface it instead of the
+   * save silently doing nothing (#3609).
    */
-  fun save(fileName: String, content: String, onSuccess: (String) -> Unit)
+  fun save(
+    fileName: String,
+    content: String,
+    onSuccess: (String) -> Unit,
+    onError: (Throwable) -> Unit,
+  )
 }
 
 /** Default no-op file saver for environments without a file dialog. */
 object NoOpFileSaver : FileSaver {
-  override fun save(fileName: String, content: String, onSuccess: (String) -> Unit) {}
+  override fun save(
+    fileName: String,
+    content: String,
+    onSuccess: (String) -> Unit,
+    onError: (Throwable) -> Unit,
+  ) {}
 }
 
 /**
  * Desktop file saver that uses Swing's JFileChooser. Suitable for standalone desktop applications.
  */
 object SwingFileSaver : FileSaver {
-  override fun save(fileName: String, content: String, onSuccess: (String) -> Unit) {
-    try {
-      val chooser = javax.swing.JFileChooser()
-      chooser.selectedFile = java.io.File(fileName)
-      val result = chooser.showSaveDialog(null)
-      if (result == javax.swing.JFileChooser.APPROVE_OPTION) {
-        val file = chooser.selectedFile
-        file.writeText(content, Charsets.UTF_8)
-        onSuccess(file.absolutePath)
+  override fun save(
+    fileName: String,
+    content: String,
+    onSuccess: (String) -> Unit,
+    onError: (Throwable) -> Unit,
+  ) {
+    val result =
+      try {
+        val chooser = javax.swing.JFileChooser()
+        chooser.selectedFile = java.io.File(fileName)
+        chooser.showSaveDialog(null) to chooser.selectedFile
+      } catch (e: Exception) {
+        LOG.warn("Failed to present save dialog for '$fileName': ${e.message}")
+        onError(e)
+        return
       }
-    } catch (_: Exception) {}
+    val (approval, selectedFile) = result
+    if (approval != javax.swing.JFileChooser.APPROVE_OPTION) return
+    writeFile(selectedFile, content).onSuccess(onSuccess).onFailure { e ->
+      LOG.warn("Failed to save file '$fileName' to '${selectedFile.absolutePath}': ${e.message}")
+      onError(e)
+    }
   }
+}
+
+/**
+ * Writes [content] to [file] as UTF-8, returning the absolute path on success or the failure
+ * (permissions, disk full, invalid path) as a [Result]. Extracted from the Swing dialog flow so the
+ * write path — the part that used to swallow errors silently (#3609) — is unit-testable without a
+ * display.
+ */
+internal fun writeFile(file: java.io.File, content: String): Result<String> = runCatching {
+  file.writeText(content, Charsets.UTF_8)
+  file.absolutePath
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/test/TestDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/test/TestDashboard.kt
@@ -1345,9 +1345,12 @@ private fun highlightYaml(yaml: String): androidx.compose.ui.text.AnnotatedStrin
 private fun savePlanToFile(
   plan: ExportedPlan,
   fileSaver: dev.jasonpearson.automobile.desktop.core.platform.FileSaver,
+  onError: (Throwable) -> Unit = {
+    LOG.warn("Failed to save plan '${plan.planName}': ${it.message}")
+  },
   onSuccess: (String) -> Unit,
 ) {
-  fileSaver.save("${plan.planName}.yaml", plan.planContent, onSuccess)
+  fileSaver.save("${plan.planName}.yaml", plan.planContent, onSuccess, onError)
 }
 
 private fun copyPlanToClipboard(content: String) {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/FileSaverTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/FileSaverTest.kt
@@ -1,0 +1,40 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Regression coverage for #3609: the file-save write path used to swallow failures (permissions,
+ * disk full, invalid path) in an empty catch, so an export could silently do nothing. [writeFile]
+ * now returns the outcome as a [Result] so callers can log/surface it.
+ */
+class FileSaverTest {
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun `writeFile writes content and returns the absolute path on success`() {
+    val target = File(tempFolder.root, "export.json")
+
+    val result = writeFile(target, "{\"ok\":true}")
+
+    assertTrue(result.isSuccess, "a writable target should succeed")
+    assertEquals(target.absolutePath, result.getOrNull())
+    assertEquals("{\"ok\":true}", target.readText())
+  }
+
+  @Test
+  fun `writeFile surfaces a failure instead of swallowing it when the write cannot complete`() {
+    // Parent directory does not exist -> writeText throws; the old empty catch hid this.
+    val target = File(tempFolder.root, "missing-subdir/export.json")
+
+    val result = writeFile(target, "payload")
+
+    assertTrue(result.isFailure, "an unwritable target should surface a failure, not be swallowed")
+    assertFalse(target.exists())
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #3609. Three desktop-core sites swallowed exceptions in empty `catch (_: Exception) {}` blocks, violating the repo error-handling convention — a user clicking start-device or exporting a file saw nothing when the operation failed.

## Fix
- **Start-device (`AutoMobileContent.kt`, both `▶` handlers):** the `startDevice(...)` calls now `LOG.warn` with the device name on failure instead of swallowing.
- **`SwingFileSaver` (`FileSaver.kt`):** `file.writeText` failures (permissions, disk full, invalid path) were swallowed. The write path is extracted into a pure `writeFile(file, content): Result<String>`; `SwingFileSaver` logs on failure and reports it through a new `onError` hook added to the `FileSaver` interface. The two callers (telemetry export in `AutoMobileContent`, plan export in `TestDashboard`) surface the failure via logging.

## Tests
`FileSaverTest` covers the extracted `writeFile` write path — success (content written, absolute path returned) and the previously-swallowed failure (unwritable target returns `Result.failure`, no partial file). The Swing dialog itself is untestable headless, so the fix deliberately isolates the write/error logic from the dialog.

Scope note: an unrelated device-images-fetch swallow (`AutoMobileContent.kt:575`) and the `GlobalScope` usage at these start-device sites are left untouched — this PR is limited to the empty-catch sites #3609 names.

Automated bug-hunt origin; verified locally via `:desktop-core:test`.