### PR TITLE
feat(video): allow long iOS recordings past the 300s cap (no segmentation)

### DIFF
--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -33,7 +33,13 @@ import { buildVideoArchiveItemUri, VIDEO_RESOURCE_URIS } from "./videoRecordingR
 import { VisualHighlightClient } from "../features/debug/VisualHighlight";
 
 const DEFAULT_MAX_DURATION_SECONDS = 30;
+// Per-platform single-recording caps chosen by resolveMaxDurationSeconds. Android >180s is
+// segmented before reaching the manager (see videoRecordingTools), so a direct Android
+// recording never legitimately exceeds MAX_DURATION_SECONDS; iOS `simctl recordVideo` has no
+// time limit and records continuously until SIGINT, so it only needs a higher cap. The
+// `videoRecording` schema's maxDuration ceiling mirrors IOS_MAX_DURATION_SECONDS.
 const MAX_DURATION_SECONDS = 300;
+export const IOS_MAX_DURATION_SECONDS = 3600;
 // Android uses HighlightAnimator's total fade-in + display + fade-out duration.
 // iOS SDK overlays auto-remove after their 3 second TTL.
 const ANDROID_HIGHLIGHT_ANIMATION_DURATION_MS = 6000;
@@ -223,15 +229,19 @@ function configToInput(config: VideoRecordingConfig): VideoRecordingConfigInput 
   };
 }
 
