### PR TITLE
fix(ci): skip LFS fetch for docs deploy

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1151,7 +1151,7 @@ jobs:
       - name: "Git Checkout"
         uses: actions/checkout@v6
         with:
-          lfs: true
+          lfs: false
           fetch-depth: 0  # Fetch full history for git-revision-date-localized plugin
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/test/bats/merge-workflow-deploy-docs-concurrency.bats
+++ b/test/bats/merge-workflow-deploy-docs-concurrency.bats
@@ -19,6 +19,14 @@ deploy_docs_block() {
   ' "$WORKFLOW"
 }
 
+deploy_docs_checkout_block() {
+  deploy_docs_block | awk '
+    /^      - name: "Git Checkout"/ { capture=1 }
+    capture && /^      - name:/ && !/^      - name: "Git Checkout"/ { exit }
+    capture { print }
+  '
+}
+
 @test "deploy-docs job has a job-scoped concurrency block" {
   block="$(deploy_docs_block)"
   [ -n "$block" ]
@@ -33,6 +41,12 @@ deploy_docs_block() {
 @test "deploy-docs concurrency does not cancel in-progress deploys" {
   block="$(deploy_docs_block)"
   echo "$block" | grep -Fq 'cancel-in-progress: false'
+}
+
+@test "deploy-docs checkout does not fetch Git LFS objects" {
+  block="$(deploy_docs_checkout_block)"
+  echo "$block" | grep -Fq 'lfs: false'
+  ! echo "$block" | grep -Fq 'lfs: true'
 }
 
 @test "top-level workflow concurrency is untouched (only deploy-docs job is scoped)" {


### PR DESCRIPTION
## Summary

Disable Git LFS fetching for the `Deploy Documentation` checkout in the `On Merge` workflow. The docs deploy still keeps full history for `git-revision-date-localized`, but it no longer fails before the build when the repository LFS budget is exhausted.

## Linked Issue

Closes #3589

## Bug / Regression Context

- **Prior attempts:** #3578 fixed a separate Pages deploy concurrency failure; this addresses the later checkout failure.
- **Observed symptom:** `Deploy Documentation` fails during `actions/checkout@v6` while running `git lfs fetch`.
- **Repro steps / conditions:** Push to `main` triggers `On Merge`; if the repository LFS budget is exhausted, the docs deploy checkout exits before setup/build steps run.

## Validation

- [x] `bats test/bats/merge-workflow-deploy-docs-concurrency.bats`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate`
- [x] `bash scripts/all_fast_validate_checks.sh --only shellcheck,shell-portability,shell-sete`
- [x] `git diff --check`
- [ ] Android/iOS changes: not applicable
- [ ] New code uses interfaces + fakes + FakeTimer; not applicable
- [x] Rebased onto latest `main`, conflicts resolved

Note: `actionlint .github/workflows/merge.yml` still reports pre-existing workflow issues unrelated to this diff, including disabled `if: ${{ false }}` jobs and existing local-action metadata parsing errors.

## Device Verification

Not applicable.

## Follow-ups

- [ ] None.
