### PR TITLE
fix(device): honest, cancellable start-device handles (no fabricated ChildProcess)

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -350,7 +350,7 @@ export function registerDeviceTools() {
       "cold-boot",
       perf,
       args,
-      childProcess.pid,
+      childProcess?.pid,
     );
   }
 

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -56,7 +56,7 @@ interface AndroidEmulator {
    * @param avdName - The AVD name to start
    * @returns Promise with the spawned child process
    */
-  startEmulator(avdName: string): Promise<ChildProcess>;
+  startEmulator(avdName: string): Promise<ChildProcess | null>;
 
   /**
    * Kill a running emulator
@@ -800,7 +800,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   async startEmulator(
     avdName: string,
-  ): Promise<ChildProcess> {
+  ): Promise<ChildProcess | null> {
     logger.info(`Using local emulator for AVD: ${avdName}`);
     const perf = createGlobalPerformanceTracker();
 
@@ -820,16 +820,16 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     if (alreadyRunning) {
       logger.info(`AVD '${avdName}' is already running - waiting for it to be ready`);
-      // AVD is already running, return a mock ChildProcess since we didn't spawn it
-      // The caller (waitForEmulatorReady) will wait for it to be ready
-      return {} as ChildProcess;
+      // We did not spawn this AVD, so there is no process handle to hand back.
+      // Return null rather than a fabricated `{} as ChildProcess` (issue #3938);
+      // the caller (waitForEmulatorReady) waits for readiness regardless.
+      return null;
     }
 
     if (alreadyStarting) {
       logger.info(`AVD '${avdName}' is already starting - waiting for it to be ready`);
-      // AVD is already starting, return a mock ChildProcess since we didn't spawn it
-      // The caller (waitForEmulatorReady) will wait for it to be ready
-      return {} as ChildProcess;
+      // Started by another actor — no process handle to hand back (issue #3938).
+      return null;
     }
 
     // Check architecture compatibility before attempting to start
@@ -1000,8 +1000,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             if (!startupValidationComplete) {
               startupValidationComplete = true;
               perf.endOperation("panicDetection");
-              // Return a mock ChildProcess - the caller will wait for the AVD to be ready
-              resolve({} as ChildProcess);
+              // Another emulator already owns this AVD; we hold no process handle
+              // for it. Resolve null rather than a fabricated handle (issue #3938);
+              // the caller waits for readiness regardless.
+              resolve(null);
             }
             return;
           }

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -63,7 +63,7 @@ export interface PlatformDeviceManager {
    * @param device - The device to start
    * @returns Promise with the spawned child process for the running device
    */
-  startDevice(device: DeviceInfo, timeoutMs?: number): Promise<ChildProcess>;
+  startDevice(device: DeviceInfo, timeoutMs?: number): Promise<ChildProcess | null>;
 
   /**
    * Kill/terminate a running device
@@ -250,7 +250,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   async startDevice(
     device: DeviceInfo,
     timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS,
-  ): Promise<ChildProcess> {
+  ): Promise<ChildProcess | null> {
     const isRunning = await this.isDeviceImageRunning(device);
     if (isRunning) {
       throw new ActionableError(

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -576,11 +576,21 @@ export class SimCtlClient implements SimCtl {
       logger.debug("Could not open Simulator.app (non-fatal)");
     }
 
-    // simctl bootstatus is synchronous, so we return a mock process handle
-    // with the minimal subset of ChildProcess fields used by callers
+    // `simctl bootstatus -b` is synchronous, so there is no long-lived OS child
+    // process to hand back. Rather than fabricate a mock handle whose `kill()` is
+    // a no-op (issue #3938), return an honest handle: `pid` is undefined (no OS
+    // process), and `kill()` performs the meaningful cancellation for a simulator
+    // — shutting it back down. `ChildProcess.kill` is synchronous, so the
+    // shutdown is fired best-effort and the boolean result reports that a
+    // cancellation was initiated.
     return {
-      pid: this.timer.now(), // Use timestamp as mock PID
-      kill: () => false,
+      pid: undefined,
+      kill: (): boolean => {
+        void this.executeCommand(`shutdown ${udid}`).catch(error => {
+          logger.debug(`[iOS] handle.kill() shutdown failed for ${udid}: ${error}`);
+        });
+        return true;
+      },
       killed: false,
       connected: false,
       exitCode: 0,

--- a/test/fakes/FakeDeviceUtils.ts
+++ b/test/fakes/FakeDeviceUtils.ts
@@ -16,7 +16,7 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
   private bootedDevices: Map<Platform, BootedDevice[]> = new Map();
   private runningDeviceNames: Set<string> = new Set();
   private executedOperations: string[] = [];
-  private mockChildProcesses: Map<string, ChildProcess> = new Map();
+  private mockChildProcesses: Map<string, ChildProcess | null> = new Map();
   private waitForDeviceReadyChildProcess: ChildProcess | null | undefined;
 
   /**
@@ -75,7 +75,7 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
    * @param deviceName - The device name
    * @param childProcess - The mock child process to return
    */
-  setMockChildProcess(deviceName: string, childProcess: ChildProcess): void {
+  setMockChildProcess(deviceName: string, childProcess: ChildProcess | null): void {
     this.mockChildProcesses.set(deviceName, childProcess);
   }
 
@@ -170,7 +170,7 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
     return { devices, succeededPlatforms };
   }
 
-  async startDevice(device: DeviceInfo, timeoutMs?: number): Promise<ChildProcess> {
+  async startDevice(device: DeviceInfo, timeoutMs?: number): Promise<ChildProcess | null> {
     this.executedOperations.push(`startDevice:${device.name}:${timeoutMs ?? "default"}`);
     this.runningDeviceNames.add(device.name);
     if (device.deviceId) {
@@ -190,7 +190,7 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
 
     // Return mock process if configured, otherwise return a default mock
     if (this.mockChildProcesses.has(device.name)) {
-      return this.mockChildProcesses.get(device.name)!;
+      return this.mockChildProcesses.get(device.name) ?? null;
     }
 
     // Return a minimal mock ChildProcess

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -126,6 +126,22 @@ describe("startDevice handler", () => {
     expect(fakeDeviceUtils.wasMethodCalled("startDevice")).toBe(true);
   });
 
+  it("cold-boots without a process handle (adopted device: startDevice returns null)", async () => {
+    fakeDeviceUtils.setBootedDevices("android", []);
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(androidImage);
+    // startEmulator adopts an already-running/starting AVD it did not spawn, so
+    // it returns null (#3938). The response must still build — bootAndRespond
+    // reads childProcess?.pid, which must tolerate a null handle without throwing.
+    fakeDeviceUtils.setMockChildProcess(androidImage.name, null);
+
+    const result = await callStartDevice({ platform: "android" });
+
+    expect(result.source).toBe("cold-boot");
+    expect(result.processId).toBeUndefined();
+  });
+
   it("passes timeout to the cold boot start operation", async () => {
     fakeDeviceUtils.setBootedDevices("ios", []);
     fakeDeviceUtils.setDeviceImages("ios", [{

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -223,6 +223,36 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     }
   });
 
+  test("returns null (not a fabricated handle) when the spawn exits with 'Running multiple emulators with the same AVD'", async () => {
+    const fakeChild = createFakeChildProcess();
+
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      process.nextTick(() => {
+        // This AVD is already owned by another emulator process; the spawned
+        // process exits non-zero with this signature. We hold no handle for the
+        // already-running instance, so startEmulator must resolve null (#3938),
+        // not a fabricated `{} as ChildProcess`.
+        fakeChild.stderr!.emit("data", Buffer.from("ERROR | Running multiple emulators with the same AVD is an experimental feature.\n"));
+        fakeChild.emit("exit", 1);
+      });
+      return fakeChild;
+    }) as any;
+
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.join(" ").includes("-list-avds")) {
+        return createExecResult("Pixel_9_Pro\n");
+      }
+      return createExecResult("");
+    };
+
+    fakeTimer.enableAutoAdvance();
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    skipEmulatorPathDetection(client);
+
+    const result = await client.startEmulator("Pixel_9_Pro");
+    expect(result).toBeNull();
+  });
+
   test("rejects with exit code when emulator exits non-zero without known error pattern", async () => {
     const fakeChild = createFakeChildProcess();
 

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-startEmulator.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-startEmulator.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { DeviceInfo, ExecResult } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const createExecResult = (stdout: string, stderr = ""): ExecResult => ({
+  stdout,
+  stderr,
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: (s: string) => stdout.includes(s),
+});
+
+const noopExec = async (): Promise<ExecResult> => createExecResult("", "");
+
+function clientWithAvd(avdName: string): AndroidEmulatorClient {
+  const client = new AndroidEmulatorClient(noopExec, null, new FakeTimer());
+  (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath = async () => "emulator";
+  (client as unknown as { listAvds: () => Promise<DeviceInfo[]> }).listAvds = async () =>
+    [{ name: avdName, platform: "android", isRunning: false } as DeviceInfo];
+  return client;
+}
+
+describe("AndroidEmulatorClient startEmulator handle", () => {
+  test("returns null (not a fabricated {} as ChildProcess) when the AVD is already running", async () => {
+    const client = clientWithAvd("Pixel_9");
+    (client as unknown as { isAvdRunning: () => Promise<boolean> }).isAvdRunning = async () => true;
+
+    const result = await client.startEmulator("Pixel_9");
+
+    // AC2: no fabricated handle — a device we did not spawn has no process handle.
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the AVD is already starting", async () => {
+    const client = clientWithAvd("Pixel_9");
+    (client as unknown as { isAvdRunning: () => Promise<boolean> }).isAvdRunning = async () => false;
+    (client as unknown as { isAvdStarting: () => Promise<boolean> }).isAvdStarting = async () => true;
+
+    const result = await client.startEmulator("Pixel_9");
+
+    expect(result).toBeNull();
+  });
+});

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -284,6 +284,45 @@ describe("Simctl", function() {
     });
   });
 
+  describe("startSimulator returned handle", function() {
+    test("does not fabricate a pid (no real OS process backs a synchronous bootstatus)", async function() {
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 1.0.0", "");
+        }
+        return createExecResult("", "");
+      };
+      simctl = new Simctl(mockDevice, mockExecAsync);
+
+      const handle = await simctl.startSimulator("iphone-udid");
+
+      // AC3: honest handle — no fabricated timestamp pid.
+      expect(handle.pid).toBeUndefined();
+    });
+
+    test("kill() shuts the simulator back down instead of being a no-op", async function() {
+      const commands: string[][] = [];
+      mockExecAsync = async (file: string, args: string[]): Promise<ExecResult> => {
+        commands.push([file, ...args]);
+        if (file === "xcrun" && args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 1.0.0", "");
+        }
+        return createExecResult("", "");
+      };
+      simctl = new Simctl(mockDevice, mockExecAsync);
+
+      const handle = await simctl.startSimulator("iphone-udid");
+
+      // AC1: kill() reports success and issues `simctl shutdown <udid>` rather
+      // than the previous no-op `() => false`.
+      expect(handle.kill()).toBe(true);
+      for (let i = 0; i < 25 && !commands.some(c => c.includes("shutdown")); i++) {
+        await Promise.resolve();
+      }
+      expect(commands).toContainEqual(["xcrun", "simctl", "shutdown", "iphone-udid"]);
+    });
+  });
+
   describe("waitForSimulatorReady", function() {
     const readyPayload = simulatorListPayload([
       {


### PR DESCRIPTION
## Summary

Final follow-up for #3938. The kill-on-timeout work (#3941/#3945/#3947) is merged; this addresses the issue's remaining **"Compounding issue: fabricated / uncancellable process handles."**

`startSimulator` / `startEmulator` returned fabricated `ChildProcess` handles:
- iOS `SimCtlClient.startSimulator` → a mock with `pid: this.timer.now()` (fake timestamp) and `kill: () => false` (no-op). A hung boot could not be cancelled via the handle.
- Android `startEmulator` → `{} as ChildProcess` (no `kill`/`once`/`pid`) for already-running / already-starting AVDs it did not spawn.

`.kill()` was never called by any caller, so this was a **type lie + a dormant no-op cancel path** rather than an active crash — which keeps this change small.

## Changes

- **iOS `startSimulator`** returns an honest handle: `pid` is `undefined` (bootstatus is synchronous — there is no OS child), and `kill()` now performs the meaningful cancellation for a simulator — `simctl shutdown <udid>` — instead of a no-op. `ChildProcess.kill` is synchronous, so the shutdown is fired best-effort and the boolean reports that a cancellation was initiated.
- **Android `startEmulator`** returns `null` (not `{} as ChildProcess`) when it adopts an already-running / already-starting AVD it did not spawn, and the real `ChildProcess` when it does spawn one. Return type → `Promise<ChildProcess | null>`.
- Threaded the nullable return through `PlatformDeviceManager.startDevice` and null-guarded the one consumer that read `.pid` (`deviceTools`). `devicePool.trackStartedDeviceProcess` already guarded `null`/non-`once` handles, so exit-eviction for real spawned Android processes is unchanged.

## Linked Issue

Closes #3938

## Acceptance criteria (inferred from the issue's follow-up bullet; approved at plan gate)

| # | Criterion | Test |
|---|---|---|
| AC1 | iOS handle `kill()` shuts the simulator down (not a no-op) | `simctl.test.ts` → "kill() shuts the simulator back down instead of being a no-op" |
| AC2 | Android `startEmulator` returns `null`, not a fabricated `{}`, for adopted AVDs | `AndroidEmulatorClient-startEmulator.test.ts` → already-running / already-starting → `null` |
| AC3 | No fabricated timestamp pid | `simctl.test.ts` → "does not fabricate a pid" |
| AC4 | No regressions in device/pool/session lifecycle | existing `deviceUtils` / `devicePool` / `deviceTools` / `DeviceSessionManager` suites |

## Testing

- [x] New tests written red-first, confirmed failing for the right reason (kill `false`, pid a number, `{}` not `null`), then green.
- [x] Affected suites green: `ios-cmdline-tools`, `android-cmdline-tools`, `deviceUtils`, `devicePool`, `deviceTools.startDevice`, `DeviceSessionManager`, autolock (500+ tests).
- [x] `bun run typecheck` — no new errors (baseline gate). `bun run build` — compiles. Targeted `eslint` — clean.
- [ ] Full local `bun test` could not complete cleanly in this sandbox due to `PortManager` host-port exhaustion in unrelated CtrlProxy/socket/tool-registry suites (0 real ports held per `ss`; failures are outside the 6-file diff). Relying on CI's clean environment for the authoritative full-suite pass.

## Scope / Follow-up

Deferred (approved): **auto-cancel on boot failure** — wiring `bootAndRespond`/pool start paths to call `handle.kill()` when readiness fails, so a hung boot is actively torn down. This is the only behavior change and larger blast radius; it will be filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019aKikdGF1c8hfSQGqf62g8)_