### PR TITLE
fix(webrtc): initialize reflect metadata for stream socket

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1050,6 +1050,7 @@ jobs:
 
       - name: "Run Lint"
         env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
           TURBO_TELEMETRY_DISABLED: "1"
           TURBO_NO_UPDATE_NOTIFIER: "1"
           DO_NOT_TRACK: "1"

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "kysely": "^0.29.0",
         "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
+        "reflect-metadata": "^0.2.2",
         "sharp": "0.34.5",
         "werift": "^0.23.0",
         "ws": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "kysely": "^0.29.0",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
+    "reflect-metadata": "^0.2.2",
     "sharp": "0.34.5",
     "werift": "^0.23.0",
     "ws": "^8.19.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import "reflect-metadata";
 import { bootstrapEnvironment } from "./utils/envBootstrap";
 import {
   DAEMON_LAUNCH_CWD_ENV,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import "reflect-metadata";
+import "./runtime/reflectMetadata";
 import { bootstrapEnvironment } from "./utils/envBootstrap";
 import {
   DAEMON_LAUNCH_CWD_ENV,

--- a/src/runtime/reflectMetadata.ts
+++ b/src/runtime/reflectMetadata.ts
@@ -1,0 +1,1 @@
+import "reflect-metadata";

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -4,12 +4,27 @@ import {
   WebRtcStreamSocketServer,
   type WebRtcStreamSocketServerDependencies,
 } from "../../src/daemon/webrtcStreamSocketServer";
+import {
+  getWebRtcStreamDescriptor,
+  listWebRtcStreams,
+  resetWebRtcStreamManager,
+  setWebRtcStreamManagerDependencies,
+  startWebRtcStream,
+  stopWebRtcStream,
+} from "../../src/server/webrtcStreamManager";
 import type {
   WebRtcStreamSocketRequest,
   WebRtcStreamSocketResponse,
 } from "../../src/daemon/webrtcStreamSocketTypes";
 import type { BootedDevice } from "../../src/models";
-import type { WebRtcStreamDescriptor, WebRtcStreamingOverrides } from "../../src/features/webrtc";
+import { WebRtcPublisher, WhipClient } from "../../src/features/webrtc";
+import type {
+  AndroidH264Source,
+  WebRtcStreamDescriptor,
+  WebRtcStreamingOverrides,
+} from "../../src/features/webrtc";
+import type { WhipClientOptions } from "../../src/features/webrtc/WhipClient";
+import type { RTCPeerConnection } from "werift";
 import { FakeSocket } from "../fakes/FakeNetServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -37,6 +52,37 @@ class TestableServer extends WebRtcStreamSocketServer {
     if (pending) {
       await pending;
     }
+  }
+}
+
+class FakePeerConnection {
+  closed = false;
+  connectionState = "connected";
+  iceGatheringState = "complete";
+  connectionStateChange = { subscribe: () => {} };
+  iceGatheringStateChange = { watch: async () => {} };
+  localDescription = { sdp: "v=0" };
+  addTransceiver() {
+    return { sender: { ssrc: 1 } };
+  }
+  async createOffer() {
+    return { type: "offer", sdp: "v=0" };
+  }
+  async setLocalDescription() {}
+  async setRemoteDescription() {}
+  async close() {
+    this.closed = true;
+  }
+}
+
+class FakeSource {
+  started = false;
+  stopped = false;
+  async start(): Promise<void> {
+    this.started = true;
+  }
+  async stop(): Promise<void> {
+    this.stopped = true;
   }
 }
 
