### PR TITLE
build(ios): make declarative-style SwiftLint rules blocking

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -38,7 +38,6 @@ disabled_rules:
   - file_length  # Can be overly restrictive for valid large files
   - type_body_length  # Can be overly restrictive
   - function_body_length  # Can be overly restrictive
-  - cyclomatic_complexity  # Can be too restrictive
   - function_parameter_count  # Some APIs legitimately need many parameters
 
 # Opt-in rules (not enabled by default)
@@ -97,6 +96,29 @@ opt_in_rules:
 force_unwrapping:
   severity: error
 
+# Declarative-style semantic rules. These are already opt-in above and each has a
+# single obvious functional rewrite (map/Array(seq)/reduce(into:)/first(where:)/
+# for-where/isEmpty). CI runs SwiftLint non-strict, so a default `warning` is
+# ignored — promote them to `error` so a new imperative accumulator fails the
+# SwiftLint job at author time. The whole existing tree was already clean of these
+# (the four pre-existing hits were fixed in the same change that added this block).
+# The noisier `contains_over_*` family is deliberately left at `warning`: it false-
+# positives on `Data.range(of:)` (Data has no subsequence `contains(_:)`).
+for_where:
+  severity: error
+array_init:
+  severity: error
+reduce_into:
+  severity: error
+first_where:
+  severity: error
+empty_count:
+  severity: error
+empty_string:
+  severity: error
+empty_collection_literal:
+  severity: error
+
 identifier_name:
   min_length:
     error: 1
@@ -133,6 +155,18 @@ type_name:
 nesting:
   type_level: 2
   function_level: 3
+
+# Readability signal, enabled warning-only for now. The goal (per the imperative-
+# patterns exploration) is to *measure* the complexity baseline before deciding
+# whether to tighten — not to force-refactor legitimate dispatch switches. CI runs
+# SwiftLint non-strict so warnings never block; the `error` threshold is set out of
+# reach (highest current function is 43, in CommandHandler/Models dispatch) so this
+# rule can never fail the build on its own. A follow-up can lower `error` and drive
+# down the ~5 functions above 20 once there's appetite for those rewrites.
+cyclomatic_complexity:
+  warning: 10
+  error: 200
+  ignores_case_statements: false
 
 large_tuple:
   warning: 3

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -539,10 +539,8 @@ public enum DaemonManager {
             "\(NSHomeDirectory())/.bun/bin/\(name)",
             "\(NSHomeDirectory())/.local/bin/\(name)",
         ]
-        for path in commonPaths {
-            if FileManager.default.isExecutableFile(atPath: path) {
-                return path
-            }
+        for path in commonPaths where FileManager.default.isExecutableFile(atPath: path) {
+            return path
         }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/which")

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
@@ -335,10 +335,8 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
             } else if char == ")", depth > 0 {
                 depth -= 1
             } else if depth == 0 {
-                for keyword in keywords {
-                    if matchesKeyword(in: query, at: i, keyword: keyword) {
-                        return SQLKeyword(keyword: keyword, index: i)
-                    }
+                for keyword in keywords where matchesKeyword(in: query, at: i, keyword: keyword) {
+                    return SQLKeyword(keyword: keyword, index: i)
                 }
             }
             i = query.index(after: i)

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -167,8 +167,8 @@ public class GesturePerformer: GesturePerforming {
             if (isKnownTextInput || isTextLikeOther) && snapshot.hasFocus {
                 return true
             }
-            for child in snapshot.children {
-                if snapshotHasTextInputWithFocus(child, depth: depth + 1) { return true }
+            for child in snapshot.children where snapshotHasTextInputWithFocus(child, depth: depth + 1) {
+                return true
             }
             return false
         }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
@@ -19,7 +19,7 @@ final class FrameWriterTests: XCTestCase {
         let height = 3
         let bytesPerRow = 8
         // 24 bytes of BGRA: 2px × 3 rows × 4 bytes
-        let payload: [UInt8] = (0..<UInt8(bytesPerRow * height)).map { $0 }
+        let payload = Array(0..<UInt8(bytesPerRow * height))
 
         payload.withUnsafeBufferPointer { ptr in
             writer.write(


### PR DESCRIPTION
## Summary

Phase 2 (enforcement) of the imperative-patterns cleanup, following [#3958](https://github.com/kaeawc/auto-mobile/pull/3958). CI runs SwiftLint **non-strict**, so the already opted-in semantic rules only emit warnings and are ignored. This promotes the low-noise, single-obvious-rewrite rules to `error` severity so a new imperative accumulator fails the SwiftLint job at author time.

### Promoted to `error`
`for_where`, `array_init`, `reduce_into`, `first_where`, `empty_count`, `empty_string`, `empty_collection_literal`

Verified a synthetic `for … { if … }` now fails as `error:`, and the whole tree is error-free after the fixes below.

### Pre-existing hits fixed first (so this lands green)
| File | Rule | Fix |
|---|---|---|
| `AutoMobileEnvironment.swift` | `for_where` | `for … where isExecutableFile` |
| `SQLiteDatabaseDriver.swift` | `for_where` | `for keyword in keywords where matchesKeyword(…)` |
| `GesturePerformer.swift` | `for_where` | `for child in … where snapshotHasTextInputWithFocus(…)` |
| `FrameWriterTests.swift` | `array_init` | `Array(0..<n)` over `.map { $0 }` |

### Deliberately left at `warning`
- `contains_over_*` — false-positives on `Data.range(of:)` (`Data` has no subsequence `contains(_:)`).

### `cyclomatic_complexity` — enabled warning-only
Enabled as a **measurement baseline** per the exploration's "measure before tightening" guidance. Error threshold is set out of reach (`error: 200`; highest current function is 43 — the `CommandHandler`/`Models` dispatch switches), so it can never block CI. Today: **22 warnings, 0 blocking**. A follow-up can lower the threshold and drive down the ~5 functions above 20 once there's appetite for those rewrites. `nesting` stays the hard backstop at function-level 3.

### Not done (per exploration guidance)
No regex bans on `var`/`append`/`for`; no syntax-aware custom rule yet.

## Validation
- SwiftLint tree-wide: **0 error-level violations**.
- Builds: control-proxy, auto-mobile-sdk, screen-capture, XCTestRunner all compile.
- Tests: `SQLiteDatabaseDriver` (7) + `FrameWriter` (2) pass; other fixes are behavior-neutral idiom swaps.