### PR TITLE
chore: update CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -200,7 +200,7 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
 export const NIGHTLY_CHECKSUM_ENTRY: ReleaseChecksumEntry = {
   version: "nightly",
   apkSha256: "1be224f4f5e5a21087a6552a9567290da64ad7deea6de6239a38324a8d91b0cc",
-  ipaSha256: "08a150376e4b367d02207d048c3600c2dfba4e00c938d6cd3bf6d2aa83f07140",
+  ipaSha256: "d71be829ab2415ac0b0027cd785b309f289855d19e4e8da1114740e5f652c577",
   runnerSha256: "ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a",
 };
 


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `1be224f4f5e5a21087a6552a9567290da64ad7deea6de6239a38324a8d91b0cc` | `1be224f4f5e5a21087a6552a9567290da64ad7deea6de6239a38324a8d91b0cc` | No |
| **IPA** | `08a150376e4b367d02207d048c3600c2dfba4e00c938d6cd3bf6d2aa83f07140` | `d71be829ab2415ac0b0027cd785b309f289855d19e4e8da1114740e5f652c577` | ✅ Yes |
| **iOS Runner** | `ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a` | `ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a` | No |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/` or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow