### PR TITLE
refactor(android): run emulator commands via execFile (argv, no shell)

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, exec, spawn } from "child_process";
+import { ChildProcess, execFile, spawn } from "child_process";
 import { existsSync } from "node:fs";
 import { promisify } from "util";
 import { logger } from "../logger";
@@ -23,7 +23,7 @@ interface AndroidEmulator {
    * @param timeoutMs - Optional timeout in milliseconds
    * @returns Promise with stdout and stderr
    */
-  executeCommand(command: string, timeoutMs?: number): Promise<ExecResult>;
+  executeCommand(args: string[], timeoutMs?: number): Promise<ExecResult>;
 
   /**
    * List all available AVDs
@@ -134,16 +134,20 @@ export function resolveHeadlessMode(
   return { headless: false, reason: "usable display detected" };
 }
 
-const execAsync = async (command: string, signal?: AbortSignal): Promise<ExecResult> => {
-  // Pass the AbortSignal to exec so a timed-out command kills its child instead
-  // of leaving it running orphaned (issue #3938).
-  const result = await (signal ? promisify(exec)(command, { signal }) : promisify(exec)(command));
+const execAsync = async (file: string, args: string[], signal?: AbortSignal): Promise<ExecResult> => {
+  // Run the emulator binary via execFile (argv, no shell) rather than exec. This
+  // removes the shell entirely — command arguments such as AVD names are passed
+  // literally instead of being interpreted/split by a shell (issue #3938) — and
+  // the AbortSignal is forwarded so a timed-out command kills its child instead
+  // of leaving it running orphaned.
+  const options: Parameters<typeof execFile>[2] = signal ? { signal } : undefined;
+  const result = await promisify(execFile)(file, args, options);
 
   // Add the required string methods
   // noinspection UnnecessaryLocalVariableJS
   const enhancedResult: ExecResult = {
-    stdout: result.stdout,
-    stderr: result.stderr,
+    stdout: typeof result.stdout === "string" ? result.stdout : result.stdout.toString(),
+    stderr: typeof result.stderr === "string" ? result.stderr : result.stderr.toString(),
     toString() {
       return this.stdout;
     },
@@ -159,7 +163,7 @@ const execAsync = async (command: string, signal?: AbortSignal): Promise<ExecRes
 };
 
 export class AndroidEmulatorClient implements AndroidEmulator {
-  private execAsync: (command: string, signal?: AbortSignal) => Promise<ExecResult>;
+  private execAsync: (file: string, args: string[], signal?: AbortSignal) => Promise<ExecResult>;
   private spawnFn: typeof spawn;
   private emulatorPath: string;
   private timer: Timer;
@@ -177,7 +181,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdConfigReader - Reader for AVD config.ini files (for testing)
    */
   constructor(
-    execAsyncFn: ((command: string, signal?: AbortSignal) => Promise<ExecResult>) | null = null,
+    execAsyncFn: ((file: string, args: string[], signal?: AbortSignal) => Promise<ExecResult>) | null = null,
     spawnFn: typeof spawn | null = null,
     timer: Timer = defaultTimer,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
@@ -384,7 +388,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     try {
       // Get AVD config to determine its architecture
-      const result = await this.executeCommand(`-avd ${avdName} -verbose`, 3000);
+      const result = await this.executeCommand(["-avd", avdName, "-verbose"], 3000);
       const output = result.stdout + result.stderr;
 
       // Look for architecture information in the output
@@ -543,9 +547,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param timeoutMs - Optional timeout in milliseconds
    * @returns Promise with stdout and stderr
    */
-  async executeCommand(command: string, timeoutMs?: number): Promise<ExecResult> {
-    await this.ensureEmulatorPath();
-    const fullCommand = `${this.emulatorPath} ${command}`;
+  async executeCommand(args: string[], timeoutMs?: number): Promise<ExecResult> {
+    const emulatorPath = await this.ensureEmulatorPath();
+    const fullCommand = `${emulatorPath} ${args.join(" ")}`;
     logger.debug(`Executing emulator command: ${fullCommand}`);
 
     // Use Promise.race to implement timeout if specified. On timeout we abort the
@@ -562,7 +566,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }, timeoutMs);
       });
 
-      const runPromise = this.execAsync(fullCommand, controller.signal);
+      const runPromise = this.execAsync(emulatorPath, args, controller.signal);
       // Once the timeout wins the race the aborted run promise rejects with an
       // AbortError; keep it handled so it can't surface as an unhandledRejection.
       runPromise.catch(() => { /* settled after timeout; result consumed via race */ });
@@ -574,7 +578,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       }
     }
 
