### PR TITLE
fix(talkback): activate the live focused node, not stale element bounds or (0,0) (#3918)

### DIFF
--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -324,8 +324,35 @@ export class TalkBackTapStrategy {
     driver: TalkBackNavigationDriver
   ): Promise<TalkBackTapResult> {
     const resourceId = element["resource-id"] as string | undefined;
-    const center = this.getElementCenter(element);
+    // Activate against the node TalkBack actually focused (live bounds), not the
+    // caller's possibly-stale element (#3918).
+    const center = await this.resolveActivationCenter(element, driver);
     const tapDuration = 50;
+
+    // No usable bounds on either the focused node or the caller's element: never
+    // tap (0,0). Try ACTION_CLICK on the resource-id, otherwise fail explicitly
+    // rather than reporting a top-left tap as success (#3918).
+    if (!center) {
+      if (resourceId) {
+        logger.warn(
+          "[TalkBackTapStrategy] Activation target has no bounds; using ACTION_CLICK fallback"
+        );
+        const clickResult = await driver.requestAction("click", resourceId);
+        if (clickResult.success) {
+          return { success: true, method: "accessibility-action" };
+        }
+        return {
+          success: false,
+          method: "focus-navigation",
+          error: `Activation failed: target has no bounds and ACTION_CLICK failed (${clickResult.error ?? "unknown"})`
+        };
+      }
+      return {
+        success: false,
+        method: "focus-navigation",
+        error: "Activation failed: target has no bounds and no resource-id for ACTION_CLICK"
+      };
+    }
 
     // First tap of double-tap activation
     const firstTap = await driver.requestTapCoordinates(center.x, center.y, tapDuration);
@@ -381,13 +408,43 @@ export class TalkBackTapStrategy {
     return { success: true, method: "focus-navigation" };
   }
 
-  private getElementCenter(element: Element): { x: number; y: number } {
+  /**
+   * Compute the center of an element's bounds, or `null` when the element has no
+   * bounds. Returning null (rather than the old `(0,0)`) forces callers to treat
+   * a bounds-less target as an explicit failure/fallback instead of silently
+   * tapping the top-left corner and reporting success (#3918).
+   */
+  private getElementCenter(element: Element): { x: number; y: number } | null {
     if (!element.bounds) {
-      return { x: 0, y: 0 };
+      return null;
     }
     return {
       x: Math.round((element.bounds.left + element.bounds.right) / 2),
       y: Math.round((element.bounds.top + element.bounds.bottom) / 2)
     };
+  }
+
+  /**
+   * Resolve the coordinates to activate against. Prefer the node TalkBack
+   * actually focused — read live via {@link TalkBackNavigationDriver.requestCurrentFocus}
+   * — over the caller-supplied `element`, whose stored bounds may be stale and
+   * land the double-tap on the wrong screen location (#3918). Falls back to the
+   * passed element when the live focus cannot be read or carries no bounds.
+   */
+  private async resolveActivationCenter(
+    element: Element,
+    driver: TalkBackNavigationDriver
+  ): Promise<{ x: number; y: number } | null> {
+    try {
+      const focus = await driver.requestCurrentFocus();
+      const focused = focus.focusedElement;
+      if (focused?.bounds) {
+        return this.getElementCenter(focused);
+      }
+    } catch (error) {
+      // Live-focus read is best-effort; fall back to the caller's element bounds.
+      logger.debug(`[TalkBackTapStrategy] Could not read current focus for activation: ${error}`);
+    }
+    return this.getElementCenter(element);
   }
 }

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -222,6 +222,71 @@ describe("TalkBackTapStrategy", () => {
       expect(result.error).toContain("both failed");
     });
 
+    // Regression for #3918: activation must double-tap the node TalkBack
+    // actually focused (live bounds), not the caller's stored element whose
+    // bounds may be stale.
+    test("activates at the live focused node's coordinates, not the passed element's stale bounds", async () => {
+      // The caller's element carries stale bounds (center 5,5)...
+      const staleElement = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 10, bottom: 10 }
+      } as Element;
+      // ...while the node TalkBack actually focused is elsewhere (center 600,700).
+      const liveFocusedElement = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 500, top: 600, right: 700, bottom: 800 }
+      } as Element;
+
+      driver.setElements([liveFocusedElement], 0);
+      spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
+
+      const result = await strategy.executeTap("device-1", staleElement, "tap", driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("focus-navigation");
+      expect(driver.getTapCount()).toBe(2);
+      // Both taps land on the live focused node, not (5,5).
+      expect(driver.tapHistory[0]).toMatchObject({ x: 600, y: 700 });
+      expect(driver.tapHistory[1]).toMatchObject({ x: 600, y: 700 });
+    });
+
+    // Regression for #3918: a bounds-less activation target must never tap (0,0).
+    test("falls back to ACTION_CLICK (never taps 0,0) when the target has no bounds", async () => {
+      const boundsLessElement = {
+        "resource-id": "test:id/button"
+        // no bounds on the caller's element...
+      } as Element;
+      // ...and the live focused node also has no bounds.
+      const boundsLessFocused = { "resource-id": "test:id/button" } as Element;
+
+      driver.setElements([boundsLessFocused], 0);
+      spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
+      driver.setActionResult({ success: true, action: "click", totalTimeMs: 1 });
+
+      const result = await strategy.executeTap("device-1", boundsLessElement, "tap", driver);
+
+      expect(result.success).toBe(true);
+      expect(result.method).toBe("accessibility-action");
+      expect(driver.getTapCount()).toBe(0); // never tapped (0,0)
+      expect(driver.actionHistory[0]).toEqual({ action: "click", resourceId: "test:id/button" });
+    });
+
+    test("fails explicitly (no 0,0 tap, no ACTION_CLICK) when a bounds-less target has no resource-id", async () => {
+      const boundsLessTextElement = { text: "Button" } as Element;
+      const boundsLessFocused = { text: "Button" } as Element;
+
+      driver.setElements([boundsLessFocused], 0);
+      spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
+
+      const result = await strategy.executeTap("device-1", boundsLessTextElement, "tap", driver);
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("focus-navigation");
+      expect(result.error).toContain("no bounds");
+      expect(driver.getTapCount()).toBe(0);
+      expect(driver.getActionCount()).toBe(0);
+    });
+
     test("returns error when navigation path cannot be calculated", async () => {
       const element = {
         "resource-id": "test:id/nonexistent",


### PR DESCRIPTION
## Summary

After `navigateToElement` reports success, `TalkBackTapStrategy.activateElement` double-tapped the center of the **element that was passed in**, not the node TalkBack actually focused. If the passed element had stale bounds, activation landed on the wrong screen location while still logging "Focus navigation successful." A bounds-less element additionally tapped the top-left corner `(0,0)` and could be reported as success (#3918).

## Changes

- **`resolveActivationCenter`** — read the currently-focused node live via `driver.requestCurrentFocus()` and activate against **its** bounds, falling back to the caller-supplied element only when the live focus can't be read or carries no bounds.
- **`getElementCenter`** now returns `null` (not `{0,0}`) for a bounds-less element.
- **`activateElement`** treats a `null` center as an explicit failure/fallback: try `ACTION_CLICK` on the resource-id, otherwise fail with a clear error — it never taps `(0,0)`.

## Tests

- Activation lands on the **live focused node's** coordinates (500,600,700,800 → 600,700), not the passed element's stale bounds (0,0,10,10 → 5,5).
- A bounds-less target falls back to `ACTION_CLICK` (asserts `getTapCount() === 0` — never taps `(0,0)`), or fails explicitly with a "no bounds" error when there is no resource-id.
- 820 tests green across the talkback + action suites; lint clean; typecheck gate 0 new errors (the lone pre-existing ajv-formats mismatch in `PlanSchemaValidator.ts` reproduces on clean `main`).

Closes #3918

Part of #3916 (umbrella #3937).