### PR TITLE
ci(desktop): add workflow to record screenshot baselines on Linux (#3752)

### DIFF
--- a/.github/workflows/record-screenshot-baselines.yml
+++ b/.github/workflows/record-screenshot-baselines.yml
@@ -1,0 +1,117 @@
+---
+name: Record Desktop Screenshot Baselines
+
+# Records the desktop-core Compose screenshot baselines on the reference OS
+# (Linux) and opens a PR with the PNGs. Screenshots are pixel-identical only on
+# one OS because font rasterization differs, so baselines cannot be recorded on a
+# developer's macOS/Windows machine and committed — they must be produced here,
+# on the same ubuntu-latest image (and JDK/font stack) that the
+# `desktop-core-unit-tests` job verifies them against. This is a manual,
+# on-demand job: run it from the Actions tab, review the PNGs in the resulting
+# PR, and merge.
+
+"on":
+  workflow_dispatch:
+    inputs:
+      test_filter:
+        description: "Gradle --tests pattern for the screenshot tests to record"
+        required: true
+        type: string
+        default: "*ComponentScreenshotTest"
+      unpend:
+        description: "Drop `pending = true` from recorded tests so they become active checks"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize record runs so two dispatches can't race to push baseline branches.
+concurrency:
+  group: record-screenshot-baselines
+  cancel-in-progress: false
+
+jobs:
+  record:
+    name: "Record baselines (Linux reference OS)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          # Admin token so the recorded-baselines branch can be pushed and a PR
+          # opened; the PR itself is reviewed by a human (visual artifacts).
+          token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
+
+      - name: "Record baselines (-Dscreenshot.record=true)"
+        uses: ./.github/actions/gradle-task-run
+        with:
+          gradle-tasks: ":desktop-core:test"
+          # --rerun-tasks forces the tests to actually execute (record mode) even
+          # when Gradle would otherwise consider them up to date.
+          gradle-flags: '["--tests", "${{ inputs.test_filter }}", "-Dscreenshot.record=true", "--rerun-tasks"]'
+          gradle-project-directory: "android"
+          gradle-home-directory: "~/.gradle/${{ github.job }}"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Un-pend recorded tests"
+        if: ${{ inputs.unpend }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/*ScreenshotTest.kt)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No screenshot test files found to un-pend."
+          else
+            scripts/screenshot/unpend_screenshot_tests.sh "${files[@]}"
+          fi
+
+      - name: "Verify baselines pass in normal mode"
+        uses: ./.github/actions/gradle-task-run
+        with:
+          gradle-tasks: ":desktop-core:test"
+          gradle-flags: '["--tests", "${{ inputs.test_filter }}", "--rerun-tasks"]'
+          gradle-project-directory: "android"
+          gradle-home-directory: "~/.gradle/${{ github.job }}"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Open PR with recorded baselines"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add android/desktop-core/src/test/resources/screenshots/ \
+                  android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/
+
+          if git diff --cached --quiet; then
+            echo "::notice::No baseline changes to commit — the committed baselines already match."
+            exit 0
+          fi
+
+          branch="chore/record-screenshot-baselines-${GITHUB_RUN_ID}"
+          git switch -c "$branch"
+          # No [skip ci]: the PR's desktop-core-unit-tests job re-verifies the
+          # recorded baselines on a fresh runner.
+          git commit -m "test(desktop): record screenshot baselines"
+          git push origin "$branch"
+
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "test(desktop): record screenshot baselines" \
+            --body "Automated screenshot baseline recording from the \`Record Desktop Screenshot Baselines\` workflow (run \`${GITHUB_RUN_ID}\`, filter \`${{ inputs.test_filter }}\`).
+
+          Recorded on \`ubuntu-latest\` (the reference OS). **Review the PNGs visually** before merging — they are the source of truth for future screenshot comparisons.
+
+          Baselines verified against the tests in normal mode within the recording job."

--- a/android/docs/screenshot-testing.md
+++ b/android/docs/screenshot-testing.md
@@ -38,7 +38,21 @@ Guidelines:
 ## Recording baselines
 
 Baselines live in `desktop-core/src/test/resources/screenshots/` and are committed to git (excluded
-from Git LFS in `.gitattributes`). Record or update them with `-Dscreenshot.record=true`:
+from Git LFS in `.gitattributes`). They must be recorded on the **reference OS (Linux)** — a baseline
+recorded on macOS or Windows will not be pixel-identical to what CI verifies (see the cross-platform
+note below), so it would fail the `desktop-core-unit-tests` job even though it looks correct locally.
+
+### Recommended: record on CI (any developer, any OS)
+
+Run the **`Record Desktop Screenshot Baselines`** workflow from the Actions tab
+(`.github/workflows/record-screenshot-baselines.yml`). It records the baselines on `ubuntu-latest`
+with `-Dscreenshot.record=true`, un-pends the recorded tests
+(`scripts/screenshot/unpend_screenshot_tests.sh`), verifies they pass in normal mode, and opens a PR
+with the PNGs. **Review the images in that PR** before merging — they are the source of truth for
+future comparisons. Inputs: `test_filter` (default `*ComponentScreenshotTest`) and `unpend` (default
+true).
+
+### Local (only on a Linux machine)
 
 ```bash
 # All screenshot baselines

--- a/scripts/screenshot/unpend_screenshot_tests.sh
+++ b/scripts/screenshot/unpend_screenshot_tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# unpend_screenshot_tests.sh — drop the `pending = true` argument from
+# `screenshotTest(...)` calls so a recorded baseline turns a placeholder test
+# into an active verification check.
+#
+# A screenshot test is authored `screenshotTest("name", pending = true) { … }`
+# while its baseline PNG does not exist yet: pending tests are skipped in verify
+# mode (so CI can't fail on the missing baseline) but still run in record mode.
+# Once the record job (see .github/workflows/record-screenshot-baselines.yml) has
+# written the baselines, this script removes the `pending = true` argument in the
+# same change, so the test becomes a real check. It is idempotent — running it on
+# an already-un-pended file is a no-op — and edits files in place.
+#
+# Usage: unpend_screenshot_tests.sh <file.kt> [<file.kt> ...]
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <file.kt> [<file.kt> ...]" >&2
+  exit 2
+fi
+
+changed=0
+for file in "$@"; do
+  if [[ ! -f "$file" ]]; then
+    echo "error: not a file: $file" >&2
+    exit 1
+  fi
+
+  backup="$file.unpend.bak"
+  cp "$file" "$backup"
+  # Remove the `pending = true` named argument in either comma position:
+  #   screenshotTest("n", pending = true)  -> screenshotTest("n")
+  #   screenshotTest(pending = true, "n")  -> screenshotTest("n")
+  # -0 slurps the whole file so a match can span the reformatted line breaks
+  # ktfmt may introduce; whitespace around `=` and the comma is tolerated. Only
+  # `= true` is removed; `pending = false` (if ever used) is left alone.
+  perl -0pi -e 's/\s*,\s*pending\s*=\s*true//g; s/pending\s*=\s*true\s*,\s*//g' "$file"
+
+  if cmp -s "$file" "$backup"; then
+    echo "no pending tests: $file"
+  else
+    echo "un-pended: $file"
+    changed=1
+  fi
+  rm -f "$backup"
+done
+
+if [[ "$changed" -eq 0 ]]; then
+  echo "No screenshot tests were pending."
+fi

--- a/test/bats/unpend-screenshot-tests.bats
+++ b/test/bats/unpend-screenshot-tests.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/screenshot/unpend_screenshot_tests.sh — the helper the
+# record-screenshot-baselines workflow runs to turn recorded placeholder tests
+# into active checks by dropping `pending = true`. The removal must be precise
+# (only `= true`, only the `pending` arg), idempotent, and byte-preserving apart
+# from the removed text, so a follow-up ktfmt pass produces no spurious churn.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/screenshot/unpend_screenshot_tests.sh"
+  TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+@test "removes trailing pending argument" {
+  printf 'x = screenshotTest("light", pending = true) {\n' > "$TEST_DIR/T.kt"
+  run "$SCRIPT" "$TEST_DIR/T.kt"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_DIR/T.kt")" = 'x = screenshotTest("light") {' ]
+}
+
+@test "removes leading pending argument" {
+  printf 'x = screenshotTest(pending = true, "light") {\n' > "$TEST_DIR/T.kt"
+  run "$SCRIPT" "$TEST_DIR/T.kt"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_DIR/T.kt")" = 'x = screenshotTest("light") {' ]
+}
+
+@test "leaves an already-active test untouched" {
+  printf 'x = screenshotTest("light") {\n' > "$TEST_DIR/T.kt"
+  run "$SCRIPT" "$TEST_DIR/T.kt"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_DIR/T.kt")" = 'x = screenshotTest("light") {' ]
+  [[ "$output" == *"no pending tests"* ]]
+}
+
+@test "is idempotent" {
+  printf 'x = screenshotTest("light", pending = true) {\n' > "$TEST_DIR/T.kt"
+  "$SCRIPT" "$TEST_DIR/T.kt"
+  first="$(cat "$TEST_DIR/T.kt")"
+  "$SCRIPT" "$TEST_DIR/T.kt"
+  [ "$(cat "$TEST_DIR/T.kt")" = "$first" ]
+}
+
+@test "does not touch pending = false" {
+  printf 'x = screenshotTest("light", pending = false) {\n' > "$TEST_DIR/T.kt"
+  run "$SCRIPT" "$TEST_DIR/T.kt"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_DIR/T.kt")" = 'x = screenshotTest("light", pending = false) {' ]
+}
+
+@test "preserves the trailing newline (no ktfmt churn)" {
+  printf 'a\nx = screenshotTest("light", pending = true) {\nb\n' > "$TEST_DIR/T.kt"
+  "$SCRIPT" "$TEST_DIR/T.kt"
+  # Last byte must remain a newline.
+  [ "$(tail -c1 "$TEST_DIR/T.kt" | od -An -tx1 | tr -d ' ')" = "0a" ]
+}
+
+@test "un-pends multiple cases across the file" {
+  cat > "$TEST_DIR/T.kt" <<'EOF'
+fun a() = screenshotTest("a", pending = true) {}
+fun b() = screenshotTest("b", pending = true) {}
+fun c() = screenshotTest("c") {}
+EOF
+  run "$SCRIPT" "$TEST_DIR/T.kt"
+  [ "$status" -eq 0 ]
+  run grep -c "pending = true" "$TEST_DIR/T.kt"
+  [ "$output" = "0" ]
+}
+
+@test "fails on a missing file" {
+  run "$SCRIPT" "$TEST_DIR/nope.kt"
+  [ "$status" -ne 0 ]
+}
+
+@test "errors with usage when given no arguments" {
+  run "$SCRIPT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"usage:"* ]]
+}


