### PR TITLE
feat(release): videoJarSha256 field + resolveVideoJar{Url,Checksum} (#3830)

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -34,6 +34,15 @@ export interface ReleaseChecksumEntry {
   apkSha256: string;
   ipaSha256: string;
   runnerSha256: string;
+  /**
+   * SHA-256 of the persistent on-device H.264 encoder jar
+   * (`automobile-video.jar`, #3776/#3830). Optional so registry entries that
+   * predate the jar's release delivery tolerate an absent/empty value: an
+   * absent checksum means the jar is unknown for that version and the client
+   * degrades to `screenrecord` (see #3834). Populated by
+   * scripts/generate-release-constants.sh (#3833) for releases that ship it.
+   */
+  videoJarSha256?: string;
 }
 
 /**
@@ -407,6 +416,44 @@ export function resolveApkChecksum(env: EnvLike = process.env): string {
 /** Expected iOS IPA SHA-256 for the pinned version (empty string if unknown). */
 export function resolveIpaChecksum(env: EnvLike = process.env): string {
   return resolveChecksum(resolvePinnedVersion(env), "ios");
+}
+
+/**
+ * Fixed asset filename of the persistent on-device H.264 encoder jar.
+ * The same name is used as the CI artifact, the release asset, and the
+ * client-side cached file (#3830–#3835).
+ */
+export const VIDEO_SERVER_JAR_FILENAME = "automobile-video.jar";
+
+/**
+ * video-server jar download URL honoring `AUTOMOBILE_VERSION` +
+ * `AUTOMOBILE_ASSET_BASE_URL`, mirroring `resolveApkUrl`/`resolveIpaUrl`.
+ */
+export function resolveVideoJarUrl(
+  env: EnvLike = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
+  return buildReleaseAssetUrl(VIDEO_SERVER_JAR_FILENAME, resolvePinnedVersion(env), resolveAssetBaseUrl(env), registry);
+}
+
+/**
+ * Expected video-server jar SHA-256 for the pinned version. Returns an empty
+ * string when unknown — either the pin is absent from the registry, or the
+ * matched entry predates jar delivery (no `videoJarSha256`). Callers treat an
+ * empty checksum as "unknown → degrade to screenrecord" (#3834).
+ */
+export function resolveVideoJarChecksum(
+  env: EnvLike = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): string {
+  if (registry.length === 0) {
+    return "";
+  }
+  const pinned = resolvePinnedVersion(env);
+  const entry = pinned === LATEST_RELEASE_VERSION
+    ? registry[0]
+    : registry.find(e => e.version === pinned);
+  return entry?.videoJarSha256 ?? "";
 }
 
 /**

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -24,6 +24,9 @@ import {
   resolveLatestVersion,
   resolvePinnedVersion,
   resolveRunnerChecksum,
+  resolveVideoJarChecksum,
+  resolveVideoJarUrl,
+  VIDEO_SERVER_JAR_FILENAME,
   type ReleaseChecksumEntry,
 } from "../../src/constants/release";
 
@@ -289,6 +292,82 @@ describe("resolveRunnerChecksum", function() {
 
   test("unknown pinned version yields an empty checksum", function() {
     expect(resolveRunnerChecksum({ AUTOMOBILE_VERSION: "99.99.99" })).toBe("");
+  });
+});
+
+describe("resolveVideoJarUrl (video-server jar delivery, #3830)", function() {
+  const newest = RELEASE_CHECKSUM_REGISTRY[0];
+
+  test("unset env resolves to the concrete latest version on the default host", function() {
+    expect(resolveVideoJarUrl({})).toBe(
+      `${DEFAULT_ASSET_BASE_URL}/${newest.version}/${VIDEO_SERVER_JAR_FILENAME}`
+    );
+    expect(VIDEO_SERVER_JAR_FILENAME).toBe("automobile-video.jar");
+  });
+
+  test("AUTOMOBILE_VERSION pins the URL version", function() {
+    expect(resolveVideoJarUrl({ AUTOMOBILE_VERSION: "0.0.18" })).toBe(
+      `${DEFAULT_ASSET_BASE_URL}/0.0.18/${VIDEO_SERVER_JAR_FILENAME}`
+    );
+  });
+
+  test("AUTOMOBILE_ASSET_BASE_URL mirrors the download host", function() {
+    expect(resolveVideoJarUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am" })).toBe(
+      `https://mirror.test/am/${newest.version}/${VIDEO_SERVER_JAR_FILENAME}`
+    );
+  });
+
+  test("both knobs compose", function() {
+    expect(resolveVideoJarUrl({
+      AUTOMOBILE_VERSION: "0.0.18",
+      AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am/",
+    })).toBe(`https://mirror.test/am/0.0.18/${VIDEO_SERVER_JAR_FILENAME}`);
+  });
+
+  test("empty registry + mirror falls back to a conventional /latest/ path", function() {
+    expect(resolveVideoJarUrl({ AUTOMOBILE_ASSET_BASE_URL: "https://mirror.test/am" }, [])).toBe(
+      `https://mirror.test/am/latest/${VIDEO_SERVER_JAR_FILENAME}`
+    );
+  });
+});
+
+describe("resolveVideoJarChecksum (video-server jar delivery, #3830)", function() {
+  const registry: ReleaseChecksumEntry[] = [
+    { version: "0.0.46", apkSha256: "apk46", ipaSha256: "ipa46", runnerSha256: "runner46", videoJarSha256: "jar46" },
+    { version: "0.0.45", apkSha256: "apk45", ipaSha256: "ipa45", runnerSha256: "runner45" },
+  ];
+
+  test("latest/unset resolves to registry[0]'s videoJarSha256", function() {
+    expect(resolveVideoJarChecksum({}, registry)).toBe("jar46");
+  });
+
+  test("AUTOMOBILE_VERSION selects that version's videoJarSha256", function() {
+    expect(resolveVideoJarChecksum({ AUTOMOBILE_VERSION: "0.0.46" }, registry)).toBe("jar46");
+  });
+
+  test("an entry predating jar delivery (no videoJarSha256) resolves to empty", function() {
+    expect(resolveVideoJarChecksum({ AUTOMOBILE_VERSION: "0.0.45" }, registry)).toBe("");
+  });
+
+  test("an unknown pinned version yields an empty checksum", function() {
+    expect(resolveVideoJarChecksum({ AUTOMOBILE_VERSION: "99.99.99" }, registry)).toBe("");
+  });
+
+  test("empty registry yields an empty checksum", function() {
+    expect(resolveVideoJarChecksum({}, [])).toBe("");
+  });
+
+  test("current committed registry tolerates an absent videoJarSha256 (empty until delivery)", function() {
+    // The field is populated by the tooling in #3833; until then every entry
+    // resolves to "" without throwing.
+    expect(resolveVideoJarChecksum({})).toBe(RELEASE_CHECKSUM_REGISTRY[0].videoJarSha256 ?? "");
+  });
+
+  test("registry entries carry empty or well-formed 64-char videoJarSha256 values", function() {
+    for (const entry of RELEASE_CHECKSUM_REGISTRY) {
+      const jar = entry.videoJarSha256 ?? "";
+      expect(jar === "" || /^[a-f0-9]{64}$/.test(jar)).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
Closes #3830.

First of the 8-PR series shipping the persistent on-device H.264 encoder jar (`automobile-video.jar`, #3776) via GitHub releases. This PR adds only the **type field + daemon-side resolvers**; the script that populates the hashes lands in #3833, and the artifact build in #3832.

## Changes
- `ReleaseChecksumEntry.videoJarSha256?: string` — optional so the auto-generated registry entries that predate jar delivery tolerate an absent/empty value (an absent checksum ⇒ unknown ⇒ client degrades to `screenrecord`, per #3834).
- `resolveVideoJarUrl(env, registry?)` and `resolveVideoJarChecksum(env, registry?)` beside the APK resolvers, reusing `buildReleaseAssetUrl` + `resolvePinnedVersion`. Fixed asset filename `VIDEO_SERVER_JAR_FILENAME = "automobile-video.jar"`. Both honor `AUTOMOBILE_VERSION` (pin) and `AUTOMOBILE_ASSET_BASE_URL` (offline mirror) automatically.

## Acceptance
- [x] `ReleaseChecksumEntry.videoJarSha256` added; type compiles, existing entries tolerate an empty value (optional field, resolver returns `""` when absent).
- [x] `resolveVideoJarUrl` / `resolveVideoJarChecksum` unit-tested: latest vs concrete pin, mirror base override, unknown pin, empty registry, and an entry predating jar delivery.

## Validation
- `bun test test/constants/release.test.ts` — 69 pass
- `bun run typecheck` — no new type errors
- `bun run lint` / `bun run build` — clean

`src/constants/release.ts` is script-populated ("DO NOT EDIT MANUALLY"); this PR adds the type + resolvers only, as scoped in the issue.