-function resolveMaxDurationSeconds(value?: number): number {
+function resolveMaxDurationSeconds(
+  value: number | undefined,
+  platform: BootedDevice["platform"]
+): number {
   if (value === undefined) {
     return DEFAULT_MAX_DURATION_SECONDS;
   }
   if (!Number.isFinite(value) || value <= 0) {
     throw new ActionableError("maxDuration must be a positive number of seconds.");
   }
-  if (value > MAX_DURATION_SECONDS) {
-    throw new ActionableError(`maxDuration must be <= ${MAX_DURATION_SECONDS} seconds.`);
+  const cap = platform === "ios" ? IOS_MAX_DURATION_SECONDS : MAX_DURATION_SECONDS;
+  if (value > cap) {
+    throw new ActionableError(`maxDuration must be <= ${cap} seconds.`);
   }
   return Math.round(value);
 }
@@ -549,7 +559,10 @@ export async function startVideoRecording(
   }
   const overrides = request.configOverrides ?? {};
   const configInput = await resolveConfigInput(overrides);
-  const maxDurationSeconds = resolveMaxDurationSeconds(request.maxDurationSeconds);
+  const maxDurationSeconds = resolveMaxDurationSeconds(
+    request.maxDurationSeconds,
+    request.device.platform
+  );
   const highlightInputs = request.highlights ?? [];
 
   for (const highlight of highlightInputs) {

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -10,6 +10,7 @@ import {
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
 import {
+  IOS_MAX_DURATION_SECONDS,
   listActiveVideoRecordings,
   startVideoRecording,
   stopVideoRecording,
@@ -168,16 +169,13 @@ const videoRecordingSchema = addDeviceTargetingToSchema(z.object({
   fps: z.number().int().positive().optional().describe("FPS"),
   resolution: resolutionSchema.optional().describe("Resolution"),
   format: z.enum(["mp4"]).optional(),
-  // Raised from 300 so long Android recordings (segmented under the hood) are
-  // accepted. Note: non-Android recordings still can't exceed the manager's
-  // single-recording cap (300s) since they aren't segmented; such a request
-  // passes schema validation but is rejected at videoRecordingManager. Left
-  // as-is intentionally (out of scope for segmented Android capture).
+  // Outer ceiling only; the manager enforces the real per-platform cap (iOS up to
+  // IOS_MAX_DURATION_SECONDS, non-iOS 300s — see resolveMaxDurationSeconds).
   maxDuration: z
     .number()
     .int()
     .positive()
-    .max(3600)
+    .max(IOS_MAX_DURATION_SECONDS)
     .optional()
     .describe("Max duration seconds"),
   outputName: z.string().optional().describe("Recording label"),

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -27,6 +27,11 @@ describe("videoRecordingManager", () => {
   let fakeRepository: FakeVideoRecordingRepository;
   let archiveRoot: string;
   let testDevice: BootedDevice;
+  const iosDevice: BootedDevice = {
+    deviceId: "ios-device",
+    platform: "ios",
+    name: "iPhone Simulator",
+  };
 
   beforeAll(async () => {
     archiveRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "auto-mobile-video-"));
@@ -196,11 +201,6 @@ describe("videoRecordingManager", () => {
   });
 
   test("records scheduled highlight timelines for iOS recordings", async () => {
-    const iosDevice: BootedDevice = {
-      deviceId: "ios-device",
-      platform: "ios",
-      name: "iPhone Simulator",
-    };
     const highlightShape = {
       type: "box",
       bounds: { x: 10, y: 20, width: 30, height: 40 },
@@ -237,11 +237,6 @@ describe("videoRecordingManager", () => {
   });
 
   test("uses iOS overlay lifetime for long recording highlight timelines", async () => {
-    const iosDevice: BootedDevice = {
-      deviceId: "ios-device",
-      platform: "ios",
-      name: "iPhone Simulator",
-    };
     const highlightShape = {
       type: "box",
       bounds: { x: 10, y: 20, width: 30, height: 40 },
@@ -305,5 +300,41 @@ describe("videoRecordingManager", () => {
         timeline: { appearedAtSeconds: 0.5, disappearedAtSeconds: 1 },
       },
     ]);
+  });
+
+  describe("maxDuration per-platform cap (#3906)", () => {
+    test("iOS recording past the 300s non-iOS cap is accepted and arms auto-stop at maxDuration", async () => {
+      // 500s: above the non-iOS cap (300), below the iOS cap (3600).
+      const active = await startVideoRecording({
+        device: iosDevice,
+        maxDurationSeconds: 500,
+      });
+
+      expect(fakeTimer.getPendingTimeoutCount()).toBe(1);
+      expect(fakeBackend.stopCalls.length).toBe(0);
+
+      // Just before 500s: still recording. At 500s: auto-stop fires.
+      fakeTimer.advanceTime(499_999);
+      expect(fakeBackend.stopCalls.length).toBe(0);
+      fakeTimer.advanceTime(1);
+      await waitForRecordingCount(0);
+      expect(fakeBackend.stopCalls.length).toBe(1);
+
+      expect(active.recordingId).toBeDefined();
+    });
+
+    test("iOS recording above the iOS cap (3600s) is rejected", async () => {
+      await expect(
+        startVideoRecording({ device: iosDevice, maxDurationSeconds: 3601 })
+      ).rejects.toThrow("maxDuration must be <= 3600 seconds.");
+      expect(fakeBackend.startCalls.length).toBe(0);
+    });
+
+    test("non-iOS recording above the 300s cap is still rejected (Android segments before the manager)", async () => {
+      await expect(
+        startVideoRecording({ device: testDevice, maxDurationSeconds: 301 })
+      ).rejects.toThrow("maxDuration must be <= 300 seconds.");
+      expect(fakeBackend.startCalls.length).toBe(0);
+    });
   });
 });

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -203,6 +203,31 @@ describe("videoRecording tool segmentation branch", () => {
     });
   });
 
+  test("iOS recording past the 300s cap starts as one continuous (non-segmented) recording (#3906)", async () => {
+    // 500s > the old 300s manager cap. iOS `simctl recordVideo` has no time limit, so this
+    // is a single continuous recording (never segmented), not a rejection or a segment set.
+    const res = parse(
+      await handler()(iosDevice, {
+        action: "start",
+        platform: "ios",
+        deviceId: iosDevice.deviceId,
+        maxDuration: 500,
+        outputName: "long-ios",
+      })
+    );
+
+    expect(res.count).toBe(1);
+    const recordings = res.recordings as Array<Record<string, unknown>>;
+    expect(recordings[0].segmented).toBeUndefined();
+    expect((recordings[0].settings as Record<string, unknown>).maxDurationSeconds).toBe(500);
+
+    await handler()(iosDevice, {
+      action: "stop",
+      platform: "ios",
+      recordingId: recordings[0].recordingId as string,
+    });
+  });
+
   test("android recording > 180s starts a segmented session and stop returns segments", async () => {
     const startRes = parse(
       await handler()(androidDevice, {


### PR DESCRIPTION
Fixes #3906. Follow-up from the review of #3847.

## Why

iOS `xcrun simctl io … recordVideo` has **no `--time-limit`** (unlike Android `screenrecord`, which hard-caps at 180s) — it records continuously until SIGINT flushes the moov atom. So iOS never needed segmentation to record long. The only thing blocking a >300s iOS recording was the manager's arbitrary `MAX_DURATION_SECONDS = 300` guard, which `resolveMaxDurationSeconds` applied to **every** platform. Before this change, an iOS `maxDuration` in `(300, 3600]` passed schema validation and then failed at runtime with `maxDuration must be <= 300 seconds`.

(This supersedes the earlier "segment iOS too" framing — segmentation exists solely to work around the Android cap; building it for iOS would fragment a continuous recording for no platform benefit.)

## What

- `resolveMaxDurationSeconds(value, platform)` is now platform-aware: iOS is bounded by the new `IOS_MAX_DURATION_SECONDS` (3600, matching the schema ceiling), non-iOS keeps 300s.
- The existing `scheduleAutoStop` already stops-and-flushes at the requested duration, so a long iOS request yields **one continuous file**.
- **Android is unchanged** — the tool segments Android >180s before the manager sees it, so a direct Android recording never legitimately exceeds 300s.
- The `videoRecording` schema's `maxDuration.max()` now references `IOS_MAX_DURATION_SECONDS` (single source of truth; no generated-schema drift — value stays 3600).

## Tests

- Manager (`videoRecordingManager.test.ts`): iOS 500s accepted **and auto-stops at 500s**; iOS 3601s rejected; non-iOS 301s still rejected — each asserting the backend start/stop calls.
- Tool (`videoRecordingToolSegmented.test.ts`): iOS 500s start stays single/non-segmented and threads `maxDurationSeconds` through the response.
- Ran `/simplify` (4-agent pass): consolidated repeated rationale comments and de-duplicated a triplicated `iosDevice` test fixture.

Local: 17/17 in the two touched suites, lint clean, build clean.