### PR TITLE
test(db): prove the shipped default barrier resolver re-resolves for all three consumers (#2960)

### DIFF
--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -78,8 +78,17 @@ export interface DbWriteBarrier {
    * them — none capture the instance at construction. TelemetryRecorder,
    * FailureAnalyticsRepository and SessionManager were converted from a captured
    * field to a per-write resolver in #2912 (decision (a)); AndroidCtrlProxyClient
-   * already resolved fresh per call. A future in-process reopen path therefore
-   * needs no consumer reconstruction and no in-place barrier reset.
+   * and IosSdkEventIngestor already resolved fresh per call. A future in-process
+   * reopen path therefore needs no consumer reconstruction and no in-place
+   * barrier reset.
+   *
+   * The two use-site consumers deliberately take NO `getBarrier` resolver
+   * parameter, unlike the three converted ones. That asymmetry is intentional,
+   * not an oversight: the conversion existed to fix construction-captured
+   * staleness, which resolving the global per call already avoids. A resolver
+   * would exist only to let a test swap the instance, and a test can `spyOn` the
+   * freshly-reset singleton instead (see CtrlProxyClient.test.ts). Unify them
+   * with the resolver pattern if a test ever genuinely needs injection (#2960).
    */
   beginDrain(): void;
 

--- a/test/db/dbWriteBarrierReopenConsumers.test.ts
+++ b/test/db/dbWriteBarrierReopenConsumers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { Kysely } from "kysely";
 import type { Database } from "../../src/db/types";
 import {
@@ -51,6 +51,26 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
   afterEach(() => {
     resetDbWriteBarrier();
   });
+
+  /**
+   * Drive the shared singleton through the shutdown sequence a real reopen would:
+   * drain the live barrier, then `resetDbWriteBarrier()` (what `closeDatabase()`
+   * does), and hand back the fresh instance. Asserts the identity actually changed
+   * so a consumer test can never "pass" against a barrier that was never swapped.
+   *
+   * Consumers under test here are constructed WITHOUT an injected resolver, so
+   * they run the shipped default (`getDbWriteBarrier`) — the injected-resolver
+   * tests prove each consumer re-resolves, but only these prove the real default
+   * does.
+   */
+  function reopenSharedBarrier(): DbWriteBarrier {
+    const shutdownBarrier = getDbWriteBarrier();
+    shutdownBarrier.beginDrain();
+    resetDbWriteBarrier();
+    const reopened = getDbWriteBarrier();
+    expect(reopened).not.toBe(shutdownBarrier);
+    return reopened;
+  }
 
   describe("TelemetryRecorder", () => {
     class FakeRepository implements TelemetryRepository {
@@ -107,11 +127,7 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
       const repo = new FakeRepository();
       const recorder = new TelemetryRecorder(repo, () => null); // default resolver
 
-      // Drain the shared barrier, then reset (models drain -> closeDatabase).
-      const shutdownBarrier = getDbWriteBarrier();
-      shutdownBarrier.beginDrain();
-      resetDbWriteBarrier();
-      expect(getDbWriteBarrier()).not.toBe(shutdownBarrier);
+      reopenSharedBarrier();
 
       await recorder.recordLogEvent(makeLogInput());
       // Resolves the fresh singleton, not the pinned drained one.
@@ -166,6 +182,28 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
         mgr.recordHeartbeat("s1");
         await Promise.resolve();
         expect(activity).toHaveLength(0);
+      } finally {
+        mgr.stopCleanupTimer();
+      }
+    });
+
+    test("default resolver reads the shared singleton at use-time (acceptance #1)", async () => {
+      const timer = new FakeTimer();
+      const { repo, activity } = makeRepo();
+      const mgr = new SessionManager(timer, repo); // default resolver
+      try {
+        // createSession only calls upsertActiveSession, so `activity` is still
+        // empty here — recordActivity is reached solely via recordHeartbeat below.
+        await mgr.createSession("s1", "emulator-5554", "android");
+        expect(activity).toHaveLength(0);
+
+        reopenSharedBarrier();
+
+        mgr.recordHeartbeat("s1");
+        await Promise.resolve();
+
+        // Resolves the fresh singleton, not the pinned drained one.
+        expect(activity).toContain("s1");
       } finally {
         mgr.stopCleanupTimer();
       }
@@ -230,6 +268,28 @@ describe("captured-reference consumers survive a same-process barrier reopen (is
 
       expect(draining.trackCalls).toBeGreaterThan(0);
       expect(draining.ranCount).toBe(0);
+    });
+
+    test("default resolver reads the shared singleton at use-time (acceptance #1)", async () => {
+      const timer = new FakeTimer();
+      timer.setCurrentTime(1000000);
+      const repo = new FailureAnalyticsRepository(timer, db); // default resolver
+
+      const reopened = reopenSharedBarrier();
+      // Spy the reopened instance rather than counting in-flight writes: this
+      // asserts the routing itself, so it stays valid no matter how quickly the
+      // retention cleanup settles. Matches the convention in
+      // test/features/observe/CtrlProxyClient.test.ts.
+      const trackSpy = spyOn(reopened, "track");
+
+      await repo.recordFailure(makeFailureInput());
+
+      // Had the repository pinned the construction-time (drained) barrier, the
+      // reopened one would never have been asked to track anything.
+      expect(trackSpy).toHaveBeenCalled();
+
+      // Settle the un-awaited retention write so it cannot outlive db.destroy().
+      await reopened.drain(1000);
     });
   });
 });

--- a/test/db/dbWriteBarrierResetOnClose.test.ts
+++ b/test/db/dbWriteBarrierResetOnClose.test.ts
@@ -29,10 +29,11 @@ import { runExclusiveResetTest } from "./resetTestSerialLock";
  * restart-without-exit) without also cold-starting the barrier, the reopened DB
  * would silently skip every tracked best-effort write. `closeDatabase()` now
  * clears the barrier via `resetDbWriteBarrier()` so the cold-start contract holds
