### PR TITLE
Fix AGP 9.3 Gradle wrapper compatibility

### DIFF
--- a/.github/actions/gradle-task-run/action.yml
+++ b/.github/actions/gradle-task-run/action.yml
@@ -126,10 +126,10 @@ runs:
         if [ "${{ inputs.gradle-version }}" == "" ]; then
           echo "Reading Gradle version from Gradle wrapper properties file."
           grep "distributionUrl" gradle/wrapper/gradle-wrapper.properties | sed -E 's/.*gradle-([0-9.]+)-(all|bin).zip/\1/' > /tmp/gradle_version.txt
-          echo 'export version="$(cat /tmp/gradle_version.txt)' >> $GITHUB_OUTPUT
+          echo "version=$(cat /tmp/gradle_version.txt)" >> "$GITHUB_OUTPUT"
         else
           echo "Reading custom Gradle version provided to action."
-          echo 'export version="${{ inputs.gradle-version }}"' >> $GITHUB_OUTPUT
+          echo "version=${{ inputs.gradle-version }}" >> "$GITHUB_OUTPUT"
         fi
 
         # Note that we do not attempt to visually align JVM args - spaces included in kotlin.daemon.jvmargs causes the Kotlin compiler daemon to not run and fallback to Gradle in-process

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ build-android-buildTools = "36.0.0"        # Used in playground Android modules
 build-android-compileSdk = "37"            # Used in playground Android modules
 build-android-minSdk = "24"                # Used in playground Android modules
 build-android-targetSdk = "36"             # Used in playground Android modules
-build-android-agp = "9.2.1"
+build-android-agp = "9.3.0"
 
 # Kotlin versions
 build-kotlin = "2.4.0"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -4,5 +4,6 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/ide-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/android/ide-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/test/scripts/gradleTaskRunAction.test.ts
+++ b/test/scripts/gradleTaskRunAction.test.ts
@@ -20,5 +20,7 @@ describe("gradle-task-run action", () => {
     expect(action).toContain("actions/cache/save@v5.1.0");
     expect(action).toContain("actions/upload-artifact@v7.0.1");
     expect(action).toContain('echo "digest=$digest" >> "$GITHUB_OUTPUT"');
+    expect(action).toContain('echo "version=$(cat /tmp/gradle_version.txt)" >> "$GITHUB_OUTPUT"');
+    expect(action).toContain('echo "version=${{ inputs.gradle-version }}" >> "$GITHUB_OUTPUT"');
   });
 });


### PR DESCRIPTION
## Summary

- update the nested IDE plugin Gradle wrapper to 9.6.1 for AGP 9.3.0 compatibility
- regenerate the root wrapper metadata with Gradle 9.6.1, adding distribution URL validation
- fix the shared Gradle composite action so `setup-gradle@v5.0.2` receives the parsed wrapper version
- add a regression assertion for the composite action output contract

## Root cause

Dependabot's AGP 9.3.0 bump in #3874 updated the shared Android version catalog, but the IDE plugin CI lane runs from `android/ide-plugin` and reads that directory's wrapper. That wrapper was still pinned to Gradle 9.4.1, while AGP 9.3.0 requires Gradle 9.5.0 or newer.

During the CI workflow review, the shared Gradle action was also passing an empty `gradle-version` to `gradle/actions/setup-gradle` because it wrote an invalid `$GITHUB_OUTPUT` line. This keeps the action pinned to `gradle/actions/setup-gradle@v5.0.2`; it does not move to v6.

## Testing

- `cd android/ide-plugin && ./gradlew --version`
- `cd android/ide-plugin && ./gradlew build -x test --continue --stacktrace`
- `cd android/ide-plugin && ./gradlew buildPlugin verifyPlugin test --stacktrace --continue`
- `bun test test/scripts/gradleTaskRunAction.test.ts`
- `git diff --check`
