### PR TITLE
Fix Compose testTag elementId matching (bare-id fallback)

### DIFF
--- a/src/features/utility/ElementFinder.ts
+++ b/src/features/utility/ElementFinder.ts
@@ -216,6 +216,14 @@ export class DefaultElementFinder implements ElementFinder {
     sortByArea: boolean = true
   ): Element[] {
     const matches: Element[] = [];
+    // Compose semantics (Modifier.testTag) surface via AccessibilityNodeInfo.viewIdResourceName
+    // WITHOUT a package qualifier, unlike traditional View resource IDs which are always
+    // reported as "pkg:id/name". A caller passing the fully-qualified form (the common case,
+    // since that's what every other resource ID in the hierarchy looks like) would otherwise
+    // never match a Compose-sourced node. This is not a fuzzy/partial match - the bare name is
+    // the node's real, exact reported ID - so it applies regardless of the partialMatch flag.
+    const idSeparatorIndex = resourceId.lastIndexOf("/");
+    const bareResourceId = idSeparatorIndex >= 0 ? resourceId.slice(idSeparatorIndex + 1) : null;
 
     for (const searchNode of rootNodes) {
       this.parser.traverseNode(searchNode, (node: any) => {
@@ -224,6 +232,7 @@ export class DefaultElementFinder implements ElementFinder {
           const nodeResourceId = nodeProperties["resource-id"];
           if (
             nodeResourceId === resourceId ||
+            (bareResourceId !== null && nodeResourceId === bareResourceId) ||
             (partialMatch && nodeResourceId.toLowerCase().includes(resourceId.toLowerCase()))
           ) {
             const parsedNode = this.parser.parseNodeBounds(node);
@@ -988,11 +997,18 @@ export class DefaultElementFinder implements ElementFinder {
       return [];
     }
 
+    // See collectResourceIdMatchesInRoots: Compose testTag nodes report a bare
+    // viewIdResourceName with no package qualifier, so a fully-qualified query must also
+    // match against the bare suffix - not just partialMatch/exact on the full string.
+    const idSeparatorIndex = resourceId.lastIndexOf("/");
+    const bareResourceId = idSeparatorIndex >= 0 ? resourceId.slice(idSeparatorIndex + 1) : null;
+
     const matchesId = (input?: string): boolean => {
       if (!input) {return false;}
-      return partialMatch
-        ? input.toLowerCase().includes(resourceId.toLowerCase())
-        : input === resourceId;
+      if (partialMatch) {
+        return input.toLowerCase().includes(resourceId.toLowerCase());
+      }
+      return input === resourceId || (bareResourceId !== null && input === bareResourceId);
     };
 
     const containerNode = container

--- a/test/features/utility/ElementFinder.test.ts
+++ b/test/features/utility/ElementFinder.test.ts
@@ -127,6 +127,24 @@ describe("DefaultElementFinder", () => {
       const results = finder.findElementsByResourceId(hierarchy, "btn_login", null, false);
       expect(results).toHaveLength(0);
     });
+
+    test("matches a bare (Compose testTag) node resource-id against a fully-qualified query", () => {
+      // Compose's Modifier.testTag surfaces via viewIdResourceName WITHOUT a package
+      // qualifier, unlike traditional View resource IDs. Callers always pass the
+      // fully-qualified form (it's what every other element in the hierarchy looks like),
+      // so this must match even with partialMatch disabled — it's the node's real ID, not
+      // a fuzzy substring hit.
+      const hierarchy = makeHierarchy({
+        $: { "resource-id": "personDetailsSpeedDial_Main", "bounds": { left: 0, top: 0, right: 100, bottom: 50 } },
+      });
+      const results = finder.findElementsByResourceId(
+        hierarchy,
+        "com.followupboss.fubandroidstaging:id/personDetailsSpeedDial_Main",
+        null,
+        false
+      );
+      expect(results).toHaveLength(1);
+    });
   });
 
   describe("findElementByResourceId", () => {
@@ -373,6 +391,21 @@ describe("DefaultElementFinder", () => {
       ]);
       const results = finder.findClickableSiblingsOfResourceId(hierarchy, "com.app:id/label");
       expect(results).toEqual([]);
+    });
+
+    test("matches a bare (Compose testTag) sibling anchor against a fully-qualified query", () => {
+      const hierarchy = makeHierarchy([
+        {
+          $: { bounds: bounds(0, 0, 1080, 200) },
+          node: [
+            { $: { "resource-id": "label", "bounds": { left: 0, top: 0, right: 500, bottom: 100 } } },
+            { $: { clickable: "true", bounds: bounds(500, 0, 1080, 100) } },
+          ],
+        },
+      ]);
+      const results = finder.findClickableSiblingsOfResourceId(hierarchy, "com.app:id/label");
+      expect(results.length).toBe(1);
+      expect(results[0].bounds).toEqual({ left: 500, top: 0, right: 1080, bottom: 100 });
     });
   });
 });


### PR DESCRIPTION
Fixes #3852.

Rescoped: #3845 and #3846 (the original two fixes this PR carried) were independently fixed and merged to `main` as #3855 and #3854 respectively - verified functionally equivalent-or-superset (main's versions are a strict superset: `mergeDaemonOptions` additionally force-preserves reuse-critical flags against an explicit client `false`, and the log-level seed happens at `logger.ts` module-load rather than only in `main()`, covering every entry point). Rebased this branch onto current `main` and dropped both now-redundant fixes, keeping only the genuinely independent one below.

**#3852 — Compose testTag elementId matching**: Jetpack Compose's `Modifier.testTag(...)` + `testTagsAsResourceId = true` surfaces via `AccessibilityNodeInfo.viewIdResourceName` *without* a package qualifier - just the bare tag - unlike traditional View resource IDs, which are always `pkg:id/name`. Resource-id matching did a strict `===` check by default, so a caller passing the fully-qualified form (the natural choice, since every other element's resource-id in the same hierarchy looks like that) never matched a Compose-sourced node, even though the element was on screen, clickable, with valid bounds.

Root-caused via a real qa-agent run where a FAB (`personDetailsSpeedDial_Main`) failed every `tapOn` with "Element not found" for exactly this reason.

Fix: when the query is fully-qualified, also try an exact match against the bare suffix (not a fuzzy/partial match - the bare name is the node's real, exact reported ID for Compose-sourced elements). Fixed in both `collectResourceIdMatchesInRoots` (plain `elementId` tapOn) and `findClickableSiblingsOfResourceId` (`sibling: true` + `elementId` tapOn). Tests added for both paths.

Full test suite green (7881/7881), typecheck clean.