### PR TITLE
feat(desktop): consume storage_update frames and add on-demand request_observation

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -1362,6 +1362,7 @@ fun AutoMobileContent(
                       deviceId = activeDeviceId,
                       packageName = selectedAppId,
                       platform = storagePlatform,
+                      observationStreamClient = observationStreamClient,
                     )
                   "diagnostics" ->
                     DiagnosticsDashboard(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.daemon
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.connection.isConnected
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.domain.KeyValueType
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.InputStreamReader
@@ -76,6 +77,17 @@ class ObservationStreamClient {
       onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
     )
   val performanceUpdates: SharedFlow<PerformanceStreamUpdate> = _performanceUpdates.asSharedFlow()
+
+  // Flow for live key/value storage changes. Storage writes can burst (a screen that persists
+  // several preferences at once), so this follows the performance flow's non-blocking policy
+  // rather than suspending the socket reader.
+  private val _storageUpdates =
+    MutableSharedFlow<StorageStreamUpdate>(
+      replay = 1,
+      extraBufferCapacity = 32,
+      onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
+    )
+  val storageUpdates: SharedFlow<StorageStreamUpdate> = _storageUpdates.asSharedFlow()
 
   // Flow for device-level stream events such as control connection loss.
   private val _deviceEvents = MutableSharedFlow<DeviceStreamEvent>(replay = 1)
@@ -383,6 +395,27 @@ class ObservationStreamClient {
           log.info("Emitted performance update to flow")
         }
       }
+      "storage_update" -> {
+        val storageEvent = response.storageEvent
+        if (storageEvent == null) {
+          log.warn("storage_update without a storageEvent payload, ignoring")
+        } else {
+          _storageUpdates.tryEmit(
+            StorageStreamUpdate(
+              deviceId = response.deviceId,
+              // The frame's own timestamp is the daemon's receive clock; the event carries the
+              // device-side time the change actually happened, which is what ordering wants.
+              timestamp = storageEvent.timestamp,
+              packageName = storageEvent.packageName,
+              fileName = storageEvent.fileName,
+              key = storageEvent.key,
+              value = storageEvent.value,
+              valueType = KeyValueType.fromProtocolName(storageEvent.valueType),
+              sequenceNumber = storageEvent.sequenceNumber,
+            )
+          )
+        }
+      }
       "ping" -> {
         log.info("Received ping, sending pong")
         sendPong()
@@ -431,6 +464,26 @@ class ObservationStreamClient {
         id = UUID.randomUUID().toString(),
         command = "request_navigation_graph",
         appId = appId,
+      )
+    sendRequest(request)
+  }
+
+  /**
+   * Ask the daemon for a single fresh observation now, without changing the subscription cadence.
+   *
+   * The captured hierarchy arrives out-of-band on [hierarchyUpdates] like any other frame; the
+   * daemon's direct reply is only an ack (or an `error` frame, which surfaces on [deviceEvents]).
+   *
+   * @param deviceId Capture just this device; null captures every subscribed device.
+   */
+  fun requestObservation(deviceId: String? = null) {
+    if (!_connectionState.value.isConnected) return
+
+    val request =
+      StreamRequest(
+        id = UUID.randomUUID().toString(),
+        command = "request_observation",
+        deviceId = deviceId,
       )
     sendRequest(request)
   }
@@ -495,7 +548,41 @@ data class StreamResponse(
   val navigationGraph: NavigationGraphStreamData? = null,
   val performanceData: PerformanceStreamData? = null,
   val hierarchyDiff: HierarchyDiffSummary? = null,
+  val storageEvent: StorageEventData? = null,
 )
