### PR TITLE
perf(db): listToolNamesBetween dedups in SQL, not JS (#3438)

### DIFF
--- a/src/db/toolCallRepository.ts
+++ b/src/db/toolCallRepository.ts
@@ -42,6 +42,14 @@ export class ToolCallRepository {
     }
   }
 
+  /**
+   * List the distinct tool names invoked in [startTime, endTime], ordered by
+   * first appearance (earliest timestamp, then id).
+   *
+   * The dedup, ordering, and exclusion are pushed into SQL (#3438): the database
+   * returns only the handful of distinct names rather than every tool-call row
+   * in the window, which the caller would otherwise transfer and dedup in JS.
+   */
   async listToolNamesBetween(
     startTime: string,
     endTime: string,
@@ -49,30 +57,23 @@ export class ToolCallRepository {
   ): Promise<string[]> {
     try {
       const db = this.getDb();
-      const rows = await db
+      let query = db
         .selectFrom("tool_calls")
-        .select(["tool_name", "timestamp"])
+        .select("tool_name")
         .where("timestamp", ">=", startTime)
         .where("timestamp", "<=", endTime)
-        .orderBy("timestamp", "asc")
-        .orderBy("id", "asc")
-        .execute();
+        .groupBy("tool_name")
+        // First-appearance order: earliest occurrence of each name, ties broken
+        // on the monotonic id (matches the prior JS timestamp-asc, id-asc dedup).
+        .orderBy(db.fn.min("timestamp"), "asc")
+        .orderBy(db.fn.min("id"), "asc");
 
-      const seen = new Set<string>();
-      const results: string[] = [];
-      const excludeSet = new Set(excludeTools);
-
-      for (const row of rows) {
-        if (excludeSet.has(row.tool_name)) {
-          continue;
-        }
-        if (!seen.has(row.tool_name)) {
-          results.push(row.tool_name);
-          seen.add(row.tool_name);
-        }
+      if (excludeTools.length > 0) {
+        query = query.where("tool_name", "not in", excludeTools);
       }
 
-      return results;
+      const rows = await query.execute();
+      return rows.map(row => row.tool_name);
     } catch (error) {
       logger.warn(`[ToolCallRepository] Failed to list tool calls: ${error}`);
       return [];

--- a/test/db/toolCallRepository.test.ts
+++ b/test/db/toolCallRepository.test.ts
@@ -88,4 +88,72 @@ describe("ToolCallRepository", () => {
     );
     expect(result).toEqual([]);
   });
+
+  // Regression for #3438: dedup/order pushed into SQL (GROUP BY tool_name
+  // ORDER BY MIN(timestamp), MIN(id)). A name is ordered by its FIRST
+  // occurrence, so re-appearing later must not move it.
+  test("listToolNamesBetween orders by first appearance, not last", async () => {
+    await repo.recordToolCall({ toolName: "alpha", timestamp: "2024-01-01T00:00:01.000Z" });
+    await repo.recordToolCall({ toolName: "beta", timestamp: "2024-01-01T00:00:02.000Z" });
+    await repo.recordToolCall({ toolName: "alpha", timestamp: "2024-01-01T00:00:09.000Z" });
+    await repo.recordToolCall({ toolName: "gamma", timestamp: "2024-01-01T00:00:03.000Z" });
+
+    const result = await repo.listToolNamesBetween(
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-01T00:00:10.000Z"
+    );
+    expect(result).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  // When two names share their earliest timestamp, the monotonic id breaks the
+  // tie (MIN(id)) — matching the prior JS timestamp-asc, id-asc dedup.
+  test("listToolNamesBetween breaks same-timestamp ties by insertion order", async () => {
+    const ts = "2024-01-01T00:00:05.000Z";
+    await repo.recordToolCall({ toolName: "first", timestamp: ts });
+    await repo.recordToolCall({ toolName: "second", timestamp: ts });
+    await repo.recordToolCall({ toolName: "third", timestamp: ts });
+
+    const result = await repo.listToolNamesBetween(
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-01T00:00:10.000Z"
+    );
+    expect(result).toEqual(["first", "second", "third"]);
+  });
+
+  test("listToolNamesBetween is inclusive of the start and end bounds", async () => {
+    await repo.recordToolCall({ toolName: "atStart", timestamp: "2024-01-01T00:00:00.000Z" });
+    await repo.recordToolCall({ toolName: "atEnd", timestamp: "2024-01-01T00:00:04.000Z" });
+
+    const result = await repo.listToolNamesBetween(
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-01T00:00:04.000Z"
+    );
+    expect(result).toEqual(["atStart", "atEnd"]);
+  });
+
+  test("listToolNamesBetween with an empty exclude list returns all distinct names", async () => {
+    await repo.recordToolCall({ toolName: "one", timestamp: "2024-01-01T00:00:01.000Z" });
+    await repo.recordToolCall({ toolName: "two", timestamp: "2024-01-01T00:00:02.000Z" });
+
+    const result = await repo.listToolNamesBetween(
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-01T00:00:04.000Z",
+      []
+    );
+    expect(result).toEqual(["one", "two"]);
+  });
+
+  test("listToolNamesBetween excludes multiple tools at once", async () => {
+    await repo.recordToolCall({ toolName: "keep1", timestamp: "2024-01-01T00:00:01.000Z" });
+    await repo.recordToolCall({ toolName: "drop1", timestamp: "2024-01-01T00:00:02.000Z" });
+    await repo.recordToolCall({ toolName: "keep2", timestamp: "2024-01-01T00:00:03.000Z" });
+    await repo.recordToolCall({ toolName: "drop2", timestamp: "2024-01-01T00:00:04.000Z" });
+
+    const result = await repo.listToolNamesBetween(
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-01T00:00:05.000Z",
+      ["drop1", "drop2"]
+    );
+    expect(result).toEqual(["keep1", "keep2"]);
+  });
 });


### PR DESCRIPTION
## Summary

`listToolNamesBetween` selected `tool_name`+`timestamp` for **every** tool call in the time window, then deduped to distinct names, ordered them by first appearance, and applied excludes in a JS loop. On a busy window that transfers every tool-call row just to produce a handful of distinct names.

Pushed into SQL (#3438):
```
SELECT tool_name FROM tool_calls
WHERE timestamp BETWEEN ? AND ? [AND tool_name NOT IN (...)]
GROUP BY tool_name
ORDER BY MIN(timestamp) ASC, MIN(id) ASC
```
The database does the dedup / order / exclude and only the distinct names cross the boundary. The `MIN(id)` tiebreak preserves the prior `timestamp asc, id asc` first-appearance order. The `timestamp` filter is served by `idx_tool_calls_timestamp`.

## Tests
Existing coverage (unique names in order, time-range filter, excludes, empty) still passes. Added regression tests for the SQL-specific semantics:
- orders by **first** appearance (a name re-appearing later doesn't move)
- same-timestamp ties broken by insertion id (`MIN(id)`)
- inclusive start/end bounds
- empty exclude list returns all distinct names (guards the conditional `NOT IN`)
- multiple excludes at once

Full `test/db` suite: 825 tests green.

## Notes
Reviewed via `/simplify`: idiom matches `db.fn.max`/`min` usage elsewhere; the JS `Set`/loop was deleted (not duplicated); only distinct names transfer.

Closes #3438.