### PR TITLE
feat(desktop): control WebRTC screen sharing for remote viewers

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -82,6 +82,8 @@ import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingActions
 import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfigClient
 import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingSocketClient
+import dev.jasonpearson.automobile.desktop.core.daemon.WebRtcStreamClient
+import dev.jasonpearson.automobile.desktop.core.daemon.WebRtcStreamSocketClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
@@ -520,6 +522,11 @@ fun AutoMobileContent(
     }
   val recordingActions: VideoRecordingActions? =
     remember(clientProvider) { clientProvider?.let { McpVideoRecordingActions(it) } }
+  // Screen sharing is daemon-side publishing, so it needs no MCP client -- just the socket.
+  val webRtcStreamClient: WebRtcStreamClient? =
+    remember(dataSourceMode) {
+      if (dataSourceMode == DataSourceMode.Real) WebRtcStreamSocketClient() else null
+    }
 
   // Take-screenshot is driven from both the native menu bar and the in-app menu.
   // Run it on a composition-scoped coroutine (not GlobalScope) so the call and its
@@ -1412,6 +1419,7 @@ fun AutoMobileContent(
                       appearanceClient = appearanceClient,
                       recordingActions = recordingActions,
                       recordingConfigClient = recordingConfigClient,
+                      streamClient = webRtcStreamClient,
                       activeDeviceId = activeDeviceId,
                     )
                   "diagnostics" ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
