### PR TITLE
ci(desktop): upload screenshot pixel diffs when a comparison fails

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -74,6 +74,7 @@ jobs:
           name: desktop-core-screenshot-diffs
           path: android/desktop-core/build/reports/screenshots/
           if-no-files-found: ignore
+          retention-days: 7
 
   build-ide-plugin:
     name: "Build IDE Plugin"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -64,6 +64,17 @@ jobs:
           name: desktop-core-test-results
           path: android/desktop-core/build/reports/tests/test/
 
+      # Screenshot comparisons fail with pixel diffs that are only inspectable
+      # as images -- the HTML test report above carries the stack trace but not
+      # the rendering. See issue #3913.
+      - name: "Upload Screenshot Diffs"
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: desktop-core-screenshot-diffs
+          path: android/desktop-core/build/reports/screenshots/
+          if-no-files-found: ignore
+
   build-ide-plugin:
     name: "Build IDE Plugin"
     # Disabled: consistently >1 minute on merge and not required for release/docs publishing.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -442,6 +442,7 @@ jobs:
           name: desktop-core-screenshot-diffs
           path: android/desktop-core/build/reports/screenshots/
           if-no-files-found: ignore
+          retention-days: 7
 
   build-ide-plugin:
     name: "Build IDE Plugin"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -432,6 +432,17 @@ jobs:
           name: desktop-core-test-results
           path: android/desktop-core/build/reports/tests/test/
 
+      # Screenshot comparisons fail with pixel diffs that are only inspectable
+      # as images -- the HTML test report above carries the stack trace but not
+      # the rendering. See issue #3913.
+      - name: "Upload Screenshot Diffs"
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: desktop-core-screenshot-diffs
+          path: android/desktop-core/build/reports/screenshots/
+          if-no-files-found: ignore
+
   build-ide-plugin:
     name: "Build IDE Plugin"
     runs-on: ubuntu-latest

--- a/.github/workflows/record-screenshot-baselines.yml
+++ b/.github/workflows/record-screenshot-baselines.yml
@@ -97,8 +97,9 @@ jobs:
           name: record-screenshot-baselines-diffs
           path: |
             android/desktop-core/build/reports/screenshots/
