### PR TITLE
ci: harden Reminders cold bring-up (structural observe, prebuilt bundle, daemon ceiling)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -457,6 +457,15 @@ jobs:
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
+      # Compile the XCTest bundle BEFORE the target-app warm-up. Otherwise `swift test`
+      # in the timed Reminders step spends tens of seconds compiling first, letting the
+      # freshly-warmed simulator/app go cold again and reintroducing the cold observe
+      # timeout this job keeps hitting (#3851 direction 4). Runs after the leg's Xcode is
+      # selected (by the bring-up above) so the build cache matches the `swift test` that follows.
+      - name: "Pre-build Reminders XCTest bundle (Xcode 26.2)"
+        timeout-minutes: 15
+        run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
+
       - name: "Warm up Reminders target app (Xcode 26.2)"
         timeout-minutes: 5
         run: ./scripts/ci/warm-reminders-target-app.sh
@@ -482,6 +491,13 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
+
+      # Pre-build the XCTest bundle before the second leg's warm-up too (same rationale
+      # as the 26.2 leg above); the freshly-booted 26.5 sim is cold again here.
+      - name: "Pre-build Reminders XCTest bundle (Xcode 26.5)"
+        if: ${{ !cancelled() }}
+        timeout-minutes: 15
+        run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
 
       - name: "Warm up Reminders target app (Xcode 26.5)"
         if: ${{ !cancelled() }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1434,6 +1434,15 @@ jobs:
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
+      # Compile the XCTest bundle BEFORE the target-app warm-up. Otherwise `swift test`
+      # in the timed Reminders step spends tens of seconds compiling first, letting the
+      # freshly-warmed simulator/app go cold again and reintroducing the cold observe
+      # timeout (#3851 direction 4). Runs after the leg's Xcode is selected (by the
+      # bring-up above) so the build cache matches the `swift test` that follows.
+      - name: "Pre-build Reminders XCTest bundle (Xcode 26.2)"
+        timeout-minutes: 15
+        run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
+
       # Keep target-app cold bring-up outside the timed Reminders plan. CtrlProxy
       # is already warm above; this leaves Reminders foregrounded so the plan's
       # first launch/observe no longer pays the first app launch cost (#3028).
@@ -1482,6 +1491,13 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
+
+      # Pre-build the XCTest bundle before the second leg's warm-up too (same rationale
+      # as the 26.2 leg above); the freshly-booted 26.5 sim is cold again here.
+      - name: "Pre-build Reminders XCTest bundle (Xcode 26.5)"
+        if: ${{ !cancelled() }}
+        timeout-minutes: 15
+        run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
 
       - name: "Warm up Reminders target app (Xcode 26.5)"
         if: ${{ !cancelled() }}

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -260,6 +260,28 @@ final class RemindersPlanContentTests: XCTestCase {
         )
     }
 
+    /// The XCTest bundle must be compiled before the target-app warm-up (#3851 direction 4):
+    /// otherwise `swift test` in the timed Reminders step compiles first, re-cooling the
+    /// freshly-warmed simulator/app and reintroducing the cold observe timeout. The pre-build
+    /// must also follow the leg's CtrlProxy warm-up (which runs after the leg's Xcode is
+    /// selected) so the build cache matches the `swift test` that follows.
+    func testPullRequestWorkflowPreBuildsXCTestBundleBeforeWarmUp() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
+
+        assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
+            workflow,
+            preBuildStepName: "Pre-build Reminders XCTest bundle (Xcode 26.2)",
+            afterCtrlProxyStepName: "Warm up iOS CtrlProxy",
+            warmupStepName: "Warm up Reminders target app (Xcode 26.2)"
+        )
+        assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
+            workflow,
+            preBuildStepName: "Pre-build Reminders XCTest bundle (Xcode 26.5)",
+            afterCtrlProxyStepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
+            warmupStepName: "Warm up Reminders target app (Xcode 26.5)"
+        )
+    }
+
     func testPullRequestWorkflowRetriesRemindersRunsOnce() throws {
         let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
 
@@ -340,6 +362,25 @@ final class RemindersPlanContentTests: XCTestCase {
             workflow,
             warmupStepName: "Warm up Reminders target app (Xcode 26.5)",
             runStepName: "Run Reminders integration tests (Xcode 26.5)"
+        )
+    }
+
+    /// See `testPullRequestWorkflowPreBuildsXCTestBundleBeforeWarmUp` — same invariant for the
+    /// nightly workflow, whose second leg brings the sim up via the composite bring-up action.
+    func testNightlyWorkflowPreBuildsXCTestBundleBeforeWarmUp() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/nightly.yml")
+
+        assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
+            workflow,
+            preBuildStepName: "Pre-build Reminders XCTest bundle (Xcode 26.2)",
+            afterCtrlProxyStepName: "Warm up iOS CtrlProxy",
+            warmupStepName: "Warm up Reminders target app (Xcode 26.2)"
+        )
+        assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
+            workflow,
+            preBuildStepName: "Pre-build Reminders XCTest bundle (Xcode 26.5)",
+            afterCtrlProxyStepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
+            warmupStepName: "Warm up Reminders target app (Xcode 26.5)"
         )
     }
 
