### PR TITLE
fix(a11y): thread force-accessibility-mode flag into tapOn/swipeOn detection (#3925)

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -46,6 +46,7 @@ import {
 import type { IosVoiceOverDetector } from "../../utils/interfaces/IosVoiceOverDetector";
 import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
 import type { TapStrategy } from "../../utils/interfaces/TapStrategy";
+import { FeatureFlagService } from "../featureFlags/FeatureFlagService";
 import { createTapStrategy } from "./strategies/createTapStrategy";
 import { LongPressMetadataDetector, type LongPressMetadata } from "./LongPressMetadataDetector";
 
@@ -65,6 +66,7 @@ interface TapOnElementDependencies {
   talkBackStrategy?: TalkBackTapStrategy;
   talkBackDriverFactory?: TalkBackNavigationDriverFactory;
   iosVoiceOverDetector?: IosVoiceOverDetector;
+  featureFlags?: FeatureFlagService;
   /**
    * Override the platform-specific {@link TapStrategy}. Tests use this
    * to inject a fake; production code leaves it unset so the constructor
@@ -200,7 +202,8 @@ export class TapOnElement extends BaseVisualChange {
       device,
       this.adb,
       this.accessibilityDetector,
-      this.iosVoiceOverDetector
+      this.iosVoiceOverDetector,
+      options.featureFlags ?? FeatureFlagService.getInstance()
     );
     this.longPressMetadataDetector = new LongPressMetadataDetector(this.elementParser);
   }

--- a/src/features/action/strategies/AndroidTapStrategy.ts
+++ b/src/features/action/strategies/AndroidTapStrategy.ts
@@ -10,6 +10,7 @@ import type { AccessibilityDetector } from "../../../utils/interfaces/Accessibil
 import { accessibilityDetector as defaultAccessibilityDetector } from "../../../utils/AccessibilityDetector";
 import { attachRawViewHierarchy } from "../../../utils/viewHierarchySearch";
 import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
+import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 
 /**
  * Android implementation of {@link TapStrategy}. Filters the response
@@ -23,7 +24,8 @@ export class AndroidTapStrategy implements TapStrategy {
   constructor(
     private readonly device: BootedDevice,
     private readonly adb: AdbExecutor,
-    private readonly accessibilityDetector: AccessibilityDetector = defaultAccessibilityDetector
+    private readonly accessibilityDetector: AccessibilityDetector = defaultAccessibilityDetector,
+    private readonly featureFlags?: FeatureFlagService
   ) {}
 
   prepareViewHierarchyForResponse(
@@ -37,7 +39,13 @@ export class AndroidTapStrategy implements TapStrategy {
   }
 
   async isAccessibilityServiceEnabled(): Promise<boolean> {
-    const method = await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb);
+    // Pass featureFlags so `force-accessibility-mode` / `accessibility-auto-detect`
+    // apply to tap detection uniformly with the observe path (#3925).
+    const method = await this.accessibilityDetector.detectMethod(
+      this.device.deviceId,
+      this.adb,
+      this.featureFlags
+    );
     return method === "talkback";
   }
 

--- a/src/features/action/strategies/IosTapStrategy.ts
+++ b/src/features/action/strategies/IosTapStrategy.ts
@@ -10,6 +10,7 @@ import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../../ut
 import { IOSCtrlProxyClient } from "../../observe/ios";
 import { attachRawViewHierarchy } from "../../../utils/viewHierarchySearch";
 import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
+import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 
 /**
  * iOS implementation of {@link TapStrategy}. Filters the response
@@ -23,7 +24,8 @@ export class IosTapStrategy implements TapStrategy {
 
   constructor(
     private readonly device: BootedDevice,
-    private readonly iosVoiceOverDetector: IosVoiceOverDetector = defaultIosVoiceOverDetector
+    private readonly iosVoiceOverDetector: IosVoiceOverDetector = defaultIosVoiceOverDetector,
+    private readonly featureFlags?: FeatureFlagService
   ) {}
 
   prepareViewHierarchyForResponse(
@@ -46,7 +48,13 @@ export class IosTapStrategy implements TapStrategy {
   async isAccessibilityServiceEnabled(): Promise<boolean> {
     // Resolve lazily so Android paths never touch the iOS singleton.
     const ctrlProxy = IOSCtrlProxyClient.getInstance(this.device);
-    return this.iosVoiceOverDetector.isVoiceOverEnabled(this.device.deviceId, ctrlProxy);
+    // Pass featureFlags so `force-accessibility-mode` / `accessibility-auto-detect`
+    // apply to tap detection uniformly with the observe path (#3925).
+    return this.iosVoiceOverDetector.isVoiceOverEnabled(
+      this.device.deviceId,
+      ctrlProxy,
+      this.featureFlags
+    );
   }
 
   shouldRunPreTapStability(_options: TapOnElementOptions): boolean {

--- a/src/features/action/strategies/createTapStrategy.ts
+++ b/src/features/action/strategies/createTapStrategy.ts
@@ -3,6 +3,7 @@ import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interface
 import type { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
 import type { IosVoiceOverDetector } from "../../../utils/interfaces/IosVoiceOverDetector";
 import type { TapStrategy } from "../../../utils/interfaces/TapStrategy";
+import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 import { AndroidTapStrategy } from "./AndroidTapStrategy";
 import { IosTapStrategy } from "./IosTapStrategy";
 
@@ -15,10 +16,11 @@ export function createTapStrategy(
   device: BootedDevice,
   adb: AdbExecutor,
   accessibilityDetector: AccessibilityDetector,
-  iosVoiceOverDetector: IosVoiceOverDetector
+  iosVoiceOverDetector: IosVoiceOverDetector,
+  featureFlags?: FeatureFlagService
 ): TapStrategy {
   if (device.platform === "ios") {
-    return new IosTapStrategy(device, iosVoiceOverDetector);
+    return new IosTapStrategy(device, iosVoiceOverDetector, featureFlags);
   }
-  return new AndroidTapStrategy(device, adb, accessibilityDetector);
+  return new AndroidTapStrategy(device, adb, accessibilityDetector, featureFlags);
 }

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -17,6 +17,7 @@ import type { ElementGeometry } from "../../../utils/interfaces/ElementGeometry"
 import type { ObserveScreen } from "../../observe/interfaces/ObserveScreen";
 import { AccessibilityDetector } from "../../../utils/interfaces/AccessibilityDetector";
 import { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 import { serverConfig } from "../../../utils/ServerConfig";
 import { Timer } from "../../../utils/SystemTimer";
 import { SwipeOnResolvedOptions, BoomerangConfig, TalkBackSwipeRunner, OverlayAnalyzer, ScrollAccessibilityService } from "./types";
@@ -41,6 +42,7 @@ interface ScrollUntilVisibleDependencies {
   accessibilityService: ScrollAccessibilityService;
   accessibilityDetector: AccessibilityDetector;
   adb: AdbExecutor;
+  featureFlags?: FeatureFlagService;
   overlayDetector: OverlayAnalyzer;
   talkBackExecutor: TalkBackSwipeRunner;
   timer: Timer;
@@ -135,9 +137,12 @@ export class ScrollUntilVisible {
       }
       // Pass the real ADB executor (not null) so TalkBack detection works on a
       // cold/expired cache instead of silently reporting "not talkback" (#3915).
+      // Pass featureFlags so `force-accessibility-mode` / `accessibility-auto-detect`
+      // apply to scroll detection uniformly with the observe path (#3925).
       const accessibilityService = await this.deps.accessibilityDetector.detectMethod(
         this.deps.device.deviceId,
-        this.deps.adb
+        this.deps.adb,
+        this.deps.featureFlags
       );
       return accessibilityService === "talkback";
     });

--- a/src/features/action/swipeon/SwipeOn.ts
+++ b/src/features/action/swipeon/SwipeOn.ts
@@ -47,6 +47,7 @@ import { getScreenBounds } from "../../../utils/screenBounds";
 import { resolveContainerSwipeCoordinates } from "./resolveContainerSwipeCoordinates";
 import { IOSCtrlProxyClient } from "../../observe/ios";
 import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../../utils/IosVoiceOverDetector";
+import { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 
 export class SwipeOn extends BaseVisualChange {
   private executeGesture: GestureExecutor;
@@ -78,6 +79,7 @@ export class SwipeOn extends BaseVisualChange {
     this.geometry = dependencies.geometry ?? new DefaultElementGeometry();
     this.accessibilityService = AndroidCtrlProxyClient.getInstance(device, this.adbFactory);
     this.accessibilityDetector = dependencies.accessibilityDetector || defaultAccessibilityDetector;
+    const featureFlags = dependencies.featureFlags ?? FeatureFlagService.getInstance();
     this.visionConfig = dependencies.visionConfig ?? DEFAULT_VISION_CONFIG;
     this.screenshotCapturer = dependencies.screenshotCapturer ?? new TakeScreenshotCapturer(device, this.adbFactory);
     this.visionAnalyzer = dependencies.visionAnalyzer;
@@ -94,7 +96,8 @@ export class SwipeOn extends BaseVisualChange {
       this.accessibilityService,
       this.accessibilityDetector,
       this.adb,
-      this.timer
+      this.timer,
+      featureFlags
     );
     const iosVoiceOverDetector = dependencies.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
     this.voiceOverExecutor = dependencies.voiceOverExecutor ?? new VoiceOverSwipeExecutor(
@@ -102,7 +105,8 @@ export class SwipeOn extends BaseVisualChange {
       this.executeGesture,
       IOSCtrlProxyClient.getInstance(device),
       iosVoiceOverDetector,
-      this.timer
+      this.timer,
+      featureFlags
     );
     this.scrollUntilVisible = new ScrollUntilVisible({
       device,
@@ -112,6 +116,7 @@ export class SwipeOn extends BaseVisualChange {
       accessibilityService: this.accessibilityService,
       accessibilityDetector: this.accessibilityDetector,
       adb: this.adb,
+      featureFlags,
       overlayDetector: this.overlayDetector,
       talkBackExecutor: this.talkBackExecutor,
       timer: this.timer,

--- a/src/features/action/swipeon/TalkBackSwipeExecutor.ts
+++ b/src/features/action/swipeon/TalkBackSwipeExecutor.ts
@@ -13,6 +13,7 @@ import { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/Adb
 import { SwipeResult } from "../../../models/SwipeResult";
 import { GestureExecutor, BoomerangConfig, TalkBackSwipeRunner } from "./types";
 import { Timer } from "../../../utils/interfaces/Timer";
+import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 
 export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
   private static readonly DEFAULT_APEX_PAUSE_MS = 100;
@@ -24,7 +25,8 @@ export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
     private readonly accessibilityService: AndroidCtrlProxyClient,
     private readonly accessibilityDetector: AccessibilityDetector,
     private readonly adb: AdbExecutor,
-    private readonly timer: Timer
+    private readonly timer: Timer,
+    private readonly featureFlags?: FeatureFlagService
   ) {}
 
   async executeSwipeGesture(
@@ -53,9 +55,12 @@ export class TalkBackSwipeExecutor implements TalkBackSwipeRunner {
     // Pass the real ADB executor so detection still works on a cold/expired
     // cache — passing null here made TalkBack-aware swipe silently degrade to
     // a coordinate swipe whenever the 60s detection cache was not warm (#3915).
+    // Pass featureFlags so `force-accessibility-mode` / `accessibility-auto-detect`
+    // apply to swipe detection uniformly with the observe path (#3925).
     const detectedService = await this.accessibilityDetector.detectMethod(
       this.device.deviceId,
-      this.adb
+      this.adb,
+      this.featureFlags
     );
     const isTalkBackEnabled = detectedService === "talkback";
 

--- a/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
+++ b/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
@@ -6,6 +6,7 @@ import { BoomerangConfig, GestureExecutor, VoiceOverSwipeRunner } from "./types"
 import type { IosVoiceOverDetector } from "../../../utils/interfaces/IosVoiceOverDetector";
 import type { IOSCtrlProxy } from "../../observe/ios";
 import { Timer } from "../../../utils/interfaces/Timer";
+import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 
 /**
  * VoiceOverSwipeExecutor handles iOS VoiceOver-compatible swipe gestures.
@@ -26,7 +27,8 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
     private readonly executeGesture: GestureExecutor,
     private readonly iosClient: IOSCtrlProxy,
     private readonly iosVoiceOverDetector: IosVoiceOverDetector,
-    private readonly timer: Timer
+    private readonly timer: Timer,
+    private readonly featureFlags?: FeatureFlagService
   ) {}
 
   /**
@@ -68,9 +70,12 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
       return this.executeGesture.swipe(x1, y1, x2, y2, gestureOptions, perf);
     }
 
+    // Pass featureFlags so `force-accessibility-mode` / `accessibility-auto-detect`
+    // apply to swipe detection uniformly with the observe path (#3925).
     const isVoiceOverEnabled = await this.iosVoiceOverDetector.isVoiceOverEnabled(
       this.device.deviceId,
-      this.iosClient
+      this.iosClient,
+      this.featureFlags
     );
 
     if (!isVoiceOverEnabled) {

--- a/src/features/action/swipeon/types.ts
+++ b/src/features/action/swipeon/types.ts
@@ -118,6 +118,7 @@ export interface SwipeOnDependencies {
   parser?: import("../../../utils/interfaces/ElementParser").ElementParser;
   accessibilityDetector?: AccessibilityDetector;
   iosVoiceOverDetector?: IosVoiceOverDetector;
+  featureFlags?: import("../../featureFlags/FeatureFlagService").FeatureFlagService;
   voiceOverExecutor?: VoiceOverSwipeRunner;
   autoTargetSelector?: AutoTargetSelectorService;
   visionConfig?: import("../../../vision/VisionTypes").VisionFallbackConfig;

--- a/src/server/platform/createPlatformClient.ts
+++ b/src/server/platform/createPlatformClient.ts
@@ -6,6 +6,7 @@ import type { NotificationUIDetector } from "../../utils/interfaces/Notification
 import type { PlatformClient } from "../../utils/interfaces/PlatformClient";
 import type { SystemConfigurationAdapter } from "../../utils/interfaces/SystemConfigurationAdapter";
 import type { TapStrategy } from "../../utils/interfaces/TapStrategy";
+import { FeatureFlagService } from "../../features/featureFlags/FeatureFlagService";
 import type { ProcessExecutor } from "../../utils/ProcessExecutor";
 import type {
   AdbClientFactory,
@@ -40,6 +41,7 @@ export interface CreatePlatformClientOptions {
   tapStrategy?: TapStrategy;
   systemConfiguration?: SystemConfigurationAdapter;
   notificationUI?: NotificationUIDetector;
+  featureFlags?: FeatureFlagService;
 }
 
 /**
@@ -71,9 +73,11 @@ export function createPlatformClient(
 
   const adb = adbFactory.create(device);
 
+  const featureFlags = options.featureFlags ?? FeatureFlagService.getInstance();
+
   const tapStrategy =
     options.tapStrategy ??
-    createTapStrategy(device, adb, accessibilityDetector, iosVoiceOverDetector);
+    createTapStrategy(device, adb, accessibilityDetector, iosVoiceOverDetector, featureFlags);
 
   const systemConfiguration =
     options.systemConfiguration ??

--- a/test/fakes/FakeAccessibilityDetector.ts
+++ b/test/fakes/FakeAccessibilityDetector.ts
@@ -19,6 +19,9 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
   /** Records the `adb` argument passed to each detectMethod call (regression guard for #3915). */
   public readonly detectMethodAdbArgs: Array<AdbExecutor | null | undefined> = [];
 
+  /** Records the `featureFlags` argument passed to each detectMethod call (regression guard for #3925). */
+  public readonly detectMethodFeatureFlagsArgs: Array<FeatureFlagService | undefined> = [];
+
   /**
    * Configure the detection result for a specific device
    */
@@ -79,6 +82,7 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
     this.invalidatedDevices = [];
     this.invalidationCountAtFirstDetection = null;
     this.detectMethodAdbArgs.length = 0;
+    this.detectMethodFeatureFlagsArgs.length = 0;
   }
 
   async isAccessibilityEnabled(
@@ -94,9 +98,10 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
   async detectMethod(
     deviceId: string,
     adb: AdbExecutor,
-    _featureFlags?: FeatureFlagService
+    featureFlags?: FeatureFlagService
   ): Promise<AccessibilityService> {
     this.detectMethodAdbArgs.push(adb);
+    this.detectMethodFeatureFlagsArgs.push(featureFlags);
     if (this.invalidationCountAtFirstDetection === null) {
       this.invalidationCountAtFirstDetection = this.invalidatedDevices.length;
     }

--- a/test/fakes/FakeIosVoiceOverDetector.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.ts
@@ -11,6 +11,9 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   private callCount: number = 0;
   private invalidatedDevices: string[] = [];
 
+  /** Records the `featureFlags` argument passed to each isVoiceOverEnabled call (regression guard for #3925). */
+  public readonly isVoiceOverEnabledFeatureFlagsArgs: Array<FeatureFlagService | undefined> = [];
+
   /**
    * Configure VoiceOver enabled state for all devices
    */
@@ -39,14 +42,16 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
     this.voiceOverEnabled = false;
     this.callCount = 0;
     this.invalidatedDevices = [];
+    this.isVoiceOverEnabledFeatureFlagsArgs.length = 0;
   }
 
   async isVoiceOverEnabled(
     _deviceId: string,
     _client: IOSCtrlProxy,
-    _featureFlags?: FeatureFlagService
+    featureFlags?: FeatureFlagService
   ): Promise<boolean> {
     this.callCount++;
+    this.isVoiceOverEnabledFeatureFlagsArgs.push(featureFlags);
     return this.voiceOverEnabled;
   }
 

--- a/test/features/action/TapStrategy.test.ts
+++ b/test/features/action/TapStrategy.test.ts
@@ -10,6 +10,7 @@ import { ViewHierarchy } from "../../../src/features/observe/ViewHierarchy";
 import type { BootedDevice, ViewHierarchyResult } from "../../../src/models";
 import type { TapOnElementOptions } from "../../../src/models/TapOnElementOptions";
 import type { TapStrategy } from "../../../src/utils/interfaces/TapStrategy";
+import type { FeatureFlagService } from "../../../src/features/featureFlags/FeatureFlagService";
 
 /**
  * Sanity-check the platform-agnostic TapStrategy contract. Tests
@@ -182,6 +183,58 @@ describe("TapStrategy", () => {
         buildViewHierarchy(iosDevice)
       );
       expect(result).toBeNull();
+    });
+  });
+
+  // Regression guard for #3925: the tap strategies must forward the injected
+  // FeatureFlagService to detection so `force-accessibility-mode` /
+  // `accessibility-auto-detect` apply to tapOn exactly as they do to observe.
+  describe("force-accessibility-mode feature flag threading (#3925)", () => {
+    const sentinelFlags = { __sentinel: true } as unknown as FeatureFlagService;
+
+    it("AndroidTapStrategy forwards featureFlags to detectMethod", async () => {
+      const detector = new FakeAccessibilityDetector();
+      const strategy = new AndroidTapStrategy(
+        androidDevice,
+        new FakeAdbClient() as any,
+        detector,
+        sentinelFlags
+      );
+      await strategy.isAccessibilityServiceEnabled();
+      expect(detector.detectMethodFeatureFlagsArgs).toEqual([sentinelFlags]);
+    });
+
+    it("IosTapStrategy forwards featureFlags to isVoiceOverEnabled", async () => {
+      const detector = new FakeIosVoiceOverDetector();
+      const strategy = new IosTapStrategy(iosDevice, detector, sentinelFlags);
+      await strategy.isAccessibilityServiceEnabled();
+      expect(detector.isVoiceOverEnabledFeatureFlagsArgs).toEqual([sentinelFlags]);
+    });
+
+    it("createTapStrategy threads featureFlags into the Android strategy", async () => {
+      const detector = new FakeAccessibilityDetector();
+      const strategy = createTapStrategy(
+        androidDevice,
+        new FakeAdbClient() as any,
+        detector,
+        new FakeIosVoiceOverDetector(),
+        sentinelFlags
+      );
+      await strategy.isAccessibilityServiceEnabled();
+      expect(detector.detectMethodFeatureFlagsArgs).toEqual([sentinelFlags]);
+    });
+
+    it("createTapStrategy threads featureFlags into the iOS strategy", async () => {
+      const detector = new FakeIosVoiceOverDetector();
+      const strategy = createTapStrategy(
+        iosDevice,
+        new FakeAdbClient() as any,
+        new FakeAccessibilityDetector(),
+        detector,
+        sentinelFlags
+      );
+      await strategy.isAccessibilityServiceEnabled();
+      expect(detector.isVoiceOverEnabledFeatureFlagsArgs).toEqual([sentinelFlags]);
     });
   });
 

--- a/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
@@ -10,6 +10,7 @@ import { FakeElementGeometry } from "../../../fakes/FakeElementGeometry";
 import { FakeAdbClient } from "../../../fakes/FakeAdbClient";
 import type { BootedDevice, Element, ObserveResult } from "../../../../src/models";
 import type { SwipeOnResolvedOptions } from "../../../../src/features/action/swipeon/types";
+import type { FeatureFlagService } from "../../../../src/features/featureFlags/FeatureFlagService";
 
 const DEVICE: BootedDevice = {
   name: "test-device",
@@ -47,7 +48,8 @@ function makeScrollUntilVisible({
   timer,
   accessibilityService,
   observeResults,
-  talkBackExecutor
+  talkBackExecutor,
+  featureFlags
 }: {
   accessibilityDetector: FakeAccessibilityDetector;
   finder: FakeElementFinder;
@@ -55,6 +57,7 @@ function makeScrollUntilVisible({
   accessibilityService: FakeScrollAccessibilityService;
   observeResults: ObserveResult[];
   talkBackExecutor: FakeTalkBackSwipeExecutor;
+  featureFlags?: FeatureFlagService;
 }): ScrollUntilVisible {
   let callIdx = 0;
 
@@ -85,6 +88,7 @@ function makeScrollUntilVisible({
     accessibilityService,
     accessibilityDetector,
     adb: new FakeAdbClient() as any,
+    featureFlags,
     overlayDetector: fakeOverlayDetector,
     talkBackExecutor,
     timer,
@@ -191,6 +195,27 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       for (const arg of detector.detectMethodAdbArgs) {
         expect(arg).not.toBeNull();
       }
+    });
+
+    test("forwards the injected featureFlags to detectMethod (#3925 regression)", async () => {
+      finder.nextScrollableContainer = CONTAINER_ELEMENT;
+      finder.nextElementByText = TARGET_ELEMENT;
+      const sentinelFlags = { __sentinel: true } as unknown as FeatureFlagService;
+
+      const suv = makeScrollUntilVisible({
+        accessibilityDetector: detector,
+        finder,
+        timer,
+        accessibilityService,
+        observeResults: [makeObserveResult(0)],
+        talkBackExecutor,
+        featureFlags: sentinelFlags
+      });
+
+      await suv.execute({ ...BASE_OPTIONS });
+
+      expect(detector.detectMethodFeatureFlagsArgs.length).toBeGreaterThan(0);
+      expect(detector.detectMethodFeatureFlagsArgs[0]).toBe(sentinelFlags);
     });
 
     test("does not call requestAction(focus) when focusTarget is not set and element already visible", async () => {

--- a/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
@@ -9,6 +9,7 @@ import { SwipeDirection } from "../../../../src/models";
 import type { AdbExecutor } from "../../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker";
 import type { BootedDevice } from "../../../../src/models";
+import type { FeatureFlagService } from "../../../../src/features/featureFlags/FeatureFlagService";
 
 const ANDROID_DEVICE: BootedDevice = {
   name: "test-device",
@@ -28,7 +29,8 @@ function makeExecutor(
   fakeProxy: FakeCtrlProxy,
   fakeDetector: FakeAccessibilityDetector,
   fakeTimer: FakeTimer,
-  fakeAdb: AdbExecutor = new FakeAdbClient() as unknown as AdbExecutor
+  fakeAdb: AdbExecutor = new FakeAdbClient() as unknown as AdbExecutor,
+  featureFlags?: FeatureFlagService
 ): TalkBackSwipeExecutor {
   return new TalkBackSwipeExecutor(
     device,
@@ -36,7 +38,8 @@ function makeExecutor(
     fakeProxy as any,
     fakeDetector,
     fakeAdb,
-    fakeTimer
+    fakeTimer,
+    featureFlags
   );
 }
 
@@ -117,6 +120,32 @@ describe("TalkBackSwipeExecutor", () => {
         expect(arg).not.toBeNull();
       }
       expect(fakeAccessibilityDetector.detectMethodAdbArgs[0]).toBe(sentinelAdb);
+    });
+  });
+
+  describe("force-accessibility-mode feature flag threading (#3925)", () => {
+    test("forwards the injected featureFlags to detectMethod on android", async () => {
+      fakeAccessibilityDetector.setTalkBackEnabled(true);
+      const sentinelFlags = { __sentinel: true } as unknown as FeatureFlagService;
+      const exec = makeExecutor(
+        ANDROID_DEVICE,
+        fakeGestureExecutor,
+        fakeCtrlProxy,
+        fakeAccessibilityDetector,
+        fakeTimer,
+        new FakeAdbClient() as unknown as AdbExecutor,
+        sentinelFlags
+      );
+
+      await exec.executeSwipeGesture(
+        100, 500, 100, 200,
+        "up" as SwipeDirection,
+        null,
+        { duration: 300 },
+        perf
+      );
+
+      expect(fakeAccessibilityDetector.detectMethodFeatureFlagsArgs[0]).toBe(sentinelFlags);
     });
   });
 

--- a/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
@@ -7,6 +7,7 @@ import { NoOpPerformanceTracker } from "../../../../src/utils/PerformanceTracker
 import type { GestureExecutor } from "../../../../src/features/action/swipeon/types";
 import type { SwipeResult } from "../../../../src/models/SwipeResult";
 import type { Element } from "../../../../src/models";
+import type { FeatureFlagService } from "../../../../src/features/featureFlags/FeatureFlagService";
 
 function makeSwipeResult(overrides: Partial<SwipeResult> = {}): SwipeResult {
   return {
@@ -99,6 +100,27 @@ describe("VoiceOverSwipeExecutor", () => {
       expect(calls[0]).toMatchObject({ x1: 100, y1: 500, x2: 100, y2: 200 });
       expect(calls[1]).toMatchObject({ x1: 100, y1: 200, x2: 100, y2: 500 });
       expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
+    });
+  });
+
+  describe("force-accessibility-mode feature flag threading (#3925)", () => {
+    test("forwards the injected featureFlags to isVoiceOverEnabled on iOS", async () => {
+      const { executor } = makeFakeGestureExecutor();
+      fakeVoiceOverDetector.setVoiceOverEnabled(false);
+      const sentinelFlags = { __sentinel: true } as unknown as FeatureFlagService;
+
+      const voiceOverExecutor = new VoiceOverSwipeExecutor(
+        { platform: "ios", deviceId: "00001234-ABCD" } as any,
+        executor,
+        fakeIosClient as any,
+        fakeVoiceOverDetector,
+        fakeTimer,
+        sentinelFlags
+      );
+
+      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
+
+      expect(fakeVoiceOverDetector.isVoiceOverEnabledFeatureFlagsArgs[0]).toBe(sentinelFlags);
     });
   });
 


### PR DESCRIPTION
## Summary

Both accessibility detectors already support the `force-accessibility-mode` / `accessibility-auto-detect` feature-flag overrides, but only the **observe** path passed `featureFlags` to detection. The `tapOn` and `swipeOn` interaction paths called `detectMethod` / `isVoiceOverEnabled` **without** flags, so forcing accessibility mode via the flag did nothing for taps/swipes — making flag-driven testing unreliable and violating the design-doc's explicit-override principle (#3925).

## Change

Thread an **optional** `FeatureFlagService` through the detection-adjacent classes and forward it to the existing (already flag-aware) detector calls:

- `AndroidTapStrategy`, `IosTapStrategy` → `detectMethod` / `isVoiceOverEnabled`
- `TalkBackSwipeExecutor`, `VoiceOverSwipeExecutor`, `ScrollUntilVisible`
- Factories/wiring: `createTapStrategy`, `createPlatformClient`, `SwipeOn`, `TapOnElement` resolve `options.featureFlags ?? FeatureFlagService.getInstance()` — the same singleton-resolution idiom the observe path (`AccessibilityStateDetector`) already uses.

Injection is optional and defaulted, so existing construction sites/tests are unaffected, and the flag stays fake-injectable per the repo's interface+fake DI convention (consistent with how `accessibilityDetector` / `iosVoiceOverDetector` are already threaded through these same files).

## Tests

Regression tests assert the injected flag actually reaches detection at the four call sites (tap Android/iOS, swipe TalkBack/VoiceOver, scroll). The fakes (`FakeAccessibilityDetector`, `FakeIosVoiceOverDetector`) now record the `featureFlags` argument, mirroring the existing `#3915` adb-arg recorder.

- `bun test` on the affected suites: 93 pass, 0 fail
- Lint clean on changed files
- Typecheck gate: 0 new errors from this change (one unrelated pre-existing ajv-formats mismatch in `PlanSchemaValidator.ts` reproduces on clean `main`)

Closes #3925

Part of #3916.