### PR TITLE
test: de-flake timer-driven segmented recording tests under CI load

### DIFF
--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -24,8 +24,16 @@ import {
   setVideoRecordingManagerDependencies,
 } from "../../src/server/videoRecordingManager";
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
-import { defaultTimer } from "../../src/utils/SystemTimer";
 import type { BootedDevice, VideoRecordingMetadata } from "../../src/models";
+
+/**
+ * Generous ceiling for the two timer-driven tests below: they poll an async rotation
+ * chain via {@link waitFor}, and under full-suite concurrency the event loop is saturated
+ * enough that the (logically-correct) poll can outlast bun's 5s default. The condition is
+ * always met well before this; the headroom just stops a loaded CI machine failing a
+ * correct test.
+ */
+const TIMER_DRIVEN_TEST_TIMEOUT_MS = 20_000;
 
 /** Drain all pending microtasks (setImmediate runs after the microtask queue). */
 const flush = () => new Promise<void>(resolve => setImmediate(resolve));
@@ -36,10 +44,11 @@ async function waitFor(condition: () => Promise<boolean>, label: string): Promis
     if (await condition()) {
       return;
     }
-    // Drain microtasks (flush) AND a macrotask turn so real fs/resource-registry
-    // awaits in the rotation chain settle even under concurrent file execution.
+    // A single macrotask yield (setImmediate) drains the microtask queue AND lets any
+    // I/O-phase callbacks in the rotation chain settle. A second real-timer yield here
+    // (defaultTimer.sleep(0)) only doubled the per-iteration wall-clock, which starved
+    // this loop past the 5s test budget under full-suite concurrency — so it's gone.
     await flush();
-    await defaultTimer.sleep(0);
   }
   throw new Error(`Timed out waiting for: ${label}`);
 }
@@ -299,7 +308,7 @@ describe("videoRecording tool segmentation branch", () => {
     segmentTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS * 3);
     await flush();
     expect(segmentStarts).toHaveLength(segmentStartsBefore);
-  });
+  }, TIMER_DRIVEN_TEST_TIMEOUT_MS);
 
   test("maxDuration auto-stop removes the session so a later bare stop reports only fresh segments", async () => {
     setSegmentedSessionRecordingDependencies({
@@ -371,7 +380,7 @@ describe("videoRecording tool segmentation branch", () => {
     expect(
       segments.some(segment => String(segment.filePath).includes("first"))
     ).toBe(false);
-  });
+  }, TIMER_DRIVEN_TEST_TIMEOUT_MS);
 
   test("by-handle stop still works after wiring the bare-stop path", async () => {
     const startRes = parse(


### PR DESCRIPTION
Fixes the two test timeouts in the latest #3847 CI run:

```
(fail) videoRecording tool segmentation branch > bare (by-device) stop ... [5002ms] timed out
(fail) videoRecording tool segmentation branch > maxDuration auto-stop removes the session ... [5006ms] timed out
```

## Root cause — a poll-loop flake, not a logic bug

Both tests pass in ~400ms solo (and under `test/server/` concurrency) but time out at bun's **5000ms default** in the full 627-file suite. They poll an async rotation chain via the file-local `waitFor()` helper, which yielded a macrotask **twice** per iteration: `flush()` (`setImmediate`) **and** `defaultTimer.sleep(0)` (a real `setTimeout`).

Under full-suite concurrency the event loop is saturated, so both yields get starved and the per-iteration wall-clock balloons — 200 iterations blow past 5000ms even though the condition is logically satisfied almost immediately.

## Fix

- **Drop the redundant real-timer yield.** These tests inject fake start/stop deps (no real fs), so a single `setImmediate` already drains the microtask queue and any I/O-phase callbacks. The `defaultTimer.sleep(0)` was pure overhead and the flake amplifier. Verified `flush()`-only settles all 6 tests deterministically.
- **Add a generous explicit 20s ceiling** to the two `waitFor`-driven tests as defense-in-depth, so a pathologically-loaded runner can't fail a logically-correct test.

Test-only. All 6 tests in the file pass in ~420ms; lint clean.

Stacks on #3847 (same base branch) — the second failing test is the registry-leak regression test added in #3891, and the first is pre-existing.