### PR TITLE
fix(device): auto-cancel a hung boot via handle.kill() on readiness failure

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -350,6 +350,10 @@
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
+        },
+        "__lockNamespace": {
+          "description": "Internal plan-scoped lock namespace (injected)",
+          "type": "string"
         }
       },
       "required": [
@@ -779,6 +783,10 @@
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
+        },
+        "__lockNamespace": {
+          "description": "Internal plan-scoped lock namespace (injected)",
+          "type": "string"
         }
       },
       "required": [

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -4,7 +4,7 @@ import { logger } from "../utils/logger";
 import { SessionManager } from "./sessionManager";
 import { ActionableError, BootedDevice, DeviceInfo, Platform } from "../models";
 import { Mutex } from "async-mutex";
-import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/deviceUtils";
+import { MultiPlatformDeviceManager, PlatformDeviceManager, waitForDeviceReadyOrCancel } from "../utils/deviceUtils";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
@@ -716,7 +716,7 @@ export class DevicePool {
         logger.info(`[DevicePool] Starting additional ${device.platform} device ${label}`);
         const childProcess = await this.deviceManager.startDevice(device);
         const ready = this.criteriaMatcher.withDeviceImageMetadata(
-          await this.deviceManager.waitForDeviceReady(device, undefined, childProcess),
+          await waitForDeviceReadyOrCancel(this.deviceManager, device, childProcess),
           device
         );
         await this.addDevice(ready);
@@ -781,7 +781,7 @@ export class DevicePool {
       excludedImageIds.add(this.criteriaMatcher.getDeviceImageKey(device));
       const childProcess = await this.deviceManager.startDevice(device);
       const ready = this.criteriaMatcher.withDeviceImageMetadata(
-        await this.deviceManager.waitForDeviceReady(device, undefined, childProcess),
+        await waitForDeviceReadyOrCancel(this.deviceManager, device, childProcess),
         device
       );
       await this.addDevice(ready);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import { ToolRegistry, ProgressCallback } from "./toolRegistry";
-import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/deviceUtils";
+import { MultiPlatformDeviceManager, PlatformDeviceManager, waitForDeviceReadyOrCancel } from "../utils/deviceUtils";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../utils/deviceTimeouts";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { ActionableError, BootedDevice, DeviceInfo, SomePlatform } from "../models";
@@ -334,7 +334,7 @@ export function registerDeviceTools() {
     }
 
     perf.startOperation("waitForReady");
-    const readyDevice = await deviceUtils.waitForDeviceReady(image, timeoutMs, childProcess);
+    const readyDevice = await waitForDeviceReadyOrCancel(deviceUtils, image, childProcess, timeoutMs);
     perf.endOperation("waitForReady");
 
     if (progress) {

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -1,5 +1,5 @@
 import { ActionableError, BootedDevice, Platform, SomePlatform } from "../models";
-import { MultiPlatformDeviceManager } from "./deviceUtils";
+import { MultiPlatformDeviceManager, waitForDeviceReadyOrCancel } from "./deviceUtils";
 import { AdbClientFactory, defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
 import { Window as WindowImpl } from "../features/observe/Window";
@@ -843,9 +843,10 @@ export class DeviceSessionManager implements DeviceSessionManager {
     const childProcess = await this.deviceUtils.startDevice(deviceImage);
     perf.endOperation("startDevice");
 
-    // Wait for the emulator to fully boot and get its device ID
+    // Wait for the emulator to fully boot and get its device ID. Cancel the boot
+    // (shut the half-booted emulator back down) if readiness fails (issue #3952).
     perf.startOperation("waitForReady");
-    const newDevice = await this.deviceUtils.waitForDeviceReady(deviceImage, undefined, childProcess);
+    const newDevice = await waitForDeviceReadyOrCancel(this.deviceUtils, deviceImage, childProcess);
     perf.endOperation("waitForReady");
 
     if (!newDevice) {

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -82,6 +82,49 @@ export interface PlatformDeviceManager {
   waitForDeviceReady(device: DeviceInfo, timeoutMs?: number, childProcess?: ChildProcess | null): Promise<BootedDevice>;
 }
 
+/**
+ * Wait for a freshly-started device to become ready, actively cancelling the
+ * boot if readiness fails (issue #3952).
+ *
+ * #3951 gave the start handle an honest `kill()` (iOS shuts the simulator down;
+ * Android kills the spawned emulator process). This wires that capability into
+ * the boot flow: if `waitForDeviceReady` throws — a readiness timeout or
+ * failure — the device we just started is torn back down instead of being left
+ * booting in the background, where a retry would collide with a half-booted
+ * device (`Unable to boot device in current state: Booting`).
+ *
+ * A `null` handle means we adopted an already-running/already-starting device we
+ * did not spawn; there is nothing to kill, so it is left untouched — which is
+ * the correct behavior for adopted devices.
+ *
+ * @param deviceManager - The platform device manager performing the readiness wait
+ * @param device - The device that was started
+ * @param handle - The start handle from `startDevice` (null for adopted devices)
+ * @param timeoutMs - Optional readiness timeout
+ * @returns The booted device once ready
+ * @throws Re-throws the original readiness error after cancelling the boot
+ */
+export async function waitForDeviceReadyOrCancel(
+  deviceManager: PlatformDeviceManager,
+  device: DeviceInfo,
+  handle: ChildProcess | null,
+  timeoutMs?: number,
+): Promise<BootedDevice> {
+  try {
+    return await deviceManager.waitForDeviceReady(device, timeoutMs, handle);
+  } catch (error) {
+    if (handle) {
+      logger.warn(
+        `[startDevice] readiness failed for ${device.deviceId ?? device.name}; ` +
+        `cancelling boot via handle.kill()`,
+        error,
+      );
+      handle.kill();
+    }
+    throw error;
+  }
+}
+
 export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   private adb: AdbExecutor;
   private emulator: AndroidEmulatorClient;

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, beforeEach } from "bun:test";
 import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -87,6 +88,30 @@ describe("DevicePool", () => {
     async startDevice(device: DeviceInfo, timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS): Promise<FakeChildProcess> {
       await super.startDevice(device, timeoutMs);
       return this.childProcess;
+    }
+  }
+
+  // Hands back a spawned handle from startDevice, then fails readiness — used to
+  // assert the pool cancels a hung boot via handle.kill() (issue #3952). Reuses
+  // FakeChildProcess, adding only a kill counter.
+  class KillTrackingChildProcess extends FakeChildProcess {
+    killCount = 0;
+    override kill(): boolean {
+      this.killCount++;
+      return true;
+    }
+  }
+
+  class FakeDeviceManagerWithFailingReadiness extends FakeDeviceManager {
+    readonly childProcess = new KillTrackingChildProcess();
+
+    async startDevice(device: DeviceInfo, timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS): Promise<ChildProcess> {
+      await super.startDevice(device, timeoutMs);
+      return this.childProcess as unknown as ChildProcess;
+    }
+
+    async waitForDeviceReady(): Promise<BootedDevice> {
+      throw new Error("readiness timeout");
     }
   }
 
@@ -627,6 +652,29 @@ describe("DevicePool", () => {
       ]);
       expect(devicePool.getDevice("emulator-5554")).toBeNull();
       expect(sessionManager.getSession("session-1")).toBeNull();
+    });
+
+    test("cancels the boot (kills the spawned handle) when a pool cold-boot fails readiness", async () => {
+      const images: DeviceInfo[] = [
+        { name: "Pixel 8", platform: "android", isRunning: false, deviceId: "emulator-5554", source: "local" },
+      ];
+      const manager = new FakeDeviceManagerWithFailingReadiness(images);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer)
+      );
+
+      // No pre-booted devices: the pool must cold-boot one, readiness then fails.
+      // Allocation cannot be satisfied (throws), but the half-booted device must
+      // have been torn back down via handle.kill() (issue #3952).
+      await expect(
+        devicePool.assignMultipleDevices(["session-1"], 1000, "android")
+      ).rejects.toThrow();
+      expect(manager.childProcess.killCount).toBe(1);
     });
 
     test("boots replacement emulator after stale pooled emulator is evicted before allocation", async () => {

--- a/test/fakes/FakeDeviceUtils.ts
+++ b/test/fakes/FakeDeviceUtils.ts
@@ -18,6 +18,7 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
   private executedOperations: string[] = [];
   private mockChildProcesses: Map<string, ChildProcess | null> = new Map();
   private waitForDeviceReadyChildProcess: ChildProcess | null | undefined;
+  private waitForDeviceReadyError: Error | undefined;
 
   /**
    * Configure available device images for a platform
@@ -89,6 +90,15 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
 
   getWaitForDeviceReadyChildProcess(): ChildProcess | null | undefined {
     return this.waitForDeviceReadyChildProcess;
+  }
+
+  /**
+   * Configure waitForDeviceReady to reject, simulating a readiness
+   * timeout/failure (issue #3952 cancel-on-failure path).
+   * @param error - The error to throw, or undefined to resolve normally
+   */
+  setWaitForDeviceReadyError(error: Error | undefined): void {
+    this.waitForDeviceReadyError = error;
   }
 
   /**
@@ -220,6 +230,10 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
     this.executedOperations.push(
       `waitForDeviceReady:${device.name}:${timeoutMs}`,
     );
+
+    if (this.waitForDeviceReadyError) {
+      throw this.waitForDeviceReadyError;
+    }
 
     // Return a booted device with the same name and platform
     return {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -142,6 +142,40 @@ describe("startDevice handler", () => {
     expect(result.processId).toBeUndefined();
   });
 
+  it("cancels the boot (kills the start handle) when cold-boot readiness fails", async () => {
+    fakeDeviceUtils.setBootedDevices("android", []);
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(androidImage);
+
+    // A freshly-spawned device hands back a real handle; readiness then fails.
+    // The boot must be torn back down via handle.kill() rather than left
+    // mid-boot (issue #3952).
+    let killed = false;
+    fakeDeviceUtils.setMockChildProcess(androidImage.name, {
+      kill: (): boolean => { killed = true; return true; },
+      pid: 4242,
+    } as any);
+    fakeDeviceUtils.setWaitForDeviceReadyError(new Error("readiness timeout"));
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow("readiness timeout");
+    expect(killed).toBe(true);
+  });
+
+  it("does not kill an adopted device (null handle) when readiness fails", async () => {
+    fakeDeviceUtils.setBootedDevices("android", []);
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(androidImage);
+
+    // Adopted device: startDevice returned null, so there is nothing to kill.
+    // The failure must still propagate without a null-deref crash (issue #3952).
+    fakeDeviceUtils.setMockChildProcess(androidImage.name, null);
+    fakeDeviceUtils.setWaitForDeviceReadyError(new Error("readiness timeout"));
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow("readiness timeout");
+  });
+
   it("passes timeout to the cold boot start operation", async () => {
     fakeDeviceUtils.setBootedDevices("ios", []);
     fakeDeviceUtils.setDeviceImages("ios", [{

--- a/test/utils/waitForDeviceReadyOrCancel.test.ts
+++ b/test/utils/waitForDeviceReadyOrCancel.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "bun:test";
+import { ChildProcess } from "child_process";
+import { waitForDeviceReadyOrCancel } from "../../src/utils/deviceUtils";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import type { DeviceInfo } from "../../src/models";
+
+/**
+ * Unit coverage for the cancel-on-readiness-failure helper (issue #3952).
+ *
+ * The helper must:
+ *  - pass the device through on success without touching the handle,
+ *  - kill the handle and re-throw when readiness fails, and
+ *  - leave a null (adopted-device) handle alone while still re-throwing.
+ */
+describe("waitForDeviceReadyOrCancel", () => {
+  const iosImage: DeviceInfo = {
+    name: "iPhone 15",
+    platform: "ios",
+    deviceId: "ABCD-1234",
+    isRunning: false,
+    osVersion: "17.2",
+  };
+
+  /** A spy handle recording whether kill() was invoked. */
+  function spyHandle(): { handle: ChildProcess; killed: () => boolean } {
+    let wasKilled = false;
+    const handle = {
+      pid: undefined,
+      kill: (): boolean => {
+        wasKilled = true;
+        return true;
+      },
+      killed: false,
+      connected: false,
+      exitCode: 0,
+      signalCode: null,
+    } as unknown as ChildProcess;
+    return { handle, killed: () => wasKilled };
+  }
+
+  it("returns the ready device and does not kill the handle on success", async () => {
+    const deviceManager = new FakeDeviceUtils();
+    const { handle, killed } = spyHandle();
+
+    const ready = await waitForDeviceReadyOrCancel(deviceManager, iosImage, handle, 30_000);
+
+    expect(ready.deviceId).toBe("ABCD-1234");
+    expect(killed()).toBe(false);
+  });
+
+  it("kills the handle and re-throws when readiness fails", async () => {
+    const deviceManager = new FakeDeviceUtils();
+    const failure = new Error("Simulator with UDID ABCD-1234 failed to become ready");
+    deviceManager.setWaitForDeviceReadyError(failure);
+    const { handle, killed } = spyHandle();
+
+    await expect(
+      waitForDeviceReadyOrCancel(deviceManager, iosImage, handle, 30_000),
+    ).rejects.toThrow("failed to become ready");
+    expect(killed()).toBe(true);
+  });
+
+  it("does not throw on a null (adopted-device) handle but still re-throws the failure", async () => {
+    const deviceManager = new FakeDeviceUtils();
+    const failure = new Error("readiness timeout");
+    deviceManager.setWaitForDeviceReadyError(failure);
+
+    await expect(
+      waitForDeviceReadyOrCancel(deviceManager, iosImage, null, 30_000),
+    ).rejects.toThrow("readiness timeout");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #3938 / PR #3951. #3951 gave the start-device handle an honest, cancellable `kill()` (iOS shuts the simulator down; Android kills the spawned emulator process), but nothing **called** it — the cancellation capability was dormant. This wires it into the boot flow.

On a readiness timeout/failure after `startDevice` returned a handle, the boot is now actively **torn back down** instead of left booting in the background — where a retry collides with `Unable to boot device in current state: Booting`.

## Change

- New shared helper **`waitForDeviceReadyOrCancel`** (`src/utils/deviceUtils.ts`) wraps `waitForDeviceReady`; on throw it calls `handle.kill()` before re-throwing. It orchestrates over the existing `PlatformDeviceManager` interface, so there is one implementation for real and fake managers alike (no per-impl duplication — the reason it's a free function rather than an interface method).
- **Null-safe**: adopted already-running/already-starting devices carry a `null` handle (#3951), so there is nothing to kill — they are left untouched.
- Converted **all four** start→wait sites:
  - `bootAndRespond` (`src/server/deviceTools.ts`) — the `startDevice` tool path
  - `startAdditionalDevices` + `startAdditionalDeviceMatchingCriteria` (`src/daemon/devicePool.ts`) — pool boot paths
  - `findOrStartAndroidDevice` (`src/utils/DeviceSessionManager.ts`) — the 4th site, surfaced during review; leaving it would have kept inconsistent boot-cancellation across entry paths

The iOS `bootSimulator` session path is intentionally out of scope — it uses a self-contained blocking boot with no separate handle+wait pair.

## Tests

- **Unit** — `test/utils/waitForDeviceReadyOrCancel.test.ts`: success (no kill), readiness-failure (kill + re-throw), null handle (no crash, still re-throws).
- **Integration** — `startDevice` handler cold-boot kill + adopted-null-handle no-kill; device-pool allocation path asserts the spawned handle is killed when a pool cold-boot fails readiness.
- `FakeDeviceUtils` gains a configurable `setWaitForDeviceReadyError`.

## Acceptance criteria (#3952)

- [x] iOS/Android cold boot readiness failure → `handle.kill()` invoked (verified via fake recording the kill)
- [x] Adopted already-running/starting devices (null handle) are **not** killed on failure
- [x] No regression on the success path (no kill on successful boot)

Closes #3952. Refs #3938, PR #3951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)