### PR TITLE
fix(tooling): restore clean validation gates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@jimp/core": "^1.6.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "adm-zip": "^0.6.0",
-        "ajv": "^8.18.0",
+        "ajv": "8.20.0",
         "ajv-formats": "^3.0.1",
         "async-mutex": "^0.5.0",
         "jimp": "^1.6.0",
@@ -1219,8 +1219,6 @@
 
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
@@ -1255,11 +1253,9 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
     "cosmiconfig/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
 
-    "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+    "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "eslint/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@jimp/core": "^1.6.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "adm-zip": "^0.6.0",
-    "ajv": "^8.18.0",
+    "ajv": "8.20.0",
     "ajv-formats": "^3.0.1",
     "async-mutex": "^0.5.0",
     "jimp": "^1.6.0",

--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -138,8 +138,8 @@ field_re = re.compile(r'(^\s+' + re.escape(field) + r': ")[^"]*(",?$)', re.M)
 if field_re.search(entry):
     updated_entry = field_re.sub(r'\g<1>' + value + r'\2', entry, count=1)
 else:
-    ipa_re = re.compile(r'(^\s+ipaSha256: "[^"]+",\n)', re.M)
-    updated_entry = ipa_re.sub(r'\1    ' + field + f': "{value}",\n', entry, count=1)
+    ipa_re = re.compile(r'(^(\s+)ipaSha256: "[^"]+",\n)', re.M)
+    updated_entry = ipa_re.sub(lambda m: m.group(1) + m.group(2) + f'{field}: "{value}",\n', entry, count=1)
 
 path.write_text(text[:match.start(1)] + updated_entry + text[match.end(1):])
 PY

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -97,10 +97,8 @@ src/features/action/TapOnElement.ts: error TS2416: Property 'hashViewHierarchy' 
 src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'getUiAutomatorHierarchy' does not exist on type 'ViewHierarchy'.
 src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'mergeHierarchies' does not exist on type 'ViewHierarchy'.
 src/features/action/swipeon/ScrollUntilVisible.ts: error TS2322: Type 'ViewHierarchyResult | undefined' is not assignable to type 'ViewHierarchyResult | null'.
-src/features/action/swipeon/ScrollUntilVisible.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'AdbExecutor'.
 src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
-src/features/action/swipeon/TalkBackSwipeExecutor.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'AdbExecutor'.
 src/features/navigation/Explore.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
 src/features/navigation/Explore.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
 src/features/navigation/Explore.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
@@ -159,7 +157,6 @@ src/features/utility/ElementParser.ts: error TS2345: Argument of type 'ViewHiera
 src/features/utility/ios/IosNotificationAuthorizationReader.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/features/video/FfmpegVideoProcessingBackend.ts: error TS2339: Property 'getBaseCommandParts' does not exist on type 'AdbExecutor'.
 src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.
-src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.
 src/features/video/PlatformVideoCaptureBackend.ts: error TS2339: Property 'getBaseCommandParts' does not exist on type 'AdbExecutor'.
 src/features/video/PlatformVideoCaptureBackend.ts: error TS2339: Property 'getBaseCommandParts' does not exist on type 'AdbExecutor'.
 src/index.ts: error TS2322: Type '["debug", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
@@ -209,12 +206,8 @@ src/server/systemTrayHelpers.ts: error TS2741: Property 'getDeviceTimestampMs' i
 src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"limit" | "testClass" | "testMethod" | "lookbackDays" | "orderDirection" | "latestOnly"'.
 src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"deviceId" | "limit" | "deviceType" | "sessionUuid" | "devicePlatform" | "testClass" | "testMethod" | "deviceName" | "appVersion" | "gitCommit" | "targetSdk" | "jdkVersion" | ... 6 more ... | "orderDirection"'.
 src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
-src/utils/CtrlProxyManager.ts: error TS7006: Parameter 'entry' implicitly has an 'any' type.
-src/utils/CtrlProxyManager.ts: error TS7006: Parameter 'entry' implicitly has an 'any' type.
-src/utils/CtrlProxyManager.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
-src/utils/IOSCtrlProxyBundleDownloader.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 src/utils/ProcessExecutor.ts: error TS2769: No overload matches this call.
 src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
 src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
@@ -232,7 +225,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2339: Property 'toString' d
 src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/utils/mcpVersion.ts: error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
 src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
-src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("node_modules/ajv/dist/ajv").Ajv' is not assignable to parameter of type 'import("node_modules/ajv-formats/node_modules/ajv/dist/core").default'.
 # swap-fp: 10 :: src/server/interactionTools.ts: error TS18048: 'freshness.actualTimestamp' is possibly 'undefined'.
 # swap-fp: 10,13,19,25,66 :: src/db/migrator.ts: error TS7006: Parameter 'row' implicitly has an 'any' type.
 # swap-fp: 11 :: src/daemon/SocketServerRegistry.ts: error TS2345: Argument of type 'Promise<void | BaseSocketServer>' is not assignable to parameter of type 'Promise<void>'.
