### PR TITLE
fix(release): repair v0.0.44 runner sha + give nightly its own checksum slot

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,18 +55,21 @@ jobs:
       - name: "Get current SHA256 values from source"
         id: current
         run: |
-          # Read each field from the FIRST registry entry via the shared helper
-          # (single source of truth with verify-artifact-sha256.sh +
-          # verify-release-integrity.sh). Anchoring on the entry's quoted
-          # `version: "` line avoids matching the `ReleaseChecksumEntry` interface
-          # declarations (`apkSha256: string;`) that precede the registry — a
-          # plain `grep | head -1` grabbed those and reported the TypeScript type
-          # line as the "current" checksum (#3784).
+          # Read each field from the dedicated NIGHTLY_CHECKSUM_ENTRY (the block
+          # anchored on `version: "nightly"`) via the shared helper — the single
+          # source of truth also used by verify-artifact-sha256.sh +
+          # verify-release-integrity.sh (which read registry[0]). Nightly must
+          # compare against — and later overwrite — the nightly slot, NEVER a
+          # tagged registry entry: writing main-built shas onto a tagged entry
+          # makes "latest" verify the immutable published asset against a
+          # main-built sha (#3784). Anchoring on the quoted `version: "nightly"`
+          # line also skips the `ReleaseChecksumEntry` interface declarations
+          # (`apkSha256: string;`) that precede the registry (#3784).
           source scripts/lib/read-registry-field.sh
           RELEASE_TS="src/constants/release.ts"
-          APK_CURRENT=$(read_registry_field apkSha256 "$RELEASE_TS")
-          IPA_CURRENT=$(read_registry_field ipaSha256 "$RELEASE_TS")
-          RUNNER_CURRENT=$(read_registry_field runnerSha256 "$RELEASE_TS")
+          APK_CURRENT=$(read_registry_field apkSha256 "$RELEASE_TS" nightly)
+          IPA_CURRENT=$(read_registry_field ipaSha256 "$RELEASE_TS" nightly)
+          RUNNER_CURRENT=$(read_registry_field runnerSha256 "$RELEASE_TS" nightly)
           echo "apk_sha256=$APK_CURRENT" >> $GITHUB_OUTPUT
           echo "ipa_sha256=$IPA_CURRENT" >> $GITHUB_OUTPUT
           echo "runner_sha256=$RUNNER_CURRENT" >> $GITHUB_OUTPUT

--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -113,10 +113,14 @@ field = sys.argv[3]
 value = sys.argv[4]
 text = path.read_text()
 
+# The closing anchor is `\n\s*\}` (zero-or-more), not `\n\s+\}`: registry array
+# entries close with an indented `  },`, but the standalone NIGHTLY_CHECKSUM_ENTRY
+# const closes with a column-0 `};`. `\s*` matches both so `version: "nightly"`
+# can be targeted the same way as a registry entry.
 if version == "__FIRST__":
-    match = re.search(r'(\{\n\s+version: "[^"]+",\n.*?\n\s+\})', text, re.S)
+    match = re.search(r'(\{\n\s+version: "[^"]+",\n.*?\n\s*\})', text, re.S)
 else:
-    match = re.search(r'(\{\n\s+version: "' + re.escape(version) + r'",\n.*?\n\s+\})', text, re.S)
+    match = re.search(r'(\{\n\s+version: "' + re.escape(version) + r'",\n.*?\n\s*\})', text, re.S)
 
 if not match:
     sys.stderr.write(f"failed to locate release registry entry for {version}\n")
@@ -159,12 +163,15 @@ if [ -n "$release_version" ]; then
     # Prepend new entry after the opening bracket of RELEASE_CHECKSUM_REGISTRY
     prepend_registry_entry "$tmp_file" "$new_entry"
 
-    # Cap registry at max_registry_entries
-    entry_count=$(grep -c 'version: "' "$tmp_file" || true)
+    # Cap registry at max_registry_entries. Count/delete only semver release
+    # entries (version starts with a digit) so the trailing
+    # NIGHTLY_CHECKSUM_ENTRY const (version: "nightly") is never counted toward
+    # the cap nor selected as the oldest entry to prune.
+    entry_count=$(grep -cE 'version: "[0-9]' "$tmp_file" || true)
     if [ "$entry_count" -gt "$max_registry_entries" ]; then
       excess=$((entry_count - max_registry_entries))
       for ((i = 0; i < excess; i++)); do
