### PR TITLE
ci(release): build, verify & attach automobile-video.jar to releases (#3832)

### DIFF
--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -10,6 +10,16 @@ name: "Build video-server jar"
 # libs.versions, exactly as the CtrlProxy APK build.
 on:
   workflow_call:
+    inputs:
+      verify-reproducible:
+        description: >-
+          When true, rebuild the jar from a clean tree and fail if the second
+          build's sha256 differs from the first. Release/prepare set this to
+          guarantee the recorded checksum is reproducible; nightly leaves it off
+          to save a build.
+        required: false
+        type: boolean
+        default: false
     secrets:
       GRADLE_ENCRYPTION_KEY:
         required: true
@@ -45,6 +55,27 @@ jobs:
           SHA256=$(sha256sum "$JAR_PATH" | cut -d' ' -f1)
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
           echo "video-server jar SHA256: $SHA256"
+
+      - name: "Verify reproducible build"
+        if: ${{ inputs.verify-reproducible }}
+        run: |
+          JAR_PATH="android/video-server/build/libs/automobile-video.jar"
+          FIRST_SHA="${{ steps.checksum.outputs.sha256 }}"
+          # Clean the module output and rebuild from scratch. A byte-identical
+          # sha across two independent d8 runs is what lets a nightly-recorded
+          # checksum be verified against the release-built jar (#3784 class).
+          ./android/gradlew -p android :video-server:clean
+          rm -f "$JAR_PATH"
+          ./android/gradlew -p android :video-server:d8Dex
+          SECOND_SHA=$(sha256sum "$JAR_PATH" | cut -d' ' -f1)
+          echo "First build:  $FIRST_SHA"
+          echo "Second build: $SECOND_SHA"
+          if [ "$FIRST_SHA" != "$SECOND_SHA" ]; then
+            echo "ERROR: video-server jar build is not reproducible."
+            echo "Two clean builds of the same commit produced different sha256."
+            exit 1
+          fi
+          echo "Reproducible: two clean builds produced an identical sha256."
 
       - name: "Copy jar to /tmp"
         run: cp android/video-server/build/libs/automobile-video.jar /tmp/automobile-video.jar

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,9 +26,16 @@ jobs:
       RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
       RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
+  build-video-server-jar:
+    uses: ./.github/workflows/build-video-server-jar.yml
+    with:
+      verify-reproducible: true
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
   prepare:
     runs-on: ubuntu-latest
-    needs: [build-ctrl-proxy-ios-ipa, build-control-proxy-apk]
+    needs: [build-ctrl-proxy-ios-ipa, build-control-proxy-apk, build-video-server-jar]
 
     steps:
       - name: Checkout code
@@ -69,6 +76,12 @@ jobs:
           name: control-proxy-apk
           path: /tmp
 
+      - name: "Download video-server jar"
+        uses: actions/download-artifact@v7
+        with:
+          name: video-server-jar
+          path: /tmp
+
       - name: Calculate SHA256 checksums
         id: checksum
         run: |
@@ -80,6 +93,10 @@ jobs:
           echo "ipa_sha256=$IPA_SHA256" >> "$GITHUB_OUTPUT"
           echo "IPA SHA256: $IPA_SHA256"
 
+          VIDEO_JAR_SHA256=$(sha256sum /tmp/automobile-video.jar | cut -d' ' -f1)
+          echo "video_jar_sha256=$VIDEO_JAR_SHA256" >> "$GITHUB_OUTPUT"
+          echo "video-server jar SHA256: $VIDEO_JAR_SHA256"
+
       - name: Update release constants
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -88,6 +105,7 @@ jobs:
             ${{ steps.checksum.outputs.ipa_sha256 }}
           IOS_CTRL_PROXY_RUNNER_SHA256:
             ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
+          VIDEO_JAR_SHA256: ${{ steps.checksum.outputs.video_jar_sha256 }}
         run: bash scripts/generate-release-constants.sh
 
       - name: Verify release integrity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,17 @@ jobs:
       RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
       RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
+  build-video-server-jar:
+    needs: validate-release-tag
+    if: needs.validate-release-tag.outputs.is_release_tag == 'true'
+    # No verify-reproducible here: the verify-and-release job already re-verifies
+    # the release-built jar against the registry sha minted by prepare-release on a
+    # different runner — a stronger cross-run reproducibility check than an in-job
+    # double-build. The double-build runs once, at mint time (prepare-release).
+    uses: ./.github/workflows/build-video-server-jar.yml
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
   verify-and-release:
     if: needs.validate-release-tag.outputs.is_release_tag == 'true'
     runs-on: ubuntu-latest
@@ -54,6 +65,7 @@ jobs:
       - validate-release-tag
       - build-ctrl-proxy-ios-ipa
       - build-control-proxy-apk
+      - build-video-server-jar
 
     steps:
       - name: Checkout code
@@ -100,6 +112,12 @@ jobs:
           name: ctrl-proxy-ios-ipa
           path: /tmp
 
+      - name: "Download video-server jar"
+        uses: actions/download-artifact@v7
+        with:
+          name: video-server-jar
+          path: /tmp
+
       - name: "Verify APK SHA256 matches source"
         id: verify_checksum
         run: |
@@ -116,6 +134,14 @@ jobs:
           CHECKSUM=$(grep '^checksum=' /tmp/ipa-verify.log | cut -d= -f2)
           echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
 
+      - name: "Verify video-server jar SHA256 matches source"
+        id: verify_video_jar_checksum
+        run: |
+          bash scripts/ci/verify-artifact-sha256.sh \
+            /tmp/automobile-video.jar videojar | tee /tmp/videojar-verify.log
+          CHECKSUM=$(grep '^checksum=' /tmp/videojar-verify.log | cut -d= -f2)
+          echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
+
       - name: Generate release constants
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
@@ -124,6 +150,8 @@ jobs:
             ${{ steps.verify_ipa_checksum.outputs.checksum }}
           IOS_CTRL_PROXY_RUNNER_SHA256:
             ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
+          VIDEO_JAR_SHA256:
+            ${{ steps.verify_video_jar_checksum.outputs.checksum }}
         run: bash scripts/generate-release-constants.sh
 
       - name: Verify release integrity
@@ -189,12 +217,16 @@ jobs:
           # Add checksum to notes
           APK_CHECKSUM="${{ steps.verify_checksum.outputs.checksum }}"
           IPA_CHECKSUM="${{ steps.verify_ipa_checksum.outputs.checksum }}"
+          VIDEO_JAR_CHECKSUM="${{ steps.verify_video_jar_checksum.outputs.checksum }}"
           NOTES="${NOTES}"$'\n\n'"## CtrlProxy APK"$'\n\n'\
             '"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'\
             '"Download the APK from the release assets below."
           NOTES="${NOTES}"$'\n\n'"## CtrlProxy iOS IPA"$'\n\n'\
             '"**SHA256 Checksum:** \`${IPA_CHECKSUM}\`"$'\n\n'\
             '"Download the IPA from the release assets below."
+          NOTES="${NOTES}"$'\n\n'"## video-server jar"$'\n\n'\
+            '"**SHA256 Checksum:** \`${VIDEO_JAR_CHECKSUM}\`"$'\n\n'\
+            '"Download automobile-video.jar from the release assets below."
 
           # Save to file for GitHub release
           echo "$NOTES" > release_notes.txt
@@ -332,6 +364,7 @@ jobs:
           files: |
             /tmp/control-proxy-debug.apk
             /tmp/control-proxy.ipa
+            /tmp/automobile-video.jar
           draft: false
           prerelease: false
         env:
@@ -342,6 +375,7 @@ jobs:
           VER: ${{ steps.version.outputs.version }}
           APK_CHECKSUM: ${{ steps.verify_checksum.outputs.checksum }}
           IPA_CHECKSUM: ${{ steps.verify_ipa_checksum.outputs.checksum }}
+          VIDEO_JAR_CHECKSUM: ${{ steps.verify_video_jar_checksum.outputs.checksum }}
           REPO: ${{ github.repository }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -353,6 +387,8 @@ jobs:
           echo "**APK SHA256:** \`$APK_CHECKSUM\`" >> "$S"
           echo "**IPA Built:** control-proxy.ipa" >> "$S"
           echo "**IPA SHA256:** \`$IPA_CHECKSUM\`" >> "$S"
+          echo "**video-server jar Built:** automobile-video.jar" >> "$S"
+          echo "**video-server jar SHA256:** \`$VIDEO_JAR_CHECKSUM\`" >> "$S"
           echo "" >> "$S"
           echo "### Published Artifacts" >> "$S"
           N="https://www.npmjs.com/package"

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -49,6 +49,31 @@
   grep -q "chore: update video-server jar SHA256" ".github/workflows/pull_request.yml"
 }
 
+@test "release.yml builds, verifies, and attaches the video-server jar (#3832)" {
+  workflow=".github/workflows/release.yml"
+  grep -Fq "uses: ./.github/workflows/build-video-server-jar.yml" "$workflow"
+  # Verified against the registry via the videojar platform token, then written.
+  grep -Fq "/tmp/automobile-video.jar videojar" "$workflow"
+  grep -Fq "VIDEO_JAR_SHA256:" "$workflow"
+  # Attached to the GitHub release assets.
+  grep -Fq "/tmp/automobile-video.jar" "$workflow"
+}
+
+@test "prepare-release.yml records the video-server jar checksum (#3832)" {
+  workflow=".github/workflows/prepare-release.yml"
+  grep -Fq "uses: ./.github/workflows/build-video-server-jar.yml" "$workflow"
+  grep -Fq "VIDEO_JAR_SHA256:" "$workflow"
+}
+
+@test "build-video-server-jar.yml can verify a reproducible build (#3832)" {
+  workflow=".github/workflows/build-video-server-jar.yml"
+  grep -Fq "verify-reproducible" "$workflow"
+  # The double-build runs once at mint time (prepare-release); release relies on
+  # the cross-run registry checksum verification instead, so it does NOT opt in.
+  grep -Fq "verify-reproducible: true" ".github/workflows/prepare-release.yml"
+  ! grep -Fq "verify-reproducible: true" ".github/workflows/release.yml"
+}
+
 @test "pull_request.yml retries GitHub API-backed change classifiers" {
   retry_count="$(sed -n '/name: "Detect Documentation-Only or SHA256-Only Changes"/,/name: "Check for Desktop Core module changes"/p' ".github/workflows/pull_request.yml" | grep -c "retries: 3")"
 


### PR DESCRIPTION
Closes #3832. Adopts the reusable `build-video-server-jar.yml` (added in #3833) into the release pipeline so the persistent on-device encoder jar (`automobile-video.jar`, #3776) ships as a GitHub release asset — the last release-engineering piece, mirroring the CtrlProxy APK/IPA delivery convention.

## Changes
- **`prepare-release.yml`**: build the jar, compute its sha256, and pass `VIDEO_JAR_SHA256` into `generate-release-constants.sh` so the prepared registry entry records `videoJarSha256` alongside apk/ipa/runner. (Without this, the first release would hard-fail the jar verify on an empty checksum.) Opts into the reproducibility guard.
- **`release.yml`**: build + download the jar, verify its sha256 against the registry (`verify-artifact-sha256.sh … videojar`), pass `VIDEO_JAR_SHA256` into the constants refresh, add `automobile-video.jar` to the `softprops/action-gh-release` `files:` list, and surface its checksum in the release notes + summary.
- **`build-video-server-jar.yml`**: add an opt-in `verify-reproducible` input that rebuilds from a clean tree and fails on a differing sha256.

## Reproducibility (#3832 acceptance)
The "two independent builds → identical sha256" guarantee is enforced at **mint time** (`prepare-release`), where the checksum is first computed and there's no prior sha to compare against — the in-job double-build catches single-runner d8 nondeterminism. **Release does not re-run it**: `verify-and-release` already cross-verifies the release-built jar against the prepare-minted registry sha (produced on a *different* runner), which is a strictly stronger cross-run reproducibility check. Nightly leaves it off to save a build. (This split came out of `/simplify` — the initial version redundantly double-built on the release path too.)

## Tests / validation
- `release-workflow-wiring.bats` extended with guards for the release + prepare jar wiring and the mint-time-only reproducibility opt-in. **15 wiring bats pass.**
- `scripts/all_fast_validate_checks.sh --only yaml,shellcheck,shell-portability,shell-sete` — clean.

## Acceptance
- [x] Release run produces and uploads `automobile-video.jar` (attached to the gh-release `files:` list; built via the shared reusable workflow).
- [x] Two independent builds of the same commit yield an identical sha256 (mint-time double-build guard + release-time cross-run registry verification).

## Not locally verifiable (per plan)
The actual release/prepare runs (real gradle `:video-server:d8Dex`, artifact upload, gh-release attach) only execute on a tag/dispatch; covered here by wiring bats + the toolchain pinning inherited from the APK build. The reproducibility guard's real behavior is exercised only in CI on a release/prepare run.