### PR TITLE
feat(video): write segments.json manifest on the plan-driven Android path

### DIFF
--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -15,6 +15,7 @@ import { buildDeviceLabelMap, registerDeviceLabelMap } from "./deviceLabelMappin
 import { importPlanFromYaml, executePlan } from "../utils/planUtils";
 import { DaemonState } from "../daemon/daemonState";
 import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
+import { type StoppedSegment, writeSegmentManifest } from "./segmentManifest";
 import {
   startVideoRecording as defaultStartVideoRecording,
   stopVideoRecording as defaultStopVideoRecording,
@@ -523,6 +524,13 @@ export class PlanExecutionOrchestrator {
         const session = new AndroidSegmentedPlanVideoSession({
           device: this.device,
           outputNamePrefix: videoOutputPrefix,
+          // Share the orchestrator's clock so step-driven rotation timing is deterministic
+          // under test (in production both are the real defaultTimer, so no behavior change).
+          timer: this.timer,
+          // Route each segment's capture through the injected recorder so tests can
+          // drive the Android plan path with fakes (production passes the real manager).
+          startVideoRecording: this.videoRecorder.startVideoRecording,
+          stopVideoRecording: this.videoRecorder.stopVideoRecording,
         });
         await session.startFirstSegment();
         state.androidSession = session;
@@ -584,6 +592,18 @@ export class PlanExecutionOrchestrator {
         async () => {
           const finalized = await video.androidSession!.finalize();
           this.perfLog(`Segmented video finalized (${finalized.filePaths.length} file(s))`);
+          // Best-effort manifest so a plan run's ordered segments are discoverable on disk,
+          // matching the raw videoRecording stop path (writeSegmentManifest logs-and-continues
+          // on failure). The session handle is the first segment's recordingId, mirroring the
+          // tool path's sessionId grouping.
+          const segments: StoppedSegment[] = finalized.recordingIds.map((recordingId, index) => ({
+            recordingId,
+            filePath: finalized.filePaths[index],
+            segmentIndex: index,
+          }));
+          if (segments.length > 0) {
+            await writeSegmentManifest(segments[0].recordingId, segments);
+          }
           return { videoFilePaths: finalized.filePaths, videoRecordingIds: finalized.recordingIds };
         }
       );

--- a/src/server/segmentManifest.ts
+++ b/src/server/segmentManifest.ts
@@ -1,0 +1,54 @@
+import { promises as fsPromises } from "node:fs";
+import path from "node:path";
+import { logger } from "../utils/logger";
+
+/** File name of the per-session manifest written alongside the first segment. */
+export const SEGMENT_MANIFEST_FILE = "segments.json";
+
+/** One finalized segment of a segmented recording session, in capture order. */
+export interface StoppedSegment {
+  recordingId: string;
+  filePath: string;
+  segmentIndex: number;
+}
+
+/**
+ * Write a `segments.json` manifest listing every segment of a session in order, so a caller
+ * (or an external process that only sees the archive on disk) can discover and concatenate
+ * the clips without re-deriving order. It is written into the FIRST segment's directory, so
+ * the existing per-recording eviction (`rm(dirname)`) cleans it up with that segment — no new
+ * eviction surface. Best-effort: a write failure is logged and returns undefined rather than
+ * failing the stop, since the caller already holds the authoritative ordering.
+ *
+ * Shared by both the raw `videoRecording` stop path and the plan-driven finalize path
+ * (`PlanExecutionOrchestrator`), which both produce ordered Android segment sets.
+ */
+export async function writeSegmentManifest(
+  sessionId: string,
+  segments: StoppedSegment[]
+): Promise<string | undefined> {
+  const first = segments[0];
+  if (!first) {
+    return undefined;
+  }
+  const manifestPath = path.join(path.dirname(first.filePath), SEGMENT_MANIFEST_FILE);
+  try {
+    const manifest = {
+      sessionId,
+      segmentCount: segments.length,
+      segments: segments.map(segment => ({
+        index: segment.segmentIndex,
+        recordingId: segment.recordingId,
+        filePath: segment.filePath,
+      })),
+    };
+    await fsPromises.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    return manifestPath;
+  } catch (error) {
+    logger.warn(
+      `[VideoRecording] Failed to write segment manifest for session ${sessionId}: ` +
+      `${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
+}

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -1,5 +1,3 @@
-import { promises as fsPromises } from "node:fs";
-import path from "node:path";
 import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import {
@@ -28,18 +26,9 @@ import {
 } from "./androidSegmentedPlanVideoSession";
 import type { Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
+import { type StoppedSegment, writeSegmentManifest } from "./segmentManifest";
 
 const DEFAULT_MAX_DURATION_SECONDS = 30;
-
-/** File name of the per-session manifest written alongside the first segment. */
-const SEGMENT_MANIFEST_FILE = "segments.json";
-
-/** One finalized segment of a timer-driven segmented session, in capture order. */
-interface StoppedSegment {
-  recordingId: string;
-  filePath: string;
-  segmentIndex: number;
-}
 
 /** Result of finalizing a segmented session: its ordered segments + grouping metadata. */
 interface StoppedSegmentedSession {
@@ -48,44 +37,6 @@ interface StoppedSegmentedSession {
   segments: StoppedSegment[];
   /** Absolute path of the written manifest, or undefined if the write failed. */
   manifestPath: string | undefined;
-}
-
-/**
- * Write a `segments.json` manifest listing every segment of a session in order, so a caller
- * (or an external process that only sees the archive on disk) can discover and concatenate
- * the clips without re-deriving order. It is written into the FIRST segment's directory, so
- * the existing per-recording eviction (`rm(dirname)`) cleans it up with that segment — no new
- * eviction surface. Best-effort: a write failure is logged and returns undefined rather than
- * failing the stop, since the tool response already carries the authoritative ordering.
- */
-async function writeSegmentManifest(
-  sessionId: string,
-  segments: StoppedSegment[]
-): Promise<string | undefined> {
-  const first = segments[0];
-  if (!first) {
-    return undefined;
-  }
-  const manifestPath = path.join(path.dirname(first.filePath), SEGMENT_MANIFEST_FILE);
-  try {
-    const manifest = {
-      sessionId,
-      segmentCount: segments.length,
-      segments: segments.map(segment => ({
-        index: segment.segmentIndex,
-        recordingId: segment.recordingId,
-        filePath: segment.filePath,
-      })),
-    };
-    await fsPromises.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
-    return manifestPath;
-  } catch (error) {
-    logger.warn(
-      `[VideoRecording] Failed to write segment manifest for session ${sessionId}: ` +
-      `${error instanceof Error ? error.message : String(error)}`
-    );
-    return undefined;
-  }
 }
 
 type SegmentedSessionRecordingDependencies = Pick<

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test, beforeEach, mock } from "bun:test";
+import { describe, expect, test, beforeEach, afterAll, mock } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { promises as fsPromises } from "node:fs";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { BootedDevice } from "../../src/models";
 import type { TestExecutionRecord, TestExecutionRepository } from "../../src/db/testExecutionRepository";
+import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
 
 // Mock planUtils so the orchestrator's runPlan() phase is observable without
 // spinning up a real PlanExecutor. The companion test
@@ -47,6 +51,13 @@ const iosDevice: BootedDevice = {
   status: "booted",
 };
 
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Android Emulator",
+  platform: "android",
+  status: "booted",
+};
+
 const SIMPLE_PLAN = `
 name: simple-test
 steps:
@@ -75,6 +86,15 @@ const baseDeps = () => ({
 });
 
 describe("PlanExecutionOrchestrator", () => {
+  // Temp dirs created by the android manifest test; removed after the suite.
+  const manifestTempDirs: string[] = [];
+
+  afterAll(async () => {
+    for (const dir of manifestTempDirs) {
+      await fsPromises.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   beforeEach(() => {
     executePlanMock.mockClear();
     // The plan-execution guard is a process-wide singleton; reset between tests
@@ -342,6 +362,79 @@ steps:
         },
       },
     ]);
+  });
+
+  test("android plan run writes a segments.json manifest with ordered segments (#3905 plan path)", async () => {
+    // Real temp dir so writeSegmentManifest has a writable directory (all segments
+    // share it, so the manifest lands next to the first segment).
+    const segmentDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "auto-mobile-plan-video-"));
+    manifestTempDirs.push(segmentDir);
+
+    // The fake recorder maps recordingId === outputName, and filePath === <segmentDir>/<id>.mp4,
+    // so each rotated segment gets a distinct, deterministic path.
+    const startedNames: string[] = [];
+    const androidRecorder: VideoRecorder = {
+      startVideoRecording: mock((options: any) => {
+        const id = options.outputName as string;
+        startedNames.push(id);
+        return Promise.resolve({
+          recordingId: id,
+          outputPath: path.join(segmentDir, `${id}.mp4`),
+          fileName: `${id}.mp4`,
+          startedAt: new Date(0).toISOString(),
+          outputName: id,
+        } as any);
+      }),
+      stopVideoRecording: mock((recordingId?: string) =>
+        Promise.resolve({
+          metadata: { recordingId, filePath: path.join(segmentDir, `${recordingId}.mp4`) },
+          evictedRecordingIds: [],
+        } as any)
+      ),
+    };
+
+    const fakeTimer = new FakeTimer();
+    // Drive step-based rotation: advance past the rotate window and invoke the
+    // orchestrator-supplied onBeforePlanStep hook twice, so finalize returns 3 ordered segments.
+    executePlanMock.mockImplementationOnce(async (...args: any[]) => {
+      const options = args[7] as { onBeforePlanStep?: () => Promise<void> } | undefined;
+      if (options?.onBeforePlanStep) {
+        fakeTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS + 1);
+        await options.onBeforePlanStep();
+        fakeTimer.advanceTime(ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS + 1);
+        await options.onBeforePlanStep();
+      }
+      return {
+        success: true,
+        executedSteps: 2,
+        totalSteps: 2,
+        debug: { executionTimeMs: 1, steps: [] },
+      };
+    });
+
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: androidDevice, request: { ...baseRequest, platform: "android" } },
+      { timer: fakeTimer, videoRecorder: androidRecorder }
+    );
+    const result = await orchestrator.execute();
+
+    expect(result.success).toBe(true);
+    // Three segments: the first plus two rotations.
+    expect(result.videoRecordingIds).toEqual(startedNames);
+    expect(result.videoRecordingIds).toHaveLength(3);
+
+    // The manifest lives next to the first segment and lists every segment in order.
+    const manifestPath = path.join(segmentDir, "segments.json");
+    const manifest = JSON.parse(await fsPromises.readFile(manifestPath, "utf8"));
+    expect(manifest.sessionId).toBe(result.videoRecordingIds![0]);
+    expect(manifest.segmentCount).toBe(3);
+    expect(manifest.segments).toEqual(
+      result.videoRecordingIds!.map((recordingId, index) => ({
+        index,
+        recordingId,
+        filePath: path.join(segmentDir, `${recordingId}.mp4`),
+      }))
+    );
   });
 
   test("repository write errors are logged and do not crash the run", async () => {

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -437,6 +437,42 @@ steps:
     );
   });
 
