### PR TITLE
Harden parallel-device coordination, session isolation, and autolock test coverage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -446,6 +446,50 @@ jobs:
           report_paths: '**/build/test-results/**/*.xml'
 
   # =============================================================================
+  # Android on-device H.264 capture integration tests (bun)
+  # =============================================================================
+  # These two integration suites (issues #3775 / #3776) are env-gated
+  # (AUTOMOBILE_ANDROID_H264_INTEGRATION / AUTOMOBILE_PERSISTENT_ENCODER_INTEGRATION)
+  # and are therefore SKIPPED by the normal `turbo run test` / coverage jobs. They
+  # cover the one seam the unit suites structurally cannot: the real
+  # `adb exec-out screenrecord --output-format=h264` command and the persistent
+  # on-device encoder against a live emulator. Nightly is the only place they run.
+  android-h264-integration-tests:
+    name: "Android H264 Capture Integration Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: build-video-server-jar
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - uses: ./.github/actions/setup-auto-mobile-npm-package
+
+      - name: "Download video-server jar"
+        uses: actions/download-artifact@v7
+        with:
+          name: video-server-jar
+          path: artifacts
+
+      - uses: ./.github/actions/android-emulator
+        with:
+          working-directory: './android/'
+          # cwd inside run-emulator-tests.sh is ./android/, so hop back to the repo
+          # root before invoking bun. The persistent-encoder suite resolves the DEX
+          # from AUTOMOBILE_VIDEO_SERVER_JAR (the artifact downloaded above).
+          script: |
+            cd "$GITHUB_WORKSPACE"
+            AUTOMOBILE_ANDROID_H264_INTEGRATION=1 \
+            AUTOMOBILE_ANDROID_H264_DEVICE_ID=emulator-5554 \
+              bun test test/integration/androidH264SourceDevice.integration.test.ts
+            AUTOMOBILE_PERSISTENT_ENCODER_INTEGRATION=1 \
+            AUTOMOBILE_ANDROID_H264_DEVICE_ID=emulator-5554 \
+            AUTOMOBILE_VIDEO_SERVER_JAR="$GITHUB_WORKSPACE/artifacts/automobile-video.jar" \
+              bun test test/integration/persistentEncoderH264SourceDevice.integration.test.ts
+
+  # =============================================================================
   # iOS simulator integration test (comprehensive daily run)
   # =============================================================================
   # Also runs on PRs that touch the native-integration surface (pull_request.yml).

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -989,6 +989,19 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
    */
   public bindSession(sessionId: string): void {
     if (this.boundSessionId !== sessionId) {
+      // A per-device client routes nav events to whichever session bound last.
+      // That is correct under the pool's one-device-one-live-session invariant
+      // (a device is released before it is reassigned). Trace the transition off
+      // a previously-bound session so a concurrent-share regression — two live
+      // sessions driving one device — is diagnosable in the logs. Debug, not
+      // warn: the common case (a released device rebinding to its next session)
+      // is expected and must not be noisy.
+      if (this.boundSessionId !== null) {
+        logger.debug(
+          `[AndroidCtrlProxyClient] Rebinding device ${this.device.deviceId} from session ` +
+          `${this.boundSessionId} to ${sessionId}`
+        );
+      }
       this.boundSessionId = sessionId;
       // Invalidate cached hierarchy detector so it picks up the new session's NavigationGraphManager
       if (this.hierarchyNavigationDetector) {
@@ -996,6 +1009,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         this.hierarchyNavigationDetector = null;
       }
     }
+  }
+
+  /**
+   * Test-only accessor for the currently bound session (or null when unbound).
+   * Lets isolation tests pin the routing invariant that `bindSession` is
+   * last-writer-wins and that an unbound client has no session.
+   */
+  public getBoundSessionIdForTesting(): string | null {
+    return this.boundSessionId;
   }
 
   /**

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -498,6 +498,16 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    */
   public bindSession(sessionId: string): void {
     if (this.boundSessionId !== sessionId) {
+      // See AndroidCtrlProxyClient.bindSession: a per-device client is
+      // last-writer-wins. Trace a transition off a previously-bound session so a
+      // concurrent-share regression is diagnosable, but stay at debug so the
+      // common released-then-reassigned case is not noisy.
+      if (this.boundSessionId !== null) {
+        logger.debug(
+          `[IOSCtrlProxyClient] Rebinding device ${this.device.deviceId} from session ` +
+          `${this.boundSessionId} to ${sessionId}`
+        );
+      }
       this.boundSessionId = sessionId;
       // Invalidate cached hierarchy detector so it picks up the new session's NavigationGraphManager
       if (this.hierarchyNavigationDetector) {
@@ -505,6 +515,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         this.hierarchyNavigationDetector = null;
       }
     }
+  }
+
+  /**
+   * Test-only accessor for the currently bound session (or null when unbound).
+   * Mirrors the Android client so isolation tests can pin the routing invariant.
+   */
+  public getBoundSessionIdForTesting(): string | null {
+    return this.boundSessionId;
   }
 
   /**

--- a/src/features/record/McpCallRecorder.ts
+++ b/src/features/record/McpCallRecorder.ts
@@ -40,6 +40,7 @@ export const INTERNAL_PARAMS = new Set([
   "devices",
   "keepScreenAwake",
   "__mcpSessionId",
+  "__lockNamespace",
   INTERNAL_NO_DIFF_PARAM,
 ]);
 

--- a/src/server/CriticalSectionCoordinator.ts
+++ b/src/server/CriticalSectionCoordinator.ts
@@ -17,6 +17,11 @@ export class CriticalSectionCoordinator {
   private readonly BARRIER_TIMEOUT_MS = 30000; // 30 seconds
   private readonly LOCK_CLEANUP_DELAY_MS = 5000; // 5 seconds after last device
 
+  // Separator used to build the internal map key from an optional namespace and
+  // the human lock name. NUL cannot appear in a plan-authored lock name or a
+  // session UUID, so `namespace + SEP + lock` is collision-free.
+  private static readonly NAMESPACE_SEPARATOR = "\u0000";
+
   private constructor() {
     this.locks = new Map();
     this.barrierCounts = new Map();
@@ -33,37 +38,51 @@ export class CriticalSectionCoordinator {
   }
 
   /**
+	 * Build the internal map key for a lock. When a namespace is supplied (the
+	 * plan's base session UUID), it scopes the lock so two independent plans that
+	 * happen to reuse the same lock name get isolated barrier/mutex state instead
+	 * of colliding (issue: cross-plan barrier collision). Callers that pass no
+	 * namespace key by the bare lock name, preserving the pre-namespace behavior.
+	 */
+  private scopedKey(lock: string, namespace?: string): string {
+    return namespace
+      ? `${namespace}${CriticalSectionCoordinator.NAMESPACE_SEPARATOR}${lock}`
+      : lock;
+  }
+
+  /**
 	 * Registers the expected number of devices for a lock.
 	 * Must be called before any device arrives at the barrier.
 	 */
