### PR TITLE
Fix accessibility-flags resync disrupting live hierarchy capture

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -118,6 +118,43 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
     // Result broadcast actions
     const val ACTION_OPERATION_RESULT = "dev.jasonpearson.automobile.OPERATION_RESULT"
+
+    /**
+     * Pure bitmask computation for [applyAccessibilityFlags], extracted so the equality check that
+     * guards the disruptive `serviceInfo =` reassignment (see call site) is unit-testable without a
+     * live [AccessibilityService]/Robolectric harness.
+     */
+    internal fun computeAccessibilityServiceFlags(
+      currentFlags: Int,
+      includeNotImportantViews: Boolean,
+      reportViewIds: Boolean,
+      retrieveInteractiveWindows: Boolean,
+    ): Int {
+      var flags = currentFlags
+
+      flags =
+        if (includeNotImportantViews) {
+          flags or AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+        } else {
+          flags and AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS.inv()
+        }
+
+      flags =
+        if (reportViewIds) {
+          flags or AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS
+        } else {
+          flags and AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS.inv()
+        }
+
+      flags =
+        if (retrieveInteractiveWindows) {
+          flags or AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
+        } else {
+          flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS.inv()
+        }
+
+      return flags
+    }
   }
 
   /**
@@ -1264,28 +1301,24 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           return
         }
 
-    var flags = info.flags
+    val flags =
+      computeAccessibilityServiceFlags(
+        currentFlags = info.flags,
+        includeNotImportantViews = includeNotImportantViews,
+        reportViewIds = reportViewIds,
+        retrieveInteractiveWindows = retrieveInteractiveWindows,
+      )
 
-    flags =
-      if (includeNotImportantViews) {
-        flags or AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
-      } else {
-        flags and AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS.inv()
-      }
-
-    flags =
-      if (reportViewIds) {
-        flags or AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS
-      } else {
-        flags and AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS.inv()
-      }
-
-    flags =
-      if (retrieveInteractiveWindows) {
-        flags or AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
-      } else {
-        flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS.inv()
-      }
+    // Skip the reassignment when the computed bitmask matches what's already applied.
+    // serviceInfo = info reconfigures a LIVE AccessibilityService on the system side, not a
+    // local no-op - the client now re-invokes this on every ensureConnected() (not just fresh
+    // connects), so without this guard every single tool call reconfigures the service even
+    // when nothing changed, which was observed to disrupt in-flight hierarchy capture
+    // (elements=0 on every observe for an entire run).
+    if (flags == info.flags) {
+      Log.d(TAG, "Accessibility flags unchanged (flags=$flags) - skipping serviceInfo reassignment")
+      return
+    }
 
     info.flags = flags
     serviceInfo = info

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityFlagsTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityFlagsTest.kt
@@ -10,8 +10,8 @@ import org.robolectric.RobolectricTestRunner
  * Regression coverage for the bug where every ensureConnected() call reconfigured a live
  * AccessibilityService (serviceInfo = info) even when nothing changed, disrupting in-flight
  * hierarchy capture (observed as elements=0 on every observe() for an entire CI run). The fix is
- * the equality check at the applyAccessibilityFlags call site in CtrlProxy.kt; this test covers
- * the extracted pure bitmask computation it depends on.
+ * the equality check at the applyAccessibilityFlags call site in CtrlProxy.kt; this test covers the
+ * extracted pure bitmask computation it depends on.
  */
 @RunWith(RobolectricTestRunner::class)
 class CtrlProxyAccessibilityFlagsTest {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityFlagsTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityFlagsTest.kt
@@ -1,0 +1,109 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression coverage for the bug where every ensureConnected() call reconfigured a live
+ * AccessibilityService (serviceInfo = info) even when nothing changed, disrupting in-flight
+ * hierarchy capture (observed as elements=0 on every observe() for an entire CI run). The fix is
+ * the equality check at the applyAccessibilityFlags call site in CtrlProxy.kt; this test covers
+ * the extracted pure bitmask computation it depends on.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CtrlProxyAccessibilityFlagsTest {
+
+  @Test
+  fun `computing the same flags twice from a stable base is idempotent`() {
+    val base = 0
+    val first =
+      CtrlProxy.computeAccessibilityServiceFlags(
+        currentFlags = base,
+        includeNotImportantViews = false,
+        reportViewIds = true,
+        retrieveInteractiveWindows = false,
+      )
+    val second =
+      CtrlProxy.computeAccessibilityServiceFlags(
+        currentFlags = first,
+        includeNotImportantViews = false,
+        reportViewIds = true,
+        retrieveInteractiveWindows = false,
+      )
+
+    // The call-site guard (flags == info.flags) relies on this: re-applying the same
+    // requested flags against the already-updated bitmask must be a true no-op.
+    assertEquals(first, second)
+  }
+
+  @Test
+  fun `sets each flag bit on when requested true`() {
+    val flags =
+      CtrlProxy.computeAccessibilityServiceFlags(
+        currentFlags = 0,
+        includeNotImportantViews = true,
+        reportViewIds = true,
+        retrieveInteractiveWindows = true,
+      )
+
+    assertEquals(
+      AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS,
+      flags and AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS,
+    )
+    assertEquals(
+      AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS,
+      flags and AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS,
+    )
+    assertEquals(
+      AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS,
+      flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS,
+    )
+  }
+
+  @Test
+  fun `clears each flag bit off when requested false, leaving unrelated bits untouched`() {
+    val unrelatedBit = AccessibilityServiceInfo.FLAG_REQUEST_TOUCH_EXPLORATION_MODE
+    val base =
+      unrelatedBit or
+        AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS or
+        AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
+        AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
+
+    val flags =
+      CtrlProxy.computeAccessibilityServiceFlags(
+        currentFlags = base,
+        includeNotImportantViews = false,
+        reportViewIds = false,
+        retrieveInteractiveWindows = false,
+      )
+
+    assertEquals(0, flags and AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS)
+    assertEquals(0, flags and AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS)
+    assertEquals(0, flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS)
+    assertEquals(unrelatedBit, flags and unrelatedBit)
+  }
+
+  @Test
+  fun `requesting the currently-applied config is a true no-op on the bitmask`() {
+    val current =
+      CtrlProxy.computeAccessibilityServiceFlags(
+        currentFlags = 0,
+        includeNotImportantViews = false,
+        reportViewIds = true,
+        retrieveInteractiveWindows = false,
+      )
+
+    val recomputed =
+      CtrlProxy.computeAccessibilityServiceFlags(
+        currentFlags = current,
+        includeNotImportantViews = false,
+        reportViewIds = true,
+        retrieveInteractiveWindows = false,
+      )
+
+    assertEquals(current, recomputed)
+  }
+}


### PR DESCRIPTION
## Problem

Since #3854-ish (`25b34de8`, "Re-sync accessibility flags on every ensureConnected, not just fresh connects"), `AndroidCtrlProxyClient.ensureConnected()` calls `syncAccessibilityFlagsToDevice()` on every invocation, not just on a fresh WebSocket connect. Its `allEnabled` early-return only skips the send when every flag is at Android's default - so any consumer running with a non-default flag (e.g. `--no-include-not-important-views`) resends `set_accessibility_flags` on essentially every tool call.

On the device side, `CtrlProxy.applyAccessibilityFlags()` unconditionally did `info.flags = flags; serviceInfo = info` on every invocation, even when the computed bitmask was identical to what was already applied. Reassigning `AccessibilityService.serviceInfo` reconfigures a *live* accessibility service on the system side - it is not a local no-op.

Combined, this meant a live service reconfiguration on every single tool call for any consumer with non-default flags.

## Observed impact

A real CI run (fub-android's qa-agent suite, non-default flags) saw **every** `observe()` for the entire session return zero elements:

```
[HIERARCHY_NAV] Received hierarchy update: hash=..., elements=0, pkg=com.followupboss.fubandroidstaging
[NAVIGATION_GRAPH] Ignoring hierarchy navigation - app has no named nodes
```

while the same device's Android launcher (not CtrlProxy-instrumented) parsed normally in the same run - pointing at the CtrlProxy-targeted app's hierarchy specifically being disrupted by the repeated live reconfiguration.

## Fix

Skip the `serviceInfo` reassignment when the newly-computed flags bitmask equals the currently-applied one. Extracted the bitmask computation into a pure `computeAccessibilityServiceFlags()` so the equality-guard logic is unit-testable without a live `AccessibilityService`/Robolectric harness.

Full `control-proxy` suite green (352/352).