### PR TITLE
fix(logger): apply AUTOMOBILE_LOG_LEVEL at process start (#3845)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -109,8 +109,14 @@ export function resolveProcessLogPrefix(argv: readonly string[], pid: number): s
   return argv.includes("--daemon-mode") ? "daemon" : `stdio-${pid}`;
 }
 
-// Default to INFO level in production, can be overridden
-let currentLogLevel: LogLevel = LogLevel.INFO;
+// Seed the level from AUTOMOBILE_LOG_LEVEL at process start (issue #3845) so a
+// user who exports the env var actually changes what the running process emits,
+// rather than silently staying at INFO. Applied here at module load — the single
+// point every process (daemon, stdio client, direct mode) passes through, and a
+// DaemonManager-spawned daemon inherits the var via its `{ ...process.env }`
+// child env. Falls back to INFO when unset/unrecognized; still overridable at
+// runtime via setLogLevel.
+let currentLogLevel: LogLevel = parseAutomobileLogLevel(process.env.AUTOMOBILE_LOG_LEVEL) ?? LogLevel.INFO;
 
 // Flag to control whether to also log to STDOUT (in addition to files)
 let logToStdout = false;

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -1,5 +1,30 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, spyOn } from "bun:test";
 import { LogLevel, parseAutomobileLogLevel, resolveProcessLogPrefix } from "../../src/utils/logger";
+
+// Re-import the logger module with AUTOMOBILE_LOG_LEVEL set so the module-load
+// seed (`currentLogLevel = parseAutomobileLogLevel(...) ?? INFO`) re-evaluates
+// against the env. A unique query per call defeats the module cache; the env is
+// restored once the import (and thus the seed read) has completed.
+let freshImportCounter = 0;
+async function loggerWithEnvLevel(
+  value: string | undefined
+): Promise<typeof import("../../src/utils/logger")> {
+  const previous = process.env.AUTOMOBILE_LOG_LEVEL;
+  if (value === undefined) {
+    delete process.env.AUTOMOBILE_LOG_LEVEL;
+  } else {
+    process.env.AUTOMOBILE_LOG_LEVEL = value;
+  }
+  try {
+    return await import(`../../src/utils/logger.ts?loglevel-seed-${freshImportCounter++}`);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.AUTOMOBILE_LOG_LEVEL;
+    } else {
+      process.env.AUTOMOBILE_LOG_LEVEL = previous;
+    }
+  }
+}
 
 describe("parseAutomobileLogLevel", () => {
   test("returns null for unset or blank", () => {
@@ -21,6 +46,66 @@ describe("parseAutomobileLogLevel", () => {
   test("returns null for garbage", () => {
     expect(parseAutomobileLogLevel("verbose")).toBeNull();
     expect(parseAutomobileLogLevel("infoo")).toBeNull();
+  });
+});
+
+describe("AUTOMOBILE_LOG_LEVEL is applied at process start (issue #3845)", () => {
+  test.each([
+    ["debug", LogLevel.DEBUG],
+    ["error", LogLevel.ERROR],
+    ["none", LogLevel.NONE],
+  ])("seeds the running level from AUTOMOBILE_LOG_LEVEL=%s", async (value, expected) => {
+    const mod = await loggerWithEnvLevel(value);
+    expect(mod.logger.getLogLevel()).toBe(expected);
+  });
+
+  test("falls back to INFO when AUTOMOBILE_LOG_LEVEL is unset", async () => {
+    const mod = await loggerWithEnvLevel(undefined);
+    expect(mod.logger.getLogLevel()).toBe(LogLevel.INFO);
+  });
+
+  test("falls back to INFO when AUTOMOBILE_LOG_LEVEL is unrecognized", async () => {
+    const mod = await loggerWithEnvLevel("verbose");
+    expect(mod.logger.getLogLevel()).toBe(LogLevel.INFO);
+  });
+
+  // The synchronous stdout sink is the deterministic seam for observing what the
+  // logger actually emits (the file stream buffers, so flush() can't guarantee
+  // on-disk bytes). If the env-seeded level gates emission correctly here, it
+  // gates the file write the same way.
+  async function captureEmit(value: string, emit: (l: typeof import("../../src/utils/logger").logger) => void): Promise<string> {
+    const mod = await loggerWithEnvLevel(value);
+    const writes: string[] = [];
+    const spy = spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      mod.logger.enableStdoutLogging();
+      emit(mod.logger);
+      await mod.logger.flush();
+    } finally {
+      mod.logger.disableStdoutLogging();
+      spy.mockRestore();
+    }
+    return writes.join("");
+  }
+
+  // Each captureEmit call has its own isolated capture buffer, so a static
+  // marker per test is sufficient to assert presence/absence.
+  test("actually emits a DEBUG line when seeded to debug", async () => {
+    const emitted = await captureEmit("debug", l => l.debug("loglevel-3845-debug"));
+    expect(emitted).toContain("loglevel-3845-debug");
+  });
+
+  test("suppresses a DEBUG line when seeded to error", async () => {
+    const emitted = await captureEmit("error", l => l.debug("loglevel-3845-suppressed"));
+    expect(emitted).not.toContain("loglevel-3845-suppressed");
+  });
+
+  test("still emits an ERROR line when seeded to error", async () => {
+    const emitted = await captureEmit("error", l => l.error("loglevel-3845-error"));
+    expect(emitted).toContain("loglevel-3845-error");
   });
 });
 


### PR DESCRIPTION
Closes #3845.

## Problem

`parseAutomobileLogLevel()` (`src/utils/logger.ts`) parsed `AUTOMOBILE_LOG_LEVEL` (debug/info/warn/error/none) and was unit-tested, but **nothing ever called it against `process.env` at startup**. Setting the env var did nothing — the daemon silently stayed at the default INFO level, so `AUTOMOBILE_LOG_LEVEL=debug` never produced a single DEBUG line. Discovered while trying to get debug-level daemon logs out of a CI job.

## Fix

Seed the module-level `currentLogLevel` from `parseAutomobileLogLevel(process.env.AUTOMOBILE_LOG_LEVEL) ?? LogLevel.INFO` **at module load** — the single choke-point every process (daemon, stdio client, direct mode) passes through, consistent with the logger already reading `process.argv`/`process.pid` there. A `DaemonManager`-spawned daemon inherits the var via its `{ ...process.env }` child env (`src/daemon/manager.ts`), so it re-seeds through the same path. Falls back to INFO when unset/unrecognized; still overridable at runtime via `setLogLevel`.

One line of production change; there is no `logger.init()` / config-bootstrap seam this belongs in, and nothing mutates `AUTOMOBILE_LOG_LEVEL` in-process after load, so module-load seeding is complete.

## Tests (`test/utils/logger-loglevel-env.test.ts`)

- Fresh-imports the logger with the env var set and asserts `getLogLevel()` reflects it (debug/error/none), and falls back to INFO when unset or unrecognized.
- Asserts a DEBUG line is **actually emitted** when seeded to debug, **suppressed** when seeded to error, and an ERROR line still emits — via the synchronous stdout sink (deterministic; the file stream buffers).

**Verified end-to-end:** a real process launched with `AUTOMOBILE_LOG_LEVEL=debug` resolves DEBUG and writes DEBUG lines to its real `~/.auto-mobile/logs/stdio-*.log`; default stays INFO.

Typecheck gate clean (no new baseline errors); lint + build green.