### PR TITLE
docs(webrtc): iOS live-streaming spike — verified blocker + recommended path (#3777)

### DIFF
--- a/docs/design-docs/mcp/observe/ios-webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/ios-webrtc-streaming.md
@@ -1,0 +1,110 @@
+# iOS WebRTC (WHIP) Live Streaming
+
+<kbd>🚧 Design Only</kbd>
+
+> **Current state:** Spike / design. WebRTC streaming (`webrtc-stream.sock`,
+> [webrtc-streaming.md](./webrtc-streaming.md)) is **Android-only**;
+> `startWebRtcStream` rejects iOS. This document scopes what an iOS source needs
+> to satisfy the existing publisher, records the empirical findings that rule out
+> the "easy" on-Mac paths, and recommends the implementation path. See the
+> [Status Glossary](../../status-glossary.md) for chip definitions.
+
+Follow-up to #3751; addresses #3777.
+
+## Goal
+
+Produce a **continuous H.264 Annex-B elementary stream** for iOS that plugs into
+the existing `WebRtcPublisher` **unchanged** — i.e. a new capture source that
+satisfies the same contract the Android sources do:
+
+```ts
+interface H264CaptureSource { start(): Promise<void>; stop(): Promise<void>; }
+// feeding: onData(chunk: Buffer /* Annex-B */) => void
+```
+
+…then drop the Android-only guard in `webrtcStreamManager.startWebRtcStream`.
+The publisher / RTP packetizer / WHIP / reconnect stack stays untouched — this is
+purely a new source plus removing the guard once a source exists.
+
+## Why the guard exists: the blocker is real
+
+Android has `adb exec-out screenrecord --output-format=h264 -` (and now the
+persistent `video-server` encoder, #3776): a live Annex-B byte stream on stdout.
+iOS has **no drop-in equivalent**. Empirically verified on macOS with a booted
+`iPhone 16 Pro` simulator (Xcode simctl):
+
+| Candidate | Result |
+|-----------|--------|
+| `xcrun simctl io <udid> recordVideo --codec h264 --force /dev/stdout` | **Fails**: `Couldn't create an asset writer … simctl.SimulatorError.allocationError`. `AVAssetWriter` requires a seekable file; it cannot target a pipe. |
+| `recordVideo … out.mov` then remux live | **Not live**: writes a QuickTime container whose `moov` atom is finalized only on clean `SIGINT` (see [iOS simctl moov atom flush]). A growing MOV cannot be `-c:v copy`-streamed. |
+| `ffmpeg -f avfoundation -list_devices` | Only exposes **`Capture screen 0`** (the whole Mac display) — there is **no per-simulator capture device**. Whole-screen capture + window-cropping is the wrong scope (captures unrelated content), permission-gated, and brittle. |
+
+So `simctl` provides screenshots and finalized recordings, not a live elementary
+stream — exactly the premise of #3777.
+
+## Options
+
+### 1. VideoToolbox encoder in the CtrlProxy runner — recommended
+
+Encode on the Mac inside the iOS CtrlProxy runner (`Sources/CtrlProxy`, see
+[ctrl-proxy-ios.md](../../plat/ios/ctrl-proxy-ios.md)), where frames are already
+reachable:
+
+- **Physical devices**: appear as an AVFoundation capture source over USB (the
+  QuickTime mechanism), documented in
+  [ios/screen-streaming.md](../../plat/ios/screen-streaming.md). Feed
+  `CMSampleBuffer`s into a `VTCompressionSession` (H.264, baseline, Annex-B) and
+  emit the elementary stream over the runner's socket.
+- **Simulators**: no AVFoundation device exists; frames come from the
+  CoreSimulator framebuffer (`SimDeviceIOClient` / `IOSurface`), then the same
+  `VTCompressionSession`.
+
+The runner emits Annex-B framed like the Android `video-server`
+([VideoServerStreamParser](../../../../src/features/webrtc/VideoServerStreamParser.ts)
+already parses that framing), so the TS side is a thin `IosH264Source`
+implementing `H264CaptureSource`: connect to the runner's stream socket, forward
+payloads to `onData`.
+
+**Cost / gate:** this is a runner change and therefore rides the **iOS runner
+release delivery gate** — `Sources/CtrlProxy` changes require re-cutting the
+runner bundle before they reach users (see [iOS runner release delivery gate]).
+
+### 2. On-Mac encoder outside the runner
+
+A standalone Mac helper (Swift + VideoToolbox, or an `ffmpeg` pipeline) feeding
+the same `onData`. Rejected for simulators: there is no per-simulator AVFoundation
+device (see table above), so the helper would still need the CoreSimulator
+framebuffer — i.e. the same private-framework work as option 1, minus the runner's
+existing plumbing.
+
+### 3. Physical device only
+
+The AVFoundation USB-capture path (option 1, physical branch) works without any
+private simulator APIs and is the smallest first increment. It does **not** cover
+simulators, which are the common CI/dev case, so it is a partial answer.
+
+## Recommended increment
+
+1. Add the `VTCompressionSession` encoder to the CtrlProxy runner, emitting
+   Annex-B over a stream socket using the existing `video-server` framing.
+2. Add a TS `IosH264Source implements H264CaptureSource` that connects to that
+   socket and forwards payloads to `onData` (mirrors
+   `PersistentEncoderH264Source`; unit-testable with fakes).
+3. Gate the platform check on **source availability**, not platform: replace the
+   hard `platform !== "android"` reject with a source-factory that returns an iOS
+   source when the runner supports the stream, else a clear "not available"
+   error. This keeps a working fallback story identical to the Android
+   persistent-vs-screenrecord selection.
+4. Re-cut the runner release so the encoder ships.
+
+Start with the physical-device branch (option 3) to validate the encoder + RTP
+path end-to-end, then add the simulator framebuffer source.
+
+## Scope note
+
+Nothing here touches `WebRtcPublisher`, the RTP packetizer, WHIP, or reconnect —
+those are platform-agnostic. The only new surface is the capture source and the
+availability-gated guard.
+
+[iOS simctl moov atom flush]: ../../../../CLAUDE.md
+[iOS runner release delivery gate]: ../../plat/ios/ctrl-proxy-ios.md

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -172,9 +172,10 @@ fresh keyframe.
 
 ## Known limitations / future work
 
-- **Android only.** iOS `simctl` provides raw frames, not a live H.264 elementary
-  stream; an on-Mac encoder (or the `video-server` VirtualDisplay path) would be
-  required.
+- **Android only.** iOS `simctl` provides screenshots/finalized recordings, not a
+  live H.264 elementary stream; a VideoToolbox encoder in the CtrlProxy runner is
+  required. See [ios-webrtc-streaming.md](./ios-webrtc-streaming.md) (#3777) for
+  the spike and recommended path.
 - **Persistent-encoder distribution.** The `video-server` jar removes the
   segment-rotation seam and is preferred when present, but is not yet shipped in
   the released package — until it is bundled/downloaded (like the CtrlProxy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
              - 'Appearance Sync': design-docs/mcp/observe/appearance.md
              - 'Screen Streaming': design-docs/mcp/observe/screen-streaming.md
              - 'WebRTC Streaming (WHIP)': design-docs/mcp/observe/webrtc-streaming.md
+             - 'iOS WebRTC Streaming': design-docs/mcp/observe/ios-webrtc-streaming.md
              - 'Video Recording': design-docs/mcp/observe/video-recording.md
              - 'Vision Fallback': design-docs/mcp/observe/vision-fallback.md
              - 'Visual Highlighting': design-docs/mcp/observe/visual-highlighting.md

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -135,8 +135,12 @@ export async function startWebRtcStream(
   request: StartWebRtcStreamRequest
 ): Promise<WebRtcStreamDescriptor> {
   if (request.device.platform !== "android") {
+    // iOS has no live H.264 elementary stream from simctl; a capture source must
+    // be built first (VideoToolbox in the CtrlProxy runner). See
+    // docs/design-docs/mcp/observe/ios-webrtc-streaming.md (#3777).
     throw new ActionableError(
-      `WebRTC streaming currently supports Android only (got ${request.device.platform}).`
+      `WebRTC streaming currently supports Android only (got ${request.device.platform}). ` +
+        `See docs/design-docs/mcp/observe/ios-webrtc-streaming.md for the iOS plan.`
     );
   }
 


### PR DESCRIPTION
## Summary

A full-implementation attempt for **#3777 (iOS live streaming)** hit a hard, **empirically verified** platform blocker. This PR ships the pre-approved *documented-spike fallback* rather than unverifiable code, and points users at the plan.

**Advances #3777 — does not close it** (no iOS capture source is implemented yet).

## What I probed (booted iPhone 16 Pro simulator, Xcode simctl)

| Candidate | Result |
|-----------|--------|
| `simctl io <udid> recordVideo --codec h264 --force /dev/stdout` | **Fails** — `Couldn't create an asset writer … simctl.SimulatorError.allocationError`. `AVAssetWriter` needs a seekable file; it can't target a pipe. |
| `recordVideo … out.mov` then live remux | **Not live** — QuickTime container whose `moov` atom is finalized only on clean SIGINT; can't `-c:v copy`-stream a growing MOV. |
| `ffmpeg -f avfoundation -list_devices` | Only **`Capture screen 0`** (whole Mac display) — **no per-simulator capture device**. Whole-screen + window-crop is wrong scope, permission-gated, brittle. |

So `simctl` gives screenshots and finalized recordings, not a live Annex-B elementary stream — exactly the issue's premise. A correct source needs a **VideoToolbox encoder in the CtrlProxy runner** (physical devices via AVFoundation USB capture; simulators via the CoreSimulator framebuffer), which also rides the iOS runner release re-cut gate.

## Changes

- **New design doc** `docs/design-docs/mcp/observe/ios-webrtc-streaming.md`: records the findings, evaluates the three options from the issue, and recommends a `VTCompressionSession` encoder in the runner emitting Annex-B (reusing the `video-server` framing that TS `VideoServerStreamParser` already parses) behind a thin `IosH264Source implements H264CaptureSource`, with the platform guard gated on **source availability** rather than platform.
- Point the `startWebRtcStream` Android-only guard error and the WebRTC design doc at the new spike.

## Why a spike, not an implementation
Per the approved option ("if it hits a hard platform blocker, fall back to a documented spike + partial PR"). The real path requires a Swift/VideoToolbox runner change that (a) can't be verified end-to-end here (no per-simulator stream; no physical device attached) and (b) needs a runner release re-cut — so shipping it unverified would violate the repo's verification norms.

## Test plan
- [x] `webrtcStreamManager` guard test still passes (message keeps `/Android only/`, adds a doc pointer)
- [x] `bun run lint` clean
- [x] All design-doc relative links resolve