+
+/**
+ * Payload of a `storage_update` frame — one key/value change observed on the device.
+ *
+ * [key] and [value] are nullable by protocol: a null [key] means the whole file was cleared, and a
+ * null [value] means the key was deleted (or the file cleared).
+ */
+@Serializable
+data class StorageEventData(
+  val packageName: String,
+  val fileName: String,
+  val key: String? = null,
+  val value: String? = null,
+  val valueType: String = KeyValueType.Unknown.protocolName,
+  val timestamp: Long = 0L,
+  val sequenceNumber: Long = 0L,
+)
+
+/** A live key/value change, surfaced to the storage inspector. */
+data class StorageStreamUpdate(
+  val deviceId: String?,
+  val timestamp: Long,
+  val packageName: String,
+  val fileName: String,
+  val key: String?,
+  val value: String?,
+  val valueType: KeyValueType,
+  val sequenceNumber: Long,
+) {
+  /** True when the whole file was cleared rather than a single key changing. */
+  val isFileCleared: Boolean
+    get() = key == null
+}
 
 /**
  * Per-frame hierarchy diff summary emitted by the daemon on `hierarchy_update` (issue #3758).

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSource.kt
@@ -12,6 +12,7 @@ import dev.jasonpearson.automobile.desktop.core.storage.KeyValueType
 import dev.jasonpearson.automobile.desktop.core.storage.QueryResult
 import dev.jasonpearson.automobile.desktop.core.storage.StoragePlatform
 import dev.jasonpearson.automobile.desktop.core.storage.TableInfo
+import dev.jasonpearson.automobile.desktop.core.storage.parseKeyValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -20,8 +21,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 private val LOG = LoggerFactory.getLogger("RealStorageDataSource")
@@ -473,39 +472,10 @@ class RealStorageDataSource(
     }
   }
 
-  private fun mapKeyValueType(type: String): KeyValueType {
-    return when (type.uppercase()) {
-      "STRING" -> KeyValueType.String
-      "INT" -> KeyValueType.Int
-      "LONG" -> KeyValueType.Long
-      "FLOAT" -> KeyValueType.Float
-      "BOOLEAN" -> KeyValueType.Boolean
-      "STRING_SET" -> KeyValueType.StringSet
-      else -> KeyValueType.Unknown
-    }
-  }
+  private fun mapKeyValueType(type: String): KeyValueType = KeyValueType.fromProtocolName(type)
 
-  private fun parseValue(jsonValue: String?, type: String): Any? {
-    if (jsonValue == null) return null
-
-    return try {
-      when (type.uppercase()) {
-        "STRING" -> jsonValue
-        "INT" -> jsonValue.toIntOrNull() ?: jsonValue
-        "LONG" -> jsonValue.toLongOrNull() ?: jsonValue
-        "FLOAT" -> jsonValue.toFloatOrNull() ?: jsonValue
-        "BOOLEAN" -> jsonValue.toBooleanStrictOrNull() ?: jsonValue
-        "STRING_SET" -> {
-          // Parse JSON array of strings to Set<String>
-          val element = json.parseToJsonElement(jsonValue)
-          element.jsonArray.map { it.jsonPrimitive.content }.toSet()
-        }
-        else -> jsonValue
-      }
-    } catch (e: Exception) {
-      jsonValue
-    }
-  }
+  private fun parseValue(jsonValue: String?, type: String): Any? =
+    parseKeyValue(jsonValue, mapKeyValueType(type))
 }
 
 // MCP response models for database resources

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueInspector.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueInspector.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,11 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-
-/** Duration for the highlight animation when a key changes */
-private const val HIGHLIGHT_DURATION_MS = 2000L
 
 /** Color for highlighting recently changed entries */
 private val HIGHLIGHT_COLOR = Color(0xFF4CAF50).copy(alpha = 0.3f)
@@ -58,6 +53,9 @@ private val HIGHLIGHT_COLOR = Color(0xFF4CAF50).copy(alpha = 0.3f)
  * @param keyValueFiles List of key-value storage files to display
  * @param onSetValue Optional callback to persist a value change. Receives (fileName, key, value,
  *   type).
+ * @param recentlyChangedKeys Entries to highlight as just-changed, as `"fileName:key"` identities.
+ *   Hoisted so the caller owns both the live-update source and the highlight lifetime; see
+ *   [StorageDashboard], which drives this from the observation stream's `storage_update` frames.
  * @param modifier Modifier for the composable
  */
 @Composable
