### PR TITLE
feat(desktop): wire device snapshot capture, restore and retention config

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -65,9 +65,13 @@ import dev.jasonpearson.automobile.desktop.core.components.Tooltip
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotActions
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotConfigClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
 import dev.jasonpearson.automobile.desktop.core.daemon.FailuresPushSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
+import dev.jasonpearson.automobile.desktop.core.daemon.McpDeviceSnapshotActions
 import dev.jasonpearson.automobile.desktop.core.daemon.McpHttpClient
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
@@ -116,6 +120,7 @@ import dev.jasonpearson.automobile.desktop.core.shell.SearchResult
 import dev.jasonpearson.automobile.desktop.core.shell.SearchResultProvider
 import dev.jasonpearson.automobile.desktop.core.shell.ThreePaneShell
 import dev.jasonpearson.automobile.desktop.core.shell.buildDefaultCommands
+import dev.jasonpearson.automobile.desktop.core.snapshot.SnapshotsDashboard
 import dev.jasonpearson.automobile.desktop.core.storage.StorageDashboard
 import dev.jasonpearson.automobile.desktop.core.storage.StoragePlatform
 import dev.jasonpearson.automobile.desktop.core.tabs.HorizontalTab
@@ -320,6 +325,7 @@ fun AutoMobileContent(
     listOf(
       HorizontalTab("test_runs", "Test Runs", AppIcons.TestRuns),
       HorizontalTab("storage", "Storage", AppIcons.Storage),
+      HorizontalTab("snapshots", "Snapshots", AppIcons.Snapshots),
       HorizontalTab("diagnostics", "Diagnostics", AppIcons.Diagnostics),
     )
   }
@@ -482,6 +488,16 @@ fun AutoMobileContent(
           }
         }
       }
+    }
+
+  // Device snapshots span two transports: the verbs are MCP tool/resource calls, while the
+  // retention config is its own Unix socket. Both are null in Fake mode so the dashboard renders
+  // its empty state instead of reaching for a daemon that isn't there.
+  val snapshotActions: DeviceSnapshotActions? =
+    remember(clientProvider) { clientProvider?.let { McpDeviceSnapshotActions(it) } }
+  val snapshotConfigClient: DeviceSnapshotConfigClient? =
+    remember(dataSourceMode) {
+      if (dataSourceMode == DataSourceMode.Real) DeviceSnapshotSocketClient() else null
     }
 
   // Take-screenshot is driven from both the native menu bar and the in-app menu.
