### PR TITLE
feat(desktop): model observation diff metadata in the hierarchy tree (#3758)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -303,6 +303,7 @@ class ObservationStreamClient {
             timestamp = response.timestamp ?: System.currentTimeMillis(),
             data = response.data,
             packageName = packageName,
+            diff = response.hierarchyDiff,
           )
         _hierarchyUpdates.emit(update)
         log.info("Emitted hierarchy update to flow")
@@ -493,6 +494,22 @@ data class StreamResponse(
   val screenshotBase64Length: Int? = null,
   val navigationGraph: NavigationGraphStreamData? = null,
   val performanceData: PerformanceStreamData? = null,
+  val hierarchyDiff: HierarchyDiffSummary? = null,
+)
+
+/**
+ * Per-frame hierarchy diff summary emitted by the daemon on `hierarchy_update` (issue #3758).
+ * Counts how the current frame differs from the previous one for a device; [hasBaseline] is false
+ * for the first frame (or first after a reconnect), where nothing is diffed and no node is
+ * annotated. Absent for daemons that do not emit diff metadata, in which case the layout inspector
+ * renders unchanged.
+ */
+@Serializable
+data class HierarchyDiffSummary(
+  val hasBaseline: Boolean = false,
+  val added: Int = 0,
+  val changed: Int = 0,
+  val removed: Int = 0,
 )
 
 @Serializable