-        last_version_line=$(grep -n 'version: "' "$tmp_file" | tail -1 | cut -d: -f1)
+        last_version_line=$(grep -nE 'version: "[0-9]' "$tmp_file" | tail -1 | cut -d: -f1)
         start_line=$((last_version_line - 1))
         end_line=$((last_version_line + 4))
         sed_inplace "${start_line},${end_line}d" "$tmp_file"
@@ -177,35 +184,35 @@ if [ -n "$release_version" ]; then
     echo "   iOS checksum: ${ios_checksum}"
   fi
 else
-  # Mode: update registry[0] checksums in place (nightly/checksum-only).
+  # Mode: update the dedicated NIGHTLY_CHECKSUM_ENTRY in place (nightly/
+  # checksum-only). Nightly builds from `main`, which is ahead of the last
+  # release tag; writing those checksums onto a tagged registry entry makes
+  # "latest" download the immutable tagged asset yet verify it against a
+  # main-built sha, which cannot match (nightly PR #3784). So nightly targets
+  # the separate `version: "nightly"` slot — never registry[0].
   #
-  # Scope every field update to the first registry ENTRY (the block beginning
-  # with `version: "`) via update_registry_field. A plain line-based match
-  # collides with the `ReleaseChecksumEntry` interface declarations
-  # (`apkSha256: string;` / `ipaSha256: string;`) that precede the registry:
-  # `grep 'apkSha256:' | head -1` returns the type line, and the follow-up sed
-  # (which only matches a 64-hex value) then silently updates nothing. That left
-  # APK/IPA registry[0] stale while only runnerSha256 moved — see nightly PR
-  # #3784, where the merged entry carried a fresh runner sha but original APK/IPA
-  # shas, breaking whole-bundle vs runner verification for a fresh install.
+  # Scope every field update to that entry via update_registry_field, anchored
+  # on the `version: "nightly"` block. A plain line-based match would collide
+  # with the `ReleaseChecksumEntry` interface declarations (`apkSha256: string;`)
+  # that precede the registry and silently update nothing (#3784).
   if [ -n "$apk_checksum" ]; then
-    update_registry_field "$tmp_file" "__FIRST__" "apkSha256" "$apk_checksum"
+    update_registry_field "$tmp_file" "nightly" "apkSha256" "$apk_checksum"
   fi
 
   if [ -n "$ios_checksum" ]; then
-    update_registry_field "$tmp_file" "__FIRST__" "ipaSha256" "$ios_checksum"
+    update_registry_field "$tmp_file" "nightly" "ipaSha256" "$ios_checksum"
   fi
 
   if [ -n "$ios_runner_sha256" ]; then
-    update_registry_field "$tmp_file" "__FIRST__" "runnerSha256" "$ios_runner_sha256"
+    update_registry_field "$tmp_file" "nightly" "runnerSha256" "$ios_runner_sha256"
   fi
 
   echo "Updated release constants:"
   if [ -n "$apk_checksum" ]; then
-    echo "   APK checksum (registry[0]): ${apk_checksum}"
+    echo "   APK checksum (nightly): ${apk_checksum}"
   fi
   if [ -n "$ios_checksum" ]; then
-    echo "   iOS checksum (registry[0]): ${ios_checksum}"
+    echo "   iOS checksum (nightly): ${ios_checksum}"
   fi
 fi
 

--- a/scripts/lib/read-registry-field.sh
+++ b/scripts/lib/read-registry-field.sh
@@ -14,8 +14,13 @@
 #
 # Anchoring on the entry's quoted `version: "` line is what makes the read
 # immune to the interface: the interface's `version: string;` has no quote, so
-# `in_first` never arms while scanning the type declarations that precede the
+# the block never arms while scanning the type declarations that precede the
 # registry.
