### PR TITLE
feat(a11y): default to direct activation under a screen reader (Model #1)

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1414,8 +1414,12 @@ export class TapOnElement extends BaseVisualChange {
   }
 
   /**
-   * Execute tap using CtrlProxy actions (TalkBack mode)
-   * Uses focus navigation when TalkBack is enabled, falls back to coordinate-based tapping if navigation fails.
+   * Execute tap using CtrlProxy actions (TalkBack mode).
+   *
+   * Default (#3936): directly activate the target via ACTION_CLICK — deterministic,
+   * no cursor stepping — then fall back to a coordinate gesture, then ADB.
+   * When `options.screenReaderNavigation` is set (opt-in fidelity mode, #3937),
+   * drive the TalkBack cursor by swipe navigation to the target before activating.
    * For longPress, tries ACTION_LONG_CLICK first, then coordinate gesture, then ADB.
    */
   private async executeAndroidTapWithAccessibility(
@@ -1424,7 +1428,7 @@ export class TapOnElement extends BaseVisualChange {
     y: number,
     element: Element,
     durationMs: number,
-    _options?: TapOnElementOptions,
+    options?: TapOnElementOptions,
     signal?: AbortSignal
   ): Promise<void> {
     const driver = this.talkBackDriverFactory.createDriver(this.device);
@@ -1449,23 +1453,40 @@ export class TapOnElement extends BaseVisualChange {
       return;
     }
 
-    // Try focus navigation for tap and doubleTap actions
     if (action === "tap" || action === "doubleTap") {
-      const result = await this.talkBackStrategy.executeTap(
-        this.device.deviceId,
-        element,
-        action as "tap" | "doubleTap",
-        driver
-      );
+      if (options?.screenReaderNavigation) {
+        // Opt-in fidelity mode (#3937): drive the TalkBack cursor by swipe
+        // navigation to the target, then activate.
+        const result = await this.talkBackStrategy.executeTap(
+          this.device.deviceId,
+          element,
+          action as "tap" | "doubleTap",
+          driver
+        );
 
-      if (result.success) {
-        return;
+        if (result.success) {
+          return;
+        }
+
+        logger.warn(
+          `[TapOnElement] Focus navigation failed (${result.error}), ` +
+          `falling back to coordinate-based tap at (${x}, ${y})`
+        );
+      } else if (action === "tap") {
+        // Default (#3936): directly activate the target node via ACTION_CLICK,
+        // without moving the cursor. doubleTap has no single accessibility action,
+        // so it drops straight to the coordinate fallback below.
+        const result = await this.talkBackStrategy.executeDirectActivation(element, driver);
+
+        if (result.success) {
+          return;
+        }
+
+        logger.warn(
+          `[TapOnElement] Direct accessibility activation failed (${result.error}), ` +
+          `falling back to coordinate-based tap at (${x}, ${y})`
+        );
       }
-
-      logger.warn(
-        `[TapOnElement] Focus navigation failed (${result.error}), ` +
-        `falling back to coordinate-based tap at (${x}, ${y})`
-      );
     }
 
     // Fallback to coordinate-based taps via accessibility service dispatchGesture
@@ -1565,8 +1586,9 @@ export class TapOnElement extends BaseVisualChange {
     y: number,
     durationMs: number
   ): Promise<void> {
-    // Resolve accessibility label: ios-accessibility-label > text > fallback
+    // Resolve accessibility label: ios-accessibility-label > content-desc > text > fallback
     const label = (element["ios-accessibility-label"] as string | undefined)
+      ?? (typeof element["content-desc"] === "string" && element["content-desc"] ? element["content-desc"] : undefined)
       ?? (typeof element.text === "string" && element.text ? element.text : undefined);
 
     if (!label) {

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -181,6 +181,46 @@ export class TalkBackTapStrategy {
   }
 
   /**
+   * Directly activate the target element via ACTION_CLICK, without moving the
+   * TalkBack cursor.
+   *
+   * This is the default screen-reader activation model (#3936): deterministic,
+   * a single accessibility action, and immune to the cursor-navigation failure
+   * modes of {@link executeTap}. It requires a resource-id to resolve the node;
+   * callers fall back to a coordinate gesture when this returns unsuccessful
+   * (e.g. no resource-id, or the node rejects the action).
+   *
+   * @param element - The target element (must have a resource-id to activate directly)
+   * @param driver - The TalkBack navigation driver
+   * @returns Result indicating success/failure; method is "accessibility-action"
+   */
+  async executeDirectActivation(
+    element: Element,
+    driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    const resourceId = element["resource-id"] as string | undefined;
+    if (!resourceId) {
+      return {
+        success: false,
+        method: "accessibility-action",
+        error: "Element has no resource-id for direct accessibility activation"
+      };
+    }
+
+    const result = await driver.requestAction("click", resourceId);
+    if (result.success) {
+      logger.info(`[TalkBackTapStrategy] Direct activation via ACTION_CLICK succeeded`);
+      return { success: true, method: "accessibility-action" };
+    }
+
+    return {
+      success: false,
+      method: "accessibility-action",
+      error: result.error ?? "ACTION_CLICK failed"
+    };
+  }
+
+  /**
    * Execute a coordinate-based tap as a fallback when focus navigation fails or isn't applicable.
    *
    * @param x - X coordinate

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -39,6 +39,13 @@ export interface TapOnElementOptions {
   // If not specified, will be determined automatically based on TalkBack state
   focusFirst?: boolean;
 
+  // Opt-in screen-reader navigation fidelity mode (see #3937). When true and a
+  // screen reader is active, drive the screen-reader cursor by swipe navigation
+  // to reach the target before activating — reproducing the real user journey.
+  // Default (false/undefined): activate the target node directly via the
+  // accessibility action (deterministic, no cursor stepping). See #3936.
+  screenReaderNavigation?: boolean;
+
   preTapStability?: boolean;
   retryIfNoChange?: boolean;
   ensureTap?: boolean;

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -13,11 +13,16 @@ export class FakeTalkBackTapStrategy {
   tapResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
   fallbackResult: TalkBackTapResult = { success: true, method: "coordinate-fallback" };
   longPressResult: TalkBackTapResult = { success: true, method: "accessibility-action" };
+  directActivationResult: TalkBackTapResult = { success: true, method: "accessibility-action" };
 
   tapCalls: Array<{
     deviceId: string;
     element: Element;
     action: TalkBackTapAction;
+  }> = [];
+
+  directActivationCalls: Array<{
+    element: Element;
   }> = [];
 
   fallbackCalls: Array<{
@@ -37,9 +42,18 @@ export class FakeTalkBackTapStrategy {
   private tapOverrides: TalkBackTapResult[] = [];
   private fallbackOverrides: TalkBackTapResult[] = [];
   private longPressOverrides: TalkBackTapResult[] = [];
+  private directActivationOverrides: TalkBackTapResult[] = [];
 
   setTapResult(result: TalkBackTapResult): void {
     this.tapResult = result;
+  }
+
+  setDirectActivationResult(result: TalkBackTapResult): void {
+    this.directActivationResult = result;
+  }
+
+  queueDirectActivationResult(result: TalkBackTapResult): void {
+    this.directActivationOverrides.push(result);
   }
 
   setFallbackResult(result: TalkBackTapResult): void {
@@ -75,6 +89,19 @@ export class FakeTalkBackTapStrategy {
     }
 
     return this.tapResult;
+  }
+
+  async executeDirectActivation(
+    element: Element,
+    _driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    this.directActivationCalls.push({ element });
+
+    if (this.directActivationOverrides.length > 0) {
+      return this.directActivationOverrides.shift()!;
+    }
+
+    return this.directActivationResult;
   }
 
   async executeCoordinateFallback(

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -460,6 +460,11 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
   let tapOnElement: TapOnElement;
   let executeAndroidTapWithCoordinates: any;
 
+  const makeElement = () => ({
+    "resource-id": "test:id/button",
+    "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+  } as any);
+
   beforeEach(() => {
     fakeAccessibilityDetector = new FakeAccessibilityDetector();
     fakeAccessibilityDetector.setTalkBackEnabled(true);
@@ -488,213 +493,161 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
     ).mockResolvedValue(undefined);
   });
 
-  test("delegates tap to TalkBackTapStrategy.executeTap", async () => {
-    const element = {
-      "resource-id": "test:id/button",
-      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-    } as any;
+  describe("default (direct activation)", () => {
+    test("tap directly activates the target via ACTION_CLICK, no cursor navigation", async () => {
+      const element = makeElement();
 
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "tap",
-      50,
-      50,
-      element,
-      500,
-      {},
-      undefined
-    );
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, {}, undefined
+      );
 
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.tapCalls[0].deviceId).toBe("emulator-5554");
-    expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
-    expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("tap");
-  });
-
-  test("delegates doubleTap to TalkBackTapStrategy.executeTap", async () => {
-    const element = {
-      "resource-id": "test:id/button",
-      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-    } as any;
-
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "doubleTap",
-      50,
-      50,
-      element,
-      500,
-      {},
-      undefined
-    );
-
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("doubleTap");
-  });
-
-  test("uses executeLongPress for longPress action", async () => {
-    const element = {
-      "resource-id": "test:id/button",
-      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-    } as any;
-
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "longPress",
-      50,
-      50,
-      element,
-      1000,
-      {},
-      undefined
-    );
-
-    // Should not call executeTap for longPress
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
-    // Should call executeLongPress (not coordinate fallback directly)
-    expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.longPressCalls[0]).toMatchObject({
-      x: 50,
-      y: 50,
-      durationMs: 1000,
-      element
-    });
-    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
-  });
-
-  test("falls back to ADB tap when executeLongPress fails", async () => {
-    const element = {
-      "resource-id": "test:id/button",
-      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-    } as any;
-
-    fakeTalkBackStrategy.setLongPressResult({
-      success: false,
-      method: "coordinate-fallback",
-      error: "Long press failed"
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.directActivationCalls[0].element).toBe(element);
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
+      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
     });
 
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "longPress",
-      50,
-      50,
-      element,
-      1000,
-      {},
-      undefined
-    );
+    test("tap falls back to coordinate gesture when direct activation fails", async () => {
+      fakeTalkBackStrategy.setDirectActivationResult({
+        success: false, method: "accessibility-action", error: "no node"
+      });
+      const element = makeElement();
 
-    expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
-    expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("longPress", 50, 50, 1000, element, undefined);
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, {}, undefined
+      );
+
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.fallbackCalls[0].action).toBe("tap");
+    });
+
+    test("tap falls back to ADB when direct activation and coordinate gesture both fail", async () => {
+      fakeTalkBackStrategy.setDirectActivationResult({
+        success: false, method: "accessibility-action", error: "no node"
+      });
+      fakeTalkBackStrategy.setFallbackResult({
+        success: false, method: "coordinate-fallback", error: "fallback failed"
+      });
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, {}, undefined
+      );
+
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+    });
+
+    test("doubleTap uses coordinate fallback (no ACTION_CLICK, no cursor navigation)", async () => {
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "doubleTap", 50, 50, element, 500, {}, undefined
+      );
+
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.fallbackCalls[0].action).toBe("doubleTap");
+    });
   });
 
-  test("uses coordinate fallback when focus navigation fails", async () => {
-    const element = {
-      "resource-id": "test:id/button",
-      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-    } as any;
+  describe("opt-in screen-reader navigation (fidelity mode)", () => {
+    const navOptions = { screenReaderNavigation: true } as any;
 
-    fakeTalkBackStrategy.setTapResult({
-      success: false,
-      method: "focus-navigation",
-      error: "Navigation failed"
+    test("tap drives the cursor via executeTap", async () => {
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, navOptions, undefined
+      );
+
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.tapCalls[0].deviceId).toBe("emulator-5554");
+      expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
+      expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("tap");
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
     });
 
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "tap",
-      50,
-      50,
-      element,
-      500,
-      {},
-      undefined
-    );
+    test("doubleTap drives the cursor via executeTap", async () => {
+      const element = makeElement();
 
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.fallbackCalls[0].action).toBe("tap");
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "doubleTap", 50, 50, element, 500, navOptions, undefined
+      );
+
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("doubleTap");
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
+    });
+
+    test("falls back to coordinate gesture when cursor navigation fails", async () => {
+      fakeTalkBackStrategy.setTapResult({
+        success: false, method: "focus-navigation", error: "Navigation failed"
+      });
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, navOptions, undefined
+      );
+
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.fallbackCalls[0].action).toBe("tap");
+    });
+
+    test("falls back to ADB when cursor navigation and coordinate gesture both fail", async () => {
+      fakeTalkBackStrategy.setTapResult({
+        success: false, method: "focus-navigation", error: "Navigation failed"
+      });
+      fakeTalkBackStrategy.setFallbackResult({
+        success: false, method: "coordinate-fallback", error: "Fallback failed"
+      });
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, navOptions, undefined
+      );
+
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+    });
   });
 
-  test("falls back to ADB tap when coordinate fallback fails", async () => {
-    const element = {
-      "resource-id": "test:id/button",
-      "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-    } as any;
+  describe("longPress (unaffected by navigation mode)", () => {
+    test("uses executeLongPress for longPress action", async () => {
+      const element = makeElement();
 
-    fakeTalkBackStrategy.setTapResult({
-      success: false,
-      method: "focus-navigation",
-      error: "Navigation failed"
-    });
-    fakeTalkBackStrategy.setFallbackResult({
-      success: false,
-      method: "coordinate-fallback",
-      error: "Fallback failed"
-    });
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "longPress", 50, 50, element, 1000, {}, undefined
+      );
 
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "tap",
-      50,
-      50,
-      element,
-      500,
-      {},
-      undefined
-    );
-
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
-    expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
-  });
-
-  test("routes text-only element through focus navigation", async () => {
-    const element = {
-      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
-      text: "Button without ID"
-    } as any;
-
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "tap",
-      50,
-      50,
-      element,
-      500,
-      {},
-      undefined
-    );
-
-    // Strategy is called even without resource-id
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
-    expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
-  });
-
-  test("falls back to ADB tap when strategy returns failure for element with no identifying info", async () => {
-    const element = {
-      bounds: { left: 0, top: 0, right: 100, bottom: 100 }
-      // no text, no resource-id, no content-desc
-    } as any;
-
-    fakeTalkBackStrategy.setTapResult({
-      success: false,
-      method: "focus-navigation",
-      error: "no identifying information"
-    });
-    fakeTalkBackStrategy.setFallbackResult({
-      success: false,
-      method: "coordinate-fallback",
-      error: "fallback failed"
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.longPressCalls[0]).toMatchObject({
+        x: 50, y: 50, durationMs: 1000, element
+      });
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
     });
 
-    await (tapOnElement as any).executeAndroidTapWithAccessibility(
-      "tap",
-      50,
-      50,
-      element,
-      500,
-      {},
-      undefined
-    );
+    test("falls back to ADB tap when executeLongPress fails", async () => {
+      fakeTalkBackStrategy.setLongPressResult({
+        success: false, method: "coordinate-fallback", error: "Long press failed"
+      });
+      const element = makeElement();
 
-    expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
-    expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
-    expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "longPress", 50, 50, element, 1000, {}, undefined
+      );
+
+      expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("longPress", 50, 50, 1000, element, undefined);
+    });
   });
 });

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -383,4 +383,53 @@ describe("TalkBackTapStrategy", () => {
       expect(result.error).toContain("tap failed");
     });
   });
+
+  describe("executeDirectActivation", () => {
+    test("activates via ACTION_CLICK when element has a resource-id", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setActionResult({ success: true, action: "click", totalTimeMs: 1 });
+
+      const result = await strategy.executeDirectActivation(element, driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("accessibility-action");
+      expect(driver.actionHistory).toHaveLength(1);
+      expect(driver.actionHistory[0]).toEqual({ action: "click", resourceId: "test:id/button" });
+      expect(driver.getTapCount()).toBe(0); // no cursor stepping, no coordinate taps
+    });
+
+    test("returns failure without attempting an action when element has no resource-id", async () => {
+      const element = {
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Button"
+      } as Element;
+
+      const result = await strategy.executeDirectActivation(element, driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("accessibility-action");
+      expect(result.error).toBeDefined();
+      expect(driver.getActionCount()).toBe(0);
+    });
+
+    test("returns failure when ACTION_CLICK is rejected", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+
+      driver.setActionResult({ success: false, action: "click", totalTimeMs: 1, error: "node not found" });
+
+      const result = await strategy.executeDirectActivation(element, driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("accessibility-action");
+      expect(result.error).toContain("node not found");
+      expect(driver.actionHistory[0]).toEqual({ action: "click", resourceId: "test:id/button" });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When a screen reader is active, the default `tapOn` path now **activates the target node directly via the accessibility action** instead of driving the TalkBack cursor by swipe navigation. Direct activation is deterministic and a single round-trip, and it sidesteps the cursor-navigation failure modes (wrong-direction stepping #3917, stale-bounds activation #3918). Cursor traversal is retained but only runs behind a new opt-in `TapOnElementOptions.screenReaderNavigation` flag — the "fidelity mode" tracked in #3937.

This is Model #1 from the label-activation-vs-cursor-traversal decision recorded on the epic (#3916).

Changes:
- `TalkBackTapStrategy.executeDirectActivation` — ACTION_CLICK by resource-id, with a typed failure when there's no id or the node rejects the action.
- `executeAndroidTapWithAccessibility` now defaults to direct activation for `tap`; `doubleTap` drops to the coordinate fallback (no single a11y action); swipe navigation runs only when `screenReaderNavigation` is set.
- iOS VoiceOver label now resolves from `content-desc` too (was `ios-accessibility-label` → `text` only), closing the content-desc gap noted in #3924.
- Fallback chain is unchanged: a11y action → coordinate (dispatchGesture) → ADB.

## Linked Issue

Closes #3936

## Validation

- [x] `bun run lint` passes (clean)
- [x] `bun run typecheck` reports no new errors (baseline gate; did not ratchet — 4 baseline entries that don't reproduce in this sandbox are dep-resolution-specific)
- [x] `test/features/talkback/` passes (39/39) — includes new `executeDirectActivation` unit coverage
- [x] `bun run build` succeeds
- [ ] `test/features/action/TapOnElement.talkback.test.ts` (delegation tests, updated for the new default + opt-in) — **could not run in this sandbox**: `TapOnElement`'s constructor allocates a real CtrlProxy port and the environment blocks socket binding (the unmodified baseline fails identically). These will run in CI.
- [x] New code uses interfaces + fakes; talkback unit tests run in <100ms

## Device Verification

- [ ] Not verified on-device — no emulator/simulator available in this environment. Recommend a manual pass: with TalkBack on, confirm `tapOn` activates a target via ACTION_CLICK (no swipe stepping) and that `screenReaderNavigation: true` still steps the cursor.

## Follow-ups

- [ ] #3937 — expose `screenReaderNavigation` as an MCP tool parameter and repair the traversal path (this PR wires the flag through the model + executor only)
- [ ] #3924 — remaining iOS focus/traversal layer (this PR only closes the content-desc label gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thhtbhq21RpzggLTxVB1oR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thhtbhq21RpzggLTxVB1oR)_