### PR TITLE
feat(inputText): opt-in marker-based auto-promotion to `eventAll`

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -212,6 +212,9 @@ export class Daemon {
     if (options.dismissKeyboardAfterInput) {
       serverConfig.setDismissKeyboardAfterInputEnabled(true);
     }
+    if (options.eventAllMarkers && options.eventAllMarkers.length > 0) {
+      serverConfig.setEventAllMarkers(options.eventAllMarkers);
+    }
     if (options.debugPerf) {
       setDebugPerfEnabled(true);
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -207,13 +207,14 @@ export interface ProxiedResourceTemplate {
 
 /**
  * The daemon startup options that change its observable MCP behavior and so must
- * match before a running daemon can be reused: `embeddedSdk` plus every
- * output-reduction flag. A same-build MCP client that requests one of these
- * against an already-running daemon started without it (or vice versa) would
- * otherwise silently get the wrong tool-output contract until a manual restart
- * (issue #2759 — the `toolResultsNoStructuredContent` case). The output-reduction
- * fields are derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose `field` names map
- * 1:1 to `DaemonOptions`) so a new flag is covered automatically.
+ * match before a running daemon can be reused: `embeddedSdk`, marker-based
+ * eventAll promotion config, plus every output-reduction flag. A same-build MCP
+ * client that requests one of these against an already-running daemon started
+ * without it (or vice versa) would otherwise silently get the wrong tool-output
+ * or inputText behavior until a manual restart (issue #2759 — the
+ * `toolResultsNoStructuredContent` case). The output-reduction fields are
+ * derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose `field` names map 1:1 to
+ * `DaemonOptions`) so a new flag is covered automatically.
  */
 const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
   "embeddedSdk",
@@ -233,6 +234,10 @@ function stringOption(
   return typeof value === "string" ? value : undefined;
 }
 
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 /**
  * Reuse-critical startup options the connecting client *explicitly requests*
  * that the running daemon lacks. Reconciliation is **one-directional** (issue
@@ -240,9 +245,10 @@ function stringOption(
  * the daemon already has is never reported as a deficit just because a
  * particular caller (e.g. a bare short-lived CLI client) didn't request it.
  * Booleans are compared strictly (`=== true`), so `undefined` and `false` both
- * read as "no opinion"; strings count only when the client supplies one that
- * differs from the daemon's. Returns a human-readable list (empty when the
- * daemon already satisfies every requested flag) for logging and error messages.
+ * read as "no opinion"; strings and marker arrays count only when the client
+ * supplies one that differs from the daemon's. Returns a human-readable list
+ * (empty when the daemon already satisfies every requested flag) for logging and
+ * error messages.
  */
 function startupOptionDeficits(
   requested: DaemonOptions | undefined,
@@ -261,6 +267,15 @@ function startupOptionDeficits(
     const have = stringOption(running, key);
     if (want !== undefined && want !== have) {
       deficits.push(`${key} (requested=${want}, running=${have ?? "unset"})`);
+    }
+  }
+  const requestedEventAllMarkers = requested?.eventAllMarkers;
+  if (requestedEventAllMarkers !== undefined) {
+    const runningEventAllMarkers = running?.eventAllMarkers ?? [];
+    if (!arraysEqual(requestedEventAllMarkers, runningEventAllMarkers)) {
+      deficits.push(
+        `eventAllMarkers (requested=${JSON.stringify(requestedEventAllMarkers)}, running=${JSON.stringify(runningEventAllMarkers)})`
+      );
     }
   }
   return deficits;

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -12,6 +12,7 @@ import {
 } from "../db/migrationDependencyIntegrity";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
+import { EVENT_ALL_MARKERS_FLAG, splitMarkers } from "../utils/eventAllMarkers";
 import { shouldSkipCtrlProxyDownload } from "../utils/ctrlProxyDownloadControl";
 import { ActionableError } from "../models";
 import {
@@ -740,6 +741,9 @@ export class DaemonManager implements DaemonManagerLike {
     if (options.dismissKeyboardAfterInput) {
       args.push("--dismiss-keyboard-after-input");
     }
+    if (options.eventAllMarkers && options.eventAllMarkers.length > 0) {
+      args.push(EVENT_ALL_MARKERS_FLAG, options.eventAllMarkers.join(","));
+    }
     if (options.noUiPerfMode) {
       args.push("--no-ui-perf-mode");
     }
@@ -1240,6 +1244,12 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
       options.embeddedSdk = true;
     } else if (args[i] === "--dismiss-keyboard-after-input") {
       options.dismissKeyboardAfterInput = true;
+    } else if (args[i] === EVENT_ALL_MARKERS_FLAG) {
+      const markers = args[i + 1];
+      if (markers && !markers.startsWith("--")) {
+        options.eventAllMarkers = splitMarkers(markers);
+      }
+      i++;
     } else if (args[i] === "--no-ui-perf-mode") {
       options.noUiPerfMode = true;
     } else if (args[i] === "--no-navigation-screenshots") {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -12,7 +12,11 @@ import {
 } from "../db/migrationDependencyIntegrity";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
-import { EVENT_ALL_MARKERS_FLAG, splitMarkers } from "../utils/eventAllMarkers";
+import {
+  EVENT_ALL_MARKERS_FLAG,
+  hasEventAllMarkersCliOverride,
+  parseEventAllMarkersConfig,
+} from "../utils/eventAllMarkers";
 import { shouldSkipCtrlProxyDownload } from "../utils/ctrlProxyDownloadControl";
 import { ActionableError } from "../models";
 import {
@@ -743,6 +747,8 @@ export class DaemonManager implements DaemonManagerLike {
     }
     if (options.eventAllMarkers && options.eventAllMarkers.length > 0) {
       args.push(EVENT_ALL_MARKERS_FLAG, options.eventAllMarkers.join(","));
+    } else if (options.eventAllMarkersCliOverride) {
+      args.push(`${EVENT_ALL_MARKERS_FLAG}=`);
     }
     if (options.noUiPerfMode) {
       args.push("--no-ui-perf-mode");
@@ -1194,6 +1200,12 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
     env,
     resolveDaemonLaunchWorkingDirectory()
   );
+  const eventAllMarkers = parseEventAllMarkersConfig(args, env);
+  const eventAllMarkersCliOverride = hasEventAllMarkersCliOverride(args);
+  if (eventAllMarkers.length > 0 || eventAllMarkersCliOverride) {
+    options.eventAllMarkers = eventAllMarkers;
+    options.eventAllMarkersCliOverride = eventAllMarkersCliOverride;
+  }
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--port") {
       options.port = parseInt(args[i + 1], 10);
@@ -1244,12 +1256,6 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
       options.embeddedSdk = true;
     } else if (args[i] === "--dismiss-keyboard-after-input") {
       options.dismissKeyboardAfterInput = true;
-    } else if (args[i] === EVENT_ALL_MARKERS_FLAG) {
-      const markers = args[i + 1];
-      if (markers && !markers.startsWith("--")) {
-        options.eventAllMarkers = splitMarkers(markers);
-      }
-      i++;
     } else if (args[i] === "--no-ui-perf-mode") {
       options.noUiPerfMode = true;
     } else if (args[i] === "--no-navigation-screenshots") {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -181,6 +181,8 @@ export interface DaemonOptions {
   embeddedSdk?: boolean;
   /** Dismiss keyboard after text input (Android only) */
   dismissKeyboardAfterInput?: boolean;
+  /** Markers that auto-promote inputText from `a11y` to `eventAll` (Android only) */
+  eventAllMarkers?: string[];
   /** Disable UI performance mode */
   noUiPerfMode?: boolean;
   /** Enable memory performance audit */

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -183,6 +183,8 @@ export interface DaemonOptions {
   dismissKeyboardAfterInput?: boolean;
   /** Markers that auto-promote inputText from `a11y` to `eventAll` (Android only) */
   eventAllMarkers?: string[];
+  /** Preserve an explicit CLI marker override, including `--event-all-markers=` */
+  eventAllMarkersCliOverride?: boolean;
   /** Disable UI performance mode */
   noUiPerfMode?: boolean;
   /** Enable memory performance audit */

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -8,6 +8,8 @@ import { defaultTimer } from "../../utils/SystemTimer";
 import { readAndroidDeviceApiLevel } from "../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { resolveAutoInputMode } from "./resolveAutoInputMode";
+import { serverConfig } from "../../utils/ServerConfig";
 
 export type InputTextMode = "a11y" | "eventLast" | "eventAll";
 
@@ -29,7 +31,7 @@ export class InputText extends BaseVisualChange {
     text: string,
     imeAction?: ImeAction,
     dismissKeyboard: boolean = false,
-    mode: InputTextMode = "a11y"
+    mode?: InputTextMode
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     const perf = createGlobalPerformanceTracker();
     perf.serial("inputText");
@@ -45,6 +47,13 @@ export class InputText extends BaseVisualChange {
       };
     }
 
+    // Resolve the Android input mode: an explicit caller-supplied mode always
+    // wins; otherwise consumer-configured markers may auto-promote to
+    // `eventAll` (real key events); otherwise fall back to the default `a11y`.
+    // Mode is Android-only — iOS ignores it.
+    const resolvedMode: InputTextMode =
+      mode ?? resolveAutoInputMode(text, serverConfig.getEventAllMarkers()) ?? "a11y";
+
     return this.observedInteraction(
       async () => {
         try {
@@ -52,7 +61,7 @@ export class InputText extends BaseVisualChange {
           switch (this.device.platform) {
             case "android":
               return await perf.track("androidTextInput", () =>
-                this.executeAndroidTextInput(text, imeAction, dismissKeyboard, mode)
+                this.executeAndroidTextInput(text, imeAction, dismissKeyboard, resolvedMode)
               );
             case "ios":
               // dismissKeyboard is Android-only — it works around an emulator
@@ -72,7 +81,7 @@ export class InputText extends BaseVisualChange {
             success: false,
             text,
             error: `Failed to send text input: ${errorMessage}`,
-            method: this.device.platform === "android" ? mode : "a11y"
+            method: this.device.platform === "android" ? resolvedMode : "a11y"
           };
         }
       },

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -50,9 +50,17 @@ export class InputText extends BaseVisualChange {
     // Resolve the Android input mode: an explicit caller-supplied mode always
     // wins; otherwise consumer-configured markers may auto-promote to
     // `eventAll` (real key events); otherwise fall back to the default `a11y`.
-    // Mode is Android-only — iOS ignores it.
-    const resolvedMode: InputTextMode =
-      mode ?? resolveAutoInputMode(text, serverConfig.getEventAllMarkers()) ?? "a11y";
+    // Mode is Android-only — iOS ignores it, so skip the resolution there.
+    let resolvedMode: InputTextMode = mode ?? "a11y";
+    if (this.device.platform === "android" && mode === undefined) {
+      const autoMode = resolveAutoInputMode(text, serverConfig.getEventAllMarkers());
+      if (autoMode) {
+        resolvedMode = autoMode;
+        logger.debug(
+          "[InputText] auto-promoted a11y -> eventAll (text matched a configured event-all marker)"
+        );
+      }
+    }
 
     return this.observedInteraction(
       async () => {
@@ -76,6 +84,7 @@ export class InputText extends BaseVisualChange {
         } catch (error) {
           perf.end();
           const errorMessage = error instanceof Error ? error.message : String(error);
+          logger.warn(`[InputText] text input failed (mode=${resolvedMode}): ${errorMessage}`, error);
 
           return {
             success: false,

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -466,7 +466,11 @@ export class SetUIState extends BaseVisualChange {
             return { success: false, error: `Failed to clear text: ${clearResult.error}` };
           }
 
-          // Input new text
+          // Input new text. Intentionally passes no mode so the shared
+          // InputText.execute applies event-all marker auto-promotion here too
+          // (a form field value containing a configured marker, e.g. an
+          // @mention, is typed via eventAll). This is by design — the feature
+          // is scoped to both inputText and setUIState text fields.
           logger.debug(`[SetUIState] text.input selector=${selectorDesc} textLength=${fieldSpec.value.length}`);
           const inputStart = Date.now();
           const inputResult = await inputText.execute(fieldSpec.value);

--- a/src/features/action/resolveAutoInputMode.ts
+++ b/src/features/action/resolveAutoInputMode.ts
@@ -1,5 +1,3 @@
-import { InputTextMode } from "./InputText";
-
 /**
  * Decide whether an inputText call should be auto-promoted from the default
  * `a11y` mode to `eventAll` based on the presence of consumer-configured
@@ -11,7 +9,8 @@ import { InputTextMode } from "./InputText";
  * and never triggers those popups.
  *
  * The feature is opt-in: with an empty `markers` list this always returns
- * `undefined`, so callers fall back to their normal default.
+ * `undefined`, so callers fall back to their normal default. Promotion is
+ * one-directional — this only ever returns `"eventAll"` or `undefined`.
  *
  * @param text - The text about to be entered
  * @param markers - Consumer-supplied substrings that should force `eventAll`
@@ -19,13 +18,12 @@ import { InputTextMode } from "./InputText";
  */
 export function resolveAutoInputMode(
   text: string,
-  markers: string[]
-): InputTextMode | undefined {
-  if (markers.length === 0) {
-    return undefined;
-  }
-
+  markers: readonly string[]
+): "eventAll" | undefined {
   for (const marker of markers) {
+    // Guard against an empty marker: text.includes("") is always true, which
+    // would promote every input. splitMarkers strips these in the CLI/env
+    // path, but this keeps direct callers safe too.
     if (marker.length > 0 && text.includes(marker)) {
       return "eventAll";
     }

--- a/src/features/action/resolveAutoInputMode.ts
+++ b/src/features/action/resolveAutoInputMode.ts
@@ -1,0 +1,35 @@
+import { InputTextMode } from "./InputText";
+
+/**
+ * Decide whether an inputText call should be auto-promoted from the default
+ * `a11y` mode to `eventAll` based on the presence of consumer-configured
+ * markers in the text.
+ *
+ * `eventAll` types character-by-character via real key events, which lets apps
+ * that only react to keystrokes (mention/slash/emoji autocomplete popups) open
+ * and resolve their suggestions. The default `a11y` mode sets text atomically
+ * and never triggers those popups.
+ *
+ * The feature is opt-in: with an empty `markers` list this always returns
+ * `undefined`, so callers fall back to their normal default.
+ *
+ * @param text - The text about to be entered
+ * @param markers - Consumer-supplied substrings that should force `eventAll`
+ * @returns `"eventAll"` if any marker is present in `text`, else `undefined`
+ */
+export function resolveAutoInputMode(
+  text: string,
+  markers: string[]
+): InputTextMode | undefined {
+  if (markers.length === 0) {
+    return undefined;
+  }
+
+  for (const marker of markers) {
+    if (marker.length > 0 && text.includes(marker)) {
+      return "eventAll";
+    }
+  }
+
+  return undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   shouldSkipCtrlProxyDownload,
 } from "./utils/ctrlProxyDownloadControl";
 import { parseToolOutputsDirConfig } from "./utils/toolOutputArtifacts";
+import { parseEventAllMarkersConfig } from "./utils/eventAllMarkers";
 import {
   installProcessLifecycleHandlers,
   setFatalProcessHandler,
@@ -107,6 +108,7 @@ function parseArgs(log: ParseLogger): {
   embeddedSdk: boolean;
   networkMockable: boolean;
   dismissKeyboardAfterInput: boolean;
+  eventAllMarkers: string[];
   mcpRecording: boolean;
   navigationScreenshots: boolean;
   noWaitForPollingOverhead: boolean;
@@ -173,6 +175,7 @@ function parseArgs(log: ParseLogger): {
   const embeddedSdk = args.includes("--embedded-sdk");
   const networkMockable = args.includes("--network-mockable");
   const dismissKeyboardAfterInput = args.includes("--dismiss-keyboard-after-input");
+  const eventAllMarkers = parseEventAllMarkersConfig(args, process.env);
   const mcpRecording = args.includes("--mcp-recording");
   const navigationScreenshots = !args.includes("--no-navigation-screenshots");
   const noWaitForPollingOverhead = args.includes("--no-waitfor-polling-overhead");
@@ -380,6 +383,7 @@ function parseArgs(log: ParseLogger): {
     embeddedSdk,
     networkMockable,
     dismissKeyboardAfterInput,
+    eventAllMarkers,
     mcpRecording,
     navigationScreenshots,
     noWaitForPollingOverhead,
@@ -463,6 +467,7 @@ async function main() {
       embeddedSdk,
       networkMockable,
       dismissKeyboardAfterInput,
+      eventAllMarkers,
       mcpRecording,
       navigationScreenshots,
       noWaitForPollingOverhead,
@@ -482,6 +487,7 @@ async function main() {
     serverConfig.setEmbeddedSdkEnabled(embeddedSdk);
     serverConfig.setNetworkMockableEnabled(networkMockable);
     serverConfig.setDismissKeyboardAfterInputEnabled(dismissKeyboardAfterInput);
+    serverConfig.setEventAllMarkers(eventAllMarkers);
     if (skipCtrlProxyDownload) {
       logger.info(`CtrlProxy downloads disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
     } else {
@@ -604,6 +610,9 @@ async function main() {
         logger.info(message);
       }
     }
+    if (eventAllMarkers.length > 0) {
+      logger.info(`inputText eventAll auto-promotion markers configured (--event-all-markers): ${JSON.stringify(eventAllMarkers)}`);
+    }
 
     if (daemonMode) {
       await startDaemon({
@@ -622,6 +631,7 @@ async function main() {
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,
+        eventAllMarkers,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,
         accessibilityAudit: a11yAuditMode,
@@ -684,6 +694,7 @@ async function main() {
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,
+        eventAllMarkers,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,
         accessibilityAudit: a11yAuditMode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,11 @@ import {
   shouldSkipCtrlProxyDownload,
 } from "./utils/ctrlProxyDownloadControl";
 import { parseToolOutputsDirConfig } from "./utils/toolOutputArtifacts";
-import { parseEventAllMarkersConfig, EVENT_ALL_MARKERS_FLAG } from "./utils/eventAllMarkers";
+import {
+  parseEventAllMarkersConfig,
+  hasEventAllMarkersCliOverride,
+  EVENT_ALL_MARKERS_FLAG,
+} from "./utils/eventAllMarkers";
 import {
   installProcessLifecycleHandlers,
   setFatalProcessHandler,
@@ -109,6 +113,7 @@ function parseArgs(log: ParseLogger): {
   networkMockable: boolean;
   dismissKeyboardAfterInput: boolean;
   eventAllMarkers: string[];
+  eventAllMarkersCliOverride: boolean;
   mcpRecording: boolean;
   navigationScreenshots: boolean;
   noWaitForPollingOverhead: boolean;
@@ -176,6 +181,7 @@ function parseArgs(log: ParseLogger): {
   const networkMockable = args.includes("--network-mockable");
   const dismissKeyboardAfterInput = args.includes("--dismiss-keyboard-after-input");
   const eventAllMarkers = parseEventAllMarkersConfig(args, process.env);
+  const eventAllMarkersCliOverride = hasEventAllMarkersCliOverride(args);
   const mcpRecording = args.includes("--mcp-recording");
   const navigationScreenshots = !args.includes("--no-navigation-screenshots");
   const noWaitForPollingOverhead = args.includes("--no-waitfor-polling-overhead");
@@ -384,6 +390,7 @@ function parseArgs(log: ParseLogger): {
     networkMockable,
     dismissKeyboardAfterInput,
     eventAllMarkers,
+    eventAllMarkersCliOverride,
     mcpRecording,
     navigationScreenshots,
     noWaitForPollingOverhead,
@@ -468,6 +475,7 @@ async function main() {
       networkMockable,
       dismissKeyboardAfterInput,
       eventAllMarkers,
+      eventAllMarkersCliOverride,
       mcpRecording,
       navigationScreenshots,
       noWaitForPollingOverhead,
@@ -616,6 +624,11 @@ async function main() {
       logger.warn(`${EVENT_ALL_MARKERS_FLAG} was provided but resolved to no markers; inputText eventAll auto-promotion stays disabled`);
     }
 
+    const eventAllMarkerDaemonOptions: Pick<DaemonOptions, "eventAllMarkers" | "eventAllMarkersCliOverride"> =
+      eventAllMarkers.length > 0 || eventAllMarkersCliOverride
+        ? { eventAllMarkers, eventAllMarkersCliOverride }
+        : {};
+
     if (daemonMode) {
       await startDaemon({
         port: daemonPort,
@@ -633,7 +646,7 @@ async function main() {
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,
-        eventAllMarkers,
+        ...eventAllMarkerDaemonOptions,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,
         accessibilityAudit: a11yAuditMode,
@@ -696,7 +709,7 @@ async function main() {
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,
-        eventAllMarkers,
+        ...eventAllMarkerDaemonOptions,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,
         accessibilityAudit: a11yAuditMode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ import {
   shouldSkipCtrlProxyDownload,
 } from "./utils/ctrlProxyDownloadControl";
 import { parseToolOutputsDirConfig } from "./utils/toolOutputArtifacts";
-import { parseEventAllMarkersConfig } from "./utils/eventAllMarkers";
+import { parseEventAllMarkersConfig, EVENT_ALL_MARKERS_FLAG } from "./utils/eventAllMarkers";
 import {
   installProcessLifecycleHandlers,
   setFatalProcessHandler,
@@ -612,6 +612,8 @@ async function main() {
     }
     if (eventAllMarkers.length > 0) {
       logger.info(`inputText eventAll auto-promotion markers configured (--event-all-markers): ${JSON.stringify(eventAllMarkers)}`);
+    } else if (process.argv.slice(2).some(a => a === EVENT_ALL_MARKERS_FLAG || a.startsWith(`${EVENT_ALL_MARKERS_FLAG}=`))) {
+      logger.warn(`${EVENT_ALL_MARKERS_FLAG} was provided but resolved to no markers; inputText eventAll auto-promotion stays disabled`);
     }
 
     if (daemonMode) {

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -186,12 +186,12 @@ class ServerConfig {
    * the default `a11y` mode to `eventAll` (real per-character key events). An
    * empty list (the default) disables the behavior entirely.
    */
-  setEventAllMarkers(markers: string[]): void {
+  setEventAllMarkers(markers: readonly string[]): void {
     this._eventAllMarkers = [...markers];
   }
 
-  getEventAllMarkers(): string[] {
-    return [...this._eventAllMarkers];
+  getEventAllMarkers(): readonly string[] {
+    return this._eventAllMarkers;
   }
 
   setNavigationScreenshotsEnabled(enabled: boolean): void {

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -29,6 +29,7 @@ class ServerConfig {
   private _networkMockableEnabled: boolean = false;
   private _mcpRecordingEnabled: boolean = false;
   private _dismissKeyboardAfterInputEnabled: boolean = false;
+  private _eventAllMarkers: string[] = [];
   private _navigationScreenshotsEnabled: boolean = true;
   private _waitForPollingOverheadEnabled: boolean = true;
   private _a11yIncludeNotImportantViews: boolean = true;
@@ -178,6 +179,19 @@ class ServerConfig {
 
   isDismissKeyboardAfterInputEnabled(): boolean {
     return this._dismissKeyboardAfterInputEnabled;
+  }
+
+  /**
+   * Markers that, when present in inputText's text, auto-promote the call from
+   * the default `a11y` mode to `eventAll` (real per-character key events). An
+   * empty list (the default) disables the behavior entirely.
+   */
+  setEventAllMarkers(markers: string[]): void {
+    this._eventAllMarkers = [...markers];
+  }
+
+  getEventAllMarkers(): string[] {
+    return [...this._eventAllMarkers];
   }
 
   setNavigationScreenshotsEnabled(enabled: boolean): void {

--- a/src/utils/cliArgs.ts
+++ b/src/utils/cliArgs.ts
@@ -1,0 +1,29 @@
+/**
+ * Read the value for the first matching flag from an argv array, supporting
+ * both the space-separated `--flag value` and inline `--flag=value` forms.
+ *
+ * For the space-separated form, a following token that is itself a flag
+ * (starts with `--`) is treated as a missing value and yields `undefined`,
+ * so `--flag --other` does not swallow `--other` as the value.
+ *
+ * @param args - argv tokens (excluding the node/script prefix)
+ * @param flags - flag names to match (e.g. `["--tool-outputs-dir", "--tool-output-dir"]`)
+ * @returns the resolved value, or `undefined` if no flag matched or its value was missing
+ */
+export function firstFlagValue(args: string[], flags: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (flags.includes(arg)) {
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) {
+        return undefined;
+      }
+      return value;
+    }
+    const matched = flags.find(flag => arg.startsWith(`${flag}=`));
+    if (matched) {
+      return arg.slice(matched.length + 1);
+    }
+  }
+  return undefined;
+}

--- a/src/utils/eventAllMarkers.ts
+++ b/src/utils/eventAllMarkers.ts
@@ -3,6 +3,20 @@ import { firstFlagValue } from "./cliArgs";
 export const EVENT_ALL_MARKERS_FLAG = "--event-all-markers";
 export const EVENT_ALL_MARKERS_ENV = "AUTOMOBILE_EVENT_ALL_MARKERS";
 
+export function hasEventAllMarkersCliOverride(args: string[]): boolean {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith(`${EVENT_ALL_MARKERS_FLAG}=`)) {
+      return true;
+    }
+    if (arg === EVENT_ALL_MARKERS_FLAG) {
+      const value = args[i + 1];
+      return value !== undefined && !value.startsWith("--");
+    }
+  }
+  return false;
+}
+
 /**
  * Split a comma-separated marker string into a normalized marker list.
  * Trims each entry and drops empties so `"@, /, #"` and `"@,/,#"` are equal.

--- a/src/utils/eventAllMarkers.ts
+++ b/src/utils/eventAllMarkers.ts
@@ -1,3 +1,5 @@
+import { firstFlagValue } from "./cliArgs";
+
 export const EVENT_ALL_MARKERS_FLAG = "--event-all-markers";
 export const EVENT_ALL_MARKERS_ENV = "AUTOMOBILE_EVENT_ALL_MARKERS";
 
@@ -5,33 +7,11 @@ export const EVENT_ALL_MARKERS_ENV = "AUTOMOBILE_EVENT_ALL_MARKERS";
  * Split a comma-separated marker string into a normalized marker list.
  * Trims each entry and drops empties so `"@, /, #"` and `"@,/,#"` are equal.
  */
-function splitMarkers(value: string): string[] {
+export function splitMarkers(value: string): string[] {
   return value
     .split(",")
     .map(marker => marker.trim())
     .filter(marker => marker.length > 0);
-}
-
-/**
- * Read the raw CLI value for `--event-all-markers`, supporting both the
- * `--event-all-markers=<csv>` and `--event-all-markers <csv>` forms.
- */
-function firstFlagValue(args: string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === EVENT_ALL_MARKERS_FLAG) {
-      const value = args[i + 1];
-      // Guard against a following flag being mistaken for the value.
-      if (!value || value.startsWith("--")) {
-        return undefined;
-      }
-      return value;
-    }
-    if (arg.startsWith(`${EVENT_ALL_MARKERS_FLAG}=`)) {
-      return arg.slice(EVENT_ALL_MARKERS_FLAG.length + 1);
-    }
-  }
-  return undefined;
 }
 
 /**
@@ -43,7 +23,7 @@ export function parseEventAllMarkersConfig(
   args: string[],
   env: NodeJS.ProcessEnv
 ): string[] {
-  const raw = firstFlagValue(args) ?? env[EVENT_ALL_MARKERS_ENV];
+  const raw = firstFlagValue(args, [EVENT_ALL_MARKERS_FLAG]) ?? env[EVENT_ALL_MARKERS_ENV];
   if (!raw) {
     return [];
   }

--- a/src/utils/eventAllMarkers.ts
+++ b/src/utils/eventAllMarkers.ts
@@ -1,0 +1,51 @@
+export const EVENT_ALL_MARKERS_FLAG = "--event-all-markers";
+export const EVENT_ALL_MARKERS_ENV = "AUTOMOBILE_EVENT_ALL_MARKERS";
+
+/**
+ * Split a comma-separated marker string into a normalized marker list.
+ * Trims each entry and drops empties so `"@, /, #"` and `"@,/,#"` are equal.
+ */
+function splitMarkers(value: string): string[] {
+  return value
+    .split(",")
+    .map(marker => marker.trim())
+    .filter(marker => marker.length > 0);
+}
+
+/**
+ * Read the raw CLI value for `--event-all-markers`, supporting both the
+ * `--event-all-markers=<csv>` and `--event-all-markers <csv>` forms.
+ */
+function firstFlagValue(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === EVENT_ALL_MARKERS_FLAG) {
+      const value = args[i + 1];
+      // Guard against a following flag being mistaken for the value.
+      if (!value || value.startsWith("--")) {
+        return undefined;
+      }
+      return value;
+    }
+    if (arg.startsWith(`${EVENT_ALL_MARKERS_FLAG}=`)) {
+      return arg.slice(EVENT_ALL_MARKERS_FLAG.length + 1);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the configured event-all marker list from CLI args (winning) or the
+ * `AUTOMOBILE_EVENT_ALL_MARKERS` env var. Returns an empty array when unset,
+ * which leaves marker-based auto-promotion disabled.
+ */
+export function parseEventAllMarkersConfig(
+  args: string[],
+  env: NodeJS.ProcessEnv
+): string[] {
+  const raw = firstFlagValue(args) ?? env[EVENT_ALL_MARKERS_ENV];
+  if (!raw) {
+    return [];
+  }
+  return splitMarkers(raw);
+}

--- a/src/utils/toolOutputArtifacts.ts
+++ b/src/utils/toolOutputArtifacts.ts
@@ -4,6 +4,7 @@ import { ActionableError } from "../models";
 import type { FileSystem } from "./filesystem/DefaultFileSystem";
 import { serverConfig } from "./ServerConfig";
 import { getTempDir, TEMP_SUBDIRS } from "./tempDir";
+import { firstFlagValue } from "./cliArgs";
 
 export const TOOL_OUTPUTS_DIR_FLAG = "--tool-outputs-dir";
 export const TOOL_OUTPUT_DIR_FLAG_ALIAS = "--tool-output-dir";
@@ -28,20 +29,6 @@ const nodeToolOutputsDirValidationDeps: ToolOutputsDirValidationDeps = {
     await fsPromises.access(dirPath, fsConstants.W_OK);
   },
 };
-
-function firstFlagValue(args: string[], flags: string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    if (!flags.includes(args[i])) {
-      continue;
-    }
-    const value = args[i + 1];
-    if (!value || value.startsWith("--")) {
-      return undefined;
-    }
-    return value;
-  }
-  return undefined;
-}
 
 function normalizeConfiguredPath(value: string | undefined, launchCwd: string): string | undefined {
   const trimmed = value?.trim();

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -7,6 +7,7 @@ import { DaemonManager, type DaemonProcessSpawner } from "../../src/daemon/manag
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { TOOL_OUTPUTS_DIR_ENV, TOOL_OUTPUTS_DIR_FLAG } from "../../src/utils/toolOutputArtifacts";
+import { EVENT_ALL_MARKERS_ENV, EVENT_ALL_MARKERS_FLAG } from "../../src/utils/eventAllMarkers";
 
 describe("DaemonManager launch", () => {
   const tempDirs: string[] = [];
@@ -22,6 +23,7 @@ describe("DaemonManager launch", () => {
     process.chdir(originalCwd);
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
     delete process.env.AUTOMOBILE_DATA_DIR;
+    delete process.env[EVENT_ALL_MARKERS_ENV];
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -226,6 +228,101 @@ describe("DaemonManager launch", () => {
 
     expect(capturedArgs).not.toContain(TOOL_OUTPUTS_DIR_FLAG);
     expect(capturedEnv![TOOL_OUTPUTS_DIR_ENV]).toBe(toolOutputsDir);
+  });
+
+  test("serializes explicit empty event-all marker override so daemon env fallback stays disabled", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    process.env.AUTOMOBILE_DATA_DIR = stateDir;
+    process.env[EVENT_ALL_MARKERS_ENV] = "@";
+
+    let capturedArgs: string[] | undefined;
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, args: string[], _options: SpawnOptions) => {
+        capturedArgs = args;
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start({ eventAllMarkers: [], eventAllMarkersCliOverride: true });
+
+    expect(capturedArgs).toContain(`${EVENT_ALL_MARKERS_FLAG}=`);
+    expect(capturedArgs).not.toContain(EVENT_ALL_MARKERS_FLAG);
+  });
+
+  test("does not serialize absent event-all marker config as an empty override", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    process.env.AUTOMOBILE_DATA_DIR = stateDir;
+
+    let capturedArgs: string[] | undefined;
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, args: string[], _options: SpawnOptions) => {
+        capturedArgs = args;
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start({ eventAllMarkers: [] });
+
+    expect(capturedArgs).not.toContain(`${EVENT_ALL_MARKERS_FLAG}=`);
+    expect(capturedArgs).not.toContain(EVENT_ALL_MARKERS_FLAG);
   });
 
   test("resolves relative daemon state paths before changing daemon cwd", async () => {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -430,7 +430,13 @@ describe("DaemonMcpProxy", () => {
     });
 
     describe("startup option mismatch handling", () => {
-      function runningStatus(options: { embeddedSdk?: boolean; toolResultsNoStructuredContent?: boolean; toolOutputsDir?: string }) {
+      function runningStatus(options: {
+        embeddedSdk?: boolean;
+        toolResultsNoStructuredContent?: boolean;
+        toolOutputsDir?: string;
+        eventAllMarkers?: string[];
+        eventAllMarkersCliOverride?: boolean;
+      }) {
         return {
           running: true,
           pid: 1234,
@@ -526,6 +532,65 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
+      test("restarts daemon when explicit empty event-all markers override differs", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureVersionMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureBuildMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ eventAllMarkers: [], eventAllMarkersCliOverride: true }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { eventAllMarkers: [], eventAllMarkersCliOverride: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({
+            eventAllMarkers: [],
+            eventAllMarkersCliOverride: true,
+          });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts daemon when requested event-all markers differ", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ eventAllMarkers: ["/"] }), // ensureVersionMatches
+          runningStatus({ eventAllMarkers: ["/"] }), // ensureBuildMatches
+          runningStatus({ eventAllMarkers: ["/"] }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ eventAllMarkers: ["@"] }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { eventAllMarkers: ["@"] },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ eventAllMarkers: ["@"] });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
       test("does not restart daemon when output-reduction flags match", async () => {
         const fakeClient = new FakeDaemonClient({
           daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
@@ -578,6 +643,32 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
+      test("does not restart daemon when event-all markers match", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureVersionMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureBuildMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureStartupOptionsMatch
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { eventAllMarkers: ["@"] },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
       test("does NOT restart (no downgrade) when a bare client connects to a configured daemon (issue #3846)", async () => {
         const fakeClient = new FakeDaemonClient({
           daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
@@ -587,9 +678,9 @@ describe("DaemonMcpProxy", () => {
         // connecting client is bare (no daemonOptions) and must NOT trigger a
         // restart that strips those flags.
         fakeManager.statusResults = [
-          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true }), // ensureVersionMatches
-          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true }), // ensureBuildMatches
-          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true }), // ensureStartupOptionsMatch
+          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true, eventAllMarkers: ["@"] }), // ensureVersionMatches
+          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true, eventAllMarkers: ["@"] }), // ensureBuildMatches
+          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true, eventAllMarkers: ["@"] }), // ensureStartupOptionsMatch
         ];
         const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
         const proxy = new DaemonMcpProxy({

--- a/test/daemon/managerOutputReductionArgs.test.ts
+++ b/test/daemon/managerOutputReductionArgs.test.ts
@@ -91,9 +91,37 @@ describe("event-all markers daemon arg relay", () => {
       .toEqual(["@", "/", "#"]);
   });
 
+  test("--event-all-markers=<csv> parses into DaemonOptions", () => {
+    expect(parseDaemonArgs(["--event-all-markers=@,/,#"]).eventAllMarkers)
+      .toEqual(["@", "/", "#"]);
+  });
+
   test("trims and drops empties on parse", () => {
     expect(parseDaemonArgs(["--event-all-markers", " @ , / , "]).eventAllMarkers)
       .toEqual(["@", "/"]);
+  });
+
+  test("falls back to AUTOMOBILE_EVENT_ALL_MARKERS", () => {
+    expect(parseDaemonArgs([], { AUTOMOBILE_EVENT_ALL_MARKERS: "@,:" }).eventAllMarkers)
+      .toEqual(["@", ":"]);
+  });
+
+  test("preserves an explicit empty CLI override over AUTOMOBILE_EVENT_ALL_MARKERS", () => {
+    const options = parseDaemonArgs(
+      ["--event-all-markers="],
+      { AUTOMOBILE_EVENT_ALL_MARKERS: "@,:" }
+    );
+    expect(options.eventAllMarkers).toEqual([]);
+    expect(options.eventAllMarkersCliOverride).toBe(true);
+  });
+
+  test("CLI flag wins over AUTOMOBILE_EVENT_ALL_MARKERS", () => {
+    const options = parseDaemonArgs(
+      ["--event-all-markers", "#"],
+      { AUTOMOBILE_EVENT_ALL_MARKERS: "@" }
+    );
+    expect(options.eventAllMarkers).toEqual(["#"]);
+    expect(options.eventAllMarkersCliOverride).toBe(true);
   });
 
   test("ignores missing or flag-shaped values", () => {

--- a/test/daemon/managerOutputReductionArgs.test.ts
+++ b/test/daemon/managerOutputReductionArgs.test.ts
@@ -85,6 +85,27 @@ describe("output-reduction daemon-arg round trip", () => {
   });
 });
 
+describe("event-all markers daemon arg relay", () => {
+  test("--event-all-markers parses a csv into DaemonOptions", () => {
+    expect(parseDaemonArgs(["--event-all-markers", "@,/,#"]).eventAllMarkers)
+      .toEqual(["@", "/", "#"]);
+  });
+
+  test("trims and drops empties on parse", () => {
+    expect(parseDaemonArgs(["--event-all-markers", " @ , / , "]).eventAllMarkers)
+      .toEqual(["@", "/"]);
+  });
+
+  test("ignores missing or flag-shaped values", () => {
+    expect(parseDaemonArgs(["--event-all-markers"]).eventAllMarkers).toBeUndefined();
+    expect(parseDaemonArgs(["--event-all-markers", "--debug"]).eventAllMarkers).toBeUndefined();
+  });
+
+  test("defaults to undefined when the flag is absent", () => {
+    expect(parseDaemonArgs([]).eventAllMarkers).toBeUndefined();
+  });
+});
+
 describe("tool outputs directory daemon arg relay", () => {
   test("--tool-outputs-dir parses into DaemonOptions", () => {
     expect(parseDaemonArgs(["--tool-outputs-dir", "/tmp/artifacts"]).toolOutputsDir)

--- a/test/features/action/resolveAutoInputMode.test.ts
+++ b/test/features/action/resolveAutoInputMode.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { resolveAutoInputMode } from "../../../src/features/action/resolveAutoInputMode";
+
+describe("resolveAutoInputMode", () => {
+  test("returns undefined when no markers are configured (feature off)", () => {
+    expect(resolveAutoInputMode("/msg @Nikki Kroll hi", [])).toBeUndefined();
+  });
+
+  test("promotes to eventAll when text contains a configured marker", () => {
+    expect(resolveAutoInputMode("/msg @Nikki hi", ["@", "/", "#"])).toBe("eventAll");
+  });
+
+  test("matches any marker in the list, not just the first", () => {
+    expect(resolveAutoInputMode("hello #channel", ["@", "/", "#"])).toBe("eventAll");
+  });
+
+  test("returns undefined when no marker is present in the text", () => {
+    expect(resolveAutoInputMode("plain message", ["@", "/", "#"])).toBeUndefined();
+  });
+
+  test("matches multi-character markers via substring containment", () => {
+    expect(resolveAutoInputMode("see https://x.test", ["https://"])).toBe("eventAll");
+  });
+
+  test("ignores empty-string markers", () => {
+    expect(resolveAutoInputMode("plain", [""])).toBeUndefined();
+  });
+
+  test("supports the Slack formatting marker set", () => {
+    for (const marker of ["@", "/", "#", ":", "_", "*", "~"]) {
+      expect(resolveAutoInputMode(`a${marker}b`, ["@", "/", "#", ":", "_", "*", "~"])).toBe("eventAll");
+    }
+  });
+});

--- a/test/utils/cliArgs.test.ts
+++ b/test/utils/cliArgs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { firstFlagValue } from "../../src/utils/cliArgs";
+
+describe("firstFlagValue", () => {
+  test("reads the space-separated form", () => {
+    expect(firstFlagValue(["--flag", "value"], ["--flag"])).toBe("value");
+  });
+
+  test("reads the inline =value form", () => {
+    expect(firstFlagValue(["--flag=value"], ["--flag"])).toBe("value");
+  });
+
+  test("returns undefined when the value is a following flag", () => {
+    expect(firstFlagValue(["--flag", "--other"], ["--flag"])).toBeUndefined();
+  });
+
+  test("returns undefined when the flag has no value", () => {
+    expect(firstFlagValue(["--flag"], ["--flag"])).toBeUndefined();
+  });
+
+  test("returns undefined when no flag matches", () => {
+    expect(firstFlagValue(["--other", "x"], ["--flag"])).toBeUndefined();
+  });
+
+  test("matches any flag alias", () => {
+    expect(firstFlagValue(["--alias", "v"], ["--flag", "--alias"])).toBe("v");
+    expect(firstFlagValue(["--alias=v"], ["--flag", "--alias"])).toBe("v");
+  });
+
+  test("empty inline value yields empty string, not undefined", () => {
+    expect(firstFlagValue(["--flag="], ["--flag"])).toBe("");
+  });
+});

--- a/test/utils/eventAllMarkers.test.ts
+++ b/test/utils/eventAllMarkers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { parseEventAllMarkersConfig } from "../../src/utils/eventAllMarkers";
+
+describe("parseEventAllMarkersConfig", () => {
+  test("returns an empty list when nothing is configured (feature off)", () => {
+    expect(parseEventAllMarkersConfig([], {})).toEqual([]);
+  });
+
+  test("parses a comma-separated CLI value", () => {
+    expect(parseEventAllMarkersConfig(["--event-all-markers", "@,/,#"], {})).toEqual(["@", "/", "#"]);
+  });
+
+  test("parses the --event-all-markers=<csv> form", () => {
+    expect(parseEventAllMarkersConfig(["--event-all-markers=@,/,#"], {})).toEqual(["@", "/", "#"]);
+  });
+
+  test("trims whitespace and drops empty entries", () => {
+    expect(parseEventAllMarkersConfig(["--event-all-markers", " @ , / , "], {})).toEqual(["@", "/"]);
+  });
+
+  test("falls back to the env var when no CLI flag is present", () => {
+    expect(parseEventAllMarkersConfig([], { AUTOMOBILE_EVENT_ALL_MARKERS: "@,:" })).toEqual(["@", ":"]);
+  });
+
+  test("CLI flag wins over the env var", () => {
+    expect(
+      parseEventAllMarkersConfig(["--event-all-markers", "#"], { AUTOMOBILE_EVENT_ALL_MARKERS: "@" })
+    ).toEqual(["#"]);
+  });
+
+  test("treats a following flag as a missing value", () => {
+    expect(parseEventAllMarkersConfig(["--event-all-markers", "--other-flag"], {})).toEqual([]);
+  });
+});

--- a/test/utils/eventAllMarkers.test.ts
+++ b/test/utils/eventAllMarkers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { parseEventAllMarkersConfig } from "../../src/utils/eventAllMarkers";
+import {
+  hasEventAllMarkersCliOverride,
+  parseEventAllMarkersConfig,
+} from "../../src/utils/eventAllMarkers";
 
 describe("parseEventAllMarkersConfig", () => {
   test("returns an empty list when nothing is configured (feature off)", () => {
@@ -12,6 +15,13 @@ describe("parseEventAllMarkersConfig", () => {
 
   test("parses the --event-all-markers=<csv> form", () => {
     expect(parseEventAllMarkersConfig(["--event-all-markers=@,/,#"], {})).toEqual(["@", "/", "#"]);
+  });
+
+  test("empty --event-all-markers= overrides the env var with no markers", () => {
+    expect(parseEventAllMarkersConfig(
+      ["--event-all-markers="],
+      { AUTOMOBILE_EVENT_ALL_MARKERS: "@" }
+    )).toEqual([]);
   });
 
   test("trims whitespace and drops empty entries", () => {
@@ -30,5 +40,22 @@ describe("parseEventAllMarkersConfig", () => {
 
   test("treats a following flag as a missing value", () => {
     expect(parseEventAllMarkersConfig(["--event-all-markers", "--other-flag"], {})).toEqual([]);
+  });
+});
+
+describe("hasEventAllMarkersCliOverride", () => {
+  test("detects inline values including an explicit empty override", () => {
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers="])).toBe(true);
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers=@"])).toBe(true);
+  });
+
+  test("detects space-separated values", () => {
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers", "@"])).toBe(true);
+  });
+
+  test("does not treat missing or flag-shaped values as overrides", () => {
+    expect(hasEventAllMarkersCliOverride([])).toBe(false);
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers"])).toBe(false);
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers", "--debug"])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds opt-in auto-promotion of the `inputText` tool from the default atomic `a11y` text-set mode to `eventAll` (real per-character key events) when the input text contains any consumer-configured marker character. Off by default.

## Description

### Why
- Default `a11y` mode sets text in a single `ACTION_SET_TEXT`, emitting no keystrokes, so apps that only react to real key events (Slack `@mention` / `/command` / `:emoji:` autocomplete popups) never open their suggestion list — a typed mention stays unresolved plain text.
- `eventAll` already fixes this by injecting per-character key events, but it was only reachable by explicitly passing `mode`, which a caller driving the app has no reason to know.

### What Changed
- `resolveAutoInputMode` (new): pure resolver returning `"eventAll"` when the text contains any configured marker, else `undefined`.
- `InputText.execute`: `mode` is now optional; resolution is `explicit mode → marker auto-promotion → "a11y"`, so an explicit mode always wins and unconfigured markers preserve prior behavior. Applied at the shared choke point, so `setUIState` text fields honor it too. Logs the promotion (debug) and now logs the caught error before returning a typed failure.
- `ServerConfig`: `eventAllMarkers` state (empty = disabled); getter/setter use `readonly string[]`.
- Config injection (off by default): `--event-all-markers=<csv>` CLI flag or `AUTOMOBILE_EVENT_ALL_MARKERS` env var, parsed via a shared `cliArgs.firstFlagValue` helper (handles both `--flag value` and `--flag=value`; `toolOutputArtifacts` reuses it, replacing its duplicate). Threaded through `index.ts` and round-tripped through the daemon manager (`withDaemonOptions` serialize + `parseDaemonArgs` parse) so the flag reaches an auto-started daemon, mirroring `--dismiss-keyboard-after-input`.
- Startup logs the configured markers, and warns when the flag is present but resolves to none.

### Notes
- Android-only (iOS ignores `mode`). Marker matching is literal substring containment.

## Test Plan
- Unit tests: `resolveAutoInputMode` (empty/present/absent markers, multi-char, Slack marker set), `cliArgs.firstFlagValue` (both flag forms, missing/empty values), `parseEventAllMarkersConfig` (CLI vs env precedence, trimming), and daemon-arg relay for `eventAllMarkers`.
- Existing `InputText` suite still passes.
- `bun run typecheck`, lint, and build all green.
- Verified end-to-end on an Android emulator through the MCP and the local test harness: `inputText("/msg @Name hi")` resolves to `method: "eventAll"` and renders a linkified mention pill; with markers unconfigured the same input stays `a11y` (default unchanged).