@@ -835,6 +876,53 @@ private func assertWorkflowWarmsTargetAppBeforeRemindersRun(
     XCTAssertTrue(
         runBlock.contains("timeout-minutes: 10"),
         "\(runStepName) must keep the Reminders step cap aligned with the retry timeout guard",
+        file: file,
+        line: line
+    )
+}
+
+private func assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
+    _ workflow: String,
+    preBuildStepName: String,
+    afterCtrlProxyStepName: String,
+    warmupStepName: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    guard let ctrlProxyRange = workflow.range(of: #"name: "\#(afterCtrlProxyStepName)""#) else {
+        XCTFail("Workflow is missing step named \(afterCtrlProxyStepName)", file: file, line: line)
+        return
+    }
+    guard let preBuildRange = workflow.range(of: #"name: "\#(preBuildStepName)""#) else {
+        XCTFail("Workflow is missing step named \(preBuildStepName)", file: file, line: line)
+        return
+    }
+    guard let warmupRange = workflow.range(of: #"name: "\#(warmupStepName)""#) else {
+        XCTFail("Workflow is missing step named \(warmupStepName)", file: file, line: line)
+        return
+    }
+
+    XCTAssertLessThan(
+        ctrlProxyRange.lowerBound,
+        preBuildRange.lowerBound,
+        "\(preBuildStepName) must run after \(afterCtrlProxyStepName) so the leg's Xcode toolchain "
+            + "is already selected and the pre-build cache matches the swift test that follows",
+        file: file,
+        line: line
+    )
+    XCTAssertLessThan(
+        preBuildRange.lowerBound,
+        warmupRange.lowerBound,
+        "\(preBuildStepName) must run before \(warmupStepName) so the swift-test compile can't "
+            + "re-cool the freshly-warmed simulator/app",
+        file: file,
+        line: line
+    )
+
+    let preBuildBlock = workflow[preBuildRange.lowerBound ..< warmupRange.lowerBound]
+    XCTAssertTrue(
+        preBuildBlock.contains("./scripts/ci/prebuild-reminders-xctest-bundle.sh"),
+        "\(preBuildStepName) must invoke the XCTest-bundle pre-build helper",
         file: file,
         line: line
     )

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/launch-reminders-app.yaml
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/Resources/Plans/launch-reminders-app.yaml
@@ -1,17 +1,26 @@
 ---
 name: launch-reminders-app
-description: Launch the iOS Reminders app and wait for the main UI
+description: Launch the iOS Reminders app and wait for it to reach the foreground
 platform: ios
 steps:
   - tool: launchApp
     appId: com.apple.reminders
     label: Launch Reminders
 
+  # Wait on a structural, locale-independent signal — the Reminders bundle id being the
+  # foreground app — instead of the localized "Reminders" label. This also rejects the
+  # transitional home screen (com.apple.springboard) a cold launch can briefly surface.
+  # On a cold simulator CtrlProxy is still reconnecting for tens of seconds after launch
+  # (observe returns springboard/empty during that window), so this bounded wait can still
+  # miss on a cold first attempt; the runner's AUTOMOBILE_TEST_RETRY_COUNT=1 then re-runs the
+  # whole plan once, warm. The timeout stays <= 30s so a genuinely-broken observe still fails
+  # fast per attempt (guarded by RemindersPlanContentTests.testLaunchRemindersPlanIsGuardedAndBounded).
   - tool: observe
     waitFor:
-      text: "Reminders"
-      timeout: 20000
-    label: Wait for Reminders UI
+      activeWindow:
+        appId: com.apple.reminders
+      timeout: 30000
+    label: Wait for Reminders to be foregrounded
 
   - tool: terminateApp
     appId: com.apple.reminders

