### PR TITLE
Add tool-level segmented video recording past the 180s screenrecord cap

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7928,7 +7928,7 @@
           "description": "Max duration seconds",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 300
+          "maximum": 3600
         },
         "outputName": {
           "description": "Recording label",

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -19,6 +19,13 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   timer?: Timer;
   /** Override for tests. */
   segmentRotateAfterMs?: number;
+  /**
+   * Overall session duration bound. When set, the session auto-stops (finalizing every
+   * completed segment) once this many seconds have elapsed since {@link start}, matching
+   * the non-segmented recording path's maxDuration-is-an-auto-stop-bound contract. Undefined
+   * means rotate indefinitely until an explicit {@link stop} call — no session-level cap.
+   */
+  maxDurationSeconds?: number;
   /** Quality/config overrides forwarded to every segment's recording. */
   configOverrides?: VideoRecordingConfigInput;
   startVideoRecording?: (
@@ -48,12 +55,17 @@ export class AndroidSegmentedPlanVideoSession {
 
   private readonly segmentRotateAfterMs: number;
 
+  private readonly maxDurationSeconds: number | undefined;
+
   private readonly configOverrides: VideoRecordingConfigInput | undefined;
 
   private activeRecordingId: string | undefined;
 
   /** Timer-driven rotation handle (set only when {@link start} is used). */
   private rotationTimerHandle: NodeJS.Timeout | undefined;
+
+  /** Session-level auto-stop handle (set only when {@link maxDurationSeconds} is provided). */
+  private maxDurationTimerHandle: NodeJS.Timeout | undefined;
 
   /** True while a timer-driven session is running, so rotations keep rescheduling. */
   private timerDriven = false;
@@ -82,6 +94,7 @@ export class AndroidSegmentedPlanVideoSession {
     this.outputNamePrefix = options.outputNamePrefix;
     this.timer = options.timer ?? defaultTimer;
     this.segmentRotateAfterMs = options.segmentRotateAfterMs ?? ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS;
+    this.maxDurationSeconds = options.maxDurationSeconds;
     this.configOverrides = options.configOverrides;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
@@ -100,13 +113,16 @@ export class AndroidSegmentedPlanVideoSession {
    * Timer-driven lifecycle (does NOT depend on plan steps). Starts the first
    * segment, then schedules a self-rescheduling rotation via the injected
    * {@link Timer} so each segment stays under {@link ANDROID_SCREENRECORD_MAX_SECONDS}.
-   * Returns the first segment's recording, whose recordingId is used as the
-   * session handle by callers.
+   * If {@link maxDurationSeconds} was provided, also arms a session-level auto-stop so
+   * overall duration is bounded the same way the non-segmented path bounds it - rotation
+   * alone never stops on its own. Returns the first segment's recording, whose
+   * recordingId is used as the session handle by callers.
    */
   async start(): Promise<ActiveVideoRecording> {
     this.timerDriven = true;
     const first = await this.startFirstSegment();
     this.scheduleRotation();
+    this.scheduleMaxDurationStop();
     return first;
   }
 
@@ -127,15 +143,35 @@ export class AndroidSegmentedPlanVideoSession {
     }, this.segmentRotateAfterMs);
   }
 
+  private scheduleMaxDurationStop(): void {
+    if (this.maxDurationSeconds === undefined) {
+      return;
+    }
+    this.maxDurationTimerHandle = this.timer.setTimeout(() => {
+      logger.info(
+        `[SegmentedPlanVideo] Session reached maxDurationSeconds=${this.maxDurationSeconds}, auto-stopping`
+      );
+      this.stop().catch(error => {
+        logger.warn(
+          `[SegmentedPlanVideo] Auto-stop at maxDurationSeconds failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      });
+    }, this.maxDurationSeconds * 1000);
+  }
+
   /**
-   * Stops the timer-driven session: clears the rotation timer, waits for any
-   * in-flight rotation, then finalizes and returns every segment.
+   * Stops the timer-driven session: clears both the rotation and max-duration timers,
+   * waits for any in-flight rotation, then finalizes and returns every segment.
    */
   async stop(): Promise<{ filePaths: string[]; recordingIds: string[] }> {
     this.timerDriven = false;
     if (this.rotationTimerHandle !== undefined) {
       this.timer.clearTimeout(this.rotationTimerHandle);
       this.rotationTimerHandle = undefined;
+    }
+    if (this.maxDurationTimerHandle !== undefined) {
+      this.timer.clearTimeout(this.maxDurationTimerHandle);
+      this.maxDurationTimerHandle = undefined;
     }
     await this.pendingRotation;
     return this.finalize();

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -28,6 +28,14 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   maxDurationSeconds?: number;
   /** Quality/config overrides forwarded to every segment's recording. */
   configOverrides?: VideoRecordingConfigInput;
+  /**
+   * Invoked exactly once when the session finalizes (via {@link stop}), whether that
+   * stop was caller-driven or the {@link maxDurationSeconds} auto-stop. Lets the owning
+   * registry drop the session so an auto-stopped, never-caller-stopped recording does
+   * not leak a tracked entry. The session does not know its own registry handle, so the
+   * hook removes by session identity.
+   */
+  onFinalized?: () => void;
   startVideoRecording?: (
     request: Parameters<typeof defaultStartVideoRecording>[0]
   ) => Promise<ActiveVideoRecording>;
@@ -70,6 +78,11 @@ export class AndroidSegmentedPlanVideoSession {
   /** True while a timer-driven session is running, so rotations keep rescheduling. */
   private timerDriven = false;
 
+  private readonly onFinalized: (() => void) | undefined;
+
+  /** Guards {@link onFinalized} so a second (no-op) {@link stop} does not re-notify. */
+  private finalizedNotified = false;
+
   /** Tracks the most recent in-flight rotation so {@link stop} can await it. */
   private pendingRotation: Promise<void> = Promise.resolve();
 
@@ -96,6 +109,7 @@ export class AndroidSegmentedPlanVideoSession {
     this.segmentRotateAfterMs = options.segmentRotateAfterMs ?? ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS;
     this.maxDurationSeconds = options.maxDurationSeconds;
     this.configOverrides = options.configOverrides;
+    this.onFinalized = options.onFinalized;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
   }
@@ -174,7 +188,18 @@ export class AndroidSegmentedPlanVideoSession {
       this.maxDurationTimerHandle = undefined;
     }
     await this.pendingRotation;
-    return this.finalize();
+    const result = await this.finalize();
+    this.notifyFinalized();
+    return result;
+  }
+
+  /** Fires {@link onFinalized} at most once, so callers can drop the session from any registry. */
+  private notifyFinalized(): void {
+    if (this.finalizedNotified) {
+      return;
+    }
+    this.finalizedNotified = true;
+    this.onFinalized?.();
   }
 
   /**

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -11,7 +11,7 @@ import {
   stopVideoRecording as defaultStopVideoRecording,
 } from "./videoRecordingManager";
 import type { ActiveVideoRecording } from "../features/video";
-import type { VideoRecordingMetadata } from "../models";
+import type { VideoRecordingConfigInput, VideoRecordingMetadata } from "../models";
 
 export interface AndroidSegmentedPlanVideoSessionOptions {
   device: BootedDevice;
@@ -19,6 +19,8 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   timer?: Timer;
   /** Override for tests. */
   segmentRotateAfterMs?: number;
+  /** Quality/config overrides forwarded to every segment's recording. */
+  configOverrides?: VideoRecordingConfigInput;
   startVideoRecording?: (
     request: Parameters<typeof defaultStartVideoRecording>[0]
   ) => Promise<ActiveVideoRecording>;
@@ -46,7 +48,18 @@ export class AndroidSegmentedPlanVideoSession {
 
   private readonly segmentRotateAfterMs: number;
 
+  private readonly configOverrides: VideoRecordingConfigInput | undefined;
+
   private activeRecordingId: string | undefined;
+
+  /** Timer-driven rotation handle (set only when {@link start} is used). */
+  private rotationTimerHandle: NodeJS.Timeout | undefined;
+
+  /** True while a timer-driven session is running, so rotations keep rescheduling. */
+  private timerDriven = false;
+
+  /** Tracks the most recent in-flight rotation so {@link stop} can await it. */
+  private pendingRotation: Promise<void> = Promise.resolve();
 
   private segmentIndex = 0;
 
@@ -69,12 +82,63 @@ export class AndroidSegmentedPlanVideoSession {
     this.outputNamePrefix = options.outputNamePrefix;
     this.timer = options.timer ?? defaultTimer;
     this.segmentRotateAfterMs = options.segmentRotateAfterMs ?? ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS;
+    this.configOverrides = options.configOverrides;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
   }
 
-  async startFirstSegment(): Promise<void> {
-    await this.startSegment();
+  /** Device this session is recording, so callers can match sessions by device. */
+  get deviceId(): string {
+    return this.device.deviceId;
+  }
+
+  async startFirstSegment(): Promise<ActiveVideoRecording> {
+    return this.startSegment();
+  }
+
+  /**
+   * Timer-driven lifecycle (does NOT depend on plan steps). Starts the first
+   * segment, then schedules a self-rescheduling rotation via the injected
+   * {@link Timer} so each segment stays under {@link ANDROID_SCREENRECORD_MAX_SECONDS}.
+   * Returns the first segment's recording, whose recordingId is used as the
+   * session handle by callers.
+   */
+  async start(): Promise<ActiveVideoRecording> {
+    this.timerDriven = true;
+    const first = await this.startFirstSegment();
+    this.scheduleRotation();
+    return first;
+  }
+
+  private scheduleRotation(): void {
+    if (!this.timerDriven) {
+      return;
+    }
+    this.rotationTimerHandle = this.timer.setTimeout(() => {
+      this.pendingRotation = this.rotateToNextSegment()
+        .catch(error => {
+          logger.warn(
+            `[SegmentedTimerVideo] Rotation failed: ${error instanceof Error ? error.message : String(error)}`
+          );
+        })
+        .then(() => {
+          this.scheduleRotation();
+        });
+    }, this.segmentRotateAfterMs);
+  }
+
+  /**
+   * Stops the timer-driven session: clears the rotation timer, waits for any
+   * in-flight rotation, then finalizes and returns every segment.
+   */
+  async stop(): Promise<{ filePaths: string[]; recordingIds: string[] }> {
+    this.timerDriven = false;
+    if (this.rotationTimerHandle !== undefined) {
+      this.timer.clearTimeout(this.rotationTimerHandle);
+      this.rotationTimerHandle = undefined;
+    }
+    await this.pendingRotation;
+    return this.finalize();
   }
 
   /**
@@ -98,11 +162,12 @@ export class AndroidSegmentedPlanVideoSession {
     return `${this.outputNamePrefix}${suffix}`;
   }
 
-  private async startSegment(): Promise<void> {
+  private async startSegment(): Promise<ActiveVideoRecording> {
     const recording = await this.startVideoRecordingFn({
       device: this.device,
       outputName: this.segmentOutputName(),
       maxDurationSeconds: ANDROID_SCREENRECORD_MAX_SECONDS,
+      configOverrides: this.configOverrides,
     });
     this.activeRecordingId = recording.recordingId;
     this.segmentStartedAtMs = this.timer.now();
@@ -110,6 +175,7 @@ export class AndroidSegmentedPlanVideoSession {
     logger.info(
       `[SegmentedPlanVideo] Started segment ${this.segmentIndex} recordingId=${recording.recordingId}`
     );
+    return recording;
   }
 
   private async rotateToNextSegment(): Promise<void> {

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -19,11 +19,19 @@ import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import type { VideoRecordingRecord } from "../db/videoRecordingRepository";
 import { highlightShapeSchema } from "../features/debug/VisualHighlight";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "../features/video/androidScreenrecord";
-import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
+import {
+  AndroidSegmentedPlanVideoSession,
+  type AndroidSegmentedPlanVideoSessionOptions,
+} from "./androidSegmentedPlanVideoSession";
 import type { Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 
 const DEFAULT_MAX_DURATION_SECONDS = 30;
+
+type SegmentedSessionRecordingDependencies = Pick<
+  AndroidSegmentedPlanVideoSessionOptions,
+  "startVideoRecording" | "stopVideoRecording"
+>;
 
 /**
  * Registry of timer-driven segmented Android recordings, keyed by the first
@@ -37,9 +45,13 @@ const segmentedSessions = (() => {
   // Undefined in production (sessions fall back to their own defaultTimer); tests
   // inject a FakeTimer so the rotation timer is controllable/inspectable.
   let injectedTimer: Timer | undefined;
+  let recordingDependencies: SegmentedSessionRecordingDependencies = {};
   return {
     get timer(): Timer | undefined {
       return injectedTimer;
+    },
+    get recordingDependencies(): SegmentedSessionRecordingDependencies {
+      return recordingDependencies;
     },
     track(handle: string, session: AndroidSegmentedPlanVideoSession): void {
       byHandle.set(handle, session);
@@ -67,9 +79,14 @@ const segmentedSessions = (() => {
     setTimer(timer: Timer | undefined): void {
       injectedTimer = timer;
     },
+    /** Test seam: inject the recording functions used by segmented sessions. */
+    setRecordingDependencies(deps: SegmentedSessionRecordingDependencies): void {
+      recordingDependencies = deps;
+    },
     /** Test seam: clear all tracked sessions + the injected timer. */
     reset(): void {
       injectedTimer = undefined;
+      recordingDependencies = {};
       byHandle.clear();
     },
   };
@@ -78,6 +95,13 @@ const segmentedSessions = (() => {
 /** Test seam: inject the Timer used by segmented sessions. */
 export function setSegmentedSessionTimer(timer: Timer | undefined): void {
   segmentedSessions.setTimer(timer);
+}
+
+/** Test seam: inject start/stop recording functions used by segmented sessions. */
+export function setSegmentedSessionRecordingDependencies(
+  deps: SegmentedSessionRecordingDependencies
+): void {
+  segmentedSessions.setRecordingDependencies(deps);
 }
 
 /** Test seam: clear injected segmented-session state (timer + tracked sessions). */
@@ -301,6 +325,7 @@ export function registerVideoRecordingTools(): void {
               configOverrides: buildConfigOverrides(args),
               timer: segmentedSessions.timer,
               maxDurationSeconds,
+              ...segmentedSessions.recordingDependencies,
             });
             const active = await session.start();
             segmentedSessions.track(active.recordingId, session);
@@ -376,7 +401,7 @@ export function registerVideoRecordingTools(): void {
       const evictedRecordingIds: string[] = [];
       let stoppedAnySegmented = false;
       const targetDevices = await resolveTargetDevices(device, args);
-      const activeRecords = await listActiveVideoRecordings({ platform: device.platform });
+      let activeRecords: VideoRecordingRecord[] | undefined;
 
       for (const target of targetDevices) {
         // A bare (by-device) stop must also finalize any timer-driven segmented
@@ -414,6 +439,7 @@ export function registerVideoRecordingTools(): void {
           continue;
         }
 
+        activeRecords ??= await listActiveVideoRecordings({ platform: device.platform });
         const matches = activeRecords.filter(record => record.deviceId === target.deviceId);
         if (matches.length === 0) {
           failures.push({

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -18,8 +18,72 @@ import type { VideoRecordingConfigInput } from "../models";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import type { VideoRecordingRecord } from "../db/videoRecordingRepository";
 import { highlightShapeSchema } from "../features/debug/VisualHighlight";
+import { ANDROID_SCREENRECORD_MAX_SECONDS } from "../features/video/androidScreenrecord";
+import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
+import type { Timer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
 
 const DEFAULT_MAX_DURATION_SECONDS = 30;
+
+/**
+ * Registry of timer-driven segmented Android recordings, keyed by the first
+ * segment's recordingId (the caller-facing handle). A single module-level owner
+ * of this state — the video tools are registered once and close over it — rather
+ * than scattered globals. Recordings whose duration fits within a single
+ * `screenrecord` are NOT registered here.
+ */
+const segmentedSessions = (() => {
+  const byHandle = new Map<string, AndroidSegmentedPlanVideoSession>();
+  // Undefined in production (sessions fall back to their own defaultTimer); tests
+  // inject a FakeTimer so the rotation timer is controllable/inspectable.
+  let injectedTimer: Timer | undefined;
+  return {
+    get timer(): Timer | undefined {
+      return injectedTimer;
+    },
+    track(handle: string, session: AndroidSegmentedPlanVideoSession): void {
+      byHandle.set(handle, session);
+    },
+    get(handle: string): AndroidSegmentedPlanVideoSession | undefined {
+      return byHandle.get(handle);
+    },
+    /** Tracked sessions recording the given device (used by the bare/by-device stop). */
+    forDevice(deviceId: string): Array<[string, AndroidSegmentedPlanVideoSession]> {
+      return [...byHandle.entries()].filter(([, session]) => session.deviceId === deviceId);
+    },
+    /**
+     * Stop a tracked session: remove it from the registry, finalize it (which clears
+     * its rotation timer), and return the ordered segment recordingId/filePath pairs.
+     */
+    async stopAndRemove(
+      handle: string,
+      session: AndroidSegmentedPlanVideoSession
+    ): Promise<Array<{ recordingId: string; filePath: string }>> {
+      byHandle.delete(handle);
+      const { filePaths, recordingIds } = await session.stop();
+      return recordingIds.map((id, index) => ({ recordingId: id, filePath: filePaths[index] }));
+    },
+    /** Test seam: inject the Timer used by segmented sessions. */
+    setTimer(timer: Timer | undefined): void {
+      injectedTimer = timer;
+    },
+    /** Test seam: clear all tracked sessions + the injected timer. */
+    reset(): void {
+      injectedTimer = undefined;
+      byHandle.clear();
+    },
+  };
+})();
+
+/** Test seam: inject the Timer used by segmented sessions. */
+export function setSegmentedSessionTimer(timer: Timer | undefined): void {
+  segmentedSessions.setTimer(timer);
+}
+
+/** Test seam: clear injected segmented-session state (timer + tracked sessions). */
+export function resetSegmentedSessions(): void {
+  segmentedSessions.reset();
+}
 
 export interface VideoRecordingArgs {
   action: "start" | "stop";
@@ -68,11 +132,16 @@ const videoRecordingSchema = addDeviceTargetingToSchema(z.object({
   fps: z.number().int().positive().optional().describe("FPS"),
   resolution: resolutionSchema.optional().describe("Resolution"),
   format: z.enum(["mp4"]).optional(),
+  // Raised from 300 so long Android recordings (segmented under the hood) are
+  // accepted. Note: non-Android recordings still can't exceed the manager's
+  // single-recording cap (300s) since they aren't segmented; such a request
+  // passes schema validation but is rejected at videoRecordingManager. Left
+  // as-is intentionally (out of scope for segmented Android capture).
   maxDuration: z
     .number()
     .int()
     .positive()
-    .max(300)
+    .max(3600)
     .optional()
     .describe("Max duration seconds"),
   outputName: z.string().optional().describe("Recording label"),
@@ -138,7 +207,37 @@ function selectLatestRecording(records: VideoRecordingRecord[]): VideoRecordingR
     })[0];
 }
 
+/**
+ * If `recordingId` is the handle for a timer-driven segmented session, stop it
+ * (clear the rotation timer + finalize) and return a response listing every
+ * segment file path/recordingId in order. Returns null otherwise so callers
+ * fall through to the single-recording stop path.
+ */
+async function tryStopSegmentedSession(recordingId: string) {
+  const session = segmentedSessions.get(recordingId);
+  if (!session) {
+    return null;
+  }
+
+  try {
+    const recordings = await segmentedSessions.stopAndRemove(recordingId, session);
+    return createJSONToolResponse({
+      action: "stop",
+      count: recordings.length,
+      recordings,
+      segmented: true,
+    });
+  } catch (error) {
+    throw new ActionableError(`Failed to stop segmented video recording: ${error}`);
+  }
+}
+
 async function stopRecordingById(recordingId: string) {
+  const segmented = await tryStopSegmentedSession(recordingId);
+  if (segmented) {
+    return segmented;
+  }
+
   const results: Array<Record<string, unknown>> = [];
   const evictedRecordingIds: string[] = [];
   const activeRecords = await listActiveVideoRecordings();
@@ -189,6 +288,38 @@ export function registerVideoRecordingTools(): void {
 
       for (const target of targetDevices) {
         try {
+          // Android `screenrecord` is hard-capped at 180s. For longer Android
+          // recordings, transparently produce ordered segments (<outputName>,
+          // <outputName>-seg1, ...) via a timer-driven segmented session.
+          if (
+            target.platform === "android" &&
+            maxDurationSeconds > ANDROID_SCREENRECORD_MAX_SECONDS
+          ) {
+            const session = new AndroidSegmentedPlanVideoSession({
+              device: target,
+              outputNamePrefix: args.outputName ?? `recording-${target.deviceId}`,
+              configOverrides: buildConfigOverrides(args),
+              timer: segmentedSessions.timer,
+            });
+            const active = await session.start();
+            segmentedSessions.track(active.recordingId, session);
+
+            recordings.push({
+              recordingId: active.recordingId,
+              outputPath: active.outputPath,
+              startedAt: active.startedAt,
+              outputName: active.outputName,
+              deviceId: target.deviceId,
+              platform: target.platform,
+              segmented: true,
+              settings: {
+                ...active.config,
+                maxDurationSeconds,
+              },
+            });
+            continue;
+          }
+
           const active = await startVideoRecording({
             device: target,
             configOverrides: buildConfigOverrides(args),
@@ -242,10 +373,46 @@ export function registerVideoRecordingTools(): void {
       const results: Array<Record<string, unknown>> = [];
       const failures: Array<Record<string, unknown>> = [];
       const evictedRecordingIds: string[] = [];
+      let stoppedAnySegmented = false;
       const targetDevices = await resolveTargetDevices(device, args);
       const activeRecords = await listActiveVideoRecordings({ platform: device.platform });
 
       for (const target of targetDevices) {
+        // A bare (by-device) stop must also finalize any timer-driven segmented
+        // session for this device; otherwise its rotation timer leaks and keeps
+        // producing segments. The session owns its segments' recording lifecycle,
+        // so finalizing it replaces the single-recording stop for this device.
+        const deviceSessions = segmentedSessions.forDevice(target.deviceId);
+        if (deviceSessions.length > 0) {
+          stoppedAnySegmented = true;
+          for (const [handle, session] of deviceSessions) {
+            try {
+              const segments = await segmentedSessions.stopAndRemove(handle, session);
+              for (const segment of segments) {
+                results.push({
+                  recordingId: segment.recordingId,
+                  filePath: segment.filePath,
+                  deviceId: target.deviceId,
+                  platform: target.platform,
+                  segmented: true,
+                });
+              }
+            } catch (error) {
+              logger.warn(
+                `[VideoRecording] Failed to finalize segmented session ${handle} on ` +
+                `device ${target.deviceId}: ${error instanceof Error ? error.message : String(error)}`,
+                error
+              );
+              failures.push({
+                deviceId: target.deviceId,
+                platform: target.platform,
+                error: String(error),
+              });
+            }
+          }
+          continue;
+        }
+
         const matches = activeRecords.filter(record => record.deviceId === target.deviceId);
         if (matches.length === 0) {
           failures.push({
@@ -299,6 +466,7 @@ export function registerVideoRecordingTools(): void {
         action: "stop",
         count: results.length,
         recordings: results,
+        segmented: stoppedAnySegmented ? true : undefined,
         failures: failures.length > 0 ? failures : undefined,
         evictedRecordingIds: evictedRecordingIds.length > 0 ? evictedRecordingIds : undefined,
       });

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -64,6 +64,18 @@ const segmentedSessions = (() => {
       return [...byHandle.entries()].filter(([, session]) => session.deviceId === deviceId);
     },
     /**
+     * Drop a session from the registry by identity (its handle is not known inside the
+     * session). Wired to the session's `onFinalized` hook so an auto-stopped,
+     * never-caller-stopped recording cleans up instead of leaking a tracked entry.
+     */
+    remove(session: AndroidSegmentedPlanVideoSession): void {
+      for (const [handle, tracked] of byHandle) {
+        if (tracked === session) {
+          byHandle.delete(handle);
+        }
+      }
+    },
+    /**
      * Stop a tracked session: remove it from the registry, finalize it (which clears
      * its rotation timer), and return the ordered segment recordingId/filePath pairs.
      */
@@ -319,12 +331,15 @@ export function registerVideoRecordingTools(): void {
             target.platform === "android" &&
             maxDurationSeconds > ANDROID_SCREENRECORD_MAX_SECONDS
           ) {
-            const session = new AndroidSegmentedPlanVideoSession({
+            const session: AndroidSegmentedPlanVideoSession = new AndroidSegmentedPlanVideoSession({
               device: target,
               outputNamePrefix: args.outputName ?? `recording-${target.deviceId}`,
               configOverrides: buildConfigOverrides(args),
               timer: segmentedSessions.timer,
               maxDurationSeconds,
+              // Auto-stop finalizes without going through stopAndRemove, so drop the
+              // tracked entry here to avoid a registry leak on fire-and-forget recordings.
+              onFinalized: () => segmentedSessions.remove(session),
               ...segmentedSessions.recordingDependencies,
             });
             const active = await session.start();

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -300,6 +300,7 @@ export function registerVideoRecordingTools(): void {
               outputNamePrefix: args.outputName ?? `recording-${target.deviceId}`,
               configOverrides: buildConfigOverrides(args),
               timer: segmentedSessions.timer,
+              maxDurationSeconds,
             });
             const active = await session.start();
             segmentedSessions.track(active.recordingId, session);

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -3,6 +3,10 @@ import { AndroidSegmentedPlanVideoSession } from "../../src/server/androidSegmen
 import type { BootedDevice } from "../../src/models";
 import type { Timer } from "../../src/utils/SystemTimer";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/** Drain all pending microtasks (setImmediate runs after the microtask queue). */
+const flush = () => new Promise<void>(resolve => setImmediate(resolve));
 
 const androidDevice: BootedDevice = {
   deviceId: "emulator-5554",
@@ -116,5 +120,77 @@ describe("AndroidSegmentedPlanVideoSession", () => {
     expect(stop).toHaveBeenCalledTimes(2);
     expect(finalized.filePaths.length).toBe(2);
     expect(finalized.recordingIds.length).toBe(2);
+  });
+});
+
+describe("AndroidSegmentedPlanVideoSession (timer-driven)", () => {
+  function makeSession(timer: FakeTimer) {
+    const outputNames: Array<string | undefined> = [];
+    const start = mock(async (req: { outputName?: string }) => {
+      outputNames.push(req.outputName);
+      return makeActiveRecording(`id-${req.outputName}`, `/tmp/${req.outputName}.mp4`);
+    });
+    const stop = mock(async (id: string | undefined) => {
+      const rid = id ?? "x";
+      return {
+        metadata: makeStopMetadata(rid, `/tmp/${rid}.mp4`),
+        evictedRecordingIds: [] as string[],
+      };
+    });
+
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: start,
+      stopVideoRecording: stop,
+    });
+
+    return { session, start, stop, outputNames };
+  }
+
+  test("start rotates segments on the timer; stop returns all in order", async () => {
+    const timer = new FakeTimer();
+    const { session, start, stop, outputNames } = makeSession(timer);
+
+    const first = await session.start();
+    expect(first.recordingId).toBe("id-vid");
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(outputNames).toEqual(["vid"]);
+
+    timer.advanceTime(1000);
+    await flush();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(outputNames[1]).toBe("vid-seg1");
+
+    timer.advanceTime(1000);
+    await flush();
+    expect(start).toHaveBeenCalledTimes(3);
+    expect(outputNames[2]).toBe("vid-seg2");
+
+    const out = await session.stop();
+    expect(out.recordingIds).toEqual(["id-vid", "id-vid-seg1", "id-vid-seg2"]);
+    expect(out.filePaths).toEqual([
+      "/tmp/id-vid.mp4",
+      "/tmp/id-vid-seg1.mp4",
+      "/tmp/id-vid-seg2.mp4",
+    ]);
+  });
+
+  test("stop clears the rotation timer so no further segments start", async () => {
+    const timer = new FakeTimer();
+    const { session, start } = makeSession(timer);
+
+    await session.start();
+    await session.stop();
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+
+    // Advancing well past the rotation interval must not start a new segment.
+    timer.advanceTime(5000);
+    await flush();
+    expect(start).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -193,4 +193,54 @@ describe("AndroidSegmentedPlanVideoSession (timer-driven)", () => {
     await flush();
     expect(start).toHaveBeenCalledTimes(1);
   });
+
+  test("auto-stops at maxDurationSeconds, finalizing every segment recorded so far (review: PR #3847)", async () => {
+    // maxDurationSeconds=2.5 does not align with the 1000ms rotation cadence, matching
+    // the reported bug: without a session-level bound, rotation reschedules indefinitely
+    // and maxDuration is never enforced as an overall cap.
+    const timer = new FakeTimer();
+    const outputNames: Array<string | undefined> = [];
+    const start = mock(async (req: { outputName?: string }) => {
+      outputNames.push(req.outputName);
+      return makeActiveRecording(`id-${req.outputName}`, `/tmp/${req.outputName}.mp4`);
+    });
+    const stop = mock(async (id: string | undefined) => {
+      const rid = id ?? "x";
+      return {
+        metadata: makeStopMetadata(rid, `/tmp/${rid}.mp4`),
+        evictedRecordingIds: [] as string[],
+      };
+    });
+
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "vid",
+      timer,
+      segmentRotateAfterMs: 1000,
+      maxDurationSeconds: 2.5,
+      startVideoRecording: start,
+      stopVideoRecording: stop,
+    });
+
+    await session.start();
+    timer.advanceTime(1000); // rotation -> seg1
+    await flush();
+    timer.advanceTime(1000); // rotation -> seg2 (2000ms elapsed)
+    await flush();
+    expect(start).toHaveBeenCalledTimes(3);
+
+    timer.advanceTime(500); // 2500ms elapsed -> maxDurationSeconds auto-stop fires
+    await flush();
+
+    expect(stop).toHaveBeenCalledTimes(3);
+    expect(outputNames).toEqual(["vid", "vid-seg1", "vid-seg2"]);
+    // Auto-stop must not leave the rotation timer armed.
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+
+    // A caller-issued stop() after auto-stop already ran must be a safe no-op, not
+    // double-finalize or throw.
+    const out = await session.stop();
+    expect(out.recordingIds).toEqual(["id-vid", "id-vid-seg1", "id-vid-seg2"]);
+    expect(stop).toHaveBeenCalledTimes(3);
+  });
 });

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -206,8 +206,10 @@ describe("videoRecording tool segmentation branch", () => {
     );
     const started = (startRes.recordings as Array<Record<string, unknown>>)[0];
     expect(started.segmented).toBe(true);
-    // The rotation timer is armed on the session's (injected) timer.
-    expect(segmentTimer.getPendingTimeoutCount()).toBe(1);
+    // Two timers are armed on the session's (injected) timer: the rotation timer, and
+    // the session-level maxDurationSeconds auto-stop (review: PR #3847 - maxDuration=300
+    // must actually bound total duration, not just gate whether segmentation kicks in).
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(2);
 
     // Rotate once so the bare stop must return more than one segment, in order.
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -1,0 +1,272 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { promises as fsPromises } from "node:fs";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeVideoCaptureBackend } from "../fakes/FakeVideoCaptureBackend";
+import { FakeHighlightClient } from "../fakes/FakeHighlightClient";
+import { FakeVideoRecordingRepository } from "../fakes/FakeVideoRecordingRepository";
+import { FakeVideoRecordingConfigRepository } from "../fakes/FakeVideoRecordingConfigRepository";
+import { VideoRecorderService } from "../../src/features/video";
+import {
+  registerVideoRecordingTools,
+  resetSegmentedSessions,
+  setSegmentedSessionTimer,
+} from "../../src/server/videoRecordingTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import {
+  resetVideoRecordingManagerDependencies,
+  setVideoRecordingManagerDependencies,
+} from "../../src/server/videoRecordingManager";
+import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+import type { BootedDevice } from "../../src/models";
+
+/** Drain all pending microtasks (setImmediate runs after the microtask queue). */
+const flush = () => new Promise<void>(resolve => setImmediate(resolve));
+
+/** Poll an async condition, yielding to the full event loop between checks. */
+async function waitFor(condition: () => Promise<boolean>, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (await condition()) {
+      return;
+    }
+    // Drain microtasks (flush) AND a macrotask turn so real fs/resource-registry
+    // awaits in the rotation chain settle even under concurrent file execution.
+    await flush();
+    await defaultTimer.sleep(0);
+  }
+  throw new Error(`Timed out waiting for: ${label}`);
+}
+
+interface ToolResponse {
+  content?: Array<{ text?: string }>;
+}
+
+function parse(response: ToolResponse): Record<string, unknown> {
+  return JSON.parse(response.content?.[0]?.text ?? "{}");
+}
+
+const androidDevice: BootedDevice = {
+  deviceId: "test-device",
+  platform: "android",
+  name: "Test Device",
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "ios-device",
+  platform: "ios",
+  name: "Test iPhone",
+};
+
+describe("videoRecording tool segmentation branch", () => {
+  let fakeTimer: FakeTimer;
+  let segmentTimer: FakeTimer;
+  let fakeBackend: FakeVideoCaptureBackend;
+  let fakeRepository: FakeVideoRecordingRepository;
+  let archiveRoot: string;
+
+  beforeAll(async () => {
+    if (!ToolRegistry.getTool("videoRecording")) {
+      registerVideoRecordingTools();
+    }
+    archiveRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "auto-mobile-video-tool-"));
+  });
+
+  beforeEach(async () => {
+    fakeTimer = new FakeTimer();
+    segmentTimer = new FakeTimer();
+    fakeBackend = new FakeVideoCaptureBackend();
+    fakeBackend.setNowProvider(() => new Date(fakeTimer.now()));
+    fakeRepository = new FakeVideoRecordingRepository();
+    await fsPromises.rm(archiveRoot, { recursive: true, force: true });
+    await fsPromises.mkdir(archiveRoot, { recursive: true });
+
+    const service = new VideoRecorderService({
+      backend: fakeBackend,
+      archiveRoot,
+      now: () => new Date(fakeTimer.now()),
+    });
+
+    await setVideoRecordingManagerDependencies({
+      videoRecorderService: service,
+      recordingRepository: fakeRepository,
+      configRepository: new FakeVideoRecordingConfigRepository(),
+      highlightClient: new FakeHighlightClient(),
+      timer: fakeTimer,
+      now: () => new Date(fakeTimer.now()),
+    });
+
+    // Segmented sessions created by the tool use this controllable timer.
+    setSegmentedSessionTimer(segmentTimer);
+  });
+
+  afterEach(() => {
+    resetVideoRecordingManagerDependencies();
+    resetSegmentedSessions();
+  });
+
+  afterAll(async () => {
+    await fsPromises.rm(archiveRoot, { recursive: true, force: true });
+  });
+
+  const handler = () => ToolRegistry.getTool("videoRecording")!.deviceAwareHandler!;
+
+  test("android recording <= 180s stays single (not segmented)", async () => {
+    const res = parse(
+      await handler()(androidDevice, {
+        action: "start",
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+        maxDuration: 60,
+        outputName: "short",
+      })
+    );
+
+    expect(res.count).toBe(1);
+    const recordings = res.recordings as Array<Record<string, unknown>>;
+    expect(recordings[0].segmented).toBeUndefined();
+
+    // Clean up the single recording.
+    await handler()(androidDevice, {
+      action: "stop",
+      platform: "android",
+      recordingId: recordings[0].recordingId as string,
+    });
+  });
+
+  test("non-android recording past the android cap stays single (not segmented)", async () => {
+    // 200s exceeds ANDROID_SCREENRECORD_MAX_SECONDS (would segment on android)
+    // but stays within the manager's single-recording cap for iOS.
+    const res = parse(
+      await handler()(iosDevice, {
+        action: "start",
+        platform: "ios",
+        deviceId: iosDevice.deviceId,
+        maxDuration: 200,
+        outputName: "long-ios",
+      })
+    );
+
+    expect(res.count).toBe(1);
+    const recordings = res.recordings as Array<Record<string, unknown>>;
+    expect(recordings[0].segmented).toBeUndefined();
+
+    await handler()(iosDevice, {
+      action: "stop",
+      platform: "ios",
+      recordingId: recordings[0].recordingId as string,
+    });
+  });
+
+  test("android recording > 180s starts a segmented session and stop returns segments", async () => {
+    const startRes = parse(
+      await handler()(androidDevice, {
+        action: "start",
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+        maxDuration: 400,
+        outputName: "vid",
+      })
+    );
+
+    expect(startRes.count).toBe(1);
+    const started = (startRes.recordings as Array<Record<string, unknown>>)[0];
+    expect(started.segmented).toBe(true);
+    expect(started.outputName).toBe("vid");
+
+    const handle = started.recordingId as string;
+    const stopRes = parse(
+      await handler()(androidDevice, {
+        action: "stop",
+        platform: "android",
+        recordingId: handle,
+      })
+    );
+
+    expect(stopRes.segmented).toBe(true);
+    const stoppedSegments = stopRes.recordings as Array<Record<string, unknown>>;
+    // No timer rotation occurred, so exactly the first segment is returned.
+    expect(stoppedSegments.length).toBe(1);
+    expect(stoppedSegments[0].recordingId).toBe(handle);
+    expect(typeof stoppedSegments[0].filePath).toBe("string");
+  });
+
+  test("bare (by-device) stop finalizes the segmented session and leaves no rotation timer", async () => {
+    // Mirrors the qa-agent's real usage: start with maxDuration=300 (> 180 so
+    // it segments), then stop WITHOUT a recordingId.
+    const startRes = parse(
+      await handler()(androidDevice, {
+        action: "start",
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+        maxDuration: 300,
+        outputName: "vid",
+      })
+    );
+    const started = (startRes.recordings as Array<Record<string, unknown>>)[0];
+    expect(started.segmented).toBe(true);
+    // The rotation timer is armed on the session's (injected) timer.
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(1);
+
+    // Rotate once so the bare stop must return more than one segment, in order.
+    segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);
+    await waitFor(
+      async () =>
+        (await fakeRepository.listRecordings()).length === 2 &&
+        (await fakeRepository.listRecordings({ status: "recording" })).length === 1,
+      "segment 2 to start after rotation"
+    );
+
+    const stopRes = parse(
+      await handler()(androidDevice, {
+        action: "stop",
+        platform: "android",
+        // NO recordingId — bare, by-device stop.
+      })
+    );
+
+    expect(stopRes.segmented).toBe(true);
+    const segments = stopRes.recordings as Array<Record<string, unknown>>;
+    expect(segments.length).toBe(2);
+    expect(segments.every(segment => segment.segmented === true)).toBe(true);
+    expect(typeof segments[0].filePath).toBe("string");
+    expect(typeof segments[1].filePath).toBe("string");
+
+    // Invariant: the rotation timer must not survive a bare stop.
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
+
+    // Advancing well past the rotation interval starts no new segment/recording.
+    const activeBefore = (await fakeRepository.listRecordings({ status: "recording" })).length;
+    segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS * 3);
+    await flush();
+    const activeAfter = (await fakeRepository.listRecordings({ status: "recording" })).length;
+    expect(activeBefore).toBe(0);
+    expect(activeAfter).toBe(0);
+  });
+
+  test("by-handle stop still works after wiring the bare-stop path", async () => {
+    const startRes = parse(
+      await handler()(androidDevice, {
+        action: "start",
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+        maxDuration: 300,
+        outputName: "vid",
+      })
+    );
+    const handle = (startRes.recordings as Array<Record<string, unknown>>)[0].recordingId as string;
+
+    const stopRes = parse(
+      await handler()(androidDevice, {
+        action: "stop",
+        platform: "android",
+        recordingId: handle,
+      })
+    );
+
+    expect(stopRes.segmented).toBe(true);
+    expect((stopRes.recordings as unknown[]).length).toBe(1);
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
+  });
+});

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -301,6 +301,78 @@ describe("videoRecording tool segmentation branch", () => {
     expect(segmentStarts).toHaveLength(segmentStartsBefore);
   });
 
+  test("maxDuration auto-stop removes the session so a later bare stop reports only fresh segments", async () => {
+    setSegmentedSessionRecordingDependencies({
+      startVideoRecording: async request => {
+        const outputName = request.outputName;
+        const recordingId = outputName ?? `segment-${segmentStarts.length}`;
+        segmentStarts.push(recordingId);
+        return makeSegmentRecording(recordingId, outputName);
+      },
+      stopVideoRecording: async recordingId => {
+        const id = recordingId ?? `segment-${segmentStops.length}`;
+        segmentStops.push(id);
+        return {
+          metadata: makeSegmentMetadata(id),
+          evictedRecordingIds: [],
+        };
+      },
+    });
+
+    // Fire-and-forget usage: start a segmented recording with a maxDuration bound and
+    // never call stop. The session-level auto-stop must fire AND clean itself out of the
+    // registry — otherwise the dead entry leaks and its stale segments resurface later.
+    await handler()(androidDevice, {
+      action: "start",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+      maxDuration: 181,
+      outputName: "first",
+    });
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(2);
+
+    // The segmented session now owns its lifecycle; don't let a late finalize rebuild the
+    // real manager/database singleton.
+    resetVideoRecordingManagerDependencies();
+
+    // Advance past the maxDuration bound (rotation at 170s, then auto-stop at 181s).
+    segmentTimer.advanceTime(181_000);
+    await waitFor(
+      async () => segmentStops.length === 2,
+      "auto-stop to finalize both segments of the first session"
+    );
+    await flush();
+
+    // Auto-stop cleared the session's timers and removed it from the registry.
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
+
+    // A new recording starts on the SAME device (the QA runner's next test case).
+    await handler()(androidDevice, {
+      action: "start",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+      maxDuration: 300,
+      outputName: "second",
+    });
+
+    // Bare (by-device) stop: with the leak fixed, forDevice() sees only the new session,
+    // so the response lists only the fresh segment — never the auto-stopped first session's.
+    const stopRes = parse(
+      await handler()(androidDevice, {
+        action: "stop",
+        platform: "android",
+        // NO recordingId — bare, by-device stop.
+      })
+    );
+
+    const segments = stopRes.recordings as Array<Record<string, unknown>>;
+    expect(segments.length).toBe(1);
+    expect(segments[0].recordingId).toBe("second");
+    expect(
+      segments.some(segment => String(segment.filePath).includes("first"))
+    ).toBe(false);
+  });
+
   test("by-handle stop still works after wiring the bare-stop path", async () => {
     const startRes = parse(
       await handler()(androidDevice, {

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -7,10 +7,15 @@ import { FakeVideoCaptureBackend } from "../fakes/FakeVideoCaptureBackend";
 import { FakeHighlightClient } from "../fakes/FakeHighlightClient";
 import { FakeVideoRecordingRepository } from "../fakes/FakeVideoRecordingRepository";
 import { FakeVideoRecordingConfigRepository } from "../fakes/FakeVideoRecordingConfigRepository";
-import { VideoRecorderService } from "../../src/features/video";
+import {
+  DEFAULT_VIDEO_RECORDING_CONFIG,
+  VideoRecorderService,
+  type ActiveVideoRecording,
+} from "../../src/features/video";
 import {
   registerVideoRecordingTools,
   resetSegmentedSessions,
+  setSegmentedSessionRecordingDependencies,
   setSegmentedSessionTimer,
 } from "../../src/server/videoRecordingTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
@@ -20,7 +25,7 @@ import {
 } from "../../src/server/videoRecordingManager";
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
 import { defaultTimer } from "../../src/utils/SystemTimer";
-import type { BootedDevice } from "../../src/models";
+import type { BootedDevice, VideoRecordingMetadata } from "../../src/models";
 
 /** Drain all pending microtasks (setImmediate runs after the microtask queue). */
 const flush = () => new Promise<void>(resolve => setImmediate(resolve));
@@ -47,6 +52,32 @@ function parse(response: ToolResponse): Record<string, unknown> {
   return JSON.parse(response.content?.[0]?.text ?? "{}");
 }
 
+function makeSegmentRecording(id: string, outputName: string | undefined): ActiveVideoRecording {
+  return {
+    recordingId: id,
+    outputPath: `/tmp/${id}.mp4`,
+    fileName: `${id}.mp4`,
+    startedAt: new Date(0).toISOString(),
+    outputName,
+    config: DEFAULT_VIDEO_RECORDING_CONFIG,
+  };
+}
+
+function makeSegmentMetadata(id: string): VideoRecordingMetadata {
+  return {
+    recordingId: id,
+    fileName: `${id}.mp4`,
+    filePath: `/tmp/${id}.mp4`,
+    format: "mp4",
+    sizeBytes: 1,
+    codec: "h264",
+    createdAt: new Date(0).toISOString(),
+    startedAt: new Date(0).toISOString(),
+    lastAccessedAt: new Date(0).toISOString(),
+    config: DEFAULT_VIDEO_RECORDING_CONFIG,
+  };
+}
+
 const androidDevice: BootedDevice = {
   deviceId: "test-device",
   platform: "android",
@@ -65,6 +96,8 @@ describe("videoRecording tool segmentation branch", () => {
   let fakeBackend: FakeVideoCaptureBackend;
   let fakeRepository: FakeVideoRecordingRepository;
   let archiveRoot: string;
+  let segmentStarts: string[];
+  let segmentStops: string[];
 
   beforeAll(async () => {
     if (!ToolRegistry.getTool("videoRecording")) {
@@ -79,6 +112,8 @@ describe("videoRecording tool segmentation branch", () => {
     fakeBackend = new FakeVideoCaptureBackend();
     fakeBackend.setNowProvider(() => new Date(fakeTimer.now()));
     fakeRepository = new FakeVideoRecordingRepository();
+    segmentStarts = [];
+    segmentStops = [];
     await fsPromises.rm(archiveRoot, { recursive: true, force: true });
     await fsPromises.mkdir(archiveRoot, { recursive: true });
 
@@ -193,6 +228,23 @@ describe("videoRecording tool segmentation branch", () => {
   });
 
   test("bare (by-device) stop finalizes the segmented session and leaves no rotation timer", async () => {
+    setSegmentedSessionRecordingDependencies({
+      startVideoRecording: async request => {
+        const outputName = request.outputName;
+        const recordingId = outputName ?? `segment-${segmentStarts.length}`;
+        segmentStarts.push(recordingId);
+        return makeSegmentRecording(recordingId, outputName);
+      },
+      stopVideoRecording: async recordingId => {
+        const id = recordingId ?? `segment-${segmentStops.length}`;
+        segmentStops.push(id);
+        return {
+          metadata: makeSegmentMetadata(id),
+          evictedRecordingIds: [],
+        };
+      },
+    });
+
     // Mirrors the qa-agent's real usage: start with maxDuration=300 (> 180 so
     // it segments), then stop WITHOUT a recordingId.
     const startRes = parse(
@@ -211,12 +263,16 @@ describe("videoRecording tool segmentation branch", () => {
     // must actually bound total duration, not just gate whether segmentation kicks in).
     expect(segmentTimer.getPendingTimeoutCount()).toBe(2);
 
+    // From this point, the segmented session owns its lifecycle. A late async
+    // rotation or bare stop must not rebuild the real manager/database singleton.
+    resetVideoRecordingManagerDependencies();
+
     // Rotate once so the bare stop must return more than one segment, in order.
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);
     await waitFor(
       async () =>
-        (await fakeRepository.listRecordings()).length === 2 &&
-        (await fakeRepository.listRecordings({ status: "recording" })).length === 1,
+        segmentStarts.length === 2 &&
+        segmentStops.length === 1,
       "segment 2 to start after rotation"
     );
 
@@ -239,12 +295,10 @@ describe("videoRecording tool segmentation branch", () => {
     expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
 
     // Advancing well past the rotation interval starts no new segment/recording.
-    const activeBefore = (await fakeRepository.listRecordings({ status: "recording" })).length;
+    const segmentStartsBefore = segmentStarts.length;
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS * 3);
     await flush();
-    const activeAfter = (await fakeRepository.listRecordings({ status: "recording" })).length;
-    expect(activeBefore).toBe(0);
-    expect(activeAfter).toBe(0);
+    expect(segmentStarts).toHaveLength(segmentStartsBefore);
   });
 
   test("by-handle stop still works after wiring the bare-stop path", async () => {

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -24,8 +24,16 @@ import {
   setVideoRecordingManagerDependencies,
 } from "../../src/server/videoRecordingManager";
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
-import { defaultTimer } from "../../src/utils/SystemTimer";
 import type { BootedDevice, VideoRecordingMetadata } from "../../src/models";
+
+/**
+ * Generous ceiling for the two timer-driven tests below: they poll an async rotation
+ * chain via {@link waitFor}, and under full-suite concurrency the event loop is saturated
+ * enough that the (logically-correct) poll can outlast bun's 5s default. The condition is
+ * always met well before this; the headroom just stops a loaded CI machine failing a
+ * correct test.
+ */
+const TIMER_DRIVEN_TEST_TIMEOUT_MS = 20_000;
 
 /** Drain all pending microtasks (setImmediate runs after the microtask queue). */
 const flush = () => new Promise<void>(resolve => setImmediate(resolve));
@@ -36,10 +44,11 @@ async function waitFor(condition: () => Promise<boolean>, label: string): Promis
     if (await condition()) {
       return;
     }
-    // Drain microtasks (flush) AND a macrotask turn so real fs/resource-registry
-    // awaits in the rotation chain settle even under concurrent file execution.
+    // A single macrotask yield (setImmediate) drains the microtask queue AND lets any
+    // I/O-phase callbacks in the rotation chain settle. A second real-timer yield here
+    // (defaultTimer.sleep(0)) only doubled the per-iteration wall-clock, which starved
+    // this loop past the 5s test budget under full-suite concurrency — so it's gone.
     await flush();
-    await defaultTimer.sleep(0);
   }
   throw new Error(`Timed out waiting for: ${label}`);
 }
@@ -299,7 +308,7 @@ describe("videoRecording tool segmentation branch", () => {
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS * 3);
     await flush();
     expect(segmentStarts).toHaveLength(segmentStartsBefore);
-  });
+  }, TIMER_DRIVEN_TEST_TIMEOUT_MS);
 
   test("maxDuration auto-stop removes the session so a later bare stop reports only fresh segments", async () => {
     setSegmentedSessionRecordingDependencies({
@@ -371,7 +380,7 @@ describe("videoRecording tool segmentation branch", () => {
     expect(
       segments.some(segment => String(segment.filePath).includes("first"))
     ).toBe(false);
-  });
+  }, TIMER_DRIVEN_TEST_TIMEOUT_MS);
 
   test("by-handle stop still works after wiring the bare-stop path", async () => {
     const startRes = parse(


### PR DESCRIPTION
Fixes #3843 (follow-up to #1959, which only covered executePlan).

#1959 was fixed for executePlan-driven recording (11882d9f), but the raw `videoRecording` tool — used directly by callers that manage start/stop themselves (e.g. a QA-agent runner calling `videoRecording --action start`/`stop` per test case, never going through executePlan) — still hit the hard 180s `adb shell screenrecord` cap with no segmentation.

This threads the same rotation approach to the tool-level path: a >180s session rolls over every ~170s into ordered clips (`<name>`, `<name>-seg1`, ...) instead of losing coverage at the cap.

Validated on-device before opening: a 200s recording → bare stop → 2 ordered clips, no leaked rotation timer.