@@ -73,6 +119,7 @@ function makeDeps(overrides: Partial<WebRtcStreamSocketServerDependencies> = {})
 afterEach(() => {
   started = [];
   stopped = [];
+  resetWebRtcStreamManager();
 });
 
 function lastResponse(socket: FakeSocket): WebRtcStreamSocketResponse {
@@ -151,6 +198,76 @@ describe("WebRtcStreamSocketServer", () => {
     expect(status.stream?.streamId).toBe("debug-1");
     expect(stoppedResponse.stream?.state).toBe("stopped");
     expect(stopped).toEqual(["debug-1"]);
+    expect(afterStop.streams).toEqual([]);
+  });
+
+  test("start reaches the real manager, posts WHIP, and remains visible until stop", async () => {
+    const posts: Array<{ url: string; method: string }> = [];
+    const sources: FakeSource[] = [];
+    setWebRtcStreamManagerDependencies({
+      createPublisher: (config, deps) =>
+        new WebRtcPublisher(config, {
+          ...deps,
+          createPeerConnection: () => new FakePeerConnection() as unknown as RTCPeerConnection,
+          createWhipClient: (options: WhipClientOptions) =>
+            new WhipClient({
+              ...options,
+              fetchImpl: async (url, init) => {
+                posts.push({ url, method: init.method });
+                return {
+                  status: 201,
+                  ok: true,
+                  headers: { get: name => (name.toLowerCase() === "location" ? "/whip/resource/debug-1" : null) },
+                  text: async () => "v=0",
+                };
+              },
+            }),
+          timer: new FakeTimer(),
+        }),
+      createSource: () => {
+        const source = new FakeSource();
+        sources.push(source);
+        return source as unknown as AndroidH264Source;
+      },
+      now: () => new Date("2026-07-14T00:00:00.000Z"),
+    });
+    const server = new TestableServer({
+      resolveDevice: async () => ANDROID,
+      startStream: startWebRtcStream,
+      stopStream: stopWebRtcStream,
+      listStreams: listWebRtcStreams,
+      getStream: getWebRtcStreamDescriptor,
+    });
+    const socket = new FakeSocket();
+
+    await server.simulate(socket, {
+      id: "start-real",
+      action: "start",
+      streamId: "debug-1",
+      whipEndpoint: "http://localhost:8000/api/v1/webrtc/whip?streamId=debug-1",
+    });
+    const start = lastResponse(socket);
+    await server.simulate(socket, { id: "list-real", action: "list" });
+    const list = lastResponse(socket);
+    await server.simulate(socket, { id: "status-real", action: "status", streamId: "debug-1" });
+    const status = lastResponse(socket);
+    await server.simulate(socket, { id: "stop-real", action: "stop", streamId: "debug-1" });
+    const stop = lastResponse(socket);
+    await server.simulate(socket, { id: "after-stop-real", action: "list" });
+    const afterStop = lastResponse(socket);
+
+    expect(start.success).toBe(true);
+    expect(posts.filter(request => request.method === "POST")).toEqual([
+      { method: "POST", url: "http://localhost:8000/api/v1/webrtc/whip?streamId=debug-1" },
+    ]);
+    expect(posts.filter(request => request.method === "DELETE")).toEqual([
+      { method: "DELETE", url: "http://localhost:8000/whip/resource/debug-1" },
+    ]);
+    expect(list.streams?.map(stream => stream.streamId)).toEqual(["debug-1"]);
+    expect(status.stream?.resourceUrl).toBe("http://localhost:8000/whip/resource/debug-1");
+    expect(stop.stream?.state).toBe("stopped");
+    expect(sources[0].started).toBe(true);
+    expect(sources[0].stopped).toBe(true);
     expect(afterStop.streams).toEqual([]);
   });
 

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -9,7 +9,7 @@ import type {
   WebRtcStreamSocketResponse,
 } from "../../src/daemon/webrtcStreamSocketTypes";
 import type { BootedDevice } from "../../src/models";
-import type { WebRtcStreamDescriptor } from "../../src/features/webrtc";
+import type { WebRtcStreamDescriptor, WebRtcStreamingOverrides } from "../../src/features/webrtc";
 import { FakeSocket } from "../fakes/FakeNetServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -40,7 +40,11 @@ class TestableServer extends WebRtcStreamSocketServer {
   }
 }
 
