### PR TITLE
fix(ios): split private-symbol availability from synthesis failure in multiFingerSwipe (#2952)

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		2BC78956D2B04A95DA43E6FB /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D7B74C318EE243B225B95 /* Protocols.swift */; };
 		2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */; };
 		2DD69FF84C0520EED9B77AFF /* ObjCExceptionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */; };
+		31606D9CB665D76FBF91C86C /* MultiFingerSwipeDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB532F74A3F3A670BD526CC /* MultiFingerSwipeDiagnostics.swift */; };
 		3841CE71EF7F67B82441E6E3 /* DisplayLinkFPSMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */; };
 		416E49D98E779D4D7D060F16 /* ObjCExceptionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */; };
 		42E706C81F51E89DEBD9C1A9 /* CtrlProxy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; };
@@ -39,6 +40,7 @@
 		5BD7FFA4EE2841F197219322 /* DefaultStorageInspecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */; };
 		5BE77C31B3E127345E3830A6 /* PinchFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB521226F4C469CBFE7296 /* PinchFallback.swift */; };
 		5DF6CF60A8796BBB8C80341C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0CDD96577EB9823B5FCF2585 /* Assets.xcassets */; };
+		5E092D55BDB7194E55190B26 /* MultiFingerSwipeDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB532F74A3F3A670BD526CC /* MultiFingerSwipeDiagnostics.swift */; };
 		5FDF9AE29841625DD7EFB7EC /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
 		6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */; };
 		6798190F766D01F963F6DFD0 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
@@ -69,6 +71,7 @@
 		C194D73F02D0776F0F7FCA7B /* CtrlProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE277596991C059142C485B /* CtrlProxy.swift */; };
 		C2DCB71857A14ED314300AAC /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CB9272A186932D89EB1072 /* WebSocketServer.swift */; };
 		C72C24EBCEFADDCA5B2C99E9 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF23F10C24C9F40E5CEC303 /* Logging.swift */; };
+		CA9CCB8B41C9BFF6FB797CA6 /* MultiFingerSwipeDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1A7B72077B573AA4582DF2 /* MultiFingerSwipeDiagnosticsTests.swift */; };
 		CB577FE46E063BB09F5D4010 /* SdkHierarchyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */; };
 		CC061B4978496D75042B253A /* CommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77305F40F85694E983987E68 /* CommandHandler.swift */; };
 		CDEF0C911EA979C4E9C54B0B /* DefaultStorageInspecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */; };
@@ -203,6 +206,7 @@
 		83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyModels.swift; sourceTree = "<group>"; };
 		878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPayloadTests.swift; sourceTree = "<group>"; };
+		8CB532F74A3F3A670BD526CC /* MultiFingerSwipeDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiFingerSwipeDiagnostics.swift; sourceTree = "<group>"; };
 		95565999DC108319DEED894A /* ElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocator.swift; sourceTree = "<group>"; };
 		9A1B2931E58B158EE51C5F4F /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
 		9BD704E3A2708D91D4FABE3E /* CtrlProxyApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CtrlProxyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -222,6 +226,7 @@
 		F2144B84CD70DB35A1030624 /* GesturePerformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturePerformer.swift; sourceTree = "<group>"; };
 		F9D3D13C3FE12BA2CD012082 /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
 		FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyMerger.swift; sourceTree = "<group>"; };
+		FD1A7B72077B573AA4582DF2 /* MultiFingerSwipeDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiFingerSwipeDiagnosticsTests.swift; sourceTree = "<group>"; };
 		FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjCExceptionCatcher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -283,6 +288,7 @@
 				3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */,
 				0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */,
 				184CFC1280E0802EBF53965F /* ModelsTests.swift */,
+				FD1A7B72077B573AA4582DF2 /* MultiFingerSwipeDiagnosticsTests.swift */,
 				649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */,
 				DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */,
 				6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */,
@@ -363,6 +369,7 @@
 				3BF23F10C24C9F40E5CEC303 /* Logging.swift */,
 				6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */,
 				D81453AD074F2A392251CFC3 /* Models.swift */,
+				8CB532F74A3F3A670BD526CC /* MultiFingerSwipeDiagnostics.swift */,
 				73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */,
 				DBA97A6C3A1240A055D9876C /* OSLogReader.swift */,
 				B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */,
@@ -583,6 +590,7 @@
 				5651AAF00833750D1DFD55CE /* Logging.swift in Sources */,
 				A9E8300EE35B13DED1A0E579 /* MainThreadRunner.swift in Sources */,
 				BD7D2FF024054ED74F17958D /* Models.swift in Sources */,
