### PR TITLE
fix(talkback): exact-sentinel a11y detection + surface focus-confirm status (#3922)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -320,6 +320,9 @@
             "bounds"
           ],
           "additionalProperties": {}
+        },
+        "confirmed": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -350,6 +353,10 @@
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
+        },
+        "__lockNamespace": {
+          "description": "Internal plan-scoped lock namespace (injected)",
+          "type": "string"
         }
       },
       "required": [
@@ -779,6 +786,10 @@
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
+        },
+        "__lockNamespace": {
+          "description": "Internal plan-scoped lock namespace (injected)",
+          "type": "string"
         }
       },
       "required": [

--- a/src/features/accessibility/SetAccessibilityFocus.ts
+++ b/src/features/accessibility/SetAccessibilityFocus.ts
@@ -87,16 +87,24 @@ export class SetAccessibilityFocus {
       return { success: false, error: message };
     }
 
-    // Confirm the cursor moved (best-effort; never fail the operation on a read error).
+    // Confirm the cursor moved (best-effort; never fail the operation on a read
+    // error). `confirmed` records whether the read-back actually succeeded so
+    // callers can distinguish "focused, couldn't confirm" from "didn't focus"
+    // (#3922).
     let focusedElement: Element | undefined;
+    let confirmed = false;
     try {
       const focus = await service.requestCurrentFocus();
       focusedElement = focus.focusedElement ?? undefined;
+      confirmed = true;
     } catch (error) {
       logger.warn(`[accessibilityFocus] Failed to read current focus after ${action}: ${error}`);
     }
 
-    return { success: true, focusedElement };
+    const warning = confirmed
+      ? undefined
+      : `Focus ${action} was dispatched but the resulting focus state could not be read back to confirm it.`;
+    return { success: true, focusedElement, confirmed, warning };
   }
 
   /**

--- a/src/models/SetAccessibilityFocusResult.ts
+++ b/src/models/SetAccessibilityFocusResult.ts
@@ -24,4 +24,13 @@ export interface SetAccessibilityFocusResult {
    * The element that received accessibility focus
    */
   focusedElement?: Element;
+
+  /**
+   * Whether the post-action focus state was successfully read back to confirm
+   * the cursor moved. `false` means the set/clear was dispatched but the
+   * confirmation read failed, so `focusedElement` may be missing even though the
+   * action itself did not error — callers can use this to decide whether to
+   * retry rather than assume the cursor never moved (#3922).
+   */
+  confirmed?: boolean;
 }