--- a/scripts/ci/ensure-daemon-ready.sh
+++ b/scripts/ci/ensure-daemon-ready.sh
@@ -37,6 +37,14 @@ BUN_BIN_DIR="${HOME}/.bun/bin"
 export PATH="${BUN_BIN_DIR}:${PATH}"
 hash -r 2>/dev/null || true
 
+# Give the cold-runner daemon a realistic startup ceiling. The default is 10s
+# (DAEMON_STARTUP_TIMEOUT_MS, src/daemon/constants.ts), which a cold CI runner can
+# exceed on the first `--daemon start` below — surfacing a misleading
+# "Daemon failed to start within 10000ms" line even though the health-poll loop
+# then brings it up fine. Raise it to 30s so the first attempt reports success
+# instead of a scary error. An explicit outer override still wins.
+export AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS="${AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS:-30000}"
+
 # Persist the bin dir for the *subsequent* workflow steps: `swift test` spawns
 # `auto-mobile` as a child, so it needs the same PATH.
 if [[ -n "${GITHUB_PATH:-}" ]]; then

--- a/scripts/ci/prebuild-reminders-xctest-bundle.sh
+++ b/scripts/ci/prebuild-reminders-xctest-bundle.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Pre-build Reminders XCTest bundle
+#
+# Compiles the XCTestRunner Swift test bundle BEFORE the target-app warm-up step so
+# the timed Reminders plan's `swift test` (run-reminders-launch-plan-tests.sh) starts
+# executing almost immediately instead of first spending tens of seconds compiling.
+#
+# Why this matters (#3851 direction 4): the CI warm-up steps
+# (ensure-ctrl-proxy-ready.sh, warm-reminders-target-app.sh) leave CtrlProxy attached
+# and Reminders foregrounded so the first timed `observe` is fast. But if `swift test`
+# then compiles the XCTest bundle before the timed plan runs, the simulator/app go cold
+# again during that compile — undoing the warm-up and reintroducing the cold
+# `observe waitFor timed out` failure. Compiling the bundle here, before the final
+# warm-up, closes that gap: `swift test` reuses the already-built products.
+#
+# Must run AFTER the leg's Xcode toolchain is selected (the ios-simulator-bring-up
+# composite does this) so the build cache matches the `swift test` that follows; a
+# mismatched toolchain would miss the cache and recompile inside the timed step anyway.
+#
+# Usage:
+#   ./scripts/ci/prebuild-reminders-xctest-bundle.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}/ios/XCTestRunner"
+
+echo "Pre-building XCTestRunner test bundle with $(xcodebuild -version 2>/dev/null | head -1 || echo 'selected Xcode')..."
+swift build --build-tests
+echo "XCTest bundle pre-built; swift test will reuse these products."

--- a/test/bats/ensure-daemon-ready.bats
+++ b/test/bats/ensure-daemon-ready.bats
@@ -28,6 +28,7 @@ make_mock_auto_mobile() {
   cat > "${MOCK_BIN}/auto-mobile" <<SCRIPT
 #!/usr/bin/env bash
 if [ "\$1" = "--daemon" ] && [ "\$2" = "start" ]; then
+  printf '%s\n' "\${AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS:-unset}" > "${MOCK_BIN}/startup-timeout"
   exit 0
 elif [ "\$1" = "--daemon" ] && [ "\$2" = "health" ]; then
   calls=0
@@ -102,4 +103,18 @@ SCRIPT
   run env DAEMON_READY_MAX_ATTEMPTS=2 DAEMON_READY_DELAY_SECONDS=0 bash "$SCRIPT"
   [ "$status" -eq 1 ]
   [[ "$output" == *"did not become ready after 2 attempts"* ]]
+}
+
+@test "gives the cold-runner daemon a 30s startup ceiling by default" {
+  make_mock_auto_mobile 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "${MOCK_BIN}/startup-timeout")" = "30000" ]
+}
+
+@test "respects an explicit daemon startup timeout override" {
+  make_mock_auto_mobile 0
+  run env AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS=45000 bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "${MOCK_BIN}/startup-timeout")" = "45000" ]
 }

