### PR TITLE
test(desktop): pin comparator fidelity for anti-aliased captures

### DIFF
--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparatorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/screenshot/ScreenshotComparatorTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.screenshot
 
 import java.awt.Color
+import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.File
 import java.nio.file.Files
@@ -27,6 +28,52 @@ class ScreenshotComparatorTest {
     val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
     for (y in 0 until height) for (x in 0 until width) image.setRGB(x, y, color.rgb)
     return image
+  }
+
+  /**
+   * A premultiplied-alpha capture with anti-aliased, partially transparent pixels — what
+   * `captureToImage().toAwtImage()` produces for real Compose content, as opposed to the solid
+   * fills the other cases use.
+   */
+  private fun premultipliedAntiAliasedCapture(width: Int, height: Int): BufferedImage {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE)
+    for (y in 0 until height) for (x in 0 until width) {
+      // Diagonal alpha ramp so most pixels are partially transparent, where a lossy
+      // premultiply/unpremultiply round-trip would show up.
+      val alpha = ((x + y) * 255 / (width + height)).coerceIn(0, 255)
+      image.setRGB(x, y, Color(20 + x % 200, 200 - y % 200, (x * y) % 256, alpha).rgb)
+    }
+    val g = image.createGraphics()
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+    g.color = Color(255, 255, 255, 180)
+    g.drawLine(0, 0, width - 1, height - 1)
+    g.dispose()
+    return image
+  }
+
+  /**
+   * Recording a baseline and immediately verifying the *same* capture against it must report
+   * [ScreenshotComparator.Result.Match] — i.e. the PNG round-trip `record` performs is lossless as
+   * far as [ScreenshotComparator.compare] is concerned.
+   *
+   * This pins the record→verify half of the reproducibility question for issue #3913: `compare`
+   * reads the baseline back through `ImageIO` while `actual` is the raw in-memory capture, so an
+   * asymmetric round-trip here would make every recorded baseline fail its own verification. It
+   * does not — which is what rules the comparator out as the cause of that failure and points at
+   * the render step instead.
+   */
+  @Test
+  fun `recording then verifying the same anti-aliased capture matches`() {
+    val captured = premultipliedAntiAliasedCapture(200, 100)
+    val baseline = File(tempDir, "anti_aliased.png")
+
+    ScreenshotComparator.record(baseline, captured)
+
+    assertEquals(
+      ScreenshotComparator.Result.Match,
+      ScreenshotComparator.compare(baseline, captured, tempDir, "anti_aliased"),
+      "a freshly recorded baseline must verify against the capture it was recorded from",
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

Every existing `ScreenshotComparatorTest` case builds its images from solid fills, so nothing covered the shape of a *real* Compose capture: a premultiplied-alpha (`TYPE_INT_ARGB_PRE`) image whose pixels are mostly partially transparent. This adds one test over that shape.

The property it pins: **recording a capture and then verifying the same capture against it reports `Match`** — across the partial-alpha and anti-aliased pixels a premultiplied round-trip would distort. `compare` reads the baseline back through `ImageIO` while `actual` stays the raw in-memory capture, so an asymmetric PNG round-trip there would make *every* recorded baseline fail its own verification.

Test-only; no production code touched.

## Linked Issue

Refs #3913 — **deliberately not `Closes`.** This does not fix that issue; the baseline mismatch is still unexplained. (Noting it because #3974 auto-closed #3913 off its branch name despite also using `Refs`; this branch is named to avoid that.)

## Bug / Regression Context

- **Prior attempts:** #3974 landed the diagnostic artifact upload for #3913 — tooling only, no fix.
- **Observed symptom:** on the reference OS, the 6 `ComponentScreenshotTest` baselines fail the verify step that immediately follows the record step that produced them.
- **Repro steps / conditions:** does *not* reproduce off-Linux. Per the #3913 thread, the full record → un-pend → verify sequence passes on macOS/arm64 as two separate Gradle invocations, which is what eliminated the record-vs-verify path-divergence hypothesis.

**Where this fits:** that elimination was a one-off manual run. This turns it into a standing regression test so it can't silently rot, and it narrows where the remaining investigation should look — the live hypotheses are comparator tolerance being too tight for real Compose AA output, and a Linux-specific rasterization difference. Neither is addressed here; both need the `record-screenshot-baselines-diffs` artifact from a `workflow_dispatch` run, which is the actual next step on #3913.

## Validation

- [x] `./gradlew -p android :desktop-core:test --tests '*ScreenshotComparatorTest' --rerun-tasks` → `tests="7" failures="0" errors="0"`
- [x] `scripts/ktfmt/apply_ktfmt.sh` on the touched file — no reformatting needed
- [x] New test is pure logic: no Compose, no display, no I/O beyond a temp dir; runs in ~0.2s
- [x] Rebased onto latest `main` (`6a25b76bd`)
- [ ] `bun run typecheck` — N/A, no TypeScript touched

## Device Verification

N/A — pure-logic test, no on-device behavior.

## Follow-ups

None filed. #3913 remains open and already tracks the unresolved root cause; a separate issue would duplicate it.