### PR TITLE
perf(nav): hoist navigation-relevant tool list to a module-level Set (#3434)

### DIFF
--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -521,17 +521,19 @@ export class DefaultAuditRunner implements AuditRunner {
   }
 }
 
+// UI interaction tools that may cause navigation. Excludes app lifecycle tools
+// (launchApp, terminateApp, homeScreen, etc.) because they don't represent
+// replayable in-app navigation paths. Module-level Set so record() does O(1)
+// membership checks without re-allocating the list on every tool call.
+export const NAVIGATION_RELEVANT_TOOLS = new Set([
+  "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
+  "pressButton", "inputText", "clearText", "imeAction"
+]);
+
 class DefaultNavigationToolCallRecorder implements NavigationToolCallRecorder {
   record(name: string, args: any, device: BootedDevice | undefined, sessionUuid: string | undefined): void {
     // Record tool call for navigation graph correlation before the handler mutates UI state.
-    // Only record UI interaction tools that may cause navigation. Excludes app lifecycle
-    // tools (launchApp, terminateApp, homeScreen, etc.) because they don't represent
-    // replayable in-app navigation paths.
-    const navigationRelevantTools = [
-      "tapOn", "swipeOn", "pinchOn", "dragAndDrop",
-      "pressButton", "inputText", "clearText", "imeAction"
-    ];
-    if (!navigationRelevantTools.includes(name)) {
+    if (!NAVIGATION_RELEVANT_TOOLS.has(name)) {
       return;
     }
 

--- a/test/server/navigationRelevantTools.test.ts
+++ b/test/server/navigationRelevantTools.test.ts
@@ -1,0 +1,20 @@
+import { expect, describe, test } from "bun:test";
+import { NAVIGATION_RELEVANT_TOOLS } from "../../src/server/toolRegistry";
+
+describe("NAVIGATION_RELEVANT_TOOLS", () => {
+  test("is a Set for O(1) membership checks", () => {
+    expect(NAVIGATION_RELEVANT_TOOLS).toBeInstanceOf(Set);
+  });
+
+  test("contains exactly the UI-interaction tools that may cause navigation", () => {
+    expect([...NAVIGATION_RELEVANT_TOOLS].sort()).toEqual(
+      ["clearText", "dragAndDrop", "imeAction", "inputText", "pinchOn", "pressButton", "swipeOn", "tapOn"]
+    );
+  });
+
+  test("excludes app-lifecycle and observation tools", () => {
+    for (const tool of ["launchApp", "terminateApp", "homeScreen", "observe", "installApp"]) {
+      expect(NAVIGATION_RELEVANT_TOOLS.has(tool)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3434. `DefaultNavigationToolCallRecorder.record` runs for **every** device-aware tool invocation and rebuilt an 8-element array literal on each call, then did a linear `.includes(name)` before early-returning for non-navigation tools.

## Change

- Hoisted the list to a module-level `NAVIGATION_RELEVANT_TOOLS` Set and switched to `.has(name)`: no per-call allocation, O(1) membership. Same members, same behavior.

## Tests

- New `navigationRelevantTools.test.ts`: asserts it is a `Set`, its exact membership (locks the list against accidental drift in the refactor), and that app-lifecycle/observation tools are excluded.
- `typecheck` / `lint` / `build` green.

Closes #3434