### PR TITLE
fix(talkback): thread real AdbExecutor into swipe/scroll detection (#3915)

### DIFF
--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -16,6 +16,7 @@ import type { ElementFinder } from "../../../utils/interfaces/ElementFinder";
 import type { ElementGeometry } from "../../../utils/interfaces/ElementGeometry";
 import type { ObserveScreen } from "../../observe/interfaces/ObserveScreen";
 import { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
+import { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { serverConfig } from "../../../utils/ServerConfig";
 import { Timer } from "../../../utils/SystemTimer";
 import { SwipeOnResolvedOptions, BoomerangConfig, TalkBackSwipeRunner, OverlayAnalyzer, ScrollAccessibilityService } from "./types";
@@ -39,6 +40,7 @@ interface ScrollUntilVisibleDependencies {
   observeScreen: ObserveScreen;
   accessibilityService: ScrollAccessibilityService;
   accessibilityDetector: AccessibilityDetector;
+  adb: AdbExecutor;
   overlayDetector: OverlayAnalyzer;
   talkBackExecutor: TalkBackSwipeRunner;
   timer: Timer;
@@ -131,9 +133,11 @@ export class ScrollUntilVisible {
       if (this.deps.device.platform !== "android") {
         return false;
       }
+      // Pass the real ADB executor (not null) so TalkBack detection works on a
+      // cold/expired cache instead of silently reporting "not talkback" (#3915).
       const accessibilityService = await this.deps.accessibilityDetector.detectMethod(
         this.deps.device.deviceId,
-        null
+        this.deps.adb
       );
       return accessibilityService === "talkback";
     });

--- a/src/features/action/swipeon/SwipeOn.ts
+++ b/src/features/action/swipeon/SwipeOn.ts
@@ -93,6 +93,7 @@ export class SwipeOn extends BaseVisualChange {
       this.executeGesture,
       this.accessibilityService,
       this.accessibilityDetector,
+      this.adb,
       this.timer
     );
     const iosVoiceOverDetector = dependencies.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
@@ -110,6 +111,7 @@ export class SwipeOn extends BaseVisualChange {
       observeScreen: this.observeScreen,
       accessibilityService: this.accessibilityService,
       accessibilityDetector: this.accessibilityDetector,
+      adb: this.adb,
       overlayDetector: this.overlayDetector,
       talkBackExecutor: this.talkBackExecutor,
       timer: this.timer,

--- a/src/features/action/swipeon/TalkBackSwipeExecutor.ts
+++ b/src/features/action/swipeon/TalkBackSwipeExecutor.ts
@@ -9,6 +9,7 @@ import { logger } from "../../../utils/logger";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { AndroidCtrlProxyClient } from "../../observe/android";
 import { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
+import { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { SwipeResult } from "../../../models/SwipeResult";
 import { GestureExecutor, BoomerangConfig, TalkBackSwipeRunner } from "./types";
 import { Timer } from "../../../utils/interfaces/Timer";
@@ -22,6 +23,7 @@ export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
     private readonly executeGesture: GestureExecutor,
     private readonly accessibilityService: AndroidCtrlProxyClient,
     private readonly accessibilityDetector: AccessibilityDetector,
+    private readonly adb: AdbExecutor,
     private readonly timer: Timer
   ) {}
 
@@ -47,10 +49,13 @@ export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
       return this.executeGesture.swipe(x1, y1, x2, y2, gestureOptions, perf);
     }
 
-    // Check if TalkBack is enabled (not just any accessibility service)
+    // Check if TalkBack is enabled (not just any accessibility service).
+    // Pass the real ADB executor so detection still works on a cold/expired
+    // cache — passing null here made TalkBack-aware swipe silently degrade to
+    // a coordinate swipe whenever the 60s detection cache was not warm (#3915).
     const detectedService = await this.accessibilityDetector.detectMethod(
       this.device.deviceId,
-      null
+      this.adb
     );
     const isTalkBackEnabled = detectedService === "talkback";
 

--- a/test/fakes/FakeAccessibilityDetector.ts
+++ b/test/fakes/FakeAccessibilityDetector.ts
@@ -16,6 +16,9 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
   private invalidatedDevices: string[] = [];
   private invalidationCountAtFirstDetection: number | null = null;
 
+  /** Records the `adb` argument passed to each detectMethod call (regression guard for #3915). */
+  public readonly detectMethodAdbArgs: Array<AdbExecutor | null | undefined> = [];
+
   /**
    * Configure the detection result for a specific device
    */
@@ -75,6 +78,7 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
     this.detectionCallCount = 0;
     this.invalidatedDevices = [];
     this.invalidationCountAtFirstDetection = null;
+    this.detectMethodAdbArgs.length = 0;
   }
 
   async isAccessibilityEnabled(
@@ -89,9 +93,10 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
 
   async detectMethod(
     deviceId: string,
-    _adb: AdbExecutor,
+    adb: AdbExecutor,
     _featureFlags?: FeatureFlagService
   ): Promise<AccessibilityService> {
+    this.detectMethodAdbArgs.push(adb);
     if (this.invalidationCountAtFirstDetection === null) {
       this.invalidationCountAtFirstDetection = this.invalidatedDevices.length;
     }

--- a/test/features/action/swipeon/ScrollUntilVisible.overshoot.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.overshoot.test.ts
@@ -7,6 +7,7 @@ import { FakeTalkBackSwipeExecutor } from "../../../fakes/FakeTalkBackSwipeExecu
 import { FakeOverlayDetector } from "../../../fakes/FakeOverlayDetector";
 import { FakeScrollAccessibilityService } from "../../../fakes/FakeScrollAccessibilityService";
 import { FakeElementGeometry } from "../../../fakes/FakeElementGeometry";
+import { FakeAdbClient } from "../../../fakes/FakeAdbClient";
 import type { BootedDevice, Element, ObserveResult } from "../../../../src/models";
 import type { OverlayCandidate, SwipeOnResolvedOptions } from "../../../../src/features/action/swipeon/types";
 
@@ -86,6 +87,7 @@ function makeScrollUntilVisible({
     observeScreen: fakeObserveScreen as any,
     accessibilityService,
     accessibilityDetector,
+    adb: new FakeAdbClient() as any,
     overlayDetector: fakeOverlayDetector,
     talkBackExecutor,
     timer,
@@ -286,6 +288,7 @@ describe("ScrollUntilVisible overshoot recovery", () => {
       observeScreen: fakeObserveScreen as any,
       accessibilityService: fakeAccessibilityService,
       accessibilityDetector: fakeDetector,
+      adb: new FakeAdbClient() as any,
       overlayDetector: fakeOverlayDetector,
       talkBackExecutor: fakeTalkBack,
       timer: fakeTimer,

--- a/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
@@ -7,6 +7,7 @@ import { FakeTalkBackSwipeExecutor } from "../../../fakes/FakeTalkBackSwipeExecu
 import { FakeOverlayDetector } from "../../../fakes/FakeOverlayDetector";
 import { FakeScrollAccessibilityService } from "../../../fakes/FakeScrollAccessibilityService";
 import { FakeElementGeometry } from "../../../fakes/FakeElementGeometry";
+import { FakeAdbClient } from "../../../fakes/FakeAdbClient";
 import type { BootedDevice, Element, ObserveResult } from "../../../../src/models";
 import type { SwipeOnResolvedOptions } from "../../../../src/features/action/swipeon/types";
 
@@ -83,6 +84,7 @@ function makeScrollUntilVisible({
     observeScreen: fakeObserveScreen as any,
     accessibilityService,
     accessibilityDetector,
+    adb: new FakeAdbClient() as any,
     overlayDetector: fakeOverlayDetector,
     talkBackExecutor,
     timer,
@@ -166,6 +168,29 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
   describe("when TalkBack is enabled", () => {
     beforeEach(() => {
       detector.setTalkBackEnabled(true);
+    });
+
+    test("passes the injected ADB executor (not null) to detectMethod (#3915 regression)", async () => {
+      finder.nextScrollableContainer = CONTAINER_ELEMENT;
+      finder.nextElementByText = TARGET_ELEMENT;
+
+      const suv = makeScrollUntilVisible({
+        accessibilityDetector: detector,
+        finder,
+        timer,
+        accessibilityService,
+        observeResults: [makeObserveResult(0)],
+        talkBackExecutor
+      });
+
+      await suv.execute({ ...BASE_OPTIONS });
+
+      // The bug passed `null`, which made TalkBack detection silently report
+      // "not talkback" on a cold cache. Detection must receive the real executor.
+      expect(detector.detectMethodAdbArgs.length).toBeGreaterThan(0);
+      for (const arg of detector.detectMethodAdbArgs) {
+        expect(arg).not.toBeNull();
+      }
     });
 
     test("does not call requestAction(focus) when focusTarget is not set and element already visible", async () => {

--- a/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
@@ -4,7 +4,9 @@ import { FakeAccessibilityDetector } from "../../../fakes/FakeAccessibilityDetec
 import { FakeGestureExecutor } from "../../../fakes/FakeGestureExecutor";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import { FakeCtrlProxy } from "../../../fakes/FakeCtrlProxy";
+import { FakeAdbClient } from "../../../fakes/FakeAdbClient";
 import { SwipeDirection } from "../../../../src/models";
+import type { AdbExecutor } from "../../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
 import type { BootedDevice } from "../../../../src/models";
 
@@ -25,13 +27,15 @@ function makeExecutor(
   fakeGesture: FakeGestureExecutor,
   fakeProxy: FakeCtrlProxy,
   fakeDetector: FakeAccessibilityDetector,
-  fakeTimer: FakeTimer
+  fakeTimer: FakeTimer,
+  fakeAdb: AdbExecutor = new FakeAdbClient() as unknown as AdbExecutor
 ): TalkBackSwipeExecutor {
   return new TalkBackSwipeExecutor(
     device,
     fakeGesture,
     fakeProxy as any,
     fakeDetector,
+    fakeAdb,
     fakeTimer
   );
 }
@@ -82,6 +86,37 @@ describe("TalkBackSwipeExecutor", () => {
       expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(1);
       expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
       expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
+    });
+  });
+
+  describe("TalkBack detection dependency (#3915 regression)", () => {
+    test("passes the injected ADB executor (not null) to detectMethod on android", async () => {
+      fakeAccessibilityDetector.setTalkBackEnabled(true);
+      const sentinelAdb = new FakeAdbClient() as unknown as AdbExecutor;
+      const exec = makeExecutor(
+        ANDROID_DEVICE,
+        fakeGestureExecutor,
+        fakeCtrlProxy,
+        fakeAccessibilityDetector,
+        fakeTimer,
+        sentinelAdb
+      );
+
+      await exec.executeSwipeGesture(
+        100, 500, 100, 200,
+        "up" as SwipeDirection,
+        null,
+        { duration: 300 },
+        perf
+      );
+
+      // The bug passed `null`, which made detectMethod throw+swallow and report
+      // "not talkback" on a cold cache. Detection must receive the real executor.
+      expect(fakeAccessibilityDetector.detectMethodAdbArgs.length).toBeGreaterThan(0);
+      for (const arg of fakeAccessibilityDetector.detectMethodAdbArgs) {
+        expect(arg).not.toBeNull();
+      }
+      expect(fakeAccessibilityDetector.detectMethodAdbArgs[0]).toBe(sentinelAdb);
     });
   });
 


### PR DESCRIPTION
## Summary

`TalkBackSwipeExecutor` and `ScrollUntilVisible` passed `null` as the `AdbExecutor` to `AccessibilityDetector.detectMethod`. On a cold/expired 60s detection cache that made `detectMethod` call `executeCommand` on `null`, throw a `TypeError`, get swallowed, and return `service: "unknown"` — so TalkBack-aware `swipeOn`/scroll silently degraded to a plain coordinate swipe whenever a prior `observe()` hadn't warmed the cache. This threads the real `AdbExecutor` (already on `BaseVisualChange` as `this.adb`) into both, matching the tap path.

## Linked Issue

Closes #3915

## Bug / Regression Context
- **Observed symptom:** With TalkBack enabled, `swipeOn` / scroll-until-visible used a plain coordinate swipe instead of the accessibility-aware path (two-finger / ACTION_SCROLL) whenever the detection cache was cold or expired.
- **Repro conditions:** TalkBack on, detection cache cold/expired (e.g. no `observe()` within the 60s TTL before the swipe), Android. `detectMethod(deviceId, null)` throws internally → swallowed → reported "not talkback".
- **Root cause:** `TalkBackSwipeExecutor` and `ScrollUntilVisible` were never given an `AdbExecutor` dependency, so `null` was passed. The tap path (`AndroidTapStrategy`, `TapOnElement`) already passes a real executor.

## Validation
- [x] `bun run lint` passes (clean)
- [x] `bun run typecheck` reports no new errors (baseline gate; not ratcheted — the "no longer occur" entries are dep-resolution-specific to this sandbox)
- [x] `bun test test/features/action/swipeon/{TalkBackSwipeExecutor,ScrollUntilVisible.talkback,ScrollUntilVisible.overshoot}.test.ts` — 48/48, including new #3915 regression tests asserting a non-null executor reaches `detectMethod` on both the swipe and scroll paths
- [x] `bun run build` succeeds
- [x] New code uses interfaces + fakes; unit tests run in <100ms
- [ ] Full `bun test` not run in this sandbox for `SwipeOn.test.ts` — those construct a real `SwipeOn` whose constructor binds a CtrlProxy port, and this environment blocks socket binding (pre-existing; runs in CI)

## Device Verification
- [ ] Not verified on-device (no emulator here). Recommend: with TalkBack on and a cold detection cache, confirm `swipeOn` uses the accessibility-aware path (two-finger / ACTION_SCROLL) rather than a coordinate swipe.

## Follow-ups
- [ ] #3925 — the same two call sites also drop the `featureFlags` argument, so `force-accessibility-mode` still doesn't apply on tap/swipe; that's cross-platform and left to its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thhtbhq21RpzggLTxVB1oR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thhtbhq21RpzggLTxVB1oR)_