### PR TITLE
refactor(release): extract shared read-registry-field helper + cover it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,27 +55,18 @@ jobs:
       - name: "Get current SHA256 values from source"
         id: current
         run: |
-          # Read a field from the FIRST registry entry (the block that starts at
-          # `version: "`). Anchoring on the entry avoids matching the
-          # `ReleaseChecksumEntry` interface declarations (`apkSha256: string;`)
-          # that precede the registry — a plain `grep | head -1` grabbed those and
-          # reported the TypeScript type line as the "current" checksum (#3784).
-          read_registry_field() {
-            awk -v field="$1" '
-              /^[[:space:]]+version: "/ { in_first = 1 }
-              in_first && $0 ~ ("^[[:space:]]+" field ": \"") {
-                line = $0
-                sub(".*" field ": \"", "", line)
-                sub(/".*/, "", line)
-                print line
-                exit
-              }
-              in_first && /^[[:space:]]+}/ { exit }
-            ' src/constants/release.ts
-          }
-          APK_CURRENT=$(read_registry_field apkSha256)
-          IPA_CURRENT=$(read_registry_field ipaSha256)
-          RUNNER_CURRENT=$(read_registry_field runnerSha256)
+          # Read each field from the FIRST registry entry via the shared helper
+          # (single source of truth with verify-artifact-sha256.sh +
+          # verify-release-integrity.sh). Anchoring on the entry's quoted
+          # `version: "` line avoids matching the `ReleaseChecksumEntry` interface
+          # declarations (`apkSha256: string;`) that precede the registry — a
+          # plain `grep | head -1` grabbed those and reported the TypeScript type
+          # line as the "current" checksum (#3784).
+          source scripts/lib/read-registry-field.sh
+          RELEASE_TS="src/constants/release.ts"
+          APK_CURRENT=$(read_registry_field apkSha256 "$RELEASE_TS")
+          IPA_CURRENT=$(read_registry_field ipaSha256 "$RELEASE_TS")
+          RUNNER_CURRENT=$(read_registry_field runnerSha256 "$RELEASE_TS")
           echo "apk_sha256=$APK_CURRENT" >> $GITHUB_OUTPUT
           echo "ipa_sha256=$IPA_CURRENT" >> $GITHUB_OUTPUT
           echo "runner_sha256=$RUNNER_CURRENT" >> $GITHUB_OUTPUT

--- a/scripts/ci/verify-artifact-sha256.sh
+++ b/scripts/ci/verify-artifact-sha256.sh
@@ -12,6 +12,9 @@
 #   verify-artifact-sha256.sh /tmp/control-proxy.ipa ios
 set -euo pipefail
 
+# shellcheck source=scripts/lib/read-registry-field.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/read-registry-field.sh"
+
 ARTIFACT_PATH="${1:?Usage: verify-artifact-sha256.sh <artifact-path> <platform>}"
 PLATFORM="${2:?Usage: verify-artifact-sha256.sh <artifact-path> <platform>}"
 
@@ -49,29 +52,17 @@ else
   exit 1
 fi
 