-            android/desktop-core/src/test/resources/screenshots/
+            android/desktop-core/src/test/resources/screenshots/*.png
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: "Open PR with recorded baselines"
         shell: bash

--- a/.github/workflows/record-screenshot-baselines.yml
+++ b/.github/workflows/record-screenshot-baselines.yml
@@ -81,6 +81,25 @@ jobs:
           reuse-configuration-cache: true
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      # A baseline that fails the verification immediately following its own
+      # recording (issue #3913) can only be diagnosed from the pixel diffs
+      # ScreenshotComparator writes as "<name>.diff.png" / "<name>.actual.png".
+      # Without this upload they die with the runner.
+      #
+      # The recorded baselines ride along: when verify fails the job stops
+      # before "Open PR", so the PNGs from the record step are discarded too,
+      # and a three-way baseline/actual/diff compare is what makes the
+      # mismatch legible.
+      - name: "Upload Screenshot Diffs"
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: record-screenshot-baselines-diffs
+          path: |
+            android/desktop-core/build/reports/screenshots/
+            android/desktop-core/src/test/resources/screenshots/
+          if-no-files-found: ignore
+
       - name: "Open PR with recorded baselines"
         shell: bash
         env:

--- a/test/bats/screenshot-diff-artifact-upload.bats
+++ b/test/bats/screenshot-diff-artifact-upload.bats
@@ -13,14 +13,22 @@
 #     baselines it just recorded (the failure reported in #3913), and
 #   - desktop-core-unit-tests in pull_request.yml / merge.yml, which verify
 #     committed baselines on a fresh runner.
+#
+# merge.yml's desktop-core-unit-tests is currently `if: ${{ false }}`, so its
+# step is inert today. It is kept and pinned so the two workflows do not
+# silently diverge if that job is re-enabled.
 
 REPORT_PATH="android/desktop-core/build/reports/screenshots/"
+BASELINE_PATH="android/desktop-core/src/test/resources/screenshots/"
 
 # Extract a job block: from its "  <job>:" line up to (but not including) the
-# next top-level (2-space-indented) job key. awk, not sed -- BSD sed lacks the
-# range/address forms this needs.
+# next top-level (2-space-indented) job key. Capture only starts after the
+# top-level "jobs:" key, so a same-named key under "on:" cannot match. awk,
+# not sed -- BSD sed lacks the range/address forms this needs.
 job_block() {
   awk -v job="$2" '
+    /^jobs:/ { in_jobs = 1; next }
+    !in_jobs { next }
     $0 ~ "^  " job ":" { capture = 1; print; next }
     capture && /^  [A-Za-z0-9_-]+:/ { exit }
     capture { print }
@@ -28,11 +36,15 @@ job_block() {
 }
 
 # From a job block on stdin, print the single step block that mentions the
-# screenshots report directory. A step block runs from its "      - " line up
-# to the next one.
+# screenshots report directory.
+#
+# Both "      - " (step start) and "      #" (a comment at step indent) close
+# the current block. Without the comment boundary, comment lines trailing a
+# step fold into *that step's* block, so a comment mentioning the report path
+# would make the preceding step match and satisfy every assertion below.
 screenshot_upload_step() {
   awk -v want="$REPORT_PATH" '
-    /^      - / {
+    /^      [-#]/ {
       if (index(block, want)) printf "%s", block
       block = ""
     }
@@ -41,21 +53,34 @@ screenshot_upload_step() {
   '
 }
 
+# Every workflow/job pair that must carry the upload.
+upload_sites() {
+  echo ".github/workflows/record-screenshot-baselines.yml record"
+  echo ".github/workflows/pull_request.yml desktop-core-unit-tests"
+  echo ".github/workflows/merge.yml desktop-core-unit-tests"
+}
+
+record_step() {
+  job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step
+}
+
 @test "record-screenshot-baselines uploads the screenshot diff reports" {
-  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
+  step="$(record_step)"
   [ -n "$step" ]
 }
 
 @test "record-screenshot-baselines diff upload uses actions/upload-artifact" {
-  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
-  echo "$step" | grep -Eq 'uses: actions/upload-artifact@v[0-9]+'
+  step="$(record_step)"
+  [ -n "$step" ]
+  [[ "$step" =~ uses:\ actions/upload-artifact@v[0-9]+ ]]
 }
 
 @test "record-screenshot-baselines diff upload only runs on failure" {
   # Without if: failure() every successful record run would upload an empty
   # (or absent) directory and warn.
-  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
-  echo "$step" | grep -Fq 'if: failure()'
+  step="$(record_step)"
+  [ -n "$step" ]
+  [[ "$step" == *"if: failure()"* ]]
 }
 
 @test "record-screenshot-baselines diff upload is ordered after the verify step" {
@@ -73,22 +98,34 @@ screenshot_upload_step() {
   # A failing verify aborts the job before "Open PR", so the just-recorded
   # PNGs are discarded with the runner. They are the third leg of the
   # baseline/actual/diff comparison and must ship with the diffs.
-  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
-  echo "$step" | grep -Fq 'android/desktop-core/src/test/resources/screenshots/'
+  step="$(record_step)"
+  [ -n "$step" ]
+  [[ "$step" == *"$BASELINE_PATH"* ]]
+}
+
+@test "record-screenshot-baselines still opens the baselines PR after the upload" {
+  # The upload is inserted directly above "Open PR with recorded baselines";
+  # guard that it displaced rather than replaced it.
+  block="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record")"
+  upload_line="$(echo "$block" | grep -n "$REPORT_PATH" | head -1 | cut -d: -f1)"
+  pr_line="$(echo "$block" | grep -n 'Open PR with recorded baselines' | head -1 | cut -d: -f1)"
+  [ -n "$upload_line" ]
+  [ -n "$pr_line" ]
+  [ "$pr_line" -gt "$upload_line" ]
 }
 
 @test "pull_request desktop-core-unit-tests uploads the screenshot diff reports on failure" {
   step="$(job_block ".github/workflows/pull_request.yml" "desktop-core-unit-tests" | screenshot_upload_step)"
   [ -n "$step" ]
-  echo "$step" | grep -Eq 'uses: actions/upload-artifact@v[0-9]+'
-  echo "$step" | grep -Fq 'if: failure()'
+  [[ "$step" =~ uses:\ actions/upload-artifact@v[0-9]+ ]]
+  [[ "$step" == *"if: failure()"* ]]
 }
 
 @test "merge desktop-core-unit-tests uploads the screenshot diff reports on failure" {
   step="$(job_block ".github/workflows/merge.yml" "desktop-core-unit-tests" | screenshot_upload_step)"
   [ -n "$step" ]
-  echo "$step" | grep -Eq 'uses: actions/upload-artifact@v[0-9]+'
-  echo "$step" | grep -Fq 'if: failure()'
+  [[ "$step" =~ uses:\ actions/upload-artifact@v[0-9]+ ]]
+  [[ "$step" == *"if: failure()"* ]]
 }
 
 @test "existing HTML test-report uploads are preserved" {
@@ -96,8 +133,21 @@ screenshot_upload_step() {
   # both desktop-core-unit-tests jobs must survive.
   for workflow in ".github/workflows/pull_request.yml" ".github/workflows/merge.yml"; do
     block="$(job_block "$workflow" "desktop-core-unit-tests")"
-    echo "$block" | grep -Fq 'name: desktop-core-test-results'
-    echo "$block" | grep -Fq 'path: android/desktop-core/build/reports/tests/test/'
+    [ -n "$block" ]
+    [[ "$block" == *"name: desktop-core-test-results"* ]]
+    [[ "$block" == *"path: android/desktop-core/build/reports/tests/test/"* ]]
+  done
+}
+
+@test "screenshot and test-report artifact names differ within a job" {
+  # Both uploads sit in the same job under the same if: failure() condition.
+  # upload-artifact@v4+ errors on two uploads sharing a name in one run, so a
+  # collision here would turn every failing run into a second, opaque failure.
+  for workflow in ".github/workflows/pull_request.yml" ".github/workflows/merge.yml"; do
+    step="$(job_block "$workflow" "desktop-core-unit-tests" | screenshot_upload_step)"
+    [ -n "$step" ]
+    [[ "$step" != *"name: desktop-core-test-results"* ]]
+    [[ "$step" == *"name: desktop-core-screenshot-diffs"* ]]
   done
 }
 
@@ -105,12 +155,19 @@ screenshot_upload_step() {
   # These jobs fail for many reasons that are not screenshot mismatches, and
   # the report dir only exists after a mismatch. Without if-no-files-found the
   # upload warns on every unrelated failure.
-  for spec in ".github/workflows/record-screenshot-baselines.yml record" \
-    ".github/workflows/pull_request.yml desktop-core-unit-tests" \
-    ".github/workflows/merge.yml desktop-core-unit-tests"; do
-    # shellcheck disable=SC2086
-    set -- $spec
-    step="$(job_block "$1" "$2" | screenshot_upload_step)"
-    echo "$step" | grep -Fq 'if-no-files-found: ignore'
-  done
+  while read -r workflow job; do
+    step="$(job_block "$workflow" "$job" | screenshot_upload_step)"
+    [ -n "$step" ]
+    [[ "$step" == *"if-no-files-found: ignore"* ]]
+  done < <(upload_sites)
+}
+
+@test "screenshot diff uploads expire on the short diagnostic retention" {
+  # Failure-diagnostic output has a short useful life; the repo's other
+  # diagnostic uploads use 7 days rather than the 90-day default.
+  while read -r workflow job; do
+    step="$(job_block "$workflow" "$job" | screenshot_upload_step)"
+    [ -n "$step" ]
+    [[ "$step" == *"retention-days: 7"* ]]
+  done < <(upload_sites)
 }

--- a/test/bats/screenshot-diff-artifact-upload.bats
+++ b/test/bats/screenshot-diff-artifact-upload.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+#
+# Guards issue #3913: recorded desktop screenshot baselines fail their own
+# immediate re-verification on the reference OS, and the failure is not
+# diagnosable because nothing uploads the pixel diffs.
+#
+# ScreenshotComparator writes "<name>.diff.png" and "<name>.actual.png" into
+# android/desktop-core/build/reports/screenshots/ on every mismatch, but that
+# directory is discarded with the runner. Every job that can fail a screenshot
+# comparison must upload it on failure:
+#
+#   - record-screenshot-baselines.yml, whose "verify" step re-checks the
+#     baselines it just recorded (the failure reported in #3913), and
+#   - desktop-core-unit-tests in pull_request.yml / merge.yml, which verify
+#     committed baselines on a fresh runner.
+
+REPORT_PATH="android/desktop-core/build/reports/screenshots/"
+
+# Extract a job block: from its "  <job>:" line up to (but not including) the
+# next top-level (2-space-indented) job key. awk, not sed -- BSD sed lacks the
+# range/address forms this needs.
+job_block() {
+  awk -v job="$2" '
+    $0 ~ "^  " job ":" { capture = 1; print; next }
+    capture && /^  [A-Za-z0-9_-]+:/ { exit }
+    capture { print }
+  ' "$1"
+}
+
+# From a job block on stdin, print the single step block that mentions the
+# screenshots report directory. A step block runs from its "      - " line up
+# to the next one.
+screenshot_upload_step() {
+  awk -v want="$REPORT_PATH" '
+    /^      - / {
+      if (index(block, want)) printf "%s", block
+      block = ""
+    }
+    { block = block $0 "\n" }
+    END { if (index(block, want)) printf "%s", block }
+  '
+}
+
+@test "record-screenshot-baselines uploads the screenshot diff reports" {
+  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
+  [ -n "$step" ]
+}
+
+@test "record-screenshot-baselines diff upload uses actions/upload-artifact" {
+  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
+  echo "$step" | grep -Eq 'uses: actions/upload-artifact@v[0-9]+'
+}
+
+@test "record-screenshot-baselines diff upload only runs on failure" {
+  # Without if: failure() every successful record run would upload an empty
+  # (or absent) directory and warn.
+  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
+  echo "$step" | grep -Fq 'if: failure()'
+}
+
+@test "record-screenshot-baselines diff upload is ordered after the verify step" {
+  # The diffs only exist once the verify step has run and failed, so the
+  # upload must come after it in the step list.
+  block="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record")"
+  verify_line="$(echo "$block" | grep -n 'Verify baselines pass in normal mode' | head -1 | cut -d: -f1)"
+  upload_line="$(echo "$block" | grep -n "$REPORT_PATH" | head -1 | cut -d: -f1)"
+  [ -n "$verify_line" ]
+  [ -n "$upload_line" ]
+  [ "$upload_line" -gt "$verify_line" ]
+}
+
+@test "record-screenshot-baselines diff upload includes the recorded baselines" {
+  # A failing verify aborts the job before "Open PR", so the just-recorded
+  # PNGs are discarded with the runner. They are the third leg of the
+  # baseline/actual/diff comparison and must ship with the diffs.
+  step="$(job_block ".github/workflows/record-screenshot-baselines.yml" "record" | screenshot_upload_step)"
+  echo "$step" | grep -Fq 'android/desktop-core/src/test/resources/screenshots/'
+}
+
+@test "pull_request desktop-core-unit-tests uploads the screenshot diff reports on failure" {
+  step="$(job_block ".github/workflows/pull_request.yml" "desktop-core-unit-tests" | screenshot_upload_step)"
+  [ -n "$step" ]
+  echo "$step" | grep -Eq 'uses: actions/upload-artifact@v[0-9]+'
+  echo "$step" | grep -Fq 'if: failure()'
+}
+
+@test "merge desktop-core-unit-tests uploads the screenshot diff reports on failure" {
+  step="$(job_block ".github/workflows/merge.yml" "desktop-core-unit-tests" | screenshot_upload_step)"
+  [ -n "$step" ]
+  echo "$step" | grep -Eq 'uses: actions/upload-artifact@v[0-9]+'
+  echo "$step" | grep -Fq 'if: failure()'
+}
+
+@test "existing HTML test-report uploads are preserved" {
+  # The screenshot upload is additive: the pre-existing test-results upload in
+  # both desktop-core-unit-tests jobs must survive.
+  for workflow in ".github/workflows/pull_request.yml" ".github/workflows/merge.yml"; do
+    block="$(job_block "$workflow" "desktop-core-unit-tests")"
+    echo "$block" | grep -Fq 'name: desktop-core-test-results'
+    echo "$block" | grep -Fq 'path: android/desktop-core/build/reports/tests/test/'
+  done
+}
+
+@test "screenshot diff uploads tolerate an absent report directory" {
+  # These jobs fail for many reasons that are not screenshot mismatches, and
+  # the report dir only exists after a mismatch. Without if-no-files-found the
+  # upload warns on every unrelated failure.
+  for spec in ".github/workflows/record-screenshot-baselines.yml record" \
+    ".github/workflows/pull_request.yml desktop-core-unit-tests" \
+    ".github/workflows/merge.yml desktop-core-unit-tests"; do
+    # shellcheck disable=SC2086
+    set -- $spec
+    step="$(job_block "$1" "$2" | screenshot_upload_step)"
+    echo "$step" | grep -Fq 'if-no-files-found: ignore'
+  done
+}


### PR DESCRIPTION
## Summary

`ScreenshotComparator` writes `<name>.diff.png` and `<name>.actual.png` into
`android/desktop-core/build/reports/screenshots/` on every mismatch, but no workflow
uploaded that directory — so the 6/6 failure in #3913 dies with the runner and can only
be guessed at. This adds the upload to every job that can fail a screenshot comparison.

This is the diagnostic prerequisite the issue itself calls for ("that upload is arguably
a prerequisite for the rest of this issue"), **not** the root-cause fix. See below for why
the root cause is not fixed here.

### Why no fix yet

I ran the issue's local repro on macOS/arm64 (JDK 21, `-Dscreenshot.reference.os=any`) —
record, un-pend, then verify as two separate Gradle invocations, exactly as the workflow does:

```
tests="6" skipped="0" failures="0" errors="0"
```

It **passes**, and no `build/reports/screenshots/` directory is even created. So:

- Hypothesis 1 (non-deterministic Compose Desktop rendering between two renders) does **not**
  reproduce off-Linux.
- Hypothesis 3 (record-vs-verify path divergence in `handleResult` / `toAwtImage()`) is
  effectively eliminated — that code path is OS-independent and would have failed here too.

That leaves a Linux-specific rasterization difference or a comparator tolerance too tight for
Linux freetype output (hypothesis 2). Neither is distinguishable without the actual pixel
diffs, so any fix written now would be guesswork. Next step after this merges: one
`workflow_dispatch` of `Record Desktop Screenshot Baselines`, then read the artifact.

## Linked Issue

Refs #3913 — deliberately **not** `Closes`, since the underlying baseline mismatch is
still unfixed. See Follow-ups.

## Bug / Regression Context

- **Prior attempts:** #3908 bumped jemalloc and cleared the exit-139 SIGSEGV that previously
  masked this; the mismatch below is what surfaced once that infra blocker was gone.
- **Observed symptom:** the record workflow records 6 baselines on `ubuntu-latest`, un-pends
  them, re-verifies in the same job on the same runner, and all 6 fail the pixel comparison
  ([run 29603004265](https://github.com/kaeawc/auto-mobile/actions/runs/29603004265)).
- **Repro steps / conditions:** per the issue; reproduces only on the Linux reference OS.

## Changes

| File | Change |
| --- | --- |
| `.github/workflows/record-screenshot-baselines.yml` | Upload the screenshot report dir on failure, after the verify step. Also uploads the just-recorded baselines from `src/test/resources/screenshots/` — a failing verify aborts the job before "Open PR", so those PNGs are otherwise discarded, and they are the third leg of a baseline/actual/diff comparison. |
| `.github/workflows/pull_request.yml` | Same upload in `desktop-core-unit-tests`, so a baseline mismatch on a PR is inspectable too. |
| `.github/workflows/merge.yml` | Same, in the merge-side `desktop-core-unit-tests`. |
| `test/bats/screenshot-diff-artifact-upload.bats` | New wiring guard (9 tests). |

All three uploads use `if: failure()` plus `if-no-files-found: ignore` — these jobs fail for
many reasons that are not screenshot mismatches, and the report dir only exists after one.

## Acceptance criteria

| Criterion | Pinned by |
| --- | --- |
| Failed verify in the record workflow uploads `build/reports/screenshots/` so the diffs are inspectable | `record-screenshot-baselines uploads the screenshot diff reports`, `... uses actions/upload-artifact`, `... only runs on failure`, `... is ordered after the verify step` |
| The recorded baselines survive a failed verify | `... diff upload includes the recorded baselines` |
| The same diffs are inspectable when baselines fail on a PR / on merge | `pull_request desktop-core-unit-tests uploads ...`, `merge desktop-core-unit-tests uploads ...` |
| The change is additive — existing test-report uploads survive | `existing HTML test-report uploads are preserved` |
| Unrelated failures do not warn on a missing dir | `screenshot diff uploads tolerate an absent report directory` |

The bats file was written before the workflow edits: 7 of 9 failed red, and the one guard that
passes pre-change (`existing HTML test-report uploads are preserved`) does so by design — it
pins behavior the change must not break. The two tests added after the edits
(`... includes the recorded baselines`, `... tolerate an absent report directory`) were
mutation-checked by removing the corresponding YAML lines and confirming they go red.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` — 15/15 pass
- [x] `bun test` — 8090 pass, 11 skip, **0 fail** (638 files)
- [x] `bats test/bats/` — 343 pass; 1 pre-existing failure in `verify-runtime-deps.bats`
      ("passes when all dependencies are present"), confirmed to fail identically on a stashed
      clean tree — a missing local runtime dep, unrelated to this diff
- [x] `bun run typecheck` — reports 1 error in `src/utils/plan/PlanSchemaValidator.ts`, also
      confirmed pre-existing on a clean tree; an `ajv`/`ajv-formats` duplicate-resolution
      artifact of this worktree sharing the central `node_modules`. This diff touches zero
      TypeScript. See Follow-ups.
- [x] No new code needing interfaces/fakes/FakeTimer — CI YAML plus a shell wiring guard

## Device Verification

N/A — CI configuration only.

## Follow-ups

- Root-cause fix for the baseline mismatch itself, which is what closes #3913. Blocked on
  a `workflow_dispatch` run against this change to produce the diff images.
- The pre-existing `PlanSchemaValidator.ts` ajv typecheck error and the
  `verify-runtime-deps.bats` failure, if they reproduce outside this worktree.
