### PR TITLE
fix(cli): kill emulator/xcodebuild child on command timeout

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -134,8 +134,10 @@ export function resolveHeadlessMode(
   return { headless: false, reason: "usable display detected" };
 }
 
-const execAsync = async (command: string): Promise<ExecResult> => {
-  const result = await promisify(exec)(command);
+const execAsync = async (command: string, signal?: AbortSignal): Promise<ExecResult> => {
+  // Pass the AbortSignal to exec so a timed-out command kills its child instead
+  // of leaving it running orphaned (issue #3938).
+  const result = await (signal ? promisify(exec)(command, { signal }) : promisify(exec)(command));
 
   // Add the required string methods
   // noinspection UnnecessaryLocalVariableJS
@@ -157,7 +159,7 @@ const execAsync = async (command: string): Promise<ExecResult> => {
 };
 
 export class AndroidEmulatorClient implements AndroidEmulator {
-  private execAsync: (command: string) => Promise<ExecResult>;
+  private execAsync: (command: string, signal?: AbortSignal) => Promise<ExecResult>;
   private spawnFn: typeof spawn;
   private emulatorPath: string;
   private timer: Timer;
@@ -175,7 +177,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdConfigReader - Reader for AVD config.ini files (for testing)
    */
   constructor(
-    execAsyncFn: ((command: string) => Promise<ExecResult>) | null = null,
+    execAsyncFn: ((command: string, signal?: AbortSignal) => Promise<ExecResult>) | null = null,
     spawnFn: typeof spawn | null = null,
     timer: Timer = defaultTimer,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
@@ -546,19 +548,27 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const fullCommand = `${this.emulatorPath} ${command}`;
     logger.debug(`Executing emulator command: ${fullCommand}`);
 
-    // Use Promise.race to implement timeout if specified
+    // Use Promise.race to implement timeout if specified. On timeout we abort the
+    // controller so the underlying child process is killed rather than left
+    // running orphaned (issue #3938).
     if (timeoutMs) {
       let timeoutId: NodeJS.Timeout;
+      const controller = new AbortController();
 
       const timeoutPromise = new Promise<ExecResult>((_, reject) => {
-        timeoutId = this.timer.setTimeout(() =>
-          reject(new ActionableError(`Command timed out after ${timeoutMs}ms: ${fullCommand}`)),
-                                          timeoutMs
-        );
+        timeoutId = this.timer.setTimeout(() => {
+          controller.abort();
+          reject(new ActionableError(`Command timed out after ${timeoutMs}ms: ${fullCommand}`));
+        }, timeoutMs);
       });
 
+      const runPromise = this.execAsync(fullCommand, controller.signal);
+      // Once the timeout wins the race the aborted run promise rejects with an
+      // AbortError; keep it handled so it can't surface as an unhandledRejection.
+      runPromise.catch(() => { /* settled after timeout; result consumed via race */ });
+
       try {
-        return await Promise.race([this.execAsync(fullCommand), timeoutPromise]);
+        return await Promise.race([runPromise, timeoutPromise]);
       } finally {
         clearTimeout(timeoutId!);
       }

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -15,8 +15,14 @@ export interface Xcodebuild {
   isAvailable(): Promise<boolean>;
 }
 
-const execAsync = async (file: string, args: string[], maxBuffer?: number): Promise<ExecResult> => {
-  const options = maxBuffer ? { maxBuffer } : undefined;
+const execAsync = async (file: string, args: string[], maxBuffer?: number, signal?: AbortSignal): Promise<ExecResult> => {
+  // Pass the AbortSignal to execFile so a timed-out command kills its child
+  // instead of leaving it running orphaned (issue #3938).
+  const options: Parameters<typeof execFile>[2] =
+    maxBuffer && signal ? { maxBuffer, signal }
+      : maxBuffer ? { maxBuffer }
+        : signal ? { signal }
+          : undefined;
   const result = await promisify(execFile)(file, args, options);
   const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
   const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
@@ -24,11 +30,11 @@ const execAsync = async (file: string, args: string[], maxBuffer?: number): Prom
 };
 
 export class XcodebuildClient implements Xcodebuild {
-  execAsync: (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
+  execAsync: (file: string, args: string[], maxBuffer?: number, signal?: AbortSignal) => Promise<ExecResult>;
   private timer: Timer;
 
   constructor(
-    execAsyncFn: ((file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>) | null = null,
+    execAsyncFn: ((file: string, args: string[], maxBuffer?: number, signal?: AbortSignal) => Promise<ExecResult>) | null = null,
     timer: Timer = defaultTimer
   ) {
     this.execAsync = execAsyncFn || execAsync;
@@ -50,19 +56,28 @@ export class XcodebuildClient implements Xcodebuild {
       throw new ActionableError("xcodebuild is not available. Please install Xcode to continue.");
     }
 
-    const runCommand = () => this.execAsync("xcodebuild", args, maxBuffer);
+    const runCommand = (signal?: AbortSignal) => this.execAsync("xcodebuild", args, maxBuffer, signal);
 
     if (timeoutMs) {
       let timeoutId: NodeJS.Timeout;
+      const controller = new AbortController();
       const timeoutPromise = new Promise<ExecResult>((_, reject) => {
         timeoutId = this.timer.setTimeout(
-          () => reject(new Error(`Command timed out after ${timeoutMs}ms: ${fullCommand}`)),
+          () => {
+            controller.abort();
+            reject(new Error(`Command timed out after ${timeoutMs}ms: ${fullCommand}`));
+          },
           timeoutMs
         );
       });
 
+      const runPromise = runCommand(controller.signal);
+      // Once the timeout wins the race the aborted run promise rejects with an
+      // AbortError; keep it handled so it can't surface as an unhandledRejection.
+      runPromise.catch(() => { /* settled after timeout; result consumed via race */ });
+
       try {
-        const result = await Promise.race([runCommand(), timeoutPromise]);
+        const result = await Promise.race([runPromise, timeoutPromise]);
         const duration = this.timer.now() - startTime;
         logger.debug(`[iOS] Command completed in ${duration}ms: ${fullCommand}`);
         return result;

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-executeCommand.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-executeCommand.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { ExecResult } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const createExecResult = (stdout: string, stderr = ""): ExecResult => ({
+  stdout,
+  stderr,
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (s: string) => stdout.includes(s),
+});
+
+// Pin the emulator path so executeCommand builds a deterministic command string
+// without touching the filesystem for path detection.
+function newClientWithFakeExec(
+  execAsync: (command: string, signal?: AbortSignal) => Promise<ExecResult>,
+  timer: FakeTimer
+): AndroidEmulatorClient {
+  const client = new AndroidEmulatorClient(execAsync, null, timer);
+  (client as unknown as { emulatorPath: string }).emulatorPath = "emulator";
+  (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath = async () => "emulator";
+  return client;
+}
+
+describe("AndroidEmulatorClient executeCommand timeout", () => {
+  test("aborts the underlying child process when the command times out", async () => {
+    const timer = new FakeTimer();
+    let capturedSignal: AbortSignal | undefined;
+    const execAsync = async (_command: string, signal?: AbortSignal): Promise<ExecResult> => {
+      capturedSignal = signal;
+      // Simulate a long-running child that only settles when aborted, mirroring
+      // exec rejecting with an AbortError once its signal fires.
+      return new Promise<ExecResult>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      });
+    };
+
+    const client = newClientWithFakeExec(execAsync, timer);
+
+    const promise = client.executeCommand("-list-avds", 1234);
+    while (!capturedSignal) {
+      await Promise.resolve();
+    }
+    expect(capturedSignal.aborted).toBe(false);
+
+    timer.advanceTime(1234);
+
+    await expect(promise).rejects.toThrow(
+      "Command timed out after 1234ms: emulator -list-avds"
+    );
+    // The timeout must abort the child rather than leave it running orphaned.
+    expect(capturedSignal.aborted).toBe(true);
+  });
+
+  test("does not abort when the command completes before the timeout", async () => {
+    const timer = new FakeTimer();
+    let capturedSignal: AbortSignal | undefined;
+    const execAsync = async (_command: string, signal?: AbortSignal): Promise<ExecResult> => {
+      capturedSignal = signal;
+      return createExecResult("Pixel_9", "");
+    };
+
+    const client = newClientWithFakeExec(execAsync, timer);
+
+    const result = await client.executeCommand("-list-avds", 5000);
+
+    expect(result.stdout).toBe("Pixel_9");
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+
+  test("passes no signal when no timeout is specified", async () => {
+    const timer = new FakeTimer();
+    let called = false;
+    let capturedSignal: AbortSignal | undefined | "unset" = "unset";
+    const execAsync = async (_command: string, signal?: AbortSignal): Promise<ExecResult> => {
+      called = true;
+      capturedSignal = signal;
+      return createExecResult("Pixel_9", "");
+    };
+
+    const client = newClientWithFakeExec(execAsync, timer);
+
+    const result = await client.executeCommand("-list-avds");
+
+    expect(called).toBe(true);
+    expect(result.stdout).toBe("Pixel_9");
+    expect(capturedSignal).toBeUndefined();
+  });
+});

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { XcodebuildClient } from "../../../src/utils/ios-cmdline-tools/XcodebuildClient";
+import type { ExecResult } from "../../../src/models";
+import { createExecResult } from "../../../src/utils/execResult";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+describe("XcodebuildClient executeCommand timeout", () => {
+  test("aborts the underlying child process when the command times out", async () => {
+    const timer = new FakeTimer();
+    let capturedSignal: AbortSignal | undefined;
+    const execAsync = async (
+      _file: string,
+      args: string[],
+      _maxBuffer?: number,
+      signal?: AbortSignal
+    ): Promise<ExecResult> => {
+      // Availability probe runs first; answer it so executeCommand proceeds.
+      if (args.join(" ") === "-version") {
+        return createExecResult("Xcode 26.5", "");
+      }
+      capturedSignal = signal;
+      // Simulate a long-running child that only settles when aborted, mirroring
+      // execFile rejecting with an AbortError once its signal fires.
+      return new Promise<ExecResult>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      });
+    };
+
+    const client = new XcodebuildClient(execAsync, timer);
+
+    const promise = client.executeCommand(["-showBuildSettings"], { timeoutMs: 1234 });
+    while (!capturedSignal) {
+      await Promise.resolve();
+    }
+    expect(capturedSignal.aborted).toBe(false);
+
+    timer.advanceTime(1234);
+
+    await expect(promise).rejects.toThrow(
+      "Command timed out after 1234ms: xcodebuild -showBuildSettings"
+    );
+    // The timeout must abort the child rather than leave it running orphaned.
+    expect(capturedSignal.aborted).toBe(true);
+  });
+
+  test("does not abort when the command completes before the timeout", async () => {
+    const timer = new FakeTimer();
+    let capturedSignal: AbortSignal | undefined;
+    const execAsync = async (
+      _file: string,
+      args: string[],
+      _maxBuffer?: number,
+      signal?: AbortSignal
+    ): Promise<ExecResult> => {
+      if (args.join(" ") === "-version") {
+        return createExecResult("Xcode 26.5", "");
+      }
+      capturedSignal = signal;
+      return createExecResult("ok", "");
+    };
+
+    const client = new XcodebuildClient(execAsync, timer);
+
+    const result = await client.executeCommand(["-list"], { timeoutMs: 5000 });
+
+    expect(result.stdout).toBe("ok");
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #3941, which fixed orphaned-process-on-timeout in `SimCtlClient`. The same "timeout race never kills the child" pattern existed in the two other command wrappers tracked in #3938:

- **`XcodebuildClient.executeCommand`** — `Promise.race([runCommand(), timeoutPromise])` with `promisify(execFile)` and no `signal`.
- **`AndroidEmulatorClient.executeCommand`** — same shape via `promisify(exec)`, i.e. a **shell subtree**, so a timed-out command could orphan a whole process group.

In both, when the timeout won the race the promise rejected but the underlying `xcodebuild`/`emulator` child kept running.

This threads an `AbortSignal` into each client's `execAsync` and aborts it when the timeout fires, so Node kills the child:
- `XcodebuildClient` passes the signal to `execFile`'s `signal` option.
- `AndroidEmulatorClient` passes the signal to `exec`'s `signal` option.

The injected-`Timer` race is preserved so `FakeTimer` unit tests stay fast and deterministic, and the aborted run promise is kept handled to avoid an `unhandledRejection`. This mirrors the merged `SimCtlClient` implementation exactly.

## Linked Issue

Refs #3938

## Bug / Regression Context

- **Prior attempts:** #3941 landed the identical fix for `SimCtlClient`; this extends it to the remaining two clients.
- **Observed symptom:** a timed-out `emulator`/`xcodebuild` command is reported as failed while its child keeps running; orphaned processes accumulate across retries.
- **Repro steps / conditions:** any `executeCommand` whose work exceeds `timeoutMs` — the race rejects but the child is never signalled.

## Validation

- [x] `bun run lint` passes (targeted)
- [x] `bun test` for the affected suites passes (`android-cmdline-tools`, `ios-cmdline-tools` — 311 tests, plus 5 new)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New tests use injected `execAsync` fakes + `FakeTimer`; unit tests run in <100ms
- [x] Branched fresh off latest `main`

## Scope / Follow-ups

Kept intentionally focused on the timeout-kill fix. Still open in #3938:
- [ ] Replace the fabricated `ChildProcess` handles (iOS `startSimulator` returns `kill: () => false`; Android `startEmulator` returns `{} as ChildProcess`) with real cancellation affordances — a distinct return-type/cancellation concern, larger and riskier, better as its own PR.
- [ ] (Separate concern) `AndroidEmulatorClient.execAsync` runs commands through a shell (`exec`); converting to argv `execFile` would harden it against argument/shell injection independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aKikdGF1c8hfSQGqf62g8)_