### PR TITLE
test(video): inject a narrow device detector to de-flake segmented bare-stop tests (#3943)

### DIFF
--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -188,6 +188,27 @@ export function resetSegmentedSessions(): void {
   segmentedSessions.reset();
 }
 
+/**
+ * Narrow device-detection seam used by {@link resolveTargetDevices} when a call targets
+ * all devices (e.g. a bare, by-device stop). The real {@link DeviceSessionManager} singleton
+ * satisfies it. Exposing only `detectConnectedPlatforms` keeps this honest under strict `tsc`
+ * (a fake need not reproduce the manager's nominal private members) and lets a test resolve
+ * devices without spawning real `adb`/`xcrun simctl` subprocesses — the latter can stall past
+ * a test's timeout on a loaded macOS CI runner (issue #3943).
+ */
+interface ConnectedDeviceDetector {
+  detectConnectedPlatforms(): Promise<BootedDevice[]>;
+}
+
+let deviceDetectorForTesting: ConnectedDeviceDetector | undefined;
+
+/** Test seam: inject the detector used to resolve all-device targets. Pass undefined to reset. */
+export function setVideoRecordingDeviceDetectorForTesting(
+  detector: ConnectedDeviceDetector | undefined
+): void {
+  deviceDetectorForTesting = detector;
+}
+
 export interface VideoRecordingArgs {
   action: "start" | "stop";
   platform: "android" | "ios";
@@ -283,7 +304,8 @@ async function resolveTargetDevices(
     return [device];
   }
 
-  const devices = await DeviceSessionManager.getInstance().detectConnectedPlatforms();
+  const detector = deviceDetectorForTesting ?? DeviceSessionManager.getInstance();
+  const devices = await detector.detectConnectedPlatforms();
   const matching = devices.filter(candidate => candidate.platform === device.platform);
 
   if (matching.length === 0) {

--- a/test/fakes/FakeDeviceSessionManager.ts
+++ b/test/fakes/FakeDeviceSessionManager.ts
@@ -23,6 +23,7 @@ export class FakeDeviceSessionManager implements DeviceSessionManager {
   // Call tracking for assertions
   private setCurrentDeviceCalls: BootedDevice[] = [];
   private ensureDeviceReadyCalls: number = 0;
+  private detectConnectedPlatformsCalls: number = 0;
   private verificationAttempts: Map<string, number> = new Map();
   private deviceVerificationCalls: Map<string, Platform> = new Map();
   private lastOptions: DeviceReadyOptions | undefined;
@@ -160,6 +161,7 @@ export class FakeDeviceSessionManager implements DeviceSessionManager {
   clearHistory(): void {
     this.setCurrentDeviceCalls = [];
     this.ensureDeviceReadyCalls = 0;
+    this.detectConnectedPlatformsCalls = 0;
     this.verificationAttempts.clear();
     this.deviceVerificationCalls.clear();
     this.lastOptions = undefined;
@@ -233,7 +235,18 @@ export class FakeDeviceSessionManager implements DeviceSessionManager {
     return selectedDevice;
   }
 
+  /**
+   * Get the number of times detectConnectedPlatforms was called (for test assertions).
+   * Lets a test prove a code path resolved devices through this fake singleton rather
+   * than reaching the real one (which would spawn adb/simctl subprocesses).
+   */
+  getDetectConnectedPlatformsCallCount(): number {
+    return this.detectConnectedPlatformsCalls;
+  }
+
   async detectConnectedPlatforms(): Promise<BootedDevice[]> {
+    this.detectConnectedPlatformsCalls++;
+
     if (this.simulateDisconnection) {
       return [];
     }

--- a/test/server/videoRecordingToolSegmented.test.ts
+++ b/test/server/videoRecordingToolSegmented.test.ts
@@ -17,12 +17,14 @@ import {
   resetSegmentedSessions,
   setSegmentedSessionRecordingDependencies,
   setSegmentedSessionTimer,
+  setVideoRecordingDeviceDetectorForTesting,
 } from "../../src/server/videoRecordingTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import {
   resetVideoRecordingManagerDependencies,
   setVideoRecordingManagerDependencies,
 } from "../../src/server/videoRecordingManager";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
 import type { BootedDevice, VideoRecordingMetadata } from "../../src/models";
 
@@ -109,6 +111,7 @@ describe("videoRecording tool segmentation branch", () => {
   let segmentTimer: FakeTimer;
   let fakeBackend: FakeVideoCaptureBackend;
   let fakeRepository: FakeVideoRecordingRepository;
+  let fakeDeviceSessionManager: FakeDeviceSessionManager;
   let archiveRoot: string;
   let segmentStarts: string[];
   let segmentStops: string[];
@@ -126,6 +129,13 @@ describe("videoRecording tool segmentation branch", () => {
     fakeBackend = new FakeVideoCaptureBackend();
     fakeBackend.setNowProvider(() => new Date(fakeTimer.now()));
     fakeRepository = new FakeVideoRecordingRepository();
+    // A bare (by-device) stop resolves target devices via detectConnectedPlatforms(), which on
+    // the real DeviceSessionManager spawns `adb`/`xcrun simctl` subprocesses. On a loaded macOS
+    // CI runner `simctl list` can stall past the test timeout (#3943), so inject a fake detector
+    // that resolves the connected device synchronously with no subprocess.
+    fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    fakeDeviceSessionManager.setConnectedDevices([androidDevice]);
+    setVideoRecordingDeviceDetectorForTesting(fakeDeviceSessionManager);
     segmentStarts = [];
     segmentStops = [];
     await fsPromises.rm(archiveRoot, { recursive: true, force: true });
@@ -154,6 +164,7 @@ describe("videoRecording tool segmentation branch", () => {
   afterEach(() => {
     resetVideoRecordingManagerDependencies();
     resetSegmentedSessions();
+    setVideoRecordingDeviceDetectorForTesting(undefined);
   });
 
   afterAll(async () => {
@@ -346,6 +357,11 @@ describe("videoRecording tool segmentation branch", () => {
       })
     );
 
+    // Regression guard for #3943: the bare stop must resolve its target device through the
+    // injected DeviceSessionManager singleton, never the real one (whose detectConnectedPlatforms
+    // spawns an `xcrun simctl` subprocess that stalls the test on macOS CI).
+    expect(fakeDeviceSessionManager.getDetectConnectedPlatformsCallCount()).toBeGreaterThanOrEqual(1);
+
     expect(stopRes.segmented).toBe(true);
     const segments = stopRes.recordings as Array<Record<string, unknown>>;
     expect(segments.length).toBe(2);
@@ -433,6 +449,10 @@ describe("videoRecording tool segmentation branch", () => {
         // NO recordingId — bare, by-device stop.
       })
     );
+
+    // Regression guard for #3943 (this bare stop hits the same device-resolution path):
+    // it must go through the injected DeviceSessionManager, never the real subprocess one.
+    expect(fakeDeviceSessionManager.getDetectConnectedPlatformsCallCount()).toBeGreaterThanOrEqual(1);
 
     const segments = stopRes.recordings as Array<Record<string, unknown>>;
     expect(segments.length).toBe(1);


### PR DESCRIPTION
## Summary

Fixes the recurring macOS-only flake in `videoRecordingToolSegmented.test.ts`
(recurrence of #3877). The bare (by-device) stop path resolves target devices via
`resolveTargetDevices` → `DeviceSessionManager.getInstance().detectConnectedPlatforms()`,
which spawns real `adb` and `xcrun simctl` subprocesses. `simctl` exists only on
macOS, so on a loaded `macos-latest` runner `xcrun simctl list devices --json` can
stall past the test's 20 s timeout. The #3877 fix faked the segmented-session
*recording* deps but never faked this *device-detection* call — the un-faked seam the
flake actually runs through.

Instead of overriding the process-wide `DeviceSessionManager` singleton, this adds a
**narrow `ConnectedDeviceDetector` seam** (`{ detectConnectedPlatforms }`) local to
`videoRecordingTools`, defaulting to the real singleton in production. The test injects a
`FakeDeviceSessionManager` through it. The narrow structural interface keeps the seam
type-honest under strict `tsc` (the fake need not reproduce the manager's nominal private
members) and avoids mutating a global — chosen over a singleton override after review.

No production behavior change: in production the detector defaults to
`DeviceSessionManager.getInstance()`, exactly as before.

## Linked Issue

Closes #3943

## Bug / Regression Context

- **Prior attempts:** #3877 (closed completed) faked `start/stopVideoRecording` and
  raised the timeout to 20 s — that only widened the race window.
- **Observed symptom:** `bare (by-device) stop finalizes the segmented session and
  leaves no rotation timer` consumes the full 20 s and times out, **only** on the
  `macos-latest` leg; ubuntu/windows pass.
- **Repro steps / conditions:** A bare stop passes no `deviceId`, so
  `resolveTargetDevices` calls `detectConnectedPlatforms()` →
  `SimCtlClient.getBootedSimulators()` → `xcrun simctl list`. `simctl` only exists on
  macOS (throws fast on the other legs — hence macOS-only); under CI load that
  subprocess can hang past the timeout. The real-DB-guard path from #3877 is never
  reached here — `segmentedSessions.forDevice()` short-circuits to the fake-injected
  segmented branch.

Root-cause verification: with the injection removed, the new regression guard fails
deterministically (`detectConnectedPlatforms` call count `0` → the real detector was
consulted). With it in place, all 7 tests in the file pass in <1 s.

## Changes

- `src/server/videoRecordingTools.ts` — add a narrow `ConnectedDeviceDetector`
  interface + module-level test seam `setVideoRecordingDeviceDetectorForTesting`;
  `resolveTargetDevices` now uses the injected detector `?? DeviceSessionManager.getInstance()`.
- `test/fakes/FakeDeviceSessionManager.ts` — track `detectConnectedPlatforms` call
  count with a `getDetectConnectedPlatformsCallCount()` accessor (additive).
- `test/server/videoRecordingToolSegmented.test.ts` — inject the fake detector in
  `beforeEach`, reset in `afterEach`, and assert both bare-stop tests resolve through it.

## Validation

- [x] `bun run lint` clean
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Type-honesty of the narrow seam confirmed via a strict-`tsc` probe (fake assignable, no cast)
- [x] Blast-radius suites green: full video suite 118 pass / 1 skip / 0 fail
- [x] New code uses interfaces + fakes; the two affected unit tests run fast
- [x] Deterministic red demonstrated (guard fails without the injection), then green

## Device Verification

N/A — test-infrastructure change plus a behavior-preserving production seam; no
on-device behavior affected.
