### PR TITLE
perf(screenshot): single-pass top-k instead of full-sort in findSimilarScreenshots (#3433)

### DIFF
--- a/src/utils/screenshot/ScreenshotMatcher.ts
+++ b/src/utils/screenshot/ScreenshotMatcher.ts
@@ -15,6 +15,50 @@ export interface SimilarScreenshotResult {
 }
 
 /**
+ * Select the `k` items with the largest `value`, returned in descending order,
+ * without fully sorting the input. Effectively O(n) for the common case (most
+ * items rejected by a single comparison against the current k-th largest) and
+ * O(n * k) worst case, versus O(n log n) for a full sort when only k << n items
+ * are needed (issue #3433).
+ *
+ * Ties preserve input order, matching a stable descending sort followed by
+ * `slice(0, k)`.
+ */
+export function topKByDescending<T>(items: T[], k: number, value: (item: T) => number): T[] {
+  if (k <= 0) {
+    return [];
+  }
+
+  // `top` is kept sorted by value, descending, with at most k entries.
+  const top: Array<{ item: T; value: number }> = [];
+  for (const item of items) {
+    const itemValue = value(item);
+    if (top.length >= k && itemValue <= top[top.length - 1].value) {
+      continue; // not large enough to enter the current top-k
+    }
+
+    // Binary search for the insertion point; `>=` skips past equal values so a
+    // new item lands after existing equals (stable ordering).
+    let lo = 0;
+    let hi = top.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (top[mid].value >= itemValue) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    top.splice(lo, 0, { item, value: itemValue });
+    if (top.length > k) {
+      top.pop();
+    }
+  }
+
+  return top.map(entry => entry.item);
+}
+
+/**
  * Assemble the final per-path results of the two-stage batch comparison:
  * precise pixel results for candidates, falling back to the stage-1 perceptual
  * similarity for everything else.
@@ -244,7 +288,8 @@ export class ScreenshotMatcher {
         };
       }
 
-      // Sort files by modification time (newest first) to check recent screenshots first
+      // Take the newest maxComparisons files. Only k << n are needed, so select
+      // the top-k by mtime in a single pass instead of a full O(n log n) sort.
       const filesWithStats = await Promise.all(
         screenshotFiles.map(async filePath => {
           const stats = await fsPromises.stat(filePath);
@@ -252,8 +297,7 @@ export class ScreenshotMatcher {
         })
       );
 
-      filesWithStats.sort((a, b) => b.mtime - a.mtime);
-      const filesToCheck = filesWithStats.slice(0, maxComparisons);
+      const filesToCheck = topKByDescending(filesWithStats, maxComparisons, f => f.mtime);
 
       logger.info(`Comparing against ${filesToCheck.length} most recent screenshots (max: ${maxComparisons})`);
 

--- a/test/utils/screenshot/topKByDescending.test.ts
+++ b/test/utils/screenshot/topKByDescending.test.ts
@@ -1,0 +1,66 @@
+import { expect, describe, test } from "bun:test";
+import { topKByDescending } from "../../../src/utils/screenshot/ScreenshotMatcher";
+
+// Reference implementation: stable descending sort + slice, which the helper
+// must match exactly (order matters — callers consume newest-first).
+function fullSortTopK<T>(items: T[], k: number, value: (item: T) => number): T[] {
+  return [...items]
+    .map((item, i) => ({ item, i, v: value(item) }))
+    .sort((a, b) => (b.v - a.v) || (a.i - b.i))
+    .slice(0, Math.max(0, k))
+    .map(entry => entry.item);
+}
+
+describe("topKByDescending", () => {
+  test("returns the k largest values in descending order", () => {
+    const items = [{ v: 3 }, { v: 1 }, { v: 5 }, { v: 2 }, { v: 4 }];
+    const result = topKByDescending(items, 3, x => x.v);
+    expect(result.map(x => x.v)).toEqual([5, 4, 3]);
+  });
+
+  test("returns everything sorted when k >= n", () => {
+    const items = [{ v: 3 }, { v: 1 }, { v: 2 }];
+    expect(topKByDescending(items, 10, x => x.v).map(x => x.v)).toEqual([3, 2, 1]);
+  });
+
+  test("returns an empty array for k <= 0 or empty input", () => {
+    expect(topKByDescending([{ v: 1 }], 0, x => x.v)).toEqual([]);
+    expect(topKByDescending([{ v: 1 }], -1, x => x.v)).toEqual([]);
+    expect(topKByDescending([] as { v: number }[], 5, x => x.v)).toEqual([]);
+  });
+
+  test("preserves input order among equal values (stable), matching sort+slice", () => {
+    // Distinguish equal-valued items by an id to observe ordering.
+    const items = [
+      { v: 5, id: "a" },
+      { v: 5, id: "b" },
+      { v: 3, id: "c" },
+      { v: 5, id: "d" },
+      { v: 3, id: "e" }
+    ];
+    const result = topKByDescending(items, 3, x => x.v);
+    // The three 5s in original order.
+    expect(result.map(x => x.id)).toEqual(["a", "b", "d"]);
+    expect(result).toEqual(fullSortTopK(items, 3, x => x.v));
+  });
+
+  test("matches full-sort-then-slice on boundary ties", () => {
+    // Two items share the boundary (k-th) value; the earlier one must win.
+    const items = [
+      { v: 10, id: "x" },
+      { v: 7, id: "boundary-first" },
+      { v: 7, id: "boundary-second" },
+      { v: 4, id: "z" }
+    ];
+    const result = topKByDescending(items, 2, x => x.v);
+    expect(result.map(x => x.id)).toEqual(["x", "boundary-first"]);
+    expect(result).toEqual(fullSortTopK(items, 2, x => x.v));
+  });
+
+  test("agrees with the reference on a larger mixed dataset", () => {
+    const items = Array.from({ length: 200 }, (_, i) => ({ v: (i * 37) % 50, i }));
+    for (const k of [1, 5, 10, 50, 199, 200, 500]) {
+      expect(topKByDescending(items, k, x => x.v)).toEqual(fullSortTopK(items, k, x => x.v));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3433. `findSimilarScreenshots` full-sorted every stat'd file by mtime (O(n log n)) then sliced the newest `maxComparisons` (default 10) — but only the top k << n are ever compared.

## Change

- Added a pure, exported `topKByDescending(items, k, value)` that selects the k largest in a single pass (O(n) common case where most items are rejected by one comparison against the current k-th largest; O(n·k) worst) and returns them **in descending order**.
- `findSimilarScreenshots` now uses it in place of `sort + slice`, so the newest-first / break-on-first-match loop is unchanged. The win scales with cache-directory size.
- Ties preserve input order, matching the previous stable descending sort + slice.

## Tests

- New `topKByDescending.test.ts`: k-largest ordering, `k >= n`, `k <= 0`/empty, **stable tie ordering**, boundary-tie equivalence, and a 200-item fuzz check that asserts exact equality against a reference stable-sort-then-slice across `k ∈ {1,5,10,50,199,200,500}`.
- `typecheck` / `lint` / `build` green.

Closes #3433