### PR TITLE
feat(desktop): wire appearance control and video recording

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -63,6 +63,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.components.Tooltip
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceClient
+import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotActions
@@ -73,12 +75,17 @@ import dev.jasonpearson.automobile.desktop.core.daemon.FailuresPushSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDeviceSnapshotActions
 import dev.jasonpearson.automobile.desktop.core.daemon.McpHttpClient
+import dev.jasonpearson.automobile.desktop.core.daemon.McpVideoRecordingActions
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingActions
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfigClient
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingSocketClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.device.DeviceControlsDashboard
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.diagnostics.DiagnosticsDashboard
 import dev.jasonpearson.automobile.desktop.core.failures.DateRange
@@ -326,6 +333,7 @@ fun AutoMobileContent(
       HorizontalTab("test_runs", "Test Runs", AppIcons.TestRuns),
       HorizontalTab("storage", "Storage", AppIcons.Storage),
       HorizontalTab("snapshots", "Snapshots", AppIcons.Snapshots),
+      HorizontalTab("device_controls", "Device", AppIcons.DeviceControls),
       HorizontalTab("diagnostics", "Diagnostics", AppIcons.Diagnostics),
     )
   }
@@ -499,6 +507,19 @@ fun AutoMobileContent(
     remember(dataSourceMode) {
       if (dataSourceMode == DataSourceMode.Real) DeviceSnapshotSocketClient() else null
     }
+
+  // Appearance and video recording follow the same split: config over their own sockets, verbs
+  // over the MCP client.
+  val appearanceClient: AppearanceClient? =
+    remember(dataSourceMode) {
+      if (dataSourceMode == DataSourceMode.Real) AppearanceSocketClient() else null
+    }
+  val recordingConfigClient: VideoRecordingConfigClient? =
+    remember(dataSourceMode) {
+      if (dataSourceMode == DataSourceMode.Real) VideoRecordingSocketClient() else null
+    }
+  val recordingActions: VideoRecordingActions? =
+    remember(clientProvider) { clientProvider?.let { McpVideoRecordingActions(it) } }
 
   // Take-screenshot is driven from both the native menu bar and the in-app menu.
   // Run it on a composition-scoped coroutine (not GlobalScope) so the call and its
@@ -1384,6 +1405,13 @@ fun AutoMobileContent(
                     SnapshotsDashboard(
                       actions = snapshotActions,
                       configClient = snapshotConfigClient,
+                      activeDeviceId = activeDeviceId,
+                    )
+                  "device_controls" ->
+                    DeviceControlsDashboard(
+                      appearanceClient = appearanceClient,
+                      recordingActions = recordingActions,
+                      recordingConfigClient = recordingConfigClient,
                       activeDeviceId = activeDeviceId,
                     )
                   "diagnostics" ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClient.kt
@@ -1,0 +1,205 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Socket file the daemon binds for appearance control. */
+internal const val APPEARANCE_SOCKET_FILE = "appearance.sock"
+
+/**
+ * Appearance a device can be told to use.
+ *
+ * `auto` means "follow the host", and is only ever a *request* or a stored default -- the daemon
+ * never reports it as the mode actually applied. See [AppearanceResult.appliedMode].
+ */
+enum class AppearanceSyncMode(val wireName: String) {
+  Light("light"),
+  Dark("dark"),
+  Auto("auto");
+
+  companion object {
+    fun fromWireName(value: String?): AppearanceSyncMode? = entries.firstOrNull {
+      it.wireName.equals(value, ignoreCase = true)
+    }
+  }
+}
+
+/** The daemon's stored appearance configuration. */
+@Serializable
+data class AppearanceConfig(
+  val syncWithHost: Boolean = false,
+  val defaultMode: String = AppearanceSyncMode.Auto.wireName,
+  val applyOnConnect: Boolean = false,
+)
+
+/**
+ * Outcome of an appearance command.
+ *
+ * [appliedMode] is the concrete light/dark actually pushed to devices. It is **null when no devices
+ * were connected** -- the daemon omits the field rather than failing, so a successful call with an
+ * empty device pool still reports the stored config. It is never `auto`.
+ */
+data class AppearanceResult(
+  val config: AppearanceConfig,
+  val appliedMode: AppearanceSyncMode? = null,
+)
+
+/**
+ * Controls device appearance through the daemon.
+ *
+ * This is deliberately not per-device: `appearance.sock` takes no device id and applies to every
+ * pooled device plus the current session device. Callers should present it as a global control.
+ */
+interface AppearanceClient {
+  fun getConfig(): AppearanceResult
+
+  /** Enables or disables following the host's appearance. */
+  fun setSyncWithHost(enabled: Boolean): AppearanceResult
+
+  /**
+   * Sets the appearance mode.
+   *
+   * Note the daemon couples these: choosing [AppearanceSyncMode.Light] or [AppearanceSyncMode.Dark]
+   * also sets `syncWithHost` to false, and choosing [AppearanceSyncMode.Auto] sets it to true.
+   */
+  fun setMode(mode: AppearanceSyncMode): AppearanceResult
+
+  /** True when the daemon exposes this socket; false on daemons that predate it. */
+  fun isAvailable(): Boolean
+}
+
+/** Client for `~/.auto-mobile/appearance.sock`. One request per connection. */
+class AppearanceSocketClient(
+  private val socketPathValue: String = AutoMobileSocketPaths.socketPath(APPEARANCE_SOCKET_FILE),
+  private val json: Json = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+    // `type` and `command` are defaults on the request class but required on the wire.
+    encodeDefaults = true
+  },
+) : AppearanceClient {
+
+  override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())
+
+  override fun getConfig(): AppearanceResult = send(request("get_appearance_config"))
+
+  override fun setSyncWithHost(enabled: Boolean): AppearanceResult =
+    send(request("set_appearance_sync", AppearanceParams(enabled = enabled)))
+
+  override fun setMode(mode: AppearanceSyncMode): AppearanceResult =
+    send(request("set_appearance", AppearanceParams(mode = mode.wireName)))
+
+  private fun request(command: String, params: AppearanceParams? = null) =
+    AppearanceSocketRequest(id = UUID.randomUUID().toString(), command = command, params = params)
+
+  private fun send(request: AppearanceSocketRequest): AppearanceResult {
+    ensureSocketExists()
+
+    val address = UnixDomainSocketAddress.of(socketPathValue)
+    SocketChannel.open(address).use { channel ->
+      val reader =
+        BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
+      val writer =
+        BufferedWriter(
+          OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+        )
+
+      writer.write(json.encodeToString(AppearanceSocketRequest.serializer(), request))
+      writer.newLine()
+      writer.flush()
+
+      val line = reader.readLine() ?: throw McpConnectionException("Appearance socket closed")
+      val response = json.decodeFromString(AppearanceSocketResponse.serializer(), line)
+
+      if (!response.success) {
+        throw McpConnectionException(response.error ?: "Appearance request failed")
+      }
+      val result =
+        response.result ?: throw McpConnectionException("Appearance response missing result")
+
+      return AppearanceResult(
+        config = result.config ?: AppearanceConfig(),
+        appliedMode = AppearanceSyncMode.fromWireName(result.appliedMode),
+      )
+    }
+  }
+
+  private fun ensureSocketExists() {
+    if (!isAvailable()) {
+      throw McpConnectionException("Appearance socket not found at $socketPathValue")
+    }
+  }
+}
+
+@Serializable
+internal data class AppearanceSocketRequest(
+  val id: String,
+  val type: String = "appearance_request",
+  val command: String,
+  val params: AppearanceParams? = null,
+)
+
+@Serializable
+internal data class AppearanceParams(val enabled: Boolean? = null, val mode: String? = null)
+
+@Serializable
+internal data class AppearanceSocketResponse(
+  val id: String? = null,
+  val type: String? = null,
+  val success: Boolean = false,
+  val result: AppearanceSocketResult? = null,
+  val error: String? = null,
+)
+
+@Serializable
+internal data class AppearanceSocketResult(
+  // get_appearance_config always returns config; the field is nullable only for safety.
+  val config: AppearanceConfig? = null,
+  // Omitted entirely when no devices were connected to apply to.
+  val appliedMode: String? = null,
+)
+
+/** In-memory [AppearanceClient] for previews and tests. */
+class FakeAppearanceClient(
+  initialConfig: AppearanceConfig = AppearanceConfig(),
+  private val available: Boolean = true,
+  /** When false, mimics a daemon with no connected devices, which omits `appliedMode`. */
+  private val hasConnectedDevices: Boolean = true,
+) : AppearanceClient {
+  var config: AppearanceConfig = initialConfig
+    private set
+
+  override fun isAvailable(): Boolean = available
+
+  override fun getConfig(): AppearanceResult = AppearanceResult(config)
+
+  override fun setSyncWithHost(enabled: Boolean): AppearanceResult {
+    config = config.copy(syncWithHost = enabled)
+    return AppearanceResult(config, appliedMode())
+  }
+
+  override fun setMode(mode: AppearanceSyncMode): AppearanceResult {
+    // Mirrors the daemon's coupling of mode and host sync.
+    config =
+      config.copy(defaultMode = mode.wireName, syncWithHost = mode == AppearanceSyncMode.Auto)
+    return AppearanceResult(config, appliedMode())
+  }
+
+  private fun appliedMode(): AppearanceSyncMode? =
+    when {
+      !hasConnectedDevices -> null
+      config.defaultMode == AppearanceSyncMode.Dark.wireName -> AppearanceSyncMode.Dark
+      else -> AppearanceSyncMode.Light
+    }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingActions.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingActions.kt
@@ -1,0 +1,137 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+private val recordingJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * One recorded artifact.
+ *
+ * A long recording is split into segments past the platform's screenrecord cap; each segment is its
+ * own artifact sharing a [sessionId], ordered by [segmentIndex].
+ */
+@Serializable
+data class VideoRecordingArtifact(
+  val recordingId: String = "",
+  val filePath: String = "",
+  val segmentIndex: Int = 0,
+  val sessionId: String? = null,
+)
+
+/**
+ * Outcome of stopping a recording.
+ *
+ * [segmented] distinguishes a multi-segment session from a plain single-file stop -- the daemon
+ * only sets it on the segmented path. [manifestPath] points at the `segments.json` written beside
+ * the first segment; it is absent when the manifest write failed, which the daemon treats as
+ * best-effort rather than failing the stop.
+ */
+data class VideoRecordingStopResult(
+  val recordings: List<VideoRecordingArtifact> = emptyList(),
+  val segmented: Boolean = false,
+  val manifestPath: String? = null,
+) {
+  /** Artifacts grouped into sessions, ordered by segment index within each session. */
+  val sessions: Map<String, List<VideoRecordingArtifact>>
+    get() =
+      recordings
+        .groupBy { it.sessionId ?: it.recordingId }
+        .mapValues { (_, segments) -> segments.sortedBy { it.segmentIndex } }
+}
+
+/** Start/stop verbs for device video recording, which live on the MCP tool path. */
+interface VideoRecordingActions {
+  fun startRecording(deviceId: String): List<VideoRecordingArtifact>
+
+  /** Stops [recordingId], or every active recording when null. */
+  fun stopRecording(deviceId: String, recordingId: String? = null): VideoRecordingStopResult
+}
+
+/** [VideoRecordingActions] backed by the `videoRecording` MCP tool. */
+class McpVideoRecordingActions(private val clientProvider: () -> AutoMobileClient) :
+  VideoRecordingActions {
+
+  override fun startRecording(deviceId: String): List<VideoRecordingArtifact> =
+    call(
+        buildJsonObject {
+          put("action", JsonPrimitive("start"))
+          put("deviceId", JsonPrimitive(deviceId))
+        }
+      )
+      .recordings
+
+  override fun stopRecording(deviceId: String, recordingId: String?): VideoRecordingStopResult {
+    val response =
+      call(
+        buildJsonObject {
+          put("action", JsonPrimitive("stop"))
+          put("deviceId", JsonPrimitive(deviceId))
+          if (recordingId != null) put("recordingId", JsonPrimitive(recordingId))
+        }
+      )
+    return VideoRecordingStopResult(
+      recordings = response.recordings,
+      segmented = response.segmented,
+      manifestPath = response.manifestPath,
+    )
+  }
+
+  private fun call(arguments: JsonObject): VideoRecordingToolResponse =
+    decodeToolResponse(
+      recordingJson,
+      clientProvider().callTool("videoRecording", arguments),
+      VideoRecordingToolResponse.serializer(),
+    )
+}
+
+@Serializable
+internal data class VideoRecordingToolResponse(
+  val action: String = "",
+  val count: Int = 0,
+  val recordings: List<VideoRecordingArtifact> = emptyList(),
+  // Only present on a segmented stop.
+  val segmented: Boolean = false,
+  // Best-effort; absent if the manifest could not be written.
+  val manifestPath: String? = null,
+)
+
+/** In-memory [VideoRecordingActions] for previews and tests. */
+class FakeVideoRecordingActions(
+  /** Segments produced by the next stop; more than one mimics a long, split recording. */
+  private val segmentsPerStop: Int = 1
+) : VideoRecordingActions {
+  private var active: String? = null
+
+  val isRecording: Boolean
+    get() = active != null
+
+  override fun startRecording(deviceId: String): List<VideoRecordingArtifact> {
+    val recordingId = "rec-${deviceId}-1"
+    active = recordingId
+    return listOf(VideoRecordingArtifact(recordingId, "/tmp/$recordingId.mp4", 0, recordingId))
+  }
+
+  override fun stopRecording(deviceId: String, recordingId: String?): VideoRecordingStopResult {
+    val sessionId = recordingId ?: active ?: "rec-${deviceId}-1"
+    active = null
+    val segments =
+      (0 until segmentsPerStop).map { index ->
+        VideoRecordingArtifact(
+          recordingId = if (index == 0) sessionId else "$sessionId-$index",
+          filePath = "/tmp/$sessionId-$index.mp4",
+          segmentIndex = index,
+          sessionId = sessionId,
+        )
+      }
+    return VideoRecordingStopResult(
+      recordings = segments,
+      segmented = segmentsPerStop > 1,
+      manifestPath = if (segmentsPerStop > 1) "/tmp/segments.json" else null,
+    )
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingSocketClient.kt
@@ -1,0 +1,188 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Socket file the daemon binds for video-recording configuration. */
+internal const val VIDEO_RECORDING_SOCKET_FILE = "video-recording.sock"
+
+/** Encoding and retention defaults for device video recordings. */
+@Serializable
+data class VideoRecordingConfig(
+  val qualityPreset: String = "medium",
+  val targetBitrateKbps: Long = 0,
+  val maxThroughputMbps: Double = 0.0,
+  val fps: Int = 0,
+  val maxArchiveSizeMb: Long = 0,
+  val format: String = "mp4",
+  val resolution: VideoResolution? = null,
+)
+
+@Serializable data class VideoResolution(val width: Int, val height: Int)
+
+/** A partial config update; only non-null fields are sent. */
+@Serializable
+data class VideoRecordingConfigInput(
+  val qualityPreset: String? = null,
+  val targetBitrateKbps: Long? = null,
+  val maxThroughputMbps: Double? = null,
+  val fps: Int? = null,
+  val maxArchiveSizeMb: Long? = null,
+  val format: String? = null,
+  val resolution: VideoResolution? = null,
+)
+
+/**
+ * Result of a config read or write.
+ *
+ * [evictedRecordingIds] is only populated by a write that shrank the archive budget; the daemon
+ * omits the field on reads and on writes that evicted nothing.
+ */
+data class VideoRecordingConfigResult(
+  val config: VideoRecordingConfig,
+  val evictedRecordingIds: List<String> = emptyList(),
+)
+
+/** Reads and writes the daemon's video-recording configuration. */
+interface VideoRecordingConfigClient {
+  fun getConfig(): VideoRecordingConfigResult
+
+  fun setConfig(input: VideoRecordingConfigInput): VideoRecordingConfigResult
+
+  /** True when the daemon exposes this socket; false on daemons that predate it. */
+  fun isAvailable(): Boolean
+}
+
+/**
+ * Client for `~/.auto-mobile/video-recording.sock`.
+ *
+ * A *config* socket: `config/get` and `config/set` only. Starting and stopping recordings is an MCP
+ * tool action, exposed through [VideoRecordingActions].
+ */
+class VideoRecordingSocketClient(
+  private val socketPathValue: String =
+    AutoMobileSocketPaths.socketPath(VIDEO_RECORDING_SOCKET_FILE),
+  private val json: Json = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+    encodeDefaults = true
+  },
+) : VideoRecordingConfigClient {
+
+  override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())
+
+  override fun getConfig(): VideoRecordingConfigResult =
+    send(VideoRecordingSocketRequest(id = UUID.randomUUID().toString(), method = "config/get"))
+
+  override fun setConfig(input: VideoRecordingConfigInput): VideoRecordingConfigResult =
+    send(
+      VideoRecordingSocketRequest(
+        id = UUID.randomUUID().toString(),
+        method = "config/set",
+        params = VideoRecordingSocketParams(config = input),
+      )
+    )
+
+  private fun send(request: VideoRecordingSocketRequest): VideoRecordingConfigResult {
+    ensureSocketExists()
+
+    val address = UnixDomainSocketAddress.of(socketPathValue)
+    SocketChannel.open(address).use { channel ->
+      val reader =
+        BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
+      val writer =
+        BufferedWriter(
+          OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+        )
+
+      writer.write(json.encodeToString(VideoRecordingSocketRequest.serializer(), request))
+      writer.newLine()
+      writer.flush()
+
+      val line = reader.readLine() ?: throw McpConnectionException("Video recording socket closed")
+      val response = json.decodeFromString(VideoRecordingSocketResponse.serializer(), line)
+
+      if (!response.success) {
+        throw McpConnectionException(response.error ?: "Video recording request failed")
+      }
+      val result =
+        response.result ?: throw McpConnectionException("Video recording response missing result")
+
+      return VideoRecordingConfigResult(
+        config = result.config,
+        evictedRecordingIds = result.evictedRecordingIds,
+      )
+    }
+  }
+
+  private fun ensureSocketExists() {
+    if (!isAvailable()) {
+      throw McpConnectionException("Video recording socket not found at $socketPathValue")
+    }
+  }
+}
+
+@Serializable
+internal data class VideoRecordingSocketRequest(
+  val id: String,
+  val type: String = "video_recording_request",
+  val method: String,
+  val params: VideoRecordingSocketParams? = null,
+)
+
+@Serializable internal data class VideoRecordingSocketParams(val config: VideoRecordingConfigInput?)
+
+@Serializable
+internal data class VideoRecordingSocketResponse(
+  val id: String? = null,
+  val type: String? = null,
+  val success: Boolean = false,
+  val result: VideoRecordingSocketResult? = null,
+  val error: String? = null,
+)
+
+@Serializable
+internal data class VideoRecordingSocketResult(
+  val config: VideoRecordingConfig,
+  // Absent on reads and on writes that evicted nothing.
+  val evictedRecordingIds: List<String> = emptyList(),
+)
+
+/** In-memory [VideoRecordingConfigClient] for previews and tests. */
+class FakeVideoRecordingConfigClient(
+  initialConfig: VideoRecordingConfig = VideoRecordingConfig(),
+  private val available: Boolean = true,
+  private val evictOnSet: List<String> = emptyList(),
+) : VideoRecordingConfigClient {
+  var config: VideoRecordingConfig = initialConfig
+    private set
+
+  override fun isAvailable(): Boolean = available
+
+  override fun getConfig(): VideoRecordingConfigResult = VideoRecordingConfigResult(config)
+
+  override fun setConfig(input: VideoRecordingConfigInput): VideoRecordingConfigResult {
+    config =
+      config.copy(
+        qualityPreset = input.qualityPreset ?: config.qualityPreset,
+        targetBitrateKbps = input.targetBitrateKbps ?: config.targetBitrateKbps,
+        maxThroughputMbps = input.maxThroughputMbps ?: config.maxThroughputMbps,
+        fps = input.fps ?: config.fps,
+        maxArchiveSizeMb = input.maxArchiveSizeMb ?: config.maxArchiveSizeMb,
+        format = input.format ?: config.format,
+        resolution = input.resolution ?: config.resolution,
+      )
+    return VideoRecordingConfigResult(config, evictOnSet)
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboard.kt
@@ -1,0 +1,285 @@
+package dev.jasonpearson.automobile.desktop.core.device
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceClient
+import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceConfig
+import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceSyncMode
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingActions
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingArtifact
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfig
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfigClient
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private val LOG = LoggerFactory.getLogger("DeviceControlsDashboard")
+
+/**
+ * Device appearance and video recording.
+ *
+ * Appearance is a *global* control: `appearance.sock` takes no device id and applies to every
+ * pooled device, so it is presented that way rather than as a per-device toggle. Recording is
+ * per-device and spans two transports -- the start/stop verbs are MCP tool calls, while quality and
+ * retention live on `video-recording.sock`.
+ */
+@Composable
+fun DeviceControlsDashboard(
+  appearanceClient: AppearanceClient?,
+  recordingActions: VideoRecordingActions?,
+  recordingConfigClient: VideoRecordingConfigClient?,
+  activeDeviceId: String?,
+  modifier: Modifier = Modifier,
+) {
+  val colors = SharedTheme.globalColors
+  val scope = rememberCoroutineScope()
+
+  var appearance by remember { mutableStateOf<AppearanceConfig?>(null) }
+  var appliedMode by remember { mutableStateOf<AppearanceSyncMode?>(null) }
+  var recordingConfig by remember { mutableStateOf<VideoRecordingConfig?>(null) }
+  var artifacts by remember { mutableStateOf<List<VideoRecordingArtifact>>(emptyList()) }
+  var manifestPath by remember { mutableStateOf<String?>(null) }
+  var isRecording by remember { mutableStateOf(false) }
+  var busy by remember { mutableStateOf(false) }
+  var notice by remember { mutableStateOf<String?>(null) }
+  var error by remember { mutableStateOf<String?>(null) }
+
+  LaunchedEffect(appearanceClient, recordingConfigClient) {
+    withContext(Dispatchers.IO) {
+      appearance =
+        try {
+          if (appearanceClient?.isAvailable() == true) appearanceClient.getConfig().config else null
+        } catch (e: Exception) {
+          LOG.warn("Appearance config unavailable: ${e.message}", e)
+          null
+        }
+      recordingConfig =
+        try {
+          if (recordingConfigClient?.isAvailable() == true) {
+            recordingConfigClient.getConfig().config
+          } else {
+            null
+          }
+        } catch (e: Exception) {
+          LOG.warn("Recording config unavailable: ${e.message}", e)
+          null
+        }
+    }
+  }
+
+  fun run(label: String, block: suspend () -> String?) {
+    busy = true
+    notice = null
+    error = null
+    scope.launch {
+      try {
+        notice = withContext(Dispatchers.IO) { block() }
+      } catch (e: Exception) {
+        LOG.warn("$label failed: ${e.message}", e)
+        error = e.message ?: "$label failed"
+      } finally {
+        busy = false
+      }
+    }
+  }
+
+  Column(
+    modifier = modifier.fillMaxSize().padding(12.dp),
+    verticalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    // -- Appearance --
+    Text(
+      "Appearance",
+      fontSize = 12.sp,
+      fontWeight = FontWeight.SemiBold,
+      color = colors.text.normal,
+    )
+
+    if (appearanceClient == null || appearance == null) {
+      Hint("Appearance control is unavailable on this daemon.", colors.text.normal)
+    } else {
+      Text(
+        "Applies to all connected devices.",
+        fontSize = 9.sp,
+        color = colors.text.normal.copy(alpha = 0.5f),
+      )
+      Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        AppearanceSyncMode.entries.forEach { mode ->
+          val selected = appearance?.defaultMode == mode.wireName
+          Chip(
+            label = mode.wireName.replaceFirstChar { it.uppercase() },
+            accent = if (selected) Color(0xFF4CAF50) else Color(0xFF9E9E9E),
+            enabled = !busy,
+          ) {
+            run("Set appearance") {
+              val result = appearanceClient.setMode(mode)
+              appearance = result.config
+              appliedMode = result.appliedMode
+              if (result.appliedMode == null) {
+                // The daemon omits appliedMode when the device pool is empty; saying "applied"
+                // would be a lie.
+                "Saved ${mode.wireName} — no connected devices to apply it to yet"
+              } else {
+                "Applied ${result.appliedMode.wireName}"
+              }
+            }
+          }
+        }
+      }
+      appearance?.let { current ->
+        Text(
+          "Follows host: ${if (current.syncWithHost) "yes" else "no"}" +
+            (appliedMode?.let { " · currently ${it.wireName}" } ?: ""),
+          fontSize = 9.sp,
+          color = colors.text.normal.copy(alpha = 0.6f),
+        )
+        if (!current.syncWithHost && current.defaultMode != AppearanceSyncMode.Auto.wireName) {
+          // Choosing an explicit mode is what turned host sync off -- make that visible rather
+          // than letting it look like an unrelated setting changed itself.
+          Hint(
+            "Choosing light or dark turns off host sync. Pick Auto to follow the host again.",
+            colors.text.normal.copy(alpha = 0.6f),
+          )
+        }
+      }
+    }
+
+    // -- Recording --
+    Text(
+      "Video recording",
+      fontSize = 12.sp,
+      fontWeight = FontWeight.SemiBold,
+      color = colors.text.normal,
+    )
+
+    if (activeDeviceId == null) {
+      Hint("Select a device to record.", colors.text.normal)
+    }
+
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+      Chip(
+        label = if (isRecording) "Stop" else "Record",
+        accent = if (isRecording) Color(0xFFE53935) else Color(0xFF4CAF50),
+        enabled = recordingActions != null && activeDeviceId != null && !busy,
+      ) {
+        val deviceId = activeDeviceId ?: return@Chip
+        if (isRecording) {
+          run("Stop recording") {
+            val result = recordingActions?.stopRecording(deviceId)
+            artifacts = result?.recordings.orEmpty()
+            manifestPath = result?.manifestPath
+            isRecording = false
+            val count = artifacts.size
+            if (result?.segmented == true) {
+              "Stopped — $count segment(s) across ${result.sessions.size} session(s)"
+            } else {
+              "Stopped — $count recording(s)"
+            }
+          }
+        } else {
+          run("Start recording") {
+            recordingActions?.startRecording(deviceId)
+            isRecording = true
+            "Recording…"
+          }
+        }
+      }
+    }
+
+    recordingConfig?.let { current ->
+      Text(
+        "${current.qualityPreset} · ${current.fps} fps · ${current.format} · archive budget " +
+          "${current.maxArchiveSizeMb} MB" +
+          (current.resolution?.let { " · ${it.width}x${it.height}" } ?: ""),
+        fontSize = 9.sp,
+        color = colors.text.normal.copy(alpha = 0.6f),
+      )
+    }
+
+    notice?.let { Hint(it, Color(0xFF4CAF50)) }
+    error?.let { Hint(it, Color(0xFFE53935)) }
+    manifestPath?.let {
+      Hint("Segment manifest: $it", colors.text.normal.copy(alpha = 0.6f))
+    }
+
+    if (artifacts.isNotEmpty()) {
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+      ) {
+        items(artifacts.sortedBy { it.segmentIndex }) { artifact ->
+          Row(
+            modifier =
+              Modifier.fillMaxWidth()
+                .background(colors.text.normal.copy(alpha = 0.03f), RoundedCornerShape(4.dp))
+                .padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text(
+                // A lone recording has no meaningful segment number to show.
+                if (artifacts.size > 1) "Segment ${artifact.segmentIndex}"
+                else artifact.recordingId,
+                fontSize = 11.sp,
+                color = colors.text.normal,
+              )
+              Text(
+                artifact.filePath,
+                fontSize = 9.sp,
+                color = colors.text.normal.copy(alpha = 0.5f),
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun Chip(label: String, accent: Color, enabled: Boolean = true, onClick: () -> Unit) {
+  val alpha = if (enabled) 1f else 0.4f
+  Box(
+    modifier =
+      Modifier.background(accent.copy(alpha = 0.15f * alpha), RoundedCornerShape(4.dp))
+        .let {
+          if (enabled) it.clickable(onClick = onClick).pointerHoverIcon(PointerIcon.Hand) else it
+        }
+        .padding(horizontal = 8.dp, vertical = 3.dp)
+  ) {
+    Text(label, fontSize = 9.sp, softWrap = false, color = accent.copy(alpha = alpha))
+  }
+}
+
+@Composable
+private fun Hint(text: String, color: Color) {
+  Text(text, fontSize = 10.sp, color = color.copy(alpha = 0.8f))
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/AppIcons.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/theme/AppIcons.kt
@@ -125,6 +125,9 @@ object AppIcons {
   val Snapshots: ImageVector
     get() = Icons.Filled.PhotoCamera
 
+  val DeviceControls: ImageVector
+    get() = Icons.Filled.Tune
+
   val Telemetry: ImageVector
     get() = Icons.Filled.Satellite
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClientTest.kt
@@ -1,0 +1,141 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Covers [AppearanceSocketClient] against a real in-process Unix socket. */
+class AppearanceSocketClientTest {
+
+  private val configJson =
+    """{"syncWithHost": false, "defaultMode": "dark", "applyOnConnect": true}"""
+
+  private fun server(resultJson: String? = null, error: String? = null) =
+    TestConfigSocketServer(
+      responseType = "appearance_response",
+      resultJson = resultJson,
+      error = error,
+      socketFileName = "appearance.sock",
+    )
+
+  @Test
+  fun `get_appearance_config sends the documented envelope`() {
+    server(resultJson = """{"config": $configJson}""").use { s ->
+      AppearanceSocketClient(socketPathValue = s.socketPath.toString()).getConfig()
+
+      val request = s.awaitRequest()
+      assertEquals("get_appearance_config", request["command"]?.jsonPrimitive?.content)
+      assertEquals("appearance_request", request["type"]?.jsonPrimitive?.content)
+    }
+  }
+
+  @Test
+  fun `set_appearance nests mode under params`() {
+    server(resultJson = """{"config": $configJson, "appliedMode": "dark"}""").use { s ->
+      AppearanceSocketClient(socketPathValue = s.socketPath.toString())
+        .setMode(AppearanceSyncMode.Dark)
+
+      val request = s.awaitRequest()
+      assertEquals("set_appearance", request["command"]?.jsonPrimitive?.content)
+      assertEquals("dark", request["params"]?.jsonObject?.get("mode")?.jsonPrimitive?.content)
+    }
+  }
+
+  @Test
+  fun `set_appearance_sync nests enabled under params`() {
+    server(resultJson = """{"config": $configJson}""").use { s ->
+      AppearanceSocketClient(socketPathValue = s.socketPath.toString()).setSyncWithHost(true)
+
+      val request = s.awaitRequest()
+      assertEquals("set_appearance_sync", request["command"]?.jsonPrimitive?.content)
+      assertEquals(
+        "true",
+        request["params"]?.jsonObject?.get("enabled")?.jsonPrimitive?.content,
+      )
+    }
+  }
+
+  @Test
+  fun `appliedMode is decoded when devices were updated`() {
+    server(resultJson = """{"config": $configJson, "appliedMode": "dark"}""").use { s ->
+      val result =
+        AppearanceSocketClient(socketPathValue = s.socketPath.toString())
+          .setMode(AppearanceSyncMode.Dark)
+
+      assertEquals(AppearanceSyncMode.Dark, result.appliedMode)
+      assertEquals("dark", result.config.defaultMode)
+    }
+  }
+
+  @Test
+  fun `an omitted appliedMode is null rather than a decode failure`() {
+    // The daemon omits appliedMode entirely when no devices are connected to apply to.
+    server(resultJson = """{"config": $configJson}""").use { s ->
+      val result =
+        AppearanceSocketClient(socketPathValue = s.socketPath.toString())
+          .setMode(AppearanceSyncMode.Light)
+
+      assertNull(result.appliedMode, "no connected devices means nothing was applied")
+      assertEquals("dark", result.config.defaultMode, "the stored config still comes back")
+    }
+  }
+
+  @Test
+  fun `an invalid mode from the daemon degrades to null instead of throwing`() {
+    server(resultJson = """{"config": $configJson, "appliedMode": "sepia"}""").use { s ->
+      val result = AppearanceSocketClient(socketPathValue = s.socketPath.toString()).getConfig()
+
+      assertNull(result.appliedMode)
+    }
+  }
+
+  @Test
+  fun `a rejected mode surfaces the daemon's message`() {
+    server(error = "set_appearance requires mode: light | dark | auto").use { s ->
+      val failure =
+        assertFailsWith<McpConnectionException> {
+          AppearanceSocketClient(socketPathValue = s.socketPath.toString())
+            .setMode(AppearanceSyncMode.Auto)
+        }
+
+      assertEquals("set_appearance requires mode: light | dark | auto", failure.message)
+    }
+  }
+
+  @Test
+  fun `a missing socket names the path`() {
+    val client = AppearanceSocketClient(socketPathValue = "/tmp/no-appearance-am.sock")
+
+    assertTrue(!client.isAvailable())
+    val failure = assertFailsWith<McpConnectionException> { client.getConfig() }
+    assertTrue(failure.message!!.contains("/tmp/no-appearance-am.sock"))
+  }
+
+  @Test
+  fun `mode names map case-insensitively and reject unknowns`() {
+    assertEquals(AppearanceSyncMode.Dark, AppearanceSyncMode.fromWireName("DARK"))
+    assertEquals(AppearanceSyncMode.Auto, AppearanceSyncMode.fromWireName("auto"))
+    assertNull(AppearanceSyncMode.fromWireName("sepia"))
+    assertNull(AppearanceSyncMode.fromWireName(null))
+  }
+
+  @Test
+  fun `the fake mirrors the daemon's coupling of mode and host sync`() {
+    val client = FakeAppearanceClient()
+
+    // Picking an explicit mode disables host sync; auto re-enables it.
+    assertEquals(false, client.setMode(AppearanceSyncMode.Dark).config.syncWithHost)
+    assertEquals(true, client.setMode(AppearanceSyncMode.Auto).config.syncWithHost)
+  }
+
+  @Test
+  fun `the fake reports no applied mode when no devices are connected`() {
+    val client = FakeAppearanceClient(hasConnectedDevices = false)
+
+    assertNull(client.setMode(AppearanceSyncMode.Dark).appliedMode)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClientTest.kt
@@ -1,16 +1,5 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
-import java.io.BufferedReader
-import java.io.BufferedWriter
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
-import java.net.StandardProtocolFamily
-import java.net.UnixDomainSocketAddress
-import java.nio.channels.Channels
-import java.nio.channels.ServerSocketChannel
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -43,54 +32,71 @@ class DeviceSnapshotSocketClientTest {
 
   @Test
   fun `config get sends the documented envelope`() {
-    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
-      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+    TestConfigSocketServer(
+        responseType = RESPONSE_TYPE,
+        resultJson = """{"config": ${configJson()}}""",
+      )
+      .use { server ->
+        val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
 
-      client.getConfig()
+        client.getConfig()
 
-      val request = server.awaitRequest()
-      assertEquals("config/get", request["method"]?.jsonPrimitive?.content)
-      assertEquals("device_snapshot_request", request["type"]?.jsonPrimitive?.content)
-      assertTrue(request["id"]?.jsonPrimitive?.content?.isNotBlank() == true, "id must be present")
-    }
+        val request = server.awaitRequest()
+        assertEquals("config/get", request["method"]?.jsonPrimitive?.content)
+        assertEquals("device_snapshot_request", request["type"]?.jsonPrimitive?.content)
+        assertTrue(
+          request["id"]?.jsonPrimitive?.content?.isNotBlank() == true,
+          "id must be present",
+        )
+      }
   }
 
   @Test
   fun `config get decodes the whole config`() {
-    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
-      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+    TestConfigSocketServer(
+        responseType = RESPONSE_TYPE,
+        resultJson = """{"config": ${configJson()}}""",
+      )
+      .use { server ->
+        val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
 
-      val result = client.getConfig()
+        val result = client.getConfig()
 
-      assertEquals(true, result.config.includeAppData)
-      assertEquals(false, result.config.includeSettings)
-      assertEquals(true, result.config.useVmSnapshot)
-      assertEquals("all", result.config.userApps)
-      assertEquals(512L, result.config.maxArchiveSizeMb)
-      assertTrue(result.evictedSnapshotNames.isEmpty(), "reads never evict")
-    }
+        assertEquals(true, result.config.includeAppData)
+        assertEquals(false, result.config.includeSettings)
+        assertEquals(true, result.config.useVmSnapshot)
+        assertEquals("all", result.config.userApps)
+        assertEquals(512L, result.config.maxArchiveSizeMb)
+        assertTrue(result.evictedSnapshotNames.isEmpty(), "reads never evict")
+      }
   }
 
   @Test
   fun `config set nests the partial update under params config`() {
-    TestConfigSocket(resultJson = """{"config": ${configJson(256)}}""").use { server ->
-      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+    TestConfigSocketServer(
+        responseType = RESPONSE_TYPE,
+        resultJson = """{"config": ${configJson(256)}}""",
+      )
+      .use { server ->
+        val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
 
-      client.setConfig(DeviceSnapshotConfigInput(maxArchiveSizeMb = 256))
+        client.setConfig(DeviceSnapshotConfigInput(maxArchiveSizeMb = 256))
 
-      val request = server.awaitRequest()
-      assertEquals("config/set", request["method"]?.jsonPrimitive?.content)
-      val config = request["params"]?.jsonObject?.get("config")?.jsonObject
-      assertEquals(256L, config?.get("maxArchiveSizeMb")?.jsonPrimitive?.content?.toLong())
-      // Unset fields must be omitted so a partial update doesn't overwrite the rest.
-      assertTrue(config?.containsKey("includeAppData") != true, "expected omitted, got $config")
-    }
+        val request = server.awaitRequest()
+        assertEquals("config/set", request["method"]?.jsonPrimitive?.content)
+        val config = request["params"]?.jsonObject?.get("config")?.jsonObject
+        assertEquals(256L, config?.get("maxArchiveSizeMb")?.jsonPrimitive?.content?.toLong())
+        // Unset fields must be omitted so a partial update doesn't overwrite the rest.
+        assertTrue(config?.containsKey("includeAppData") != true, "expected omitted, got $config")
+      }
   }
 
   @Test
   fun `evicted snapshot names are surfaced from a set`() {
-    TestConfigSocket(
-        resultJson = """{"config": ${configJson(64)}, "evictedSnapshotNames": ["old-1", "old-2"]}"""
+    TestConfigSocketServer(
+        responseType = RESPONSE_TYPE,
+        resultJson =
+          """{"config": ${configJson(64)}, "evictedSnapshotNames": ["old-1", "old-2"]}""",
       )
       .use { server ->
         val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
@@ -104,22 +110,30 @@ class DeviceSnapshotSocketClientTest {
   @Test
   fun `an absent evicted list defaults to empty rather than failing to decode`() {
     // The daemon omits the key entirely when nothing was evicted.
-    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
-      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+    TestConfigSocketServer(
+        responseType = RESPONSE_TYPE,
+        resultJson = """{"config": ${configJson()}}""",
+      )
+      .use { server ->
+        val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
 
-      assertTrue(client.setConfig(DeviceSnapshotConfigInput()).evictedSnapshotNames.isEmpty())
-    }
+        assertTrue(client.setConfig(DeviceSnapshotConfigInput()).evictedSnapshotNames.isEmpty())
+      }
   }
 
   @Test
   fun `a failure response surfaces the daemon's message`() {
-    TestConfigSocket(error = "config/set requires params.config").use { server ->
-      val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
+    TestConfigSocketServer(
+        responseType = RESPONSE_TYPE,
+        error = "config/set requires params.config",
+      )
+      .use { server ->
+        val client = DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString())
 
-      val failure = assertFailsWith<McpConnectionException> { client.getConfig() }
+        val failure = assertFailsWith<McpConnectionException> { client.getConfig() }
 
-      assertEquals("config/set requires params.config", failure.message)
-    }
+        assertEquals("config/set requires params.config", failure.message)
+      }
   }
 
   @Test
@@ -141,71 +155,18 @@ class DeviceSnapshotSocketClientTest {
 
   @Test
   fun `isAvailable is true once the socket is bound`() {
-    TestConfigSocket(resultJson = """{"config": ${configJson()}}""").use { server ->
-      assertTrue(
-        DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString()).isAvailable()
+    TestConfigSocketServer(
+        responseType = RESPONSE_TYPE,
+        resultJson = """{"config": ${configJson()}}""",
       )
-    }
-  }
-
-  /** A one-shot Unix socket server speaking the daemon's config-socket envelope. */
-  private inner class TestConfigSocket(
-    private val resultJson: String? = null,
-    private val error: String? = null,
-  ) : AutoCloseable {
-    private val tempDir = Files.createTempDirectory(Path.of("/tmp"), "amsnap-")
-    val socketPath: Path = tempDir.resolve("device-snapshot.sock")
-    private val serverChannel =
-      ServerSocketChannel.open(StandardProtocolFamily.UNIX)
-        .bind(UnixDomainSocketAddress.of(socketPath))
-    private var captured: kotlinx.serialization.json.JsonObject? = null
-    private var failure: Throwable? = null
-    private val thread = Thread {
-      try {
-        serverChannel.accept().use { channel ->
-          val reader =
-            BufferedReader(
-              InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
-            )
-          val writer =
-            BufferedWriter(
-              OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
-            )
-          val request = json.parseToJsonElement(reader.readLine()).jsonObject
-          captured = request
-          writer.write(responseLine(request["id"]?.jsonPrimitive?.content ?: "unknown"))
-          writer.newLine()
-          writer.flush()
-        }
-      } catch (throwable: Throwable) {
-        failure = throwable
+      .use { server ->
+        assertTrue(
+          DeviceSnapshotSocketClient(socketPathValue = server.socketPath.toString()).isAvailable()
+        )
       }
-    }
-      .also { it.start() }
-
-    fun awaitRequest(): kotlinx.serialization.json.JsonObject {
-      thread.join(REQUEST_TIMEOUT_MILLIS)
-      if (thread.isAlive) throw AssertionError("Client did not send a request before timeout")
-      failure?.let { throw AssertionError("Test config socket failed", it) }
-      return captured ?: throw AssertionError("Client did not send a request")
-    }
-
-    private fun responseLine(requestId: String): String {
-      val compactResult = (resultJson ?: "{}").lineSequence().joinToString("") { it.trim() }
-      val body =
-        if (error == null) """"result": $compactResult"""
-        else """"error": ${kotlinx.serialization.json.JsonPrimitive(error)}"""
-      return """{"id":"$requestId","type":"device_snapshot_response","success":${error == null},$body}"""
-    }
-
-    override fun close() {
-      serverChannel.close()
-      Files.deleteIfExists(socketPath)
-      Files.deleteIfExists(tempDir)
-    }
   }
 
   private companion object {
-    const val REQUEST_TIMEOUT_MILLIS = 5_000L
+    const val RESPONSE_TYPE = "device_snapshot_response"
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestConfigSocketServer.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestConfigSocketServer.kt
@@ -1,0 +1,97 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * A one-shot Unix domain socket speaking the daemon's request/response envelope, for exercising the
+ * auxiliary socket clients without a running daemon.
+ *
+ * Accepts exactly one connection, captures the request, and replies with either
+ * `{"success":true,"result":...}` or `{"success":false,"error":...}` -- matching the daemon, which
+ * omits `result` entirely on failure but still stamps the response `type`.
+ */
+class TestConfigSocketServer(
+  private val responseType: String,
+  private val resultJson: String? = null,
+  private val error: String? = null,
+  socketFileName: String = "test.sock",
+) : AutoCloseable {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val tempDir: Path = Files.createTempDirectory(Path.of("/tmp"), "amsock-")
+
+  val socketPath: Path = tempDir.resolve(socketFileName)
+
+  private val serverChannel =
+    ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+      .bind(UnixDomainSocketAddress.of(socketPath))
+
+  private var captured: JsonObject? = null
+  private var failure: Throwable? = null
+
+  private val thread = Thread {
+    try {
+      serverChannel.accept().use { channel ->
+        val reader =
+          BufferedReader(
+            InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+          )
+        val writer =
+          BufferedWriter(
+            OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+          )
+        val request = json.parseToJsonElement(reader.readLine()).jsonObject
+        captured = request
+        writer.write(responseLine(request["id"]?.jsonPrimitive?.content ?: "unknown"))
+        writer.newLine()
+        writer.flush()
+      }
+    } catch (throwable: Throwable) {
+      failure = throwable
+    }
+  }
+    .also { it.start() }
+
+  /** The request the client sent. Fails the test if none arrived before the timeout. */
+  fun awaitRequest(): JsonObject {
+    thread.join(REQUEST_TIMEOUT_MILLIS)
+    if (thread.isAlive) throw AssertionError("Client did not send a request before timeout")
+    failure?.let { throw AssertionError("Test socket server failed", it) }
+    return captured ?: throw AssertionError("Client did not send a request")
+  }
+
+  private fun responseLine(requestId: String): String {
+    val body =
+      if (error == null) {
+        val compact = (resultJson ?: "{}").lineSequence().joinToString("") { it.trim() }
+        """"result":$compact"""
+      } else {
+        """"error":${JsonPrimitive(error)}"""
+      }
+    return """{"id":"$requestId","type":"$responseType","success":${error == null},$body}"""
+  }
+
+  override fun close() {
+    serverChannel.close()
+    Files.deleteIfExists(socketPath)
+    Files.deleteIfExists(tempDir)
+  }
+
+  private companion object {
+    const val REQUEST_TIMEOUT_MILLIS = 5_000L
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingClientTest.kt
@@ -1,0 +1,226 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/** Covers the video-recording config socket and the MCP-tool start/stop verbs. */
+class VideoRecordingClientTest {
+
+  private val configJson =
+    """
+    {
+      "qualityPreset": "high",
+      "targetBitrateKbps": 8000,
+      "maxThroughputMbps": 12.5,
+      "fps": 60,
+      "maxArchiveSizeMb": 2048,
+      "format": "mp4",
+      "resolution": {"width": 1080, "height": 2400}
+    }
+    """
+
+  private fun server(resultJson: String? = null, error: String? = null) =
+    TestConfigSocketServer(
+      responseType = "video_recording_response",
+      resultJson = resultJson,
+      error = error,
+      socketFileName = "video-recording.sock",
+    )
+
+  private fun toolResponse(bodyJson: String): JsonElement = buildJsonObject {
+    put(
+      "content",
+      buildJsonArray {
+        add(
+          buildJsonObject {
+            put("type", "text")
+            put("text", bodyJson)
+          }
+        )
+      },
+    )
+  }
+
+  // -- config socket --
+
+  @Test
+  fun `config get decodes the full config including resolution`() {
+    server(resultJson = """{"config": $configJson}""").use { s ->
+      val result = VideoRecordingSocketClient(socketPathValue = s.socketPath.toString()).getConfig()
+
+      assertEquals("high", result.config.qualityPreset)
+      assertEquals(60, result.config.fps)
+      assertEquals(12.5, result.config.maxThroughputMbps)
+      assertEquals(VideoResolution(1080, 2400), result.config.resolution)
+    }
+  }
+
+  @Test
+  fun `config set sends only the changed field`() {
+    server(resultJson = """{"config": $configJson}""").use { s ->
+      VideoRecordingSocketClient(socketPathValue = s.socketPath.toString())
+        .setConfig(VideoRecordingConfigInput(qualityPreset = "low"))
+
+      val request = s.awaitRequest()
+      assertEquals("config/set", request["method"]?.jsonPrimitive?.content)
+      assertEquals("video_recording_request", request["type"]?.jsonPrimitive?.content)
+      val config = request["params"]?.jsonObject?.get("config")?.jsonObject
+      assertEquals("low", config?.get("qualityPreset")?.jsonPrimitive?.content)
+      assertTrue(config?.containsKey("fps") != true, "untouched fields must be omitted")
+    }
+  }
+
+  @Test
+  fun `evicted recording ids are surfaced from a set`() {
+    server(resultJson = """{"config": $configJson, "evictedRecordingIds": ["rec-1"]}""").use { s ->
+      val result =
+        VideoRecordingSocketClient(socketPathValue = s.socketPath.toString())
+          .setConfig(VideoRecordingConfigInput(maxArchiveSizeMb = 10))
+
+      assertEquals(listOf("rec-1"), result.evictedRecordingIds)
+    }
+  }
+
+  @Test
+  fun `an absent evicted list defaults to empty`() {
+    server(resultJson = """{"config": $configJson}""").use { s ->
+      assertTrue(
+        VideoRecordingSocketClient(socketPathValue = s.socketPath.toString())
+          .getConfig()
+          .evictedRecordingIds
+          .isEmpty()
+      )
+    }
+  }
+
+  @Test
+  fun `a missing socket names the path`() {
+    val client = VideoRecordingSocketClient(socketPathValue = "/tmp/no-video-am.sock")
+
+    assertTrue(!client.isAvailable())
+    assertTrue(
+      assertFailsWith<McpConnectionException> { client.getConfig() }
+        .message!!
+        .contains("/tmp/no-video-am.sock")
+    )
+  }
+
+  // -- MCP tool verbs --
+
+  @Test
+  fun `start returns the new recording`() {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse(
+        """{"action":"start","count":1,"recordings":[{"recordingId":"rec-1","filePath":"/tmp/rec-1.mp4"}]}"""
+      )
+
+    val recordings = McpVideoRecordingActions { client }.startRecording("emulator-5554")
+
+    assertEquals(1, recordings.size)
+    assertEquals("rec-1", recordings.single().recordingId)
+  }
+
+  @Test
+  fun `a plain stop is not marked segmented and has no manifest`() {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse(
+        """{"action":"stop","count":1,"recordings":[{"recordingId":"rec-1","filePath":"/tmp/rec-1.mp4","segmentIndex":0}]}"""
+      )
+
+    val result = McpVideoRecordingActions { client }.stopRecording("emulator-5554", "rec-1")
+
+    assertTrue(!result.segmented)
+    assertNull(result.manifestPath)
+    assertEquals(1, result.recordings.size)
+  }
+
+  @Test
+  fun `a segmented stop keeps every segment and the manifest path`() {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse(
+        """
+        {"action":"stop","count":3,"manifestPath":"/tmp/a/segments.json","segmented":true,
+         "recordings":[
+           {"recordingId":"rec-1","filePath":"/tmp/a/0.mp4","segmentIndex":0,"sessionId":"rec-1"},
+           {"recordingId":"rec-2","filePath":"/tmp/a/1.mp4","segmentIndex":1,"sessionId":"rec-1"},
+           {"recordingId":"rec-3","filePath":"/tmp/a/2.mp4","segmentIndex":2,"sessionId":"rec-1"}
+         ]}
+        """
+          .trimIndent()
+      )
+
+    val result = McpVideoRecordingActions { client }.stopRecording("emulator-5554")
+
+    assertTrue(result.segmented)
+    assertEquals("/tmp/a/segments.json", result.manifestPath)
+    assertEquals(3, result.recordings.size)
+  }
+
+  @Test
+  fun `segments group by session in index order`() {
+    val result =
+      VideoRecordingStopResult(
+        recordings =
+          listOf(
+            VideoRecordingArtifact("rec-3", "/tmp/2.mp4", 2, "rec-1"),
+            VideoRecordingArtifact("rec-1", "/tmp/0.mp4", 0, "rec-1"),
+            VideoRecordingArtifact("rec-2", "/tmp/1.mp4", 1, "rec-1"),
+          ),
+        segmented = true,
+      )
+
+    val session = result.sessions.getValue("rec-1")
+
+    assertEquals(listOf(0, 1, 2), session.map { it.segmentIndex }, "out-of-order input is sorted")
+  }
+
+  @Test
+  fun `an artifact with no sessionId groups under its own recording id`() {
+    // Non-segmented stops omit sessionId entirely.
+    val result =
+      VideoRecordingStopResult(listOf(VideoRecordingArtifact("rec-9", "/tmp/rec-9.mp4", 0, null)))
+
+    assertEquals(setOf("rec-9"), result.sessions.keys)
+  }
+
+  @Test
+  fun `a segmented stop may omit the manifest path when the write failed`() {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse(
+        """{"action":"stop","count":1,"segmented":true,"recordings":[{"recordingId":"rec-1","filePath":"/tmp/0.mp4","segmentIndex":0,"sessionId":"rec-1"}]}"""
+      )
+
+    val result = McpVideoRecordingActions { client }.stopRecording("emulator-5554")
+
+    assertTrue(result.segmented, "still a segmented session")
+    assertNull(result.manifestPath, "manifest writing is best-effort")
+  }
+
+  @Test
+  fun `the fake records a multi-segment session`() {
+    val actions = FakeVideoRecordingActions(segmentsPerStop = 3)
+
+    actions.startRecording("emulator-5554")
+    assertTrue(actions.isRecording)
+
+    val result = actions.stopRecording("emulator-5554")
+
+    assertTrue(!actions.isRecording)
+    assertTrue(result.segmented)
+    assertEquals(3, result.sessions.values.single().size)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboardUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboardUiTest.kt
@@ -1,0 +1,185 @@
+package dev.jasonpearson.automobile.desktop.core.device
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceConfig
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeAppearanceClient
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeVideoRecordingActions
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeVideoRecordingConfigClient
+import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfig
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DeviceControlsDashboardUiTest {
+
+  @Test
+  fun `renders both control groups`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Appearance").assertIsDisplayed()
+    onNodeWithText("Video recording").assertIsDisplayed()
+  }
+
+  @Test
+  fun `appearance is labelled as applying to all devices, not the active one`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Applies to all connected devices.").assertIsDisplayed()
+  }
+
+  @Test
+  fun `degrades when the appearance socket is absent`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(available = false),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Appearance control is unavailable on this daemon.").assertIsDisplayed()
+    // Recording must still work.
+    onNodeWithText("Record").assertIsDisplayed()
+  }
+
+  @Test
+  fun `prompts for a device before recording`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = null,
+        )
+      }
+    }
+
+    onNodeWithText("Select a device to record.").assertIsDisplayed()
+  }
+
+  @Test
+  fun `shows the recording config summary`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient =
+            FakeVideoRecordingConfigClient(
+              VideoRecordingConfig(qualityPreset = "high", fps = 60, maxArchiveSizeMb = 2048)
+            ),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("high", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `setting an explicit mode warns that host sync is now off`() = runComposeUiTest {
+    // The daemon couples these; surfacing it prevents the setting looking self-changing.
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient =
+            FakeAppearanceClient(AppearanceConfig(syncWithHost = false, defaultMode = "dark")),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("turns off host sync", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `auto mode does not warn about host sync`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient =
+            FakeAppearanceClient(AppearanceConfig(syncWithHost = true, defaultMode = "auto")),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("turns off host sync", substring = true).assertDoesNotExist()
+  }
+
+  @Test
+  fun `recording toggles to stop once started`() = runComposeUiTest {
+    val actions = FakeVideoRecordingActions()
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = actions,
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Record").performClick()
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) { actions.isRecording }
+  }
+
+  @Test
+  fun `stopping a segmented session lists every segment`() = runComposeUiTest {
+    val actions = FakeVideoRecordingActions(segmentsPerStop = 3)
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = actions,
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Record").performClick()
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) { actions.isRecording }
+
+    onNodeWithText("Stop").performClick()
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) { !actions.isRecording }
+
+    onNodeWithText("Segment 0").assertIsDisplayed()
+    onNodeWithText("Segment 2").assertIsDisplayed()
+  }
+
+  private companion object {
+    const val ACTION_TIMEOUT_MS = 5_000L
+  }
+}


### PR DESCRIPTION
Closes #3932 (epic #3933).

## Video recording needs two transports, not one

The issue asks to start/stop recordings and list segmented artifacts "via `video-recording.sock`". That socket is a `ConfigSocketServer` — `config/get` and `config/set` only — and the `segments.json` manifest is written on the MCP tool path ([segmentManifest.ts:34](src/server/segmentManifest.ts:34)). A client mirroring only the socket would get zero segment data.

| concern | transport |
|---|---|
| quality, fps, format, archive budget | `video-recording.sock` |
| start / stop / segments | `videoRecording` MCP tool |

## Appearance: two traps worth naming

`appearance.sock` *is* a genuine command socket (three commands), but its semantics surprised me twice:

**1. `appliedMode` is omitted when no devices are connected.** `applyToTargets` returns null and the daemon maps it to `undefined` ([appearanceSocketServer.ts:64](src/daemon/appearanceSocketServer.ts:64)), so a *successful* call against an empty device pool returns config with no applied mode. Reporting "Applied dark" there would be a lie, so the UI says **"Saved dark — no connected devices to apply it to yet"**.

**2. `set_appearance` silently disables host sync.** It writes `syncWithHost: normalizedMode === "auto"` ([appearanceSocketServer.ts:76](src/daemon/appearanceSocketServer.ts:76)), so choosing light or dark turns host-following off as a side effect. The dashboard surfaces this — otherwise the setting appears to change itself.

**3. It is global, not per-device.** The socket takes no `deviceId`; it applies to every pooled device plus the session device. The issue describes a per-device toggle, so this is presented as a global control instead, labelled as such.

## Segmented recordings

Modelled explicitly rather than flattened:

- `segmented` is the daemon's own discriminator — non-segmented stops omit it.
- `manifestPath` is nullable because the manifest write is best-effort; a segmented stop can legitimately have no manifest.
- `sessions` groups artifacts by `sessionId` and orders by `segmentIndex`.

One asymmetry to be aware of: the manifest calls the field `index` while the stop response calls it `segmentIndex`. This consumes the stop response, so it uses `segmentIndex`.

## Reuse

The one-shot Unix socket harness written for #3931 is generalized into `TestConfigSocketServer` and now serves all three clients (snapshot, appearance, recording). `DeviceSnapshotSocketClientTest` is migrated onto it — same 9 tests passing, one fewer inline copy.

## Testing

32 new tests, **500 desktop-core green**, 0 failures. `:desktop-app:compileKotlin` passes.

- **`AppearanceSocketClientTest` (11)** — envelope shapes; `appliedMode` present, omitted, *and* unparseable (degrades to null rather than throwing); the mode/host-sync coupling; daemon rejection text.
- **`VideoRecordingClientTest` (12)** — config socket including evicted ids and partial-update omission; plain vs segmented stops; a segmented stop with no manifest; session grouping of deliberately out-of-order segments.
- **`DeviceControlsDashboardUiTest` (9)** — both control groups; recording still works when the appearance socket is absent; the host-sync warning appearing for explicit modes and *not* for auto; a 3-segment stop listing every segment.

## Note on formatting

`scripts/ktfmt/validate_ktfmt.sh` silently validates zero files when the checkout lives under a dot-directory (`find ... -not -path "*/.*"` matches the whole worktree), which is what let unformatted code reach CI on #3980. Formatting here was verified by running ktfmt directly against the changed files.