### PR TITLE
fix(ios): commit the pbxproj xcodegen actually generates (drift check green)

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -546,11 +546,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				829FFB06AC273BEE7049A7F2 /* CtrlProxyApp */,
-				E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
 				61A21F82A43E4D436CD13CCD /* CtrlProxy */,
+				829FFB06AC273BEE7049A7F2 /* CtrlProxyApp */,
 				D665478F817F2DF283B43BFB /* CtrlProxyTests */,
 				2B5458099134F47AA1A7C4DA /* CtrlProxyUITests */,
+				E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
 			);
 		};
 /* End PBXProject section */


### PR DESCRIPTION
## Summary

#3969 (embed `ObjCExceptionCatcher` into the UITests bundle) landed a `project.pbxproj` whose **target-dependency ordering** differs from what `xcodegen` emits on a clean checkout, so `Build Xcode Projects` / `xcodegen-drift-check.sh` now fails on `main`. That job is **not a required check**, so the PR auto-merged despite it.

The file content is otherwise identical — only the order of the `CtrlProxyApp` and `ObjCExceptionCatcher` dependency entries differs (2 lines, same UUIDs, same names).

## Fix

Regenerated on a **fresh checkout** with **xcodegen 2.45.4** (the version CI installs) and committed exactly that output.

## Verification

- Commit before #3969 → regenerates with **no drift** (so #3969 introduced it).
- This commit → regenerates with **no drift**.
- Confirmed the earlier theory of a 2.46.0-vs-2.45.4 version skew was insufficient: the drift reproduced under 2.45.4 too, because the committed ordering came from a dirty working tree rather than a clean generation.

## Follow-up worth considering

CI installs `xcodegen` unpinned (`brew install xcodegen`) but the drift check demands byte-identical output, so contributors on a newer xcodegen will keep tripping it. Pinning the version in CI (and documenting it) would remove a recurring class of false failures.