### PR TITLE
ci: harden required PR gates (least-privilege, diagnosability, timeouts, guard)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1198,6 +1198,10 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
     needs: detect-changes
     if: needs.detect-changes.outputs.ios_should_run == 'true'
+    # Fail fast on a hung/evicted macOS runner instead of sitting until GHA
+    # infra-cancels the job (a cancelled terminal run blocks the required
+    # "iOS Build" gate). Generous backstop, not a tight bound.
+    timeout-minutes: 45
     env:
       IOS_SIGNING_ENABLED: ${{ secrets.IOS_CERTIFICATE_BASE64 != '' }}
       MACOS_SIGNING_ENABLED: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 != '' }}
@@ -1256,6 +1260,10 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
     needs: detect-changes
     if: needs.detect-changes.outputs.ios_should_run == 'true'
+    # Fail fast on a hung/evicted macOS runner instead of sitting until GHA
+    # infra-cancels the job (a cancelled terminal run blocks the required
+    # "iOS Build" gate). Generous backstop, not a tight bound.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -2409,21 +2417,29 @@ jobs:
       - detect-changes
       - ios-swift-packages
       - ios-xcode-build
+    # Roll-up only reads needs.*.result — it needs no token scopes.
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: "Check results"
         run: |
-          results=( \
-            "${{ needs.detect-changes.result }}" \
-            "${{ needs.ios-swift-packages.result }}" \
-            "${{ needs.ios-xcode-build.result }}" \
+          declare -A results=(
+            [detect-changes]="${{ needs.detect-changes.result }}"
+            [ios-swift-packages]="${{ needs.ios-swift-packages.result }}"
+            [ios-xcode-build]="${{ needs.ios-xcode-build.result }}"
           )
-          for r in "${results[@]}"; do
+          fail=
+          for name in "${!results[@]}"; do
+            r="${results[$name]}"
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
-              echo "One or more jobs failed or were cancelled"
-              exit 1
+              echo "::error::iOS Build gate dependency ${name} = ${r}"
+              fail=1
             fi
           done
+          if [[ -n "${fail}" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
 
   # Stable roll-up of the CodeQL matrix so it can be required. codeql-node is a
   # per-language matrix; when it is gated out (non-TypeScript PRs) the matrix
@@ -2435,20 +2451,28 @@ jobs:
     needs:
       - detect-changes
       - codeql-node
+    # Roll-up only reads needs.*.result — it needs no token scopes.
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: "Check results"
         run: |
-          results=( \
-            "${{ needs.detect-changes.result }}" \
-            "${{ needs.codeql-node.result }}" \
+          declare -A results=(
+            [detect-changes]="${{ needs.detect-changes.result }}"
+            [codeql-node]="${{ needs.codeql-node.result }}"
           )
-          for r in "${results[@]}"; do
+          fail=
+          for name in "${!results[@]}"; do
+            r="${results[$name]}"
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
-              echo "One or more jobs failed or were cancelled"
-              exit 1
+              echo "::error::CodeQL gate dependency ${name} = ${r}"
+              fail=1
             fi
           done
+          if [[ -n "${fail}" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
 
   # Stable roll-up of the BATS shell tests so they can be required. bats-tests
   # is an OS matrix; when it is gated out (sha256-only / auto-chore PRs) it
@@ -2460,17 +2484,25 @@ jobs:
     needs:
       - detect-changes
       - bats-tests
+    # Roll-up only reads needs.*.result — it needs no token scopes.
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: "Check results"
         run: |
-          results=( \
-            "${{ needs.detect-changes.result }}" \
-            "${{ needs.bats-tests.result }}" \
+          declare -A results=(
+            [detect-changes]="${{ needs.detect-changes.result }}"
+            [bats-tests]="${{ needs.bats-tests.result }}"
           )
-          for r in "${results[@]}"; do
+          fail=
+          for name in "${!results[@]}"; do
+            r="${results[$name]}"
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
-              echo "One or more jobs failed or were cancelled"
-              exit 1
+              echo "::error::Shell Tests gate dependency ${name} = ${r}"
+              fail=1
             fi
           done
+          if [[ -n "${fail}" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -54,7 +54,22 @@ job_block() {
 
 @test "ios-build-gate EXCLUDES the simulator-flaky job (keeps the required check deterministic)" {
   block="$(job_block ios-build-gate)"
+  # Guard against a vacuous pass: a renamed gate id would make job_block return
+  # "", and the `!=` below would pass on an empty string.
+  [[ -n "$block" ]]
   [[ "$block" != *"ios-xctest-runner-simulator-tests"* ]]
+}
+
+@test "required gates fail on a failing/cancelled dependency (not just declare membership)" {
+  # The whole point of the gate is to go red when a dependency fails; a gate that
+  # never `exit 1`s is a permanent false-green. Pin the failure semantics so
+  # weakening the loop (e.g. exit 1 -> exit 0) fails this guard.
+  for job in ios-build-gate codeql-gate shell-tests-gate; do
+    block="$(job_block "$job")"
+    [[ -n "$block" ]]
+    [[ "$block" == *'"$r" == "failure" || "$r" == "cancelled"'* ]]
+    [[ "$block" == *"exit 1"* ]]
+  done
 }
 
 @test "codeql-gate rolls up codeql-node" {
@@ -73,6 +88,7 @@ job_block() {
   # The broad non-required "iOS" gate must not re-list the build jobs (that would
   # double the drift surface); it depends on ios-build-gate instead.
   block="$(job_block ios-gate)"
+  [[ -n "$block" ]]
   [[ "$block" == *"- ios-build-gate"* ]]
   [[ "$block" == *"needs.ios-build-gate.result"* ]]
   [[ "$block" != *"- ios-swift-packages"* ]]


### PR DESCRIPTION
Follow-up to #3860. A second round of multi-perspective review (security / test-guard robustness / operational failure-modes) surfaced five actionable items on the newly-mergeable required gate jobs. #3860 had already merged, so these land here.

## Changes

**1. Least-privilege — `permissions: {}` on the three gate jobs** (security review)
`ios-build-gate`/`codeql-gate`/`shell-tests-gate` only read `needs.*.result` and run a bash loop, but inherited the workflow-default token (`checks`/`security-events`/`pull-requests`/`packages: write`). They now declare `permissions: {}`, matching the `codeql-node` least-privilege convention already in this file.

**2. Diagnosability — name the culprit in gate failures** (operational review)
Each gate echoed a bare `"One or more jobs failed or were cancelled"`. Since these are becoming *required* (merge-blocking), the loop now emits `::error::<gate> gate dependency <job> = <result>` naming the exact failing leg.

**3. Hung-runner backstop — `timeout-minutes: 45` on `ios-swift-packages`/`ios-xcode-build`** (operational review)
These macOS-26 build legs (brew + xcodegen + simulator-runtime provisioning) had no timeout. A hung/evicted runner would sit until GHA *infra-cancels* the job, and a `cancelled` terminal run blocks the required `iOS Build` gate. A generous timeout fails fast and cleanly instead.

**4. Guard hardening — assert gate *failure semantics*, not just membership** (test-guard review — **Medium**)
The reviewer empirically showed the original `pr-gate-wiring.bats` pinned each gate's `needs` membership but never its `exit 1` behavior: mutating a gate's `exit 1`→`exit 0` (a permanent false-green — the exact thing the guard exists to prevent) still passed all 7 tests. Added a test asserting each required gate contains the `failure`/`cancelled` condition **and** `exit 1`. Verified: the mutation now fails the guard.

**5. Guard hardening — no vacuous passes on empty blocks** (test-guard review)
The negative (`!=`) assertions passed vacuously if `job_block` returned `""` (e.g. a renamed gate id). Added `[[ -n "$block" ]]` guards.

## Validation
- `bats test/bats/pr-gate-wiring.bats` — 8/8 pass.
- YAML parses; `permissions: {}` and `timeout-minutes` confirmed on the right jobs.
- Empirically reproduced that the new failure-semantics guard catches the `exit 1`→`exit 0` weakening the old guard missed.

## Not changed (reviewed, deliberately left)
- `cancelled → exit 1` semantics: a defensible correctness choice (ignoring cancelled risks a false-green on a cancelled build), copied from the pre-existing `ios-gate`/`android-gate`. Kept.
- Pre-existing `ios-gate`/`android-gate`/`ide-plugin-gate` were not given `permissions: {}`/named-culprit output here to keep the diff scoped to the required gates; easy to back-port later.
- Head-controlled-workflow integrity (a PR author can no-op a required check in their own branch) is inherent to every existing required check and out of scope.

## Post-merge (unchanged from #3860)
Add `iOS Build` / `CodeQL` / `Shell Tests` to the `green-main` ruleset **after** this merges, then rebase open PRs. Confirm `Build Xcode Projects`/`Swift Packages` are reliably green on macOS-26 (incl. one unsigned fork PR) before flipping them to required.