### PR TITLE
feat(daemon): serve the device H.264 stream locally over video-stream.sock

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -46,6 +46,7 @@ import { startFailuresStreamSocketServer, stopFailuresStreamSocketServer } from 
 import { startFailuresPushSocketServer, stopFailuresPushSocketServer } from "./failuresPushSocketServer";
 import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from "./telemetryPushSocketServer";
 import { startWebRtcStreamSocketServer, stopWebRtcStreamSocketServer } from "./webrtcStreamSocketServer";
+import { startVideoStreamSocketServer, stopVideoStreamSocketServer } from "./videoStreamSocketServer";
 import { getDaemonSocketPaths } from "./socketPaths";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
@@ -349,6 +350,7 @@ export class Daemon {
     await startFailuresPushSocketServer();
     await startTelemetryPushSocketServer();
     await startWebRtcStreamSocketServer();
+    await startVideoStreamSocketServer();
 
     // Wire up callback to establish WebSocket connections when IDE plugins subscribe
     this.setupDeviceDataStreamCallback();
@@ -1483,6 +1485,7 @@ export class Daemon {
     await stopFailuresPushSocketServer();
     await stopTelemetryPushSocketServer();
     await stopWebRtcStreamSocketServer();
+    await stopVideoStreamSocketServer();
     stopAppearanceSyncScheduler();
     stopPerformanceMonitor();
 

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -11,6 +11,10 @@ export const VIDEO_RECORDING_SOCKET_CONFIG: SocketServerConfig = {
   defaultPath: path.join(os.homedir(), ".auto-mobile", "video-recording.sock"),
 };
 
+export const VIDEO_STREAM_SOCKET_CONFIG: SocketServerConfig = {
+  defaultPath: path.join(os.homedir(), ".auto-mobile", "video-stream.sock"),
+};
+
 export const TEST_RECORDING_SOCKET_CONFIG: SocketServerConfig = {
   defaultPath: path.join(os.homedir(), ".auto-mobile", "test-recording.sock"),
 };

--- a/src/daemon/videoStreamFraming.ts
+++ b/src/daemon/videoStreamFraming.ts
@@ -1,0 +1,97 @@
+/**
+ * Encoders for the `VideoStreamProtocol` framing, mirroring
+ * `android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt`.
+ *
+ * The capture sources normalize both the persistent encoder and `screenrecord` down to a raw
+ * Annex-B elementary stream, which drops the on-device framing. The relay re-applies it so every
+ * client sees one stable format regardless of which source produced the bytes.
+ */
+
+/** "h264" as a big-endian int. */
+export const CODEC_ID_H264 = 0x68323634;
+
+/** Bit 63 of `ptsAndFlags`: codec configuration data. */
+export const PACKET_FLAG_CONFIG = 1n << 63n;
+
+/** Bit 62 of `ptsAndFlags`: key frame. */
+export const PACKET_FLAG_KEY_FRAME = 1n << 62n;
+
+/** Bits 0-61 carry the presentation timestamp. */
+export const PTS_MASK = (1n << 62n) - 1n;
+
+/**
+ * The 12-byte stream header: codec id, then width and height.
+ *
+ * Zero dimensions are legitimate here — the capture sources do not report them, and every decoder
+ * takes the true dimensions from the in-band SPS. A caller that knows the size may pass it so a
+ * client can size its surface before the first key frame arrives.
+ */
+export function encodeStreamHeader(width: number = 0, height: number = 0): Buffer {
+  const header = Buffer.allocUnsafe(12);
+  header.writeInt32BE(CODEC_ID_H264, 0);
+  header.writeInt32BE(width, 4);
+  header.writeInt32BE(height, 8);
+  return header;
+}
+
+export function encodePtsAndFlags(
+  presentationTimeUs: bigint,
+  { isConfig = false, isKeyFrame = false }: { isConfig?: boolean; isKeyFrame?: boolean } = {}
+): bigint {
+  let ptsAndFlags = presentationTimeUs & PTS_MASK;
+  if (isConfig) {
+    ptsAndFlags |= PACKET_FLAG_CONFIG;
+  }
+  if (isKeyFrame) {
+    ptsAndFlags |= PACKET_FLAG_KEY_FRAME;
+  }
+  return ptsAndFlags;
+}
+
+/** The 12-byte per-packet header: `ptsAndFlags`, then payload length. */
+export function encodePacketHeader(ptsAndFlags: bigint, size: number): Buffer {
+  const header = Buffer.allocUnsafe(12);
+  header.writeBigInt64BE(BigInt.asIntN(64, ptsAndFlags), 0);
+  header.writeInt32BE(size, 8);
+  return header;
+}
+
+/** A framed packet: header followed by the Annex-B payload. */
+export function encodePacket(ptsAndFlags: bigint, payload: Buffer): Buffer {
+  return Buffer.concat([encodePacketHeader(ptsAndFlags, payload.length), payload]);
+}
+
+/**
+ * True when an Annex-B chunk starts with a parameter-set NAL (SPS=7, PPS=8), which is what the
+ * CONFIG flag marks. Callers use this so a decoder can find the parameter sets without parsing.
+ */
+export function isParameterSetChunk(chunk: Buffer): boolean {
+  const nalType = firstNalUnitType(chunk);
+  return nalType === 7 || nalType === 8;
+}
+
+/** True when the chunk carries an IDR NAL (type 5), i.e. a key frame. */
+export function isKeyFrameChunk(chunk: Buffer): boolean {
+  return firstNalUnitType(chunk) === 5;
+}
+
+/**
+ * Type of the first NAL unit in an Annex-B chunk, or null when no start code is found.
+ *
+ * Start codes are 3 or 4 bytes (`00 00 01` / `00 00 00 01`); the low 5 bits of the byte after the
+ * start code are the NAL type.
+ */
+function firstNalUnitType(chunk: Buffer): number | null {
+  for (let i = 0; i + 3 < chunk.length; i++) {
+    if (chunk[i] !== 0x00 || chunk[i + 1] !== 0x00) {
+      continue;
+    }
+    if (chunk[i + 2] === 0x01) {
+      return chunk[i + 3] & 0x1f;
+    }
+    if (chunk[i + 2] === 0x00 && i + 4 < chunk.length && chunk[i + 3] === 0x01) {
+      return chunk[i + 4] & 0x1f;
+    }
+  }
+  return null;
+}

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -1,0 +1,351 @@
+import type { Socket } from "node:net";
+import { logger } from "../utils/logger";
+import { toActionableError } from "../models/ActionableError";
+import { ActionableError } from "../models";
+import { DeviceSessionManager } from "../utils/DeviceSessionManager";
+import { createH264CaptureSource } from "../features/webrtc/h264CaptureSourceFactory";
+import { resolveVideoServerJar } from "../features/webrtc/videoServerJar";
+import type { BootedDevice } from "../models";
+import { Timer, defaultTimer } from "../utils/SystemTimer";
+import type { H264CaptureSource } from "../features/webrtc/H264CaptureSource";
+import { VIDEO_STREAM_SOCKET_CONFIG } from "./daemonFiles";
+import { BaseSocketServer, getSocketPath } from "./socketServer/index";
+import {
+  encodePacket,
+  encodePtsAndFlags,
+  encodeStreamHeader,
+  isKeyFrameChunk,
+  isParameterSetChunk,
+} from "./videoStreamFraming";
+import type { VideoStreamSocketRequest, VideoStreamSocketResponse } from "./videoStreamSocketTypes";
+
+/** Creates the capture source for a device. Injected so tests never touch adb. */
+export type CaptureSourceFactory = (options: {
+  device: BootedDevice;
+  onData: (chunk: Buffer) => void;
+  onError: (error: Error) => void;
+  bitrateBps?: number;
+  size?: { width: number; height: number };
+}) => Promise<H264CaptureSource>;
+
+export interface VideoStreamSocketServerDependencies {
+  createCaptureSource: CaptureSourceFactory;
+  resolveDevice: (deviceId?: string) => Promise<BootedDevice>;
+  /** Monotonic microseconds, used for packet presentation timestamps. */
+  nowUs: () => bigint;
+}
+
+/** One capture shared by every subscriber watching the same device. */
+interface DeviceCapture {
+  source: H264CaptureSource | null;
+  subscribers: Set<Socket>;
+  /**
+   * Most recent parameter sets (SPS/PPS). A client that joins mid-stream cannot decode until it
+   * sees these, and the encoder only re-emits them on key frames.
+   */
+  parameterSets: Buffer | null;
+}
+
+/**
+ * Relays a device's live H.264 stream to local clients over `~/.auto-mobile/video-stream.sock`.
+ *
+ * This is the local live-mirroring path, deliberately separate from the WebRTC/WHIP publisher —
+ * that one pushes to a remote coordination server for browser viewers and exposes no playback URL,
+ * so it cannot serve a viewer running on this machine.
+ *
+ * The handshake is one JSON line in and one JSON line out, which is why this extends
+ * [BaseSocketServer] like every other daemon socket. Everything after the acknowledgement is raw
+ * binary in the `VideoStreamProtocol` framing the on-device encoder already speaks, so a 4–8 Mbps
+ * stream does not pay a ~33% base64 tax per frame. That is the one place this server departs from
+ * the newline-JSON convention, and it is why it writes to the socket directly instead of through
+ * `sendJson`.
+ *
+ * One capture is shared by every subscriber watching the same device, so a second viewer does not
+ * start a second encoder; the capture stops when the last subscriber for that device disconnects.
+ */
+export class VideoStreamSocketServer extends BaseSocketServer {
+  private readonly captures = new Map<string, DeviceCapture>();
+  private readonly socketDeviceIds = new Map<Socket, string>();
+
+  constructor(
+    private readonly deps: VideoStreamSocketServerDependencies,
+    socketPath: string = getSocketPath(VIDEO_STREAM_SOCKET_CONFIG),
+    timer: Timer = defaultTimer
+  ) {
+    // Idle timeout disabled: this stream is outbound-only after the handshake, and a viewer that
+    // never sends another byte is the normal case, not a dead peer.
+    super(socketPath, timer, "VideoStream", 0);
+  }
+
+  /** Devices with an active capture, for diagnostics and tests. */
+  activeDeviceIds(): string[] {
+    return [...this.captures.keys()];
+  }
+
+  /** Subscriber count for a device, for diagnostics and tests. */
+  subscriberCount(deviceId: string): number {
+    return this.captures.get(deviceId)?.subscribers.size ?? 0;
+  }
+
+  override async close(): Promise<void> {
+    for (const deviceId of [...this.captures.keys()]) {
+      await this.stopCapture(deviceId);
+    }
+    this.socketDeviceIds.clear();
+    await super.close();
+  }
+
+  protected async processLine(socket: Socket, line: string): Promise<void> {
+    if (this.socketDeviceIds.has(socket)) {
+      // Already streaming; clients send nothing else, so ignore stray input rather than
+      // interrupting the stream.
+      return;
+    }
+
+    const request = this.parseJson<VideoStreamSocketRequest>(line);
+    if (!request) {
+      this.sendJson(socket, {
+        type: "video_stream_response",
+        success: false,
+        error: "Invalid JSON",
+      } satisfies VideoStreamSocketResponse);
+      socket.end();
+      return;
+    }
+
+    if (request.action !== "subscribe") {
+      this.sendJson(socket, {
+        id: request.id,
+        type: "video_stream_response",
+        success: false,
+        error: `Unsupported video stream action: ${request.action}`,
+      } satisfies VideoStreamSocketResponse);
+      socket.end();
+      return;
+    }
+
+    try {
+      const device = await this.deps.resolveDevice(request.deviceId);
+      const capture = await this.attach(socket, device, request);
+
+      this.sendJson(socket, {
+        id: request.id,
+        type: "video_stream_response",
+        success: true,
+        action: "subscribe",
+        deviceId: device.deviceId,
+        framing: "h264",
+      } satisfies VideoStreamSocketResponse);
+
+      socket.write(encodeStreamHeader(request.size?.width ?? 0, request.size?.height ?? 0));
+
+      // Replay the parameter sets so a late joiner can decode immediately instead of waiting for
+      // the encoder's next key frame.
+      if (capture.parameterSets) {
+        socket.write(
+          encodePacket(
+            encodePtsAndFlags(this.deps.nowUs(), { isConfig: true }),
+            capture.parameterSets
+          )
+        );
+      }
+    } catch (error) {
+      logger.warn(`[VideoStream] subscribe failed: ${error}`);
+      this.sendJson(socket, {
+        id: request.id,
+        type: "video_stream_response",
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      } satisfies VideoStreamSocketResponse);
+      socket.end();
+    }
+  }
+
+  protected override onConnectionClose(socket: Socket): void {
+    this.detach(socket);
+  }
+
+  protected override onConnectionError(socket: Socket, _error: Error): void {
+    this.detach(socket);
+  }
+
+  private async attach(
+    socket: Socket,
+    device: BootedDevice,
+    request: VideoStreamSocketRequest
+  ): Promise<DeviceCapture> {
+    const deviceId = device.deviceId;
+    const existing = this.captures.get(deviceId);
+    if (existing) {
+      existing.subscribers.add(socket);
+      this.socketDeviceIds.set(socket, deviceId);
+      return existing;
+    }
+
+    const capture: DeviceCapture = {
+      source: null,
+      subscribers: new Set([socket]),
+      parameterSets: null,
+    };
+    // Registered before start() so a chunk arriving during startup still finds its subscribers.
+    this.captures.set(deviceId, capture);
+    this.socketDeviceIds.set(socket, deviceId);
+
+    try {
+      capture.source = await this.deps.createCaptureSource({
+        device,
+        onData: chunk => this.broadcast(deviceId, chunk),
+        onError: error => {
+          logger.warn(`[VideoStream] capture failed for ${deviceId}: ${error}`);
+          void this.stopCapture(deviceId);
+        },
+        bitrateBps: request.bitrateKbps ? request.bitrateKbps * 1000 : undefined,
+        size: request.size,
+      });
+      await capture.source.start();
+    } catch (error) {
+      this.captures.delete(deviceId);
+      this.socketDeviceIds.delete(socket);
+      throw toActionableError(error, `Failed to start video capture for ${deviceId}`);
+    }
+
+    return capture;
+  }
+
+  private broadcast(deviceId: string, chunk: Buffer): void {
+    const capture = this.captures.get(deviceId);
+    if (!capture || chunk.length === 0) {
+      return;
+    }
+
+    const isConfig = isParameterSetChunk(chunk);
+    if (isConfig) {
+      capture.parameterSets = Buffer.from(chunk);
+    }
+
+    const packet = encodePacket(
+      encodePtsAndFlags(this.deps.nowUs(), { isConfig, isKeyFrame: isKeyFrameChunk(chunk) }),
+      chunk
+    );
+
+    for (const subscriber of capture.subscribers) {
+      if (subscriber.destroyed) {
+        capture.subscribers.delete(subscriber);
+        continue;
+      }
+      // A slow viewer must not stall the encoder or the other viewers. write() returning false
+      // only means the kernel buffer is full and Node is queueing; for live video a backlog is
+      // worth a trace, not a disconnect.
+      if (!subscriber.write(packet)) {
+        logger.debug(`[VideoStream] subscriber is behind on ${deviceId}`);
+      }
+    }
+  }
+
+  private detach(socket: Socket): void {
+    const deviceId = this.socketDeviceIds.get(socket);
+    if (!deviceId) {
+      return;
+    }
+    this.socketDeviceIds.delete(socket);
+
+    const capture = this.captures.get(deviceId);
+    if (!capture) {
+      return;
+    }
+    capture.subscribers.delete(socket);
+    if (capture.subscribers.size === 0) {
+      void this.stopCapture(deviceId);
+    }
+  }
+
+  private async stopCapture(deviceId: string): Promise<void> {
+    const capture = this.captures.get(deviceId);
+    if (!capture) {
+      return;
+    }
+    this.captures.delete(deviceId);
+
+    for (const subscriber of capture.subscribers) {
+      this.socketDeviceIds.delete(subscriber);
+      subscriber.end();
+    }
+    capture.subscribers.clear();
+
+    try {
+      await capture.source?.stop();
+    } catch (error) {
+      // The capture is already detached, so a failure to tear down the device side is worth a
+      // trace but must not propagate into socket teardown.
+      logger.warn(`[VideoStream] failed to stop capture for ${deviceId}: ${error}`);
+    }
+  }
+}
+
+let socketServer: VideoStreamSocketServer | null = null;
+
+export function getVideoStreamSocketPath(): string {
+  return socketServer?.getSocketPath?.() ?? getSocketPath(VIDEO_STREAM_SOCKET_CONFIG);
+}
+
+export function setVideoStreamSocketServerForTesting(server: VideoStreamSocketServer | null): void {
+  socketServer = server;
+}
+
+/**
+ * Device resolution for the relay: an explicit id must match a connected device, and an omitted id
+ * is only unambiguous when exactly one device is connected.
+ */
+async function defaultResolveDevice(deviceId?: string): Promise<BootedDevice> {
+  const devices = await DeviceSessionManager.getInstance().detectConnectedPlatforms();
+
+  if (deviceId) {
+    const match = devices.find(device => device.deviceId === deviceId);
+    if (!match) {
+      throw new ActionableError(`No connected device with id ${deviceId}.`);
+    }
+    return match;
+  }
+
+  if (devices.length === 0) {
+    throw new ActionableError("No connected devices found.");
+  }
+  if (devices.length > 1) {
+    throw new ActionableError(
+      `Multiple connected devices; specify deviceId. Found: ${devices
+        .map(device => device.deviceId)
+        .join(", ")}`
+    );
+  }
+  return devices[0];
+}
+
+function defaultDependencies(): VideoStreamSocketServerDependencies {
+  return {
+    resolveDevice: defaultResolveDevice,
+    createCaptureSource: async options => {
+      // Resolved once per stream, off the frame path. A null jar means the Android source falls
+      // back to `screenrecord`.
+      const jarPath = await resolveVideoServerJar();
+      return createH264CaptureSource(options, jarPath);
+    },
+    nowUs: () => BigInt(Math.round(performance.now() * 1000)),
+  };
+}
+
+export async function startVideoStreamSocketServer(): Promise<void> {
+  if (!socketServer) {
+    socketServer = new VideoStreamSocketServer(defaultDependencies());
+  }
+  if (!socketServer.isListening()) {
+    await socketServer.start();
+  }
+}
+
+export async function stopVideoStreamSocketServer(): Promise<void> {
+  if (!socketServer) {
+    return;
+  }
+  await socketServer.close();
+  socketServer = null;
+}

--- a/src/daemon/videoStreamSocketTypes.ts
+++ b/src/daemon/videoStreamSocketTypes.ts
@@ -1,0 +1,41 @@
+/**
+ * Wire types for the local video-stream relay socket (`~/.auto-mobile/video-stream.sock`).
+ *
+ * Unlike every other daemon socket this one is **not** newline-JSON end to end. A client sends a
+ * single JSON subscribe line and receives a single JSON acknowledgement line; after that the
+ * connection carries raw binary in the `VideoStreamProtocol` framing the on-device encoder already
+ * speaks (see `android/video-server/.../VideoStreamProtocol.kt`), so a 4-8 Mbps H.264 stream does
+ * not pay a ~33% base64 tax per frame.
+ *
+ * This is the local live-mirroring path. It is deliberately separate from the WebRTC/WHIP path,
+ * which publishes to a remote coordination server for browser viewers and cannot be consumed
+ * locally.
+ */
+
+export type VideoStreamAction = "subscribe" | "unsubscribe";
+
+export interface VideoStreamSocketRequest {
+  id?: string;
+  action: VideoStreamAction;
+  /** Device to mirror. Defaults to the sole connected device when omitted. */
+  deviceId?: string;
+  /** Encoder bitrate hint, passed through to the capture source. */
+  bitrateKbps?: number;
+  /** Capture size hint. Decoders read true dimensions from the in-band SPS regardless. */
+  size?: { width: number; height: number };
+}
+
+export interface VideoStreamSocketResponse {
+  id?: string;
+  type: "video_stream_response";
+  success: boolean;
+  action?: VideoStreamAction;
+  /** Device the stream is bound to, echoed so a client that omitted it learns the resolution. */
+  deviceId?: string;
+  /**
+   * Framing that follows this line on the same connection. `h264` is the 12-byte legacy header
+   * plus 12-byte packet headers; audio muxing is not offered by this relay.
+   */
+  framing?: "h264";
+  error?: string;
+}

--- a/test/daemon/videoStreamFraming.test.ts
+++ b/test/daemon/videoStreamFraming.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CODEC_ID_H264,
+  encodePacket,
+  encodePacketHeader,
+  encodePtsAndFlags,
+  encodeStreamHeader,
+  isKeyFrameChunk,
+  isParameterSetChunk,
+  PACKET_FLAG_CONFIG,
+  PACKET_FLAG_KEY_FRAME,
+} from "../../src/daemon/videoStreamFraming";
+
+/** Annex-B chunk with a 4-byte start code and the given NAL type. */
+function annexB(nalType: number, payload: number[] = [0x00]): Buffer {
+  return Buffer.from([0x00, 0x00, 0x00, 0x01, nalType & 0x1f, ...payload]);
+}
+
+describe("videoStreamFraming", () => {
+  describe("stream header", () => {
+    test("carries the h264 codec id and dimensions", () => {
+      const header = encodeStreamHeader(1080, 2400);
+
+      expect(header.length).toBe(12);
+      expect(header.readInt32BE(0)).toBe(CODEC_ID_H264);
+      expect(header.readInt32BE(4)).toBe(1080);
+      expect(header.readInt32BE(8)).toBe(2400);
+    });
+
+    test("defaults to zero dimensions, which decoders take from the SPS instead", () => {
+      const header = encodeStreamHeader();
+
+      expect(header.readInt32BE(4)).toBe(0);
+      expect(header.readInt32BE(8)).toBe(0);
+    });
+
+    test("the codec id matches the on-device encoder's constant", () => {
+      // "h264" big-endian, per VideoStreamProtocol.CODEC_ID_H264.
+      expect(CODEC_ID_H264).toBe(0x68323634);
+      expect(Buffer.from("h264", "ascii").readInt32BE(0)).toBe(CODEC_ID_H264);
+    });
+  });
+
+  describe("pts and flags", () => {
+    test("a plain frame carries only the timestamp", () => {
+      expect(encodePtsAndFlags(12345n)).toBe(12345n);
+    });
+
+    test("config and key-frame bits sit above the timestamp", () => {
+      const ptsAndFlags = encodePtsAndFlags(12345n, { isConfig: true, isKeyFrame: true });
+
+      expect(ptsAndFlags & PACKET_FLAG_CONFIG).toBe(PACKET_FLAG_CONFIG);
+      expect(ptsAndFlags & PACKET_FLAG_KEY_FRAME).toBe(PACKET_FLAG_KEY_FRAME);
+      expect(ptsAndFlags & ((1n << 62n) - 1n)).toBe(12345n);
+    });
+
+    test("a timestamp wider than 62 bits is masked rather than corrupting the flags", () => {
+      const ptsAndFlags = encodePtsAndFlags((1n << 63n) | 7n);
+
+      expect(ptsAndFlags & PACKET_FLAG_CONFIG).toBe(0n);
+      expect(ptsAndFlags).toBe(7n);
+    });
+  });
+
+  describe("packet header", () => {
+    test("is 12 bytes of ptsAndFlags then size", () => {
+      const header = encodePacketHeader(42n, 1024);
+
+      expect(header.length).toBe(12);
+      expect(header.readBigInt64BE(0)).toBe(42n);
+      expect(header.readInt32BE(8)).toBe(1024);
+    });
+
+    test("the config flag survives the round trip as a negative int64", () => {
+      // Bit 63 set means the signed 64-bit read comes back negative; the client masks it off.
+      const header = encodePacketHeader(encodePtsAndFlags(1n, { isConfig: true }), 0);
+
+      expect(header.readBigInt64BE(0)).toBeLessThan(0n);
+      expect(BigInt.asUintN(64, header.readBigInt64BE(0)) & PACKET_FLAG_CONFIG).toBe(
+        PACKET_FLAG_CONFIG
+      );
+    });
+
+    test("a packet is its header followed by the payload verbatim", () => {
+      const payload = Buffer.from([1, 2, 3, 4, 5]);
+
+      const packet = encodePacket(7n, payload);
+
+      expect(packet.length).toBe(12 + payload.length);
+      expect(packet.readInt32BE(8)).toBe(payload.length);
+      expect(packet.subarray(12)).toEqual(payload);
+    });
+  });
+
+  describe("NAL classification", () => {
+    test("SPS and PPS are parameter sets", () => {
+      expect(isParameterSetChunk(annexB(7))).toBe(true);
+      expect(isParameterSetChunk(annexB(8))).toBe(true);
+    });
+
+    test("an IDR NAL is a key frame and not a parameter set", () => {
+      expect(isKeyFrameChunk(annexB(5))).toBe(true);
+      expect(isParameterSetChunk(annexB(5))).toBe(false);
+    });
+
+    test("a non-IDR slice is neither", () => {
+      expect(isKeyFrameChunk(annexB(1))).toBe(false);
+      expect(isParameterSetChunk(annexB(1))).toBe(false);
+    });
+
+    test("three-byte start codes are recognized too", () => {
+      expect(isParameterSetChunk(Buffer.from([0x00, 0x00, 0x01, 0x07, 0x10]))).toBe(true);
+    });
+
+    test("a chunk with no start code classifies as neither rather than throwing", () => {
+      expect(isKeyFrameChunk(Buffer.from([0xaa, 0xbb, 0xcc]))).toBe(false);
+      expect(isParameterSetChunk(Buffer.from([]))).toBe(false);
+    });
+
+    test("leading padding before the start code is skipped", () => {
+      const padded = Buffer.concat([Buffer.from([0xff, 0xfe]), annexB(7)]);
+
+      expect(isParameterSetChunk(padded)).toBe(true);
+    });
+  });
+});

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import net from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { defaultTimer } from "../../src/utils/SystemTimer";
+import type { BootedDevice } from "../../src/models";
+import type { H264CaptureSource } from "../../src/features/webrtc/H264CaptureSource";
+import { VideoStreamSocketServer } from "../../src/daemon/videoStreamSocketServer";
+import { CODEC_ID_H264 } from "../../src/daemon/videoStreamFraming";
+
+const DEVICE: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android",
+} as BootedDevice;
+
+/** A capture source that never touches adb; tests push chunks by hand. */
+class FakeCaptureSource implements H264CaptureSource {
+  started = false;
+  stopped = false;
+  startError: Error | null = null;
+
+  async start(): Promise<void> {
+    if (this.startError) {
+      throw this.startError;
+    }
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+  }
+}
+
+interface Harness {
+  server: VideoStreamSocketServer;
+  socketPath: string;
+  sources: FakeCaptureSource[];
+  emit: (chunk: Buffer) => void;
+  cleanup: () => Promise<void>;
+}
+
+const harnesses: Harness[] = [];
+
+async function startHarness(
+  options: { startError?: Error; resolveError?: Error } = {}
+): Promise<Harness> {
+  const dir = mkdtempSync(path.join(tmpdir(), "amvs-"));
+  const socketPath = path.join(dir, "video-stream.sock");
+  const sources: FakeCaptureSource[] = [];
+  let onData: ((chunk: Buffer) => void) | null = null;
+
+  const server = new VideoStreamSocketServer(
+    {
+      resolveDevice: async () => {
+        if (options.resolveError) {
+          throw options.resolveError;
+        }
+        return DEVICE;
+      },
+      createCaptureSource: async opts => {
+        onData = opts.onData;
+        const source = new FakeCaptureSource();
+        source.startError = options.startError ?? null;
+        sources.push(source);
+        return source;
+      },
+      nowUs: () => 1_000n,
+    },
+    socketPath
+  );
+  await server.start();
+
+  const harness: Harness = {
+    server,
+    socketPath,
+    sources,
+    emit: chunk => onData?.(chunk),
+    cleanup: async () => {
+      await server.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+  harnesses.push(harness);
+  return harness;
+}
+
+/** Connects, subscribes, and resolves with the ack line plus a reader for subsequent binary. */
+async function subscribe(
+  socketPath: string,
+  request: Record<string, unknown> = { action: "subscribe", deviceId: DEVICE.deviceId }
+): Promise<{ socket: net.Socket; ack: Record<string, unknown>; binary: () => Buffer }> {
+  const socket = net.createConnection(socketPath);
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", () => resolve());
+    socket.once("error", reject);
+  });
+
+  const chunks: Buffer[] = [];
+  socket.on("data", data => chunks.push(data));
+  socket.write(`${JSON.stringify(request)}\n`);
+
+  // Wait for the newline-terminated acknowledgement.
+  const deadline = Date.now() + 2000;
+  let ackLine = "";
+  while (Date.now() < deadline) {
+    const combined = Buffer.concat(chunks);
+    const newlineIndex = combined.indexOf(0x0a);
+    if (newlineIndex !== -1) {
+      ackLine = combined.subarray(0, newlineIndex).toString("utf8");
+      // Keep whatever followed the ack for binary assertions.
+      const rest = combined.subarray(newlineIndex + 1);
+      chunks.length = 0;
+      if (rest.length > 0) {
+        chunks.push(rest);
+      }
+      break;
+    }
+    await defaultTimer.sleep(10);
+  }
+
+  return {
+    socket,
+    ack: ackLine ? (JSON.parse(ackLine) as Record<string, unknown>) : {},
+    binary: () => Buffer.concat(chunks),
+  };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await defaultTimer.sleep(10);
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+afterEach(async () => {
+  while (harnesses.length > 0) {
+    await harnesses.pop()?.cleanup();
+  }
+});
+
+describe("VideoStreamSocketServer", () => {
+  test("acknowledges a subscribe and announces the framing", async () => {
+    const h = await startHarness();
+
+    const { ack } = await subscribe(h.socketPath);
+
+    expect(ack.success).toBe(true);
+    expect(ack.type).toBe("video_stream_response");
+    expect(ack.deviceId).toBe(DEVICE.deviceId);
+    expect(ack.framing).toBe("h264");
+  });
+
+  test("sends the stream header immediately after the ack", async () => {
+    const h = await startHarness();
+
+    const { binary } = await subscribe(h.socketPath);
+    await waitFor(() => binary().length >= 12);
+
+    const header = binary().subarray(0, 12);
+    expect(header.readInt32BE(0)).toBe(CODEC_ID_H264);
+  });
+
+  test("starts exactly one capture and forwards framed packets", async () => {
+    const h = await startHarness();
+    const { binary } = await subscribe(h.socketPath);
+    await waitFor(() => binary().length >= 12);
+
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01, 0xaa, 0xbb]));
+    await waitFor(() => binary().length > 12);
+
+    expect(h.sources).toHaveLength(1);
+    expect(h.sources[0].started).toBe(true);
+
+    const packet = binary().subarray(12);
+    expect(packet.readInt32BE(8)).toBe(7); // payload length
+    expect(packet.subarray(12, 19)).toEqual(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01, 0xaa, 0xbb]));
+  });
+
+  test("a second viewer of the same device shares the capture", async () => {
+    const h = await startHarness();
+
+    await subscribe(h.socketPath);
+    await waitFor(() => h.server.subscriberCount(DEVICE.deviceId) === 1);
+    await subscribe(h.socketPath);
+    await waitFor(() => h.server.subscriberCount(DEVICE.deviceId) === 2);
+
+    expect(h.sources).toHaveLength(1);
+  });
+
+  test("both viewers receive the same packet", async () => {
+    const h = await startHarness();
+    const first = await subscribe(h.socketPath);
+    const second = await subscribe(h.socketPath);
+    await waitFor(() => first.binary().length >= 12 && second.binary().length >= 12);
+
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01, 0x42]));
+    await waitFor(() => first.binary().length > 12 && second.binary().length > 12);
+
+    expect(first.binary().subarray(12)).toEqual(second.binary().subarray(12));
+  });
+
+  test("the capture stops only when the last viewer leaves", async () => {
+    const h = await startHarness();
+    const first = await subscribe(h.socketPath);
+    const second = await subscribe(h.socketPath);
+    await waitFor(() => h.server.subscriberCount(DEVICE.deviceId) === 2);
+
+    first.socket.destroy();
+    await waitFor(() => h.server.subscriberCount(DEVICE.deviceId) === 1);
+    expect(h.sources[0].stopped).toBe(false);
+
+    second.socket.destroy();
+    await waitFor(() => h.server.activeDeviceIds().length === 0);
+    expect(h.sources[0].stopped).toBe(true);
+  });
+
+  test("a late joiner is replayed the parameter sets", async () => {
+    const h = await startHarness();
+    await subscribe(h.socketPath);
+    await waitFor(() => h.server.subscriberCount(DEVICE.deviceId) === 1);
+
+    // SPS arrives before the second viewer connects.
+    const sps = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x07, 0x64, 0x00]);
+    h.emit(sps);
+
+    const late = await subscribe(h.socketPath);
+    await waitFor(() => late.binary().length > 12);
+
+    // Header, then a replayed CONFIG packet carrying the SPS.
+    const packet = late.binary().subarray(12);
+    expect(packet.readInt32BE(8)).toBe(sps.length);
+    expect(packet.subarray(12, 12 + sps.length)).toEqual(sps);
+    expect(packet.readBigInt64BE(0)).toBeLessThan(0n); // CONFIG flag is bit 63
+  });
+
+  test("a failed capture start is reported and starts nothing", async () => {
+    const h = await startHarness({ startError: new Error("adb: device offline") });
+
+    const { ack } = await subscribe(h.socketPath);
+
+    expect(ack.success).toBe(false);
+    expect(String(ack.error)).toContain("adb: device offline");
+    expect(h.server.activeDeviceIds()).toHaveLength(0);
+  });
+
+  test("an unresolvable device is reported without starting a capture", async () => {
+    const h = await startHarness({ resolveError: new Error("No devices connected") });
+
+    const { ack } = await subscribe(h.socketPath);
+
+    expect(ack.success).toBe(false);
+    expect(String(ack.error)).toContain("No devices connected");
+    expect(h.sources).toHaveLength(0);
+  });
+
+  test("an unknown action is rejected by name", async () => {
+    const h = await startHarness();
+
+    const { ack } = await subscribe(h.socketPath, { action: "teleport" });
+
+    expect(ack.success).toBe(false);
+    expect(String(ack.error)).toContain("teleport");
+  });
+
+  test("malformed JSON is rejected rather than crashing the server", async () => {
+    const h = await startHarness();
+    const socket = net.createConnection(h.socketPath);
+    await new Promise<void>(resolve => socket.once("connect", () => resolve()));
+
+    const chunks: Buffer[] = [];
+    socket.on("data", data => chunks.push(data));
+    socket.write("{not json\n");
+    await waitFor(() => Buffer.concat(chunks).includes("\n"));
+
+    expect(Buffer.concat(chunks).toString()).toContain("Invalid JSON");
+    // The server is still serving.
+    const { ack } = await subscribe(h.socketPath);
+    expect(ack.success).toBe(true);
+  });
+
+  test("close stops every capture", async () => {
+    const h = await startHarness();
+    await subscribe(h.socketPath);
+    await waitFor(() => h.server.activeDeviceIds().length === 1);
+
+    await h.server.close();
+
+    expect(h.sources[0].stopped).toBe(true);
+    expect(h.server.activeDeviceIds()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
First half of the live device mirroring path. Refs #3928 (epic #3933).

## Why not the WebRTC stream #3928 asked for

The desktop app cannot consume it. That path **publishes** to an external coordination server over WHIP so browsers can pull it over WHEP:

```
daemon ──WHIP──▶ coordination server ──WHEP──▶ browser
```

- The daemon hosts no SFU — the WHIP endpoint is a third-party server the operator deploys ([docs/webrtc-streaming-ci-worker.md:11](docs/webrtc-streaming-ci-worker.md:11) names MediaMTX/LiveKit/Janus/Cloudflare).
- The descriptor carries only the **ingest** endpoint and send-side counters ([WebRtcPublisher.ts:63](src/features/webrtc/WebRtcPublisher.ts:63)); there is no playback URL to subscribe to.
- Streaming is inert unless `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` is set.

A viewer on the same machine as the daemon would be routing a local device's screen out to a remote server and back.

The repo's own design already anticipated this: [screen-streaming.md](docs/design-docs/plat/android/screen-streaming.md) specifies a separate local path, and [webrtc-streaming.md:20-23](docs/design-docs/mcp/observe/webrtc-streaming.md:20) states the two are deliberately distinct. The socket that design names was never built. This is that socket.

## What this adds

`~/.auto-mobile/video-stream.sock`, reusing the H.264 capture the WebRTC publisher already drives — no second encoder, no new device-side machinery. Whichever source the existing factory picks (persistent-encoder jar, or `screenrecord` fallback) feeds subscribers here too.

**Protocol:** one JSON line in, one JSON line out, then raw binary in the `VideoStreamProtocol` framing the on-device encoder already speaks. Because the handshake is line-based this still extends `BaseSocketServer` like every other daemon socket, per `src/daemon/CLAUDE.md`; it only departs from the newline-JSON convention for the frame body, which is called out in the class doc. Base64-in-JSON was the alternative and would add ~33% to a 4–8 Mbps stream plus a per-frame encode.

## Decisions worth reviewing

- **One capture per device, shared.** A second viewer doesn't start a second encoder; capture stops when the last viewer disconnects.
- **Late joiners get the parameter sets replayed.** Otherwise a viewer that connects mid-stream cannot decode until the encoder's next key frame.
- **Idle timeout disabled for this server.** The stream is outbound-only after the handshake, so a silent viewer is the normal case, not a dead peer. (Node refreshes its socket timer on writes, so the default would probably have been survivable — I'd rather not have live video depend on that subtlety.)
- **A slow subscriber is logged, not disconnected.** For live video a backlog is that viewer's problem; killing the capture would punish everyone else.
- **Header dimensions default to zero.** The capture sources don't report size and every decoder takes the true dimensions from the in-band SPS. A caller may pass a hint to lay out before the first key frame.

## Testing

27 new tests; **8104 TS tests green**, 0 failures; build and lint clean.

- `videoStreamFraming.test.ts` (15) — header/packet encoding against the constants in `VideoStreamProtocol.kt`, the CONFIG/KEY_FRAME bits surviving as a negative int64, PTS masking so an oversized timestamp can't corrupt the flags, and NAL classification incl. 3-byte start codes and chunks with no start code.
- `videoStreamSocketServer.test.ts` (12) — drives a **real Unix socket** with an injected capture source (no adb, no device): shared capture across two viewers, both receiving identical packets, capture stopping only on the last disconnect, late-joiner SPS replay, capture-start failure, unresolvable device, unknown action, and malformed JSON leaving the server still serving.

## What's next

The desktop consumer is **blocked on a decoder decision**. The design doc picked Klarity, but [its README](https://github.com/numq/Klarity) shows it is not published to Maven Central or JitPack — you download per-platform JARs (win-x64, linux-x64, macos-x64, macos-arm64, FFmpeg/PortAudio bundled) from GitHub releases. That is likely why `- [ ] Add Klarity dependency` is still unchecked. Options are vendoring ~4 binary JARs, a checksum-verified download task at build time (the repo already does something like this for `automobile-video.jar`), or a decoder that ships on Maven Central. Worth deciding before the client PR.