### PR TITLE
refactor(android): extract shared correlated-error-on-throw core (#3086)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
@@ -66,10 +66,11 @@ class AsyncActionRunner(
       val launchScope = this
       reporter.guarding(
         requestId = requestId,
-        failureLogMessage = "Async action '$action' failed (requestId=$requestId)",
-        errorMessagePrefix = "Action '$action' failed",
-        doubleFailureLogMessage =
-          "Failed to broadcast async error for action '$action' (requestId=$requestId)",
+        failureLogMessage = { "Async action '$action' failed (requestId=$requestId)" },
+        errorMessagePrefix = { "Action '$action' failed" },
+        doubleFailureLogMessage = {
+          "Failed to broadcast async error for action '$action' (requestId=$requestId)"
+        },
       ) {
         block(launchScope)
       }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/AsyncActionRunner.kt
@@ -3,7 +3,6 @@ package dev.jasonpearson.automobile.ctrlproxy
 import android.util.Log
 import dev.jasonpearson.automobile.protocol.ErrorResponse
 import dev.jasonpearson.automobile.protocol.WebSocketResponse
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -39,10 +38,13 @@ class AsyncActionRunner(
     Log.e(TAG, message, error)
   },
 ) {
+  /** The shared correlated-error-on-throw core (#3086). */
+  private val reporter = CorrelatedErrorReporter(broadcastResponse, logError)
+
   /**
-   * Launch [block] on [scope]. If it throws anything other than a cooperative
-   * [CancellationException], broadcast an [ErrorResponse] correlated by [requestId] so the awaiting
-   * client fails fast instead of hanging.
+   * Launch [block] on [scope]. If it throws anything other than a cooperative cancellation,
+   * broadcast an [ErrorResponse] correlated by [requestId] so the awaiting client fails fast
+   * instead of hanging. See [CorrelatedErrorReporter.guarding] for the semantics.
    *
    * @param requestId correlation id from the originating request; null when the request carried
    *   none (the error frame then carries a null requestId, exactly as the synchronous decode path
@@ -59,31 +61,17 @@ class AsyncActionRunner(
     // catch — a non-[Exception] [Throwable] such as an [Error]/[AssertionError] — still escapes
     // with
     // the correlation id attached, letting the scope-level [ServiceScopeGuard] emit a *correlated*
-    // error frame instead of a null-id one. The common `Exception` case is handled below directly.
+    // error frame instead of a null-id one. The common `Exception` case is handled by the reporter.
     scope.launch(RequestIdContext(requestId)) {
-      try {
-        block()
-      } catch (e: CancellationException) {
-        // Cooperative cancellation means the service scope is shutting down — never convert it into
-        // a client-facing error frame; let it propagate so the coroutine unwinds cleanly.
-        throw e
-      } catch (e: Exception) {
-        val cause = e.message ?: e::class.simpleName ?: "unknown error"
-        logError("Async action '$action' failed (requestId=$requestId)", e)
-        try {
-          broadcastResponse(
-            ErrorResponse(requestId = requestId, error = "Action '$action' failed: $cause")
-          )
-        } catch (broadcastError: CancellationException) {
-          throw broadcastError
-        } catch (broadcastError: Exception) {
-          // A failure while reporting the error must not escape and crash the launch (which would
-          // defeat the whole point). Log and swallow — the client will fall back to its timeout.
-          logError(
-            "Failed to broadcast async error for action '$action' (requestId=$requestId)",
-            broadcastError,
-          )
-        }
+      val launchScope = this
+      reporter.guarding(
+        requestId = requestId,
+        failureLogMessage = "Async action '$action' failed (requestId=$requestId)",
+        errorMessagePrefix = "Action '$action' failed",
+        doubleFailureLogMessage =
+          "Failed to broadcast async error for action '$action' (requestId=$requestId)",
+      ) {
+        block(launchScope)
       }
     }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
@@ -1,0 +1,133 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import kotlinx.coroutines.CancellationException
+
+/**
+ * The single canonical implementation of *"a throw on a requestId-correlated path must become a
+ * correlated `type:"error"` frame, never a silent hang"*.
+ *
+ * Three seams close that hang-class on three different paths, and each one used to hand-roll the
+ * same body:
+ * - [AsyncActionRunner] (#3023) — a throw *inside* a launched action coroutine.
+ * - [ResultBroadcaster] (#3045) — a throw while *sending* a result.
+ * - [ServiceScopeGuard] (#3104) — a throw escaping a *raw* `serviceScope.launch { … }`.
+ *
+ * Issue #3086 filed the duplication as a deliberate YAGNI defer while there were only two
+ * consumers, and named the trigger to act: a third consumer, or the first observed drift. The third
+ * consumer arrived. The risk the issue actually tracked is that nothing *forced* the copies to stay
+ * in lock-step — a fix to one catch-body (changing the cause derivation, folding the requestId into
+ * the message, adjusting cancellation handling) would silently leave the others behind. That risk
+ * is now structural: this type is the one place the body lives, and `CorrelatedErrorDriftGuardTest`
+ * fails CI if a consumer starts hand-rolling it again.
+ *
+ * Three layers, because the consumers enter at different points:
+ * - [guarding] — run a block, report anything it throws. Used by [ResultBroadcaster] and
+ *   [AsyncActionRunner].
+ * - [report] — log an *already-caught* throwable, then emit its frame.
+ * - [emit] + [causeOf] — the frame-emitting tail and the cause rule on their own, for
+ *   [ServiceScopeGuard]: a [kotlinx.coroutines.CoroutineExceptionHandler] is handed a throwable
+ *   rather than a block, and must log synchronously (see [emit]).
+ *
+ * @param broadcastError sink for the correlated fallback frame — `webSocketServer.broadcast(…)` in
+ *   production (lazily resolving the `lateinit` server), a capturing lambda in tests.
+ * @param logError diagnostic sink; `Log.e` in production, a capturing lambda in tests. This type
+ *   holds no Android dependency of its own so it stays unit-testable.
+ */
+class CorrelatedErrorReporter(
+  private val broadcastError: suspend (ErrorResponse) -> Unit,
+  private val logError: (String, Throwable) -> Unit,
+) {
+
+  /**
+   * Run [block]. If it throws anything other than a cooperative [CancellationException], [report]
+   * the failure as a correlated error frame.
+   *
+   * A [CancellationException] always propagates: cooperative cancellation means the scope is
+   * shutting down, and converting it into a client-facing error frame would report a shutdown as a
+   * request failure.
+   *
+   * @param requestId correlation id from the originating request; null when the request carried
+   *   none (the frame then carries a null requestId, exactly as the synchronous decode path does —
+   *   `resolveError` no-ops on an absent id).
+   * @param failureLogMessage what to log when [block] throws.
+   * @param errorMessagePrefix prefix for the client-facing error text; the derived cause is
+   *   appended as `"$errorMessagePrefix: $cause"`.
+   * @param doubleFailureLogMessage what to log if the fallback broadcast *itself* throws.
+   */
+  suspend fun guarding(
+    requestId: String?,
+    failureLogMessage: String,
+    errorMessagePrefix: String,
+    doubleFailureLogMessage: String,
+    block: suspend () -> Unit,
+  ) {
+    try {
+      block()
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      report(
+        requestId = requestId,
+        throwable = e,
+        failureLogMessage = failureLogMessage,
+        errorMessagePrefix = errorMessagePrefix,
+        doubleFailureLogMessage = doubleFailureLogMessage,
+      )
+    }
+  }
+
+  /**
+   * Log [throwable] and emit a best-effort [ErrorResponse] correlated by [requestId], so the
+   * awaiting client fails fast instead of hanging to its `RequestManager` timeout.
+   *
+   * Best-effort is load-bearing: a failure raised while *reporting* the failure must not escape.
+   * Letting it out would defeat the entire guarantee — it would bubble to the launched coroutine
+   * (or, for [ServiceScopeGuard], re-enter the handler and loop). It is logged and swallowed; the
+   * client then falls back to its timeout, but only for this genuinely-unrecoverable double-failure
+   * tail. A [CancellationException] from the fallback still propagates, for the same reason as in
+   * [guarding].
+   */
+  suspend fun report(
+    requestId: String?,
+    throwable: Throwable,
+    failureLogMessage: String,
+    errorMessagePrefix: String,
+    doubleFailureLogMessage: String,
+  ) {
+    logError(failureLogMessage, throwable)
+    emit(
+      requestId = requestId,
+      errorMessage = "$errorMessagePrefix: ${causeOf(throwable)}",
+      doubleFailureLogMessage = doubleFailureLogMessage,
+    )
+  }
+
+  /**
+   * The emit tail of [report], split out for [ServiceScopeGuard]. That consumer must log
+   * *synchronously* on the failing thread — a [kotlinx.coroutines.CoroutineExceptionHandler] cannot
+   * suspend, so it dispatches this broadcast onto a scope, and folding the log in here would lose
+   * the diagnostic entirely whenever that scope is already shut down.
+   *
+   * Emits a best-effort [ErrorResponse] correlated by [requestId]. Best-effort is load-bearing: see
+   * [report].
+   */
+  suspend fun emit(requestId: String?, errorMessage: String, doubleFailureLogMessage: String) {
+    try {
+      broadcastError(ErrorResponse(requestId = requestId, error = errorMessage))
+    } catch (fallbackError: CancellationException) {
+      throw fallbackError
+    } catch (fallbackError: Exception) {
+      logError(doubleFailureLogMessage, fallbackError)
+    }
+  }
+
+  companion object {
+    /**
+     * The one cause-derivation rule: the throwable's message, else its simple class name, else a
+     * constant. Shared so a consumer that logs the cause itself cannot derive it differently.
+     */
+    fun causeOf(throwable: Throwable): String =
+      throwable.message ?: throwable::class.simpleName ?: "unknown error"
+  }
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
@@ -49,6 +49,12 @@ class CorrelatedErrorReporter(
    * shutting down, and converting it into a client-facing error frame would report a shutdown as a
    * request failure.
    *
+   * The three message parameters are lambdas so that nothing is built on the success path. Every
+   * call site passes an interpolated string, and the guarded block succeeds on all but a vanishing
+   * fraction of the ~70 calls routed through here — taking them by value would allocate three
+   * strings per broadcast for the sole benefit of the failure case. Before the extraction these
+   * lived inside the `catch` and cost nothing when the block succeeded; this keeps that property.
+   *
    * @param requestId correlation id from the originating request; null when the request carried
    *   none (the frame then carries a null requestId, exactly as the synchronous decode path does —
    *   `resolveError` no-ops on an absent id).
@@ -59,9 +65,9 @@ class CorrelatedErrorReporter(
    */
   suspend fun guarding(
     requestId: String?,
-    failureLogMessage: String,
-    errorMessagePrefix: String,
-    doubleFailureLogMessage: String,
+    failureLogMessage: () -> String,
+    errorMessagePrefix: () -> String,
+    doubleFailureLogMessage: () -> String,
     block: suspend () -> Unit,
   ) {
     try {
@@ -83,24 +89,30 @@ class CorrelatedErrorReporter(
    * Log [throwable] and emit a best-effort [ErrorResponse] correlated by [requestId], so the
    * awaiting client fails fast instead of hanging to its `RequestManager` timeout.
    *
-   * Best-effort is load-bearing: a failure raised while *reporting* the failure must not escape.
-   * Letting it out would defeat the entire guarantee — it would bubble to the launched coroutine
-   * (or, for [ServiceScopeGuard], re-enter the handler and loop). It is logged and swallowed; the
-   * client then falls back to its timeout, but only for this genuinely-unrecoverable double-failure
-   * tail. A [CancellationException] from the fallback still propagates, for the same reason as in
-   * [guarding].
+   * Best-effort is load-bearing: an `Exception` raised while *reporting* the failure must not
+   * escape. Letting it out would defeat the entire guarantee — it would bubble to the launched
+   * coroutine (or, for [ServiceScopeGuard], re-enter the handler and loop). It is logged and
+   * swallowed; the client then falls back to its timeout, but only for this genuinely-unrecoverable
+   * double-failure tail. A [CancellationException] from the fallback still propagates, for the same
+   * reason as in [guarding].
+   *
+   * Scoped to `Exception` deliberately, matching the three bodies this replaced: a non-`Exception`
+   * `Throwable` from the sink (an `Error`, realistically OOM) still escapes, and for
+   * [ServiceScopeGuard] can re-enter its handler. Widening to `Throwable` would swallow errors that
+   * should kill the process, so the pre-existing behavior is kept rather than quietly changed by a
+   * refactor whose contract is byte-identical behavior.
    */
   private suspend fun report(
     requestId: String?,
     throwable: Throwable,
-    failureLogMessage: String,
-    errorMessagePrefix: String,
-    doubleFailureLogMessage: String,
+    failureLogMessage: () -> String,
+    errorMessagePrefix: () -> String,
+    doubleFailureLogMessage: () -> String,
   ) {
-    logError(failureLogMessage, throwable)
+    logError(failureLogMessage(), throwable)
     emit(
       requestId = requestId,
-      errorMessage = "$errorMessagePrefix: ${causeOf(throwable)}",
+      errorMessage = "${errorMessagePrefix()}: ${causeOf(throwable)}",
       doubleFailureLogMessage = doubleFailureLogMessage,
     )
   }
@@ -114,13 +126,17 @@ class CorrelatedErrorReporter(
    * Emits a best-effort [ErrorResponse] correlated by [requestId]. Best-effort is load-bearing: see
    * [report].
    */
-  suspend fun emit(requestId: String?, errorMessage: String, doubleFailureLogMessage: String) {
+  suspend fun emit(
+    requestId: String?,
+    errorMessage: String,
+    doubleFailureLogMessage: () -> String,
+  ) {
     try {
       broadcastError(ErrorResponse(requestId = requestId, error = errorMessage))
     } catch (fallbackError: CancellationException) {
       throw fallbackError
     } catch (fallbackError: Exception) {
-      logError(doubleFailureLogMessage, fallbackError)
+      logError(doubleFailureLogMessage(), fallbackError)
     }
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
@@ -21,13 +21,15 @@ import kotlinx.coroutines.CancellationException
  * is now structural: this type is the one place the body lives, and `CorrelatedErrorDriftGuardTest`
  * fails CI if a consumer starts hand-rolling it again.
  *
- * Three layers, because the consumers enter at different points:
+ * Two entry points, because the consumers enter at different points:
  * - [guarding] — run a block, report anything it throws. Used by [ResultBroadcaster] and
  *   [AsyncActionRunner].
- * - [report] — log an *already-caught* throwable, then emit its frame.
  * - [emit] + [causeOf] — the frame-emitting tail and the cause rule on their own, for
  *   [ServiceScopeGuard]: a [kotlinx.coroutines.CoroutineExceptionHandler] is handed a throwable
  *   rather than a block, and must log synchronously (see [emit]).
+ *
+ * The log-then-emit middle (`report`) is deliberately private: nothing outside needs it today, and
+ * per CLAUDE.md the interface grows when a second consumer arrives, not ahead of need.
  *
  * @param broadcastError sink for the correlated fallback frame — `webSocketServer.broadcast(…)` in
  *   production (lazily resolving the `lateinit` server), a capturing lambda in tests.
@@ -88,7 +90,7 @@ class CorrelatedErrorReporter(
    * tail. A [CancellationException] from the fallback still propagates, for the same reason as in
    * [guarding].
    */
-  suspend fun report(
+  private suspend fun report(
     requestId: String?,
     throwable: Throwable,
     failureLogMessage: String,

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcaster.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcaster.kt
@@ -2,7 +2,6 @@ package dev.jasonpearson.automobile.ctrlproxy
 
 import android.util.Log
 import dev.jasonpearson.automobile.protocol.ErrorResponse
-import kotlinx.coroutines.CancellationException
 
 /**
  * Guards a result broadcast so that a throw while *sending* a result still yields a correlated
@@ -35,10 +34,14 @@ class ResultBroadcaster(
     Log.e(TAG, message, error)
   },
 ) {
+  /** The shared correlated-error-on-throw core (#3086). */
+  private val reporter = CorrelatedErrorReporter(broadcastError, logError)
+
   /**
    * Run [block] (which performs the actual result broadcast). If it throws anything other than a
-   * cooperative [CancellationException], broadcast an [ErrorResponse] correlated by [requestId] so
-   * the awaiting client fails fast instead of hanging.
+   * cooperative cancellation, broadcast an [ErrorResponse] correlated by [requestId] so the
+   * awaiting client fails fast instead of hanging. See [CorrelatedErrorReporter.guarding] for the
+   * semantics.
    *
    * @param requestId correlation id from the originating request; null when the request carried
    *   none (the fallback frame then carries a null requestId, exactly as the synchronous decode
@@ -47,32 +50,14 @@ class ResultBroadcaster(
    *   triage.
    */
   suspend fun guard(requestId: String?, action: String, block: suspend () -> Unit) {
-    try {
-      block()
-    } catch (e: CancellationException) {
-      // Cooperative cancellation means the service scope is shutting down — never convert it into a
-      // client-facing error frame; let it propagate so the coroutine unwinds cleanly.
-      throw e
-    } catch (e: Exception) {
-      val cause = e.message ?: e::class.simpleName ?: "unknown error"
-      logError("Error broadcasting $action (requestId=$requestId)", e)
-      try {
-        broadcastError(
-          ErrorResponse(requestId = requestId, error = "Broadcast failed for $action: $cause")
-        )
-      } catch (fallbackError: CancellationException) {
-        throw fallbackError
-      } catch (fallbackError: Exception) {
-        // A failure while reporting the broadcast failure must not escape (which would let the
-        // exception bubble to the launched coroutine and defeat the fix). Log and swallow — the
-        // client then falls back to its timeout, but only for this genuinely-unrecoverable
-        // double-failure tail.
-        logError(
-          "Failed to broadcast fallback error for $action (requestId=$requestId)",
-          fallbackError,
-        )
-      }
-    }
+    reporter.guarding(
+      requestId = requestId,
+      failureLogMessage = "Error broadcasting $action (requestId=$requestId)",
+      errorMessagePrefix = "Broadcast failed for $action",
+      doubleFailureLogMessage =
+        "Failed to broadcast fallback error for $action (requestId=$requestId)",
+      block = block,
+    )
   }
 
   companion object {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcaster.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ResultBroadcaster.kt
@@ -52,10 +52,11 @@ class ResultBroadcaster(
   suspend fun guard(requestId: String?, action: String, block: suspend () -> Unit) {
     reporter.guarding(
       requestId = requestId,
-      failureLogMessage = "Error broadcasting $action (requestId=$requestId)",
-      errorMessagePrefix = "Broadcast failed for $action",
-      doubleFailureLogMessage =
-        "Failed to broadcast fallback error for $action (requestId=$requestId)",
+      failureLogMessage = { "Error broadcasting $action (requestId=$requestId)" },
+      errorMessagePrefix = { "Broadcast failed for $action" },
+      doubleFailureLogMessage = {
+        "Failed to broadcast fallback error for $action (requestId=$requestId)"
+      },
       block = block,
     )
   }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuard.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuard.kt
@@ -48,6 +48,14 @@ class ServiceScopeGuard(
     Log.e(TAG, message, error)
   },
 ) {
+  /**
+   * The shared correlated-error-on-throw core (#3086). This consumer uses the
+   * [CorrelatedErrorReporter.emit] / [CorrelatedErrorReporter.causeOf] tail rather than `guarding`
+   * or `report`: a [CoroutineExceptionHandler] is handed an already-caught throwable (so there is
+   * no block to wrap) and cannot suspend, so it must log synchronously here and dispatch only the
+   * broadcast onto [emitScope].
+   */
+  private val reporter = CorrelatedErrorReporter(broadcastResponse, logError)
 
   /**
    * The handler to add to the `serviceScope` context. On any uncaught throwable other than a
@@ -61,25 +69,18 @@ class ServiceScopeGuard(
     if (throwable is CancellationException) return@CoroutineExceptionHandler
 
     val requestId = context[RequestIdContext]?.requestId
-    val cause = throwable.message ?: throwable::class.simpleName ?: "unknown error"
+    val cause = CorrelatedErrorReporter.causeOf(throwable)
+    // Logged synchronously on the failing thread, before dispatching the broadcast: if the emit
+    // scope is already shut down the launch below never runs, and this log is then the only trace.
     logError("Uncaught exception in a serviceScope launch (requestId=$requestId)", throwable)
 
     emitScope().launch {
-      try {
-        broadcastResponse(
-          ErrorResponse(requestId = requestId, error = "Uncaught async failure: $cause")
-        )
-      } catch (broadcastError: CancellationException) {
-        throw broadcastError
-      } catch (broadcastError: Exception) {
-        // A failure while reporting the uncaught exception must not escape — it would re-enter this
-        // same handler and loop. Log and swallow; the client then falls back to its timeout, but
-        // only for this genuinely-unrecoverable double-failure tail.
-        logError(
+      reporter.emit(
+        requestId = requestId,
+        errorMessage = "Uncaught async failure: $cause",
+        doubleFailureLogMessage =
           "Failed to broadcast uncaught-exception error frame (requestId=$requestId)",
-          broadcastError,
-        )
-      }
+      )
     }
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuard.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ServiceScopeGuard.kt
@@ -78,8 +78,9 @@ class ServiceScopeGuard(
       reporter.emit(
         requestId = requestId,
         errorMessage = "Uncaught async failure: $cause",
-        doubleFailureLogMessage =
-          "Failed to broadcast uncaught-exception error frame (requestId=$requestId)",
+        doubleFailureLogMessage = {
+          "Failed to broadcast uncaught-exception error frame (requestId=$requestId)"
+        },
       )
     }
   }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorConsumerContractTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorConsumerContractTest.kt
@@ -5,6 +5,7 @@ import dev.jasonpearson.automobile.protocol.WebSocketResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -131,6 +132,27 @@ class CorrelatedErrorConsumerContractTest {
 
     assertSame("the block must receive the launched coroutine's Job", job, receivedJob)
     assertTrue("it must not be the outer scope's Job", receivedJob !== outerJob)
+  }
+
+  @Test
+  fun `genuinely cancelling a suspended action emits no error frame`() = runTest {
+    // The other cancellation tests throw a synthetic CancellationException from the block. This one
+    // cancels the Job while the block is really suspended, so the cancellation unwinds through the
+    // added `guarding` frame the way production shutdown does.
+    val runner =
+      AsyncActionRunner(
+        scope = this,
+        broadcastResponse = { broadcasts += it },
+        logError = { message, _ -> logs += message },
+      )
+
+    val job = runner.launch(requestId = "req-1", action = "screenshot") { delay(60_000) }
+    advanceUntilIdle()
+    job.cancel()
+    job.join()
+
+    assertTrue("a cancelled action must not emit a frame: $broadcasts", broadcasts.isEmpty())
+    assertTrue("nor log a failure: $logs", logs.isEmpty())
   }
 
   @Test

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorConsumerContractTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorConsumerContractTest.kt
@@ -1,0 +1,150 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.WebSocketResponse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the two properties that made the #3086 extraction safe but that no existing suite actually
+ * asserts.
+ *
+ * 1. **Byte-identical messages.** The extraction's whole claim is that routing three hand-rolled
+ *    bodies through [CorrelatedErrorReporter] changes no emitted text. The three consumer suites
+ *    assert with `contains(...)`, so they would not have caught byte-level drift in the composed
+ *    `"$prefix: $cause"` — and those suites had to stay unchanged to satisfy the issue's second
+ *    acceptance criterion. These tests pin the exact strings instead, so a future edit to a prefix
+ *    or to the cause rule fails loudly rather than silently reshaping what the daemon receives.
+ * 2. **The launched coroutine's scope is what the action body receives.** [AsyncActionRunner] used
+ *    to invoke its `suspend CoroutineScope.() -> Unit` block via an implicit receiver, which could
+ *    not be wrong. It now passes the scope explicitly, which *could* be handed the outer scope by
+ *    mistake — a change that would break structured concurrency for every action while leaving
+ *    every existing assertion green.
+ */
+class CorrelatedErrorConsumerContractTest {
+
+  private val broadcasts = mutableListOf<WebSocketResponse>()
+  private val logs = mutableListOf<String>()
+
+  private fun errors(): List<ErrorResponse> = broadcasts.filterIsInstance<ErrorResponse>()
+
+  // ---------------------------------------------------------------------------
+  // Exact emitted text, per consumer
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `ResultBroadcaster emits the exact documented strings`() = runTest {
+    val broadcaster =
+      ResultBroadcaster(
+        broadcastError = { broadcasts += it },
+        logError = { message, _ -> logs += message },
+      )
+
+    broadcaster.guard(requestId = "req-1", action = "swipe_result") {
+      throw IllegalStateException("socket closed")
+    }
+
+    assertEquals("Broadcast failed for swipe_result: socket closed", errors().single().error)
+    assertEquals("req-1", errors().single().requestId)
+    assertEquals(listOf("Error broadcasting swipe_result (requestId=req-1)"), logs)
+  }
+
+  @Test
+  fun `AsyncActionRunner emits the exact documented strings`() = runTest {
+    val runner =
+      AsyncActionRunner(
+        scope = this,
+        broadcastResponse = { broadcasts += it },
+        logError = { message, _ -> logs += message },
+      )
+
+    runner.launch(requestId = "req-1", action = "screenshot") {
+      throw IllegalStateException("boom")
+    }
+    advanceUntilIdle()
+
+    assertEquals("Action 'screenshot' failed: boom", errors().single().error)
+    assertEquals(listOf("Async action 'screenshot' failed (requestId=req-1)"), logs)
+  }
+
+  @Test
+  fun `ServiceScopeGuard emits the exact documented strings`() = runTest {
+    val guard =
+      ServiceScopeGuard(
+        emitScope = { this },
+        broadcastResponse = { broadcasts += it },
+        logError = { message, _ -> logs += message },
+      )
+
+    val scope =
+      CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler) + guard.handler)
+    scope.launch(RequestIdContext("req-1")) { throw IllegalStateException("boom") }
+    advanceUntilIdle()
+
+    assertEquals("Uncaught async failure: boom", errors().single().error)
+    assertEquals("req-1", errors().single().requestId)
+    assertEquals(
+      listOf("Uncaught exception in a serviceScope launch (requestId=req-1)"),
+      logs,
+    )
+  }
+
+  @Test
+  fun `the shared cause rule still falls back to the class name for every consumer`() = runTest {
+    val broadcaster =
+      ResultBroadcaster(broadcastError = { broadcasts += it }, logError = { _, _ -> })
+
+    broadcaster.guard(requestId = null, action = "swipe_result") {
+      throw IllegalStateException()
+    }
+
+    assertEquals(
+      "Broadcast failed for swipe_result: IllegalStateException",
+      errors().single().error,
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // The action body receives the launched coroutine's scope
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `the action body's receiver is the launched coroutine, not the outer scope`() = runTest {
+    val runner = AsyncActionRunner(scope = this, broadcastResponse = {}, logError = { _, _ -> })
+    val outerJob = coroutineContext[Job]
+    var receivedJob: Job? = null
+
+    val job =
+      runner.launch(requestId = "req-1", action = "screenshot") {
+        receivedJob = coroutineContext[Job]
+      }
+    job.join()
+
+    assertSame("the block must receive the launched coroutine's Job", job, receivedJob)
+    assertTrue("it must not be the outer scope's Job", receivedJob !== outerJob)
+  }
+
+  @Test
+  fun `a child coroutine started by the action body is awaited by the launched job`() = runTest {
+    val runner = AsyncActionRunner(scope = this, broadcastResponse = {}, logError = { _, _ -> })
+    var childRan = false
+
+    val job =
+      runner.launch(requestId = "req-1", action = "screenshot") {
+        // `this` is the action body's receiver — structured concurrency must hold through it.
+        launch { childRan = true }
+      }
+    job.join()
+
+    assertTrue("a child launched from the body must run before the parent completes", childRan)
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
@@ -1,0 +1,361 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Structural backstop for issue #3086. Enforces that the three seams which emit a correlated
+ * `type:"error"` frame on a throw — [ResultBroadcaster], [AsyncActionRunner] and
+ * [ServiceScopeGuard] — keep delegating to the single [CorrelatedErrorReporter] core instead of
+ * hand-rolling it.
+ *
+ * #3086 was filed as a deliberate YAGNI defer while only two consumers existed, tracking one
+ * specific risk: nothing *forced* the duplicated catch-bodies to stay in lock-step, so a future fix
+ * to one (changing the cause derivation, folding the requestId into the message, adjusting
+ * cancellation handling) would silently leave the others behind. [ServiceScopeGuard] (#3104) then
+ * arrived as the third consumer and duplicated the body a third time, which is the trigger the
+ * issue named.
+ *
+ * Extracting the core removes today's duplication; this scanner is what stops it coming back. The
+ * scanning logic is factored into [CorrelatedErrorDriftScanner] (a pure function over source text)
+ * so the enforcement contract is itself unit-tested against synthetic good/bad snippets — the
+ * real-file assertions then prove the live sources comply.
+ */
+class CorrelatedErrorDriftGuardTest {
+
+  // ---------------------------------------------------------------------------
+  // Contract tests: the scanner itself, over synthetic snippets
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `a consumer that delegates to the reporter is clean`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        suspend fun guard(requestId: String?, action: String, block: suspend () -> Unit) {
+          reporter.guarding(requestId, action, "Broadcast failed for", block)
+        }
+      }
+      """
+        .trimIndent()
+
+    assertEquals(emptyList<CorrelatedErrorDriftScanner.Violation>(), scan(source))
+  }
+
+  @Test
+  fun `a hand-rolled cause derivation is flagged`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        suspend fun guard(e: Exception) {
+          val cause = e.message ?: e::class.simpleName ?: "unknown error"
+          reporter.report(null, cause)
+        }
+      }
+      """
+        .trimIndent()
+
+    assertEquals(
+      listOf(CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_CAUSE),
+      scan(source).map { it.kind },
+    )
+  }
+
+  @Test
+  fun `a hand-rolled error frame construction is flagged`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        suspend fun guard(requestId: String?) {
+          broadcastError(ErrorResponse(requestId = requestId, error = "boom"))
+        }
+      }
+      """
+        .trimIndent()
+
+    assertEquals(
+      listOf(CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_ERROR_FRAME),
+      scan(source).map { it.kind },
+    )
+  }
+
+  @Test
+  fun `a consumer that never mentions the reporter is flagged as not delegating`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example {
+        suspend fun guard(block: suspend () -> Unit) {
+          block()
+        }
+      }
+      """
+        .trimIndent()
+
+    assertEquals(
+      listOf(CorrelatedErrorDriftScanner.Kind.MISSING_DELEGATION),
+      scan(source).map { it.kind },
+    )
+  }
+
+  @Test
+  fun `KDoc and imports naming the frame type are not mistaken for a hand-rolled body`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      import dev.jasonpearson.automobile.protocol.ErrorResponse
+
+      /**
+       * Emits a best-effort [ErrorResponse] correlated by requestId. The cause falls back to
+       * "unknown error" when the throwable carries no message.
+       */
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        suspend fun guard(requestId: String?, action: String, block: suspend () -> Unit) {
+          reporter.guarding(requestId, action, "Broadcast failed for", block)
+        }
+      }
+      """
+        .trimIndent()
+
+    assertTrue(
+      "comments and imports must not trip the scanner: ${scan(source)}",
+      scan(source).isEmpty(),
+    )
+  }
+
+  @Test
+  fun `a line comment mentioning the cause literal is not flagged`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        // The reporter derives the cause, falling back to "unknown error".
+        suspend fun guard(requestId: String?, action: String, block: suspend () -> Unit) {
+          reporter.guarding(requestId, action, "Broadcast failed for", block)
+        }
+      }
+      """
+        .trimIndent()
+
+    assertTrue("line comments must not trip the scanner: ${scan(source)}", scan(source).isEmpty())
+  }
+
+  @Test
+  fun `the reporter core itself is exempt — it is where the body is allowed to live`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class CorrelatedErrorReporter {
+        suspend fun report(requestId: String?, throwable: Throwable) {
+          val cause = throwable.message ?: throwable::class.simpleName ?: "unknown error"
+          broadcast(ErrorResponse(requestId = requestId, error = cause))
+        }
+      }
+      """
+        .trimIndent()
+
+    assertTrue(
+      "the core must not flag itself: ${CorrelatedErrorDriftScanner.scan(CorrelatedErrorDriftScanner.CORE_FILE, source)}",
+      CorrelatedErrorDriftScanner.scan(CorrelatedErrorDriftScanner.CORE_FILE, source).isEmpty(),
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Real-file assertions: the live sources comply
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `every live consumer delegates to the single correlated-error core`() {
+    val violations =
+      CorrelatedErrorDriftScanner.CONSUMER_FILES.flatMap { fileName ->
+        CorrelatedErrorDriftScanner.scan(fileName, readProductionSource(fileName))
+      }
+
+    assertTrue(
+      "Correlated-error-on-throw drift detected (issue #3086). Each of " +
+        "${CorrelatedErrorDriftScanner.CONSUMER_FILES} must delegate to " +
+        "${CorrelatedErrorDriftScanner.CORE_FILE} rather than hand-roll the cause derivation or " +
+        "the ErrorResponse fallback: $violations",
+      violations.isEmpty(),
+    )
+  }
+
+  @Test
+  fun `the correlated-error core exists as a single file`() {
+    val core = locateProductionSource(CorrelatedErrorDriftScanner.CORE_FILE)
+    assertTrue("${CorrelatedErrorDriftScanner.CORE_FILE} must exist", core.isFile)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private fun scan(source: String): List<CorrelatedErrorDriftScanner.Violation> =
+    CorrelatedErrorDriftScanner.scan("Example.kt", source)
+
+  private fun readProductionSource(fileName: String): String =
+    locateProductionSource(fileName).readText()
+
+  private fun locateProductionSource(fileName: String): File {
+    val rel = "src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/$fileName"
+    // Depending on the Gradle working directory the module root may be the cwd (AGP unit tests),
+    // the `android` dir, or the repo root. Try the common anchors, then walk up as a fallback.
+    val direct =
+      listOf(File(rel), File("control-proxy/$rel"), File("android/control-proxy/$rel"))
+        .firstOrNull {
+          it.isFile
+        }
+    if (direct != null) return direct
+
+    val userDir = System.getProperty("user.dir") ?: "."
+    var dir: File? = File(userDir).absoluteFile
+    while (dir != null) {
+      for (candidate in
+        listOf(
+          File(dir, rel),
+          File(dir, "control-proxy/$rel"),
+          File(dir, "android/control-proxy/$rel"),
+        )) {
+        if (candidate.isFile) return candidate
+      }
+      dir = dir.parentFile
+    }
+    fail("Could not locate $fileName from user.dir=$userDir")
+    error("unreachable")
+  }
+}
+
+/**
+ * Pure, Android-free source scanner for the [CorrelatedErrorDriftGuardTest] enforcement. Reads
+ * Kotlin source as text and reports correlated-error-core drift. Test-only (lives in the test
+ * source set) — ships no scanning code in the app.
+ *
+ * The contract is deliberately blunt: the cause derivation and the fallback [ErrorResponse]
+ * construction may appear in exactly one production file, and every consumer must name the core. A
+ * blunt contract is what makes it hard to drift past by accident.
+ */
+object CorrelatedErrorDriftScanner {
+
+  /** The single file allowed to contain the correlated-error-on-throw body. */
+  const val CORE_FILE = "CorrelatedErrorReporter.kt"
+
+  /** The seams that must delegate to [CORE_FILE] rather than hand-roll the body. */
+  val CONSUMER_FILES =
+    listOf("ResultBroadcaster.kt", "AsyncActionRunner.kt", "ServiceScopeGuard.kt")
+
+  enum class Kind {
+    /** The `message ?: simpleName ?: "unknown error"` fallback re-implemented outside the core. */
+    HAND_ROLLED_CAUSE,
+    /** An `ErrorResponse(…)` fallback frame constructed outside the core. */
+    HAND_ROLLED_ERROR_FRAME,
+    /** A consumer that never references the core at all. */
+    MISSING_DELEGATION,
+  }
+
+  data class Violation(val kind: Kind, val file: String, val line: Int)
+
+  /**
+   * Scan one Kotlin source file. [fileName] selects the rule set: [CORE_FILE] is exempt (it is
+   * where the body is supposed to live); everything else is treated as a consumer.
+   */
+  fun scan(fileName: String, source: String): List<Violation> {
+    if (fileName == CORE_FILE) return emptyList()
+
+    val code = stripComments(source)
+    val violations = mutableListOf<Violation>()
+
+    code.lineSequence().forEachIndexed { index, line ->
+      val lineNumber = index + 1
+      if (line.contains(CAUSE_FALLBACK_LITERAL)) {
+        violations += Violation(Kind.HAND_ROLLED_CAUSE, fileName, lineNumber)
+      }
+      if (line.contains(ERROR_FRAME_CONSTRUCTION)) {
+        violations += Violation(Kind.HAND_ROLLED_ERROR_FRAME, fileName, lineNumber)
+      }
+    }
+
+    if (!code.contains(CORE_TYPE)) {
+      violations += Violation(Kind.MISSING_DELEGATION, fileName, 0)
+    }
+
+    return violations
+  }
+
+  private const val CAUSE_FALLBACK_LITERAL = "\"unknown error\""
+  private const val ERROR_FRAME_CONSTRUCTION = "ErrorResponse("
+  private const val CORE_TYPE = "CorrelatedErrorReporter"
+
+  /**
+   * Blank out `//` line comments and `/* … */` block comments (including KDoc) so prose describing
+   * the core is never mistaken for a re-implementation of it. Lines are preserved so reported line
+   * numbers still point at the real source.
+   */
+  private fun stripComments(source: String): String {
+    val out = StringBuilder(source.length)
+    var inBlockComment = false
+    var inString = false
+    var index = 0
+
+    while (index < source.length) {
+      val char = source[index]
+      val next = source.getOrNull(index + 1)
+
+      when {
+        char == '\n' -> {
+          inString = false
+          out.append(char)
+          index++
+        }
+        inBlockComment -> {
+          if (char == '*' && next == '/') {
+            inBlockComment = false
+            index += 2
+          } else {
+            index++
+          }
+        }
+        inString -> {
+          if (char == '\\') {
+            out.append(char).append(next ?: ' ')
+            index += 2
+          } else {
+            if (char == '"') inString = false
+            out.append(char)
+            index++
+          }
+        }
+        char == '/' && next == '*' -> {
+          inBlockComment = true
+          index += 2
+        }
+        char == '/' && next == '/' -> {
+          while (index < source.length && source[index] != '\n') index++
+        }
+        char == '"' -> {
+          inString = true
+          out.append(char)
+          index++
+        }
+        else -> {
+          out.append(char)
+          index++
+        }
+      }
+    }
+
+    return out.toString()
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
@@ -23,6 +23,16 @@ import org.junit.Test
  * scanning logic is factored into [CorrelatedErrorDriftScanner] (a pure function over source text)
  * so the enforcement contract is itself unit-tested against synthetic good/bad snippets — the
  * real-file assertions then prove the live sources comply.
+ *
+ * **Scope, and why it stops where it does.** [CorrelatedErrorDriftScanner.CONSUMER_FILES] is a
+ * hand-maintained list of three, so a *fourth* seam that hand-rolls the body is not caught.
+ * Widening the scan to every file in the package was considered and rejected: `WebSocketServer.kt`
+ * (the decode path, #2985) and `HierarchyExtractErrorFrames.kt` both construct `ErrorResponse` for
+ * legitimate non-fallback reasons, so a package-wide rule would fire on correct code. This is the
+ * same limit [BroadcastGuardAdoptionTest] documents for raw `serviceScope.launch` — it "cannot
+ * distinguish such an action from the ~30 legitimate raw launches without false positives" — and it
+ * is why [ServiceScopeGuard] closed that gap *by construction* rather than by scanning. A text
+ * scanner is a backstop against reintroducing a known body, not a proof of absence.
  */
 class CorrelatedErrorDriftGuardTest {
 
@@ -56,7 +66,7 @@ class CorrelatedErrorDriftGuardTest {
       class Example(private val reporter: CorrelatedErrorReporter) {
         suspend fun guard(e: Exception) {
           val cause = e.message ?: e::class.simpleName ?: "unknown error"
-          reporter.report(null, cause)
+          reporter.emit(null, cause, "double failure")
         }
       }
       """
@@ -77,14 +87,104 @@ class CorrelatedErrorDriftGuardTest {
       class Example(private val reporter: CorrelatedErrorReporter) {
         suspend fun guard(requestId: String?) {
           broadcastError(ErrorResponse(requestId = requestId, error = "boom"))
+          reporter.emit(requestId, "x", "y")
+        }
+      }
+      """
+        .trimIndent()
+
+    // Delegating elsewhere does not excuse constructing a fallback frame by hand.
+    assertEquals(
+      listOf(CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_ERROR_FRAME),
+      scan(source).map { it.kind },
+    )
+  }
+
+  @Test
+  fun `a cause derivation that changes the fallback constant is still flagged`() {
+    // The point of drift is that the copy *differs*. Matching only today's literal would miss this.
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        suspend fun guard(e: Exception, requestId: String?) {
+          val cause = e.message ?: e::class.simpleName ?: "unspecified failure"
+          reporter.emit(requestId, cause, "double failure")
         }
       }
       """
         .trimIndent()
 
     assertEquals(
+      listOf(CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_CAUSE),
+      scan(source).map { it.kind },
+    )
+  }
+
+  @Test
+  fun `holding a reporter field without ever calling it does not count as delegating`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(broadcast: suspend (ErrorResponse) -> Unit) {
+        private val reporter = CorrelatedErrorReporter(broadcast) { _, _ -> }
+
+        suspend fun guard(block: suspend () -> Unit) {
+          try {
+            block()
+          } catch (e: Exception) {
+            log(e)
+          }
+        }
+      }
+      """
+        .trimIndent()
+
+    assertTrue(
+      "a field that is never invoked must not satisfy the check: ${scan(source)}",
+      scan(source).any { it.kind == CorrelatedErrorDriftScanner.Kind.MISSING_DELEGATION },
+    )
+  }
+
+  @Test
+  fun `a raw string containing a comment opener does not blank the rest of the file`() {
+    val source =
+      "package dev.jasonpearson.automobile.ctrlproxy\n" +
+        "\n" +
+        "class Example(private val reporter: CorrelatedErrorReporter) {\n" +
+        "  val doc = \"\"\"not a comment: /* still code below */\"\"\"\n" +
+        "\n" +
+        "  suspend fun guard(requestId: String?) {\n" +
+        "    broadcastError(ErrorResponse(requestId = requestId, error = \"boom\"))\n" +
+        "    reporter.emit(requestId, \"x\", \"y\")\n" +
+        "  }\n" +
+        "}\n"
+
+    assertEquals(
+      "code after a raw string must still be scanned",
       listOf(CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_ERROR_FRAME),
       scan(source).map { it.kind },
+    )
+  }
+
+  @Test
+  fun `a char literal holding a quote does not swallow the rest of the line`() {
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        val quote = '"' // the reporter owns the "unknown error" fallback
+        suspend fun guard(requestId: String?) = reporter.emit(requestId, "x", "y")
+      }
+      """
+        .trimIndent()
+
+    assertTrue(
+      "a trailing comment after a char literal must still be stripped: ${scan(source)}",
+      scan(source).isEmpty(),
     )
   }
 
@@ -279,7 +379,7 @@ object CorrelatedErrorDriftScanner {
 
     code.lineSequence().forEachIndexed { index, line ->
       val lineNumber = index + 1
-      if (line.contains(CAUSE_FALLBACK_LITERAL)) {
+      if (CAUSE_DERIVATION_TOKENS.any { line.contains(it) }) {
         violations += Violation(Kind.HAND_ROLLED_CAUSE, fileName, lineNumber)
       }
       if (line.contains(ERROR_FRAME_CONSTRUCTION)) {
@@ -287,54 +387,96 @@ object CorrelatedErrorDriftScanner {
       }
     }
 
-    if (!code.contains(CORE_TYPE)) {
+    if (DELEGATION_CALLS.none { code.contains(it) }) {
       violations += Violation(Kind.MISSING_DELEGATION, fileName, 0)
     }
 
     return violations
   }
 
-  private const val CAUSE_FALLBACK_LITERAL = "\"unknown error\""
+  /**
+   * Both halves of the cause rule, so that drift which *changes* the fallback constant is caught
+   * too. Matching only the literal would miss `?: e::class.simpleName ?: "unspecified failure"` —
+   * and a body that differs from today's is exactly what drift looks like.
+   */
+  private val CAUSE_DERIVATION_TOKENS = listOf("\"unknown error\"", "::class.simpleName")
+
   private const val ERROR_FRAME_CONSTRUCTION = "ErrorResponse("
-  private const val CORE_TYPE = "CorrelatedErrorReporter"
+
+  /**
+   * Delegation must be an actual *call*, not a bare mention of the type: a consumer that holds a
+   * `CorrelatedErrorReporter` field, never invokes it, and hand-rolls the body beside it would
+   * otherwise satisfy the check by construction.
+   *
+   * The receiver is spelled out rather than matching a bare `.emit(` — the package is full of
+   * `Flow.emit(` calls (`WebSocketServer`, `HierarchyDebouncer`), any of which would otherwise pass
+   * for delegation.
+   */
+  private val DELEGATION_CALLS =
+    listOf("reporter.guarding(", "reporter.emit(", "CorrelatedErrorReporter.causeOf(")
 
   /**
    * Blank out `//` line comments and `/* … */` block comments (including KDoc) so prose describing
    * the core is never mistaken for a re-implementation of it. Lines are preserved so reported line
    * numbers still point at the real source.
+   *
+   * String and character literals are tracked, not stripped — the scanner needs to see the cause
+   * constant, which *is* a string literal. Tracking them is what stops a comment opener appearing
+   * inside a literal from opening a comment and blanking the real code after it.
    */
   private fun stripComments(source: String): String {
     val out = StringBuilder(source.length)
     var inBlockComment = false
-    var inString = false
+    var inLineString = false
+    var inRawString = false
+    var inCharLiteral = false
     var index = 0
 
     while (index < source.length) {
       val char = source[index]
       val next = source.getOrNull(index + 1)
+      val isRawDelimiter = char == '"' && next == '"' && source.getOrNull(index + 2) == '"'
 
       when {
-        char == '\n' -> {
-          inString = false
-          out.append(char)
-          index++
-        }
         inBlockComment -> {
           if (char == '*' && next == '/') {
             inBlockComment = false
             index += 2
           } else {
+            if (char == '\n') out.append(char)
             index++
           }
         }
-        inString -> {
-          if (char == '\\') {
-            out.append(char).append(next ?: ' ')
-            index += 2
+        // A raw string spans lines and honors no escapes; only `"""` closes it.
+        inRawString -> {
+          if (isRawDelimiter) {
+            inRawString = false
+            out.append("\"\"\"")
+            index += 3
           } else {
-            if (char == '"') inString = false
             out.append(char)
             index++
+          }
+        }
+        inLineString || inCharLiteral -> {
+          when {
+            char == '\\' -> {
+              out.append(char).append(next ?: ' ')
+              index += 2
+            }
+            // An unterminated literal cannot span a line; recover rather than swallow the file.
+            char == '\n' -> {
+              inLineString = false
+              inCharLiteral = false
+              out.append(char)
+              index++
+            }
+            else -> {
+              if (inLineString && char == '"') inLineString = false
+              if (inCharLiteral && char == '\'') inCharLiteral = false
+              out.append(char)
+              index++
+            }
           }
         }
         char == '/' && next == '*' -> {
@@ -344,8 +486,18 @@ object CorrelatedErrorDriftScanner {
         char == '/' && next == '/' -> {
           while (index < source.length && source[index] != '\n') index++
         }
+        isRawDelimiter -> {
+          inRawString = true
+          out.append("\"\"\"")
+          index += 3
+        }
         char == '"' -> {
-          inString = true
+          inLineString = true
+          out.append(char)
+          index++
+        }
+        char == '\'' -> {
+          inCharLiteral = true
           out.append(char)
           index++
         }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
@@ -66,7 +66,7 @@ class CorrelatedErrorDriftGuardTest {
       class Example(private val reporter: CorrelatedErrorReporter) {
         suspend fun guard(e: Exception) {
           val cause = e.message ?: e::class.simpleName ?: "unknown error"
-          reporter.emit(null, cause, "double failure")
+          reporter.guarding(null, { "a" }, { "b" }, { "c" }) {}
         }
       }
       """
@@ -87,7 +87,7 @@ class CorrelatedErrorDriftGuardTest {
       class Example(private val reporter: CorrelatedErrorReporter) {
         suspend fun guard(requestId: String?) {
           broadcastError(ErrorResponse(requestId = requestId, error = "boom"))
-          reporter.emit(requestId, "x", "y")
+          reporter.guarding(requestId, { "a" }, { "b" }, { "c" }) {}
         }
       }
       """
@@ -110,7 +110,7 @@ class CorrelatedErrorDriftGuardTest {
       class Example(private val reporter: CorrelatedErrorReporter) {
         suspend fun guard(e: Exception, requestId: String?) {
           val cause = e.message ?: e::class.simpleName ?: "unspecified failure"
-          reporter.emit(requestId, cause, "double failure")
+          reporter.guarding(requestId, { "a" }, { "b" }, { "c" }) {}
         }
       }
       """
@@ -119,6 +119,78 @@ class CorrelatedErrorDriftGuardTest {
     assertEquals(
       listOf(CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_CAUSE),
       scan(source).map { it.kind },
+    )
+  }
+
+  @Test
+  fun `the Java-interop spellings of the cause rule are flagged too`() {
+    // `javaClass.simpleName` is at least as idiomatic in Android code as the Kotlin spelling, so
+    // matching only `::class.simpleName` would let the most likely drift through untouched.
+    listOf(
+        "e.message ?: e.javaClass.simpleName ?: \"boom\"",
+        "e.message ?: e::class.java.simpleName ?: \"boom\"",
+      )
+      .forEach { derivation ->
+        val source =
+          """
+          package dev.jasonpearson.automobile.ctrlproxy
+
+          class Example(private val reporter: CorrelatedErrorReporter) {
+            suspend fun guard(e: Exception, requestId: String?) {
+              val cause = $derivation
+              reporter.guarding(requestId, "a", "b", "c") {}
+            }
+          }
+          """
+            .trimIndent()
+
+        assertEquals(
+          "must flag: $derivation",
+          listOf(CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_CAUSE),
+          scan(source).map { it.kind },
+        )
+      }
+  }
+
+  @Test
+  fun `renaming the reporter field does not break a correctly delegating consumer`() {
+    // A guard that fails CI on a pure rename is a guard that gets deleted.
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val errorReporter: CorrelatedErrorReporter) {
+        suspend fun guard(requestId: String?, action: String, block: suspend () -> Unit) {
+          errorReporter.guarding(requestId, "a", "b", "c", block)
+        }
+      }
+      """
+        .trimIndent()
+
+    assertTrue("a renamed field still delegates: ${scan(source)}", scan(source).isEmpty())
+  }
+
+  @Test
+  fun `a nested block comment stays fully commented out`() {
+    // Kotlin block comments nest. Commenting out an old implementation that carries its own KDoc
+    // must not leak the disabled body back into the scan.
+    val source =
+      """
+      package dev.jasonpearson.automobile.ctrlproxy
+
+      class Example(private val reporter: CorrelatedErrorReporter) {
+        /* old path, kept for reference:
+         /** derives the cause */
+         val cause = e.message ?: e::class.simpleName ?: "unknown error"
+        */
+        suspend fun guard(requestId: String?) = reporter.guarding(requestId, "a", "b", "c") {}
+      }
+      """
+        .trimIndent()
+
+    assertTrue(
+      "commented-out code must not be scanned as live: ${scan(source)}",
+      scan(source).isEmpty(),
     )
   }
 
@@ -158,7 +230,7 @@ class CorrelatedErrorDriftGuardTest {
         "\n" +
         "  suspend fun guard(requestId: String?) {\n" +
         "    broadcastError(ErrorResponse(requestId = requestId, error = \"boom\"))\n" +
-        "    reporter.emit(requestId, \"x\", \"y\")\n" +
+        "    reporter.guarding(requestId, { \"a\" }) {}\n" +
         "  }\n" +
         "}\n"
 
@@ -177,7 +249,7 @@ class CorrelatedErrorDriftGuardTest {
 
       class Example(private val reporter: CorrelatedErrorReporter) {
         val quote = '"' // the reporter owns the "unknown error" fallback
-        suspend fun guard(requestId: String?) = reporter.emit(requestId, "x", "y")
+        suspend fun guard(requestId: String?) = reporter.guarding(requestId) {}
       }
       """
         .trimIndent()
@@ -343,9 +415,16 @@ class CorrelatedErrorDriftGuardTest {
  * Kotlin source as text and reports correlated-error-core drift. Test-only (lives in the test
  * source set) — ships no scanning code in the app.
  *
- * The contract is deliberately blunt: the cause derivation and the fallback [ErrorResponse]
- * construction may appear in exactly one production file, and every consumer must name the core. A
- * blunt contract is what makes it hard to drift past by accident.
+ * The contract is deliberately blunt: within the three enumerated [CONSUMER_FILES], the cause
+ * derivation and the fallback [ErrorResponse] construction may not appear at all, and each file
+ * must both name the core and call it. A blunt contract is what makes it hard to drift past by
+ * accident.
+ *
+ * Note the scope precisely — this is *not* "the cause rule exists in exactly one file in the
+ * package". It does not: `WebSocketServer.kt`, `HierarchyExtractErrorFrames.kt` and `CtrlProxy.kt`
+ * each derive a cause on paths this scanner does not police. See the class KDoc on
+ * [CorrelatedErrorDriftGuardTest] for why the scan stops at three files, and issue #3992 for the
+ * residual.
  */
 object CorrelatedErrorDriftScanner {
 
@@ -387,7 +466,8 @@ object CorrelatedErrorDriftScanner {
       }
     }
 
-    if (DELEGATION_CALLS.none { code.contains(it) }) {
+    val delegates = code.contains(CORE_TYPE) && DELEGATION_CALLS.any { code.contains(it) }
+    if (!delegates) {
       violations += Violation(Kind.MISSING_DELEGATION, fileName, 0)
     }
 
@@ -395,25 +475,37 @@ object CorrelatedErrorDriftScanner {
   }
 
   /**
-   * Both halves of the cause rule, so that drift which *changes* the fallback constant is caught
-   * too. Matching only the literal would miss `?: e::class.simpleName ?: "unspecified failure"` —
-   * and a body that differs from today's is exactly what drift looks like.
+   * Every spelling of the cause rule, not just today's. Drift means the copy *differs*: matching
+   * only the literal would miss `?: e::class.simpleName ?: "unspecified failure"`, and matching
+   * only `::class.simpleName` would miss the Java-interop spellings that are at least as idiomatic
+   * in Android code as the Kotlin one.
    */
-  private val CAUSE_DERIVATION_TOKENS = listOf("\"unknown error\"", "::class.simpleName")
+  private val CAUSE_DERIVATION_TOKENS =
+    listOf(
+      "\"unknown error\"",
+      "::class.simpleName",
+      "::class.java",
+      "javaClass.simpleName",
+    )
 
   private const val ERROR_FRAME_CONSTRUCTION = "ErrorResponse("
 
   /**
    * Delegation must be an actual *call*, not a bare mention of the type: a consumer that holds a
    * `CorrelatedErrorReporter` field, never invokes it, and hand-rolls the body beside it would
-   * otherwise satisfy the check by construction.
+   * otherwise satisfy the check by construction. Both halves are required — the type must be named
+   * *and* one of these called.
    *
-   * The receiver is spelled out rather than matching a bare `.emit(` — the package is full of
-   * `Flow.emit(` calls (`WebSocketServer`, `HierarchyDebouncer`), any of which would otherwise pass
-   * for delegation.
+   * Deliberately receiver-agnostic. An earlier version required a literal `reporter.` prefix, which
+   * would have failed CI on correct code the moment someone renamed the field to `errorReporter` or
+   * wrapped the call in `with(reporter) { … }` — and a test that breaks on a pure rename is a test
+   * that gets deleted. `.emit(` is excluded because the package is full of `Flow.emit(` calls
+   * (`WebSocketServer`, `HierarchyDebouncer`) that would pass for delegation; `ServiceScopeGuard`
+   * qualifies through `causeOf` instead.
    */
-  private val DELEGATION_CALLS =
-    listOf("reporter.guarding(", "reporter.emit(", "CorrelatedErrorReporter.causeOf(")
+  private val DELEGATION_CALLS = listOf(".guarding(", ".causeOf(")
+
+  private const val CORE_TYPE = "CorrelatedErrorReporter"
 
   /**
    * Blank out `//` line comments and `/* … */` block comments (including KDoc) so prose describing
@@ -426,7 +518,10 @@ object CorrelatedErrorDriftScanner {
    */
   private fun stripComments(source: String): String {
     val out = StringBuilder(source.length)
-    var inBlockComment = false
+    // Kotlin block comments nest, so this is a depth counter rather than a flag: commenting out an
+    // old implementation that contains its own KDoc must stay fully commented out, or the disabled
+    // code gets scanned as live and fails CI on something that isn't even compiled.
+    var blockCommentDepth = 0
     var inLineString = false
     var inRawString = false
     var inCharLiteral = false
@@ -438,13 +533,20 @@ object CorrelatedErrorDriftScanner {
       val isRawDelimiter = char == '"' && next == '"' && source.getOrNull(index + 2) == '"'
 
       when {
-        inBlockComment -> {
-          if (char == '*' && next == '/') {
-            inBlockComment = false
-            index += 2
-          } else {
-            if (char == '\n') out.append(char)
-            index++
+        blockCommentDepth > 0 -> {
+          when {
+            char == '/' && next == '*' -> {
+              blockCommentDepth++
+              index += 2
+            }
+            char == '*' && next == '/' -> {
+              blockCommentDepth--
+              index += 2
+            }
+            else -> {
+              if (char == '\n') out.append(char)
+              index++
+            }
           }
         }
         // A raw string spans lines and honors no escapes; only `"""` closes it.
@@ -480,7 +582,7 @@ object CorrelatedErrorDriftScanner {
           }
         }
         char == '/' && next == '*' -> {
-          inBlockComment = true
+          blockCommentDepth++
           index += 2
         }
         char == '/' && next == '/' -> {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
@@ -1,0 +1,178 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Direct unit tests for the shared correlated-error-on-throw core extracted in issue #3086.
+ *
+ * The three consumers ([ResultBroadcaster], [AsyncActionRunner], [ServiceScopeGuard]) keep their
+ * own suites, which now exercise this core through their public surfaces. These tests pin the
+ * core's semantics on their own, so a future change to it is described in one place.
+ */
+class CorrelatedErrorReporterTest {
+
+  private val broadcasts = mutableListOf<ErrorResponse>()
+  private val logs = mutableListOf<Pair<String, Throwable>>()
+
+  private fun reporter(
+    broadcastError: suspend (ErrorResponse) -> Unit = { broadcasts += it }
+  ): CorrelatedErrorReporter =
+    CorrelatedErrorReporter(broadcastError) { message, error -> logs += message to error }
+
+  // ---------------------------------------------------------------------------
+  // guarding
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `guarding emits a correlated frame when the block throws`() = runTest {
+    reporter().guarding(
+      requestId = "req-1",
+      failureLogMessage = "failure log",
+      errorMessagePrefix = "Action 'foo' failed",
+      doubleFailureLogMessage = "double failure log",
+    ) {
+      throw IllegalStateException("boom")
+    }
+
+    assertEquals(1, broadcasts.size)
+    assertEquals("req-1", broadcasts.single().requestId)
+    assertEquals("Action 'foo' failed: boom", broadcasts.single().error)
+    assertEquals(false, broadcasts.single().success)
+    assertEquals(listOf("failure log"), logs.map { it.first })
+  }
+
+  @Test
+  fun `guarding emits nothing when the block succeeds`() = runTest {
+    reporter().guarding(
+      requestId = "req-1",
+      failureLogMessage = "failure log",
+      errorMessagePrefix = "Action 'foo' failed",
+      doubleFailureLogMessage = "double failure log",
+    ) {
+      // no-op
+    }
+
+    assertTrue(broadcasts.isEmpty())
+    assertTrue(logs.isEmpty())
+  }
+
+  @Test
+  fun `guarding propagates cancellation without emitting a frame`() = runTest {
+    try {
+      reporter().guarding(
+        requestId = "req-1",
+        failureLogMessage = "failure log",
+        errorMessagePrefix = "Action 'foo' failed",
+        doubleFailureLogMessage = "double failure log",
+      ) {
+        throw CancellationException("shutting down")
+      }
+      fail("expected the cancellation to propagate")
+    } catch (expected: CancellationException) {
+      assertEquals("shutting down", expected.message)
+    }
+
+    assertTrue("cancellation must never become a client-facing frame", broadcasts.isEmpty())
+    assertTrue(logs.isEmpty())
+  }
+
+  @Test
+  fun `guarding carries a null requestId through to the frame`() = runTest {
+    reporter().guarding(
+      requestId = null,
+      failureLogMessage = "failure log",
+      errorMessagePrefix = "Action 'foo' failed",
+      doubleFailureLogMessage = "double failure log",
+    ) {
+      throw IllegalStateException("boom")
+    }
+
+    assertNull(broadcasts.single().requestId)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Double-failure tail
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `a failure raised while emitting the frame is logged and swallowed`() = runTest {
+    reporter(broadcastError = { throw IllegalStateException("sink down") }).guarding(
+      requestId = "req-1",
+      failureLogMessage = "failure log",
+      errorMessagePrefix = "Action 'foo' failed",
+      doubleFailureLogMessage = "double failure log",
+    ) {
+      throw IllegalStateException("boom")
+    }
+
+    assertEquals(listOf("failure log", "double failure log"), logs.map { it.first })
+    assertEquals("sink down", logs.last().second.message)
+  }
+
+  @Test
+  fun `a cancellation raised while emitting the frame propagates`() = runTest {
+    try {
+      reporter(broadcastError = { throw CancellationException("scope died") }).guarding(
+        requestId = "req-1",
+        failureLogMessage = "failure log",
+        errorMessagePrefix = "Action 'foo' failed",
+        doubleFailureLogMessage = "double failure log",
+      ) {
+        throw IllegalStateException("boom")
+      }
+      fail("expected the cancellation to propagate")
+    } catch (expected: CancellationException) {
+      assertEquals("scope died", expected.message)
+    }
+
+    assertEquals(listOf("failure log"), logs.map { it.first })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cause derivation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `cause falls back to the class name when the throwable has no message`() {
+    assertEquals(
+      "IllegalStateException",
+      CorrelatedErrorReporter.causeOf(IllegalStateException()),
+    )
+  }
+
+  @Test
+  fun `cause uses the message when present`() {
+    assertEquals("boom", CorrelatedErrorReporter.causeOf(IllegalStateException("boom")))
+  }
+
+  @Test
+  fun `cause falls back to a constant for an anonymous throwable with no message`() {
+    val anonymous = object : Throwable() {}
+    assertEquals("unknown error", CorrelatedErrorReporter.causeOf(anonymous))
+  }
+
+  // ---------------------------------------------------------------------------
+  // emit
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `emit sends the error text verbatim without logging on success`() = runTest {
+    reporter()
+      .emit(
+        requestId = "req-1",
+        errorMessage = "Uncaught async failure: boom",
+        doubleFailureLogMessage = "double failure log",
+      )
+
+    assertEquals("Uncaught async failure: boom", broadcasts.single().error)
+    assertEquals("req-1", broadcasts.single().requestId)
+    assertTrue("a successful emit must not log", logs.isEmpty())
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
@@ -175,4 +175,46 @@ class CorrelatedErrorReporterTest {
     assertEquals("req-1", broadcasts.single().requestId)
     assertTrue("a successful emit must not log", logs.isEmpty())
   }
+
+  @Test
+  fun `emit carries a null requestId through to the frame`() = runTest {
+    reporter()
+      .emit(
+        requestId = null,
+        errorMessage = "Uncaught async failure: boom",
+        doubleFailureLogMessage = "double failure log",
+      )
+
+    assertNull(broadcasts.single().requestId)
+  }
+
+  @Test
+  fun `emit swallows a failing sink rather than escaping to its caller`() = runTest {
+    // ServiceScopeGuard enters here directly; an escape would re-enter its handler and loop.
+    reporter(broadcastError = { throw IllegalStateException("sink down") })
+      .emit(
+        requestId = "req-1",
+        errorMessage = "Uncaught async failure: boom",
+        doubleFailureLogMessage = "double failure log",
+      )
+
+    assertEquals(listOf("double failure log"), logs.map { it.first })
+  }
+
+  @Test
+  fun `emit propagates a cancellation raised by the sink`() = runTest {
+    try {
+      reporter(broadcastError = { throw CancellationException("scope died") })
+        .emit(
+          requestId = "req-1",
+          errorMessage = "Uncaught async failure: boom",
+          doubleFailureLogMessage = "double failure log",
+        )
+      fail("expected the cancellation to propagate")
+    } catch (expected: CancellationException) {
+      assertEquals("scope died", expected.message)
+    }
+
+    assertTrue(logs.isEmpty())
+  }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
@@ -34,9 +34,9 @@ class CorrelatedErrorReporterTest {
   fun `guarding emits a correlated frame when the block throws`() = runTest {
     reporter().guarding(
       requestId = "req-1",
-      failureLogMessage = "failure log",
-      errorMessagePrefix = "Action 'foo' failed",
-      doubleFailureLogMessage = "double failure log",
+      failureLogMessage = { "failure log" },
+      errorMessagePrefix = { "Action 'foo' failed" },
+      doubleFailureLogMessage = { "double failure log" },
     ) {
       throw IllegalStateException("boom")
     }
@@ -52,9 +52,9 @@ class CorrelatedErrorReporterTest {
   fun `guarding emits nothing when the block succeeds`() = runTest {
     reporter().guarding(
       requestId = "req-1",
-      failureLogMessage = "failure log",
-      errorMessagePrefix = "Action 'foo' failed",
-      doubleFailureLogMessage = "double failure log",
+      failureLogMessage = { "failure log" },
+      errorMessagePrefix = { "Action 'foo' failed" },
+      doubleFailureLogMessage = { "double failure log" },
     ) {
       // no-op
     }
@@ -68,9 +68,9 @@ class CorrelatedErrorReporterTest {
     try {
       reporter().guarding(
         requestId = "req-1",
-        failureLogMessage = "failure log",
-        errorMessagePrefix = "Action 'foo' failed",
-        doubleFailureLogMessage = "double failure log",
+        failureLogMessage = { "failure log" },
+        errorMessagePrefix = { "Action 'foo' failed" },
+        doubleFailureLogMessage = { "double failure log" },
       ) {
         throw CancellationException("shutting down")
       }
@@ -87,9 +87,9 @@ class CorrelatedErrorReporterTest {
   fun `guarding carries a null requestId through to the frame`() = runTest {
     reporter().guarding(
       requestId = null,
-      failureLogMessage = "failure log",
-      errorMessagePrefix = "Action 'foo' failed",
-      doubleFailureLogMessage = "double failure log",
+      failureLogMessage = { "failure log" },
+      errorMessagePrefix = { "Action 'foo' failed" },
+      doubleFailureLogMessage = { "double failure log" },
     ) {
       throw IllegalStateException("boom")
     }
@@ -105,9 +105,9 @@ class CorrelatedErrorReporterTest {
   fun `a failure raised while emitting the frame is logged and swallowed`() = runTest {
     reporter(broadcastError = { throw IllegalStateException("sink down") }).guarding(
       requestId = "req-1",
-      failureLogMessage = "failure log",
-      errorMessagePrefix = "Action 'foo' failed",
-      doubleFailureLogMessage = "double failure log",
+      failureLogMessage = { "failure log" },
+      errorMessagePrefix = { "Action 'foo' failed" },
+      doubleFailureLogMessage = { "double failure log" },
     ) {
       throw IllegalStateException("boom")
     }
@@ -121,9 +121,9 @@ class CorrelatedErrorReporterTest {
     try {
       reporter(broadcastError = { throw CancellationException("scope died") }).guarding(
         requestId = "req-1",
-        failureLogMessage = "failure log",
-        errorMessagePrefix = "Action 'foo' failed",
-        doubleFailureLogMessage = "double failure log",
+        failureLogMessage = { "failure log" },
+        errorMessagePrefix = { "Action 'foo' failed" },
+        doubleFailureLogMessage = { "double failure log" },
       ) {
         throw IllegalStateException("boom")
       }
@@ -168,7 +168,7 @@ class CorrelatedErrorReporterTest {
       .emit(
         requestId = "req-1",
         errorMessage = "Uncaught async failure: boom",
-        doubleFailureLogMessage = "double failure log",
+        doubleFailureLogMessage = { "double failure log" },
       )
 
     assertEquals("Uncaught async failure: boom", broadcasts.single().error)
@@ -182,7 +182,7 @@ class CorrelatedErrorReporterTest {
       .emit(
         requestId = null,
         errorMessage = "Uncaught async failure: boom",
-        doubleFailureLogMessage = "double failure log",
+        doubleFailureLogMessage = { "double failure log" },
       )
 
     assertNull(broadcasts.single().requestId)
@@ -195,7 +195,7 @@ class CorrelatedErrorReporterTest {
       .emit(
         requestId = "req-1",
         errorMessage = "Uncaught async failure: boom",
-        doubleFailureLogMessage = "double failure log",
+        doubleFailureLogMessage = { "double failure log" },
       )
 
     assertEquals(listOf("double failure log"), logs.map { it.first })
@@ -208,7 +208,7 @@ class CorrelatedErrorReporterTest {
         .emit(
           requestId = "req-1",
           errorMessage = "Uncaught async failure: boom",
-          doubleFailureLogMessage = "double failure log",
+          doubleFailureLogMessage = { "double failure log" },
         )
       fail("expected the cancellation to propagate")
     } catch (expected: CancellationException) {


### PR DESCRIPTION
## Summary

Issue #3086 filed the duplicated correlated-error catch-body between `ResultBroadcaster` (#3045) and `AsyncActionRunner` (#3023) as a **deliberate YAGNI defer**, and named the trigger to act: *a third consumer, or the first observed drift*. `ServiceScopeGuard` (#3104, PR #3120) landed after that and hand-rolled the same body a third time — the trigger fired, so this extracts the shared core.

Behavior-preserving: every emitted frame and log string is byte-identical, and all three consumer test suites pass **completely unchanged**.

## Linked Issue

Closes #3086

## Changes

New `CorrelatedErrorReporter` is the one place the body lives. Three layers, because the consumers enter at different points:

| Layer | Used by |
|---|---|
| `guarding(...)` — run a block, report anything it throws | `ResultBroadcaster.guard`, `AsyncActionRunner.launch` |
| `report(...)` — log an already-caught throwable, then emit its frame | (the `guarding` tail) |
| `emit(...)` / `causeOf(...)` — the emit tail and the cause rule alone | `ServiceScopeGuard` |

**Why the issue's suggested one-function shape wasn't enough.** #3086 sketched a single `broadcastCorrelatedErrorOnThrow(…, block)`. That fits two consumers but not `ServiceScopeGuard`: a `CoroutineExceptionHandler` is handed a *throwable* rather than a block, so there is nothing to wrap.

**Why `ServiceScopeGuard` keeps its own log call.** It logs synchronously on the failing thread and dispatches only the broadcast onto `emitScope`. Folding that log into `report` would have moved it inside the launched coroutine — and lost the diagnostic entirely whenever the emit scope is already shut down, which is exactly when you most want the trace. Splitting `emit` out preserves today's guarantee.

## Testing

- **`CorrelatedErrorReporterTest`** (new) — pins the core directly: correlated frame on throw, silence on success, cancellation propagates without emitting, null requestId passthrough, the double-failure tail (logged-and-swallowed / cancellation re-thrown), and all three cause-derivation branches.
- **`CorrelatedErrorDriftGuardTest`** (new) — the structural backstop, and the one test that was **red before this change**. See below.
- **`ResultBroadcasterTest`, `AsyncActionRunnerTest`, `ServiceScopeGuardTest`** — pass with **zero edits** (issue AC2). They now exercise the core through their public surfaces.
- Full `:control-proxy:testDebugUnitTest` green; ktfmt 0.64 `--google-style` applied.

## Acceptance criteria

- [x] **AC1** — *Only when a third consumer arrives OR the first drift is observed:* extract the shared core; both `ResultBroadcaster.guard` and `AsyncActionRunner.launch` delegate to it. Trigger verified (`ServiceScopeGuard`, `e8911620c`); all three delegate.
- [x] **AC2** — Existing `ResultBroadcasterTest` / `AsyncActionRunnerTest` continue to pass **unchanged** (verified: zero diff in those files).

## The drift guard

The risk #3086 actually tracked was that nothing *forced* the copies to stay in lock-step — a fix to one catch-body would silently leave the others behind. Extraction removes today's duplication; `CorrelatedErrorDriftGuardTest` is what stops it coming back.

It source-scans the three consumers and fails CI if any reintroduces the cause derivation or an `ErrorResponse` fallback instead of delegating. Following the `BroadcastGuardAdoptionTest` precedent, the scanning logic is a pure function (`CorrelatedErrorDriftScanner`) unit-tested against synthetic good/bad snippets — including that KDoc, imports, and line comments naming those symbols don't trip it — so the enforcement contract is itself covered rather than only asserted against live files.

This is a small addition beyond the two literal criteria; it was explicitly approved as in-scope because it addresses the issue's stated risk.

## Validation

- [x] `bun run lint` clean
- [x] `bun run typecheck` — no new errors attributable to this PR (Kotlin-only diff; see note)
- [x] Android changes: `:control-proxy:testDebugUnitTest` green + ktfmt applied
- [x] New code uses interfaces + fakes; unit tests are Android-free and fast
- [ ] Device verification — N/A, no on-device behavior change (frames are byte-identical)

> **Note on the local typecheck gate:** running it from a git worktree reports the `PlanSchemaValidator.ts` ajv error as "new". It is not — it is already baselined at `scripts/typecheck-baseline.txt:235`, and only fails to string-match because a worktree resolves `node_modules` to the main clone's *absolute* path while the baseline stores a relative one. CI checks out normally and matches.

## Follow-ups

- [x] #3992 — two residual drift gaps deliberately left out of scope, each with an explicit trigger (following the convention #3086 itself set): the drift scanner does not cover a *fourth* consumer, and six hand-written `(requestId=$requestId)` log suffixes remain undeduplicated.

## Review round (`597dcfdd9`)

Three orthogonal lenses; full triage in [this comment](https://github.com/kaeawc/auto-mobile/pull/3990#issuecomment-5017517962). Headline: `report` is now `private` (zero production callers), the drift scanner was hardened from a *verbatim-copy* detector into an actual drift detector, two `stripComments` bugs that could hide violations were fixed, and `CorrelatedErrorConsumerContractTest` was added to pin the byte-identical strings this PR claims — nothing asserted them before, since the three consumer suites use `contains(...)` and AC2 required leaving them untouched.
