### PR TITLE
Fix raw Android video segmentation

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -209,12 +209,8 @@ src/server/systemTrayHelpers.ts: error TS2741: Property 'getDeviceTimestampMs' i
 src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"limit" | "testClass" | "testMethod" | "lookbackDays" | "orderDirection" | "latestOnly"'.
 src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"deviceId" | "limit" | "deviceType" | "sessionUuid" | "devicePlatform" | "testClass" | "testMethod" | "deviceName" | "appVersion" | "gitCommit" | "targetSdk" | "jdkVersion" | ... 6 more ... | "orderDirection"'.
 src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
-src/utils/CtrlProxyManager.ts: error TS7006: Parameter 'entry' implicitly has an 'any' type.
-src/utils/CtrlProxyManager.ts: error TS7006: Parameter 'entry' implicitly has an 'any' type.
-src/utils/CtrlProxyManager.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
-src/utils/IOSCtrlProxyBundleDownloader.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 src/utils/ProcessExecutor.ts: error TS2769: No overload matches this call.
 src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
 src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
@@ -267,8 +263,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 19 :: src/server/networkGraph.ts: error TS2345: Argument of type 'EventGroup | undefined' is not assignable to parameter of type 'EventGroup'.
 # swap-fp: 19,19,19,19 :: src/doctor/checks/ios.ts: error TS18048: 'elements' is possibly 'undefined'.
 # swap-fp: 20 :: src/features/accessibility/WcagAudit.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"resource-id"' can't be used to index type 'ViewHierarchyNode'.
-# swap-fp: 20 :: src/utils/CtrlProxyManager.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
-# swap-fp: 20 :: src/utils/IOSCtrlProxyBundleDownloader.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 # swap-fp: 21,28 :: src/db/migrator.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 # swap-fp: 23 :: src/features/accessibility/ContrastChecker.ts: error TS2345: Argument of type 'Map<string, number>' is not assignable to parameter of type 'Map<string, { timestamp: number; }>'.
 # swap-fp: 24 :: src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string | undefined>' is not assignable to type 'Promise<void>'.
@@ -313,7 +307,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 39 :: src/server/interactionTools.ts: error TS18048: 'freshness.requestedAfter' is possibly 'undefined'.
 # swap-fp: 39,45 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AccessibilityHierarchy' is not assignable to parameter of type 'ViewHierarchyResult'.
 # swap-fp: 40 :: src/features/performance/PerformanceAudit.ts: error TS2551: Property 'refreshRateHz' does not exist on type 'DeviceCapabilities'. Did you mean 'refreshRate'?
-# swap-fp: 40,40 :: src/utils/CtrlProxyManager.ts: error TS7006: Parameter 'entry' implicitly has an 'any' type.
 # swap-fp: 40,58 :: src/db/migrator.ts: error TS7006: Parameter 'migration' implicitly has an 'any' type.
 # swap-fp: 40,74 :: src/db/migrator.ts: error TS2307: Cannot find module 'kysely/migration' or its corresponding type declarations.
 # swap-fp: 43 :: src/doctor/index.ts: error TS2367: This comparison appears to be unintentional because the types 'false | undefined' and 'true' have no overlap.

--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -11,20 +11,31 @@ import {
   stopVideoRecording as defaultStopVideoRecording,
 } from "./videoRecordingManager";
 import type { ActiveVideoRecording } from "../features/video";
-import type { VideoRecordingMetadata } from "../models";
+import type {
+  VideoRecordingConfigInput,
+  VideoRecordingHighlightInput,
+  VideoRecordingMetadata,
+} from "../models";
 
 export interface AndroidSegmentedPlanVideoSessionOptions {
   device: BootedDevice;
   outputNamePrefix: string;
+  configOverrides?: VideoRecordingConfigInput;
+  highlights?: VideoRecordingHighlightInput[];
   timer?: Timer;
   /** Override for tests. */
   segmentRotateAfterMs?: number;
+  onSegmentStarted?: (recording: ActiveVideoRecording) => void;
   startVideoRecording?: (
     request: Parameters<typeof defaultStartVideoRecording>[0]
   ) => Promise<ActiveVideoRecording>;
   stopVideoRecording?: (
     recordingId?: string
   ) => Promise<{ metadata: VideoRecordingMetadata; evictedRecordingIds: string[] }>;
+}
+
+export interface AndroidSegmentedPlanVideoFinalizeOptions {
+  strict?: boolean;
 }
 
 /**
@@ -42,11 +53,27 @@ export class AndroidSegmentedPlanVideoSession {
 
   private readonly outputNamePrefix: string;
 
+  private readonly configOverrides: VideoRecordingConfigInput | undefined;
+
+  private readonly highlights: VideoRecordingHighlightInput[] | undefined;
+
   private readonly timer: Timer;
 
   private readonly segmentRotateAfterMs: number;
 
+  private readonly onSegmentStarted: ((recording: ActiveVideoRecording) => void) | undefined;
+
   private activeRecordingId: string | undefined;
+
+  private backgroundRotationHandle: NodeJS.Timeout | undefined;
+
+  private rotationInFlight = false;
+
+  private rotationPromise: Promise<void> | undefined;
+
+  private finalizing = false;
+
+  private recordingStartedAtMs: number | undefined;
 
   private segmentIndex = 0;
 
@@ -55,6 +82,10 @@ export class AndroidSegmentedPlanVideoSession {
   private readonly completedFilePaths: string[] = [];
 
   private readonly completedRecordingIds: string[] = [];
+
+  private readonly completedMetadata: VideoRecordingMetadata[] = [];
+
+  private readonly segmentStopErrors: unknown[] = [];
 
   private readonly startVideoRecordingFn: (
     request: Parameters<typeof defaultStartVideoRecording>[0]
@@ -67,21 +98,68 @@ export class AndroidSegmentedPlanVideoSession {
   constructor(options: AndroidSegmentedPlanVideoSessionOptions) {
     this.device = options.device;
     this.outputNamePrefix = options.outputNamePrefix;
+    this.configOverrides = options.configOverrides;
+    this.highlights = options.highlights;
     this.timer = options.timer ?? defaultTimer;
     this.segmentRotateAfterMs = options.segmentRotateAfterMs ?? ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS;
+    this.onSegmentStarted = options.onSegmentStarted;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
   }
 
-  async startFirstSegment(): Promise<void> {
-    await this.startSegment();
+  async startFirstSegment(): Promise<ActiveVideoRecording> {
+    return this.startSegment();
+  }
+
+  startBackgroundRotation(): void {
+    if (this.backgroundRotationHandle) {
+      return;
+    }
+
+    this.backgroundRotationHandle = this.timer.setInterval(() => {
+      void this.runTrackedRotationCheck();
+    }, this.segmentRotateAfterMs);
+  }
+
+  stopBackgroundRotation(): void {
+    if (!this.backgroundRotationHandle) {
+      return;
+    }
+
+    this.timer.clearInterval(this.backgroundRotationHandle);
+    this.backgroundRotationHandle = undefined;
   }
 
   /**
    * Pass to {@link PlanExecutionOptions.onBeforePlanStep} for Android segmented capture.
    */
   onBeforePlanStep = async (): Promise<void> => {
+    await this.runTrackedRotationCheck();
+  };
+
+  private async runTrackedRotationCheck(): Promise<void> {
+    if (this.rotationPromise) {
+      await this.rotationPromise;
+      return;
+    }
+
+    const rotation = this.rotateIfDue();
+    this.rotationPromise = rotation;
+    try {
+      await rotation;
+    } finally {
+      this.rotationPromise = undefined;
+    }
+  }
+
+  private async rotateIfDue(): Promise<void> {
+    if (this.finalizing) {
+      return;
+    }
     if (!this.activeRecordingId) {
+      return;
+    }
+    if (this.rotationInFlight) {
       return;
     }
 
@@ -90,26 +168,74 @@ export class AndroidSegmentedPlanVideoSession {
       return;
     }
 
-    await this.rotateToNextSegment();
-  };
+    this.rotationInFlight = true;
+    try {
+      await this.rotateToNextSegment();
+    } finally {
+      this.rotationInFlight = false;
+    }
+  }
 
   private segmentOutputName(): string {
     const suffix = this.segmentIndex === 0 ? "" : `-seg${this.segmentIndex}`;
     return `${this.outputNamePrefix}${suffix}`;
   }
 
