### PR TITLE
fix(inputText): honor eventAll marker parser in daemon args

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -207,13 +207,14 @@ export interface ProxiedResourceTemplate {
 
 /**
  * The daemon startup options that change its observable MCP behavior and so must
- * match before a running daemon can be reused: `embeddedSdk` plus every
- * output-reduction flag. A same-build MCP client that requests one of these
- * against an already-running daemon started without it (or vice versa) would
- * otherwise silently get the wrong tool-output contract until a manual restart
- * (issue #2759 — the `toolResultsNoStructuredContent` case). The output-reduction
- * fields are derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose `field` names map
- * 1:1 to `DaemonOptions`) so a new flag is covered automatically.
+ * match before a running daemon can be reused: `embeddedSdk`, marker-based
+ * eventAll promotion config, plus every output-reduction flag. A same-build MCP
+ * client that requests one of these against an already-running daemon started
+ * without it (or vice versa) would otherwise silently get the wrong tool-output
+ * or inputText behavior until a manual restart (issue #2759 — the
+ * `toolResultsNoStructuredContent` case). The output-reduction fields are
+ * derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose `field` names map 1:1 to
+ * `DaemonOptions`) so a new flag is covered automatically.
  */
 const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
   "embeddedSdk",
@@ -233,6 +234,10 @@ function stringOption(
   return typeof value === "string" ? value : undefined;
 }
 
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 /**
  * Reuse-critical startup options the connecting client *explicitly requests*
  * that the running daemon lacks. Reconciliation is **one-directional** (issue
@@ -240,9 +245,10 @@ function stringOption(
  * the daemon already has is never reported as a deficit just because a
  * particular caller (e.g. a bare short-lived CLI client) didn't request it.
  * Booleans are compared strictly (`=== true`), so `undefined` and `false` both
- * read as "no opinion"; strings count only when the client supplies one that
- * differs from the daemon's. Returns a human-readable list (empty when the
- * daemon already satisfies every requested flag) for logging and error messages.
+ * read as "no opinion"; strings and marker arrays count only when the client
+ * supplies one that differs from the daemon's. Returns a human-readable list
+ * (empty when the daemon already satisfies every requested flag) for logging and
+ * error messages.
  */
 function startupOptionDeficits(
   requested: DaemonOptions | undefined,
@@ -261,6 +267,15 @@ function startupOptionDeficits(
     const have = stringOption(running, key);
     if (want !== undefined && want !== have) {
       deficits.push(`${key} (requested=${want}, running=${have ?? "unset"})`);
+    }
+  }
+  const requestedEventAllMarkers = requested?.eventAllMarkers;
+  if (requestedEventAllMarkers !== undefined) {
+    const runningEventAllMarkers = running?.eventAllMarkers ?? [];
+    if (!arraysEqual(requestedEventAllMarkers, runningEventAllMarkers)) {
+      deficits.push(
+        `eventAllMarkers (requested=${JSON.stringify(requestedEventAllMarkers)}, running=${JSON.stringify(runningEventAllMarkers)})`
+      );
     }
   }
   return deficits;

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -12,7 +12,11 @@ import {
 } from "../db/migrationDependencyIntegrity";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
-import { EVENT_ALL_MARKERS_FLAG, parseEventAllMarkersConfig } from "../utils/eventAllMarkers";
+import {
+  EVENT_ALL_MARKERS_FLAG,
+  hasEventAllMarkersCliOverride,
+  parseEventAllMarkersConfig,
+} from "../utils/eventAllMarkers";
 import { shouldSkipCtrlProxyDownload } from "../utils/ctrlProxyDownloadControl";
 import { ActionableError } from "../models";
 import {
@@ -743,6 +747,8 @@ export class DaemonManager implements DaemonManagerLike {
     }
     if (options.eventAllMarkers && options.eventAllMarkers.length > 0) {
       args.push(EVENT_ALL_MARKERS_FLAG, options.eventAllMarkers.join(","));
+    } else if (options.eventAllMarkersCliOverride) {
+      args.push(`${EVENT_ALL_MARKERS_FLAG}=`);
     }
     if (options.noUiPerfMode) {
       args.push("--no-ui-perf-mode");
@@ -1195,8 +1201,10 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
     resolveDaemonLaunchWorkingDirectory()
   );
   const eventAllMarkers = parseEventAllMarkersConfig(args, env);
-  if (eventAllMarkers.length > 0) {
+  const eventAllMarkersCliOverride = hasEventAllMarkersCliOverride(args);
+  if (eventAllMarkers.length > 0 || eventAllMarkersCliOverride) {
     options.eventAllMarkers = eventAllMarkers;
+    options.eventAllMarkersCliOverride = eventAllMarkersCliOverride;
   }
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--port") {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -12,7 +12,7 @@ import {
 } from "../db/migrationDependencyIntegrity";
 import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
-import { EVENT_ALL_MARKERS_FLAG, splitMarkers } from "../utils/eventAllMarkers";
+import { EVENT_ALL_MARKERS_FLAG, parseEventAllMarkersConfig } from "../utils/eventAllMarkers";
 import { shouldSkipCtrlProxyDownload } from "../utils/ctrlProxyDownloadControl";
 import { ActionableError } from "../models";
 import {
@@ -1194,6 +1194,10 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
     env,
     resolveDaemonLaunchWorkingDirectory()
   );
+  const eventAllMarkers = parseEventAllMarkersConfig(args, env);
+  if (eventAllMarkers.length > 0) {
+    options.eventAllMarkers = eventAllMarkers;
+  }
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--port") {
       options.port = parseInt(args[i + 1], 10);
@@ -1244,12 +1248,6 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
       options.embeddedSdk = true;
     } else if (args[i] === "--dismiss-keyboard-after-input") {
       options.dismissKeyboardAfterInput = true;
-    } else if (args[i] === EVENT_ALL_MARKERS_FLAG) {
-      const markers = args[i + 1];
-      if (markers && !markers.startsWith("--")) {
-        options.eventAllMarkers = splitMarkers(markers);
-      }
-      i++;
     } else if (args[i] === "--no-ui-perf-mode") {
       options.noUiPerfMode = true;
     } else if (args[i] === "--no-navigation-screenshots") {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -183,6 +183,8 @@ export interface DaemonOptions {
   dismissKeyboardAfterInput?: boolean;
   /** Markers that auto-promote inputText from `a11y` to `eventAll` (Android only) */
   eventAllMarkers?: string[];
+  /** Preserve an explicit CLI marker override, including `--event-all-markers=` */
+  eventAllMarkersCliOverride?: boolean;
   /** Disable UI performance mode */
   noUiPerfMode?: boolean;
   /** Enable memory performance audit */

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,11 @@ import {
   shouldSkipCtrlProxyDownload,
 } from "./utils/ctrlProxyDownloadControl";
 import { parseToolOutputsDirConfig } from "./utils/toolOutputArtifacts";
-import { parseEventAllMarkersConfig, EVENT_ALL_MARKERS_FLAG } from "./utils/eventAllMarkers";
+import {
+  parseEventAllMarkersConfig,
+  hasEventAllMarkersCliOverride,
+  EVENT_ALL_MARKERS_FLAG,
+} from "./utils/eventAllMarkers";
 import {
   installProcessLifecycleHandlers,
   setFatalProcessHandler,
@@ -109,6 +113,7 @@ function parseArgs(log: ParseLogger): {
   networkMockable: boolean;
   dismissKeyboardAfterInput: boolean;
   eventAllMarkers: string[];
+  eventAllMarkersCliOverride: boolean;
   mcpRecording: boolean;
   navigationScreenshots: boolean;
   noWaitForPollingOverhead: boolean;
@@ -176,6 +181,7 @@ function parseArgs(log: ParseLogger): {
   const networkMockable = args.includes("--network-mockable");
   const dismissKeyboardAfterInput = args.includes("--dismiss-keyboard-after-input");
   const eventAllMarkers = parseEventAllMarkersConfig(args, process.env);
+  const eventAllMarkersCliOverride = hasEventAllMarkersCliOverride(args);
   const mcpRecording = args.includes("--mcp-recording");
   const navigationScreenshots = !args.includes("--no-navigation-screenshots");
   const noWaitForPollingOverhead = args.includes("--no-waitfor-polling-overhead");
@@ -384,6 +390,7 @@ function parseArgs(log: ParseLogger): {
     networkMockable,
     dismissKeyboardAfterInput,
     eventAllMarkers,
+    eventAllMarkersCliOverride,
     mcpRecording,
     navigationScreenshots,
     noWaitForPollingOverhead,
@@ -468,6 +475,7 @@ async function main() {
       networkMockable,
       dismissKeyboardAfterInput,
       eventAllMarkers,
+      eventAllMarkersCliOverride,
       mcpRecording,
       navigationScreenshots,
       noWaitForPollingOverhead,
@@ -616,6 +624,11 @@ async function main() {
       logger.warn(`${EVENT_ALL_MARKERS_FLAG} was provided but resolved to no markers; inputText eventAll auto-promotion stays disabled`);
     }
 
+    const eventAllMarkerDaemonOptions: Pick<DaemonOptions, "eventAllMarkers" | "eventAllMarkersCliOverride"> =
+      eventAllMarkers.length > 0 || eventAllMarkersCliOverride
+        ? { eventAllMarkers, eventAllMarkersCliOverride }
+        : {};
+
     if (daemonMode) {
       await startDaemon({
         port: daemonPort,
@@ -633,7 +646,7 @@ async function main() {
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,
-        eventAllMarkers,
+        ...eventAllMarkerDaemonOptions,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,
         accessibilityAudit: a11yAuditMode,
@@ -696,7 +709,7 @@ async function main() {
         networkMockable,
         embeddedSdk,
         dismissKeyboardAfterInput,
-        eventAllMarkers,
+        ...eventAllMarkerDaemonOptions,
         noUiPerfMode: !uiPerfMode,
         memPerfAudit: memPerfAuditMode,
         accessibilityAudit: a11yAuditMode,

--- a/src/utils/eventAllMarkers.ts
+++ b/src/utils/eventAllMarkers.ts
@@ -3,6 +3,20 @@ import { firstFlagValue } from "./cliArgs";
 export const EVENT_ALL_MARKERS_FLAG = "--event-all-markers";
 export const EVENT_ALL_MARKERS_ENV = "AUTOMOBILE_EVENT_ALL_MARKERS";
 
+export function hasEventAllMarkersCliOverride(args: string[]): boolean {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith(`${EVENT_ALL_MARKERS_FLAG}=`)) {
+      return true;
+    }
+    if (arg === EVENT_ALL_MARKERS_FLAG) {
+      const value = args[i + 1];
+      return value !== undefined && !value.startsWith("--");
+    }
+  }
+  return false;
+}
+
 /**
  * Split a comma-separated marker string into a normalized marker list.
  * Trims each entry and drops empties so `"@, /, #"` and `"@,/,#"` are equal.

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -7,6 +7,7 @@ import { DaemonManager, type DaemonProcessSpawner } from "../../src/daemon/manag
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { TOOL_OUTPUTS_DIR_ENV, TOOL_OUTPUTS_DIR_FLAG } from "../../src/utils/toolOutputArtifacts";
+import { EVENT_ALL_MARKERS_ENV, EVENT_ALL_MARKERS_FLAG } from "../../src/utils/eventAllMarkers";
 
 describe("DaemonManager launch", () => {
   const tempDirs: string[] = [];
@@ -22,6 +23,7 @@ describe("DaemonManager launch", () => {
     process.chdir(originalCwd);
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
     delete process.env.AUTOMOBILE_DATA_DIR;
+    delete process.env[EVENT_ALL_MARKERS_ENV];
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -226,6 +228,101 @@ describe("DaemonManager launch", () => {
 
     expect(capturedArgs).not.toContain(TOOL_OUTPUTS_DIR_FLAG);
     expect(capturedEnv![TOOL_OUTPUTS_DIR_ENV]).toBe(toolOutputsDir);
+  });
+
+  test("serializes explicit empty event-all marker override so daemon env fallback stays disabled", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    process.env.AUTOMOBILE_DATA_DIR = stateDir;
+    process.env[EVENT_ALL_MARKERS_ENV] = "@";
+
+    let capturedArgs: string[] | undefined;
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, args: string[], _options: SpawnOptions) => {
+        capturedArgs = args;
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start({ eventAllMarkers: [], eventAllMarkersCliOverride: true });
+
+    expect(capturedArgs).toContain(`${EVENT_ALL_MARKERS_FLAG}=`);
+    expect(capturedArgs).not.toContain(EVENT_ALL_MARKERS_FLAG);
+  });
+
+  test("does not serialize absent event-all marker config as an empty override", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    process.env.AUTOMOBILE_DATA_DIR = stateDir;
+
+    let capturedArgs: string[] | undefined;
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, args: string[], _options: SpawnOptions) => {
+        capturedArgs = args;
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start({ eventAllMarkers: [] });
+
+    expect(capturedArgs).not.toContain(`${EVENT_ALL_MARKERS_FLAG}=`);
+    expect(capturedArgs).not.toContain(EVENT_ALL_MARKERS_FLAG);
   });
 
   test("resolves relative daemon state paths before changing daemon cwd", async () => {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -430,7 +430,13 @@ describe("DaemonMcpProxy", () => {
     });
 
     describe("startup option mismatch handling", () => {
-      function runningStatus(options: { embeddedSdk?: boolean; toolResultsNoStructuredContent?: boolean; toolOutputsDir?: string }) {
+      function runningStatus(options: {
+        embeddedSdk?: boolean;
+        toolResultsNoStructuredContent?: boolean;
+        toolOutputsDir?: string;
+        eventAllMarkers?: string[];
+        eventAllMarkersCliOverride?: boolean;
+      }) {
         return {
           running: true,
           pid: 1234,
@@ -526,6 +532,65 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
+      test("restarts daemon when explicit empty event-all markers override differs", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureVersionMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureBuildMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ eventAllMarkers: [], eventAllMarkersCliOverride: true }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { eventAllMarkers: [], eventAllMarkersCliOverride: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({
+            eventAllMarkers: [],
+            eventAllMarkersCliOverride: true,
+          });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts daemon when requested event-all markers differ", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ eventAllMarkers: ["/"] }), // ensureVersionMatches
+          runningStatus({ eventAllMarkers: ["/"] }), // ensureBuildMatches
+          runningStatus({ eventAllMarkers: ["/"] }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ eventAllMarkers: ["@"] }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { eventAllMarkers: ["@"] },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ eventAllMarkers: ["@"] });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
       test("does not restart daemon when output-reduction flags match", async () => {
         const fakeClient = new FakeDaemonClient({
           daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
@@ -578,6 +643,32 @@ describe("DaemonMcpProxy", () => {
         }
       });
 
+      test("does not restart daemon when event-all markers match", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureVersionMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureBuildMatches
+          runningStatus({ eventAllMarkers: ["@"] }), // ensureStartupOptionsMatch
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { eventAllMarkers: ["@"] },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(false);
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
       test("does NOT restart (no downgrade) when a bare client connects to a configured daemon (issue #3846)", async () => {
         const fakeClient = new FakeDaemonClient({
           daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
@@ -587,9 +678,9 @@ describe("DaemonMcpProxy", () => {
         // connecting client is bare (no daemonOptions) and must NOT trigger a
         // restart that strips those flags.
         fakeManager.statusResults = [
-          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true }), // ensureVersionMatches
-          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true }), // ensureBuildMatches
-          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true }), // ensureStartupOptionsMatch
+          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true, eventAllMarkers: ["@"] }), // ensureVersionMatches
+          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true, eventAllMarkers: ["@"] }), // ensureBuildMatches
+          runningStatus({ embeddedSdk: true, toolResultsNoStructuredContent: true, eventAllMarkers: ["@"] }), // ensureStartupOptionsMatch
         ];
         const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
         const proxy = new DaemonMcpProxy({

--- a/test/daemon/managerOutputReductionArgs.test.ts
+++ b/test/daemon/managerOutputReductionArgs.test.ts
@@ -91,9 +91,28 @@ describe("event-all markers daemon arg relay", () => {
       .toEqual(["@", "/", "#"]);
   });
 
+  test("--event-all-markers=<csv> parses into DaemonOptions", () => {
+    expect(parseDaemonArgs(["--event-all-markers=@,/,#"]).eventAllMarkers)
+      .toEqual(["@", "/", "#"]);
+  });
+
   test("trims and drops empties on parse", () => {
     expect(parseDaemonArgs(["--event-all-markers", " @ , / , "]).eventAllMarkers)
       .toEqual(["@", "/"]);
+  });
+
+  test("falls back to AUTOMOBILE_EVENT_ALL_MARKERS", () => {
+    expect(parseDaemonArgs([], { AUTOMOBILE_EVENT_ALL_MARKERS: "@,:" }).eventAllMarkers)
+      .toEqual(["@", ":"]);
+  });
+
+  test("CLI flag wins over AUTOMOBILE_EVENT_ALL_MARKERS", () => {
+    expect(
+      parseDaemonArgs(
+        ["--event-all-markers", "#"],
+        { AUTOMOBILE_EVENT_ALL_MARKERS: "@" }
+      ).eventAllMarkers
+    ).toEqual(["#"]);
   });
 
   test("ignores missing or flag-shaped values", () => {

--- a/test/daemon/managerOutputReductionArgs.test.ts
+++ b/test/daemon/managerOutputReductionArgs.test.ts
@@ -106,13 +106,22 @@ describe("event-all markers daemon arg relay", () => {
       .toEqual(["@", ":"]);
   });
 
+  test("preserves an explicit empty CLI override over AUTOMOBILE_EVENT_ALL_MARKERS", () => {
+    const options = parseDaemonArgs(
+      ["--event-all-markers="],
+      { AUTOMOBILE_EVENT_ALL_MARKERS: "@,:" }
+    );
+    expect(options.eventAllMarkers).toEqual([]);
+    expect(options.eventAllMarkersCliOverride).toBe(true);
+  });
+
   test("CLI flag wins over AUTOMOBILE_EVENT_ALL_MARKERS", () => {
-    expect(
-      parseDaemonArgs(
-        ["--event-all-markers", "#"],
-        { AUTOMOBILE_EVENT_ALL_MARKERS: "@" }
-      ).eventAllMarkers
-    ).toEqual(["#"]);
+    const options = parseDaemonArgs(
+      ["--event-all-markers", "#"],
+      { AUTOMOBILE_EVENT_ALL_MARKERS: "@" }
+    );
+    expect(options.eventAllMarkers).toEqual(["#"]);
+    expect(options.eventAllMarkersCliOverride).toBe(true);
   });
 
   test("ignores missing or flag-shaped values", () => {

--- a/test/utils/eventAllMarkers.test.ts
+++ b/test/utils/eventAllMarkers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { parseEventAllMarkersConfig } from "../../src/utils/eventAllMarkers";
+import {
+  hasEventAllMarkersCliOverride,
+  parseEventAllMarkersConfig,
+} from "../../src/utils/eventAllMarkers";
 
 describe("parseEventAllMarkersConfig", () => {
   test("returns an empty list when nothing is configured (feature off)", () => {
@@ -12,6 +15,13 @@ describe("parseEventAllMarkersConfig", () => {
 
   test("parses the --event-all-markers=<csv> form", () => {
     expect(parseEventAllMarkersConfig(["--event-all-markers=@,/,#"], {})).toEqual(["@", "/", "#"]);
+  });
+
+  test("empty --event-all-markers= overrides the env var with no markers", () => {
+    expect(parseEventAllMarkersConfig(
+      ["--event-all-markers="],
+      { AUTOMOBILE_EVENT_ALL_MARKERS: "@" }
+    )).toEqual([]);
   });
 
   test("trims whitespace and drops empty entries", () => {
@@ -30,5 +40,22 @@ describe("parseEventAllMarkersConfig", () => {
 
   test("treats a following flag as a missing value", () => {
     expect(parseEventAllMarkersConfig(["--event-all-markers", "--other-flag"], {})).toEqual([]);
+  });
+});
+
+describe("hasEventAllMarkersCliOverride", () => {
+  test("detects inline values including an explicit empty override", () => {
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers="])).toBe(true);
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers=@"])).toBe(true);
+  });
+
+  test("detects space-separated values", () => {
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers", "@"])).toBe(true);
+  });
+
+  test("does not treat missing or flag-shaped values as overrides", () => {
+    expect(hasEventAllMarkersCliOverride([])).toBe(false);
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers"])).toBe(false);
+    expect(hasEventAllMarkersCliOverride(["--event-all-markers", "--debug"])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Reuse `parseEventAllMarkersConfig(args, env)` inside `parseDaemonArgs` so daemon command parsing follows the same CLI/env contract as main startup.
- Preserve explicit empty marker CLI overrides (`--event-all-markers=`) across proxy/auto-started daemon launch when `AUTOMOBILE_EVENT_ALL_MARKERS` is inherited.
- Treat requested event-all marker config as reuse-critical so same-build proxy mode restarts an already-running daemon when marker settings differ.
- Add parser and daemon launch coverage for equals-form values, env fallback, CLI-over-env precedence, and empty override serialization.

## Testing
- `bun test test/utils/eventAllMarkers.test.ts test/daemon/managerOutputReductionArgs.test.ts test/daemon/daemonManagerLaunch.test.ts test/daemon/daemonMcpProxy.test.ts`
- `bun run build`
- `bun run lint`

Fixes review feedback on #3870.
