### PR TITLE
perf(screenshot): index batch results instead of O(n^2) .find() stitching (#3430)

### DIFF
--- a/src/utils/screenshot/ScreenshotMatcher.ts
+++ b/src/utils/screenshot/ScreenshotMatcher.ts
@@ -14,6 +14,43 @@ export interface SimilarScreenshotResult {
   matchFound: boolean;
 }
 
+/**
+ * Assemble the final per-path results of the two-stage batch comparison:
+ * precise pixel results for candidates, falling back to the stage-1 perceptual
+ * similarity for everything else.
+ *
+ * The two result arrays are indexed by file path once (O(n)) instead of running
+ * a linear `.find()` per screenshot path, which made stitching O(n^2) in the
+ * number of cached screenshots (issue #3430).
+ */
+export function stitchBatchResults(
+  screenshotPaths: string[],
+  preciseResults: SimilarScreenshotResult[],
+  stage1Results: Array<{ filePath: string; perceptualSimilarity: number } | null>
+): SimilarScreenshotResult[] {
+  const preciseByPath = new Map(preciseResults.map(result => [result.filePath, result]));
+  const stage1ByPath = new Map<string, number>();
+  for (const result of stage1Results) {
+    if (result) {
+      stage1ByPath.set(result.filePath, result.perceptualSimilarity);
+    }
+  }
+
+  return screenshotPaths.map(filePath => {
+    const preciseResult = preciseByPath.get(filePath);
+    if (preciseResult) {
+      return preciseResult;
+    }
+
+    // For non-candidates, use perceptual similarity as approximate result
+    return {
+      filePath,
+      similarity: stage1ByPath.get(filePath) || 0,
+      matchFound: false
+    };
+  });
+}
+
 export class ScreenshotMatcher {
   /**
    * Batch compare multiple screenshots in parallel for better performance
@@ -157,21 +194,8 @@ export class ScreenshotMatcher {
         })
       );
 
-      // Fill in results for non-candidates
-      const finalResults = screenshotPaths.map(filePath => {
-        const preciseResult = preciseResults.find(r => r.filePath === filePath);
-        if (preciseResult) {
-          return preciseResult;
-        }
-
-        // For non-candidates, use perceptual similarity as approximate result
-        const stage1Result = stage1Results.find(r => r?.filePath === filePath);
-        return {
-          filePath,
-          similarity: stage1Result?.perceptualSimilarity || 0,
-          matchFound: false
-        };
-      });
+      // Fill in results for non-candidates (indexed lookup, not O(n^2) .find())
+      const finalResults = stitchBatchResults(screenshotPaths, preciseResults, stage1Results);
 
       const stage2Time = timer.now() - stage2Start;
       const totalTime = timer.now() - batchStart;

--- a/test/utils/screenshot/stitchBatchResults.test.ts
+++ b/test/utils/screenshot/stitchBatchResults.test.ts
@@ -1,0 +1,65 @@
+import { expect, describe, test } from "bun:test";
+import { stitchBatchResults, type SimilarScreenshotResult } from "../../../src/utils/screenshot/ScreenshotMatcher";
+
+describe("stitchBatchResults", () => {
+  test("returns precise results for candidates in the original path order", () => {
+    const paths = ["a.png", "b.png", "c.png"];
+    const precise: SimilarScreenshotResult[] = [
+      { filePath: "b.png", similarity: 99, matchFound: true },
+      { filePath: "a.png", similarity: 40, matchFound: false }
+    ];
+    const stage1 = [
+      { filePath: "a.png", perceptualSimilarity: 42 },
+      { filePath: "b.png", perceptualSimilarity: 95 },
+      { filePath: "c.png", perceptualSimilarity: 30 }
+    ];
+
+    const result = stitchBatchResults(paths, precise, stage1);
+
+    expect(result.map(r => r.filePath)).toEqual(["a.png", "b.png", "c.png"]);
+    // Candidates keep their precise result...
+    expect(result[0]).toEqual({ filePath: "a.png", similarity: 40, matchFound: false });
+    expect(result[1]).toEqual({ filePath: "b.png", similarity: 99, matchFound: true });
+    // ...non-candidate falls back to stage-1 perceptual similarity.
+    expect(result[2]).toEqual({ filePath: "c.png", similarity: 30, matchFound: false });
+  });
+
+  test("falls back to 0 when there is no precise and no stage-1 entry", () => {
+    const result = stitchBatchResults(["x.png"], [], []);
+    expect(result).toEqual([{ filePath: "x.png", similarity: 0, matchFound: false }]);
+  });
+
+  test("tolerates null entries in stage1Results", () => {
+    const result = stitchBatchResults(
+      ["x.png", "y.png"],
+      [],
+      [null, { filePath: "y.png", perceptualSimilarity: 55 }]
+    );
+    expect(result).toEqual([
+      { filePath: "x.png", similarity: 0, matchFound: false },
+      { filePath: "y.png", similarity: 55, matchFound: false }
+    ]);
+  });
+
+  test("prefers a precise result over the stage-1 fallback for the same path", () => {
+    const result = stitchBatchResults(
+      ["p.png"],
+      [{ filePath: "p.png", similarity: 88, matchFound: false }],
+      [{ filePath: "p.png", perceptualSimilarity: 70 }]
+    );
+    expect(result).toEqual([{ filePath: "p.png", similarity: 88, matchFound: false }]);
+  });
+
+  test("handles a large batch without quadratic scanning (order preserved)", () => {
+    const n = 1000;
+    const paths = Array.from({ length: n }, (_, i) => `s${i}.png`);
+    // No precise results; every path uses its stage-1 similarity.
+    const stage1 = paths.map((filePath, i) => ({ filePath, perceptualSimilarity: i % 100 }));
+
+    const result = stitchBatchResults(paths, [], stage1);
+
+    expect(result).toHaveLength(n);
+    expect(result[0]).toEqual({ filePath: "s0.png", similarity: 0, matchFound: false });
+    expect(result[999]).toEqual({ filePath: "s999.png", similarity: 99, matchFound: false });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3430. `optimizedBatchCompareScreenshots` assembled its final per-path results by running **two** linear `.find()` scans (over `preciseResults` and `stage1Results`) for each of the `n` screenshot paths — O(n²) stitching on the fuzzy screenshot-matching path where the cache can hold many entries.

## Change

- Extracted the assembly into a pure, exported `stitchBatchResults(screenshotPaths, preciseResults, stage1Results)` that indexes both arrays by file path once (O(n)) then does O(1) lookups per path.
- Behavior is unchanged: precise result wins for candidates, stage-1 perceptual similarity is the fallback (with the original `|| 0` coercion), null stage-1 entries tolerated, original path order preserved.

## Tests

- New `stitchBatchResults.test.ts`: precise-wins ordering, 0-fallback when neither result exists, null-entry tolerance, precise-over-fallback preference, and a 1000-path batch (no quadratic scan; order preserved). This assembly had no prior direct coverage.
- `typecheck` / `lint` / `build` green.

Note: the separate full-sort in `findSimilarScreenshots` (issue #3433) is intentionally left for its own PR.

Closes #3430