### PR TITLE
ci: add stable gate jobs so deterministic build/scan checks can be required

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2305,13 +2305,18 @@ jobs:
   # of the individual conditional jobs, avoiding the GitHub Actions issue where
   # skipped matrix jobs produce uninterpolated check names that block merges.
 
+  # Full iOS roll-up (superset). This is the broad, NON-required signal: it
+  # includes the simulator-flaky ios-xctest-runner-simulator-tests, so it must
+  # not gate merges. The required, deterministic subset lives in ios-build-gate
+  # below ("iOS Build"), which this gate reuses so the build-leg membership is
+  # declared in exactly one place (add a new iOS *build* job to ios-build-gate,
+  # not here).
   ios-gate:
     name: "iOS"
     if: always() && needs.detect-changes.outputs.auto_chore != 'true'
     needs:
       - detect-changes
-      - ios-swift-packages
-      - ios-xcode-build
+      - ios-build-gate
       - ios-xctest-runner-simulator-tests
       - ios-spm-root-package-build
     runs-on: ubuntu-latest
@@ -2320,8 +2325,7 @@ jobs:
         run: |
           results=( \
             "${{ needs.detect-changes.result }}" \
-            "${{ needs.ios-swift-packages.result }}" \
-            "${{ needs.ios-xcode-build.result }}" \
+            "${{ needs.ios-build-gate.result }}" \
             "${{ needs.ios-xctest-runner-simulator-tests.result }}" \
             "${{ needs.ios-spm-root-package-build.result }}" \
           )
