### PR TITLE
feat(video): emit a segments.json manifest + grouping metadata for segmented recordings

### DIFF
--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -1,3 +1,5 @@
+import { promises as fsPromises } from "node:fs";
+import path from "node:path";
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import {
@@ -28,6 +30,63 @@ import type { Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 
 const DEFAULT_MAX_DURATION_SECONDS = 30;
+
+/** File name of the per-session manifest written alongside the first segment. */
+const SEGMENT_MANIFEST_FILE = "segments.json";
+
+/** One finalized segment of a timer-driven segmented session, in capture order. */
+interface StoppedSegment {
+  recordingId: string;
+  filePath: string;
+  segmentIndex: number;
+}
+
+/** Result of finalizing a segmented session: its ordered segments + grouping metadata. */
+interface StoppedSegmentedSession {
+  /** Stable session handle — the first segment's recordingId. Groups the segments. */
+  sessionId: string;
+  segments: StoppedSegment[];
+  /** Absolute path of the written manifest, or undefined if the write failed. */
+  manifestPath: string | undefined;
+}
+
+/**
+ * Write a `segments.json` manifest listing every segment of a session in order, so a caller
+ * (or an external process that only sees the archive on disk) can discover and concatenate
+ * the clips without re-deriving order. It is written into the FIRST segment's directory, so
+ * the existing per-recording eviction (`rm(dirname)`) cleans it up with that segment — no new
+ * eviction surface. Best-effort: a write failure is logged and returns undefined rather than
+ * failing the stop, since the tool response already carries the authoritative ordering.
+ */
+async function writeSegmentManifest(
+  sessionId: string,
+  segments: StoppedSegment[]
+): Promise<string | undefined> {
+  const first = segments[0];
+  if (!first) {
+    return undefined;
+  }
+  const manifestPath = path.join(path.dirname(first.filePath), SEGMENT_MANIFEST_FILE);
+  try {
+    const manifest = {
+      sessionId,
+      segmentCount: segments.length,
+      segments: segments.map(segment => ({
+        index: segment.segmentIndex,
+        recordingId: segment.recordingId,
+        filePath: segment.filePath,
+      })),
+    };
+    await fsPromises.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    return manifestPath;
+  } catch (error) {
+    logger.warn(
+      `[VideoRecording] Failed to write segment manifest for session ${sessionId}: ` +
+      `${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
+}
 
 type SegmentedSessionRecordingDependencies = Pick<
   AndroidSegmentedPlanVideoSessionOptions,
@@ -77,16 +136,23 @@ const segmentedSessions = (() => {
       }
     },
     /**
-     * Stop a tracked session: remove it from the registry, finalize it (which clears
-     * its rotation timer), and return the ordered segment recordingId/filePath pairs.
+     * Stop a tracked session: remove it from the registry, finalize it (which clears its
+     * rotation timer), write the session manifest, and return the ordered segments plus the
+     * grouping metadata (sessionId + manifestPath). The handle is the sessionId.
      */
     async stopAndRemove(
       handle: string,
       session: AndroidSegmentedPlanVideoSession
-    ): Promise<Array<{ recordingId: string; filePath: string }>> {
+    ): Promise<StoppedSegmentedSession> {
       byHandle.delete(handle);
       const { filePaths, recordingIds } = await session.stop();
-      return recordingIds.map((id, index) => ({ recordingId: id, filePath: filePaths[index] }));
+      const segments: StoppedSegment[] = recordingIds.map((id, index) => ({
+        recordingId: id,
+        filePath: filePaths[index],
+        segmentIndex: index,
+      }));
+      const manifestPath = await writeSegmentManifest(handle, segments);
+      return { sessionId: handle, segments, manifestPath };
     },
     /** Test seam: inject the Timer used by segmented sessions. */
     setTimer(timer: Timer | undefined): void {
@@ -254,11 +320,17 @@ async function tryStopSegmentedSession(recordingId: string) {
   }
 
   try {
-    const recordings = await segmentedSessions.stopAndRemove(recordingId, session);
+    const { sessionId, segments, manifestPath } = await segmentedSessions.stopAndRemove(
+      recordingId,
+      session
+    );
     return createJSONToolResponse({
       action: "stop",
-      count: recordings.length,
-      recordings,
+      count: segments.length,
+      manifestPath,
+      // Each segment carries sessionId + segmentIndex, so `recordings[]` has the same shape
+      // whether it came from a by-handle or a bare (multi-session) stop.
+      recordings: segments.map(segment => ({ ...segment, sessionId })),
       segmented: true,
     });
   } catch (error) {
@@ -345,6 +417,8 @@ export function registerVideoRecordingTools(): void {
 
             recordings.push({
               recordingId: active.recordingId,
+              // Session handle grouping the segments; matches the stop response's sessionId.
+              sessionId: active.recordingId,
               outputPath: active.outputPath,
               startedAt: active.startedAt,
               outputName: active.outputName,
@@ -412,6 +486,7 @@ export function registerVideoRecordingTools(): void {
       const results: Array<Record<string, unknown>> = [];
       const failures: Array<Record<string, unknown>> = [];
       const evictedRecordingIds: string[] = [];
+      const manifestPaths: string[] = [];
       let stoppedAnySegmented = false;
       const targetDevices = await resolveTargetDevices(device, args);
       let activeRecords: VideoRecordingRecord[] | undefined;
@@ -426,11 +501,19 @@ export function registerVideoRecordingTools(): void {
           stoppedAnySegmented = true;
           for (const [handle, session] of deviceSessions) {
             try {
-              const segments = await segmentedSessions.stopAndRemove(handle, session);
+              const { sessionId, segments, manifestPath } = await segmentedSessions.stopAndRemove(
+                handle,
+                session
+              );
+              if (manifestPath) {
+                manifestPaths.push(manifestPath);
+              }
               for (const segment of segments) {
                 results.push({
                   recordingId: segment.recordingId,
                   filePath: segment.filePath,
+                  segmentIndex: segment.segmentIndex,
+                  sessionId,
                   deviceId: target.deviceId,
                   platform: target.platform,
                   segmented: true,
@@ -507,6 +590,7 @@ export function registerVideoRecordingTools(): void {
         count: results.length,
         recordings: results,
         segmented: stoppedAnySegmented ? true : undefined,
+        manifestPaths: manifestPaths.length > 0 ? manifestPaths : undefined,
         failures: failures.length > 0 ? failures : undefined,
         evictedRecordingIds: evictedRecordingIds.length > 0 ? evictedRecordingIds : undefined,
       });

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -61,10 +61,15 @@ function parse(response: ToolResponse): Record<string, unknown> {
   return JSON.parse(response.content?.[0]?.text ?? "{}");
 }
 
+// Directory the fake segment paths live under. Set to the per-test archiveRoot in
+// beforeEach so a real, cross-platform, auto-cleaned dir exists when the tool writes the
+// segments.json manifest there (a hardcoded "/tmp" is not writable on the Windows CI leg).
+let fakeSegmentDir = os.tmpdir();
+
 function makeSegmentRecording(id: string, outputName: string | undefined): ActiveVideoRecording {
   return {
     recordingId: id,
-    outputPath: `/tmp/${id}.mp4`,
+    outputPath: path.join(fakeSegmentDir, `${id}.mp4`),
     fileName: `${id}.mp4`,
     startedAt: new Date(0).toISOString(),
     outputName,
@@ -76,7 +81,7 @@ function makeSegmentMetadata(id: string): VideoRecordingMetadata {
   return {
     recordingId: id,
     fileName: `${id}.mp4`,
-    filePath: `/tmp/${id}.mp4`,
+    filePath: path.join(fakeSegmentDir, `${id}.mp4`),
     format: "mp4",
     sizeBytes: 1,
     codec: "h264",
@@ -125,6 +130,7 @@ describe("videoRecording tool segmentation branch", () => {
     segmentStops = [];
     await fsPromises.rm(archiveRoot, { recursive: true, force: true });
     await fsPromises.mkdir(archiveRoot, { recursive: true });
+    fakeSegmentDir = archiveRoot;
 
     const service = new VideoRecorderService({
       backend: fakeBackend,
@@ -228,7 +234,7 @@ describe("videoRecording tool segmentation branch", () => {
     });
   });
 
-  test("android recording > 180s starts a segmented session and stop returns segments", async () => {
+  test("android recording > 180s: stop returns ordered segments + a segments.json manifest (#3905)", async () => {
     const startRes = parse(
       await handler()(androidDevice, {
         action: "start",
@@ -243,6 +249,8 @@ describe("videoRecording tool segmentation branch", () => {
     const started = (startRes.recordings as Array<Record<string, unknown>>)[0];
     expect(started.segmented).toBe(true);
     expect(started.outputName).toBe("vid");
+    // start echoes the session handle as sessionId so it matches stop output.
+    expect(started.sessionId).toBe(started.recordingId);
 
     const handle = started.recordingId as string;
     const stopRes = parse(
@@ -254,11 +262,31 @@ describe("videoRecording tool segmentation branch", () => {
     );
 
     expect(stopRes.segmented).toBe(true);
-    const stoppedSegments = stopRes.recordings as Array<Record<string, unknown>>;
+    const segments = stopRes.recordings as Array<Record<string, unknown>>;
     // No timer rotation occurred, so exactly the first segment is returned.
-    expect(stoppedSegments.length).toBe(1);
-    expect(stoppedSegments[0].recordingId).toBe(handle);
-    expect(typeof stoppedSegments[0].filePath).toBe("string");
+    expect(segments.length).toBe(1);
+    expect(segments[0].recordingId).toBe(handle);
+    expect(typeof segments[0].filePath).toBe("string");
+    // Grouping metadata: capture order + shared sessionId on every segment.
+    expect(segments[0].segmentIndex).toBe(0);
+    expect(segments[0].sessionId).toBe(handle);
+
+    // Manifest lives in the first segment's directory (so per-recording eviction cleans it up).
+    const manifestPath = stopRes.manifestPath as string;
+    expect(path.basename(manifestPath)).toBe("segments.json");
+    expect(path.dirname(manifestPath)).toBe(path.dirname(segments[0].filePath as string));
+
+    // On-disk manifest content matches the response, in order.
+    const manifest = JSON.parse(await fsPromises.readFile(manifestPath, "utf8"));
+    expect(manifest.sessionId).toBe(handle);
+    expect(manifest.segmentCount).toBe(segments.length);
+    expect(manifest.segments).toEqual(
+      segments.map((segment, index) => ({
+        index,
+        recordingId: segment.recordingId,
+        filePath: segment.filePath,
+      }))
+    );
   });
 
   test("bare (by-device) stop finalizes the segmented session and leaves no rotation timer", async () => {
@@ -324,6 +352,13 @@ describe("videoRecording tool segmentation branch", () => {
     expect(segments.every(segment => segment.segmented === true)).toBe(true);
     expect(typeof segments[0].filePath).toBe("string");
     expect(typeof segments[1].filePath).toBe("string");
+    // Segments carry their capture order and a shared sessionId (the first segment's id),
+    // and a bare stop surfaces the manifest path(s) it wrote (#3905).
+    expect(segments.map(segment => segment.segmentIndex)).toEqual([0, 1]);
+    const sessionId = segments[0].sessionId;
+    expect(sessionId).toBe(segments[0].recordingId);
+    expect(segments.every(segment => segment.sessionId === sessionId)).toBe(true);
+    expect((stopRes.manifestPaths as string[]).length).toBe(1);
 
     // Invariant: the rotation timer must not survive a bare stop.
     expect(segmentTimer.getPendingTimeoutCount()).toBe(0);


### PR DESCRIPTION
Fixes #3905. Follow-up from the review of #3847.

## Problem

A >180s Android `videoRecording` is split into ordered segments, each in its own per-recording directory. A caller (e.g. a QA-agent runner driving `videoRecording --action start/stop` directly) got back N file paths across N directories with nothing tying them together on disk.

## Why manifest-only (not a shared directory)

The archive eviction/delete path does `rm(path.dirname(record.filePath), {recursive:true})` ([videoRecordingManager.ts:757-759](../blob/main/src/server/videoRecordingManager.ts#L757)) — one directory per recording. A **true shared directory** for all segments would break that: evicting/deleting one segment would `rm -rf` the whole session folder, destroying sibling segments whose DB rows still point at the deleted files (the [VideoRecorderService invariant](../blob/main/src/features/video/VideoRecorderService.ts#L154): *"folders must not be shared across recordings"*). So this keeps per-recording dirs and adds a manifest instead — zero change to the correctness-critical eviction model.

## What

- On segmented stop, write a best-effort **`segments.json`** (`sessionId`, `segmentCount`, ordered `segments[]`) into the **first segment's directory**, so the existing per-recording eviction cleans it up — no new eviction surface. A write failure is logged and the stop still succeeds (the response carries authoritative ordering).
- The stop response gains `manifestPath` (by-handle) / `manifestPaths` (bare by-device). Every segment row carries **`sessionId`** (the session handle = first segment's `recordingId`, reusing the existing registry handle — no new id primitive) + **`segmentIndex`**, so `recordings[]` has a uniform shape across both stop modes. The start response echoes `sessionId` for symmetry.

## Tests

- `segments.json` file content + on-disk location match the response and are in order (real-deps, single segment, under the temp archiveRoot — deterministic, no flake).
- Bare by-device stop: `segmentIndex`/`sessionId` ordering + `manifestPaths` surfaced.
- Fake segment paths now resolve under the per-test `archiveRoot` instead of a hardcoded `/tmp`, so the manifest write is valid + auto-cleaned on **all platforms including Windows**.
- `/simplify` (4-agent): dropped a redundant top-level `sessionId`, folded a near-duplicate test into the existing one, trimmed comments.

Local: 22/22 in the touched suites, lint clean, build clean.

## Out of scope / follow-up

The plan-driven (`executePlan`) path finalizes via `AndroidSegmentedPlanVideoSession.finalize()` directly (not through the tool's `stopAndRemove`) and does not get a manifest. Captured as a follow-up to lift the writer into a shared module and cover both paths (deferred here to keep #3905 tool-scoped and respect YAGNI until a second consumer exists).