### PR TITLE
test(android): record API 29 biometric validation

### DIFF
--- a/docs/design-docs/plat/android/biometrics.md
+++ b/docs/design-docs/plat/android/biometrics.md
@@ -49,11 +49,16 @@ Capability probing:
 - `adb -s <device> shell getprop ro.kernel.qemu` (1 indicates emulator)
 - `adb -s <device> emu help` to confirm `finger` commands are available
 
-## ADB validation (API 35)
+## ADB validation (API 29/35)
 
 Status:
 
-- API 29 not validated yet (no local AVD available).
+- API 35: enrollment/match/unlock sequence validated.
+- API 29 (`am-api29-ga-arm64`, July 15, 2026): enrollment and non-enrolled
+  rejection validate, but keyguard unlock with the enrolled `emu finger` id
+  remains unsupported/failed on the tested AVD. The probe handles API 29's
+  legacy keyguard dump fields and PIN/lockscreen setup, then reports this as a
+  failed unlock rather than a parser/setup failure.
 
 Automated smoke test:
 
@@ -67,7 +72,7 @@ Automated smoke test:
   `test/bats/probe-biometric-enrollment.bats`, and the tool-layer sequence is
   unit-covered in `test/features/action/BiometricAuth.test.ts`.
 
-Enrollment + auth steps (confirmed):
+Enrollment + auth steps (API 35 confirmed; API 29 status above):
 
 1. Set a device PIN (required for enrollment).
    - `adb -s <device> shell locksettings set-pin 1234`

--- a/scripts/local-dev/probe-biometric-enrollment.sh
+++ b/scripts/local-dev/probe-biometric-enrollment.sh
@@ -150,10 +150,18 @@ require_finger_support() {
 }
 
 keyguard_showing() {
-  adb_cmd shell dumpsys window \
-    | tr -d '\r' \
-    | grep -o 'isKeyguardShowing=[a-z]*' \
-    | head -1
+  local window_dump keyguard_state
+  window_dump="$(adb_cmd shell dumpsys window | tr -d '\r')"
+  keyguard_state="$(
+    printf '%s\n' "${window_dump}" \
+      | sed -nE \
+        -e 's/.*isKeyguardShowing=(true|false).*/isKeyguardShowing=\1/p' \
+        -e 's/.*mShowingLockscreen=(true|false).*/isKeyguardShowing=\1/p' \
+        -e 's/^[[:space:]]*showing=(true|false)[[:space:]]*$/isKeyguardShowing=\1/p' \
+        -e 's/^[[:space:]]*mIsShowing=(true|false)[[:space:]]*$/isKeyguardShowing=\1/p' \
+      | head -1
+  )"
+  printf '%s\n' "${keyguard_state:-unknown}"
 }
 
 enrolled_print_count() {
@@ -167,6 +175,9 @@ enrolled_print_count() {
 enroll_fingerprint() {
   log "Enrolling fingerprint id ${ENROLLED_FINGER_ID} (PIN ${DEVICE_PIN})"
   adb_cmd shell locksettings set-pin "${DEVICE_PIN}"
+  adb_cmd shell cmd lock_settings set-pin --old "${DEVICE_PIN}" "${DEVICE_PIN}"
+  adb_cmd shell cmd lock_settings set-disabled --old "${DEVICE_PIN}" false
+  adb_cmd shell settings put secure lock_screen_lock_after_timeout 0
   adb_cmd shell am start -a android.settings.FINGERPRINT_ENROLL > /dev/null 2>&1
   sleep 1
   adb_cmd shell input text "${DEVICE_PIN}"
@@ -184,10 +195,24 @@ enroll_fingerprint() {
 }
 
 lock_device() {
+  # Enrollment can leave API 29 in a credential Settings activity that does not
+  # show keyguard until the task is backgrounded.
+  adb_cmd shell input keyevent 3
+  sleep 1
   # Two keyevent 26 presses ensure the keyguard is shown (first may only wake).
   adb_cmd shell input keyevent 26
+  sleep 2
   adb_cmd shell input keyevent 26
   sleep 1
+}
+
+prime_fingerprint_unlock() {
+  log "Priming fingerprint unlock with PIN"
+  lock_device
+  adb_cmd shell input text "${DEVICE_PIN}"
+  adb_cmd shell input keyevent 66
+  sleep 1
+  printf 'keyguard after PIN prime: %s\n' "$(keyguard_showing)"
 }
 
 log "Probe configuration"
@@ -245,6 +270,8 @@ enroll_result="failed"
 if [[ "${enroll_count}" =~ ^[0-9]+$ && "${enroll_count}" -ge 1 ]]; then
   enroll_result="succeeded"
 fi
+
+prime_fingerprint_unlock
 
 log "Validating unlock with enrolled finger id ${ENROLLED_FINGER_ID}"
 lock_device

--- a/test/bats/probe-biometric-enrollment.bats
+++ b/test/bats/probe-biometric-enrollment.bats
@@ -72,13 +72,17 @@ case "$*" in
     printf 'android console command help:\n  finger        manage emulator fingerprint\n  kill          kill the emulator\n'
     exit 0
     ;;
-  "shell locksettings set-pin 1234")
+  "shell locksettings set-pin 1234"|"shell cmd lock_settings set-pin --old 1234 1234"|"shell cmd lock_settings set-disabled --old 1234 false"|"shell settings put secure lock_screen_lock_after_timeout 0")
     exit 0
     ;;
   "shell am start -a android.settings.FINGERPRINT_ENROLL")
     exit 0
     ;;
