### PR TITLE
ci(release): wire videoJarSha256 into checksum tooling + nightly (#3833)

### DIFF
--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -1,0 +1,57 @@
+name: "Build video-server jar"
+
+# Builds the persistent on-device H.264 encoder DEX (`automobile-video.jar`,
+# #3776) via `./gradlew :video-server:d8Dex` and uploads it as a CI artifact.
+# Shared by nightly.yml (drift detection → checksum PR) and release.yml (attach
+# to the GitHub release), so both compute the sha256 from the SAME build — a
+# divergent build would record a nightly sha the release cannot reproduce (the
+# #3784 failure class). Reproducibility rests on the pinned toolchain: JDK 21
+# (installed by the gradle-task-run composite) + buildToolsVersion from
+# libs.versions, exactly as the CtrlProxy APK build.
+on:
+  workflow_call:
+    secrets:
+      GRADLE_ENCRYPTION_KEY:
+        required: true
+    outputs:
+      sha256:
+        description: "SHA256 checksum of the built automobile-video.jar"
+        value: ${{ jobs.build.outputs.sha256 }}
+
+jobs:
+  build:
+    name: "Build video-server jar"
+    runs-on: ubuntu-latest
+    outputs:
+      sha256: ${{ steps.checksum.outputs.sha256 }}
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - uses: ./.github/actions/gradle-task-run
+        with:
+          gradle-tasks: ":video-server:d8Dex"
+          gradle-project-directory: "android"
+          gradle-home-directory: "~/.gradle/build-video-server-jar"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: "Calculate jar SHA256"
+        id: checksum
+        run: |
+          JAR_PATH="android/video-server/build/libs/automobile-video.jar"
+          SHA256=$(sha256sum "$JAR_PATH" | cut -d' ' -f1)
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "video-server jar SHA256: $SHA256"
+
+      - name: "Copy jar to /tmp"
+        run: cp android/video-server/build/libs/automobile-video.jar /tmp/automobile-video.jar
+
+      - name: "Upload video-server jar"
+        uses: actions/upload-artifact@v6
+        with:
+          name: video-server-jar
+          path: /tmp/automobile-video.jar
+          retention-days: 7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,10 +24,15 @@ jobs:
   build-ctrl-proxy-ios-ipa:
     uses: ./.github/workflows/build-ctrl-proxy-ios-ipa.yml
 
+  build-video-server-jar:
+    uses: ./.github/workflows/build-video-server-jar.yml
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
   update-sha256:
     name: "Update SHA256 Checksums"
     runs-on: ubuntu-latest
-    needs: [build-control-proxy-apk, build-ctrl-proxy-ios-ipa]
+    needs: [build-control-proxy-apk, build-ctrl-proxy-ios-ipa, build-video-server-jar]
     steps:
       - name: "Git Checkout"
         uses: actions/checkout@v6
@@ -46,11 +51,20 @@ jobs:
           name: ctrl-proxy-ios-ipa
           path: /tmp
 
+      - name: "Download video-server jar artifact"
+        uses: actions/download-artifact@v7
+        with:
+          name: video-server-jar
+          path: /tmp
+
       - name: "Verify APK SHA256"
         run: bash scripts/ci/verify-transit-sha256.sh /tmp/control-proxy-debug.apk "${{ needs.build-control-proxy-apk.outputs.sha256 }}"
 
       - name: "Verify IPA SHA256"
         run: bash scripts/ci/verify-transit-sha256.sh /tmp/control-proxy.ipa "${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}"
+
+      - name: "Verify video-server jar SHA256"
+        run: bash scripts/ci/verify-transit-sha256.sh /tmp/automobile-video.jar "${{ needs.build-video-server-jar.outputs.sha256 }}"
 
       - name: "Get current SHA256 values from source"
         id: current
@@ -70,12 +84,15 @@ jobs:
           APK_CURRENT=$(read_registry_field apkSha256 "$RELEASE_TS" nightly)
           IPA_CURRENT=$(read_registry_field ipaSha256 "$RELEASE_TS" nightly)
           RUNNER_CURRENT=$(read_registry_field runnerSha256 "$RELEASE_TS" nightly)
+          VIDEO_JAR_CURRENT=$(read_registry_field videoJarSha256 "$RELEASE_TS" nightly)
           echo "apk_sha256=$APK_CURRENT" >> $GITHUB_OUTPUT
           echo "ipa_sha256=$IPA_CURRENT" >> $GITHUB_OUTPUT
           echo "runner_sha256=$RUNNER_CURRENT" >> $GITHUB_OUTPUT
+          echo "video_jar_sha256=$VIDEO_JAR_CURRENT" >> $GITHUB_OUTPUT
           echo "Current APK SHA256: ${APK_CURRENT:-(empty)}"
           echo "Current IPA SHA256: ${IPA_CURRENT:-(empty)}"
           echo "Current iOS runner SHA256: ${RUNNER_CURRENT:-(empty)}"
+          echo "Current video-server jar SHA256: ${VIDEO_JAR_CURRENT:-(empty)}"
 
       - name: "Check if updates needed"
         id: check
@@ -86,10 +103,13 @@ jobs:
           OLD_IPA="${{ steps.current.outputs.ipa_sha256 }}"
           NEW_RUNNER="${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}"
           OLD_RUNNER="${{ steps.current.outputs.runner_sha256 }}"
+          NEW_VIDEO_JAR="${{ needs.build-video-server-jar.outputs.sha256 }}"
+          OLD_VIDEO_JAR="${{ steps.current.outputs.video_jar_sha256 }}"
 
           APK_CHANGED="false"
           IPA_CHANGED="false"
           RUNNER_CHANGED="false"
+          VIDEO_JAR_CHANGED="false"
 
           if [ "$NEW_APK" != "$OLD_APK" ]; then
             APK_CHANGED="true"
@@ -122,11 +142,21 @@ jobs:
             echo "iOS runner SHA256 unchanged"
           fi
 
+          if [ "$NEW_VIDEO_JAR" != "$OLD_VIDEO_JAR" ]; then
+            VIDEO_JAR_CHANGED="true"
+            echo "video-server jar SHA256 changed"
+            echo "  Previous: ${OLD_VIDEO_JAR:-(empty)}"
+            echo "  New:      $NEW_VIDEO_JAR"
+          else
+            echo "video-server jar SHA256 unchanged"
+          fi
+
           echo "apk_changed=$APK_CHANGED" >> $GITHUB_OUTPUT
           echo "ipa_changed=$IPA_CHANGED" >> $GITHUB_OUTPUT
           echo "runner_changed=$RUNNER_CHANGED" >> $GITHUB_OUTPUT
+          echo "video_jar_changed=$VIDEO_JAR_CHANGED" >> $GITHUB_OUTPUT
 
-          if [ "$APK_CHANGED" = "true" ] || [ "$IPA_CHANGED" = "true" ] || [ "$RUNNER_CHANGED" = "true" ]; then
+          if [ "$APK_CHANGED" = "true" ] || [ "$IPA_CHANGED" = "true" ] || [ "$RUNNER_CHANGED" = "true" ] || [ "$VIDEO_JAR_CHANGED" = "true" ]; then
             echo "needed=true" >> $GITHUB_OUTPUT
           else
             echo "needed=false" >> $GITHUB_OUTPUT
@@ -138,31 +168,34 @@ jobs:
           APK_SHA256_CHECKSUM: ${{ needs.build-control-proxy-apk.outputs.sha256 }}
           IOS_CTRL_PROXY_SHA256_CHECKSUM: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}
           IOS_CTRL_PROXY_RUNNER_SHA256: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
