### PR TITLE
perf(db): getTimelineData buckets and counts in SQL, not JS (#3439)

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -19,8 +19,6 @@ src/db/failureAnalyticsRepository.ts: error TS2322: Type 'FailureType' is not as
 src/db/failureAnalyticsRepository.ts: error TS2322: Type 'FailureType' is not assignable to type 'ValueExpression<Database, "failure_groups", "crash" | "anr" | "tool_failure">'.
 src/db/failureAnalyticsRepository.ts: error TS2345: Argument of type 'FailureType' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_groups", "type">'.
 src/db/failureAnalyticsRepository.ts: error TS2345: Argument of type 'FailureType' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_notifications", "type">'.
-src/db/failureAnalyticsRepository.ts: error TS2367: This comparison appears to be unintentional because the types '"crash" | "anr" | "tool_failure"' and '"nonfatal"' have no overlap.
-src/db/failureAnalyticsRepository.ts: error TS2678: Type '"nonfatal"' is not comparable to type '"crash" | "anr" | "tool_failure"'.
 src/db/logEventRepository.ts: error TS2322: Type '{ deviceId: string | null; timestamp: number; applicationId: string | null; sessionId: string | null; level: number; tag: string; message: string; filterName: string | null; }[]' is not assignable to type 'RecordLogEventInput[]'.
 src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
@@ -257,7 +255,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 13 :: src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2769: No overload matches this call.
 # swap-fp: 13 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type '(Element | null)[]' is not assignable to type 'Element[]'.
 # swap-fp: 13,13,27 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
-# swap-fp: 14 :: src/db/failureAnalyticsRepository.ts: error TS2678: Type '"nonfatal"' is not comparable to type '"crash" | "anr" | "tool_failure"'.
 # swap-fp: 14 :: src/features/accessibility/WcagAudit.ts: error TS2352: Conversion of type 'ViewHierarchyNode[]' to type 'ViewHierarchyNode' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 # swap-fp: 14,32 :: src/features/accessibility/WcagAudit.ts: error TS2339: Property 'children' does not exist on type 'ViewHierarchyNode'.
 # swap-fp: 149 :: src/server/navigationTools.ts: error TS2339: Property 'coverage' does not exist on type 'ExploreExecutionResult'.
@@ -343,7 +340,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 5 :: src/server/bootedDeviceResources.ts: error TS2322: Type '"local" | "remote"' is not assignable to type '"local" | undefined'.
 # swap-fp: 5,21,76 :: src/db/migrator.ts: error TS7006: Parameter 'name' implicitly has an 'any' type.
 # swap-fp: 5,7,7 :: src/server/networkGraph.ts: error TS18048: 'group' is possibly 'undefined'.
-# swap-fp: 50 :: src/db/failureAnalyticsRepository.ts: error TS2367: This comparison appears to be unintentional because the types '"crash" | "anr" | "tool_failure"' and '"nonfatal"' have no overlap.
 # swap-fp: 51 :: src/server/navigationTools.ts: error TS2339: Property 'interactionsPerformed' does not exist on type 'ExploreExecutionResult'.
 # swap-fp: 52 :: src/features/observe/collectors/DeviceStateCollector.ts: error TS2554: Expected 0 arguments, but got 1.
 # swap-fp: 52 :: src/features/performance/PerformanceMonitor.ts: error TS2345: Argument of type 'PerformanceDataPusher' is not assignable to parameter of type 'PerformancePushSocketServer'.

--- a/src/db/failureAnalyticsRepository.ts
+++ b/src/db/failureAnalyticsRepository.ts
@@ -453,17 +453,28 @@ export class FailureAnalyticsRepository {
     const bucketMs = this.getAggregationMs(aggregation);
     const periodDuration = endTime - startTime;
 
-    // Get occurrences in the time range
-    const occurrences = await db
+    // Aggregate occurrences per (bucket, type) in SQL rather than transferring
+    // every occurrence and bucketing/counting in JS (#3439). `bucketMs` is a
+    // constant here, so integer-dividing the timestamp yields the bucket index;
+    // CAST(... AS INTEGER) makes the truncation explicit regardless of how the
+    // bound value types. Only O(buckets * types) rows transfer.
+    const bucketIndex = sql<number>`cast(failure_occurrences.timestamp / ${bucketMs} as integer)`;
+    const bucketedCounts = await db
       .selectFrom("failure_occurrences")
       .innerJoin("failure_groups", "failure_occurrences.group_id", "failure_groups.id")
-      .select(["failure_occurrences.timestamp", "failure_groups.type"])
+      .select([
+        bucketIndex.as("bucket"),
+        "failure_groups.type",
+        db.fn.countAll<number>().as("count"),
+      ])
       .where("failure_occurrences.timestamp", ">=", startTime)
       .where("failure_occurrences.timestamp", "<=", endTime)
+      .groupBy([bucketIndex, "failure_groups.type"])
       .execute();
 
-    // Pre-create all buckets for the time range with zero values
-    const buckets = new Map<number, { crashes: number; anrs: number; toolFailures: number; nonfatals: number }>();
+    // Pre-create all buckets for the time range with zero values, then fill from
+    // the aggregate so empty buckets still appear as zeros.
+    const buckets = new Map<number, PeriodTotals>();
     const firstBucketStart = Math.floor(startTime / bucketMs) * bucketMs;
     const lastBucketStart = Math.floor(endTime / bucketMs) * bucketMs;
 
@@ -471,26 +482,11 @@ export class FailureAnalyticsRepository {
       buckets.set(bucketStart, { crashes: 0, anrs: 0, toolFailures: 0, nonfatals: 0 });
     }
 
-    // Fill in data from occurrences
-    for (const occ of occurrences) {
-      const bucketStart = Math.floor(occ.timestamp / bucketMs) * bucketMs;
+    for (const row of bucketedCounts) {
+      const bucketStart = Number(row.bucket) * bucketMs;
       const bucket = buckets.get(bucketStart);
       if (!bucket) {continue;} // Should not happen, but guard against it
-
-      switch (occ.type) {
-        case "crash":
-          bucket.crashes++;
-          break;
-        case "anr":
-          bucket.anrs++;
-          break;
-        case "tool_failure":
-          bucket.toolFailures++;
-          break;
-        case "nonfatal":
-          bucket.nonfatals++;
-          break;
-      }
+      this.addTypeCount(bucket, row.type as FailureType, Number(row.count));
     }
 
     // Convert to sorted array
@@ -507,26 +503,46 @@ export class FailureAnalyticsRepository {
       });
     }
 
-    // Get previous period totals
+    // Previous period totals: one grouped COUNT(*) rather than fetching every
+    // occurrence and running four full `.filter().length` passes (#3439).
     const previousStart = startTime - periodDuration;
     const previousEnd = startTime;
 
-    const previousOccurrences = await db
+    const previousCounts = await db
       .selectFrom("failure_occurrences")
       .innerJoin("failure_groups", "failure_occurrences.group_id", "failure_groups.id")
-      .select(["failure_groups.type"])
+      .select(["failure_groups.type", db.fn.countAll<number>().as("count")])
       .where("failure_occurrences.timestamp", ">=", previousStart)
       .where("failure_occurrences.timestamp", "<", previousEnd)
+      .groupBy("failure_groups.type")
       .execute();
 
-    const previousPeriodTotals: PeriodTotals = {
-      crashes: previousOccurrences.filter(o => o.type === "crash").length,
-      anrs: previousOccurrences.filter(o => o.type === "anr").length,
-      toolFailures: previousOccurrences.filter(o => o.type === "tool_failure").length,
-      nonfatals: previousOccurrences.filter(o => o.type === "nonfatal").length,
-    };
+    const previousPeriodTotals: PeriodTotals = { crashes: 0, anrs: 0, toolFailures: 0, nonfatals: 0 };
+    for (const row of previousCounts) {
+      this.addTypeCount(previousPeriodTotals, row.type as FailureType, Number(row.count));
+    }
 
     return { dataPoints, previousPeriodTotals };
+  }
+
+  // Add `count` to the field of `target` matching the failure `type`. Both the
+  // per-bucket tallies and the previous-period totals share the same four
+  // fields, so one accumulator serves both.
+  private addTypeCount(target: PeriodTotals, type: FailureType, count: number): void {
+    switch (type) {
+      case "crash":
+        target.crashes += count;
+        break;
+      case "anr":
+        target.anrs += count;
+        break;
+      case "tool_failure":
+        target.toolFailures += count;
+        break;
+      case "nonfatal":
+        target.nonfatals += count;
+        break;
+    }
   }
 
   /**

--- a/test/db/failureAnalyticsRepository.test.ts
+++ b/test/db/failureAnalyticsRepository.test.ts
@@ -997,3 +997,105 @@ describe("FailureAnalyticsRepository row-cap retention (#3436)", () => {
     expect(await db.selectFrom("failure_groups").selectAll().execute()).toHaveLength(2);
   });
 });
+
+describe("FailureAnalyticsRepository.getTimelineData (#3439)", () => {
+  let db: Kysely<Database>;
+  let timer: FakeTimer;
+  let repo: FailureAnalyticsRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    timer = new FakeTimer();
+    repo = new FailureAnalyticsRepository(timer, db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  // Records one occurrence of `type` at `ts`. Distinct signatures per type keep
+  // each type in its own group; the occurrence timestamp is the timer's value.
+  async function record(type: "crash" | "anr" | "tool_failure" | "nonfatal", ts: number): Promise<void> {
+    timer.setCurrentTime(ts);
+    await repo.recordFailure({
+      type,
+      signature: `sig-${type}`,
+      title: `title ${type}`,
+      message: "m",
+      severity: "critical",
+      occurrence: { deviceModel: "Pixel 7", os: "Android 14", appVersion: "1.0.0", sessionId: "s" },
+    });
+  }
+
+  const MINUTE = 60_000;
+
+  test("buckets counts per type by minute and zero-fills empty buckets", async () => {
+    await record("crash", 30_000); // bucket 0
+    await record("nonfatal", 45_000); // bucket 0
+    await record("crash", 90_000); // bucket 60_000
+    await record("anr", 95_000); // bucket 60_000
+    await record("tool_failure", 150_000); // bucket 120_000
+    // bucket 180_000 stays empty
+
+    const { dataPoints } = await repo.getTimelineData({
+      startTime: 0,
+      endTime: 180_000,
+      aggregation: "minute",
+    });
+
+    // Buckets: 0, 60_000, 120_000, 180_000 (inclusive of the end bucket).
+    expect(dataPoints).toHaveLength(4);
+    expect(dataPoints[0]).toMatchObject({ crashes: 1, anrs: 0, toolFailures: 0, nonfatals: 1 });
+    expect(dataPoints[1]).toMatchObject({ crashes: 1, anrs: 1, toolFailures: 0, nonfatals: 0 });
+    expect(dataPoints[2]).toMatchObject({ crashes: 0, anrs: 0, toolFailures: 1, nonfatals: 0 });
+    expect(dataPoints[3]).toMatchObject({ crashes: 0, anrs: 0, toolFailures: 0, nonfatals: 0 });
+  });
+
+  test("an occurrence on a bucket boundary lands in that bucket", async () => {
+    await record("crash", MINUTE); // exactly bucket 60_000, not bucket 0
+
+    const { dataPoints } = await repo.getTimelineData({
+      startTime: 0,
+      endTime: 2 * MINUTE,
+      aggregation: "minute",
+    });
+
+    expect(dataPoints).toHaveLength(3);
+    expect(dataPoints[0].crashes).toBe(0);
+    expect(dataPoints[1].crashes).toBe(1);
+    expect(dataPoints[2].crashes).toBe(0);
+  });
+
+  test("previousPeriodTotals counts the prior equal-length window by type", async () => {
+    // Current window [180_000, 360_000); previous window [0, 180_000).
+    await record("crash", 10_000);
+    await record("crash", 20_000);
+    await record("anr", 30_000);
+    await record("tool_failure", 40_000);
+    await record("nonfatal", 50_000);
+    // Exactly at startTime belongs to the CURRENT window (previousEnd is exclusive).
+    await record("crash", 180_000);
+
+    const { previousPeriodTotals } = await repo.getTimelineData({
+      startTime: 180_000,
+      endTime: 360_000,
+      aggregation: "minute",
+    });
+
+    expect(previousPeriodTotals).toEqual({ crashes: 2, anrs: 1, toolFailures: 1, nonfatals: 1 });
+  });
+
+  test("returns zeroed totals and buckets when the range is empty", async () => {
+    const { dataPoints, previousPeriodTotals } = await repo.getTimelineData({
+      startTime: 0,
+      endTime: 2 * MINUTE,
+      aggregation: "minute",
+    });
+
+    expect(previousPeriodTotals).toEqual({ crashes: 0, anrs: 0, toolFailures: 0, nonfatals: 0 });
+    expect(dataPoints).toHaveLength(3);
+    for (const dp of dataPoints) {
+      expect(dp).toMatchObject({ crashes: 0, anrs: 0, toolFailures: 0, nonfatals: 0 });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`getTimelineData` fetched **every** failure occurrence in the range and bucketed/counted them in a JS loop; `previousPeriodTotals` fetched all previous-period occurrences and ran **four** `.filter().length` full passes to count per type.

Pushed both into SQL (#3439):
- **Timeline:** `GROUP BY CAST(timestamp / bucketMs AS INTEGER), type` with `COUNT(*)`. JS only zero-fills empty buckets from the sparse aggregate. Row transfer drops from O(occurrences) to O(buckets × types).
- **Previous period:** one `GROUP BY type COUNT(*)` replaces fetch-all + four scans.

A shared `addTypeCount(target, type, count)` accumulator folds a per-type count into the matching field — the per-bucket tallies and the previous-period totals share the same four fields (`crashes`/`anrs`/`toolFailures`/`nonfatals`), so one helper serves both. The range filter and join are index-served (`idx_failure_occurrences_timestamp`, `idx_failure_occurrences_group`, `idx_failure_groups_type`).

Removing the old narrow-typed `switch (occ.type)` / `.filter(o => o.type === "nonfatal")` eliminates two baselined `tsc` errors (the `failure_groups.type` column type omits `"nonfatal"`); the baseline ratchets **down** 235 → 233.

## Tests
`getTimelineData` had **no** prior coverage. Added:
- buckets counts per type by minute and **zero-fills empty buckets**
- an occurrence on a bucket boundary lands in that bucket
- `previousPeriodTotals` counts the prior equal-length window by type, with `previousEnd` exclusive (an occurrence exactly at `startTime` belongs to the current window)
- empty range returns zeroed totals and buckets

Full `test/db` suite: 837 tests green.

## Notes
Reviewed via `/simplify` (reuse/efficiency + simplification/altitude agents). Applied their main finding: typed `addTypeCount` as `FailureType` (not `string`) with `row.type as FailureType` casts at call sites, matching the existing convention (the generated `Database` type narrows the column while app-level `FailureType` includes `"nonfatal"`) — keeps switch exhaustiveness. Out of scope / noted for follow-up: the `getFailureGroups` summary totals build four `.filter().reduce()` passes that could also reuse `addTypeCount`.

Closes #3439.