### PR TITLE
Add --no-occlusion runtime flag to disable observe occlusion filtering

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1897,7 +1897,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       if (!allWindows.isNullOrEmpty()) {
         Log.d(
           TAG,
-          "Extracting from ${allWindows.size} windows (disableAllFiltering: $disableAllFiltering)",
+          "Extracting from ${allWindows.size} windows " +
+            "(disableAllFiltering: $disableAllFiltering, occlusionEnabled: $occlusionEnabled)",
         )
         viewHierarchyExtractor.extractFromAllWindows(
           allWindows,
@@ -2038,6 +2039,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     return if (!allWindows.isNullOrEmpty()) {
+      Log.d(
+        TAG,
+        "extractHierarchy from ${allWindows.size} windows " +
+          "(disableAllFiltering: $disableAllFiltering, occlusionEnabled: $occlusionEnabled)",
+      )
       viewHierarchyExtractor.extractFromAllWindows(
         allWindows,
         rootNode,

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -243,6 +243,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
   @Volatile private var isRecording: Boolean = false
 
+  // Not an AccessibilityServiceInfo flag — read directly by extractHierarchyDirect/extractHierarchy
+  // when calling into ViewHierarchyExtractor. Set via setAccessibilityFlags (--no-occlusion).
+  @Volatile private var occlusionEnabled: Boolean = true
+
   // Debounce timestamps — @Volatile since interaction events may trigger coroutines
   @Volatile private var lastInputTextBroadcastMs: Long = 0
   private val inputTextDebounceMs: Long = 100
@@ -1149,11 +1153,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     includeNotImportantViews: Boolean,
     reportViewIds: Boolean,
     retrieveInteractiveWindows: Boolean,
+    occlusionEnabled: Boolean,
   ) =
     applyAccessibilityFlags(
       includeNotImportantViews = includeNotImportantViews,
       reportViewIds = reportViewIds,
       retrieveInteractiveWindows = retrieveInteractiveWindows,
+      occlusionEnabled = occlusionEnabled,
     )
 
   override fun setNetworkMockRules(rulesJson: String) = broadcastNetworkMockRules(rulesJson)
@@ -1256,7 +1262,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     includeNotImportantViews: Boolean,
     reportViewIds: Boolean,
     retrieveInteractiveWindows: Boolean,
+    occlusionEnabled: Boolean,
   ) {
+    // occlusionEnabled isn't an AccessibilityServiceInfo flag, so store it unconditionally —
+    // it must take effect even before serviceInfo is available (the early-return below).
+    this.occlusionEnabled = occlusionEnabled
+
     val info =
       serviceInfo
         ?: run {
@@ -1295,7 +1306,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       "Applied accessibility flags: " +
         "includeNotImportantViews=$includeNotImportantViews, " +
         "reportViewIds=$reportViewIds, " +
-        "retrieveInteractiveWindows=$retrieveInteractiveWindows",
+        "retrieveInteractiveWindows=$retrieveInteractiveWindows, " +
+        "occlusionEnabled=$occlusionEnabled",
     )
   }
 
@@ -1894,6 +1906,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           screenDimensions,
           true,
           disableAllFiltering,
+          occlusionEnabled,
         )
       } else {
         viewHierarchyExtractor.extractFromActiveWindow(
@@ -2032,6 +2045,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         screenDimensions,
         true,
         disableAllFiltering,
+        occlusionEnabled,
       )
     } else {
       viewHierarchyExtractor.extractFromActiveWindow(

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
@@ -103,6 +103,7 @@ interface CtrlProxyActions {
     includeNotImportantViews: Boolean,
     reportViewIds: Boolean,
     retrieveInteractiveWindows: Boolean,
+    occlusionEnabled: Boolean,
   )
 
   fun setNetworkMockRules(rulesJson: String)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -249,6 +249,7 @@ class CtrlProxyMessageHandler(
           request.includeNotImportantViews,
           request.reportViewIds,
           request.retrieveInteractiveWindows,
+          request.occlusionEnabled,
         )
       is SetNetworkMockRules ->
         actions.setNetworkMockRules(

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -157,9 +157,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
    * @param dedupeTextContentDesc When true, omit content-desc when it equals text (default: true)
    * @param disableAllFiltering When true, disable all optimizations and filtering (for observe with
    *   raw:true)
-   * @param occlusionEnabled When false, skip the cross-window occlusion pass entirely — no
-   *   occluder loop, no occlusionState/occludedBy/occludedByViewId fields (daemon's
-   *   --no-occlusion flag, default true)
+   * @param occlusionEnabled When false, skip the cross-window occlusion pass entirely — no occluder
+   *   loop, no occlusionState/occludedBy/occludedByViewId fields (daemon's --no-occlusion flag,
+   *   default true)
    */
   fun extractFromAllWindows(
     windows: List<AccessibilityWindowInfo>,

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -31,7 +31,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     private const val TAG = "ViewHierarchyExtractor"
     private const val MAX_DEPTH = 100 // Prevent infinite recursion
     private const val MAX_CHILDREN = 256 // Limit children to prevent memory issues
-    private const val OCCLUSION_FILTER_ENABLED = true
     private const val OCCLUSION_THRESHOLD = 0.95
     private const val DEFAULT_WINDOW_KEY = -1
     private const val CONTENT_HIDDEN_REASON_COMPOSE_INTEROP = "compose-interop-no-hide-descendants"
@@ -158,6 +157,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
    * @param dedupeTextContentDesc When true, omit content-desc when it equals text (default: true)
    * @param disableAllFiltering When true, disable all optimizations and filtering (for observe with
    *   raw:true)
+   * @param occlusionEnabled When false, skip the cross-window occlusion pass entirely — no
+   *   occluder loop, no occlusionState/occludedBy/occludedByViewId fields (daemon's
+   *   --no-occlusion flag, default true)
    */
   fun extractFromAllWindows(
     windows: List<AccessibilityWindowInfo>,
@@ -166,6 +168,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     screenDimensions: ScreenDimensions? = null,
     dedupeTextContentDesc: Boolean = true,
     disableAllFiltering: Boolean = false,
+    occlusionEnabled: Boolean = true,
   ): ViewHierarchy {
     if (windows.isEmpty() && activeWindowRoot == null) {
       Log.w(TAG, "No windows available for extraction")
@@ -369,10 +372,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       }
     }
 
-    // Skip occlusion filtering when disabled, or when there's only one window
-    // (within-window "occlusion" between peer subtrees like notification_panel and
-    // keyguard_message_area_container incorrectly strips content in system UI)
-    if (!disableAllFiltering && OCCLUSION_FILTER_ENABLED && windowEntries.size > 1) {
+    // Skip occlusion filtering when disabled (disableAllFiltering or the --no-occlusion
+    // daemon flag), or when there's only one window (within-window "occlusion" between peer
+    // subtrees like notification_panel and keyguard_message_area_container incorrectly strips
+    // content in system UI)
+    if (isOcclusionFilteringActive(disableAllFiltering, occlusionEnabled, windowEntries.size)) {
       val occlusionInfo = buildOcclusionInfo(windowEntries)
       val filteredEntries = windowEntries.mapNotNull { windowEntry ->
         val hierarchy =
@@ -1510,6 +1514,17 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   // applyOcclusionFilteringSingleWindow removed: within-window occlusion filtering is disabled
   // because optimizeHierarchy restructures the tree in ways that break path-based relationship
   // detection, causing false occlusion between visual siblings at different depths.
+
+  /**
+   * Whether the cross-window occlusion pass (buildOcclusionInfo + filterOccludedHierarchy) should
+   * run for this extraction. `internal` so it's directly unit-testable without needing to stand up
+   * a full multi-window AccessibilityNodeInfo tree.
+   */
+  internal fun isOcclusionFilteringActive(
+    disableAllFiltering: Boolean,
+    occlusionEnabled: Boolean,
+    windowCount: Int,
+  ): Boolean = !disableAllFiltering && occlusionEnabled && windowCount > 1
 
   private fun buildOcclusionInfo(windowEntries: List<WindowEntry>): Map<NodeKey, OcclusionInfo> {
     val nodes = mutableListOf<OcclusionNode>()

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -376,7 +376,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     // daemon flag), or when there's only one window (within-window "occlusion" between peer
     // subtrees like notification_panel and keyguard_message_area_container incorrectly strips
     // content in system UI)
-    if (isOcclusionFilteringActive(disableAllFiltering, occlusionEnabled, windowEntries.size)) {
+    val occlusionFilteringActive =
+      isOcclusionFilteringActive(disableAllFiltering, occlusionEnabled, windowEntries.size)
+    Log.d(
+      TAG,
+      "Occlusion filtering active: $occlusionFilteringActive " +
+        "(disableAllFiltering=$disableAllFiltering, occlusionEnabled=$occlusionEnabled, " +
+        "windowCount=${windowEntries.size})",
+    )
+    if (occlusionFilteringActive) {
       val occlusionInfo = buildOcclusionInfo(windowEntries)
       val filteredEntries = windowEntries.mapNotNull { windowEntry ->
         val hierarchy =

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
@@ -96,6 +96,7 @@ open class NoOpCtrlProxyActions : CtrlProxyActions {
     includeNotImportantViews: Boolean,
     reportViewIds: Boolean,
     retrieveInteractiveWindows: Boolean,
+    occlusionEnabled: Boolean,
   ) {}
 
   override fun setNetworkMockRules(rulesJson: String) {}
@@ -305,12 +306,14 @@ class RecordingCtrlProxyActions : CtrlProxyActions {
     includeNotImportantViews: Boolean,
     reportViewIds: Boolean,
     retrieveInteractiveWindows: Boolean,
+    occlusionEnabled: Boolean,
   ) =
     record(
       "setAccessibilityFlags",
       includeNotImportantViews,
       reportViewIds,
       retrieveInteractiveWindows,
+      occlusionEnabled,
     )
 
   override fun setNetworkMockRules(rulesJson: String) = record("setNetworkMockRules", rulesJson)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -541,15 +541,15 @@ class CtrlProxyMessageHandlerTest {
   @Test
   fun `dispatches set_accessibility_flags`() = runTest {
     dispatch(
-      """{"type":"set_accessibility_flags","includeNotImportantViews":false,"reportViewIds":true,"retrieveInteractiveWindows":false}"""
+      """{"type":"set_accessibility_flags","includeNotImportantViews":false,"reportViewIds":true,"retrieveInteractiveWindows":false,"occlusionEnabled":false}"""
     )
-    assertEquals("setAccessibilityFlags" to listOf<Any?>(false, true, false), lastCall)
+    assertEquals("setAccessibilityFlags" to listOf<Any?>(false, true, false, false), lastCall)
   }
 
   @Test
   fun `set_accessibility_flags defaults all flags to true`() = runTest {
     dispatch("""{"type":"set_accessibility_flags"}""")
-    assertEquals("setAccessibilityFlags" to listOf<Any?>(true, true, true), lastCall)
+    assertEquals("setAccessibilityFlags" to listOf<Any?>(true, true, true, true), lastCall)
   }
 
   @Test

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -374,6 +374,50 @@ class ViewHierarchyExtractorTest {
   // MARK: - Occlusion Filtering Tests
 
   @Test
+  fun `occlusion filtering is active by default with multiple windows`() {
+    assertTrue(
+      extractor.isOcclusionFilteringActive(
+        disableAllFiltering = false,
+        occlusionEnabled = true,
+        windowCount = 2,
+      )
+    )
+  }
+
+  @Test
+  fun `occlusion filtering is skipped when occlusionEnabled is false (--no-occlusion)`() {
+    assertFalse(
+      extractor.isOcclusionFilteringActive(
+        disableAllFiltering = false,
+        occlusionEnabled = false,
+        windowCount = 2,
+      )
+    )
+  }
+
+  @Test
+  fun `occlusion filtering is skipped when disableAllFiltering is true regardless of occlusionEnabled`() {
+    assertFalse(
+      extractor.isOcclusionFilteringActive(
+        disableAllFiltering = true,
+        occlusionEnabled = true,
+        windowCount = 2,
+      )
+    )
+  }
+
+  @Test
+  fun `occlusion filtering is skipped with a single window regardless of occlusionEnabled`() {
+    assertFalse(
+      extractor.isOcclusionFilteringActive(
+        disableAllFiltering = false,
+        occlusionEnabled = true,
+        windowCount = 1,
+      )
+    )
+  }
+
+  @Test
   fun `same-window nodes never occlude each other even when fully overlapping`() {
     // Regression test for the channel-header disappearance bug.
     // Previously, an UNRELATED same-window node that fully covered another node would mark it

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -401,6 +401,7 @@ data class SetAccessibilityFlags(
   val includeNotImportantViews: Boolean = true,
   val reportViewIds: Boolean = true,
   val retrieveInteractiveWindows: Boolean = true,
+  val occlusionEnabled: Boolean = true,
 ) : WebSocketRequest()
 
 @Serializable

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -374,7 +374,7 @@ class WebSocketRequestTest {
   @Test
   fun `deserialize set_accessibility_flags`() {
     val message =
-      """{"type":"set_accessibility_flags","includeNotImportantViews":false,"reportViewIds":true,"retrieveInteractiveWindows":false}"""
+      """{"type":"set_accessibility_flags","includeNotImportantViews":false,"reportViewIds":true,"retrieveInteractiveWindows":false,"occlusionEnabled":false}"""
     val request = json.decodeFromString<WebSocketRequest>(message)
 
     assertIs<SetAccessibilityFlags>(request)
@@ -382,6 +382,7 @@ class WebSocketRequestTest {
     assertEquals(false, request.includeNotImportantViews)
     assertEquals(true, request.reportViewIds)
     assertEquals(false, request.retrieveInteractiveWindows)
+    assertEquals(false, request.occlusionEnabled)
   }
 
   @Test
@@ -393,6 +394,7 @@ class WebSocketRequestTest {
     assertEquals(true, request.includeNotImportantViews)
     assertEquals(true, request.reportViewIds)
     assertEquals(true, request.retrieveInteractiveWindows)
+    assertEquals(true, request.occlusionEnabled)
   }
 
   @Test

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -245,6 +245,9 @@ export class Daemon {
     if (options.noA11yRetrieveInteractiveWindows) {
       serverConfig.setA11yRetrieveInteractiveWindows(false);
     }
+    if (options.noOcclusion) {
+      serverConfig.setOcclusionEnabled(false);
+    }
     if (options.observeResultDropElements) {
       serverConfig.setObserveResultDropElementsEnabled(true);
     }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -749,6 +749,9 @@ export class DaemonManager implements DaemonManagerLike {
     if (options.noWaitForPollingOverhead) {
       args.push("--no-waitfor-polling-overhead");
     }
+    if (options.noOcclusion) {
+      args.push("--no-occlusion");
+    }
     if (options.memPerfAudit) {
       args.push("--mem-perf-audit");
     }
@@ -1246,6 +1249,8 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
       options.noNavigationScreenshots = true;
     } else if (args[i] === "--no-waitfor-polling-overhead") {
       options.noWaitForPollingOverhead = true;
+    } else if (args[i] === "--no-occlusion") {
+      options.noOcclusion = true;
     } else if (args[i] === "--mem-perf-audit") {
       options.memPerfAudit = true;
     } else if (args[i] === "--accessibility-audit") {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -213,6 +213,8 @@ export interface DaemonOptions {
   noA11yReportViewIds?: boolean;
   /** Disable FLAG_RETRIEVE_INTERACTIVE_WINDOWS on the accessibility service */
   noA11yRetrieveInteractiveWindows?: boolean;
+  /** Disable the observe occlusion pass (occlusionState/occludedBy/occludedByViewId) */
+  noOcclusion?: boolean;
   /** Output reduction: drop the flattened elements array from observe results (issue #2756) */
   observeResultDropElements?: boolean;
   /** Output reduction: emit observe results in compact form (issue #2756) */

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1191,6 +1191,28 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     return this.handleWebSocketMessage(data);
   }
 
+  /**
+   * Defense in depth on top of onConnectionEstablished(): every caller that needs the
+   * device connected already routes through ensureConnected() (getLatestHierarchy,
+   * requestHierarchySync, etc.), so re-syncing accessibility flags here guarantees the
+   * device has the current config before any hierarchy request goes out — regardless of
+   * whether this call freshly opened the WebSocket (onConnectionEstablished fires) or
+   * reused an already-open one (connectWebSocket's early-return skips it). Cost: the
+   * allEnabled early-return in syncAccessibilityFlagsToDevice() skips the send entirely
+   * in the common case (all flags default). When a flag IS disabled (e.g. --no-occlusion)
+   * it re-sends the config on each call — a small, idempotent, order-preserved message,
+   * kept deliberately simple as defense-in-depth so a reused connection can't drift.
+   */
+  public override async ensureConnected(
+    perf: PerformanceTracker = new NoOpPerformanceTracker()
+  ): Promise<boolean> {
+    const connected = await super.ensureConnected(perf);
+    if (connected) {
+      this.syncAccessibilityFlagsToDevice();
+    }
+    return connected;
+  }
+
   protected onConnectionEstablished(): void {
     this.syncNetworkStateToDevice();
     this.syncAccessibilityFlagsToDevice();
@@ -1233,6 +1255,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       const allEnabled =
           flags.includeNotImportantViews && flags.reportViewIds && flags.retrieveInteractiveWindows
           && flags.occlusionEnabled;
+      // Diagnostic: without this, "did the push ever get attempted" is unanswerable from
+      // logs alone — the only prior signal was the (info-level) send below, so a no-op
+      // skip and "never called" were indistinguishable (issue occlusion-flag).
+      logger.debug(
+        `[AndroidCtrlProxyClient] syncAccessibilityFlagsToDevice invoked: allEnabled=${allEnabled}, ` +
+        `occlusionEnabled=${flags.occlusionEnabled}`
+      );
       if (allEnabled) {
         return;
       }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1231,7 +1231,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     try {
       const flags = serverConfig.getAccessibilityFlagsConfig();
       const allEnabled =
-          flags.includeNotImportantViews && flags.reportViewIds && flags.retrieveInteractiveWindows;
+          flags.includeNotImportantViews && flags.reportViewIds && flags.retrieveInteractiveWindows
+          && flags.occlusionEnabled;
       if (allEnabled) {
         return;
       }
@@ -1240,12 +1241,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         `[AndroidCtrlProxyClient] Sending accessibility flags config: ` +
         `includeNotImportantViews=${flags.includeNotImportantViews}, ` +
         `reportViewIds=${flags.reportViewIds}, ` +
-        `retrieveInteractiveWindows=${flags.retrieveInteractiveWindows}`
+        `retrieveInteractiveWindows=${flags.retrieveInteractiveWindows}, ` +
+        `occlusionEnabled=${flags.occlusionEnabled}`
       );
       this.sendMessage(serializeCtrlProxyRequest(ctrlProxyRequests.setAccessibilityFlags({
         includeNotImportantViews: flags.includeNotImportantViews,
         reportViewIds: flags.reportViewIds,
         retrieveInteractiveWindows: flags.retrieveInteractiveWindows,
+        occlusionEnabled: flags.occlusionEnabled,
       })));
     } catch (e) {
       logger.debug(`[AndroidCtrlProxyClient] Failed to sync accessibility flags on reconnect: ${e}`);

--- a/src/features/observe/android/ctrlProxyProtocol.ts
+++ b/src/features/observe/android/ctrlProxyProtocol.ts
@@ -425,6 +425,7 @@ export interface SetAccessibilityFlagsMessage {
   includeNotImportantViews: boolean;
   reportViewIds: boolean;
   retrieveInteractiveWindows: boolean;
+  occlusionEnabled: boolean;
 }
 
 /** `@SerialName("set_network_mock_rules")` → `SetNetworkMockRules` (sent without requestId) */
@@ -840,12 +841,14 @@ export const ctrlProxyRequests = {
     includeNotImportantViews: boolean;
     reportViewIds: boolean;
     retrieveInteractiveWindows: boolean;
+    occlusionEnabled: boolean;
   }): SetAccessibilityFlagsMessage {
     return {
       type: "set_accessibility_flags",
       includeNotImportantViews: args.includeNotImportantViews,
       reportViewIds: args.reportViewIds,
       retrieveInteractiveWindows: args.retrieveInteractiveWindows,
+      occlusionEnabled: args.occlusionEnabled,
     };
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,7 @@ function parseArgs(log: ParseLogger): {
   noA11yIncludeNotImportantViews: boolean;
   noA11yReportViewIds: boolean;
   noA11yRetrieveInteractiveWindows: boolean;
+  noOcclusion: boolean;
   outputReduction: OutputReductionFlags;
   toolOutputsDir: string | undefined;
   } {
@@ -179,6 +180,7 @@ function parseArgs(log: ParseLogger): {
   const noA11yIncludeNotImportantViews = args.includes("--no-include-not-important-views");
   const noA11yReportViewIds = args.includes("--no-report-view-ids");
   const noA11yRetrieveInteractiveWindows = args.includes("--no-retrieve-interactive-windows");
+  const noOcclusion = args.includes("--no-occlusion");
   // Output-size reduction flags (issue #2756): each parses from CLI OR its
   // AUTOMOBILE_* env var, CLI winning via ||.
   const outputReduction = parseOutputReductionFlags(args, process.env);
@@ -388,6 +390,7 @@ function parseArgs(log: ParseLogger): {
     noA11yIncludeNotImportantViews,
     noA11yReportViewIds,
     noA11yRetrieveInteractiveWindows,
+    noOcclusion,
     outputReduction,
     toolOutputsDir,
   };
@@ -471,6 +474,7 @@ async function main() {
       noA11yIncludeNotImportantViews,
       noA11yReportViewIds,
       noA11yRetrieveInteractiveWindows,
+      noOcclusion,
       outputReduction,
       toolOutputsDir,
     } = parseArgs(logger);
@@ -598,6 +602,7 @@ async function main() {
       [noA11yIncludeNotImportantViews, "Accessibility includeNotImportantViews disabled (--no-include-not-important-views)"],
       [noA11yReportViewIds, "Accessibility reportViewIds disabled (--no-report-view-ids)"],
       [noA11yRetrieveInteractiveWindows, "Accessibility retrieveInteractiveWindows disabled (--no-retrieve-interactive-windows)"],
+      [noOcclusion, "Observe occlusion pass disabled (--no-occlusion)"],
     ];
     for (const [active, message] of silentDaemonFlags) {
       if (active) {
@@ -638,6 +643,7 @@ async function main() {
         noA11yIncludeNotImportantViews,
         noA11yReportViewIds,
         noA11yRetrieveInteractiveWindows,
+        noOcclusion,
         // OutputReductionFlags field names match these DaemonOptions fields 1:1.
         ...outputReduction,
       });
@@ -699,6 +705,7 @@ async function main() {
         noA11yIncludeNotImportantViews,
         noA11yReportViewIds,
         noA11yRetrieveInteractiveWindows,
+        noOcclusion,
         // OutputReductionFlags field names match these DaemonOptions fields 1:1.
         ...outputReduction,
       };

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -34,6 +34,7 @@ class ServerConfig {
   private _a11yIncludeNotImportantViews: boolean = true;
   private _a11yReportViewIds: boolean = true;
   private _a11yRetrieveInteractiveWindows: boolean = true;
+  private _occlusionEnabled: boolean = true;
   private _planExecutionActive: boolean = false;
   private _observeResultDropElements: boolean = false;
   private _observeResultCompact: boolean = false;
@@ -208,11 +209,16 @@ class ServerConfig {
     this._a11yRetrieveInteractiveWindows = enabled;
   }
 
-  getAccessibilityFlagsConfig(): { includeNotImportantViews: boolean; reportViewIds: boolean; retrieveInteractiveWindows: boolean } {
+  setOcclusionEnabled(enabled: boolean): void {
+    this._occlusionEnabled = enabled;
+  }
+
+  getAccessibilityFlagsConfig(): { includeNotImportantViews: boolean; reportViewIds: boolean; retrieveInteractiveWindows: boolean; occlusionEnabled: boolean } {
     return {
       includeNotImportantViews: this._a11yIncludeNotImportantViews,
       reportViewIds: this._a11yReportViewIds,
       retrieveInteractiveWindows: this._a11yRetrieveInteractiveWindows,
+      occlusionEnabled: this._occlusionEnabled,
     };
   }
 

--- a/test/daemon/daemonOcclusionFlag.test.ts
+++ b/test/daemon/daemonOcclusionFlag.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
+import { parseDaemonArgs } from "../../src/daemon/manager";
 import { serverConfig } from "../../src/utils/ServerConfig";
 
 describe("Daemon --no-occlusion option", () => {
@@ -25,5 +26,24 @@ describe("Daemon --no-occlusion option", () => {
     new Daemon({ noOcclusion: true });
 
     expect(serverConfig.getAccessibilityFlagsConfig().occlusionEnabled).toBe(false);
+  });
+});
+
+/**
+ * The MCP-process -> daemon-process hand-off (issue occlusion-flag): when the daemon is
+ * auto-spawned or explicitly managed via `--daemon start`, the parent relays flags to the
+ * child daemon subprocess as CLI args (DaemonManager.withDaemonOptions), and the child parses
+ * them back into DaemonOptions via parseDaemonArgs. --no-occlusion was previously missing from
+ * both halves of this relay, so a parent process that parsed --no-occlusion never actually
+ * forwarded it to the daemon subprocess that holds the ServerConfig singleton consulted during
+ * extraction, silently leaving occlusion on regardless of the flag.
+ */
+describe("parseDaemonArgs --no-occlusion (daemon-side of the MCP-process -> daemon-process relay)", () => {
+  test("defaults to undefined when no flag is passed", () => {
+    expect(parseDaemonArgs([]).noOcclusion).toBeUndefined();
+  });
+
+  test("--no-occlusion sets noOcclusion", () => {
+    expect(parseDaemonArgs(["--no-occlusion"]).noOcclusion).toBe(true);
   });
 });

--- a/test/daemon/daemonOcclusionFlag.test.ts
+++ b/test/daemon/daemonOcclusionFlag.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { serverConfig } from "../../src/utils/ServerConfig";
+
+describe("Daemon --no-occlusion option", () => {
+  afterEach(() => {
+    serverConfig.setOcclusionEnabled(true);
+    // Constructing a Daemon initializes the global DaemonState singleton.
+    // Reset it so this test does not leak initialized state into other test
+    // files (bun shares module/singleton state across files in a run, and file
+    // execution order is platform-dependent).
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("occlusion stays enabled when noOcclusion is not set", () => {
+    new Daemon({});
+
+    expect(serverConfig.getAccessibilityFlagsConfig().occlusionEnabled).toBe(true);
+  });
+
+  test("applies noOcclusion option to disable the occlusion pass", () => {
+    new Daemon({ noOcclusion: true });
+
+    expect(serverConfig.getAccessibilityFlagsConfig().occlusionEnabled).toBe(false);
+  });
+});

--- a/test/features/observe/android/AndroidCtrlProxyClientAccessibilityFlagsSync.test.ts
+++ b/test/features/observe/android/AndroidCtrlProxyClientAccessibilityFlagsSync.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { serverConfig } from "../../../../src/utils/ServerConfig";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
+import { BootedDevice } from "../../../../src/models";
+import { FakeWebSocket, WebSocketState } from "../../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+/**
+ * Regression coverage (issue occlusion-flag): the daemon computed occlusionEnabled=false
+ * correctly, but the on-device push only ever fired from onConnectionEstablished() — which
+ * connectWebSocket() skips entirely when a connection is already open and reused. This left
+ * a window where a client that connected before the flag flipped (or reused a connection
+ * across multiple observe calls) never received the updated accessibility flags. ensureConnected()
+ * now re-syncs unconditionally on every call, not just on a fresh connect.
+ */
+describe("AndroidCtrlProxyClient - accessibility flags re-sync on ensureConnected", function() {
+  let fakeAdb: FakeAdbExecutor;
+  let testDevice: BootedDevice;
+  let fakeTimer: FakeTimer;
+  const serverPort: number = 8765;
+
+  beforeEach(function() {
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+
+    fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setCommandResponse("forward", { stdout: `${serverPort}`, stderr: "" });
+    fakeAdb.setScreenState(true);
+
+    testDevice = {
+      deviceId: "test-device-a11y-flags-sync",
+      platform: "android",
+      isEmulator: true,
+      name: "Test Device"
+    };
+
+    AndroidCtrlProxyManager.resetInstances();
+    AndroidCtrlProxyClient.resetInstances();
+    AndroidCtrlProxyManager.getInstance(testDevice, new FakeAdbClientFactory()).clearAvailabilityCache();
+  });
+
+  afterEach(function() {
+    // ServerConfig is a process-wide singleton; restore the default so this test
+    // does not leak occlusionEnabled=false into other test files.
+    serverConfig.setOcclusionEnabled(true);
+  });
+
+  class CapturingWebSocket extends FakeWebSocket {
+    sentMessages: string[] = [];
+    send(data: any): void {
+      this.sentMessages.push(data.toString());
+      super.send(data);
+    }
+  }
+
+  const createCapturingFactory = (timer?: FakeTimer): {
+    factory: (url: string) => CapturingWebSocket;
+    getSocket: () => CapturingWebSocket | null;
+  } => {
+    let socket: CapturingWebSocket | null = null;
+    return {
+      factory: (url: string) => {
+        socket = new CapturingWebSocket(url, "none", 0, timer);
+        return socket;
+      },
+      getSocket: () => socket
+    };
+  };
+
+  const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
+    if (!socket || socket.readyState === WebSocketState.OPEN) {return;}
+    await new Promise<void>(resolve => socket.once("open", () => resolve()));
+  };
+
+  const waitForSocket = async (getSocket: () => CapturingWebSocket | null): Promise<CapturingWebSocket | null> => {
+    for (let i = 0; i < 5; i++) {
+      const s = getSocket();
+      if (s) {return s;}
+      await new Promise(r => setImmediate(r));
+    }
+    return getSocket();
+  };
+
+  const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount: number): Promise<void> => {
+    if (!socket) {return;}
+    for (let i = 0; i < 10; i++) {
+      if (socket.sentMessages.length >= minCount) {return;}
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  const findSentMessages = (socket: CapturingWebSocket, type: string): any[] =>
+    socket.sentMessages
+      .map(raw => { try { return JSON.parse(raw); } catch { return null; } })
+      .filter(parsed => parsed?.type === type);
+
+  test("pushes set_accessibility_flags with occlusionEnabled=false on the first connect", async function() {
+    serverConfig.setOcclusionEnabled(false);
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+      await waitForSentMessages(socket, 1);
+
+      const flagMessages = findSentMessages(socket!, "set_accessibility_flags");
+      expect(flagMessages.length).toBeGreaterThanOrEqual(1);
+      expect(flagMessages[0].occlusionEnabled).toBe(false);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("re-syncs set_accessibility_flags on ensureConnected even when reusing an already-open connection", async function() {
+    serverConfig.setOcclusionEnabled(false);
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+      await waitForSentMessages(socket, 1);
+
+      const afterFirstConnect = findSentMessages(socket!, "set_accessibility_flags").length;
+      expect(afterFirstConnect).toBeGreaterThanOrEqual(1);
+
+      // Second ensureConnected() call reuses the already-open socket (connectWebSocket's
+      // "already connected, reusing" early-return skips onConnectionEstablished entirely),
+      // so this only re-sends if ensureConnected's own re-sync fires independently of that.
+      await client.ensureConnected();
+      await waitForSentMessages(socket, afterFirstConnect + 1);
+
+      const afterSecondCall = findSentMessages(socket!, "set_accessibility_flags").length;
+      expect(afterSecondCall).toBeGreaterThan(afterFirstConnect);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("does not push set_accessibility_flags when every flag is already at its default", async function() {
+    // occlusionEnabled defaults to true and is left untouched here — matches
+    // reportViewIds/includeNotImportantViews/retrieveInteractiveWindows all being
+    // default-enabled, so the allEnabled early-return should skip the push entirely.
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    try {
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket);
+      await waitForSocketOpen(socket);
+      await new Promise(r => setImmediate(r));
+
+      expect(findSentMessages(socket!, "set_accessibility_flags").length).toBe(0);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/test/features/observe/android/ctrlProxyProtocol.test.ts
+++ b/test/features/observe/android/ctrlProxyProtocol.test.ts
@@ -283,8 +283,8 @@ describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
 
   test("set_accessibility_flags — no requestId on the wire", () => {
     expect(serializeCtrlProxyRequest(ctrlProxyRequests.setAccessibilityFlags({
-      includeNotImportantViews: true, reportViewIds: false, retrieveInteractiveWindows: true,
-    }))).toBe('{"type":"set_accessibility_flags","includeNotImportantViews":true,"reportViewIds":false,"retrieveInteractiveWindows":true}');
+      includeNotImportantViews: true, reportViewIds: false, retrieveInteractiveWindows: true, occlusionEnabled: false,
+    }))).toBe('{"type":"set_accessibility_flags","includeNotImportantViews":true,"reportViewIds":false,"retrieveInteractiveWindows":true,"occlusionEnabled":false}');
   });
 
   test("set_network_mock_rules — no requestId, rules array passed through", () => {

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -291,3 +291,43 @@ describe("observe tool registration advertises the schema (#3025)", () => {
     }
   });
 });
+
+describe("occlusionState/occludedBy/occludedByViewId: --no-occlusion (issue occlusion-flag)", () => {
+  // These node properties are always optional in the schema (see viewHierarchyNodeSchema tests
+  // above) — the APK only computes and sends them at all when occlusionEnabled is true, so the
+  // meaningful "present by default, absent when disabled" behavior lives in ServerConfig, which is
+  // what actually gets pushed to the device over the set_accessibility_flags message.
+  test("occlusion is enabled by default", () => {
+    const original = serverConfig.getAccessibilityFlagsConfig().occlusionEnabled;
+    try {
+      serverConfig.setOcclusionEnabled(true);
+      expect(serverConfig.getAccessibilityFlagsConfig().occlusionEnabled).toBe(true);
+    } finally {
+      serverConfig.setOcclusionEnabled(original);
+    }
+  });
+
+  test("--no-occlusion disables occlusion via ServerConfig", () => {
+    const original = serverConfig.getAccessibilityFlagsConfig().occlusionEnabled;
+    try {
+      serverConfig.setOcclusionEnabled(false);
+      expect(serverConfig.getAccessibilityFlagsConfig().occlusionEnabled).toBe(false);
+    } finally {
+      serverConfig.setOcclusionEnabled(original);
+    }
+  });
+
+  test("occlusion node properties remain optional in the schema regardless of the flag", () => {
+    // Schema shape doesn't change with the flag — a client observing an older daemon or a
+    // hierarchy captured before occlusion was disabled must still be able to parse these fields.
+    expect(() => viewHierarchyNodeSchema.parse({ bounds: { left: 0, top: 0, right: 1, bottom: 1 } })).not.toThrow();
+    expect(() =>
+      viewHierarchyNodeSchema.parse({
+        bounds: { left: 0, top: 0, right: 1, bottom: 1 },
+        occlusionState: "partial",
+        occludedBy: "unlabeled view",
+        occludedByViewId: "id/occluder",
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #3844.

Threads an `occlusionEnabled` flag end-to-end: CLI `--no-occlusion`, MCP server config, the spawned daemon subprocess, and the Kotlin-side `ViewHierarchyExtractor`/CtrlProxy request. Defaults to the current always-on behavior; opt-out only, for callers (e.g. CI/QA-agent runs) where every bit of per-call latency and log volume matters and fully-occluded views showing up in the hierarchy is an acceptable tradeoff.