+#
+# An optional third argument anchors on a SPECIFIC `version: "<version>"` block
+# instead of the first entry. The nightly checksum job uses this to read the
+# dedicated NIGHTLY_CHECKSUM_ENTRY (`version: "nightly"`) — a standalone const
+# after the registry — without ever touching a tagged release entry (#3784).
 #
 # Sourcing convention mirrors scripts/lib/tool-install.sh:
 #   # shellcheck source=scripts/lib/read-registry-field.sh disable=SC1091
@@ -23,27 +28,33 @@
 # GitHub Actions run-steps execute from the repo root, so a workflow can source
 # it by repo-relative path: `source scripts/lib/read-registry-field.sh`.
 
-# read_registry_field <field> <release.ts path>
-# Prints the field's value from registry[0], or nothing if the field is absent
-# or the file has no registry entry. Never prints the interface type line.
+# read_registry_field <field> <release.ts path> [version]
+# Prints the field's value from the target entry, or nothing if the field is
+# absent or the entry does not exist. Never prints the interface type line.
+# When [version] is empty/omitted, reads registry[0] (the first entry). When
+# given (e.g. "nightly"), reads the block anchored on `version: "<version>"`.
+# The closing anchor allows a column-0 `}` so the standalone NIGHTLY_CHECKSUM_ENTRY
+# const (which closes with `};`) is matched as well as indented registry entries.
 read_registry_field() {
-  local field="$1" file="$2"
-  awk -v field="$field" '
-    /^[[:space:]]+version: "/ { in_first = 1 }
-    in_first && $0 ~ ("^[[:space:]]+" field ": \"") {
+  local field="$1" file="$2" version="${3:-}"
+  awk -v field="$field" -v want="$version" '
+    want == "" && /^[[:space:]]+version: "/ { in_block = 1 }
+    want != "" && $0 ~ ("^[[:space:]]+version: \"" want "\"") { in_block = 1 }
+    in_block && $0 ~ ("^[[:space:]]+" field ": \"") {
       line = $0
       sub(".*" field ": \"", "", line)
       sub(/".*/, "", line)
       print line
       exit
     }
-    in_first && /^[[:space:]]+}/ { exit }
+    in_block && /^[[:space:]]*}/ { exit }
   ' "$file"
 }
 
-# Allow direct invocation: read-registry-field.sh <field> <release.ts>
+# Allow direct invocation: read-registry-field.sh <field> <release.ts> [version]
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   read_registry_field \
-    "${1:?Usage: read-registry-field.sh <field> <release.ts>}" \
-    "${2:?Usage: read-registry-field.sh <field> <release.ts>}"
+    "${1:?Usage: read-registry-field.sh <field> <release.ts> [version]}" \
+    "${2:?Usage: read-registry-field.sh <field> <release.ts> [version]}" \
+    "${3:-}"
 fi

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -10,6 +10,19 @@
  *
  * During CI/CD release builds, new entries are prepended to the registry via
  * scripts/generate-release-constants.sh
+ *
+ * RELEASE_CHECKSUM_REGISTRY is append-only and records TAGGED releases only.
+ * The nightly checksum job must never mutate a tagged entry: nightly builds
+ * from `main` (ahead of the last tag), yet a tagged entry's download URL points
+ * at immutable, already-published assets — overwriting its checksums in place
+ * makes "latest" download the tagged asset but verify it against a main-built
+ * sha, which cannot match (see PR #3784, where a nightly runner sha landed on
+ * the tagged 0.0.44 entry and broke fresh-install integrity verification).
+ * Nightly instead overwrites the dedicated, mutable NIGHTLY_CHECKSUM_ENTRY
+ * below, which is deliberately kept OUT of RELEASE_CHECKSUM_REGISTRY so the
+ * resolvers ("latest", pinned lookups, resolveLatestVersion) and the release
+ * integrity gate — all of which key off the registry's first entry — never see
+ * it.
  */
 
 import { ActionableError } from "../models/ActionableError";
@@ -32,7 +45,7 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     version: "0.0.44",
     apkSha256: "e95f2b14e218bc51e92a44680cf38ceca9c9143014b2f74b803f47650614cf39",
     ipaSha256: "73dd4551ef7226d67a46423f6925775fc10d68198913b5b23bc1cbdceb50b663",
-    runnerSha256: "ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a",
+    runnerSha256: "b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982",
   },
   {
     version: "0.0.43",
@@ -167,6 +180,29 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     runnerSha256: "",
   },
 ];
