### PR TITLE
Fix segmented recording test isolation

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7928,7 +7928,7 @@
           "description": "Max duration seconds",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 300
+          "maximum": 3600
         },
         "outputName": {
           "description": "Recording label",

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -19,11 +19,19 @@ import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import type { VideoRecordingRecord } from "../db/videoRecordingRepository";
 import { highlightShapeSchema } from "../features/debug/VisualHighlight";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "../features/video/androidScreenrecord";
-import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
+import {
+  AndroidSegmentedPlanVideoSession,
+  type AndroidSegmentedPlanVideoSessionOptions,
+} from "./androidSegmentedPlanVideoSession";
 import type { Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 
 const DEFAULT_MAX_DURATION_SECONDS = 30;
+
+type SegmentedSessionRecordingDependencies = Pick<
+  AndroidSegmentedPlanVideoSessionOptions,
+  "startVideoRecording" | "stopVideoRecording"
+>;
 
 /**
  * Registry of timer-driven segmented Android recordings, keyed by the first
@@ -37,9 +45,13 @@ const segmentedSessions = (() => {
   // Undefined in production (sessions fall back to their own defaultTimer); tests
   // inject a FakeTimer so the rotation timer is controllable/inspectable.
   let injectedTimer: Timer | undefined;
+  let recordingDependencies: SegmentedSessionRecordingDependencies = {};
   return {
     get timer(): Timer | undefined {
       return injectedTimer;
+    },
+    get recordingDependencies(): SegmentedSessionRecordingDependencies {
+      return recordingDependencies;
     },
     track(handle: string, session: AndroidSegmentedPlanVideoSession): void {
       byHandle.set(handle, session);
@@ -67,9 +79,14 @@ const segmentedSessions = (() => {
     setTimer(timer: Timer | undefined): void {
       injectedTimer = timer;
     },
+    /** Test seam: inject the recording functions used by segmented sessions. */
+    setRecordingDependencies(deps: SegmentedSessionRecordingDependencies): void {
+      recordingDependencies = deps;
+    },
     /** Test seam: clear all tracked sessions + the injected timer. */
     reset(): void {
       injectedTimer = undefined;
+      recordingDependencies = {};
       byHandle.clear();
     },
   };
@@ -78,6 +95,13 @@ const segmentedSessions = (() => {
 /** Test seam: inject the Timer used by segmented sessions. */
 export function setSegmentedSessionTimer(timer: Timer | undefined): void {
   segmentedSessions.setTimer(timer);
+}
+
+/** Test seam: inject start/stop recording functions used by segmented sessions. */
+export function setSegmentedSessionRecordingDependencies(
+  deps: SegmentedSessionRecordingDependencies
+): void {
+  segmentedSessions.setRecordingDependencies(deps);
 }
 
 /** Test seam: clear injected segmented-session state (timer + tracked sessions). */
@@ -301,6 +325,7 @@ export function registerVideoRecordingTools(): void {
               configOverrides: buildConfigOverrides(args),
               timer: segmentedSessions.timer,
               maxDurationSeconds,
+              ...segmentedSessions.recordingDependencies,
             });
             const active = await session.start();
             segmentedSessions.track(active.recordingId, session);
@@ -376,7 +401,7 @@ export function registerVideoRecordingTools(): void {
       const evictedRecordingIds: string[] = [];
       let stoppedAnySegmented = false;
       const targetDevices = await resolveTargetDevices(device, args);
-      const activeRecords = await listActiveVideoRecordings({ platform: device.platform });
+      let activeRecords: VideoRecordingRecord[] | undefined;
 
       for (const target of targetDevices) {
         // A bare (by-device) stop must also finalize any timer-driven segmented
@@ -414,6 +439,7 @@ export function registerVideoRecordingTools(): void {
           continue;
         }
 
+        activeRecords ??= await listActiveVideoRecordings({ platform: device.platform });
         const matches = activeRecords.filter(record => record.deviceId === target.deviceId);
         if (matches.length === 0) {
           failures.push({

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -7,10 +7,15 @@ import { FakeVideoCaptureBackend } from "../fakes/FakeVideoCaptureBackend";
 import { FakeHighlightClient } from "../fakes/FakeHighlightClient";
 import { FakeVideoRecordingRepository } from "../fakes/FakeVideoRecordingRepository";
 import { FakeVideoRecordingConfigRepository } from "../fakes/FakeVideoRecordingConfigRepository";
-import { VideoRecorderService } from "../../src/features/video";
+import {
+  DEFAULT_VIDEO_RECORDING_CONFIG,
+  VideoRecorderService,
+  type ActiveVideoRecording,
+} from "../../src/features/video";
 import {
   registerVideoRecordingTools,
   resetSegmentedSessions,
+  setSegmentedSessionRecordingDependencies,
   setSegmentedSessionTimer,
 } from "../../src/server/videoRecordingTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
@@ -20,7 +25,7 @@ import {
 } from "../../src/server/videoRecordingManager";
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
 import { defaultTimer } from "../../src/utils/SystemTimer";
-import type { BootedDevice } from "../../src/models";
+import type { BootedDevice, VideoRecordingMetadata } from "../../src/models";
 
 /** Drain all pending microtasks (setImmediate runs after the microtask queue). */
 const flush = () => new Promise<void>(resolve => setImmediate(resolve));
@@ -47,6 +52,32 @@ function parse(response: ToolResponse): Record<string, unknown> {
   return JSON.parse(response.content?.[0]?.text ?? "{}");
 }
 
+function makeSegmentRecording(id: string, outputName: string | undefined): ActiveVideoRecording {
+  return {
+    recordingId: id,
+    outputPath: `/tmp/${id}.mp4`,
+    fileName: `${id}.mp4`,
+    startedAt: new Date(0).toISOString(),
+    outputName,
+    config: DEFAULT_VIDEO_RECORDING_CONFIG,
+  };
+}
+
+function makeSegmentMetadata(id: string): VideoRecordingMetadata {
+  return {
+    recordingId: id,
+    fileName: `${id}.mp4`,
+    filePath: `/tmp/${id}.mp4`,
+    format: "mp4",
+    sizeBytes: 1,
+    codec: "h264",
+    createdAt: new Date(0).toISOString(),
+    startedAt: new Date(0).toISOString(),
+    lastAccessedAt: new Date(0).toISOString(),
+    config: DEFAULT_VIDEO_RECORDING_CONFIG,
+  };
+}
+
 const androidDevice: BootedDevice = {
   deviceId: "test-device",
   platform: "android",
@@ -65,6 +96,8 @@ describe("videoRecording tool segmentation branch", () => {
   let fakeBackend: FakeVideoCaptureBackend;
   let fakeRepository: FakeVideoRecordingRepository;
   let archiveRoot: string;
+  let segmentStarts: string[];
+  let segmentStops: string[];
 
   beforeAll(async () => {
     if (!ToolRegistry.getTool("videoRecording")) {
@@ -79,6 +112,8 @@ describe("videoRecording tool segmentation branch", () => {
     fakeBackend = new FakeVideoCaptureBackend();
     fakeBackend.setNowProvider(() => new Date(fakeTimer.now()));
     fakeRepository = new FakeVideoRecordingRepository();
+    segmentStarts = [];
+    segmentStops = [];
     await fsPromises.rm(archiveRoot, { recursive: true, force: true });
     await fsPromises.mkdir(archiveRoot, { recursive: true });
 
@@ -193,6 +228,23 @@ describe("videoRecording tool segmentation branch", () => {
   });
 
   test("bare (by-device) stop finalizes the segmented session and leaves no rotation timer", async () => {
+    setSegmentedSessionRecordingDependencies({
+      startVideoRecording: async request => {
+        const outputName = request.outputName;
+        const recordingId = outputName ?? `segment-${segmentStarts.length}`;
+        segmentStarts.push(recordingId);
+        return makeSegmentRecording(recordingId, outputName);
+      },
+      stopVideoRecording: async recordingId => {
+        const id = recordingId ?? `segment-${segmentStops.length}`;
+        segmentStops.push(id);
+        return {
+          metadata: makeSegmentMetadata(id),
+          evictedRecordingIds: [],
+        };
+      },
+    });
+
     // Mirrors the qa-agent's real usage: start with maxDuration=300 (> 180 so
     // it segments), then stop WITHOUT a recordingId.
     const startRes = parse(
@@ -211,12 +263,16 @@ describe("videoRecording tool segmentation branch", () => {
     // must actually bound total duration, not just gate whether segmentation kicks in).
     expect(segmentTimer.getPendingTimeoutCount()).toBe(2);
 
+    // From this point, the segmented session owns its lifecycle. A late async
+    // rotation or bare stop must not rebuild the real manager/database singleton.
+    resetVideoRecordingManagerDependencies();
+
     // Rotate once so the bare stop must return more than one segment, in order.
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);
     await waitFor(
       async () =>
-        (await fakeRepository.listRecordings()).length === 2 &&
-        (await fakeRepository.listRecordings({ status: "recording" })).length === 1,
+        segmentStarts.length === 2 &&
+        segmentStops.length === 1,
       "segment 2 to start after rotation"
     );
 
@@ -239,12 +295,10 @@ describe("videoRecording tool segmentation branch", () => {
     expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
 
     // Advancing well past the rotation interval starts no new segment/recording.
-    const activeBefore = (await fakeRepository.listRecordings({ status: "recording" })).length;
+    const segmentStartsBefore = segmentStarts.length;
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS * 3);
     await flush();
-    const activeAfter = (await fakeRepository.listRecordings({ status: "recording" })).length;
-    expect(activeBefore).toBe(0);
-    expect(activeAfter).toBe(0);
+    expect(segmentStarts).toHaveLength(segmentStartsBefore);
   });
 
   test("by-handle stop still works after wiring the bare-stop path", async () => {


### PR DESCRIPTION
## Summary

Isolates the timer-driven segmented `videoRecording` tool session from the module-level video-recording manager singleton under test. Tool-created segmented sessions can now receive injected segment `startVideoRecording` / `stopVideoRecording` functions, and bare by-device stop checks tracked segmented sessions before touching `listActiveVideoRecordings`, so a segmented-owned device does not rebuild the real repository after test cleanup races.

Also includes the generated `schemas/tool-definitions.json` update for PR #3847's `maxDuration` schema increase from 300 to 3600.

## Linked Issue

Closes #3877

## Bug / Regression Context

- **Prior attempts:** PR #3847 added tool-level segmented Android recording and the flaky test coverage.
- **Observed symptom:** `videoRecordingToolSegmented.test.ts` timed out on macOS CI after the unit-test real-DB guard fired through `getDatabase()`.
- **Repro steps / conditions:** The bare by-device segmented stop test reset manager dependencies while a timer-driven rotation/stop path could still resolve default manager functions or call `listActiveVideoRecordings` before checking segmented ownership.

## Validation

- [x] `bun test test/server/videoRecordingToolSegmented.test.ts`
- [x] `bun test test/server/androidSegmentedPlanVideoSession.test.ts test/server/videoRecordingManager.test.ts test/server/planExecutionOrchestrator.test.ts`
- [x] `bun run typecheck` reports no new errors (233 known baseline errors)
- [x] `bun run turbo:validate` passes (`lint`, `build`, full `bun test`: 7843 pass / 11 skip / 0 fail)
- [x] `git diff --check HEAD~1..HEAD`
- [x] New test code uses fakes + FakeTimer

## Device Verification

N/A. This is a unit-test isolation fix for the segmented tool path.

## Follow-ups

- [ ] None.
