### PR TITLE
feat(webrtc): video-server jar resolution precedence + fail-modes (#3834)

### DIFF
--- a/src/features/webrtc/VideoServerJarProvider.ts
+++ b/src/features/webrtc/VideoServerJarProvider.ts
@@ -6,6 +6,7 @@ import {
   resolveVideoJarChecksum,
   resolveVideoJarUrl,
 } from "../../constants/release";
+import { ActionableError } from "../../models/ActionableError";
 import { type ChecksumCalculator, DefaultChecksumCalculator } from "../../utils/ChecksumCalculator";
 import { type FileDownloader, DefaultFileDownloader } from "../../utils/FileDownloader";
 import { logger } from "../../utils/logger";
@@ -232,15 +233,23 @@ export class VideoServerJarProvider {
 
       const { checksum: actual } = await this.checksumCalculator.computeFileSha256(tempPath);
       if (actual.toLowerCase() !== expected.toLowerCase()) {
-        throw new Error(
-          `video-server jar checksum verification failed. Expected: ${expected}, Got: ${actual}`
+        // A downloaded jar that does not match its pinned checksum is corrupted
+        // or tampered — an actionable failure surfaced to the caller, never
+        // silently cached. (The caller decides degrade-vs-fatal for the *absent*
+        // checksum case; a mismatch is unconditional.)
+        throw new ActionableError(
+          `video-server jar checksum verification failed. Expected: ${expected}, Got: ${actual}. ` +
+          "The downloaded automobile-video.jar does not match the pinned release checksum; " +
+          "this indicates a corrupted or tampered download and is never silently accepted."
         );
       }
 
       // Structural check catches a truncated file or an HTML error page saved
       // with a .jar name before it is ever pushed to a device.
       if (!this.hasClassesDex(tempPath)) {
-        throw new Error("video-server jar is not a valid zip containing classes.dex");
+        throw new ActionableError(
+          "video-server jar is not a valid zip containing classes.dex (truncated or error-page download)."
+        );
       }
 
       const { size } = await fs.stat(tempPath);

--- a/src/features/webrtc/videoServerJar.ts
+++ b/src/features/webrtc/videoServerJar.ts
@@ -1,38 +1,133 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { ActionableError } from "../../models/ActionableError";
+import { isTruthyEnvValue } from "../../utils/ctrlProxyDownloadControl";
+import { logger } from "../../utils/logger";
+import { VideoServerJarProvider } from "./VideoServerJarProvider";
 
 /**
- * Resolve the local path to the built `automobile-video.jar` (the persistent
- * on-device encoder DEX). The persistent WebRTC source needs this to push and
- * launch the server; when it cannot be found the source is unavailable and the
- * stream manager falls back to segment-rotated `screenrecord`.
- *
- * Resolution order:
- * 1. `AUTOMOBILE_VIDEO_SERVER_JAR` env override (absolute path).
- * 2. The Gradle build output under the repo (`android/video-server/build/libs`).
+ * Env override pointing at an explicit, already-built `automobile-video.jar`.
+ * Highest resolution precedence; never verified against a checksum (it is a
+ * developer's own local artifact).
  */
 export const VIDEO_SERVER_JAR_ENV = "AUTOMOBILE_VIDEO_SERVER_JAR";
 
+/**
+ * When set (`1`/`true`), any degrade-to-`screenrecord` case (no verifiable jar
+ * available) becomes a hard `ActionableError` instead. Mirrors the #2746
+ * `assertPinnedVersionVerifiable` fail-closed pattern. A checksum MISMATCH is
+ * always fatal regardless of this flag.
+ */
+export const REQUIRE_VIDEO_SERVER_ENV = "AUTOMOBILE_REQUIRE_VIDEO_SERVER";
+
+/**
+ * When set (`1`/`true`), never touch the network: resolve from the local
+ * override or Gradle build output only. Dedicated flag — intentionally NOT
+ * `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD`, whose CtrlProxy APK is mandatory
+ * (different semantics; the jar is optional and degrades to `screenrecord`).
+ */
+export const SKIP_VIDEO_SERVER_DOWNLOAD_ENV = "AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD";
+
+/** Resolve the explicit env override iff it points at an existing file. */
+function resolveOverride(env: NodeJS.ProcessEnv): string | null {
+  const override = env[VIDEO_SERVER_JAR_ENV];
+  return override && existsSync(override) ? override : null;
+}
+
+/** Resolve the local Gradle build output iff it exists (dev convenience). */
+function resolveLocalBuild(cwd: string): string | null {
+  const built = path.resolve(cwd, "android", "video-server", "build", "libs", "automobile-video.jar");
+  return existsSync(built) ? built : null;
+}
+
+/**
+ * Synchronous local-only resolution: env override, then the Gradle build
+ * output. Returns `null` when neither exists. Kept for callers that must not do
+ * async work; the full precedence (which also fetches from GitHub releases)
+ * lives in {@link resolveVideoServerJar}.
+ */
 export function resolveVideoServerJarPath(
   env: NodeJS.ProcessEnv = process.env,
   cwd: string = process.cwd()
 ): string | null {
-  const override = env[VIDEO_SERVER_JAR_ENV];
-  if (override && existsSync(override)) {
+  return resolveOverride(env) ?? resolveLocalBuild(cwd);
+}
+
+/** Just the ensure() surface {@link resolveVideoServerJar} needs from the provider. */
+export interface VideoJarEnsurer {
+  ensure(): Promise<string | null>;
+}
+
+export interface ResolveVideoServerJarDeps {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  /** Injectable for tests; defaults to the shared provider singleton. */
+  provider?: VideoJarEnsurer;
+}
+
+/**
+ * Full resolution precedence for `automobile-video.jar` (#3834), on top of the
+ * download provider (#3831):
+ *
+ *   1. `AUTOMOBILE_VIDEO_SERVER_JAR` explicit local override.
+ *   2. Valid cached download        ┐ both via the provider's `ensure()`
+ *   3. Fresh download + sha256 verify ┘ (skipped entirely when SKIP is set).
+ *   4. Local Gradle build output (dev).
+ *   5. else `null` → caller uses `screenrecord`.
+ *
+ * Fail-modes:
+ *   - checksum known + matches   → use the jar.
+ *   - checksum known + mismatch  → fatal `ActionableError` (thrown by the
+ *     provider), even in degrade mode — never silently accepted.
+ *   - checksum absent/unknown    → degrade (provider returns `null`).
+ *   - `AUTOMOBILE_REQUIRE_VIDEO_SERVER` → a degrade result becomes fatal.
+ *   - `AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD` → local-only; the provider (cache
+ *     + network) is never consulted.
+ */
+export async function resolveVideoServerJar(deps: ResolveVideoServerJarDeps = {}): Promise<string | null> {
+  const env = deps.env ?? process.env;
+  const cwd = deps.cwd ?? process.cwd();
+
+  // 1. Explicit override always wins.
+  const override = resolveOverride(env);
+  if (override) {
+    logger.info("[VIDEO_JAR] Using AUTOMOBILE_VIDEO_SERVER_JAR override", { path: override });
     return override;
   }
 
-  const built = path.resolve(
-    cwd,
-    "android",
-    "video-server",
-    "build",
-    "libs",
-    "automobile-video.jar"
-  );
-  if (existsSync(built)) {
+  const skip = isTruthyEnvValue(env[SKIP_VIDEO_SERVER_DOWNLOAD_ENV]);
+  const requireJar = isTruthyEnvValue(env[REQUIRE_VIDEO_SERVER_ENV]);
+
+  // 2 & 3. Cached-or-downloaded, verified jar — unless downloads are skipped.
+  // A checksum mismatch/corruption throws here and is intentionally NOT caught:
+  // it must stay fatal even when REQUIRE is off.
+  if (!skip) {
+    const provider = deps.provider ?? VideoServerJarProvider.getInstance();
+    const downloaded = await provider.ensure();
+    if (downloaded) {
+      return downloaded;
+    }
+  } else {
+    logger.info("[VIDEO_JAR] AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD set; resolving local sources only");
+  }
+
+  // 4. Local Gradle build output (developer convenience).
+  const built = resolveLocalBuild(cwd);
+  if (built) {
+    logger.info("[VIDEO_JAR] Using local Gradle build output", { path: built });
     return built;
   }
 
+  // 5. Nothing verifiable available.
+  if (requireJar) {
+    throw new ActionableError(
+      `${REQUIRE_VIDEO_SERVER_ENV} is set but no verifiable automobile-video.jar is available ` +
+      `(no override, no ${skip ? "" : "downloadable or "}locally-built jar). ` +
+      `Provide ${VIDEO_SERVER_JAR_ENV}, build \`:video-server:d8Dex\`, ` +
+      `pin a release whose checksum registry includes videoJarSha256, ` +
+      `or unset ${REQUIRE_VIDEO_SERVER_ENV} to allow the screenrecord fallback.`
+    );
+  }
+  logger.info("[VIDEO_JAR] No verifiable jar available; degrading to screenrecord");
   return null;
 }

--- a/test/features/webrtc/videoServerJarResolution.test.ts
+++ b/test/features/webrtc/videoServerJarResolution.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ActionableError } from "../../../src/models/ActionableError";
+import {
+  REQUIRE_VIDEO_SERVER_ENV,
+  SKIP_VIDEO_SERVER_DOWNLOAD_ENV,
+  VIDEO_SERVER_JAR_ENV,
+  resolveVideoServerJar,
+  type VideoJarEnsurer,
+} from "../../../src/features/webrtc/videoServerJar";
+
+/** Fake provider recording whether ensure() was consulted. */
+class FakeEnsurer implements VideoJarEnsurer {
+  public calls = 0;
+  constructor(private readonly result: string | null, private readonly error?: Error) {}
+  async ensure(): Promise<string | null> {
+    this.calls++;
+    if (this.error) {
+      throw this.error;
+    }
+    return this.result;
+  }
+}
+
+describe("resolveVideoServerJar precedence + fail-modes (#3834)", function() {
+  let root: string;
+  let overridePath: string;
+  let buildCwd: string;
+  let buildPath: string;
+
+  beforeEach(async function() {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "video-jar-resolve-"));
+    overridePath = path.join(root, "override.jar");
+    await fs.writeFile(overridePath, "override");
+    buildCwd = path.join(root, "repo");
+    buildPath = path.join(buildCwd, "android", "video-server", "build", "libs", "automobile-video.jar");
+  });
+
+  afterEach(async function() {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function makeBuild(): Promise<void> {
+    await fs.mkdir(path.dirname(buildPath), { recursive: true });
+    await fs.writeFile(buildPath, "built");
+  }
+
+  test("1. env override wins and the provider is never consulted", async function() {
+    const provider = new FakeEnsurer("/downloaded.jar");
+    const result = await resolveVideoServerJar({
+      env: { [VIDEO_SERVER_JAR_ENV]: overridePath },
+      cwd: buildCwd,
+      provider,
+    });
+    expect(result).toBe(overridePath);
+    expect(provider.calls).toBe(0);
+  });
+
+  test("2/3. no override → provider's cached/downloaded jar is used", async function() {
+    const provider = new FakeEnsurer("/cache/automobile-video.jar");
+    const result = await resolveVideoServerJar({ env: {}, cwd: buildCwd, provider });
+    expect(result).toBe("/cache/automobile-video.jar");
+    expect(provider.calls).toBe(1);
+  });
+
+  test("4. provider returns null (unknown checksum) → falls back to local build", async function() {
+    await makeBuild();
+    const provider = new FakeEnsurer(null);
+    const result = await resolveVideoServerJar({ env: {}, cwd: buildCwd, provider });
+    expect(result).toBe(buildPath);
+  });
+
+  test("5. provider returns null and no local build → degrade to null", async function() {
+    const provider = new FakeEnsurer(null);
+    const result = await resolveVideoServerJar({ env: {}, cwd: buildCwd, provider });
+    expect(result).toBeNull();
+  });
+
+  test("checksum mismatch is fatal (propagates) even with REQUIRE off", async function() {
+    const provider = new FakeEnsurer(null, new ActionableError("checksum verification failed"));
+    await expect(
+      resolveVideoServerJar({ env: {}, cwd: buildCwd, provider })
+    ).rejects.toThrow(/checksum verification failed/);
+  });
+
+  test("REQUIRE flips a degrade (null, no build) into a fatal ActionableError", async function() {
+    const provider = new FakeEnsurer(null);
+    const promise = resolveVideoServerJar({
+      env: { [REQUIRE_VIDEO_SERVER_ENV]: "1" },
+      cwd: buildCwd,
+      provider,
+    });
+    await expect(promise).rejects.toThrow(ActionableError);
+    await expect(promise).rejects.toThrow(new RegExp(REQUIRE_VIDEO_SERVER_ENV));
+  });
+
+  test("REQUIRE is satisfied by a local build (no throw)", async function() {
+    await makeBuild();
+    const provider = new FakeEnsurer(null);
+    const result = await resolveVideoServerJar({
+      env: { [REQUIRE_VIDEO_SERVER_ENV]: "1" },
+      cwd: buildCwd,
+      provider,
+    });
+    expect(result).toBe(buildPath);
+  });
+
+  test("SKIP resolves local-only: build is used and the provider is never consulted", async function() {
+    await makeBuild();
+    const provider = new FakeEnsurer("/downloaded.jar");
+    const result = await resolveVideoServerJar({
+      env: { [SKIP_VIDEO_SERVER_DOWNLOAD_ENV]: "1" },
+      cwd: buildCwd,
+      provider,
+    });
+    expect(result).toBe(buildPath);
+    expect(provider.calls).toBe(0);
+  });
+
+  test("SKIP with no local source degrades to null without touching the provider", async function() {
+    const provider = new FakeEnsurer("/downloaded.jar");
+    const result = await resolveVideoServerJar({
+      env: { [SKIP_VIDEO_SERVER_DOWNLOAD_ENV]: "true" },
+      cwd: buildCwd,
+      provider,
+    });
+    expect(result).toBeNull();
+    expect(provider.calls).toBe(0);
+  });
+
+  test("SKIP + REQUIRE with no local source is fatal (never downloads)", async function() {
+    const provider = new FakeEnsurer("/downloaded.jar");
+    const promise = resolveVideoServerJar({
+      env: { [SKIP_VIDEO_SERVER_DOWNLOAD_ENV]: "1", [REQUIRE_VIDEO_SERVER_ENV]: "1" },
+      cwd: buildCwd,
+      provider,
+    });
+    await expect(promise).rejects.toThrow(ActionableError);
+    expect(provider.calls).toBe(0);
+  });
+
+  test("override wins even under SKIP + REQUIRE", async function() {
+    const provider = new FakeEnsurer(null);
+    const result = await resolveVideoServerJar({
+      env: {
+        [VIDEO_SERVER_JAR_ENV]: overridePath,
+        [SKIP_VIDEO_SERVER_DOWNLOAD_ENV]: "1",
+        [REQUIRE_VIDEO_SERVER_ENV]: "1",
+      },
+      cwd: buildCwd,
+      provider,
+    });
+    expect(result).toBe(overridePath);
+    expect(provider.calls).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #3834. Defines how `automobile-video.jar` (#3776) is resolved and how failures behave, on top of the download provider (#3831). Governing principle: the jar is **optional** (the persistent encoder already falls back to `screenrecord`), so unavailability degrades gracefully — but a checksum **mismatch is always fatal**.

## Resolution precedence
New async `resolveVideoServerJar(deps)` in `src/features/webrtc/videoServerJar.ts`:
1. `AUTOMOBILE_VIDEO_SERVER_JAR` explicit override
2/3. `provider.ensure()` — valid cached download, else fresh download + sha256 verify
4. Local Gradle build output (dev)
5. else `null` → caller uses `screenrecord`

The sync `resolveVideoServerJarPath` (override + build) is retained for the current sync factory seam; both share `resolveOverride`/`resolveLocalBuild` helpers.

## Fail-modes (confirmed decisions)
| Case | Behavior |
|---|---|
| checksum known + matches | use the jar |
| checksum known + **mismatch** | **fatal `ActionableError`** (thrown by the provider at the detection point), even in degrade mode |
| checksum absent/unknown | degrade (provider returns `null`) |
| `AUTOMOBILE_REQUIRE_VIDEO_SERVER=1` | a degrade result becomes fatal (mirrors the #2746 `assertPinnedVersionVerifiable` fail-closed pattern) |
| `AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD=1` | local-only; the provider (cache + network) is never consulted |

`AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD` is a **dedicated** flag — deliberately not overloading `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` (the CtrlProxy APK is mandatory; the jar is optional/degradable). The provider's mismatch/corrupt throws are upgraded from `Error` to `ActionableError` per the repo error convention.

## Acceptance
- [x] Each precedence branch + each fail-mode unit-tested.
- [x] Mismatch throws (regardless of REQUIRE); absent degrades; REQUIRE flips degrade to fatal; SKIP avoids the network (provider never consulted).

## Validation
- `bun test` webrtc-jar suites — **24 pass** (12 new orchestrator + 8 provider + 4 existing `resolveVideoServerJarPath`)
- `bun run typecheck` / `lint` / `build` — clean

Ran `/simplify` (reuse + altitude + simplification agents): renamed a `require`-shadowing local, and reworded the provider comments so the fail-mode *policy* framing stays in the orchestrator (mechanism throws a well-typed error; the orchestrator owns degrade-vs-fatal). Confirmed `resolveVideoServerJarPath` is still the live sync resolver.

## Scope note
The orchestrator is intentionally not yet wired into production — `webrtcStreamManager` still uses the sync seam. **#3836** swaps it to `await resolveVideoServerJar(...)`; **#3835** adds the gated startup prefetch. This PR lands the resolution + fail-mode logic with full unit coverage.