+
+/**
+ * Dedicated, mutable "nightly" checksum slot — the current state of `main`.
+ *
+ * This is the ONLY entry the nightly checksum job overwrites in place. It is
+ * intentionally NOT part of RELEASE_CHECKSUM_REGISTRY: keeping it separate is
+ * what makes it structurally impossible for nightly to corrupt a tagged release
+ * entry (the #3784 failure mode). Because no resolver consults it, pinning
+ * `AUTOMOBILE_VERSION=nightly` is treated as an unknown version and fails closed
+ * — there is no published, downloadable nightly asset to verify against. This
+ * slot exists purely as a drift record: the nightly workflow compares a fresh
+ * `main` build against these values and opens a PR when they diverge.
+ *
+ * The `version: "nightly"` sentinel is how scripts/generate-release-constants.sh
+ * (checksum-only mode) and .github/workflows/nightly.yml target this entry
+ * without touching registry[0].
+ */
+export const NIGHTLY_CHECKSUM_ENTRY: ReleaseChecksumEntry = {
+  version: "nightly",
+  apkSha256: "1be224f4f5e5a21087a6552a9567290da64ad7deea6de6239a38324a8d91b0cc",
+  ipaSha256: "bfceb921d0d55088f9a209f0519f332ed731025d8e0fe802f53eab62a7272996",
+  runnerSha256: "ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a",
+};
 
 /**
  * Resolve a checksum from the registry.

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -49,27 +49,49 @@ teardown() {
   grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
 }
 
-@test "writes registry[0].runnerSha256 in checksum-only mode" {
+# Read a field from the block anchored on `version: "$1"` (either a registry
+# entry like "0.0.44" or the standalone NIGHTLY_CHECKSUM_ENTRY, "nightly").
+read_field_for_version() {
+  awk -v want="$1" -v field="$2" '
+    $0 ~ ("^[[:space:]]+version: \"" want "\"") { in_block = 1 }
+    in_block && $0 ~ ("^[[:space:]]+" field ": \"") {
+      line = $0
+      sub(".*" field ": \"", "", line)
+      sub(/".*/, "", line)
+      print line
+      exit
+    }
+    in_block && /^[[:space:]]*}/ { exit }
+  ' "$3"
+}
+
+@test "writes NIGHTLY_CHECKSUM_ENTRY runnerSha256 in checksum-only mode" {
+  release_runner_before="$(read_field_for_version 0.0.44 runnerSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ -n "$release_runner_before" ]
+
   run env \
     IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
     IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
     bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
 
   [ "$status" -eq 0 ]
-  grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+  # The nightly slot moved.
+  nightly_runner="$(read_field_for_version nightly runnerSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$nightly_runner" = "$RUNNER_SHA" ]
+  # The tagged release entry (registry[0], 0.0.44) is untouched.
+  release_runner_after="$(read_field_for_version 0.0.44 runnerSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$release_runner_after" = "$release_runner_before" ]
 }
 
