### PR TITLE
ci: surface failing coverage test names

### DIFF
--- a/scripts/ci/run-ts-coverage.sh
+++ b/scripts/ci/run-ts-coverage.sh
@@ -28,5 +28,8 @@ if rg -q 'error: An internal error occurred \(WriteFailed\)' "${log_file}" && rg
   exit 0
 fi
 
+echo "::group::Failing tests"
+rg -a '\(fail\)|^error:|^Ran [0-9]+ tests' "${log_file}" || true
+echo "::endgroup::"
 tail -n 200 "${log_file}"
 exit "${status}"

--- a/test/bats/run-ts-coverage.bats
+++ b/test/bats/run-ts-coverage.bats
@@ -47,3 +47,20 @@ EOF
   run env PATH="$STUB_DIR:$PATH" bash "$SCRIPT" "$WORK_DIR/out.log"
   [ "$status" -ne 0 ]
 }
+
+@test "prints failing test names before the coverage tail on failure" {
+  STUB_LOG="$WORK_DIR/coverage-failure.log"
+  {
+    printf '(fail) test/server/example.test.ts > identifies flaky behavior\n'
+    printf 'expect(received).toBe(expected)\n'
+    for i in $(seq 1 260); do
+      printf 'coverage/file-%03d.ts | 100.00 | 100.00 | 100.00 | 100.00\n' "$i"
+    done
+    printf ' 1 fail\n'
+  } > "$STUB_LOG"
+  make_bun_stub
+
+  run env PATH="$STUB_DIR:$PATH" bash "$SCRIPT" "$WORK_DIR/out.log"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"(fail) test/server/example.test.ts > identifies flaky behavior"* ]]
+}


### PR DESCRIPTION
## Summary

Surface Bun's failing-test lines in the inline "Run Tests with Coverage" CI log before printing the existing coverage-table tail. The coverage run still writes to `ci-logs/ts-coverage.log` to avoid the large-output WriteFailed path, but failure triage no longer requires downloading the artifact just to identify the failed test.

## Linked Issue

Closes #3861

## Bug / Regression Context

- **Prior attempts:** N/A
- **Observed symptom:** A failing TypeScript coverage run could show only `N fail` plus the coverage table because `tail -n 200` omitted earlier `(fail)` blocks from the Bun log.
- **Repro steps / conditions:** A failed `bun test --coverage` run whose coverage table is long enough to push `(fail)` lines outside the failure-path tail.

## Validation

- [x] `bats test/bats/run-ts-coverage.bats`
- [x] `shellcheck scripts/ci/run-ts-coverage.sh`
- [x] `git diff --check`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate`
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A; CI shell-script diagnostics only.

## Follow-ups

None.
