### PR TITLE
fix(nightly): scope SHA updates to registry entry, not interface line

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,18 +55,27 @@ jobs:
       - name: "Get current SHA256 values from source"
         id: current
         run: |
-          APK_CURRENT=$(grep 'apkSha256' src/constants/release.ts | head -1 | sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/')
-          IPA_CURRENT=$(grep 'ipaSha256' src/constants/release.ts | head -1 | sed 's/.*"\([a-f0-9]\{64\}\)".*/\1/')
-          RUNNER_CURRENT=$(awk '
-            /^[[:space:]]+version: "/ { in_first = 1 }
-            in_first && /^[[:space:]]+runnerSha256: "/ {
-              sub(/.*runnerSha256: "/, "")
-              sub(/".*/, "")
-              print
-              exit
-            }
-            in_first && /^[[:space:]]+}/ { exit }
-          ' src/constants/release.ts)
+          # Read a field from the FIRST registry entry (the block that starts at
+          # `version: "`). Anchoring on the entry avoids matching the
+          # `ReleaseChecksumEntry` interface declarations (`apkSha256: string;`)
+          # that precede the registry — a plain `grep | head -1` grabbed those and
+          # reported the TypeScript type line as the "current" checksum (#3784).
+          read_registry_field() {
+            awk -v field="$1" '
+              /^[[:space:]]+version: "/ { in_first = 1 }
+              in_first && $0 ~ ("^[[:space:]]+" field ": \"") {
+                line = $0
+                sub(".*" field ": \"", "", line)
+                sub(/".*/, "", line)
+                print line
+                exit
+              }
+              in_first && /^[[:space:]]+}/ { exit }
+            ' src/constants/release.ts
+          }
+          APK_CURRENT=$(read_registry_field apkSha256)
+          IPA_CURRENT=$(read_registry_field ipaSha256)
+          RUNNER_CURRENT=$(read_registry_field runnerSha256)
           echo "apk_sha256=$APK_CURRENT" >> $GITHUB_OUTPUT
           echo "ipa_sha256=$IPA_CURRENT" >> $GITHUB_OUTPUT
           echo "runner_sha256=$RUNNER_CURRENT" >> $GITHUB_OUTPUT

--- a/scripts/ci/verify-artifact-sha256.sh
+++ b/scripts/ci/verify-artifact-sha256.sh
@@ -49,11 +49,32 @@ else
   exit 1
 fi
 
-# `sed -n ... p` only prints on a real 64-hex match, so an empty or malformed
-# value (e.g. `ipaSha256: ""`) yields an empty SOURCE_SHA256 and the guard
-# below fires. The old unanchored `s///` passed the whole line through on no
-# match, making SOURCE_SHA256 non-empty and defeating the -z check (#3658).
-SOURCE_SHA256=$(grep "$FIELD" "$RELEASE_TS" | head -1 | sed -n 's/.*"\([a-f0-9]\{64\}\)".*/\1/p')
+# Read the field from the FIRST registry ENTRY (the block beginning with
+# `version: "`), mirroring verify-release-integrity.sh. A plain
+# `grep "$FIELD" | head -1` matches the `ReleaseChecksumEntry` interface
+# declaration (`ipaSha256: string;`) that precedes the registry and returns the
+# type line, not registry[0] — so a real release aborts with a misleading
+# "No SHA256 checksum found" even though the checksum is populated (same
+# interface-collision bug fixed in nightly.yml + generate-release-constants.sh).
+# `in_first` only arms after a quoted `version: "` line, which the interface
+# (`version: string;`, no quote) never trips.
+SOURCE_SHA256=$(awk -v field="$FIELD" '
+  /^[[:space:]]+version: "/ { in_first = 1 }
+  in_first && $0 ~ ("^[[:space:]]+" field ": \"") {
+    line = $0
+    sub(".*" field ": \"", "", line)
+    sub(/".*/, "", line)
+    print line
+    exit
+  }
+  in_first && /^[[:space:]]+}/ { exit }
+' "$RELEASE_TS")
+# Only a real 64-hex value counts; an empty or malformed registry value (e.g.
+# `ipaSha256: ""`) yields empty SOURCE_SHA256 so the `-z` guard below fires with
+# the actionable "No checksum" error rather than a spurious mismatch (#3658).
+if ! [[ "$SOURCE_SHA256" =~ ^[a-f0-9]{64}$ ]]; then
+  SOURCE_SHA256=""
+fi
 echo "Source SHA256:         $SOURCE_SHA256"
 
 if [ -z "$SOURCE_SHA256" ]; then

--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -177,19 +177,23 @@ if [ -n "$release_version" ]; then
     echo "   iOS checksum: ${ios_checksum}"
   fi
 else
-  # Mode: update registry[0] checksums in place (nightly/checksum-only)
+  # Mode: update registry[0] checksums in place (nightly/checksum-only).
+  #
+  # Scope every field update to the first registry ENTRY (the block beginning
+  # with `version: "`) via update_registry_field. A plain line-based match
+  # collides with the `ReleaseChecksumEntry` interface declarations
+  # (`apkSha256: string;` / `ipaSha256: string;`) that precede the registry:
+  # `grep 'apkSha256:' | head -1` returns the type line, and the follow-up sed
+  # (which only matches a 64-hex value) then silently updates nothing. That left
+  # APK/IPA registry[0] stale while only runnerSha256 moved — see nightly PR
+  # #3784, where the merged entry carried a fresh runner sha but original APK/IPA
+  # shas, breaking whole-bundle vs runner verification for a fresh install.
   if [ -n "$apk_checksum" ]; then
-    first_apk_line=$(grep -n 'apkSha256:' "$tmp_file" | head -1 | cut -d: -f1)
-    if [ -n "$first_apk_line" ]; then
-      sed_inplace_extended "${first_apk_line}s/apkSha256: \"[a-f0-9]{64}\"/apkSha256: \"${apk_checksum}\"/" "$tmp_file"
-    fi
+    update_registry_field "$tmp_file" "__FIRST__" "apkSha256" "$apk_checksum"
   fi
 
   if [ -n "$ios_checksum" ]; then
-    first_ipa_line=$(grep -n 'ipaSha256:' "$tmp_file" | head -1 | cut -d: -f1)
-    if [ -n "$first_ipa_line" ]; then
-      sed_inplace_extended "${first_ipa_line}s/ipaSha256: \"[a-f0-9]{64}\"/ipaSha256: \"${ios_checksum}\"/" "$tmp_file"
-    fi
+    update_registry_field "$tmp_file" "__FIRST__" "ipaSha256" "$ios_checksum"
   fi
 
   if [ -n "$ios_runner_sha256" ]; then

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -59,6 +59,41 @@ teardown() {
   grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
 }
 
+@test "updates registry[0].apkSha256 and ipaSha256 in checksum-only mode" {
+  # Regression for #3784: the nightly checksum-only path must move the APK/IPA
+  # shas on registry[0], not the `apkSha256: string;` interface declaration that
+  # precedes the registry. Capture the pre-update values so we assert they change
+  # (and that the update lands inside the first registry entry).
+  old_apk="$(awk '
+    /^[[:space:]]+version: "/ { in_first = 1 }
+    in_first && /^[[:space:]]+apkSha256: "/ { sub(/.*apkSha256: "/, ""); sub(/".*/, ""); print; exit }
+  ' "${TEST_ROOT}/src/constants/release.ts")"
+  [ -n "$old_apk" ]
+  [ "$old_apk" != "$APK_SHA" ]
+
+  run env \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+  [ "$status" -eq 0 ]
+
+  # First registry entry now carries the new shas.
+  first_apk="$(awk '
+    /^[[:space:]]+version: "/ { in_first = 1 }
+    in_first && /^[[:space:]]+apkSha256: "/ { sub(/.*apkSha256: "/, ""); sub(/".*/, ""); print; exit }
+  ' "${TEST_ROOT}/src/constants/release.ts")"
+  first_ipa="$(awk '
+    /^[[:space:]]+version: "/ { in_first = 1 }
+    in_first && /^[[:space:]]+ipaSha256: "/ { sub(/.*ipaSha256: "/, ""); sub(/".*/, ""); print; exit }
+  ' "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$first_apk" = "$APK_SHA" ]
+  [ "$first_ipa" = "$IPA_SHA" ]
+
+  # The interface declaration must remain a type, never a checksum.
+  grep -q '^  apkSha256: string;$' "${TEST_ROOT}/src/constants/release.ts"
+  grep -q '^  ipaSha256: string;$' "${TEST_ROOT}/src/constants/release.ts"
+}
+
 @test "refreshes runner sha for an already-registered version (no duplicate entry)" {
   # First release adds the entry but with an empty runner sha (pre-wiring state).
   run env \

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -89,6 +89,10 @@ teardown() {
   [ "$first_apk" = "$APK_SHA" ]
   [ "$first_ipa" = "$IPA_SHA" ]
 
+  # Only registry[0] moves: the second entry (0.0.43) keeps its original apkSha256.
+  grep -q 'apkSha256: "7e4e2ce3c19b7473d171433186dbc7487df60ff6045dba66da7a320d31e63cd3"' \
+    "${TEST_ROOT}/src/constants/release.ts"
+
   # The interface declaration must remain a type, never a checksum.
   grep -q '^  apkSha256: string;$' "${TEST_ROOT}/src/constants/release.ts"
   grep -q '^  ipaSha256: string;$' "${TEST_ROOT}/src/constants/release.ts"

--- a/test/bats/verify-artifact-sha256.bats
+++ b/test/bats/verify-artifact-sha256.bats
@@ -31,10 +31,28 @@ teardown() {
 }
 
 # $1 = ipaSha256 value (may be empty)
+#
+# Mirrors the production release.ts layout: a `ReleaseChecksumEntry` interface
+# (whose `ipaSha256: string;` line is the interface-collision trap) followed by a
+# multi-line registry entry. A fixture without the interface line silently masks
+# the `grep | head -1` collision bug — the extraction must be anchored to the
+# registry entry, not the type declaration.
 write_release_ts() {
   cat > "$PROJECT/src/constants/release.ts" <<EOF
-export const RELEASE_CHECKSUM_REGISTRY = [
-  { version: "1.0.0", apkSha256: "", ipaSha256: "$1" },
+export interface ReleaseChecksumEntry {
+  version: string;
+  apkSha256: string;
+  ipaSha256: string;
+  runnerSha256: string;
+}
+
+export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
+  {
+    version: "1.0.0",
+    apkSha256: "",
+    ipaSha256: "$1",
+    runnerSha256: "",
+  },
 ];
 EOF
 }


### PR DESCRIPTION
## Problem

Nightly SHA-update PR #3784 shipped an incoherent registry entry: a fresh `runnerSha256` (`ff289…`) alongside **stale** `apkSha256`/`ipaSha256`, and its PR body "Previous" column showed the TypeScript type line `  apkSha256: string;` instead of a checksum.

Both symptoms share one root cause. A `ReleaseChecksumEntry` interface was added to `src/constants/release.ts` declaring `apkSha256: string;` / `ipaSha256: string;` **before** the registry. The tooling matched fields with `grep 'apkSha256:' | head -1`, which now grabs the interface line, not the `registry[0]` value.

- The generator's nightly-mode `sed` targeted that interface line, where `apkSha256: "[a-f0-9]{64}"` never matches → **APK/IPA registry values silently never updated**. Only `runnerSha256` moved (it uses a separate entry-scoped path).
- The workflow's change-detection / PR-body extraction read the type declaration as the "current" checksum.
- **The same collision also lives in the release path** (`scripts/ci/verify-artifact-sha256.sh`, wired into `release.yml`): against the real `release.ts` it extracts empty and a release aborts with a misleading "No SHA256 checksum found".

As the P1 review on #3784 noted, incoherent `ipaSha256`/`runnerSha256` break integrity verification for a fresh install: `verifyBundle()` checks the IPA against `ipaSha256`, then `verifyPlatformArtifacts()` checks the extracted runner against `runnerSha256` — out of sync, one must fail.

## Fix

- **`scripts/generate-release-constants.sh`** — nightly checksum-only mode routes APK/IPA (and runner) through the existing entry-scoped `update_registry_field "__FIRST__"` helper, anchored on the `version: "` block and immune to the interface line. Backfills empty values correctly.
- **`.github/workflows/nightly.yml`** — replaced the three ad-hoc extractors with one `read_registry_field` awk helper scoped to the first registry entry.
- **`scripts/ci/verify-artifact-sha256.sh`** — read the field from the first registry entry via the same entry-anchored awk as `verify-release-integrity.sh` (preserving the #3658 empty/malformed → `-z` guard behavior).
- **Tests** — `generate-release-constants.bats` asserts checksum-only mode moves `registry[0]` APK **and** IPA while leaving the interface declarations as types and `registry[1]` untouched; `verify-artifact-sha256.bats` fixture now emits the production layout (interface + multi-line entry) so its "matching verifies" test actually reproduces the collision. Both new guards fail against the old code.

## Validation

- `bats test/bats/generate-release-constants.bats test/bats/verify-artifact-sha256.bats` — 10/10 pass
- `shellcheck` on all touched scripts — clean; fast-validation shellcheck gate — pass
- Reproduced old-vs-new for both scripts: old returns `  apkSha256: string;` / empty; new returns the real registry[0] hash
- awk verified byte-identical on BSD awk (macOS) and gawk 5.4.1 (ubuntu-latest runner)

## Code review

Reviewed by four independent perspectives (correctness/regression, shell-awk/CI portability, test quality, consistency/integrity). Correctness, portability, and test-quality passes were clean (the new tests were confirmed to fail against the pre-fix code). The consistency pass surfaced the release-path collision in `verify-artifact-sha256.sh` — **fixed in this PR**.

### Follow-ups (out of scope, tracked separately)

- **Incoherent merged v0.0.44 entry** — #3784 left `registry[0]` with an `ipaSha256`/`runnerSha256` pair drawn from different IPAs, so `latest` integrity verification is currently broken. This PR fixes the *process*; the *data* needs the true published-artifact checksums, plus a design decision on whether nightly should overwrite a tagged release entry in place (registry[0] doubles as both the pinned `0.0.44` entry and the mutable "latest" slot). Filed as a follow-up.
- **Extraction-logic consolidation (YAGNI)** — "read field from registry[0]" now has three consistent implementations (workflow awk, generator python, verify-integrity awk). All agree on the `version: "` anchor; consolidating into one sourced helper (which would also make the workflow awk unit-testable) is a low-priority follow-up, deliberately not bundled here to limit blast radius.