### PR TITLE
ci: namespace junit-runner heap-dump artifacts by job, guard duplicate artifact names

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1596,7 +1596,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: junit-runner-heap-dumps
+          name: junit-runner-heap-dumps-unit
           path: heap-dump
           if-no-files-found: ignore
 
@@ -1665,7 +1665,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: junit-runner-heap-dumps
+          name: junit-runner-heap-dumps-emulator
           path: heap-dump
           if-no-files-found: ignore
 

--- a/test/bats/workflow-artifact-name-uniqueness.bats
+++ b/test/bats/workflow-artifact-name-uniqueness.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+#
+# Guards issue #3976: two `actions/upload-artifact` steps in different jobs of
+# `pull_request.yml` uploaded under the same artifact name.
+#
+# upload-artifact v4 and later error on a duplicate artifact name within a
+# single workflow run (v3 silently merged them). Both heap-dump steps are
+# failure-gated, so the collision only bites when *both* junit-runner jobs fail
+# in the same run -- exactly when you most need the dumps. The second upload
+# then fails, adding an opaque failure on top of the one being diagnosed, and
+# one job's heap dumps are lost.
+#
+# The scope here is deliberately global rather than a pin on the two known
+# steps: the same class of collision is invisible until it fires, and it fires
+# only on an already-failing run.
+
+# Print "<job>\t<artifact name>" for every upload-artifact step in a workflow.
+#
+# Capture starts only after the top-level "jobs:" key so a same-named key under
+# "on:" cannot match, matching the convention in
+# screenshot-diff-artifact-upload.bats. awk, not sed -- BSD sed lacks the
+# range/address forms this needs.
+#
+# `name:` is read as the first name key following the `uses:` line, which is
+# the `with.name` input; the *step's* own display name precedes `uses:` and so
+# is never picked up.
+upload_artifact_names() {
+  awk '
+    /^jobs:/ { in_jobs = 1; next }
+    !in_jobs { next }
+    /^  [A-Za-z0-9_-]+:/ { job = $1; sub(":", "", job) }
+    /uses: actions\/upload-artifact/ { pending = 1; next }
+    pending && /^ *name: / {
+      artifact = $0
+      sub(/^ *name: /, "", artifact)
+      print job "\t" artifact
+      pending = 0
+    }
+  ' "$1"
+}
+
+workflows() {
+  find .github/workflows -maxdepth 1 -name '*.yml' | sort
+}
+
+@test "the extractor finds upload-artifact steps at all" {
+  # A silently-empty extractor would make every uniqueness assertion below
+  # vacuously pass. Pin that it actually parses the workflow the issue is about.
+  run upload_artifact_names ".github/workflows/pull_request.yml"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -gt 5 ]
+}
+
+@test "no two upload-artifact steps in one workflow share an artifact name" {
+  duplicates=""
+  while read -r workflow; do
+    dupes="$(upload_artifact_names "$workflow" \
+      | cut -f2 \
+      | sort \
+      | uniq -d)"
+    if [ -n "$dupes" ]; then
+      duplicates="$duplicates$workflow: $(echo "$dupes" | tr '\n' ' ')"$'\n'
+    fi
+  done < <(workflows)
+
+  if [ -n "$duplicates" ]; then
+    echo "Duplicate upload-artifact names within a single workflow:"
+    echo "$duplicates"
+  fi
+  [ -z "$duplicates" ]
+}
+
+@test "junit-runner heap dumps are namespaced by job" {
+  names="$(upload_artifact_names ".github/workflows/pull_request.yml")"
+  [[ "$names" == *$'junit-runner-unit-tests\tjunit-runner-heap-dumps-unit'* ]]
+  [[ "$names" == *$'junit-runner-emulator-tests\tjunit-runner-heap-dumps-emulator'* ]]
+}
+
+@test "junit-runner heap dump uploads stay failure-gated and tolerant" {
+  # The rename must not disturb the surrounding step wiring: these dumps only
+  # exist after a crash, so an unconditional upload would warn on every run.
+  block="$(awk '
+    /name: junit-runner-heap-dumps/ { print prev3 "\n" prev2 "\n" prev1 "\n" $0 }
+    { prev3 = prev2; prev2 = prev1; prev1 = $0 }
+  ' ".github/workflows/pull_request.yml")"
+  [ -n "$block" ]
+  [ "$(echo "$block" | grep -c 'if: failure()')" -eq 2 ]
+  [ "$(echo "$block" | grep -c 'uses: actions/upload-artifact@v[0-9]')" -eq 2 ]
+}

