### PR TITLE
ci: retry Reminders launch plan once

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -469,40 +469,45 @@ jobs:
         timeout-minutes: 10
         env:
           AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"
-        run: |
-          cd ios/XCTestRunner
-          swift test --filter RemindersLaunchPlanTests 2>&1
+          AUTOMOBILE_TEST_RETRY_COUNT: "1"
+        run: ./scripts/ci/run-reminders-launch-plan-tests.sh
 
       - name: "Shutdown iOS Simulators"
         if: always()
         run: xcrun simctl shutdown all || true
 
       - name: "Select Xcode 26.5"
+        if: ${{ !cancelled() }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26.5"
 
       - name: "Ensure iOS Simulator runtime (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
       - name: "Boot iOS Simulator (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         run: ./scripts/ios/boot-simulator.sh
 
       - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
       - name: "Warm up Reminders target app (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         timeout-minutes: 5
         run: ./scripts/ci/warm-reminders-target-app.sh
 
       - name: "Run Reminders integration tests (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         timeout-minutes: 10
         env:
           AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"
-        run: |
-          cd ios/XCTestRunner
-          swift test --filter RemindersLaunchPlanTests 2>&1
+          AUTOMOBILE_TEST_RETRY_COUNT: "1"
+        run: ./scripts/ci/run-reminders-launch-plan-tests.sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1418,23 +1418,25 @@ jobs:
         timeout-minutes: 10
         env:
           AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"
-        run: |
-          cd ios/XCTestRunner
-          swift test --filter RemindersLaunchPlanTests 2>&1
+          AUTOMOBILE_TEST_RETRY_COUNT: "1"
+        run: ./scripts/ci/run-reminders-launch-plan-tests.sh
 
       - name: "Shutdown iOS Simulators"
         if: always()
         run: xcrun simctl shutdown all || true
 
       - name: "Select Xcode 26.5"
+        if: ${{ !cancelled() }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26.5"
 
       - name: "Ensure iOS Simulator runtime (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
       - name: "Boot iOS Simulator (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         run: ./scripts/ios/boot-simulator.sh
 
       - name: "Run videoRecording MP4 integration test"
@@ -1446,23 +1448,26 @@ jobs:
       # This is a freshly-booted sim, so re-confirm the daemon and warm CtrlProxy
       # again before the second Reminders run (same rationale as the 26.2 block).
       - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
       - name: "Warm up Reminders target app (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         timeout-minutes: 5
         run: ./scripts/ci/warm-reminders-target-app.sh
 
       - name: "Run Reminders integration tests (Xcode 26.5)"
+        if: ${{ !cancelled() }}
         timeout-minutes: 10
         env:
           AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"
-        run: |
-          cd ios/XCTestRunner
-          swift test --filter RemindersLaunchPlanTests 2>&1
+          AUTOMOBILE_TEST_RETRY_COUNT: "1"
+        run: ./scripts/ci/run-reminders-launch-plan-tests.sh
 
       # Daemon-internal logs (CtrlProxy startup/health/observe timing) are the only
       # way to diagnose iOS observe failures — the swift-test stdout doesn't include

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -199,6 +199,6 @@ fresh keyframe.
 - [WHEP — draft-ietf-wish-whep](https://datatracker.ietf.org/doc/draft-ietf-wish-whep/)
 - [RFC 6184 — RTP Payload Format for H.264 Video](https://datatracker.ietf.org/doc/html/rfc6184)
 - [werift-webrtc](https://github.com/shinyoshiaki/werift-webrtc)
-- [CI worker setup guide](../../webrtc-streaming-ci-worker.md)
+- [CI worker setup guide](../../../webrtc-streaming-ci-worker.md)
 - [Reference coordination server](../../../../examples/webrtc-coordination-server/README.md)
 - [IDE live mirroring (Unix socket + Klarity)](./screen-streaming.md)

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -158,8 +158,8 @@ final class RemindersPlanContentTests: XCTestCase {
         XCTAssertTrue(guardStep.mentions("Title"), "The title input guard must target the Title field")
     }
 
-    /// The Reminders tests must run as single-attempt plans by default. CI warms the target app before
-    /// the timed plan step, so retrying here would hide the root-cause fix regressing.
+    /// Reminders tests default to single-attempt plans for local runs, but CI can opt into a bounded
+    /// retry for known cold-runner flakes through `AUTOMOBILE_TEST_RETRY_COUNT`.
     func testRemindersPlansDefaultToZeroRetries() {
         // An explicit env override legitimately wins, so only assert the default when unset.
         let env = ProcessInfo.processInfo.environment
@@ -225,8 +225,8 @@ final class RemindersPlanContentTests: XCTestCase {
         XCTAssertEqual(RemindersAddPlanTests().timeoutSeconds, 120)
     }
 
-    /// Retry is no longer the stabilization mechanism for Reminders. The integration base should only
-    /// own simulator/daemon readiness; retry behavior comes from `AutoMobileTestCase`.
+    /// CI enables Reminders retries through workflow env, not a test-class override. The integration
+    /// base should only own simulator/daemon readiness; retry behavior comes from `AutoMobileTestCase`.
     func testRemindersIntegrationBaseDoesNotOverrideRetryCount() throws {
         let source = try loadRemindersIntegrationTestSource()
 
@@ -260,6 +260,67 @@ final class RemindersPlanContentTests: XCTestCase {
         )
     }
 
+    func testPullRequestWorkflowRetriesRemindersRunsOnce() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
+
+        assertWorkflowRetriesRemindersRunOnce(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowRetriesRemindersRunOnce(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.5)"
+        )
+        assertWorkflowRunsGuardedRemindersTest(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowRunsGuardedRemindersTest(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.5)"
+        )
+    }
+
+    func testPullRequestWorkflowRunsSecondRemindersLegAfterFirstLegFailureUnlessCancelled() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
+
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Select Xcode 26.5",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Ensure iOS Simulator runtime (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Boot iOS Simulator (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Ensure AutoMobile daemon ready (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Warm up Reminders target app (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Run Reminders integration tests (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+    }
+
     func testNightlyWorkflowWarmsTargetAppBeforeRemindersRuns() throws {
         let workflow = try loadRepositoryFile(".github/workflows/nightly.yml")
 
@@ -272,6 +333,67 @@ final class RemindersPlanContentTests: XCTestCase {
             workflow,
             warmupStepName: "Warm up Reminders target app (Xcode 26.5)",
             runStepName: "Run Reminders integration tests (Xcode 26.5)"
+        )
+    }
+
+    func testNightlyWorkflowRetriesRemindersRunsOnce() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/nightly.yml")
+
+        assertWorkflowRetriesRemindersRunOnce(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowRetriesRemindersRunOnce(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.5)"
+        )
+        assertWorkflowRunsGuardedRemindersTest(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowRunsGuardedRemindersTest(
+            workflow,
+            runStepName: "Run Reminders integration tests (Xcode 26.5)"
+        )
+    }
+
+    func testNightlyWorkflowRunsSecondRemindersLegAfterFirstLegFailureUnlessCancelled() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/nightly.yml")
+
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Select Xcode 26.5",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Ensure iOS Simulator runtime (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Boot iOS Simulator (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Ensure AutoMobile daemon ready (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Warm up Reminders target app (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+        )
+        assertWorkflowStepRunsWhenNotCancelled(
+            workflow,
+            stepName: "Run Reminders integration tests (Xcode 26.5)",
+            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
         )
     }
 
@@ -728,4 +850,116 @@ private func assertWorkflowWarmsTargetAppBeforeRemindersRun(
         file: file,
         line: line
     )
+}
+
+private func assertWorkflowRetriesRemindersRunOnce(
+    _ workflow: String,
+    runStepName: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let runBlock = workflowStepBlock(workflow, stepName: runStepName, file: file, line: line)
+    XCTAssertTrue(
+        stepBlockHasActiveEnvValue(runBlock, key: "AUTOMOBILE_TEST_RETRY_COUNT", value: "\"1\""),
+        "\(runStepName) must enable exactly one bounded retry for cold first-leg bring-up flakes",
+        file: file,
+        line: line
+    )
+}
+
+private func assertWorkflowRunsGuardedRemindersTest(
+    _ workflow: String,
+    runStepName: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let runBlock = workflowStepBlock(workflow, stepName: runStepName, file: file, line: line)
+    XCTAssertTrue(
+        stepBlockHasActiveTopLevelValue(
+            runBlock,
+            key: "run",
+            value: "./scripts/ci/run-reminders-launch-plan-tests.sh"
+        ),
+        "\(runStepName) must fail when the filtered Reminders test command executes zero XCTest cases",
+        file: file,
+        line: line
+    )
+}
+
+private func assertWorkflowStepRunsWhenNotCancelled(
+    _ workflow: String,
+    stepName: String,
+    afterStepName: String? = nil,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let stepBlock = workflowStepBlock(
+        workflow,
+        stepName: stepName,
+        afterStepName: afterStepName,
+        file: file,
+        line: line
+    )
+    XCTAssertTrue(
+        stepBlockHasActiveTopLevelValue(stepBlock, key: "if", value: "${{ !cancelled() }}"),
+        "\(stepName) must run after an earlier Reminders leg fails, but still respect cancellation",
+        file: file,
+        line: line
+    )
+}
+
+private func workflowStepBlock(
+    _ workflow: String,
+    stepName: String,
+    afterStepName: String? = nil,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) -> Substring {
+    let searchStart: String.Index
+    if let afterStepName {
+        guard let afterRange = workflow.range(of: #"name: "\#(afterStepName)""#) else {
+            XCTFail("Workflow is missing step named \(afterStepName)", file: file, line: line)
+            return ""
+        }
+        searchStart = afterRange.upperBound
+    } else {
+        searchStart = workflow.startIndex
+    }
+
+    guard let stepRange = workflow[searchStart...].range(of: #"name: "\#(stepName)""#) else {
+        XCTFail("Workflow is missing step named \(stepName)", file: file, line: line)
+        return ""
+    }
+
+    let nextStepRange = workflow[stepRange.upperBound...].range(of: "\n      - name:")
+    let stepBlockEnd = nextStepRange?.lowerBound ?? workflow.endIndex
+    return workflow[stepRange.lowerBound ..< stepBlockEnd]
+}
+
+private func stepBlockHasActiveTopLevelValue(_ stepBlock: Substring, key: String, value: String) -> Bool {
+    return stepBlockActiveLines(stepBlock).contains { line in
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return line.hasPrefix("        \(key):") && trimmed == "\(key): \(value)"
+    }
+}
+
+private func stepBlockHasActiveEnvValue(_ stepBlock: Substring, key: String, value: String) -> Bool {
+    var inEnv = false
+    for line in stepBlockActiveLines(stepBlock) {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if line.hasPrefix("        ") && !line.hasPrefix("          ") {
+            inEnv = trimmed == "env:"
+            continue
+        }
+        if inEnv, line.hasPrefix("          "), trimmed == "\(key): \(value)" {
+            return true
+        }
+    }
+    return false
+}
+
+private func stepBlockActiveLines(_ stepBlock: Substring) -> [String] {
+    return stepBlock.split(separator: "\n", omittingEmptySubsequences: false)
+        .map(String.init)
+        .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
 }

--- a/scripts/ci/run-reminders-launch-plan-tests.sh
+++ b/scripts/ci/run-reminders-launch-plan-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/reminders-launch-plan-tests.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+cd "$REPO_ROOT/ios/XCTestRunner"
+
+set +e
+swift test --filter XCTestRunnerTests.RemindersLaunchPlanTests/testLaunchRemindersPlan 2>&1 | tee "$LOG_FILE"
+swift_status="${PIPESTATUS[0]}"
+set -e
+
+if ! grep -Eq "Test Case '-\\[XCTestRunnerTests\\.RemindersLaunchPlanTests testLaunchRemindersPlan\\]' (passed|failed)" "$LOG_FILE"; then
+  echo "::error::RemindersLaunchPlanTests filter completed without executing testLaunchRemindersPlan"
+  exit 1
+fi
+
+exit "$swift_status"

--- a/test/bats/run-reminders-launch-plan-tests.bats
+++ b/test/bats/run-reminders-launch-plan-tests.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/ci/run-reminders-launch-plan-tests.sh"
+  TEST_DIR="$(mktemp -d)"
+  STUB_BIN="$TEST_DIR/bin"
+  mkdir -p "$STUB_BIN"
+  cat > "$STUB_BIN/swift" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${SWIFT_STUB_ARGS_FILE:?}"
+case "${SWIFT_STUB_MODE:-pass}" in
+  pass)
+    echo "Test Case '-[XCTestRunnerTests.RemindersLaunchPlanTests testLaunchRemindersPlan]' passed (1.0 seconds)."
+    exit 0
+    ;;
+  zero)
+    echo "Test Suite 'Selected tests' passed"
+    echo "Executed 0 tests, with 0 failures"
+    exit 0
+    ;;
+  fail)
+    echo "Test Case '-[XCTestRunnerTests.RemindersLaunchPlanTests testLaunchRemindersPlan]' failed (1.0 seconds)."
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/swift"
+  export PATH="$STUB_BIN:$PATH"
+  export SWIFT_STUB_ARGS_FILE="$TEST_DIR/swift-args.txt"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+@test "runs the RemindersLaunchPlanTests filter" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$SWIFT_STUB_ARGS_FILE")" = "test --filter XCTestRunnerTests.RemindersLaunchPlanTests/testLaunchRemindersPlan" ]
+}
+
+@test "fails when SwiftPM reports zero filtered XCTest cases" {
+  run env SWIFT_STUB_MODE=zero bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"without executing testLaunchRemindersPlan"* ]]
+}
+
+@test "preserves a real Reminders test failure status" {
+  run env SWIFT_STUB_MODE=fail bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"testLaunchRemindersPlan]' failed"* ]]
+  [[ "$output" != *"without executing testLaunchRemindersPlan"* ]]
+}


### PR DESCRIPTION
## Summary

- enable one bounded retry for the Reminders launch integration plan in PR and nightly XCTestRunner jobs
- keep the second Xcode Reminders leg observable by running it after a first-leg failure
- route Reminders workflow invocations through a guard script that fails if SwiftPM reports success while executing zero filtered Reminders tests
- add structural Swift guards plus BATS coverage for the workflow retry, continuation behavior, and guarded test runner
- fix a broken WebRTC docs link that was failing the repo fast-validation link check

Closes #3592

## Validation

- `swift test --filter RemindersPlanContentTests`
- `bats test/bats/run-reminders-launch-plan-tests.bats`
- `shellcheck scripts/ci/run-reminders-launch-plan-tests.sh`
- `bun run typecheck`
- `bun run turbo:validate`
- `scripts/all_fast_validate_checks.sh` (14 checks passed)
- `git diff --check`
