### PR TITLE
feat(webrtc): gated background startup prefetch for video-server jar (#3835)

### DIFF
--- a/src/features/webrtc/videoServerJar.ts
+++ b/src/features/webrtc/videoServerJar.ts
@@ -4,6 +4,7 @@ import { ActionableError } from "../../models/ActionableError";
 import { isTruthyEnvValue } from "../../utils/ctrlProxyDownloadControl";
 import { logger } from "../../utils/logger";
 import { VideoServerJarProvider } from "./VideoServerJarProvider";
+import { WEBRTC_ENV } from "./webrtcStreamingConfig";
 
 /**
  * Env override pointing at an explicit, already-built `automobile-video.jar`.
@@ -130,4 +131,60 @@ export async function resolveVideoServerJar(deps: ResolveVideoServerJarDeps = {}
   }
   logger.info("[VIDEO_JAR] No verifiable jar available; degrading to screenrecord");
   return null;
+}
+
+export interface PrefetchVideoServerJarDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Injectable for tests; defaults to the shared provider singleton. */
+  provider?: VideoJarEnsurer;
+}
+
+/**
+ * Warm the jar cache at daemon startup, but only when WebRTC streaming is
+ * actually configured (`AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` present) so daemons
+ * that never stream pull nothing (~2.5 MB saved). Best-effort and non-blocking:
+ * the caller invokes it as `void prefetchVideoServerJar()`; the returned promise
+ * exists only so tests can await completion. Reuses the provider's single-flight,
+ * so a concurrent first-stream `ensure()` shares this download rather than
+ * starting a second. Mirrors `AndroidCtrlProxyManager.prefetchApk`.
+ *
+ * Skips (no download) when downloads are disabled or an explicit override makes
+ * the download unnecessary. A fatal fail-mode (checksum mismatch) is swallowed
+ * here — the first real stream re-resolves via {@link resolveVideoServerJar} and
+ * surfaces it there.
+ */
+export async function prefetchVideoServerJar(deps: PrefetchVideoServerJarDeps = {}): Promise<void> {
+  const env = deps.env ?? process.env;
+
+  const whip = env[WEBRTC_ENV.WHIP_ENDPOINT]?.trim();
+  if (!whip) {
+    logger.debug("[VIDEO_JAR] No WHIP endpoint configured; skipping background jar prefetch");
+    return;
+  }
+  // Prefetch warms the DOWNLOAD cache specifically, so it re-derives the two
+  // download-relevant gates from resolveVideoServerJar's precedence: an override
+  // or SKIP means the download is never used, so there is nothing to warm.
+  if (isTruthyEnvValue(env[SKIP_VIDEO_SERVER_DOWNLOAD_ENV])) {
+    logger.debug(`[VIDEO_JAR] ${SKIP_VIDEO_SERVER_DOWNLOAD_ENV} set; skipping background jar prefetch`);
+    return;
+  }
+  if (resolveOverride(env)) {
+    logger.debug("[VIDEO_JAR] Local override present; skipping background jar prefetch (download unused)");
+    return;
+  }
+
+  const provider = deps.provider ?? VideoServerJarProvider.getInstance();
+  logger.info("[VIDEO_JAR] Prefetching video-server jar in the background (WebRTC streaming configured)");
+  try {
+    const jarPath = await provider.ensure();
+    if (jarPath) {
+      logger.info("[VIDEO_JAR] Background prefetch warmed the jar cache", { path: jarPath });
+    }
+  } catch (error) {
+    // Best-effort: the first stream re-resolves and surfaces any fatal error.
+    logger.warn(
+      `[VIDEO_JAR] Background jar prefetch failed: ${error instanceof Error ? error.message : String(error)}`,
+      error
+    );
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   SKIP_CTRL_PROXY_DOWNLOAD_FLAG,
   shouldSkipCtrlProxyDownload,
 } from "./utils/ctrlProxyDownloadControl";
+import { prefetchVideoServerJar } from "./features/webrtc/videoServerJar";
 import { parseToolOutputsDirConfig } from "./utils/toolOutputArtifacts";
 import {
   installProcessLifecycleHandlers,
@@ -505,6 +506,12 @@ async function main() {
         IOSCtrlProxyBuilder.prefetchBuild();
       }
     }
+
+    // Warm the persistent-encoder jar cache in the background, but only when
+    // WebRTC streaming is configured (AUTOMOBILE_WEBRTC_WHIP_ENDPOINT) — daemons
+    // that never stream pull nothing. Non-blocking; reuses the provider's
+    // single-flight so a first stream shares this download (#3835).
+    void prefetchVideoServerJar();
 
     const featureFlagService = FeatureFlagService.getInstance();
 

--- a/test/features/webrtc/videoServerJarResolution.test.ts
+++ b/test/features/webrtc/videoServerJarResolution.test.ts
@@ -7,9 +7,11 @@ import {
   REQUIRE_VIDEO_SERVER_ENV,
   SKIP_VIDEO_SERVER_DOWNLOAD_ENV,
   VIDEO_SERVER_JAR_ENV,
+  prefetchVideoServerJar,
   resolveVideoServerJar,
   type VideoJarEnsurer,
 } from "../../../src/features/webrtc/videoServerJar";
+import { WEBRTC_ENV } from "../../../src/features/webrtc/webrtcStreamingConfig";
 
 /** Fake provider recording whether ensure() was consulted. */
 class FakeEnsurer implements VideoJarEnsurer {
@@ -154,5 +156,44 @@ describe("resolveVideoServerJar precedence + fail-modes (#3834)", function() {
     });
     expect(result).toBe(overridePath);
     expect(provider.calls).toBe(0);
+  });
+});
+
+describe("prefetchVideoServerJar gating (#3835)", function() {
+  const WHIP = { [WEBRTC_ENV.WHIP_ENDPOINT]: "https://whip.example/publish" };
+
+  test("with a WHIP endpoint configured, the jar is fetched in the background", async function() {
+    const provider = new FakeEnsurer("/cache/automobile-video.jar");
+    await prefetchVideoServerJar({ env: { ...WHIP }, provider });
+    expect(provider.calls).toBe(1);
+  });
+
+  test("without a WHIP endpoint, no prefetch occurs", async function() {
+    const provider = new FakeEnsurer("/cache/automobile-video.jar");
+    await prefetchVideoServerJar({ env: {}, provider });
+    expect(provider.calls).toBe(0);
+  });
+
+  test("SKIP disables the prefetch even with a WHIP endpoint", async function() {
+    const provider = new FakeEnsurer("/cache/automobile-video.jar");
+    await prefetchVideoServerJar({
+      env: { ...WHIP, [SKIP_VIDEO_SERVER_DOWNLOAD_ENV]: "1" },
+      provider,
+    });
+    expect(provider.calls).toBe(0);
+  });
+
+  test("an explicit override skips the prefetch (download unused)", async function() {
+    const provider = new FakeEnsurer("/cache/automobile-video.jar");
+    const overrideEnv: NodeJS.ProcessEnv = { ...WHIP, [VIDEO_SERVER_JAR_ENV]: __filename };
+    await prefetchVideoServerJar({ env: overrideEnv, provider });
+    expect(provider.calls).toBe(0);
+  });
+
+  test("a prefetch failure is swallowed (best-effort, does not throw)", async function() {
+    const provider = new FakeEnsurer(null, new Error("checksum verification failed"));
+    // Must resolve, not reject — startup must not crash on a prefetch failure.
+    await prefetchVideoServerJar({ env: { ...WHIP }, provider });
+    expect(provider.calls).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #3835. Warm the `automobile-video.jar` (#3776) cache at daemon startup so the first WebRTC stream pays no download latency — but only when streaming is actually in use. Builds on the provider (#3831) and resolver (#3834).

## Changes
- **`prefetchVideoServerJar(deps)`** in `src/features/webrtc/videoServerJar.ts`: fire the provider's `ensure()` in the background, **gated on `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` being present**. No WHIP config → no prefetch, so daemons that never stream pull nothing (~2.5 MB saved). Skips when downloads are disabled (`SKIP`) or an explicit override makes the download unused. Reuses the provider's single-flight, so a concurrent first-stream `ensure()` shares this download rather than starting a second. A fatal fail-mode (checksum mismatch) is swallowed here — the first stream re-resolves via `resolveVideoServerJar` and surfaces it. Mirrors `AndroidCtrlProxyManager.prefetchApk`.
- **`src/index.ts`**: `void prefetchVideoServerJar()` at daemon startup, beside the CtrlProxy prefetches. The static import stays light — `webrtcStreamingConfig`'s `werift` import is `import type` (erased), and `adm-zip` is already loaded via `CtrlProxyManager`.

## Acceptance
- [x] With `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` set, the jar is fetched in the background at startup and the first stream hits a warm cache (single-flight shared).
- [x] Without it, no prefetch occurs.

## Validation
- `bun test` webrtc-jar suite — **16 pass** (5 new prefetch-gating tests: fires with WHIP, no-ops without, skips under SKIP + override, swallows failures without throwing).
- `bun run typecheck` / `lint` / `build` — clean.

Ran `/simplify`: review confirmed the diff clean and the werift chain light. The one borderline point (prefetch re-deriving the SKIP/override gates vs delegating to `resolveVideoServerJar`) was kept as-is — prefetch warms the *download* cache specifically, so the two download-relevant gates are intentional; added a comment documenting the mirror.

Next: **#3836** wires `resolveVideoServerJar` into `webrtcStreamManager` (async at stream start); **#3837** docs.