-@test "updates registry[0].apkSha256 and ipaSha256 in checksum-only mode" {
-  # Regression for #3784: the nightly checksum-only path must move the APK/IPA
-  # shas on registry[0], not the `apkSha256: string;` interface declaration that
-  # precedes the registry. Capture the pre-update values so we assert they change
-  # (and that the update lands inside the first registry entry).
-  old_apk="$(awk '
-    /^[[:space:]]+version: "/ { in_first = 1 }
-    in_first && /^[[:space:]]+apkSha256: "/ { sub(/.*apkSha256: "/, ""); sub(/".*/, ""); print; exit }
-  ' "${TEST_ROOT}/src/constants/release.ts")"
-  [ -n "$old_apk" ]
-  [ "$old_apk" != "$APK_SHA" ]
+@test "updates NIGHTLY_CHECKSUM_ENTRY apk/ipa (not registry[0]) in checksum-only mode" {
+  # Regression for #3784 + the follow-up design fix: the nightly checksum-only
+  # path must move the APK/IPA shas on the dedicated `nightly` slot, never on a
+  # tagged registry entry, and never on the `apkSha256: string;` interface
+  # declaration that precedes the registry.
+  release_apk_before="$(read_field_for_version 0.0.44 apkSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  release_ipa_before="$(read_field_for_version 0.0.44 ipaSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ -n "$release_apk_before" ]
+  [ "$release_apk_before" != "$APK_SHA" ]
 
   run env \
     APK_SHA256_CHECKSUM="$APK_SHA" \
@@ -77,21 +99,21 @@ teardown() {
     bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
   [ "$status" -eq 0 ]
 
-  # First registry entry now carries the new shas.
-  first_apk="$(awk '
-    /^[[:space:]]+version: "/ { in_first = 1 }
-    in_first && /^[[:space:]]+apkSha256: "/ { sub(/.*apkSha256: "/, ""); sub(/".*/, ""); print; exit }
-  ' "${TEST_ROOT}/src/constants/release.ts")"
-  first_ipa="$(awk '
-    /^[[:space:]]+version: "/ { in_first = 1 }
-    in_first && /^[[:space:]]+ipaSha256: "/ { sub(/.*ipaSha256: "/, ""); sub(/".*/, ""); print; exit }
-  ' "${TEST_ROOT}/src/constants/release.ts")"
-  [ "$first_apk" = "$APK_SHA" ]
-  [ "$first_ipa" = "$IPA_SHA" ]
+  # The nightly slot now carries the new shas.
+  nightly_apk="$(read_field_for_version nightly apkSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  nightly_ipa="$(read_field_for_version nightly ipaSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$nightly_apk" = "$APK_SHA" ]
+  [ "$nightly_ipa" = "$IPA_SHA" ]
 
-  # Only registry[0] moves: the second entry (0.0.43) keeps its original
-  # apkSha256. Coupled to the real release.ts the harness copies in setup(); if
-  # 0.0.43 ever ages out of the registry or its sha changes, update this literal.
+  # The tagged release entry (registry[0], 0.0.44) is untouched.
+  release_apk_after="$(read_field_for_version 0.0.44 apkSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  release_ipa_after="$(read_field_for_version 0.0.44 ipaSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$release_apk_after" = "$release_apk_before" ]
+  [ "$release_ipa_after" = "$release_ipa_before" ]
+
+  # The second registry entry (0.0.43) keeps its original apkSha256. Coupled to
+  # the real release.ts the harness copies in setup(); if 0.0.43 ever ages out of
+  # the registry or its sha changes, update this literal.
   grep -q 'apkSha256: "7e4e2ce3c19b7473d171433186dbc7487df60ff6045dba66da7a320d31e63cd3"' \
     "${TEST_ROOT}/src/constants/release.ts"
 
@@ -160,11 +182,15 @@ PY
     bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
 
   [ "$status" -eq 0 ]
-  version_count="$(grep -c 'version: "' "${TEST_ROOT}/src/constants/release.ts")"
+  # Count only semver release entries; the standalone NIGHTLY_CHECKSUM_ENTRY
+  # (version: "nightly") is not part of the capped registry.
+  version_count="$(grep -cE 'version: "[0-9]' "${TEST_ROOT}/src/constants/release.ts")"
   open_count="$(grep -c '^  {$' "${TEST_ROOT}/src/constants/release.ts")"
   close_count="$(grep -c '^  },$' "${TEST_ROOT}/src/constants/release.ts")"
   [ "$version_count" -eq 100 ]
   [ "$open_count" -eq "$close_count" ]
+  # The nightly slot survives the cap untouched.
+  grep -q '^  version: "nightly",$' "${TEST_ROOT}/src/constants/release.ts"
 }
 
 @test "rejects a malformed IOS_CTRL_PROXY_RUNNER_SHA256" {

--- a/test/bats/read-registry-field.bats
+++ b/test/bats/read-registry-field.bats
@@ -43,11 +43,24 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     runnerSha256: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
   },
 ];
+
+// The dedicated nightly slot is a standalone const AFTER the registry array, so
+// it closes with a column-0 `};` (not an indented `  },`).
+export const NIGHTLY_CHECKSUM_ENTRY: ReleaseChecksumEntry = {
+  version: "nightly",
+  apkSha256: "1111111111111111111111111111111111111111111111111111111111111111",
+  ipaSha256: "2222222222222222222222222222222222222222222222222222222222222222",
+  runnerSha256: "3333333333333333333333333333333333333333333333333333333333333333",
+};
 EOF
 }
 
 read_field() {
   bash "$ABS_HELPER" "$1" "$RELEASE_TS"
+}
+
+read_field_v() {
+  bash "$ABS_HELPER" "$1" "$RELEASE_TS" "$2"
 }
 
 @test "reads registry[0].apkSha256, not the interface type line" {
@@ -79,6 +92,29 @@ read_field() {
   run read_field runnerSha256
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+}
+
+@test "default (no version) still reads registry[0], not the nightly slot" {
+  write_release_ts
+  run read_field apkSha256
+  [ "$output" = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ]
+}
+
+@test "version anchor reads the nightly slot (standalone const, column-0 close)" {
+  write_release_ts
+  run read_field_v apkSha256 nightly
+  [ "$status" -eq 0 ]
+  [ "$output" = "1111111111111111111111111111111111111111111111111111111111111111" ]
+  run read_field_v ipaSha256 nightly
+  [ "$output" = "2222222222222222222222222222222222222222222222222222222222222222" ]
+  run read_field_v runnerSha256 nightly
+  [ "$output" = "3333333333333333333333333333333333333333333333333333333333333333" ]
+}
+
+@test "version anchor reads a specific registry entry (0.0.43), not registry[0]" {
+  write_release_ts
+  run read_field_v apkSha256 0.0.43
+  [ "$output" = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" ]
 }
 
 @test "can be sourced and called as a function" {

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -9,6 +9,7 @@ import {
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
+  NIGHTLY_CHECKSUM_ENTRY,
   RELEASE_CHECKSUM_REGISTRY,
   isExplicitPin,
   isPinnedVersionKnown,
@@ -407,5 +408,46 @@ describe("iOS runner-binary checksum", function() {
 
   test("module-level runner checksum export resolves from registry[0]", function() {
     expect(IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM).toBe(RELEASE_CHECKSUM_REGISTRY[0].runnerSha256);
+  });
+
+  test("registry[0] (0.0.44) is a coherent triple after the #3784 runner-sha repair", function() {
+    const v0044 = RELEASE_CHECKSUM_REGISTRY[0];
+    expect(v0044.version).toBe("0.0.44");
+    // The runner inside the published 0.0.44 IPA, not the orphaned nightly sha.
+    expect(v0044.runnerSha256).toBe("b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982");
+    expect(v0044.runnerSha256).not.toBe(NIGHTLY_CHECKSUM_ENTRY.runnerSha256);
+  });
+});
+
+describe("NIGHTLY_CHECKSUM_ENTRY (dedicated mutable nightly slot)", function() {
+  test("is the 'nightly' sentinel with a well-formed, populated triple", function() {
+    expect(NIGHTLY_CHECKSUM_ENTRY.version).toBe("nightly");
+    for (const sha of [
+      NIGHTLY_CHECKSUM_ENTRY.apkSha256,
+      NIGHTLY_CHECKSUM_ENTRY.ipaSha256,
+      NIGHTLY_CHECKSUM_ENTRY.runnerSha256,
+    ]) {
+      expect(/^[a-f0-9]{64}$/.test(sha)).toBe(true);
+    }
+  });
+
+  test("is kept OUT of the release registry so resolvers never see it", function() {
+    // The whole point of the separate slot: nightly can overwrite it in place
+    // without ever corrupting a tagged release entry (the #3784 failure mode).
+    expect(RELEASE_CHECKSUM_REGISTRY.some(e => e.version === "nightly")).toBe(false);
+    expect(RELEASE_CHECKSUM_REGISTRY).not.toContain(NIGHTLY_CHECKSUM_ENTRY);
+  });
+
+  test("does not leak into 'latest' or pinned resolution", function() {
+    expect(resolveLatestVersion()).not.toBe("nightly");
+    expect(resolveChecksum("nightly", "android")).toBe("");
+    expect(resolveChecksum("nightly", "ios")).toBe("");
+    expect(resolveRunnerChecksum({ AUTOMOBILE_VERSION: "nightly" })).toBe("");
+  });
+
+  test("pinning AUTOMOBILE_VERSION=nightly is unknown and fails closed", function() {
+    // No published nightly asset exists to download/verify, so the pin must not
+    // be treated as a known, integrity-verifiable version.
+    expect(isPinnedVersionKnown({ AUTOMOBILE_VERSION: "nightly" })).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Two coupled defects in `registry[0]` (v0.0.44) of `src/constants/release.ts`, both surfaced as the data-half follow-up to #3828.

**Incoherent data.** Nightly PR #3784 wrote a fresh `runnerSha256` (`ff2890…`, the runner from the *nightly* IPA `bfceb9…`) onto the tagged v0.0.44 entry while — due to the interface-line collision bug #3828 later fixed — leaving `apkSha256`/`ipaSha256` at their v0.0.44 values. `verify-release-integrity.sh` binds `registry[0].runnerSha256` to the runner inside the *shipped* IPA, so this triple fails a fresh-install integrity check.

**Root design flaw.** `registry[0]` served double duty: the pinned `"0.0.44"` entry *and* the mutable "latest" slot nightly overwrites in place. But `"latest"` resolves its **download URL** to the tagged asset (`releases/download/0.0.44/control-proxy.ipa`, immutable) while its **checksum** is just `registry[0]`. Nightly builds from `main` (always ahead of the last tag), so any in-place overwrite makes "latest" download the tagged asset and verify it against a main-built sha → guaranteed mismatch. Confirmed empirically (`resolveIpaUrl` → 0.0.44 URL, checksum → `registry[0]`).

## Fix

**DATA** — Fetched the published v0.0.44 assets, extracted `CtrlProxyUITests-Runner` from the real `73dd…` IPA, hashed it, and set `runnerSha256` to its true value `b281f9fd…` (unchanged since 0.0.40; apk/ipa already matched GitHub's published digests). `verify-release-integrity.sh 0.0.44 <published-ipa>` now passes all checks including the runner binding.

**DESIGN** — Introduced a dedicated, mutable `NIGHTLY_CHECKSUM_ENTRY` (`version: "nightly"`), kept **out** of `RELEASE_CHECKSUM_REGISTRY` so no resolver or release-integrity script sees it. The registry is now append-only and immutable-by-nightly; nightly overwrites only the separate slot. `AUTOMOBILE_VERSION=nightly` is unknown → fails closed (no published nightly asset to verify against). The orphaned `ff2890/1be224/bfceb9` triple seeds the nightly slot, where it belongs.

- `release.ts` — add `NIGHTLY_CHECKSUM_ENTRY` after the registry; repair v0.0.44 runner sha.
- `generate-release-constants.sh` — checksum-only mode targets `version: "nightly"` (not `registry[0]`); loosen the brace-regex closing anchor `\n\s+}` → `\n\s*}` so the standalone const's column-0 `};` matches; scope the cap to semver (`grep -cE 'version: "[0-9]'`) so the nightly slot is never counted or pruned.
- `nightly.yml` — `read_nightly_field` awk anchors on `version: "nightly"`.
- Tests — `generate-release-constants.bats` asserts checksum-only mode moves the nightly slot and leaves `registry[0]` (0.0.44) untouched; `release.test.ts` pins the repaired triple, the slot's separation from the registry, and fail-closed pinning.

Scope: separate-slot + repoint only (no downloadable nightly channel — that remains a possible follow-up). Zero blast radius on the 40+ `"latest"`/`registry[0]` consumers; `verify-release-integrity.sh` and `verify-artifact-sha256.sh` are untouched (the nightly const sits after the array, so "first version block" is still `registry[0]`).

## Validation

- `bun test test/constants/release.test.ts` — **57 pass** (5 new nightly-slot tests)
- `bats test/bats/generate-release-constants.bats` — **7 pass**; `verify-artifact-sha256.bats` — **3 pass**
- `verify-release-integrity.sh 0.0.44 <published-ipa>` — full pass with runner-sha binding
- E2E: simulated nightly checksum-only update moves the nightly slot, `registry[0]` stays coherent
- `shellcheck` clean · fast-validation (yaml+shellcheck) pass · typecheck introduces zero new errors (the 9 reported are pre-existing `werift`/`adm-zip` dep issues in the worktree, present without this change)

Builds on #3828 (interface-line collision fix).