-# Read the field from the FIRST registry ENTRY (the block beginning with
-# `version: "`), mirroring verify-release-integrity.sh. A plain
-# `grep "$FIELD" | head -1` matches the `ReleaseChecksumEntry` interface
-# declaration (`ipaSha256: string;`) that precedes the registry and returns the
-# type line, not registry[0] — so a real release aborts with a misleading
-# "No SHA256 checksum found" even though the checksum is populated (same
-# interface-collision bug fixed in nightly.yml + generate-release-constants.sh).
-# `in_first` only arms after a quoted `version: "` line, which the interface
-# (`version: string;`, no quote) never trips.
-SOURCE_SHA256=$(awk -v field="$FIELD" '
-  /^[[:space:]]+version: "/ { in_first = 1 }
-  in_first && $0 ~ ("^[[:space:]]+" field ": \"") {
-    line = $0
-    sub(".*" field ": \"", "", line)
-    sub(/".*/, "", line)
-    print line
-    exit
-  }
-  in_first && /^[[:space:]]+}/ { exit }
-' "$RELEASE_TS")
-# Only a real 64-hex value counts; an empty or malformed registry value (e.g.
-# `ipaSha256: ""`) yields empty SOURCE_SHA256 so the `-z` guard below fires with
-# the actionable "No checksum" error rather than a spurious mismatch (#3658).
+# Read the checksum from registry[0] via the shared, entry-anchored helper. A
+# plain `grep "$FIELD" | head -1` would instead match the `ReleaseChecksumEntry`
+# interface declaration (`ipaSha256: string;`) that precedes the registry: the
+# whole pipeline then yields an empty value and a real release aborts with a
+# misleading "No SHA256 checksum found" even though the checksum is populated
+# (interface-collision bug, #3784).
+SOURCE_SHA256=$(read_registry_field "$FIELD" "$RELEASE_TS")
+# The helper does no format validation, so enforce the 64-hex floor here: an
+# empty or malformed registry value (e.g. `ipaSha256: ""`) yields empty
+# SOURCE_SHA256 so the `-z` guard below fires with the actionable "No checksum"
+# error rather than a spurious mismatch (#3658).
 if ! [[ "$SOURCE_SHA256" =~ ^[a-f0-9]{64}$ ]]; then
   SOURCE_SHA256=""
 fi

--- a/scripts/ci/verify-release-integrity.sh
+++ b/scripts/ci/verify-release-integrity.sh
@@ -22,6 +22,9 @@
 #              non-empty) floor is checked.
 set -euo pipefail
 
+# shellcheck source=scripts/lib/read-registry-field.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/read-registry-field.sh"
+
 RAW_VERSION="${1:?Usage: verify-release-integrity.sh <version> [ipa-path]}"
 EXPECTED="${RAW_VERSION#v}"
 IPA_PATH="${2:-}"
@@ -100,17 +103,9 @@ check "src/constants/release.ts registry[0].version" "$registry_version"
 
 # Runner-binary checksum must be populated on the newest registry entry. Empty
 # means integrity verification is silently skipped — exactly the gap this gate
-# exists to catch.
-runner_sha="$(awk '
-  /^[[:space:]]+version: "/ { in_first = 1 }
-  in_first && /^[[:space:]]+runnerSha256: "/ {
-    sub(/.*runnerSha256: "/, "")
-    sub(/".*/, "")
-    print
-    exit
-  }
-  in_first && /^[[:space:]]+}/ { exit }
-' "$RELEASE_TS")"
+# exists to catch. Read via the shared entry-anchored helper (single source of
+# truth with nightly.yml + verify-artifact-sha256.sh).
+runner_sha="$(read_registry_field runnerSha256 "$RELEASE_TS")"
 
 sha256_stdin() {
   if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/lib/read-registry-field.sh
+++ b/scripts/lib/read-registry-field.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Single source of truth for reading a scalar field out of the FIRST entry of
+# RELEASE_CHECKSUM_REGISTRY in src/constants/release.ts.
+#
+# Historically the same entry-anchored awk was copy-pasted into
+# nightly.yml, verify-artifact-sha256.sh, and verify-release-integrity.sh, and
+# a *fourth*, subtly-different `grep "$FIELD" | head -1 | sed` variant existed
+# that matched the `ReleaseChecksumEntry` interface declaration
+# (`apkSha256: string;`) instead of registry[0]. That collision silently
+# no-op'd nightly APK/IPA updates and aborted releases with a misleading
+# "No SHA256 checksum found" (#3784). Consolidating the readers here removes the
+# drift surface and lets one bats suite cover the extraction.
+#
+# Anchoring on the entry's quoted `version: "` line is what makes the read
+# immune to the interface: the interface's `version: string;` has no quote, so
+# `in_first` never arms while scanning the type declarations that precede the
+# registry.
+#
+# Sourcing convention mirrors scripts/lib/tool-install.sh:
+#   # shellcheck source=scripts/lib/read-registry-field.sh disable=SC1091
+#   source "$(dirname "${BASH_SOURCE[0]}")/../lib/read-registry-field.sh"
+# GitHub Actions run-steps execute from the repo root, so a workflow can source
+# it by repo-relative path: `source scripts/lib/read-registry-field.sh`.
+
+# read_registry_field <field> <release.ts path>
+# Prints the field's value from registry[0], or nothing if the field is absent
+# or the file has no registry entry. Never prints the interface type line.
+read_registry_field() {
+  local field="$1" file="$2"
+  awk -v field="$field" '
+    /^[[:space:]]+version: "/ { in_first = 1 }
+    in_first && $0 ~ ("^[[:space:]]+" field ": \"") {
+      line = $0
+      sub(".*" field ": \"", "", line)
+      sub(/".*/, "", line)
+      print line
+      exit
+    }
+    in_first && /^[[:space:]]+}/ { exit }
+  ' "$file"
+}
+
+# Allow direct invocation: read-registry-field.sh <field> <release.ts>
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  read_registry_field \
+    "${1:?Usage: read-registry-field.sh <field> <release.ts>}" \
+    "${2:?Usage: read-registry-field.sh <field> <release.ts>}"
+fi

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -89,7 +89,9 @@ teardown() {
   [ "$first_apk" = "$APK_SHA" ]
   [ "$first_ipa" = "$IPA_SHA" ]
 
-  # Only registry[0] moves: the second entry (0.0.43) keeps its original apkSha256.
+  # Only registry[0] moves: the second entry (0.0.43) keeps its original
+  # apkSha256. Coupled to the real release.ts the harness copies in setup(); if
+  # 0.0.43 ever ages out of the registry or its sha changes, update this literal.
   grep -q 'apkSha256: "7e4e2ce3c19b7473d171433186dbc7487df60ff6045dba66da7a320d31e63cd3"' \
     "${TEST_ROOT}/src/constants/release.ts"
 

--- a/test/bats/read-registry-field.bats
+++ b/test/bats/read-registry-field.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/lib/read-registry-field.sh — the shared reader that extracts
+# a scalar field from registry[0] of RELEASE_CHECKSUM_REGISTRY. This is the
+# regression guard for the interface-collision bug (#3784): the extraction must
+# read the registry entry, never the `ReleaseChecksumEntry` interface
+# declaration (`apkSha256: string;`) that precedes it.
+
+HELPER="scripts/lib/read-registry-field.sh"
+
+setup() {
+  ABS_HELPER="$(cd "$(dirname "$HELPER")" && pwd)/$(basename "$HELPER")"
+  PROJECT="$(mktemp -d)"
+  RELEASE_TS="$PROJECT/release.ts"
+}
+
+teardown() {
+  rm -rf "$PROJECT"
+}
+
+# Emits a production-shaped release.ts: the interface (whose field names collide
+# with the registry field names) followed by two multi-line registry entries.
+write_release_ts() {
+  cat > "$RELEASE_TS" <<'EOF'
+export interface ReleaseChecksumEntry {
+  version: string;
+  apkSha256: string;
+  ipaSha256: string;
+  runnerSha256: string;
+}
+
+export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
+  {
+    version: "0.0.44",
+    apkSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ipaSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    runnerSha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  },
+  {
+    version: "0.0.43",
+    apkSha256: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    ipaSha256: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    runnerSha256: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  },
+];
+EOF
+}
+
+read_field() {
+  bash "$ABS_HELPER" "$1" "$RELEASE_TS"
+}
+
+@test "reads registry[0].apkSha256, not the interface type line" {
+  write_release_ts
+  run read_field apkSha256
+  [ "$status" -eq 0 ]
+  [ "$output" = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ]
+}
+
+@test "reads registry[0].ipaSha256 and runnerSha256" {
+  write_release_ts
+  run read_field ipaSha256
+  [ "$output" = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]
+  run read_field runnerSha256
+  [ "$output" = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" ]
+}
+
+@test "returns registry[0], never a later entry" {
+  write_release_ts
+  run read_field apkSha256
+  # 0.0.43's apk (dddd…) must never be returned.
+  [ "$output" != "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" ]
+}
+
+@test "empty registry[0] field yields empty output (not the interface line)" {
+  write_release_ts
+  # Blank registry[0].runnerSha256.
+  sed -i.bak 's/runnerSha256: "cccc[c]*"/runnerSha256: ""/' "$RELEASE_TS"
+  run read_field runnerSha256
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "can be sourced and called as a function" {
+  write_release_ts
+  run bash -c 'source "$1"; read_registry_field ipaSha256 "$2"' _ "$ABS_HELPER" "$RELEASE_TS"
+  [ "$status" -eq 0 ]
+  [ "$output" = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]
+}

--- a/test/bats/verify-artifact-sha256.bats
+++ b/test/bats/verify-artifact-sha256.bats
@@ -66,6 +66,19 @@ EOF
   [[ "$output" != *"SHA256 mismatch"* ]]
 }
 
+@test "non-64-hex ipaSha256 reports 'no checksum', not a spurious mismatch" {
+  # The shared reader does no format validation, so verify-artifact-sha256.sh's
+  # own `^[a-f0-9]{64}$` guard is the only thing that blanks a non-empty but
+  # malformed registry value. Without it, this input would surface the wrong
+  # "SHA256 mismatch" error instead of the actionable "No checksum found".
+  write_release_ts "notahexvalue"
+  cd "$PROJECT"
+  run bash "$ABS_SCRIPT" "$ARTIFACT" ios
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No SHA256 checksum found"* ]]
+  [[ "$output" != *"SHA256 mismatch"* ]]
+}
+
 @test "matching ipaSha256 verifies successfully" {
   write_release_ts "$ART_SHA"
   cd "$PROJECT"


### PR DESCRIPTION
Follow-up to #3828 (merged). That PR fixed the interface-line collision in the nightly + release checksum tooling; this PR addresses the two items a second round of multi-perspective code review converged on.

## Motivation

1. **Duplicated, partly-untestable extraction.** The entry-anchored awk that reads `registry[0]` from `src/constants/release.ts` was copy-pasted into three places — `.github/workflows/nightly.yml`, `scripts/ci/verify-artifact-sha256.sh`, and `scripts/ci/verify-release-integrity.sh` — plus the (now-fixed) fourth `grep|head` variant that caused the #3784 incident. The `nightly.yml` copy is inline YAML, so no bats suite could reach it, and any edit to one copy silently skips the others.

2. **Uncovered hex-guard branch.** `verify-artifact-sha256.sh`'s `^[a-f0-9]{64}$` guard — the only format check now that the awk does none — had no test exercising a non-empty-but-malformed registry value.

## Changes

- **`scripts/lib/read-registry-field.sh`** — new single source of truth, following the repo's `scripts/lib` sourcing convention (`# shellcheck source=… disable=SC1091`). Sourced by `verify-artifact-sha256.sh`, `verify-release-integrity.sh`, and `nightly.yml` (repo-relative source in the GHA run-step).
- **`test/bats/read-registry-field.bats`** — covers registry[0] extraction, interface-line immunity, later-entry isolation, empty-value handling, and the sourced-function form. The extraction logic behind all three callers is now unit-tested.
- **`test/bats/verify-artifact-sha256.bats`** — adds a non-64-hex case (verified to produce a wrong "SHA256 mismatch" against a guard-stripped script, and the actionable "No checksum found" with the guard).
- Minor: documents the `release.ts` data coupling on the registry[1]-unchanged assertion.

## Deferred (with reason)

The adversarial review's "hand-compacted single-line entry" fall-through is **unreachable**: `release.ts` is machine-generated multi-line and marked DO NOT EDIT MANUALLY, and re-anchoring would diverge the shared helper from its callers for no reachable benefit.

## Validation

- `bats` — 32/32 across `read-registry-field`, `verify-artifact-sha256`, `verify-release-integrity`, `generate-release-constants`
- `shellcheck` / `shell-portability` / `shell-sete` — clean
- `yaml` / `xml` / `mkdocs-nav` / `claude-plugin` / `codex-skills` fast-validation — green
- Simulated the exact `nightly.yml` run-step sourcing (`bash -eo pipefail`, repo-relative source) → returns real registry[0] values

## Related follow-up (NOT in this PR — tracked in #3839)

The **merged v0.0.44 registry entry is still internally incoherent** (its `runnerSha256` is from a different IPA than its `ipaSha256`), which breaks fresh-install integrity verification for `latest`. This PR fixes the *process/tooling*; the *data* + the design question (should nightly overwrite a tagged release entry in place?) are being worked separately. Tracked in #3839.
