### PR TITLE
fix(schema): hide injected deviceId from tools list

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -31,9 +31,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "additionalProperties": false
@@ -104,9 +101,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -420,9 +414,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -466,9 +457,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -543,9 +531,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -605,9 +590,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -644,9 +626,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "additionalProperties": false
@@ -675,9 +654,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -725,9 +701,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -895,9 +868,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -980,9 +950,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -1121,9 +1088,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -1458,9 +1422,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -1558,9 +1519,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -1595,9 +1553,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -1641,9 +1596,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "additionalProperties": false
@@ -1673,9 +1625,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -1724,9 +1673,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "additionalProperties": false
@@ -1759,9 +1705,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -1816,9 +1759,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -2515,9 +2455,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -2602,9 +2539,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -2648,9 +2582,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -2714,9 +2645,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -2753,9 +2681,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -2797,9 +2722,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -2883,9 +2805,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -3010,9 +2929,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -3050,9 +2966,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -3144,9 +3057,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -3367,9 +3277,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -4790,9 +4697,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -4840,9 +4744,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -4939,9 +4840,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5030,9 +4928,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5093,9 +4988,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -5162,9 +5054,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5198,9 +5087,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -5323,9 +5209,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5366,9 +5249,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5401,9 +5281,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -5444,9 +5321,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -5551,9 +5425,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5606,9 +5477,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -5683,9 +5551,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5728,9 +5593,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -5811,9 +5673,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -5893,9 +5752,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -6013,9 +5869,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -6058,9 +5911,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -6310,9 +6160,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -6384,9 +6231,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -6486,9 +6330,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -6650,9 +6491,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },
@@ -7959,9 +7797,6 @@
         "device": {
           "description": "Device label",
           "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
         }
       },
       "required": [
@@ -8000,9 +7835,6 @@
         },
         "device": {
           "description": "Device label",
-          "type": "string"
-        },
-        "deviceId": {
           "type": "string"
         }
       },

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -29,7 +29,7 @@ import { finalizeToolResponse, type ObservationArtifactWriter, type ObservationB
 import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "./internalToolCall";
 import { ListChangedBroadcaster } from "./listChangedBroadcast";
 import { getStructuredField, StructuredToolResponse } from "../utils/toolUtils";
-import { applyJsonSchemaOverride } from "./toolSchemaHelpers";
+import { applyJsonSchemaOverride, isInjectedDeviceIdSchema } from "./toolSchemaHelpers";
 import {
   InternalToolName,
   InternalToolPayloads,
@@ -46,6 +46,12 @@ function toAdvertisedJsonSchema(schema: any): Record<string, unknown> {
   return flattenTopLevelUnion(toJSONSchema(schema, {
     override: ({ zodSchema, jsonSchema }) => {
       applyJsonSchemaOverride(zodSchema, jsonSchema);
+      if (isInjectedDeviceIdSchema(zodSchema)) {
+        const properties = jsonSchema.properties as Record<string, unknown> | undefined;
+        if (properties) {
+          delete properties.deviceId;
+        }
+      }
     },
   }));
 }

--- a/src/server/toolSchemaHelpers.ts
+++ b/src/server/toolSchemaHelpers.ts
@@ -32,6 +32,7 @@ export type FieldAliasMap = Record<string, readonly string[]>;
 export type JsonSchemaOverride = (jsonSchema: Record<string, unknown>) => void;
 
 const jsonSchemaOverrides = new WeakMap<object, JsonSchemaOverride>();
+const injectedDeviceIdSchemas = new WeakSet<object>();
 
 export function withJsonSchemaOverride<T extends z.ZodTypeAny>(schema: T, override: JsonSchemaOverride): T {
   jsonSchemaOverrides.set(schema, override);
@@ -43,6 +44,13 @@ export function applyJsonSchemaOverride(
   jsonSchema: Record<string, unknown>
 ): void {
   jsonSchemaOverrides.get(zodSchema)?.(jsonSchema);
+}
+
+export function isInjectedDeviceIdSchema(zodSchema: object): boolean {
+  if (injectedDeviceIdSchemas.has(zodSchema)) {
+    return true;
+  }
+  return zodSchema instanceof z.ZodObject && zodSchema.shape.deviceId === deviceTargetingShape.deviceId;
 }
 
 /**
@@ -111,7 +119,11 @@ export function compactExclusiveSelectorProperties(
 }
 
 export function withFieldAliases<T extends z.ZodTypeAny>(schema: T, aliases: FieldAliasMap): T {
-  return z.preprocess(input => normalizeFieldAliases(input, aliases), schema) as unknown as T;
+  const aliased = z.preprocess(input => normalizeFieldAliases(input, aliases), schema) as unknown as T;
+  if (isInjectedDeviceIdSchema(schema)) {
+    injectedDeviceIdSchemas.add(aliased);
+  }
+  return aliased;
 }
 
 export function withAppIdAliases<T extends z.ZodTypeAny>(schema: T): T {
@@ -222,5 +234,9 @@ export function addSessionUuidToSchema<T extends z.ZodObject<z.ZodRawShape>>(sch
  * Helper to add sessionUuid + device label + deviceId + platform fields to tool schemas.
  */
 export function addDeviceTargetingToSchema<T extends z.ZodObject<z.ZodRawShape>>(schema: T) {
-  return extendPreservingBase(schema, deviceTargetingShape);
+  const extended = extendPreservingBase(schema, deviceTargetingShape);
+  if (!("deviceId" in schema.shape)) {
+    injectedDeviceIdSchemas.add(extended);
+  }
+  return extended;
 }

--- a/test/server/tools/deviceIdAdvertisement.test.ts
+++ b/test/server/tools/deviceIdAdvertisement.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createMcpServer } from "../../../src/server";
+import { ToolRegistry } from "../../../src/server/toolRegistry";
+
+type AdvertisedTool = ReturnType<typeof ToolRegistry.getToolDefinitions>[number];
+
+function getTool(definitions: AdvertisedTool[], name: string): AdvertisedTool {
+  const tool = definitions.find(candidate => candidate.name === name);
+  expect(tool, `${name} should be advertised`).toBeDefined();
+  return tool!;
+}
+
+function propertiesFor(tool: AdvertisedTool): Record<string, unknown> {
+  const properties = tool.inputSchema.properties;
+  expect(properties, `${tool.name} should advertise object properties`).toBeDefined();
+  return properties as Record<string, unknown>;
+}
+
+describe("advertised deviceId schema", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  test("hides executor-injected deviceId while keeping agent-facing deviceId", () => {
+    createMcpServer();
+
+    const definitions = ToolRegistry.getToolDefinitions();
+
+    for (const toolName of ["observe", "tapOn", "swipeOn", "changeLocalization"]) {
+      expect(propertiesFor(getTool(definitions, toolName)).deviceId, `${toolName} should hide injected deviceId`).toBeUndefined();
+    }
+
+    for (const toolName of ["setActiveDevice", "videoRecording", "highlight"]) {
+      expect(propertiesFor(getTool(definitions, toolName)).deviceId, `${toolName} should keep agent-facing deviceId`).toBeDefined();
+    }
+
+    const killDeviceProperties = propertiesFor(getTool(definitions, "killDevice"));
+    const deviceProperty = killDeviceProperties.device as { properties?: Record<string, unknown> };
+    expect(deviceProperty.properties?.deviceId, "killDevice should keep agent-facing nested device.deviceId").toBeDefined();
+  });
+
+  test("keeps executor-injected deviceId accepted by runtime validation", () => {
+    createMcpServer();
+
+    const observeTool = ToolRegistry.getTool("observe");
+    expect(observeTool, "observe should be registered").toBeDefined();
+
+    expect(() => observeTool!.schema.parse({ platform: "android", deviceId: "emulator-5554" })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Hides the executor-only `deviceId` field from advertised `tools/list` input schemas when it was injected by `addDeviceTargetingToSchema`, while preserving runtime validation so executor device allocation can still inject the resolved id. Explicit, agent-facing `deviceId` parameters remain advertised for tools such as `setActiveDevice`, `videoRecording`, `highlight`, and `killDevice`.

## Linked Issue

Closes #3768

## Bug / Regression Context

- **Prior attempts:** Follow-up to the tool-context trims in #3750 and #3754.
- **Observed symptom:** Device-aware tools advertised `deviceId` even when it was only an internal executor injection field, wasting tools/list context and implying agents should set it directly.
- **Repro steps / conditions:** Inspect `tools/list` / `schemas/tool-definitions.json` for injected-only tools such as `observe`, `tapOn`, or `swipeOn`.

## Validation

- [x] `bun test test/server/tools/deviceIdAdvertisement.test.ts test/server/toolSchemaHelpers.test.ts test/server/toolRegistry.getToolDefinitions.test.ts test/server/observeWaitForSchema.test.ts --bail`
- [x] `bun test test/server test/features/action test/plan test/utils/plan --bail`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate`
- [x] `git diff --check`
- [ ] Android/iOS changes: ran the matching `scripts/` validation
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A; this changes advertised JSON schemas only. Runtime validation for executor-injected `deviceId` is covered by unit tests.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
