### PR TITLE
chore: update CtrlProxy APK and CtrlProxy iOS IPA SHA256

### DIFF
--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -208,8 +208,9 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
  */
 export const NIGHTLY_CHECKSUM_ENTRY: ReleaseChecksumEntry = {
   version: "nightly",
-  apkSha256: "1be224f4f5e5a21087a6552a9567290da64ad7deea6de6239a38324a8d91b0cc",
-  ipaSha256: "d71be829ab2415ac0b0027cd785b309f289855d19e4e8da1114740e5f652c577",
+  apkSha256: "4e824ccccd3a61a7098b2cf3365f55d36a73881e4a423f57670300ae9990ed2d",
+  ipaSha256: "d59b8ff38d5431f4994f45dedd992f567eeb52203ac39f7c02a2bd181a0a3fdb",
+    videoJarSha256: "9bec0f10cf2b055707bbea3337e17e7de17aa53df0ce153e14d29626c04903e3",
   runnerSha256: "ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a",
 };
 


### PR DESCRIPTION
## Automated Checksum Update

The nightly build produced artifacts with updated SHA256 checksums.

| Artifact | Previous | New | Changed |
|----------|----------|-----|---------|
| **APK** | `1be224f4f5e5a21087a6552a9567290da64ad7deea6de6239a38324a8d91b0cc` | `4e824ccccd3a61a7098b2cf3365f55d36a73881e4a423f57670300ae9990ed2d` | ✅ Yes |
| **IPA** | `d71be829ab2415ac0b0027cd785b309f289855d19e4e8da1114740e5f652c577` | `d59b8ff38d5431f4994f45dedd992f567eeb52203ac39f7c02a2bd181a0a3fdb` | ✅ Yes |
| **iOS Runner** | `ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a` | `ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a` | No |
| **video-server jar** | `(empty)` | `9bec0f10cf2b055707bbea3337e17e7de17aa53df0ce153e14d29626c04903e3` | ✅ Yes |

### Why did this happen?

SHA256 checksums change when any of these change:
- Source code in `android/control-proxy/src/`, `android/video-server/src/`, or `ios/control-proxy/`
- Build configuration (`build.gradle.kts` or `project.yml`)
- Dependencies or SDK versions

### What to do

1. Review this PR to ensure the changes are expected
2. Merge when ready
3. Future releases will use these checksums for artifact verification

---
Auto-generated by the `nightly` workflow