- * for consumers that resolve `getDbWriteBarrier()` at use-time; the three
- * construction-captured consumers (`TelemetryRecorder`, `FailureAnalyticsRepository`,
- * `SessionManager`) pin the barrier at construction and never observe the identity
- * swap, and remain the documented reopen exception (#2912).
+ * for consumers that resolve `getDbWriteBarrier()` at use-time. #2912 removed the
+ * last exceptions: `TelemetryRecorder`, `FailureAnalyticsRepository` and
+ * `SessionManager` were the three construction-captured consumers, and PR #2925
+ * converted them to resolve per write, so every consumer now observes the identity
+ * swap. `test/db/dbWriteBarrierReopenConsumers.test.ts` is the per-consumer proof.
  *
  * These assertions are about `getDbWriteBarrier()` **identity** and
  * `isDraining()` across the `getDatabase()`/`closeDatabase()` lifecycle — they


### PR DESCRIPTION
Closes out the two acceptance items from #2960 that were never actually blocked on an in-process DB reopen path. The third item — the end-to-end reopen integration test — remains blocked and #2960 stays open and parked.

## Why

#2925 converted `TelemetryRecorder`, `FailureAnalyticsRepository` and `SessionManager` to resolve `getDbWriteBarrier()` per write. Only `TelemetryRecorder` got a test that drives the **shipped default resolver** through a barrier reset; the other two were covered only via injected resolvers, which by construction cannot catch a regression in the default.

## What

**Two missing default-resolver tests.** Verified discriminating rather than assumed: reintroducing the #2912 defect (capture the barrier once in the constructor) fails all three default-resolver tests; reverting makes them pass.

**`reopenSharedBarrier()` helper.** The `drain → reset → assert-fresh-identity` sequence was open-coded at three sites and had already drifted cosmetically (two asserted inline, one bound a local).

**`spyOn` instead of `inFlightCount()`** for the `FailureAnalyticsRepository` case, matching the existing convention in `test/features/observe/CtrlProxyClient.test.ts`. Counting in-flight writes only works while the un-awaited retention cleanup happens not to have settled — a future fast path in `cleanupRetention` would turn that into a silent false green. Spying the routing is timing-independent.

**`AndroidCtrlProxyClient` injection decision → documented YAGNI**, recorded in `DbWriteBarrier.beginDrain`'s doc rather than on the consumer. That doc already owns this invariant, and the decision is not Android-specific: `IosSdkEventIngestor` resolves the global per call too. Both deliberately take no resolver parameter — one would exist solely to let a test swap the instance, and a test can `spyOn` the freshly-reset singleton instead.

**Fixed a stale doc claim.** `dbWriteBarrierResetOnClose.test.ts` still said the three consumers *"pin the barrier at construction and never observe the identity swap, and remain the documented reopen exception."* #2925 made that false, and it directly contradicts the tests added here.

## Risk

No production behavior change. One source file touched, doc comment only.

## Validation

- `bun test` — 8107 pass, 0 fail
- `bun run lint`, `bun run build` — clean
- Mutation-tested: all three default-resolver tests fail with the defect reintroduced

## Notes for the reviewer

Two pre-existing issues on `main`, both out of scope and neither introduced here:

1. `bun run typecheck` fails on a **clean** checkout (verified in two worktrees) — `PlanSchemaValidator.ts` TS2345, caused by `ajv-formats` resolving its own nested `ajv`. Deliberately not absorbed into the typecheck baseline, since that ratchet should not swallow a real dependency bug.
2. `bun run lint` (which runs `--fix`) reformats `src/constants/release.ts` on a clean checkout, so every local lint run leaves a stray diff in the checksum registry — easy to commit by accident.
