### PR TITLE
fix: drop segmented session from registry on maxDuration auto-stop

### DIFF
--- a/src/server/androidSegmentedPlanVideoSession.ts
+++ b/src/server/androidSegmentedPlanVideoSession.ts
@@ -28,6 +28,14 @@ export interface AndroidSegmentedPlanVideoSessionOptions {
   maxDurationSeconds?: number;
   /** Quality/config overrides forwarded to every segment's recording. */
   configOverrides?: VideoRecordingConfigInput;
+  /**
+   * Invoked exactly once when the session finalizes (via {@link stop}), whether that
+   * stop was caller-driven or the {@link maxDurationSeconds} auto-stop. Lets the owning
+   * registry drop the session so an auto-stopped, never-caller-stopped recording does
+   * not leak a tracked entry. The session does not know its own registry handle, so the
+   * hook removes by session identity.
+   */
+  onFinalized?: () => void;
   startVideoRecording?: (
     request: Parameters<typeof defaultStartVideoRecording>[0]
   ) => Promise<ActiveVideoRecording>;
@@ -70,6 +78,11 @@ export class AndroidSegmentedPlanVideoSession {
   /** True while a timer-driven session is running, so rotations keep rescheduling. */
   private timerDriven = false;
 
+  private readonly onFinalized: (() => void) | undefined;
+
+  /** Guards {@link onFinalized} so a second (no-op) {@link stop} does not re-notify. */
+  private finalizedNotified = false;
+
   /** Tracks the most recent in-flight rotation so {@link stop} can await it. */
   private pendingRotation: Promise<void> = Promise.resolve();
 
@@ -96,6 +109,7 @@ export class AndroidSegmentedPlanVideoSession {
     this.segmentRotateAfterMs = options.segmentRotateAfterMs ?? ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS;
     this.maxDurationSeconds = options.maxDurationSeconds;
     this.configOverrides = options.configOverrides;
+    this.onFinalized = options.onFinalized;
     this.startVideoRecordingFn = options.startVideoRecording ?? defaultStartVideoRecording;
     this.stopVideoRecordingFn = options.stopVideoRecording ?? defaultStopVideoRecording;
   }
@@ -174,7 +188,18 @@ export class AndroidSegmentedPlanVideoSession {
       this.maxDurationTimerHandle = undefined;
     }
     await this.pendingRotation;
-    return this.finalize();
+    const result = await this.finalize();
+    this.notifyFinalized();
+    return result;
+  }
+
+  /** Fires {@link onFinalized} at most once, so callers can drop the session from any registry. */
+  private notifyFinalized(): void {
+    if (this.finalizedNotified) {
+      return;
+    }
+    this.finalizedNotified = true;
+    this.onFinalized?.();
   }
 
   /**

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -64,6 +64,18 @@ const segmentedSessions = (() => {
       return [...byHandle.entries()].filter(([, session]) => session.deviceId === deviceId);
     },
     /**
+     * Drop a session from the registry by identity (its handle is not known inside the
+     * session). Wired to the session's `onFinalized` hook so an auto-stopped,
+     * never-caller-stopped recording cleans up instead of leaking a tracked entry.
+     */
+    remove(session: AndroidSegmentedPlanVideoSession): void {
+      for (const [handle, tracked] of byHandle) {
+        if (tracked === session) {
+          byHandle.delete(handle);
+        }
+      }
+    },
+    /**
      * Stop a tracked session: remove it from the registry, finalize it (which clears
      * its rotation timer), and return the ordered segment recordingId/filePath pairs.
      */
@@ -319,12 +331,15 @@ export function registerVideoRecordingTools(): void {
             target.platform === "android" &&
             maxDurationSeconds > ANDROID_SCREENRECORD_MAX_SECONDS
           ) {
-            const session = new AndroidSegmentedPlanVideoSession({
+            const session: AndroidSegmentedPlanVideoSession = new AndroidSegmentedPlanVideoSession({
               device: target,
               outputNamePrefix: args.outputName ?? `recording-${target.deviceId}`,
               configOverrides: buildConfigOverrides(args),
               timer: segmentedSessions.timer,
               maxDurationSeconds,
+              // Auto-stop finalizes without going through stopAndRemove, so drop the
+              // tracked entry here to avoid a registry leak on fire-and-forget recordings.
+              onFinalized: () => segmentedSessions.remove(session),
               ...segmentedSessions.recordingDependencies,
             });
             const active = await session.start();

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -301,6 +301,78 @@ describe("videoRecording tool segmentation branch", () => {
     expect(segmentStarts).toHaveLength(segmentStartsBefore);
   });
 
+  test("maxDuration auto-stop removes the session so a later bare stop reports only fresh segments", async () => {
+    setSegmentedSessionRecordingDependencies({
+      startVideoRecording: async request => {
+        const outputName = request.outputName;
+        const recordingId = outputName ?? `segment-${segmentStarts.length}`;
+        segmentStarts.push(recordingId);
+        return makeSegmentRecording(recordingId, outputName);
+      },
+      stopVideoRecording: async recordingId => {
+        const id = recordingId ?? `segment-${segmentStops.length}`;
+        segmentStops.push(id);
+        return {
+          metadata: makeSegmentMetadata(id),
+          evictedRecordingIds: [],
+        };
+      },
+    });
+
+    // Fire-and-forget usage: start a segmented recording with a maxDuration bound and
+    // never call stop. The session-level auto-stop must fire AND clean itself out of the
+    // registry — otherwise the dead entry leaks and its stale segments resurface later.
+    await handler()(androidDevice, {
+      action: "start",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+      maxDuration: 181,
+      outputName: "first",
+    });
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(2);
+
+    // The segmented session now owns its lifecycle; don't let a late finalize rebuild the
+    // real manager/database singleton.
+    resetVideoRecordingManagerDependencies();
+
+    // Advance past the maxDuration bound (rotation at 170s, then auto-stop at 181s).
+    segmentTimer.advanceTime(181_000);
+    await waitFor(
+      async () => segmentStops.length === 2,
+      "auto-stop to finalize both segments of the first session"
+    );
+    await flush();
+
+    // Auto-stop cleared the session's timers and removed it from the registry.
+    expect(segmentTimer.getPendingTimeoutCount()).toBe(0);
+
+    // A new recording starts on the SAME device (the QA runner's next test case).
+    await handler()(androidDevice, {
+      action: "start",
+      platform: "android",
+      deviceId: androidDevice.deviceId,
+      maxDuration: 300,
+      outputName: "second",
+    });
+
+    // Bare (by-device) stop: with the leak fixed, forDevice() sees only the new session,
+    // so the response lists only the fresh segment — never the auto-stopped first session's.
+    const stopRes = parse(
+      await handler()(androidDevice, {
+        action: "stop",
+        platform: "android",
+        // NO recordingId — bare, by-device stop.
+      })
+    );
+
+    const segments = stopRes.recordings as Array<Record<string, unknown>>;
+    expect(segments.length).toBe(1);
+    expect(segments[0].recordingId).toBe("second");
+    expect(
+      segments.some(segment => String(segment.filePath).includes("first"))
+    ).toBe(false);
+  });
+
   test("by-handle stop still works after wiring the bare-stop path", async () => {
     const startRes = parse(
       await handler()(androidDevice, {


### PR DESCRIPTION
Addresses the open review thread on #3847 (the registry-leak follow-on gap).

## The bug

The `maxDuration` auto-stop added in `5671d830` calls `session.stop()` directly, but `byHandle` removal lives only in `stopAndRemove` — reached only from the two caller-driven stop paths (by-handle and by-device). So a **fire-and-forget** recording (sets `maxDuration`, never calls stop — the exact use case this feature enables) finalizes but stays tracked forever:

1. **Map leak** — one dead entry per auto-stopped session; `forDevice()` iterates all of them on every bare stop.
2. **Stale segments** — after auto-stop the per-device guard (`videoRecordingManager.ts:545`) sees no active record, so a *new* recording can start on the same device under a new handle. A later bare by-device stop then returns the dead session's old segment paths mixed in with the fresh ones, reported as if just recorded.

## The fix

Give `AndroidSegmentedPlanVideoSession` an `onFinalized?: () => void` hook, fired **exactly once** at the end of `stop()` (covering both caller-driven and auto-stop). The tool wires it to a new `segmentedSessions.remove(session)` that drops the entry **by session identity** (the session doesn't know its own registry handle). The registry stays the single owner of the map, and the existing `stopAndRemove` delete becomes a harmless idempotent no-op on the auto-stop path.

## Test

New regression test in `videoRecordingToolSegmented.test.ts`: start a segmented recording with a `maxDuration` bound, let it auto-stop without calling stop, then start + bare-stop a new recording on the same device. The response must list only the fresh segment.

- **Without the fix:** bare stop returns **3** segments (two stale + one fresh) — verified by temporarily disabling the hook.
- **With the fix:** **1**.

All 6 tests in the file pass in ~470ms. Lint clean; build passes. (The one `typecheck` gate error in `PlanSchemaValidator.ts` is a pre-existing ajv/node_modules baseline drift present on the branch head without this change — unrelated.)