@@ -262,13 +254,10 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 15,67 :: src/features/navigation/Explore.ts: error TS2345: Argument of type 'NavigationGraphService' is not assignable to parameter of type 'NavigationGraphManager'.
 # swap-fp: 159,161 :: src/features/action/BaseVisualChange.ts: error TS2339: Property 'signal' does not exist on type '{ changeExpected: boolean; tolerancePercent?: number | undefined; queryOptions?: ViewHierarchyQueryOptions | undefined; gfxMetrics?: GfxMetrics | null | undefined; perf?: PerformanceTracker | undefined; actionStartTime?: number | undefined; predictionContext?: PredictionActionContext | undefined; }'.
 # swap-fp: 16 :: src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be created from object types.
-# swap-fp: 16 :: src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("node_modules/ajv/dist/ajv").Ajv' is not assignable to parameter of type 'import("node_modules/ajv-formats/node_modules/ajv/dist/core").default'.
 # swap-fp: 18 :: src/server/appFileService.ts: error TS2430: Interface 'PutAppFileRequest' incorrectly extends interface 'PutAppFileArgs'.
 # swap-fp: 19 :: src/server/networkGraph.ts: error TS2345: Argument of type 'EventGroup | undefined' is not assignable to parameter of type 'EventGroup'.
 # swap-fp: 19,19,19,19 :: src/doctor/checks/ios.ts: error TS18048: 'elements' is possibly 'undefined'.
 # swap-fp: 20 :: src/features/accessibility/WcagAudit.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"resource-id"' can't be used to index type 'ViewHierarchyNode'.
-# swap-fp: 20 :: src/utils/CtrlProxyManager.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
-# swap-fp: 20 :: src/utils/IOSCtrlProxyBundleDownloader.ts: error TS7016: Could not find a declaration file for module 'adm-zip'. 'node_modules/adm-zip/adm-zip.js' implicitly has an 'any' type.
 # swap-fp: 21,28 :: src/db/migrator.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 # swap-fp: 23 :: src/features/accessibility/ContrastChecker.ts: error TS2345: Argument of type 'Map<string, number>' is not assignable to parameter of type 'Map<string, { timestamp: number; }>'.
 # swap-fp: 24 :: src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string | undefined>' is not assignable to type 'Promise<void>'.
@@ -313,7 +302,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 39 :: src/server/interactionTools.ts: error TS18048: 'freshness.requestedAfter' is possibly 'undefined'.
 # swap-fp: 39,45 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2345: Argument of type 'AccessibilityHierarchy' is not assignable to parameter of type 'ViewHierarchyResult'.
 # swap-fp: 40 :: src/features/performance/PerformanceAudit.ts: error TS2551: Property 'refreshRateHz' does not exist on type 'DeviceCapabilities'. Did you mean 'refreshRate'?
-# swap-fp: 40,40 :: src/utils/CtrlProxyManager.ts: error TS7006: Parameter 'entry' implicitly has an 'any' type.
 # swap-fp: 40,58 :: src/db/migrator.ts: error TS7006: Parameter 'migration' implicitly has an 'any' type.
 # swap-fp: 40,74 :: src/db/migrator.ts: error TS2307: Cannot find module 'kysely/migration' or its corresponding type declarations.
 # swap-fp: 43 :: src/doctor/index.ts: error TS2367: This comparison appears to be unintentional because the types 'false | undefined' and 'true' have no overlap.
@@ -358,11 +346,11 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 7 :: src/features/action/BaseVisualChange.ts: error TS2322: Type '{ warning: string; requestedAfter?: number; actualTimestamp?: number; isFresh?: boolean | undefined; staleDurationMs?: number; }' is not assignable to type '{ requestedAfter?: number | undefined; actualTimestamp?: number | undefined; isFresh: boolean; staleDurationMs?: number | undefined; warning?: string | undefined; }'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
-# swap-fp: 7 :: src/features/action/swipeon/TalkBackSwipeExecutor.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'AdbExecutor'.
 # swap-fp: 7 :: src/features/navigation/NavigateTo.ts: error TS2345: Argument of type 'NavigationGraphService' is not assignable to parameter of type 'NavigationGraphManager'.
 # swap-fp: 7 :: src/features/navigation/NavigationGraphManager.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 # swap-fp: 7 :: src/features/observe/GetScreenSize.ts: error TS2739: Type 'ScreenSize' is missing the following properties from type 'ScreenSize': width, height
 # swap-fp: 7 :: src/features/observe/Idle.ts: error TS2741: Property 'updatedPrevTotalFrames' is missing in type '{ isStable: false; shouldUpdateLastNonIdleTime: true; updatedPrevMissedVsync: null; updatedPrevSlowUiThread: null; updatedPrevFrameDeadlineMissed: null; updatedFirstGfxInfoLog: false; }' but required in type 'UiStabilityResult'.