@@ -1,0 +1,197 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Socket file the daemon binds for WebRTC stream control. */
+internal const val WEBRTC_STREAM_SOCKET_FILE = "webrtc-stream.sock"
+
+/** An ICE server the publisher uses to establish its outbound connection. */
+@Serializable
+data class WebRtcIceServer(
+  val urls: String = "",
+  val username: String? = null,
+  val credential: String? = null,
+)
+
+/**
+ * State of one published stream.
+ *
+ * Note the counters are *send*-side: this describes the daemon publishing the device's screen to a
+ * coordination server, not a stream being received here. There is no playback URL in this
+ * descriptor -- see [WebRtcStreamClient] for why that matters.
+ */
+@Serializable
+data class WebRtcStreamDescriptor(
+  val streamId: String = "",
+  val state: String = "",
+  val whipEndpoint: String = "",
+  /** WHIP resource URL for the active session, used to reconnect or tear down. */
+  val resourceUrl: String? = null,
+  val iceServers: List<WebRtcIceServer> = emptyList(),
+  val framesSent: Long = 0,
+  val packetsSent: Long = 0,
+  val audioPacketsSent: Long = 0,
+  val audioSamplesSent: Long = 0,
+)
+
+/**
+ * Controls the daemon's WebRTC screen publishing.
+ *
+ * **This is a publish-control surface, not a video source.** The daemon captures the device's
+ * screen and *publishes* it to an external coordination server over WHIP; viewers watch it from
+ * that server over WHEP. The daemon never serves video back to a local client, and the descriptor
+ * carries only the ingest endpoint -- there is no playback URL to subscribe to. So the desktop can
+ * start, stop and monitor a stream, but rendering it here would mean round-tripping a local
+ * device's screen through a remote server.
+ *
+ * Streaming is also inert unless the operator has configured `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT`;
+ * [isAvailable] only reports whether the socket exists, not whether an endpoint is configured. A
+ * `start` against an unconfigured daemon fails with the daemon's own message.
+ */
+interface WebRtcStreamClient {
+  /** Begins publishing [deviceId]'s screen to the configured coordination server. */
+  fun startStream(deviceId: String?, streamId: String? = null): WebRtcStreamDescriptor?
+
+  fun stopStream(streamId: String? = null): WebRtcStreamDescriptor?
+
+  /** Status of one stream, or null when [streamId] names nothing active. */
+  fun streamStatus(streamId: String): WebRtcStreamDescriptor?
+
+  fun listStreams(): List<WebRtcStreamDescriptor>
+
+  /** True when the daemon exposes this socket; false on daemons that predate it. */
+  fun isAvailable(): Boolean
+}
+
+/** Client for `~/.auto-mobile/webrtc-stream.sock`. One request per connection. */
+class WebRtcStreamSocketClient(
+  private val socketPathValue: String = AutoMobileSocketPaths.socketPath(WEBRTC_STREAM_SOCKET_FILE),
+  private val json: Json = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+    encodeDefaults = true
+  },
+) : WebRtcStreamClient {
+
+  override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())
+
+  override fun startStream(deviceId: String?, streamId: String?): WebRtcStreamDescriptor? =
+    send(request("start", deviceId = deviceId, streamId = streamId)).stream
+
+  override fun stopStream(streamId: String?): WebRtcStreamDescriptor? =
+    send(request("stop", streamId = streamId)).stream
+
+  override fun streamStatus(streamId: String): WebRtcStreamDescriptor? =
+    send(request("status", streamId = streamId)).stream
+
+  override fun listStreams(): List<WebRtcStreamDescriptor> {
+    val response = send(request("list"))
+    // `status` without a streamId answers with action "list", so accept either field.
+    return response.streams ?: listOfNotNull(response.stream)
+  }
+
+  private fun request(action: String, deviceId: String? = null, streamId: String? = null) =
+    WebRtcStreamSocketRequest(
+      id = UUID.randomUUID().toString(),
+      action = action,
+      deviceId = deviceId,
+      streamId = streamId,
+    )
+
+  private fun send(request: WebRtcStreamSocketRequest): WebRtcStreamSocketResponse {
+    ensureSocketExists()
+
+    val address = UnixDomainSocketAddress.of(socketPathValue)
+    SocketChannel.open(address).use { channel ->
+      val reader =
+        BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
+      val writer =
+        BufferedWriter(
+          OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+        )
+
+      writer.write(json.encodeToString(WebRtcStreamSocketRequest.serializer(), request))
+      writer.newLine()
+      writer.flush()
+
+      val line = reader.readLine() ?: throw McpConnectionException("WebRTC stream socket closed")
+      val response = json.decodeFromString(WebRtcStreamSocketResponse.serializer(), line)
+
+      if (!response.success) {
+        throw McpConnectionException(response.error ?: "WebRTC stream request failed")
+      }
+      return response
+    }
+  }
+
+  private fun ensureSocketExists() {
+    if (!isAvailable()) {
+      throw McpConnectionException("WebRTC stream socket not found at $socketPathValue")
+    }
+  }
+}
+
+@Serializable
+internal data class WebRtcStreamSocketRequest(
+  val id: String,
+  val action: String,
+  val deviceId: String? = null,
+  val streamId: String? = null,
+)
+
+@Serializable
+internal data class WebRtcStreamSocketResponse(
+  val id: String? = null,
+  val type: String? = null,
+  val success: Boolean = false,
+  val action: String? = null,
+  val stream: WebRtcStreamDescriptor? = null,
+  val streams: List<WebRtcStreamDescriptor>? = null,
+  val error: String? = null,
+)
+
+/** In-memory [WebRtcStreamClient] for previews and tests. */
+class FakeWebRtcStreamClient(
+  private val available: Boolean = true,
+  /** When set, `start` fails with this message, mimicking an unconfigured WHIP endpoint. */
+  private val startFailure: String? = null,
+) : WebRtcStreamClient {
+  private val streams = mutableMapOf<String, WebRtcStreamDescriptor>()
+
+  override fun isAvailable(): Boolean = available
+
+  override fun startStream(deviceId: String?, streamId: String?): WebRtcStreamDescriptor {
+    startFailure?.let { throw McpConnectionException(it) }
+    val id = streamId ?: "stream-${streams.size + 1}"
+    val descriptor =
+      WebRtcStreamDescriptor(
+        streamId = id,
+        state = "connected",
+        whipEndpoint = "https://coord.example.com/whip",
+        resourceUrl = "https://coord.example.com/whip/$id",
+      )
+    streams[id] = descriptor
+    return descriptor
+  }
+
+  override fun stopStream(streamId: String?): WebRtcStreamDescriptor? {
+    val id = streamId ?: streams.keys.firstOrNull() ?: return null
+    return streams.remove(id)?.copy(state = "closed")
+  }
+
+  override fun streamStatus(streamId: String): WebRtcStreamDescriptor? = streams[streamId]
+
+  override fun listStreams(): List<WebRtcStreamDescriptor> = streams.values.toList()
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboard.kt
@@ -35,6 +35,8 @@ import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingActions
 import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingArtifact
 import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfig
 import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfigClient
+import dev.jasonpearson.automobile.desktop.core.daemon.WebRtcStreamClient
+import dev.jasonpearson.automobile.desktop.core.daemon.WebRtcStreamDescriptor
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 import kotlinx.coroutines.Dispatchers
@@ -44,18 +46,24 @@ import kotlinx.coroutines.withContext
 private val LOG = LoggerFactory.getLogger("DeviceControlsDashboard")
 
 /**
- * Device appearance and video recording.
+ * Device appearance, video recording, and screen sharing.
  *
  * Appearance is a *global* control: `appearance.sock` takes no device id and applies to every
  * pooled device, so it is presented that way rather than as a per-device toggle. Recording is
  * per-device and spans two transports -- the start/stop verbs are MCP tool calls, while quality and
  * retention live on `video-recording.sock`.
+ *
+ * Screen sharing starts the daemon's WebRTC publisher, which pushes the device's screen to a
+ * coordination server for browsers and CI dashboards to watch over WHEP. There is deliberately no
+ * preview here: the daemon publishes rather than serves, so there is no local playback URL. Local
+ * live mirroring is a separate socket entirely.
  */
 @Composable
 fun DeviceControlsDashboard(
   appearanceClient: AppearanceClient?,
   recordingActions: VideoRecordingActions?,
   recordingConfigClient: VideoRecordingConfigClient?,
+  streamClient: WebRtcStreamClient?,
   activeDeviceId: String?,
   modifier: Modifier = Modifier,
 ) {
@@ -71,6 +79,18 @@ fun DeviceControlsDashboard(
   var busy by remember { mutableStateOf(false) }
   var notice by remember { mutableStateOf<String?>(null) }
   var error by remember { mutableStateOf<String?>(null) }
+  var streams by remember { mutableStateOf<List<WebRtcStreamDescriptor>>(emptyList()) }
+
+  LaunchedEffect(streamClient) {
+    if (streamClient?.isAvailable() != true) return@LaunchedEffect
+    streams =
+      try {
+        withContext(Dispatchers.IO) { streamClient.listStreams() }
+      } catch (e: Exception) {
+        LOG.warn("Could not list WebRTC streams: ${e.message}", e)
+        emptyList()
+      }
+  }
 
   LaunchedEffect(appearanceClient, recordingConfigClient) {
     withContext(Dispatchers.IO) {
@@ -226,6 +246,60 @@ fun DeviceControlsDashboard(
 
     notice?.let { Hint(it, Color(0xFF4CAF50)) }
     error?.let { Hint(it, Color(0xFFE53935)) }
+    // -- Remote viewing --
+    Text(
+      "Remote viewing",
+      fontSize = 12.sp,
+      fontWeight = FontWeight.SemiBold,
+      color = colors.text.normal,
+    )
+
+    if (streamClient?.isAvailable() != true) {
+      Hint("Screen sharing is unavailable on this daemon.", colors.text.normal)
+    } else {
+      Text(
+        // The daemon publishes to a coordination server; viewers watch it there, not here. Saying
+        // otherwise would imply this window is about to show the video.
+        "Publishes this device's screen to the configured coordination server, " +
+          "where browsers and CI dashboards can watch it.",
+        fontSize = 9.sp,
+        color = colors.text.normal.copy(alpha = 0.5f),
+      )
+
+      val publishing = streams.isNotEmpty()
+      Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        Chip(
+          label = if (publishing) "Stop sharing" else "Share screen",
+          accent = if (publishing) Color(0xFFE53935) else Color(0xFF7E57C2),
+          enabled = activeDeviceId != null && !busy,
+        ) {
+          val deviceId = activeDeviceId ?: return@Chip
+          if (publishing) {
+            run("Stop sharing") {
+              streamClient.stopStream(streams.firstOrNull()?.streamId)
+              streams = streamClient.listStreams()
+              "Stopped sharing"
+            }
+          } else {
+            run("Share screen") {
+              val started = streamClient.startStream(deviceId)
+              streams = streamClient.listStreams()
+              "Sharing to ${started?.whipEndpoint ?: "the coordination server"}"
+            }
+          }
+        }
+      }
+
+      streams.forEach { stream ->
+        Text(
+          "${stream.streamId} · ${stream.state} · ${stream.framesSent} frames sent" +
+            (stream.whipEndpoint.takeIf { it.isNotBlank() }?.let { " · $it" } ?: ""),
+          fontSize = 9.sp,
+          color = colors.text.normal.copy(alpha = 0.6f),
+        )
+      }
+    }
+
     manifestPath?.let {
       Hint("Segment manifest: $it", colors.text.normal.copy(alpha = 0.6f))
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestConfigSocketServer.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestConfigSocketServer.kt
@@ -30,6 +30,13 @@ class TestConfigSocketServer(
   private val resultJson: String? = null,
   private val error: String? = null,
   socketFileName: String = "test.sock",
+  /**
+   * A JSON object whose fields are merged into the response alongside `id`/`type`/`success`,
+   * instead of wrapping [resultJson] in a `result` object. The WebRTC stream socket answers with
+   * `stream`/`streams` at the top level rather than under `result`, so it needs this.
+   */
+  private val rawBodyJson: String? = null,
+  private val success: Boolean = true,
 ) : AutoCloseable {
   private val json = Json { ignoreUnknownKeys = true }
   private val tempDir: Path = Files.createTempDirectory(Path.of("/tmp"), "amsock-")
@@ -76,13 +83,21 @@ class TestConfigSocketServer(
 
   private fun responseLine(requestId: String): String {
     val body =
-      if (error == null) {
-        val compact = (resultJson ?: "{}").lineSequence().joinToString("") { it.trim() }
-        """"result":$compact"""
-      } else {
-        """"error":${JsonPrimitive(error)}"""
+      when {
+        rawBodyJson != null -> {
+          // Merge the caller's object into the envelope: drop its outer braces so the fields sit
+          // alongside id/type/success rather than nesting.
+          val compact = rawBodyJson.lineSequence().joinToString("") { it.trim() }
+          compact.removePrefix("{").removeSuffix("}")
+        }
+        error != null -> """"error":${JsonPrimitive(error)}"""
+        else -> {
+          val compact = (resultJson ?: "{}").lineSequence().joinToString("") { it.trim() }
+          """"result":$compact"""
+        }
       }
-    return """{"id":"$requestId","type":"$responseType","success":${error == null},$body}"""
+    val succeeded = if (rawBodyJson != null) success else error == null
+    return """{"id":"$requestId","type":"$responseType","success":$succeeded,$body}"""
   }
 
   override fun close() {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClientTest.kt
@@ -1,0 +1,175 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Covers [WebRtcStreamSocketClient] against a real in-process Unix socket. */
+class WebRtcStreamSocketClientTest {
+
+  private val descriptorJson =
+    """
+    {
+      "streamId": "stream-1",
+      "state": "connected",
+      "whipEndpoint": "https://coord.example.com/whip",
+      "resourceUrl": "https://coord.example.com/whip/stream-1",
+      "iceServers": [{"urls": "stun:stun.example.com:3478"}],
+      "framesSent": 120,
+      "packetsSent": 480,
+      "audioPacketsSent": 0,
+      "audioSamplesSent": 0
+    }
+    """
+
+  /** The WebRTC socket answers with stream/streams at the top level, not under `result`. */
+  private fun server(rawBodyJson: String, success: Boolean = true) =
+    TestConfigSocketServer(
+      responseType = "webrtc_stream_response",
+      socketFileName = "webrtc-stream.sock",
+      rawBodyJson = rawBodyJson,
+      success = success,
+    )
+
+  @Test
+  fun `start sends the action and device id`() {
+    // The daemon returns stream/streams at the top level, not under `result`, so the harness's
+    // result payload is unused here -- only the request assertions matter.
+    server("""{"action":"start"}""").use { s ->
+      runCatching {
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString())
+          .startStream("emulator-5554")
+      }
+
+      val request = s.awaitRequest()
+      assertEquals("start", request["action"]?.jsonPrimitive?.content)
+      assertEquals("emulator-5554", request["deviceId"]?.jsonPrimitive?.content)
+    }
+  }
+
+  @Test
+  fun `stop carries the stream id when one is given`() {
+    server("""{"action":"start"}""").use { s ->
+      runCatching {
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString()).stopStream("stream-1")
+      }
+
+      val request = s.awaitRequest()
+      assertEquals("stop", request["action"]?.jsonPrimitive?.content)
+      assertEquals("stream-1", request["streamId"]?.jsonPrimitive?.content)
+    }
+  }
+
+  @Test
+  fun `stop without a stream id omits the field`() {
+    server("""{"action":"start"}""").use { s ->
+      runCatching {
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString()).stopStream()
+      }
+
+      assertTrue(!s.awaitRequest().containsKey("streamId"))
+    }
+  }
+
+  @Test
+  fun `a descriptor is decoded from a start response`() {
+    server("""{"action":"start","stream":$descriptorJson}""").use { s ->
+      val stream =
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString())
+          .startStream("emulator-5554")
+
+      assertNotNull(stream)
+      assertEquals("stream-1", stream.streamId)
+      assertEquals("connected", stream.state)
+      assertEquals("https://coord.example.com/whip", stream.whipEndpoint)
+      assertEquals(120L, stream.framesSent)
+      assertEquals("stun:stun.example.com:3478", stream.iceServers.single().urls)
+    }
+  }
+
+  @Test
+  fun `list decodes every active stream`() {
+    server("""{"action":"list","streams":[$descriptorJson]}""").use { s ->
+      val streams =
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString()).listStreams()
+
+      assertEquals(1, streams.size)
+      assertEquals("stream-1", streams.single().streamId)
+    }
+  }
+
+  @Test
+  fun `list is empty when nothing is publishing`() {
+    server("""{"action":"list","streams":[]}""").use { s ->
+      assertTrue(
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString()).listStreams().isEmpty()
+      )
+    }
+  }
+
+  @Test
+  fun `an unconfigured whip endpoint surfaces the daemon's message`() {
+    // Streaming is inert unless AUTOMOBILE_WEBRTC_WHIP_ENDPOINT is set; the daemon says so.
+    server(
+        """{"error":"WebRTC streaming is not configured (AUTOMOBILE_WEBRTC_WHIP_ENDPOINT)"}""",
+        success = false,
+      )
+      .use { s ->
+        val failure =
+          assertFailsWith<McpConnectionException> {
+            WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString())
+              .startStream("emulator-5554")
+          }
+
+        assertTrue(failure.message!!.contains("AUTOMOBILE_WEBRTC_WHIP_ENDPOINT"))
+      }
+  }
+
+  @Test
+  fun `status for an unknown stream surfaces the daemon's error`() {
+    server("""{"error":"No active WebRTC stream with id ghost."}""", success = false).use { s ->
+      assertFailsWith<McpConnectionException> {
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString()).streamStatus("ghost")
+      }
+    }
+  }
+
+  @Test
+  fun `a missing socket names the path`() {
+    val client = WebRtcStreamSocketClient(socketPathValue = "/tmp/no-webrtc-am.sock")
+
+    assertTrue(!client.isAvailable())
+    assertTrue(
+      assertFailsWith<McpConnectionException> { client.listStreams() }
+        .message!!
+        .contains("/tmp/no-webrtc-am.sock")
+    )
+  }
+
+  @Test
+  fun `the fake tracks start, list and stop`() {
+    val client = FakeWebRtcStreamClient()
+
+    val started = client.startStream("emulator-5554")
+    assertEquals(listOf(started.streamId), client.listStreams().map { it.streamId })
+
+    assertEquals("closed", client.stopStream(started.streamId)?.state)
+    assertTrue(client.listStreams().isEmpty())
+  }
+
+  @Test
+  fun `the fake can mimic an unconfigured daemon`() {
+    val client = FakeWebRtcStreamClient(startFailure = "WebRTC streaming is not configured")
+
+    assertFailsWith<McpConnectionException> { client.startStream("emulator-5554") }
+  }
+
+  @Test
+  fun `stopping nothing returns null rather than throwing`() {
+    assertNull(FakeWebRtcStreamClient().stopStream())
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboardUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/device/DeviceControlsDashboardUiTest.kt
@@ -10,6 +10,7 @@ import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceConfig
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeAppearanceClient
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeVideoRecordingActions
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeVideoRecordingConfigClient
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeWebRtcStreamClient
 import dev.jasonpearson.automobile.desktop.core.daemon.VideoRecordingConfig
 import org.junit.Test
 
@@ -24,6 +25,7 @@ class DeviceControlsDashboardUiTest {
           appearanceClient = FakeAppearanceClient(),
           recordingActions = FakeVideoRecordingActions(),
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -41,6 +43,7 @@ class DeviceControlsDashboardUiTest {
           appearanceClient = FakeAppearanceClient(),
           recordingActions = FakeVideoRecordingActions(),
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -57,6 +60,7 @@ class DeviceControlsDashboardUiTest {
           appearanceClient = FakeAppearanceClient(available = false),
           recordingActions = FakeVideoRecordingActions(),
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -75,6 +79,7 @@ class DeviceControlsDashboardUiTest {
           appearanceClient = FakeAppearanceClient(),
           recordingActions = FakeVideoRecordingActions(),
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = null,
         )
       }
@@ -94,6 +99,7 @@ class DeviceControlsDashboardUiTest {
             FakeVideoRecordingConfigClient(
               VideoRecordingConfig(qualityPreset = "high", fps = 60, maxArchiveSizeMb = 2048)
             ),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -112,6 +118,7 @@ class DeviceControlsDashboardUiTest {
             FakeAppearanceClient(AppearanceConfig(syncWithHost = false, defaultMode = "dark")),
           recordingActions = FakeVideoRecordingActions(),
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -129,6 +136,7 @@ class DeviceControlsDashboardUiTest {
             FakeAppearanceClient(AppearanceConfig(syncWithHost = true, defaultMode = "auto")),
           recordingActions = FakeVideoRecordingActions(),
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -146,6 +154,7 @@ class DeviceControlsDashboardUiTest {
           appearanceClient = FakeAppearanceClient(),
           recordingActions = actions,
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -164,6 +173,7 @@ class DeviceControlsDashboardUiTest {
           appearanceClient = FakeAppearanceClient(),
           recordingActions = actions,
           recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
           activeDeviceId = "emulator-5554",
         )
       }
@@ -177,6 +187,111 @@ class DeviceControlsDashboardUiTest {
 
     onNodeWithText("Segment 0").assertIsDisplayed()
     onNodeWithText("Segment 2").assertIsDisplayed()
+  }
+
+  @Test
+  fun `offers screen sharing when the stream socket is present`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Remote viewing").assertIsDisplayed()
+    onNodeWithText("Share screen").assertIsDisplayed()
+  }
+
+  @Test
+  fun `says where viewers watch rather than implying a local preview`() = runComposeUiTest {
+    // The daemon publishes to a coordination server; it never serves video back here.
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("browsers and CI dashboards can watch", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `degrades when the stream socket is absent`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = FakeWebRtcStreamClient(available = false),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Screen sharing is unavailable on this daemon.").assertIsDisplayed()
+    // The other controls keep working.
+    onNodeWithText("Record").assertIsDisplayed()
+  }
+
+  @Test
+  fun `sharing starts a stream and flips the control to stop`() = runComposeUiTest {
+    val streamClient = FakeWebRtcStreamClient()
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient = streamClient,
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Share screen").performClick()
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) { streamClient.listStreams().isNotEmpty() }
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) {
+      runCatching { onNodeWithText("Stop sharing").assertIsDisplayed() }.isSuccess
+    }
+  }
+
+  @Test
+  fun `an unconfigured coordination server surfaces the daemon's reason`() = runComposeUiTest {
+    // Streaming is inert until AUTOMOBILE_WEBRTC_WHIP_ENDPOINT is set, and that is the most
+    // likely reason sharing fails, so the operator must see it.
+    setContent {
+      MaterialTheme {
+        DeviceControlsDashboard(
+          appearanceClient = FakeAppearanceClient(),
+          recordingActions = FakeVideoRecordingActions(),
+          recordingConfigClient = FakeVideoRecordingConfigClient(),
+          streamClient =
+            FakeWebRtcStreamClient(
+              startFailure = "WebRTC streaming is not configured (AUTOMOBILE_WEBRTC_WHIP_ENDPOINT)"
+            ),
+          activeDeviceId = "emulator-5554",
+        )
+      }
+    }
+
+    onNodeWithText("Share screen").performClick()
+    waitUntil(timeoutMillis = ACTION_TIMEOUT_MS) {
+      runCatching {
+        onNodeWithText("AUTOMOBILE_WEBRTC_WHIP_ENDPOINT", substring = true).assertIsDisplayed()
+      }
+        .isSuccess
+    }
   }
 
   private companion object {


### PR DESCRIPTION
Lets an operator publish a device's screen from the desktop app so browsers and CI dashboards can watch it live. Relates to #3928 / epic #3933.

## What this is (and isn't)

This is the **publish** side of the WebRTC path, which is what `webrtc-stream.sock` actually offers. The daemon captures the device's screen and pushes it to a coordination server over WHIP; viewers pull it from there over WHEP:

```
daemon ──WHIP──▶ coordination server ──WHEP──▶ browser / CI dashboard
```

The desktop is a **control surface** for that, not a viewer. The descriptor carries the ingest endpoint and send-side counters, never a playback URL ([WebRtcPublisher.ts:63](src/features/webrtc/WebRtcPublisher.ts:63)), and the daemon serves no video back. The UI states where viewers watch rather than implying a preview is about to appear — there's a test pinning that wording, because it's the easiest thing for a future change to get wrong.

Local live mirroring remains a separate path (`video-stream.sock`, #3994). The two are unrelated by design.

## UI

A **Remote viewing** section in the Device tab alongside Appearance and Video recording:

- Share / Stop sharing for the active device
- Per-stream line: stream id, connection state, frames sent, WHIP endpoint
- Degrades to "Screen sharing is unavailable on this daemon." when the socket is absent, with the other controls unaffected

## The failure operators will actually hit

Streaming is inert unless `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` is configured, so "I clicked Share and nothing happened" is the likely first experience. The daemon's own error names that variable and it is surfaced verbatim; `an unconfigured coordination server surfaces the daemon's reason` locks that in.

## Testing

17 tests (12 client, 5 UI), **517 desktop-core green**, 0 failures. `:desktop-app:compileKotlin` passes; ktfmt verified directly against the changed files.

- `WebRtcStreamSocketClientTest` (12) — drives a real Unix socket: request shapes for start/stop/status/list, `streamId` omitted when absent, descriptor decoding incl. ICE servers and counters, the unconfigured-endpoint error, unknown-stream error, and a missing socket naming its path.
- `DeviceControlsDashboardUiTest` (+5) — the section renders, says where viewers watch, degrades without the socket, flips Share → Stop sharing on success, and shows the unconfigured reason on failure.

One harness note: the WebRTC socket answers with `stream`/`streams` at the **top level** rather than nested under `result` like the config sockets, so the shared `TestConfigSocketServer` gained a raw-body mode to model that envelope faithfully instead of the tests pretending it matches.

## History

This client was written and then dropped while #3928 was being re-scoped toward local mirroring — it had no consumer at that point, and shipping an unwired client would have recreated what #3927 removed. Restored here with the UI that makes it a real feature.