### PR TITLE
test(android): skippable emu-finger enrollment smoke test (#3584)

### DIFF
--- a/docs/design-docs/plat/android/biometrics.md
+++ b/docs/design-docs/plat/android/biometrics.md
@@ -55,6 +55,18 @@ Status:
 
 - API 29 not validated yet (no local AVD available).
 
+Automated smoke test:
+
+- `scripts/local-dev/probe-biometric-enrollment.sh` runs the full
+  enrollment/match/unlock sequence below against any running emulator (pass
+  `AVD_NAME` / `ADB_SERIAL`, or let it boot the default AVD). It probes
+  `ro.kernel.qemu` and `emu help` first and **skips cleanly** when no emulator
+  (or no `emu finger` support) is present, so it is safe to invoke on any leg;
+  set `REQUIRE_DEVICE=true` to make an unavailable device a hard failure. The
+  control flow is regression-tested against a mock `adb` in
+  `test/bats/probe-biometric-enrollment.bats`, and the tool-layer sequence is
+  unit-covered in `test/features/action/BiometricAuth.test.ts`.
+
 Enrollment + auth steps (confirmed):
 
 1. Set a device PIN (required for enrollment).

--- a/scripts/local-dev/probe-biometric-enrollment.sh
+++ b/scripts/local-dev/probe-biometric-enrollment.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Live-emulator smoke test for the `emu finger` biometric enrollment/match/unlock
+# sequence documented in docs/design-docs/plat/android/biometrics.md.
+#
+# This is a best-effort probe, not a hermetic unit test. The fake-backed unit
+# coverage lives in test/features/action/BiometricAuth.test.ts; this script
+# exercises the same sequence against real emulator hardware where the
+# fingerprint HAL, lock screen, and `emu finger` transport actually exist.
+#
+# It SKIPS cleanly (exit 0) when no emulator is available or the running device
+# does not expose `emu finger`, so it is safe to invoke from a live-device leg
+# without gating CI on the presence of hardware. Set REQUIRE_DEVICE=true to turn
+# an unavailable/unsupported device into a hard failure instead.
+#
+# adb helpers deliberately swallow their own errors (returning 0) because every
+# individual adb call here is best-effort: pass/fail is decided by the observed
+# enrollment count and keyguard state, not by adb exit codes. Keeping the
+# helpers non-failing also avoids set -e-suppression footguns (SC2310).
+
+set -euo pipefail
+
+AVD_NAME="${AVD_NAME:-Pixel_9}"
+ADB_SERIAL="${ADB_SERIAL:-}"
+DEVICE_PIN="${DEVICE_PIN:-1234}"
+ENROLLED_FINGER_ID="${ENROLLED_FINGER_ID:-1}"
+UNENROLLED_FINGER_ID="${UNENROLLED_FINGER_ID:-2}"
+ENROLL_TOUCH_CYCLES="${ENROLL_TOUCH_CYCLES:-8}"
+BOOT_TIMEOUT_SECONDS="${BOOT_TIMEOUT_SECONDS:-180}"
+EMULATOR_PORT="${EMULATOR_PORT:-5554}"
+EMULATOR_ARGS="${EMULATOR_ARGS:-}"
+REQUIRE_DEVICE="${REQUIRE_DEVICE:-false}"
+KILL_ON_EXIT="${KILL_ON_EXIT:-false}"
+
+EMULATOR_PID=""
+STARTED_EMULATOR="false"
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+# shellcheck disable=SC2329 # Invoked indirectly from the cleanup trap.
+warn() {
+  printf 'WARN: %s\n' "$*" >&2
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+# Skip cleanly unless the caller demanded a device (REQUIRE_DEVICE=true).
+skip_or_fail() {
+  local reason="$1"
+  if [[ "${REQUIRE_DEVICE}" == "true" ]]; then
+    fail "${reason}"
+  fi
+  printf 'SKIP: %s\n' "${reason}"
+  exit 0
+}
+
+# Prints the resolved tool path (empty when not found); always returns 0 so
+# callers gate on the captured value rather than on a set -e-suppressed status.
+find_sdk_tool() {
+  local relative_path="$1"
+  local command_name="$2"
+
+  if [[ -n "${ANDROID_SDK_ROOT:-}" && -x "${ANDROID_SDK_ROOT}/${relative_path}" ]]; then
+    printf '%s\n' "${ANDROID_SDK_ROOT}/${relative_path}"
+    return 0
+  fi
+  if [[ -n "${ANDROID_HOME:-}" && -x "${ANDROID_HOME}/${relative_path}" ]]; then
+    printf '%s\n' "${ANDROID_HOME}/${relative_path}"
+    return 0
+  fi
+  command -v "${command_name}" 2> /dev/null || true
+}
+
+ADB_BIN="$(find_sdk_tool "platform-tools/adb" "adb")"
+
+[[ -n "${ADB_BIN}" ]] || skip_or_fail "adb not found. Set ANDROID_SDK_ROOT or ANDROID_HOME."
+
+# Best-effort adb wrapper: never fails the script itself (see header note).
+adb_cmd() {
+  "${ADB_BIN}" -s "${ADB_SERIAL}" "$@" || true
+}
+
+# shellcheck disable=SC2329 # Invoked indirectly via `trap cleanup EXIT`.
+cleanup() {
+  if [[ "${KILL_ON_EXIT}" == "true" && "${STARTED_EMULATOR}" == "true" && -n "${ADB_SERIAL}" ]]; then
+    warn "KILL_ON_EXIT=true, stopping ${ADB_SERIAL}"
+    adb_cmd emu kill > /dev/null 2>&1
+  elif [[ -n "${EMULATOR_PID}" ]]; then
+    warn "Leaving emulator process running (pid ${EMULATOR_PID}). Set KILL_ON_EXIT=true to stop it."
+  fi
+}
+trap cleanup EXIT
+
+# Prints the serial of a running emulator matching AVD_NAME (empty if none).
+running_serial_for_avd() {
+  local serial
+  while read -r serial; do
+    [[ -n "${serial}" ]] || continue
+    local avd
+    avd="$("${ADB_BIN}" -s "${serial}" emu avd name 2> /dev/null | tr -d '\r' | awk 'NF {print; exit}')"
+    if [[ "${avd}" == "${AVD_NAME}" ]]; then
+      printf '%s\n' "${serial}"
+      return 0
+    fi
+  done < <("${ADB_BIN}" devices 2> /dev/null | awk 'NR > 1 && $2 == "device" && $1 ~ /^emulator-/ {print $1}')
+  return 0
+}
+
+# Prints the first running emulator serial (empty if none).
+first_running_emulator() {
+  "${ADB_BIN}" devices 2> /dev/null \
+    | awk 'NR > 1 && $2 == "device" && $1 ~ /^emulator-/ {print $1; exit}' || true
+}
+
+# Returns 0 once the device reports boot completion, 1 on timeout.
+wait_for_boot() {
+  local deadline=$((SECONDS + BOOT_TIMEOUT_SECONDS))
+
+  adb_cmd wait-for-device
+  while ((SECONDS < deadline)); do
+    local boot_completed sys_boot_completed
+    boot_completed="$(adb_cmd shell getprop dev.bootcomplete | tr -d '\r')"
+    sys_boot_completed="$(adb_cmd shell getprop sys.boot_completed | tr -d '\r')"
+    if [[ "${boot_completed}" == "1" && "${sys_boot_completed}" == "1" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  return 1
+}
+
+# Confirm this is an emulator exposing `emu finger`, else skip.
+require_finger_support() {
+  local is_emulator
+  is_emulator="$(adb_cmd shell getprop ro.kernel.qemu | tr -d '\r')"
+  if [[ "${is_emulator}" != "1" ]]; then
+    skip_or_fail "device ${ADB_SERIAL} is not an emulator (ro.kernel.qemu=${is_emulator:-unset}); emu finger unavailable."
+  fi
+
+  local emu_help
+  emu_help="$(adb_cmd emu help | tr -d '\r')"
+  if [[ "${emu_help}" != *finger* ]]; then
+    skip_or_fail "emulator ${ADB_SERIAL} does not expose 'emu finger' commands."
+  fi
+}
+
+keyguard_showing() {
+  adb_cmd shell dumpsys window \
+    | tr -d '\r' \
+    | grep -o 'isKeyguardShowing=[a-z]*' \
+    | head -1
+}
+
+enrolled_print_count() {
+  adb_cmd shell dumpsys fingerprint \
+    | tr -d '\r' \
+    | grep -o '"id":[0-9]*' \
+    | wc -l \
+    | tr -d ' '
+}
+
+enroll_fingerprint() {
+  log "Enrolling fingerprint id ${ENROLLED_FINGER_ID} (PIN ${DEVICE_PIN})"
+  adb_cmd shell locksettings set-pin "${DEVICE_PIN}"
+  adb_cmd shell am start -a android.settings.FINGERPRINT_ENROLL > /dev/null 2>&1
+  sleep 1
+  adb_cmd shell input text "${DEVICE_PIN}"
+  adb_cmd shell input keyevent 66
+  sleep 1
+
+  local cycle
+  for ((cycle = 0; cycle < ENROLL_TOUCH_CYCLES; cycle++)); do
+    adb_cmd emu finger touch "${ENROLLED_FINGER_ID}"
+    adb_cmd emu finger remove "${ENROLLED_FINGER_ID}"
+    sleep 1
+  done
+
+  adb_cmd shell cmd fingerprint sync > /dev/null 2>&1
+}
+
+lock_device() {
+  # Two keyevent 26 presses ensure the keyguard is shown (first may only wake).
+  adb_cmd shell input keyevent 26
+  adb_cmd shell input keyevent 26
+  sleep 1
+}
+
+log "Probe configuration"
+printf 'AVD_NAME=%s\nADB_SERIAL=%s\nENROLLED_FINGER_ID=%s\nUNENROLLED_FINGER_ID=%s\nREQUIRE_DEVICE=%s\n' \
+  "${AVD_NAME}" "${ADB_SERIAL:-<auto>}" "${ENROLLED_FINGER_ID}" "${UNENROLLED_FINGER_ID}" "${REQUIRE_DEVICE}"
+
+if [[ -z "${ADB_SERIAL}" ]]; then
+  ADB_SERIAL="$(running_serial_for_avd)"
+fi
+if [[ -z "${ADB_SERIAL}" ]]; then
+  ADB_SERIAL="$(first_running_emulator)"
+fi
+
+if [[ -z "${ADB_SERIAL}" ]]; then
+  EMULATOR_BIN="$(find_sdk_tool "emulator/emulator" "emulator")"
+  if [[ -z "${EMULATOR_BIN}" ]]; then
+    skip_or_fail "no running emulator and emulator binary not found; nothing to probe."
+  fi
+
+  log "Starting AVD ${AVD_NAME}"
+  emulator_args_array=("-no-window" "-no-audio" "-no-snapshot")
+  if [[ -n "${EMULATOR_ARGS}" ]]; then
+    extra_emulator_args=()
+    while IFS= read -r arg; do
+      [[ -n "${arg}" ]] || continue
+      extra_emulator_args+=("${arg}")
+    done <<< "${EMULATOR_ARGS}"
+    emulator_args_array+=("${extra_emulator_args[@]}")
+  fi
+  "${EMULATOR_BIN}" -avd "${AVD_NAME}" -port "${EMULATOR_PORT}" "${emulator_args_array[@]}" \
+    > /tmp/auto-mobile-biometric-probe-emulator.log 2>&1 &
+  EMULATOR_PID="$!"
+  STARTED_EMULATOR="true"
+  ADB_SERIAL="emulator-${EMULATOR_PORT}"
+fi
+
+log "Waiting for ${ADB_SERIAL} to boot"
+# Invoke separately (not in a condition) so set -e stays armed inside the call.
+set +e
+wait_for_boot
+boot_status=$?
+set -e
+if [[ "${boot_status}" -ne 0 ]]; then
+  skip_or_fail "device ${ADB_SERIAL} did not boot within ${BOOT_TIMEOUT_SECONDS}s"
+fi
+
+require_finger_support
+
+enroll_fingerprint
+
+log "Verifying enrollment via dumpsys fingerprint"
+enroll_count="$(enrolled_print_count)"
+printf 'enrolled prints: %s\n' "${enroll_count}"
+enroll_result="failed"
+if [[ "${enroll_count}" =~ ^[0-9]+$ && "${enroll_count}" -ge 1 ]]; then
+  enroll_result="succeeded"
+fi
+
+log "Validating unlock with enrolled finger id ${ENROLLED_FINGER_ID}"
+lock_device
+before_match="$(keyguard_showing)"
+adb_cmd emu finger touch "${ENROLLED_FINGER_ID}"
+adb_cmd emu finger remove "${ENROLLED_FINGER_ID}"
+sleep 1
+after_match="$(keyguard_showing)"
+printf 'keyguard before match: %s\n' "${before_match:-unknown}"
+printf 'keyguard after match:  %s\n' "${after_match:-unknown}"
+match_result="failed"
+if [[ "${after_match}" == "isKeyguardShowing=false" ]]; then
+  match_result="succeeded"
+fi
+
+log "Validating non-enrolled finger id ${UNENROLLED_FINGER_ID} does NOT unlock"
+lock_device
+adb_cmd emu finger touch "${UNENROLLED_FINGER_ID}"
+adb_cmd emu finger remove "${UNENROLLED_FINGER_ID}"
+sleep 1
+after_mismatch="$(keyguard_showing)"
+printf 'keyguard after mismatch: %s\n' "${after_mismatch:-unknown}"
+mismatch_result="failed"
+if [[ "${after_mismatch}" == "isKeyguardShowing=true" ]]; then
+  mismatch_result="succeeded"
+fi
+
+log "Summary"
+printf 'enrollment (dumpsys fingerprint): %s\n' "${enroll_result}"
+printf 'unlock with enrolled finger:      %s\n' "${match_result}"
+printf 'reject non-enrolled finger:       %s\n' "${mismatch_result}"
+
+if [[ "${enroll_result}" == "succeeded" && "${match_result}" == "succeeded" && "${mismatch_result}" == "succeeded" ]]; then
+  log "emu finger enrollment/match/unlock smoke test PASSED"
+  exit 0
+fi
+
+fail "emu finger smoke test did not pass on ${ADB_SERIAL} (see summary above)."

--- a/scripts/local-dev/probe-biometric-enrollment.sh
+++ b/scripts/local-dev/probe-biometric-enrollment.sh
@@ -38,7 +38,7 @@ log() {
   printf '\n==> %s\n' "$*"
 }
 
-# shellcheck disable=SC2329 # Invoked indirectly from the cleanup trap.
+# shellcheck disable=SC2317,SC2329 # Invoked indirectly from the cleanup trap.
 warn() {
   printf 'WARN: %s\n' "$*" >&2
 }
@@ -84,7 +84,7 @@ adb_cmd() {
   "${ADB_BIN}" -s "${ADB_SERIAL}" "$@" || true
 }
 
-# shellcheck disable=SC2329 # Invoked indirectly via `trap cleanup EXIT`.
+# shellcheck disable=SC2317,SC2329 # Invoked indirectly via `trap cleanup EXIT`.
 cleanup() {
   if [[ "${KILL_ON_EXIT}" == "true" && "${STARTED_EMULATOR}" == "true" && -n "${ADB_SERIAL}" ]]; then
     warn "KILL_ON_EXIT=true, stopping ${ADB_SERIAL}"

--- a/test/bats/probe-biometric-enrollment.bats
+++ b/test/bats/probe-biometric-enrollment.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/local-dev/probe-biometric-enrollment.sh.
+#
+# The script is a live-emulator smoke test; these BATS cases drive it against a
+# mock `adb` so the enrollment/match/unlock control flow is exercised without a
+# real device, and confirm the skip-cleanly contract when no device exists.
+
+SCRIPT="scripts/local-dev/probe-biometric-enrollment.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  ORIG_ANDROID_HOME="${ANDROID_HOME-}"
+  ORIG_ANDROID_HOME_SET="${ANDROID_HOME+x}"
+  ORIG_ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT-}"
+  ORIG_ANDROID_SDK_ROOT_SET="${ANDROID_SDK_ROOT+x}"
+  export INVOCATION_FILE="${MOCK_BIN}/adb-invocations"
+  export KEYGUARD_STATE_FILE="${MOCK_BIN}/keyguard-state"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+  export PATH="$ORIG_PATH"
+  if [ -n "$ORIG_ANDROID_HOME_SET" ]; then
+    export ANDROID_HOME="$ORIG_ANDROID_HOME"
+  else
+    unset ANDROID_HOME
+  fi
+  if [ -n "$ORIG_ANDROID_SDK_ROOT_SET" ]; then
+    export ANDROID_SDK_ROOT="$ORIG_ANDROID_SDK_ROOT"
+  else
+    unset ANDROID_SDK_ROOT
+  fi
+}
+
+# A stateful mock emulator: `emu finger touch 1` (the enrolled id) unlocks the
+# keyguard, any other finger leaves it locked, and `input keyevent 26` re-locks.
+make_mock_adb() {
+  printf 'isKeyguardShowing=true' > "${KEYGUARD_STATE_FILE}"
+  cat > "${MOCK_BIN}/adb" << 'SCRIPT'
+#!/usr/bin/env bash
+if [ "$1" = "-s" ]; then
+  serial="$2"
+  shift 2
+else
+  serial=""
+fi
+printf '%s %s\n' "${serial}" "$*" >> "${INVOCATION_FILE}"
+
+case "$*" in
+  "devices")
+    printf 'List of devices attached\nemulator-5554\tdevice\n'
+    exit 0
+    ;;
+  "-s emulator-5554 emu avd name"|"emu avd name")
+    echo "Pixel_9"
+    exit 0
+    ;;
+  "wait-for-device")
+    exit 0
+    ;;
+  "shell getprop dev.bootcomplete"|"shell getprop sys.boot_completed")
+    echo "1"
+    exit 0
+    ;;
+  "shell getprop ro.kernel.qemu")
+    echo "1"
+    exit 0
+    ;;
+  "emu help")
+    printf 'android console command help:\n  finger        manage emulator fingerprint\n  kill          kill the emulator\n'
+    exit 0
+    ;;
+  "shell locksettings set-pin 1234")
+    exit 0
+    ;;
+  "shell am start -a android.settings.FINGERPRINT_ENROLL")
+    exit 0
+    ;;
+  "shell input text 1234"|"shell input keyevent 66")
+    exit 0
+    ;;
+  "shell cmd fingerprint sync")
+    exit 0
+    ;;
+  "shell dumpsys fingerprint")
+    echo 'prints:[{"id":0,"count":1,"deviceId":0}]'
+    exit 0
+    ;;
+  "shell input keyevent 26")
+    printf 'isKeyguardShowing=true' > "${KEYGUARD_STATE_FILE}"
+    exit 0
+    ;;
+  "emu finger touch 1")
+    printf 'isKeyguardShowing=false' > "${KEYGUARD_STATE_FILE}"
+    exit 0
+    ;;
+  "emu finger remove "*|"emu finger touch "*)
+    exit 0
+    ;;
+  "shell dumpsys window")
+    cat "${KEYGUARD_STATE_FILE}"
+    printf '\n'
+    exit 0
+    ;;
+esac
+
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/adb"
+  unset ANDROID_HOME
+  unset ANDROID_SDK_ROOT
+  export PATH="${MOCK_BIN}:/usr/bin:/bin"
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "script has bash shebang" {
+  head -1 "$SCRIPT" | grep -q "bash"
+}
+
+@test "skips cleanly when adb is not on PATH" {
+  export PATH="${MOCK_BIN}:/usr/bin:/bin"
+  unset ANDROID_HOME
+  unset ANDROID_SDK_ROOT
+
+  run env BOOT_TIMEOUT_SECONDS=5 bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SKIP:"* ]]
+  [[ "$output" == *"adb not found"* ]]
+}
+
+@test "fails instead of skipping when REQUIRE_DEVICE=true and adb missing" {
+  export PATH="${MOCK_BIN}:/usr/bin:/bin"
+  unset ANDROID_HOME
+  unset ANDROID_SDK_ROOT
+
+  run env REQUIRE_DEVICE=true BOOT_TIMEOUT_SECONDS=5 bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ERROR:"* ]]
+  [[ "$output" == *"adb not found"* ]]
+}
+
+@test "runs the enrollment/match/unlock sequence against a mock emulator" {
+  make_mock_adb
+
+  run env ADB_SERIAL=emulator-5554 BOOT_TIMEOUT_SECONDS=5 ENROLL_TOUCH_CYCLES=2 bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"enrollment (dumpsys fingerprint): succeeded"* ]]
+  [[ "$output" == *"unlock with enrolled finger:      succeeded"* ]]
+  [[ "$output" == *"reject non-enrolled finger:       succeeded"* ]]
+  [[ "$output" == *"smoke test PASSED"* ]]
+
+  # The documented enrollment + validation adb calls were actually issued.
+  grep -q "emu finger touch 1" "$INVOCATION_FILE"
+  grep -q "emu finger touch 2" "$INVOCATION_FILE"
+  grep -q "shell dumpsys fingerprint" "$INVOCATION_FILE"
+  grep -q "shell locksettings set-pin 1234" "$INVOCATION_FILE"
+}
+
+@test "skips cleanly when the device does not expose emu finger" {
+  make_mock_adb
+  # Override emu help so `finger` is absent.
+  cat > "${MOCK_BIN}/adb" << 'SCRIPT'
+#!/usr/bin/env bash
+if [ "$1" = "-s" ]; then shift 2; fi
+case "$*" in
+  "wait-for-device") exit 0 ;;
+  "shell getprop dev.bootcomplete"|"shell getprop sys.boot_completed") echo "1"; exit 0 ;;
+  "shell getprop ro.kernel.qemu") echo "1"; exit 0 ;;
+  "emu help") printf 'android console command help:\n  kill  kill the emulator\n'; exit 0 ;;
+esac
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/adb"
+
+  run env ADB_SERIAL=emulator-5554 BOOT_TIMEOUT_SECONDS=5 bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SKIP:"* ]]
+  [[ "$output" == *"does not expose 'emu finger'"* ]]
+}
+
+@test "skips cleanly when the target is not an emulator" {
+  make_mock_adb
+  cat > "${MOCK_BIN}/adb" << 'SCRIPT'
+#!/usr/bin/env bash
+if [ "$1" = "-s" ]; then shift 2; fi
+case "$*" in
+  "wait-for-device") exit 0 ;;
+  "shell getprop dev.bootcomplete"|"shell getprop sys.boot_completed") echo "1"; exit 0 ;;
+  "shell getprop ro.kernel.qemu") echo ""; exit 0 ;;
+esac
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/adb"
+
+  run env ADB_SERIAL=emulator-5554 BOOT_TIMEOUT_SECONDS=5 bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SKIP:"* ]]
+  [[ "$output" == *"is not an emulator"* ]]
+}


