### PR TITLE
feat(a11y): screen-reader-navigation feature flag for cursor-traversal fidelity mode (#3937)

### DIFF
--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -109,6 +109,7 @@ export class TapOnElement extends BaseVisualChange {
   private elementSelector: ElementSelector;
   private viewHierarchy: ViewHierarchy;
   private talkBackStrategy: TalkBackTapStrategy;
+  private readonly featureFlags: FeatureFlagService;
   private talkBackDriverFactory: TalkBackNavigationDriverFactory;
   private iosVoiceOverDetector: IosVoiceOverDetector;
   private strategy: TapStrategy;
@@ -198,12 +199,13 @@ export class TapOnElement extends BaseVisualChange {
     this.talkBackStrategy = options.talkBackStrategy ?? new TalkBackTapStrategy({ timer: this.timer });
     this.talkBackDriverFactory = options.talkBackDriverFactory ?? new DefaultTalkBackNavigationDriverFactory(this.adbFactory);
     this.iosVoiceOverDetector = options.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
+    this.featureFlags = options.featureFlags ?? FeatureFlagService.getInstance();
     this.strategy = options.tapStrategy ?? createTapStrategy(
       device,
       this.adb,
       this.accessibilityDetector,
       this.iosVoiceOverDetector,
-      options.featureFlags ?? FeatureFlagService.getInstance()
+      this.featureFlags
     );
     this.longPressMetadataDetector = new LongPressMetadataDetector(this.elementParser);
   }
@@ -1425,6 +1427,17 @@ export class TapOnElement extends BaseVisualChange {
    * drive the TalkBack cursor by swipe navigation to the target before activating.
    * For longPress, tries ACTION_LONG_CLICK first, then coordinate gesture, then ADB.
    */
+  /**
+   * Whether opt-in screen-reader navigation (cursor-traversal fidelity mode,
+   * #3937) is requested. Enabled by the `screen-reader-navigation` feature flag
+   * (the global opt-in) OR the per-call `screenReaderNavigation` option. Default
+   * stays direct-activation (#3936).
+   */
+  private isScreenReaderNavigationEnabled(options?: TapOnElementOptions): boolean {
+    return Boolean(options?.screenReaderNavigation)
+      || this.featureFlags.isEnabled("screen-reader-navigation");
+  }
+
   private async executeAndroidTapWithAccessibility(
     action: string,
     x: number,
@@ -1457,7 +1470,7 @@ export class TapOnElement extends BaseVisualChange {
     }
 
     if (action === "tap" || action === "doubleTap") {
-      if (options?.screenReaderNavigation) {
+      if (this.isScreenReaderNavigationEnabled(options)) {
         // Opt-in fidelity mode (#3937): drive the TalkBack cursor by swipe
         // navigation to the target, then activate.
         const result = await this.talkBackStrategy.executeTap(

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -7,6 +7,7 @@ export type FeatureFlagKey =
   | "predictive-ui"
   | "force-accessibility-mode"
   | "accessibility-auto-detect"
+  | "screen-reader-navigation"
   | "raw-element-search"
   | "ai-recovery"
   | "mcp-recording"
@@ -113,6 +114,13 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     label: "Accessibility auto-detect",
     description: "Automatically detect and adapt to TalkBack/VoiceOver when enabled.",
     defaultValue: true,
+  },
+  {
+    key: "screen-reader-navigation",
+    label: "Screen-reader navigation (fidelity mode)",
+    description:
+      "Opt-in: when a screen reader is active, drive the cursor by swipe traversal to the target before activating (reproduces the real user journey) instead of activating the node directly. For accessibility validation — reachability, traversal order, focus traps.",
+    defaultValue: false,
   },
   {
     key: "ai-recovery",

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -4,6 +4,7 @@ import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeTalkBackTapStrategy } from "../../fakes/FakeTalkBackTapStrategy";
+import type { FeatureFlagService } from "../../../src/features/featureFlags/FeatureFlagService";
 
 describe("TapOnElement TalkBack mode detection", () => {
   let fakeAccessibilityDetector: FakeAccessibilityDetector;
@@ -616,6 +617,53 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
       expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
       expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+    });
+  });
+
+  // #3937: the `screen-reader-navigation` feature flag is the global opt-in for
+  // fidelity mode — it drives cursor traversal even without the per-call option.
+  describe("screen-reader-navigation feature flag (global opt-in)", () => {
+    const makeFlaggedTapOnElement = (flagEnabled: boolean) => {
+      const featureFlags = {
+        isEnabled: (key: string) => flagEnabled && key === "screen-reader-navigation"
+      } as unknown as FeatureFlagService;
+      const tap = new TapOnElement(
+        { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
+        fakeAdb as any,
+        {
+          accessibilityDetector: fakeAccessibilityDetector,
+          timer: fakeTimer,
+          talkBackStrategy: fakeTalkBackStrategy,
+          featureFlags
+        }
+      );
+      spyOn(tap as any, "executeAndroidTapWithCoordinates").mockResolvedValue(undefined);
+      return tap;
+    };
+
+    test("flag ON drives cursor traversal even without the per-call option", async () => {
+      const tap = makeFlaggedTapOnElement(true);
+      const element = makeElement();
+
+      await (tap as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, {}, undefined
+      );
+
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
+    });
+
+    test("flag OFF keeps the direct-activation default", async () => {
+      const tap = makeFlaggedTapOnElement(false);
+      const element = makeElement();
+
+      await (tap as any).executeAndroidTapWithAccessibility(
+        "tap", 50, 50, element, 500, {}, undefined
+      );
+
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

**Model #3** from #3916: an explicit, opt-in mode that drives the screen-reader cursor element-by-element (swipe to step focus, double-tap to activate) the way a real user does — for accessibility validation (reachability, traversal order, focus traps) — instead of the direct-activation default (#3936).

The cursor-traversal path already exists (`TalkBackTapStrategy.executeTap`) and its Android bugs are now fixed (#3917 non-converging-cursor guard, #3918 activate the live focused node, #3920 nav leftovers). This PR wires the **global opt-in**:

- Add a `screen-reader-navigation` feature flag (default **off**). Not tool-definition-affecting.
- `TapOnElement` takes the fidelity path when the flag is enabled **OR** the per-call `screenReaderNavigation` option is set (`isScreenReaderNavigationEnabled`), storing the resolved `FeatureFlagService` so the check is a single in-memory read.

## Scope (per design decision)

- **Exposure = feature flag only.** The per-call `screenReaderNavigation` option stays internal (unchanged); the flag is the user-facing opt-in, mirroring the `force-accessibility-mode` pattern.
- **Deferred to follow-ups:** the iOS traversal layer (#3924) and the fidelity-assertion surface — reachability / traversal-order / focus-trap results — now tracked in #3963.

## Tests

- Flag ON drives cursor traversal even without the per-call option; flag OFF keeps the direct-activation default.
- 804 tests green across the feature-flag + action + server suites; lint clean; typecheck gate 0 new errors (the lone pre-existing ajv-formats mismatch in `PlanSchemaValidator.ts` reproduces on clean `main`).

Closes #3937

Part of #3916. Follow-ups: #3924 (iOS traversal), #3963 (fidelity assertions).