-let started: Array<{ device: BootedDevice; streamId?: string }> = [];
+let started: Array<{
+  device: BootedDevice;
+  streamId?: string;
+  overrides?: WebRtcStreamingOverrides;
+}> = [];
 let stopped: string[] = [];
 
 function makeDeps(overrides: Partial<WebRtcStreamSocketServerDependencies> = {}): WebRtcStreamSocketServerDependencies {
@@ -49,7 +53,7 @@ function makeDeps(overrides: Partial<WebRtcStreamSocketServerDependencies> = {})
     resolveDevice: async () => ANDROID,
     startStream: async request => {
       const streamId = request.streamId ?? "webrtc_generated";
-      started.push({ device: request.device, streamId: request.streamId });
+      started.push({ device: request.device, streamId: request.streamId, overrides: request.overrides });
       const d = descriptor(streamId);
       active.set(streamId, d);
       return d;
@@ -119,6 +123,35 @@ describe("WebRtcStreamSocketServer", () => {
     const response = lastResponse(socket);
     expect(response.action).toBe("list");
     expect(response.streams?.map(s => s.streamId).sort()).toEqual(["s1", "s2"]);
+  });
+
+  test("start forwards WHIP endpoint and stream stays visible until stop", async () => {
+    const server = new TestableServer(makeDeps());
+    const socket = new FakeSocket();
+
+    await server.simulate(socket, {
+      id: "start",
+      action: "start",
+      streamId: "debug-1",
+      whipEndpoint: "http://localhost:8000/api/v1/webrtc/whip?streamId=debug-1",
+    });
+    await server.simulate(socket, { id: "list", action: "list" });
+    const listed = lastResponse(socket);
+    await server.simulate(socket, { id: "status", action: "status", streamId: "debug-1" });
+    const status = lastResponse(socket);
+    await server.simulate(socket, { id: "stop", action: "stop", streamId: "debug-1" });
+    const stoppedResponse = lastResponse(socket);
+    await server.simulate(socket, { id: "after-stop", action: "list" });
+    const afterStop = lastResponse(socket);
+
+    expect(started[0].overrides).toEqual({
+      whipEndpoint: "http://localhost:8000/api/v1/webrtc/whip?streamId=debug-1",
+    });
+    expect(listed.streams?.map(s => s.streamId)).toEqual(["debug-1"]);
+    expect(status.stream?.streamId).toBe("debug-1");
+    expect(stoppedResponse.stream?.state).toBe("stopped");
+    expect(stopped).toEqual(["debug-1"]);
+    expect(afterStop.streams).toEqual([]);
   });
 
   test("status for an unknown stream returns an error response", async () => {

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -27,6 +27,12 @@ import type { WhipClientOptions } from "../../src/features/webrtc/WhipClient";
 import type { RTCPeerConnection } from "werift";
 import { FakeSocket } from "../fakes/FakeNetServer";
 import { FakeTimer } from "../fakes/FakeTimer";
+import {
+  createSuccessfulWhipFetch,
+  FakeConnectedPeerConnection,
+  FakeH264Source,
+  type RecordedWhipRequest,
+} from "../helpers/webrtcFakes";
 
 const ANDROID: BootedDevice = { deviceId: "emulator-5554", platform: "android", name: "a" } as BootedDevice;
 
@@ -52,37 +58,6 @@ class TestableServer extends WebRtcStreamSocketServer {
     if (pending) {
       await pending;
     }
-  }
-}
-
-class FakePeerConnection {
-  closed = false;
-  connectionState = "connected";
-  iceGatheringState = "complete";
-  connectionStateChange = { subscribe: () => {} };
-  iceGatheringStateChange = { watch: async () => {} };
-  localDescription = { sdp: "v=0" };
-  addTransceiver() {
-    return { sender: { ssrc: 1 } };
-  }
-  async createOffer() {
-    return { type: "offer", sdp: "v=0" };
-  }
-  async setLocalDescription() {}
-  async setRemoteDescription() {}
-  async close() {
-    this.closed = true;
-  }
-}
-
-class FakeSource {
-  started = false;
-  stopped = false;
-  async start(): Promise<void> {
-    this.started = true;
-  }
-  async stop(): Promise<void> {
-    this.stopped = true;
   }
 }
 
@@ -202,30 +177,22 @@ describe("WebRtcStreamSocketServer", () => {
   });
 
   test("start reaches the real manager, posts WHIP, and remains visible until stop", async () => {
-    const posts: Array<{ url: string; method: string }> = [];
-    const sources: FakeSource[] = [];
+    const posts: RecordedWhipRequest[] = [];
+    const sources: FakeH264Source[] = [];
     setWebRtcStreamManagerDependencies({
       createPublisher: (config, deps) =>
         new WebRtcPublisher(config, {
           ...deps,
-          createPeerConnection: () => new FakePeerConnection() as unknown as RTCPeerConnection,
+          createPeerConnection: () => new FakeConnectedPeerConnection() as unknown as RTCPeerConnection,
           createWhipClient: (options: WhipClientOptions) =>
             new WhipClient({
               ...options,
-              fetchImpl: async (url, init) => {
-                posts.push({ url, method: init.method });
-                return {
-                  status: 201,
-                  ok: true,
-                  headers: { get: name => (name.toLowerCase() === "location" ? "/whip/resource/debug-1" : null) },
-                  text: async () => "v=0",
-                };
-              },
+              fetchImpl: createSuccessfulWhipFetch(posts),
             }),
           timer: new FakeTimer(),
         }),
       createSource: () => {
-        const source = new FakeSource();
+        const source = new FakeH264Source();
         sources.push(source);
         return source as unknown as AndroidH264Source;
       },

--- a/test/helpers/webrtcFakes.ts
+++ b/test/helpers/webrtcFakes.ts
@@ -1,0 +1,59 @@
+import type { FetchLike } from "../../src/features/webrtc/WhipClient";
+
+export interface RecordedWhipRequest {
+  url: string;
+  method: string;
+}
+
+export class FakeConnectedPeerConnection {
+  closed = false;
+  connectionState = "connected";
+  iceGatheringState = "complete";
+  connectionStateChange = { subscribe: () => {} };
+  iceGatheringStateChange = { watch: async () => {} };
+  localDescription = { sdp: "v=0" };
+
+  addTransceiver() {
+    return { sender: { ssrc: 1 } };
+  }
+
+  async createOffer() {
+    return { type: "offer", sdp: "v=0" };
+  }
+
+  async setLocalDescription() {}
+
+  async setRemoteDescription() {}
+
+  async close() {
+    this.closed = true;
+  }
+}
+
+export class FakeH264Source {
+  started = false;
+  stopped = false;
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+  }
+}
+
+export function createSuccessfulWhipFetch(
+  requests: RecordedWhipRequest[],
+  location: string = "/whip/resource/debug-1"
+): FetchLike {
+  return async (url, init) => {
+    requests.push({ url, method: init.method });
+    return {
+      status: 201,
+      ok: true,
+      headers: { get: name => (name.toLowerCase() === "location" ? location : null) },
+      text: async () => "v=0",
+    };
+  };
+}

--- a/test/package/webrtcRuntimeMetadata.test.ts
+++ b/test/package/webrtcRuntimeMetadata.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+describe("packaged WebRTC runtime metadata", () => {
+  test("reflect-metadata is a direct runtime dependency", async () => {
+    const pkg = await Bun.file("package.json").json();
+
+    expect(pkg.dependencies["reflect-metadata"]).toBeString();
+  });
+
+  test("the packaged entrypoint initializes reflect metadata first", async () => {
+    const entrypoint = await Bun.file("src/index.ts").text();
+    const executableBody = entrypoint.replace(/^#!.*\n/, "");
+    const firstImportLine = executableBody
+      .split("\n")
+      .find(line => line.startsWith("import "));
+
+    expect(firstImportLine).toBe('import "reflect-metadata";');
+  });
+});

--- a/test/package/webrtcRuntimeMetadata.test.ts
+++ b/test/package/webrtcRuntimeMetadata.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 
 describe("packaged WebRTC runtime metadata", () => {
   test("reflect-metadata is a direct runtime dependency", async () => {
@@ -15,5 +17,98 @@ describe("packaged WebRTC runtime metadata", () => {
       .find(line => line.startsWith("import "));
 
     expect(firstImportLine).toBe('import "reflect-metadata";');
+  });
+
+  test("a bundled WebRTC startup path reaches WHIP publish", async () => {
+    const workspaceScratch = join(import.meta.dir, "../../scratch");
+    const dir = await mkdtemp(join(workspaceScratch, "webrtc-bundle-"));
+    try {
+      const entrypoint = join(dir, "entry.ts");
+      await writeFile(
+        entrypoint,
+        `
+import "reflect-metadata";
+import { WebRtcPublisher, WhipClient } from ${JSON.stringify(
+    join(import.meta.dir, "../../src/features/webrtc/index.ts")
+  )};
+
+class FakePeerConnection {
+  connectionState = "connected";
+  iceGatheringState = "complete";
+  connectionStateChange = { subscribe: () => {} };
+  iceGatheringStateChange = { watch: async () => {} };
+  localDescription = { sdp: "v=0" };
+  addTransceiver() {
+    return { sender: { ssrc: 1 } };
+  }
+  async createOffer() {
+    return { type: "offer", sdp: "v=0" };
+  }
+  async setLocalDescription() {}
+  async setRemoteDescription() {}
+  async close() {}
+}
+
+const posts = [];
+const publisher = new WebRtcPublisher(
+  {
+    streamId: "debug-1",
+    whipEndpoint: "http://localhost:8000/api/v1/webrtc/whip?streamId=debug-1",
+    maxReconnectAttempts: 1,
+  },
+  {
+    createPeerConnection: () => new FakePeerConnection(),
+    createWhipClient: options =>
+      new WhipClient({
+        ...options,
+        fetchImpl: async (url, init) => {
+          posts.push({ url, method: init.method });
+          return {
+            status: 201,
+            ok: true,
+            headers: { get: name => (name.toLowerCase() === "location" ? "/whip/resource/debug-1" : null) },
+            text: async () => "v=0",
+          };
+        },
+      }),
+  }
+);
+
+await publisher.start();
+await publisher.stop();
+if (!posts.some(post => post.method === "POST" && post.url.includes("streamId=debug-1"))) {
+  throw new Error("WHIP POST was not reached");
+}
+console.log("ok");
+`
+      );
+
+      const build = await Bun.build({
+        entrypoints: [entrypoint],
+        outdir: dir,
+        target: "bun",
+        format: "esm",
+        minify: true,
+      });
+      expect(build.success).toBe(true);
+      expect(build.outputs).toHaveLength(1);
+      const bundledEntrypoint = build.outputs[0].path;
+
+      const proc = Bun.spawn([process.execPath, bundledEntrypoint], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/package/webrtcRuntimeMetadata.test.ts
+++ b/test/package/webrtcRuntimeMetadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe("packaged WebRTC runtime metadata", () => {
@@ -9,28 +9,33 @@ describe("packaged WebRTC runtime metadata", () => {
     expect(pkg.dependencies["reflect-metadata"]).toBeString();
   });
 
-  test("the packaged entrypoint initializes reflect metadata first", async () => {
+  test("the packaged entrypoint initializes runtime metadata first", async () => {
     const entrypoint = await Bun.file("src/index.ts").text();
-    const executableBody = entrypoint.replace(/^#!.*\n/, "");
+    const executableBody = entrypoint.replace(/^#!.*\r?\n/, "");
     const firstImportLine = executableBody
-      .split("\n")
+      .split(/\r?\n/)
       .find(line => line.startsWith("import "));
 
-    expect(firstImportLine).toBe('import "reflect-metadata";');
+    expect(firstImportLine).toBe('import "./runtime/reflectMetadata";');
+  });
+
+  test("runtime metadata initialization loads reflect-metadata", async () => {
+    const runtimeInit = await Bun.file("src/runtime/reflectMetadata.ts").text();
+
+    expect(runtimeInit.trim()).toBe('import "reflect-metadata";');
   });
 
   test("a bundled WebRTC startup path reaches WHIP publish", async () => {
     const workspaceScratch = join(import.meta.dir, "../../scratch");
+    await mkdir(workspaceScratch, { recursive: true });
     const dir = await mkdtemp(join(workspaceScratch, "webrtc-bundle-"));
     try {
       const entrypoint = join(dir, "entry.ts");
       await writeFile(
         entrypoint,
         `
-import "reflect-metadata";
-import { WebRtcPublisher, WhipClient } from ${JSON.stringify(
-    join(import.meta.dir, "../../src/features/webrtc/index.ts")
-  )};
+import "../../src/runtime/reflectMetadata.ts";
+import { WebRtcPublisher, WhipClient } from "../../src/features/webrtc/index.ts";
 
 class FakePeerConnection {
   connectionState = "connected";


### PR DESCRIPTION
## Summary

Adds `reflect-metadata` as an explicit runtime dependency and initializes it at the packaged AutoMobile entrypoint before any daemon/WebRTC import path can evaluate. This keeps the WebRTC stream socket from failing during werift/tsyringe startup before WHIP publish.

## Linked Issue

Closes #3857

## Bug / Regression Context

- **Prior attempts:** None referenced in the issue.
- **Observed symptom:** `webrtc-stream.sock` `start` returned `tsyringe requires a reflect polyfill` or a later minified runtime error before sending a WHIP request.
- **Repro steps / conditions:** Start the daemon, connect to `~/.auto-mobile/webrtc-stream.sock`, and send a newline-delimited WebRTC `start` request with a configured WHIP endpoint.

## Validation

- [x] `bun test test/package/webrtcRuntimeMetadata.test.ts test/daemon/webrtcStreamSocketServer.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] New/changed tests use fakes and run in <100ms for the touched unit files.
- [ ] Rebased onto latest `main`, conflicts resolved

## Acceptance Criteria

- [x] `webrtc-stream.sock` `start` no longer returns `tsyringe requires a reflect polyfill` by explicitly loading the polyfill before WebRTC paths.
- [x] `start` sends the configured WHIP endpoint through to stream startup.
- [x] `list`/`status` report the active stream in the socket lifecycle test.
- [x] `stop` tears the stream down cleanly in the socket lifecycle test.
- [x] Packaged/bundled behavior is covered by direct dependency + entrypoint initialization contract tests and `bun run build` via Turbo validation.

## Device Verification

N/A: this change is runtime initialization and socket-control coverage using existing fakes; no device UI behavior changed.

## Follow-ups

None.

Made with [Cursor](https://cursor.com)