@@ -2384,6 +2388,85 @@ jobs:
             "${{ needs.detect-changes.result }}" \
             "${{ needs.build-ide-plugin.result }}" \
             "${{ needs.ide-plugin-unit-tests.result }}" \
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              echo "One or more jobs failed or were cancelled"
+              exit 1
+            fi
+          done
+
+  # Deterministic-only roll-up of the iOS *build* legs (Swift packages + Xcode
+  # projects). Reports a stable context name so it can be a required status
+  # check without the matrix-skip footgun (a gated-out matrix job reports its
+  # literal "(${{ ... }})" name instead of the expanded one). Deliberately
+  # excludes ios-xctest-runner-simulator-tests, which is simulator-flaky and
+  # must not gate merges — that stays covered by the non-required "iOS" gate.
+  ios-build-gate:
+    name: "iOS Build"
+    if: always() && needs.detect-changes.outputs.auto_chore != 'true'
+    needs:
+      - detect-changes
+      - ios-swift-packages
+      - ios-xcode-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check results"
+        run: |
+          results=( \
+            "${{ needs.detect-changes.result }}" \
+            "${{ needs.ios-swift-packages.result }}" \
+            "${{ needs.ios-xcode-build.result }}" \
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              echo "One or more jobs failed or were cancelled"
+              exit 1
+            fi
+          done
+
+  # Stable roll-up of the CodeQL matrix so it can be required. codeql-node is a
+  # per-language matrix; when it is gated out (non-TypeScript PRs) the matrix
+  # never expands and reports its literal name, so the expanded
+  # "... (typescript)" context would hang as a required check.
+  codeql-gate:
+    name: "CodeQL"
+    if: always() && needs.detect-changes.outputs.auto_chore != 'true'
+    needs:
+      - detect-changes
+      - codeql-node
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check results"
+        run: |
+          results=( \
+            "${{ needs.detect-changes.result }}" \
+            "${{ needs.codeql-node.result }}" \
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              echo "One or more jobs failed or were cancelled"
+              exit 1
+            fi
+          done
+
+  # Stable roll-up of the BATS shell tests so they can be required. bats-tests
+  # is an OS matrix; when it is gated out (sha256-only / auto-chore PRs) it
+  # reports its literal "(${{ matrix.os }})" name, so requiring the expanded
+  # "(macos-latest)" context would hang those PRs.
+  shell-tests-gate:
+    name: "Shell Tests"
+    if: always() && needs.detect-changes.outputs.auto_chore != 'true'
+    needs:
+      - detect-changes
+      - bats-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check results"
+        run: |
+          results=( \
+            "${{ needs.detect-changes.result }}" \
+            "${{ needs.bats-tests.result }}" \
           )
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+#
+# Guards the "required status check" gate wiring in pull_request.yml (PR #3860).
+#
+# ios-build-gate / codeql-gate / shell-tests-gate are always() roll-up jobs that
+# report STABLE context names so their families' deterministic build/scan legs
+# can be promoted to required checks without the matrix-skip footgun (a gated-out
+# matrix job reports its literal "(${{ ... }})" name, which would hang a required
+# check as "Expected").
+#
+# These gates roll up NAMED jobs, so their completeness depends on humans keeping
+# each gate's `needs:` in sync. The required-checks config lives in GitHub's
+# ruleset API (no in-repo source of truth), so a gate that silently drops a job
+# would turn a required check into a permanent false-green. This suite is that
+# backstop: rename/remove a rolled-up job, or slip the flaky simulator leg into
+# the required iOS gate, and Fast Validation (BATS Shell Tests → Shell Tests) goes
+# red instead.
+
+WF=".github/workflows/pull_request.yml"
+
+# Print the YAML block for a top-level job id (2-space indent), from its header
+# up to the next job header.
+job_block() {
+  awk -v j="$1" '
+    $0 ~ "^  " j ":[[:space:]]*$" { cap = 1; next }
+    cap && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    cap { print }
+  ' "$WF"
+}
+
+@test "required gate jobs exist with stable context names" {
+  grep -q '^    name: "iOS Build"$' "$WF"
+  grep -q '^    name: "CodeQL"$' "$WF"
+  grep -q '^    name: "Shell Tests"$' "$WF"
+}
+
+@test "required gates run with always() so they always post a conclusion" {
+  # A required check that never posts hangs as "Expected"; always() guarantees a
+  # success/failure/skipped conclusion in every path.
+  for job in ios-build-gate codeql-gate shell-tests-gate; do
+    block="$(job_block "$job")"
+    [[ "$block" == *"if: always() &&"* ]]
+  done
+}
+
+@test "ios-build-gate rolls up both deterministic iOS build legs" {
+  block="$(job_block ios-build-gate)"
+  [[ "$block" == *"- ios-swift-packages"* ]]
+  [[ "$block" == *"- ios-xcode-build"* ]]
+  # And actually checks their results (not just declares needs).
+  [[ "$block" == *"needs.ios-swift-packages.result"* ]]
+  [[ "$block" == *"needs.ios-xcode-build.result"* ]]
+}
+
+@test "ios-build-gate EXCLUDES the simulator-flaky job (keeps the required check deterministic)" {
+  block="$(job_block ios-build-gate)"
+  [[ "$block" != *"ios-xctest-runner-simulator-tests"* ]]
+}
+
+@test "codeql-gate rolls up codeql-node" {
+  block="$(job_block codeql-gate)"
+  [[ "$block" == *"- codeql-node"* ]]
+  [[ "$block" == *"needs.codeql-node.result"* ]]
+}
+
+@test "shell-tests-gate rolls up bats-tests" {
+  block="$(job_block shell-tests-gate)"
+  [[ "$block" == *"- bats-tests"* ]]
+  [[ "$block" == *"needs.bats-tests.result"* ]]
+}
+
+@test "ios-gate reuses ios-build-gate so build-leg membership is declared once" {
+  # The broad non-required "iOS" gate must not re-list the build jobs (that would
+  # double the drift surface); it depends on ios-build-gate instead.
+  block="$(job_block ios-gate)"
+  [[ "$block" == *"- ios-build-gate"* ]]
+  [[ "$block" == *"needs.ios-build-gate.result"* ]]
+  [[ "$block" != *"- ios-swift-packages"* ]]
+  [[ "$block" != *"- ios-xcode-build"* ]]
+}


### PR DESCRIPTION
## What

Adds three `always()` roll-up **gate jobs** to `pull_request.yml` that report **stable context names**, so the deterministic iOS build legs, CodeQL scan, and BATS shell tests can be promoted to **required** status checks:

- **iOS Build** — rolls up `ios-swift-packages` + `ios-xcode-build`, deliberately **excluding** the simulator-flaky `ios-xctest-runner-simulator-tests` (that stays covered by the existing non-required `iOS` gate).
- **CodeQL** — rolls up `codeql-node` (per-language matrix).
- **Shell Tests** — rolls up `bats-tests` (OS matrix).

Each gate follows the same *structure* as the existing `iOS` / `Android` / `IDE Plugin` gates: `if: always() && auto_chore != 'true'`, fails only on `failure`/`cancelled`, passes on `success`/`skipped`. (Note: those existing gates are **not** currently required — this PR introduces the first gates intended to be required, so the required-check behavior is new to the repo, though it matches how already-required matrix checks like `Installer Development (*)` behave when skipped.)

## Why

These checks are always green but weren't required. They couldn't be required directly because of a **matrix-skip footgun**: when a matrix job is gated out, the matrix never expands and the check reports its **literal** `(${{ ... }})` context name instead of the expanded one (e.g. `Build Xcode Projects (${{ matrix.config.name }})` vs `Build Xcode Projects (Xcode 26.5)`). Requiring the expanded name would leave the check permanently *Expected* → **blocking merges** on any PR where the family doesn't run. A non-matrix `always()` gate reports one stable name in every path (runs, gated-out, sha256/docs/auto_chore), which is safe to require.

Companion change (already applied to the `green-main` ruleset): 7 non-matrix always-green checks were made required — `Bun Security Audit`, `Memory Leak Detection`, `SwiftLint`, `Swift Code Coverage`, `Build Root SPM Package`, `Build CtrlProxy APK`, `JUnit Runner Kotlin Consumer Compatibility`.

## Review follow-ups included in this PR

- **Drift guard** — `test/bats/pr-gate-wiring.bats` (mirrors `release-workflow-wiring.bats`) pins each required gate's `needs` and asserts the flaky simulator leg stays out of `iOS Build`. Since required-checks config lives in GitHub's ruleset API (no in-repo source of truth), a renamed/dropped rolled-up job would otherwise silently turn a required check into a false-green; now it fails Fast Validation (via the required `Shell Tests` gate) instead.
- **De-dup** — `ios-gate` now depends on `ios-build-gate` rather than re-listing `ios-swift-packages`/`ios-xcode-build`, so iOS build-leg membership is declared in exactly one place. A comment documents the required-subset (`iOS Build`) vs non-required-superset (`iOS`) split.

## Reviewer notes / follow-up (post-merge)

1. **After this merges**, add `iOS Build`, `CodeQL`, and `Shell Tests` to the `green-main` ruleset's required status checks. Doing it before merge would hang open PRs that lack the new gates.
2. **Then rebase any already-open PRs** onto post-merge main — until rebased, they will show the three new required contexts as *Expected* (blocked), since their base doesn't contain the gate jobs. Inherent to adding any new required check.
3. `Build Desktop App (*)` is still un-required (same matrix-skip footgun); its unit tests are already required. A `Desktop App Build` gate can be added for parity if wanted.
4. Fork-PR note: `ios-swift-packages`/`ios-xcode-build` run unsigned on forks (empty signing secrets). Confirm a recent fork PR's legs go green unsigned before relying on `iOS Build` as required for external contributors.
5. Pre-existing actionlint warnings in this file (`background:`/`wait:` parallel-steps syntax, composite-action metadata) are unrelated to this change and untouched.