### PR TITLE
perf(ci): background iOS simulator boot during CtrlProxy build (#3781)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1341,6 +1341,18 @@ jobs:
       - name: "Check CtrlProxy XcodeGen Project Drift"
         run: ./scripts/ios/xcodegen-drift-check.sh --ctrl-proxy
 
+      # Simulator boot is minutes of otherwise-idle wall-clock and needs neither
+      # xcodegen nor the build, so start it in the background here and let the
+      # CtrlProxy build (below) run concurrently. Boot is wait/I/O-bound, so it
+      # overlaps the CPU-bound xcodebuild cleanly (mild contention, per #3779).
+      # The #3779 spike confirmed a backgrounded step's outputs survive `wait`,
+      # so the UI test can still read steps.ctrlproxy-simulator.outputs.simulator_udid
+      # after the barrier — no file fallback needed.
+      - name: "Boot iOS Simulator for CtrlProxy UI tests (Xcode 26.5)"
+        id: ctrlproxy-simulator
+        run: ./scripts/ios/boot-simulator.sh
+        background: true
+
       - name: "Build CtrlProxy iOS for Testing"
         run: ./scripts/ios/ctrl-proxy-build-for-testing.sh
 
@@ -1352,9 +1364,9 @@ jobs:
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
           echo "xctestrun file: ${XCTESTRUN}"
 
-      - name: "Boot iOS Simulator for CtrlProxy UI tests (Xcode 26.5)"
-        id: ctrlproxy-simulator
-        run: ./scripts/ios/boot-simulator.sh
+      # Re-sync before the test, which needs both the build artifacts and the
+      # booted sim's UDID.
+      - wait: ctrlproxy-simulator
 
       - name: "Run CtrlProxy privacy resource mapping UI test (Xcode 26.5)"
         timeout-minutes: 5


### PR DESCRIPTION
## What

In `ios-xctest-runner-simulator-tests`, the simulator boot and the CtrlProxy build are independent but ran serially. This backgrounds the boot so it overlaps the CPU-bound `xcodebuild` (and the artifact-verify), then re-syncs with a `wait` before the UI test.

```yaml
- name: "Check CtrlProxy XcodeGen Project Drift" …
- name: "Boot iOS Simulator for CtrlProxy UI tests (Xcode 26.5)"
  id: ctrlproxy-simulator
  run: ./scripts/ios/boot-simulator.sh
  background: true                 # start boot early…
- name: "Build CtrlProxy iOS for Testing" …          # …build runs concurrently
- name: "Verify CtrlProxy iOS Artifacts" …           # (also overlaps boot; no sim needed)
- wait: ctrlproxy-simulator        # re-sync before the test needs the sim
- name: "Run CtrlProxy privacy resource mapping UI test (Xcode 26.5)"
  run: |
    … -destination "id=${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}" …
```

## Why it's safe
- The boot needs neither xcodegen nor the build; the build/verify need no sim — so the overlap has no data dependency. The `wait` precedes the first step (the UI test) that needs the sim.
- **The #3779 spike confirmed a backgrounded step's `outputs` survive `wait`** (`steps.<id>.outputs.*` is readable after the barrier), so the test reads `simulator_udid` directly — **no file fallback needed**, resolving the issue's primary risk.
- Boot is wait/I/O-bound, so it overlaps the CPU-bound `xcodebuild` cleanly (mild contention only, per the spike's CPU-contention finding).

## Scope correction
The issue estimated the win compounds ~3× across the three Xcode segments. In the **current** structure that doesn't hold: only **segment 1 (26.5)** has a boot-independent build to overlap. Segments 2 (26.2) and 3 (26.5) boot and then immediately run `ensure-daemon-ready` → `warm-up CtrlProxy` → Reminders — **all of which depend on the booted sim**, so there is nothing to overlap there. This PR applies the overlap to segment 1 only.

## Acceptance criteria
- [x] Simulator boot overlaps the CtrlProxy build; test resolves the correct UDID via the surviving background output.
- [x] ~~Applied to all three Xcode segments~~ → only segment 1 has an overlap opportunity (see Scope correction).
- [ ] Measured wall-clock delta recorded below once CI completes.

Closes #3781