### PR TITLE
ci: run workflow-assertion tests when the asserted workflows change (#3862)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -252,6 +252,18 @@ jobs:
               - 'scripts/ios/**'
               - '.swiftformat'
               - '.swiftlint.yml'
+              # RemindersPlanContentTests (in the ios-swift-packages job) asserts the
+              # structure of these workflow files via loadRepositoryFile(). Listing them
+              # here makes an edit to either file run the iOS macOS job set (swiftlint,
+              # swift-code-coverage, ios-swift-packages, ios-xcode-build,
+              # ios-spm-root-package-build — all gated on ios_should_run) so the
+              # assertions are validated pre-merge; otherwise the drift only surfaces on
+              # nightly (see #3862 — #3850 broke nightly this way). Trade-off: any edit
+              # to these files, even a comment, now triggers that macOS job set. The
+              # workflow-assertion-triggers fast-validation check enforces that every
+              # asserted .github path stays listed here.
+              - '.github/workflows/nightly.yml'
+              - '.github/workflows/pull_request.yml'
 
       # The MCP server (src/**) is what drives real devices end-to-end. A change to
       # the device discovery / observe / gesture-action / iOS-runner / schema surface

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -44,6 +44,7 @@ add_check "dependabot" "\"$PROJECT_ROOT/scripts/validate_dependabot.sh\"" "confi
 add_check "debug-tags" "\"$PROJECT_ROOT/scripts/validate-no-debug-log-tags.sh\"" "lint" "Reject stray [*-DEBUG] log tags in src/"
 add_check "datetime-now-literal" "\"$PROJECT_ROOT/scripts/validate-no-datetime-now-literal.sh\"" "lint" "Reject string-literal SQL time-expression defaults in migrations"
 add_check "desktop-core-unified" "\"$PROJECT_ROOT/scripts/android/validate-no-desktop-core-unified.sh\"" "lint,android" "Reject abandoned desktop-core unified socket-client package"
+add_check "workflow-assertion-triggers" "\"$PROJECT_ROOT/scripts/ci/validate_workflow_assertion_triggers.sh\"" "config,ci" "Ensure workflow-YAML assertion tests are triggered by the paths they assert"
 
 print_usage() {
   cat <<'EOF'

--- a/scripts/ci/validate_workflow_assertion_triggers.sh
+++ b/scripts/ci/validate_workflow_assertion_triggers.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# validate_workflow_assertion_triggers.sh
+#
+# Guard the CI trigger contract for workflow-structure tests.
+#
+# RemindersPlanContentTests (run by the `ios-swift-packages` job) asserts the
+# structure of workflow YAML via loadRepositoryFile(".github/..."). That job is
+# gated on the `ios` paths-filter in .github/workflows/pull_request.yml. If an
+# asserted .github path is NOT covered by that filter, a change to the workflow
+# does not run the tests that validate it, so the drift only surfaces on nightly
+# (this is exactly how #3850 broke nightly — see #3862).
+#
+# This check fails when any .github path asserted by a Swift test is not covered
+# by the `ios` filter, forcing the trigger and the assertions to stay in sync.
+#
+# Scope: this verifies membership in the `ios` filter only. It assumes — but does
+# NOT verify — the downstream wiring (`ios` filter -> ios_should_run step ->
+# ios-swift-packages job -> the assertion tests). A refactor that renames the
+# filter, repoints ios_should_run, or moves the tests to a differently-gated job
+# is out of scope and would not be caught here.
+#
+# Usage:
+#   ./scripts/ci/validate_workflow_assertion_triggers.sh
+#
+# Exit codes:
+#   0 - every asserted .github path is covered by the ios filter
+#   1 - an asserted .github path is missing from the ios filter
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Scan targets default to the real repo; overridable so tests can point the guard
+# at fixtures instead of mutating the tracked workflow / test sources.
+SWIFT_TEST_DIR="${WORKFLOW_ASSERTION_SWIFT_DIR:-$PROJECT_ROOT/ios/XCTestRunner/Sources/XCTestRunnerTests}"
+WORKFLOW_FILE="${WORKFLOW_ASSERTION_WORKFLOW_FILE:-$PROJECT_ROOT/.github/workflows/pull_request.yml}"
+
+if [[ ! -d "$SWIFT_TEST_DIR" ]]; then
+  echo "[ERROR] Swift test directory not found: $SWIFT_TEST_DIR" >&2
+  exit 1
+fi
+if [[ ! -f "$WORKFLOW_FILE" ]]; then
+  echo "[ERROR] Workflow file not found: $WORKFLOW_FILE" >&2
+  exit 1
+fi
+
+# Collect every .github/* path asserted via loadRepositoryFile("...").
+asserted_paths=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] && asserted_paths+=("$path")
+done < <(
+  grep -rhoE 'loadRepositoryFile\("[^"]+"\)' "$SWIFT_TEST_DIR" 2>/dev/null \
+    | sed -E 's/^loadRepositoryFile\("(.*)"\)$/\1/' \
+    | grep -E '^\.github/' \
+    | sort -u
+)
+
+if [[ ${#asserted_paths[@]} -eq 0 ]]; then
+  echo "[INFO] No .github paths asserted by Swift tests; nothing to enforce."
+  exit 0
+fi
+
+# Extract the entries of the `ios:` paths-filter as a newline-separated list.
+# The block is the contiguous run of list items / comments indented under the
+# `ios:` key inside the filter-ios step; it ends at the first blank line or a
+# line dedented to (or past) the `ios:` key. awk (2-arg match, portable across
+# BSD/GNU) isolates the block; grep/sed pull the single-quoted glob out of each
+# list item.
+filter_block="$(
+  awk '
+    match($0, /^[[:space:]]*ios:[[:space:]]*$/) {
+      collecting = 1
+      ios_indent = match($0, /[^[:space:]]/)
+      next
+    }
+    collecting {
+      if ($0 ~ /^[[:space:]]*$/) { collecting = 0; next }
+      first = match($0, /[^[:space:]]/)
+      if (first > 0 && first <= ios_indent && substr($0, first, 1) != "-" && substr($0, first, 1) != "#") {
+        collecting = 0
+        next
+      }
+      print
+    }
+  ' "$WORKFLOW_FILE"
+)"
+
+filter_entries="$(
+  printf '%s\n' "$filter_block" \
+    | sed -nE "s/^[[:space:]]*-[[:space:]]*'([^']+)'.*/\1/p"
+)"
+
+# A dorny/paths-filter entry covers a path when it matches verbatim, or is a
+# `dir/**` glob whose prefix is the path or an ancestor, or a single-level `dir/*`
+# glob and the path sits directly under that dir. Inlined (rather than a helper
+# invoked in an `if`) so `set -e` stays armed and no SC2310 suppression is added.
+missing=()
+for path in "${asserted_paths[@]}"; do
+  covered=0
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    if [[ "$entry" == "$path" ]]; then
+      covered=1
+      break
+    elif [[ "$entry" == *"/**" ]]; then
+      prefix="${entry%/**}"
+      if [[ "$path" == "$prefix" || "$path" == "$prefix"/* ]]; then
+        covered=1
+        break
+      fi
+    elif [[ "$entry" == *"/*" ]]; then
+      prefix="${entry%/*}"
+      if [[ "$path" == "$prefix"/* && "${path#"$prefix"/}" != */* ]]; then
+        covered=1
+        break
+      fi
+    fi
+  done <<< "$filter_entries"
+  [[ "$covered" -eq 0 ]] && missing+=("$path")
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  {
+    echo "[ERROR] Swift tests assert these .github paths, but the 'ios' paths-filter"
+    echo "        in .github/workflows/pull_request.yml does not cover them, so a change"
+    echo "        to the file would not run the ios-swift-packages tests that validate it:"
+    for path in "${missing[@]}"; do
+      echo "          - $path"
+    done
+    echo
+    echo "        Add each path (or a covering glob) to the 'ios:' filter, or drop the"
+    echo "        loadRepositoryFile assertion. See #3862 for why this drift is dangerous."
+  } >&2
+  exit 1
+fi
+
+echo "[INFO] All ${#asserted_paths[@]} asserted .github path(s) are covered by the ios filter."

--- a/test/bats/validate-workflow-assertion-triggers.bats
+++ b/test/bats/validate-workflow-assertion-triggers.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/validate_workflow_assertion_triggers.sh
+
+SCRIPT="scripts/ci/validate_workflow_assertion_triggers.sh"
+
+setup() {
+  FIXTURE_DIR="$(mktemp -d)"
+  SWIFT_DIR="$FIXTURE_DIR/swift"
+  mkdir -p "$SWIFT_DIR"
+  WORKFLOW_FILE="$FIXTURE_DIR/pull_request.yml"
+}
+
+teardown() {
+  rm -rf "$FIXTURE_DIR"
+}
+
+# Write a Swift test source asserting the given .github paths.
+write_swift() {
+  local out="$SWIFT_DIR/Fixture.swift"
+  {
+    echo "func t() throws {"
+    for p in "$@"; do
+      echo "    let workflow = try loadRepositoryFile(\"$p\")"
+    done
+    echo "}"
+  } > "$out"
+}
+
+# Write a pull_request.yml with an ios: filter containing the given entries.
+write_workflow() {
+  {
+    echo "      - name: \"Check for iOS-related changes\""
+    echo "        id: filter-ios"
+    echo "        with:"
+    echo "          filters: |"
+    echo "            ios:"
+    for e in "$@"; do
+      echo "              - '$e'"
+    done
+    echo ""
+    echo "      - name: \"Next step\""
+  } > "$WORKFLOW_FILE"
+}
+
+run_guard() {
+  WORKFLOW_ASSERTION_SWIFT_DIR="$SWIFT_DIR" \
+    WORKFLOW_ASSERTION_WORKFLOW_FILE="$WORKFLOW_FILE" \
+    run bash "$SCRIPT"
+}
+
+@test "passes when every asserted .github path is listed verbatim in the ios filter" {
+  write_swift ".github/workflows/nightly.yml" ".github/workflows/pull_request.yml"
+  write_workflow "ios/**" ".github/workflows/nightly.yml" ".github/workflows/pull_request.yml"
+  run_guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"asserted .github path(s) are covered"* ]]
+}
+
+@test "passes when a covering /** glob matches the asserted path" {
+  write_swift ".github/workflows/nightly.yml"
+  write_workflow "ios/**" ".github/workflows/**"
+  run_guard
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when a single-level /* glob matches a path directly under the dir" {
+  write_swift ".github/workflows/nightly.yml"
+  write_workflow "ios/**" ".github/workflows/*"
+  run_guard
+  [ "$status" -eq 0 ]
+}
+
+@test "a single-level /* glob does not cover a nested path" {
+  write_swift ".github/actions/foo/action.yml"
+  write_workflow "ios/**" ".github/actions/*"
+  run_guard
+  [ "$status" -ne 0 ]
+  [[ "$output" == *".github/actions/foo/action.yml"* ]]
+}
+
+@test "fails when an asserted .github path is missing from the ios filter" {
+  write_swift ".github/workflows/nightly.yml" ".github/workflows/pull_request.yml"
+  write_workflow "ios/**" ".github/workflows/pull_request.yml"
+  run_guard
+  [ "$status" -ne 0 ]
+  [[ "$output" == *".github/workflows/nightly.yml"* ]]
+}
+
+@test "fails when the ios filter covers no .github path at all" {
+  write_swift ".github/workflows/nightly.yml"
+  write_workflow "ios/**" "scripts/ios/**"
+  run_guard
+  [ "$status" -ne 0 ]
+}
+
+@test "non-.github assertions are ignored" {
+  write_swift "ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift"
+  write_workflow "ios/**"
+  run_guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No .github paths asserted"* ]]
+}


### PR DESCRIPTION
Fixes #3862.

## Problem

`RemindersPlanContentTests` (in the `ios-swift-packages` job) asserts the *structure* of `.github/workflows/nightly.yml` and `pull_request.yml` via `loadRepositoryFile()`. But that job is gated on the `ios` paths-filter (`ios/**`, `scripts/ios/**`, `.swiftformat`, `.swiftlint.yml`) — which does **not** include `.github/**`. So a PR that edits those workflow YAMLs never runs the tests that validate them; the drift only surfaces on the nightly schedule.

This is exactly how **#3850** ("extract iOS simulator bring-up into a composite action", touched only `.github/**`) merged green and then broke the 07-14 nightly Swift Packages Sweep on all four Xcode legs. #3850 wired the composite into the `native_integration` filter (the *integration* job), but the assertion tests live in `ios-swift-packages`, which stayed skipped.

## Fix

1. **Add the two asserted workflow files to the `ios` filter** so an edit to either runs `ios-swift-packages` (and thus `RemindersPlanContentTests`) pre-merge. This PR touches `pull_request.yml`, so it self-validates.
2. **Add a fast-validation guard** `workflow-assertion-triggers` that fails if any `.github` path a Swift `loadRepositoryFile()` call asserts is not covered by the `ios` filter — so the trigger and the assertions can't silently drift again. Registered in `all_fast_validate_checks.sh` (cheap ubuntu, always runs).

## Scope / trade-offs (called out honestly in the code)

- The guard verifies **membership** in the `ios` filter only. It assumes but does not verify the downstream wiring (`ios` filter → `ios_should_run` → `ios-swift-packages` → the tests); a refactor renaming/repointing that chain is out of scope. Noted in the script header.
- Listing whole workflow files in the `ios` filter means any edit to them (even a comment) triggers the full iOS macOS job set. These files change rarely, and a dedicated finer filter isn't cleanly possible without splitting `ios-swift-packages`. Trade-off documented in the inline comment.

## Tests

- New BATS suite `test/bats/validate-workflow-assertion-triggers.bats` (7 cases): verbatim match, `/**` glob cover, `/*` single-level cover + nested-not-covered, missing-path failure, no-coverage failure, non-`.github` ignore.
- Full `all_fast_validate_checks.sh` suite passes (15/15), including the new check.

## Note

The specific drift that broke the 07-14 nightly was already reconciled on `main` by `72d24eebd` (forward-compat test helper). This PR closes the **gate hole** that let it merge, so the class of bug can't recur.