@@ -1363,6 +1379,12 @@ fun AutoMobileContent(
                       packageName = selectedAppId,
                       platform = storagePlatform,
                       observationStreamClient = observationStreamClient,
+                    )
+                  "snapshots" ->
+                    SnapshotsDashboard(
+                      actions = snapshotActions,
+                      configClient = snapshotConfigClient,
+                      activeDeviceId = activeDeviceId,
                     )
                   "diagnostics" ->
                     DiagnosticsDashboard(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileSocketPaths.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileSocketPaths.kt
@@ -1,0 +1,27 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Resolves the daemon's auxiliary socket paths, which all live in `~/.auto-mobile/`.
+ *
+ * This is the single place that knows that layout. The control socket is deliberately not here --
+ * it lives under the temp dir with a uid suffix and its own Windows fallback, so it keeps its own
+ * resolver in [DaemonSocketPaths].
+ */
+object AutoMobileSocketPaths {
+  private const val SOCKET_DIR = ".auto-mobile"
+
+  /** Absolute path of the named socket, e.g. `socketPath("device-snapshot.sock")`. */
+  fun socketPath(fileName: String): String {
+    // Falling back to "." keeps this a relative path rather than interpolating "null" into it on
+    // the rare JVM where user.home is unset.
+    val home = System.getProperty("user.home", "").ifBlank { "." }
+    return File(home, "$SOCKET_DIR/$fileName").path
+  }
+
+  /** True when the daemon currently exposes this socket. False on daemons that predate it. */
+  fun socketExists(fileName: String): Boolean = Files.exists(Path.of(socketPath(fileName)))
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
@@ -85,7 +85,8 @@ class McpDeviceSnapshotActions(private val clientProvider: () -> AutoMobileClien
         }
       )
     return DeviceSnapshotCaptureResult(
-      snapshotName = response.snapshotName ?: throw McpConnectionException("Capture returned no snapshotName"),
+      snapshotName =
+        response.snapshotName ?: throw McpConnectionException("Capture returned no snapshotName"),
       snapshotType = response.snapshotType.orEmpty(),
       evictedSnapshotNames = response.evictedSnapshotNames,
     )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
@@ -1,0 +1,156 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/** MCP resource listing every captured snapshot. */
+internal const val DEVICE_SNAPSHOT_ARCHIVE_URI = "automobile:deviceSnapshots/archive"
+
+private val snapshotJson = Json { ignoreUnknownKeys = true }
+
+/** Metadata for one captured snapshot, as listed by the archive resource. */
+@Serializable
+data class DeviceSnapshotMetadata(
+  val snapshotName: String,
+  val deviceId: String = "",
+  val deviceName: String = "",
+  val platform: String = "",
+  val snapshotType: String = "",
+  val includeAppData: Boolean = false,
+  val includeSettings: Boolean = false,
+  val createdAt: String = "",
+  val lastAccessedAt: String = "",
+  val sizeBytes: Long = 0,
+)
+
+/** The archive resource payload. */
+@Serializable
+internal data class DeviceSnapshotArchive(
+  val snapshots: List<DeviceSnapshotMetadata> = emptyList(),
+  val count: Int = 0,
+  val totalSizeBytes: Long = 0,
+  val error: String? = null,
+)
+
+/** Outcome of a capture, including anything the daemon evicted to make room. */
+data class DeviceSnapshotCaptureResult(
+  val snapshotName: String,
+  val snapshotType: String,
+  val evictedSnapshotNames: List<String> = emptyList(),
+)
+
+/**
+ * Capture, restore and list operations for device snapshots.
+ *
+ * These are deliberately *not* on `device-snapshot.sock` -- that socket only carries configuration.
+ * The verbs are MCP tool actions and a resource read, so they go over the regular client.
+ */
+interface DeviceSnapshotActions {
+  fun listSnapshots(): List<DeviceSnapshotMetadata>
+
+  fun captureSnapshot(deviceId: String, snapshotName: String? = null): DeviceSnapshotCaptureResult
+
+  fun restoreSnapshot(deviceId: String, snapshotName: String)
+}
+
+/** [DeviceSnapshotActions] backed by the `deviceSnapshot` MCP tool and the archive resource. */
+class McpDeviceSnapshotActions(private val clientProvider: () -> AutoMobileClient) :
+  DeviceSnapshotActions {
+
+  override fun listSnapshots(): List<DeviceSnapshotMetadata> {
+    val client = clientProvider()
+    val archive =
+      decodeResourceResponse(
+        snapshotJson,
+        client.readResource(DEVICE_SNAPSHOT_ARCHIVE_URI),
+        DeviceSnapshotArchive.serializer(),
+      )
+    return archive.snapshots
+  }
+
+  override fun captureSnapshot(
+    deviceId: String,
+    snapshotName: String?,
+  ): DeviceSnapshotCaptureResult {
+    val response =
+      callSnapshotTool(
+        buildJsonObject {
+          put("action", JsonPrimitive("capture"))
+          put("deviceId", JsonPrimitive(deviceId))
+          if (snapshotName != null) put("snapshotName", JsonPrimitive(snapshotName))
+        }
+      )
+    return DeviceSnapshotCaptureResult(
+      snapshotName = response.snapshotName ?: throw McpConnectionException("Capture returned no snapshotName"),
+      snapshotType = response.snapshotType.orEmpty(),
+      evictedSnapshotNames = response.evictedSnapshotNames,
+    )
+  }
+
+  override fun restoreSnapshot(deviceId: String, snapshotName: String) {
+    callSnapshotTool(
+      buildJsonObject {
+        put("action", JsonPrimitive("restore"))
+        put("deviceId", JsonPrimitive(deviceId))
+        // Required by the tool schema for restore; capture treats it as optional.
+        put("snapshotName", JsonPrimitive(snapshotName))
+      }
+    )
+  }
+
+  private fun callSnapshotTool(arguments: JsonObject): DeviceSnapshotToolResponse {
+    val client = clientProvider()
+    return decodeToolResponse(
+      snapshotJson,
+      client.callTool("deviceSnapshot", arguments),
+      DeviceSnapshotToolResponse.serializer(),
+    )
+  }
+}
+
+@Serializable
+internal data class DeviceSnapshotToolResponse(
+  val message: String? = null,
+  val snapshotName: String? = null,
+  val snapshotType: String? = null,
+  val deviceId: String? = null,
+  val deviceName: String? = null,
+  // Omitted by the daemon when nothing was evicted.
+  val evictedSnapshotNames: List<String> = emptyList(),
+)
+
+/** In-memory [DeviceSnapshotActions] for previews and tests. */
+class FakeDeviceSnapshotActions(
+  initialSnapshots: List<DeviceSnapshotMetadata> = emptyList(),
+  private val evictOnCapture: List<String> = emptyList(),
+) : DeviceSnapshotActions {
+  private val snapshots = initialSnapshots.toMutableList()
+
+  var restoredSnapshotName: String? = null
+    private set
+
+  override fun listSnapshots(): List<DeviceSnapshotMetadata> = snapshots.toList()
+
+  override fun captureSnapshot(
+    deviceId: String,
+    snapshotName: String?,
+  ): DeviceSnapshotCaptureResult {
+    val name = snapshotName ?: "snapshot-${snapshots.size + 1}"
+    snapshots.add(
+      DeviceSnapshotMetadata(snapshotName = name, deviceId = deviceId, snapshotType = "full")
+    )
+    snapshots.removeAll { it.snapshotName in evictOnCapture }
+    return DeviceSnapshotCaptureResult(name, "full", evictOnCapture)
+  }
+
+  override fun restoreSnapshot(deviceId: String, snapshotName: String) {
+    if (snapshots.none { it.snapshotName == snapshotName }) {
+      throw McpConnectionException("Snapshot '$snapshotName' not found")
+    }
+    restoredSnapshotName = snapshotName
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
@@ -118,22 +118,22 @@ class DeviceSnapshotSocketClient(
       val reader =
         BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
       val writer =
-        BufferedWriter(OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8))
+        BufferedWriter(
+          OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+        )
 
       writer.write(json.encodeToString(DeviceSnapshotSocketRequest.serializer(), request))
       writer.newLine()
       writer.flush()
 
-      val line =
-        reader.readLine() ?: throw McpConnectionException("Device snapshot socket closed")
+      val line = reader.readLine() ?: throw McpConnectionException("Device snapshot socket closed")
       val response = json.decodeFromString(DeviceSnapshotSocketResponse.serializer(), line)
 
       if (!response.success) {
         throw McpConnectionException(response.error ?: "Device snapshot request failed")
       }
       val result =
-        response.result
-          ?: throw McpConnectionException("Device snapshot response missing result")
+        response.result ?: throw McpConnectionException("Device snapshot response missing result")
 
       return DeviceSnapshotConfigResult(
         config = result.config,
@@ -157,8 +157,7 @@ internal data class DeviceSnapshotSocketRequest(
   val params: DeviceSnapshotSocketParams? = null,
 )
 
-@Serializable
-internal data class DeviceSnapshotSocketParams(val config: DeviceSnapshotConfigInput?)
+@Serializable internal data class DeviceSnapshotSocketParams(val config: DeviceSnapshotConfigInput?)
 
 @Serializable
 internal data class DeviceSnapshotSocketResponse(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
@@ -1,0 +1,207 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Socket file the daemon binds for device-snapshot configuration. */
+internal const val DEVICE_SNAPSHOT_SOCKET_FILE = "device-snapshot.sock"
+
+/**
+ * Retention and capture defaults for device snapshots, as stored by the daemon.
+ *
+ * Every field is required in a daemon response; defaults exist only so that a daemon which grows a
+ * new field doesn't break decoding here.
+ */
+@Serializable
+data class DeviceSnapshotConfig(
+  val includeAppData: Boolean = true,
+  val includeSettings: Boolean = true,
+  val useVmSnapshot: Boolean = false,
+  val strictBackupMode: Boolean = false,
+  val backupTimeoutMs: Long = 0,
+  val userApps: String = "current",
+  val vmSnapshotTimeoutMs: Long = 0,
+  val maxArchiveSizeMb: Long = 0,
+)
+
+/**
+ * A partial config update. Only non-null fields are sent, so callers can change one setting without
+ * restating the rest.
+ */
+@Serializable
+data class DeviceSnapshotConfigInput(
+  val includeAppData: Boolean? = null,
+  val includeSettings: Boolean? = null,
+  val useVmSnapshot: Boolean? = null,
+  val strictBackupMode: Boolean? = null,
+  val backupTimeoutMs: Long? = null,
+  val userApps: String? = null,
+  val vmSnapshotTimeoutMs: Long? = null,
+  val maxArchiveSizeMb: Long? = null,
+)
+
+/**
+ * Result of a config read or write.
+ *
+ * [evictedSnapshotNames] is only ever populated by a write that shrank the archive budget; the
+ * daemon omits the field entirely when nothing was evicted, and on every read.
+ */
+data class DeviceSnapshotConfigResult(
+  val config: DeviceSnapshotConfig,
+  val evictedSnapshotNames: List<String> = emptyList(),
+)
+
+/** Reads and writes the daemon's device-snapshot configuration. */
+interface DeviceSnapshotConfigClient {
+  fun getConfig(): DeviceSnapshotConfigResult
+
+  /** Applies a partial update. Passing an all-null [input] resets the config to daemon defaults. */
+  fun setConfig(input: DeviceSnapshotConfigInput): DeviceSnapshotConfigResult
+
+  /** True when the daemon exposes this socket; false on daemons that predate it. */
+  fun isAvailable(): Boolean
+}
+
+/**
+ * Client for `~/.auto-mobile/device-snapshot.sock`.
+ *
+ * This socket is a *config* socket: its entire method surface is `config/get` and `config/set`.
+ * Capturing and restoring snapshots is not available here -- those are MCP tool actions, exposed
+ * through [DeviceSnapshotActions].
+ *
+ * One request per connection, matching the daemon's line-per-message request/response contract.
+ */
+class DeviceSnapshotSocketClient(
+  private val socketPathValue: String =
+    AutoMobileSocketPaths.socketPath(DEVICE_SNAPSHOT_SOCKET_FILE),
+  private val json: Json = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+    // The daemon requires `type` and `method` on every request; kotlinx omits properties left at
+    // their default, so without this the envelope would go out incomplete.
+    encodeDefaults = true
+  },
+) : DeviceSnapshotConfigClient {
+
+  override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())
+
+  override fun getConfig(): DeviceSnapshotConfigResult =
+    send(DeviceSnapshotSocketRequest(id = UUID.randomUUID().toString(), method = "config/get"))
+
+  override fun setConfig(input: DeviceSnapshotConfigInput): DeviceSnapshotConfigResult =
+    send(
+      DeviceSnapshotSocketRequest(
+        id = UUID.randomUUID().toString(),
+        method = "config/set",
+        // `config` must be present for config/set even when empty -- the daemon rejects a request
+        // whose params omit the key.
+        params = DeviceSnapshotSocketParams(config = input),
+      )
+    )
+
+  private fun send(request: DeviceSnapshotSocketRequest): DeviceSnapshotConfigResult {
+    ensureSocketExists()
+
+    val address = UnixDomainSocketAddress.of(socketPathValue)
+    SocketChannel.open(address).use { channel ->
+      val reader =
+        BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
+      val writer =
+        BufferedWriter(OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8))
+
+      writer.write(json.encodeToString(DeviceSnapshotSocketRequest.serializer(), request))
+      writer.newLine()
+      writer.flush()
+
+      val line =
+        reader.readLine() ?: throw McpConnectionException("Device snapshot socket closed")
+      val response = json.decodeFromString(DeviceSnapshotSocketResponse.serializer(), line)
+
+      if (!response.success) {
+        throw McpConnectionException(response.error ?: "Device snapshot request failed")
+      }
+      val result =
+        response.result
+          ?: throw McpConnectionException("Device snapshot response missing result")
+
+      return DeviceSnapshotConfigResult(
+        config = result.config,
+        evictedSnapshotNames = result.evictedSnapshotNames,
+      )
+    }
+  }
+
+  private fun ensureSocketExists() {
+    if (!isAvailable()) {
+      throw McpConnectionException("Device snapshot socket not found at $socketPathValue")
+    }
+  }
+}
+
+@Serializable
+internal data class DeviceSnapshotSocketRequest(
+  val id: String,
+  val type: String = "device_snapshot_request",
+  val method: String,
+  val params: DeviceSnapshotSocketParams? = null,
+)
+
+@Serializable
+internal data class DeviceSnapshotSocketParams(val config: DeviceSnapshotConfigInput?)
+
+@Serializable
+internal data class DeviceSnapshotSocketResponse(
+  val id: String? = null,
+  val type: String? = null,
+  val success: Boolean = false,
+  val result: DeviceSnapshotSocketResult? = null,
+  val error: String? = null,
+)
+
+@Serializable
+internal data class DeviceSnapshotSocketResult(
+  val config: DeviceSnapshotConfig,
+  // Absent on reads and on writes that evicted nothing.
+  val evictedSnapshotNames: List<String> = emptyList(),
+)
+
+/** In-memory [DeviceSnapshotConfigClient] for previews and tests. */
+class FakeDeviceSnapshotConfigClient(
+  initialConfig: DeviceSnapshotConfig = DeviceSnapshotConfig(),
+  private val available: Boolean = true,
+  /** Names reported as evicted by the next [setConfig], mirroring a shrunken archive budget. */
+  private val evictOnSet: List<String> = emptyList(),
+) : DeviceSnapshotConfigClient {
+  var config: DeviceSnapshotConfig = initialConfig
+    private set
+
+  override fun isAvailable(): Boolean = available
+
+  override fun getConfig(): DeviceSnapshotConfigResult = DeviceSnapshotConfigResult(config)
+
+  override fun setConfig(input: DeviceSnapshotConfigInput): DeviceSnapshotConfigResult {
+    config =
+      config.copy(
+        includeAppData = input.includeAppData ?: config.includeAppData,
+        includeSettings = input.includeSettings ?: config.includeSettings,
+        useVmSnapshot = input.useVmSnapshot ?: config.useVmSnapshot,
+        strictBackupMode = input.strictBackupMode ?: config.strictBackupMode,
+        backupTimeoutMs = input.backupTimeoutMs ?: config.backupTimeoutMs,
+        userApps = input.userApps ?: config.userApps,
+        vmSnapshotTimeoutMs = input.vmSnapshotTimeoutMs ?: config.vmSnapshotTimeoutMs,
+        maxArchiveSizeMb = input.maxArchiveSizeMb ?: config.maxArchiveSizeMb,
+      )
+    return DeviceSnapshotConfigResult(config, evictOnSet)
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
@@ -40,9 +40,7 @@ import kotlinx.serialization.json.Json
  */
 class FailuresPushSocketClient {
   companion object {
-    private fun getSocketPath(): String {
-      return "${System.getProperty("user.home")}/.auto-mobile/failures-push.sock"
-    }
+    private fun getSocketPath(): String = AutoMobileSocketPaths.socketPath("failures-push.sock")
   }
 
   private val log = LoggerFactory.getLogger(FailuresPushSocketClient::class.java)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresStreamSocketClient.kt
@@ -424,8 +424,5 @@ class FailuresStreamSocketClient(
 }
 
 object FailuresStreamSocketPaths {
-  fun socketPath(): String {
-    val home = System.getProperty("user.home", "").ifBlank { "." }
-    return File(home, ".auto-mobile/failures-stream.sock").path
-  }
+  fun socketPath(): String = AutoMobileSocketPaths.socketPath("failures-stream.sock")
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -42,9 +42,8 @@ import kotlinx.serialization.json.contentOrNull
  */
 class ObservationStreamClient {
   companion object {
-    internal fun getSocketPath(): String {
-      return "${System.getProperty("user.home")}/.auto-mobile/observation-stream.sock"
-    }
+    internal fun getSocketPath(): String =
+      AutoMobileSocketPaths.socketPath("observation-stream.sock")
 
     fun socketExists(): Boolean = Files.exists(Path.of(getSocketPath()))
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
@@ -42,9 +42,7 @@ import kotlinx.serialization.json.Json
  */
 class TelemetryPushSocketClient : TelemetryPushClient {
   companion object {
-    private fun getSocketPath(): String {
-      return "${System.getProperty("user.home")}/.auto-mobile/telemetry-push.sock"
-    }
+    private fun getSocketPath(): String = AutoMobileSocketPaths.socketPath("telemetry-push.sock")
 
     fun socketExists(): Boolean = Files.exists(Path.of(getSocketPath()))
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestRecordingSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestRecordingSocketClient.kt
@@ -200,10 +200,7 @@ class FakeTestRecordingClient(
 }
 
 object TestRecordingSocketPaths {
-  fun socketPath(): String {
-    val home = System.getProperty("user.home", "").ifBlank { "." }
-    return File(home, ".auto-mobile/test-recording.sock").path
-  }
+  fun socketPath(): String = AutoMobileSocketPaths.socketPath("test-recording.sock")
 }
 
 @Serializable

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/snapshot/SnapshotsDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/snapshot/SnapshotsDashboard.kt
@@ -1,0 +1,263 @@
+package dev.jasonpearson.automobile.desktop.core.snapshot
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotConfig
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotConfigClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotMetadata
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotActions
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private val LOG = LoggerFactory.getLogger("SnapshotsDashboard")
+
+/**
+ * Device snapshot archive: capture, restore, and the daemon's retention configuration.
+ *
+ * The two halves come from different transports on purpose. The snapshot list and the
+ * capture/restore verbs are MCP tool/resource calls ([DeviceSnapshotActions]); the retention config
+ * is the `device-snapshot.sock` config socket ([DeviceSnapshotConfigClient]), which supports only
+ * `config/get` and `config/set`. Either half degrades on its own -- an older daemon without the
+ * socket still lists and captures.
+ */
+@Composable
+fun SnapshotsDashboard(
+  actions: DeviceSnapshotActions?,
+  configClient: DeviceSnapshotConfigClient?,
+  activeDeviceId: String?,
+  modifier: Modifier = Modifier,
+) {
+  val colors = SharedTheme.globalColors
+  val scope = rememberCoroutineScope()
+
+  var snapshots by remember { mutableStateOf<List<DeviceSnapshotMetadata>>(emptyList()) }
+  var config by remember { mutableStateOf<DeviceSnapshotConfig?>(null) }
+  var isLoading by remember { mutableStateOf(true) }
+  var error by remember { mutableStateOf<String?>(null) }
+  var busyMessage by remember { mutableStateOf<String?>(null) }
+  var notice by remember { mutableStateOf<String?>(null) }
+  var reloadToken by remember { mutableStateOf(0) }
+
+  LaunchedEffect(actions, configClient, reloadToken) {
+    isLoading = true
+    error = null
+    withContext(Dispatchers.IO) {
+      snapshots =
+        try {
+          actions?.listSnapshots().orEmpty()
+        } catch (e: Exception) {
+          LOG.warn("Failed to list snapshots: ${e.message}", e)
+          error = e.message ?: "Failed to list snapshots"
+          emptyList()
+        }
+
+      // Retention config is optional: a daemon predating device-snapshot.sock still lists and
+      // captures, so a failure here must not blank the dashboard.
+      config =
+        try {
+          if (configClient?.isAvailable() == true) configClient.getConfig().config else null
+        } catch (e: Exception) {
+          LOG.warn("Snapshot config unavailable: ${e.message}", e)
+          null
+        }
+    }
+    isLoading = false
+  }
+
+  fun runAction(label: String, block: suspend () -> String?) {
+    busyMessage = label
+    notice = null
+    error = null
+    scope.launch {
+      try {
+        val message = withContext(Dispatchers.IO) { block() }
+        notice = message
+        reloadToken += 1
+      } catch (e: Exception) {
+        LOG.warn("$label failed: ${e.message}", e)
+        error = e.message ?: "$label failed"
+      } finally {
+        busyMessage = null
+      }
+    }
+  }
+
+  Column(
+    modifier = modifier.fillMaxSize().padding(12.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Text(
+        "Device Snapshots",
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = colors.text.normal,
+      )
+
+      Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        ActionChip(
+          label = if (busyMessage != null) "Working…" else "Capture",
+          accent = Color(0xFF4CAF50),
+          enabled = actions != null && activeDeviceId != null && busyMessage == null,
+        ) {
+          val deviceId = activeDeviceId ?: return@ActionChip
+          runAction("Capture") {
+            val result = actions?.captureSnapshot(deviceId)
+            val evicted = result?.evictedSnapshotNames.orEmpty()
+            buildString {
+              append("Captured '${result?.snapshotName}'")
+              if (evicted.isNotEmpty()) {
+                append(" — evicted ${evicted.size} older snapshot(s) to stay within the budget")
+              }
+            }
+          }
+        }
+        ActionChip("Refresh", Color(0xFF2196F3), enabled = busyMessage == null) {
+          reloadToken += 1
+        }
+      }
+    }
+
+    if (activeDeviceId == null) {
+      Hint("Select a device to capture or restore snapshots.", colors.text.normal)
+    }
+
+    config?.let { current ->
+      Text(
+        "Archive budget ${current.maxArchiveSizeMb} MB · app data " +
+          "${if (current.includeAppData) "on" else "off"} · settings " +
+          "${if (current.includeSettings) "on" else "off"} · VM snapshot " +
+          "${if (current.useVmSnapshot) "on" else "off"}",
+        fontSize = 10.sp,
+        color = colors.text.normal.copy(alpha = 0.6f),
+      )
+    }
+
+    notice?.let { Hint(it, Color(0xFF4CAF50)) }
+    error?.let { Hint(it, Color(0xFFE53935)) }
+
+    when {
+      isLoading -> Hint("Loading snapshots…", colors.text.normal)
+      snapshots.isEmpty() ->
+        Hint("No snapshots captured yet.", colors.text.normal.copy(alpha = 0.6f))
+      else ->
+        LazyColumn(
+          modifier = Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          items(snapshots) { snapshot ->
+            SnapshotRow(
+              snapshot = snapshot,
+              canRestore = actions != null && activeDeviceId != null && busyMessage == null,
+              onRestore = {
+                val deviceId = activeDeviceId ?: return@SnapshotRow
+                runAction("Restore") {
+                  actions?.restoreSnapshot(deviceId, snapshot.snapshotName)
+                  "Restored '${snapshot.snapshotName}'"
+                }
+              },
+            )
+          }
+        }
+    }
+  }
+}
+
+@Composable
+private fun SnapshotRow(
+  snapshot: DeviceSnapshotMetadata,
+  canRestore: Boolean,
+  onRestore: () -> Unit,
+) {
+  val colors = SharedTheme.globalColors
+
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .background(colors.text.normal.copy(alpha = 0.03f), RoundedCornerShape(4.dp))
+        .padding(horizontal = 10.dp, vertical = 6.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(snapshot.snapshotName, fontSize = 11.sp, color = colors.text.normal)
+      Text(
+        listOfNotNull(
+            snapshot.deviceName.takeIf { it.isNotBlank() },
+            snapshot.snapshotType.takeIf { it.isNotBlank() },
+            formatSize(snapshot.sizeBytes),
+            snapshot.createdAt.takeIf { it.isNotBlank() },
+          )
+          .joinToString(" · "),
+        fontSize = 9.sp,
+        color = colors.text.normal.copy(alpha = 0.5f),
+      )
+    }
+    ActionChip("Restore", Color(0xFFFFA726), enabled = canRestore, onClick = onRestore)
+  }
+}
+
+@Composable
+private fun ActionChip(
+  label: String,
+  accent: Color,
+  enabled: Boolean = true,
+  onClick: () -> Unit,
+) {
+  val alpha = if (enabled) 1f else 0.4f
+  Box(
+    modifier =
+      Modifier.background(accent.copy(alpha = 0.15f * alpha), RoundedCornerShape(4.dp))
+        .let { if (enabled) it.clickable(onClick = onClick).pointerHoverIcon(PointerIcon.Hand) else it }
+        .padding(horizontal = 8.dp, vertical = 3.dp)
+  ) {
+    Text(label, fontSize = 9.sp, softWrap = false, color = accent.copy(alpha = alpha))
+  }
+}
+
+@Composable
+private fun Hint(text: String, color: Color) {
+  Text(text, fontSize = 10.sp, color = color.copy(alpha = 0.8f))
+}
+
+internal fun formatSize(bytes: Long): String =
+  when {
+    bytes <= 0 -> "unknown size"
+    bytes >= 1_000_000_000 -> "${bytes / 1_000_000_000} GB"
+    bytes >= 1_000_000 -> "${bytes / 1_000_000} MB"
+    bytes >= 1_000 -> "${bytes / 1_000} KB"
+    else -> "$bytes B"
+  }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/snapshot/SnapshotsDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/snapshot/SnapshotsDashboard.kt
@@ -28,10 +28,10 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotActions
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotConfig
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotConfigClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotMetadata
-import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotActions
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 import kotlinx.coroutines.Dispatchers
@@ -241,7 +241,9 @@ private fun ActionChip(
   Box(
     modifier =
       Modifier.background(accent.copy(alpha = 0.15f * alpha), RoundedCornerShape(4.dp))
-        .let { if (enabled) it.clickable(onClick = onClick).pointerHoverIcon(PointerIcon.Hand) else it }
+        .let {
+          if (enabled) it.clickable(onClick = onClick).pointerHoverIcon(PointerIcon.Hand) else it
+        }
         .padding(horizontal = 8.dp, vertical = 3.dp)
   ) {
     Text(label, fontSize = 9.sp, softWrap = false, color = accent.copy(alpha = alpha))

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/AppIcons.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/AppIcons.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.LocalHospital
 import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material.icons.filled.Public
@@ -120,6 +121,9 @@ object AppIcons {
 
   val Diagnostics: ImageVector
     get() = Icons.Filled.LocalHospital
+
+  val Snapshots: ImageVector
+    get() = Icons.Filled.PhotoCamera
 
   val Telemetry: ImageVector
     get() = Icons.Filled.Satellite

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActionsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActionsTest.kt
@@ -115,8 +115,7 @@ class DeviceSnapshotActionsTest {
   @Test
   fun `capture with no evictions defaults the list to empty`() {
     val client = FakeAutoMobileClient()
-    client.callToolResult =
-      toolResponse("""{"snapshotName":"snap-2","snapshotType":"vm"}""")
+    client.callToolResult = toolResponse("""{"snapshotName":"snap-2","snapshotType":"vm"}""")
 
     assertTrue(actionsWith(client).captureSnapshot("emulator-5554").evictedSnapshotNames.isEmpty())
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActionsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActionsTest.kt
@@ -1,0 +1,165 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Covers [McpDeviceSnapshotActions], the MCP-tool half of device snapshots.
+ *
+ * Capture/restore/list are not available on `device-snapshot.sock` -- that socket only carries
+ * config -- so these go through the regular client's `tools/call` and `resources/read`.
+ */
+class DeviceSnapshotActionsTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /** Wraps tool result JSON the way the MCP tool response envelope does. */
+  private fun toolResponse(bodyJson: String): JsonElement = buildJsonObject {
+    put(
+      "content",
+      buildJsonArray {
+        add(
+          buildJsonObject {
+            put("type", "text")
+            put("text", bodyJson)
+          }
+        )
+      },
+    )
+  }
+
+  private fun actionsWith(client: FakeAutoMobileClient) = McpDeviceSnapshotActions { client }
+
+  @Test
+  fun `listSnapshots reads the archive resource`() {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      DEVICE_SNAPSHOT_ARCHIVE_URI,
+      """
+      {
+        "snapshots": [
+          {"snapshotName":"nightly","deviceId":"emulator-5554","deviceName":"Pixel",
+           "platform":"android","snapshotType":"full","includeAppData":true,
+           "includeSettings":true,"createdAt":"2026-07-19T00:00:00Z",
+           "lastAccessedAt":"2026-07-19T01:00:00Z","sizeBytes":2048}
+        ],
+        "count": 1,
+        "totalSizeBytes": 2048
+      }
+      """
+        .trimIndent(),
+    )
+
+    val snapshots = actionsWith(client).listSnapshots()
+
+    assertEquals(1, snapshots.size)
+    assertEquals("nightly", snapshots.single().snapshotName)
+    assertEquals("android", snapshots.single().platform)
+    assertEquals(2048L, snapshots.single().sizeBytes)
+  }
+
+  @Test
+  fun `listSnapshots is empty when nothing has been captured`() {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      DEVICE_SNAPSHOT_ARCHIVE_URI,
+      """{"snapshots": [], "count": 0, "totalSizeBytes": 0}""",
+    )
+
+    assertTrue(actionsWith(client).listSnapshots().isEmpty())
+  }
+
+  @Test
+  fun `an archive error surfaces rather than reading as an empty list`() {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      DEVICE_SNAPSHOT_ARCHIVE_URI,
+      """{"error": "Failed to list snapshots: disk unreadable"}""",
+    )
+
+    val failure = assertFailsWith<McpConnectionException> { actionsWith(client).listSnapshots() }
+
+    assertTrue(
+      failure.message!!.contains("disk unreadable"),
+      "should surface the daemon's reason: ${failure.message}",
+    )
+  }
+
+  @Test
+  fun `capture returns the assigned name and any evictions`() {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse(
+        """
+        {"message":"captured","snapshotName":"snap-1","snapshotType":"full",
+         "evictedSnapshotNames":["old-1"]}
+        """
+          .trimIndent()
+      )
+
+    val result = actionsWith(client).captureSnapshot("emulator-5554")
+
+    assertEquals("snap-1", result.snapshotName)
+    assertEquals("full", result.snapshotType)
+    assertEquals(listOf("old-1"), result.evictedSnapshotNames)
+  }
+
+  @Test
+  fun `capture with no evictions defaults the list to empty`() {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse("""{"snapshotName":"snap-2","snapshotType":"vm"}""")
+
+    assertTrue(actionsWith(client).captureSnapshot("emulator-5554").evictedSnapshotNames.isEmpty())
+  }
+
+  @Test
+  fun `restore succeeds without requiring a snapshotName in the response`() {
+    val client = FakeAutoMobileClient()
+    client.callToolResult = toolResponse("""{"message":"restored"}""")
+
+    actionsWith(client).restoreSnapshot("emulator-5554", "snap-1")
+
+    assertTrue(client.calls.contains("callTool"))
+  }
+
+  @Test
+  fun `the fake actions capture, list and restore coherently`() {
+    val actions = FakeDeviceSnapshotActions()
+
+    val captured = actions.captureSnapshot("emulator-5554", "manual")
+    assertEquals("manual", captured.snapshotName)
+    assertEquals(listOf("manual"), actions.listSnapshots().map { it.snapshotName })
+
+    actions.restoreSnapshot("emulator-5554", "manual")
+    assertEquals("manual", actions.restoredSnapshotName)
+  }
+
+  @Test
+  fun `restoring an unknown snapshot fails in the fake too`() {
+    val actions = FakeDeviceSnapshotActions()
+
+    assertFailsWith<McpConnectionException> { actions.restoreSnapshot("emulator-5554", "ghost") }
+  }
+
+  @Test
+  fun `the fake config client applies partial updates without clobbering other fields`() {
+    val client =
+      FakeDeviceSnapshotConfigClient(
+        DeviceSnapshotConfig(includeAppData = true, maxArchiveSizeMb = 1024)
+      )
+
+    val result = client.setConfig(DeviceSnapshotConfigInput(maxArchiveSizeMb = 256))
+
+    assertEquals(256L, result.config.maxArchiveSizeMb)
+    assertEquals(true, result.config.includeAppData, "untouched fields should survive")
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClientTest.kt
@@ -1,0 +1,213 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Covers [DeviceSnapshotSocketClient] against a real in-process Unix socket, mirroring the harness
+ * in `McpDaemonClientInputTest`.
+ */
+class DeviceSnapshotSocketClientTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun configJson(maxArchiveSizeMb: Long = 512) =
+    """
+    {
+      "includeAppData": true,
+      "includeSettings": false,
+      "useVmSnapshot": true,
+      "strictBackupMode": false,
+      "backupTimeoutMs": 1000,
+      "userApps": "all",
+      "vmSnapshotTimeoutMs": 2000,
+      "maxArchiveSizeMb": $maxArchiveSizeMb
+    }
+    """
+
+  @Test
+  fun `config get sends the documented envelope`() {
+    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
+      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+
+      client.getConfig()
+
+      val request = server.awaitRequest()
+      assertEquals("config/get", request["method"]?.jsonPrimitive?.content)
+      assertEquals("device_snapshot_request", request["type"]?.jsonPrimitive?.content)
+      assertTrue(request["id"]?.jsonPrimitive?.content?.isNotBlank() == true, "id must be present")
+    }
+  }
+
+  @Test
+  fun `config get decodes the whole config`() {
+    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
+      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+
+      val result = client.getConfig()
+
+      assertEquals(true, result.config.includeAppData)
+      assertEquals(false, result.config.includeSettings)
+      assertEquals(true, result.config.useVmSnapshot)
+      assertEquals("all", result.config.userApps)
+      assertEquals(512L, result.config.maxArchiveSizeMb)
+      assertTrue(result.evictedSnapshotNames.isEmpty(), "reads never evict")
+    }
+  }
+
+  @Test
+  fun `config set nests the partial update under params config`() {
+    TestConfigSocket(resultJson = """{"config": ${configJson(256)}}""").use { server ->
+      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+
+      client.setConfig(DeviceSnapshotConfigInput(maxArchiveSizeMb = 256))
+
+      val request = server.awaitRequest()
+      assertEquals("config/set", request["method"]?.jsonPrimitive?.content)
+      val config = request["params"]?.jsonObject?.get("config")?.jsonObject
+      assertEquals(256L, config?.get("maxArchiveSizeMb")?.jsonPrimitive?.content?.toLong())
+      // Unset fields must be omitted so a partial update doesn't overwrite the rest.
+      assertTrue(config?.containsKey("includeAppData") != true, "expected omitted, got $config")
+    }
+  }
+
+  @Test
+  fun `evicted snapshot names are surfaced from a set`() {
+    TestConfigSocket(
+        resultJson =
+          """{"config": ${configJson(64)}, "evictedSnapshotNames": ["old-1", "old-2"]}"""
+      )
+      .use { server ->
+        val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+
+        val result = client.setConfig(DeviceSnapshotConfigInput(maxArchiveSizeMb = 64))
+
+        assertEquals(listOf("old-1", "old-2"), result.evictedSnapshotNames)
+      }
+  }
+
+  @Test
+  fun `an absent evicted list defaults to empty rather than failing to decode`() {
+    // The daemon omits the key entirely when nothing was evicted.
+    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
+      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+
+      assertTrue(client.setConfig(DeviceSnapshotConfigInput()).evictedSnapshotNames.isEmpty())
+    }
+  }
+
+  @Test
+  fun `a failure response surfaces the daemon's message`() {
+    TestConfigSocket(error = "config/set requires params.config").use { server ->
+      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+
+      val failure = assertFailsWith<McpConnectionException> { client.getConfig() }
+
+      assertEquals("config/set requires params.config", failure.message)
+    }
+  }
+
+  @Test
+  fun `a missing socket reports the path rather than throwing something opaque`() {
+    val client = DeviceSnapshotSocketClient(socketPathValue = "/tmp/does-not-exist-am.sock")
+
+    val failure = assertFailsWith<McpConnectionException> { client.getConfig() }
+
+    assertTrue(
+      failure.message!!.contains("/tmp/does-not-exist-am.sock"),
+      "message should name the socket: ${failure.message}",
+    )
+  }
+
+  @Test
+  fun `isAvailable is false for a daemon that predates this socket`() {
+    assertTrue(!DeviceSnapshotSocketClient(socketPathValue = "/tmp/nope-am.sock").isAvailable())
+  }
+
+  @Test
+  fun `isAvailable is true once the socket is bound`() {
+    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
+      assertTrue(
+        DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString()).isAvailable()
+      )
+    }
+  }
+
+  /** A one-shot Unix socket server speaking the daemon's config-socket envelope. */
+  private inner class TestConfigSocket(
+    private val resultJson: String? = null,
+    private val error: String? = null,
+  ) : AutoCloseable {
+    private val tempDir = Files.createTempDirectory(Path.of("/tmp"), "amsnap-")
+    val socketPath: Path = tempDir.resolve("device-snapshot.sock")
+    private val serverChannel =
+      ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        .bind(UnixDomainSocketAddress.of(socketPath))
+    private var captured: kotlinx.serialization.json.JsonObject? = null
+    private var failure: Throwable? = null
+    private val thread =
+      Thread {
+          try {
+            serverChannel.accept().use { channel ->
+              val reader =
+                BufferedReader(
+                  InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+                )
+              val writer =
+                BufferedWriter(
+                  OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+                )
+              val request = json.parseToJsonElement(reader.readLine()).jsonObject
+              captured = request
+              writer.write(responseLine(request["id"]?.jsonPrimitive?.content ?: "unknown"))
+              writer.newLine()
+              writer.flush()
+            }
+          } catch (throwable: Throwable) {
+            failure = throwable
+          }
+        }
+        .also { it.start() }
+
+    fun awaitRequest(): kotlinx.serialization.json.JsonObject {
+      thread.join(REQUEST_TIMEOUT_MILLIS)
+      if (thread.isAlive) throw AssertionError("Client did not send a request before timeout")
+      failure?.let { throw AssertionError("Test config socket failed", it) }
+      return captured ?: throw AssertionError("Client did not send a request")
+    }
+
+    private fun responseLine(requestId: String): String {
+      val compactResult = (resultJson ?: "{}").lineSequence().joinToString("") { it.trim() }
+      val body =
+        if (error == null) """"result": $compactResult"""
+        else """"error": ${kotlinx.serialization.json.JsonPrimitive(error)}"""
+      return """{"id":"$requestId","type":"device_snapshot_response","success":${error == null},$body}"""
+    }
+
+    override fun close() {
+      serverChannel.close()
+      Files.deleteIfExists(socketPath)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+
+  private companion object {
+    const val REQUEST_TIMEOUT_MILLIS = 5_000L
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClientTest.kt
@@ -90,8 +90,7 @@ class DeviceSnapshotSocketClientTest {
   @Test
   fun `evicted snapshot names are surfaced from a set`() {
     TestConfigSocket(
-        resultJson =
-          """{"config": ${configJson(64)}, "evictedSnapshotNames": ["old-1", "old-2"]}"""
+        resultJson = """{"config": ${configJson(64)}, "evictedSnapshotNames": ["old-1", "old-2"]}"""
       )
       .use { server ->
         val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
@@ -161,29 +160,28 @@ class DeviceSnapshotSocketClientTest {
         .bind(UnixDomainSocketAddress.of(socketPath))
     private var captured: kotlinx.serialization.json.JsonObject? = null
     private var failure: Throwable? = null
-    private val thread =
-      Thread {
-          try {
-            serverChannel.accept().use { channel ->
-              val reader =
-                BufferedReader(
-                  InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
-                )
-              val writer =
-                BufferedWriter(
-                  OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
-                )
-              val request = json.parseToJsonElement(reader.readLine()).jsonObject
-              captured = request
-              writer.write(responseLine(request["id"]?.jsonPrimitive?.content ?: "unknown"))
-              writer.newLine()
-              writer.flush()
-            }
-          } catch (throwable: Throwable) {
-            failure = throwable
-          }
+    private val thread = Thread {
+      try {
+        serverChannel.accept().use { channel ->
+          val reader =
+            BufferedReader(
+              InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+            )
+          val writer =
+            BufferedWriter(
+              OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+            )
+          val request = json.parseToJsonElement(reader.readLine()).jsonObject
+          captured = request
+          writer.write(responseLine(request["id"]?.jsonPrimitive?.content ?: "unknown"))
+          writer.newLine()
+          writer.flush()
         }
-        .also { it.start() }
+      } catch (throwable: Throwable) {
+        failure = throwable
+      }
+    }
+      .also { it.start() }
 
     fun awaitRequest(): kotlinx.serialization.json.JsonObject {
       thread.join(REQUEST_TIMEOUT_MILLIS)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/snapshot/SnapshotsDashboardUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/snapshot/SnapshotsDashboardUiTest.kt
@@ -1,0 +1,160 @@
+package dev.jasonpearson.automobile.desktop.core.snapshot
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotConfig
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotMetadata
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeDeviceSnapshotActions
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeDeviceSnapshotConfigClient
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class SnapshotsDashboardUiTest {
+
+  private fun snapshot(name: String) =
+    DeviceSnapshotMetadata(
+      snapshotName = name,
+      deviceId = "emulator-5554",
+      deviceName = "Pixel 8",
+      snapshotType = "full",
+      sizeBytes = 2_500_000,
+      createdAt = "2026-07-19T00:00:00Z",
+    )
+
+  @Test
+  fun `lists captured snapshots`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(
+          actions = FakeDeviceSnapshotActions(listOf(snapshot("nightly"))),
+          configClient = FakeDeviceSnapshotConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Device Snapshots").assertIsDisplayed()
+    onNodeWithText("nightly").assertIsDisplayed()
+  }
+
+  @Test
+  fun `prompts for a device when none is selected`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(
+          actions = FakeDeviceSnapshotActions(),
+          configClient = FakeDeviceSnapshotConfigClient(),
+          activeDeviceId = null,
+        )
+      }
+    }
+
+    onNodeWithText("Select a device to capture or restore snapshots.").assertIsDisplayed()
+  }
+
+  @Test
+  fun `shows the empty state when nothing has been captured`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(
+          actions = FakeDeviceSnapshotActions(),
+          configClient = FakeDeviceSnapshotConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("No snapshots captured yet.").assertIsDisplayed()
+  }
+
+  @Test
+  fun `renders the retention budget from the config socket`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(
+          actions = FakeDeviceSnapshotActions(),
+          configClient =
+            FakeDeviceSnapshotConfigClient(DeviceSnapshotConfig(maxArchiveSizeMb = 4096)),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Archive budget 4096 MB", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `still lists snapshots when the config socket is unavailable`() = runComposeUiTest {
+    // A daemon predating device-snapshot.sock must not blank out the archive.
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(
+          actions = FakeDeviceSnapshotActions(listOf(snapshot("nightly"))),
+          configClient = FakeDeviceSnapshotConfigClient(available = false),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("nightly").assertIsDisplayed()
+    onNodeWithText("Archive budget", substring = true).assertDoesNotExist()
+  }
+
+  @Test
+  fun `renders with no daemon clients at all`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(actions = null, configClient = null, activeDeviceId = null)
+      }
+    }
+
+    onNodeWithText("Device Snapshots").assertIsDisplayed()
+    onNodeWithText("No snapshots captured yet.").assertIsDisplayed()
+  }
+
+  @Test
+  fun `capture adds a snapshot and reports it`() = runComposeUiTest {
+    val actions = FakeDeviceSnapshotActions()
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(
+          actions = actions,
+          configClient = FakeDeviceSnapshotConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Capture").performClick()
+
+    // The capture runs on Dispatchers.IO, which waitForIdle() does not join -- poll instead so
+    // this can't pass or fail on timing.
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) { actions.listSnapshots().size == 1 }
+  }
+
+  @Test
+  fun `restore routes the selected snapshot name through the actions`() = runComposeUiTest {
+    val actions = FakeDeviceSnapshotActions(listOf(snapshot("nightly")))
+    setContent {
+      MaterialTheme {
+        SnapshotsDashboard(
+          actions = actions,
+          configClient = FakeDeviceSnapshotConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Restore").performClick()
+
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) { actions.restoredSnapshotName == "nightly" }
+  }
+
+  private companion object {
+    const val ACTION_TIMEOUT_MS = 5_000L
+  }
+}


### PR DESCRIPTION
Closes #3931 (epic #3933).

## The issue's premise needed correcting

#3931 asks for capture / list / restore "via `device-snapshot.sock`". That socket **cannot do any of those**. `DeviceSnapshotSocketServer` extends `ConfigSocketServer`, whose entire method surface is `config/get | config/set` ([ConfigSocketServer.ts:5](src/daemon/socketServer/ConfigSocketServer.ts:5)), and it adds nothing on top. The verbs live in [snapshotTools.ts:26-31](src/server/snapshotTools.ts:26) as MCP tool actions, and listing is the `automobile:deviceSnapshots/archive` resource.

So the feature needs **two transports**, and this PR implements both:

| concern | transport |
|---|---|
| retention + capture defaults | `device-snapshot.sock` (`config/get` / `config/set`) |
| capture, restore | `deviceSnapshot` MCP tool |
| list | `deviceSnapshots/archive` MCP resource |

## Protocol details that shaped the code

- **`evictedSnapshotNames` is conditional.** The daemon attaches it only on `config/set`, and only when the list is non-empty ([ConfigSocketServer.ts:110](src/daemon/socketServer/ConfigSocketServer.ts:110)). Decoding it as required would fail on every normal read, so it defaults to empty — covered by a test for both the present and absent cases.
- **A partial config update must omit untouched fields**, or a single change would overwrite the rest. `explicitNulls = false` handles that, and a test asserts the omission rather than trusting it.
- **`encodeDefaults = true` is required.** The daemon needs `type` and `method` on every request, and kotlinx omits properties left at their default — without this the envelope goes out incomplete.
- **An archive `error` is raised, not swallowed.** Otherwise a failed listing renders identically to "no snapshots captured".

## Graceful degradation

The two halves fail independently. A daemon predating `device-snapshot.sock` still lists and captures — only the retention summary line disappears. `SnapshotsDashboard` treats the config read as optional for exactly this reason, and `still lists snapshots when the config socket is unavailable` pins the behavior.

## UI placement

A new **Snapshots** tab beside Storage and Diagnostics, rather than more buttons on the device row. `BootedDeviceRow` already carries three inline hand-rolled buttons; adding capture/restore there would have forced an overflow-menu refactor, and #3932 would have added three more. A list-plus-config view also simply belongs in a dashboard.

## Reuse: one socket-path resolver instead of six

Five clients had each hand-rolled the `~/.auto-mobile/<name>.sock` path across two different idioms, and this change would have added a sixth. They now share `AutoMobileSocketPaths`, which adopts the more defensive of the two idioms (the blank-`user.home` fallback that the `File`-based copies had and the interpolated ones lacked), so every migrated call site is a strict improvement. The control socket keeps its own resolver — different directory, uid suffix, Windows fallback.

## Testing

26 new tests, **468 desktop-core green**, 0 failures. `:desktop-app:compileKotlin` passes; ktfmt applied.

- **`DeviceSnapshotSocketClientTest` (9)** — drives a real in-process Unix domain socket (same harness style as `McpDaemonClientInputTest`): envelope shape, partial-update omission, evicted names present *and* absent, daemon error text surfacing, and a missing socket naming its own path.
- **`DeviceSnapshotActionsTest` (9)** — the tool/resource half, including the archive-error case and the fakes behaving coherently.
- **`SnapshotsDashboardUiTest` (8)** — rendering, the degraded no-socket path, no-client-at-all, and capture/restore driving through to the fakes.

The two async UI assertions poll via `waitUntil` instead of `waitForIdle()`, which does not join work dispatched to `Dispatchers.IO` — they passed either way, but only by timing.