### PR TITLE
feat(webrtc): opt-in trickle ICE for WHIP publishing (#3778)

### DIFF
--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -180,11 +180,18 @@ fresh keyframe.
   segment-rotation seam and is preferred when present, but is not yet shipped in
   the released package — until it is bundled/downloaded (like the CtrlProxy
   runner), production installs resolve no jar and fall back to `screenrecord`.
-- **No audio.** Video only.
+- **No audio.** Video only; a device-audio capture source would be required to
+  add an audio track (#3778).
 - **Reference server is single-process/in-memory.** Use a hardened WHIP/WHEP SFU
   (MediaMTX, LiveKit, Janus, Cloudflare) in production; the publisher is unchanged.
-- **Trickle ICE not used.** The publisher gathers candidates before POSTing the
-  WHIP offer (non-trickle), which is simplest and widely compatible.
+- **Trickle ICE is opt-in.** By default the publisher gathers candidates before
+  POSTing the WHIP offer (non-trickle), which is simplest and widely compatible.
+  Set `AUTOMOBILE_WEBRTC_TRICKLE_ICE=1` (or `trickleIce: true`) to publish the
+  offer immediately and PATCH candidates incrementally
+  (`application/trickle-ice-sdpfrag`) so setup doesn't stall on the gathering
+  timeout — requires an ingest server that supports the WHIP trickle extension
+  (the bundled reference server does; see `trickleIce.ts` /
+  `WhipClient.patchCandidate`).
 
 ## References
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -88,3 +88,4 @@ overridden per request on the `webrtc-stream.sock` control socket.
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate (kbps). | encoder default |
 | `AUTOMOBILE_WEBRTC_MAX_SIZE` | Capture downscale as `WIDTHxHEIGHT` (e.g. `720x1280`). | native |
 | `AUTOMOBILE_VIDEO_SERVER_JAR` | Path to the built `automobile-video.jar` (persistent on-device encoder). When resolvable, capture prefers the persistent encoder over `screenrecord`. | Gradle build output, else `screenrecord` |
+| `AUTOMOBILE_WEBRTC_TRICKLE_ICE` | Enable trickle ICE: publish the WHIP offer immediately and PATCH candidates incrementally instead of blocking on ICE gathering. Requires an ingest server supporting the WHIP trickle extension. | `false` |

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -197,6 +197,33 @@ export class CoordinationServer {
     await entry.ingestPc.close().catch(() => {});
   }
 
+  /**
+   * Apply trickle-ICE candidates (WHIP PATCH, `application/trickle-ice-sdpfrag`)
+   * from the publisher to the ingest peer connection. Returns false when the
+   * stream id is unknown so the HTTP layer can answer 404. Parses leniently: the
+   * `a=mid:` line (if any) applies to the following `a=candidate:` lines.
+   */
+  async addIngestCandidates(streamId: string, fragment: string): Promise<boolean> {
+    const entry = this.streams.get(streamId);
+    if (!entry) {
+      return false;
+    }
+    let sdpMid: string | undefined;
+    for (const rawLine of fragment.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (line.startsWith("a=mid:")) {
+        sdpMid = line.slice("a=mid:".length).trim() || undefined;
+      } else if (line.startsWith("a=candidate:")) {
+        await entry.ingestPc
+          .addIceCandidate({ candidate: line.slice("a=".length), sdpMid })
+          .catch(() => {
+            // A malformed or duplicate candidate is non-fatal; keep the stream up.
+          });
+      }
+    }
+    return true;
+  }
+
   async stopSubscriber(streamId: string, subscriberId: string): Promise<void> {
     const entry = this.streams.get(streamId);
     const subscriber = entry?.subscribers.get(subscriberId);

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -99,6 +99,22 @@ export class HttpCoordinationServer {
       res.end(answerSdp);
       return;
     }
+    // WHIP trickle ICE: incremental candidates from the publisher --------------
+    const whipPatchMatch = /^\/whip\/([^/]+)$/.exec(path);
+    if (method === "PATCH" && whipPatchMatch) {
+      if (!this.authorizeIngest(req)) {
+        res.writeHead(401).end("Unauthorized");
+        return;
+      }
+      const fragment = await readBody(req);
+      const applied = await this.coordinator.addIngestCandidates(
+        decodeURIComponent(whipPatchMatch[1]),
+        fragment
+      );
+      // 204 on success; 404 if the stream id is unknown (stale resource).
+      res.writeHead(applied ? 204 : 404).end();
+      return;
+    }
     const whipDeleteMatch = /^\/whip\/([^/]+)$/.exec(path);
     if (method === "DELETE" && whipDeleteMatch) {
       // Terminating an ingest is as privileged as creating one — gate on the

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -10,6 +10,7 @@ import type { BackoffInput } from "../../utils/Backoff";
 import { DEFAULT_RTP_MTU } from "./h264";
 import { ReconnectController, type ReconnectState } from "./ReconnectController";
 import { RtpH264TrackWriter } from "./RtpH264TrackWriter";
+import { TrickleIceForwarder } from "./trickleIce";
 import { WhipClient, type WhipClientOptions } from "./WhipClient";
 
 /** How long to wait for ICE gathering before publishing the offer. */
@@ -25,6 +26,12 @@ export interface WebRtcPublisherConfig {
   mtu?: number;
   maxReconnectAttempts?: number;
   reconnectBackoff?: BackoffInput;
+  /**
+   * Use trickle ICE: publish the offer immediately and PATCH local candidates
+   * as they gather, instead of blocking on ICE gathering. Requires an ingest
+   * server that supports the WHIP trickle extension. Defaults to false.
+   */
+  trickleIce?: boolean;
 }
 
 export interface WebRtcPublisherDeps {
@@ -76,6 +83,8 @@ export class WebRtcPublisher {
   private readonly onConnected?: () => Promise<void> | void;
   private readonly controller: ReconnectController;
 
+  private readonly trickleIce: boolean;
+
   private pc: RTCPeerConnection | null = null;
   private writer: RtpH264TrackWriter | null = null;
   private resourceUrl: string | null = null;
@@ -83,9 +92,12 @@ export class WebRtcPublisher {
   private closed = false;
   private establishing = false;
   private connectedFired = false;
+  private trickle: TrickleIceForwarder | null = null;
+  private candidateSub: { unSubscribe: () => void } | null = null;
 
   constructor(config: WebRtcPublisherConfig, deps: WebRtcPublisherDeps = {}) {
     this.config = config;
+    this.trickleIce = config.trickleIce ?? false;
     this.timer = deps.timer ?? defaultTimer;
     this.onBeforeEstablish = deps.onBeforeEstablish;
     this.onConnected = deps.onConnected;
@@ -194,7 +206,15 @@ export class WebRtcPublisher {
 
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
-      await this.waitForIceGathering(pc);
+
+      // Trickle ICE: start forwarding candidates (buffered until the resource URL
+      // is known) and publish the offer immediately instead of blocking on ICE
+      // gathering. Non-trickle: gather (bounded) before publishing.
+      if (this.trickleIce) {
+        this.startTrickle(pc);
+      } else {
+        await this.waitForIceGathering(pc);
+      }
 
       const localSdp = pc.localDescription?.sdp;
       if (!localSdp) {
@@ -216,6 +236,8 @@ export class WebRtcPublisher {
       }
 
       this.resourceUrl = session.resourceUrl;
+      // Flush candidates gathered during the WHIP round-trip and stream the rest.
+      this.trickle?.setResource(session.resourceUrl);
       await pc.setRemoteDescription({ type: "answer", sdp: session.answerSdp });
 
       this.establishing = false;
@@ -237,6 +259,10 @@ export class WebRtcPublisher {
       if (this.pc === pc) {
         this.pc = null;
         this.writer = null;
+        this.trickle?.stop();
+        this.trickle = null;
+        this.candidateSub?.unSubscribe();
+        this.candidateSub = null;
         await pc.close().catch(() => {});
       }
       throw error;
@@ -277,6 +303,31 @@ export class WebRtcPublisher {
     });
   }
 
+  /**
+   * Begin trickling local ICE candidates for this session. Candidates are
+   * buffered by the forwarder until the WHIP resource URL is known (set right
+   * after publish), then PATCHed as `application/trickle-ice-sdpfrag`.
+   */
+  private startTrickle(pc: RTCPeerConnection): void {
+    const forwarder = new TrickleIceForwarder((resourceUrl, fragment) => {
+      void this.whip.patchCandidate(resourceUrl, fragment).catch(error => {
+        logger.debug(`[WebRTC] trickle candidate PATCH failed: ${error}`);
+      });
+    });
+    this.trickle = forwarder;
+    this.candidateSub = pc.onIceCandidate.subscribe(candidate => {
+      // Ignore the end-of-candidates signal (undefined) and any candidate from a
+      // peer connection a concurrent teardown/establish already replaced.
+      if (candidate && this.pc === pc) {
+        forwarder.addCandidate({
+          candidate: candidate.candidate,
+          sdpMid: candidate.sdpMid,
+          sdpMLineIndex: candidate.sdpMLineIndex,
+        });
+      }
+    });
+  }
+
   private async waitForIceGathering(pc: RTCPeerConnection): Promise<void> {
     if (pc.iceGatheringState === "complete") {
       return;
@@ -299,6 +350,12 @@ export class WebRtcPublisher {
     this.pc = null;
     this.writer = null;
     this.resourceUrl = null;
+
+    // Stop forwarding candidates and detach the listener before the pc closes.
+    this.trickle?.stop();
+    this.trickle = null;
+    this.candidateSub?.unSubscribe();
+    this.candidateSub = null;
 
     if (resourceUrl) {
       try {

--- a/src/features/webrtc/WhipClient.ts
+++ b/src/features/webrtc/WhipClient.ts
@@ -92,6 +92,30 @@ export class WhipClient {
     return { answerSdp, resourceUrl };
   }
 
+  /**
+   * PATCH a trickle-ICE SDP fragment to the session resource (WHIP trickle
+   * extension, `application/trickle-ice-sdpfrag`). Best-effort: a server that
+   * does not support trickle answers 405/501 and the publisher keeps the
+   * candidates it already sent in the offer.
+   */
+  async patchCandidate(
+    resourceUrl: string,
+    sdpFragment: string,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const response = await this.fetchImpl(resourceUrl, {
+      method: "PATCH",
+      headers: this.headers({ "Content-Type": "application/trickle-ice-sdpfrag" }),
+      body: sdpFragment,
+      signal,
+    });
+    // 204 No Content is the success case; 200 is tolerated. Anything else is a
+    // server that does not implement trickle — log and move on.
+    if (response.status !== 204 && response.status !== 200) {
+      logger.debug(`[WHIP] trickle PATCH ${resourceUrl} returned ${response.status}`);
+    }
+  }
+
   /** DELETE the ingest resource to terminate the session (best-effort). */
   async delete(resourceUrl: string, signal?: AbortSignal): Promise<void> {
     const response = await this.fetchImpl(resourceUrl, {

--- a/src/features/webrtc/index.ts
+++ b/src/features/webrtc/index.ts
@@ -8,6 +8,7 @@ export * from "./PersistentEncoderH264Source";
 export * from "./videoServerJar";
 export * from "./androidH264CaptureSourceFactory";
 export * from "./WhipClient";
+export * from "./trickleIce";
 export * from "./ReconnectController";
 export * from "./WebRtcPublisher";
 export * from "./webrtcStreamingConfig";

--- a/src/features/webrtc/trickleIce.ts
+++ b/src/features/webrtc/trickleIce.ts
@@ -1,0 +1,120 @@
+/**
+ * Trickle-ICE helpers for the WHIP publisher.
+ *
+ * WHIP's trickle extension exchanges ICE candidates incrementally as
+ * `application/trickle-ice-sdpfrag` bodies (RFC 8840) via HTTP PATCH to the
+ * session resource, instead of blocking on ICE gathering before the offer is
+ * POSTed. These functions are pure/serialization-only so they can be unit-tested
+ * without a peer connection or HTTP.
+ */
+
+/** Minimal candidate shape (matches the fields werift's RTCIceCandidate exposes). */
+export interface TrickleCandidate {
+  candidate: string;
+  sdpMid?: string;
+  sdpMLineIndex?: number;
+}
+
+/** Optional ICE credentials identifying the generation the candidate belongs to. */
+export interface IceCredentials {
+  ufrag?: string;
+  pwd?: string;
+}
+
+/** Ensure the candidate value carries the `candidate:` prefix exactly once. */
+function normalizeCandidateLine(candidate: string): string {
+  const trimmed = candidate.trim();
+  return trimmed.startsWith("candidate:") ? trimmed : `candidate:${trimmed}`;
+}
+
+/**
+ * Serialize one candidate into a trickle-ICE SDP fragment. Includes the ICE
+ * ufrag/pwd (when known) and the media `mid` so the receiver can attribute the
+ * candidate to the correct m-line.
+ */
+export function serializeTrickleFragment(
+  candidate: TrickleCandidate,
+  ice: IceCredentials = {}
+): string {
+  const lines: string[] = [];
+  if (ice.ufrag) {
+    lines.push(`a=ice-ufrag:${ice.ufrag}`);
+  }
+  if (ice.pwd) {
+    lines.push(`a=ice-pwd:${ice.pwd}`);
+  }
+  if (candidate.sdpMid !== undefined && candidate.sdpMid !== null) {
+    lines.push(`a=mid:${candidate.sdpMid}`);
+  }
+  lines.push(`a=${normalizeCandidateLine(candidate.candidate)}`);
+  return `${lines.join("\r\n")}\r\n`;
+}
+
+/**
+ * Parse a trickle-ICE SDP fragment back into candidate inits. Lenient: it reads
+ * the `a=mid:` (applied to following candidates) and every `a=candidate:` line,
+ * ignoring anything else.
+ */
+export function parseTrickleFragment(fragment: string): TrickleCandidate[] {
+  const candidates: TrickleCandidate[] = [];
+  let mid: string | undefined;
+  for (const rawLine of fragment.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith("a=mid:")) {
+      mid = line.slice("a=mid:".length).trim() || undefined;
+    } else if (line.startsWith("a=candidate:")) {
+      candidates.push({ candidate: line.slice("a=".length), sdpMid: mid });
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Buffers local ICE candidates until the WHIP resource URL is known, then sends
+ * them (and every later candidate) as trickle fragments. Pure of any transport:
+ * `send` performs the actual PATCH. Safe to call `addCandidate` before or after
+ * `setResource`; `stop` drops anything not yet sent.
+ */
+export class TrickleIceForwarder {
+  private resourceUrl: string | null = null;
+  private buffered: string[] = [];
+  private stopped = false;
+
+  constructor(
+    private readonly send: (resourceUrl: string, fragment: string) => void,
+    private readonly ice: IceCredentials = {}
+  ) {}
+
+  addCandidate(candidate: TrickleCandidate): void {
+    if (this.stopped) {
+      return;
+    }
+    const fragment = serializeTrickleFragment(candidate, this.ice);
+    if (this.resourceUrl === null) {
+      this.buffered.push(fragment);
+    } else {
+      this.send(this.resourceUrl, fragment);
+    }
+  }
+
+  /** Record the resource URL and flush any candidates buffered before it. */
+  setResource(resourceUrl: string | null): void {
+    if (this.stopped) {
+      return;
+    }
+    this.resourceUrl = resourceUrl;
+    if (resourceUrl === null) {
+      return;
+    }
+    const pending = this.buffered;
+    this.buffered = [];
+    for (const fragment of pending) {
+      this.send(resourceUrl, fragment);
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.buffered = [];
+  }
+}

--- a/src/features/webrtc/webrtcStreamingConfig.ts
+++ b/src/features/webrtc/webrtcStreamingConfig.ts
@@ -17,6 +17,12 @@ export interface WebRtcStreamingConfig {
   bitrateKbps?: number;
   /** Optional capture downscale. */
   size?: { width: number; height: number };
+  /**
+   * Use trickle ICE: publish the WHIP offer immediately and send local
+   * candidates incrementally (HTTP PATCH) instead of blocking on ICE gathering.
+   * Opt-in — the ingest server must support the WHIP PATCH trickle extension.
+   */
+  trickleIce: boolean;
 }
 
 export interface WebRtcStreamingOverrides {
@@ -25,6 +31,7 @@ export interface WebRtcStreamingOverrides {
   iceServers?: RTCIceServer[];
   bitrateKbps?: number;
   size?: { width: number; height: number };
+  trickleIce?: boolean;
 }
 
 /** Environment variable names read for default configuration. */
@@ -34,6 +41,7 @@ export const WEBRTC_ENV = {
   ICE_SERVERS: "AUTOMOBILE_WEBRTC_ICE_SERVERS",
   BITRATE_KBPS: "AUTOMOBILE_WEBRTC_BITRATE_KBPS",
   MAX_SIZE: "AUTOMOBILE_WEBRTC_MAX_SIZE",
+  TRICKLE_ICE: "AUTOMOBILE_WEBRTC_TRICKLE_ICE",
 } as const;
 
 const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
@@ -98,6 +106,14 @@ export function parseSize(raw: string | undefined): { width: number; height: num
   return { width: Number(match[1]), height: Number(match[2]) };
 }
 
+/** Parse a boolean env flag (`1/true/yes/on`, case-insensitive). */
+export function parseBooleanFlag(raw: string | undefined): boolean {
+  if (!raw) {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
+
 function parseBitrate(raw: string | undefined): number | undefined {
   if (!raw || !raw.trim()) {
     return undefined;
@@ -129,6 +145,7 @@ export function resolveWebRtcStreamingConfig(
     overrides.iceServers ?? parseIceServers(env[WEBRTC_ENV.ICE_SERVERS]) ?? DEFAULT_ICE_SERVERS;
   const bitrateKbps = overrides.bitrateKbps ?? parseBitrate(env[WEBRTC_ENV.BITRATE_KBPS]);
   const size = overrides.size ?? parseSize(env[WEBRTC_ENV.MAX_SIZE]);
+  const trickleIce = overrides.trickleIce ?? parseBooleanFlag(env[WEBRTC_ENV.TRICKLE_ICE]);
 
   return {
     whipEndpoint: whipEndpoint.trim(),
@@ -136,5 +153,6 @@ export function resolveWebRtcStreamingConfig(
     iceServers,
     bitrateKbps,
     size,
+    trickleIce,
   };
 }

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -174,6 +174,7 @@ export async function startWebRtcStream(
       bearerToken: config.bearerToken,
       iceServers: config.iceServers,
       bitrateBps,
+      trickleIce: config.trickleIce,
     },
     {
       onBeforeEstablish: () => withRecord(streamId, stopSource),

--- a/test/features/webrtc/WebRtcPublisher.trickle.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.trickle.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import type { RTCPeerConnection } from "werift";
+import { WebRtcPublisher } from "../../../src/features/webrtc/WebRtcPublisher";
+import type { WhipClient } from "../../../src/features/webrtc/WhipClient";
+
+/**
+ * Fake peer connection whose ICE gathering NEVER completes, so a publisher that
+ * (incorrectly) waited on gathering would hang. Exposes `emitCandidate` to drive
+ * the trickle path.
+ */
+class FakeTricklePc {
+  closed = false;
+  connectionState = "connected";
+  iceGatheringState = "gathering";
+  private candidateCb?: (candidate: unknown) => void;
+  connectionStateChange = { subscribe: () => ({ unSubscribe: () => {} }) };
+  // Never resolves: proves the trickle path does not block on gathering.
+  iceGatheringStateChange = { watch: () => new Promise<void>(() => {}) };
+  onIceCandidate = {
+    subscribe: (cb: (candidate: unknown) => void) => {
+      this.candidateCb = cb;
+      return { unSubscribe: () => {} };
+    },
+  };
+  localDescription = { sdp: "v=0" };
+  addTransceiver() {
+    return { sender: { ssrc: 1 } };
+  }
+  async createOffer() {
+    return { type: "offer", sdp: "v=0" };
+  }
+  async setLocalDescription() {}
+  async setRemoteDescription() {}
+  async close() {
+    this.closed = true;
+  }
+  emitCandidate(candidate: { candidate: string; sdpMid?: string; sdpMLineIndex?: number }): void {
+    this.candidateCb?.(candidate);
+  }
+}
+
+function makePublisher(pc: FakeTricklePc, trickleIce: boolean) {
+  const patched: Array<{ url: string; fragment: string }> = [];
+  const publisher = new WebRtcPublisher(
+    { streamId: "s", whipEndpoint: "https://coord/whip", trickleIce, maxReconnectAttempts: 1 },
+    {
+      createPeerConnection: () => pc as unknown as RTCPeerConnection,
+      createWhipClient: () =>
+        ({
+          publish: async () => ({ answerSdp: "v=0", resourceUrl: "https://coord/whip/s" }),
+          patchCandidate: async (url: string, fragment: string) => {
+            patched.push({ url, fragment });
+          },
+          delete: async () => {},
+        }) as unknown as WhipClient,
+    }
+  );
+  return { publisher, patched };
+}
+
+describe("WebRtcPublisher trickle ICE", () => {
+  test("publishes without waiting for gathering and PATCHes candidates to the resource", async () => {
+    const pc = new FakeTricklePc();
+    const { publisher, patched } = makePublisher(pc, true);
+
+    // Would hang here if the publisher blocked on the never-completing gathering.
+    await publisher.start();
+
+    pc.emitCandidate({
+      candidate: "candidate:1 1 udp 2113 1.2.3.4 5000 typ host",
+      sdpMid: "0",
+      sdpMLineIndex: 0,
+    });
+
+    expect(patched).toHaveLength(1);
+    expect(patched[0].url).toBe("https://coord/whip/s");
+    expect(patched[0].fragment).toContain("a=candidate:1 1 udp 2113 1.2.3.4 5000 typ host");
+    expect(patched[0].fragment).toContain("a=mid:0");
+
+    await publisher.stop();
+  });
+
+  test("candidates emitted after stop are not PATCHed", async () => {
+    const pc = new FakeTricklePc();
+    const { publisher, patched } = makePublisher(pc, true);
+    await publisher.start();
+    await publisher.stop();
+
+    pc.emitCandidate({ candidate: "candidate:2 1 udp 1 1.2.3.4 6000 typ host", sdpMid: "0" });
+    expect(patched).toHaveLength(0);
+  });
+});

--- a/test/features/webrtc/WhipClient.test.ts
+++ b/test/features/webrtc/WhipClient.test.ts
@@ -109,6 +109,31 @@ describe("WhipClient.delete", () => {
   });
 });
 
+describe("WhipClient.patchCandidate", () => {
+  test("PATCHes the trickle fragment as application/trickle-ice-sdpfrag", async () => {
+    const { fetchImpl, calls } = fakeFetch(() => ({ status: 204 }));
+    const client = new WhipClient({
+      endpoint: "https://coord.example.com/whip",
+      bearerToken: "tok",
+      fetchImpl,
+    });
+    await client.patchCandidate("https://coord.example.com/whip/s", "a=candidate:1 1 udp ...\r\n");
+    expect(calls[0].method).toBe("PATCH");
+    expect(calls[0].url).toBe("https://coord.example.com/whip/s");
+    expect(calls[0].headers["Content-Type"]).toBe("application/trickle-ice-sdpfrag");
+    expect(calls[0].headers["Authorization"]).toBe("Bearer tok");
+    expect(calls[0].body).toContain("a=candidate:1 1 udp");
+  });
+
+  test("does not throw when the server does not support trickle (405)", async () => {
+    const { fetchImpl } = fakeFetch(() => ({ status: 405 }));
+    const client = new WhipClient({ endpoint: "https://coord.example.com/whip", fetchImpl });
+    await expect(
+      client.patchCandidate("https://coord.example.com/whip/s", "a=candidate:...")
+    ).resolves.toBeUndefined();
+  });
+});
+
 describe("WhipClient construction", () => {
   test("requires an endpoint", () => {
     expect(() => new WhipClient({ endpoint: "", fetchImpl: (async () => ({})) as unknown as FetchLike })).toThrow(

--- a/test/features/webrtc/trickleIce.test.ts
+++ b/test/features/webrtc/trickleIce.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  TrickleIceForwarder,
+  parseTrickleFragment,
+  serializeTrickleFragment,
+} from "../../../src/features/webrtc/trickleIce";
+
+describe("serializeTrickleFragment / parseTrickleFragment", () => {
+  test("round-trips a candidate with mid and ICE credentials", () => {
+    const fragment = serializeTrickleFragment(
+      { candidate: "candidate:1 1 udp 2113 1.2.3.4 5000 typ host", sdpMid: "0", sdpMLineIndex: 0 },
+      { ufrag: "abc", pwd: "def" }
+    );
+    expect(fragment).toContain("a=ice-ufrag:abc");
+    expect(fragment).toContain("a=ice-pwd:def");
+    expect(fragment).toContain("a=mid:0");
+    expect(fragment).toContain("a=candidate:1 1 udp 2113 1.2.3.4 5000 typ host");
+
+    const parsed = parseTrickleFragment(fragment);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].candidate).toBe("candidate:1 1 udp 2113 1.2.3.4 5000 typ host");
+    expect(parsed[0].sdpMid).toBe("0");
+  });
+
+  test("adds the candidate: prefix when missing", () => {
+    const fragment = serializeTrickleFragment({ candidate: "1 1 udp 2113 1.2.3.4 5000 typ host" });
+    expect(fragment).toContain("a=candidate:1 1 udp");
+  });
+
+  test("parses multiple candidates under one mid", () => {
+    const fragment = ["a=mid:1", "a=candidate:a 1 udp 1 h 1 typ host", "a=candidate:b 1 udp 1 h 2 typ host"].join(
+      "\r\n"
+    );
+    const parsed = parseTrickleFragment(fragment);
+    expect(parsed.map(c => c.sdpMid)).toEqual(["1", "1"]);
+    expect(parsed).toHaveLength(2);
+  });
+});
+
+describe("TrickleIceForwarder", () => {
+  test("buffers candidates until the resource URL is known, then flushes in order", () => {
+    const sent: Array<{ url: string; fragment: string }> = [];
+    const forwarder = new TrickleIceForwarder((url, fragment) => sent.push({ url, fragment }));
+
+    forwarder.addCandidate({ candidate: "candidate:a 1 udp 1 h 1 typ host" });
+    forwarder.addCandidate({ candidate: "candidate:b 1 udp 1 h 2 typ host" });
+    expect(sent).toHaveLength(0); // buffered — no resource URL yet
+
+    forwarder.setResource("https://coord/whip/s");
+    expect(sent).toHaveLength(2);
+    expect(sent[0].url).toBe("https://coord/whip/s");
+    expect(sent[0].fragment).toContain("candidate:a");
+    expect(sent[1].fragment).toContain("candidate:b");
+  });
+
+  test("sends immediately once the resource URL is set", () => {
+    const sent: string[] = [];
+    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment));
+    forwarder.setResource("https://coord/whip/s");
+    forwarder.addCandidate({ candidate: "candidate:c 1 udp 1 h 3 typ host" });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("candidate:c");
+  });
+
+  test("stop() drops buffered candidates and ignores further ones", () => {
+    const sent: string[] = [];
+    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment));
+    forwarder.addCandidate({ candidate: "candidate:a 1 udp 1 h 1 typ host" });
+    forwarder.stop();
+    forwarder.setResource("https://coord/whip/s");
+    forwarder.addCandidate({ candidate: "candidate:b 1 udp 1 h 2 typ host" });
+    expect(sent).toHaveLength(0);
+  });
+
+  test("null resource (no Location header) keeps candidates unsent without error", () => {
+    const sent: string[] = [];
+    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment));
+    forwarder.addCandidate({ candidate: "candidate:a 1 udp 1 h 1 typ host" });
+    expect(() => forwarder.setResource(null)).not.toThrow();
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/test/features/webrtc/webrtcStreamingConfig.test.ts
+++ b/test/features/webrtc/webrtcStreamingConfig.test.ts
@@ -66,6 +66,23 @@ describe("resolveWebRtcStreamingConfig", () => {
     expect(config.iceServers).toEqual([{ urls: "stun:s:1" }]);
     expect(config.bitrateKbps).toBe(4000);
     expect(config.size).toEqual({ width: 1280, height: 720 });
+    expect(config.trickleIce).toBe(false);
+  });
+
+  test("enables trickle ICE from the environment flag", () => {
+    const env = {
+      [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip",
+      [WEBRTC_ENV.TRICKLE_ICE]: "true",
+    } as NodeJS.ProcessEnv;
+    expect(resolveWebRtcStreamingConfig({}, env).trickleIce).toBe(true);
+  });
+
+  test("trickle ICE override takes precedence over the environment", () => {
+    const env = {
+      [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip",
+      [WEBRTC_ENV.TRICKLE_ICE]: "1",
+    } as NodeJS.ProcessEnv;
+    expect(resolveWebRtcStreamingConfig({ trickleIce: false }, env).trickleIce).toBe(false);
   });
 
   test("overrides take precedence over environment", () => {

--- a/test/integration/webrtcCoordinationServer.e2e.test.ts
+++ b/test/integration/webrtcCoordinationServer.e2e.test.ts
@@ -141,4 +141,62 @@ describe("WebRTC coordination server e2e", () => {
     },
     30000
   );
+
+  test(
+    "trickle ICE: publisher PATCHes candidates and frames still forward end-to-end",
+    async () => {
+      const http = new HttpCoordinationServer({ iceServers: [] });
+      const port = await http.listen(0, "127.0.0.1");
+      const base = `http://127.0.0.1:${port}`;
+
+      // trickleIce: publish the offer immediately and PATCH candidates as they
+      // gather; the reference server applies them via addIngestCandidates.
+      const publisher = new WebRtcPublisher({
+        streamId: "e2e-trickle",
+        whipEndpoint: `${base}/whip?streamId=e2e-trickle`,
+        trickleIce: true,
+      });
+
+      const viewer = new RTCPeerConnection({ codecs: { video: [useH264()] } });
+      const received: RtpPacket[] = [];
+      viewer.onTrack.subscribe((track: MediaStreamTrack) => {
+        track.onReceiveRtp.subscribe((rtp: RtpPacket) => received.push(rtp));
+      });
+
+      try {
+        await publisher.start();
+        expect(publisher.getState()).toBe("connected");
+
+        viewer.addTransceiver("video", { direction: "recvonly" });
+        const offer = await viewer.createOffer();
+        await viewer.setLocalDescription(offer);
+        await waitForIce(viewer);
+        const whepRes = await fetch(`${base}/whep/e2e-trickle`, {
+          method: "POST",
+          headers: { "Content-Type": "application/sdp" },
+          body: viewer.localDescription?.sdp ?? "",
+        });
+        expect(whepRes.status).toBe(201);
+        await viewer.setRemoteDescription({ type: "answer", sdp: await whepRes.text() });
+        await waitFor(() => viewer.connectionState === "connected", 8000);
+
+        publisher.writeH264Chunk(keyframe());
+        for (let i = 0; i < 40; i++) {
+          publisher.writeH264Chunk(pFrame(0x40 + (i % 32)));
+          await sleep(20);
+          if (received.length > 5) {
+            break;
+          }
+        }
+
+        await waitFor(() => received.length > 5, 5000);
+        expect(received.length).toBeGreaterThan(5);
+      } finally {
+        await publisher.stop();
+        await viewer.close();
+        await http.close();
+      }
+    },
+    30000
+  );
 });


### PR DESCRIPTION
## Summary

Advances **#3778** by adding **trickle ICE** so WHIP connection setup doesn't stall on the ICE gathering timeout (most costly behind restrictive NATs). **Opt-in** via `AUTOMOBILE_WEBRTC_TRICKLE_ICE=1` / `trickleIce: true`; the default remains the non-trickle full-gather path so servers that don't implement the WHIP trickle extension keep working.

**Audio (the issue's other half) is deferred** — it needs a device-audio capture source that doesn't exist yet (both `screenrecord` and the `video-server` are video-only). This PR closes out the trickle checkbox; audio stays open on #3778.

## Changes

| File | Role |
|------|------|
| `trickleIce.ts` | Pure `application/trickle-ice-sdpfrag` serialize/parse + `TrickleIceForwarder` (buffers candidates until the WHIP resource URL is known, then streams them). Transport-free, fully unit-tested. |
| `WhipClient.patchCandidate` | HTTP `PATCH` of a trickle fragment to the resource; best-effort (tolerates 405/501 from non-trickle servers). |
| `WebRtcPublisher` | When trickle is on: publish the offer immediately (no gather wait) and PATCH each local candidate; teardown stops the forwarder + unsubscribes. |
| `webrtcStreamingConfig` / `webrtcStreamManager` | New `trickleIce` config + `AUTOMOBILE_WEBRTC_TRICKLE_ICE` env flag, wired to the publisher. |
| reference coordination server | Accept `PATCH /whip/:id` and apply candidates to the ingest peer via `addIceCandidate`. |

## Tests

- **Unit**: sdpfrag round-trip; forwarder buffering/flush/stop/null-resource; `patchCandidate` (content-type, 405 tolerance); config flag parsing; publisher no-wait-publish + PATCH-on-candidate + no-PATCH-after-stop (fake pc whose gathering never completes, proving the trickle path doesn't block).
- **E2E**: a new variant of the werift `publisher → WHIP ingest → WHEP` loop with `trickleIce: true` — confirms candidates are PATCHed, the reference server applies them, and frames still forward end-to-end.

### Evidence
`test/features/webrtc` + manager + e2e: **101 pass**; e2e trickle variant stable across repeated runs; `lint` + `typecheck` clean.

## Test plan
- [x] Unit + e2e suites pass (101)
- [x] Trickle e2e forwards frames end-to-end, stable on repeat
- [x] Default (non-trickle) path unchanged; existing tests green
- [x] `bun run lint` / `bun run typecheck` clean