### PR TITLE
Pin JUnit runner Kotlin consumer floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,11 @@ updates:
       - "android"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # The published JUnit runner/test-plan artifacts intentionally keep their
+      # Kotlin stdlib consumer floor on Kotlin 2.2.x.
+      - dependency-name: "org.jetbrains.kotlin:kotlin-stdlib"
+        versions: ["[2.3,)"]
   # iOS Swift Package Manager dependencies
   - package-ecosystem: "swift"
     directory: "/ios/XCTestService"

--- a/scripts/android/validate-junit-runner-kotlin-consumer.sh
+++ b/scripts/android/validate-junit-runner-kotlin-consumer.sh
@@ -9,6 +9,10 @@ CONSUMER_DIR="${SCRATCH_DIR}/consumer"
 LOG_DIR="${SCRATCH_DIR}/logs"
 
 KOTLIN_CONSUMER_VERSION="${KOTLIN_CONSUMER_VERSION:-2.2.21}"
+KOTLIN_CONSUMER_STDLIB_VERSION=$(
+  sed -n 's/^build-kotlin-consumer = "\([^"]*\)".*/\1/p' \
+    "${ANDROID_DIR}/gradle/libs.versions.toml" | head -n 1
+)
 RUNNER_VERSION=$(
   sed -n 's/^VERSION_NAME=//p' "${ANDROID_DIR}/gradle.properties" | head -n 1
 )
@@ -18,6 +22,17 @@ GROUP_ID=$(
 
 if [[ -z "${RUNNER_VERSION}" || -z "${GROUP_ID}" ]]; then
   echo "Could not read GROUP and VERSION_NAME from android/gradle.properties" >&2
+  exit 1
+fi
+
+if [[ -z "${KOTLIN_CONSUMER_STDLIB_VERSION}" ]]; then
+  echo "Could not read build-kotlin-consumer from android/gradle/libs.versions.toml" >&2
+  exit 1
+fi
+
+if [[ ! "${KOTLIN_CONSUMER_STDLIB_VERSION}" =~ ^2\.2\. ]]; then
+  echo "Published runner/test-plan Kotlin stdlib consumer floor must remain on 2.2.x." >&2
+  echo "Found build-kotlin-consumer=${KOTLIN_CONSUMER_STDLIB_VERSION} in android/gradle/libs.versions.toml." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add a Dependabot ignore rule for `org.jetbrains.kotlin:kotlin-stdlib` versions `>= 2.3` in the Android Gradle update block.
- Keep the published JUnit runner/test-plan Kotlin stdlib consumer floor pinned to Kotlin `2.2.x` while still allowing `2.2.x` patch updates.
- Tighten the JUnit runner Kotlin consumer compatibility validator so CI fails if `build-kotlin-consumer` drifts off `2.2.x`.
- Follow-up to the closed Dependabot PR #3873, which attempted to raise the floor to `2.3.21`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml parses"'
- `bash -n scripts/android/validate-junit-runner-kotlin-consumer.sh`
- `shellcheck scripts/android/validate-junit-runner-kotlin-consumer.sh`
- `bash scripts/android/validate-junit-runner-kotlin-consumer.sh`

Reference: GitHub Dependabot supports `ignore.versions` ranges for dependency update filtering, using Gradle/Maven range syntax for Gradle dependencies.
