### PR TITLE
perf(select): single-pass min/max instead of full-sort-then-[0] (#3432)

### DIFF
--- a/src/features/navigation/ExploreElementScoring.ts
+++ b/src/features/navigation/ExploreElementScoring.ts
@@ -69,6 +69,24 @@ export function estimateCoverageGain(element: Element): number {
 }
 
 /**
+ * Return the first item with the maximum score in a single pass, computing each
+ * item's score exactly once. Equivalent to a stable descending sort followed by
+ * `[0]`, but O(n) instead of O(n log n) and without mutating the input.
+ */
+function maxByScore<T>(items: T[], score: (item: T) => number): T {
+  let best = items[0];
+  let bestScore = score(best);
+  for (let i = 1; i < items.length; i++) {
+    const itemScore = score(items[i]);
+    if (itemScore > bestScore) {
+      bestScore = itemScore;
+      best = items[i];
+    }
+  }
+  return best;
+}
+
+/**
  * Breadth-first selection: prefer unexplored elements on current screen
  */
 export function selectBreadthFirst(elements: Element[]): Element | null {
@@ -76,12 +94,8 @@ export function selectBreadthFirst(elements: Element[]): Element | null {
     return null;
   }
 
-  // Sort by navigation score
-  const sorted = elements.sort((a, b) => {
-    return calculateNavigationScore(b) - calculateNavigationScore(a);
-  });
-
-  return sorted[0];
+  // Highest navigation score wins; only O(n) scores, no full sort.
+  return maxByScore(elements, calculateNavigationScore);
 }
 
 /**
@@ -95,22 +109,25 @@ export function selectDepthFirst(
     return null;
   }
 
-  // Prefer elements we haven't tried yet, then by score
-  const sorted = elements.sort((a, b) => {
-    const aNever = !exploredElements.has(getElementKey(a));
-    const bNever = !exploredElements.has(getElementKey(b));
-
-    if (aNever && !bNever) {
-      return -1;
+  // Prefer elements we haven't tried yet, then by score. Single pass with each
+  // element's explored-status and score computed once (the old comparator
+  // recomputed getElementKey + calculateNavigationScore O(n log n) times).
+  let best = elements[0];
+  let bestNever = !exploredElements.has(getElementKey(best));
+  let bestScore = calculateNavigationScore(best);
+  for (let i = 1; i < elements.length; i++) {
+    const element = elements[i];
+    const never = !exploredElements.has(getElementKey(element));
+    const score = calculateNavigationScore(element);
+    // Unexplored beats explored; within the same status, higher score wins.
+    if ((never && !bestNever) || (never === bestNever && score > bestScore)) {
+      best = element;
+      bestNever = never;
+      bestScore = score;
     }
-    if (!aNever && bNever) {
-      return 1;
-    }
+  }
 
-    return calculateNavigationScore(b) - calculateNavigationScore(a);
-  });
-
-  return sorted[0];
+  return best;
 }
 
 /**
@@ -161,11 +178,8 @@ export function selectWeighted(
     };
   });
 
-  // Sort by final score
-  scored.sort((a, b) => b.finalScore - a.finalScore);
-
-  // Return selection with stats
-  const selected = scored[0];
+  // Highest final score wins; single pass instead of a full sort for [0].
+  const selected = maxByScore(scored, s => s.finalScore);
   return {
     element: selected.element,
     stats: {

--- a/src/server/deviceMatcher.ts
+++ b/src/server/deviceMatcher.ts
@@ -23,9 +23,11 @@ export interface DeviceMatcher {
  * Compare two version strings using semver-like logic.
  * Returns negative if a < b, 0 if equal, positive if a > b.
  */
-export function compareVersions(a: string, b: string): number {
-  const partsA = a.split(".").map(Number);
-  const partsB = b.split(".").map(Number);
+function parseVersion(version: string): number[] {
+  return version.split(".").map(Number);
+}
+
+function compareParsedVersions(partsA: number[], partsB: number[]): number {
   const len = Math.max(partsA.length, partsB.length);
   for (let i = 0; i < len; i++) {
     const va = partsA[i] ?? 0;
@@ -33,6 +35,10 @@ export function compareVersions(a: string, b: string): number {
     if (va !== vb) {return va - vb;}
   }
   return 0;
+}
+
+export function compareVersions(a: string, b: string): number {
+  return compareParsedVersions(parseVersion(a), parseVersion(b));
 }
 
 function matchesPlatform<T extends { platform: Platform }>(item: T, platform: Platform): boolean {
@@ -93,13 +99,24 @@ function applyStrategy<T extends { osVersion?: string }>(
 
   switch (strategy) {
     case "LATEST":
-      return [...candidates].sort((a, b) =>
-        compareVersions(b.osVersion ?? "0", a.osVersion ?? "0")
-      )[0];
-    case "MINIMUM":
-      return [...candidates].sort((a, b) =>
-        compareVersions(a.osVersion ?? "0", b.osVersion ?? "0")
-      )[0];
+    case "MINIMUM": {
+      // Parse each candidate's version once (the old comparator re-split every
+      // version on every comparison), then pick the extreme in a single pass.
+      const wantLatest = strategy === "LATEST";
+      const parsed = candidates.map(candidate => ({
+        candidate,
+        version: parseVersion(candidate.osVersion ?? "0")
+      }));
+      let best = parsed[0];
+      for (let i = 1; i < parsed.length; i++) {
+        const cmp = compareParsedVersions(parsed[i].version, best.version);
+        // Keep the first candidate on ties, matching the previous stable sort.
+        if (wantLatest ? cmp > 0 : cmp < 0) {
+          best = parsed[i];
+        }
+      }
+      return best.candidate;
+    }
     case "RANDOM":
       return random.pick(candidates);
   }

--- a/test/features/navigation/ExploreElementScoring.test.ts
+++ b/test/features/navigation/ExploreElementScoring.test.ts
@@ -166,6 +166,25 @@ describe("ExploreElementScoring", () => {
 
       expect(selected?.text).toBe("High");
     });
+
+    test("returns the first element on a score tie", () => {
+      const first = createMockElement({ text: "First" });
+      const second = createMockElement({ text: "Second" });
+
+      expect(selectBreadthFirst([first, second])?.text).toBe("First");
+    });
+
+    test("does not mutate the input array order", () => {
+      const lowScore = createMockElement({ text: "Low" });
+      (lowScore as any).hierarchyDepth = 10;
+      const highScore = createMockElement({ text: "High" });
+      (highScore as any).hierarchyDepth = 1;
+
+      const input = [lowScore, highScore];
+      selectBreadthFirst(input);
+
+      expect(input.map(e => e.text)).toEqual(["Low", "High"]);
+    });
   });
 
   describe("selectDepthFirst", () => {
@@ -211,6 +230,32 @@ describe("ExploreElementScoring", () => {
       const selected = selectDepthFirst([lowScore, highScore], trackedElements);
 
       expect(selected?.text).toBe("High");
+    });
+
+    test("returns the first unexplored element on a score tie", () => {
+      const first = createMockElement({ text: "First" });
+      const second = createMockElement({ text: "Second" });
+
+      // Both unexplored, equal score -> first wins.
+      expect(selectDepthFirst([first, second], new Map())?.text).toBe("First");
+    });
+
+    test("does not mutate the input array order", () => {
+      const explored = createMockElement({ text: "Explored" });
+      (explored as any).hierarchyDepth = 0;
+      const unexplored = createMockElement({ text: "Unexplored" });
+      (unexplored as any).hierarchyDepth = 10;
+
+      const trackedElements = new Map<string, TrackedElement>();
+      trackedElements.set(getElementKey(explored), {
+        interactionCount: 1,
+        lastInteractionScreen: "Screen1"
+      });
+
+      const input = [explored, unexplored];
+      selectDepthFirst(input, trackedElements);
+
+      expect(input.map(e => e.text)).toEqual(["Explored", "Unexplored"]);
     });
   });
 

--- a/test/server/deviceMatcher.test.ts
+++ b/test/server/deviceMatcher.test.ts
@@ -102,6 +102,27 @@ describe("DefaultDeviceMatcher.matchBootedDevice", () => {
     expect(result?.deviceId).toBe("3");
   });
 
+  it("LATEST returns the first candidate when versions tie", () => {
+    const devices = [
+      bootedDevice({ deviceId: "1", osVersion: "15" }),
+      bootedDevice({ deviceId: "2", osVersion: "15" }),
+    ];
+
+    const result = matcher.matchBootedDevice({ platform: "android" }, devices, "LATEST");
+    expect(result?.deviceId).toBe("1");
+  });
+
+  it("MINIMUM returns the lowest version, first candidate on ties", () => {
+    const devices = [
+      bootedDevice({ deviceId: "1", osVersion: "15" }),
+      bootedDevice({ deviceId: "2", osVersion: "13" }),
+      bootedDevice({ deviceId: "3", osVersion: "13" }),
+    ];
+
+    const result = matcher.matchBootedDevice({ platform: "android" }, devices, "MINIMUM");
+    expect(result?.deviceId).toBe("2");
+  });
+
   it("returns null when no osVersion matches range", () => {
     const devices = [
       bootedDevice({ deviceId: "1", osVersion: "12" }),


### PR DESCRIPTION
## Summary

Fixes #3432. Several selection helpers sorted an entire array only to return the first element.

## Change

- **`ExploreElementScoring`** `selectBreadthFirst` / `selectDepthFirst` / `selectWeighted`: replaced `elements.sort(...)[0]` with a single-pass max. The breadth/depth comparators previously recomputed `calculateNavigationScore` (and `getElementKey`) for *both operands on every comparison* — O(n log n) scorings — and mutated the caller-owned array in place. Now each element's score/explored-status is computed **once** and selected in one O(n) pass, no mutation. Extracted a small `maxByScore` helper for the two score-based selectors.
- **`deviceMatcher`** `applyStrategy` LATEST/MINIMUM: replaced `[...candidates].sort(...)[0]` (which re-ran `version.split(".").map(Number)` inside every comparison) with parse-once + single-pass. Refactored `compareVersions` into `parseVersion` + `compareParsedVersions` so parsing has a single source.
- `rankElementsForDryRun` is intentionally left as a real full sort.

Behavior preserved: first element wins on ties (matching the previous stable sort); inputs are no longer mutated (bonus correctness improvement — callers only use the return value).

## Tests

- Added regression tests: first-wins-on-tie and **no input mutation** for `selectBreadthFirst`/`selectDepthFirst`; LATEST/MINIMUM first-candidate-on-version-tie for the device matcher. All 68 existing + new scoring/matcher tests pass.
- `typecheck` / `lint` / `build` green.

Closes #3432