### PR TITLE
Add optional WebRTC audio streaming

### DIFF
--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -1,7 +1,7 @@
 name: "Build video-server jar"
 
 # Builds the persistent on-device H.264 encoder DEX (`automobile-video.jar`,
-# #3776) via `./gradlew :video-server:d8Dex` and uploads it as a CI artifact.
+# #3776) via `./gradlew :video-server:test :video-server:d8Dex` and uploads it as a CI artifact.
 # Shared by nightly.yml (drift detection → checksum PR) and release.yml (attach
 # to the GitHub release), so both compute the sha256 from the SAME build — a
 # divergent build would record a nightly sha the release cannot reproduce (the
@@ -42,7 +42,7 @@ jobs:
 
       - uses: ./.github/actions/gradle-task-run
         with:
-          gradle-tasks: ":video-server:d8Dex"
+          gradle-tasks: ":video-server:test :video-server:d8Dex"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/build-video-server-jar"
           reuse-configuration-cache: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1088,7 +1088,7 @@ jobs:
 
       - uses: ./.github/actions/gradle-task-run
         with:
-          gradle-tasks: ":junit-runner:test :junit-runner:jacocoTestReport :control-proxy:testDebugUnitTest :control-proxy:createDebugUnitTestCoverageReport :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:createDebugUnitTestCoverageReport :test-plan-validation:test :test-plan-validation:jacocoTestReport :protocol:test :protocol:jacocoTestReport"
+          gradle-tasks: ":junit-runner:test :junit-runner:jacocoTestReport :control-proxy:testDebugUnitTest :control-proxy:createDebugUnitTestCoverageReport :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:createDebugUnitTestCoverageReport :test-plan-validation:test :test-plan-validation:jacocoTestReport :protocol:test :protocol:jacocoTestReport :video-server:test"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1130,7 +1130,7 @@ jobs:
 
       - uses: ./.github/actions/gradle-task-run
         with:
-          gradle-tasks: ":junit-runner:test :junit-runner:jacocoTestReport :control-proxy:testDebugUnitTest :control-proxy:createDebugUnitTestCoverageReport :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:createDebugUnitTestCoverageReport :test-plan-validation:test :test-plan-validation:jacocoTestReport :protocol:test :protocol:jacocoTestReport"
+          gradle-tasks: ":junit-runner:test :junit-runner:jacocoTestReport :control-proxy:testDebugUnitTest :control-proxy:createDebugUnitTestCoverageReport :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:createDebugUnitTestCoverageReport :test-plan-validation:test :test-plan-validation:jacocoTestReport :protocol:test :protocol:jacocoTestReport :video-server:test"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true