+  test("android plan run: a failing manifest write is best-effort and does not fail the run", async () => {
+    // Segments land in a directory that does not exist, so writeSegmentManifest's
+    // fs.writeFile rejects with ENOENT. The write is best-effort (log-and-continue),
+    // so the plan run must still succeed and still surface the recording ids.
+    const missingDir = path.join(os.tmpdir(), "auto-mobile-plan-video-missing", "nope");
+    const androidRecorder: VideoRecorder = {
+      startVideoRecording: mock((options: any) =>
+        Promise.resolve({
+          recordingId: options.outputName as string,
+          outputPath: path.join(missingDir, `${options.outputName}.mp4`),
+          fileName: `${options.outputName}.mp4`,
+          startedAt: new Date(0).toISOString(),
+          outputName: options.outputName,
+        } as any)
+      ),
+      stopVideoRecording: mock((recordingId?: string) =>
+        Promise.resolve({
+          metadata: { recordingId, filePath: path.join(missingDir, `${recordingId}.mp4`) },
+          evictedRecordingIds: [],
+        } as any)
+      ),
+    };
+
+    const orchestrator = new PlanExecutionOrchestrator(
+      { device: androidDevice, request: { ...baseRequest, platform: "android" } },
+      { timer: new FakeTimer(), videoRecorder: androidRecorder }
+    );
+    const result = await orchestrator.execute();
+
+    expect(result.success).toBe(true);
+    // Finalize still returns the segment even though the manifest could not be written.
+    expect(result.videoRecordingIds).toHaveLength(1);
+    // No manifest was written (the target directory does not exist).
+    await expect(fsPromises.access(path.join(missingDir, "segments.json"))).rejects.toThrow();
+  });
+
   test("repository write errors are logged and do not crash the run", async () => {
     const exploding = {
       recordExecution: () => Promise.reject(new Error("db down")),


### PR DESCRIPTION
## Summary

Extends the segmented Android video `segments.json` manifest (added in #3905) to the **plan-driven** execution path.

Previously the manifest was written only in the raw `videoRecording` tool stop path (`writeSegmentManifest()` called from the `segmentedSessions.stopAndRemove` choke point). The plan path (`PlanExecutionOrchestrator`) finalizes segmented recordings via `AndroidSegmentedPlanVideoSession.finalize()` directly — never through `stopAndRemove` — so `executePlan` runs produced **no manifest**, despite being the longest multi-segment producers that arguably benefit most.

## Changes

- **New `src/server/segmentManifest.ts`** — lifts `writeSegmentManifest`, `StoppedSegment`, and `SEGMENT_MANIFEST_FILE` out of `videoRecordingTools.ts` into a shared module. Keeps `AndroidSegmentedPlanVideoSession` fs-free and gives both consumers one canonical writer. Behavior unchanged: best-effort, log-and-continue on write failure, written into the first segment's directory so existing per-recording eviction cleans it up.
- **`videoRecordingTools.ts`** — imports from the shared module; removed the local copies and now-unused `node:fs`/`node:path` imports. `stopAndRemove` unchanged.
- **`planExecutionOrchestrator.ts`** — `finalizeVideo`'s Android branch now maps the finalized `filePaths`/`recordingIds` into ordered `StoppedSegment`s and calls `writeSegmentManifest` (best-effort). Also threads the injected `videoRecorder` start/stop fns and the orchestrator `timer` into the constructed session — a no-op in production (both default to the real manager/`defaultTimer`) that provides a clean DI seam for testing the Android plan path with fakes.
- **`planExecutionOrchestrator.test.ts`** — new plan-path test driving an Android run through the orchestrator, triggering two step-based rotations via the mocked `onBeforePlanStep`, and asserting the on-disk `segments.json` lists all 3 segments in capture order with matching `sessionId`/`segmentCount`/per-segment fields.

## Context

Deferred from the #3905 PR as out-of-scope (that issue was scoped to the raw tool path) and to respect YAGNI until a second consumer existed — the plan path is that second consumer.

## Validation

- All 26 tests pass (`planExecutionOrchestrator` + `videoRecordingToolSegmented`).
- `bun run typecheck`: no new type errors.
- `turbo run build`: succeeded.
- ESLint on changed files: clean.