+# swap-fp: 7 :: src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug-perf", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["mcp-recording", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
@@ -372,7 +360,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/server/deviceTools.ts: error TS2322: Type 'TimingData | null' is not assignable to type 'Record<string, number>'.
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
-# swap-fp: 7,7 :: src/features/video/PlatformVideoCaptureBackend.ts: error TS2322: Type 'ChildProcessByStdio<null, Readable, Readable>' is not assignable to type 'ChildProcessWithoutNullStreams'.
 # swap-fp: 74 :: src/features/utility/ElementParser.ts: error TS2339: Property 'hierarchy' does not exist on type '{ windowLayer: number; }'.
 # swap-fp: 74,75,76,77,77 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 78 :: src/features/navigation/NavigateTo.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
@@ -384,7 +371,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS2345: Argument of type 'import("n
 # swap-fp: 88 :: src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"limit" | "testClass" | "testMethod" | "lookbackDays" | "orderDirection" | "latestOnly"'.
 # swap-fp: 9 :: src/daemon/manager.ts: error TS18048: 'signal' is possibly 'undefined'.
 # swap-fp: 9 :: src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.
-# swap-fp: 9 :: src/features/action/swipeon/ScrollUntilVisible.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'AdbExecutor'.
 # swap-fp: 9 :: src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type 'null | undefined' is not assignable to type 'NormalizedHighlightBounds | undefined'.
 # swap-fp: 9 :: src/server/networkGraph.ts: error TS2322: Type 'string | null | undefined' is not assignable to type 'string | null'.
 # swap-fp: 9,12 :: src/server/interactionTools.ts: error TS18048: 'searchStats' is possibly 'undefined'.

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -210,7 +210,7 @@ export const NIGHTLY_CHECKSUM_ENTRY: ReleaseChecksumEntry = {
   version: "nightly",
   apkSha256: "4f5ccef86f545cb6f44cb85cbd0c253bec78b24ae103ea5cd70fc262eb1c71df",
   ipaSha256: "0736fcafc4ee5e7b0b079f700a951b9e7cfae7c20540c4193abc2664005b921c",
-    videoJarSha256: "90075a9a20e3e23a2f951e82e764ee0b6f0f3079696550f946d9a6e8a985fc20",
+  videoJarSha256: "90075a9a20e3e23a2f951e82e764ee0b6f0f3079696550f946d9a6e8a985fc20",
   runnerSha256: "ff2890c45650d1b2fb15cc840fe92a648fbb1f5b955a5fe0537790d41296531a",
 };
 

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -234,6 +234,39 @@ PY
   [ "$nightly_video" = "$VIDEO_JAR_SHA" ]
 }
 
+@test "inserts missing videoJarSha256 using the entry's existing indentation" {
+  python3 - "${TEST_ROOT}/src/constants/release.ts" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text()
+text = re.sub(r'\n\s+videoJarSha256: "[^"]+",', '', text)
+path.write_text(text)
+PY
+
+  run env \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    VIDEO_JAR_SHA256="$VIDEO_JAR_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+  [ "$status" -eq 0 ]
+
+  grep -q '^  videoJarSha256: "' "${TEST_ROOT}/src/constants/release.ts"
+  ! grep -q '^    videoJarSha256: "' "${TEST_ROOT}/src/constants/release.ts"
+
+  run env \
+    RELEASE_VERSION="0.0.44" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    VIDEO_JAR_SHA256="$VIDEO_JAR_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+  [ "$status" -eq 0 ]
+
+  grep -q '^    videoJarSha256: "' "${TEST_ROOT}/src/constants/release.ts"
+}
+
 @test "rejects a malformed VIDEO_JAR_SHA256" {
   run env \
     IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \


### PR DESCRIPTION
## Summary

Fixes the two clean-checkout validation defects from issue #4000: aligns the project Ajv dependency with `ajv-formats` so `bun run typecheck` no longer sees a duplicate-Ajv nominal type mismatch, and fixes release checksum insertion so new fields inherit the target entry's indentation.

## Linked Issue

Closes #4000

## Bug / Regression Context

- **Prior attempts:** N/A
- **Observed symptom:** `bun run typecheck` reported a new `PlanSchemaValidator.ts` Ajv type error on a clean checkout, and `bun run lint` rewrote `src/constants/release.ts` by reindenting `NIGHTLY_CHECKSUM_ENTRY.videoJarSha256`.
- **Repro steps / conditions:** Clean checkout of `main`, then run `bun run typecheck` or `bun run lint`.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) equivalent covered by `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran the matching `scripts/` validation (N/A; tooling-only)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms (N/A; shell-script regression uses BATS)
- [x] Rebased onto latest `main`, conflicts resolved

Additional validation:
- [x] `bats test/bats/generate-release-constants.bats`
- [x] fresh `bun install` has no `node_modules/ajv-formats/node_modules/ajv`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate`
- [x] `git diff --check`

## Device Verification

N/A; tooling-only change.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: N/A
