### PR TITLE
perf(ci): parallelize independent iOS tool installs (#3780)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1313,17 +1313,21 @@ jobs:
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
+      # These two installs are independent, network/I/O-bound, and neither the
+      # Bun setup nor the npm-package install below consumes them — so background
+      # them and let the Bun pair overlap. The `wait` barrier re-syncs before the
+      # first consumer (the drift check needs xcodegen; the build needs both).
+      # Validated by the #3779 spike: outputs unused here, `- wait: [ids]` list
+      # barrier works, and an install failure surfaces loudly at the wait.
       - name: "Install XcodeGen"
         run: brew install xcodegen
+        background: true
+        id: install-xcodegen
 
       - name: "Install xcpretty"
         run: gem install xcpretty
-
-      - name: "Check CtrlProxy XcodeGen Project Drift"
-        run: ./scripts/ios/xcodegen-drift-check.sh --ctrl-proxy
-
-      - name: "Build CtrlProxy iOS for Testing"
-        run: ./scripts/ios/ctrl-proxy-build-for-testing.sh
+        background: true
+        id: install-xcpretty
 
       - name: "Setup Bun"
         uses: oven-sh/setup-bun@v2
@@ -1331,6 +1335,14 @@ jobs:
           bun-version: 1.3.9
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
+
+      - wait: [install-xcodegen, install-xcpretty]
+
+      - name: "Check CtrlProxy XcodeGen Project Drift"
+        run: ./scripts/ios/xcodegen-drift-check.sh --ctrl-proxy
+
+      - name: "Build CtrlProxy iOS for Testing"
+        run: ./scripts/ios/ctrl-proxy-build-for-testing.sh
 
       - name: "Verify CtrlProxy iOS Artifacts"
         run: |


### PR DESCRIPTION
## What

In `ios-xctest-runner-simulator-tests` (`.github/workflows/pull_request.yml`), the `xcodegen` and `xcpretty` installs ran strictly serially even though they are independent, network/I/O-bound installs. This backgrounds both and lets the Bun setup + npm-package install (which consume neither) overlap them, then re-syncs with a `wait` barrier before the first consumer.

```yaml
- name: "Install XcodeGen"
  run: brew install xcodegen
  background: true
  id: install-xcodegen
- name: "Install xcpretty"
  run: gem install xcpretty
  background: true
  id: install-xcpretty
- name: "Setup Bun" …          # overlaps the two installs
- uses: ./.github/actions/setup-auto-mobile-npm-package
- wait: [install-xcodegen, install-xcpretty]
- name: "Check CtrlProxy XcodeGen Project Drift" …   # first xcodegen consumer
- name: "Build CtrlProxy iOS for Testing" …          # first xcpretty consumer
```

## Why it's safe
- The drift check and build scripts consume `xcodegen`/`xcpretty`; neither the Bun setup nor the npm-package install touches them (verified) — so the overlap has no data dependency.
- The `wait` barrier precedes the first consumer of either install.
- Per the #3779 spike: `- wait: [ids]` list barrier works; a failed background install surfaces **loudly at the wait** (downstream steps skip, `if: always()` cleanup still runs — no silent green); and these are I/O-bound so they overlap the CPU-bound Bun/npm work with negligible contention on `macos-26`.

## Acceptance criteria
- [x] Independent installs run concurrently; ordering preserved by the `wait` barrier before the first consumer.
- [ ] Job stays green on this PR run.
- [ ] Wall-clock delta recorded below once CI completes.

Follow-up: the same install trio appears in `merge.yml`, `nightly.yml`, and `build-ctrl-proxy-ios-ipa.yml`; replicate by inlining (the #3779 spike confirmed composite actions reject `background`/`wait`, so no shared-action refactor).

Closes #3780