### PR TITLE
feat(voiceover): report the VoiceOver cursor + implement iOS focus/traversal commands (#3924)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
@@ -39,6 +39,11 @@ public struct SdkViewNode: Codable, Sendable {
     public let accessibilityLabel: String?
     public let accessibilityIdentifier: String?
     public let isAccessibilityElement: Bool
+    /// Whether this element currently holds the VoiceOver cursor. Captured in-app
+    /// via `accessibilityElementIsFocused()`, which the out-of-process runner
+    /// cannot read itself — this is the signal that lets AutoMobile report
+    /// `accessibilityFocusedElement` on iOS (#3924).
+    public let isAccessibilityFocused: Bool
     public let accessibilityElementsHidden: Bool
     public let accessibilityTraits: [String]
     public let accessibilityCustomActions: [String]
@@ -61,6 +66,7 @@ public struct SdkViewNode: Codable, Sendable {
         accessibilityLabel: String? = nil,
         accessibilityIdentifier: String? = nil,
         isAccessibilityElement: Bool = false,
+        isAccessibilityFocused: Bool = false,
         accessibilityElementsHidden: Bool = false,
         accessibilityTraits: [String] = [],
         accessibilityCustomActions: [String] = [],
@@ -82,6 +88,7 @@ public struct SdkViewNode: Codable, Sendable {
         self.accessibilityLabel = accessibilityLabel
         self.accessibilityIdentifier = accessibilityIdentifier
         self.isAccessibilityElement = isAccessibilityElement
+        self.isAccessibilityFocused = isAccessibilityFocused
         self.accessibilityElementsHidden = accessibilityElementsHidden
         self.accessibilityTraits = accessibilityTraits
         self.accessibilityCustomActions = accessibilityCustomActions
@@ -101,7 +108,7 @@ public struct SdkViewNode: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case className, bounds, accessibilityLabel, accessibilityIdentifier,
-             isAccessibilityElement, accessibilityElementsHidden,
+             isAccessibilityElement, isAccessibilityFocused, accessibilityElementsHidden,
              accessibilityTraits, accessibilityCustomActions, gestureRecognizers,
              alpha, backgroundColor, cornerRadius,
              borderColor, borderWidth, isLayerNode,
@@ -115,6 +122,7 @@ public struct SdkViewNode: Codable, Sendable {
         self.accessibilityLabel = try c.decodeIfPresent(String.self, forKey: .accessibilityLabel)
         self.accessibilityIdentifier = try c.decodeIfPresent(String.self, forKey: .accessibilityIdentifier)
         self.isAccessibilityElement = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityElement) ?? false
+        self.isAccessibilityFocused = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityFocused) ?? false
         self.accessibilityElementsHidden = try c.decodeIfPresent(Bool.self, forKey: .accessibilityElementsHidden) ?? false
         self.accessibilityTraits = try c.decodeIfPresent([String].self, forKey: .accessibilityTraits) ?? []
         self.accessibilityCustomActions = try c.decodeIfPresent([String].self, forKey: .accessibilityCustomActions) ?? []

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -170,6 +170,9 @@ public enum ViewHierarchyWalker {
             accessibilityLabel: view.accessibilityLabel,
             accessibilityIdentifier: view.accessibilityIdentifier,
             isAccessibilityElement: view.isAccessibilityElement,
+            // Only readable in-process: the out-of-process runner cannot query the
+            // VoiceOver cursor, so the SDK captures it here (#3924).
+            isAccessibilityFocused: view.accessibilityElementIsFocused(),
             accessibilityElementsHidden: view.accessibilityElementsHidden,
             accessibilityTraits: traits,
             accessibilityCustomActions: customActions,

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -1007,24 +1007,75 @@ public class CommandHandler: CommandHandling {
 
     // MARK: - Accessibility Features
 
-    private func handleGetCurrentFocus(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
-        // Stub: Focus tracking not yet implemented
-        return WebSocketResponse.error(
-            type: ResponseType.currentFocusResult.rawValue,
+    /// Report the element holding the VoiceOver cursor. The cursor is only visible
+    /// in-process, so it reaches us as `accessibility-focused` on the SDK-enriched
+    /// hierarchy (see HierarchyMerger, #3924). Returns a null focusedElement when
+    /// nothing is focused — that is a success, not an error.
+    private func handleGetCurrentFocus(_ request: RequestEnvelope, startTime: Date) throws -> CurrentFocusResponse {
+        let enriched = try enrichedHierarchyForAccessibility()
+        let focused = enriched.hierarchy.flatMap { Self.findAccessibilityFocused($0) }
+        return CurrentFocusResponse(
             requestId: request.requestId,
-            error: "Current focus not yet implemented on iOS",
+            focusedElement: focused,
             totalTimeMs: totalTimeMs(from: startTime)
         )
     }
 
-    private func handleGetTraversalOrder(_ request: RequestEnvelope, startTime: Date) throws -> WebSocketResponse {
-        // Stub: Traversal order not yet implemented
-        return WebSocketResponse.error(
-            type: ResponseType.traversalOrderResult.rawValue,
+    /// Report accessibility elements in VoiceOver traversal (depth-first) order,
+    /// plus the index of the focused one when the cursor is present (#3924).
+    private func handleGetTraversalOrder(_ request: RequestEnvelope, startTime: Date) throws -> TraversalOrderResponse {
+        let enriched = try enrichedHierarchyForAccessibility()
+        var ordered: [UIElementInfo] = []
+        if let root = enriched.hierarchy {
+            Self.collectAccessibilityElements(root, into: &ordered)
+        }
+        let focusedIndex = ordered.firstIndex { $0.accessibilityFocused == "true" }
+        return TraversalOrderResponse(
             requestId: request.requestId,
-            error: "Traversal order not yet implemented on iOS",
+            elements: ordered,
+            focusedIndex: focusedIndex,
             totalTimeMs: totalTimeMs(from: startTime)
         )
+    }
+
+    /// Extract the hierarchy and merge the in-app SDK view tree into it, so
+    /// accessibility-only signals (the VoiceOver cursor, `isAccessibilityElement`)
+    /// are present. Shared by the focus and traversal handlers.
+    private func enrichedHierarchyForAccessibility() throws -> ViewHierarchy {
+        let hierarchy: ViewHierarchy
+        do {
+            hierarchy = try perfProvider.track("extraction") {
+                try elementLocator.getViewHierarchy(disableAllFiltering: false)
+            }
+        } catch {
+            throw CommandError.executionFailed("Failed to get view hierarchy: \(error.localizedDescription)")
+        }
+        return enrichWithMatchingSdkHierarchy(hierarchy)
+    }
+
+    /// Depth-first search for the element carrying the VoiceOver cursor.
+    static func findAccessibilityFocused(_ element: UIElementInfo) -> UIElementInfo? {
+        if element.accessibilityFocused == "true" {
+            return element
+        }
+        for child in element.node ?? [] {
+            if let match = findAccessibilityFocused(child) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    /// Collect, depth-first, the elements VoiceOver would stop on. `isAccessibilityElement`
+    /// is the precise signal and is carried through from the in-app SDK; containers that
+    /// merely hold other elements are skipped but still traversed into.
+    static func collectAccessibilityElements(_ element: UIElementInfo, into ordered: inout [UIElementInfo]) {
+        if element.extras?["sdk.isAccessibilityElement"] == "true" {
+            ordered.append(element)
+        }
+        for child in element.node ?? [] {
+            collectAccessibilityElements(child, into: &ordered)
+        }
     }
 
     private func handleAddHighlight(_ request: RequestAddHighlight, startTime: Date) throws -> WebSocketResponse {

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -276,7 +276,11 @@ public enum HierarchyMerger {
             enabled: element.enabled,
             focusable: element.focusable,
             focused: element.focused,
-            accessibilityFocused: element.accessibilityFocused,
+            // XCUITest cannot observe the VoiceOver cursor, so this flag only ever
+            // arrives from the matched in-app SDK node; fall back to the existing
+            // value when there is no SDK match. Follows the "true"-or-nil
+            // convention used for the other boolean attributes (#3924).
+            accessibilityFocused: sdkNode?.isAccessibilityFocused == true ? "true" : element.accessibilityFocused,
             scrollable: element.scrollable,
             password: element.password,
             checkable: element.checkable,
@@ -581,6 +585,9 @@ public enum HierarchyMerger {
                 right: node.bounds.right,
                 bottom: node.bounds.bottom
             ),
+            // Preserve the VoiceOver cursor flag on SDK-only nodes that are injected
+            // into the tree without an XCUITest counterpart (#3924).
+            accessibilityFocused: node.isAccessibilityFocused ? "true" : nil,
             extras: extras,
             node: convertedChildren?.isEmpty == true ? nil : convertedChildren
         )

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -856,6 +856,61 @@ public struct HierarchyUpdateResponse: Codable {
     }
 }
 
+/// Response for `get_current_focus` — the element holding the VoiceOver cursor.
+/// Mirrors Android's `CurrentFocusResult` so the TS client can share a shape (#3924).
+public struct CurrentFocusResponse: Codable {
+    public let type: String
+    public let requestId: String?
+    public let success: Bool
+    public let focusedElement: UIElementInfo?
+    public let totalTimeMs: Int64
+    public let error: String?
+
+    public init(
+        requestId: String? = nil,
+        focusedElement: UIElementInfo? = nil,
+        totalTimeMs: Int64,
+        error: String? = nil
+    ) {
+        type = ResponseType.currentFocusResult.rawValue
+        self.requestId = requestId
+        success = error == nil
+        self.focusedElement = focusedElement
+        self.totalTimeMs = totalTimeMs
+        self.error = error
+    }
+}
+
+/// Response for `get_traversal_order` — accessibility elements in VoiceOver
+/// traversal (depth-first) order. Mirrors Android's `TraversalOrderResult` (#3924).
+public struct TraversalOrderResponse: Codable {
+    public let type: String
+    public let requestId: String?
+    public let success: Bool
+    public let elements: [UIElementInfo]
+    public let focusedIndex: Int?
+    public let totalCount: Int
+    public let totalTimeMs: Int64
+    public let error: String?
+
+    public init(
+        requestId: String? = nil,
+        elements: [UIElementInfo] = [],
+        focusedIndex: Int? = nil,
+        totalTimeMs: Int64,
+        error: String? = nil
+    ) {
+        type = ResponseType.traversalOrderResult.rawValue
+        self.requestId = requestId
+        success = error == nil
+        self.elements = elements
+        self.focusedIndex = focusedIndex
+        totalCount = elements.count
+        self.totalTimeMs = totalTimeMs
+        self.error = error
+    }
+}
+
 /// View hierarchy structure (matching Android's ViewHierarchy)
 public struct ViewHierarchy: Codable {
     public let updatedAt: Int64

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
@@ -31,6 +31,10 @@ public struct SdkViewNode: Codable, Sendable {
     public let accessibilityLabel: String?
     public let accessibilityIdentifier: String?
     public let isAccessibilityElement: Bool
+    /// Whether this element holds the VoiceOver cursor. Reported by the in-app SDK
+    /// (`accessibilityElementIsFocused()`), which this out-of-process runner cannot
+    /// read itself; decoded tolerantly so older SDK payloads stay compatible (#3924).
+    public let isAccessibilityFocused: Bool
     public let accessibilityElementsHidden: Bool
     public let accessibilityTraits: [String]
     public let accessibilityCustomActions: [String]
@@ -53,6 +57,7 @@ public struct SdkViewNode: Codable, Sendable {
         accessibilityLabel: String? = nil,
         accessibilityIdentifier: String? = nil,
         isAccessibilityElement: Bool = false,
+        isAccessibilityFocused: Bool = false,
         accessibilityElementsHidden: Bool = false,
         accessibilityTraits: [String] = [],
         accessibilityCustomActions: [String] = [],
@@ -74,6 +79,7 @@ public struct SdkViewNode: Codable, Sendable {
         self.accessibilityLabel = accessibilityLabel
         self.accessibilityIdentifier = accessibilityIdentifier
         self.isAccessibilityElement = isAccessibilityElement
+        self.isAccessibilityFocused = isAccessibilityFocused
         self.accessibilityElementsHidden = accessibilityElementsHidden
         self.accessibilityTraits = accessibilityTraits
         self.accessibilityCustomActions = accessibilityCustomActions
@@ -93,7 +99,7 @@ public struct SdkViewNode: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case className, bounds, accessibilityLabel, accessibilityIdentifier,
-             isAccessibilityElement, accessibilityElementsHidden,
+             isAccessibilityElement, isAccessibilityFocused, accessibilityElementsHidden,
              accessibilityTraits, accessibilityCustomActions, gestureRecognizers,
              alpha, backgroundColor, cornerRadius,
              borderColor, borderWidth, isLayerNode,
@@ -107,6 +113,7 @@ public struct SdkViewNode: Codable, Sendable {
         self.accessibilityLabel = try c.decodeIfPresent(String.self, forKey: .accessibilityLabel)
         self.accessibilityIdentifier = try c.decodeIfPresent(String.self, forKey: .accessibilityIdentifier)
         self.isAccessibilityElement = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityElement) ?? false
+        self.isAccessibilityFocused = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityFocused) ?? false
         self.accessibilityElementsHidden = try c.decodeIfPresent(Bool.self, forKey: .accessibilityElementsHidden) ?? false
         self.accessibilityTraits = try c.decodeIfPresent([String].self, forKey: .accessibilityTraits) ?? []
         self.accessibilityCustomActions = try c.decodeIfPresent([String].self, forKey: .accessibilityCustomActions) ?? []

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -570,22 +570,66 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
         XCTAssertEqual(response?.type, "voiceover_state_result")
     }
 
-    func testGetCurrentFocusDecodeDispatchReturnsNotImplemented() {
+    // #3924: both commands are implemented now — they answer from the SDK-enriched
+    // hierarchy instead of returning the old "not yet implemented" error.
+    func testGetCurrentFocusDecodeDispatch() {
         let response = dispatch(
             #"{"type":"get_current_focus","requestId":"cf-1"}"#,
-            as: WebSocketResponse.self
+            as: CurrentFocusResponse.self
         )
         XCTAssertEqual(response?.type, "current_focus_result")
-        XCTAssertEqual(response?.success, false)
+        XCTAssertEqual(response?.requestId, "cf-1")
+        XCTAssertEqual(response?.success, true)
     }
 
-    func testGetTraversalOrderDecodeDispatchReturnsNotImplemented() {
+    func testGetTraversalOrderDecodeDispatch() {
         let response = dispatch(
             #"{"type":"get_traversal_order","requestId":"to-1"}"#,
-            as: WebSocketResponse.self
+            as: TraversalOrderResponse.self
         )
         XCTAssertEqual(response?.type, "traversal_order_result")
-        XCTAssertEqual(response?.success, false)
+        XCTAssertEqual(response?.requestId, "to-1")
+        XCTAssertEqual(response?.success, true)
+        XCTAssertEqual(response?.totalCount, response?.elements.count)
+    }
+
+    // MARK: - VoiceOver focus / traversal helpers (#3924)
+
+    /// Build an element tree: root > [container > [a11yChild], plainChild]
+    private func makeAccessibilityTree(focusedLabel: String?) -> UIElementInfo {
+        func element(_ label: String, isA11y: Bool, children: [UIElementInfo]? = nil) -> UIElementInfo {
+            UIElementInfo(
+                text: label,
+                className: "View",
+                bounds: ElementBounds(left: 0, top: 0, right: 10, bottom: 10),
+                accessibilityFocused: label == focusedLabel ? "true" : nil,
+                extras: ["sdk.isAccessibilityElement": isA11y ? "true" : "false"],
+                node: children
+            )
+        }
+        let a11yChild = element("a11yChild", isA11y: true)
+        let container = element("container", isA11y: false, children: [a11yChild])
+        let plainChild = element("plainChild", isA11y: true)
+        return element("root", isA11y: false, children: [container, plainChild])
+    }
+
+    func testFindAccessibilityFocusedLocatesNestedFocusedElement() {
+        let tree = makeAccessibilityTree(focusedLabel: "a11yChild")
+        let focused = CommandHandler.findAccessibilityFocused(tree)
+        XCTAssertEqual(focused?.text, "a11yChild")
+    }
+
+    func testFindAccessibilityFocusedReturnsNilWhenCursorAbsent() {
+        let tree = makeAccessibilityTree(focusedLabel: nil)
+        XCTAssertNil(CommandHandler.findAccessibilityFocused(tree))
+    }
+
+    func testCollectAccessibilityElementsReturnsOnlyA11yElementsInTraversalOrder() {
+        let tree = makeAccessibilityTree(focusedLabel: nil)
+        var ordered: [UIElementInfo] = []
+        CommandHandler.collectAccessibilityElements(tree, into: &ordered)
+        // Containers are traversed into but not themselves reported.
+        XCTAssertEqual(ordered.map(\.text), ["a11yChild", "plainChild"])
     }
 
     func testAddHighlightDecodeParsesNestedShape() throws {


### PR DESCRIPTION
## Summary

iOS had **no accessibility focus layer**: `get_current_focus` / `get_traversal_order` were declared in the runner contract but **stubbed** ("not yet implemented on iOS"), and observe never populated `accessibilityFocusedElement` — the parity design doc's headline **Gap 1** (#3924).

The VoiceOver cursor is only observable **in-process** (`accessibilityElementIsFocused()`), which the out-of-process runner cannot read — so the chain has to start in the in-app SDK:

- **`auto-mobile-sdk`** — `ViewHierarchyWalker` captures `accessibilityElementIsFocused()` into a new `SdkViewNode.isAccessibilityFocused`.
- **`control-proxy`** — mirror the field (decoded via `decodeIfPresent ?? false`, so **older SDK payloads stay compatible**) and have `HierarchyMerger` project it onto the merged element as `accessibility-focused`, following the existing `"true"`-or-`nil` convention — for both SDK-matched and SDK-only injected nodes.
- **`control-proxy`** — implement `handleGetCurrentFocus` / `handleGetTraversalOrder` against the SDK-enriched hierarchy, with `CurrentFocusResponse` / `TraversalOrderResponse` mirroring Android's result shapes. Traversal order keys off the precise `sdk.isAccessibilityElement` signal: containers are traversed **into** but not reported.

### Gap 1 closes with no TS changes

`HierarchyCollector` already derives `accessibilityFocusedElement` generically via `findAccessibilityFocusedElement`, which matches `accessibility-focused` on **any** platform. So iOS observe starts reporting the VoiceOver cursor as soon as this runner ships — no TS wiring required.

## Tests

- The two dispatch tests that asserted the stubs now assert the **implemented** responses (type, requestId, success, `totalCount === elements.count`).
- New unit tests for the focus DFS and traversal collection (containers skipped, traversal order preserved, nil when no cursor).
- **405 control-proxy tests pass**; full TS suite green (8088 pass, 0 fail); all Swift packages build.
- Appended to an existing test file deliberately, so **no xcodegen/pbxproj regen** is needed.

## Delivery / validation

- `ios/control-proxy` changes require an **iOS runner release re-cut**, and the in-app SDK must be rebuilt for the focus flag to appear.
- **On-device validation is pending** — to be checked on a simulator via the hot-reload script.

## Scope

Deliberately the **read path**. Still open on #3924 (kept open):
- TS emitters — `requestCurrentFocus` / `requestTraversalOrder` on `IOSCtrlProxyClient` (the runner commands work; TS can't call them yet).
- Write path — iOS `setAccessibilityFocus` / `clearAccessibilityFocus` and cursor stepping, which need new protocol commands plus SDK focus-posting.

Part of #3924 and #3916.