@@ -66,6 +64,7 @@ fun KeyValueInspector(
   onSetValue:
     (suspend (fileName: String, key: String, value: String, type: KeyValueType) -> Result<Unit>)? =
     null,
+  recentlyChangedKeys: Set<String> = emptySet(),
   modifier: Modifier = Modifier,
 ) {
   val colors = SharedTheme.globalColors
@@ -79,20 +78,6 @@ fun KeyValueInspector(
   var editValue by remember { mutableStateOf("") }
   var isSaving by remember { mutableStateOf(false) }
   var saveError by remember { mutableStateOf<String?>(null) }
-
-  // Track recently changed keys for highlight animation
-  // Key format: "fileName:key" to uniquely identify entries across files.
-  // The producer (a live storage-change subscription) is intentionally not wired here yet;
-  // it will be reconnected via the observation stream's `storage_update` frames (#3930).
-  var recentlyChangedKeys by remember { mutableStateOf<Set<String>>(emptySet()) }
-
-  // Auto-clear highlighted keys after animation duration
-  LaunchedEffect(recentlyChangedKeys) {
-    if (recentlyChangedKeys.isNotEmpty()) {
-      delay(HIGHLIGHT_DURATION_MS)
-      recentlyChangedKeys = emptySet()
-    }
-  }
 
   // Filter entries by search query
   val filteredEntries =
@@ -286,7 +271,7 @@ fun KeyValueInspector(
             val isEditing = entry == editingEntry
 
             // Check if this entry was recently changed
-            val changeKey = "${selectedFile?.name}:${entry.key}"
+            val changeKey = highlightKey(selectedFile?.name.orEmpty(), entry.key)
             val isRecentlyChanged = changeKey in recentlyChangedKeys
 
             // Animate background color for recently changed entries

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueLiveUpdates.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueLiveUpdates.kt
@@ -1,0 +1,103 @@
+package dev.jasonpearson.automobile.desktop.core.storage
+
+import dev.jasonpearson.automobile.desktop.core.daemon.StorageStreamUpdate
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+private val json = Json { ignoreUnknownKeys = true }
+
+/**
+ * Identifies an entry for highlight purposes. Keys are only unique within a file, so the file name
+ * is part of the identity.
+ */
+internal fun highlightKey(fileName: String, key: String): String = "$fileName:$key"
+
+/**
+ * Decodes a daemon-supplied value string into the representation [KeyValueEntry.value] holds.
+ *
+ * Falls back to the raw string whenever the declared type doesn't parse, which keeps a malformed or
+ * newly-added device type visible in the inspector instead of dropping it.
+ */
+internal fun parseKeyValue(rawValue: String?, type: KeyValueType): Any? {
+  if (rawValue == null) return null
+
+  return try {
+    when (type) {
+      KeyValueType.String -> rawValue
+      KeyValueType.Int -> rawValue.toIntOrNull() ?: rawValue
+      KeyValueType.Long -> rawValue.toLongOrNull() ?: rawValue
+      KeyValueType.Float -> rawValue.toFloatOrNull() ?: rawValue
+      KeyValueType.Boolean -> rawValue.toBooleanStrictOrNull() ?: rawValue
+      KeyValueType.StringSet ->
+        json.parseToJsonElement(rawValue).jsonArray.map { it.jsonPrimitive.content }.toSet()
+      KeyValueType.Unknown -> rawValue
+    }
+  } catch (_: Exception) {
+    // A value that doesn't match its declared type is the device's business, not a client error --
+    // show it verbatim rather than losing the update.
+    rawValue
+  }
+}
+
+/**
+ * Applies one live [StorageStreamUpdate] to the currently displayed files.
+ *
+ * The three protocol cases are distinguished by nullability, per `StorageChangedEvent`:
+ * - null `key` — the whole file was cleared, so its entries are emptied.
+ * - null `value` with a non-null key — that key was deleted.
+ * - otherwise — the key was added or updated.
+ *
+ * Updates for a file the inspector hasn't loaded are ignored: the fetched file list defines what is
+ * visible, and synthesizing a file here would require inventing an on-device path.
+ *
+ * Returns the receiver unchanged when nothing matched, so callers can skip recomposition.
+ */
+internal fun List<KeyValueFile>.applyStorageUpdate(
+  update: StorageStreamUpdate
+): List<KeyValueFile> {
+  val target = firstOrNull { it.name == update.fileName } ?: return this
+  val changedKey = update.key
+  val newValue = update.value
+
+  val updatedEntries =
+    when {
+      changedKey == null -> emptyList()
+      newValue == null -> target.entries.filterNot { it.key == changedKey }
+      else -> {
+        val entry =
+          KeyValueEntry(
+            key = changedKey,
+            value = parseKeyValue(newValue, update.valueType),
+            type = update.valueType,
+          )
+        val existingIndex = target.entries.indexOfFirst { it.key == changedKey }
+        if (existingIndex >= 0) {
+          target.entries.toMutableList().apply { this[existingIndex] = entry }
+        } else {
+          target.entries + entry
+        }
+      }
+    }
+
+  if (updatedEntries == target.entries) return this
+
+  return map { file ->
+    if (file.name == update.fileName) file.copy(entries = updatedEntries) else file
+  }
+}
+
+/**
+ * The highlight identities a live update should light up: the single changed key, or every key in a
+ * cleared file.
+ */
+internal fun StorageStreamUpdate.highlightKeys(files: List<KeyValueFile>): Set<String> =
+  if (isFileCleared) {
+    files
+      .firstOrNull { it.name == fileName }
+      ?.entries
+      ?.map { highlightKey(fileName, it.key) }
+      ?.toSet() ?: emptySet()
+  } else {
+    key?.let { setOf(highlightKey(fileName, it)) } ?: emptySet()
+  }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/StorageDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/storage/StorageDashboard.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.datasource.StorageDataSource
@@ -33,6 +34,9 @@ import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 
 private val LOG = LoggerFactory.getLogger("StorageDashboard")
+
+/** How long a live-changed entry stays highlighted in the key-value inspector. */
+private const val HIGHLIGHT_DURATION_MS = 2000L
 
 /** Storage tab options. */
 enum class StorageTab(val title: String, val icon: String) {
@@ -49,6 +53,8 @@ fun StorageDashboard(
   deviceId: String? = null,
   packageName: String? = null,
   platform: StoragePlatform = StoragePlatform.Android,
+  observationStreamClient: ObservationStreamClient? =
+    null, // Shared stream client for live storage changes
 ) {
   val graph = LocalAutoMobileGraph.current
   val colors = SharedTheme.globalColors
@@ -60,6 +66,39 @@ fun StorageDashboard(
   var keyValueFiles by remember { mutableStateOf<List<KeyValueFile>>(emptyList()) }
   var isLoading by remember { mutableStateOf(true) }
   var error by remember { mutableStateOf<String?>(null) }
+
+  // Live key/value changes pushed by the daemon. Highlight expiry is tracked per key rather than
+  // as one shared deadline, so a later change can't cut short an earlier key's highlight.
+  var highlightExpiries by remember { mutableStateOf<Map<String, Long>>(emptyMap()) }
+  val recentlyChangedKeys = highlightExpiries.keys
+
+  LaunchedEffect(observationStreamClient, deviceId, packageName) {
+    if (observationStreamClient == null) return@LaunchedEffect
+
+    observationStreamClient.storageUpdates.collect { update ->
+      // The stream is device-scoped but not package-scoped, so filter to the inspected app.
+      if (deviceId != null && update.deviceId != null && update.deviceId != deviceId) {
+        return@collect
+      }
+      if (packageName != null && update.packageName != packageName) return@collect
+
+      val newlyHighlighted = update.highlightKeys(keyValueFiles)
+      keyValueFiles = keyValueFiles.applyStorageUpdate(update)
+      if (newlyHighlighted.isNotEmpty()) {
+        val expiresAt = System.currentTimeMillis() + HIGHLIGHT_DURATION_MS
+        highlightExpiries = highlightExpiries + newlyHighlighted.associateWith { expiresAt }
+      }
+    }
+  }
+
+  // Drop highlights as they individually expire. Writing the map restarts this effect, which then
+  // schedules the next-soonest expiry, so one pass per restart is enough -- no loop needed.
+  LaunchedEffect(highlightExpiries) {
+    val nextExpiry = highlightExpiries.values.minOrNull() ?: return@LaunchedEffect
+    val waitMs = nextExpiry - System.currentTimeMillis()
+    if (waitMs > 0) kotlinx.coroutines.delay(waitMs)
+    highlightExpiries = highlightExpiries.filterValues { it > System.currentTimeMillis() }
+  }
 
   LaunchedEffect(dataSourceMode, clientProvider, deviceId, packageName) {
     LOG.info(
@@ -203,6 +242,7 @@ fun StorageDashboard(
             dataSource?.let { ds ->
               { fileName, key, value, type -> ds.setKeyValue(fileName, key, value, type) }
             },
+          recentlyChangedKeys = recentlyChangedKeys,
           modifier = Modifier.fillMaxSize(),
         )
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamStorageTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamStorageTest.kt
@@ -1,0 +1,158 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import app.cash.turbine.test
+import dev.jasonpearson.automobile.desktop.domain.KeyValueType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Covers the `storage_update` frame and the `request_observation` command added for #3930.
+ *
+ * Inbound frames are injected through `handleMessage` in the same way as the sibling stream tests;
+ * no socket is involved.
+ */
+class ObservationStreamStorageTest {
+  private val wireJson = Json { ignoreUnknownKeys = true }
+
+  private fun storageFrame(
+    key: String? = "\"theme\"",
+    value: String? = "\"dark\"",
+    valueType: String = "STRING",
+  ) =
+    """
+    {
+      "type": "storage_update",
+      "deviceId": "emulator-5554",
+      "timestamp": 9999,
+      "storageEvent": {
+        "packageName": "com.example",
+        "fileName": "prefs.xml",
+        "key": ${key ?: "null"},
+        "value": ${value ?: "null"},
+        "valueType": "$valueType",
+        "timestamp": 1234,
+        "sequenceNumber": 7
+      }
+    }
+    """
+      .trimIndent()
+
+  @Test
+  fun `emits a storage update from a storage_update frame`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.storageUpdates.test {
+      client.handleMessage(storageFrame())
+
+      val update = awaitItem()
+      assertEquals("emulator-5554", update.deviceId)
+      assertEquals("com.example", update.packageName)
+      assertEquals("prefs.xml", update.fileName)
+      assertEquals("theme", update.key)
+      assertEquals("dark", update.value)
+      assertEquals(KeyValueType.String, update.valueType)
+      assertEquals(7L, update.sequenceNumber)
+    }
+  }
+
+  @Test
+  fun `uses the device-side event timestamp rather than the frame timestamp`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.storageUpdates.test {
+      client.handleMessage(storageFrame())
+
+      // 1234 is when the change happened on device; 9999 is when the daemon relayed it.
+      assertEquals(1234L, awaitItem().timestamp)
+    }
+  }
+
+  @Test
+  fun `a null key marks the frame as a whole-file clear`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.storageUpdates.test {
+      client.handleMessage(storageFrame(key = null, value = null))
+
+      val update = awaitItem()
+      assertNull(update.key)
+      assertTrue(update.isFileCleared)
+    }
+  }
+
+  @Test
+  fun `a null value with a key is a delete, not a clear`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.storageUpdates.test {
+      client.handleMessage(storageFrame(value = null))
+
+      val update = awaitItem()
+      assertEquals("theme", update.key)
+      assertNull(update.value)
+      assertTrue(!update.isFileCleared)
+    }
+  }
+
+  @Test
+  fun `an unrecognized value type degrades to Unknown`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.storageUpdates.test {
+      // iOS emits DICTIONARY, which the desktop enum has no member for.
+      client.handleMessage(storageFrame(valueType = "DICTIONARY"))
+
+      assertEquals(KeyValueType.Unknown, awaitItem().valueType)
+    }
+  }
+
+  @Test
+  fun `a storage_update without a payload is ignored rather than crashing`() = runTest {
+    val client = ObservationStreamClient()
+
+    client.storageUpdates.test {
+      client.handleMessage("""{"type":"storage_update","deviceId":"emulator-5554"}""")
+
+      expectNoEvents()
+    }
+  }
+
+  @Test
+  fun `request_observation carries the device id and no cadence fields`() {
+    val request =
+      StreamRequest(
+        id = "req-1",
+        command = "request_observation",
+        deviceId = "emulator-5554",
+      )
+
+    val encoded = wireJson.encodeToString(StreamRequest.serializer(), request)
+
+    assertTrue(encoded.contains("\"command\":\"request_observation\""), encoded)
+    assertTrue(encoded.contains("\"deviceId\":\"emulator-5554\""), encoded)
+    // A one-shot capture must not disturb the subscription's cadence.
+    assertTrue(!encoded.contains("screenshotIntervalMs"), encoded)
+    assertTrue(!encoded.contains("hierarchyIntervalMs"), encoded)
+  }
+
+  @Test
+  fun `request_observation omits the device id when capturing every device`() {
+    val request = StreamRequest(id = "req-1", command = "request_observation", deviceId = null)
+
+    val encoded = wireJson.encodeToString(StreamRequest.serializer(), request)
+
+    assertTrue(!encoded.contains("deviceId"), encoded)
+  }
+
+  @Test
+  fun `requestObservation is a no-op while disconnected`() {
+    val client = ObservationStreamClient()
+
+    // Must not throw despite there being no socket; the daemon may not be running.
+    client.requestObservation("emulator-5554")
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueLiveUpdatesTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/storage/KeyValueLiveUpdatesTest.kt
@@ -1,0 +1,190 @@
+package dev.jasonpearson.automobile.desktop.core.storage
+
+import dev.jasonpearson.automobile.desktop.core.daemon.StorageStreamUpdate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/** Covers how a live `storage_update` frame is folded into the displayed key-value files. */
+class KeyValueLiveUpdatesTest {
+
+  private fun file(name: String, vararg entries: Pair<String, Any?>) =
+    KeyValueFile(
+      name = name,
+      path = "/data/data/com.example/shared_prefs/$name",
+      platform = StoragePlatform.Android,
+      entries = entries.map { (k, v) -> KeyValueEntry(k, v, KeyValueType.String) },
+    )
+
+  private fun update(
+    fileName: String = "prefs.xml",
+    key: String? = "theme",
+    value: String? = "dark",
+    valueType: KeyValueType = KeyValueType.String,
+    packageName: String = "com.example",
+  ) =
+    StorageStreamUpdate(
+      deviceId = "emulator-5554",
+      timestamp = 1_000L,
+      packageName = packageName,
+      fileName = fileName,
+      key = key,
+      value = value,
+      valueType = valueType,
+      sequenceNumber = 1L,
+    )
+
+  @Test
+  fun `an updated key replaces its value in place`() {
+    val files = listOf(file("prefs.xml", "theme" to "light", "locale" to "en"))
+
+    val result = files.applyStorageUpdate(update(key = "theme", value = "dark"))
+
+    val entries = result.single().entries
+    assertEquals(listOf("theme", "locale"), entries.map { it.key }, "order should be preserved")
+    assertEquals("dark", entries.first { it.key == "theme" }.value)
+  }
+
+  @Test
+  fun `a new key is appended`() {
+    val files = listOf(file("prefs.xml", "theme" to "light"))
+
+    val result = files.applyStorageUpdate(update(key = "fontScale", value = "1.5"))
+
+    assertEquals(listOf("theme", "fontScale"), result.single().entries.map { it.key })
+  }
+
+  @Test
+  fun `a null value deletes the key`() {
+    val files = listOf(file("prefs.xml", "theme" to "light", "locale" to "en"))
+
+    val result = files.applyStorageUpdate(update(key = "theme", value = null))
+
+    assertEquals(listOf("locale"), result.single().entries.map { it.key })
+  }
+
+  @Test
+  fun `a null key clears the whole file`() {
+    val files = listOf(file("prefs.xml", "theme" to "light", "locale" to "en"))
+
+    val result = files.applyStorageUpdate(update(key = null, value = null))
+
+    assertTrue(result.single().entries.isEmpty())
+  }
+
+  @Test
+  fun `other files are left untouched`() {
+    val files = listOf(file("prefs.xml", "theme" to "light"), file("other.xml", "theme" to "keep"))
+
+    val result = files.applyStorageUpdate(update(fileName = "prefs.xml", value = "dark"))
+
+    assertEquals("keep", result.first { it.name == "other.xml" }.entries.single().value)
+  }
+
+  @Test
+  fun `an update for an unloaded file is ignored`() {
+    val files = listOf(file("prefs.xml", "theme" to "light"))
+
+    val result = files.applyStorageUpdate(update(fileName = "never-fetched.xml"))
+
+    assertSame(files, result, "unchanged input should be returned as-is")
+  }
+
+  @Test
+  fun `a no-op delete returns the same instance`() {
+    val files = listOf(file("prefs.xml", "theme" to "light"))
+
+    val result = files.applyStorageUpdate(update(key = "absent", value = null))
+
+    assertSame(files, result, "no entry changed, so recomposition should be skippable")
+  }
+
+  @Test
+  fun `typed values are decoded to their kotlin types`() {
+    val files = listOf(file("prefs.xml", "count" to 0))
+
+    val asInt =
+      files.applyStorageUpdate(update(key = "count", value = "42", valueType = KeyValueType.Int))
+    assertEquals(42, asInt.single().entries.single().value)
+
+    val asBool =
+      files.applyStorageUpdate(
+        update(key = "count", value = "true", valueType = KeyValueType.Boolean)
+      )
+    assertEquals(true, asBool.single().entries.single().value)
+
+    val asSet =
+      files.applyStorageUpdate(
+        update(key = "count", value = """["a","b"]""", valueType = KeyValueType.StringSet)
+      )
+    assertEquals(setOf("a", "b"), asSet.single().entries.single().value)
+  }
+
+  @Test
+  fun `a value that does not match its declared type falls back to the raw string`() {
+    val files = listOf(file("prefs.xml", "count" to 0))
+
+    val result =
+      files.applyStorageUpdate(
+        update(key = "count", value = "not-a-number", valueType = KeyValueType.Int)
+      )
+
+    assertEquals("not-a-number", result.single().entries.single().value)
+  }
+
+  @Test
+  fun `a malformed string set falls back rather than throwing`() {
+    val files = listOf(file("prefs.xml", "tags" to ""))
+
+    val result =
+      files.applyStorageUpdate(
+        update(key = "tags", value = "{not json", valueType = KeyValueType.StringSet)
+      )
+
+    assertEquals("{not json", result.single().entries.single().value)
+  }
+
+  @Test
+  fun `highlight keys are scoped by file name`() {
+    val files = listOf(file("prefs.xml", "theme" to "light"))
+
+    assertEquals(setOf("prefs.xml:theme"), update(key = "theme").highlightKeys(files))
+  }
+
+  @Test
+  fun `clearing a file highlights every key it had`() {
+    val files = listOf(file("prefs.xml", "theme" to "light", "locale" to "en"))
+
+    assertEquals(
+      setOf("prefs.xml:theme", "prefs.xml:locale"),
+      update(key = null, value = null).highlightKeys(files),
+    )
+  }
+
+  @Test
+  fun `an unknown protocol type degrades to Unknown instead of dropping the update`() {
+    val files = listOf(file("prefs.xml", "when" to ""))
+
+    // DATE is emitted by iOS devices but has no desktop enum member.
+    val result =
+      files.applyStorageUpdate(
+        update(
+          key = "when",
+          value = "2026-07-19",
+          valueType = KeyValueType.fromProtocolName("DATE"),
+        )
+      )
+
+    val entry = result.single().entries.single()
+    assertEquals(KeyValueType.Unknown, entry.type)
+    assertEquals("2026-07-19", entry.value)
+  }
+
+  @Test
+  fun `protocol names map case-insensitively`() {
+    assertEquals(KeyValueType.StringSet, KeyValueType.fromProtocolName("string_set"))
+    assertEquals(KeyValueType.Int, KeyValueType.fromProtocolName("INT"))
+    assertEquals(KeyValueType.Unknown, KeyValueType.fromProtocolName("nonsense"))
+  }
+}

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/StorageModels.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/StorageModels.kt
@@ -68,7 +68,18 @@ public enum class KeyValueType(public val protocolName: kotlin.String) {
   Float("FLOAT"),
   Boolean("BOOLEAN"),
   StringSet("STRING_SET"),
-  Unknown("UNKNOWN"),
+  Unknown("UNKNOWN");
+
+  public companion object {
+    /**
+     * Maps a daemon `valueType` string onto this enum, case-insensitively.
+     *
+     * The daemon's type union is wider than this enum — it also emits DOUBLE, DATA, DATE, ARRAY and
+     * DICTIONARY for iOS — so anything unrecognized becomes [Unknown] rather than failing.
+     */
+    public fun fromProtocolName(protocolName: kotlin.String): KeyValueType =
+      entries.firstOrNull { it.protocolName.equals(protocolName, ignoreCase = true) } ?: Unknown
+  }
 }
 
 public enum class StoragePlatform {


### PR DESCRIPTION
Two of the three signals from #3930 (epic #3933). The third is split out to #3978 — rationale below.

## `storage_update` → live key-value inspector

The daemon has been pushing live key/value changes on the observation stream (`pushStorageUpdate`, `deviceDataStreamSocketServer.ts:357`), but `ObservationStreamClient` had no branch for the frame, so it fell through to the unknown-type warning and `KeyValueInspector` never saw a change. The inspector even carried a placeholder comment for a producer that was never connected.

The client now parses the frame onto a new `storageUpdates` flow, using the performance flow's non-blocking buffer policy since storage writes arrive in bursts (a screen persisting several preferences at once). The update carries the event's **device-side** timestamp rather than the daemon's relay clock, since that is what ordering wants.

The merge itself is a pure function, `applyStorageUpdate`, rather than logic buried in a composable — which is what makes the three protocol cases directly testable:

| wire | meaning | behavior |
|---|---|---|
| `key: null` | whole file cleared | entries emptied |
| `value: null`, key set | key deleted | entry removed |
| otherwise | added or updated | upserted **in place**, preserving order |

Updates for a file the inspector never fetched are ignored — synthesizing one would mean inventing an on-device path — and an unchanged result returns the receiver unchanged so recomposition can be skipped.

`recentlyChangedKeys` is hoisted out of `KeyValueInspector` up to `StorageDashboard`, which owns the live source. Highlight expiry is now tracked **per key** rather than as one shared deadline; previously a later change would have cut short an earlier key's highlight window.

## `request_observation` → one-shot capture

Adds `requestObservation(deviceId)`, mirroring the existing `requestNavigationGraph`: a single capture that leaves the subscription cadence untouched, with the hierarchy arriving out-of-band on the existing flow. The wire test asserts the request carries no cadence fields, since the whole point is not to disturb the subscription.

## Reuse rather than duplication

Value coercion and type mapping were private to `RealStorageDataSource` and needed by the live path too. Instead of a second copy, the type mapping moves to `KeyValueType.fromProtocolName` next to the enum it maps to (and is now case-insensitive), and value parsing to a shared `parseKeyValue`; `RealStorageDataSource` delegates to both — a net deletion there.

Unrecognized wire types degrade to `Unknown` instead of dropping the update. This matters concretely: the daemon's type union emits `DOUBLE`/`DATA`/`DATE`/`ARRAY`/`DICTIONARY` for iOS, none of which the desktop enum has members for.

## Why `list_changed` is not here

It is not a small self-contained addition, for a reason #3930 did not anticipate. `McpDaemonClient` opens a fresh socket per call, writes one line, reads one line, and closes ([McpDaemonClient.kt:469](android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt:469)) — there is no persistent connection or reader loop, so an unprompted `daemon_notification` frame can never arrive. Separately, #3930 says "its cached tool/resource lists can go stale," but the client caches nothing; the actual staleness is in `McpProcessesPanel.kt:1071`, which fetches once per pid into composable state.

So that item is a transport change affecting every `McpDaemonClient` caller, and it is tracked with full findings in #3978 to land on its own.

## Testing

23 new tests, 442 desktop-core green, 0 failures. `:desktop-app:compileKotlin` passes; ktfmt applied.

- `KeyValueLiveUpdatesTest` (14) — the merge matrix above, order preservation, unloaded-file and no-op cases returning the same instance, typed decoding (Int/Boolean/StringSet), and malformed values falling back to the raw string instead of throwing.
- `ObservationStreamStorageTest` (9) — frame parsing, the timestamp choice, clear-vs-delete, unknown type degradation, a payload-less frame being ignored rather than crashing, and the `request_observation` wire shape.

No socket or device is required by any of them.