### PR TITLE
fix(ios): embed ObjCExceptionCatcher in the CtrlProxyUITests bundle

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		818C27D4C9349EE5D7B46AC4 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F9D3D13C3FE12BA2CD012082 /* ObjCExceptionCatcher.m */; };
 		81E23C054BAEC85A37171E29 /* CtrlProxy.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8AC18133C075D1909F9D04E6 /* ObjCExceptionCatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; };
+		8D5933C825193DD5F0FDF354 /* ObjCExceptionCatcher.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8E00E330C839DBF9AC5DCC8E /* ObjCExceptionCatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; };
 		96ED92C8F268021CE148C4FF /* CtrlProxy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; };
 		9E975A4E407F93A21BD80EB4 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
@@ -131,6 +132,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		20E17E3CCC662C873AD48A47 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8D5933C825193DD5F0FDF354 /* ObjCExceptionCatcher.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		882047DB62E7BA5C6856C006 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -399,6 +411,7 @@
 			buildPhases = (
 				7CFC5122F30AA08D7EB28C15 /* Sources */,
 				DAD3A99273A4DAD849C7E1B0 /* Frameworks */,
+				20E17E3CCC662C873AD48A47 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -533,11 +546,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				61A21F82A43E4D436CD13CCD /* CtrlProxy */,
 				829FFB06AC273BEE7049A7F2 /* CtrlProxyApp */,
+				E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
+				61A21F82A43E4D436CD13CCD /* CtrlProxy */,
 				D665478F817F2DF283B43BFB /* CtrlProxyTests */,
 				2B5458099134F47AA1A7C4DA /* CtrlProxyUITests */,
-				E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
 			);
 		};
 /* End PBXProject section */

--- a/ios/control-proxy/project.yml
+++ b/ios/control-proxy/project.yml
@@ -91,8 +91,12 @@ targets:
       - target: CtrlProxyApp
         # Note: We don't depend on CtrlProxy framework - sources are compiled directly into UI tests
         # to give XCTest access for XCUIApplication
+      # Must embed: the xctest bundle is loaded from CtrlProxyUITests-Runner.app, a
+      # different bundle from CtrlProxyApp.app, so @rpath cannot reach the copy the
+      # app embeds. Without this the runner dies at dlopen with
+      # "Library not loaded: @rpath/ObjCExceptionCatcher.framework".
       - target: ObjCExceptionCatcher
-        embed: false
+        embed: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.jasonpearson.automobile.ctrlproxy.uitests


### PR DESCRIPTION
## Summary

Running the iOS CtrlProxy runner locally died immediately at `dlopen`:

```
The bundle "CtrlProxyUITests" couldn't be loaded.
Library not loaded: @rpath/ObjCExceptionCatcher.framework/ObjCExceptionCatcher
  ... CtrlProxyUITests.xctest/Frameworks/ObjCExceptionCatcher.framework (no such file)
```

`CtrlProxyApp` embeds `ObjCExceptionCatcher`, but the `CtrlProxyUITests` target declared **`embed: false`** — so the xctest bundle shipped with **no `Frameworks/` directory at all**. The test bundle is loaded from `CtrlProxyUITests-Runner.app`, a *different* bundle from `CtrlProxyApp.app`, so `@rpath` cannot reach the copy the app embeds. It has to be embedded in the test bundle too.

**Fix:** `embed: true` for that dependency + regenerate the Xcode project.

## Verification

- After: `CtrlProxyUITests.xctest/Frameworks/ObjCExceptionCatcher.framework` is present, the runner boots on an iOS 26.2 simulator, and its WebSocket listens on **8765**.
- Before: the runner never started.
- Ruled out **stale artifacts** (reproduced after a clean `/tmp/automobile-ctrl-proxy` wipe) and a **runtime mismatch** (reproduced on a simulator whose runtime matched the build).

## Impact

This blocked the entire local iOS hot-reload workflow (`scripts/ios/ctrl-proxy-run.sh`). Pre-existing — `project.yml` was last touched in #2165 (2026-05-18); found while running a manual-test iteration.