-  private async startSegment(): Promise<void> {
+  private highlightsForSegment(): VideoRecordingHighlightInput[] | undefined {
+    if (!this.highlights || this.highlights.length === 0) {
+      return undefined;
+    }
+
+    const segmentStartOffsetMs = this.recordingStartedAtMs === undefined
+      ? 0
+      : Math.max(0, this.timer.now() - this.recordingStartedAtMs);
+    const segmentEndOffsetMs = segmentStartOffsetMs + this.segmentRotateAfterMs;
+    const segmentHighlights = this.highlights
+      .filter(highlight => {
+        const startTimeMs = highlight.timing?.startTimeMs ?? 0;
+        if (!Number.isFinite(startTimeMs) || startTimeMs < 0) {
+          return segmentStartOffsetMs === 0;
+        }
+        return startTimeMs >= segmentStartOffsetMs && startTimeMs < segmentEndOffsetMs;
+      })
+      .map(highlight => {
+        const startTimeMs = highlight.timing?.startTimeMs ?? 0;
+        if (!Number.isFinite(startTimeMs) || startTimeMs < 0) {
+          return highlight;
+        }
+
+        return {
+          ...highlight,
+          timing: {
+            ...highlight.timing,
+            startTimeMs: startTimeMs - segmentStartOffsetMs,
+          },
+        };
+      });
+
+    return segmentHighlights.length > 0 ? segmentHighlights : undefined;
+  }
+
+  private async startSegment(): Promise<ActiveVideoRecording> {
+    if (this.recordingStartedAtMs === undefined) {
+      this.recordingStartedAtMs = this.timer.now();
+    }
+
     const recording = await this.startVideoRecordingFn({
       device: this.device,
       outputName: this.segmentOutputName(),
+      configOverrides: this.configOverrides,
       maxDurationSeconds: ANDROID_SCREENRECORD_MAX_SECONDS,
+      highlights: this.highlightsForSegment(),
     });
     this.activeRecordingId = recording.recordingId;
     this.segmentStartedAtMs = this.timer.now();
     this.segmentIndex += 1;
+    this.onSegmentStarted?.(recording);
     logger.info(
       `[SegmentedPlanVideo] Started segment ${this.segmentIndex} recordingId=${recording.recordingId}`
     );
+    return recording;
   }
 
   private async rotateToNextSegment(): Promise<void> {
@@ -122,15 +248,21 @@ export class AndroidSegmentedPlanVideoSession {
       const stopped = await this.stopVideoRecordingFn(previousId);
       this.completedRecordingIds.push(previousId);
       this.completedFilePaths.push(stopped.metadata.filePath);
+      this.completedMetadata.push(stopped.metadata);
       logger.info(
         `[SegmentedPlanVideo] Stopped segment recordingId=${previousId} path=${stopped.metadata.filePath}`
       );
     } catch (error) {
+      this.segmentStopErrors.push(error);
       logger.warn(
         `[SegmentedPlanVideo] Failed to stop segment ${previousId}: ${error instanceof Error ? error.message : String(error)}`
       );
     } finally {
       this.activeRecordingId = undefined;
+    }
+
+    if (this.finalizing) {
+      return;
     }
 
     try {
@@ -145,26 +277,50 @@ export class AndroidSegmentedPlanVideoSession {
   /**
    * Stops the active segment (if any) and returns every finished file path and recording id.
    */
-  async finalize(): Promise<{ filePaths: string[]; recordingIds: string[] }> {
+  async finalize(options: AndroidSegmentedPlanVideoFinalizeOptions = {}): Promise<{
+    filePaths: string[];
+    recordingIds: string[];
+    metadata: VideoRecordingMetadata[];
+  }> {
+    this.finalizing = true;
+    this.stopBackgroundRotation();
+    await this.rotationPromise;
+
     if (this.activeRecordingId) {
       const id = this.activeRecordingId;
+      let shouldClearActiveRecording = true;
       try {
         const stopped = await this.stopVideoRecordingFn(id);
         this.completedRecordingIds.push(id);
         this.completedFilePaths.push(stopped.metadata.filePath);
+        this.completedMetadata.push(stopped.metadata);
         logger.info(`[SegmentedPlanVideo] Final stop recordingId=${id} path=${stopped.metadata.filePath}`);
       } catch (error) {
         logger.warn(
           `[SegmentedPlanVideo] Failed to finalize segment ${id}: ${error instanceof Error ? error.message : String(error)}`
         );
+        if (options.strict) {
+          shouldClearActiveRecording = false;
+          throw error;
+        }
       } finally {
-        this.activeRecordingId = undefined;
+        if (shouldClearActiveRecording) {
+          this.activeRecordingId = undefined;
+        }
       }
+    }
+
+    if (options.strict && this.segmentStopErrors.length > 0) {
+      const details = this.segmentStopErrors
+        .map(error => error instanceof Error ? error.message : String(error))
+        .join("; ");
+      throw new Error(`Failed to stop one or more video recording segments: ${details}`);
     }
 
     return {
       filePaths: [...this.completedFilePaths],
       recordingIds: [...this.completedRecordingIds],
+      metadata: [...this.completedMetadata],
     };
   }
 }

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -9,17 +9,54 @@ import {
 } from "../models";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
+import { ANDROID_SCREENRECORD_MAX_SECONDS } from "../features/video/androidScreenrecord";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
 import {
   listActiveVideoRecordings,
   startVideoRecording,
   stopVideoRecording,
 } from "./videoRecordingManager";
-import type { VideoRecordingConfigInput } from "../models";
+import type { VideoRecordingConfigInput, VideoRecordingMetadata } from "../models";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import type { VideoRecordingRecord } from "../db/videoRecordingRepository";
 import { highlightShapeSchema } from "../features/debug/VisualHighlight";
 
 const DEFAULT_MAX_DURATION_SECONDS = 30;
+
+interface RegisterVideoRecordingToolsOptions {
+  timer?: Timer;
+  startVideoRecording?: typeof startVideoRecording;
+  stopVideoRecording?: typeof stopVideoRecording;
+  listActiveVideoRecordings?: typeof listActiveVideoRecordings;
+}
+
+interface VideoRecordingToolDependencies {
+  timer: Timer;
+  startVideoRecording: typeof startVideoRecording;
+  stopVideoRecording: typeof stopVideoRecording;
+  listActiveVideoRecordings: typeof listActiveVideoRecordings;
+}
+
+interface RawAndroidSegmentedRecording {
+  device: BootedDevice;
+  session: AndroidSegmentedPlanVideoSession;
+  segmentRecordingIds: Set<string>;
+  timer: Timer;
+  totalDurationHandle: NodeJS.Timeout | undefined;
+  finalized: boolean;
+}
+
+const rawAndroidSessionsByRecordingId = new Map<string, RawAndroidSegmentedRecording>();
+const rawAndroidSessionsByDeviceId = new Map<string, RawAndroidSegmentedRecording>();
+
+export function resetRawAndroidSegmentedVideoSessionsForTesting(): void {
+  for (const recording of rawAndroidSessionsByDeviceId.values()) {
+    cleanupRawAndroidSession(recording);
+  }
+  rawAndroidSessionsByRecordingId.clear();
+  rawAndroidSessionsByDeviceId.clear();
+}
 
 export interface VideoRecordingArgs {
   action: "start" | "stop";
@@ -138,28 +175,159 @@ function selectLatestRecording(records: VideoRecordingRecord[]): VideoRecordingR
     })[0];
 }
 
-async function stopRecordingById(recordingId: string) {
+function shouldUseRawAndroidSegmentation(
+  device: BootedDevice,
+  maxDurationSeconds: number
+): boolean {
+  return device.platform === "android" && maxDurationSeconds > ANDROID_SCREENRECORD_MAX_SECONDS;
+}
+
+function recordingResponseFromMetadata(
+  metadata: VideoRecordingMetadata,
+  device: Pick<BootedDevice, "deviceId" | "platform">
+): Record<string, unknown> {
+  const codec = metadata.codec ?? "unknown";
+  const durationMs = metadata.durationMs ?? 0;
+  const sizeBytes = metadata.sizeBytes ?? 0;
+
+  return {
+    recordingId: metadata.recordingId,
+    filePath: metadata.filePath,
+    durationMs,
+    sizeBytes,
+    codec,
+    metadata: { ...metadata, durationMs, sizeBytes, codec },
+    deviceId: device.deviceId,
+    platform: device.platform,
+  };
+}
+
+function cleanupRawAndroidSession(recording: RawAndroidSegmentedRecording): void {
+  recording.session.stopBackgroundRotation();
+
+  if (recording.totalDurationHandle) {
+    recording.timer.clearTimeout(recording.totalDurationHandle);
+    recording.totalDurationHandle = undefined;
+  }
+
+  rawAndroidSessionsByDeviceId.delete(recording.device.deviceId);
+  for (const recordingId of recording.segmentRecordingIds) {
+    rawAndroidSessionsByRecordingId.delete(recordingId);
+  }
+}
+
+async function finalizeRawAndroidSession(
+  recording: RawAndroidSegmentedRecording
+): Promise<VideoRecordingMetadata[]> {
+  if (recording.finalized) {
+    return [];
+  }
+
+  recording.finalized = true;
+  recording.session.stopBackgroundRotation();
+  if (recording.totalDurationHandle) {
+    recording.timer.clearTimeout(recording.totalDurationHandle);
+    recording.totalDurationHandle = undefined;
+  }
+
+  try {
+    const finalized = await recording.session.finalize({ strict: true });
+    cleanupRawAndroidSession(recording);
+    return finalized.metadata;
+  } catch (error) {
+    recording.finalized = false;
+    throw error;
+  }
+}
+
+async function startRawAndroidSegmentedRecording(
+  device: BootedDevice,
+  args: VideoRecordingArgs,
+  maxDurationSeconds: number,
+  dependencies: VideoRecordingToolDependencies
+): Promise<{
+  active: Awaited<ReturnType<typeof startVideoRecording>>;
+}> {
+  const segmentRecordingIds = new Set<string>();
+  const session = new AndroidSegmentedPlanVideoSession({
+    device,
+    outputNamePrefix: args.outputName ?? `video-${device.deviceId}`,
+    configOverrides: buildConfigOverrides(args),
+    highlights: args.highlights,
+    timer: dependencies.timer,
+    startVideoRecording: dependencies.startVideoRecording,
+    stopVideoRecording: dependencies.stopVideoRecording,
+    onSegmentStarted: recording => {
+      segmentRecordingIds.add(recording.recordingId);
+      const rawSession = rawAndroidSessionsByDeviceId.get(device.deviceId);
+      if (rawSession) {
+        rawAndroidSessionsByRecordingId.set(recording.recordingId, rawSession);
+      }
+    },
+  });
+
+  const active = await session.startFirstSegment();
+  const rawSession: RawAndroidSegmentedRecording = {
+    device,
+    session,
+    segmentRecordingIds,
+    timer: dependencies.timer,
+    totalDurationHandle: undefined,
+    finalized: false,
+  };
+
+  rawAndroidSessionsByDeviceId.set(device.deviceId, rawSession);
+  for (const recordingId of segmentRecordingIds) {
+    rawAndroidSessionsByRecordingId.set(recordingId, rawSession);
+  }
+  session.startBackgroundRotation();
+  rawSession.totalDurationHandle = dependencies.timer.setTimeout(() => {
+    void finalizeRawAndroidSession(rawSession).catch(error => {
+      rawSession.finalized = false;
+      rawAndroidSessionsByDeviceId.set(device.deviceId, rawSession);
+      for (const recordingId of segmentRecordingIds) {
+        rawAndroidSessionsByRecordingId.set(recordingId, rawSession);
+      }
+      // A later manual stop should still have a chance to report the original failure.
+      void error;
+    });
+  }, maxDurationSeconds * 1000);
+
+  return { active };
+}
+
+async function stopRecordingById(
+  recordingId: string,
+  dependencies: VideoRecordingToolDependencies
+) {
+  const rawAndroidSession = rawAndroidSessionsByRecordingId.get(recordingId);
+  if (rawAndroidSession) {
+    try {
+      const metadata = await finalizeRawAndroidSession(rawAndroidSession);
+      return createJSONToolResponse({
+        action: "stop",
+        count: metadata.length,
+        recordings: metadata.map(segment =>
+          recordingResponseFromMetadata(segment, rawAndroidSession.device)
+        ),
+      });
+    } catch (error) {
+      throw new ActionableError(`Failed to stop video recording: ${error}`);
+    }
+  }
+
   const results: Array<Record<string, unknown>> = [];
   const evictedRecordingIds: string[] = [];
-  const activeRecords = await listActiveVideoRecordings();
+  const activeRecords = await dependencies.listActiveVideoRecordings();
   const matching = activeRecords.find(record => record.recordingId === recordingId);
 
   try {
-    const { metadata, evictedRecordingIds: evicted } = await stopVideoRecording(recordingId);
-    const codec = metadata.codec ?? "unknown";
-    const durationMs = metadata.durationMs ?? 0;
-    const sizeBytes = metadata.sizeBytes ?? 0;
-
-    results.push({
-      recordingId: metadata.recordingId,
-      filePath: metadata.filePath,
-      durationMs,
-      sizeBytes,
-      codec,
-      metadata: { ...metadata, durationMs, sizeBytes, codec },
-      deviceId: matching?.deviceId,
-      platform: matching?.platform,
-    });
+    const { metadata, evictedRecordingIds: evicted } =
+      await dependencies.stopVideoRecording(recordingId);
+    results.push(recordingResponseFromMetadata(metadata, {
+      deviceId: matching?.deviceId ?? "",
+      platform: matching?.platform ?? "android",
+    }));
 
     for (const evictedId of evicted) {
       evictedRecordingIds.push(evictedId);
@@ -176,7 +344,22 @@ async function stopRecordingById(recordingId: string) {
   });
 }
 
-export function registerVideoRecordingTools(): void {
+export function createVideoRecordingToolHandlersForTesting(
+  options: RegisterVideoRecordingToolsOptions = {}
+): {
+  videoRecordingHandler: (
+    device: BootedDevice,
+    args: VideoRecordingArgs
+  ) => Promise<unknown>;
+  videoRecordingNonDeviceHandler: (args: VideoRecordingArgs) => Promise<unknown>;
+} {
+  const dependencies: VideoRecordingToolDependencies = {
+    timer: options.timer ?? defaultTimer,
+    startVideoRecording: options.startVideoRecording ?? startVideoRecording,
+    stopVideoRecording: options.stopVideoRecording ?? stopVideoRecording,
+    listActiveVideoRecordings: options.listActiveVideoRecordings ?? listActiveVideoRecordings,
+  };
+
   const videoRecordingHandler = async (
     device: BootedDevice,
     args: VideoRecordingArgs
@@ -189,13 +372,20 @@ export function registerVideoRecordingTools(): void {
 
       for (const target of targetDevices) {
         try {
-          const active = await startVideoRecording({
-            device: target,
-            configOverrides: buildConfigOverrides(args),
-            outputName: args.outputName,
-            maxDurationSeconds: args.maxDuration,
-            highlights: args.highlights,
-          });
+          const active = shouldUseRawAndroidSegmentation(target, maxDurationSeconds)
+            ? (await startRawAndroidSegmentedRecording(
+              target,
+              args,
+              maxDurationSeconds,
+              dependencies
+            )).active
+            : await dependencies.startVideoRecording({
+              device: target,
+              configOverrides: buildConfigOverrides(args),
+              outputName: args.outputName,
+              maxDurationSeconds: args.maxDuration,
+              highlights: args.highlights,
+            });
 
           recordings.push({
             recordingId: active.recordingId,
@@ -236,16 +426,35 @@ export function registerVideoRecordingTools(): void {
 
     if (args.action === "stop") {
       if (args.recordingId) {
-        return stopRecordingById(args.recordingId);
+        return stopRecordingById(args.recordingId, dependencies);
       }
 
       const results: Array<Record<string, unknown>> = [];
       const failures: Array<Record<string, unknown>> = [];
       const evictedRecordingIds: string[] = [];
       const targetDevices = await resolveTargetDevices(device, args);
-      const activeRecords = await listActiveVideoRecordings({ platform: device.platform });
+      const activeRecords = await dependencies.listActiveVideoRecordings({
+        platform: device.platform,
+      });
 
       for (const target of targetDevices) {
+        const rawAndroidSession = rawAndroidSessionsByDeviceId.get(target.deviceId);
+        if (rawAndroidSession) {
+          try {
+            const metadata = await finalizeRawAndroidSession(rawAndroidSession);
+            for (const segment of metadata) {
+              results.push(recordingResponseFromMetadata(segment, target));
+            }
+          } catch (error) {
+            failures.push({
+              deviceId: target.deviceId,
+              platform: target.platform,
+              error: String(error),
+            });
+          }
+          continue;
+        }
+
         const matches = activeRecords.filter(record => record.deviceId === target.deviceId);
         if (matches.length === 0) {
           failures.push({
@@ -258,23 +467,10 @@ export function registerVideoRecordingTools(): void {
 
         const latest = selectLatestRecording(matches);
         try {
-          const { metadata, evictedRecordingIds: evicted } = await stopVideoRecording(
+          const { metadata, evictedRecordingIds: evicted } = await dependencies.stopVideoRecording(
             latest.recordingId
           );
-          const codec = metadata.codec ?? "unknown";
-          const durationMs = metadata.durationMs ?? 0;
-          const sizeBytes = metadata.sizeBytes ?? 0;
-
-          results.push({
-            recordingId: metadata.recordingId,
-            filePath: metadata.filePath,
-            durationMs,
-            sizeBytes,
-            codec,
-            metadata: { ...metadata, durationMs, sizeBytes, codec },
-            deviceId: target.deviceId,
-            platform: target.platform,
-          });
+          results.push(recordingResponseFromMetadata(metadata, target));
 
           for (const evictedId of evicted) {
             evictedRecordingIds.push(evictedId);
@@ -309,13 +505,22 @@ export function registerVideoRecordingTools(): void {
 
   const videoRecordingNonDeviceHandler = async (args: VideoRecordingArgs) => {
     if (args.action === "stop" && args.recordingId) {
-      return stopRecordingById(args.recordingId);
+      return stopRecordingById(args.recordingId, dependencies);
     }
 
     throw new ActionableError(
       "Video recording start/stop requires a connected device unless recordingId is provided."
     );
   };
+
+  return { videoRecordingHandler, videoRecordingNonDeviceHandler };
+}
+
+export function registerVideoRecordingTools(
+  options: RegisterVideoRecordingToolsOptions = {}
+): void {
+  const { videoRecordingHandler, videoRecordingNonDeviceHandler } =
+    createVideoRecordingToolHandlersForTesting(options);
 
   ToolRegistry.registerDeviceAware("videoRecording", "Start or stop device video recording.", videoRecordingSchema, videoRecordingHandler, { shouldEnsureDevice: args => !(args.action === "stop" && args.recordingId),
     nonDeviceHandler: videoRecordingNonDeviceHandler, });

--- a/test/server/androidSegmentedPlanVideoSession.test.ts
+++ b/test/server/androidSegmentedPlanVideoSession.test.ts
@@ -3,6 +3,7 @@ import { AndroidSegmentedPlanVideoSession } from "../../src/server/androidSegmen
 import type { BootedDevice } from "../../src/models";
 import type { Timer } from "../../src/utils/SystemTimer";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import type { VideoRecordingHighlightInput } from "../../src/models";
 
 const androidDevice: BootedDevice = {
   deviceId: "emulator-5554",
@@ -17,6 +18,16 @@ const lowConfig = {
   fps: 15,
   maxArchiveSizeMb: 100,
   format: "mp4" as const,
+};
+
+const boxHighlightShape = {
+  type: "box" as const,
+  bounds: {
+    x: 1,
+    y: 2,
+    width: 3,
+    height: 4,
+  },
 };
 
 function makeStopMetadata(recordingId: string, filePath: string) {
@@ -116,5 +127,258 @@ describe("AndroidSegmentedPlanVideoSession", () => {
     expect(stop).toHaveBeenCalledTimes(2);
     expect(finalized.filePaths.length).toBe(2);
     expect(finalized.recordingIds.length).toBe(2);
+  });
+
+  test("finalize waits for in-flight rotation and prevents a replacement segment", async () => {
+    let now = 0;
+    let releaseStop: (() => void) | undefined;
+    let resolveStopEntered: (() => void) | undefined;
+    const stopEntered = new Promise<void>(resolve => {
+      resolveStopEntered = resolve;
+    });
+    const start = mock(async (req: { outputName?: string }) =>
+      makeActiveRecording(`id-${req.outputName}`, `/tmp/${req.outputName}.mp4`)
+    );
+    const stop = mock(async (id: string | undefined) => {
+      resolveStopEntered?.();
+      await new Promise<void>(stopResolve => {
+        releaseStop = stopResolve;
+      });
+      const rid = id ?? "x";
+      return {
+        metadata: makeStopMetadata(rid, `/tmp/${rid}.mp4`),
+        evictedRecordingIds: [] as string[],
+      };
+    });
+
+    const timer: Timer = {
+      now: () => now,
+      sleep: defaultTimer.sleep.bind(defaultTimer),
+      setTimeout: defaultTimer.setTimeout.bind(defaultTimer),
+      clearTimeout: defaultTimer.clearTimeout.bind(defaultTimer),
+      setInterval: defaultTimer.setInterval.bind(defaultTimer),
+      clearInterval: defaultTimer.clearInterval.bind(defaultTimer),
+    };
+
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "plan-c",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: start,
+      stopVideoRecording: stop,
+    });
+
+    await session.startFirstSegment();
+    now = 1000;
+    const rotation = session.onBeforePlanStep();
+
+    await stopEntered;
+    const finalizedPromise = session.finalize({ strict: true });
+    releaseStop?.();
+    const finalized = await finalizedPromise;
+    await rotation;
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(finalized.recordingIds).toEqual(["id-plan-c"]);
+  });
+
+  test("concurrent rotation checks wait for the tracked in-flight rotation", async () => {
+    let now = 0;
+    let releaseStop: (() => void) | undefined;
+    let resolveStopEntered: (() => void) | undefined;
+    const stopEntered = new Promise<void>(resolve => {
+      resolveStopEntered = resolve;
+    });
+    const start = mock(async (req: { outputName?: string }) =>
+      makeActiveRecording(`id-${req.outputName}`, `/tmp/${req.outputName}.mp4`)
+    );
+    const stop = mock(async (id: string | undefined) => {
+      resolveStopEntered?.();
+      await new Promise<void>(stopResolve => {
+        releaseStop = stopResolve;
+      });
+      const rid = id ?? "x";
+      return {
+        metadata: makeStopMetadata(rid, `/tmp/${rid}.mp4`),
+        evictedRecordingIds: [] as string[],
+      };
+    });
+
+    const timer: Timer = {
+      now: () => now,
+      sleep: defaultTimer.sleep.bind(defaultTimer),
+      setTimeout: defaultTimer.setTimeout.bind(defaultTimer),
+      clearTimeout: defaultTimer.clearTimeout.bind(defaultTimer),
+      setInterval: defaultTimer.setInterval.bind(defaultTimer),
+      clearInterval: defaultTimer.clearInterval.bind(defaultTimer),
+    };
+
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "plan-d",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: start,
+      stopVideoRecording: stop,
+    });
+
+    await session.startFirstSegment();
+    now = 1000;
+    const firstRotation = session.onBeforePlanStep();
+
+    await stopEntered;
+    let secondRotationSettled = false;
+    const secondRotation = session.onBeforePlanStep().then(() => {
+      secondRotationSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(secondRotationSettled).toBe(false);
+
+    releaseStop?.();
+    await Promise.all([firstRotation, secondRotation]);
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  test("strict finalize rejects when an earlier rotated segment failed to stop", async () => {
+    let now = 0;
+    const start = mock(async (req: { outputName?: string }) =>
+      makeActiveRecording(`id-${req.outputName}`, `/tmp/${req.outputName}.mp4`)
+    );
+    const stop = mock(async (id: string | undefined) => {
+      if (id === "id-plan-e") {
+        throw new Error("rotation stop failed");
+      }
+      const rid = id ?? "x";
+      return {
+        metadata: makeStopMetadata(rid, `/tmp/${rid}.mp4`),
+        evictedRecordingIds: [] as string[],
+      };
+    });
+
+    const timer: Timer = {
+      now: () => now,
+      sleep: defaultTimer.sleep.bind(defaultTimer),
+      setTimeout: defaultTimer.setTimeout.bind(defaultTimer),
+      clearTimeout: defaultTimer.clearTimeout.bind(defaultTimer),
+      setInterval: defaultTimer.setInterval.bind(defaultTimer),
+      clearInterval: defaultTimer.clearInterval.bind(defaultTimer),
+    };
+
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "plan-e",
+      timer,
+      segmentRotateAfterMs: 1000,
+      startVideoRecording: start,
+      stopVideoRecording: stop,
+    });
+
+    await session.startFirstSegment();
+    now = 1000;
+    await session.onBeforePlanStep();
+
+    await expect(session.finalize({ strict: true })).rejects.toThrow(
+      "Failed to stop one or more video recording segments: rotation stop failed"
+    );
+
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  test("rebases delayed highlights onto the segment that contains them", async () => {
+    let now = 0;
+    const startCalls: Array<{ outputName?: string; highlights?: VideoRecordingHighlightInput[] }> = [];
+    const start = mock(async (req: {
+      outputName?: string;
+      highlights?: VideoRecordingHighlightInput[];
+    }) => {
+      startCalls.push({
+        outputName: req.outputName,
+        highlights: req.highlights,
+      });
+      return makeActiveRecording(`id-${req.outputName}`, `/tmp/${req.outputName}.mp4`);
+    });
+    const stop = mock(async (id: string | undefined) => {
+      const rid = id ?? "x";
+      return {
+        metadata: makeStopMetadata(rid, `/tmp/${rid}.mp4`),
+        evictedRecordingIds: [] as string[],
+      };
+    });
+
+    const timer: Timer = {
+      now: () => now,
+      sleep: defaultTimer.sleep.bind(defaultTimer),
+      setTimeout: defaultTimer.setTimeout.bind(defaultTimer),
+      clearTimeout: defaultTimer.clearTimeout.bind(defaultTimer),
+      setInterval: defaultTimer.setInterval.bind(defaultTimer),
+      clearInterval: defaultTimer.clearInterval.bind(defaultTimer),
+    };
+
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "plan-f",
+      timer,
+      segmentRotateAfterMs: 1000,
+      highlights: [
+        { description: "first", shape: boxHighlightShape, timing: { startTimeMs: 0 } },
+        { description: "second", shape: boxHighlightShape, timing: { startTimeMs: 1200 } },
+        { description: "third", shape: boxHighlightShape, timing: { startTimeMs: 2500 } },
+      ],
+      startVideoRecording: start,
+      stopVideoRecording: stop,
+    });
+
+    await session.startFirstSegment();
+    now = 1000;
+    await session.onBeforePlanStep();
+    now = 2000;
+    await session.onBeforePlanStep();
+
+    expect(startCalls[0]?.highlights?.map(highlight => highlight.description)).toEqual(["first"]);
+    expect(startCalls[0]?.highlights?.[0]?.timing?.startTimeMs).toBe(0);
+    expect(startCalls[1]?.highlights?.map(highlight => highlight.description)).toEqual(["second"]);
+    expect(startCalls[1]?.highlights?.[0]?.timing?.startTimeMs).toBe(200);
+    expect(startCalls[2]?.highlights?.map(highlight => highlight.description)).toEqual(["third"]);
+    expect(startCalls[2]?.highlights?.[0]?.timing?.startTimeMs).toBe(500);
+  });
+
+  test("strict finalize keeps the active segment retryable after a stop failure", async () => {
+    let failedOnce = false;
+    const start = mock(async (req: { outputName?: string }) =>
+      makeActiveRecording(`id-${req.outputName}`, `/tmp/${req.outputName}.mp4`)
+    );
+    const stop = mock(async (id: string | undefined) => {
+      if (!failedOnce) {
+        failedOnce = true;
+        throw new Error("temporary stop failure");
+      }
+      const rid = id ?? "x";
+      return {
+        metadata: makeStopMetadata(rid, `/tmp/${rid}.mp4`),
+        evictedRecordingIds: [] as string[],
+      };
+    });
+
+    const session = new AndroidSegmentedPlanVideoSession({
+      device: androidDevice,
+      outputNamePrefix: "plan-g",
+      startVideoRecording: start,
+      stopVideoRecording: stop,
+    });
+
+    await session.startFirstSegment();
+    await expect(session.finalize({ strict: true })).rejects.toThrow("temporary stop failure");
+
+    const finalized = await session.finalize({ strict: true });
+
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(stop.mock.calls).toEqual([["id-plan-g"], ["id-plan-g"]]);
+    expect(finalized.recordingIds).toEqual(["id-plan-g"]);
   });
 });

--- a/test/server/videoRecordingTools.segmented.test.ts
+++ b/test/server/videoRecordingTools.segmented.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { BootedDevice, VideoRecordingConfig, VideoRecordingMetadata } from "../../src/models";
+import type { ActiveVideoRecording } from "../../src/features/video";
+import type { VideoRecordingRecord } from "../../src/db/videoRecordingRepository";
+import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS, ANDROID_SCREENRECORD_MAX_SECONDS } from "../../src/features/video/androidScreenrecord";
+import {
+  createVideoRecordingToolHandlersForTesting,
+  resetRawAndroidSegmentedVideoSessionsForTesting,
+} from "../../src/server/videoRecordingTools";
+import type { VideoRecordingArgs } from "../../src/server/videoRecordingTools";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel API 35",
+  platform: "android",
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "AAAA1111-BBBB-2222-CCCC-3333DDDD4444",
+  name: "iPhone 15",
+  platform: "ios",
+};
+
+const lowConfig: VideoRecordingConfig = {
+  qualityPreset: "low",
+  targetBitrateKbps: 1000,
+  maxThroughputMbps: 5,
+  fps: 15,
+  maxArchiveSizeMb: 100,
+  format: "mp4",
+};
+
+function parseToolPayload(response: { content: Array<{ type: "text"; text: string }> }) {
+  return JSON.parse(response.content[0]?.text ?? "{}") as {
+    action: string;
+    count: number;
+    recordings: Array<{
+      recordingId: string;
+      filePath?: string;
+      outputPath?: string;
+      deviceId: string;
+      platform: string;
+      settings?: { maxDurationSeconds?: number };
+    }>;
+  };
+}
+
+function createFakeVideoManager(timer: FakeTimer) {
+  const startCalls: Array<{
+    device: BootedDevice;
+    outputName?: string;
+    maxDurationSeconds?: number;
+  }> = [];
+  const stopCalls: Array<string | undefined> = [];
+  const records = new Map<string, VideoRecordingRecord>();
+  const stopFailures = new Map<string, Error>();
+  let nextRecordingId = 0;
+
+  const start = async (request: {
+    device: BootedDevice;
+    outputName?: string;
+    maxDurationSeconds?: number;
+  }): Promise<ActiveVideoRecording> => {
+    startCalls.push(request);
+    const recordingId = `rec-${++nextRecordingId}`;
+    const startedAt = new Date(timer.now()).toISOString();
+    const outputPath = `/tmp/${recordingId}.mp4`;
+    records.set(recordingId, {
+      recordingId,
+      deviceId: request.device.deviceId,
+      platform: request.device.platform,
+      status: "recording",
+      outputName: request.outputName,
+      fileName: `${recordingId}.mp4`,
+      filePath: outputPath,
+      format: "mp4",
+      sizeBytes: 0,
+      durationMs: undefined,
+      codec: undefined,
+      createdAt: startedAt,
+      startedAt,
+      endedAt: undefined,
+      lastAccessedAt: startedAt,
+      config: lowConfig,
+    });
+
+    return {
+      recordingId,
+      outputPath,
+      fileName: `${recordingId}.mp4`,
+      startedAt,
+      config: lowConfig,
+      outputName: request.outputName,
+    };
+  };
+
+  const stop = async (
+    recordingId?: string
+  ): Promise<{ metadata: VideoRecordingMetadata; evictedRecordingIds: string[] }> => {
+    stopCalls.push(recordingId);
+    const id = recordingId ?? Array.from(records.values()).find(record => record.status === "recording")?.recordingId;
+    const record = id ? records.get(id) : undefined;
+    if (!record) {
+      throw new Error(`No active recording found for id ${recordingId ?? ""}`);
+    }
+    const stopFailure = stopFailures.get(record.recordingId);
+    if (stopFailure) {
+      throw stopFailure;
+    }
+
+    const endedAt = new Date(timer.now()).toISOString();
+    const durationMs = Math.max(0, Date.parse(endedAt) - Date.parse(record.startedAt));
+    const metadata: VideoRecordingMetadata = {
+      recordingId: record.recordingId,
+      fileName: record.fileName,
+      filePath: record.filePath,
+      format: record.format,
+      sizeBytes: 1,
+      durationMs,
+      codec: "h264",
+      outputName: record.outputName,
+      createdAt: record.createdAt,
+      startedAt: record.startedAt,
+      endedAt,
+      lastAccessedAt: endedAt,
+      config: record.config,
+    };
+
+    records.set(record.recordingId, {
+      ...record,
+      ...metadata,
+      status: "completed",
+    });
+
+    return { metadata, evictedRecordingIds: [] };
+  };
+
+  const listActive = async (query: { platform?: "android" | "ios" } = {}) =>
+    Array.from(records.values()).filter(record =>
+      record.status === "recording" &&
+      (query.platform === undefined || record.platform === query.platform)
+    );
+
+  return { failStop: (recordingId: string, error: Error) => stopFailures.set(recordingId, error), listActive, start, startCalls, stop, stopCalls };
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  throw new Error(message);
+}
+
+describe("videoRecording raw Android segmentation", () => {
+  let fakeTimer: FakeTimer;
+  let fakeVideoManager: ReturnType<typeof createFakeVideoManager>;
+  let videoRecordingHandler: (
+    device: BootedDevice,
+    args: VideoRecordingArgs
+  ) => Promise<unknown>;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+    fakeVideoManager = createFakeVideoManager(fakeTimer);
+
+    resetRawAndroidSegmentedVideoSessionsForTesting();
+    videoRecordingHandler = createVideoRecordingToolHandlersForTesting({
+      timer: fakeTimer,
+      startVideoRecording: fakeVideoManager.start as never,
+      stopVideoRecording: fakeVideoManager.stop,
+      listActiveVideoRecordings: fakeVideoManager.listActive,
+    }).videoRecordingHandler;
+  });
+
+  afterEach(() => {
+    resetRawAndroidSegmentedVideoSessionsForTesting();
+  });
+
+  test("raw Android recording rotates segments and returns every segment on stop", async () => {
+    const startResponse = await videoRecordingHandler(androidDevice, {
+      action: "start",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+      outputName: "qa-case",
+      maxDuration: 300,
+    });
+    const startPayload = parseToolPayload(startResponse);
+    const originalRecordingId = startPayload.recordings[0]?.recordingId;
+
+    expect(startPayload.count).toBe(1);
+    expect(startPayload.recordings[0]?.settings?.maxDurationSeconds).toBe(300);
+    expect(fakeVideoManager.startCalls).toHaveLength(1);
+    expect(fakeVideoManager.startCalls[0]?.maxDurationSeconds).toBe(ANDROID_SCREENRECORD_MAX_SECONDS);
+
+    await fakeTimer.advanceTimersByTimeAsync(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);
+    await waitForCondition(
+      () => fakeVideoManager.startCalls.length === 2,
+      "Timed out waiting for Android raw recording rotation"
+    );
+
+    expect(fakeVideoManager.stopCalls).toHaveLength(1);
+    expect(fakeVideoManager.startCalls).toHaveLength(2);
+    expect(fakeVideoManager.startCalls[1]?.maxDurationSeconds).toBe(ANDROID_SCREENRECORD_MAX_SECONDS);
+
+    const stopResponse = await videoRecordingHandler(androidDevice, {
+      action: "stop",
+      platform: "android",
+      recordingId: originalRecordingId,
+    });
+    const stopPayload = parseToolPayload(stopResponse);
+
+    expect(stopPayload.count).toBe(2);
+    expect(stopPayload.recordings.map(recording => recording.recordingId)).toEqual(["rec-1", "rec-2"]);
+    expect(stopPayload.recordings.every(recording => recording.platform === "android")).toBe(true);
+    expect(fakeVideoManager.stopCalls).toHaveLength(2);
+  });
+
+  test("raw Android recording can stop rotated segments by device without recordingId", async () => {
+    await videoRecordingHandler(androidDevice, {
+      action: "start",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+      outputName: "qa-case",
+      maxDuration: 300,
+    });
+
+    await fakeTimer.advanceTimersByTimeAsync(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);
+    await waitForCondition(
+      () => fakeVideoManager.startCalls.length === 2,
+      "Timed out waiting for Android raw recording rotation"
+    );
+
+    const stopResponse = await videoRecordingHandler(androidDevice, {
+      action: "stop",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+    });
+    const stopPayload = parseToolPayload(stopResponse);
+
+    expect(stopPayload.count).toBe(2);
+    expect(stopPayload.recordings.map(recording => recording.recordingId)).toEqual(["rec-1", "rec-2"]);
+    expect(fakeVideoManager.stopCalls).toEqual(["rec-1", "rec-2"]);
+  });
+
+  test("raw Android recording fails stop when the final segment cannot stop", async () => {
+    const startResponse = await videoRecordingHandler(androidDevice, {
+      action: "start",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+      outputName: "qa-case",
+      maxDuration: 300,
+    });
+    const startPayload = parseToolPayload(startResponse);
+
+    await fakeTimer.advanceTimersByTimeAsync(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);
+    await waitForCondition(
+      () => fakeVideoManager.startCalls.length === 2,
+      "Timed out waiting for Android raw recording rotation"
+    );
+
+    fakeVideoManager.failStop("rec-2", new Error("final stop failed"));
+
+    await expect(videoRecordingHandler(androidDevice, {
+      action: "stop",
+      platform: "android",
+      recordingId: startPayload.recordings[0]?.recordingId,
+    })).rejects.toThrow("Failed to stop video recording");
+  });
+
+  test("raw iOS recording remains a single manager-backed recording", async () => {
+    const startResponse = await videoRecordingHandler(iosDevice, {
+      action: "start",
+      platform: "ios",
+      deviceId: iosDevice.deviceId,
+      outputName: "ios-case",
+      maxDuration: 300,
+    });
+    const startPayload = parseToolPayload(startResponse);
+
+    expect(startPayload.count).toBe(1);
+    expect(fakeVideoManager.startCalls).toHaveLength(1);
+    expect(fakeVideoManager.startCalls[0]?.maxDurationSeconds).toBe(300);
+
+    const stopResponse = await videoRecordingHandler(iosDevice, {
+      action: "stop",
+      platform: "ios",
+      recordingId: startPayload.recordings[0]?.recordingId,
+    });
+    const stopPayload = parseToolPayload(stopResponse);
+
+    expect(stopPayload.count).toBe(1);
+    expect(stopPayload.recordings[0]?.platform).toBe("ios");
+    expect(fakeVideoManager.stopCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds segmented Android recording support to the raw `videoRecording` tool path for recordings whose requested `maxDuration` exceeds the 180-second `screenrecord` cap. The raw tool now reuses the existing segmented Android session helper, rotates segments on a timer, and returns every completed segment when callers stop by device or by the original recording id.

## Linked Issue

Closes #3843

## Bug / Regression Context

- **Prior attempts:** #1959 landed segmented Android video for `executePlan` only.
- **Observed symptom:** Direct callers using `videoRecording --action start` / `stop` still hit the hard `adb shell screenrecord` 180s cap.
- **Repro steps / conditions:** Start raw Android video recording with a duration past 180s, run interactions beyond the cap, then stop the recording.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) via `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [ ] Android/iOS changes: ran the matching `scripts/` validation
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