+				5E092D55BDB7194E55190B26 /* MultiFingerSwipeDiagnostics.swift in Sources */,
 				C1398B388B401E28BC727863 /* OSLogReader.swift in Sources */,
 				2DD69FF84C0520EED9B77AFF /* ObjCExceptionBridge.swift in Sources */,
 				D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */,
@@ -618,6 +626,7 @@
 				4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */,
 				CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */,
 				F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */,
+				CA9CCB8B41C9BFF6FB797CA6 /* MultiFingerSwipeDiagnosticsTests.swift in Sources */,
 				6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */,
 				0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */,
 				F428A1892AAF5D4F83AD4C1B /* PinchFallbackTests.swift in Sources */,
@@ -645,6 +654,7 @@
 				C72C24EBCEFADDCA5B2C99E9 /* Logging.swift in Sources */,
 				AF0C3A37F5AD66261DF7ED24 /* MainThreadRunner.swift in Sources */,
 				BD627F44D1B9F2D3976AA0EC /* Models.swift in Sources */,
+				31606D9CB665D76FBF91C86C /* MultiFingerSwipeDiagnostics.swift in Sources */,
 				141E5CD4FAF4509F538E736C /* OSLogReader.swift in Sources */,
 				416E49D98E779D4D7D060F16 /* ObjCExceptionBridge.swift in Sources */,
 				4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -456,11 +456,13 @@ public class GesturePerformer: GesturePerforming {
 
                 if !succeeded {
                     // Unlike pinch (#2910) there is no public-API fallback to take
-                    // here — no XCUITest API synthesizes an N-finger swipe along an
-                    // arbitrary vector, and a single-finger substitute would be a
-                    // different gesture. The availability signal therefore only
-                    // distinguishes the failure message (#2952); see
-                    // MultiFingerSwipeDiagnostics for the full rationale.
+                    // here — for two or more fingers no XCUITest API delivers
+                    // parallel simultaneous touch paths, and a single-finger
+                    // substitute would be a different gesture. The availability
+                    // signal therefore only distinguishes the failure message
+                    // (#2952); see MultiFingerSwipeDiagnostics for the full
+                    // rationale, including why the public `scroll(byDeltaX:deltaY:)`
+                    // does not qualify despite being available on iOS.
                     throw GestureError.gestureFailed(
                         MultiFingerSwipeDiagnostics.failureMessage(
                             symbolsUnavailable: symbolsUnavailable.boolValue,

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -440,6 +440,7 @@ public class GesturePerformer: GesturePerforming {
             try runOnMainThread {
                 let orientation = GesturePerformer.currentInterfaceOrientation()
                 var errorMessage: NSString?
+                var symbolsUnavailable: ObjCBool = false
                 let succeeded = ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
                     CGFloat(startX),
                     CGFloat(startY),
@@ -449,11 +450,23 @@ public class GesturePerformer: GesturePerforming {
                     CGFloat(fingerSpacing),
                     duration,
                     orientation.rawValue,
+                    &symbolsUnavailable,
                     &errorMessage
                 )
 
                 if !succeeded {
-                    throw GestureError.gestureFailed(errorMessage as String? ?? "multi-finger swipe synthesis failed")
+                    // Unlike pinch (#2910) there is no public-API fallback to take
+                    // here — no XCUITest API synthesizes an N-finger swipe along an
+                    // arbitrary vector, and a single-finger substitute would be a
+                    // different gesture. The availability signal therefore only
+                    // distinguishes the failure message (#2952); see
+                    // MultiFingerSwipeDiagnostics for the full rationale.
+                    throw GestureError.gestureFailed(
+                        MultiFingerSwipeDiagnostics.failureMessage(
+                            symbolsUnavailable: symbolsUnavailable.boolValue,
+                            underlying: errorMessage as String? ?? "multi-finger swipe synthesis failed"
+                        )
+                    )
                 }
             }
         }

--- a/ios/control-proxy/Sources/CtrlProxy/MultiFingerSwipeDiagnostics.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/MultiFingerSwipeDiagnostics.swift
@@ -6,21 +6,43 @@ import Foundation
 /// symbols as pinch (`XCPointerEventPath` / `XCSynthesizedEventRecord`). Issue
 /// #2910 gave pinch a `symbolsUnavailable` split so a missing-symbol gap could
 /// degrade to the public `pinch(withScale:velocity:)`. Issue #2952 adopts the
-/// same split here — but stops at the message, because there is **no** public
-/// fallback to degrade to:
+/// same split here — but stops at the message, because for **two or more
+/// fingers** there is no public XCUITest API that delivers simultaneous touch
+/// paths translating in parallel.
 ///
-/// - `XCUIElement.swipeLeft/Right/Up/Down` — single-finger, direction-only; they
-///   take neither a finger count nor start/end coordinates.
-/// - `XCUIElement.pinch(withScale:velocity:)` — two-finger, but the fingers move
-///   toward/away from each other; it cannot express a parallel pan.
-/// - `XCUIElement.scroll(byDeltaX:deltaY:)` — macOS only.
-/// - `XCUICoordinate.press(forDuration:thenDragTo:)` — single-finger.
+/// #2952 specifically asked whether the 2-finger case could be approximated with
+/// the public `pinch`/`scroll` primitives. It cannot. The full public multi-touch
+/// surface of `XCUIElement` is `twoFingerTap`,
+/// `tapWithNumberOfTaps:numberOfTouches:`, `pinch(withScale:velocity:)`, and
+/// `rotate(_:withVelocity:)`. The two continuous ones move the touches toward and
+/// away from each other (pinch) or circularly about a center (rotate); neither
+/// takes a translation vector, so neither can express a parallel two-finger pan.
+/// The tap-based ones are discrete.
 ///
-/// Substituting a single-finger swipe would silently perform a *different*
-/// gesture — two-finger swipes drive VoiceOver commands and map panning, where a
-/// one-finger swipe means something else entirely. A wrong gesture that reports
-/// success is worse than a clear failure, so the availability signal is spent on
-/// making that failure actionable instead.
+/// The single-finger APIs are unusable for a different reason:
+/// `XCUIElement.swipeLeft/Right/Up/Down` are direction-only (no coordinates), and
+/// `XCUICoordinate.press(forDuration:thenDragTo:)` carries one touch.
+///
+/// `XCUIElement.scroll(byDeltaX:deltaY:)` is **not** ruled out by availability —
+/// it is `API_AVAILABLE(ios(15.0))`. It is ruled out because it lives in the
+/// `XCUIElementMouseEvents` category and delivers a pointer/scroll-wheel event
+/// rather than synthesized touches, so it cannot drive a VoiceOver two- or
+/// three-finger gesture or a two-finger map pan — the semantics `multiFingerSwipe`
+/// exists to produce.
+///
+/// Scope of that claim: it holds for `fingerCount >= 2`. A `fingerCount` of 1 is
+/// reachable (the bridge clamps with `fingerCount > 1 ? fingerCount : 1`) and does
+/// have a public equivalent — `GesturePerformer.swipe` — but a 1-finger
+/// "multi-finger" swipe is a degenerate call that no caller makes deliberately, so
+/// the runner does not special-case it.
+///
+/// Why the runner does not substitute a single-finger swipe for N >= 2: it would
+/// silently perform a *different* gesture — multi-finger swipes drive VoiceOver
+/// commands and map panning, where a one-finger swipe means something else
+/// entirely. The runner therefore reports a clear failure and spends the
+/// availability signal on making that failure actionable. Note this is the
+/// *runner's* policy only: a TypeScript caller may still choose to degrade, and
+/// `VoiceOverSwipeExecutor` currently does exactly that (see issue #3993).
 ///
 /// The real synthesis path is device-only, so this selection is extracted here to
 /// stay verifiable off-device — the same pattern as `PinchFallback`.
@@ -37,15 +59,16 @@ public enum MultiFingerSwipeDiagnostics {
     ///   this is an OS/XCTest gap with no degraded path rather than a bad request;
     ///   for a genuine failure, `underlying` unchanged (it is already descriptive,
     ///   and availability framing would misdirect).
+    ///
+    /// The framing is kept short deliberately. `GestureError.gestureFailed` prepends
+    /// "Gesture failed: " and the TypeScript layer prepends "iOS multi-finger gesture
+    /// failed: ", so this string is the third segment of a stacked message — and long
+    /// error text costs agent context (the repo's output-reduction posture).
     public static func failureMessage(symbolsUnavailable: Bool, underlying: String) -> String {
         guard symbolsUnavailable else {
             return underlying
         }
-        return """
-            multi-finger swipe unavailable: the private XCTest touch-synthesis symbols this \
-            gesture depends on are missing on this OS/XCTest version, and there is no public \
-            XCUITest API to approximate an N-finger swipe along an arbitrary vector, so the \
-            gesture cannot be degraded. Underlying detail: \(underlying)
-            """
+        return "private XCTest touch synthesis unavailable on this OS/XCTest version, "
+            + "and no public XCUITest API can substitute for a 2+-finger swipe. \(underlying)"
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/MultiFingerSwipeDiagnostics.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/MultiFingerSwipeDiagnostics.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Failure-message selection for `multiFingerSwipe`.
+///
+/// `multiFingerSwipe` synthesizes touches through the same Apple-private XCTest
+/// symbols as pinch (`XCPointerEventPath` / `XCSynthesizedEventRecord`). Issue
+/// #2910 gave pinch a `symbolsUnavailable` split so a missing-symbol gap could
+/// degrade to the public `pinch(withScale:velocity:)`. Issue #2952 adopts the
+/// same split here — but stops at the message, because there is **no** public
+/// fallback to degrade to:
+///
+/// - `XCUIElement.swipeLeft/Right/Up/Down` — single-finger, direction-only; they
+///   take neither a finger count nor start/end coordinates.
+/// - `XCUIElement.pinch(withScale:velocity:)` — two-finger, but the fingers move
+///   toward/away from each other; it cannot express a parallel pan.
+/// - `XCUIElement.scroll(byDeltaX:deltaY:)` — macOS only.
+/// - `XCUICoordinate.press(forDuration:thenDragTo:)` — single-finger.
+///
+/// Substituting a single-finger swipe would silently perform a *different*
+/// gesture — two-finger swipes drive VoiceOver commands and map panning, where a
+/// one-finger swipe means something else entirely. A wrong gesture that reports
+/// success is worse than a clear failure, so the availability signal is spent on
+/// making that failure actionable instead.
+///
+/// The real synthesis path is device-only, so this selection is extracted here to
+/// stay verifiable off-device — the same pattern as `PinchFallback`.
+public enum MultiFingerSwipeDiagnostics {
+
+    /// Build the client-facing failure message for a failed multi-finger swipe.
+    ///
+    /// - Parameters:
+    ///   - symbolsUnavailable: the bridge's availability signal — `true` only when
+    ///     the private XCTest classes/selectors are missing, never for a genuine
+    ///     synthesis error.
+    ///   - underlying: the bridge's own description of the failure.
+    /// - Returns: for an availability gap, `underlying` framed so the reader knows
+    ///   this is an OS/XCTest gap with no degraded path rather than a bad request;
+    ///   for a genuine failure, `underlying` unchanged (it is already descriptive,
+    ///   and availability framing would misdirect).
+    public static func failureMessage(symbolsUnavailable: Bool, underlying: String) -> String {
+        guard symbolsUnavailable else {
+            return underlying
+        }
+        return """
+            multi-finger swipe unavailable: the private XCTest touch-synthesis symbols this \
+            gesture depends on are missing on this OS/XCTest version, and there is no public \
+            XCUITest API to approximate an N-finger swipe along an arbitrary vector, so the \
+            gesture cannot be degraded. Underlying detail: \(underlying)
+            """
+    }
+}

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/ObjCExceptionCatcher.m
@@ -48,29 +48,39 @@ BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
     CGFloat fingerSpacing,
     NSTimeInterval duration,
     NSInteger interfaceOrientation,
+    BOOL *_Nullable symbolsUnavailable,
     NSString *_Nullable *_Nullable errorMessage
 ) {
+    // Default: symbols are assumed present until a guard proves otherwise, so a
+    // genuine synthesis error is not misreported as an availability gap.
+    if (symbolsUnavailable != NULL) {
+        *symbolsUnavailable = NO;
+    }
 #if TARGET_OS_IOS
     __block BOOL success = NO;
     __block NSString *failure = nil;
+    __block BOOL unavailable = NO;
 
     NSException *exception = ObjCExceptionCatcher_tryBlock(^{
         Class pathClass = NSClassFromString(@"XCPointerEventPath");
         Class recordClass = NSClassFromString(@"XCSynthesizedEventRecord");
 
         if (pathClass == Nil || recordClass == Nil) {
+            unavailable = YES;
             failure = @"XCTest private multi-touch event synthesis classes are unavailable";
             return;
         }
         if (![pathClass instancesRespondToSelector:@selector(initForTouchAtPoint:offset:)] ||
             ![pathClass instancesRespondToSelector:@selector(moveToPoint:atOffset:)] ||
             ![pathClass instancesRespondToSelector:@selector(liftUpAtOffset:)]) {
+            unavailable = YES;
             failure = @"XCPointerEventPath does not support the expected multi-touch selectors";
             return;
         }
         if (![recordClass instancesRespondToSelector:@selector(initWithName:interfaceOrientation:)] ||
             ![recordClass instancesRespondToSelector:@selector(addPointerEventPath:)] ||
             ![recordClass instancesRespondToSelector:@selector(synthesizeWithError:)]) {
+            unavailable = YES;
             failure = @"XCSynthesizedEventRecord does not support the expected synthesis selectors";
             return;
         }
@@ -103,16 +113,29 @@ BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
     });
 
     if (exception != nil) {
+        // A caught exception is a genuine synthesis failure, not an availability
+        // gap, so leave `unavailable` as-is (NO unless a guard already set it).
         NSString *reason = exception.reason != nil ? exception.reason : @"no reason";
         failure = [NSString stringWithFormat:@"Objective-C exception during multi-finger swipe synthesis: %@ - %@",
                    exception.name, reason];
     }
-    if (!success && errorMessage != NULL) {
-        *errorMessage = failure != nil ? failure : @"multi-finger swipe synthesis failed";
+    if (!success) {
+        if (symbolsUnavailable != NULL) {
+            *symbolsUnavailable = unavailable;
+        }
+        if (errorMessage != NULL) {
+            *errorMessage = failure != nil ? failure : @"multi-finger swipe synthesis failed";
+        }
     }
 
     return success;
 #else
+    // Off-iOS the private symbols are definitionally unavailable. There is no
+    // public-API fallback for a multi-finger swipe, so this only selects the
+    // availability-flavored failure message (see MultiFingerSwipeDiagnostics).
+    if (symbolsUnavailable != NULL) {
+        *symbolsUnavailable = YES;
+    }
     if (errorMessage != NULL) {
         *errorMessage = @"XCTest private multi-touch event synthesis is only available on iOS";
     }

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -61,6 +61,21 @@ FOUNDATION_EXPORT NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS
 /// Synthesizes a simultaneous multi-finger swipe through XCTest private event APIs.
 /// Returns NO with a descriptive error message when the private symbols are unavailable
 /// or synthesis fails. Objective-C exceptions are caught and reported through errorMessage.
+///
+/// `symbolsUnavailable` mirrors `ObjCExceptionCatcher_synthesizePinch` (see issue #2952):
+/// it is set to YES only when the required private classes/selectors are missing (or the
+/// platform is not iOS), and left NO for a genuine synthesis error or a caught
+/// Objective-C exception.
+///
+/// Unlike pinch, a YES here does NOT enable a degraded gesture — there is no public
+/// XCUITest API that can synthesize an N-finger swipe along an arbitrary vector:
+/// `XCUIElement.swipeLeft/Right/Up/Down` are single-finger and direction-only,
+/// `pinch(withScale:velocity:)` moves the fingers toward/away from each other rather
+/// than in parallel, `scroll(byDeltaX:deltaY:)` is macOS-only, and
+/// `press(forDuration:thenDragTo:)` is single-finger. Substituting a one-finger swipe
+/// would perform a semantically different gesture (VoiceOver two-finger gestures, map
+/// pan vs. drag), which is worse than a clear failure. The flag therefore selects a
+/// distinct, actionable error message — see `MultiFingerSwipeDiagnostics`.
 FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
     CGFloat startX,
     CGFloat startY,
@@ -70,6 +85,7 @@ FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
     CGFloat fingerSpacing,
     NSTimeInterval duration,
     NSInteger interfaceOrientation,
+    BOOL *_Nullable symbolsUnavailable,
     NSString *_Nullable *_Nullable errorMessage
 );
 

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -67,15 +67,19 @@ FOUNDATION_EXPORT NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS
 /// platform is not iOS), and left NO for a genuine synthesis error or a caught
 /// Objective-C exception.
 ///
-/// Unlike pinch, a YES here does NOT enable a degraded gesture — there is no public
-/// XCUITest API that can synthesize an N-finger swipe along an arbitrary vector:
-/// `XCUIElement.swipeLeft/Right/Up/Down` are single-finger and direction-only,
-/// `pinch(withScale:velocity:)` moves the fingers toward/away from each other rather
-/// than in parallel, `scroll(byDeltaX:deltaY:)` is macOS-only, and
-/// `press(forDuration:thenDragTo:)` is single-finger. Substituting a one-finger swipe
-/// would perform a semantically different gesture (VoiceOver two-finger gestures, map
-/// pan vs. drag), which is worse than a clear failure. The flag therefore selects a
-/// distinct, actionable error message — see `MultiFingerSwipeDiagnostics`.
+/// Unlike pinch, a YES here does NOT enable a degraded gesture: for two or more
+/// fingers no public XCUITest API delivers simultaneous touch paths translating in
+/// parallel. `pinch(withScale:velocity:)` and `rotate(_:withVelocity:)` are the only
+/// continuous public multi-touch gestures, and they move the touches toward/away or
+/// circularly — neither takes a translation vector. `swipeLeft/Right/Up/Down` are
+/// single-finger and direction-only, and `press(forDuration:thenDragTo:)` carries one
+/// touch. `scroll(byDeltaX:deltaY:)` IS available on iOS (15.0+) but belongs to the
+/// `XCUIElementMouseEvents` category and emits a pointer/scroll-wheel event, not
+/// synthesized touches. Substituting a one-finger swipe would perform a semantically
+/// different gesture (VoiceOver multi-finger commands, map pan vs. drag), which is
+/// worse than a clear failure. The flag therefore selects a distinct, actionable
+/// error message — see `MultiFingerSwipeDiagnostics` for the full rationale and its
+/// scope (`fingerCount >= 2`).
 FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
     CGFloat startX,
     CGFloat startY,

--- a/ios/control-proxy/Tests/CtrlProxyTests/MultiFingerSwipeDiagnosticsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/MultiFingerSwipeDiagnosticsTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import CtrlProxy
+
+/// Unit tests for the multi-finger-swipe failure-message split.
+///
+/// `multiFingerSwipe` has no public-API fallback (see `MultiFingerSwipeDiagnostics`
+/// for why), so the `symbolsUnavailable` signal from the ObjC bridge is spent on
+/// telling the two failure modes apart in the message the client sees. The real
+/// `GesturePerformer.multiFingerSwipe` synthesis path is device-only, so the
+/// message selection is extracted here to be verifiable off-device — the same
+/// pattern `PinchFallback` uses. See issue #2952.
+final class MultiFingerSwipeDiagnosticsTests: XCTestCase {
+
+    func testUnavailableAndSynthesisFailureProduceDistinctMessages() {
+        let unavailable = MultiFingerSwipeDiagnostics.failureMessage(
+            symbolsUnavailable: true,
+            underlying: "boom"
+        )
+        let genuine = MultiFingerSwipeDiagnostics.failureMessage(
+            symbolsUnavailable: false,
+            underlying: "boom"
+        )
+        XCTAssertNotEqual(
+            unavailable,
+            genuine,
+            "an availability gap must not be conflated with a genuine synthesis error"
+        )
+    }
+
+    func testUnavailableMessageNamesThePrivateSymbolGapAndTheLackOfFallback() {
+        let message = MultiFingerSwipeDiagnostics.failureMessage(
+            symbolsUnavailable: true,
+            underlying: "XCPointerEventPath does not support the expected multi-touch selectors"
+        )
+        // Actionable: says what is missing and that the gesture cannot degrade,
+        // so a caller knows this is an OS/XCTest gap and not a bad request.
+        XCTAssertTrue(
+            message.contains("private XCTest"),
+            "must name the private-symbol gap, got: \(message)"
+        )
+        XCTAssertTrue(
+            message.contains("no public"),
+            "must state that no public fallback exists, got: \(message)"
+        )
+    }
+
+    func testBothBranchesPreserveTheUnderlyingDetail() {
+        let detail = "multi-finger swipe synthesis failed: unknown error"
+        XCTAssertTrue(
+            MultiFingerSwipeDiagnostics.failureMessage(symbolsUnavailable: true, underlying: detail)
+                .contains(detail),
+            "the availability message must keep the bridge's detail"
+        )
+        XCTAssertTrue(
+            MultiFingerSwipeDiagnostics.failureMessage(symbolsUnavailable: false, underlying: detail)
+                .contains(detail),
+            "the synthesis-error message must keep the bridge's detail"
+        )
+    }
+
+    func testGenuineFailurePassesTheUnderlyingDetailThroughUnchanged() {
+        // A real synthesis error is already descriptive; do not bury it in
+        // availability framing that would misdirect the reader.
+        let detail = "multi-finger swipe synthesis failed: touch delivery timed out"
+        XCTAssertEqual(
+            MultiFingerSwipeDiagnostics.failureMessage(symbolsUnavailable: false, underlying: detail),
+            detail
+        )
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/MultiFingerSwipeDiagnosticsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/MultiFingerSwipeDiagnosticsTests.swift
@@ -45,6 +45,24 @@ final class MultiFingerSwipeDiagnosticsTests: XCTestCase {
         )
     }
 
+    /// This string is the third segment of a stacked message (`GestureError`
+    /// prepends "Gesture failed: ", the TS layer prepends "iOS multi-finger gesture
+    /// failed: "), and long error text costs agent context. Keep the framing tight
+    /// and single-line so it renders cleanly in a JSON error field.
+    func testUnavailableMessageStaysCompactAndSingleLine() {
+        let message = MultiFingerSwipeDiagnostics.failureMessage(
+            symbolsUnavailable: true,
+            underlying: ""
+        )
+        XCTAssertFalse(message.contains("\n"), "must be single-line on the wire")
+        XCTAssertFalse(message.contains("  "), "must not contain doubled spaces")
+        XCTAssertLessThanOrEqual(
+            message.count,
+            160,
+            "framing must stay compact, got \(message.count) chars: \(message)"
+        )
+    }
+
     func testBothBranchesPreserveTheUnderlyingDetail() {
         let detail = "multi-finger swipe synthesis failed: unknown error"
         XCTAssertTrue(

--- a/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
@@ -159,4 +159,23 @@ final class ObjCExceptionBridgeTests: XCTestCase {
         XCTAssertTrue(symbolsUnavailable.boolValue, "must flag the private symbols as unavailable")
         XCTAssertNotNil(errorMessage)
     }
+
+    // MARK: - Multi-Finger Swipe Symbol Availability (issue #2952)
+
+    /// Mirrors the pinch case above: off-device the private XCTest symbols are
+    /// definitionally unavailable, so `synthesizeMultiFingerSwipe` must report
+    /// `symbolsUnavailable == true` rather than conflating the availability gap
+    /// with a genuine synthesis error. Unlike pinch there is no public-API
+    /// fallback to take (see `MultiFingerSwipeDiagnostics`); the signal instead
+    /// selects a distinct, actionable failure message.
+    func testSynthesizeMultiFingerSwipeReportsSymbolsUnavailableOffDevice() {
+        var symbolsUnavailable: ObjCBool = false
+        var errorMessage: NSString?
+        let succeeded = ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
+            10, 20, 110, 220, 2, 25, 0.3, 0, &symbolsUnavailable, &errorMessage
+        )
+        XCTAssertFalse(succeeded, "private synthesis cannot succeed off-device")
+        XCTAssertTrue(symbolsUnavailable.boolValue, "must flag the private symbols as unavailable")
+        XCTAssertNotNil(errorMessage)
+    }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ObjCExceptionBridgeTests.swift
@@ -178,4 +178,15 @@ final class ObjCExceptionBridgeTests: XCTestCase {
         XCTAssertTrue(symbolsUnavailable.boolValue, "must flag the private symbols as unavailable")
         XCTAssertNotNil(errorMessage)
     }
+
+    /// `symbolsUnavailable` is declared `_Nullable`, so a caller that does not care
+    /// about the availability split must be able to pass NULL without crashing.
+    func testSynthesizeMultiFingerSwipeToleratesNilSymbolsUnavailableOutParam() {
+        var errorMessage: NSString?
+        let succeeded = ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
+            10, 20, 110, 220, 2, 25, 0.3, 0, nil, &errorMessage
+        )
+        XCTAssertFalse(succeeded, "private synthesis cannot succeed off-device")
+        XCTAssertNotNil(errorMessage, "the error message must still be reported")
+    }
 }


### PR DESCRIPTION
## Summary

`multiFingerSwipe` synthesizes touches through the same Apple-private XCTest symbols as pinch (`XCPointerEventPath` / `XCSynthesizedEventRecord`). Before this change, every failure — a private symbol vanishing on a future iOS, or a genuine synthesis error — collapsed into one indistinct `success:false`, so an OS-level capability gap was indistinguishable from a bad request.

This mirrors the #2910 / PR #2926 pinch treatment: `ObjCExceptionCatcher_synthesizeMultiFingerSwipe` gains a `symbolsUnavailable` out-param, set `YES` only when the private classes/selectors are missing (or the platform is not iOS), and left `NO` for a caught Objective-C exception or a real `synthesizeWithError:` failure.

**Unlike pinch, the signal does not enable a degraded gesture — and that is deliberate.** There is no public XCUITest API that synthesizes an N-finger swipe along an arbitrary vector:

- `pinch(withScale:velocity:)` and `rotate(_:withVelocity:)` — the only two continuous public multi-touch gestures. They move the touches toward/away from each other, or circularly about a center; neither takes a translation vector.
- `twoFingerTap` / `tapWithNumberOfTaps:numberOfTouches:` — discrete taps, not continuous.
- `XCUIElement.swipeLeft/Right/Up/Down` — single-finger, direction-only; take neither a finger count nor coordinates.
- `XCUICoordinate.press(forDuration:thenDragTo:)` — single-finger.
- `XCUIElement.scroll(byDeltaX:deltaY:)` — **available on iOS 15+**, but in the `XCUIElementMouseEvents` category: it emits a pointer/scroll-wheel event, not synthesized touches, so it cannot drive a VoiceOver multi-finger gesture or a two-finger map pan.

Scope: this holds for `fingerCount >= 2`. A `fingerCount` of 1 is reachable and does have a public equivalent (`GesturePerformer.swipe`), but no caller passes 1 deliberately, so the runner does not special-case it.

Substituting a single-finger swipe would silently perform a *different* gesture — multi-finger swipes drive VoiceOver commands and map panning. A wrong gesture reporting success is worse than a clear failure, so the availability signal is spent on making the failure actionable instead. That rationale is documented on the bridge header and in `MultiFingerSwipeDiagnostics` so it is not re-litigated later.

Note this is the **runner's** policy only. `VoiceOverSwipeExecutor` in the TypeScript layer already degrades to a single-finger swipe and reports success; that pre-existing contradiction is filed as #3993 rather than fixed here.

## Linked Issue

Closes #2952

## Changes

- `ObjCExceptionCatcher.{h,m}` — `symbolsUnavailable` out-param, mirroring `synthesizePinch` exactly (including the non-iOS `#else` branch); header documents why no public fallback exists.
- `MultiFingerSwipeDiagnostics.swift` (new) — pure, platform-agnostic failure-message selection. Extracted so it is verifiable off-device, the same pattern `PinchFallback` uses for the pinch fallback math.
- `GesturePerformer.multiFingerSwipe` — threads the signal into the thrown `GestureError.gestureFailed` message.

No wire-protocol change: no new response fields, and `src/` has no coupling to multi-finger-swipe error text (unlike the `pinchPath` plumbing pinch needed).

## Validation

- [x] `bunx turbo run lint build test` — 8077 pass / 0 fail
- [x] `swift test` — 410 pass / 0 fail (405 before; +5 from this PR)
- [x] `bash scripts/swiftlint/validate_swiftlint.sh` passes
- [x] `xcodegen generate` re-run; `project.pbxproj` committed for the two new files
- [x] New tests are pure/off-device and run in well under 100ms
- [ ] `bun run typecheck` — see note below

**Typecheck note:** the gate reports one "new" error in `src/utils/plan/PlanSchemaValidator.ts` (ajv/ajv-formats nested-copy TS2345). It is the *same* error already in the baseline, differing only in path form — the baseline records `node_modules/ajv/...` while a git-worktree checkout (no local `node_modules`, resolving to the parent clone outside the worktree root) makes `tsc` emit an absolute path, so the string match misses. Not caused by this PR, which touches zero TypeScript. Deliberately did **not** run `typecheck:update`, which would have written machine-specific absolute paths into the baseline.

## Device Verification

Not applicable — the changed branch is reachable only when Apple's private XCTest symbols are absent, which cannot be induced on a working simulator or device.

Being precise about what the off-device test does and does not prove: on a macOS host `TARGET_OS_IOS` is 0, so `testSynthesizeMultiFingerSwipeReportsSymbolsUnavailableOffDevice` exercises the `#else` branch where `*symbolsUnavailable = YES` is a compile-time constant. It pins the out-param contract, **not** the three `instancesRespondToSelector:` guards. Those are compiled only for iOS and have no behavioral coverage — inherent to the private-symbol approach, and identical to the pinch precedent.

## Acceptance criteria

| Criterion | Where | Pinned by |
|---|---|---|
| Bridge reports symbol availability distinctly | `ObjCExceptionCatcher.m` | `ObjCExceptionBridgeTests.testSynthesizeMultiFingerSwipeReportsSymbolsUnavailableOffDevice` |
| Unavailable → actionable, distinct message | `MultiFingerSwipeDiagnostics` + `GesturePerformer` | `MultiFingerSwipeDiagnosticsTests` (4 tests: distinctness, actionable content, detail preservation both branches, genuine-failure passthrough) |
| Public approximation, or document why not | Header + `MultiFingerSwipeDiagnostics` doc comment | Documentation — not test-pinnable |
| Swift tests for the availability branch | — | The 5 tests above |

**Known coverage limit:** `GesturePerformer.multiFingerSwipe` itself needs a live `XCUIApplication` and cannot run in a macOS test host — the same constraint PR #2926 hit, and the reason the message logic is extracted into a pure type. Coverage is bridge-level plus pure-logic; the wiring between them is device-only.

## Follow-ups

- #3985 — source-scan guard that `GesturePerformer` actually consumes the `symbolsUnavailable` flag (the wiring is unpinnable by any unit test, since the body is behind `#if os(iOS)`).
- #3993 — `VoiceOverSwipeExecutor` silently degrades to a single-finger swipe and reports success. Pre-existing; contradicts this PR's runner-side policy.

The "public approximation" half of the issue resolves to the documented-infeasible branch rather than deferred work.

⚠️ **Delivery gate:** `ios/control-proxy` changes need a runner release re-cut to reach users; this fix is inert until then.

