### PR TITLE
refactor: tighten over-broad / vacuous catch handlers (#3623)

### DIFF
--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -2,6 +2,7 @@ import { closeSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, w
 import { dirname } from "path";
 import { isProcessRunning as defaultIsProcessRunning } from "../daemon/daemonFiles";
 import { logger } from "./logger";
+import { toActionableError } from "../models/ActionableError";
 
 /**
  * The canonical cross-process file-lock primitive (issue #2794).
@@ -256,9 +257,17 @@ function writeExclusiveLockFile(lockFilePath: string, pid: number, ownerToken?: 
     closeSync(fd);
     return true;
   } catch (error) {
-    // `wx` create fails when the lock file already exists (another holder got there
-    // first); false tells the caller to fall through to the read/reclaim path.
-    logger.debug(`src/utils/fileLock.ts fallback failed: ${error}`, error);
-    return false;
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      // Expected contention: `wx` create fails when the lock file already exists
+      // (another holder got there first). false tells the caller to fall through to
+      // the read/reclaim path.
+      logger.debug(`src/utils/fileLock.ts: lock already held at ${lockFilePath}: ${error}`);
+      return false;
+    }
+    // A genuine IO error (EACCES/ENOSPC/EROFS/ENOTDIR/…) is NOT lock contention.
+    // Returning false would disguise a permissions/disk failure as "another process
+    // holds the lock" and let the caller busy-wait to a misleading migration-lock
+    // timeout. Surface the real cause instead (#3623).
+    throw toActionableError(error, `Failed to create exclusive lock file at ${lockFilePath}`);
   }
 }

--- a/src/utils/image/webp/WebpBinaryResolver.ts
+++ b/src/utils/image/webp/WebpBinaryResolver.ts
@@ -163,9 +163,7 @@ export class WebpBinaryResolver implements WebpBinaryProvider {
       return;
     }
 
-    const provision = this.provisionArchive(archive).catch(error => {
-      throw error;
-    }).finally(() => {
+    const provision = this.provisionArchive(archive).finally(() => {
       archiveProvisioningByPath.delete(archivePath);
     });
     archiveProvisioningByPath.set(archivePath, provision);

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -38,6 +38,20 @@ describe("fileLock primitive", () => {
     expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true })).toBe(false);
   });
 
+  test("surfaces a genuine IO error instead of reporting contention (#3623)", () => {
+    // Make an intermediate path component a regular file so the lock's parent can't
+    // be created: mkdirSync fails with a non-EEXIST errno (ENOTDIR), i.e. a real IO
+    // error rather than lock contention. The old uniform catch swallowed this as
+    // `return false`, disguising it as "another holder owns the lock".
+    const filePath = join(dir, "not-a-dir");
+    writeFileSync(filePath, "x");
+    const badLockPath = join(filePath, "sub", "child.lock");
+
+    expect(() => tryAcquireExclusiveLock(badLockPath, { pid: 100, isProcessRunning: () => true })).toThrow(
+      /Failed to create exclusive lock file/
+    );
+  });
+
   test("treats an unreadable PID as held", () => {
     writeFileSync(lockPath, "not-a-pid");
     expect(tryAcquireExclusiveLock(lockPath, { pid: 100, isProcessRunning: () => true })).toBe(false);

--- a/test/utils/image/webp/WebpBinaryResolver.test.ts
+++ b/test/utils/image/webp/WebpBinaryResolver.test.ts
@@ -211,6 +211,35 @@ describe("WebpBinaryResolver", () => {
     expect(processExecutor.wasCommandExecuted("tar -xzf")).toBe(false);
   });
 
+  test("a failed provision is not cached — the .finally clears the in-flight map so a retry re-downloads (#3623)", async () => {
+    const root = await makeTempDir();
+    const cacheDir = path.join(root, "cache");
+    const downloader = new CountingFileDownloader();
+    const processExecutor = new FakeProcessExecutor();
+    // A mismatching checksum makes every provisionArchive attempt throw.
+    const checksumCalculator = fakeArchiveChecksumCalculator("0".repeat(64));
+
+    const resolver = new WebpBinaryResolver({
+      projectRoot: root,
+      cacheDir,
+      platform: "darwin",
+      arch: "arm64",
+      env: { PATH: "" },
+      fileDownloader: downloader,
+      processExecutor,
+      checksumCalculator,
+    });
+
+    await resolver.resolveCwebp().catch(() => undefined);
+    await resolver.resolveCwebp().catch(() => undefined);
+
+    // If provisionArchiveOnce's .finally didn't run after the rejection, the second
+    // attempt would await the cached rejected promise and skip the download. Two
+    // downloads proves the failed entry was cleared (removing the no-op .catch left
+    // that cleanup intact).
+    expect(downloader.downloadedUrls).toHaveLength(2);
+  });
+
   test("provisions the shared off-platform archive once when resolving both binaries", async () => {
     const root = await makeTempDir();
     const cacheDir = path.join(root, "cache");


### PR DESCRIPTION
## Summary
Closes #3623. Two catch-handler cleanups from an adversarial 0.0.40→0.0.44 diff review.

### 1. `WebpBinaryResolver.ts` — remove vacuous `.catch`
`provisionArchiveOnce` had `.catch(error => { throw error; })` that caught and immediately rethrew, doing nothing the trailing `.finally()` doesn't already handle. Removed; behavior is identical — errors still propagate and `.finally()` still clears the in-flight provisioning map.

### 2. `fileLock.ts` — distinguish `EEXIST` from genuine IO errors
`writeExclusiveLockFile`'s catch-all treated **every** failure as "could not acquire" → `return false`. `openSync(.., "wx")` throws `EEXIST` for expected contention, but a genuine IO error (`EACCES`/`ENOSPC`/`EROFS`/`ENOTDIR`) threw identically and also became `return false` — so a permissions/disk failure was disguised as lock contention, and the caller (`MigrationLock.acquire`) busy-waited to a **misleading** "another process is likely migrating" timeout.

Now: `EEXIST` → expected, `return false` (fall through to the read/reclaim path, logged at debug); any other errno → `throw toActionableError(...)` surfacing the real cause. Both branches follow the repo error-handling convention.

Both `tryAcquireExclusiveLock` callers (`MigrationLock`, daemon `manager`) benefit — a real IO error now surfaces immediately with an accurate message instead of being masked as contention.

## Tests
- `fileLock`: new test points the lock path under a regular file so `mkdirSync` fails with `ENOTDIR` (non-`EEXIST`) and asserts it **throws** an actionable error rather than reporting contention. Existing `EEXIST → false` behavior still covered by "fails when a different live holder owns it".
- `WebpBinaryResolver`: new test forces a failed provision (checksum mismatch) twice and asserts the archive is re-downloaded — proving `.finally` still clears the dedup map after the `.catch` removal. Existing SHA-256-mismatch test already proves errors still propagate.

`bun test` (both suites), `bunx turbo run build lint`, `bun run typecheck` all green.