### PR TITLE
feat(webrtc): async jar resolution at stream start (#3836)

### DIFF
--- a/src/features/webrtc/androidH264CaptureSourceFactory.ts
+++ b/src/features/webrtc/androidH264CaptureSourceFactory.ts
@@ -5,20 +5,17 @@ import {
   PersistentEncoderH264Source,
   type PersistentEncoderH264SourceOptions,
 } from "./PersistentEncoderH264Source";
-import { resolveVideoServerJarPath } from "./videoServerJar";
 
 /**
  * Injectable seams for {@link createAndroidH264CaptureSource} so the selection
  * and fallback behavior can be unit-tested without a device.
  */
 export interface AndroidH264CaptureSourceDeps {
-  resolveJarPath: (env?: NodeJS.ProcessEnv, cwd?: string) => string | null;
   createPersistent: (options: PersistentEncoderH264SourceOptions) => H264CaptureSource;
   createScreenrecord: (options: AndroidH264SourceOptions) => H264CaptureSource;
 }
 
 const defaultDeps: AndroidH264CaptureSourceDeps = {
-  resolveJarPath: resolveVideoServerJarPath,
   createPersistent: options => new PersistentEncoderH264Source(options),
   createScreenrecord: options => new AndroidH264Source(options),
 };
@@ -61,16 +58,19 @@ class FallbackH264CaptureSource implements H264CaptureSource {
 }
 
 /**
- * Build the WebRTC capture source for an Android device. When the persistent
- * encoder jar is resolvable it is preferred (no ~175s rotation seam), with an
- * automatic fallback to `screenrecord`; otherwise `screenrecord` is used
- * directly.
+ * Build the WebRTC capture source for an Android device from a PRE-RESOLVED jar
+ * path. Resolution (override → cached/downloaded → local build → null, with the
+ * download off the frame path) happens once at stream start in
+ * `webrtcStreamManager`; this factory stays synchronous and pure. When a jar
+ * path is provided the persistent encoder is preferred (no ~175s rotation seam),
+ * with an automatic fallback to `screenrecord`; a `null` path uses
+ * `screenrecord` directly.
  */
 export function createAndroidH264CaptureSource(
   options: AndroidH264SourceOptions,
+  jarPath: string | null,
   deps: AndroidH264CaptureSourceDeps = defaultDeps
 ): H264CaptureSource {
-  const jarPath = deps.resolveJarPath();
   if (!jarPath) {
     return deps.createScreenrecord(options);
   }

--- a/src/features/webrtc/h264CaptureSourceFactory.ts
+++ b/src/features/webrtc/h264CaptureSourceFactory.ts
@@ -3,11 +3,19 @@ import type { H264CaptureSource, H264CaptureSourceOptions } from "./H264CaptureS
 import { createAndroidH264CaptureSource } from "./androidH264CaptureSourceFactory";
 import { IosH264Source } from "./IosH264Source";
 
-export type H264CaptureSourceFactory = (options: H264CaptureSourceOptions) => H264CaptureSource;
+/**
+ * Build a capture source for a device. `jarPath` is the pre-resolved Android
+ * persistent-encoder jar (or `null` to force `screenrecord`); it is resolved
+ * once at stream start, off the frame path, and ignored for non-Android devices.
+ */
+export type H264CaptureSourceFactory = (
+  options: H264CaptureSourceOptions,
+  jarPath: string | null
+) => H264CaptureSource;
 
-export const createH264CaptureSource: H264CaptureSourceFactory = options => {
+export const createH264CaptureSource: H264CaptureSourceFactory = (options, jarPath) => {
   if (options.device.platform === "android") {
-    return createAndroidH264CaptureSource(options);
+    return createAndroidH264CaptureSource(options, jarPath);
   }
   if (options.device.platform === "ios") {
     return new IosH264Source(options);

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -3,6 +3,7 @@ import { logger } from "../utils/logger";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import {
   createH264CaptureSource,
+  resolveVideoServerJar,
   WebRtcPublisher,
   resolveWebRtcStreamingConfig,
   type H264CaptureSource,
@@ -24,6 +25,8 @@ interface WebRtcStreamRecord {
   device: BootedDevice;
   publisher: WebRtcPublisher;
   source: H264CaptureSource | null;
+  /** Persistent-encoder jar resolved once at stream start; null → screenrecord. */
+  jarPath: string | null;
   bitrateBps?: number;
   size?: { width: number; height: number };
   startedAt: string;
@@ -32,14 +35,23 @@ interface WebRtcStreamRecord {
 export interface WebRtcStreamManagerDependencies {
   idGenerator: IdGenerator;
   createPublisher: (config: WebRtcPublisherConfig, deps: WebRtcPublisherDeps) => WebRtcPublisher;
-  createSource: (options: H264CaptureSourceOptions) => H264CaptureSource;
+  createSource: (options: H264CaptureSourceOptions, jarPath: string | null) => H264CaptureSource;
+  /**
+   * Resolve the Android persistent-encoder jar once, off the frame path. Returns
+   * the verified path, or null to degrade to screenrecord; throws on a fatal
+   * fail-mode (checksum mismatch, or REQUIRE with nothing available). Non-Android
+   * devices resolve to null.
+   */
+  resolveVideoJar: (device: BootedDevice) => Promise<string | null>;
   now: () => Date;
 }
 
 const defaultDependencies: WebRtcStreamManagerDependencies = {
   idGenerator: defaultIdGenerator,
   createPublisher: (config, deps) => new WebRtcPublisher(config, deps),
-  createSource: options => createH264CaptureSource(options),
+  createSource: (options, jarPath) => createH264CaptureSource(options, jarPath),
+  resolveVideoJar: device =>
+    device.platform === "android" ? resolveVideoServerJar() : Promise.resolve(null),
   now: () => new Date(),
 };
 
@@ -105,15 +117,18 @@ async function startSource(record: WebRtcStreamRecord): Promise<void> {
   if (streams.get(record.streamId) !== record) {
     return;
   }
-  const source = dependencies.createSource({
-    device: record.device,
-    onData: chunk => record.publisher.writeH264Chunk(chunk),
-    onError: () => {
-      record.publisher.notifySourceFailed();
+  const source = dependencies.createSource(
+    {
+      device: record.device,
+      onData: chunk => record.publisher.writeH264Chunk(chunk),
+      onError: () => {
+        record.publisher.notifySourceFailed();
+      },
+      bitrateBps: record.bitrateBps,
+      size: record.size,
     },
-    bitrateBps: record.bitrateBps,
-    size: record.size,
-  });
+    record.jarPath
+  );
   record.source = source;
   await source.start();
   // The stream may have been stopped while the source was starting. stop() only
@@ -154,6 +169,14 @@ export async function startWebRtcStream(
 
   const bitrateBps = config.bitrateKbps ? config.bitrateKbps * 1000 : undefined;
 
+  // Resolve the persistent-encoder jar ONCE, before establishing the WHIP
+  // session — a fatal fail-mode (checksum mismatch, or REQUIRE with nothing
+  // available) must abort the stream start with its ActionableError rather than
+  // surfacing mid-capture. The download resolves here, off the per-frame path;
+  // startSource() only constructs the (synchronous) capture source. A degrade
+  // returns null → screenrecord.
+  const jarPath = await dependencies.resolveVideoJar(request.device);
+
   // The publisher's lifecycle hooks resolve the record by id (rather than
   // closing over it) so the record can be constructed with the publisher in one
   // shot. The hooks only run during publisher.start() (below), after the record
@@ -177,6 +200,7 @@ export async function startWebRtcStream(
     device: request.device,
     publisher,
     source: null,
+    jarPath,
     bitrateBps,
     size: config.size,
     startedAt: dependencies.now().toISOString(),

--- a/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
@@ -36,7 +36,6 @@ function makeDeps(overrides: Partial<AndroidH264CaptureSourceDeps>): {
   const persistent = new FakeSource();
   const screenrecord = new FakeSource();
   const deps: AndroidH264CaptureSourceDeps = {
-    resolveJarPath: () => "/tmp/automobile-video.jar",
     createPersistent: () => persistent,
     createScreenrecord: () => screenrecord,
     ...overrides,
@@ -45,17 +44,17 @@ function makeDeps(overrides: Partial<AndroidH264CaptureSourceDeps>): {
 }
 
 describe("createAndroidH264CaptureSource", () => {
-  test("uses screenrecord directly when no jar is resolvable", async () => {
-    const { deps, persistent, screenrecord } = makeDeps({ resolveJarPath: () => null });
-    const source = createAndroidH264CaptureSource(baseOptions(), deps);
+  test("uses screenrecord directly when the resolved jar path is null", async () => {
+    const { deps, persistent, screenrecord } = makeDeps({});
+    const source = createAndroidH264CaptureSource(baseOptions(), null, deps);
     await source.start();
     expect(screenrecord.started).toBe(1);
     expect(persistent.started).toBe(0);
   });
 
-  test("prefers the persistent encoder when the jar is available", async () => {
+  test("prefers the persistent encoder when a jar path is provided", async () => {
     const { deps, persistent, screenrecord } = makeDeps({});
-    const source = createAndroidH264CaptureSource(baseOptions(), deps);
+    const source = createAndroidH264CaptureSource(baseOptions(), "/tmp/automobile-video.jar", deps);
     await source.start();
     expect(persistent.started).toBe(1);
     expect(screenrecord.started).toBe(0);
@@ -69,11 +68,10 @@ describe("createAndroidH264CaptureSource", () => {
     const persistent = new FakeSource(() => Promise.reject(new Error("app_process killed")));
     const screenrecord = new FakeSource();
     const deps: AndroidH264CaptureSourceDeps = {
-      resolveJarPath: () => "/tmp/automobile-video.jar",
       createPersistent: () => persistent,
       createScreenrecord: () => screenrecord,
     };
-    const source = createAndroidH264CaptureSource(baseOptions(), deps);
+    const source = createAndroidH264CaptureSource(baseOptions(), "/tmp/automobile-video.jar", deps);
     await source.start();
 
     expect(persistent.started).toBe(1);
@@ -85,17 +83,16 @@ describe("createAndroidH264CaptureSource", () => {
     expect(persistent.stopped).toBe(0);
   });
 
-  test("passes the resolved jar path to the persistent source", () => {
+  test("passes the provided jar path to the persistent source", () => {
     let capturedJar: string | undefined;
     const deps: AndroidH264CaptureSourceDeps = {
-      resolveJarPath: () => "/custom/video.jar",
       createPersistent: options => {
         capturedJar = options.jarPath;
         return new FakeSource();
       },
       createScreenrecord: () => new FakeSource(),
     };
-    createAndroidH264CaptureSource(baseOptions(), deps);
+    createAndroidH264CaptureSource(baseOptions(), "/custom/video.jar", deps);
     expect(capturedJar).toBe("/custom/video.jar");
   });
 });

--- a/test/features/webrtc/h264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/h264CaptureSourceFactory.test.ts
@@ -18,16 +18,16 @@ const IOS: BootedDevice = {
 } as BootedDevice;
 
 describe("createH264CaptureSource", () => {
-  test("routes Android devices to the Android source path", () => {
-    const source = createH264CaptureSource({ device: ANDROID, onData: () => {} });
+  test("routes Android devices to the Android source path (null jar → screenrecord)", () => {
+    const source = createH264CaptureSource({ device: ANDROID, onData: () => {} }, null);
 
     expect(source).not.toBeInstanceOf(IosH264Source);
     expect(typeof source.start).toBe("function");
     expect(typeof source.stop).toBe("function");
   });
 
-  test("routes iOS devices to the iOS source path", () => {
-    const source = createH264CaptureSource({ device: IOS, onData: () => {} });
+  test("routes iOS devices to the iOS source path (jar path ignored)", () => {
+    const source = createH264CaptureSource({ device: IOS, onData: () => {} }, "/tmp/automobile-video.jar");
 
     expect(source).toBeInstanceOf(IosH264Source);
   });

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -8,7 +8,7 @@ import {
   stopWebRtcStream,
 } from "../../src/server/webrtcStreamManager";
 import { CountingIdGenerator } from "../../src/utils/IdGenerator";
-import type { BootedDevice } from "../../src/models";
+import { ActionableError, type BootedDevice } from "../../src/models";
 import type {
   AndroidH264Source,
   WebRtcPublisher,
@@ -95,6 +95,9 @@ function installFakes() {
       sources.push(source);
       return source as unknown as AndroidH264Source;
     },
+    // Hermetic: never resolve the real jar (which could attempt a GitHub
+    // download once the registry carries a videoJarSha256).
+    resolveVideoJar: async () => null,
     now: () => new Date("2026-07-11T00:00:00.000Z"),
   });
   return { publishers, sources };
@@ -197,6 +200,7 @@ describe("webrtcStreamManager", () => {
         sources.push(source);
         return source as unknown as AndroidH264Source;
       },
+      resolveVideoJar: async () => null,
       now: () => new Date("2026-07-11T00:00:00.000Z"),
     });
 
@@ -226,6 +230,7 @@ describe("webrtcStreamManager", () => {
         sources.push(source);
         return source as unknown as AndroidH264Source;
       },
+      resolveVideoJar: async () => null,
       now: () => new Date("2026-07-11T00:00:00.000Z"),
     });
 
@@ -245,5 +250,70 @@ describe("webrtcStreamManager", () => {
       overrides: { whipEndpoint: ENDPOINT },
     });
     expect(descriptor.streamId).toBe("ci-run-42");
+  });
+
+  // --- #3836: async jar resolution wiring ---
+
+  test("resolves the jar once at stream start and threads the path into createSource", async () => {
+    let resolveCalls = 0;
+    const jarPaths: (string | null)[] = [];
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => new FakePublisher(config, deps) as unknown as WebRtcPublisher,
+      createSource: (_options, jarPath) => {
+        jarPaths.push(jarPath);
+        return new FakeSource() as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => {
+        resolveCalls++;
+        return "/verified/automobile-video.jar";
+      },
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    await startWebRtcStream({ device: ANDROID, overrides: { whipEndpoint: ENDPOINT } });
+
+    expect(resolveCalls).toBe(1);
+    expect(jarPaths).toEqual(["/verified/automobile-video.jar"]);
+  });
+
+  test("degrade (null) proceeds and passes null (screenrecord) to createSource", async () => {
+    const jarPaths: (string | null)[] = [];
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => new FakePublisher(config, deps) as unknown as WebRtcPublisher,
+      createSource: (_options, jarPath) => {
+        jarPaths.push(jarPath);
+        return new FakeSource() as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => null,
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    const descriptor = await startWebRtcStream({ device: ANDROID, overrides: { whipEndpoint: ENDPOINT } });
+    expect(descriptor.streamId).toBeDefined();
+    expect(jarPaths).toEqual([null]);
+  });
+
+  test("a fatal jar fail-mode aborts stream start before any publisher/stream is created", async () => {
+    let publisherCreated = 0;
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => {
+        publisherCreated++;
+        return new FakePublisher(config, deps) as unknown as WebRtcPublisher;
+      },
+      createSource: () => new FakeSource() as unknown as AndroidH264Source,
+      resolveVideoJar: async () => {
+        throw new ActionableError("video-server jar checksum verification failed");
+      },
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    await expect(
+      startWebRtcStream({ device: ANDROID, overrides: { whipEndpoint: ENDPOINT } })
+    ).rejects.toThrow(/checksum verification failed/);
+    expect(publisherCreated).toBe(0);
+    expect(listWebRtcStreams()).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #3836. Makes jar resolution async at WebRTC stream start without touching the per-frame hot path or the sync capture-source factory. Builds on the provider (#3831) and resolver/fail-modes (#3834).

## Changes
- **`webrtcStreamManager.startWebRtcStream`** resolves the persistent-encoder jar **once**, before `publisher.start()`, via a new injectable `resolveVideoJar(device)` dependency (default: Android → `resolveVideoServerJar()`, non-Android → `null`). The resolved path (or `null`) is stored on the stream record and passed into the capture-source factory. A **fatal fail-mode** (checksum mismatch, or `REQUIRE` with nothing available) throws here and aborts the stream start **before any WHIP session / publisher / record exists**; a **degrade** returns `null` → screenrecord.
- **The Android factory is now pure/synchronous**: `createAndroidH264CaptureSource(options, jarPath, deps)` takes a pre-resolved `jarPath` and its internal `resolveJarPath` seam is removed — so it no longer re-resolves (and re-downloads) on every reconnect via `onConnected`. `jarPath` threads `createSource` seam → `createH264CaptureSource(options, jarPath)` → the Android factory; iOS ignores it.

## Why resolve in the manager (altitude)
`startSource` runs on **every** `onConnected` (the reconnect loop). Resolving inside the factory would re-run the download per reconnect and surface a fatal error mid-capture. Pre-resolving once, off the frame path, keeps the per-connection path synchronous and makes a fatal error abort the *start*, as the acceptance requires.

## Acceptance
- [x] Stream start resolves the jar once and selects persistent-vs-screenrecord accordingly.
- [x] Manager/factory unit tests cover both the resolved-jar and null (degrade) paths (+ fatal-abort-before-publisher).

## Validation
- `bun test test/features/webrtc/` — **143 pass**; the 3 affected suites updated (factory now takes `jarPath`; manager tests inject `resolveVideoJar` to stay **hermetic** — critical so they never attempt a real GitHub download once the registry carries a `videoJarSha256`).
- `bun run typecheck` / `lint` / `build` — clean.

Ran `/simplify`: review confirmed clean — resolve-in-manager and the pure factory are the right altitude; storing `jarPath` on the record is necessary (the `onConnected` hook reaches the record by id, per the file's documented pattern); the positional-`jarPath` param was endorsed over an options field (keeps an Android-only value off the shared iOS-inclusive options type).

Only **#3837** (docs) remains in the series.