### PR TITLE
ci: bump kaeawc/setup-jemalloc v0.0.3 -> v0.0.5

### DIFF
--- a/.github/actions/gradle-task-run/action.yml
+++ b/.github/actions/gradle-task-run/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - name: "Set up jemalloc"
       if: ${{ inputs.malloc-replacement == 'jemalloc' }}
-      uses: kaeawc/setup-jemalloc@v0.0.3
+      uses: kaeawc/setup-jemalloc@v0.0.5
 
     - name: "Set up tcmalloc"
       if: ${{ inputs.malloc-replacement == 'tcmalloc' }}


### PR DESCRIPTION
## What

Bumps the pinned `kaeawc/setup-jemalloc` action from `v0.0.3` to `v0.0.5` in `.github/actions/gradle-task-run/action.yml` (our only usage; applied on Linux gradle runs via `malloc-replacement: jemalloc`).

## Why

Not a cosmetic bump — **v0.0.4 fixed a real SIGSEGV (exit 139)** that triggers when the composite action is invoked **more than once in the same job**. The old relocate step overwrote a live `LD_PRELOAD`'d `libjemalloc.so.2` in place with `cp`; the install is now atomic (temp file + `rename(2)`) and idempotent.

**Scope of the crash fix:** today exactly one job hits the double-invocation case — the manual `record` job in `record-screenshot-baselines.yml`, which calls the composite action twice (steps at lines 50 and 75). Every other callsite invokes the action once per job, where the in-place-overwrite crash can't trigger. So the crash fix's blast radius is that single `workflow_dispatch` baseline job, not the build fleet — but bumping everywhere keeps the pin consistent and picks up the fix for that job.

v0.0.5 layers on Linux-safe dead-code removal and efficiency cleanup with no consumer-facing behavior change (inputs/outputs unchanged: single optional `jemalloc-version` input, no outputs; cache key unchanged).

## Validation

- `scripts/all_fast_validate_checks.sh`: 14/15 pass. The one failure is `lychee` (doc link-liveness), unrelated to a version-pin bump.
- No open auto-mobile issues reference jemalloc.
- Reviewed from supply-chain (tag-pinning is repo convention; first-party action), claim-accuracy (release notes verified), and CI-behavior lenses.

Refs: [setup-jemalloc v0.0.4](https://github.com/kaeawc/setup-jemalloc/releases/tag/v0.0.4) · [v0.0.5](https://github.com/kaeawc/setup-jemalloc/releases/tag/v0.0.5)