### PR TITLE
fix(ios): encode timing query values safely

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -175,6 +175,15 @@ large_tuple:
 # Reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)
 reporter: "xcode"
 
+# A logical query value must be passed to URLComponents/URLQueryItem. The
+# urlQueryAllowed character set permits query delimiters such as `&` and `=`,
+# allowing manual encoding to split one value into multiple fields.
+custom_rules:
+  no_manual_url_query_value_encoding:
+    regex: 'addingPercentEncoding\s*\(\s*withAllowedCharacters\s*:\s*(?:\.|CharacterSet\s*\.)urlQueryAllowed\s*\)'
+    message: "Use URLComponents and URLQueryItem for query values instead of .urlQueryAllowed."
+    severity: error
+
 # Test targets file-disable the fail-fast crash rules (force-unwrap/force-try are
 # idiomatic in fixtures). Allow those rules to be blanket-disabled without tripping
 # blanket_disable_command; every other rule still requires scoped this/next/previous.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Bun TypeScript MCP server providing Android & iOS device automation capabilities
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation
 - Always use interfaces & fakes & FakeTimer to decouple implementations and keep tests extremely fast and non-flaky
 - Unit tests should pass in 100ms or less. Do not assume that a failing test can be allowed to fail.
+- For Swift, prefer an existing standard-library or Foundation API before adding an extension, helper, or package. Use `URLComponents` plus `URLQueryItem` for query values and `Codable` for AutoMobile-owned stable schemas. Keep `JSONSerialization` only at documented dynamic/bridge boundaries. A convenience dependency requires a stated platform-API gap, deployment-target check, and tests using interfaces/fakes.
 
 # Project Structure
 

--- a/ios/XCTestRunner/Sources/XCTestRunner/TestTimingCache.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/TestTimingCache.swift
@@ -173,16 +173,36 @@ final class TestTimingCache {
             params["sessionUuid"] = sessionUuid
         }
 
-        if params.isEmpty {
+        return Self.buildRequestUri(parameters: params)
+    }
+
+    /// Builds the daemon resource URI using Foundation's query-item encoding.
+    ///
+    /// Session UUIDs normally contain only URL-safe characters, but treating that
+    /// as an invariant would let a future value containing `&` or `=` change the
+    /// query structure. `URLComponents` keeps each logical value as one item.
+    static func buildRequestUri(parameters: [String: String]) -> String {
+        guard !parameters.isEmpty else {
             return "automobile:test-timings"
         }
 
-        let query = params
-            .map { key, value in
-                "\(key)=\(encodeQueryParam(value))"
-            }
-            .joined(separator: "&")
-        return "automobile:test-timings?\(query)"
+        var components = URLComponents()
+        components.scheme = "automobile"
+        components.path = "test-timings"
+        components.queryItems = parameters.map { key, value in
+            URLQueryItem(name: key, value: value)
+        }
+
+        // URLComponents deliberately leaves `+` unescaped. The daemon parses
+        // this query with URLSearchParams, where a literal plus is form-decoded
+        // as a space, so preserve it as data for that cross-runtime boundary.
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B")
+
+        // The scheme, path, and logical values above are all valid Foundation
+        // components. Keep the protocol's no-query resource URI as a defensive
+        // fallback instead of ever emitting a partly encoded query.
+        return components.string ?? "automobile:test-timings"
     }
 
     private func resolveMinSamples() -> Int {
@@ -198,10 +218,6 @@ final class TestTimingCache {
     private func resolveTimeoutMs() -> Int {
         let value = config.intValue(forKey: "automobile.junit.timing.fetch.timeout.ms", defaultValue: 5000)
         return value > 0 ? value : 5000
-    }
-
-    private func encodeQueryParam(_ value: String) -> String {
-        return value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
     }
 
     private var config: TimingConfig {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/TestTimingCacheTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/TestTimingCacheTests.swift
@@ -46,4 +46,25 @@ final class TestTimingCacheTests: XCTestCase {
     func testBuildTimingMapEmpty() {
         XCTAssertTrue(TestTimingCache.buildTimingMap(from: []).isEmpty)
     }
+
+    func testBuildRequestUriKeepsQueryValueAsSingleItem() throws {
+        let sessionUuid = "session+plus&unexpected=value space 🐶"
+        let uri = TestTimingCache.buildRequestUri(parameters: [
+            "devicePlatform": "ios",
+            "sessionUuid": sessionUuid,
+        ])
+        let components = try XCTUnwrap(URLComponents(string: uri))
+        let queryItems = try XCTUnwrap(components.queryItems)
+
+        XCTAssertEqual(components.scheme, "automobile")
+        XCTAssertEqual(components.path, "test-timings")
+        XCTAssertEqual(queryItems.count, 2)
+        XCTAssertEqual(queryItems.first(where: { $0.name == "sessionUuid" })?.value, sessionUuid)
+        XCTAssertTrue(uri.contains("sessionUuid=session%2Bplus"))
+        XCTAssertFalse(uri.contains("sessionUuid=session+plus&unexpected=value"))
+    }
+
+    func testBuildRequestUriWithoutParametersUsesBaseResourceUri() {
+        XCTAssertEqual(TestTimingCache.buildRequestUri(parameters: [:]), "automobile:test-timings")
+    }
 }


### PR DESCRIPTION
## Summary

Build XCTest timing-resource query strings with `URLComponents` and `URLQueryItem`, preserving delimiter, Unicode, and `+` values across the Swift-to-`URLSearchParams` boundary. Add a blocking SwiftLint rule for unsafe `.urlQueryAllowed` query-value encoding and document the stdlib/Foundation-first convention for Swift changes.

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** A logical query value containing `&` or `=` could alter the timing resource query structure; a literal `+` is interpreted as a space by the daemon's `URLSearchParams` parser.
- **Repro steps / conditions:** Build a timing request with a session value containing `+`, `&`, `=`, whitespace, or Unicode and parse it in the daemon.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — not run; this PR contains no TypeScript changes.
- [ ] `bun run typecheck` reports no new errors (baseline gate) — not run; this PR contains no TypeScript changes.
- [x] Android/iOS changes: ran the matching `scripts/` validation (`swift test --filter TestTimingCacheTests`, full-tree SwiftLint, SwiftFormat).
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms.
- [x] Rebased onto latest `main`, conflicts resolved.
