### PR TITLE
chore(talkback): remove dead nav leftovers — intermediateCheckpoints and ignored tap/doubleTap (#3920)

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1463,7 +1463,6 @@ export class TapOnElement extends BaseVisualChange {
         const result = await this.talkBackStrategy.executeTap(
           this.device.deviceId,
           element,
-          action as "tap" | "doubleTap",
           driver
         );
 

--- a/src/features/talkback/FocusNavigationExecutor.ts
+++ b/src/features/talkback/FocusNavigationExecutor.ts
@@ -176,8 +176,7 @@ export class FocusNavigationExecutor {
       const recalculated = this.pathCalculator.calculatePath(
         initialVerification.currentFocus,
         targetSelector,
-        initialVerification.orderedElements,
-        verificationInterval
+        initialVerification.orderedElements
       );
       if (!recalculated) {
         throw new ActionableError(
@@ -236,8 +235,7 @@ export class FocusNavigationExecutor {
       const recalculated = this.pathCalculator.calculatePath(
         verification.currentFocus,
         targetSelector,
-        verification.orderedElements,
-        verificationInterval
+        verification.orderedElements
       );
       if (!recalculated) {
         throw new ActionableError(

--- a/src/features/talkback/FocusPathCalculator.ts
+++ b/src/features/talkback/FocusPathCalculator.ts
@@ -7,7 +7,6 @@ export interface FocusNavigationPath {
   targetFocusIndex: number;
   swipeCount: number;
   direction: "forward" | "backward";
-  intermediateCheckpoints: number[];
 }
 
 export class FocusPathCalculator {
@@ -20,8 +19,7 @@ export class FocusPathCalculator {
   calculatePath(
     currentFocus: Element | null,
     targetSelector: FocusElementSelector,
-    orderedElements: Element[],
-    checkpointInterval: number = 5
+    orderedElements: Element[]
   ): FocusNavigationPath | null {
     if (!orderedElements.length) {
       return null;
@@ -47,32 +45,8 @@ export class FocusPathCalculator {
       currentFocusIndex: resolvedCurrentIndex,
       targetFocusIndex: targetIndex,
       swipeCount,
-      direction,
-      intermediateCheckpoints: this.buildCheckpoints(
-        boundedCurrentIndex,
-        swipeCount,
-        direction,
-        checkpointInterval
-      )
+      direction
     };
-  }
-
-  private buildCheckpoints(
-    startIndex: number,
-    swipeCount: number,
-    direction: "forward" | "backward",
-    checkpointInterval: number
-  ): number[] {
-    if (swipeCount === 0 || checkpointInterval <= 0) {
-      return [];
-    }
-
-    const checkpoints: number[] = [];
-    for (let i = checkpointInterval; i < swipeCount; i += checkpointInterval) {
-      const offset = direction === "forward" ? i : -i;
-      checkpoints.push(startIndex + offset);
-    }
-    return checkpoints;
   }
 
   private clampIndex(index: number, length: number): number {

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -17,7 +17,6 @@ export interface TalkBackTapResult {
   error?: string;
 }
 
-export type TalkBackTapAction = "tap" | "doubleTap";
 export type TalkBackFallbackAction = "tap" | "doubleTap" | "longPress";
 
 interface TalkBackTapStrategyDependencies {
@@ -62,16 +61,17 @@ export class TalkBackTapStrategy {
    * 4. Navigates to the element
    * 5. Activates it with double-tap (with ACTION_CLICK fallback)
    *
+   * TalkBack activation is always a double-tap-to-activate on the focused node,
+   * so there is no single-vs-double distinction to honour here (#3920).
+   *
    * @param deviceId - The device ID
    * @param element - The target element (must have at least one of resource-id, text, or content-desc)
-   * @param action - The action to perform ("tap" or "doubleTap")
    * @param driver - The TalkBack navigation driver
    * @returns Result indicating success/failure and method used
    */
   async executeTap(
     deviceId: string,
     element: Element,
-    action: TalkBackTapAction,
     driver: TalkBackNavigationDriver
   ): Promise<TalkBackTapResult> {
     const resourceId = element?.["resource-id"] as string | undefined;
@@ -127,8 +127,7 @@ export class TalkBackTapStrategy {
       const navigationPath = this.pathCalculator.calculatePath(
         currentFocus,
         targetSelector,
-        orderedElements,
-        5 // verification interval
+        orderedElements
       );
 
       if (!navigationPath) {

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -1,7 +1,6 @@
 import type { Element } from "../../src/models/Element";
 import type {
   TalkBackTapResult,
-  TalkBackTapAction,
   TalkBackFallbackAction
 } from "../../src/features/talkback/TalkBackTapStrategy";
 import type { TalkBackNavigationDriver } from "../../src/features/talkback/TalkBackNavigationDriver";
@@ -18,7 +17,6 @@ export class FakeTalkBackTapStrategy {
   tapCalls: Array<{
     deviceId: string;
     element: Element;
-    action: TalkBackTapAction;
   }> = [];
 
   directActivationCalls: Array<{
@@ -79,10 +77,9 @@ export class FakeTalkBackTapStrategy {
   async executeTap(
     deviceId: string,
     element: Element,
-    action: TalkBackTapAction,
     _driver: TalkBackNavigationDriver
   ): Promise<TalkBackTapResult> {
-    this.tapCalls.push({ deviceId, element, action });
+    this.tapCalls.push({ deviceId, element });
 
     if (this.tapOverrides.length > 0) {
       return this.tapOverrides.shift()!;

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -568,20 +568,20 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
       expect(fakeTalkBackStrategy.tapCalls[0].deviceId).toBe("emulator-5554");
       expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
-      expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("tap");
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
       expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
     });
 
-    test("doubleTap drives the cursor via executeTap", async () => {
+    test("doubleTap also drives the cursor via executeTap (activation is always double-tap)", async () => {
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
         "doubleTap", 50, 50, element, 500, navOptions, undefined
       );
 
+      // Both "tap" and "doubleTap" route to executeTap; TalkBack activation is
+      // always a double-tap-to-activate, so there is no distinct behavior (#3920).
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
-      expect(fakeTalkBackStrategy.tapCalls[0].action).toBe("doubleTap");
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
     });
 

--- a/test/features/talkback/FocusNavigationExecutor.test.ts
+++ b/test/features/talkback/FocusNavigationExecutor.test.ts
@@ -36,9 +36,7 @@ describe("FocusNavigationExecutor", () => {
       currentFocusIndex: 0,
       targetFocusIndex: 2,
       swipeCount: 5,
-      direction: "forward",
-      intermediateCheckpoints: []
-    };
+      direction: "forward"    };
 
     const driverFactory: FocusNavigationDriverFactory = {
       createDriver: () => driver
@@ -81,9 +79,7 @@ describe("FocusNavigationExecutor", () => {
       currentFocusIndex: 0,
       targetFocusIndex: 2,
       swipeCount: 3,
-      direction: "forward",
-      intermediateCheckpoints: []
-    };
+      direction: "forward"    };
 
     const driverFactory: FocusNavigationDriverFactory = {
       createDriver: () => driver
@@ -168,9 +164,7 @@ describe("FocusNavigationExecutor", () => {
       currentFocusIndex: 2,
       targetFocusIndex: 2,
       swipeCount: 0,
-      direction: "forward",
-      intermediateCheckpoints: []
-    };
+      direction: "forward"    };
 
     const driverFactory: FocusNavigationDriverFactory = {
       createDriver: () => driver
@@ -202,9 +196,7 @@ describe("FocusNavigationExecutor", () => {
       currentFocusIndex: 0,
       targetFocusIndex: 2,
       swipeCount: 0,
-      direction: "forward",
-      intermediateCheckpoints: []
-    };
+      direction: "forward"    };
 
     const driverFactory: FocusNavigationDriverFactory = {
       createDriver: () => driver
@@ -241,9 +233,7 @@ describe("FocusNavigationExecutor", () => {
       currentFocusIndex: 0,
       targetFocusIndex: 0,
       swipeCount: 0,
-      direction: "forward",
-      intermediateCheckpoints: []
-    };
+      direction: "forward"    };
 
     const driverFactory: FocusNavigationDriverFactory = {
       createDriver: () => driver
@@ -284,9 +274,7 @@ describe("FocusNavigationExecutor", () => {
       currentFocusIndex: null,
       targetFocusIndex: 0,
       swipeCount: 2,
-      direction: "forward",
-      intermediateCheckpoints: []
-    };
+      direction: "forward"    };
 
     const driverFactory: FocusNavigationDriverFactory = {
       createDriver: () => driver
@@ -329,9 +317,7 @@ describe("FocusNavigationExecutor", () => {
       currentFocusIndex: null,
       targetFocusIndex: 2,
       swipeCount: 50,
-      direction: "forward",
-      intermediateCheckpoints: []
-    };
+      direction: "forward"    };
 
     const driverFactory: FocusNavigationDriverFactory = {
       createDriver: () => driver

--- a/test/features/talkback/FocusPathCalculator.test.ts
+++ b/test/features/talkback/FocusPathCalculator.test.ts
@@ -46,7 +46,6 @@ describe("FocusPathCalculator", () => {
     expect(path?.targetFocusIndex).toBe(7);
     expect(path?.swipeCount).toBe(6);
     expect(path?.direction).toBe("forward");
-    expect(path?.intermediateCheckpoints).toEqual([6]);
   });
 
   test("calculates backward path", () => {
@@ -68,7 +67,6 @@ describe("FocusPathCalculator", () => {
     expect(path?.targetFocusIndex).toBe(1);
     expect(path?.swipeCount).toBe(3);
     expect(path?.direction).toBe("backward");
-    expect(path?.intermediateCheckpoints).toEqual([]);
   });
 
   test("defaults to index 0 when there is no current focus", () => {

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -43,7 +43,7 @@ describe("TalkBackTapStrategy", () => {
         // no text, no resource-id, no content-desc
       } as Element;
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
@@ -61,7 +61,7 @@ describe("TalkBackTapStrategy", () => {
       const navigateToElement = spyOn(mockExecutor, "navigateToElement")
         .mockResolvedValue(true);
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("focus-navigation");
@@ -80,7 +80,7 @@ describe("TalkBackTapStrategy", () => {
       const navigateToElement = spyOn(mockExecutor, "navigateToElement")
         .mockResolvedValue(true);
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("focus-navigation");
@@ -99,26 +99,7 @@ describe("TalkBackTapStrategy", () => {
       const navigateToElement = spyOn(mockExecutor, "navigateToElement")
         .mockResolvedValue(true);
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
-
-      expect(result.success).toBe(true);
-      expect(result.method).toBe("focus-navigation");
-      expect(navigateToElement).toHaveBeenCalledTimes(1);
-      expect(driver.getTapCount()).toBe(2); // Double-tap to activate
-    });
-
-    test("uses focus navigation for doubleTap action", async () => {
-      const element = {
-        "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-      } as Element;
-
-      driver.setElements([element], 0);
-
-      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
-        .mockResolvedValue(true);
-
-      const result = await strategy.executeTap("device-1", element, "doubleTap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("focus-navigation");
@@ -137,7 +118,7 @@ describe("TalkBackTapStrategy", () => {
       const navigateToElement = spyOn(mockExecutor, "navigateToElement")
         .mockRejectedValue(new Error("Navigation failed"));
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
@@ -157,7 +138,7 @@ describe("TalkBackTapStrategy", () => {
       driver.queueTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
       driver.setActionResult({ success: true, action: "click", totalTimeMs: 1 });
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("accessibility-action");
@@ -177,7 +158,7 @@ describe("TalkBackTapStrategy", () => {
       spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
       driver.setTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
@@ -196,7 +177,7 @@ describe("TalkBackTapStrategy", () => {
       driver.queueTapResult({ success: true, totalTimeMs: 1 }); // first tap succeeds
       driver.setTapResult({ success: false, totalTimeMs: 1, error: "second tap failed" });
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
@@ -215,7 +196,7 @@ describe("TalkBackTapStrategy", () => {
       driver.queueTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
       driver.setActionResult({ success: false, action: "click", totalTimeMs: 1, error: "click failed" });
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
@@ -240,7 +221,7 @@ describe("TalkBackTapStrategy", () => {
       driver.setElements([liveFocusedElement], 0);
       spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
 
-      const result = await strategy.executeTap("device-1", staleElement, "tap", driver);
+      const result = await strategy.executeTap("device-1", staleElement, driver);
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("focus-navigation");
@@ -263,7 +244,7 @@ describe("TalkBackTapStrategy", () => {
       spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
       driver.setActionResult({ success: true, action: "click", totalTimeMs: 1 });
 
-      const result = await strategy.executeTap("device-1", boundsLessElement, "tap", driver);
+      const result = await strategy.executeTap("device-1", boundsLessElement, driver);
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("accessibility-action");
@@ -278,7 +259,7 @@ describe("TalkBackTapStrategy", () => {
       driver.setElements([boundsLessFocused], 0);
       spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
 
-      const result = await strategy.executeTap("device-1", boundsLessTextElement, "tap", driver);
+      const result = await strategy.executeTap("device-1", boundsLessTextElement, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
@@ -298,7 +279,7 @@ describe("TalkBackTapStrategy", () => {
         { "resource-id": "test:id/other", "bounds": { left: 0, top: 0, right: 50, bottom: 50 } } as Element
       ], 0);
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
@@ -313,7 +294,7 @@ describe("TalkBackTapStrategy", () => {
 
       driver.queueTraversalResult({ error: "Service unavailable", totalTimeMs: 1 });
 
-      const result = await strategy.executeTap("device-1", element, "tap", driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");


### PR DESCRIPTION
## Summary

Two half-wired, misleading leftovers in the TalkBack navigation code (#3920). Neither was a live bug; both are **removed** rather than finished, since what they gestured at either already exists elsewhere or has no meaningful distinction here.

### 1. `intermediateCheckpoints` — computed, never consumed

`FocusPathCalculator` built `path.intermediateCheckpoints` via `buildCheckpoints`, but no consumer read it — `FocusNavigationExecutor` does its own verification cadence via `totalSwipes % verificationInterval`. Removed the field from `FocusNavigationPath`, the `buildCheckpoints` method, and the now-unused `checkpointInterval` parameter from `calculatePath` (updating its three call sites).

### 2. `executeTap` ignored `tap` vs `doubleTap`

`TalkBackTapStrategy.executeTap` accepted `action: "tap" | "doubleTap"` but never branched on it — TalkBack activation is always a double-tap-to-activate on the focused node. Removed the parameter and the `TalkBackTapAction` type; the `TapOnElement` caller and `FakeTalkBackTapStrategy` no longer thread it.

## Why remove (not wire up)

Both mechanisms are redundant or semantically empty: checkpoint verification already exists in the executor, and there is no distinct single-vs-double activation in TalkBack. Removing the dead surface follows the repo's YAGNI / narrow-interface guidance; if the fidelity-mode work (#3937) needs either, it can add them with real behavior.

## Tests

- Dropped the `intermediateCheckpoints` assertions/fixtures and the `action` argument across the talkback + `TapOnElement` suites.
- Removed the now-duplicate "doubleTap" activation test; the `TapOnElement` delegation test documents that both `tap` and `doubleTap` route to the same activation.
- 818 tests green across the talkback + action suites; lint clean; typecheck gate 0 new errors (the lone pre-existing ajv-formats mismatch in `PlanSchemaValidator.ts` reproduces on clean `main`).

Closes #3920

Part of #3916 (umbrella #3937).