--- a/test/bats/workflow-artifact-name-uniqueness.bats
+++ b/test/bats/workflow-artifact-name-uniqueness.bats
@@ -13,6 +13,17 @@
 # The scope here is deliberately global rather than a pin on the two known
 # steps: the same class of collision is invisible until it fires, and it fires
 # only on an already-failing run.
+#
+# Two axes are out of reach of a file-static check, so do not over-trust this:
+#
+#   - A reusable workflow's uploads land in the *caller's* artifact namespace,
+#     so a caller/callee collision spans two files. (build-control-proxy-apk,
+#     build-ctrl-proxy-ios-ipa and build-video-server-jar are called this way;
+#     their names do not collide with any caller's today.)
+#   - A matrix job whose artifact name is a single static literal collides with
+#     itself at runtime across matrix legs. Every matrix upload here correctly
+#     interpolates ${{ matrix.os }}; dropping that interpolation would be the
+#     same failure class as #3976 and would still pass this guard.
 
 # Print "<job>\t<artifact name>" for every upload-artifact step in a workflow.
 #
@@ -21,21 +32,44 @@
 # screenshot-diff-artifact-upload.bats. awk, not sed -- BSD sed lacks the
 # range/address forms this needs.
 #
-# `name:` is read as the first name key following the `uses:` line, which is
-# the `with.name` input; the *step's* own display name precedes `uses:` and so
-# is never picked up.
+# Whole step blocks are buffered and scanned at flush time rather than read as
+# a "uses: then name:" sequence. YAML mapping keys are unordered, so a step
+# written `with:` first and `uses:` second is legal; a sequential reader skips
+# it AND then mis-attributes the *next* step's name to it, which would let a
+# duplicate slip through the very guard meant to catch it. The `uses:` value is
+# matched with optional quotes for the same reason.
+#
+# Within a block the artifact name is the `name:` under `with:` -- the step's
+# own display name is `- name:`, which carries a leading dash and so cannot
+# match, and it precedes `with:` in any case.
 upload_artifact_names() {
   awk '
+    function flush() {
+      if (n_lines == 0) return
+      is_upload = 0
+      for (i = 1; i <= n_lines; i++) {
+        if (lines[i] ~ /uses: *["'"'"']?actions\/upload-artifact/) is_upload = 1
+      }
+      if (is_upload) {
+        in_with = 0
+        for (i = 1; i <= n_lines; i++) {
+          if (lines[i] ~ /^ *with: *$/) { in_with = 1; continue }
+          if (in_with && lines[i] ~ /^ *name: /) {
+            artifact = lines[i]
+            sub(/^ *name: /, "", artifact)
+            print job "\t" artifact
+            break
+          }
+        }
+      }
+      n_lines = 0
+    }
     /^jobs:/ { in_jobs = 1; next }
     !in_jobs { next }
-    /^  [A-Za-z0-9_-]+:/ { job = $1; sub(":", "", job) }
-    /uses: actions\/upload-artifact/ { pending = 1; next }
-    pending && /^ *name: / {
-      artifact = $0
-      sub(/^ *name: /, "", artifact)
-      print job "\t" artifact
-      pending = 0
-    }
+    /^  [A-Za-z0-9_-]+:/ { flush(); job = $1; sub(":", "", job) }
+    /^ *- / { flush() }
+    { lines[++n_lines] = $0 }
+    END { flush() }
   ' "$1"
 }
 
