### PR TITLE
refactor(ios): declarative rewrites of collection-building loops

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/UserDefaultsInspector.swift
@@ -265,12 +265,11 @@ public final class UserDefaultsInspector: @unchecked Sendable {
     /// snapshot means system keys can never appear as an add, modify, or
     /// remove. Inspection reads via ``getDriver()`` are unaffected.
     private static func snapshotDict(_ pairs: [KeyValuePair]) -> [String: KeyValuePair] {
-        var dict: [String: KeyValuePair] = [:]
-        dict.reserveCapacity(pairs.count)
-        for pair in pairs where !isSystemKey(pair.key) {
-            dict[pair.key] = pair
-        }
-        return dict
+        // Later pairs win on duplicate keys, matching the prior append-order loop.
+        Dictionary(
+            pairs.lazy.filter { !isSystemKey($0.key) }.map { ($0.key, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
     }
 
     /// Diff two key→value snapshots into per-key changes, sorted by key so

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -387,8 +387,7 @@ public enum HierarchyMerger {
         // Recurse into existing children, pairing each with its SDK counterpart
         let processedChildren: [UIElementInfo]?
         if let children = element.node {
-            var processed: [UIElementInfo] = []
-            for child in children {
+            processedChildren = children.map { child in
                 let childSdk = findDirectMatch(
                     className: child.className,
                     resourceId: child.resourceId,
@@ -397,19 +396,16 @@ public enum HierarchyMerger {
                     boundsLookup: boundsLookup,
                     identifierLookup: identifierLookup
                 )
-                processed.append(
-                    injectSdkOnlyNodes(
-                        element: child,
-                        sdkNode: childSdk,
-                        lookup: lookup,
-                        boundsLookup: boundsLookup,
-                        identifierLookup: identifierLookup,
-                        matchedSdkKeyCounts: matchedSdkKeyCounts,
-                        injectedParentKeys: &injectedParentKeys
-                    )
+                return injectSdkOnlyNodes(
+                    element: child,
+                    sdkNode: childSdk,
+                    lookup: lookup,
+                    boundsLookup: boundsLookup,
+                    identifierLookup: identifierLookup,
+                    matchedSdkKeyCounts: matchedSdkKeyCounts,
+                    injectedParentKeys: &injectedParentKeys
                 )
             }
-            processedChildren = processed
         } else {
             processedChildren = nil
         }

--- a/ios/control-proxy/Sources/CtrlProxy/PerfProvider.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/PerfProvider.swift
@@ -499,10 +499,7 @@ public class PerfProvider {
         defer { lock.unlock() }
 
         // Collect all completed entries
-        var entries: [PerfTiming] = []
-        for entry in completedEntries {
-            entries.append(entry.toTiming(timeProvider: timeProvider))
-        }
+        var entries = completedEntries.map { $0.toTiming(timeProvider: timeProvider) }
         completedEntries.removeAll()
 
         // Include debounce info if any


### PR DESCRIPTION
## Summary

Phase 1 of moving Swift toward declarative/functional style, scoped **only** to the clear "build an empty collection, then loop-and-append" accumulators identified in exploration. No behavior change; no touching of `var`/loops generally.

| Site | Before | After |
|---|---|---|
| `PerfProvider.flush` | `var entries` + `for … append(toTiming)` | `completedEntries.map { … }` |
| `HierarchyMerger.injectSdkOnlyNodes` | `var processed` + child `for … append(inject…)` | `children.map { … }` |
| `UserDefaultsInspector.snapshotDict` | filtered `for … dict[key]=pair` | `Dictionary(_:uniquingKeysWith:)` (preserves last-wins + system-key filter) |

## Explicitly out of scope
- The stateful sibling-count injection loop in `HierarchyMerger` (line ~424) — legitimately stateful.
- The `add`/`modify`/`remove` `diff()` in `UserDefaultsInspector` — readability judged in review, not mechanized.

## Tests
Behavior-preserving; existing suites exercise the exact refactored paths and pass locally:
- `UserDefaultsInspectorTests` — 23 passed (add/modify/remove + system-key filtering run through `snapshotDict`/`diff`)
- `HierarchyMergerTests` — 24 passed
- `PerfProviderTests` — 14 passed

SwiftLint clean on the changed regions.

## Follow-up
Enforcement path (promoting `for_where`/`array_init`/`reduce_into`/`first_where`/`empty_*` to error severity + `cyclomatic_complexity` warning) lands as a separate PR once this merges.