### PR TITLE
ci(nightly): add Xcode 26.6 to the toolchain sweep matrices

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -235,6 +235,7 @@ jobs:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26", runner: "macos-26", xcode: "26.0" }
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
+          - { name: "Xcode 26.6", runner: "macos-26", xcode: "26.6" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -286,6 +287,7 @@ jobs:
         config:
           - { name: "Xcode 15", runner: "macos-14", xcode: "15.4" }
           - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
+          - { name: "Xcode 26.6", runner: "macos-26", xcode: "26.6" }
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6


### PR DESCRIPTION
Closes #3630.

The `macos-26` runner image now ships **Xcode 26.6** (build 17F113) with the iOS 26.5 simulator runtime. This adds a `26.6` entry to both nightly sweep matrices in `.github/workflows/nightly.yml` (test sweep ~L234, build sweep ~L286) so we catch toolchain drift on the newest available Xcode one step ahead of the runner default.

- Additive only — keeps `15.4` / `26.0` / `26.5` for min-floor + default coverage.
- No source changes: the iOS simulator runtime max is derived dynamically from the active Xcode SDK (`scripts/ios/setup-ios-simulator.sh`), so the matrix entry alone is sufficient.
- Nightly-only workflow; does not run on PR CI. `maxim-lobanov/setup-xcode` will resolve `26.6` on the current image; if the version string drifts as the image updates, the nightly sweep will surface it as a targeted failure (its whole purpose).

YAML validated (`yaml.safe_load`).