+          VIDEO_JAR_SHA256: ${{ needs.build-video-server-jar.outputs.sha256 }}
         run: bash scripts/generate-release-constants.sh
 
       - name: "Build PR title"
         if: steps.check.outputs.needed == 'true'
         id: pr-title
         run: |
-          APK_CHANGED="${{ steps.check.outputs.apk_changed }}"
-          IPA_CHANGED="${{ steps.check.outputs.ipa_changed }}"
-          RUNNER_CHANGED="${{ steps.check.outputs.runner_changed }}"
+          # Assemble the title from the list of changed artifacts. A list scales
+          # to N artifacts (the old nested elif chain was already 7 branches for
+          # 3 artifacts; a 4th would need 15) and never mis-titles a single-jar
+          # change as an IPA change.
+          changed=()
+          [ "${{ steps.check.outputs.apk_changed }}" = "true" ] && changed+=("CtrlProxy APK")
+          [ "${{ steps.check.outputs.ipa_changed }}" = "true" ] && changed+=("CtrlProxy iOS IPA")
+          [ "${{ steps.check.outputs.runner_changed }}" = "true" ] && changed+=("iOS runner")
+          [ "${{ steps.check.outputs.video_jar_changed }}" = "true" ] && changed+=("video-server jar")
 
-          if [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256" >> "$GITHUB_OUTPUT"
-          elif [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256" >> "$GITHUB_OUTPUT"
-          elif [ "$APK_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256" >> "$GITHUB_OUTPUT"
-          elif [ "$IPA_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy iOS IPA and iOS runner SHA256" >> "$GITHUB_OUTPUT"
-          elif [ "$APK_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy APK SHA256" >> "$GITHUB_OUTPUT"
-          elif [ "$RUNNER_CHANGED" = "true" ]; then
-            echo "title=chore: update CtrlProxy iOS runner SHA256" >> "$GITHUB_OUTPUT"
+          count=${#changed[@]}
+          if [ "$count" -eq 1 ]; then
+            list="${changed[0]}"
+          elif [ "$count" -eq 2 ]; then
+            list="${changed[0]} and ${changed[1]}"
           else
-            echo "title=chore: update CtrlProxy iOS IPA SHA256" >> "$GITHUB_OUTPUT"
+            # Oxford-comma join: "a, b, and c".
+            last="${changed[$((count - 1))]}"
+            list="$(IFS=, ; echo "${changed[*]:0:$((count - 1))}" | sed 's/,/, /g'), and ${last}"
           fi
+          echo "title=chore: update ${list} SHA256" >> "$GITHUB_OUTPUT"
 
       - name: "Create PR for SHA256 update"
         if: steps.check.outputs.needed == 'true'
@@ -176,6 +209,7 @@ jobs:
             APK: ${{ steps.current.outputs.apk_sha256 || '(empty)' }} -> ${{ needs.build-control-proxy-apk.outputs.sha256 }}${{ steps.check.outputs.apk_changed == 'true' && ' (changed)' || ' (unchanged)' }}
             IPA: ${{ steps.current.outputs.ipa_sha256 || '(empty)' }} -> ${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}${{ steps.check.outputs.ipa_changed == 'true' && ' (changed)' || ' (unchanged)' }}
             iOS Runner: ${{ steps.current.outputs.runner_sha256 || '(empty)' }} -> ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}${{ steps.check.outputs.runner_changed == 'true' && ' (changed)' || ' (unchanged)' }}
+            video-server jar: ${{ steps.current.outputs.video_jar_sha256 || '(empty)' }} -> ${{ needs.build-video-server-jar.outputs.sha256 }}${{ steps.check.outputs.video_jar_changed == 'true' && ' (changed)' || ' (unchanged)' }}
           title: ${{ steps.pr-title.outputs.title }}
           body: |
             ## Automated Checksum Update
@@ -187,11 +221,12 @@ jobs:
             | **APK** | `${{ steps.current.outputs.apk_sha256 || '(empty)' }}` | `${{ needs.build-control-proxy-apk.outputs.sha256 }}` | ${{ steps.check.outputs.apk_changed == 'true' && '✅ Yes' || 'No' }} |
             | **IPA** | `${{ steps.current.outputs.ipa_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}` | ${{ steps.check.outputs.ipa_changed == 'true' && '✅ Yes' || 'No' }} |
             | **iOS Runner** | `${{ steps.current.outputs.runner_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}` | ${{ steps.check.outputs.runner_changed == 'true' && '✅ Yes' || 'No' }} |
+            | **video-server jar** | `${{ steps.current.outputs.video_jar_sha256 || '(empty)' }}` | `${{ needs.build-video-server-jar.outputs.sha256 }}` | ${{ steps.check.outputs.video_jar_changed == 'true' && '✅ Yes' || 'No' }} |
 
             ### Why did this happen?
 
             SHA256 checksums change when any of these change:
-            - Source code in `android/control-proxy/src/` or `ios/control-proxy/`
+            - Source code in `android/control-proxy/src/`, `android/video-server/src/`, or `ios/control-proxy/`
             - Build configuration (`build.gradle.kts` or `project.yml`)
             - Dependencies or SDK versions
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,27 +175,33 @@ jobs:
         if: steps.check.outputs.needed == 'true'
         id: pr-title
         run: |
-          # Assemble the title from the list of changed artifacts. A list scales
-          # to N artifacts (the old nested elif chain was already 7 branches for
-          # 3 artifacts; a 4th would need 15) and never mis-titles a single-jar
-          # change as an IPA change.
-          changed=()
-          [ "${{ steps.check.outputs.apk_changed }}" = "true" ] && changed+=("CtrlProxy APK")
-          [ "${{ steps.check.outputs.ipa_changed }}" = "true" ] && changed+=("CtrlProxy iOS IPA")
-          [ "${{ steps.check.outputs.runner_changed }}" = "true" ] && changed+=("iOS runner")
-          [ "${{ steps.check.outputs.video_jar_changed }}" = "true" ] && changed+=("video-server jar")
+          APK_CHANGED="${{ steps.check.outputs.apk_changed }}"
+          IPA_CHANGED="${{ steps.check.outputs.ipa_changed }}"
+          RUNNER_CHANGED="${{ steps.check.outputs.runner_changed }}"
 
-          count=${#changed[@]}
-          if [ "$count" -eq 1 ]; then
-            list="${changed[0]}"
-          elif [ "$count" -eq 2 ]; then
-            list="${changed[0]} and ${changed[1]}"
+          # The CtrlProxy artifact titles are matched EXACTLY by the sha256-only PR
+          # classifier in pull_request.yml (which skips heavy CI for these). Keep
+          # these strings verbatim. When the video-server jar also changed it is
+          # reflected in the PR body table below; only the jar-ONLY case gets its
+          # own title (also registered in the pull_request.yml classifier).
+          if [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$APK_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$IPA_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy iOS IPA and iOS runner SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$APK_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy APK SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$RUNNER_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy iOS runner SHA256" >> "$GITHUB_OUTPUT"
+          elif [ "$IPA_CHANGED" = "true" ]; then
+            echo "title=chore: update CtrlProxy iOS IPA SHA256" >> "$GITHUB_OUTPUT"
           else
-            # Oxford-comma join: "a, b, and c".
-            last="${changed[$((count - 1))]}"
-            list="$(IFS=, ; echo "${changed[*]:0:$((count - 1))}" | sed 's/,/, /g'), and ${last}"
+            # Only the video-server jar changed (no CtrlProxy artifact did).
+            echo "title=chore: update video-server jar SHA256" >> "$GITHUB_OUTPUT"
           fi
-          echo "title=chore: update ${list} SHA256" >> "$GITHUB_OUTPUT"
 
       - name: "Create PR for SHA256 update"
         if: steps.check.outputs.needed == 'true'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -111,6 +111,7 @@ jobs:
             const titleMatches = pr.title === 'chore: update CtrlProxy APK SHA256' ||
                                  pr.title === 'chore: update CtrlProxy iOS IPA SHA256' ||
                                  pr.title === 'chore: update CtrlProxy iOS runner SHA256' ||
+                                 pr.title === 'chore: update video-server jar SHA256' ||
                                  pr.title === 'chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256' ||
                                  pr.title === 'chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256' ||
                                  pr.title === 'chore: update CtrlProxy iOS IPA and iOS runner SHA256' ||

--- a/scripts/ci/verify-artifact-sha256.sh
+++ b/scripts/ci/verify-artifact-sha256.sh
@@ -4,12 +4,13 @@
 #
 # Usage: verify-artifact-sha256.sh <artifact-path> <platform>
 #
-# Platform is "android" or "ios", which selects apkSha256 or ipaSha256
-# from the first (newest) registry entry.
+# Platform is "android", "ios", or "videojar", which selects apkSha256,
+# ipaSha256, or videoJarSha256 from the first (newest) registry entry.
 #
 # Example:
 #   verify-artifact-sha256.sh /tmp/control-proxy-debug.apk android
 #   verify-artifact-sha256.sh /tmp/control-proxy.ipa ios
+#   verify-artifact-sha256.sh /tmp/automobile-video.jar videojar
 set -euo pipefail
 
 # shellcheck source=scripts/lib/read-registry-field.sh disable=SC1091
@@ -47,8 +48,10 @@ if [ "$PLATFORM" = "android" ]; then
   FIELD="apkSha256"
 elif [ "$PLATFORM" = "ios" ]; then
   FIELD="ipaSha256"
+elif [ "$PLATFORM" = "videojar" ]; then
+  FIELD="videoJarSha256"
 else
-  echo "ERROR: Platform must be 'android' or 'ios', got '$PLATFORM'"
+  echo "ERROR: Platform must be 'android', 'ios', or 'videojar', got '$PLATFORM'"
   exit 1
 fi
 

--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -8,6 +8,7 @@ apk_checksum="${APK_SHA256_CHECKSUM:-}"
 ios_checksum="${IOS_CTRL_PROXY_SHA256_CHECKSUM:-}"
 ios_app_hash="${IOS_CTRL_PROXY_APP_HASH:-}"
 ios_runner_sha256="${IOS_CTRL_PROXY_RUNNER_SHA256:-}"
+video_jar_checksum="${VIDEO_JAR_SHA256:-}"
 
 max_registry_entries=100
 
@@ -16,7 +17,7 @@ max_registry_entries=100
 #   - Checksums only (no version): update registry[0] checksums in place
 #   - Nothing set: no-op
 has_checksums=false
-if [ -n "$apk_checksum" ] || [ -n "$ios_checksum" ]; then
+if [ -n "$apk_checksum" ] || [ -n "$ios_checksum" ] || [ -n "$video_jar_checksum" ]; then
   has_checksums=true
 fi
 
@@ -47,6 +48,12 @@ fi
 if [ -n "$ios_runner_sha256" ] && ! [[ "$ios_runner_sha256" =~ ^[a-f0-9]{64}$ ]]; then
   echo "ERROR: IOS_CTRL_PROXY_RUNNER_SHA256 must be a valid SHA256 hash (64 hex characters)"
   echo "   Got: ${ios_runner_sha256}"
+  exit 1
+fi
+
+if [ -n "$video_jar_checksum" ] && ! [[ "$video_jar_checksum" =~ ^[a-f0-9]{64}$ ]]; then
+  echo "ERROR: VIDEO_JAR_SHA256 must be a valid SHA256 hash (64 hex characters)"
+  echo "   Got: ${video_jar_checksum}"
   exit 1
 fi
 
@@ -158,6 +165,7 @@ if [ -n "$release_version" ]; then
     apkSha256: \"${apk_checksum}\",
     ipaSha256: \"${ios_checksum}\",
     runnerSha256: \"${ios_runner_sha256}\",
+    videoJarSha256: \"${video_jar_checksum}\",
   },"
 
     # Prepend new entry after the opening bracket of RELEASE_CHECKSUM_REGISTRY
@@ -173,7 +181,14 @@ if [ -n "$release_version" ]; then
       for ((i = 0; i < excess; i++)); do
         last_version_line=$(grep -nE 'version: "[0-9]' "$tmp_file" | tail -1 | cut -d: -f1)
         start_line=$((last_version_line - 1))
-        end_line=$((last_version_line + 4))
+        # Delete from the entry's opening `{` through its closing `},`. The
+        # entry line count is NOT fixed — it grew from apk/ipa/runner to include
+        # an optional videoJarSha256 (#3833) — so anchor the end on the first
+        # `  },` at/after the version line instead of a hardcoded offset, or the
+        # cap orphans a dangling `},` for a longer entry.
+        rel_close=$(awk 'NR>=start && /^[[:space:]]*},[[:space:]]*$/ {print NR; exit}' \
+          start="$last_version_line" "$tmp_file")
+        end_line="${rel_close:-$((last_version_line + 4))}"
         sed_inplace "${start_line},${end_line}d" "$tmp_file"
       done
     fi
@@ -207,12 +222,19 @@ else
     update_registry_field "$tmp_file" "nightly" "runnerSha256" "$ios_runner_sha256"
   fi
 
+  if [ -n "$video_jar_checksum" ]; then
+    update_registry_field "$tmp_file" "nightly" "videoJarSha256" "$video_jar_checksum"
+  fi
+
   echo "Updated release constants:"
   if [ -n "$apk_checksum" ]; then
     echo "   APK checksum (nightly): ${apk_checksum}"
   fi
   if [ -n "$ios_checksum" ]; then
     echo "   iOS checksum (nightly): ${ios_checksum}"
+  fi
+  if [ -n "$video_jar_checksum" ]; then
+    echo "   video-server jar checksum (nightly): ${video_jar_checksum}"
   fi
 fi
 
@@ -227,6 +249,18 @@ if [ -n "$ios_runner_sha256" ]; then
     update_registry_field "$tmp_file" "$release_version" "runnerSha256" "$ios_runner_sha256"
   fi
   echo "   iOS runner SHA256: ${ios_runner_sha256}"
+fi
+
+if [ -n "$video_jar_checksum" ]; then
+  # In new-entry release mode the template above already carries videoJarSha256;
+  # this refreshes it for the already-registered-version path (prepare-release
+  # added the entry first) — mirroring how runnerSha256 is refreshed. The
+  # update_registry_field fallback inserts the field for older entries that
+  # predate videoJarSha256.
+  if [ -n "$release_version" ]; then
+    update_registry_field "$tmp_file" "$release_version" "videoJarSha256" "$video_jar_checksum"
+  fi
+  echo "   video-server jar SHA256: ${video_jar_checksum}"
 fi
 
 if cmp -s "$constants_path" "$tmp_file"; then

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -6,6 +6,7 @@ SCRIPT="scripts/generate-release-constants.sh"
 APK_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 IPA_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 RUNNER_SHA="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+VIDEO_JAR_SHA="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
 
 setup() {
   TEST_ROOT="$(mktemp -d)"
@@ -201,4 +202,93 @@ PY
 
   [ "$status" -ne 0 ]
   [[ "$output" == *"IOS_CTRL_PROXY_RUNNER_SHA256 must be a valid SHA256"* ]]
+}
+
+# --- video-server jar (#3833) ---
+
+@test "writes videoJarSha256 into the new registry entry in release mode" {
+  run env \
+    RELEASE_VERSION="99.99.99" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
+    VIDEO_JAR_SHA256="$VIDEO_JAR_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  # registry[0] (the new entry) carries the videoJarSha256.
+  first_video="$(read_field_for_version 99.99.99 videoJarSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$first_video" = "$VIDEO_JAR_SHA" ]
+}
+
+@test "writes NIGHTLY_CHECKSUM_ENTRY videoJarSha256 (not registry[0]) in checksum-only mode" {
+  run env \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    VIDEO_JAR_SHA256="$VIDEO_JAR_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  # The dedicated nightly slot carries the jar sha; registry[0] is untouched.
+  nightly_video="$(read_field_for_version nightly videoJarSha256 "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$nightly_video" = "$VIDEO_JAR_SHA" ]
+}
+
+@test "rejects a malformed VIDEO_JAR_SHA256" {
+  run env \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    VIDEO_JAR_SHA256="not-a-sha" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"VIDEO_JAR_SHA256 must be a valid SHA256"* ]]
+}
+
+@test "caps registry without orphan braces when entries include videoJarSha256" {
+  # Guards the dynamic cap-deletion range: entries with a videoJarSha256 line are
+  # 7 lines, not 6, so a hardcoded +4 offset would orphan a trailing `},` when
+  # such an entry is pruned. The end anchor must follow the entry's `},`.
+  python3 - "${TEST_ROOT}/src/constants/release.ts" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+entries = []
+for i in range(100):
+    entries.append(f'''  {{
+    version: "1.0.{i}",
+    apkSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ipaSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    runnerSha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    videoJarSha256: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  }},''')
+
+text = path.read_text()
+replacement = "export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [\n" + "\n".join(entries) + "\n];"
+text = re.sub(
+    r'export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry\[\] = \[\n.*?\n\];',
+    replacement,
+    text,
+    count=1,
+    flags=re.S,
+)
+path.write_text(text)
+PY
+
+  run env \
+    RELEASE_VERSION="99.99.99" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
+    VIDEO_JAR_SHA256="$VIDEO_JAR_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  version_count="$(grep -cE 'version: "[0-9]' "${TEST_ROOT}/src/constants/release.ts")"
+  open_count="$(grep -c '^  {$' "${TEST_ROOT}/src/constants/release.ts")"
+  close_count="$(grep -c '^  },$' "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$version_count" -eq 100 ]
+  [ "$open_count" -eq "$close_count" ]
+  grep -q '^  version: "nightly",$' "${TEST_ROOT}/src/constants/release.ts"
 }

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -28,11 +28,25 @@
   grep -Fq "| **iOS Runner** |" ".github/workflows/nightly.yml"
 }
 
+@test "nightly.yml includes video-server jar sha256 in generated PR metadata (#3833)" {
+  # The change detector exposes a video_jar_changed output consumed by the PR body.
+  grep -Fq "video_jar_changed=\$VIDEO_JAR_CHANGED" ".github/workflows/nightly.yml"
+  grep -Fq "steps.check.outputs.video_jar_changed" ".github/workflows/nightly.yml"
+  # Jar-only nightly PRs get their own title, registered in the pull_request.yml
+  # sha256-only classifier so heavy CI is still skipped.
+  grep -q "chore: update video-server jar SHA256" ".github/workflows/nightly.yml"
+  grep -Fq "| **video-server jar** |" ".github/workflows/nightly.yml"
+}
+
 @test "pull_request.yml treats iOS runner checksum PR titles as sha256-only" {
   grep -q "chore: update CtrlProxy iOS runner SHA256" ".github/workflows/pull_request.yml"
   grep -q "chore: update CtrlProxy APK and CtrlProxy iOS runner SHA256" ".github/workflows/pull_request.yml"
   grep -q "chore: update CtrlProxy iOS IPA and iOS runner SHA256" ".github/workflows/pull_request.yml"
   grep -q "chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256" ".github/workflows/pull_request.yml"
+}
+
+@test "pull_request.yml treats video-server jar checksum PR titles as sha256-only (#3833)" {
+  grep -q "chore: update video-server jar SHA256" ".github/workflows/pull_request.yml"
 }
 
 @test "pull_request.yml retries GitHub API-backed change classifiers" {

--- a/test/bats/verify-artifact-sha256.bats
+++ b/test/bats/verify-artifact-sha256.bats
@@ -37,13 +37,22 @@ teardown() {
 # multi-line registry entry. A fixture without the interface line silently masks
 # the `grep | head -1` collision bug — the extraction must be anchored to the
 # registry entry, not the type declaration.
+# $1 = ipaSha256 value (may be empty)
+# $2 = videoJarSha256 value (optional; the field is omitted when unset, matching
+#      real registry entries that predate jar delivery)
 write_release_ts() {
+  local video_line=""
+  if [ "$#" -ge 2 ]; then
+    video_line="
+    videoJarSha256: \"$2\","
+  fi
   cat > "$PROJECT/src/constants/release.ts" <<EOF
 export interface ReleaseChecksumEntry {
   version: string;
   apkSha256: string;
   ipaSha256: string;
   runnerSha256: string;
+  videoJarSha256?: string;
 }
 
 export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
@@ -51,7 +60,7 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     version: "1.0.0",
     apkSha256: "",
     ipaSha256: "$1",
-    runnerSha256: "",
+    runnerSha256: "",$video_line
   },
 ];
 EOF
@@ -85,6 +94,41 @@ EOF
   run bash "$ABS_SCRIPT" "$ARTIFACT" ios
   [ "$status" -eq 0 ]
   [[ "$output" == *"verified successfully"* ]]
+}
+
+@test "matching videoJarSha256 verifies successfully (videojar platform)" {
+  write_release_ts "" "$ART_SHA"
+  cd "$PROJECT"
+  run bash "$ABS_SCRIPT" "$ARTIFACT" videojar
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"verified successfully"* ]]
+}
+
+@test "absent videoJarSha256 (entry predates jar) reports 'no checksum', not a mismatch" {
+  # A registry entry without a videoJarSha256 field must hard-fail with the
+  # actionable 'No checksum' error (same as apk/ios), never a spurious mismatch.
+  write_release_ts "$ART_SHA"
+  cd "$PROJECT"
+  run bash "$ABS_SCRIPT" "$ARTIFACT" videojar
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No SHA256 checksum found"* ]]
+  [[ "$output" != *"SHA256 mismatch"* ]]
+}
+
+@test "mismatched videoJarSha256 reports a mismatch" {
+  write_release_ts "" "0000000000000000000000000000000000000000000000000000000000000000"
+  cd "$PROJECT"
+  run bash "$ABS_SCRIPT" "$ARTIFACT" videojar
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SHA256 mismatch"* ]]
+}
+
+@test "unknown platform token is rejected" {
+  write_release_ts "$ART_SHA"
+  cd "$PROJECT"
+  run bash "$ABS_SCRIPT" "$ARTIFACT" bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Platform must be"* ]]
 }
 
 @test "sha256_of falls back to shasum when sha256sum is absent" {


### PR DESCRIPTION
Closes #3833. Keeps the `automobile-video.jar` (#3776) checksum current in the nightly PR and verifiable at release, alongside apk/ipa/runner. Builds on #3830 (the `videoJarSha256` field).

**Ordering note:** shipped *before* #3832 so #3832's `release.yml` wiring can reference the `videojar` verify token and `VIDEO_JAR_SHA256` generate env that land here (no forward reference). The reusable `build-video-server-jar.yml` also lands here rather than #3832 — nightly needs it now, and release must compute the jar sha from the **same** build (a divergent build would record a nightly sha the release can't reproduce — the #3784 failure class). #3832 adopts this same workflow for the release upload.

## Changes
- **`scripts/generate-release-constants.sh`**: accept `VIDEO_JAR_SHA256` in both modes — prepend into the new registry entry (`videoJarSha256`), and nightly checksum-only updates the dedicated nightly slot in place. Validates `^[a-f0-9]{64}$`. The registry-cap deletion now anchors its end line on the entry's closing `},` instead of a hardcoded `+4` offset: entries became variable-length once the optional `videoJarSha256` was added, so a fixed 6-line delete would orphan a dangling `},`.
- **`scripts/ci/verify-artifact-sha256.sh`**: add a `videojar` platform token reading `videoJarSha256` from `registry[0]`; hard-fails on empty/mismatch, same as apk/ios.
- **`.github/workflows/build-video-server-jar.yml`** (new): reusable workflow running `:video-server:d8Dex` and uploading `automobile-video.jar`, mirroring `build-control-proxy-apk.yml` (minus keystore — an unsigned DEX needs none). Reproducibility rests on the pinned toolchain (JDK 21 + `buildToolsVersion`), as the APK build.
- **`.github/workflows/nightly.yml`**: build the jar, read/compare the nightly slot's `videoJarSha256`, and include it in the `auto-update/nightly-sha256` PR. The combinatorial `elif` PR-title chain is replaced with a list-based assembler that scales to N artifacts and can't mis-title a jar-only change.

## Tests / validation
- Extended both bats suites: new-entry + nightly-slot `videoJarSha256` writes, malformed rejection, `videojar` verify (match / absent / mismatch / unknown-platform), and a **cap orphan-brace guard for 7-line (videoJar-bearing) entries** — the regression guard for the dynamic cap change. **19 bats pass.**
- `scripts/all_fast_validate_checks.sh --only yaml,shellcheck,shell-portability,shell-sete` — all clean.
- PR-title assembler unit-verified across single/pair/triple(Oxford)/quad/jar-only combinations.

## Acceptance
- [x] Nightly PR updates `videoJarSha256` alongside apk/ipa/runner.
- [x] `verify-artifact-sha256.sh <jar> videojar` passes on a matching artifact, fails on mismatch/empty.

## Not locally verifiable (per plan)
The nightly `videoJarSha256` bump and the reusable build's reproducibility (two independent builds → identical sha256, #3832's acceptance) can only be exercised by a real scheduled/release run; covered here by script/bats unit tests + toolchain pinning.

Ran `/simplify` (reuse + simplification + altitude agents): confirmed clean — the videoJar plumbing mirrors the established `runnerSha256`/apk patterns; the cap fix and title refactor were judged the right depth.