--- a/test/bats/prebuild-reminders-xctest-bundle.bats
+++ b/test/bats/prebuild-reminders-xctest-bundle.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/prebuild-reminders-xctest-bundle.sh
+# Mocks `swift` and `xcodebuild` so no real toolchain build runs.
+
+SCRIPT="scripts/ci/prebuild-reminders-xctest-bundle.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  export INVOCATION_FILE="${MOCK_BIN}/invocations"
+  export CWD_FILE="${MOCK_BIN}/cwd"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+  export PATH="$ORIG_PATH"
+}
+
+make_mock_toolchain() {
+  local swift_status="${1:-0}"
+  cat > "${MOCK_BIN}/swift" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${INVOCATION_FILE}"
+pwd >> "${CWD_FILE}"
+exit ${swift_status}
+SCRIPT
+  cat > "${MOCK_BIN}/xcodebuild" <<'SCRIPT'
+#!/usr/bin/env bash
+echo "Xcode 26.2"
+SCRIPT
+  chmod +x "${MOCK_BIN}/swift" "${MOCK_BIN}/xcodebuild"
+  export PATH="${MOCK_BIN}:${PATH}"
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "script has bash shebang" {
+  head -1 "$SCRIPT" | grep -q "bash"
+}
+
+@test "builds the test bundle from ios/XCTestRunner" {
+  make_mock_toolchain 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -q -- "build --build-tests" "$INVOCATION_FILE"
+  # The build must run with ios/XCTestRunner as the working directory so it
+  # compiles the Reminders XCTest targets.
+  grep -q "ios/XCTestRunner" "$CWD_FILE"
+}
+
+@test "propagates a swift build failure" {
+  make_mock_toolchain 3
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

Belt-and-braces de-flaking on top of the landed `retryCount=1` (#3827) for the 6-night `RemindersLaunchPlanTests` cold-bring-up streak (#3851). Implements the remaining go-forward directions from the issue, grounded in a fresh-simulator reproduction.

Root-cause finding from the repro: on a cold sim the failure is **CtrlProxy reconnection churn** — `launchApp` returns `"error": "CtrlProxy reconnecting, retry in 2s"` while Reminders is already running (`launchctl` confirms). On iOS `activeWindow.appId` derives from the same hierarchy extraction as the text node, so **no observe predicate can shortcut the ~38s cold CtrlProxy attach**. The retry stays the only effective cold fix; these changes make the surrounding signal robust and shrink the windows that force a retry.

## Changes

**Direction 3 — structural observe signal** (`launch-reminders-app.yaml`)
- Swap the localized `text: "Reminders"` for `activeWindow.appId: com.apple.reminders` — locale-independent, and it rejects the `com.apple.springboard` transitional home screen a cold launch briefly surfaces.
- Raise the observe timeout 20s → 30s (the ceiling enforced by `testLaunchRemindersPlanIsGuardedAndBounded`).

**Direction 4 — pre-build the XCTest bundle** (new `scripts/ci/prebuild-reminders-xctest-bundle.sh`; `nightly.yml` + `pull_request.yml`, both Xcode legs)
- Compile the bundle *after* the leg's Xcode is selected (so the build cache matches `swift test`) and *before* the target-app warm-up, so `swift test` starts immediately instead of compiling and re-cooling the freshly-warmed app.

**Direction 5 — daemon startup ceiling** (`ensure-daemon-ready.sh`)
- Export `AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS=30000` (default 10s) before `--daemon start`, silencing the misleading `Daemon failed to start within 10000ms` line on cold runners. An explicit outer override still wins.

## Tests

- New workflow-assertion guards: `testPullRequestWorkflowPreBuildsXCTestBundleBeforeWarmUp`, `testNightlyWorkflowPreBuildsXCTestBundleBeforeWarmUp` (assert the pre-build runs after CtrlProxy warm-up and before target-app warm-up, and invokes the helper).
- New BATS `test/bats/prebuild-reminders-xctest-bundle.bats`; 2 new cases in `ensure-daemon-ready.bats` (default 30s ceiling + honors override).

## Validation (local, fresh iOS 26.2 simulators)

- **Cold e2e** (fresh sim, killed daemon, `retryCount=1`): attempt 1 `observe waitFor timed out after 30655ms` → `Retry attempt 2 of 2` → warm pass. Test **passed in 43.6s**, well within the 10-min step cap.
- **Warm e2e** (`retryCount=0`): 3/3 steps in 1.8s — confirms the parser passes the nested `waitFor.activeWindow` and the matcher resolves it on iOS.
- `RemindersPlanContentTests` 26/26 · BATS 13/13 · fast-validate (yaml + shellcheck) OK.

## Notes

- This does **not** claim to eliminate the flake — the retry (#3827) is still the mechanism that carries a cold first attempt. These changes reduce reliance on it and remove the localization/compile-gap fragilities the issue documented.
- Because Phase 2 edits the PR workflow, this branch's own PR run exercises the new pre-build path — a useful pre-merge signal, complementing the scheduled nightly.

Refs #3851