### PR DESCRIPTION
Addresses #3752 (part 1: infrastructure to record baselines; the baselines themselves are produced by running the new workflow after this merges).

## Problem
The desktop-core screenshot harness (#3746) shipped `screenshotTest(...)`, the comparator, and example tests, but **no baseline PNGs** — the examples are `pending = true` (skipped in verify mode). Baselines couldn't be recorded because screenshots are pixel-identical only on the **reference OS (Linux)**: a baseline recorded on a developer's macOS/Windows machine would fail the `desktop-core-unit-tests` job (which runs on `ubuntu-latest`) even though it looks correct locally. So there was no path for a non-Linux developer to record and commit valid baselines.

## Solution
A manual **`workflow_dispatch`** job that records baselines on the reference OS and opens a PR with them.

### `.github/workflows/record-screenshot-baselines.yml`
Runs on `ubuntu-latest`. Steps:
1. **Record** — `:desktop-core:test --tests <filter> -Dscreenshot.record=true --rerun-tasks`, via the same `gradle-task-run` composite the `desktop-core-unit-tests` job uses, so the recording JDK/font stack is identical to what verifies the baselines (critical for pixel parity).
2. **Un-pend** — runs `scripts/screenshot/unpend_screenshot_tests.sh` so recorded tests become active checks (skippable via the `unpend` input).
3. **Verify** — re-runs the tests in normal mode to confirm the fresh baselines pass before opening a PR.
4. **Open PR** — commits the PNGs + un-pended tests on a branch and opens a PR (via `AUTO_MOBILE_PR_TOKEN`) for **visual review**. No `[skip ci]`, so the PR's `desktop-core-unit-tests` job re-verifies on a clean runner.

Inputs: `test_filter` (default `*ComponentScreenshotTest`), `unpend` (default true). Serialized via a `concurrency` group.

### `scripts/screenshot/unpend_screenshot_tests.sh`
Precise, idempotent, byte-preserving removal of the `pending = true` argument from `screenshotTest(...)` calls (handles either comma position; leaves `pending = false` alone; preserves the trailing newline so a follow-up ktfmt pass produces no churn). Extracted into a script — rather than an inline YAML `sed` — so it is shellcheck-clean and unit-testable.

### Tests & docs
- `test/bats/unpend-screenshot-tests.bats` — 9 cases (comma positions, already-active no-op, idempotency, `pending = false` untouched, trailing-newline preservation, multi-case, missing file, no-args usage).
- `android/docs/screenshot-testing.md` — makes the CI workflow the canonical recording path and marks the local `-Dscreenshot.record=true` command as Linux-only.

## Validation
- `actionlint` clean (only the pre-existing `gradle-task-run` action-metadata note that fires on every workflow using it).
- `all_fast_validate_checks.sh --only shellcheck,shell-portability,shell-sete,yaml` → all pass.
- BATS: 9/9 pass.

## After merge
Run the **`Record Desktop Screenshot Baselines`** workflow from the Actions tab to produce the actual baseline PNGs; review the images in the PR it opens, then merge. That completes #3752's "record the starter baselines" goal. Growing coverage beyond the starter set (issue part 3) is left as normal follow-up: add `screenshotTest(name, pending = true)` cases, then re-run the workflow.