--- a/src/server/accessibilityFocusTools.ts
+++ b/src/server/accessibilityFocusTools.ts
@@ -62,6 +62,7 @@ export function registerAccessibilityFocusTools() {
     return createStructuredToolResponse({
       success: true,
       focusedElement: result.focusedElement,
+      confirmed: result.confirmed,
       warning: result.warning
     });
   };

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -252,7 +252,8 @@ export const accessibilityFocusResultSchema = z.object({
   success: z.boolean(),
   error: z.string().optional(),
   warning: z.string().optional(),
-  focusedElement: elementSchema.optional()
+  focusedElement: elementSchema.optional(),
+  confirmed: z.boolean().optional()
 }).passthrough();
 
 /**

--- a/src/utils/AccessibilityDetector.ts
+++ b/src/utils/AccessibilityDetector.ts
@@ -176,8 +176,13 @@ export class DefaultAccessibilityDetector implements IAccessibilityDetector {
         return { enabled: true, service: "talkback" };
       }
 
-      // Check if any accessibility service is enabled (but not TalkBack specifically)
-      const isAnyServiceEnabled = output !== "null" && output.length > 0 && !output.includes("null");
+      // Check if any accessibility service is enabled (but not TalkBack specifically).
+      // `settings get` returns the literal string "null" when the setting is unset;
+      // otherwise a colon-separated list of component names. Key off that exact
+      // sentinel — a substring scan (`!output.includes("null")`) misclassified any
+      // legitimately-enabled service whose component string merely contains "null"
+      // as disabled (#3922).
+      const isAnyServiceEnabled = output.length > 0 && output !== "null";
 
       if (isAnyServiceEnabled) {
         logger.debug(

--- a/test/features/accessibility/SetAccessibilityFocus.test.ts
+++ b/test/features/accessibility/SetAccessibilityFocus.test.ts
@@ -91,6 +91,9 @@ describe("SetAccessibilityFocus", () => {
 
     expect(result.success).toBe(true);
     expect(result.focusedElement?.["resource-id"]).toBe("com.example:id/title");
+    // Focus was read back, so the move is confirmed and there is no warning (#3922).
+    expect(result.confirmed).toBe(true);
+    expect(result.warning).toBeUndefined();
   });
 
   test("resolves text selector to a resource-id via the element finder", async () => {
@@ -263,6 +266,10 @@ describe("SetAccessibilityFocus", () => {
 
     expect(result.success).toBe(true);
     expect(result.focusedElement).toBeUndefined();
+    // The confirmation read failed: surface confirmed:false + a warning so callers
+    // can distinguish "focused, couldn't confirm" from "didn't focus" (#3922).
+    expect(result.confirmed).toBe(false);
+    expect(result.warning).toContain("could not be read back");
   });
 
   test("throws ActionableError on iOS (Android-only gating)", async () => {

--- a/test/utils/AccessibilityDetector.test.ts
+++ b/test/utils/AccessibilityDetector.test.ts
@@ -152,6 +152,29 @@ describe("AccessibilityDetector - Unit Tests", () => {
       const service = await detector.detectMethod("device123", fakeAdb);
       expect(service).toBe("unknown");
     });
+
+    // Regression for #3922: a legitimately-enabled service whose component name
+    // merely contains the substring "null" (e.g. a package literally named
+    // "...null...") must not be misclassified as disabled by a substring scan.
+    test("detects a service whose component name contains the substring 'null'", async () => {
+      fakeAdb.setResponse("com.nullsoft.player/com.nullsoft.player.A11yService");
+
+      const enabled = await detector.isAccessibilityEnabled("device123", fakeAdb);
+      expect(enabled).toBe(true);
+
+      const service = await detector.detectMethod("device123", fakeAdb);
+      expect(service).toBe("unknown");
+    });
+
+    test("treats the literal 'null' sentinel (setting unset) as disabled", async () => {
+      fakeAdb.setResponse("null");
+
+      const enabled = await detector.isAccessibilityEnabled("device123", fakeAdb);
+      expect(enabled).toBe(false);
+
+      const service = await detector.detectMethod("device123", fakeAdb);
+      expect(service).toBe("unknown");
+    });
   });
 
   describe("Caching Behavior", () => {


### PR DESCRIPTION
## Summary

Two robustness fixes on the TalkBack detection/focus paths (#3922), both found via a code audit.

### 1. `"null"` substring misclassification in `AccessibilityDetector`

`detectAccessibilityState` classified "any accessibility service enabled" with:

```ts
const isAnyServiceEnabled = output !== "null" && output.length > 0 && !output.includes("null");
```

`settings get secure enabled_accessibility_services` returns the literal string `"null"` **only** when the setting is unset; otherwise a colon-separated list of component names. The `!output.includes("null")` clause misclassified any legitimately-enabled service whose component string merely *contains* the substring `"null"` (e.g. a package named `com.nullsoft.…`) as disabled. Detection now keys off the exact sentinel:

```ts
const isAnyServiceEnabled = output.length > 0 && output !== "null";
```

### 2. `SetAccessibilityFocus` masked confirmation failure

After dispatching set/clear, the feature reads back current focus best-effort, but on a read error it still returned `{ success: true }` with no signal — callers couldn't tell "focused, couldn't confirm" from "didn't focus." Added a `confirmed` flag (and a `warning`) recording whether the read-back succeeded, surfaced through the result model, the `accessibilityFocus` tool handler, and its output schema.

## Tests

- A service whose component name contains the substring `"null"` is detected as enabled (`service: "unknown"`); the literal `"null"` sentinel stays disabled.
- Focus confirm reports `confirmed: true` (no warning) on read success, and `confirmed: false` + a warning on read failure.
- Affected suites: 36 pass, 0 fail. Lint clean. Typecheck gate: 0 new errors (one unrelated pre-existing ajv-formats mismatch in `PlanSchemaValidator.ts` reproduces on clean `main`).

Closes #3922

Part of #3916.