### PR TITLE
fix(talkback): guard focus navigation against a non-converging cursor (#3917)

### DIFF
--- a/src/features/talkback/FocusNavigationExecutor.ts
+++ b/src/features/talkback/FocusNavigationExecutor.ts
@@ -155,7 +155,8 @@ export class FocusNavigationExecutor {
     let remainingSwipes = currentPath.swipeCount;
     let totalSwipes = 0;
     let lastFocusSignature: string | null = null;
-    let stuckChecks = 0;
+    let noProgressChecks = 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
 
     if (remainingSwipes === 0) {
       const initialVerification = await this.verifyNavigationState(
@@ -232,20 +233,6 @@ export class FocusNavigationExecutor {
         );
       }
 
-      const focusSignature = this.buildFocusSignature(verification.currentFocus);
-      if (focusSignature && focusSignature === lastFocusSignature) {
-        stuckChecks += 1;
-        if (stuckChecks >= FocusNavigationExecutor.DEFAULT_MAX_STUCK_CHECKS) {
-          throw new ActionableError(
-            "Focus did not move after multiple swipes. " +
-            "Try scrolling the container or ensure the element is focusable."
-          );
-        }
-      } else {
-        stuckChecks = 0;
-        lastFocusSignature = focusSignature;
-      }
-
       const recalculated = this.pathCalculator.calculatePath(
         verification.currentFocus,
         targetSelector,
@@ -257,6 +244,41 @@ export class FocusNavigationExecutor {
           `Target element disappeared during navigation (${this.describeSelector(targetSelector)}). ` +
           "Try using debugSearch to validate the selector."
         );
+      }
+
+      // Progress guard (#3917): the distance to the target is the recalculated
+      // swipe count when the cursor is resolved, and unknown when the cursor
+      // can't be located in the traversal order. If we fail to get closer for
+      // several consecutive checks, bail instead of swiping in a (possibly wrong)
+      // direction until maxSwipes — this catches a cursor moving the wrong way or
+      // one we can't track. When the cursor is resolvable, an initially wrong
+      // direction is still corrected below via shouldRecalculatePath.
+      const focusSignature = this.buildFocusSignature(verification.currentFocus);
+      const focusMoved = focusSignature === null || focusSignature !== lastFocusSignature;
+      lastFocusSignature = focusSignature;
+
+      const distanceToTarget =
+        recalculated.currentFocusIndex === null ? null : recalculated.swipeCount;
+      if (distanceToTarget !== null && distanceToTarget < bestDistance) {
+        bestDistance = distanceToTarget;
+        noProgressChecks = 0;
+      } else {
+        noProgressChecks += 1;
+        if (noProgressChecks >= FocusNavigationExecutor.DEFAULT_MAX_STUCK_CHECKS) {
+          if (!focusMoved) {
+            throw new ActionableError(
+              "Focus did not move after multiple swipes. " +
+              "Try scrolling the container or ensure the element is focusable."
+            );
+          }
+          throw new ActionableError(
+            distanceToTarget === null
+              ? "Focus navigation could not track the TalkBack cursor position. " +
+                "Try scrolling the container first or narrow the selector."
+              : "Focus navigation is not converging on the target. " +
+                "Try scrolling the container first or narrow the selector."
+          );
+        }
       }
 
       if (this.shouldRecalculatePath(currentPath, recalculated)) {

--- a/src/features/talkback/FocusPathCalculator.ts
+++ b/src/features/talkback/FocusPathCalculator.ts
@@ -32,6 +32,10 @@ export class FocusPathCalculator {
       return null;
     }
 
+    // When the cursor can't be located in the traversal order, plan a forward
+    // sweep from the start — the reasonable default for "no focus yet". The
+    // unresolved state is surfaced as `currentFocusIndex: null` so the executor
+    // can guard against a non-converging march (see FocusNavigationExecutor, #3917).
     const resolvedCurrentIndex = this.matcher.findCurrentFocusIndex(currentFocus, orderedElements);
     const currentIndex = resolvedCurrentIndex ?? 0;
 

--- a/test/features/talkback/FocusNavigationExecutor.test.ts
+++ b/test/features/talkback/FocusNavigationExecutor.test.ts
@@ -263,4 +263,97 @@ describe("FocusNavigationExecutor", () => {
     expect(thrownError!.message).toContain("Target not found");
     expect(driver.getSwipeCount()).toBe(0);
   });
+
+  test("self-corrects when the supplied path points the wrong direction (#3917)", async () => {
+    const timer = new FakeTimer();
+    const driver = new FakeFocusNavigationDriver();
+    const elements = [
+      makeElement("a", 0),
+      makeElement("b", 1),
+      makeElement("c", 2),
+      makeElement("d", 3),
+      makeElement("e", 4)
+    ];
+    // Cursor is really on "c" (index 2); the target "a" is behind it (index 0).
+    driver.setElements(elements, 2);
+
+    const targetSelector: FocusElementSelector = { resourceId: "a" };
+    // A path built while the cursor was unresolved: forward-from-0, which points
+    // AWAY from the target.
+    const path: FocusNavigationPath = {
+      currentFocusIndex: null,
+      targetFocusIndex: 0,
+      swipeCount: 2,
+      direction: "forward",
+      intermediateCheckpoints: []
+    };
+
+    const driverFactory: FocusNavigationDriverFactory = {
+      createDriver: () => driver
+    };
+    const executor = new FocusNavigationExecutor({ timer, driverFactory });
+
+    const resultPromise = executor.navigateToElement("device-1", targetSelector, path, {
+      verificationInterval: 1,
+      swipeDelay: 0
+    });
+    for (let i = 0; i < 15; i++) {
+      timer.advanceTime(100);
+      await new Promise(r => setImmediate(r));
+    }
+    const result = await resultPromise;
+
+    expect(result).toBe(true);
+    // Once the cursor is observed, navigation reverses and converges on "a" —
+    // the final swipe is backward (endX < startX).
+    const lastSwipe = driver.swipeHistory[driver.swipeHistory.length - 1];
+    expect(lastSwipe.x2).toBeLessThan(lastSwipe.x1);
+  });
+
+  test("bails when the TalkBack cursor can't be tracked instead of marching to maxSwipes (#3917)", async () => {
+    const timer = new FakeTimer();
+    const driver = new FakeFocusNavigationDriver();
+    const elements = [
+      makeElement("a", 0),
+      makeElement("b", 1),
+      makeElement("c", 2)
+    ];
+    // No cursor is ever reported (focusedIndex null, autoAdvance off), so the
+    // cursor position can never be resolved in the traversal order.
+    driver.setElements(elements, null);
+    driver.autoAdvanceOnSwipe = false;
+
+    const targetSelector: FocusElementSelector = { resourceId: "c" };
+    // A large swipe count that, without the progress guard, would march blindly.
+    const path: FocusNavigationPath = {
+      currentFocusIndex: null,
+      targetFocusIndex: 2,
+      swipeCount: 50,
+      direction: "forward",
+      intermediateCheckpoints: []
+    };
+
+    const driverFactory: FocusNavigationDriverFactory = {
+      createDriver: () => driver
+    };
+    const executor = new FocusNavigationExecutor({ timer, driverFactory });
+
+    let thrownError: Error | null = null;
+    const resultPromise = executor.navigateToElement("device-1", targetSelector, path, {
+      verificationInterval: 1,
+      swipeDelay: 0
+    }).catch(e => {
+      thrownError = e as Error;
+    });
+    for (let i = 0; i < 20; i++) {
+      timer.advanceTime(100);
+      await new Promise(r => setImmediate(r));
+    }
+    await resultPromise;
+
+    expect(thrownError).not.toBeNull();
+    expect(thrownError!.message).toContain("could not track the TalkBack cursor position");
+    // Bailed after a couple of no-progress checks, nowhere near the 50 swipes.
+    expect(driver.getSwipeCount()).toBeLessThan(10);
+  });
 });


### PR DESCRIPTION
## Summary

`FocusPathCalculator` plans a forward-from-0 sweep when the TalkBack cursor can't be located in the traversal order — reporting `currentFocusIndex: null`. The executor's stuck detection was signature-based, and a **null** focus signature is falsy, so a cursor that never resolves never tripped it: navigation swiped the full (possibly wrong-direction) `swipeCount` up to `maxSwipes`.

This replaces the signature-only stuck check with a **distance-to-target progress guard**. The distance is the recalculated swipe count when the cursor is resolved, and unknown when it isn't; if we fail to get closer for `DEFAULT_MAX_STUCK_CHECKS` consecutive verifications, it bails with an actionable error. This catches a cursor moving the wrong way or one we can't track, while preserving the existing "focus did not move" message for the still-resolvable-but-stuck case.

## Linked Issue

Closes #3917

## Bug / Regression Context
- **Observed symptom:** With the opt-in TalkBack focus-navigation path (`screenReaderNavigation`, #3937), an unresolvable/non-converging cursor caused navigation to swipe up to `maxSwipes` (100) in a possibly-wrong direction before failing, rather than failing fast.
- **Root cause:** stuck detection keyed off `buildFocusSignature`, which returns `null` for a null cursor; `if (focusSignature && …)` short-circuits on the falsy `null`, so the counter never advanced.
- **Scope note on the issue's other two points:**
  - *"Wrong direction on a null cursor"* — when the cursor **is** resolvable, the executor already self-corrects: `shouldRecalculatePath` adopts the reversed direction after the first verification. A new test locks this in. The `null`-cursor forward-from-0 default is the reasonable "no focus yet" plan; the real hazard was only the unbounded march, now guarded.
  - *"`shouldRecalculatePath` null-vs-0 ambiguity"* — benign: the `(currentFocusIndex ?? 0)` clause is one of four OR'd conditions, and the direction/swipeCount clauses catch any real change. The new progress guard reads `recalculated.currentFocusIndex === null` directly, so it never conflates null with index 0.
  - *"stuck-detection off-by-one"* — on review this isn't a defect: detecting "no progress" needs a baseline sample, so a genuinely-stuck cursor is caught on the 3rd verification (2 consecutive no-progress checks). Left as-is; message preserved.

## Validation
- [x] `bun test test/features/talkback/` — 41/41 (was 39), including two new tests: wrong-initial-direction self-correction, and untrackable-cursor early bail (asserts `< 10` swipes, not 50)
- [x] `bun run lint` clean · `bun run typecheck` no new errors · `bun run build` succeeds
- [x] Existing "focus did not move" test still passes with its original message

## Device Verification
- [ ] Not verified on-device (no emulator here, and the path is opt-in until #3937 exposes it). Recommend: with `screenReaderNavigation` set and a target the cursor can't reach, confirm it fails fast with an actionable error rather than swiping ~100 times.

## Follow-ups
- [ ] #3937 exposes this path via an MCP parameter and is the natural place to exercise it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thhtbhq21RpzggLTxVB1oR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thhtbhq21RpzggLTxVB1oR)_