--- a/android/video-server/build.gradle.kts
+++ b/android/video-server/build.gradle.kts
@@ -30,6 +30,7 @@ val androidPlatformJar: File =
 
 dependencies {
   compileOnly(files(androidPlatformJar))
+  testImplementation(libs.junit)
 }
 
 // Configure Kotlin compilation options

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/AudioCapture.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/AudioCapture.kt
@@ -1,0 +1,110 @@
+package dev.jasonpearson.automobile.video
+
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Captures device playback audio as 8 kHz mono PCM16LE.
+ *
+ * This runs from the shell-owned app_process video server. It uses REMOTE_SUBMIX, which is
+ * privileged and may be unavailable on some builds; in that case start() throws and the TypeScript
+ * caller reports a clear stream startup failure for audio-enabled sessions.
+ */
+class AudioCapture(
+  private val sampleRate: Int = SAMPLE_RATE_HZ,
+  private val channels: Int = CHANNELS,
+) {
+  private var record: AudioRecord? = null
+  private var thread: Thread? = null
+  private val running = AtomicBoolean(false)
+
+  fun start(onData: (ByteArray, Long) -> Boolean, onError: (String) -> Unit = {}) {
+    if (running.getAndSet(true)) {
+      throw IllegalStateException("Audio capture already started")
+    }
+
+    val minBuffer =
+      AudioRecord.getMinBufferSize(
+        sampleRate,
+        AudioFormat.CHANNEL_IN_MONO,
+        AudioFormat.ENCODING_PCM_16BIT,
+      )
+    val bufferSize = if (minBuffer > 0) minBuffer * 2 else sampleRate * channels * BYTES_PER_SAMPLE
+
+    val audioFormat =
+      AudioFormat.Builder()
+        .setSampleRate(sampleRate)
+        .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+        .build()
+
+    val recorder =
+      AudioRecord.Builder()
+        .setAudioSource(MediaRecorder.AudioSource.REMOTE_SUBMIX)
+        .setAudioFormat(audioFormat)
+        .setBufferSizeInBytes(bufferSize)
+        .build()
+
+    if (recorder.state != AudioRecord.STATE_INITIALIZED) {
+      running.set(false)
+      recorder.release()
+      throw IllegalStateException("AudioRecord REMOTE_SUBMIX failed to initialize")
+    }
+
+    recorder.startRecording()
+    record = recorder
+    thread =
+      Thread(
+          {
+            val buffer = ByteArray(bufferSize)
+            val startedAtUs = System.nanoTime() / 1_000L
+            try {
+              while (running.get()) {
+                val read = recorder.read(buffer, 0, buffer.size)
+                if (read > 0) {
+                  val ptsUs = (System.nanoTime() / 1_000L) - startedAtUs
+                  if (!onData(buffer.copyOf(read), ptsUs)) {
+                    running.set(false)
+                    break
+                  }
+                } else if (read < 0) {
+                  running.set(false)
+                  onError("AudioRecord read failed with code $read")
+                  break
+                }
+              }
+            } catch (e: RuntimeException) {
+              if (running.get()) {
+                running.set(false)
+                onError("AudioRecord read failed: ${e.message}")
+              }
+            }
+          },
+          "automobile-audio-capture",
+        )
+        .also { it.start() }
+  }
+
+  fun stop() {
+    running.set(false)
+    try {
+      record?.stop()
+    } catch (_: IllegalStateException) {}
+    try {
+      thread?.join(1_000)
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+    record?.release()
+    record = null
+    thread = null
+  }
+
+  companion object {
+    const val SAMPLE_RATE_HZ = 8_000
+    const val CHANNELS = 1
+    private const val BYTES_PER_SAMPLE = 2
+  }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -33,6 +33,7 @@ object VideoServer {
 
   private var encoder: VideoEncoder? = null
   private var capture: ScreenCapture? = null
+  private var audioCapture: AudioCapture? = null
   private var streamWriter: VideoStreamWriter? = null
 
   @JvmStatic
@@ -48,6 +49,7 @@ object VideoServer {
     val quality = parseQuality(args)
     val bitrateOverride = parseIntFlag(args, "--bit-rate")
     val sizeOverride = parseSizeFlag(args)
+    val audioEnabled = args.contains("--audio")
 
     println("AutoMobile Video Server")
     println("Quality preset: ${quality.name}")
@@ -63,6 +65,7 @@ object VideoServer {
     println(
       "Output: ${outputWidth}x${outputHeight} @ ${bitrate / 1_000_000}Mbps @ ${quality.fps}fps"
     )
+    println("Audio: ${if (audioEnabled) "enabled" else "disabled"}")
 
     // Install shutdown hook for clean termination
     Runtime.getRuntime()
@@ -75,7 +78,7 @@ object VideoServer {
       )
 
     try {
-      run(outputWidth, outputHeight, displayInfo.densityDpi, bitrate, quality.fps)
+      run(outputWidth, outputHeight, displayInfo.densityDpi, bitrate, quality.fps, audioEnabled)
     } catch (e: Exception) {
       System.err.println("Error: ${e.message}")
       e.printStackTrace()
@@ -144,6 +147,7 @@ object VideoServer {
         --quality, -q <preset>  Quality preset: low, medium, high (default: medium)
         --bit-rate <bps>        Override the preset bitrate (bits per second)
         --size <WxH>            Override the output resolution (e.g. 720x1280)
+        --audio                 Capture device playback audio as 8 kHz mono PCM16
         --help, -h              Show this help message
 
       Quality presets:
@@ -185,7 +189,14 @@ object VideoServer {
     }
   }
 
-  private fun run(width: Int, height: Int, densityDpi: Int, bitrate: Int, fps: Int) {
+  private fun run(
+    width: Int,
+    height: Int,
+    densityDpi: Int,
+    bitrate: Int,
+    fps: Int,
+    audioEnabled: Boolean,
+  ) {
     // Create encoder
     encoder =
       VideoEncoder(
@@ -201,8 +212,19 @@ object VideoServer {
     capture!!.start(surface)
 
     // Create stream writer
-    streamWriter = VideoStreamWriter(SOCKET_NAME, width, height)
+    streamWriter = VideoStreamWriter(SOCKET_NAME, width, height, audioEnabled)
     streamWriter!!.start()
+
+    if (audioEnabled) {
+      audioCapture = AudioCapture()
+      audioCapture!!.start(
+        onData = { data, ptsUs -> streamWriter?.writeAudioPacket(data, ptsUs) == true },
+        onError = { message ->
+          System.err.println(message)
+          running = false
+        },
+      )
+    }
 
     println("Streaming started")
 
@@ -233,10 +255,12 @@ object VideoServer {
   }
 
   private fun shutdown() {
+    audioCapture?.stop()
     streamWriter?.stop()
     capture?.stop()
     encoder?.stop()
 
+    audioCapture = null
     streamWriter = null
     capture = null
     encoder = null

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
@@ -1,0 +1,60 @@
+package dev.jasonpearson.automobile.video
+
+import java.nio.ByteBuffer
+
+object VideoStreamProtocol {
+  /** "h264" as big-endian int: 0x68323634 */
+  const val CODEC_ID_H264 = 0x68323634
+  /** "amux" as big-endian int: 0x616d7578 */
+  const val CODEC_ID_AMUX = 0x616d7578
+  /** "s16l" as big-endian int: 0x7331366c */
+  const val CODEC_ID_PCM16 = 0x7331366c
+  const val TRACK_ID_VIDEO = 1
+  const val TRACK_ID_AUDIO = 2
+  private const val MUX_VERSION = 1
+
+  /** Bit 63: codec configuration data */
+  const val PACKET_FLAG_CONFIG = 1L shl 63
+
+  /** Bit 62: key frame (I-frame) */
+  const val PACKET_FLAG_KEY_FRAME = 1L shl 62
+
+  /** Mask for PTS (bits 0-61) */
+  const val PTS_MASK = (1L shl 62) - 1
+
+  fun legacyHeader(width: Int, height: Int): ByteArray =
+    ByteBuffer.allocate(12).putInt(CODEC_ID_H264).putInt(width).putInt(height).array()
+
+  fun muxHeader(width: Int, height: Int, audioSampleRateHz: Int, audioChannels: Int): ByteArray =
+    ByteBuffer.allocate(44)
+      .putInt(CODEC_ID_AMUX)
+      .putInt(MUX_VERSION)
+      .putInt(2)
+      .putInt(TRACK_ID_VIDEO)
+      .putInt(CODEC_ID_H264)
+      .putInt(width)
+      .putInt(height)
+      .putInt(TRACK_ID_AUDIO)
+      .putInt(CODEC_ID_PCM16)
+      .putInt(audioSampleRateHz)
+      .putInt(audioChannels)
+      .array()
+
+  fun ptsAndFlags(presentationTimeUs: Long, isConfig: Boolean, isKeyFrame: Boolean): Long {
+    var ptsAndFlags = presentationTimeUs and PTS_MASK
+    if (isConfig) {
+      ptsAndFlags = ptsAndFlags or PACKET_FLAG_CONFIG
+    }
+    if (isKeyFrame) {
+      ptsAndFlags = ptsAndFlags or PACKET_FLAG_KEY_FRAME
+    }
+    return ptsAndFlags
+  }
+
+  fun packetHeader(audioEnabled: Boolean, trackId: Int, ptsAndFlags: Long, size: Int): ByteArray =
+    if (audioEnabled) {
+      ByteBuffer.allocate(16).putInt(trackId).putLong(ptsAndFlags).putInt(size).array()
+    } else {
+      ByteBuffer.allocate(12).putLong(ptsAndFlags).putInt(size).array()
+    }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -39,11 +39,19 @@ import java.nio.ByteBuffer
  * - bits 0-61: presentation timestamp in microseconds
  *
  * Followed by `size` bytes of encoded frame data.
+ *
+ * When audio is enabled, the stream uses a multiplexed header:
+ * ```
+ * amux header: magic "amux" (4) | version (4) | track_count (4)
+ * track:       track_id (4) | codec_id (4) | param1 (4) | param2 (4)
+ * packet:      track_id (4) | pts_and_flags (8) | size (4) | payload
+ * ```
  */
 class VideoStreamWriter(
   private val socketName: String,
   private val width: Int,
   private val height: Int,
+  private val audioEnabled: Boolean = false,
 ) {
   private var serverSocket: LocalServerSocket? = null
   private var clientSocket: LocalSocket? = null
@@ -54,6 +62,13 @@ class VideoStreamWriter(
   companion object {
     /** "h264" as big-endian int: 0x68323634 */
     const val CODEC_ID_H264 = 0x68323634
+    /** "amux" as big-endian int: 0x616d7578 */
+    const val CODEC_ID_AMUX = 0x616d7578
+    /** "s16l" as big-endian int: 0x7331366c */
+    const val CODEC_ID_PCM16 = 0x7331366c
+    const val TRACK_ID_VIDEO = 1
+    const val TRACK_ID_AUDIO = 2
+    private const val MUX_VERSION = 1
 
     /** Bit 63: codec configuration data */
     const val PACKET_FLAG_CONFIG = 1L shl 63
@@ -85,14 +100,35 @@ class VideoStreamWriter(
     println("Client connected, writing stream header")
 
     // Write stream header
-    writeHeader()
+    if (audioEnabled) {
+      writeMuxHeader()
+    } else {
+      writeLegacyHeader()
+    }
   }
 
-  private fun writeHeader() {
+  private fun writeLegacyHeader() {
     val header = ByteBuffer.allocate(12)
     header.putInt(CODEC_ID_H264)
     header.putInt(width)
     header.putInt(height)
+    outputStream!!.write(header.array())
+    outputStream!!.flush()
+  }
+
+  private fun writeMuxHeader() {
+    val header = ByteBuffer.allocate(12 + 16 + 16)
+    header.putInt(CODEC_ID_AMUX)
+    header.putInt(MUX_VERSION)
+    header.putInt(2)
+    header.putInt(TRACK_ID_VIDEO)
+    header.putInt(CODEC_ID_H264)
+    header.putInt(width)
+    header.putInt(height)
+    header.putInt(TRACK_ID_AUDIO)
+    header.putInt(CODEC_ID_PCM16)
+    header.putInt(AudioCapture.SAMPLE_RATE_HZ)
+    header.putInt(AudioCapture.CHANNELS)
     outputStream!!.write(header.array())
     outputStream!!.flush()
   }
@@ -105,32 +141,47 @@ class VideoStreamWriter(
    * @return true if the packet was written successfully, false if the stream was closed
    */
   fun writePacket(buffer: ByteBuffer, bufferInfo: MediaCodec.BufferInfo): Boolean {
+    val data = ByteArray(bufferInfo.size)
+    buffer.position(bufferInfo.offset)
+    buffer.get(data, 0, bufferInfo.size)
+    var ptsAndFlags = bufferInfo.presentationTimeUs and PTS_MASK
+
+    if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+      ptsAndFlags = ptsAndFlags or PACKET_FLAG_CONFIG
+    }
+
+    if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0) {
+      ptsAndFlags = ptsAndFlags or PACKET_FLAG_KEY_FRAME
+    }
+
+    return writePacketData(TRACK_ID_VIDEO, ptsAndFlags, data)
+  }
+
+  fun writeAudioPacket(data: ByteArray, ptsUs: Long): Boolean {
+    return writePacketData(TRACK_ID_AUDIO, ptsUs and PTS_MASK, data)
+  }
+
+  @Synchronized
+  private fun writePacketData(trackId: Int, ptsAndFlags: Long, data: ByteArray): Boolean {
     if (stopped) return false
 
     val output = outputStream ?: return false
 
     try {
-      // Build pts_and_flags
-      var ptsAndFlags = bufferInfo.presentationTimeUs and PTS_MASK
-
-      if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
-        ptsAndFlags = ptsAndFlags or PACKET_FLAG_CONFIG
-      }
-
-      if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0) {
-        ptsAndFlags = ptsAndFlags or PACKET_FLAG_KEY_FRAME
-      }
-
-      // Write packet header (12 bytes)
-      val packetHeader = ByteBuffer.allocate(12)
-      packetHeader.putLong(ptsAndFlags)
-      packetHeader.putInt(bufferInfo.size)
+      val packetHeader =
+        if (audioEnabled) {
+          ByteBuffer.allocate(16).also {
+            it.putInt(trackId)
+            it.putLong(ptsAndFlags)
+            it.putInt(data.size)
+          }
+        } else {
+          ByteBuffer.allocate(12).also {
+            it.putLong(ptsAndFlags)
+            it.putInt(data.size)
+          }
+        }
       output.write(packetHeader.array())
-
-      // Write packet data
-      val data = ByteArray(bufferInfo.size)
-      buffer.position(bufferInfo.offset)
-      buffer.get(data, 0, bufferInfo.size)
       output.write(data)
 
       return true

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -61,23 +61,22 @@ class VideoStreamWriter(
 
   companion object {
     /** "h264" as big-endian int: 0x68323634 */
-    const val CODEC_ID_H264 = 0x68323634
+    const val CODEC_ID_H264 = VideoStreamProtocol.CODEC_ID_H264
     /** "amux" as big-endian int: 0x616d7578 */
-    const val CODEC_ID_AMUX = 0x616d7578
+    const val CODEC_ID_AMUX = VideoStreamProtocol.CODEC_ID_AMUX
     /** "s16l" as big-endian int: 0x7331366c */
-    const val CODEC_ID_PCM16 = 0x7331366c
-    const val TRACK_ID_VIDEO = 1
-    const val TRACK_ID_AUDIO = 2
-    private const val MUX_VERSION = 1
+    const val CODEC_ID_PCM16 = VideoStreamProtocol.CODEC_ID_PCM16
+    const val TRACK_ID_VIDEO = VideoStreamProtocol.TRACK_ID_VIDEO
+    const val TRACK_ID_AUDIO = VideoStreamProtocol.TRACK_ID_AUDIO
 
     /** Bit 63: codec configuration data */
-    const val PACKET_FLAG_CONFIG = 1L shl 63
+    const val PACKET_FLAG_CONFIG = VideoStreamProtocol.PACKET_FLAG_CONFIG
 
     /** Bit 62: key frame (I-frame) */
-    const val PACKET_FLAG_KEY_FRAME = 1L shl 62
+    const val PACKET_FLAG_KEY_FRAME = VideoStreamProtocol.PACKET_FLAG_KEY_FRAME
 
     /** Mask for PTS (bits 0-61) */
-    const val PTS_MASK = (1L shl 62) - 1
+    const val PTS_MASK = VideoStreamProtocol.PTS_MASK
   }
 
   /**
@@ -108,28 +107,19 @@ class VideoStreamWriter(
   }
 
   private fun writeLegacyHeader() {
-    val header = ByteBuffer.allocate(12)
-    header.putInt(CODEC_ID_H264)
-    header.putInt(width)
-    header.putInt(height)
-    outputStream!!.write(header.array())
+    outputStream!!.write(VideoStreamProtocol.legacyHeader(width, height))
     outputStream!!.flush()
   }
 
   private fun writeMuxHeader() {
-    val header = ByteBuffer.allocate(12 + 16 + 16)
-    header.putInt(CODEC_ID_AMUX)
-    header.putInt(MUX_VERSION)
-    header.putInt(2)
-    header.putInt(TRACK_ID_VIDEO)
-    header.putInt(CODEC_ID_H264)
-    header.putInt(width)
-    header.putInt(height)
-    header.putInt(TRACK_ID_AUDIO)
-    header.putInt(CODEC_ID_PCM16)
-    header.putInt(AudioCapture.SAMPLE_RATE_HZ)
-    header.putInt(AudioCapture.CHANNELS)
-    outputStream!!.write(header.array())
+    outputStream!!.write(
+      VideoStreamProtocol.muxHeader(
+        width,
+        height,
+        AudioCapture.SAMPLE_RATE_HZ,
+        AudioCapture.CHANNELS,
+      )
+    )
     outputStream!!.flush()
   }
 
@@ -144,15 +134,12 @@ class VideoStreamWriter(
     val data = ByteArray(bufferInfo.size)
     buffer.position(bufferInfo.offset)
     buffer.get(data, 0, bufferInfo.size)
-    var ptsAndFlags = bufferInfo.presentationTimeUs and PTS_MASK
-
-    if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
-      ptsAndFlags = ptsAndFlags or PACKET_FLAG_CONFIG
-    }
-
-    if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0) {
-      ptsAndFlags = ptsAndFlags or PACKET_FLAG_KEY_FRAME
-    }
+    val ptsAndFlags =
+      VideoStreamProtocol.ptsAndFlags(
+        bufferInfo.presentationTimeUs,
+        (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0,
+        (bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0,
+      )
 
     return writePacketData(TRACK_ID_VIDEO, ptsAndFlags, data)
   }
@@ -168,20 +155,7 @@ class VideoStreamWriter(
     val output = outputStream ?: return false
 
     try {
-      val packetHeader =
-        if (audioEnabled) {
-          ByteBuffer.allocate(16).also {
-            it.putInt(trackId)
-            it.putLong(ptsAndFlags)
-            it.putInt(data.size)
-          }
-        } else {
-          ByteBuffer.allocate(12).also {
-            it.putLong(ptsAndFlags)
-            it.putInt(data.size)
-          }
-        }
-      output.write(packetHeader.array())
+      output.write(VideoStreamProtocol.packetHeader(audioEnabled, trackId, ptsAndFlags, data.size))
       output.write(data)
 
       return true

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
@@ -1,0 +1,182 @@
+package dev.jasonpearson.automobile.video
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoStreamProtocolTest {
+  @Test
+  fun legacyHeaderUsesH264WidthAndHeight() {
+    val expected =
+      byteArrayOf(
+        0x68,
+        0x32,
+        0x36,
+        0x34,
+        0x00,
+        0x00,
+        0x01,
+        0xe0.toByte(),
+        0x00,
+        0x00,
+        0x04,
+        0x10,
+      )
+
+    assertArrayEquals(expected, VideoStreamProtocol.legacyHeader(width = 480, height = 1040))
+  }
+
+  @Test
+  fun muxHeaderAdvertisesVideoAndAudioTracks() {
+    val expected =
+      byteArrayOf(
+        0x61,
+        0x6d,
+        0x75,
+        0x78,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x02,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x68,
+        0x32,
+        0x36,
+        0x34,
+        0x00,
+        0x00,
+        0x01,
+        0xe0.toByte(),
+        0x00,
+        0x00,
+        0x04,
+        0x10,
+        0x00,
+        0x00,
+        0x00,
+        0x02,
+        0x73,
+        0x31,
+        0x36,
+        0x6c,
+        0x00,
+        0x00,
+        0x1f,
+        0x40,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+      )
+
+    assertArrayEquals(
+      expected,
+      VideoStreamProtocol.muxHeader(
+        width = 480,
+        height = 1040,
+        audioSampleRateHz = 8000,
+        audioChannels = 1,
+      ),
+    )
+  }
+
+  @Test
+  fun videoPacketHeaderPreservesFlagsAndSizeInLegacyAndMuxForms() {
+    val ptsAndFlags =
+      VideoStreamProtocol.ptsAndFlags(
+        presentationTimeUs = 123,
+        isConfig = true,
+        isKeyFrame = true,
+      )
+
+    assertEquals(
+      VideoStreamProtocol.PACKET_FLAG_CONFIG or VideoStreamProtocol.PACKET_FLAG_KEY_FRAME or 123,
+      ptsAndFlags,
+    )
+    assertArrayEquals(
+      byteArrayOf(
+        0xc0.toByte(),
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x7b,
+        0x00,
+        0x00,
+        0x00,
+        0x03,
+      ),
+      VideoStreamProtocol.packetHeader(
+        audioEnabled = false,
+        trackId = VideoStreamProtocol.TRACK_ID_VIDEO,
+        ptsAndFlags = ptsAndFlags,
+        size = 3,
+      ),
+    )
+    assertArrayEquals(
+      byteArrayOf(
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0xc0.toByte(),
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x7b,
+        0x00,
+        0x00,
+        0x00,
+        0x03,
+      ),
+      VideoStreamProtocol.packetHeader(
+        audioEnabled = true,
+        trackId = VideoStreamProtocol.TRACK_ID_VIDEO,
+        ptsAndFlags = ptsAndFlags,
+        size = 3,
+      ),
+    )
+  }
+
+  @Test
+  fun audioPacketHeaderUsesAudioTrackWithoutFlags() {
+    assertArrayEquals(
+      byteArrayOf(
+        0x00,
+        0x00,
+        0x00,
+        0x02,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x04,
+        0xd2.toByte(),
+        0x00,
+        0x00,
+        0x00,
+        0x04,
+      ),
+      VideoStreamProtocol.packetHeader(
+        audioEnabled = true,
+        trackId = VideoStreamProtocol.TRACK_ID_AUDIO,
+        ptsAndFlags = 1234,
+        size = 4,
+      ),
+    )
+  }
+}

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -64,8 +64,9 @@ by common media servers (MediaMTX, LiveKit, Janus, Cloudflare).
 |------|----------------|
 | `h264.ts` | Annex-B NAL splitter, access-unit assembler, RFC 6184 RTP packetizer (single-NAL + FU-A) |
 | `RtpH264TrackWriter.ts` | Turns the elementary stream into werift `RtpPacket`s; wall-clock 90 kHz timestamps, marker bit on the last packet of a frame |
+| `RtpPcmuTrackWriter.ts` | Turns 8 kHz mono PCM16LE audio into PCMU/G.711 RTP packets |
 | `AndroidH264Source.ts` | Runs `adb exec-out screenrecord --output-format=h264 -`; rotates segments before the 180 s `--time-limit` cap so the stream stays continuous |
-| `PersistentEncoderH264Source.ts` | Runs the long-lived `video-server` (VirtualDisplay + MediaCodec) via `app_process`; a single continuous encoder with no rotation seam. Parsed by `VideoServerStreamParser.ts` |
+| `PersistentEncoderH264Source.ts` | Runs the long-lived `video-server` (VirtualDisplay + MediaCodec, plus optional playback audio) via `app_process`; parsed by `VideoServerStreamParser.ts` |
 | `androidH264CaptureSourceFactory.ts` | Prefers the persistent encoder when `automobile-video.jar` is resolvable (`videoServerJar.ts`), falling back to `screenrecord` on unavailability or start failure |
 | `WhipClient.ts` | WHIP `POST` (offer→answer) and `DELETE`; resolves the `Location` resource URL used to reconnect/tear down |
 | `ReconnectController.ts` | Connect / reconnect with injectable backoff (default exponential 1 s→30 s) |
@@ -104,7 +105,8 @@ Newline-delimited JSON request/response.
   "whipToken": "…",             // optional bearer token
   "iceServers": [{ "urls": "stun:stun.l.google.com:19302" }],
   "bitrateKbps": 4000,          // optional
-  "size": { "width": 720, "height": 1280 }    // optional downscale
+  "size": { "width": 720, "height": 1280 },   // optional downscale
+  "audio": true                               // optional Android audio
 }
 ```
 
@@ -123,7 +125,9 @@ Newline-delimited JSON request/response.
     "resourceUrl": "https://coord:8080/whip/ci-run-42",
     "iceServers": [ … ],
     "framesSent": 0,
-    "packetsSent": 0
+    "packetsSent": 0,
+    "audioPacketsSent": 0,
+    "audioSamplesSent": 0
   }
 }
 ```
@@ -137,6 +141,7 @@ Newline-delimited JSON request/response.
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate |
 | `AUTOMOBILE_WEBRTC_MAX_SIZE` | Capture downscale, `WIDTHxHEIGHT` |
+| `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional Android audio (`audio: true` per request). Requires the persistent `video-server` jar. |
 
 Per-request fields override the environment defaults.
 
@@ -209,6 +214,21 @@ compromised:
 See [Environment variables](../../../using/environment-variables.md) for the full
 flag reference.
 
+## Optional audio
+
+Audio is opt-in (`AUTOMOBILE_WEBRTC_AUDIO=1` or `"audio": true`) and currently
+Android-only. The publisher adds a sendonly PCMU audio track and the Android
+`video-server` captures 8 kHz mono PCM16 from `REMOTE_SUBMIX`; the TypeScript
+publisher converts that PCM to PCMU RTP. Because `screenrecord` is video-only,
+audio-enabled streams require the persistent `automobile-video.jar` path. If the
+jar is unavailable or `REMOTE_SUBMIX` cannot initialize on the device build, the
+stream start fails instead of silently publishing video-only audio.
+
+Android playback capture is policy-limited: some apps/usages cannot be captured,
+and `REMOTE_SUBMIX` is privileged. The reference coordination server forwards
+both the H.264 and PCMU tracks to WHEP subscribers and exposes `audio` plus
+`audioPacketsForwarded` in its reconnect descriptor.
+
 ## Known limitations / future work
 
 - **Android only.** iOS `simctl` provides screenshots/finalized recordings, not a
@@ -220,8 +240,9 @@ flag reference.
   demand, so production installs use the persistent encoder by default. See
   [Persistent-encoder delivery](#persistent-encoder-delivery-automobile-videojar)
   above.
-- **No audio.** Video only; a device-audio capture source would be required to
-  add an audio track (#3778).
+- **Audio is Android-only and opt-in.** iOS WebRTC capture remains video-only,
+  and Android audio depends on `REMOTE_SUBMIX` availability for the shell-owned
+  `video-server` process.
 - **Reference server is single-process/in-memory.** Use a hardened WHIP/WHEP SFU
   (MediaMTX, LiveKit, Janus, Cloudflare) in production; the publisher is unchanged.
 - **Trickle ICE is opt-in.** By default the publisher gathers candidates before

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -1,19 +1,19 @@
 # WebRTC Screen Streaming (WHIP egress)
 
-<kbd>⚠️ Partial</kbd> <kbd>🧪 Tested</kbd> <kbd>🤖 Android Only</kbd>
+<kbd>⚠️ Partial</kbd> <kbd>🧪 Tested</kbd> <kbd>🤖 Android + iOS Video</kbd>
 
 > **Current state:** The AutoMobile publish path is implemented and tested — an
-> Android device's screen is captured as H.264, packetized to RTP, and pushed to
+> Android or iOS device screen video is captured as H.264, packetized to RTP, and pushed to
 > a coordination server over **WHIP** using [werift](https://github.com/shinyoshiaki/werift-webrtc)
 > (pure-TypeScript WebRTC). Control is via the daemon `webrtc-stream.sock` Unix
 > socket. A reference coordination server + browser viewer ships under
 > [`examples/webrtc-coordination-server/`](../../../../examples/webrtc-coordination-server/).
 >
-> Live device capture depends on `adb screenrecord` on a real Android device/emulator
-> (not exercised in unit tests); everything up to and including the WebRTC media
-> transport is covered by a real werift↔werift loopback and a full
-> publisher→server→subscriber end-to-end test. iOS is not yet supported (no live
-> H.264 source — see [iOS Screen Streaming](../../plat/ios/screen-streaming.md)).
+> Live Android capture depends on `adb screenrecord` or the persistent
+> `video-server` jar on a real device/emulator; iOS capture depends on the
+> CtrlProxy screen streaming helper plus local `ffmpeg` H.264 encoding. Everything
+> up to and including the WebRTC media transport is covered by a real
+> werift↔werift loopback and a full publisher→server→subscriber end-to-end test.
 >
 > See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
@@ -231,10 +231,10 @@ both the H.264 and PCMU tracks to WHEP subscribers and exposes `audio` plus
 
 ## Known limitations / future work
 
-- **Android only.** iOS `simctl` provides screenshots/finalized recordings, not a
-  live H.264 elementary stream; a VideoToolbox encoder in the CtrlProxy runner is
-  required. See [ios-webrtc-streaming.md](./ios-webrtc-streaming.md) (#3777) for
-  the spike and recommended path.
+- **Platform capture differs.** Android capture prefers the persistent
+  `video-server` jar and falls back to `screenrecord`; iOS capture uses the
+  CtrlProxy helper and local `ffmpeg` H.264 encoding. Keep both helper binaries
+  available on workers that may stream either platform.
 - ~~**Persistent-encoder distribution.**~~ *Resolved:* the `video-server` jar now
   ships as a checksum-verified GitHub release asset and is downloaded/cached on
   demand, so production installs use the persistent encoder by default. See

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -93,6 +93,7 @@ overridden per request on the `webrtc-stream.sock` control socket.
 | `AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER` | Path to the built `screen-capture-helper` binary for iOS WebRTC capture. Build with `swift build` in `ios/screen-capture` from a repo checkout, or in `dist/ios/screen-capture` from a package install. | repo/package-local debug/release build output when present |
 | `AUTOMOBILE_IOS_WEBRTC_FFMPEG` | Path to the `ffmpeg` binary used to encode iOS helper BGRA frames into H.264 Annex-B. | `ffmpeg` on `PATH` |
 | `AUTOMOBILE_WEBRTC_TRICKLE_ICE` | Enable trickle ICE: publish the WHIP offer immediately and PATCH candidates incrementally instead of blocking on ICE gathering. Requires an ingest server supporting the WHIP trickle extension. | `false` |
+| `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional audio alongside video. Android only; requires the persistent `video-server` jar and captures shell-privileged `REMOTE_SUBMIX` PCM16 audio, sent over WebRTC as PCMU. | `false` |
 
 ### `automobile-video.jar` resolution
 

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -32,6 +32,8 @@ export AUTOMOBILE_WEBRTC_ICE_SERVERS="stun:stun.l.google.com:19302"
 # Optional tuning:
 export AUTOMOBILE_WEBRTC_BITRATE_KBPS="4000"
 export AUTOMOBILE_WEBRTC_MAX_SIZE="720x1280"
+# Optional Android audio (requires AUTOMOBILE_VIDEO_SERVER_JAR / built video-server):
+export AUTOMOBILE_WEBRTC_AUDIO="1"
 ```
 
 > **NAT/firewall:** CI workers are usually behind NAT. Add a **TURN** server to
@@ -65,6 +67,8 @@ Response:
 If multiple Android devices are attached, pass `"deviceId":"emulator-5554"`.
 You can also override any config per call, e.g.
 `{"action":"start","whipEndpoint":"https://other/whip","bitrateKbps":2000}`.
+For audio, pass `"audio":true`; it is Android-only and requires the persistent
+`video-server` jar because `screenrecord` is video-only.
 
 ### From Node / Bun
 
@@ -122,4 +126,5 @@ today.
 | `No connected android devices found` | Emulator/device not booted, or pass the right `deviceId`. |
 | `WHIP ingest failed: … 401` | Coordination server requires a token — set `AUTOMOBILE_WEBRTC_WHIP_TOKEN`. |
 | Stream shows `connected` but the browser video is black | ICE could not traverse NAT — add a TURN server. |
-| Brief hitch every ~3 minutes | Expected `screenrecord` segment rotation (180 s cap). |
+| Brief hitch every ~3 minutes | Expected `screenrecord` segment rotation (180 s cap). Build/provide `automobile-video.jar` to use the persistent encoder. |
+| Audio-enabled stream fails to start | The persistent `video-server` jar is missing, or the device build does not allow shell `REMOTE_SUBMIX` capture. Disable audio or use a compatible Android image. |

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -1,8 +1,8 @@
 # Streaming a device's screen from a CI worker (WebRTC / WHIP)
 
 This guide shows how to make an AutoMobile daemon running on a CI worker **push**
-the screen of the Android device it is driving to a coordination server over
-WebRTC, so the stream can be watched live in a browser.
+the screen of the Android or iOS device it is driving to a coordination server
+over WebRTC, so the stream can be watched live in a browser.
 
 For the full design, see
 [WebRTC Screen Streaming](./design-docs/mcp/observe/webrtc-streaming.md).
@@ -15,7 +15,9 @@ CI worker (AutoMobile daemon) ──WHIP──▶ coordination server ──WHEP
 
 - An AutoMobile daemon running on the CI worker (the streaming control socket is
   started with the daemon).
-- A connected/booted **Android** emulator or device (`adb devices` lists it).
+- A connected/booted **Android** emulator or device (`adb devices` lists it), or
+  a booted **iOS** simulator with the CtrlProxy screen streaming helper and
+  local `ffmpeg` available.
 - A reachable **coordination server** that accepts WHIP ingest. Use the bundled
   [reference server](../examples/webrtc-coordination-server/README.md) to try it
   out, or a production SFU such as MediaMTX / LiveKit / Janus / Cloudflare.
@@ -64,8 +66,8 @@ Response:
            "resourceUrl":"https://coord.example.com/whip/ci-run-42", ...}}
 ```
 
-If multiple Android devices are attached, pass `"deviceId":"emulator-5554"`.
-You can also override any config per call, e.g.
+If multiple devices are attached, pass `"deviceId":"emulator-5554"` or the iOS
+simulator UDID. You can also override any config per call, e.g.
 `{"action":"start","whipEndpoint":"https://other/whip","bitrateKbps":2000}`.
 For audio, pass `"audio":true`; it is Android-only and requires the persistent
 `video-server` jar because `screenrecord` is video-only.
@@ -106,7 +108,7 @@ echo '{"action":"status","streamId":"ci-run-42"}' | nc -U ~/.auto-mobile/webrtc-
 ## Typical CI shape
 
 ```bash
-# 1. boot emulator + start daemon (project-specific)
+# 1. boot emulator/simulator + start daemon (project-specific)
 # 2. begin streaming so humans can watch the run live
 echo '{"action":"start","streamId":"'"$CI_JOB_ID"'"}' | nc -U ~/.auto-mobile/webrtc-stream.sock
 # 3. run your AutoMobile test plan ...
@@ -115,8 +117,8 @@ echo '{"action":"stop","streamId":"'"$CI_JOB_ID"'"}'  | nc -U ~/.auto-mobile/web
 ```
 
 The publisher reconnects automatically if the network blips; the browser viewer
-reconnects via the coordination server's reconnect API. Streaming is Android-only
-today.
+reconnects via the coordination server's reconnect API. Video streaming supports
+Android and iOS; optional audio is Android-only today.
 
 ## Troubleshooting
 

--- a/examples/webrtc-coordination-server/README.md
+++ b/examples/webrtc-coordination-server/README.md
@@ -2,9 +2,9 @@
 
 A minimal, self-contained **WHIP ingest → WHEP egress** coordination server for
 AutoMobile's WebRTC screen streaming. An AutoMobile daemon (typically on a CI
-worker) **publishes** a device's screen here over WHIP; browsers **subscribe**
-over WHEP and watch it live. A small REST "reconnect API" lets a frontend
-discover active streams and reconnect.
+worker) **publishes** a device's screen, plus optional audio, here over WHIP;
+browsers **subscribe** over WHEP and watch it live. A small REST "reconnect API"
+lets a frontend discover active streams and reconnect.
 
 ```
  Android device                AutoMobile daemon              This server                 Browser
@@ -84,7 +84,9 @@ echo '{"action":"start","deviceId":"emulator-5554","streamId":"ci-run-42"}' \
   "createdAt": "2026-07-11T00:00:00.000Z",
   "whepUrl": "/whep/ci-run-42", // POST an SDP offer here to (re)connect
   "iceServers": [{ "urls": "stun:stun.l.google.com:19302" }],
-  "framesForwarded": 512
+  "framesForwarded": 512,
+  "audio": true,
+  "audioPacketsForwarded": 2400
 }
 ```
 

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -4,6 +4,7 @@ import {
   RTCPeerConnection,
   RtpPacket,
   useH264,
+  usePCMU,
   type RTCIceServer,
 } from "werift";
 
@@ -37,21 +38,26 @@ export interface StreamDescriptor {
   iceServers: RTCIceServer[];
   /** Frames forwarded from the publisher so far. */
   framesForwarded: number;
+  /** Whether the publisher negotiated an audio track. */
+  audio: boolean;
+  /** Audio RTP packets forwarded from the publisher so far. */
+  audioPacketsForwarded: number;
 }
 
 interface Subscriber {
   id: string;
   pc: RTCPeerConnection;
-  track: MediaStreamTrack;
+  tracks: Map<"audio" | "video", MediaStreamTrack>;
 }
 
 interface StreamEntry {
   streamId: string;
   ingestPc: RTCPeerConnection;
-  inboundTrack: MediaStreamTrack | null;
+  inboundTracks: Map<"audio" | "video", MediaStreamTrack>;
   subscribers: Map<string, Subscriber>;
   createdAt: string;
   framesForwarded: number;
+  audioPacketsForwarded: number;
 }
 
 const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
@@ -76,22 +82,34 @@ export class CoordinationServer {
   ): Promise<{ streamId: string; answerSdp: string }> {
     const streamId = requestedStreamId?.trim() || `stream-${randomUUID().slice(0, 8)}`;
 
-    const pc = new RTCPeerConnection({ codecs: { video: [useH264()] } });
+    const pc = new RTCPeerConnection({ codecs: { video: [useH264()], audio: [usePCMU()] } });
     const entry: StreamEntry = {
       streamId,
       ingestPc: pc,
-      inboundTrack: null,
+      inboundTracks: new Map(),
       subscribers: new Map(),
       createdAt: new Date().toISOString(),
       framesForwarded: 0,
+      audioPacketsForwarded: 0,
     };
     pc.onTrack.subscribe(track => {
-      entry.inboundTrack = track;
+      if (track.kind !== "audio" && track.kind !== "video") {
+        return;
+      }
+      entry.inboundTracks.set(track.kind, track);
       track.onReceiveRtp.subscribe((rtp: RtpPacket) => {
-        entry.framesForwarded += rtp.header.marker ? 1 : 0;
+        if (track.kind === "video") {
+          entry.framesForwarded += rtp.header.marker ? 1 : 0;
+        } else {
+          entry.audioPacketsForwarded++;
+        }
         for (const subscriber of entry.subscribers.values()) {
+          const outbound = subscriber.tracks.get(track.kind);
+          if (!outbound) {
+            continue;
+          }
           try {
-            subscriber.track.writeRtp(rtp);
+            outbound.writeRtp(rtp);
           } catch {
             // A dead subscriber is reaped on its connection-state change.
           }
@@ -146,9 +164,16 @@ export class CoordinationServer {
       throw new Error(`No such stream: ${streamId}`);
     }
 
-    const pc = new RTCPeerConnection({ codecs: { video: [useH264()] } });
-    const track = new MediaStreamTrack({ kind: "video" });
-    pc.addTransceiver(track, { direction: "sendonly" });
+    const pc = new RTCPeerConnection({ codecs: { video: [useH264()], audio: [usePCMU()] } });
+    const tracks = new Map<"audio" | "video", MediaStreamTrack>();
+    const videoTrack = new MediaStreamTrack({ kind: "video" });
+    tracks.set("video", videoTrack);
+    pc.addTransceiver(videoTrack, { direction: "sendonly" });
+    if (entry.inboundTracks.has("audio")) {
+      const audioTrack = new MediaStreamTrack({ kind: "audio" });
+      tracks.set("audio", audioTrack);
+      pc.addTransceiver(audioTrack, { direction: "sendonly" });
+    }
 
     const subscriberId = randomUUID();
 
@@ -181,7 +206,7 @@ export class CoordinationServer {
       throw new Error(`Stream ${streamId} is no longer available`);
     }
 
-    entry.subscribers.set(subscriberId, { id: subscriberId, pc, track });
+    entry.subscribers.set(subscriberId, { id: subscriberId, pc, tracks });
     return { subscriberId, answerSdp: pc.localDescription?.sdp ?? "" };
   }
 
@@ -252,7 +277,7 @@ export class CoordinationServer {
   private describe(entry: StreamEntry): StreamDescriptor {
     return {
       streamId: entry.streamId,
-      state: entry.inboundTrack ? "live" : "connecting",
+      state: entry.inboundTracks.has("video") ? "live" : "connecting",
       subscriberCount: entry.subscribers.size,
       createdAt: entry.createdAt,
       // Encode so an id with a path separator (e.g. a CI ref "feature/foo")
@@ -260,6 +285,8 @@ export class CoordinationServer {
       whepUrl: `/whep/${encodeURIComponent(entry.streamId)}`,
       iceServers: this.iceServers,
       framesForwarded: entry.framesForwarded,
+      audio: entry.inboundTracks.has("audio"),
+      audioPacketsForwarded: entry.audioPacketsForwarded,
     };
   }
 

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -60,6 +60,32 @@ interface StreamEntry {
   audioPacketsForwarded: number;
 }
 
+export interface RtpOutboundTrack {
+  writeRtp(rtp: RtpPacket): void;
+}
+
+export function forwardRtpToOutboundTracks(outboundTracks: Iterable<RtpOutboundTrack>, rtp: RtpPacket): void {
+  for (const outbound of outboundTracks) {
+    try {
+      outbound.writeRtp(rtp.clone());
+    } catch {
+      // A dead subscriber is reaped on its connection-state change.
+    }
+  }
+}
+
+function* outboundTracksFor(
+  subscribers: Iterable<Subscriber>,
+  kind: "audio" | "video"
+): Iterable<RtpOutboundTrack> {
+  for (const subscriber of subscribers) {
+    const outbound = subscriber.tracks.get(kind);
+    if (outbound) {
+      yield outbound;
+    }
+  }
+}
+
 const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
 
 export class CoordinationServer {
@@ -103,17 +129,7 @@ export class CoordinationServer {
         } else {
           entry.audioPacketsForwarded++;
         }
-        for (const subscriber of entry.subscribers.values()) {
-          const outbound = subscriber.tracks.get(track.kind);
-          if (!outbound) {
-            continue;
-          }
-          try {
-            outbound.writeRtp(rtp);
-          } catch {
-            // A dead subscriber is reaped on its connection-state change.
-          }
-        }
+        forwardRtpToOutboundTracks(outboundTracksFor(entry.subscribers.values(), track.kind), rtp);
       });
     });
 

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -187,7 +187,7 @@ export class HttpCoordinationServer {
 
   private applyCors(res: ServerResponse): void {
     res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
   }
 

--- a/examples/webrtc-coordination-server/viewer.html
+++ b/examples/webrtc-coordination-server/viewer.html
@@ -96,8 +96,16 @@
 
         pc = new RTCPeerConnection({ iceServers: descriptor.iceServers || [] });
         pc.addTransceiver("video", { direction: "recvonly" });
+        if (descriptor.audio) {
+          pc.addTransceiver("audio", { direction: "recvonly" });
+          videoEl.muted = false;
+        } else {
+          videoEl.muted = true;
+        }
+        const media = new MediaStream();
+        videoEl.srcObject = media;
         pc.ontrack = (event) => {
-          videoEl.srcObject = event.streams[0] || new MediaStream([event.track]);
+          media.addTrack(event.track);
         };
         pc.onconnectionstatechange = () => {
           statusEl.textContent = "Connection: " + pc.connectionState;

--- a/src/daemon/webrtcStreamClient.ts
+++ b/src/daemon/webrtcStreamClient.ts
@@ -7,7 +7,7 @@ import type {
   WebRtcStreamSocketResponse,
 } from "./webrtcStreamSocketTypes";
 
-const DEFAULT_TIMEOUT_MS = 15_000;
+export const DEFAULT_WEBRTC_STREAM_REQUEST_TIMEOUT_MS = 45_000;
 
 /**
  * Minimal client for the WebRTC stream control socket. Connects, sends one
@@ -19,7 +19,7 @@ export async function sendWebRtcStreamRequest(
   options: { socketPath?: string; timeoutMs?: number } = {}
 ): Promise<WebRtcStreamSocketResponse> {
   const socketPath = options.socketPath ?? getSocketPath(WEBRTC_STREAM_SOCKET_CONFIG);
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_WEBRTC_STREAM_REQUEST_TIMEOUT_MS;
 
   return new Promise<WebRtcStreamSocketResponse>((resolve, reject) => {
     const socket = new Socket();

--- a/src/daemon/webrtcStreamSocketServer.ts
+++ b/src/daemon/webrtcStreamSocketServer.ts
@@ -151,6 +151,9 @@ export class WebRtcStreamSocketServer extends RequestResponseSocketServer<
     if (request.size) {
       overrides.size = request.size;
     }
+    if (request.audio !== undefined) {
+      overrides.audioEnabled = request.audio;
+    }
 
     const stream = await deps.startStream({ device, streamId: request.streamId, overrides });
     logger.info(`[WebRtcStream] started stream ${stream.streamId} for device ${device.deviceId}`);

--- a/src/daemon/webrtcStreamSocketTypes.ts
+++ b/src/daemon/webrtcStreamSocketTypes.ts
@@ -26,6 +26,8 @@ export interface WebRtcStreamSocketRequest extends SocketRequest {
   iceServers?: WebRtcIceServerInput[];
   bitrateKbps?: number;
   size?: { width: number; height: number };
+  /** Enable optional audio capture/publishing. */
+  audio?: boolean;
 }
 
 export interface WebRtcStreamSocketResponse extends SocketResponse {

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -228,12 +228,16 @@ export async function waitForStderrMessage(
   if (hasStderrMessage(tracker, expected)) {
     return;
   }
+  const stderrStream = tracker.process.stderr;
+  if (!stderrStream) {
+    throw new Error(`Cannot wait for ${expectedDescription}: process stderr is not captured`);
+  }
 
   let timeoutId: NodeJS.Timeout | undefined;
   await new Promise<void>((resolve, reject) => {
     let settled = false;
     const cleanup = () => {
-      tracker.process.stderr.off("data", onData);
+      stderrStream.off("data", onData);
       tracker.process.off("exit", onExit);
       tracker.process.off("error", onError);
       if (timeoutId) {
@@ -260,7 +264,7 @@ export async function waitForStderrMessage(
       complete(() => reject(error));
     };
 
-    tracker.process.stderr.on("data", onData);
+    stderrStream.on("data", onData);
     tracker.process.once("exit", onExit);
     tracker.process.once("error", onError);
     onData();
@@ -451,7 +455,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       capturePath,
     ];
 
-    const captureProcess = spawn("xcrun", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const captureProcess = spawn("xcrun", args, { stdio: ["ignore", "ignore", "pipe"] });
 
     try {
       await waitForSpawn(captureProcess);

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -16,6 +16,7 @@ import {
   waitForExit,
   waitForSpawn,
   type ProcessExitState,
+  type TrackedChildProcess,
 } from "../../utils/ChildProcessTracker";
 import type {
   RecordingHandle,
@@ -37,7 +38,7 @@ interface AndroidBackendHandle {
 
 interface IosBackendHandle {
   kind: "ios";
-  process: ChildProcessWithoutNullStreams;
+  process: TrackedChildProcess;
   exitState: ProcessExitState;
   exitPromise: Promise<void>;
   stderr: string[];
@@ -307,7 +308,7 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       rawOutputPath,
     ];
 
-    const process = spawn("xcrun", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const process = spawn("xcrun", args, { stdio: ["ignore", "ignore", "ignore"] });
 
     try {
       await waitForSpawn(process);

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -4,10 +4,13 @@ export interface H264CaptureSourceOptions {
   device: BootedDevice;
   /** Called with each chunk of the raw H.264 (Annex-B) elementary stream. */
   onData: (chunk: Buffer) => void;
+  /** Called with each chunk of 8 kHz mono PCM16LE audio when audio is enabled. */
+  onAudioData?: (chunk: Buffer) => void;
   /** Called when the source fails fatally after it has started. */
   onError?: (error: Error) => void;
   bitrateBps?: number;
   size?: { width: number; height: number };
+  audioEnabled?: boolean;
 }
 
 /**

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -11,6 +11,8 @@ import { defaultProcessSpawner, type ProcessSpawner, type SpawnedProcess } from 
 import {
   VIDEO_SERVER_CODEC_ID_H264,
   VIDEO_SERVER_CODEC_ID_PCM16,
+  type VideoServerPacket,
+  type VideoServerStreamHeader,
   VideoServerStreamParser,
 } from "./VideoServerStreamParser";
 
@@ -90,6 +92,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private socket: StreamSocket | null = null;
   private forwardedPort: number | null = null;
   private running = false;
+  private resolveStartupAudioHeader: ((header: VideoServerStreamHeader) => void) | undefined;
+  private resolveStartupAudioPacket: ((packet: VideoServerPacket) => void) | undefined;
 
   constructor(options: PersistentEncoderH264SourceOptions) {
     this.options = options;
@@ -167,24 +171,53 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     }
     this.forwardedPort = port;
 
+    const streamingStarted = this.options.audioEnabled
+      ? this.waitForStreamingStarted(server)
+      : null;
+    // The waiter is installed before connecting so a fast server cannot print
+    // the marker in the gap between client connect and the later startup await.
+    streamingStarted?.catch(() => {});
+
     const socket = await this.connector(port);
     if (!this.running) {
       socket.destroy();
       return;
     }
     this.socket = socket;
-    this.wireSocket(socket);
+    const startupAudioReady = this.options.audioEnabled
+      ? this.waitForStartupAudioReady()
+      : null;
+    let socketFailureMode: "startup" | "post-start" = this.options.audioEnabled
+      ? "startup"
+      : "post-start";
+    let rejectStartupSocketFailure: ((error: Error) => void) | undefined;
+    const startupSocketFailure = this.options.audioEnabled
+      ? new Promise<never>((_, reject) => {
+        rejectStartupSocketFailure = reject;
+      })
+      : null;
+    this.wireSocket(socket, error => {
+      if (socketFailureMode === "startup") {
+        rejectStartupSocketFailure?.(error);
+        return;
+      }
+      this.failIfRunning(error);
+    }, header => this.resolveStartupAudioHeader?.(header));
 
     // For audio-enabled streams, REMOTE_SUBMIX initialization happens after the
     // socket client connects. Do not resolve start() until that succeeds, or an
     // unavailable audio source would look like a successful start followed by a
     // reconnect-looping post-start failure.
     if (this.options.audioEnabled) {
-      await this.waitForStreamingStarted(server);
+      await Promise.race([
+        Promise.all([streamingStarted, startupAudioReady]),
+        startupSocketFailure,
+      ]);
       if (!this.running) {
         return;
       }
     }
+    socketFailureMode = "post-start";
 
     // Now that the source is live, a later server exit or socket drop IS a fatal
     // post-start failure: surface it via onError so the publisher reconnects.
@@ -240,6 +273,57 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     );
   }
 
+  private waitForStartupAudioReady(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let muxAudioHeaderSeen = false;
+      const timeout = this.timer.setTimeout(() => {
+        finish(() =>
+          reject(
+            new ActionableError(
+              `video-server did not produce PCM audio within ${this.readyTimeoutMs}ms`
+            )
+          )
+        );
+      }, this.readyTimeoutMs);
+
+      const finish = (fn: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.timer.clearTimeout(timeout);
+        this.resolveStartupAudioHeader = undefined;
+        this.resolveStartupAudioPacket = undefined;
+        fn();
+      };
+
+      this.resolveStartupAudioHeader = header => {
+        if (header.muxed === true && header.audio === true) {
+          muxAudioHeaderSeen = true;
+          return;
+        }
+        finish(() => {
+          reject(
+            new ActionableError(
+              "Audio was requested, but video-server did not advertise muxed PCM audio. Rebuild or provide a current automobile-video.jar."
+            )
+          );
+        });
+      };
+
+      this.resolveStartupAudioPacket = packet => {
+        if (
+          muxAudioHeaderSeen &&
+          packet.codecId === VIDEO_SERVER_CODEC_ID_PCM16 &&
+          packet.data.length > 0
+        ) {
+          finish(resolve);
+        }
+      };
+    });
+  }
+
   private waitForServerLine(
     server: SpawnedProcess,
     marker: string,
@@ -286,25 +370,32 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     });
   }
 
-  private wireSocket(socket: StreamSocket): void {
+  private wireSocket(
+    socket: StreamSocket,
+    onSocketFailure: (error: Error) => void,
+    onStreamHeader?: (header: VideoServerStreamHeader) => void
+  ): void {
     const parser = new VideoServerStreamParser({
-      onHeader: header =>
+      onHeader: header => {
+        onStreamHeader?.(header);
         logger.info(
           `[PersistentEncoderH264Source] stream ${header.width}x${header.height} codec=0x${header.codecId.toString(16)}`
-        ),
+        );
+      },
       onPacket: packet => {
         if (this.socket === socket) {
           if (packet.codecId === VIDEO_SERVER_CODEC_ID_H264) {
             this.options.onData(packet.data);
           } else if (packet.codecId === VIDEO_SERVER_CODEC_ID_PCM16) {
             this.options.onAudioData?.(packet.data);
+            this.resolveStartupAudioPacket?.(packet);
           }
         }
       },
     });
     socket.on("data", chunk => parser.push(chunk));
-    socket.on("error", error => this.failIfRunning(error));
-    socket.on("close", () => this.failIfRunning(new Error("video-server socket closed")));
+    socket.on("error", onSocketFailure);
+    socket.on("close", () => onSocketFailure(new Error("video-server socket closed")));
   }
 
   /** Surface a post-start fatal failure exactly once and stop feeding data. */

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -8,7 +8,11 @@ import {
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { H264CaptureSource } from "./H264CaptureSource";
 import { defaultProcessSpawner, type ProcessSpawner, type SpawnedProcess } from "./processSpawner";
-import { VideoServerStreamParser } from "./VideoServerStreamParser";
+import {
+  VIDEO_SERVER_CODEC_ID_H264,
+  VIDEO_SERVER_CODEC_ID_PCM16,
+  VideoServerStreamParser,
+} from "./VideoServerStreamParser";
 
 /** Remote path the DEX jar is pushed to before launch. */
 export const VIDEO_SERVER_REMOTE_JAR_PATH = "/data/local/tmp/automobile-video.jar";
@@ -17,6 +21,8 @@ export const VIDEO_SERVER_SOCKET_NAME = "automobile_video";
 const VIDEO_SERVER_MAIN_CLASS = "dev.jasonpearson.automobile.video.VideoServer";
 /** Server stdout line printed once it is ready to accept the socket client. */
 const READY_MARKER = "Waiting for client connection";
+/** Server stdout line printed after capture has fully started. */
+const STREAMING_STARTED_MARKER = "Streaming started";
 
 /** Minimal socket surface the source needs, for injectable testing. */
 export interface StreamSocket {
@@ -40,10 +46,13 @@ export interface PersistentEncoderH264SourceOptions {
   device: BootedDevice;
   /** Called with each chunk of the raw H.264 (Annex-B) elementary stream. */
   onData: (chunk: Buffer) => void;
+  /** Called with each chunk of 8 kHz mono PCM16LE audio when enabled. */
+  onAudioData?: (chunk: Buffer) => void;
   /** Called when the source fails fatally after a successful start. */
   onError?: (error: Error) => void;
   bitrateBps?: number;
   size?: { width: number; height: number };
+  audioEnabled?: boolean;
   quality?: "low" | "medium" | "high";
   /** Local path to the built `automobile-video.jar`. Required to run. */
   jarPath: string;
@@ -166,6 +175,17 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.socket = socket;
     this.wireSocket(socket);
 
+    // For audio-enabled streams, REMOTE_SUBMIX initialization happens after the
+    // socket client connects. Do not resolve start() until that succeeds, or an
+    // unavailable audio source would look like a successful start followed by a
+    // reconnect-looping post-start failure.
+    if (this.options.audioEnabled) {
+      await this.waitForStreamingStarted(server);
+      if (!this.running) {
+        return;
+      }
+    }
+
     // Now that the source is live, a later server exit or socket drop IS a fatal
     // post-start failure: surface it via onError so the publisher reconnects.
     server.once("exit", (code, signal) => {
@@ -196,10 +216,36 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     if (this.options.size) {
       args.push("--size", `${this.options.size.width}x${this.options.size.height}`);
     }
+    if (this.options.audioEnabled) {
+      args.push("--audio");
+    }
     return args;
   }
 
   private waitForReady(server: SpawnedProcess): Promise<void> {
+    return this.waitForServerLine(
+      server,
+      READY_MARKER,
+      `video-server did not become ready within ${this.readyTimeoutMs}ms`,
+      "video-server exited before ready"
+    );
+  }
+
+  private waitForStreamingStarted(server: SpawnedProcess): Promise<void> {
+    return this.waitForServerLine(
+      server,
+      STREAMING_STARTED_MARKER,
+      `video-server did not start streaming within ${this.readyTimeoutMs}ms`,
+      "video-server exited before streaming started"
+    );
+  }
+
+  private waitForServerLine(
+    server: SpawnedProcess,
+    marker: string,
+    timeoutMessage: string,
+    exitMessagePrefix: string
+  ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       let settled = false;
       let stdoutBuffer = "";
@@ -209,31 +255,34 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         }
         settled = true;
         this.timer.clearTimeout(timeout);
+        server.stdout.off("data", onData);
+        server.removeListener("exit", onExit);
+        server.removeListener("error", onError);
         fn();
       };
       const timeout = this.timer.setTimeout(() => {
-        finish(() =>
-          reject(
-            new ActionableError(`video-server did not become ready within ${this.readyTimeoutMs}ms`)
-          )
-        );
+        finish(() => reject(new ActionableError(timeoutMessage)));
       }, this.readyTimeoutMs);
 
-      server.stdout.on("data", (chunk: Buffer) => {
+      const onData = (chunk: Buffer): void => {
         if (settled) {
           return; // stop accumulating once ready (or failed)
         }
         stdoutBuffer += chunk.toString();
-        if (stdoutBuffer.includes(READY_MARKER)) {
+        if (stdoutBuffer.includes(marker)) {
           finish(resolve);
         }
-      });
-      server.once("exit", (code, signal) => {
+      };
+      const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
         finish(() =>
-          reject(new Error(`video-server exited before ready (code=${code}, signal=${signal})`))
+          reject(new Error(`${exitMessagePrefix} (code=${code}, signal=${signal})`))
         );
-      });
-      server.once("error", (error: Error) => finish(() => reject(error)));
+      };
+      const onError = (error: Error): void => finish(() => reject(error));
+
+      server.stdout.on("data", onData);
+      server.once("exit", onExit);
+      server.once("error", onError);
     });
   }
 
@@ -245,7 +294,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         ),
       onPacket: packet => {
         if (this.socket === socket) {
-          this.options.onData(packet.data);
+          if (packet.codecId === VIDEO_SERVER_CODEC_ID_H264) {
+            this.options.onData(packet.data);
+          } else if (packet.codecId === VIDEO_SERVER_CODEC_ID_PCM16) {
+            this.options.onAudioData?.(packet.data);
+          }
         }
       },
     });

--- a/src/features/webrtc/RtpPcmuTrackWriter.ts
+++ b/src/features/webrtc/RtpPcmuTrackWriter.ts
@@ -1,0 +1,94 @@
+import { RtpHeader, RtpPacket } from "werift";
+import type { RtpPacketSink } from "./RtpH264TrackWriter";
+
+/** PCMU/G.711 RTP clock rate. */
+export const PCMU_CLOCK_RATE = 8_000;
+export const PCMU_PAYLOAD_TYPE = 0;
+const DEFAULT_AUDIO_MTU = 1200;
+
+export interface RtpPcmuTrackWriterOptions {
+  sink: RtpPacketSink;
+  ssrc: number;
+  payloadType?: number;
+  mtu?: number;
+  initialSequenceNumber?: number;
+}
+
+/**
+ * Consumes 8 kHz mono signed 16-bit little-endian PCM and writes PCMU RTP
+ * packets. The Android audio source emits exactly that format, keeping this
+ * writer dependency-free and fast to unit-test.
+ */
+export class RtpPcmuTrackWriter {
+  private readonly sink: RtpPacketSink;
+  private readonly ssrc: number;
+  private readonly payloadType: number;
+  private readonly mtu: number;
+  private sequenceNumber: number;
+  private timestamp = 0;
+  private packetsWritten = 0;
+  private samplesWritten = 0;
+
+  constructor(options: RtpPcmuTrackWriterOptions) {
+    this.sink = options.sink;
+    this.ssrc = options.ssrc >>> 0;
+    this.payloadType = options.payloadType ?? PCMU_PAYLOAD_TYPE;
+    this.mtu = options.mtu ?? DEFAULT_AUDIO_MTU;
+    this.sequenceNumber = (options.initialSequenceNumber ?? 0) & 0xffff;
+  }
+
+  writePcm16Chunk(chunk: Buffer): void {
+    const sampleCount = Math.floor(chunk.length / 2);
+    if (sampleCount === 0) {
+      return;
+    }
+
+    const payload = Buffer.alloc(sampleCount);
+    for (let i = 0; i < sampleCount; i++) {
+      payload[i] = linear16ToMuLaw(chunk.readInt16LE(i * 2));
+    }
+
+    for (let offset = 0; offset < payload.length; offset += this.mtu) {
+      const part = payload.subarray(offset, Math.min(offset + this.mtu, payload.length));
+      const header = new RtpHeader({
+        version: 2,
+        payloadType: this.payloadType,
+        marker: false,
+        sequenceNumber: this.sequenceNumber,
+        timestamp: this.timestamp,
+        ssrc: this.ssrc,
+      });
+      this.sink.writeRtp(new RtpPacket(header, Buffer.from(part)));
+      this.sequenceNumber = (this.sequenceNumber + 1) & 0xffff;
+      this.timestamp = (this.timestamp + part.length) >>> 0;
+      this.packetsWritten++;
+    }
+    this.samplesWritten += sampleCount;
+  }
+
+  get stats(): { packetsWritten: number; samplesWritten: number } {
+    return {
+      packetsWritten: this.packetsWritten,
+      samplesWritten: this.samplesWritten,
+    };
+  }
+}
+
+function linear16ToMuLaw(sample: number): number {
+  const bias = 0x84;
+  const clip = 32635;
+  let sign = 0;
+  let magnitude = sample;
+  if (magnitude < 0) {
+    magnitude = -magnitude;
+    sign = 0x80;
+  }
+  magnitude = Math.min(magnitude, clip) + bias;
+
+  let exponent = 7;
+  for (let mask = 0x4000; exponent > 0 && (magnitude & mask) === 0; mask >>= 1) {
+    exponent--;
+  }
+  const mantissa = (magnitude >> (exponent + 3)) & 0x0f;
+  return (~(sign | (exponent << 4) | mantissa)) & 0xff;
+}

--- a/src/features/webrtc/VideoServerStreamParser.ts
+++ b/src/features/webrtc/VideoServerStreamParser.ts
@@ -20,9 +20,17 @@
 
 /** "h264" as a big-endian int: 0x68323634. */
 export const VIDEO_SERVER_CODEC_ID_H264 = 0x68323634;
+/** "amux" as a big-endian int: multiplexed audio/video protocol marker. */
+export const VIDEO_SERVER_CODEC_ID_AMUX = 0x616d7578;
+/** "s16l" as a big-endian int: signed 16-bit little-endian PCM. */
+export const VIDEO_SERVER_CODEC_ID_PCM16 = 0x7331366c;
+export const VIDEO_SERVER_TRACK_ID_VIDEO = 1;
+export const VIDEO_SERVER_TRACK_ID_AUDIO = 2;
 
 const STREAM_HEADER_BYTES = 12;
 const PACKET_HEADER_BYTES = 12;
+const MUX_TRACK_BYTES = 16;
+const MUX_PACKET_HEADER_BYTES = 16;
 const FLAG_CONFIG = 1n << 63n;
 const FLAG_KEY_FRAME = 1n << 62n;
 
@@ -33,6 +41,8 @@ export interface VideoServerStreamHeader {
 }
 
 export interface VideoServerPacket {
+  trackId: number;
+  codecId: number;
   /** The encoded payload (Annex-B H.264). */
   data: Buffer;
   /** Codec configuration data (SPS/PPS), not a displayable frame. */
@@ -58,6 +68,7 @@ export interface VideoServerStreamParserCallbacks {
 export class VideoServerStreamParser {
   private buffered: Buffer = Buffer.alloc(0);
   private header: VideoServerStreamHeader | null = null;
+  private muxTracks: Map<number, { codecId: number; param1: number; param2: number }> | null = null;
 
   constructor(private readonly callbacks: VideoServerStreamParserCallbacks) {}
 
@@ -65,17 +76,45 @@ export class VideoServerStreamParser {
     this.buffered =
       this.buffered.length === 0 ? chunk : Buffer.concat([this.buffered, chunk]);
 
-    if (!this.header) {
+    if (!this.header && !this.muxTracks) {
       if (this.buffered.length < STREAM_HEADER_BYTES) {
         return;
       }
-      this.header = {
-        codecId: this.buffered.readUInt32BE(0),
-        width: this.buffered.readUInt32BE(4),
-        height: this.buffered.readUInt32BE(8),
-      };
-      this.buffered = this.buffered.subarray(STREAM_HEADER_BYTES);
-      this.callbacks.onHeader?.(this.header);
+      const codecOrMagic = this.buffered.readUInt32BE(0);
+      if (codecOrMagic === VIDEO_SERVER_CODEC_ID_AMUX) {
+        const trackCount = this.buffered.readUInt32BE(8);
+        const headerBytes = STREAM_HEADER_BYTES + trackCount * MUX_TRACK_BYTES;
+        if (this.buffered.length < headerBytes) {
+          return;
+        }
+        this.muxTracks = new Map();
+        for (let i = 0; i < trackCount; i++) {
+          const offset = STREAM_HEADER_BYTES + i * MUX_TRACK_BYTES;
+          const trackId = this.buffered.readUInt32BE(offset);
+          const codecId = this.buffered.readUInt32BE(offset + 4);
+          const param1 = this.buffered.readUInt32BE(offset + 8);
+          const param2 = this.buffered.readUInt32BE(offset + 12);
+          this.muxTracks.set(trackId, { codecId, param1, param2 });
+          if (codecId === VIDEO_SERVER_CODEC_ID_H264) {
+            this.header = { codecId, width: param1, height: param2 };
+            this.callbacks.onHeader?.(this.header);
+          }
+        }
+        this.buffered = this.buffered.subarray(headerBytes);
+      } else {
+        this.header = {
+          codecId: codecOrMagic,
+          width: this.buffered.readUInt32BE(4),
+          height: this.buffered.readUInt32BE(8),
+        };
+        this.buffered = this.buffered.subarray(STREAM_HEADER_BYTES);
+        this.callbacks.onHeader?.(this.header);
+      }
+    }
+
+    if (this.muxTracks) {
+      this.drainMuxPackets();
+      return;
     }
 
     while (this.buffered.length >= PACKET_HEADER_BYTES) {
@@ -89,6 +128,35 @@ export class VideoServerStreamParser {
       );
       this.buffered = this.buffered.subarray(PACKET_HEADER_BYTES + size);
       this.callbacks.onPacket({
+        trackId: VIDEO_SERVER_TRACK_ID_VIDEO,
+        codecId: this.header?.codecId ?? VIDEO_SERVER_CODEC_ID_H264,
+        data,
+        config: (flags & FLAG_CONFIG) !== 0n,
+        keyFrame: (flags & FLAG_KEY_FRAME) !== 0n,
+        ptsUs: Number(flags & (FLAG_KEY_FRAME - 1n)),
+      });
+    }
+  }
+
+  private drainMuxPackets(): void {
+    while (this.buffered.length >= MUX_PACKET_HEADER_BYTES) {
+      const trackId = this.buffered.readUInt32BE(0);
+      const flags = this.buffered.readBigUInt64BE(4);
+      const size = this.buffered.readUInt32BE(12);
+      if (this.buffered.length < MUX_PACKET_HEADER_BYTES + size) {
+        break;
+      }
+      const data = Buffer.from(
+        this.buffered.subarray(MUX_PACKET_HEADER_BYTES, MUX_PACKET_HEADER_BYTES + size)
+      );
+      this.buffered = this.buffered.subarray(MUX_PACKET_HEADER_BYTES + size);
+      const track = this.muxTracks?.get(trackId);
+      if (!track) {
+        continue;
+      }
+      this.callbacks.onPacket({
+        trackId,
+        codecId: track.codecId,
         data,
         config: (flags & FLAG_CONFIG) !== 0n,
         keyFrame: (flags & FLAG_KEY_FRAME) !== 0n,

--- a/src/features/webrtc/VideoServerStreamParser.ts
+++ b/src/features/webrtc/VideoServerStreamParser.ts
@@ -38,6 +38,8 @@ export interface VideoServerStreamHeader {
   codecId: number;
   width: number;
   height: number;
+  muxed?: boolean;
+  audio?: boolean;
 }
 
 export interface VideoServerPacket {
@@ -88,6 +90,8 @@ export class VideoServerStreamParser {
           return;
         }
         this.muxTracks = new Map();
+        let videoHeader: Pick<VideoServerStreamHeader, "codecId" | "width" | "height"> | null = null;
+        let hasPcmAudioTrack = false;
         for (let i = 0; i < trackCount; i++) {
           const offset = STREAM_HEADER_BYTES + i * MUX_TRACK_BYTES;
           const trackId = this.buffered.readUInt32BE(offset);
@@ -96,9 +100,14 @@ export class VideoServerStreamParser {
           const param2 = this.buffered.readUInt32BE(offset + 12);
           this.muxTracks.set(trackId, { codecId, param1, param2 });
           if (codecId === VIDEO_SERVER_CODEC_ID_H264) {
-            this.header = { codecId, width: param1, height: param2 };
-            this.callbacks.onHeader?.(this.header);
+            videoHeader = { codecId, width: param1, height: param2 };
+          } else if (trackId === VIDEO_SERVER_TRACK_ID_AUDIO && codecId === VIDEO_SERVER_CODEC_ID_PCM16) {
+            hasPcmAudioTrack = true;
           }
+        }
+        if (videoHeader) {
+          this.header = { ...videoHeader, muxed: true, audio: hasPcmAudioTrack };
+          this.callbacks.onHeader?.(this.header);
         }
         this.buffered = this.buffered.subarray(headerBytes);
       } else {

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -2,6 +2,7 @@ import {
   MediaStreamTrack,
   RTCPeerConnection,
   useH264,
+  usePCMU,
   type RTCIceServer,
 } from "werift";
 import { logger } from "../../utils/logger";
@@ -10,6 +11,7 @@ import type { BackoffInput } from "../../utils/Backoff";
 import { DEFAULT_RTP_MTU } from "./h264";
 import { ReconnectController, type ReconnectState } from "./ReconnectController";
 import { RtpH264TrackWriter } from "./RtpH264TrackWriter";
+import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
 import { TrickleIceForwarder } from "./trickleIce";
 import { WhipClient, type WhipClientOptions } from "./WhipClient";
 
@@ -32,6 +34,8 @@ export interface WebRtcPublisherConfig {
    * server that supports the WHIP trickle extension. Defaults to false.
    */
   trickleIce?: boolean;
+  /** Add a sendonly PCMU audio track alongside video. Defaults to false. */
+  audioEnabled?: boolean;
 }
 
 export interface WebRtcPublisherDeps {
@@ -65,6 +69,8 @@ export interface WebRtcStreamDescriptor {
   iceServers: RTCIceServer[];
   framesSent: number;
   packetsSent: number;
+  audioPacketsSent: number;
+  audioSamplesSent: number;
 }
 
 /**
@@ -84,9 +90,11 @@ export class WebRtcPublisher {
   private readonly controller: ReconnectController;
 
   private readonly trickleIce: boolean;
+  private readonly audioEnabled: boolean;
 
   private pc: RTCPeerConnection | null = null;
   private writer: RtpH264TrackWriter | null = null;
+  private audioWriter: RtpPcmuTrackWriter | null = null;
   private resourceUrl: string | null = null;
   private state: ReconnectState = "idle";
   private closed = false;
@@ -98,6 +106,7 @@ export class WebRtcPublisher {
   constructor(config: WebRtcPublisherConfig, deps: WebRtcPublisherDeps = {}) {
     this.config = config;
     this.trickleIce = config.trickleIce ?? false;
+    this.audioEnabled = config.audioEnabled ?? false;
     this.timer = deps.timer ?? defaultTimer;
     this.onBeforeEstablish = deps.onBeforeEstablish;
     this.onConnected = deps.onConnected;
@@ -106,7 +115,9 @@ export class WebRtcPublisher {
       (iceServers =>
         new RTCPeerConnection({
           iceServers,
-          codecs: { video: [useH264()] },
+          codecs: this.audioEnabled
+            ? { video: [useH264()], audio: [usePCMU()] }
+            : { video: [useH264()] },
         }));
     const createWhip = deps.createWhipClient ?? (options => new WhipClient(options));
     this.whip = createWhip({
@@ -141,6 +152,11 @@ export class WebRtcPublisher {
     this.writer?.writeChunk(chunk);
   }
 
+  /** Feed 8 kHz mono PCM16LE audio; ignored when audio is not enabled. */
+  writePcmAudioChunk(chunk: Buffer): void {
+    this.audioWriter?.writePcm16Chunk(chunk);
+  }
+
   /**
    * Report that the capture source failed. Unlike a WebRTC connection drop this
    * does not change the peer `connectionState`, so without this hook a dead
@@ -161,6 +177,7 @@ export class WebRtcPublisher {
 
   getDescriptor(): WebRtcStreamDescriptor {
     const stats = this.writer?.stats;
+    const audioStats = this.audioWriter?.stats;
     return {
       streamId: this.config.streamId,
       state: this.state,
@@ -169,6 +186,8 @@ export class WebRtcPublisher {
       iceServers: this.config.iceServers ?? [],
       framesSent: stats?.framesWritten ?? 0,
       packetsSent: stats?.packetsWritten ?? 0,
+      audioPacketsSent: audioStats?.packetsWritten ?? 0,
+      audioSamplesSent: audioStats?.samplesWritten ?? 0,
     };
   }
 
@@ -203,6 +222,14 @@ export class WebRtcPublisher {
         mtu: this.config.mtu ?? DEFAULT_RTP_MTU,
         timer: this.timer,
       });
+      if (this.audioEnabled) {
+        const audioTrack = new MediaStreamTrack({ kind: "audio" });
+        const audioTransceiver = pc.addTransceiver(audioTrack, { direction: "sendonly" });
+        this.audioWriter = new RtpPcmuTrackWriter({
+          sink: audioTrack,
+          ssrc: audioTransceiver.sender.ssrc,
+        });
+      }
 
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
@@ -259,6 +286,7 @@ export class WebRtcPublisher {
       if (this.pc === pc) {
         this.pc = null;
         this.writer = null;
+        this.audioWriter = null;
         this.trickle?.stop();
         this.trickle = null;
         this.candidateSub?.unSubscribe();
@@ -349,6 +377,7 @@ export class WebRtcPublisher {
     const resourceUrl = this.resourceUrl;
     this.pc = null;
     this.writer = null;
+    this.audioWriter = null;
     this.resourceUrl = null;
 
     // Stop forwarding candidates and detach the listener before the pc closes.

--- a/src/features/webrtc/androidH264CaptureSourceFactory.ts
+++ b/src/features/webrtc/androidH264CaptureSourceFactory.ts
@@ -72,15 +72,35 @@ export function createAndroidH264CaptureSource(
   deps: AndroidH264CaptureSourceDeps = defaultDeps
 ): H264CaptureSource {
   if (!jarPath) {
+    if (options.audioEnabled) {
+      throw new Error("WebRTC audio requires the persistent Android video-server jar.");
+    }
     return deps.createScreenrecord(options);
+  }
+
+  if (options.audioEnabled) {
+    return deps.createPersistent({
+      device: options.device,
+      onData: options.onData,
+      onAudioData: options.onAudioData,
+      onError: options.onError,
+      bitrateBps: options.bitrateBps,
+      size: options.size,
+      audioEnabled: true,
+      adbFactory: options.adbFactory,
+      timer: options.timer,
+      jarPath,
+    });
   }
 
   const persistent = deps.createPersistent({
     device: options.device,
     onData: options.onData,
+    onAudioData: options.onAudioData,
     onError: options.onError,
     bitrateBps: options.bitrateBps,
     size: options.size,
+    audioEnabled: options.audioEnabled,
     adbFactory: options.adbFactory,
     timer: options.timer,
     jarPath,

--- a/src/features/webrtc/h264CaptureSourceFactory.ts
+++ b/src/features/webrtc/h264CaptureSourceFactory.ts
@@ -18,6 +18,9 @@ export const createH264CaptureSource: H264CaptureSourceFactory = (options, jarPa
     return createAndroidH264CaptureSource(options, jarPath);
   }
   if (options.device.platform === "ios") {
+    if (options.audioEnabled) {
+      throw new ActionableError("WebRTC audio capture is currently supported only on Android.");
+    }
     return new IosH264Source(options);
   }
   throw new ActionableError(`WebRTC streaming does not support ${options.device.platform} devices.`);

--- a/src/features/webrtc/index.ts
+++ b/src/features/webrtc/index.ts
@@ -1,5 +1,6 @@
 export * from "./h264";
 export * from "./RtpH264TrackWriter";
+export * from "./RtpPcmuTrackWriter";
 export * from "./processSpawner";
 export * from "./H264CaptureSource";
 export * from "./AndroidH264Source";

--- a/src/features/webrtc/processSpawner.ts
+++ b/src/features/webrtc/processSpawner.ts
@@ -8,6 +8,8 @@ export interface SpawnedProcess {
   kill(signal?: NodeJS.Signals): boolean;
   once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
   once(event: "error", listener: (error: Error) => void): void;
+  removeListener(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  removeListener(event: "error", listener: (error: Error) => void): void;
 }
 
 export type ProcessSpawner = (command: string, args: string[]) => SpawnedProcess;

--- a/src/features/webrtc/webrtcStreamingConfig.ts
+++ b/src/features/webrtc/webrtcStreamingConfig.ts
@@ -23,6 +23,8 @@ export interface WebRtcStreamingConfig {
    * Opt-in — the ingest server must support the WHIP PATCH trickle extension.
    */
   trickleIce: boolean;
+  /** Add an optional audio track alongside video. Defaults to false. */
+  audioEnabled: boolean;
 }
 
 export interface WebRtcStreamingOverrides {
@@ -32,6 +34,7 @@ export interface WebRtcStreamingOverrides {
   bitrateKbps?: number;
   size?: { width: number; height: number };
   trickleIce?: boolean;
+  audioEnabled?: boolean;
 }
 
 /** Environment variable names read for default configuration. */
@@ -42,6 +45,7 @@ export const WEBRTC_ENV = {
   BITRATE_KBPS: "AUTOMOBILE_WEBRTC_BITRATE_KBPS",
   MAX_SIZE: "AUTOMOBILE_WEBRTC_MAX_SIZE",
   TRICKLE_ICE: "AUTOMOBILE_WEBRTC_TRICKLE_ICE",
+  AUDIO: "AUTOMOBILE_WEBRTC_AUDIO",
 } as const;
 
 const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
@@ -146,6 +150,7 @@ export function resolveWebRtcStreamingConfig(
   const bitrateKbps = overrides.bitrateKbps ?? parseBitrate(env[WEBRTC_ENV.BITRATE_KBPS]);
   const size = overrides.size ?? parseSize(env[WEBRTC_ENV.MAX_SIZE]);
   const trickleIce = overrides.trickleIce ?? parseBooleanFlag(env[WEBRTC_ENV.TRICKLE_ICE]);
+  const audioEnabled = overrides.audioEnabled ?? parseBooleanFlag(env[WEBRTC_ENV.AUDIO]);
 
   return {
     whipEndpoint: whipEndpoint.trim(),
@@ -154,5 +159,6 @@ export function resolveWebRtcStreamingConfig(
     bitrateKbps,
     size,
     trickleIce,
+    audioEnabled,
   };
 }

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -1,6 +1,7 @@
 import { ActionableError, type BootedDevice } from "../models";
 import { logger } from "../utils/logger";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
+import { defaultTimer } from "../utils/SystemTimer";
 import {
   createH264CaptureSource,
   resolveVideoServerJar,
@@ -58,6 +59,7 @@ const defaultDependencies: WebRtcStreamManagerDependencies = {
 
 let dependencies: WebRtcStreamManagerDependencies = { ...defaultDependencies };
 const streams = new Map<string, WebRtcStreamRecord>();
+const INITIAL_AUDIO_SOURCE_START_TIMEOUT_MS = 30_000;
 
 /** Override manager dependencies (tests). */
 export function setWebRtcStreamManagerDependencies(
@@ -109,14 +111,14 @@ async function stopSource(record: WebRtcStreamRecord): Promise<void> {
  * A capture failure is surfaced to the publisher so the reconnect loop runs
  * instead of leaving the viewer on a frozen frame.
  */
-async function startSource(record: WebRtcStreamRecord): Promise<void> {
+async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
   await stopSource(record);
   // stopWebRtcStream() may have deleted (or replaced) this record while we were
   // awaiting the source stop above. Starting capture now would spawn a
   // screenrecord process attached to a record no later stop/list can reach,
   // leaking it. Bail if we no longer own the stream.
   if (streams.get(record.streamId) !== record) {
-    return;
+    return false;
   }
   const source = dependencies.createSource(
     {
@@ -140,7 +142,33 @@ async function startSource(record: WebRtcStreamRecord): Promise<void> {
   if (streams.get(record.streamId) !== record) {
     record.source = null;
     await source.stop().catch(() => {});
+    return false;
   }
+  return true;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = defaultTimer.setTimeout(() => reject(new ActionableError(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) {
+      defaultTimer.clearTimeout(timeout);
+    }
+  });
+}
+
+async function cleanupFailedStart(
+  streamId: string,
+  record: WebRtcStreamRecord,
+  publisher: WebRtcPublisher
+): Promise<void> {
+  if (streams.get(streamId) === record) {
+    streams.delete(streamId);
+  }
+  await record.source?.stop().catch(() => {});
+  await publisher.stop().catch(() => {});
 }
 
 /**
@@ -180,10 +208,33 @@ export async function startWebRtcStream(
   // returns null → screenrecord.
   const jarPath = await dependencies.resolveVideoJar(request.device);
 
-  // The publisher's lifecycle hooks resolve the record by id (rather than
-  // closing over it) so the record can be constructed with the publisher in one
-  // shot. The hooks only run during publisher.start() (below), after the record
-  // is registered.
+  let settleInitialAudioSourceStart:
+    | ((result: { ok: true } | { ok: false; error: unknown }) => void)
+    | undefined;
+  let initialAudioSourceStartSettled = false;
+  const initialAudioSourceStart = config.audioEnabled
+    ? new Promise<void>((resolve, reject) => {
+      settleInitialAudioSourceStart = result => {
+        if (initialAudioSourceStartSettled) {
+          return;
+        }
+        initialAudioSourceStartSettled = true;
+        if (result.ok) {
+          resolve();
+        } else {
+          reject(result.error);
+        }
+      };
+    })
+    : null;
+  const settleInitialAudioStart = (error?: unknown): void => {
+    if (!config.audioEnabled) {
+      return;
+    }
+    settleInitialAudioSourceStart?.(error ? { ok: false, error } : { ok: true });
+  };
+
+  const publisherRef: { current?: WebRtcPublisher } = {};
   const publisher = dependencies.createPublisher(
     {
       streamId,
@@ -196,9 +247,31 @@ export async function startWebRtcStream(
     },
     {
       onBeforeEstablish: () => withRecord(streamId, stopSource),
-      onConnected: () => withRecord(streamId, startSource),
+      onConnected: async () => {
+        const currentRecord = streams.get(streamId);
+        if (!currentRecord || currentRecord.publisher !== publisherRef.current) {
+          settleInitialAudioStart(new Error(`WebRTC stream ${streamId} stopped before capture source started.`));
+          return;
+        }
+        try {
+          const started = await startSource(currentRecord);
+          if (!started) {
+            const error = new Error(`WebRTC stream ${streamId} stopped before capture source started.`);
+            settleInitialAudioStart(error);
+            if (config.audioEnabled) {
+              throw error;
+            }
+            return;
+          }
+          settleInitialAudioStart();
+        } catch (error) {
+          settleInitialAudioStart(error);
+          throw error;
+        }
+      },
     }
   );
+  publisherRef.current = publisher;
   const record: WebRtcStreamRecord = {
     streamId,
     device: request.device,
@@ -214,10 +287,15 @@ export async function startWebRtcStream(
 
   try {
     await publisher.start();
+    if (initialAudioSourceStart) {
+      await withTimeout(
+        initialAudioSourceStart,
+        INITIAL_AUDIO_SOURCE_START_TIMEOUT_MS,
+        "Timed out waiting for WebRTC audio capture source to start."
+      );
+    }
   } catch (error) {
-    streams.delete(streamId);
-    await record.source?.stop().catch(() => {});
-    await publisher.stop().catch(() => {});
+    await cleanupFailedStart(streamId, record, publisher);
     throw new ActionableError(
       `Failed to start WebRTC stream: ${error instanceof Error ? error.message : String(error)}`
     );

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -29,6 +29,7 @@ interface WebRtcStreamRecord {
   jarPath: string | null;
   bitrateBps?: number;
   size?: { width: number; height: number };
+  audioEnabled: boolean;
   startedAt: string;
 }
 
@@ -121,11 +122,13 @@ async function startSource(record: WebRtcStreamRecord): Promise<void> {
     {
       device: record.device,
       onData: chunk => record.publisher.writeH264Chunk(chunk),
+      onAudioData: chunk => record.publisher.writePcmAudioChunk(chunk),
       onError: () => {
         record.publisher.notifySourceFailed();
       },
       bitrateBps: record.bitrateBps,
       size: record.size,
+      audioEnabled: record.audioEnabled,
     },
     record.jarPath
   );
@@ -189,6 +192,7 @@ export async function startWebRtcStream(
       iceServers: config.iceServers,
       bitrateBps,
       trickleIce: config.trickleIce,
+      audioEnabled: config.audioEnabled,
     },
     {
       onBeforeEstablish: () => withRecord(streamId, stopSource),
@@ -203,6 +207,7 @@ export async function startWebRtcStream(
     jarPath,
     bitrateBps,
     size: config.size,
+    audioEnabled: config.audioEnabled,
     startedAt: dependencies.now().toISOString(),
   };
   streams.set(streamId, record);

--- a/src/utils/ChildProcessTracker.ts
+++ b/src/utils/ChildProcessTracker.ts
@@ -44,7 +44,7 @@ export interface TrackedChildProcess extends StoppableProcess {
   stderr: {
     on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
     off(event: "data", listener: (chunk: Buffer | string) => void): unknown;
-  };
+  } | null;
   once(event: "spawn", listener: () => void): unknown;
   once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
   once(event: "error", listener: (error: Error) => void): unknown;
@@ -76,7 +76,7 @@ export function createExitTracker(
     resolvePromise();
   });
 
-  process.stderr.on("data", chunk => {
+  process.stderr?.on("data", chunk => {
     stderr.push(chunk.toString());
   });
 

--- a/test/daemon/webrtcStreamClient.test.ts
+++ b/test/daemon/webrtcStreamClient.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_WEBRTC_STREAM_REQUEST_TIMEOUT_MS } from "../../src/daemon/webrtcStreamClient";
+
+describe("webrtcStreamClient", () => {
+  test("default timeout is longer than the server's initial audio startup gate", () => {
+    expect(DEFAULT_WEBRTC_STREAM_REQUEST_TIMEOUT_MS).toBeGreaterThan(30_000);
+  });
+});

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -156,6 +156,7 @@ describe("WebRtcStreamSocketServer", () => {
       action: "start",
       streamId: "debug-1",
       whipEndpoint: "http://localhost:8000/api/v1/webrtc/whip?streamId=debug-1",
+      audio: true,
     });
     await server.simulate(socket, { id: "list", action: "list" });
     const listed = lastResponse(socket);
@@ -168,6 +169,7 @@ describe("WebRtcStreamSocketServer", () => {
 
     expect(started[0].overrides).toEqual({
       whipEndpoint: "http://localhost:8000/api/v1/webrtc/whip?streamId=debug-1",
+      audioEnabled: true,
     });
     expect(listed.streams?.map(s => s.streamId)).toEqual(["debug-1"]);
     expect(status.stream?.streamId).toBe("debug-1");

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -8,7 +8,13 @@ import {
   type StreamSocket,
 } from "../../../src/features/webrtc/PersistentEncoderH264Source";
 import type { ProcessSpawner, SpawnedProcess } from "../../../src/features/webrtc/processSpawner";
-import { VIDEO_SERVER_CODEC_ID_H264 } from "../../../src/features/webrtc/VideoServerStreamParser";
+import {
+  VIDEO_SERVER_CODEC_ID_AMUX,
+  VIDEO_SERVER_CODEC_ID_H264,
+  VIDEO_SERVER_CODEC_ID_PCM16,
+  VIDEO_SERVER_TRACK_ID_AUDIO,
+  VIDEO_SERVER_TRACK_ID_VIDEO,
+} from "../../../src/features/webrtc/VideoServerStreamParser";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
 import type { BootedDevice } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -29,6 +35,9 @@ class FakeProcess extends EventEmitter implements SpawnedProcess {
   }
   ready(): void {
     this.stdout.write(Buffer.from("Waiting for client connection on localabstract:x\n"));
+  }
+  streamingStarted(): void {
+    this.stdout.write(Buffer.from("Streaming started\n"));
   }
   exit(code: number | null = 0, signal: NodeJS.Signals | null = null): void {
     this.emit("exit", code, signal);
@@ -60,14 +69,40 @@ function framedPacket(payload: Buffer): Buffer {
   return Buffer.concat([header, payload]);
 }
 
+function muxHeader(): Buffer {
+  const header = Buffer.alloc(44);
+  header.writeUInt32BE(VIDEO_SERVER_CODEC_ID_AMUX, 0);
+  header.writeUInt32BE(1, 4);
+  header.writeUInt32BE(2, 8);
+  header.writeUInt32BE(VIDEO_SERVER_TRACK_ID_VIDEO, 12);
+  header.writeUInt32BE(VIDEO_SERVER_CODEC_ID_H264, 16);
+  header.writeUInt32BE(480, 20);
+  header.writeUInt32BE(1040, 24);
+  header.writeUInt32BE(VIDEO_SERVER_TRACK_ID_AUDIO, 28);
+  header.writeUInt32BE(VIDEO_SERVER_CODEC_ID_PCM16, 32);
+  header.writeUInt32BE(8000, 36);
+  header.writeUInt32BE(1, 40);
+  return header;
+}
+
+function muxPacket(trackId: number, payload: Buffer): Buffer {
+  const header = Buffer.alloc(16);
+  header.writeUInt32BE(trackId, 0);
+  header.writeBigUInt64BE(0n, 4);
+  header.writeUInt32BE(payload.length, 12);
+  return Buffer.concat([header, payload]);
+}
+
 function makeSource(overrides: Record<string, unknown> = {}) {
   const commands: string[] = [];
   const processes: FakeProcess[] = [];
   const sockets: FakeSocket[] = [];
   const spawnArgs: string[][] = [];
   const chunks: Buffer[] = [];
+  const audioChunks: Buffer[] = [];
   const errors: Error[] = [];
   const timer = new FakeTimer();
+  const audioEnabled = overrides.audioEnabled === true;
 
   const adbFactory: AdbClientFactory = {
     create() {
@@ -100,6 +135,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
   const source = new PersistentEncoderH264Source({
     device: DEVICE,
     onData: chunk => chunks.push(chunk),
+    onAudioData: chunk => audioChunks.push(chunk),
     onError: error => errors.push(error),
     jarPath: "/tmp/automobile-video.jar",
     adbFactory,
@@ -109,7 +145,18 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     ...overrides,
   });
 
-  return { source, commands, processes, sockets, spawnArgs, chunks, errors, timer };
+  return {
+    source,
+    commands,
+    processes,
+    sockets,
+    spawnArgs,
+    chunks,
+    audioChunks,
+    errors,
+    timer,
+    audioEnabled,
+  };
 }
 
 /** Drive a successful start: launch -> ready -> forward -> connect. */
@@ -118,6 +165,10 @@ async function startReady(ctx: ReturnType<typeof makeSource>): Promise<void> {
   await tick(); // push + spawn
   ctx.processes[0].ready();
   await tick(); // ready resolves, forward + connect
+  if (ctx.audioEnabled) {
+    ctx.processes[0].streamingStarted();
+    await tick(); // audio-ready marker resolves
+  }
   await startPromise;
 }
 
@@ -142,6 +193,35 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.chunks).toEqual([Buffer.from([0, 0, 0, 1, 0x67])]);
 
     await ctx.source.stop();
+  });
+
+  test("passes --audio and routes muxed PCM audio packets separately from video", async () => {
+    const ctx = makeSource({ audioEnabled: true });
+    await startReady(ctx);
+
+    expect(ctx.spawnArgs[0]).toContain("--audio");
+
+    ctx.sockets[0].feed(muxHeader());
+    ctx.sockets[0].feed(muxPacket(VIDEO_SERVER_TRACK_ID_AUDIO, Buffer.from([1, 2, 3, 4])));
+    ctx.sockets[0].feed(muxPacket(VIDEO_SERVER_TRACK_ID_VIDEO, Buffer.from([0, 0, 0, 1, 0x65])));
+
+    expect(ctx.audioChunks).toEqual([Buffer.from([1, 2, 3, 4])]);
+    expect(ctx.chunks).toEqual([Buffer.from([0, 0, 0, 1, 0x65])]);
+
+    await ctx.source.stop();
+  });
+
+  test("audio startup rejects when the server exits before the post-audio-ready marker", async () => {
+    const ctx = makeSource({ audioEnabled: true });
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].ready();
+    await tick(); // ready resolves, forward + connect, now waiting for Streaming started
+    ctx.processes[0].exit(1, null);
+
+    await expect(startPromise).rejects.toThrow(/before streaming started/);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
   });
 
   test("stop terminates the server, destroys the socket, and removes the forward", async () => {

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -129,6 +129,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
   const connector: SocketConnector = async () => {
     const socket = new FakeSocket();
     sockets.push(socket);
+    (overrides.connectorHook as ((socket: FakeSocket) => void) | undefined)?.(socket);
     return socket;
   };
 
@@ -166,10 +167,15 @@ async function startReady(ctx: ReturnType<typeof makeSource>): Promise<void> {
   ctx.processes[0].ready();
   await tick(); // ready resolves, forward + connect
   if (ctx.audioEnabled) {
+    ctx.sockets[0].feed(muxHeader());
     ctx.processes[0].streamingStarted();
-    await tick(); // audio-ready marker resolves
+    ctx.sockets[0].feed(muxPacket(VIDEO_SERVER_TRACK_ID_AUDIO, Buffer.from([0x7f])));
+    await tick(); // audio-ready marker + first PCM packet resolve
   }
   await startPromise;
+  if (ctx.audioEnabled) {
+    ctx.audioChunks.length = 0;
+  }
 }
 
 describe("PersistentEncoderH264Source", () => {
@@ -201,12 +207,33 @@ describe("PersistentEncoderH264Source", () => {
 
     expect(ctx.spawnArgs[0]).toContain("--audio");
 
-    ctx.sockets[0].feed(muxHeader());
     ctx.sockets[0].feed(muxPacket(VIDEO_SERVER_TRACK_ID_AUDIO, Buffer.from([1, 2, 3, 4])));
     ctx.sockets[0].feed(muxPacket(VIDEO_SERVER_TRACK_ID_VIDEO, Buffer.from([0, 0, 0, 1, 0x65])));
 
     expect(ctx.audioChunks).toEqual([Buffer.from([1, 2, 3, 4])]);
     expect(ctx.chunks).toEqual([Buffer.from([0, 0, 0, 1, 0x65])]);
+
+    await ctx.source.stop();
+  });
+
+  test("audio startup does not miss the streaming marker emitted during socket connect", async () => {
+    const ctx = makeSource({
+      audioEnabled: true,
+      connectorHook: (socket: FakeSocket) => {
+        ctx.processes[0].streamingStarted();
+      },
+    });
+
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].ready();
+    await tick(); // ready resolves, forward + connect, socket listeners are wired
+    ctx.sockets[0].feed(muxHeader());
+    ctx.sockets[0].feed(muxPacket(VIDEO_SERVER_TRACK_ID_AUDIO, Buffer.from([0x7f])));
+
+    await startPromise;
+    expect(ctx.source.isRunning).toBe(true);
+    expect(ctx.audioChunks).toEqual([Buffer.from([0x7f])]);
 
     await ctx.source.stop();
   });
@@ -222,6 +249,70 @@ describe("PersistentEncoderH264Source", () => {
     await expect(startPromise).rejects.toThrow(/before streaming started/);
     expect(ctx.errors).toEqual([]);
     expect(ctx.source.isRunning).toBe(false);
+  });
+
+  test("audio startup rejects when a stale video-server jar streams the legacy H.264 header", async () => {
+    const ctx = makeSource({ audioEnabled: true });
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].ready();
+    await tick(); // ready resolves, forward + connect, now waiting for Streaming started + mux header
+    ctx.sockets[0].feed(streamHeader(480, 1040));
+    ctx.processes[0].streamingStarted();
+
+    await expect(startPromise).rejects.toThrow(/did not advertise muxed PCM audio/);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
+    expect(ctx.sockets[0].destroyed).toBe(true);
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+  });
+
+  test("audio startup rejects when the muxed server never produces PCM audio", async () => {
+    const ctx = makeSource({ audioEnabled: true, readyTimeoutMs: 5000 });
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].ready();
+    await tick(); // ready resolves, forward + connect, now waiting for Streaming started + first PCM packet
+    ctx.sockets[0].feed(muxHeader());
+    ctx.processes[0].streamingStarted();
+    await tick(); // streaming marker resolves; PCM packet is still missing
+    ctx.timer.advanceTime(5000);
+
+    await expect(startPromise).rejects.toThrow(/did not produce PCM audio/);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
+    expect(ctx.sockets[0].destroyed).toBe(true);
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+  });
+
+  test("audio startup rejects when the socket closes before the post-audio-ready marker", async () => {
+    const ctx = makeSource({ audioEnabled: true });
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].ready();
+    await tick(); // ready resolves, forward + connect, now waiting for Streaming started
+    ctx.sockets[0].emit("close");
+
+    await expect(startPromise).rejects.toThrow(/socket closed/);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
+    expect(ctx.sockets[0].destroyed).toBe(true);
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+  });
+
+  test("audio startup rejects when the socket errors before the post-audio-ready marker", async () => {
+    const ctx = makeSource({ audioEnabled: true });
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].ready();
+    await tick(); // ready resolves, forward + connect, now waiting for Streaming started
+    ctx.sockets[0].emit("error", new Error("REMOTE_SUBMIX socket failed"));
+
+    await expect(startPromise).rejects.toThrow(/REMOTE_SUBMIX socket failed/);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
+    expect(ctx.sockets[0].destroyed).toBe(true);
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
   });
 
   test("stop terminates the server, destroys the socket, and removes the forward", async () => {

--- a/test/features/webrtc/RtpPcmuTrackWriter.test.ts
+++ b/test/features/webrtc/RtpPcmuTrackWriter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import type { RtpPacket } from "werift";
+import { RtpPcmuTrackWriter } from "../../../src/features/webrtc/RtpPcmuTrackWriter";
+
+describe("RtpPcmuTrackWriter", () => {
+  test("encodes 8kHz mono PCM16LE as PCMU RTP packets", () => {
+    const packets: RtpPacket[] = [];
+    const writer = new RtpPcmuTrackWriter({
+      sink: { writeRtp: packet => packets.push(packet) },
+      ssrc: 0x1234,
+      initialSequenceNumber: 7,
+    });
+
+    writer.writePcm16Chunk(Buffer.from([0x00, 0x00, 0xff, 0x7f, 0x00, 0x80]));
+
+    expect(packets).toHaveLength(1);
+    expect(packets[0].header.payloadType).toBe(0);
+    expect(packets[0].header.sequenceNumber).toBe(7);
+    expect(packets[0].header.timestamp).toBe(0);
+    expect(packets[0].header.ssrc).toBe(0x1234);
+    expect(packets[0].payload).toHaveLength(3);
+    expect(writer.stats).toEqual({ packetsWritten: 1, samplesWritten: 3 });
+  });
+
+  test("splits large PCM chunks on the RTP payload limit and advances timestamps", () => {
+    const packets: RtpPacket[] = [];
+    const writer = new RtpPcmuTrackWriter({
+      sink: { writeRtp: packet => packets.push(packet) },
+      ssrc: 1,
+      mtu: 2,
+    });
+
+    writer.writePcm16Chunk(Buffer.alloc(10));
+
+    expect(packets.map(packet => packet.payload.length)).toEqual([2, 2, 1]);
+    expect(packets.map(packet => packet.header.timestamp)).toEqual([0, 2, 4]);
+    expect(writer.stats).toEqual({ packetsWritten: 3, samplesWritten: 5 });
+  });
+});

--- a/test/features/webrtc/VideoServerStreamParser.test.ts
+++ b/test/features/webrtc/VideoServerStreamParser.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  VIDEO_SERVER_CODEC_ID_AMUX,
   VIDEO_SERVER_CODEC_ID_H264,
+  VIDEO_SERVER_CODEC_ID_PCM16,
+  VIDEO_SERVER_TRACK_ID_AUDIO,
+  VIDEO_SERVER_TRACK_ID_VIDEO,
   VideoServerStreamParser,
   type VideoServerPacket,
   type VideoServerStreamHeader,
@@ -21,6 +25,30 @@ function packet(payload: Buffer, flags: bigint, ptsUs: number): Buffer {
   const header = Buffer.alloc(12);
   header.writeBigUInt64BE(flags | (BigInt(ptsUs) & (FLAG_KEY_FRAME - 1n)), 0);
   header.writeUInt32BE(payload.length, 8);
+  return Buffer.concat([header, payload]);
+}
+
+function muxHeader(): Buffer {
+  const header = Buffer.alloc(12 + 16 + 16);
+  header.writeUInt32BE(VIDEO_SERVER_CODEC_ID_AMUX, 0);
+  header.writeUInt32BE(1, 4);
+  header.writeUInt32BE(2, 8);
+  header.writeUInt32BE(VIDEO_SERVER_TRACK_ID_VIDEO, 12);
+  header.writeUInt32BE(VIDEO_SERVER_CODEC_ID_H264, 16);
+  header.writeUInt32BE(720, 20);
+  header.writeUInt32BE(1280, 24);
+  header.writeUInt32BE(VIDEO_SERVER_TRACK_ID_AUDIO, 28);
+  header.writeUInt32BE(VIDEO_SERVER_CODEC_ID_PCM16, 32);
+  header.writeUInt32BE(8000, 36);
+  header.writeUInt32BE(1, 40);
+  return header;
+}
+
+function muxPacket(trackId: number, payload: Buffer, flags: bigint, ptsUs: number): Buffer {
+  const header = Buffer.alloc(16);
+  header.writeUInt32BE(trackId, 0);
+  header.writeBigUInt64BE(flags | (BigInt(ptsUs) & (FLAG_KEY_FRAME - 1n)), 4);
+  header.writeUInt32BE(payload.length, 12);
   return Buffer.concat([header, payload]);
 }
 
@@ -48,12 +76,16 @@ describe("VideoServerStreamParser", () => {
     expect(headers).toEqual([{ codecId: VIDEO_SERVER_CODEC_ID_H264, width: 242, height: 540 }]);
     expect(packets).toHaveLength(2);
     expect(packets[0]).toEqual({
+      trackId: VIDEO_SERVER_TRACK_ID_VIDEO,
+      codecId: VIDEO_SERVER_CODEC_ID_H264,
       data: Buffer.from([0, 0, 0, 1, 0x67]),
       config: true,
       keyFrame: false,
       ptsUs: 0,
     });
     expect(packets[1]).toEqual({
+      trackId: VIDEO_SERVER_TRACK_ID_VIDEO,
+      codecId: VIDEO_SERVER_CODEC_ID_H264,
       data: Buffer.from([0, 0, 0, 1, 0x65]),
       config: false,
       keyFrame: true,
@@ -94,5 +126,20 @@ describe("VideoServerStreamParser", () => {
     ]);
     parser.push(combined);
     expect(packets.map(p => p.data[0])).toEqual([0xaa, 0xbb, 0xcc]);
+  });
+
+  test("parses muxed video and audio packets", () => {
+    const { parser, headers, packets } = collect();
+    parser.push(Buffer.concat([
+      muxHeader(),
+      muxPacket(VIDEO_SERVER_TRACK_ID_AUDIO, Buffer.from([1, 2, 3, 4]), 0n, 10),
+      muxPacket(VIDEO_SERVER_TRACK_ID_VIDEO, Buffer.from([0, 0, 0, 1, 0x65]), FLAG_KEY_FRAME, 20),
+    ]));
+
+    expect(headers).toEqual([{ codecId: VIDEO_SERVER_CODEC_ID_H264, width: 720, height: 1280 }]);
+    expect(packets.map(packet => [packet.trackId, packet.codecId, packet.ptsUs])).toEqual([
+      [VIDEO_SERVER_TRACK_ID_AUDIO, VIDEO_SERVER_CODEC_ID_PCM16, 10],
+      [VIDEO_SERVER_TRACK_ID_VIDEO, VIDEO_SERVER_CODEC_ID_H264, 20],
+    ]);
   });
 });

--- a/test/features/webrtc/VideoServerStreamParser.test.ts
+++ b/test/features/webrtc/VideoServerStreamParser.test.ts
@@ -136,7 +136,15 @@ describe("VideoServerStreamParser", () => {
       muxPacket(VIDEO_SERVER_TRACK_ID_VIDEO, Buffer.from([0, 0, 0, 1, 0x65]), FLAG_KEY_FRAME, 20),
     ]));
 
-    expect(headers).toEqual([{ codecId: VIDEO_SERVER_CODEC_ID_H264, width: 720, height: 1280 }]);
+    expect(headers).toEqual([
+      {
+        codecId: VIDEO_SERVER_CODEC_ID_H264,
+        width: 720,
+        height: 1280,
+        muxed: true,
+        audio: true,
+      },
+    ]);
     expect(packets.map(packet => [packet.trackId, packet.codecId, packet.ptsUs])).toEqual([
       [VIDEO_SERVER_TRACK_ID_AUDIO, VIDEO_SERVER_CODEC_ID_PCM16, 10],
       [VIDEO_SERVER_TRACK_ID_VIDEO, VIDEO_SERVER_CODEC_ID_H264, 20],

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -24,6 +24,14 @@ class FakePeerConnection {
   }
 }
 
+class RecordingPeerConnection extends FakePeerConnection {
+  transceiverKinds: string[] = [];
+  addTransceiver(track: { kind: string }) {
+    this.transceiverKinds.push(track.kind);
+    return { sender: { ssrc: this.transceiverKinds.length } };
+  }
+}
+
 /**
  * Unit tests for publisher wiring that can be asserted without a real peer
  * connection. The full media path is covered by WebRtcPublisher.loopback.test.ts
@@ -96,5 +104,53 @@ describe("WebRtcPublisher.notifySourceFailed", () => {
     );
     await publisher.stop();
     expect(() => publisher.notifySourceFailed()).not.toThrow();
+  });
+});
+
+describe("WebRtcPublisher audio", () => {
+  test("adds an audio transceiver only when audio is enabled and writes PCMU packets", async () => {
+    const pc = new RecordingPeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip", audioEnabled: true },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({ answerSdp: "v=0", resourceUrl: "https://coord/whip/s" }),
+            delete: async () => {},
+          }) as unknown as WhipClient,
+      }
+    );
+
+    await publisher.start();
+    publisher.writePcmAudioChunk(Buffer.alloc(4));
+
+    expect(pc.transceiverKinds).toEqual(["video", "audio"]);
+    expect(publisher.getDescriptor().audioPacketsSent).toBe(1);
+
+    await publisher.stop();
+  });
+
+  test("keeps the default video-only transceiver set", async () => {
+    const pc = new RecordingPeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({ answerSdp: "v=0", resourceUrl: "https://coord/whip/s" }),
+            delete: async () => {},
+          }) as unknown as WhipClient,
+      }
+    );
+
+    await publisher.start();
+    publisher.writePcmAudioChunk(Buffer.alloc(4));
+
+    expect(pc.transceiverKinds).toEqual(["video"]);
+    expect(publisher.getDescriptor().audioPacketsSent).toBe(0);
+
+    await publisher.stop();
   });
 });

--- a/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
@@ -97,9 +97,9 @@ describe("createAndroidH264CaptureSource", () => {
   });
 
   test("audio requires the persistent encoder jar", () => {
-    const { deps } = makeDeps({ resolveJarPath: () => null });
+    const { deps } = makeDeps({});
     expect(() =>
-      createAndroidH264CaptureSource({ ...baseOptions(), audioEnabled: true }, deps)
+      createAndroidH264CaptureSource({ ...baseOptions(), audioEnabled: true }, null, deps)
     ).toThrow(/persistent Android video-server jar/);
   });
 
@@ -107,11 +107,14 @@ describe("createAndroidH264CaptureSource", () => {
     const persistent = new FakeSource(() => Promise.reject(new Error("remote submix unavailable")));
     const screenrecord = new FakeSource();
     const deps: AndroidH264CaptureSourceDeps = {
-      resolveJarPath: () => "/tmp/automobile-video.jar",
       createPersistent: () => persistent,
       createScreenrecord: () => screenrecord,
     };
-    const source = createAndroidH264CaptureSource({ ...baseOptions(), audioEnabled: true }, deps);
+    const source = createAndroidH264CaptureSource(
+      { ...baseOptions(), audioEnabled: true },
+      "/tmp/automobile-video.jar",
+      deps
+    );
 
     await expect(source.start()).rejects.toThrow(/remote submix/);
     expect(persistent.started).toBe(1);

--- a/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
@@ -95,4 +95,26 @@ describe("createAndroidH264CaptureSource", () => {
     createAndroidH264CaptureSource(baseOptions(), "/custom/video.jar", deps);
     expect(capturedJar).toBe("/custom/video.jar");
   });
+
+  test("audio requires the persistent encoder jar", () => {
+    const { deps } = makeDeps({ resolveJarPath: () => null });
+    expect(() =>
+      createAndroidH264CaptureSource({ ...baseOptions(), audioEnabled: true }, deps)
+    ).toThrow(/persistent Android video-server jar/);
+  });
+
+  test("audio does not silently fall back to screenrecord when persistent startup fails", async () => {
+    const persistent = new FakeSource(() => Promise.reject(new Error("remote submix unavailable")));
+    const screenrecord = new FakeSource();
+    const deps: AndroidH264CaptureSourceDeps = {
+      resolveJarPath: () => "/tmp/automobile-video.jar",
+      createPersistent: () => persistent,
+      createScreenrecord: () => screenrecord,
+    };
+    const source = createAndroidH264CaptureSource({ ...baseOptions(), audioEnabled: true }, deps);
+
+    await expect(source.start()).rejects.toThrow(/remote submix/);
+    expect(persistent.started).toBe(1);
+    expect(screenrecord.started).toBe(0);
+  });
 });

--- a/test/features/webrtc/webrtcStreamingConfig.test.ts
+++ b/test/features/webrtc/webrtcStreamingConfig.test.ts
@@ -67,6 +67,7 @@ describe("resolveWebRtcStreamingConfig", () => {
     expect(config.bitrateKbps).toBe(4000);
     expect(config.size).toEqual({ width: 1280, height: 720 });
     expect(config.trickleIce).toBe(false);
+    expect(config.audioEnabled).toBe(false);
   });
 
   test("enables trickle ICE from the environment flag", () => {
@@ -83,6 +84,22 @@ describe("resolveWebRtcStreamingConfig", () => {
       [WEBRTC_ENV.TRICKLE_ICE]: "1",
     } as NodeJS.ProcessEnv;
     expect(resolveWebRtcStreamingConfig({ trickleIce: false }, env).trickleIce).toBe(false);
+  });
+
+  test("enables audio from the environment flag", () => {
+    const env = {
+      [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip",
+      [WEBRTC_ENV.AUDIO]: "on",
+    } as NodeJS.ProcessEnv;
+    expect(resolveWebRtcStreamingConfig({}, env).audioEnabled).toBe(true);
+  });
+
+  test("audio override takes precedence over the environment", () => {
+    const env = {
+      [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip",
+      [WEBRTC_ENV.AUDIO]: "1",
+    } as NodeJS.ProcessEnv;
+    expect(resolveWebRtcStreamingConfig({ audioEnabled: false }, env).audioEnabled).toBe(false);
   });
 
   test("overrides take precedence over environment", () => {

--- a/test/integration/webrtcCoordinationServer.e2e.test.ts
+++ b/test/integration/webrtcCoordinationServer.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   RTCPeerConnection,
   RtpPacket,
   useH264,
+  usePCMU,
 } from "werift";
 import { HttpCoordinationServer } from "../../examples/webrtc-coordination-server/httpServer";
 import { WebRtcPublisher } from "../../src/features/webrtc/WebRtcPublisher";
@@ -191,6 +192,62 @@ describe("WebRTC coordination server e2e", () => {
 
         await waitFor(() => received.length > 5, 5000);
         expect(received.length).toBeGreaterThan(5);
+      } finally {
+        await publisher.stop();
+        await viewer.close();
+        await http.close();
+      }
+    },
+    30000
+  );
+
+  test(
+    "audio enabled: publisher -> WHIP ingest -> WHEP subscriber forwards audio RTP",
+    async () => {
+      const http = new HttpCoordinationServer({ iceServers: [] });
+      const port = await http.listen(0, "127.0.0.1");
+      const base = `http://127.0.0.1:${port}`;
+
+      const publisher = new WebRtcPublisher({
+        streamId: "e2e-audio",
+        whipEndpoint: `${base}/whip?streamId=e2e-audio`,
+        audioEnabled: true,
+      });
+
+      const viewer = new RTCPeerConnection({
+        codecs: { video: [useH264()], audio: [usePCMU()] },
+      });
+      const audioPackets: RtpPacket[] = [];
+      viewer.onTrack.subscribe((track: MediaStreamTrack) => {
+        if (track.kind === "audio") {
+          track.onReceiveRtp.subscribe((rtp: RtpPacket) => audioPackets.push(rtp));
+        }
+      });
+
+      try {
+        await publisher.start();
+
+        viewer.addTransceiver("video", { direction: "recvonly" });
+        viewer.addTransceiver("audio", { direction: "recvonly" });
+        const offer = await viewer.createOffer();
+        await viewer.setLocalDescription(offer);
+        await waitForIce(viewer);
+        const whepRes = await fetch(`${base}/whep/e2e-audio`, {
+          method: "POST",
+          headers: { "Content-Type": "application/sdp" },
+          body: viewer.localDescription?.sdp ?? "",
+        });
+        expect(whepRes.status).toBe(201);
+        await viewer.setRemoteDescription({ type: "answer", sdp: await whepRes.text() });
+        await waitFor(() => viewer.connectionState === "connected", 8000);
+
+        publisher.writePcmAudioChunk(Buffer.alloc(320));
+        await waitFor(() => audioPackets.length > 0, 5000);
+
+        const streamRes = await fetch(`${base}/api/streams/e2e-audio`);
+        const descriptor = (await streamRes.json()) as { audio: boolean; audioPacketsForwarded: number };
+        expect(descriptor.audio).toBe(true);
+        expect(descriptor.audioPacketsForwarded).toBeGreaterThan(0);
       } finally {
         await publisher.stop();
         await viewer.close();

--- a/test/integration/webrtcCoordinationServer.e2e.test.ts
+++ b/test/integration/webrtcCoordinationServer.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   useH264,
   usePCMU,
 } from "werift";
+import { forwardRtpToOutboundTracks } from "../../examples/webrtc-coordination-server/coordinationServer";
 import { HttpCoordinationServer } from "../../examples/webrtc-coordination-server/httpServer";
 import { WebRtcPublisher } from "../../src/features/webrtc/WebRtcPublisher";
 
@@ -42,6 +43,16 @@ function pFrame(fill: number): Buffer {
   return Buffer.concat([nal(1, 800, fill), START]);
 }
 
+function rtpPacket(sequenceNumber: number, timestamp: number, ssrc: number): RtpPacket {
+  const buffer = Buffer.alloc(12);
+  buffer[0] = 0x80;
+  buffer[1] = 96;
+  buffer.writeUInt16BE(sequenceNumber, 2);
+  buffer.writeUInt32BE(timestamp, 4);
+  buffer.writeUInt32BE(ssrc, 8);
+  return RtpPacket.deSerialize(buffer);
+}
+
 async function waitForIce(pc: RTCPeerConnection): Promise<void> {
   if (pc.iceGatheringState === "complete") {
     return;
@@ -63,6 +74,40 @@ async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<voi
 }
 
 describe("WebRTC coordination server e2e", () => {
+  test("clones RTP before forwarding to each subscriber track", () => {
+    const packet = rtpPacket(0x1234, 0x01020304, 0x05060708);
+    const secondTrackPackets: Array<{ sequenceNumber: number; timestamp: number; ssrc: number }> = [];
+
+    forwardRtpToOutboundTracks(
+      [
+        {
+          writeRtp: forwarded => {
+            forwarded.header.sequenceNumber = 1;
+            forwarded.header.timestamp = 2;
+            forwarded.header.ssrc = 3;
+          },
+        },
+        {
+          writeRtp: forwarded => {
+            secondTrackPackets.push({
+              sequenceNumber: forwarded.header.sequenceNumber,
+              timestamp: forwarded.header.timestamp,
+              ssrc: forwarded.header.ssrc,
+            });
+          },
+        },
+      ],
+      packet
+    );
+
+    expect(secondTrackPackets).toEqual([
+      { sequenceNumber: 0x1234, timestamp: 0x01020304, ssrc: 0x05060708 },
+    ]);
+    expect(packet.header.sequenceNumber).toBe(0x1234);
+    expect(packet.header.timestamp).toBe(0x01020304);
+    expect(packet.header.ssrc).toBe(0x05060708);
+  });
+
   test(
     "publisher -> WHIP ingest -> WHEP subscriber forwards frames, reconnect API lists the stream",
     async () => {

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -26,29 +26,18 @@ import {
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
 import type { BootedDevice, VideoRecordingMetadata } from "../../src/models";
 
-/**
- * Generous ceiling for the two timer-driven tests below: they poll an async rotation
- * chain via {@link waitFor}, and under full-suite concurrency the event loop is saturated
- * enough that the (logically-correct) poll can outlast bun's 5s default. The condition is
- * always met well before this; the headroom just stops a loaded CI machine failing a
- * correct test.
- */
-const TIMER_DRIVEN_TEST_TIMEOUT_MS = 20_000;
+async function drainMicrotasks(turns = 10): Promise<void> {
+  for (let turn = 0; turn < turns; turn++) {
+    await Promise.resolve();
+  }
+}
 
-/** Drain all pending microtasks (setImmediate runs after the microtask queue). */
-const flush = () => new Promise<void>(resolve => setImmediate(resolve));
-
-/** Poll an async condition, yielding to the full event loop between checks. */
-async function waitFor(condition: () => Promise<boolean>, label: string): Promise<void> {
-  for (let attempt = 0; attempt < 200; attempt++) {
-    if (await condition()) {
+async function waitFor(condition: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (condition()) {
       return;
     }
-    // A single macrotask yield (setImmediate) drains the microtask queue AND lets any
-    // I/O-phase callbacks in the rotation chain settle. A second real-timer yield here
-    // (defaultTimer.sleep(0)) only doubled the per-iteration wall-clock, which starved
-    // this loop past the 5s test budget under full-suite concurrency — so it's gone.
-    await flush();
+    await drainMicrotasks();
   }
   throw new Error(`Timed out waiting for: ${label}`);
 }
@@ -279,9 +268,7 @@ describe("videoRecording tool segmentation branch", () => {
     // Rotate once so the bare stop must return more than one segment, in order.
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS);
     await waitFor(
-      async () =>
-        segmentStarts.length === 2 &&
-        segmentStops.length === 1,
+      () => segmentStarts.length === 2 && segmentStops.length === 1,
       "segment 2 to start after rotation"
     );
 
@@ -306,9 +293,9 @@ describe("videoRecording tool segmentation branch", () => {
     // Advancing well past the rotation interval starts no new segment/recording.
     const segmentStartsBefore = segmentStarts.length;
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS * 3);
-    await flush();
+    await drainMicrotasks();
     expect(segmentStarts).toHaveLength(segmentStartsBefore);
-  }, TIMER_DRIVEN_TEST_TIMEOUT_MS);
+  });
 
   test("maxDuration auto-stop removes the session so a later bare stop reports only fresh segments", async () => {
     setSegmentedSessionRecordingDependencies({
@@ -347,10 +334,10 @@ describe("videoRecording tool segmentation branch", () => {
     // Advance past the maxDuration bound (rotation at 170s, then auto-stop at 181s).
     segmentTimer.advanceTime(181_000);
     await waitFor(
-      async () => segmentStops.length === 2,
+      () => segmentStops.length === 2,
       "auto-stop to finalize both segments of the first session"
     );
-    await flush();
+    await drainMicrotasks();
 
     // Auto-stop cleared the session's timers and removed it from the registry.
     expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
@@ -380,7 +367,7 @@ describe("videoRecording tool segmentation branch", () => {
     expect(
       segments.some(segment => String(segment.filePath).includes("first"))
     ).toBe(false);
-  }, TIMER_DRIVEN_TEST_TIMEOUT_MS);
+  });
 
   test("by-handle stop still works after wiring the bare-stop path", async () => {
     const startRes = parse(

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -50,6 +50,10 @@ class FakePublisher {
     this.stopped = true;
   }
   writeH264Chunk(): void {}
+  pcmAudioChunks: Buffer[] = [];
+  writePcmAudioChunk(chunk: Buffer): void {
+    this.pcmAudioChunks.push(chunk);
+  }
   notifySourceFailed(): void {
     this.sourceFailedCount++;
   }
@@ -315,5 +319,40 @@ describe("webrtcStreamManager", () => {
     ).rejects.toThrow(/checksum verification failed/);
     expect(publisherCreated).toBe(0);
     expect(listWebRtcStreams()).toHaveLength(0);
+  });
+
+  test("passes audio config to publisher/source and routes PCM audio chunks", async () => {
+    const publishers: FakePublisher[] = [];
+    let capturedSourceOptions:
+      | Parameters<NonNullable<Parameters<typeof setWebRtcStreamManagerDependencies>[0]["createSource"]>>[0]
+      | undefined;
+    let capturedJarPath: string | null | undefined;
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => {
+        const publisher = new FakePublisher(config, deps);
+        publishers.push(publisher);
+        return publisher as unknown as WebRtcPublisher;
+      },
+      createSource: (options, jarPath) => {
+        capturedSourceOptions = options;
+        capturedJarPath = jarPath;
+        return new FakeSource() as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => "/verified/automobile-video.jar",
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    await startWebRtcStream({
+      device: ANDROID,
+      overrides: { whipEndpoint: ENDPOINT, audioEnabled: true },
+    });
+
+    expect((publishers[0].config as { audioEnabled?: boolean }).audioEnabled).toBe(true);
+    expect(capturedSourceOptions?.audioEnabled).toBe(true);
+    expect(capturedJarPath).toBe("/verified/automobile-video.jar");
+
+    capturedSourceOptions?.onAudioData?.(Buffer.from([1, 2, 3, 4]));
+    expect(publishers[0].pcmAudioChunks).toEqual([Buffer.from([1, 2, 3, 4])]);
   });
 });

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -73,6 +73,14 @@ class FakePublisher {
   }
 }
 
+class AsyncConnectedPublisher extends FakePublisher {
+  override async start(): Promise<void> {
+    await this.onBeforeEstablish?.();
+    this.started = true;
+    void Promise.resolve(this.onConnected?.()).catch(() => this.notifySourceFailed());
+  }
+}
+
 class FakeSource {
   started = false;
   stopped = false;
@@ -354,5 +362,103 @@ describe("webrtcStreamManager", () => {
 
     capturedSourceOptions?.onAudioData?.(Buffer.from([1, 2, 3, 4]));
     expect(publishers[0].pcmAudioChunks).toEqual([Buffer.from([1, 2, 3, 4])]);
+  });
+
+  test("rejects audio stream start when the initial async source start fails", async () => {
+    const publishers: AsyncConnectedPublisher[] = [];
+    const sources: FakeSource[] = [];
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => {
+        const publisher = new AsyncConnectedPublisher(config, deps);
+        publishers.push(publisher);
+        return publisher as unknown as WebRtcPublisher;
+      },
+      createSource: () => {
+        const source = new FakeSource();
+        source.start = async () => {
+          source.started = true;
+          throw new Error("REMOTE_SUBMIX failed");
+        };
+        sources.push(source);
+        return source as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => "/verified/automobile-video.jar",
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    await expect(
+      startWebRtcStream({
+        device: ANDROID,
+        overrides: { whipEndpoint: ENDPOINT, audioEnabled: true },
+      })
+    ).rejects.toThrow(/REMOTE_SUBMIX failed/);
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].started).toBe(true);
+    expect(sources[0].stopped).toBe(true);
+    expect(publishers[0].stopped).toBe(true);
+    expect(publishers[0].sourceFailedCount).toBe(1);
+    expect(listWebRtcStreams()).toHaveLength(0);
+  });
+
+  test("failed async audio startup cleanup does not delete a replacement stream with the same id", async () => {
+    const publishers: AsyncConnectedPublisher[] = [];
+    const sources: FakeSource[] = [];
+    let firstStartReject: ((error: Error) => void) | undefined;
+    let firstSourceStarted!: () => void;
+    const firstSourceStartedPromise = new Promise<void>(resolve => {
+      firstSourceStarted = resolve;
+    });
+    let createSourceCalls = 0;
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => {
+        const publisher = new AsyncConnectedPublisher(config, deps);
+        publishers.push(publisher);
+        return publisher as unknown as WebRtcPublisher;
+      },
+      createSource: () => {
+        createSourceCalls++;
+        const source = new FakeSource();
+        if (createSourceCalls === 1) {
+          source.start = async () => {
+            source.started = true;
+            firstSourceStarted();
+            await new Promise<void>((_resolve, reject) => {
+              firstStartReject = reject;
+            });
+          };
+        }
+        sources.push(source);
+        return source as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => "/verified/automobile-video.jar",
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    const firstStart = startWebRtcStream({
+      device: ANDROID,
+      streamId: "replace-me",
+      overrides: { whipEndpoint: ENDPOINT, audioEnabled: true },
+    });
+    await firstSourceStartedPromise;
+    expect(listWebRtcStreams().map(stream => stream.streamId)).toEqual(["replace-me"]);
+
+    await stopWebRtcStream("replace-me");
+    const replacement = await startWebRtcStream({
+      device: ANDROID,
+      streamId: "replace-me",
+      overrides: { whipEndpoint: ENDPOINT, audioEnabled: true },
+    });
+
+    firstStartReject?.(new Error("REMOTE_SUBMIX failed after replacement"));
+    await expect(firstStart).rejects.toThrow(/REMOTE_SUBMIX failed after replacement/);
+
+    expect(replacement.streamId).toBe("replace-me");
+    expect(getWebRtcStreamDescriptor("replace-me")?.streamId).toBe("replace-me");
+    expect(listWebRtcStreams().map(stream => stream.streamId)).toEqual(["replace-me"]);
+    expect(publishers[1].stopped).toBe(false);
+    expect(sources[1].stopped).toBe(false);
   });
 });

--- a/test/utils/ChildProcessTracker.test.ts
+++ b/test/utils/ChildProcessTracker.test.ts
@@ -4,9 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
+  createExitTracker,
   getFileSize,
   waitForExit,
   waitForSpawn,
+  type TrackedChildProcess,
   type StoppableProcess,
 } from "../../src/utils/ChildProcessTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -46,6 +48,27 @@ function createExitOrErrorPromise(process: EventEmitter): Promise<void> {
 }
 
 describe("ChildProcessTracker", () => {
+  describe("createExitTracker", () => {
+    test("tracks ignored-stdio processes without a stderr stream", async () => {
+      const process = new EventEmitter() as TrackedChildProcess;
+      process.exitCode = null;
+      process.signalCode = null;
+      process.killed = false;
+      process.stderr = null;
+      process.kill = () => true;
+
+      const stderr: string[] = [];
+      const { exitState, exitPromise } = createExitTracker(process, stderr);
+
+      process.emit("exit", 0, null);
+      await exitPromise;
+
+      expect(stderr).toEqual([]);
+      expect(exitState.exitCode).toBe(0);
+      expect(exitState.signal).toBeNull();
+    });
+  });
+
   describe("waitForExit", () => {
     test("sends SIGINT first and escalates to SIGKILL after the configured timeout", async () => {
       const timer = new FakeTimer();


### PR DESCRIPTION
## Summary

Adds optional audio to the WebRTC streaming path. Android persistent video-server streams can now emit 8 kHz mono PCM16 audio alongside H.264 video, and the TypeScript publisher packetizes it as PCMU/G.711 RTP for the coordination server and browser viewer.

This keeps existing video-only behavior as the default. Audio is opt-in through `AUTOMOBILE_WEBRTC_AUDIO=true` or the WebRTC stream socket request field `"audio": true`, and iOS currently returns an actionable unsupported error for audio requests.

## Linked Issue

Closes #3778

## Bug / Regression Context

Deleted for feature work.

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + build + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android changes: `cd android && ./gradlew :video-server:d8Dex`
- [x] New code uses interfaces + fakes + FakeTimer-compatible tests; focused unit tests stay fast
- [x] Rebased onto latest `main`, conflicts resolved

Additional checks:

- [x] `git diff --check`
- [x] `bun test test/features/webrtc/RtpPcmuTrackWriter.test.ts test/features/webrtc/WebRtcPublisher.test.ts test/features/webrtc/VideoServerStreamParser.test.ts test/features/webrtc/PersistentEncoderH264Source.test.ts test/features/webrtc/androidH264CaptureSourceFactory.test.ts test/server/webrtcStreamManager.test.ts test/daemon/webrtcStreamSocketServer.test.ts test/features/webrtc/webrtcStreamingConfig.test.ts`
- [x] `bun test test/integration/webrtcCoordinationServer.e2e.test.ts`
- [x] `cd android && ./gradlew :video-server:compileKotlin`

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`
- [ ] Screenshots or before/after attached

Not manually device-verified yet. The Android audio path uses `MediaRecorder.AudioSource.REMOTE_SUBMIX`, so final confirmation should run against a device/API level where remote submix capture is available.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: none
