### PR TITLE
fix(db): repair-datetime 07_03 reads pragma_table_info via sql.lit (#3612)

### DIFF
--- a/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
+++ b/src/db/migrations/2026_07_03_000_repair_datetime_now_defaults.ts
@@ -126,8 +126,15 @@ async function findTablesWithBrokenDefaults(db: Kysely<unknown>): Promise<string
 
   const broken: string[] = [];
   for (const { name: table } of tables.rows) {
+    // Inline the table name as a literal (sql.lit), not a bound parameter: a
+    // parameterized pragma_table_info(?) was observed to intermittently return a
+    // null dflt_value under parallel-file load (bun:sqlite quirk, see #2922's
+    // test). Here a spurious null on a genuinely-poisoned column would fail the
+    // `!== null` guard below, so the column would never be added to the broken set
+    // and its poisoned default would be silently skipped and never rebuilt (#3612).
+    // Matches 2026_07_05_000_repair_updated_at_defaults.ts.
     const columns = await sql<ColumnInfoRow>`
-      SELECT dflt_value FROM pragma_table_info(${table})
+      SELECT dflt_value FROM pragma_table_info(${sql.lit(table)})
     `.execute(db);
     if (columns.rows.some(column => column.dflt_value !== null && column.dflt_value in BROKEN_DEFAULTS)) {
       broken.push(table);
@@ -138,8 +145,10 @@ async function findTablesWithBrokenDefaults(db: Kysely<unknown>): Promise<string
 
 async function rebuildAndRepair(trx: Kysely<unknown>, tables: string[]): Promise<void> {
   for (const table of tables) {
+    // sql.lit (not a bound param) for the same bun:sqlite null-dflt_value quirk
+    // guarded in findTablesWithBrokenDefaults above (#2922 / #3612).
     const columns = await sql<ColumnInfoRow>`
-      SELECT name, dflt_value FROM pragma_table_info(${table})
+      SELECT name, dflt_value FROM pragma_table_info(${sql.lit(table)})
     `.execute(trx);
 
     const brokenColumns = columns.rows.filter(

--- a/test/db/repairDatetimeNowDefaultsMigration.test.ts
+++ b/test/db/repairDatetimeNowDefaultsMigration.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
@@ -236,4 +238,34 @@ describe("2026_07_03_000_repair_datetime_now_defaults migration (#2895)", () => 
       await expect(repairDown()).resolves.toBeUndefined();
     });
   });
+});
+
+/**
+ * The under-load null-`dflt_value` quirk (#2922) is intermittent and not
+ * deterministically reproducible, so this guards the fix structurally: both
+ * repair migrations must read column defaults via an inlined `sql.lit(table)`,
+ * never a bound `pragma_table_info(${table})`. A bound parameter can
+ * intermittently return a null `dflt_value` under parallel-file load; because
+ * null is the very signal that a column is poisoned, a bound read would silently
+ * skip a genuinely-broken column and never rebuild it (#3612).
+ */
+describe("repair migrations read pragma_table_info consistently (#3612)", () => {
+  const migrationsDir = join(import.meta.dir, "../../src/db/migrations");
+  const sources = {
+    "07_03": readFileSync(
+      join(migrationsDir, "2026_07_03_000_repair_datetime_now_defaults.ts"),
+      "utf8"
+    ),
+    "07_05": readFileSync(
+      join(migrationsDir, "2026_07_05_000_repair_updated_at_defaults.ts"),
+      "utf8"
+    ),
+  };
+
+  for (const [label, source] of Object.entries(sources)) {
+    test(`${label} inlines the table name with sql.lit and never binds it`, () => {
+      expect(source).toContain("pragma_table_info(${sql.lit(table)})");
+      expect(source).not.toContain("pragma_table_info(${table})");
+    });
+  }
 });


### PR DESCRIPTION
## Summary
Closes #3612.

`2026_07_03_000_repair_datetime_now_defaults.ts` read column defaults with a **bound parameter** — `pragma_table_info(${table})` — at both its `findTablesWithBrokenDefaults` (~line 130) and `rebuildAndRepair` (~line 142) reads. A parameterized `pragma_table_info(?)` was observed to intermittently return a `null` `dflt_value` under parallel-file load (bun:sqlite quirk, see #2922's test).

Here `null` is exactly the signal that a column is poisoned (`column.dflt_value !== null && column.dflt_value in BROKEN_DEFAULTS`), so a spurious `null` on a genuinely-poisoned column failed the `!== null` guard → the column was never added to the broken set → its poisoned `datetime('now')` default was **silently skipped and never rebuilt**, defeating the migration's purpose.

Its sibling `2026_07_05_000_repair_updated_at_defaults.ts` already inlines the table name with `sql.lit(table)` and documents exactly this quirk (lines ~121-125); this retrofits the same pattern into `07_03`'s two reads.

## Change
- Both `07_03` `pragma_table_info` reads now use `${sql.lit(table)}`, with the quirk rationale carried over from `07_05`.
- **No shared helper** is introduced on purpose: historical migrations stay self-contained, so a later edit to a shared module can't retroactively change an already-run migration's behavior. Consistency is instead enforced by a test.

## Test
A structural guard asserts **both** repair migrations read `pragma_table_info` via `sql.lit(table)` and never via a bound `${table}`. The under-load null quirk is intermittent and not deterministically reproducible, so a source-consistency guard is the honest regression protection; it fails against the pre-fix bound-param form. Existing behavioral `07_03` rebuild/repair tests stay green with the literal read.

`bun test` (both repair-migration suites), `bunx turbo run build lint`, `bun run typecheck` all green.