### PR TITLE
fix(a11y): confirm screen-reader toggles instead of optimistic success (#3921)

### DIFF
--- a/src/features/accessibility/TalkBackToggle.ts
+++ b/src/features/accessibility/TalkBackToggle.ts
@@ -40,12 +40,7 @@ export class TalkBackToggle {
     // already in the requested state.  Use detectMethod rather than
     // isAccessibilityEnabled so that other active services (e.g. CtrlProxy)
     // do not cause a false positive.
-    this.detector.invalidateCache(this.device.deviceId);
-    const detectedService = await this.detector.detectMethod(
-      this.device.deviceId,
-      this.adb
-    );
-    const talkBackCurrentlyEnabled = detectedService === "talkback";
+    const talkBackCurrentlyEnabled = await this.detectTalkBackEnabled();
     if (talkBackCurrentlyEnabled === enabled) {
       return {
         supported: true,
@@ -54,23 +49,51 @@ export class TalkBackToggle {
       };
     }
 
-    // Step 3: Apply ADB commands
-    if (enabled) {
-      await this.enableTalkBack(serviceComponent);
-      // Step 4: Best-effort permission dialog dismissal
-      await this.dismissPermissionDialog();
-    } else {
-      await this.disableTalkBack();
+    // Step 3: Apply ADB commands. A settings-write failure here (e.g. the a11y
+    // path AND the ADB fallback both fail) is wrapped into a typed result rather
+    // than propagating raw out of toggle(), matching the graceful contract of the
+    // other paths (#3921).
+    try {
+      if (enabled) {
+        await this.enableTalkBack(serviceComponent);
+        // Step 4: Best-effort permission dialog dismissal
+        await this.dismissPermissionDialog();
+      } else {
+        await this.disableTalkBack();
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      logger.warn(`[TalkBackToggle] Failed to ${enabled ? "enable" : "disable"} TalkBack: ${reason}`);
+      return {
+        supported: true,
+        applied: false,
+        currentState: talkBackCurrentlyEnabled,
+        reason
+      };
     }
 
-    // Step 5: Invalidate detection cache so next check reflects the new state
-    this.detector.invalidateCache(this.device.deviceId);
+    // Step 5: Invalidate the detection cache and re-detect to CONFIRM the state
+    // actually changed — never report success optimistically. If dialog dismissal
+    // failed (or TalkBack never fully activated), `applied` reflects the real
+    // post-apply state instead of the requested one (#3921).
+    const confirmedEnabled = await this.detectTalkBackEnabled();
 
     return {
       supported: true,
-      applied: true,
-      currentState: enabled
+      applied: confirmedEnabled === enabled,
+      currentState: confirmedEnabled
     };
+  }
+
+  /**
+   * Invalidate the stale detection cache and re-detect whether TalkBack
+   * specifically is the active service. Used both for the pre-apply idempotency
+   * check and the post-apply confirmation so the two never drift.
+   */
+  private async detectTalkBackEnabled(): Promise<boolean> {
+    this.detector.invalidateCache(this.device.deviceId);
+    const service = await this.detector.detectMethod(this.device.deviceId, this.adb);
+    return service === "talkback";
   }
 
   // Why: try the a11y service first to skip ADB round-trip latency; fall back to ADB
@@ -208,10 +231,7 @@ export class TalkBackToggle {
         await this.timer.sleep(DIALOG_DISMISS_DELAY_MS);
       }
       try {
-        const dumpResult = await this.adb.executeCommand(
-          "shell uiautomator dump /dev/tty"
-        );
-        const xml = dumpResult.stdout;
+        const xml = await this.dumpWindowHierarchy();
 
         // Guard: only tap when the TalkBack consent dialog is on screen.
         // "TalkBack" is a brand name that stays untranslated in all locales,
@@ -246,5 +266,19 @@ export class TalkBackToggle {
       }
     }
     logger.warn("[TalkBackToggle] TalkBack permission dialog not found — continuing");
+  }
+
+  /**
+   * Capture the current window hierarchy XML. Dumps to a device file and reads
+   * it back rather than to `/dev/tty`: `uiautomator dump /dev/tty` frequently
+   * prints its own status line ("UI hierarchy dumped to: /dev/tty") to stdout
+   * instead of the XML, so the consent dialog is never matched and dismissal
+   * silently stalls (#3921).
+   */
+  private async dumpWindowHierarchy(): Promise<string> {
+    const remotePath = "/sdcard/window_dump.xml";
+    await this.adb.executeCommand(`shell uiautomator dump ${remotePath}`);
+    const catResult = await this.adb.executeCommand(`shell cat ${remotePath}`);
+    return catResult.stdout;
   }
 }

--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -1,10 +1,12 @@
 import type { BootedDevice } from "../../models";
+import { logger } from "../../utils/logger";
 import type { VoiceOverResult } from "../../models/AccessibilityResult";
 import type { IosVoiceOverDetector } from "../../utils/interfaces/IosVoiceOverDetector";
 import { iosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
 import type { ProcessExecutor } from "../../utils/ProcessExecutor";
 import { DefaultProcessExecutor } from "../../utils/ProcessExecutor";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { IOSCtrlProxyClient } from "../observe/ios";
 
 export class VoiceOverToggle {
   constructor(
@@ -26,21 +28,41 @@ export class VoiceOverToggle {
     // based on a detection result is unsafe: IosVoiceOverDetector maps
     // detection failures to false, so a CtrlProxy outage would cause
     // toggle(false) to silently no-op when VoiceOver is actually on.
+    //
+    // A simctl failure is wrapped into a typed result rather than propagating
+    // raw out of toggle(), matching TalkBackToggle's graceful contract (#3921).
     const boolValue = enabled ? "YES" : "NO";
-    await this.processExecutor.exec(
-      `xcrun simctl spawn ${this.device.deviceId} defaults write com.apple.Accessibility VoiceOverTouchEnabled -bool ${boolValue}`
-    );
-    await this.processExecutor.exec(
-      `xcrun simctl spawn ${this.device.deviceId} notifyutil -p com.apple.accessibility.VoiceOverStatusDidChange`
-    );
+    try {
+      await this.processExecutor.exec(
+        `xcrun simctl spawn ${this.device.deviceId} defaults write com.apple.Accessibility VoiceOverTouchEnabled -bool ${boolValue}`
+      );
+      await this.processExecutor.exec(
+        `xcrun simctl spawn ${this.device.deviceId} notifyutil -p com.apple.accessibility.VoiceOverStatusDidChange`
+      );
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      logger.warn(`[VoiceOverToggle] Failed to ${enabled ? "enable" : "disable"} VoiceOver: ${reason}`);
+      return {
+        supported: true,
+        applied: false,
+        reason
+      };
+    }
 
-    // Flush the detection cache so the next observe() reflects the new state.
+    // Flush the detection cache and re-detect to CONFIRM the state actually
+    // changed — never report success optimistically. If the simctl write + post
+    // did not land, `applied` reflects the real post-apply state rather than the
+    // requested one (#3921). Detection failure maps to `false`, so a confirmation
+    // that cannot be read reports the toggle as not-applied (conservative).
     this.detector.invalidateCache(this.device.deviceId);
+    // Resolve lazily so the iOS singleton is only touched on the iOS path.
+    const client = IOSCtrlProxyClient.getInstance(this.device);
+    const confirmedEnabled = await this.detector.isVoiceOverEnabled(this.device.deviceId, client);
 
     return {
       supported: true,
-      applied: true,
-      currentState: enabled
+      applied: confirmedEnabled === enabled,
+      currentState: confirmedEnabled
     };
   }
 

--- a/test/fakes/FakeAccessibilityDetector.ts
+++ b/test/fakes/FakeAccessibilityDetector.ts
@@ -15,6 +15,7 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
   private detectionCallCount = 0;
   private invalidatedDevices: string[] = [];
   private invalidationCountAtFirstDetection: number | null = null;
+  private detectMethodQueue: AccessibilityService[] = [];
 
   /** Records the `adb` argument passed to each detectMethod call (regression guard for #3915). */
   public readonly detectMethodAdbArgs: Array<AdbExecutor | null | undefined> = [];
@@ -34,6 +35,17 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
    */
   setDefaultResult(enabled: boolean, service: AccessibilityService = "unknown"): void {
     this.defaultResult = { enabled, service };
+  }
+
+  /**
+   * Queue a sequence of `detectMethod` results consumed in FIFO order; once the
+   * queue is exhausted, detection falls back to the per-device / default result.
+   * Lets a test model a state transition across the two detections a toggle now
+   * performs — the pre-apply idempotency check and the post-apply confirmation
+   * (#3921). Only affects `detectMethod`; `isAccessibilityEnabled` is unchanged.
+   */
+  enqueueDetectMethodResults(...services: AccessibilityService[]): void {
+    this.detectMethodQueue.push(...services);
   }
 
   /**
@@ -83,6 +95,7 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
     this.invalidationCountAtFirstDetection = null;
     this.detectMethodAdbArgs.length = 0;
     this.detectMethodFeatureFlagsArgs.length = 0;
+    this.detectMethodQueue.length = 0;
   }
 
   async isAccessibilityEnabled(
@@ -106,6 +119,9 @@ export class FakeAccessibilityDetector implements AccessibilityDetector {
       this.invalidationCountAtFirstDetection = this.invalidatedDevices.length;
     }
     this.detectionCallCount++;
+    if (this.detectMethodQueue.length > 0) {
+      return this.detectMethodQueue.shift()!;
+    }
     const result = this.detectionResults.get(deviceId) || this.defaultResult;
     return result.service;
   }

--- a/test/features/accessibility/TalkBackToggle.test.ts
+++ b/test/features/accessibility/TalkBackToggle.test.ts
@@ -72,7 +72,9 @@ describe("TalkBackToggle", () => {
   describe("enable TalkBack", () => {
     test("returns supported:true applied:true when TalkBack is installed and currently disabled", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
-      fakeDetector.setDefaultResult(false);
+      // Pre-apply idempotency detect: not talkback -> proceed. Post-apply
+      // confirmation detect: talkback -> applied:true (#3921).
+      fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       const result = await toggle.toggle(true);
@@ -81,6 +83,20 @@ describe("TalkBackToggle", () => {
       expect(result.applied).toBe(true);
       expect(result.currentState).toBe(true);
       expect(result.reason).toBeUndefined();
+    });
+
+    test("reports applied:false when TalkBack did not activate after apply (e.g. consent dialog blocked it)", async () => {
+      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
+      // Idempotency detect: not talkback -> proceed. Confirmation detect: STILL
+      // not talkback -> the toggle must not claim success optimistically (#3921).
+      fakeDetector.enqueueDetectMethodResults("unknown", "unknown");
+
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const result = await toggle.toggle(true);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(false);
+      expect(result.currentState).toBe(false);
     });
 
     test("runs the correct enable ADB commands", async () => {
@@ -121,20 +137,23 @@ describe("TalkBackToggle", () => {
       expect(fakeDetector.getInvalidationCountBeforeFirstDetection()).toBeGreaterThanOrEqual(1);
     });
 
-    test("attempts dialog dismissal after enabling", async () => {
+    test("attempts dialog dismissal via a file dump (not /dev/tty) after enabling", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(false);
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       await toggle.toggle(true);
 
-      expect(fakeAdb.wasCommandExecuted("shell uiautomator dump /dev/tty")).toBe(true);
+      // #3921: dump to a device file and read it back, never to /dev/tty.
+      expect(fakeAdb.wasCommandExecuted("shell uiautomator dump /sdcard/window_dump.xml")).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("shell cat /sdcard/window_dump.xml")).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("/dev/tty")).toBe(false);
     });
 
     test("taps Allow button when permission dialog is present (English)", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
-        "shell uiautomator dump /dev/tty",
+        "shell cat /sdcard/window_dump.xml",
         makeExecResult(DIALOG_XML_WITH_BUTTON1)
       );
       fakeDetector.setDefaultResult(false);
@@ -149,7 +168,7 @@ describe("TalkBackToggle", () => {
     test("taps Allow button on non-English locale using resource-id", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
-        "shell uiautomator dump /dev/tty",
+        "shell cat /sdcard/window_dump.xml",
         makeExecResult(DIALOG_XML_NON_ENGLISH)
       );
       fakeDetector.setDefaultResult(false);
@@ -164,10 +183,11 @@ describe("TalkBackToggle", () => {
     test("does not tap when no permission dialog appears", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
-        "shell uiautomator dump /dev/tty",
+        "shell cat /sdcard/window_dump.xml",
         makeExecResult("<hierarchy><node text='Home' /></hierarchy>")
       );
-      fakeDetector.setDefaultResult(false);
+      // Idempotency: not talkback -> proceed. Confirmation: talkback -> applied:true.
+      fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       const result = await toggle.toggle(true);
@@ -185,10 +205,11 @@ describe("TalkBackToggle", () => {
 </hierarchy>`;
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
-        "shell uiautomator dump /dev/tty",
+        "shell cat /sdcard/window_dump.xml",
         makeExecResult(unrelatedDialogXml)
       );
-      fakeDetector.setDefaultResult(false);
+      // Idempotency: not talkback -> proceed. Confirmation: talkback -> applied:true.
+      fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       const result = await toggle.toggle(true);
@@ -212,8 +233,9 @@ describe("TalkBackToggle", () => {
 
     test("enables TalkBack when another service is active but TalkBack is not", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
-      // isAccessibilityEnabled would return true, but TalkBack specifically is not active
-      fakeDetector.setDefaultResult(true, "unknown");
+      // Idempotency: another service active but not talkback ("unknown") -> proceed.
+      // Confirmation: talkback -> applied:true (#3921).
+      fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       const result = await toggle.toggle(true);
@@ -245,7 +267,9 @@ describe("TalkBackToggle", () => {
   describe("disable TalkBack", () => {
     test("returns supported:true applied:true when TalkBack is installed and currently enabled", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
-      fakeDetector.setDefaultResult(true, "talkback");
+      // Idempotency: talkback (currently on) -> proceed to disable. Confirmation:
+      // not talkback -> applied:true, currentState:false (#3921).
+      fakeDetector.enqueueDetectMethodResults("talkback", "unknown");
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       const result = await toggle.toggle(false);
@@ -277,7 +301,7 @@ describe("TalkBackToggle", () => {
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       await toggle.toggle(false);
 
-      expect(fakeAdb.wasCommandExecuted("shell uiautomator dump /dev/tty")).toBe(false);
+      expect(fakeAdb.wasCommandExecuted("shell uiautomator dump /sdcard/window_dump.xml")).toBe(false);
     });
 
     test("invalidates the detector cache after disabling", async () => {
@@ -369,8 +393,8 @@ describe("TalkBackToggle", () => {
     });
   });
 
-  describe("ADB error propagation during apply phase", () => {
-    test("propagates ADB error thrown during enable when TalkBack is installed", async () => {
+  describe("ADB error during apply phase", () => {
+    test("returns a typed failure (not an uncaught throw) when an apply-phase ADB command fails", async () => {
       // dumpsys succeeds so detectInstalledService() passes (TalkBack is found)
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       // The apply phase reads the current services list; make that command throw
@@ -381,7 +405,13 @@ describe("TalkBackToggle", () => {
       fakeDetector.setDefaultResult(false);
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
-      await expect(toggle.toggle(true)).rejects.toThrow();
+      // #3921: the apply failure is wrapped into a typed result, matching the
+      // graceful contract of the other paths, rather than propagating raw.
+      const result = await toggle.toggle(true);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(false);
+      expect(result.reason).toContain("ADB command failed during apply");
     });
   });
 

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -49,6 +49,9 @@ describe("VoiceOverToggle", () => {
 
   describe("enable VoiceOver on simulator", () => {
     test("returns supported:true applied:true", async () => {
+      // Post-apply confirmation re-detect reports VoiceOver on (#3921).
+      fakeDetector.setVoiceOverEnabled(true);
+
       const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
       const result = await toggle.toggle(true);
 
@@ -56,6 +59,19 @@ describe("VoiceOverToggle", () => {
       expect(result.applied).toBe(true);
       expect(result.currentState).toBe(true);
       expect(result.reason).toBeUndefined();
+    });
+
+    test("reports applied:false when VoiceOver did not turn on after apply", async () => {
+      // simctl write ran but the confirmation re-detect still reports off — the
+      // toggle must not claim success optimistically (#3921).
+      fakeDetector.setVoiceOverEnabled(false);
+
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const result = await toggle.toggle(true);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(false);
+      expect(result.currentState).toBe(false);
     });
 
     test("runs correct xcrun simctl spawn commands when enabling", async () => {
@@ -115,6 +131,23 @@ describe("VoiceOverToggle", () => {
           `xcrun simctl spawn ${udid} notifyutil -p com.apple.accessibility.VoiceOverStatusDidChange`
         )
       ).toBe(true);
+    });
+  });
+
+  describe("simctl failure during apply phase", () => {
+    test("returns a typed failure (not an uncaught throw) when a simctl command fails", async () => {
+      fakeExec.setCommandHandler("VoiceOverTouchEnabled", () => {
+        throw new Error("simctl spawn failed");
+      });
+
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      // #3921: the simctl failure is wrapped into a typed result, matching
+      // TalkBackToggle's graceful contract, rather than propagating raw.
+      const result = await toggle.toggle(true);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(false);
+      expect(result.reason).toContain("simctl spawn failed");
     });
   });
 


### PR DESCRIPTION
## Summary

`TalkBackToggle` and `VoiceOverToggle` both returned `{ applied: true, currentState: enabled }` immediately after dispatching the enable/disable commands, **without verifying** the screen reader actually reached the requested state (#3921). If the TalkBack consent dialog wasn't dismissed, or a `simctl` write didn't land, callers were told the toggle succeeded when it hadn't.

## Changes

1. **TalkBack — re-detect after apply.** Confirm the state via a shared `detectTalkBackEnabled()` helper (used for both the pre-apply idempotency check and the post-apply confirmation) and derive `applied` / `currentState` from the confirmed result.
2. **VoiceOver — re-detect after apply.** Same pattern via `isVoiceOverEnabled` (resolving the CtrlProxy client lazily, matching `IosTapStrategy`).
3. **TalkBack consent-dialog detection robustness.** Dump the window hierarchy to a device file and `cat` it back instead of `uiautomator dump /dev/tty` — the `/dev/tty` form frequently prints its status line to stdout instead of the XML, so the dialog was never matched and dismissal silently stalled.
4. **Consistent error contract.** Wrap the apply phase in both toggles so an ADB/`simctl` failure returns a typed result (`applied: false` + `reason`) instead of propagating raw out of `toggle()`.

## Tests

- `FakeAccessibilityDetector` gains a `detectMethod` result queue (`enqueueDetectMethodResults`) so a test can model the pre-apply idempotency detect and the post-apply confirmation detect independently.
- New cases: "did not activate after apply → `applied:false`" (both platforms), the file-based dialog dump (asserts no `/dev/tty`), and the typed apply-phase failure (both platforms).
- 916 tests green across the accessibility + action suites; lint clean; typecheck gate 0 new errors (the lone pre-existing ajv-formats mismatch in `PlanSchemaValidator.ts` reproduces on clean `main`).

Closes #3921

Part of #3916.