### PR TITLE
docs(webrtc): video-server jar release delivery + env flags (#3837)

### DIFF
--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -160,9 +160,7 @@ Two independent reconnection layers:
 Capture prefers the persistent on-device encoder (`video-server`): a single
 long-lived VirtualDisplay + MediaCodec pipeline with no ~175 s rotation seam and
 one continuous timestamp base. It honors `--bit-rate` (from `bitrateKbps`) and
-`--size` (from `size`). The jar is resolved via `AUTOMOBILE_VIDEO_SERVER_JAR` or
-the Gradle build output (`android/video-server/build/libs/automobile-video.jar`,
-built with `./gradlew :video-server:d8Dex`).
+`--size` (from `size`).
 
 When the jar is not resolvable — or the persistent encoder fails to start —
 capture falls back to `screenrecord`, which encodes on-device H.264 with the same
@@ -170,16 +168,58 @@ capture falls back to `screenrecord`, which encodes on-device H.264 with the sam
 segment rotation (`ANDROID_STREAM_SEGMENT_ROTATE_MS`); each new segment emits a
 fresh keyframe.
 
+## Persistent-encoder delivery (`automobile-video.jar`)
+
+The `video-server` jar ships as a GitHub release asset, mirroring the CtrlProxy
+APK/IPA delivery convention — so the persistent encoder is the production default
+rather than falling back to `screenrecord` because the jar wasn't distributed.
+
+**Resolution precedence** (resolved once at stream start, off the per-frame path,
+in `webrtcStreamManager`; the capture-source factory stays synchronous):
+
+1. `AUTOMOBILE_VIDEO_SERVER_JAR` — explicit local override (an already-built jar).
+2. A valid **cached download** at `~/.auto-mobile/video-server/automobile-video.jar`
+   (with a `video-server-jar.json` sidecar recording `{version, sha256, size,
+   downloadedAt}`).
+3. A **fresh download** from the release, sha256-verified against the pinned
+   release's `videoJarSha256` in the checksum registry.
+4. The local Gradle build output
+   (`android/video-server/build/libs/automobile-video.jar`, from
+   `./gradlew :video-server:d8Dex`) — for development.
+5. else **`null` → `screenrecord`**.
+
+`AUTOMOBILE_VERSION` (pin one coherent version) and `AUTOMOBILE_ASSET_BASE_URL`
+(offline mirror host) apply to the jar exactly as they do to the APK/IPA. The jar
+is warmed by a **background prefetch at daemon startup**, but only when WebRTC
+streaming is configured (`AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` is set) — daemons that
+never stream download nothing.
+
+**Fail-modes.** The jar is *optional* (the encoder already degrades to
+`screenrecord`), so unavailability degrades gracefully — but integrity is never
+compromised:
+
+| Situation | Behavior |
+| --- | --- |
+| Checksum known + **matches** | use the jar |
+| Checksum known + **mismatch** | **fatal** `ActionableError` from stream start, even in degrade mode — a corrupted/tampered download is never silently accepted |
+| Checksum **absent** (a pin predating jar delivery / unknown) | **degrade** to `screenrecord` |
+| `AUTOMOBILE_REQUIRE_VIDEO_SERVER=1` | any degrade case becomes a **hard error** — for CI that must not silently fall back |
+| `AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD=1` | **local-only** (override / Gradle build); the network is never touched. A dedicated flag — it does **not** overload `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD`, whose CtrlProxy APK is mandatory |
+
+See [Environment variables](../../../using/environment-variables.md) for the full
+flag reference.
+
 ## Known limitations / future work
 
 - **Android only.** iOS `simctl` provides screenshots/finalized recordings, not a
   live H.264 elementary stream; a VideoToolbox encoder in the CtrlProxy runner is
   required. See [ios-webrtc-streaming.md](./ios-webrtc-streaming.md) (#3777) for
   the spike and recommended path.
-- **Persistent-encoder distribution.** The `video-server` jar removes the
-  segment-rotation seam and is preferred when present, but is not yet shipped in
-  the released package — until it is bundled/downloaded (like the CtrlProxy
-  runner), production installs resolve no jar and fall back to `screenrecord`.
+- ~~**Persistent-encoder distribution.**~~ *Resolved:* the `video-server` jar now
+  ships as a checksum-verified GitHub release asset and is downloaded/cached on
+  demand, so production installs use the persistent encoder by default. See
+  [Persistent-encoder delivery](#persistent-encoder-delivery-automobile-videojar)
+  above.
 - **No audio.** Video only; a device-audio capture source would be required to
   add an audio track (#3778).
 - **Reference server is single-process/in-memory.** Use a hardened WHIP/WHEP SFU

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -87,7 +87,21 @@ overridden per request on the `webrtc-stream.sock` control socket.
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}`. | `stun:stun.l.google.com:19302` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate (kbps). | encoder default |
 | `AUTOMOBILE_WEBRTC_MAX_SIZE` | Capture downscale as `WIDTHxHEIGHT` (e.g. `720x1280`). | native |
-| `AUTOMOBILE_VIDEO_SERVER_JAR` | Path to the built `automobile-video.jar` (persistent on-device encoder). When resolvable, capture prefers the persistent encoder over `screenrecord`. | Gradle build output, else `screenrecord` |
+| `AUTOMOBILE_VIDEO_SERVER_JAR` | Explicit path to a built `automobile-video.jar` (persistent on-device encoder). Highest resolution precedence: when set it is used directly, ahead of the cached/downloaded release jar and the Gradle build output. | (resolution precedence, see below) |
+| `AUTOMOBILE_REQUIRE_VIDEO_SERVER` | When `1`/`true`, a degrade-to-`screenrecord` case (no verifiable jar available) becomes a hard `ActionableError` instead. For CI that must run the persistent encoder. A checksum **mismatch** is always fatal regardless of this flag. | unset |
+| `AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD` | When `1`/`true`, never fetch the jar from the network: resolve from the local override or Gradle build output only. Dedicated flag — **not** `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` (the CtrlProxy APK is mandatory; the jar is optional and degrades). | unset |
 | `AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER` | Path to the built `screen-capture-helper` binary for iOS WebRTC capture. Build with `swift build` in `ios/screen-capture` from a repo checkout, or in `dist/ios/screen-capture` from a package install. | repo/package-local debug/release build output when present |
 | `AUTOMOBILE_IOS_WEBRTC_FFMPEG` | Path to the `ffmpeg` binary used to encode iOS helper BGRA frames into H.264 Annex-B. | `ffmpeg` on `PATH` |
 | `AUTOMOBILE_WEBRTC_TRICKLE_ICE` | Enable trickle ICE: publish the WHIP offer immediately and PATCH candidates incrementally instead of blocking on ICE gathering. Requires an ingest server supporting the WHIP trickle extension. | `false` |
+
+### `automobile-video.jar` resolution
+
+The persistent on-device encoder jar is resolved once at stream start, in this
+order: `AUTOMOBILE_VIDEO_SERVER_JAR` override → a valid cached download at
+`~/.auto-mobile/video-server/` → a fresh, sha256-verified download from the
+GitHub release → the local Gradle build output → else `screenrecord`. The jar is
+optional, so an unverifiable version degrades to `screenrecord`; a checksum
+**mismatch** is always fatal. `AUTOMOBILE_VERSION` (pin one coherent version) and
+`AUTOMOBILE_ASSET_BASE_URL` (offline mirror host) apply to the jar download just
+as they do to the CtrlProxy APK/IPA. See
+[WebRTC streaming — persistent-encoder delivery](../design-docs/mcp/observe/webrtc-streaming.md#persistent-encoder-delivery-automobile-videojar).


### PR DESCRIPTION
Closes #3837. Documents the jar delivery model and its new env flags — the final piece of the 8-PR series shipping `automobile-video.jar` (#3776) via GitHub releases.

## Changes
- **`docs/design-docs/mcp/observe/webrtc-streaming.md`**: new **Persistent-encoder delivery** section — the GitHub-release delivery / sha256-verify / persistent-cache (`~/.auto-mobile/video-server/` + sidecar) model, the resolution precedence (override → cached → download+verify → Gradle build → `screenrecord`), a fail-mode table (matches vs **mismatch-fatal** vs absent-degrade vs `REQUIRE` vs `SKIP`), the WHIP-gated startup prefetch, and that `AUTOMOBILE_VERSION`/`AUTOMOBILE_ASSET_BASE_URL` apply. Marks the old "Persistent-encoder distribution" limitation **resolved**.
- **`docs/using/environment-variables.md`**: add `AUTOMOBILE_REQUIRE_VIDEO_SERVER` and `AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD`; clarify `AUTOMOBILE_VIDEO_SERVER_JAR` as the highest-precedence override; add an `automobile-video.jar resolution` note spelling out precedence and that `AUTOMOBILE_VERSION` (pin) + `AUTOMOBILE_ASSET_BASE_URL` (mirror) apply to the jar too.

## Acceptance
- [x] Both docs updated.
- [x] No new page added, so `mkdocs.yml` nav is unchanged (per the "if a new page is added" clause).

## Validation
- `scripts/all_fast_validate_checks.sh --only mkdocs-nav,yaml` — clean.
- Cross-doc links + heading anchors verified consistent; all documented behavior checked against the shipped code (#3831 cache/sidecar, #3834 precedence/fail-modes/flags, #3835 prefetch gate).