@@ -525,6 +542,7 @@ data class HierarchyStreamUpdate(
   val timestamp: Long,
   val data: JsonElement?,
   val packageName: String? = null,
+  val diff: HierarchyDiffSummary? = null,
 )
 
 data class ScreenshotStreamUpdate(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.layout
 
+import dev.jasonpearson.automobile.desktop.domain.NodeDiffState
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -100,6 +101,10 @@ private fun parseJsonObjectNode(
   // Parse extras map (sdk.* properties from the hierarchy merger)
   val extras = parseExtras(attrs, nodeObj)
 
+  // Parse the per-frame diff annotation stamped by the daemon (issue #3758).
+  // Absent on hierarchies without diff metadata, so the node renders unmarked.
+  val diffState = parseDiffState(attrs.getString("diffState"))
+
   // Parse children from "node" field
   val childrenElement = nodeObj["node"]
   val children = parseChildren(childrenElement, depth + 1, elementMap, parentMap)
@@ -129,6 +134,7 @@ private fun parseJsonObjectNode(
       depth = depth,
       children = children,
       extras = extras,
+      diffState = diffState,
     )
 
   // Populate lookup indexes as side-effect during parsing — zero extra traversals
@@ -212,6 +218,16 @@ private fun parseChildren(
     else -> emptyList()
   }
 }
+
+/**
+ * Map the daemon's `diffState` wire value to the typed enum; unknown/absent values render unmarked.
+ */
+private fun parseDiffState(value: String?): NodeDiffState? =
+  when (value) {
+    "added" -> NodeDiffState.Added
+    "changed" -> NodeDiffState.Changed
+    else -> null
+  }
 
 /** Parse the "extras" map from node JSON. Checks both the attributes object and the node itself. */
 private fun parseExtras(attrs: JsonObject, nodeObj: JsonObject): Map<String, String> {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyTreeView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyTreeView.kt
@@ -244,10 +244,15 @@ private fun TreeNodeRow(
 ) {
   val colors = SharedTheme.globalColors
 
+  // Per-frame diff accent (issue #3758): tint added/changed nodes so live changes
+  // are visible in the tree. Selection/hover take priority; unmarked nodes render
+  // transparently, so hierarchies without diff metadata look unchanged.
+  val diffColor = diffAccentColor(node.element.diffState)
   val bgColor =
     when {
       isSelected -> Color(0xFF2196F3).copy(alpha = 0.2f)
       isHovered -> colors.text.normal.copy(alpha = 0.08f)
+      diffColor != null -> diffColor.copy(alpha = 0.14f)
       isInSelectedPath -> colors.text.normal.copy(alpha = 0.04f)
       else -> Color.Transparent
     }
@@ -354,6 +359,15 @@ private fun TreeNodeRow(
       if (node.element.isScrollable) {
         StateIndicator("\u2195", "Scrollable") // Up-down arrow
       }
+      node.element.diffState?.let { state ->
+        StateIndicator(
+          icon = if (state == NodeDiffState.Added) "+" else "\u25CF",
+          tooltip =
+            if (state == NodeDiffState.Added) "Added since last frame"
+            else "Changed since last frame",
+          color = diffAccentColor(state),
+        )
+      }
     }
 
     // Copy selector button — visible on row hover
@@ -412,15 +426,23 @@ private fun ElementIcon(className: String) {
 }
 
 @Composable
-private fun StateIndicator(icon: String, tooltip: String) {
+private fun StateIndicator(icon: String, tooltip: String, color: Color? = null) {
   val colors = SharedTheme.globalColors
 
   Text(
     icon,
     fontSize = 9.sp,
-    color = colors.text.normal.copy(alpha = 0.4f),
+    color = color ?: colors.text.normal.copy(alpha = 0.4f),
   )
 }
+
+/** Accent color for a node's diff state, or null when the node is unchanged/unmarked. */
+private fun diffAccentColor(state: NodeDiffState?): Color? =
+  when (state) {
+    NodeDiffState.Added -> Color(0xFF4CAF50)
+    NodeDiffState.Changed -> Color(0xFFFFC107)
+    null -> null
+  }
 
 private fun getSimpleClassName(fullName: String): String {
   return fullName.substringAfterLast(".")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorModels.kt
@@ -2,6 +2,8 @@ package dev.jasonpearson.automobile.desktop.core.layout
 
 typealias UIElementInfo = dev.jasonpearson.automobile.desktop.domain.UIElementInfo
 
+typealias NodeDiffState = dev.jasonpearson.automobile.desktop.domain.NodeDiffState
+
 typealias ElementBounds = dev.jasonpearson.automobile.desktop.domain.ElementBounds
 
 typealias ScreenshotFrame = dev.jasonpearson.automobile.desktop.domain.ScreenshotFrame

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -108,6 +108,54 @@ class ObservationStreamClientTest {
   }
 
   @Test
+  fun `emits hierarchy diff summary when the daemon provides it`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.hierarchyUpdates.test {
+      client.handleMessage(
+        """
+        {
+          "type": "hierarchy_update",
+          "deviceId": "emulator-5554",
+          "timestamp": 2000,
+          "data": { "packageName": "com.example" },
+          "hierarchyDiff": { "hasBaseline": true, "added": 2, "changed": 3, "removed": 1 }
+        }
+        """
+          .trimIndent()
+      )
+
+      val update = awaitItem()
+      assertEquals(
+        HierarchyDiffSummary(hasBaseline = true, added = 2, changed = 3, removed = 1),
+        update.diff,
+      )
+    }
+  }
+
+  @Test
+  fun `hierarchy update diff is null when the daemon omits it`() = runTest {
+    // Older daemons predate diff metadata; the layout inspector must render cleanly with no diff.
+    val client = ObservationStreamClient()
+
+    client.hierarchyUpdates.test {
+      client.handleMessage(
+        """
+        {
+          "type": "hierarchy_update",
+          "deviceId": "emulator-5554",
+          "timestamp": 2001,
+          "data": { "packageName": "com.example" }
+        }
+        """
+          .trimIndent()
+      )
+
+      assertEquals(null, awaitItem().diff)
+    }
+  }
+
+  @Test
   fun `emits device connection lost event for disconnect error message`() = runTest {
     val client = ObservationStreamClient()
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParserDiffStateTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParserDiffStateTest.kt
@@ -1,0 +1,60 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import dev.jasonpearson.automobile.desktop.domain.NodeDiffState
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * Coverage for parsing the daemon's per-frame `diffState` node annotation (issue #3758).
+ * Hierarchies without the attribute must parse with a null [UIElementInfo.diffState] so the layout
+ * inspector renders unchanged for daemons that do not emit diff metadata.
+ */
+class HierarchyParserDiffStateTest {
+
+  private fun parse(hierarchyJson: String): ParsedHierarchy {
+    val parsed = parseHierarchyFromJson(Json.parseToJsonElement(hierarchyJson))
+    return assertNotNull(parsed, "hierarchy should parse")
+  }
+
+  @Test
+  fun `parses added and changed diff states from node attributes`() {
+    val json =
+      """
+      { "hierarchy": { "node": {
+        "resource-id": "com.example:id/root",
+        "diffState": "changed",
+        "node": [
+          { "resource-id": "com.example:id/added", "diffState": "added" },
+          { "resource-id": "com.example:id/plain" }
+        ]
+      } } }
+      """
+    val root = parse(json).root
+
+    assertEquals(NodeDiffState.Changed, root.diffState)
+    assertEquals(NodeDiffState.Added, root.children[0].diffState)
+    assertNull(root.children[1].diffState, "unmarked node has no diff state")
+  }
+
+  @Test
+  fun `absent diff state parses as null`() {
+    val json =
+      """
+      { "hierarchy": { "node": { "resource-id": "com.example:id/root" } } }
+      """
+    assertNull(parse(json).root.diffState)
+  }
+
+  @Test
+  fun `unknown diff state value parses as null`() {
+    // Forward compatibility: a future/unknown marker must not crash or mis-render.
+    val json =
+      """
+      { "hierarchy": { "node": { "resource-id": "com.example:id/root", "diffState": "moved" } } }
+      """
+    assertNull(parse(json).root.diffState)
+  }
+}

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/LayoutModels.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/LayoutModels.kt
@@ -1,5 +1,16 @@
 package dev.jasonpearson.automobile.desktop.domain
 
+/**
+ * How a hierarchy node changed since the previous observation-stream frame, as annotated by the
+ * daemon's per-frame diff. [Added] nodes are new this frame; [Changed] nodes exist at the same tree
+ * position with a changed attribute. Unchanged nodes carry no state (null), so hierarchies without
+ * diff metadata render exactly as before.
+ */
+public enum class NodeDiffState {
+  Added,
+  Changed,
+}
+
 public data class UIElementInfo(
   val id: String,
   val className: String,
@@ -17,6 +28,7 @@ public data class UIElementInfo(
   val children: List<UIElementInfo>,
   val depth: Int,
   val extras: Map<String, String> = emptyMap(),
+  val diffState: NodeDiffState? = null,
 )
 
 public data class ElementBounds(

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -10,6 +10,7 @@ import type { ObserveResult, ViewHierarchyResult } from "../models";
 import type { StorageChangedEvent } from "../features/storage/storageTypes";
 import { DEVICE_DATA_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 import type { ScreenshotMetadata } from "../features/observe/ScreenshotMetadata";
+import { annotateHierarchyDiff, type HierarchyDiffSummary } from "./hierarchyStreamDiff";
 
 /**
  * Navigation graph summary for streaming to IDE plugins.
@@ -89,6 +90,8 @@ interface DeviceDataStreamMessage extends ScreenshotMetadata {
   navigationGraph?: NavigationGraphStreamData;
   performanceData?: PerformanceStreamData;
   storageEvent?: StorageChangedEvent;
+  /** Per-frame hierarchy diff summary (present on hierarchy_update messages). */
+  hierarchyDiff?: HierarchyDiffSummary;
 }
 
 /**
@@ -184,6 +187,11 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   private onNavigationGraphRequested: OnNavigationGraphRequestedCallback | null = null;
   private observationRequestTimeoutMs = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS;
 
+  // Previous hierarchy per device, used to compute the per-frame diff annotation
+  // pushed on hierarchy_update. Cleared on device connection loss so a reconnect
+  // starts from a clean baseline instead of diffing against a stale pre-drop tree.
+  private previousHierarchyByDevice = new Map<string, ViewHierarchyResult>();
+
   constructor(socketPath: string = getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG), timer: Timer = defaultTimer) {
     super(socketPath, timer, "DeviceDataStream");
   }
@@ -232,11 +240,30 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * Push a hierarchy update to all subscribers interested in this device.
    */
   pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult): void {
+    // Skip the diff clone+walk when nobody is listening (the layout inspector is
+    // usually closed): the frame would reach zero subscribers anyway. Drop the
+    // baseline too so a later re-subscribe diffs from a fresh frame, not a tree
+    // captured while it was away.
+    if (!this.hasSubscriberForDevice(deviceId)) {
+      this.previousHierarchyByDevice.delete(deviceId);
+      return;
+    }
+
+    // Annotate the frame with its per-node diff versus the last frame for this
+    // device (added/changed nodes carry a `diffState` attribute; a summary rides
+    // the message). The input is cloned, so the annotated copy pushed to clients
+    // never mutates the caller's hierarchy; the un-annotated original is retained
+    // as the next baseline.
+    const previous = this.previousHierarchyByDevice.get(deviceId) ?? null;
+    const { hierarchy: annotated, summary } = annotateHierarchyDiff(previous, hierarchy);
+    this.previousHierarchyByDevice.set(deviceId, hierarchy);
+
     const message: DeviceDataStreamMessage = {
       type: "hierarchy_update",
       deviceId,
       timestamp: hierarchy.updatedAt ?? this.timer.now(),
-      data: hierarchy,
+      data: annotated,
+      hierarchyDiff: summary,
     };
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
@@ -437,6 +464,10 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * Notify subscribers that the underlying device control connection was lost.
    */
   onDeviceConnectionLost(deviceId: string): void {
+    // Drop the diff baseline: the next hierarchy after a reconnect is a fresh
+    // full frame, not a delta from the tree captured before the connection dropped.
+    this.previousHierarchyByDevice.delete(deviceId);
+
     const message: DeviceDataStreamMessage = {
       type: "error",
       success: false,

--- a/src/daemon/hierarchyStreamDiff.ts
+++ b/src/daemon/hierarchyStreamDiff.ts
@@ -1,0 +1,167 @@
+import type { ViewHierarchyResult, ViewHierarchyNode } from "../models/ViewHierarchyResult";
+
+/**
+ * Per-frame diff state stamped onto a node in the observation stream's hierarchy
+ * payload. `added` = the node (and its subtree) is new versus the previous frame;
+ * `changed` = the node exists at the same tree position but one of its compared
+ * attributes changed. Unchanged nodes carry no marker at all, so a consumer that
+ * ignores the field renders exactly as before.
+ */
+export type HierarchyNodeDiffState = "added" | "changed";
+
+/**
+ * The wire attribute key under a node's `$` attributes that carries its
+ * {@link HierarchyNodeDiffState}. Kept in one place so the daemon writer and any
+ * reader (e.g. the desktop `HierarchyParser`) agree on the exact string.
+ */
+export const HIERARCHY_DIFF_STATE_KEY = "diffState";
+
+/**
+ * Summary of how the current hierarchy frame differs from the previous one for a
+ * device. Rides the `hierarchy_update` stream message alongside the annotated
+ * hierarchy so a client can show an at-a-glance "what changed" badge without
+ * re-walking the tree. `hasBaseline` is false for the first frame (or the first
+ * frame after a reset), where there is nothing to diff against and no node is
+ * annotated.
+ */
+export interface HierarchyDiffSummary {
+  hasBaseline: boolean;
+  added: number;
+  changed: number;
+  removed: number;
+}
+
+export interface HierarchyDiffResult {
+  /** Deep clone of the current hierarchy with added/changed nodes annotated. */
+  hierarchy: ViewHierarchyResult;
+  summary: HierarchyDiffSummary;
+}
+
+/** Attributes compared to decide whether a node at a stable tree position changed. */
+function nodeSignature(node: ViewHierarchyNode): string {
+  const attrs = node.$ ?? {};
+  const get = (...keys: string[]): string => {
+    for (const key of keys) {
+      const value = attrs[key];
+      if (value !== undefined && value !== null) {return String(value);}
+    }
+    return "";
+  };
+  const bounds = node.bounds;
+  const boundsSig = bounds
+    ? `${bounds.left ?? ""},${bounds.top ?? ""},${bounds.right ?? ""},${bounds.bottom ?? ""}`
+    : get("bounds");
+  // Attribute names differ across capture sources (class vs className, etc.), so
+  // each field falls back through its known aliases before comparison.
+  return [
+    get("class", "className"),
+    get("text"),
+    get("resource-id", "resourceId"),
+    get("content-desc", "contentDesc"),
+    boundsSig,
+    get("clickable"),
+    get("enabled"),
+    get("focused"),
+    get("selected"),
+    get("checked"),
+    get("scrollable"),
+  ].join("\u0000");
+}
+
+function children(node: ViewHierarchyNode): ViewHierarchyNode[] {
+  return node.node ?? [];
+}
+
+function markState(node: ViewHierarchyNode, state: HierarchyNodeDiffState): void {
+  // Nodes may arrive without a populated `$` (defensive); create it so the marker
+  // survives serialization to the client.
+  if (node.$ === undefined || node.$ === null) {
+    node.$ = {};
+  }
+  node.$[HIERARCHY_DIFF_STATE_KEY] = state;
+}
+
+/** Stamp every node in an added subtree as `added` and count them. */
+function markSubtreeAdded(node: ViewHierarchyNode): number {
+  markState(node, "added");
+  let count = 1;
+  for (const child of children(node)) {
+    count += markSubtreeAdded(child);
+  }
+  return count;
+}
+
+/** Count every node in a removed subtree (it is absent from the current frame). */
+function countSubtree(node: ViewHierarchyNode): number {
+  let count = 1;
+  for (const child of children(node)) {
+    count += countSubtree(child);
+  }
+  return count;
+}
+
+/**
+ * Walk the current node against its previous counterpart at the same tree
+ * position, annotating and counting changes into [summary]. Children are matched
+ * positionally (by index): the observation stream re-captures the same screen at
+ * a cadence, so same-position nodes are the same UI element in the common case,
+ * and a structural shift simply surfaces as added/changed — which is the honest
+ * "this moved" signal for a layout inspector.
+ */
+function walk(
+  previous: ViewHierarchyNode,
+  current: ViewHierarchyNode,
+  summary: HierarchyDiffSummary
+): void {
+  if (nodeSignature(previous) !== nodeSignature(current)) {
+    markState(current, "changed");
+    summary.changed += 1;
+  }
+
+  const previousChildren = children(previous);
+  const currentChildren = children(current);
+
+  for (let i = 0; i < currentChildren.length; i++) {
+    if (i < previousChildren.length) {
+      walk(previousChildren[i], currentChildren[i], summary);
+    } else {
+      summary.added += markSubtreeAdded(currentChildren[i]);
+    }
+  }
+
+  for (let i = currentChildren.length; i < previousChildren.length; i++) {
+    summary.removed += countSubtree(previousChildren[i]);
+  }
+}
+
+/**
+ * Compute the per-frame diff between the [previous] and [current] hierarchy for a
+ * device and return a deep clone of the current hierarchy with added/changed
+ * nodes annotated (via the `diffState` attribute) plus a numeric [summary].
+ *
+ * The input is never mutated (the caller may keep [current] as the next
+ * baseline). When there is no baseline — first frame, or `previous`/either root
+ * node is absent — nothing is annotated and `summary.hasBaseline` is false.
+ */
+export function annotateHierarchyDiff(
+  previous: ViewHierarchyResult | null,
+  current: ViewHierarchyResult
+): HierarchyDiffResult {
+  const hierarchy = structuredClone(current);
+  const summary: HierarchyDiffSummary = {
+    hasBaseline: false,
+    added: 0,
+    changed: 0,
+    removed: 0,
+  };
+
+  const previousRoot = previous?.hierarchy?.node;
+  const currentRoot = hierarchy.hierarchy?.node;
+  if (!previousRoot || !currentRoot) {
+    return { hierarchy, summary };
+  }
+
+  summary.hasBaseline = true;
+  walk(previousRoot, currentRoot, summary);
+  return { hierarchy, summary };
+}

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -542,6 +542,58 @@ describe("DeviceDataStreamSocketServer", () => {
     });
   });
 
+  describe("hierarchy diff annotation", () => {
+    const frame = (text: string) =>
+      ({ hierarchy: { node: { $: { class: "Root" }, node: [{ $: { class: "Child", text } }] } } }) as any;
+
+    it("reports no baseline and annotates nothing on the first frame", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+
+      server.pushHierarchyUpdate("device-1", frame("a"));
+
+      const [message] = socket.getWrittenMessages<any>();
+      expect(message.type).toBe("hierarchy_update");
+      expect(message.hierarchyDiff).toEqual({ hasBaseline: false, added: 0, changed: 0, removed: 0 });
+      expect(message.data.hierarchy.node.node[0].$.diffState).toBeUndefined();
+    });
+
+    it("annotates changed nodes and summarizes the diff against the previous frame", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+
+      server.pushHierarchyUpdate("device-1", frame("a"));
+      server.pushHierarchyUpdate("device-1", frame("b"));
+
+      const messages = socket.getWrittenMessages<any>();
+      expect(messages).toHaveLength(2);
+      expect(messages[1].hierarchyDiff).toEqual({ hasBaseline: true, added: 0, changed: 1, removed: 0 });
+      expect(messages[1].data.hierarchy.node.node[0].$.diffState).toBe("changed");
+    });
+
+    it("resets the diff baseline when the device connection is lost", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-1" });
+
+      server.pushHierarchyUpdate("device-1", frame("a"));
+      server.onDeviceConnectionLost("device-1");
+      server.pushHierarchyUpdate("device-1", frame("b"));
+
+      // The post-reconnect frame is diffed against a fresh baseline, not the
+      // pre-drop tree, so it reports no baseline rather than a spurious change.
+      const messages = socket.getWrittenMessages<any>();
+      const hierarchyMessages = messages.filter(m => m.type === "hierarchy_update");
+      expect(hierarchyMessages[hierarchyMessages.length - 1].hierarchyDiff.hasBaseline).toBe(false);
+    });
+
+    it("does not mutate the caller's hierarchy when annotating", () => {
+      server.simulateSubscription({ deviceId: "device-1" });
+
+      server.pushHierarchyUpdate("device-1", frame("a"));
+      const second = frame("b");
+      server.pushHierarchyUpdate("device-1", second);
+
+      expect(second.hierarchy.node.node[0].$.diffState).toBeUndefined();
+    });
+  });
+
   describe("hasSubscriberForDevice", () => {
     it("returns false when there are no subscribers", () => {
       expect(server.hasSubscriberForDevice("device-1")).toBe(false);

--- a/test/daemon/hierarchyStreamDiff.test.ts
+++ b/test/daemon/hierarchyStreamDiff.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import {
+  annotateHierarchyDiff,
+  HIERARCHY_DIFF_STATE_KEY,
+} from "../../src/daemon/hierarchyStreamDiff";
+import type { ViewHierarchyNode, ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
+
+function node(
+  attrs: Record<string, unknown>,
+  children: ViewHierarchyNode[] = []
+): ViewHierarchyNode {
+  return children.length > 0 ? { $: attrs, node: children } : { $: attrs };
+}
+
+function hierarchy(root: ViewHierarchyNode): ViewHierarchyResult {
+  return { hierarchy: { node: root } };
+}
+
+/** Read the diff annotation stamped on a node's attributes, if any. */
+function diffState(n: ViewHierarchyNode | undefined): unknown {
+  return n?.$?.[HIERARCHY_DIFF_STATE_KEY];
+}
+
+describe("annotateHierarchyDiff", () => {
+  test("first frame has no baseline and annotates nothing", () => {
+    const current = hierarchy(node({ class: "Root" }, [node({ class: "Child", text: "a" })]));
+
+    const { hierarchy: out, summary } = annotateHierarchyDiff(null, current);
+
+    expect(summary).toEqual({ hasBaseline: false, added: 0, changed: 0, removed: 0 });
+    expect(diffState(out.hierarchy.node)).toBeUndefined();
+    expect(diffState(out.hierarchy.node?.node?.[0])).toBeUndefined();
+  });
+
+  test("unchanged frame annotates nothing but reports a baseline", () => {
+    const build = () => hierarchy(node({ class: "Root" }, [node({ class: "Child", text: "a" })]));
+
+    const { hierarchy: out, summary } = annotateHierarchyDiff(build(), build());
+
+    expect(summary).toEqual({ hasBaseline: true, added: 0, changed: 0, removed: 0 });
+    expect(diffState(out.hierarchy.node)).toBeUndefined();
+    expect(diffState(out.hierarchy.node?.node?.[0])).toBeUndefined();
+  });
+
+  test("a changed attribute marks the node changed", () => {
+    const previous = hierarchy(node({ class: "Root" }, [node({ class: "Child", text: "old" })]));
+    const current = hierarchy(node({ class: "Root" }, [node({ class: "Child", text: "new" })]));
+
+    const { hierarchy: out, summary } = annotateHierarchyDiff(previous, current);
+
+    expect(summary).toEqual({ hasBaseline: true, added: 0, changed: 1, removed: 0 });
+    expect(diffState(out.hierarchy.node)).toBeUndefined();
+    expect(diffState(out.hierarchy.node?.node?.[0])).toBe("changed");
+  });
+
+  test("a bounds change marks the node changed", () => {
+    const previous = hierarchy({ $: { class: "Root" }, bounds: { left: 0, top: 0, right: 10, bottom: 10 } });
+    const current = hierarchy({ $: { class: "Root" }, bounds: { left: 0, top: 0, right: 20, bottom: 10 } });
+
+    const { summary } = annotateHierarchyDiff(previous, current);
+
+    expect(summary.changed).toBe(1);
+  });
+
+  test("an added subtree is fully annotated and counted", () => {
+    const previous = hierarchy(node({ class: "Root" }, [node({ class: "A" })]));
+    const current = hierarchy(
+      node({ class: "Root" }, [node({ class: "A" }), node({ class: "B" }, [node({ class: "C" })])])
+    );
+
+    const { hierarchy: out, summary } = annotateHierarchyDiff(previous, current);
+
+    expect(summary).toEqual({ hasBaseline: true, added: 2, changed: 0, removed: 0 });
+    expect(diffState(out.hierarchy.node?.node?.[0])).toBeUndefined();
+    expect(diffState(out.hierarchy.node?.node?.[1])).toBe("added");
+    expect(diffState(out.hierarchy.node?.node?.[1]?.node?.[0])).toBe("added");
+  });
+
+  test("a removed subtree is counted but not annotated (it is gone)", () => {
+    const previous = hierarchy(
+      node({ class: "Root" }, [node({ class: "A" }), node({ class: "B" }, [node({ class: "C" })])])
+    );
+    const current = hierarchy(node({ class: "Root" }, [node({ class: "A" })]));
+
+    const { summary } = annotateHierarchyDiff(previous, current);
+
+    expect(summary).toEqual({ hasBaseline: true, added: 0, changed: 0, removed: 2 });
+  });
+
+  test("does not mutate the input current hierarchy", () => {
+    const previous = hierarchy(node({ class: "Root" }, [node({ class: "Child", text: "old" })]));
+    const current = hierarchy(node({ class: "Root" }, [node({ class: "Child", text: "new" })]));
+
+    annotateHierarchyDiff(previous, current);
+
+    expect(diffState(current.hierarchy.node?.node?.[0])).toBeUndefined();
+  });
+
+  test("no baseline when the current frame has no root node", () => {
+    const previous = hierarchy(node({ class: "Root" }));
+    const current: ViewHierarchyResult = { hierarchy: {} };
+
+    const { summary } = annotateHierarchyDiff(previous, current);
+
+    expect(summary.hasBaseline).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3758.

## What & why
The observation stream forwarded each hierarchy frame verbatim — the desktop layout inspector had no notion of what changed between frames. #3338's `observationDiff` metadata only rides the **agent-facing tool response** (`finalizeToolResponse`), never the stream socket, so there was nothing on the stream to model. Per the issue's follow-up decision, this expands scope to **emit** a per-frame diff on the stream and surface it on the desktop.

## Approach
The daemon computes a per-frame diff between consecutive hierarchies per device and annotates changed/added nodes **inline** in the hierarchy JSON (a `diffState` node attribute), plus a top-level summary. Putting the marker in the node's own attribute bag means there is **no cross-language node-identity contract** to keep in sync — the marker travels with the node through the existing parser.

### Daemon (TS)
- `src/daemon/hierarchyStreamDiff.ts` — pure, tested `annotateHierarchyDiff(previous, current)`: deep-clones the current frame, stamps `diffState: "added" | "changed"` on nodes, returns `{ hierarchy, summary }` (`hasBaseline` / `added` / `changed` / `removed`). Never mutates the input.
- `deviceDataStreamSocketServer.pushHierarchyUpdate` keeps a per-device baseline, annotates each frame, and attaches `hierarchyDiff` to the `hierarchy_update` message. The diff work is **skipped when no subscriber is listening** (the inspector is usually closed), and the baseline is dropped on connection loss / while unsubscribed so a re-subscribe diffs from a fresh frame rather than a stale pre-drop tree.

### Desktop (Kotlin)
- `NodeDiffState` enum + nullable `UIElementInfo.diffState`, parsed by `HierarchyParser` (unknown/absent maps to `null`, renders unchanged).
- Typed `HierarchyDiffSummary` on `ObservationStreamClient` (`hierarchy_update` to `HierarchyStreamUpdate.diff`).
- A subtle background tint + inline marker for added/changed nodes in `HierarchyTreeView`.

## Acceptance criteria
1. Diff metadata is parsed into a typed model (`NodeDiffState`, `HierarchyDiffSummary`), not raw JSON.
2. Changed nodes are visually distinguishable in the tree; absent metadata renders cleanly.
3. Tests cover parsing with and without diff metadata present.

## Tests
- TS: `hierarchyStreamDiff.test.ts` (first-frame / unchanged / changed / bounds-change / added subtree / removed subtree / no-mutation / no-root) and `deviceDataStreamSocketServer.test.ts` (annotation rides the message, baseline reset on connection loss, no caller mutation).
- Kotlin: `HierarchyParserDiffStateTest` (added/changed/absent/unknown) and `ObservationStreamClientTest` (summary present/absent).

## Follow-up
The stream differ matches nodes positionally (documented), so a list scroll re-reports shifted rows as changed — noisier than the content-identity diff engine in `src/features/observe/output/ObserveResultOutput.ts`. Reusing that engine here is captured as a separate follow-up (out of scope here: it requires exporting internals of a critical agent-facing module).

## Notes
- The issue lists "changing what the daemon emits" as out of scope; that was expanded deliberately per the decision to surface diffs on the stream.
- The signature join in the differ uses a NUL separator written as a \\u0000 escape (matching the repo's existing `nodeKey` NUL-join convention) so the source stays plain text.