@@ -68,6 +102,39 @@ workflows() {
     echo "$duplicates"
   fi
   [ -z "$duplicates" ]
+}
+
+@test "the extractor is not fooled by key order or quoting" {
+  # A guard that silently misses a duplicate is worse than no guard, so pin the
+  # two shapes a sequential "uses: then name:" reader would drop: `with:` before
+  # `uses:`, and a quoted `uses:` value. Both are legal YAML that nothing in the
+  # repo happens to use today.
+  fixture="$BATS_TEST_TMPDIR/synthetic.yml"
+  cat > "$fixture" <<'YAML'
+jobs:
+  example:
+    steps:
+      - name: "With before uses"
+        with:
+          name: artifact-alpha
+          path: out
+        uses: actions/upload-artifact@v6
+      - name: "Quoted uses"
+        uses: "actions/upload-artifact@v6"
+        with:
+          name: artifact-beta
+      - name: "Ordinary"
+        uses: actions/upload-artifact@v6
+        with:
+          name: artifact-gamma
+YAML
+
+  run upload_artifact_names "$fixture"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 3 ]
+  [[ "$output" == *$'example\tartifact-alpha'* ]]
+  [[ "$output" == *$'example\tartifact-beta'* ]]
+  [[ "$output" == *$'example\tartifact-gamma'* ]]
 }
 
 @test "junit-runner heap dumps are namespaced by job" {


### PR DESCRIPTION
## Summary

Two `actions/upload-artifact@v6` steps in `.github/workflows/pull_request.yml` uploaded under the same artifact name, `junit-runner-heap-dumps`, from different jobs in the same workflow run — `junit-runner-unit-tests` ([:1599](https://github.com/kaeawc/auto-mobile/blob/main/.github/workflows/pull_request.yml#L1599)) and `junit-runner-emulator-tests` ([:1668](https://github.com/kaeawc/auto-mobile/blob/main/.github/workflows/pull_request.yml#L1668)).

`upload-artifact` v4 and later error on a duplicate artifact name within a single run (v3 merged them). Both steps are `if: failure()`-gated, so the collision only fired when **both** junit-runner jobs failed in the same run — precisely when the dumps are most wanted. The second upload then failed too, stacking an opaque failure on top of the one being diagnosed, and one job's heap dumps were lost.

This suffixes each name with its job and adds a wiring guard that asserts the property globally, since this class of bug is invisible until it fires and fires only on an already-failing run.

## Linked Issue

Closes #3976

## Bug / Regression Context

- **Prior attempts:** none. Pre-existing; surfaced during review of #3974 (screenshot-diff uploads for #3913), which added a guard asserting its own two same-job uploads use distinct names.
- **Observed symptom:** when both junit-runner jobs fail in one run, the second `Upload Heap Dumps` step fails with a duplicate-artifact-name error and those heap dumps are not retained.
- **Repro conditions:** any run where `junit-runner-unit-tests` and `junit-runner-emulator-tests` both fail.

## Changes

- `junit-runner-unit-tests` now uploads `junit-runner-heap-dumps-unit`; `junit-runner-emulator-tests` uploads `junit-runner-heap-dumps-emulator`. Surrounding step wiring (`if: failure()`, `path`, `if-no-files-found: ignore`) is untouched.
- New `test/bats/workflow-artifact-name-uniqueness.bats` parses every `.github/workflows/*.yml`, collects the `with.name` of each `upload-artifact` step, and fails on any duplicate within a workflow.

## Acceptance Criteria

The issue carries no explicit AC list; these were inferred from its "Suggested fix" and closing paragraph, and confirmed at the plan gate.

| # | Criterion | Pinned by |
|---|---|---|
| 1 | The two heap-dump uploads use distinct, job-suffixed names | `junit-runner heap dumps are namespaced by job` |
| 2 | No two `upload-artifact` steps in one workflow share a `name:`, asserted globally | `no two upload-artifact steps in one workflow share an artifact name` |

Two supporting tests guard the guard: one pins that the extractor actually finds steps (an empty extractor would make every uniqueness assertion vacuously pass), and one pins that the rename left both steps failure-gated.

## Validation

- [x] New guard red before the change (AC-1 and AC-2 tests both failed, AC-2 reporting the real collision by name), green after
- [x] Full `bats test/bats/` suite: 351/352
- [x] `shellcheck --shell=bash` clean on the new file; workflow YAML parses
- [x] Confirmed nothing else in the repo downloads or references the old artifact name
- [x] `bun run typecheck` — green in CI (see note below)
- [ ] Android/iOS changes: N/A
- [ ] New code uses interfaces + fakes + FakeTimer: N/A (bats)

Both local reds turned out to be local-environment only — **CI is green on both**:

1. `test/bats/verify-runtime-deps.bats` — a runtime dep missing from my machine. The `BATS Shell Tests (macos-latest)` job passes.
2. `bun run typecheck` — an `ajv` / `ajv-formats` nested-copy resolution artifact in my local `node_modules`. All three `Node TypeScript Build and Test` legs pass, which is where the gate runs (`pull_request.yml:1084`).

The TypeScript suite was not run locally: this diff is YAML + bats only and has no TS surface to regress.

The three failing iOS checks are [#3975](https://github.com/kaeawc/auto-mobile/issues/3975) (XcodeGen pbxproj target order not reproducible in CI), unrelated to this diff, which touches no iOS files. They ran here only because editing a workflow file trips change-detection's "everything changed" path; they skip on ordinary PRs.

## Device Verification

N/A — CI workflow configuration.

## Follow-ups

Nothing new filed — the one CI failure is already tracked as #3975.

Two latent scope gaps in the guard were found in review and are documented in the file header rather than filed, since neither has a live collision today: reusable-workflow uploads land in the *caller's* artifact namespace (spanning two files), and a matrix job with a static artifact name would collide with itself at runtime. Both are invisible to a file-static check.

