### PR TITLE
perf(db): run PRAGMA optimize periodically, not only on close (#3497)

### DIFF
--- a/src/db/bunSqliteDialect.ts
+++ b/src/db/bunSqliteDialect.ts
@@ -36,6 +36,16 @@ const DEFAULT_RETRY_BACKOFF: BackoffPolicy = exponentialBackoff({
   maxDelayMs: 50,
 });
 
+/**
+ * Low-frequency cadence for the periodic `PRAGMA optimize` (#3497). A long-lived
+ * daemon that rarely restarts otherwise only refreshes planner statistics at
+ * close, so index selection can drift as tables grow between restarts. `optimize`
+ * is cheap and no-ops when nothing needs updating, so a several-minute tick keeps
+ * stats fresh without meaningful overhead. Enabled only for the daemon's
+ * file-backed connection (see database.ts); in-memory connections leave it off.
+ */
+export const DEFAULT_OPTIMIZE_INTERVAL_MS = 5 * 60 * 1000;
+
 type BunStatement = ReturnType<BunDatabase["prepare"]>;
 type SchemaVersionRow = { schema_version?: number | bigint };
 
@@ -76,6 +86,12 @@ interface BunSqliteDialectConfig {
    * <100ms and non-flaky. Defaults are production-safe.
    */
   retry?: BunSqliteRetryConfig;
+  /**
+   * When set and > 0, run `PRAGMA optimize` on this connection every N ms (#3497)
+   * using the connection's injected timer. Left unset (disabled) for in-memory
+   * connections; the daemon's file-backed connection enables it.
+   */
+  optimizeIntervalMs?: number;
 }
 
 interface BunSqliteRetryConfig {
@@ -101,7 +117,8 @@ class BunSqliteDriver implements Driver {
     this.#connectionState = new BunSqliteConnectionState(
       this.#config.database,
       this.#config.beforeQuery,
-      this.#config.retry
+      this.#config.retry,
+      this.#config.optimizeIntervalMs
     );
   }
 
@@ -160,11 +177,13 @@ export class BunSqliteConnectionState {
   readonly #retryBackoff: BackoffPolicy;
   readonly #timer: Timer;
   readonly #random: Random;
+  #optimizeTimer: NodeJS.Timeout | null = null;
 
   constructor(
     database: BunDatabase | (() => BunDatabase),
     beforeQuery?: () => Promise<void>,
-    retry?: BunSqliteRetryConfig
+    retry?: BunSqliteRetryConfig,
+    optimizeIntervalMs?: number
   ) {
     this.#databaseSource = database;
     this.#db = typeof database === "function" ? null : database;
@@ -173,6 +192,37 @@ export class BunSqliteConnectionState {
     this.#retryBackoff = retry?.backoff ?? DEFAULT_RETRY_BACKOFF;
     this.#timer = retry?.timer ?? defaultTimer;
     this.#random = retry?.random ?? defaultRandom;
+
+    if (optimizeIntervalMs && optimizeIntervalMs > 0) {
+      this.#optimizeTimer = this.#timer.setInterval(
+        () => this.#runPeriodicOptimize(),
+        optimizeIntervalMs
+      );
+      // A background maintenance tick must never keep the process alive.
+      // FakeTimer handles have no unref, hence the optional call.
+      (this.#optimizeTimer as { unref?: () => void }).unref?.();
+    }
+  }
+
+  // Best-effort periodic refresh of the query-planner statistics (#3497). Skips
+  // when the connection is closed, not yet opened, or mid-query/transaction so it
+  // never runs inside another statement's transaction; the next tick retries.
+  #runPeriodicOptimize(): void {
+    if (
+      this.#closed ||
+      !this.#db ||
+      this.#transactionOwner !== null ||
+      this.#pendingTransactions > 0 ||
+      this.#activeQueries > 0
+    ) {
+      return;
+    }
+    try {
+      this.#db.exec("PRAGMA optimize;");
+    } catch (error) {
+      // Stale planner stats are preferable to a throwing background timer.
+      logger.debug(`periodic PRAGMA optimize failed: ${error}`);
+    }
   }
 
   async beginTransaction(owner: symbol): Promise<void> {
@@ -364,6 +414,10 @@ export class BunSqliteConnectionState {
     // observes the closed state and rejects instead of running against a dead
     // handle. Then wake waiters so queued queries settle promptly.
     this.#closed = true;
+    if (this.#optimizeTimer) {
+      this.#timer.clearInterval(this.#optimizeTimer);
+      this.#optimizeTimer = null;
+    }
     this.#clearStatementCache();
     if (this.#db) {
       try {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -12,7 +12,7 @@ import {
 } from "./migrationLock";
 import { logger } from "../utils/logger";
 import { ActionableError, toActionableError } from "../models/ActionableError";
-import { BunSqliteDialect } from "./bunSqliteDialect";
+import { BunSqliteDialect, DEFAULT_OPTIMIZE_INTERVAL_MS } from "./bunSqliteDialect";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import {
   createIncompleteExtractionError,
@@ -369,6 +369,9 @@ function createSqliteKysely<T>(
     dialect: new BunSqliteDialect({
       database: () => openConfiguredSqliteDatabase(dbPath),
       beforeQuery,
+      // Refresh planner statistics periodically over a long-lived daemon, not
+      // only at connection close (#3497).
+      optimizeIntervalMs: DEFAULT_OPTIMIZE_INTERVAL_MS,
     }),
   });
 }

--- a/test/db/bunSqlitePeriodicOptimize.test.ts
+++ b/test/db/bunSqlitePeriodicOptimize.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import type { Database as BunDatabase } from "bun:sqlite";
+import { BunSqliteConnectionState } from "../../src/db/bunSqliteDialect";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { logger } from "../../src/utils/logger";
+
+/**
+ * Periodic `PRAGMA optimize` for a long-lived daemon connection (#3497).
+ *
+ * The optimize runs on a low-frequency timer using the connection's injected
+ * `Timer`, so these tests drive a `FakeTimer` and a fake `bun:sqlite` handle to
+ * prove — deterministically and <100ms — that it fires on the interval, repeats,
+ * swallows/logs failures without throwing, is disabled by default, does not
+ * force-open a lazy connection, and stops on close.
+ */
+
+// Minimal fake of the bun:sqlite surface the connection touches. Records every
+// `exec()` SQL; optionally makes `exec` throw to exercise the best-effort path.
+function makeFakeDb(opts: { execThrows?: boolean } = {}): { db: BunDatabase; execs: string[] } {
+  const execs: string[] = [];
+  const db = {
+    prepare: (_sql: string) => ({
+      all: () => [],
+      run: () => ({ changes: 0, lastInsertRowid: 0 }),
+      get: () => ({ schema_version: 0 }),
+      finalize: () => {},
+    }),
+    exec: (sql: string) => {
+      execs.push(sql);
+      if (opts.execThrows) {
+        throw new Error("optimize boom");
+      }
+    },
+    close: () => {},
+  } as unknown as BunDatabase;
+  return { db, execs };
+}
+
+const optimizeCount = (execs: string[]): number =>
+  execs.filter(s => s.includes("PRAGMA optimize")).length;
+
+describe("periodic PRAGMA optimize (#3497)", () => {
+  test("fires on the interval and repeats", () => {
+    const timer = new FakeTimer();
+    const { db, execs } = makeFakeDb();
+    new BunSqliteConnectionState(db, undefined, { timer }, 1000);
+
+    expect(optimizeCount(execs)).toBe(0);
+
+    timer.advanceTime(1000);
+    expect(optimizeCount(execs)).toBe(1);
+
+    timer.advanceTime(1000);
+    expect(optimizeCount(execs)).toBe(2);
+  });
+
+  test("swallows and logs an optimize failure without throwing", () => {
+    const timer = new FakeTimer();
+    const { db } = makeFakeDb({ execThrows: true });
+    const debugSpy = spyOn(logger, "debug");
+    try {
+      new BunSqliteConnectionState(db, undefined, { timer }, 1000);
+
+      expect(() => timer.advanceTime(1000)).not.toThrow();
+      const logged = debugSpy.mock.calls.map(c => String(c[0])).join("\n");
+      expect(logged).toContain("periodic PRAGMA optimize failed");
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  test("is disabled when no interval is configured", () => {
+    const timer = new FakeTimer();
+    const { db, execs } = makeFakeDb();
+    new BunSqliteConnectionState(db, undefined, { timer });
+
+    timer.advanceTime(100_000);
+    expect(optimizeCount(execs)).toBe(0);
+  });
+
+  test("does not force-open a lazy connection", () => {
+    const timer = new FakeTimer();
+    let opened = false;
+    const source = (): BunDatabase => {
+      opened = true;
+      return makeFakeDb().db;
+    };
+    new BunSqliteConnectionState(source, undefined, { timer }, 1000);
+
+    timer.advanceTime(5000);
+    // The tick skips when the connection has not been opened by a query yet,
+    // rather than opening one just to optimize.
+    expect(opened).toBe(false);
+  });
+
+  test("stops firing after close", () => {
+    const timer = new FakeTimer();
+    const { db, execs } = makeFakeDb();
+    const state = new BunSqliteConnectionState(db, undefined, { timer }, 1000);
+
+    state.close(); // runs the close-time optimize once, then clears the timer
+    const afterClose = optimizeCount(execs);
+
+    timer.advanceTime(10_000);
+    expect(optimizeCount(execs)).toBe(afterClose);
+  });
+});


### PR DESCRIPTION
## Summary

`PRAGMA optimize` previously ran **only** at connection close (shipped in #3458/#3407). A long-lived daemon that rarely restarts therefore never refreshed query-planner statistics mid-life, so index selection can drift as tables grow between restarts. This is the deferred half of #3407 (whose ACs allowed "on close **and/or** a low-frequency timer").

Adds a low-frequency periodic `PRAGMA optimize` on the connection's injected `Timer`:
- `BunSqliteConnectionState` takes an `optimizeIntervalMs`; when set (> 0) it starts an **unref'd** interval that runs `#runPeriodicOptimize()` and clears it in `close()`.
- Best-effort: a failure is logged at `debug` and never thrown (matches the close-time pattern).
- The tick **skips** when the connection is closed, not yet opened, or mid-query/transaction (`#transactionOwner`/`#pendingTransactions`/`#activeQueries`), so it never runs inside another statement's transaction — the next tick retries. Direct-exec (like the close-time optimize) is correct here because a synchronous `bun:sqlite` timer callback can't participate in the async mutex; the idle guard is the serialization mechanism.
- Enabled **only** for the daemon's file-backed connection (`DEFAULT_OPTIMIZE_INTERVAL_MS` = 5 min) in `database.ts`. In-memory connections leave it off, so the 800+ unit-test DBs don't each spin a timer.

No per-query overhead; the timer is `unref`'d so it never keeps the process alive (same as the daemon's `healthCheckTimer`).

## Tests
`test/db/bunSqlitePeriodicOptimize.test.ts` (FakeTimer + fake `bun:sqlite` handle, <100ms):
- fires on the interval and repeats
- swallows and logs an optimize failure without throwing
- disabled when no interval is configured
- does not force-open a lazy connection
- stops firing after `close()`

Full `test/db` suite: 844 tests green.

## Notes
Reviewed via `/simplify` (reuse/efficiency + simplification/altitude agents) — confirmed the self-contained connection timer (vs driving from the daemon loop) is the right altitude, the skip guard is correct, and default-off is the right boundary.

Closes #3497. Follow-up to #3407.