-  public registerExpectedDevices(lock: string, deviceCount: number): void {
+  public registerExpectedDevices(lock: string, deviceCount: number, namespace?: string): void {
     if (deviceCount < 1) {
       throw new Error(
         `Invalid device count ${deviceCount} for lock "${lock}". Must be at least 1.`
       );
     }
 
+    const key = this.scopedKey(lock, namespace);
     logger.debug(
       `Registering ${deviceCount} expected devices for lock "${lock}"`
     );
-    this.expectedDeviceCounts.set(lock, deviceCount);
+    this.expectedDeviceCounts.set(key, deviceCount);
 
     // Ensure lock mutex exists
-    if (!this.locks.has(lock)) {
-      this.locks.set(lock, new Mutex());
+    if (!this.locks.has(key)) {
+      this.locks.set(key, new Mutex());
     }
 
-    if (!this.barrierCounts.has(lock)) {
-      this.barrierCounts.set(lock, new Set());
+    if (!this.barrierCounts.has(key)) {
+      this.barrierCounts.set(key, new Set());
     }
-    if (!this.barrierResolvers.has(lock)) {
-      this.barrierResolvers.set(lock, []);
+    if (!this.barrierResolvers.has(key)) {
+      this.barrierResolvers.set(key, []);
     }
 
-    const existingTimer = this.cleanupTimers.get(lock);
+    const existingTimer = this.cleanupTimers.get(key);
     if (existingTimer) {
       defaultTimer.clearTimeout(existingTimer);
-      this.cleanupTimers.delete(lock);
+      this.cleanupTimers.delete(key);
     }
   }
 
@@ -74,21 +93,23 @@ export class CriticalSectionCoordinator {
   public async enterCriticalSection(
     lock: string,
     deviceId: string,
-    timeout: number = this.BARRIER_TIMEOUT_MS
+    timeout: number = this.BARRIER_TIMEOUT_MS,
+    namespace?: string
   ): Promise<() => void> {
+    const key = this.scopedKey(lock, namespace);
     logger.debug(`Device ${deviceId} entering critical section "${lock}"`);
 
     // Ensure lock exists
-    if (!this.locks.has(lock)) {
-      this.locks.set(lock, new Mutex());
+    if (!this.locks.has(key)) {
+      this.locks.set(key, new Mutex());
     }
 
     // Wait at barrier
-    await this.waitAtBarrier(lock, deviceId, timeout);
+    await this.waitAtBarrier(key, deviceId, timeout, lock);
 
     // Acquire the mutex for serial execution
     logger.debug(`Device ${deviceId} acquiring lock "${lock}"`);
-    const release = await this.locks.get(lock)!.acquire();
+    const release = await this.locks.get(key)!.acquire();
 
     logger.debug(`Device ${deviceId} acquired lock "${lock}"`);
 
@@ -96,7 +117,7 @@ export class CriticalSectionCoordinator {
     return () => {
       logger.debug(`Device ${deviceId} releasing lock "${lock}"`);
       release();
-      this.scheduleCleanup(lock);
+      this.scheduleCleanup(key);
     };
   }
 
@@ -115,40 +136,47 @@ export class CriticalSectionCoordinator {
     lock: string,
     deviceId: string,
     deviceCount: number,
-    timeout: number = this.BARRIER_TIMEOUT_MS
+    timeout: number = this.BARRIER_TIMEOUT_MS,
+    namespace?: string
   ): Promise<void> {
-    this.registerExpectedDevices(lock, deviceCount);
-    await this.waitAtBarrier(lock, deviceId, timeout);
-    this.scheduleCleanup(lock);
+    this.registerExpectedDevices(lock, deviceCount, namespace);
+    const key = this.scopedKey(lock, namespace);
+    await this.waitAtBarrier(key, deviceId, timeout, lock);
+    this.scheduleCleanup(key);
   }
 
   /**
 	 * Wait at the barrier until all expected devices have arrived.
+	 *
+	 * Operates on the already-scoped map `key`; `label` is the human lock name
+	 * used only for log/error messages so namespaced keys never leak into
+	 * user-facing text.
 	 */
   private async waitAtBarrier(
-    lock: string,
+    key: string,
     deviceId: string,
-    timeout: number
+    timeout: number,
+    label: string
   ): Promise<void> {
-    const expectedCount = this.expectedDeviceCounts.get(lock);
+    const expectedCount = this.expectedDeviceCounts.get(key);
 
     if (expectedCount === undefined) {
       throw new Error(
-        `No expected device count registered for lock "${lock}". ` +
+        `No expected device count registered for lock "${label}". ` +
 					`Call registerExpectedDevices() before entering critical section.`
       );
     }
 
     // Add this device to the barrier
-    let arrivedDevices = this.barrierCounts.get(lock);
+    let arrivedDevices = this.barrierCounts.get(key);
     if (!arrivedDevices) {
       arrivedDevices = new Set();
-      this.barrierCounts.set(lock, arrivedDevices);
+      this.barrierCounts.set(key, arrivedDevices);
     }
 
     if (arrivedDevices.has(deviceId)) {
       throw new Error(
-        `Device ${deviceId} already arrived at barrier for lock "${lock}". ` +
+        `Device ${deviceId} already arrived at barrier for lock "${label}". ` +
 					`Nested critical sections with the same lock are not supported.`
       );
     }
@@ -157,17 +185,17 @@ export class CriticalSectionCoordinator {
     const currentCount = arrivedDevices.size;
 
     logger.debug(
-      `Device ${deviceId} arrived at barrier "${lock}" (${currentCount}/${expectedCount})`
+      `Device ${deviceId} arrived at barrier "${label}" (${currentCount}/${expectedCount})`
     );
 
     // If all devices have arrived, release all waiting devices
     if (currentCount === expectedCount) {
       logger.debug(
-        `All ${expectedCount} devices arrived at barrier "${lock}", releasing all`
+        `All ${expectedCount} devices arrived at barrier "${label}", releasing all`
       );
 
-      const resolvers = this.barrierResolvers.get(lock) || [];
-      this.barrierResolvers.set(lock, []);
+      const resolvers = this.barrierResolvers.get(key) || [];
+      this.barrierResolvers.set(key, []);
 
       // Release all waiting devices
       for (const resolve of resolvers) {
@@ -183,23 +211,23 @@ export class CriticalSectionCoordinator {
     // Wait for other devices to arrive
     await new Promise<void>((resolve, reject) => {
       // Add to waiters
-      const resolvers = this.barrierResolvers.get(lock) || [];
+      const resolvers = this.barrierResolvers.get(key) || [];
       resolvers.push(resolve);
-      this.barrierResolvers.set(lock, resolvers);
+      this.barrierResolvers.set(key, resolvers);
 
       // Set timeout
       const timer = defaultTimer.setTimeout(() => {
         // Remove this resolver
-        const currentResolvers = this.barrierResolvers.get(lock) || [];
+        const currentResolvers = this.barrierResolvers.get(key) || [];
         const index = currentResolvers.indexOf(resolve);
         if (index > -1) {
           currentResolvers.splice(index, 1);
         }
 
-        const arrivedCount = this.barrierCounts.get(lock)?.size || 0;
+        const arrivedCount = this.barrierCounts.get(key)?.size || 0;
         reject(
           new Error(
-            `Timeout waiting for critical section "${lock}". ` +
+            `Timeout waiting for critical section "${label}". ` +
 							`${arrivedCount}/${expectedCount} devices arrived after ${timeout}ms. ` +
 							`Missing devices may have failed or not reached the critical section.`
           )
@@ -214,7 +242,7 @@ export class CriticalSectionCoordinator {
       };
 
       // Replace the resolver with the wrapped version
-      const currentResolvers = this.barrierResolvers.get(lock) || [];
+      const currentResolvers = this.barrierResolvers.get(key) || [];
       const resolverIndex = currentResolvers.indexOf(resolve);
       if (resolverIndex > -1) {
         currentResolvers[resolverIndex] = wrappedResolve;
@@ -225,41 +253,45 @@ export class CriticalSectionCoordinator {
   /**
 	 * Schedule cleanup of lock resources after all devices have finished.
 	 */
-  private scheduleCleanup(lock: string): void {
-    const existingTimer = this.cleanupTimers.get(lock);
+  private scheduleCleanup(key: string): void {
+    const existingTimer = this.cleanupTimers.get(key);
     if (existingTimer) {
       defaultTimer.clearTimeout(existingTimer);
     }
 
     // Schedule new cleanup
     const timer = defaultTimer.setTimeout(() => {
-      logger.debug(`Cleaning up lock resources for "${lock}"`);
-      this.locks.delete(lock);
-      this.barrierCounts.delete(lock);
-      this.expectedDeviceCounts.delete(lock);
-      this.barrierResolvers.delete(lock);
-      this.cleanupTimers.delete(lock);
+      logger.debug(`Cleaning up lock resources for "${key}"`);
+      this.locks.delete(key);
+      this.barrierCounts.delete(key);
+      this.expectedDeviceCounts.delete(key);
+      this.barrierResolvers.delete(key);
+      this.cleanupTimers.delete(key);
     }, this.LOCK_CLEANUP_DELAY_MS);
 
-    this.cleanupTimers.set(lock, timer);
+    this.cleanupTimers.set(key, timer);
   }
 
   /**
 	 * Immediately clean up resources for a lock (used in error scenarios).
+	 *
+	 * Scoped by the same optional namespace as the other methods so one plan's
+	 * error-path cleanup cannot wipe a different plan's live lock state.
 	 */
-  public forceCleanup(lock: string): void {
+  public forceCleanup(lock: string, namespace?: string): void {
+    const key = this.scopedKey(lock, namespace);
     logger.debug(`Force cleaning up lock resources for "${lock}"`);
 
-    const existingTimer = this.cleanupTimers.get(lock);
+    const existingTimer = this.cleanupTimers.get(key);
     if (existingTimer) {
       defaultTimer.clearTimeout(existingTimer);
     }
 
-    this.locks.delete(lock);
-    this.barrierCounts.delete(lock);
-    this.expectedDeviceCounts.delete(lock);
-    this.barrierResolvers.delete(lock);
-    this.cleanupTimers.delete(lock);
+    this.locks.delete(key);
+    this.barrierCounts.delete(key);
+    this.expectedDeviceCounts.delete(key);
+    this.barrierResolvers.delete(key);
+    this.cleanupTimers.delete(key);
   }
 
   /**

--- a/src/server/barrierTools.ts
+++ b/src/server/barrierTools.ts
@@ -25,6 +25,14 @@ const barrierSchema = z.object({
     .positive()
     .optional()
     .describe("Barrier timeout ms (default 30000)"),
+  // Internal: the plan's base session UUID, injected by PlanExecutor
+  // (buildEnhancedStepParams). Scopes the shared coordinator so two independent
+  // plans that reuse the same lock name get isolated barriers instead of
+  // colliding. Not authored by users; stripped from recordings via INTERNAL_PARAMS.
+  __lockNamespace: z
+    .string()
+    .optional()
+    .describe("Internal plan-scoped lock namespace (injected)"),
 });
 
 type BarrierParams = z.infer<typeof barrierSchema>;
@@ -40,7 +48,7 @@ const barrierHandler = async (
   _progress?: unknown,
   signal?: AbortSignal
 ): Promise<any> => {
-  const { lock, deviceCount, timeout } = params;
+  const { lock, deviceCount, timeout, __lockNamespace: namespace } = params;
   const coordinator = CriticalSectionCoordinator.getInstance();
 
   logger.info(
@@ -50,11 +58,11 @@ const barrierHandler = async (
   throwIfAborted(signal);
 
   try {
-    await coordinator.awaitBarrier(lock, device.deviceId, deviceCount, timeout);
+    await coordinator.awaitBarrier(lock, device.deviceId, deviceCount, timeout, namespace);
   } catch (error) {
     // Release any devices still waiting so they fail fast instead of hanging
     // until their own barrier timeout.
-    coordinator.forceCleanup(lock);
+    coordinator.forceCleanup(lock, namespace);
 
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error(

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -61,6 +61,14 @@ const criticalSectionSchema = z.object({
     .describe(
       "Barrier timeout ms (default 30000)"
     ),
+  // Internal: the plan's base session UUID, injected by PlanExecutor
+  // (buildEnhancedStepParams). Scopes the shared coordinator so two independent
+  // plans that reuse the same lock name get isolated barriers instead of
+  // colliding. Not authored by users; stripped from recordings via INTERNAL_PARAMS.
+  __lockNamespace: z
+    .string()
+    .optional()
+    .describe("Internal plan-scoped lock namespace (injected)"),
 });
 
 type CriticalSectionParams = z.infer<typeof criticalSectionSchema>;
@@ -75,7 +83,7 @@ const criticalSectionHandler = async (
   _progress?: unknown,
   signal?: AbortSignal
 ): Promise<any> => {
-  const { lock, steps, deviceCount, timeout } = params;
+  const { lock, steps, deviceCount, timeout, __lockNamespace: namespace } = params;
   const normalizedSteps = PlanNormalizer.normalizeSteps(
     steps as CriticalSectionStepInput[]
   );
@@ -101,7 +109,7 @@ const criticalSectionHandler = async (
 
   // Register expected device count
   try {
-    coordinator.registerExpectedDevices(lock, deviceCount);
+    coordinator.registerExpectedDevices(lock, deviceCount, namespace);
   } catch (error) {
     throw new ActionableError(
       `Failed to register devices for critical section "${lock}": ${error}`
@@ -115,7 +123,8 @@ const criticalSectionHandler = async (
     release = await coordinator.enterCriticalSection(
       lock,
       device.deviceId,
-      timeout
+      timeout,
+      namespace
     );
 
     logger.info(
@@ -196,7 +205,7 @@ const criticalSectionHandler = async (
     });
   } catch (error) {
     // Force cleanup on error to prevent other devices from waiting forever
-    coordinator.forceCleanup(lock);
+    coordinator.forceCleanup(lock, namespace);
 
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error(

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -345,6 +345,16 @@ export class DefaultPlanExecutor implements PlanExecutor {
       logger.info(`[PlanExecutor] Injecting sessionUuid ${sessionUuid} into ${step.tool}`);
     }
 
+    // Scope the shared CriticalSectionCoordinator by the plan's base session UUID
+    // (identical across every device track of one plan, distinct across plans),
+    // so two concurrent plans reusing a lock name get isolated barriers. Only the
+    // criticalSection/barrier schemas declare __lockNamespace, so every other
+    // tool strips it at schema.parse; resolveExecutionTarget ignores __-params,
+    // so device routing is unaffected.
+    if (sessionUuid && !enhancedParams.__lockNamespace) {
+      enhancedParams.__lockNamespace = sessionUuid;
+    }
+
     return enhancedParams;
   }
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -2849,5 +2849,31 @@ describe("AndroidCtrlProxyClient", function() {
       // Simply verify the client was created without error
       expect(client).toBeDefined();
     });
+
+    // Pins the session-isolation invariants a per-device client relies on. A
+    // per-device CtrlProxy client is last-writer-wins: it is safe only because
+    // the pool guarantees one live session per device at a time. These assertions
+    // make a routing-semantics regression fail loudly instead of silently mixing
+    // one session's navigation state into another's.
+    test("is unbound (null) until a session is bound", function() {
+      // The per-test client from beforeEach is created without a session bound.
+      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBeNull();
+    });
+
+    test("is last-writer-wins: the most recently bound session is the active one", function() {
+      accessibilityServiceClient.bindSession("session-A");
+      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBe("session-A");
+
+      // Rebinding (e.g. the device is reassigned to a new session) switches the
+      // active session; the previous binding does not linger.
+      accessibilityServiceClient.bindSession("session-B");
+      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBe("session-B");
+    });
+
+    test("re-binding the same session is idempotent", function() {
+      accessibilityServiceClient.bindSession("session-A");
+      accessibilityServiceClient.bindSession("session-A");
+      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBe("session-A");
+    });
   });
 });

--- a/test/plan/planExecutorSessionRouting.test.ts
+++ b/test/plan/planExecutorSessionRouting.test.ts
@@ -234,6 +234,79 @@ describe("PlanExecutor - Session-based Device Routing", () => {
     expect(capturedParams[0]).toHaveProperty("testParam", "value1");
   });
 
+  test("injects __lockNamespace (base sessionUuid) into a tool whose schema declares it", async () => {
+    // The plan's base sessionUuid must reach the coordination tools as
+    // __lockNamespace so the shared CriticalSectionCoordinator is scoped per
+    // plan. Only schemas that declare the field keep it through schema.parse.
+    const capturedParams: any[] = [];
+    const mockHandler = mock(async (params: any) => {
+      capturedParams.push({ ...params });
+      return { success: true };
+    });
+
+    const testToolSchema = z.object({
+      platform: z.string().optional(),
+      sessionUuid: z.string().optional(),
+      __lockNamespace: z.string().optional(),
+      testParam: z.string().optional(),
+    });
+
+    ToolRegistry.register(
+      "testLockNamespaceTool",
+      "Test tool that declares __lockNamespace",
+      testToolSchema,
+      mockHandler
+    );
+    (ToolRegistry.getTool("testLockNamespaceTool")! as any).requiresDevice = true;
+
+    const plan: Plan = {
+      name: "Test Lock Namespace Injection",
+      mcpVersion: "1.0",
+      steps: [{ tool: "testLockNamespaceTool", params: { testParam: "v" } }],
+    };
+
+    const sessionUuid = "base-session-uuid-789";
+    await planExecutor.executePlan(plan, 0, "android", undefined, sessionUuid);
+
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0]).toHaveProperty("__lockNamespace", sessionUuid);
+  });
+
+  test("does NOT leak __lockNamespace to tools whose schema omits it", async () => {
+    // A regular tool's schema (no __lockNamespace) must strip the injected field,
+    // so the internal namespace never surfaces on ordinary tool params.
+    const capturedParams: any[] = [];
+    const mockHandler = mock(async (params: any) => {
+      capturedParams.push({ ...params });
+      return { success: true };
+    });
+
+    const testToolSchema = z.object({
+      platform: z.string().optional(),
+      sessionUuid: z.string().optional(),
+      testParam: z.string().optional(),
+    });
+
+    ToolRegistry.register(
+      "testNoLockNamespaceTool",
+      "Test tool that does not declare __lockNamespace",
+      testToolSchema,
+      mockHandler
+    );
+    (ToolRegistry.getTool("testNoLockNamespaceTool")! as any).requiresDevice = true;
+
+    const plan: Plan = {
+      name: "Test Lock Namespace Not Leaked",
+      mcpVersion: "1.0",
+      steps: [{ tool: "testNoLockNamespaceTool", params: { testParam: "v" } }],
+    };
+
+    await planExecutor.executePlan(plan, 0, "android", undefined, "base-session-uuid-000");
+
+    expect(capturedParams.length).toBe(1);
+    expect(capturedParams[0]).not.toHaveProperty("__lockNamespace");
+  });
+
   test("should NOT override deviceId if already present in step params", async () => {
     // Register a mock tool
     const capturedParams: any[] = [];

--- a/test/server/CriticalSectionCoordinator.test.ts
+++ b/test/server/CriticalSectionCoordinator.test.ts
@@ -377,4 +377,117 @@ describe("CriticalSectionCoordinator", () => {
 
     expect(executionLog.length).toBe(2);
   });
+
+  // Regression: the coordinator is a process-wide singleton, and the plan
+  // execution lock defaults to scope "session" — so two DIFFERENT plans (from
+  // different sessions) can run concurrently in one daemon. Before namespacing,
+  // both plans keyed barrier state by the bare lock name, so a device from plan
+  // B could satisfy plan A's barrier and release plan A's devices before plan
+  // A's own devices arrived. The namespace (the plan's base session UUID) scopes
+  // each plan's barrier so this cannot happen.
+  describe("cross-plan namespace isolation", () => {
+    // Yield the microtask queue so any synchronous barrier resolutions settle.
+    const flush = async (): Promise<void> => {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    };
+
+    test("WITHOUT a namespace, two plans reusing a lock name collide (documents the bug)", async () => {
+      // Both "plans" use the bare lock "sync" with deviceCount 2. A device from
+      // each plan arrives; with no namespace they share one barrier and 2/2 lifts
+      // it — releasing devices that belong to different plans.
+      let aReleased = false;
+      let bReleased = false;
+
+      const a1 = coordinator
+        .awaitBarrier("sync", "planA-device-1", 2, 30000)
+        .then(() => { aReleased = true; });
+      const b1 = coordinator
+        .awaitBarrier("sync", "planB-device-1", 2, 30000)
+        .then(() => { bReleased = true; });
+
+      await flush();
+
+      // The shared bare-lock barrier saw 2 arrivals and released both — even
+      // though neither plan actually had both of ITS devices present.
+      expect(aReleased).toBe(true);
+      expect(bReleased).toBe(true);
+      await Promise.all([a1, b1]);
+    });
+
+    test("WITH a per-plan namespace, one plan's devices cannot satisfy another plan's barrier", async () => {
+      let aReleased = false;
+      let bReleased = false;
+
+      // One device from each plan arrives at the same lock name but different
+      // namespaces. Neither barrier should lift: each still needs its own second
+      // device.
+      const a1 = coordinator
+        .awaitBarrier("sync", "planA-device-1", 2, 30000, "session-A")
+        .then(() => { aReleased = true; });
+      const b1 = coordinator
+        .awaitBarrier("sync", "planB-device-1", 2, 30000, "session-B")
+        .then(() => { bReleased = true; });
+
+      await flush();
+      expect(aReleased).toBe(false);
+      expect(bReleased).toBe(false);
+
+      // Plan A's second device arrives -> only plan A's barrier lifts.
+      const a2 = coordinator
+        .awaitBarrier("sync", "planA-device-2", 2, 30000, "session-A");
+      await flush();
+      expect(aReleased).toBe(true);
+      expect(bReleased).toBe(false);
+
+      // Plan B's second device arrives -> plan B's barrier lifts.
+      const b2 = coordinator
+        .awaitBarrier("sync", "planB-device-2", 2, 30000, "session-B");
+      await flush();
+      expect(bReleased).toBe(true);
+
+      await Promise.all([a1, a2, b1, b2]);
+    });
+
+    test("forceCleanup on one plan does not wipe another plan's live barrier state", async () => {
+      let aReleased = false;
+
+      // Plan A parks one device at the barrier.
+      const a1 = coordinator
+        .awaitBarrier("sync", "planA-device-1", 2, 30000, "session-A")
+        .then(() => { aReleased = true; });
+      await flush();
+
+      // Plan B (same lock name, different namespace) hits an error and force-
+      // cleans up ITS scope. This must not disturb plan A's waiting device.
+      coordinator.forceCleanup("sync", "session-B");
+      await flush();
+      expect(aReleased).toBe(false);
+
+      // Plan A's second device still completes the barrier normally.
+      const a2 = coordinator
+        .awaitBarrier("sync", "planA-device-2", 2, 30000, "session-A");
+      await flush();
+      expect(aReleased).toBe(true);
+
+      await Promise.all([a1, a2]);
+    });
+
+    test("critical-section mutexes are isolated per namespace (concurrent, not serialized, across plans)", async () => {
+      // Two plans each run a single-device critical section under the same lock
+      // name. With per-plan namespaces they use different mutexes, so plan B does
+      // not block on plan A's still-held lock.
+      coordinator.registerExpectedDevices("edit", 1, "session-A");
+      coordinator.registerExpectedDevices("edit", 1, "session-B");
+
+      const releaseA = await coordinator.enterCriticalSection("edit", "A-d1", 30000, "session-A");
+      // Plan B can still acquire its own namespaced lock while A holds A's.
+      const releaseB = await coordinator.enterCriticalSection("edit", "B-d1", 30000, "session-B");
+
+      // Both acquired independently.
+      expect(typeof releaseA).toBe("function");
+      expect(typeof releaseB).toBe("function");
+      releaseA();
+      releaseB();
+    });
+  });
 });

--- a/test/server/barrierTools.test.ts
+++ b/test/server/barrierTools.test.ts
@@ -84,4 +84,39 @@ describe("barrier tool", () => {
       )
     ).rejects.toThrow(/Barrier "lonely" failed for device device-1/);
   });
+
+  test("schema preserves the injected __lockNamespace (not stripped by parse)", () => {
+    const tool = ToolRegistry.getToolForPlan("barrier");
+    const parsed = tool!.schema.parse({
+      lock: "sync",
+      deviceCount: 2,
+      __lockNamespace: "session-A",
+    });
+    expect(parsed.__lockNamespace).toBe("session-A");
+  });
+
+  test("__lockNamespace scopes the barrier: same lock name, different plans do not cross-satisfy", async () => {
+    const tool = ToolRegistry.getToolForPlan("barrier");
+
+    // One device from plan A and one from plan B arrive at the same lock name
+    // "sync" (deviceCount 2) but with different namespaces. If the namespace were
+    // ignored the shared barrier would lift at 2 arrivals and both would pass;
+    // with scoping each still waits for its own second device, so both time out.
+    const aTimedOut = tool!.deviceAwareHandler!(
+      makeDevice("planA-device-1"),
+      { lock: "sync", deviceCount: 2, timeout: 50, __lockNamespace: "session-A" },
+      undefined,
+      undefined
+    ).then(() => "passed").catch(() => "timed-out");
+
+    const bTimedOut = tool!.deviceAwareHandler!(
+      makeDevice("planB-device-1"),
+      { lock: "sync", deviceCount: 2, timeout: 50, __lockNamespace: "session-B" },
+      undefined,
+      undefined
+    ).then(() => "passed").catch(() => "timed-out");
+
+    expect(await aTimedOut).toBe("timed-out");
+    expect(await bTimedOut).toBe("timed-out");
+  });
 });

--- a/test/utils/KeepScreenAwakeManager.test.ts
+++ b/test/utils/KeepScreenAwakeManager.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { KeepScreenAwakeManager } from "../../src/utils/KeepScreenAwakeManager";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android/AndroidCtrlProxyClient";
+import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { ExecResult } from "../../src/models";
+import type { BootedDevice } from "../../src/models";
+
+/**
+ * Unit coverage for KeepScreenAwakeManager (previously only tested indirectly
+ * through the session keep-awake slot). Exercises the device-type gate, the
+ * svc-stayon vs. settings-fallback branching in apply(), and the restore path.
+ *
+ * The a11y ctrl-proxy is stubbed to report failure so every settings read/write
+ * deterministically falls through to the injected fake AdbExecutor.
+ */
+
+const execResult = (stdout: string): ExecResult => ({
+  stdout,
+  stderr: "",
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (s: string) => stdout.includes(s),
+});
+
+interface FakeAdbOptions {
+  // command substring -> stdout to return
+  responses?: Array<{ match: string; stdout: string }>;
+  // command substrings that should reject (simulate command failure)
+  reject?: string[];
+}
+
+class FakeAdb implements Partial<AdbExecutor> {
+  calls: string[] = [];
+  constructor(private readonly opts: FakeAdbOptions = {}) {}
+
+  async executeCommand(command: string): Promise<ExecResult> {
+    this.calls.push(command);
+    if (this.opts.reject?.some(r => command.includes(r))) {
+      throw new Error(`fake adb: command failed: ${command}`);
+    }
+    const hit = this.opts.responses?.find(r => command.includes(r.match));
+    return execResult(hit ? hit.stdout : "");
+  }
+
+  called(substring: string): boolean {
+    return this.calls.some(c => c.includes(substring));
+  }
+}
+
+const makeFactory = (adb: FakeAdb): AdbClientFactory => ({
+  create: () => adb as unknown as AdbExecutor,
+});
+
+const physicalDevice: BootedDevice = {
+  platform: "android",
+  deviceId: "R58N9ABC123", // not "emulator-*"
+  name: "Pixel 8",
+};
+
+describe("KeepScreenAwakeManager", () => {
+  let a11ySpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Force all settings get/put through adb by making the a11y proxy report failure.
+    a11ySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestSettingsGet: async () => ({ success: false }),
+      requestSettingsPut: async () => ({ success: false }),
+    } as unknown as AndroidCtrlProxyClient);
+  });
+
+  afterEach(() => {
+    a11ySpy.mockRestore();
+  });
+
+  test("apply(false) is a no-op with skipReason 'disabled' and touches no adb", async () => {
+    const adb = new FakeAdb();
+    const mgr = new KeepScreenAwakeManager(physicalDevice, makeFactory(adb));
+
+    const state = await mgr.apply(false);
+
+    expect(state).toEqual({ applied: false, skipReason: "disabled" });
+    expect(adb.calls.length).toBe(0);
+  });
+
+  test("skips non-android devices with skipReason 'unsupported'", async () => {
+    const adb = new FakeAdb();
+    const iosDevice: BootedDevice = { platform: "ios", deviceId: "sim-1", name: "iPhone" };
+    const mgr = new KeepScreenAwakeManager(iosDevice, makeFactory(adb));
+
+    const state = await mgr.apply(true);
+
+    expect(state).toEqual({ applied: false, skipReason: "unsupported" });
+    expect(adb.calls.length).toBe(0);
+  });
+
+  test("skips emulator devices (by deviceId prefix) with skipReason 'emulator'", async () => {
+    const adb = new FakeAdb();
+    const emulator: BootedDevice = { platform: "android", deviceId: "emulator-5554", name: "AVD" };
+    const mgr = new KeepScreenAwakeManager(emulator, makeFactory(adb));
+
+    const state = await mgr.apply(true);
+
+    expect(state.applied).toBe(false);
+    expect(state.skipReason).toBe("emulator");
+  });
+
+  test("returns 'detection_failed' when ro.kernel.qemu is an unexpected value", async () => {
+    const adb = new FakeAdb({
+      responses: [{ match: "getprop ro.kernel.qemu", stdout: "garbage" }],
+    });
+    const mgr = new KeepScreenAwakeManager(physicalDevice, makeFactory(adb));
+
+    const state = await mgr.apply(true);
+
+    expect(state.applied).toBe(false);
+    expect(state.skipReason).toBe("detection_failed");
+  });
+
+  test("physical device: uses svc stayon when it succeeds (method 'svc')", async () => {
+    const adb = new FakeAdb({
+      responses: [
+        { match: "getprop ro.kernel.qemu", stdout: "0" }, // physical
+        { match: "settings get global stay_on_while_plugged_in", stdout: "0" },
+      ],
+      // svc power stayon true resolves (not in reject list)
+    });
+    const mgr = new KeepScreenAwakeManager(physicalDevice, makeFactory(adb));
+
+    const state = await mgr.apply(true);
+
+    expect(state.applied).toBe(true);
+    expect(state.method).toBe("svc");
+    expect(state.svcWasEnabled).toBe(false); // parsed from "0"
+    expect(adb.called("shell input keyevent KEYCODE_WAKEUP")).toBe(true);
+    expect(adb.called("shell svc power stayon true")).toBe(true);
+    // Should not have fallen back to the settings put path.
+    expect(adb.called("settings put system screen_off_timeout")).toBe(false);
+  });
+
+  test("physical device: falls back to settings when svc stayon fails (method 'settings')", async () => {
+    const adb = new FakeAdb({
+      responses: [
+        { match: "getprop ro.kernel.qemu", stdout: "0" },
+        { match: "settings get global stay_on_while_plugged_in", stdout: "0" },
+        { match: "settings get system screen_off_timeout", stdout: "120000" },
+      ],
+      reject: ["svc power stayon true"],
+    });
+    const mgr = new KeepScreenAwakeManager(physicalDevice, makeFactory(adb));
+
+    const state = await mgr.apply(true);
+
+    expect(state.applied).toBe(true);
+    expect(state.method).toBe("settings");
+    expect(state.appliedSettings).toEqual({ stayOnWhilePluggedIn: true, screenOffTimeout: true });
+    expect(state.originalScreenOffTimeout).toBe("120000");
+    expect(adb.called("settings put global stay_on_while_plugged_in 7")).toBe(true);
+    expect(adb.called("settings put system screen_off_timeout 2147483647")).toBe(true);
+  });
+
+  test("restore() reverts the settings method to the captured original values", async () => {
+    const adb = new FakeAdb();
+    const mgr = new KeepScreenAwakeManager(physicalDevice, makeFactory(adb));
+
+    await mgr.restore({
+      applied: true,
+      method: "settings",
+      originalStayOnWhilePluggedIn: "0",
+      originalScreenOffTimeout: "60000",
+      appliedSettings: { stayOnWhilePluggedIn: true, screenOffTimeout: true },
+    });
+
+    expect(adb.called("settings put global stay_on_while_plugged_in 0")).toBe(true);
+    expect(adb.called("settings put system screen_off_timeout 60000")).toBe(true);
+  });
+
+  test("restore() is a no-op when nothing was applied", async () => {
+    const adb = new FakeAdb();
+    const mgr = new KeepScreenAwakeManager(physicalDevice, makeFactory(adb));
+
+    await mgr.restore({ applied: false, skipReason: "disabled" });
+
+    expect(adb.calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Investigation of AutoMobile's support for parallel device operation, session isolation, and autolock surfaced one live correctness bug and two test-coverage gaps. This PR fixes the bug and closes the gaps, wiring everything into CI.

**1. Critical-section/barrier coordinator collided across concurrent plans (live bug).** `CriticalSectionCoordinator` is a process-wide singleton whose barrier/mutex state was keyed only by the plan-authored lock name. The plan-execution lock defaults to scope `"session"`, so two plans from *different* sessions run concurrently in one daemon. When both reused a lock name (e.g. the docs' `"chat-room"`), a device from one plan could satisfy the other plan's barrier and release its devices before that plan's own devices arrived; one plan's error-path `forceCleanup` also wiped the other's live lock state. Every coordinator key is now scoped by an optional namespace — the plan's base session UUID, identical across all device tracks of one plan and distinct across plans — injected by `PlanExecutor` as the internal `__lockNamespace` param (declared only by the `criticalSection`/`barrier` schemas, ignored by device routing, stripped from recordings). Callers that pass no namespace keep the prior bare-lock behavior.

**2. `KeepScreenAwakeManager` had no dedicated unit test.** Added hermetic coverage of the device-type gate, the `svc power stayon` vs. settings-fallback branching, and the restore path (a11y proxy stubbed; settings I/O routed through an injected fake `AdbExecutor`).

**3. Two Android on-device H.264 integration suites had no CI execution path** — they were skipped everywhere because their env vars were set nowhere. Wired into a new nightly emulator job that downloads the video-server jar artifact and runs both suites against a booted device.

Also added a debug trace + isolation-invariant tests for the per-device CtrlProxy `bindSession` (last-writer-wins is safe only under the one-live-session-per-device pool invariant), so a concurrent-share routing regression fails loudly in CI rather than silently mixing session state.

## Linked Issue

<!-- No pre-existing issue; surfaced during investigation. -->

## Bug / Regression Context

- **Observed symptom:** two concurrent multi-device plans (different sessions) that reuse a `criticalSection`/`barrier` lock name interfere — barriers lift with the wrong devices, and one plan's cleanup wipes the other's lock state.
- **Repro steps / conditions:** default `planExecutionLockScope: "session"`; two sessions each `executePlan` a multi-device plan whose `criticalSection`/`barrier` step uses the same `lock` value. Deterministically reproduced by the new coordinator interleave tests.
- **Prior attempts:** none; the collision was untested (existing tests `reset()` between cases and never interleave two plans).

## Validation

- [x] `bun test` on all touched suites passes (coordinator, barrier/criticalSection handlers, PlanExecutor injection, KeepScreenAwakeManager, record/INTERNAL_PARAMS, parallel-execution, plan validators) — 359 tests green
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` succeeds
- [x] `scripts/all_fast_validate_checks.sh --only yaml` passes for the workflow change
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [ ] Note: `test/features/observe/CtrlProxyClient.test.ts` can't run in the sandbox (PortManager probes host ports, none free ≥8765); the added tests are pure in-memory and reuse the per-test client, so they run in CI. Verified the file fails identically on the unmodified tree, confirming it's environmental, not introduced here.

## Device Verification

- [ ] The nightly H.264 emulator job is the on-device verification path for the wired-in integration suites; not run locally in this sandbox.

## Follow-ups

- [ ] A true runtime *assertion* against concurrent device-sharing (throw, not debug-trace) would require coupling the CtrlProxy client to session liveness; deferred to keep this change conservative. The current trace + invariant tests make a regression diagnosable and CI-visible.
- [ ] The persisted navigation-graph SQLite DB is intentionally shared across sessions (keyed by appId, not sessionId); flagged during investigation as in-memory-only isolation, not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017cwSQsC9sgD6TnzWD9DFDP)_