-  "shell input text 1234"|"shell input keyevent 66")
+  "shell input text 1234")
+    exit 0
+    ;;
+  "shell input keyevent 66")
+    printf 'isKeyguardShowing=false' > "${KEYGUARD_STATE_FILE}"
     exit 0
     ;;
   "shell cmd fingerprint sync")
@@ -100,8 +104,16 @@ case "$*" in
     exit 0
     ;;
   "shell dumpsys window")
-    cat "${KEYGUARD_STATE_FILE}"
-    printf '\n'
+    if [ "${KEYGUARD_FIELD_STYLE:-modern}" = "legacy" ]; then
+      state="$(sed 's/isKeyguardShowing=//' "${KEYGUARD_STATE_FILE}")"
+      printf '    KeyguardServiceDelegate\n'
+      printf '      showing=%s\n' "${state}"
+      printf '      KeyguardStateMonitor\n'
+      printf '        mIsShowing=%s\n' "${state}"
+    else
+      cat "${KEYGUARD_STATE_FILE}"
+      printf '\n'
+    fi
     exit 0
     ;;
 esac
@@ -162,6 +174,22 @@ SCRIPT
   grep -q "emu finger touch 2" "$INVOCATION_FILE"
   grep -q "shell dumpsys fingerprint" "$INVOCATION_FILE"
   grep -q "shell locksettings set-pin 1234" "$INVOCATION_FILE"
+  grep -q "shell cmd lock_settings set-pin --old 1234 1234" "$INVOCATION_FILE"
+  grep -q "shell cmd lock_settings set-disabled --old 1234 false" "$INVOCATION_FILE"
+  grep -q "shell settings put secure lock_screen_lock_after_timeout 0" "$INVOCATION_FILE"
+  grep -q "shell input keyevent 3" "$INVOCATION_FILE"
+}
+
+@test "accepts legacy API 29 KeyguardServiceDelegate keyguard output" {
+  make_mock_adb
+
+  run env ADB_SERIAL=emulator-5554 BOOT_TIMEOUT_SECONDS=5 ENROLL_TOUCH_CYCLES=2 KEYGUARD_FIELD_STYLE=legacy bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"keyguard before match: isKeyguardShowing=true"* ]]
+  [[ "$output" == *"keyguard after match:  isKeyguardShowing=false"* ]]
+  [[ "$output" == *"keyguard after mismatch: isKeyguardShowing=true"* ]]
+  [[ "$output" == *"smoke test PASSED"* ]]
 }
 
 @test "skips cleanly when the device does not expose emu finger" {


### PR DESCRIPTION
## Summary

Records the live API 29 biometric validation result from `am-api29-ga-arm64` and tightens the `emu finger` probe so it can distinguish real API 29 unlock behavior from parser/setup failures.

## Linked Issue

Refs #3584

## Bug / Regression Context

- **Prior attempts:** #3882 added the skippable live-emulator probe, but the issue remained open for API 29 validation.
- **Observed symptom:** API 29 uses legacy keyguard fields and needs explicit PIN/lockscreen setup after enrollment. Once those probe issues are fixed, enrollment and non-enrolled rejection pass, but keyguard unlock with the enrolled `emu finger` id still fails on the tested API 29 AVD.
- **Repro steps / conditions:** `AVD_NAME=am-api29-ga-arm64 REQUIRE_DEVICE=true KILL_ON_EXIT=true BOOT_TIMEOUT_SECONDS=300 ENROLL_TOUCH_CYCLES=10 bash scripts/local-dev/probe-biometric-enrollment.sh`

## Validation

- [x] `shfmt -i 2 -bn -ci -sr -d scripts/local-dev/probe-biometric-enrollment.sh test/bats/probe-biometric-enrollment.bats`
- [x] `shellcheck scripts/local-dev/probe-biometric-enrollment.sh`
- [x] `bats test/bats/probe-biometric-enrollment.bats` - 8/8 pass
- [x] `bash scripts/shellcheck/validate_shell_sete.sh`
- [x] `bash scripts/shellcheck/validate_shell_portability.sh`
- [x] `git diff --check`

## Device Verification

- [x] API 29 AVD `am-api29-ga-arm64`: enrollment succeeded (`enrolled prints: 1`), PIN prime unlocked keyguard, non-enrolled finger remained rejected, but enrolled finger did not unlock keyguard. Evidence saved locally in `scratch/issue-3584-api29-probe-after-prime.log` and `scratch/issue-3584-api29-probe-finger0.log`.
- [ ] API 29 `biometricAuth` app-prompt flow was not verified; no in-repo Android app screen with `BiometricPrompt` was found to exercise the callback path live.

## Follow-ups

- [ ] Keep #3584 open for the remaining API 29 unlock/tool validation decision.
