### PR TITLE
ci: extract iOS simulator bring-up prelude into a composite action (#3782)

### DIFF
--- a/.github/actions/ios-simulator-bring-up/action.yml
+++ b/.github/actions/ios-simulator-bring-up/action.yml
@@ -1,0 +1,39 @@
+name: "iOS Simulator Bring-up"
+description: >
+  Select an Xcode toolchain, ensure the iOS simulator runtime, boot a simulator,
+  and bring the AutoMobile daemon to ready. This is the contiguous, timeout-free
+  prelude shared by the iOS integration segments in pull_request.yml and
+  nightly.yml.
+
+  Scope note: the downstream warm/test steps (ensure-ctrl-proxy-ready,
+  warm-reminders-target-app, run-*-plan-tests) deliberately stay inline in the
+  callers because they carry per-step `timeout-minutes` budgets (#2730/#3028/#3110)
+  and GitHub composite-action steps do not support `timeout-minutes`. Folding them
+  in here would silently drop those load-bearing hang-diagnostic ceilings. The
+  parallelized CtrlProxy-UI segment (backgrounded boot + build overlap, #3779) and
+  the video-interleaved segment (a test runs between boot and daemon-ready) are
+  also left as-is — their bring-up is not contiguous.
+
+inputs:
+  xcode-version:
+    description: "Xcode version to select via maxim-lobanov/setup-xcode (e.g. 26.2, 26.5)."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Select Xcode ${{ inputs.xcode-version }}"
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: "${{ inputs.xcode-version }}"
+
+    - name: "Ensure iOS Simulator runtime"
+      uses: ./.github/actions/ensure-ios-simulator-runtime
+
+    - name: "Boot iOS Simulator (Xcode ${{ inputs.xcode-version }})"
+      shell: bash
+      run: ./scripts/ios/boot-simulator.sh
+
+    - name: "Ensure AutoMobile daemon ready"
+      shell: bash
+      run: ./scripts/ci/ensure-daemon-ready.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -448,19 +448,10 @@ jobs:
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
           echo "xctestrun file: ${XCTESTRUN}"
 
-      - name: "Select Xcode 26.2"
-        uses: maxim-lobanov/setup-xcode@v1
+      - name: "iOS simulator bring-up (Xcode 26.2)"
+        uses: ./.github/actions/ios-simulator-bring-up
         with:
           xcode-version: "26.2"
-
-      - name: "Ensure iOS Simulator runtime (Xcode 26.2)"
-        uses: ./.github/actions/ensure-ios-simulator-runtime
-
-      - name: "Boot iOS Simulator (Xcode 26.2)"
-        run: ./scripts/ios/boot-simulator.sh
-
-      - name: "Ensure AutoMobile daemon ready"
-        run: ./scripts/ci/ensure-daemon-ready.sh
 
       - name: "Warm up iOS CtrlProxy"
         timeout-minutes: 12
@@ -481,23 +472,11 @@ jobs:
         if: always()
         run: xcrun simctl shutdown all || true
 
-      - name: "Select Xcode 26.5"
+      - name: "iOS simulator bring-up (Xcode 26.5)"
         if: ${{ !cancelled() }}
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: ./.github/actions/ios-simulator-bring-up
         with:
           xcode-version: "26.5"
-
-      - name: "Ensure iOS Simulator runtime (Xcode 26.5)"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/ensure-ios-simulator-runtime
-
-      - name: "Boot iOS Simulator (Xcode 26.5)"
-        if: ${{ !cancelled() }}
-        run: ./scripts/ios/boot-simulator.sh
-
-      - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
-        if: ${{ !cancelled() }}
-        run: ./scripts/ci/ensure-daemon-ready.sh
 
       - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
         if: ${{ !cancelled() }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -284,6 +284,12 @@ jobs:
               # The XCTestRunner job runs these readiness scripts directly, so
               # changes to them must exercise the job (they were skipped before).
               - 'scripts/ci/**'
+              # The XCTestRunner job composes its simulator bring-up (select Xcode,
+              # ensure runtime, boot, daemon-ready) from this composite action, so a
+              # change to it must exercise the job — otherwise a bring-up refactor
+              # would land unvalidated and only surface on nightly / the next
+              # native_integration PR.
+              - '.github/actions/ios-simulator-bring-up/**'
               # This job runs a bun-side integration test (iosVideoRecordingStartStop),
               # so the bun test config and any test-setup preload affect it. bunfig.toml
               # wires a [test].preload that runs before EVERY bun test the job invokes,
@@ -1381,22 +1387,14 @@ jobs:
         if: always()
         run: xcrun simctl shutdown all || true
 
-      - name: "Select Xcode 26.2"
-        uses: maxim-lobanov/setup-xcode@v1
+      # Select Xcode → ensure runtime → boot sim → pre-start the daemon and wait
+      # for readiness so a startup failure surfaces loudly here instead of
+      # silently skipping the test (#2730). `auto-mobile` (installed to ~/.bun/bin
+      # by `bun add -g .`) is thereby on PATH for the swift-test step.
+      - name: "iOS simulator bring-up (Xcode 26.2)"
+        uses: ./.github/actions/ios-simulator-bring-up
         with:
           xcode-version: "26.2"
-
-      - name: "Ensure iOS Simulator runtime (Xcode 26.2)"
-        uses: ./.github/actions/ensure-ios-simulator-runtime
-
-      - name: "Boot iOS Simulator (Xcode 26.2)"
-        run: ./scripts/ios/boot-simulator.sh
-
-      # Put `auto-mobile` (installed to ~/.bun/bin by `bun add -g .`) on PATH for
-      # the swift-test step, and pre-start + wait for the daemon so a startup
-      # failure surfaces loudly here instead of silently skipping the test (#2730).
-      - name: "Ensure AutoMobile daemon ready"
-        run: ./scripts/ci/ensure-daemon-ready.sh
 
       # Launch CtrlProxy on the booted sim now (a slow, one-time xcodebuild launch)
       # so the test's first `observe` doesn't pay that cost inside its short


### PR DESCRIPTION
Closes #3782. Conservative DRY of the copy-pasted iOS simulator bring-up ritual.

## What

Adds `.github/actions/ios-simulator-bring-up` covering the **contiguous, timeout-free** prelude shared by the iOS integration segments:

```
select Xcode → ensure simulator runtime → boot simulator → ensure daemon ready
```

Applied to the three clean contiguous sites (each collapses 4 steps → one `uses:`):
- `pull_request.yml` `ios-xctest-runner-simulator-tests` — Reminders **26.2** segment
- `nightly.yml` iOS integration — **26.2** segment
- `nightly.yml` iOS integration — **26.5** segment (keeps its `if: ${{ !cancelled() }}` guard on the single `uses:`)

Net across the workflows: `boot-simulator.sh` **5→2** refs, `ensure-daemon-ready.sh` **4→1**.

## Conservative scope — what's intentionally left inline

Per the issue's conservative framing, two segments are **not** migrated because their bring-up is genuinely not contiguous:
- **CtrlProxy-UI segment** — backgrounded boot + build overlap (`#3779` spike), a bespoke shape.
- **Video-interleaved 26.5 segment** (`pull_request.yml`) — a `videoRecording` test runs *between* boot and daemon-ready.

The downstream **warm/test** steps (`ensure-ctrl-proxy-ready`, `warm-reminders-target-app`, `run-*-plan-tests`) also stay inline: they carry per-step `timeout-minutes` budgets (#2730/#3028/#3110) and **GitHub composite-action steps do not support `timeout-minutes`** — folding them in would silently drop those load-bearing hang-diagnostic ceilings. This is the key reason the composite stops at daemon-ready.

## Pre-merge validation

Wired `.github/actions/ios-simulator-bring-up/**` into the `native_integration` paths-filter (mirroring the existing `scripts/ci/**` rationale) so a change to the composite **exercises the XCTestRunner job pre-merge** — including this PR — instead of landing unvalidated and only surfacing on nightly. So the iOS integration job on this PR *is* the behavior-preserving check.

## Local validation
- `yaml.safe_load` clean on the composite + both workflows.
- `actionlint` raises no new errors on the composite or the edited sites (pre-existing `background:`/`wait:` custom-keyword and metadata-bool warnings are unrelated).