-    return await this.execAsync(fullCommand);
+    return await this.execAsync(emulatorPath, args);
   }
 
   /**
@@ -583,7 +587,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   async listAvds(): Promise<DeviceInfo[]> {
     try {
-      const result = await this.executeCommand("-list-avds");
+      const result = await this.executeCommand(["-list-avds"]);
       const devices = result.stdout
         .split("\n")
         .map(line => line.trim())

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -91,7 +91,7 @@ const createExecResult = (stdout: string, stderr: string = ""): ExecResult => ({
   includes: (s: string) => stdout.includes(s),
 });
 
-const mockExecAsync = async (_command: string): Promise<ExecResult> => {
+const mockExecAsync = async (_file: string, _args: string[]): Promise<ExecResult> => {
   return createExecResult("", "");
 };
 
@@ -202,8 +202,8 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
       return fakeChild;
     }) as any;
 
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("-list-avds")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
         return createExecResult("Pixel_9_Pro\n");
       }
       return createExecResult("");
@@ -234,8 +234,8 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
       return fakeChild;
     }) as any;
 
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("-list-avds")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
         return createExecResult("Pixel_9_Pro\n");
       }
       return createExecResult("");
@@ -262,8 +262,8 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
       return fakeChild;
     }) as any;
 
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("-list-avds")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
         return createExecResult("Pixel_9_Pro\n");
       }
       return createExecResult("");
@@ -319,8 +319,8 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     const fakeChild = createFakeChildProcess();
 
     // Mock exec to return no running emulators (simulating the device never appearing)
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("adb devices")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("adb devices")) {
         return createExecResult("List of devices attached\n\n");
       }
       return createExecResult("");
@@ -348,8 +348,8 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
   test("throws with exit code when child process exits non-zero without known pattern", async () => {
     const fakeChild = createFakeChildProcess();
 
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("adb devices")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("adb devices")) {
         return createExecResult("List of devices attached\n\n");
       }
       return createExecResult("");
@@ -373,8 +373,8 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
   });
 
   test("works normally without child process (backward compatible)", async () => {
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("adb devices")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("adb devices")) {
         return createExecResult("List of devices attached\n\n");
       }
       return createExecResult("");

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-executeCommand.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-executeCommand.test.ts
@@ -14,7 +14,7 @@ const createExecResult = (stdout: string, stderr = ""): ExecResult => ({
 // Pin the emulator path so executeCommand builds a deterministic command string
 // without touching the filesystem for path detection.
 function newClientWithFakeExec(
-  execAsync: (command: string, signal?: AbortSignal) => Promise<ExecResult>,
+  execAsync: (file: string, args: string[], signal?: AbortSignal) => Promise<ExecResult>,
   timer: FakeTimer
 ): AndroidEmulatorClient {
   const client = new AndroidEmulatorClient(execAsync, null, timer);
@@ -27,10 +27,12 @@ describe("AndroidEmulatorClient executeCommand timeout", () => {
   test("aborts the underlying child process when the command times out", async () => {
     const timer = new FakeTimer();
     let capturedSignal: AbortSignal | undefined;
-    const execAsync = async (_command: string, signal?: AbortSignal): Promise<ExecResult> => {
+    let capturedArgs: string[] | undefined;
+    const execAsync = async (_file: string, args: string[], signal?: AbortSignal): Promise<ExecResult> => {
       capturedSignal = signal;
+      capturedArgs = args;
       // Simulate a long-running child that only settles when aborted, mirroring
-      // exec rejecting with an AbortError once its signal fires.
+      // execFile rejecting with an AbortError once its signal fires.
       return new Promise<ExecResult>((_resolve, reject) => {
         signal?.addEventListener("abort", () => {
           reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
@@ -40,11 +42,13 @@ describe("AndroidEmulatorClient executeCommand timeout", () => {
 
     const client = newClientWithFakeExec(execAsync, timer);
 
-    const promise = client.executeCommand("-list-avds", 1234);
+    const promise = client.executeCommand(["-list-avds"], 1234);
     while (!capturedSignal) {
       await Promise.resolve();
     }
     expect(capturedSignal.aborted).toBe(false);
+    // Arguments are forwarded as a literal argv array (no shell).
+    expect(capturedArgs).toEqual(["-list-avds"]);
 
     timer.advanceTime(1234);
 
@@ -58,35 +62,40 @@ describe("AndroidEmulatorClient executeCommand timeout", () => {
   test("does not abort when the command completes before the timeout", async () => {
     const timer = new FakeTimer();
     let capturedSignal: AbortSignal | undefined;
-    const execAsync = async (_command: string, signal?: AbortSignal): Promise<ExecResult> => {
+    const execAsync = async (_file: string, _args: string[], signal?: AbortSignal): Promise<ExecResult> => {
       capturedSignal = signal;
       return createExecResult("Pixel_9", "");
     };
 
     const client = newClientWithFakeExec(execAsync, timer);
 
-    const result = await client.executeCommand("-list-avds", 5000);
+    const result = await client.executeCommand(["-list-avds"], 5000);
 
     expect(result.stdout).toBe("Pixel_9");
     expect(capturedSignal?.aborted).toBe(false);
   });
 
-  test("passes no signal when no timeout is specified", async () => {
+  test("passes each argument literally and no signal when no timeout is specified", async () => {
     const timer = new FakeTimer();
-    let called = false;
+    let capturedFile: string | undefined;
+    let capturedArgs: string[] | undefined;
     let capturedSignal: AbortSignal | undefined | "unset" = "unset";
-    const execAsync = async (_command: string, signal?: AbortSignal): Promise<ExecResult> => {
-      called = true;
+    const execAsync = async (file: string, args: string[], signal?: AbortSignal): Promise<ExecResult> => {
+      capturedFile = file;
+      capturedArgs = args;
       capturedSignal = signal;
-      return createExecResult("Pixel_9", "");
+      return createExecResult("ok", "");
     };
 
     const client = newClientWithFakeExec(execAsync, timer);
 
-    const result = await client.executeCommand("-list-avds");
+    // An AVD name with a space must survive as a single argv element (a shell
+    // would have split it) — the core win of moving off exec.
+    const result = await client.executeCommand(["-avd", "My Pixel", "-verbose"]);
 
-    expect(called).toBe(true);
-    expect(result.stdout).toBe("Pixel_9");
+    expect(result.stdout).toBe("ok");
+    expect(capturedFile).toBe("emulator");
+    expect(capturedArgs).toEqual(["-avd", "My Pixel", "-verbose"]);
     expect(capturedSignal).toBeUndefined();
   });
 });

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -155,8 +155,8 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
       return fakeChild;
     }) as any;
 
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("-list-avds")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
         return createExecResult("Pixel_9_Pro\n");
       }
       return createExecResult("");
@@ -188,8 +188,8 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
       return fakeChild;
     }) as any;
 
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("-list-avds")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
         return createExecResult("Pixel_9_Pro\n");
       }
       return createExecResult("");
@@ -221,8 +221,8 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
       return fakeChild;
     }) as any;
 
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("-list-avds")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
         return createExecResult("Pixel_9_Pro\n");
       }
       return createExecResult("");
@@ -245,8 +245,8 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
   });
 
   test("lists available AVD names when requested AVD does not exist", async () => {
-    const execAsync = async (command: string): Promise<ExecResult> => {
-      if (command.includes("-list-avds")) {
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
         return createExecResult("Pixel_9_Pro\nMedium_Phone_API_35\n");
       }
       return createExecResult("");


### PR DESCRIPTION
## Summary

Follow-up to #3941 / #3945 (issue #3938). `AndroidEmulatorClient.executeCommand` built a single command string (`${emulatorPath} ${command}`) and ran it through a **shell** via `exec`. Two problems:

- The emulator path derives from environment variables (`ANDROID_HOME`, `ANDROID_SDK_ROOT`, `HOME`, …), so CodeQL flagged the shell call as an **indirect uncontrolled command line** (the review finding on #3945).
- Arguments like AVD names were interpolated into the shell string, so a name with a space or shell metacharacter would be mis-split or mis-interpreted.

This removes the shell entirely:

- `execAsync` now uses **`execFile`** (argv) instead of `exec`.
- `executeCommand(command: string)` → **`executeCommand(args: string[])`** — the emulator binary is invoked directly with a literal argv array. No shell to interpret or split; each argument (e.g. an AVD name) is passed verbatim.
- Kill-on-timeout via `AbortSignal` (from #3945) is preserved unchanged.

The two internal call sites (`checkArchitectureCompatibility` → `["-avd", avdName, "-verbose"]`, `listAvds` → `["-list-avds"]`) and the injected-`execAsync` fakes in the emulator tests are updated to the argv form.

## Linked Issue

Refs #3938

## Bug / Regression Context

- **Prior attempts:** #3945 added kill-on-timeout to the emulator's `exec` path; this converts that path off the shell, resolving the CodeQL "indirect uncontrolled command line" review finding it surfaced.
- **Observed symptom:** CodeQL indirect-command-line alert on the shell `exec`; AVD names with spaces/metacharacters not passed safely.
- **Repro steps / conditions:** any emulator command whose arguments contain shell-significant characters, or static analysis of the env-derived shell command.

## Validation

- [x] `bun run lint` passes (targeted)
- [x] `bun test` for the affected suites passes (`android-cmdline-tools`, `deviceUtils`, `devicePool` — 250 tests)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Tests use injected `execAsync` fakes + `FakeTimer`; a new test asserts an AVD name with a space survives as one argv element
- [x] Branched fresh off latest `main`

## Scope / Follow-ups

Still open in #3938:
- [ ] Replace the fabricated `ChildProcess` handles (iOS `startSimulator` returns `kill: () => false`; Android `startEmulator` returns `{} as ChildProcess`) with real cancellation affordances — the last remaining item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aKikdGF1c8hfSQGqf62g8)_