### PR TITLE
fix(ios): kill simctl child on timeout and drop redundant boot wait

### DIFF
--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -299,7 +299,15 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       case "android":
         return this.emulator.waitForEmulatorReady(device.name, timeoutMs, childProcess, device.deviceId);
       case "ios":
-        return this.simctl.waitForSimulatorReady(device.deviceId ?? device.name, timeoutMs);
+        // A `childProcess` is only supplied on the cold-boot path, where
+        // `startSimulator` has already run `bootstatus -b`. Signal that so the
+        // wait doesn't redundantly repeat the full boot-readiness wait; the
+        // already-running path (no childProcess) still performs it.
+        return this.simctl.waitForSimulatorReady(
+          device.deviceId ?? device.name,
+          timeoutMs,
+          { assumeBooted: Boolean(childProcess) }
+        );
       default:
         throw new ActionableError("Unknown platform");
     }

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -600,34 +600,44 @@ export class SimCtlClient implements SimCtl {
   ): Promise<BootedDevice> {
     const perf = createGlobalPerformanceTracker();
 
+    // The cold-boot path passes `assumeBooted`: startSimulator already ran
+    // `bootstatus -b` (which throws on failure/timeout), so the device is
+    // already fully booted. Re-running the wait here would be a redundant second
+    // boot wait with its own independent timeout budget (issue #3938 follow-up),
+    // so skip straight to metadata resolution.
+    if (options?.assumeBooted) {
+      return this.resolveReadySimulator(udid);
+    }
+
     // Use `simctl bootstatus -b` which blocks until the simulator is fully
     // booted (data migration complete, system app ready, springboard launched).
     // This is far more reliable than polling `simctl list devices` for state.
-    //
-    // Skip it when `assumeBooted` is set: the cold-boot path already ran
-    // `bootstatus -b` inside `startSimulator` (which throws on failure/timeout),
-    // so reaching here with a started handle means the device is already fully
-    // booted. Re-running it would be a redundant second boot wait with its own
-    // independent timeout budget (issue #3938 follow-up).
-    if (!options?.assumeBooted) {
-      perf.startOperation("bootstatus");
-      try {
-        await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
-      } catch (error) {
-        perf.endOperation("bootstatus");
-        const message = error instanceof Error ? error.message : String(error);
-        // "Invalid device" means the UDID doesn't exist at all
-        if (message.includes("Invalid device")) {
-          throw new ActionableError(`Simulator with UDID ${udid} not found`);
-        }
-        throw new ActionableError(
-          `Simulator with UDID ${udid} failed to become ready: ${message}`
-        );
-      }
+    perf.startOperation("bootstatus");
+    try {
+      await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
+    } catch (error) {
       perf.endOperation("bootstatus");
+      const message = error instanceof Error ? error.message : String(error);
+      // "Invalid device" means the UDID doesn't exist at all
+      if (message.includes("Invalid device")) {
+        throw new ActionableError(`Simulator with UDID ${udid} not found`);
+      }
+      throw new ActionableError(
+        `Simulator with UDID ${udid} failed to become ready: ${message}`
+      );
     }
+    perf.endOperation("bootstatus");
 
-    // Now look up device metadata to return a full BootedDevice
+    return this.resolveReadySimulator(udid);
+  }
+
+  /**
+   * Look up full device metadata for an already-booted simulator and return it
+   * as a BootedDevice. Shared by the cold-boot (assumeBooted) and already-running
+   * branches of {@link waitForSimulatorReady}.
+   */
+  private async resolveReadySimulator(udid: string): Promise<BootedDevice> {
+    const perf = createGlobalPerformanceTracker();
     perf.startOperation("deviceLookup");
     const simulator = (await this.listSimulatorImages())
       .find(device => device.deviceId === udid);

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -102,9 +102,12 @@ export interface SimCtl {
    * Wait for a simulator to be ready
    * @param udid - Device UDID to wait for
    * @param timeoutMs - Maximum time to wait in milliseconds
+   * @param options - When `assumeBooted` is set, skip the blocking `bootstatus -b`
+   *   readiness wait because the caller (e.g. `startSimulator`) already performed
+   *   it, and only resolve device metadata.
    * @returns Promise with booted device information
    */
-  waitForSimulatorReady(udid: string, timeoutMs?: number): Promise<BootedDevice>;
+  waitForSimulatorReady(udid: string, timeoutMs?: number, options?: { assumeBooted?: boolean }): Promise<BootedDevice>;
 
   /**
    * Get the list of available (booted and shutdown) simulator UDIDs
@@ -237,8 +240,21 @@ export interface SimCtl {
 }
 
 // Enhance the standard execAsync result to implement the ExecResult interface
-const execAsync = async (file: string, args: string[], maxBuffer?: number): Promise<ExecResult> => {
-  const options = maxBuffer ? { maxBuffer } : undefined;
+const execAsync = async (
+  file: string,
+  args: string[],
+  maxBuffer?: number,
+  signal?: AbortSignal
+): Promise<ExecResult> => {
+  // Pass the AbortSignal to execFile so that when a caller's timeout aborts, Node
+  // kills the child process (SIGTERM) instead of leaving it running orphaned
+  // (issue #3938). Without this a timed-out `bootstatus -b` keeps booting the
+  // simulator in the background after the tool has already reported failure.
+  const options: Parameters<typeof execFile>[2] =
+    maxBuffer && signal ? { maxBuffer, signal }
+      : maxBuffer ? { maxBuffer }
+        : signal ? { signal }
+          : undefined;
   const result = await promisify(execFile)(file, args, options);
 
   const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
@@ -336,7 +352,7 @@ interface SimulatorList {
 
 export class SimCtlClient implements SimCtl {
   device: BootedDevice | null;
-  execAsync: (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
+  execAsync: (file: string, args: string[], maxBuffer?: number, signal?: AbortSignal) => Promise<ExecResult>;
   private timer: Timer;
   private platform: NodeJS.Platform;
   private readonly usesInjectedExecAsync: boolean;
@@ -356,7 +372,7 @@ export class SimCtlClient implements SimCtl {
    */
   constructor(
     device: BootedDevice | null = null,
-    execAsyncFn: ((file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>) | null = null,
+    execAsyncFn: ((file: string, args: string[], maxBuffer?: number, signal?: AbortSignal) => Promise<ExecResult>) | null = null,
     timer: Timer = defaultTimer,
     platform: NodeJS.Platform = process.platform
   ) {
@@ -413,21 +429,32 @@ export class SimCtlClient implements SimCtl {
       throw new ActionableError(message);
     }
 
-    const runCommand = () => this.execAsync("xcrun", localArgs);
+    const runCommand = (signal?: AbortSignal) => this.execAsync("xcrun", localArgs, undefined, signal);
 
-    // Use Promise.race to implement timeout if specified
+    // Use Promise.race to implement timeout if specified. On timeout we abort the
+    // controller so the underlying child process is killed rather than left
+    // running orphaned (issue #3938).
     if (timeoutMs) {
       let timeoutId: NodeJS.Timeout;
+      const controller = new AbortController();
 
       const timeoutPromise = new Promise<ExecResult>((_, reject) => {
         timeoutId = this.timer.setTimeout(
-          () => reject(new Error(`Command timed out after ${timeoutMs}ms: ${fullCommand}`)),
+          () => {
+            controller.abort();
+            reject(new Error(`Command timed out after ${timeoutMs}ms: ${fullCommand}`));
+          },
           timeoutMs
         );
       });
 
+      const runPromise = runCommand(controller.signal);
+      // Once the timeout wins the race the aborted run promise rejects with an
+      // AbortError; keep it handled so it can't surface as an unhandledRejection.
+      runPromise.catch(() => { /* settled after timeout; result consumed via race */ });
+
       try {
-        const result = await Promise.race([runCommand(), timeoutPromise]);
+        const result = await Promise.race([runPromise, timeoutPromise]);
         const duration = this.timer.now() - startTime;
         logger.debug(`[iOS] Command completed in ${duration}ms: ${command}`);
         return result;
@@ -566,27 +593,39 @@ export class SimCtlClient implements SimCtl {
     await this.executeCommand(`shutdown ${device.deviceId}`);
   }
 
-  async waitForSimulatorReady(udid: string, timeoutMs?: number): Promise<BootedDevice> {
+  async waitForSimulatorReady(
+    udid: string,
+    timeoutMs?: number,
+    options?: { assumeBooted?: boolean }
+  ): Promise<BootedDevice> {
     const perf = createGlobalPerformanceTracker();
 
     // Use `simctl bootstatus -b` which blocks until the simulator is fully
     // booted (data migration complete, system app ready, springboard launched).
     // This is far more reliable than polling `simctl list devices` for state.
-    perf.startOperation("bootstatus");
-    try {
-      await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
-    } catch (error) {
-      perf.endOperation("bootstatus");
-      const message = error instanceof Error ? error.message : String(error);
-      // "Invalid device" means the UDID doesn't exist at all
-      if (message.includes("Invalid device")) {
-        throw new ActionableError(`Simulator with UDID ${udid} not found`);
+    //
+    // Skip it when `assumeBooted` is set: the cold-boot path already ran
+    // `bootstatus -b` inside `startSimulator` (which throws on failure/timeout),
+    // so reaching here with a started handle means the device is already fully
+    // booted. Re-running it would be a redundant second boot wait with its own
+    // independent timeout budget (issue #3938 follow-up).
+    if (!options?.assumeBooted) {
+      perf.startOperation("bootstatus");
+      try {
+        await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
+      } catch (error) {
+        perf.endOperation("bootstatus");
+        const message = error instanceof Error ? error.message : String(error);
+        // "Invalid device" means the UDID doesn't exist at all
+        if (message.includes("Invalid device")) {
+          throw new ActionableError(`Simulator with UDID ${udid} not found`);
+        }
+        throw new ActionableError(
+          `Simulator with UDID ${udid} failed to become ready: ${message}`
+        );
       }
-      throw new ActionableError(
-        `Simulator with UDID ${udid} failed to become ready: ${message}`
-      );
+      perf.endOperation("bootstatus");
     }
-    perf.endOperation("bootstatus");
 
     // Now look up device metadata to return a full BootedDevice
     perf.startOperation("deviceLookup");

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -32,7 +32,7 @@ function simulatorListPayload(devices: unknown[]): string {
 describe("Simctl", function() {
   let simctl: Simctl;
   let mockDevice: BootedDevice;
-  let mockExecAsync: (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
+  let mockExecAsync: (file: string, args: string[], maxBuffer?: number, signal?: AbortSignal) => Promise<ExecResult>;
 
   beforeEach(function() {
     resetSimctlCaches();
@@ -247,6 +247,89 @@ describe("Simctl", function() {
         `Command timed out after ${DEFAULT_DEVICE_READY_TIMEOUT_MS}ms: xcrun simctl bootstatus test-ios-device-id -b`,
       );
       resolveCommand?.(createExecResult("late bootstatus", ""));
+    });
+
+    test("aborts the underlying child process when the bootstatus wait times out", async function() {
+      const timer = new FakeTimer();
+      let capturedSignal: AbortSignal | undefined;
+      mockExecAsync = async (file: string, args: string[], _maxBuffer?: number, signal?: AbortSignal): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 1.0.0", "");
+        }
+        capturedSignal = signal;
+        // Simulate a long-running child that only settles when aborted, mirroring
+        // execFile rejecting with an AbortError once its signal fires.
+        return new Promise<ExecResult>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          });
+        });
+      };
+
+      simctl = new Simctl(mockDevice, mockExecAsync, timer);
+
+      const bootPromise = simctl.startSimulator("test-ios-device-id", 1234);
+      while (!capturedSignal) {
+        await Promise.resolve();
+      }
+      expect(capturedSignal.aborted).toBe(false);
+
+      timer.advanceTime(1234);
+
+      await expect(bootPromise).rejects.toThrow(
+        "Command timed out after 1234ms: xcrun simctl bootstatus test-ios-device-id -b",
+      );
+      // The timeout must abort the child rather than leave it running orphaned.
+      expect(capturedSignal.aborted).toBe(true);
+    });
+  });
+
+  describe("waitForSimulatorReady", function() {
+    const readyPayload = simulatorListPayload([
+      {
+        udid: "iphone-17-pro-udid",
+        name: "iPhone 17 Pro",
+        state: "Booted",
+        isAvailable: true,
+        deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro",
+        os_version: "26.4"
+      }
+    ]);
+
+    function recordingReadyExec(commands: string[][]): typeof mockExecAsync {
+      return async (file: string, args: string[]): Promise<ExecResult> => {
+        commands.push([file, ...args]);
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 1.0.0", "");
+        }
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          return createExecResult(readyPayload, "");
+        }
+        return createExecResult("", "");
+      };
+    }
+
+    test("runs bootstatus -b on the already-running path (no assumeBooted)", async function() {
+      const commands: string[][] = [];
+      simctl = new Simctl(mockDevice, recordingReadyExec(commands));
+
+      const device = await simctl.waitForSimulatorReady("iphone-17-pro-udid");
+
+      expect(device.deviceId).toBe("iphone-17-pro-udid");
+      expect(commands).toContainEqual([
+        "xcrun", "simctl", "bootstatus", "iphone-17-pro-udid", "-b",
+      ]);
+    });
+
+    test("skips the redundant bootstatus -b when assumeBooted is set (cold-boot path)", async function() {
+      const commands: string[][] = [];
+      simctl = new Simctl(mockDevice, recordingReadyExec(commands));
+
+      const device = await simctl.waitForSimulatorReady("iphone-17-pro-udid", 1234, { assumeBooted: true });
+
+      expect(device.deviceId).toBe("iphone-17-pro-udid");
+      // The cold-boot path already waited via startSimulator; no second boot wait.
+      expect(commands.some(c => c.includes("bootstatus"))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Two related fixes to the iOS `startDevice` boot path:

1. **Kill the child process on timeout.** `SimCtlClient` implemented its per-command timeout with `Promise.race([runCommand(), timeoutPromise])` but never killed the underlying child (`promisify(execFile)` was called with no `signal`). When a `bootstatus -b` exceeded its budget the tool reported failure while `xcrun simctl bootstatus` kept booting the simulator in the background; retries then collided with a half-booted device and orphaned processes accumulated. An `AbortSignal` is now threaded into `execAsync`/`execFile` and aborted when the timeout fires, so Node kills the child. The injected-`Timer` race is preserved so `FakeTimer` unit tests stay fast and deterministic.

2. **Stop waiting for boot twice.** In the cold-boot path `startSimulator` already runs `bootstatus -b` (throwing on failure/timeout), yet the subsequent `waitForSimulatorReady` ran `bootstatus -b` a second time with its own independent timeout budget. It now skips that redundant second wait via an `assumeBooted` signal (the presence of a started child handle) and only resolves device metadata. The already-running path — which has no started handle — still performs the `bootstatus -b` readiness wait.

## Linked Issue

Refs #3938

## Bug / Regression Context

- **Prior attempts:** n/a — first fix for this path.
- **Observed symptom:** user reports of iOS `startDevice` boot timing out / hanging; failures compounded on retry.
- **Repro steps / conditions:** a cold `startDevice` whose `bootstatus -b` exceeds its timeout budget — the command rejects but the `simctl` child keeps running, so the simulator finishes booting after the tool has reported failure and the next attempt hits a device stuck in `Booting`.

## Validation

- [x] `bun run lint` passes
- [x] `bun test` for the affected suites passes (`simctl`, `deviceUtils`, `devicePool`, `ios-cmdline-tools`, `fakes` — 220+ tests)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New tests use injected `execAsync` fakes + `FakeTimer`; unit tests run in <100ms
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Not run here — no real simulator in this environment. Recommend verifying a cold `startDevice` against a simulator whose first boot approaches the 120s budget, and confirming no orphaned `xcrun simctl bootstatus` processes remain after a timeout.

## Follow-ups

The same "timeout race never kills the child" pattern exists in two more clients, tracked in #3938:
- [ ] `AndroidEmulatorClient.executeCommand` (`promisify(exec)` — shell subtree)
- [ ] `XcodebuildClient.executeCommand`
- [ ] Replace the fabricated `ChildProcess` handles (iOS `kill: () => false`; Android `{} as ChildProcess`) with real cancellation affordances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aKikdGF1c8hfSQGqf62g8)_