### PR DESCRIPTION
## What

Adds a live-emulator smoke test for the `emu finger` biometric enrollment/match/unlock sequence documented in `docs/design-docs/plat/android/biometrics.md`, addressing the test-coverage task on #3584.

- **`scripts/local-dev/probe-biometric-enrollment.sh`** — runs enrollment → verify (`dumpsys fingerprint`) → unlock-with-enrolled → reject-non-enrolled against any running emulator (or boots the default AVD). Probes `ro.kernel.qemu` + `emu help` first and **skips cleanly (exit 0)** when no emulator / no `emu finger` support is present, so it's safe to invoke on any leg. `REQUIRE_DEVICE=true` turns an unavailable device into a hard failure.
- **`test/bats/probe-biometric-enrollment.bats`** — 7 cases driving the script against a stateful mock `adb`: skip-when-adb-absent, `REQUIRE_DEVICE` failure, full happy path (asserts the documented `emu finger`/`locksettings`/`dumpsys` calls fire), and the two capability-gate skips.
- **`biometrics.md`** — references the probe so the "API 29 not validated / no local AVD" note has a reproducible backstop.

## Why

Per the #3584 triage, the doc fix shipped in #3729 and the tool layer is unit-covered in `test/features/action/BiometricAuth.test.ts`, but there was no scripted backstop for the raw `emu finger` shell sequence. This adds one that runs live and is CI-safe.

## Notes

- adb helpers intentionally swallow errors (best-effort probe; pass/fail is decided by observed enrollment count + keyguard state), which also keeps the script free of new `set -e`-suppression (SC2310) baseline entries.
- Live API-29 hardware validation still requires real hardware and is out of scope here; #3584 can stay open to track that.

## Validation

- `shfmt -i 2 -bn -ci -sr -d` clean
- `shellcheck` clean; shell-portability + `set -e`-suppression gates clean (baseline unchanged)
- `bats test/bats/probe-biometric-enrollment.bats` — 7/7 pass