### PR TITLE
fix(desktop-core): terminate getPathFromParentMap on a cyclic parent map (#3610)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorModels.kt
@@ -124,10 +124,15 @@ fun findNonCompliantTapTargets(
  */
 fun getPathFromParentMap(parentMap: Map<String, String>, targetId: String): List<String> {
   val path = mutableListOf(targetId)
+  val visited = mutableSetOf(targetId)
   var current = targetId
-  while (parentMap.containsKey(current)) {
-    current = parentMap[current]!!
-    path.add(0, current)
+  while (true) {
+    val parent = parentMap[current] ?: break
+    // A malformed/corrupted hierarchy can contain a self-parent or a cycle; stop on the first
+    // revisit so this terminates instead of looping forever and growing path until OOM (#3610).
+    if (!visited.add(parent)) break
+    path.add(0, parent)
+    current = parent
   }
   return path
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyPerformanceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyPerformanceTest.kt
@@ -109,6 +109,40 @@ class HierarchyPerformanceTest {
   }
 
   @Test
+  fun `getPathFromParentMap terminates on a self-parent entry`() {
+    // Malformed input: an element that is its own parent used to loop forever (#3610).
+    val parentMap = mapOf("a" to "a")
+
+    val path = getPathFromParentMap(parentMap, "a")
+
+    assertEquals(listOf("a"), path)
+  }
+
+  @Test
+  fun `getPathFromParentMap terminates on a two-node cycle`() {
+    // Malformed input: a -> b -> a used to loop forever and grow the path until OOM (#3610).
+    val parentMap = mapOf("a" to "b", "b" to "a")
+
+    val path = getPathFromParentMap(parentMap, "a")
+
+    // Stops on the first revisit; each id appears at most once and the target is included.
+    assertEquals(path.toSet().size, path.size, "no id should be repeated")
+    assertTrue(path.contains("a"), "the target should be present")
+    assertTrue(path.size <= parentMap.size + 1, "path is bounded by the number of distinct ids")
+  }
+
+  @Test
+  fun `getPathFromParentMap terminates on a longer cycle`() {
+    // a -> b -> c -> a: still a cycle, just longer.
+    val parentMap = mapOf("a" to "b", "b" to "c", "c" to "a")
+
+    val path = getPathFromParentMap(parentMap, "a")
+
+    assertEquals(path.toSet().size, path.size, "no id should be repeated")
+    assertEquals("a", path.last(), "target remains the last element")
+  }
+
+  @Test
   fun `computeChangedElements detects new elements`() {
     val state = LayoutInspectorState()
     val root1 = buildTree(depth = 2, branching = 2)


### PR DESCRIPTION
## Summary
Fixes #3610. `getPathFromParentMap` walked the parent map with `while (parentMap.containsKey(current)) { current = parentMap[current]!! }`, which never terminates — and grows `path` until OOM — if the map contains a cycle or a self-parent entry. Well-formed trees never cycle, so this only bites on malformed/corrupted hierarchy input.

## Fix
Track visited ids and break on the first revisit. Well-formed trees are unaffected (their path is identical); a self-parent or cycle now stops instead of looping forever.

## Tests
`HierarchyPerformanceTest` gains cases for a self-parent (`a -> a`), a 2-node cycle (`a -> b -> a`), and a 3-node cycle (`a -> b -> c -> a`), each asserting termination with a bounded, non-repeating path.

Automated bug-hunt origin; verified locally via `:desktop-core:test`.