### PR TITLE
refactor(sdk): convert accumulate-and-return loops to declarative collection ops

### DIFF
--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiver.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import dev.jasonpearson.automobile.sdk.AutoMobileNotifications
 import dev.jasonpearson.automobile.sdk.NotificationAction
 import dev.jasonpearson.automobile.sdk.NotificationStyle
@@ -49,7 +50,8 @@ class AutoMobileNotificationReceiver : BroadcastReceiver() {
     }
   }
 
-  private fun parseActions(actionsJson: String?): List<NotificationAction> {
+  @VisibleForTesting
+  internal fun parseActions(actionsJson: String?): List<NotificationAction> {
     if (actionsJson.isNullOrBlank()) return emptyList()
     return try {
       val array = JSONArray(actionsJson)

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiver.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiver.kt
@@ -8,7 +8,6 @@ import dev.jasonpearson.automobile.sdk.AutoMobileNotifications
 import dev.jasonpearson.automobile.sdk.NotificationAction
 import dev.jasonpearson.automobile.sdk.NotificationStyle
 import org.json.JSONArray
-import org.json.JSONObject
 
 class AutoMobileNotificationReceiver : BroadcastReceiver() {
   override fun onReceive(context: Context, intent: Intent?) {
@@ -53,17 +52,17 @@ class AutoMobileNotificationReceiver : BroadcastReceiver() {
   private fun parseActions(actionsJson: String?): List<NotificationAction> {
     if (actionsJson.isNullOrBlank()) return emptyList()
     return try {
-      val actions = mutableListOf<NotificationAction>()
       val array = JSONArray(actionsJson)
-      for (i in 0 until array.length()) {
-        val obj = array.optJSONObject(i) ?: JSONObject()
+      (0 until array.length()).mapNotNull { i ->
+        val obj = array.optJSONObject(i) ?: return@mapNotNull null
         val label = obj.optString("label")
         val actionId = obj.optString("actionId")
         if (label.isNotBlank() && actionId.isNotBlank()) {
-          actions.add(NotificationAction(label = label, actionId = actionId))
+          NotificationAction(label = label, actionId = actionId)
+        } else {
+          null
         }
       }
-      actions
     } catch (e: Exception) {
       Log.w(TAG, "Failed to parse notification actions", e)
       emptyList()

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileNotifications.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileNotifications.kt
@@ -239,15 +239,12 @@ object AutoMobileNotifications {
       }
     }
 
-    val candidatePaths = mutableListOf<String>()
-    when {
-      trimmed.startsWith("file://") -> candidatePaths.add(trimmed.removePrefix("file://"))
-      trimmed.startsWith("/") -> candidatePaths.add(trimmed)
-      else -> {
-        candidatePaths.add(trimmed)
-        candidatePaths.add("$DEFAULT_IMAGE_DIR/$trimmed")
+    val candidatePaths =
+      when {
+        trimmed.startsWith("file://") -> listOf(trimmed.removePrefix("file://"))
+        trimmed.startsWith("/") -> listOf(trimmed)
+        else -> listOf(trimmed, "$DEFAULT_IMAGE_DIR/$trimmed")
       }
-    }
 
     for (path in candidatePaths) {
       val file = File(path)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -107,11 +107,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
 
           // Get row data
           while (cursor.moveToNext()) {
-            val row = mutableListOf<Any?>()
-            for (i in 0 until cursor.columnCount) {
-              row.add(getColumnValue(cursor, i))
-            }
-            rows.add(row)
+            rows.add((0 until cursor.columnCount).map { getColumnValue(cursor, it) })
           }
         }
 
@@ -299,11 +295,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
         columns.addAll(cursor.columnNames)
 
         while (cursor.moveToNext()) {
-          val row = mutableListOf<Any?>()
-          for (i in 0 until cursor.columnCount) {
-            row.add(getColumnValue(cursor, i))
-          }
-          rows.add(row)
+          rows.add((0 until cursor.columnCount).map { getColumnValue(cursor, it) })
         }
       }
     } catch (e: Exception) {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -18,38 +18,35 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   private val openDatabases = ConcurrentHashMap<String, SQLiteDatabase>()
 
   override fun getDatabases(): List<DatabaseDescriptor> {
-    val databases = mutableListOf<DatabaseDescriptor>()
-
-    // Get databases from Context.databaseList()
-    context.databaseList().forEach { dbName ->
-      if (!dbName.endsWith("-journal") && !dbName.endsWith("-wal") && !dbName.endsWith("-shm")) {
-        val dbFile = context.getDatabasePath(dbName)
-        if (dbFile.exists() && dbFile.isFile) {
-          databases.add(DatabaseDescriptor(name = dbName, path = dbFile.absolutePath))
+    val declared =
+      context
+        .databaseList()
+        .filterNot { it.isJournalSidecar() }
+        .mapNotNull { name ->
+          context
+            .getDatabasePath(name)
+            .takeIf { it.exists() && it.isFile }
+            ?.let { file ->
+              DatabaseDescriptor(name = name, path = file.absolutePath)
+            }
         }
-      }
-    }
 
-    // Also scan for databases in the databases directory
-    val dbDir = File(context.applicationInfo.dataDir, "databases")
-    if (dbDir.exists() && dbDir.isDirectory) {
-      dbDir
-        .listFiles { file ->
-          file.isFile &&
-            !file.name.endsWith("-journal") &&
-            !file.name.endsWith("-wal") &&
-            !file.name.endsWith("-shm")
-        }
-        ?.forEach { file ->
-          // Only add if not already in list
-          if (databases.none { it.path == file.absolutePath }) {
-            databases.add(DatabaseDescriptor(name = file.name, path = file.absolutePath))
-          }
-        }
-    }
+    // Also scan the databases directory. listFiles() returns null when the directory is
+    // absent or is not a directory, which the orEmpty() below folds into "nothing found".
+    val scanned =
+      File(context.applicationInfo.dataDir, "databases")
+        .listFiles { file -> file.isFile && !file.name.isJournalSidecar() }
+        ?.map { DatabaseDescriptor(name = it.name, path = it.absolutePath) }
+        .orEmpty()
 
-    return databases.sortedBy { it.name }
+    // distinctBy keeps the first occurrence, so databaseList() entries win on a path
+    // collision -- the same precedence the previous "only add if not already in list" had.
+    return (declared + scanned).distinctBy { it.path }.sortedBy { it.name }
   }
+
+  /** SQLite write-ahead/journal companions that sit next to a real database file. */
+  private fun String.isJournalSidecar(): Boolean =
+    endsWith("-journal") || endsWith("-wal") || endsWith("-shm")
 
   override fun getTables(databasePath: String): List<String> {
     synchronized(databaseLock) {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -68,7 +68,7 @@ internal class AutoMobileNetworkInterceptor(
     // Capture request headers — include OkHttp defaults that will be added later
     val reqHeaders =
       if (captureHeaders) {
-        val headers = request.headers.toMap().toMutableMap()
+        val headers = request.headers.toHeaderMap().toMutableMap()
         if ("Host" !in headers) headers["Host"] = request.url.host
         if ("User-Agent" !in headers) headers["User-Agent"] = "okhttp/${okhttp3.OkHttp.VERSION}"
         headers
@@ -145,12 +145,12 @@ internal class AutoMobileNetworkInterceptor(
 
     val finalReqHeaders =
       if (captureHeaders) {
-        response.request.headers.toMap()
+        response.request.headers.toHeaderMap()
       } else reqHeaders
 
     val respHeaders =
       if (captureHeaders) {
-        response.headers.toMap()
+        response.headers.toHeaderMap()
       } else null
 
     val respBody =
@@ -289,9 +289,26 @@ internal class AutoMobileNetworkInterceptor(
     }
   }
 
-  private fun okhttp3.Headers.toMap(): Map<String, String> =
-    (0 until size).groupBy(keySelector = { name(it) }, valueTransform = { value(it) }).mapValues {
-      (_, values) ->
-      values.joinToString(", ")
+  /**
+   * Flatten headers into a map, joining repeated names with ", " in encounter order.
+   *
+   * Deliberately hand-rolled rather than delegating to okhttp's `Headers.toMultimap()`: that
+   * lowercases every name, which would silently change the header casing we report as telemetry.
+   * Named `toHeaderMap` rather than `toMap` because okhttp's `Headers` is an `Iterable<Pair<..>>`,
+   * so a `toMap` extension here shadows the stdlib one -- and the stdlib version takes last-wins on
+   * duplicate names instead of joining them.
+   *
+   * Single-pass on purpose: this runs up to three times per intercepted request, and the common
+   * single-valued header must not allocate an intermediate list or copy its value string.
+   */
+  private fun okhttp3.Headers.toHeaderMap(): Map<String, String> {
+    // Deliberately not buildMap: its MutableMap receiver shadows `size`, so `0 until size`
+    // would read the map being built (0) rather than the header count and silently produce
+    // an empty map.
+    val merged = LinkedHashMap<String, String>(size)
+    for (i in 0 until size) {
+      merged.merge(name(i), value(i)) { existing, next -> "$existing, $next" }
     }
+    return merged
+  }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -289,13 +289,9 @@ internal class AutoMobileNetworkInterceptor(
     }
   }
 
-  private fun okhttp3.Headers.toMap(): Map<String, String> {
-    val map = mutableMapOf<String, String>()
-    for (i in 0 until size) {
-      val name = name(i)
-      val existing = map[name]
-      map[name] = if (existing != null) "$existing, ${value(i)}" else value(i)
+  private fun okhttp3.Headers.toMap(): Map<String, String> =
+    (0 until size).groupBy(keySelector = { name(it) }, valueTransform = { value(it) }).mapValues {
+      (_, values) ->
+      values.joinToString(", ")
     }
-    return map
-  }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/persistence/EventPersistence.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/persistence/EventPersistence.kt
@@ -224,16 +224,15 @@ internal class FileEventPersistence(
 
   internal fun deserializeEvents(json: String): List<SdkEvent> {
     val array = JSONArray(json)
-    val events = mutableListOf<SdkEvent>()
-    for (i in 0 until array.length()) {
+    return (0 until array.length()).mapNotNull { i ->
       val obj = array.getJSONObject(i)
-      val type = obj.optString("type")
-      val timestamp = obj.optLong("timestamp")
-      val appId = obj.optString("applicationId").ifEmpty { null }
-      val event = deserializeEvent(type, obj, timestamp, appId)
-      if (event != null) events.add(event)
+      deserializeEvent(
+        type = obj.optString("type"),
+        obj = obj,
+        timestamp = obj.optLong("timestamp"),
+        appId = obj.optString("applicationId").ifEmpty { null },
+      )
     }
-    return events
   }
 
   @Suppress("CyclomaticComplexMethod")
@@ -399,10 +398,6 @@ internal class FileEventPersistence(
 
   private fun jsonObjectToMap(obj: JSONObject?): Map<String, String> {
     if (obj == null) return emptyMap()
-    val map = mutableMapOf<String, String>()
-    for (key in obj.keys()) {
-      map[key] = obj.optString(key)
-    }
-    return map
+    return obj.keys().asSequence().associateWith { key -> obj.optString(key) }
   }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriverTest.kt
@@ -43,6 +43,37 @@ class SQLiteDatabaseDriverTest {
   }
 
   @Test
+  fun `getDatabases lists each database once sorted by name excluding journal sidecars`() {
+    val beta = createDatabase("zz-beta-${System.nanoTime()}.db")
+    val alpha = createDatabase("aa-alpha-${System.nanoTime()}.db")
+    // Sidecars sit next to a real database and must never be reported as databases
+    // themselves. They are also the reason the discovery pass cannot be a bare listFiles().
+    val sidecars =
+      listOf("-journal", "-wal", "-shm").map { suffix ->
+        File(alpha.parentFile, alpha.name + suffix).also {
+          it.writeText("not a database")
+          filesToDelete.add(it)
+        }
+      }
+
+    val discovered = SQLiteDatabaseDriver(context).getDatabases()
+    val names = discovered.map { it.name }
+
+    // Both databases are reachable via BOTH context.databaseList() and the directory scan,
+    // so a dedup regression would surface here as a duplicated entry.
+    assertEquals(names.distinct(), names, "getDatabases must not report a database twice")
+    assertEquals(discovered.map { it.path }.distinct(), discovered.map { it.path })
+    assertTrue(
+      names.containsAll(listOf(alpha.name, beta.name)),
+      "expected both databases in $names",
+    )
+    sidecars.forEach { sidecar ->
+      assertTrue(names.none { it == sidecar.name }, "sidecar ${sidecar.name} leaked into $names")
+    }
+    assertEquals(names.sorted(), names, "getDatabases must return entries sorted by name")
+  }
+
+  @Test
   fun `serializes parallel reads and writes through one driver`() {
     val dbFile = createDatabase("parallel-${System.nanoTime()}.db")
     val driver = SQLiteDatabaseDriver(context)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptorTest.kt
@@ -294,6 +294,49 @@ class AutoMobileNetworkInterceptorTest {
   }
 
   @Test
+  fun `captureHeaders joins repeated request header values in encounter order`() {
+    val (buffer, flushed) = collectingBuffer()
+    val interceptor = AutoMobileNetworkInterceptor(buffer, captureHeaders = true)
+    // addHeader appends rather than replacing, so this is the only way to produce a
+    // Headers instance with a repeated name. Three values, not two: two would still pass
+    // if the join order were reversed or the fold kept only the outermost pair.
+    val request =
+      Request.Builder()
+        .url("https://api.example.com/users")
+        .addHeader("X-Trace", "first")
+        .addHeader("X-Trace", "second")
+        .addHeader("X-Trace", "third")
+        .build()
+
+    interceptor.intercept(fakeChain(request = request))
+    buffer.flush()
+
+    val event = flushed[0][0] as SdkNetworkRequestEvent
+    assertEquals("first, second, third", event.requestHeaders!!["X-Trace"])
+  }
+
+  @Test
+  fun `captureHeaders keeps repeated header names case sensitive`() {
+    val (buffer, flushed) = collectingBuffer()
+    val interceptor = AutoMobileNetworkInterceptor(buffer, captureHeaders = true)
+    // Differently-cased names are distinct keys -- they must not be folded together, which
+    // is why this cannot delegate to okhttp's Headers.toMultimap() (that lowercases names).
+    val request =
+      Request.Builder()
+        .url("https://api.example.com/users")
+        .addHeader("X-Case", "lower")
+        .addHeader("X-CASE", "upper")
+        .build()
+
+    interceptor.intercept(fakeChain(request = request))
+    buffer.flush()
+
+    val event = flushed[0][0] as SdkNetworkRequestEvent
+    assertEquals("lower", event.requestHeaders!!["X-Case"])
+    assertEquals("upper", event.requestHeaders!!["X-CASE"])
+  }
+
+  @Test
   fun `captureHeaders true captures response headers`() {
     val (buffer, flushed) = collectingBuffer()
     val interceptor = AutoMobileNetworkInterceptor(buffer, captureHeaders = true)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiverTest.kt
@@ -8,11 +8,11 @@ import org.robolectric.RobolectricTestRunner
 
 /**
  * Pins [AutoMobileNotificationReceiver.parseActions] against the malformed-entry cases that the
- * receiver has to tolerate, since notification action JSON arrives over a broadcast extra and is not
- * schema-validated before it gets here.
+ * receiver has to tolerate, since notification action JSON arrives over a broadcast extra and is
+ * not schema-validated before it gets here.
  *
- * Robolectric supplies a real `org.json` implementation; the android.jar stub on the plain unit-test
- * classpath would return default values instead of parsing.
+ * Robolectric supplies a real `org.json` implementation; the android.jar stub on the plain
+ * unit-test classpath would return default values instead of parsing.
  */
 @RunWith(RobolectricTestRunner::class)
 class AutoMobileNotificationReceiverTest {
@@ -22,7 +22,8 @@ class AutoMobileNotificationReceiverTest {
   @Test
   fun `parseActions returns actions in array order`() {
     val json =
-      """[{"label":"Reply","actionId":"reply"},{"label":"Snooze","actionId":"snooze"}]""".trimIndent()
+      """[{"label":"Reply","actionId":"reply"},{"label":"Snooze","actionId":"snooze"}]"""
+        .trimIndent()
 
     assertEquals(
       listOf(NotificationAction("Reply", "reply"), NotificationAction("Snooze", "snooze")),

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/notifications/AutoMobileNotificationReceiverTest.kt
@@ -1,0 +1,62 @@
+package dev.jasonpearson.automobile.sdk.notifications
+
+import dev.jasonpearson.automobile.sdk.NotificationAction
+import kotlin.test.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Pins [AutoMobileNotificationReceiver.parseActions] against the malformed-entry cases that the
+ * receiver has to tolerate, since notification action JSON arrives over a broadcast extra and is not
+ * schema-validated before it gets here.
+ *
+ * Robolectric supplies a real `org.json` implementation; the android.jar stub on the plain unit-test
+ * classpath would return default values instead of parsing.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AutoMobileNotificationReceiverTest {
+
+  private val receiver = AutoMobileNotificationReceiver()
+
+  @Test
+  fun `parseActions returns actions in array order`() {
+    val json =
+      """[{"label":"Reply","actionId":"reply"},{"label":"Snooze","actionId":"snooze"}]""".trimIndent()
+
+    assertEquals(
+      listOf(NotificationAction("Reply", "reply"), NotificationAction("Snooze", "snooze")),
+      receiver.parseActions(json),
+    )
+  }
+
+  @Test
+  fun `parseActions skips null and non-object entries`() {
+    // The null entry is the load-bearing case: it is what the removed `?: JSONObject()`
+    // sentinel used to absorb by producing blank fields that the blank check then dropped.
+    val json = """[{"label":"Reply","actionId":"reply"},null,"nonsense",42,["nested"]]"""
+
+    assertEquals(listOf(NotificationAction("Reply", "reply")), receiver.parseActions(json))
+  }
+
+  @Test
+  fun `parseActions drops entries with a blank label or actionId`() {
+    val json =
+      """
+      [{"label":"","actionId":"a"},{"label":"B","actionId":""},
+       {"label":"  ","actionId":"c"},{"label":"Keep","actionId":"keep"}]
+      """
+        .trimIndent()
+
+    assertEquals(listOf(NotificationAction("Keep", "keep")), receiver.parseActions(json))
+  }
+
+  @Test
+  fun `parseActions returns empty list for absent or malformed json`() {
+    assertEquals(emptyList(), receiver.parseActions(null))
+    assertEquals(emptyList(), receiver.parseActions(""))
+    assertEquals(emptyList(), receiver.parseActions("   "))
+    assertEquals(emptyList(), receiver.parseActions("{not valid json"))
+    assertEquals(emptyList(), receiver.parseActions("[]"))
+  }
+}


### PR DESCRIPTION
## What

Converts index-loop-into-mutable-collection patterns in the Android SDK to the equivalent declarative form. Every change is behavior-preserving — no functional change intended.

| Site | Before | After |
|---|---|---|
| `EventPersistence.deserializeEvents` | indexed loop + `mutableListOf` + null-guarded `add` | `mapNotNull` |
| `EventPersistence.jsonObjectToMap` | key loop + `mutableMapOf` | `keys().asSequence().associateWith` |
| `AutoMobileNetworkInterceptor.toHeaderMap` | duplicate-header merge loop | single-pass `LinkedHashMap.merge` (see below) |
| `AutoMobileNotificationReceiver.parseActions` | indexed loop + `mutableListOf` | `mapNotNull` |
| `AutoMobileNotifications.loadBitmap` | branch-built candidate list | `when` **is** the list expression |
| `SQLiteDatabaseDriver.getDatabases` | `mutableListOf` + two `forEach` accumulations | `filterNot`/`mapNotNull` + `distinctBy` |
| `SQLiteDatabaseDriver` rows (×2) | per-row `for (i in 0 until columnCount)` | `map` |

`deserializeEvents` also inlines four locals into named arguments — slightly more than a mechanical swap, but it keeps the call readable inline.

## Why

Follow-up to an exploration of imperative Kotlin patterns across the repo. That analysis found ~128 `for` loops / ~80 `while` loops / ~817 `var`s across 436 production Kotlin files, but concluded most are appropriate — stateful algorithms, cursor/socket/retry/polling loops, Compose `remember` state, and indexed Android/JSON APIs. The one unequivocal category was **collection-building traversals that could be a single stdlib operator**. This PR does that category and nothing else.

## The header map is deliberately *not* the declarative form

`toHeaderMap` was first written as `groupBy(...).mapValues { it.value.joinToString(", ") }`. That reads well but is the wrong shape for this particular site: it runs up to three times per intercepted request, and it allocates an intermediate `ArrayList` **per header name**, a second `LinkedHashMap`, and a `StringBuilder` + copied `String` per key — even when a header appears once. Roughly 7× the objects of the original loop, and the copied strings are then retained in the event buffer. Review flagged it as a pure loss with no readability gain, so it is now a single-pass `LinkedHashMap` + `merge`.

Two traps documented in-code so they aren't "simplified" back:

- **Not `Headers.toMultimap()`** — okhttp lowercases every name there, which would silently change reported header casing.
- **Not `buildMap { }`** — its `MutableMap` receiver shadows `size`, so `0 until size` reads the *map being built* (0) rather than the header count. I actually made this mistake; it produced an empty map and the tests below caught it.
- **Renamed `toMap` → `toHeaderMap`** — okhttp's `Headers` is an `Iterable<Pair<..>>`, so a `toMap` extension shadows the stdlib one. The private extension wins resolution today, but if it ever moved to file scope this would silently become stdlib `toMap()`, which is last-wins on duplicate names instead of joining.

## Tests added

The original push added no tests while touching a path the suite was already blind to. Now covered:

- **Duplicate request header names join in encounter order** — the only algorithmic change in the PR, and it had *zero* coverage on either side: no test in the repo ever built a `Headers` with a repeated name (every existing header test uses `.header()`, which replaces). Uses three values, not two, so a reversed join or a dropped fold can't pass.
- **Differently-cased header names stay distinct keys** — pins the reason `toMultimap()` is unusable.
- **`parseActions`** — array order, `null`/non-object entries, blank `label`/`actionId`, absent/malformed JSON. Made `internal` + `@VisibleForTesting` so it's testable without driving a broadcast. The `null` entry is the load-bearing case: it's what the removed `?: JSONObject()` sentinel used to absorb.
- **`getDatabases`** — dedup, journal-sidecar exclusion, name sorting.

## Deliberately out of scope

- **Cursor loops** (`while (cursor.moveToNext())`) — `Cursor` isn't `Iterable`, so there's no stdlib operator without inventing a `Cursor.asSequence()` extension. Only the *inner* per-row range loop was converted.
- **Class-level mutable state** — `SdkContext._tags`, `SdkEventBuffer.buffer`, `AutoMobileLog.filters`.
- **`AutoMobileClickTracker` `props`** — conditional heterogeneous assembly with an `info.recycle()` side effect mid-block.
- **Defensive snapshot copies** — `HashMap(_tags)`, `ArrayList(buffer)`, `BreadcrumbTrail` `ArrayList(deque)`.
- **`DatabaseInspectorProvider` `JSONArray` builders** — `org.json` mutable builders with no stdlib equivalent; zero converted, consistently.

**No lint rule or enforcement gate is added**, and none is proposed here. (An earlier draft of this description floated Detekt; that contradicts the project's standing no-Detekt decision. If a gate is ever wanted, the fit for this repo is a Bun source-scan in the style of `test/lint/registrationTeardownGuard.test.ts`.)

## Testing

- `:auto-mobile-sdk:testDebugUnitTest` — full SDK unit suite green, including the 7 new tests.
- `scripts/ktfmt/validate_ktfmt.sh` — all touched files formatted.

Scope is the `auto-mobile-sdk` module. The same shapes likely exist in `desktop-core` and `control-proxy`; not swept here.