### PR TITLE
chore: enforce stdlib-first convention

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,6 +19,7 @@ If you have a question file an issue or discussion, but small contributions like
 - **Run validation** - `bun run lint` and `bun test` before submitting. If modifying Android or iOS code check for appropriate validation scripts in the `scripts/` directory
 - **Keep PRs focused** - One feature or fix per PR
 - **Add tests** - Cover new functionality with tests
+- **Prefer standard and existing code** - Before adding a dependency or a generic utility, check the JavaScript/Node standard library and `src/utils/`. Keep time, randomness, I/O, concurrency, and process access behind an interface with a fake when tests need control. See [Standard Library First](../docs/contributing/stdlib-first.md).
 
 ## Pull Request Process
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,7 @@ Closes #
 - [ ] `bun run typecheck` reports no new errors (baseline gate)
 - [ ] Android/iOS changes: ran the matching `scripts/` validation
 - [ ] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
+- [ ] New generic code reuses the standard library or an existing project helper; any new direct dependency has a decision record under `docs/decisions/`
 - [ ] Rebased onto latest `main`, conflicts resolved
 
 ## Device Verification

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -625,7 +625,7 @@ jobs:
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \
-            --only yaml,xml,shellcheck,shell-portability,shell-sete,stdlib-first,mkdocs-nav,ktfmt,claude-plugin,codex-skills \
+            --only yaml,xml,shellcheck,shell-portability,shell-sete,stdlib-first,dependency-decisions,mkdocs-nav,ktfmt,claude-plugin,codex-skills \
             --max-parallel 4
 
       - name: "Run BATS Tests (Ubuntu)"
@@ -1047,6 +1047,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          # The stdlib-first gate compares package.json with the PR base SHA.
+          # Keep that commit locally available instead of relying on checkout's
+          # default one-commit shallow clone.
+          fetch-depth: 0
 
       - name: "Cache Bun dependencies"
         uses: actions/cache@v5
@@ -1078,6 +1082,12 @@ jobs:
           DO_NOT_TRACK: "1"
           NO_COLOR: "1"
         run: turbo run lint --output-logs=errors-only --log-order=grouped
+
+      - name: "Check stdlib-first dependency decisions"
+        if: needs.detect-changes.outputs.ts_changed == 'true'
+        env:
+          STDLIB_FIRST_BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: bun run check:stdlib-first
 
       # Scoped `tsc --noEmit` gate (issue #3001). Bun's bundler skips type
       # checking, so the build/test steps cannot catch type errors. A repo-wide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Bun TypeScript MCP server providing Android & iOS device automation capabilities
 - Always use interfaces & fakes & FakeTimer to decouple implementations and keep tests extremely fast and non-flaky
 - Unit tests should pass in 100ms or less. Do not assume that a failing test can be allowed to fail.
 - For Swift, prefer an existing standard-library or Foundation API before adding an extension, helper, or package. Use `URLComponents` plus `URLQueryItem` for query values and `Codable` for AutoMobile-owned stable schemas. Keep `JSONSerialization` only at documented dynamic/bridge boundaries. A convenience dependency requires a stated platform-API gap, deployment-target check, and tests using interfaces/fakes.
+- For TypeScript changes, prefer the JavaScript/Node standard library, then an existing AutoMobile seam, before adding a local generic helper or direct dependency. Keep time, randomness, I/O, concurrency, and process access injectable when tests need control; justify any new direct dependency in `docs/decisions/`.
 
 # Project Structure
 

--- a/docs/contributing/stdlib-first.md
+++ b/docs/contributing/stdlib-first.md
@@ -1,0 +1,47 @@
+# Standard library first
+
+Before adding a package or introducing a generic helper, first look for the
+JavaScript/Node standard-library API and existing code under `src/utils/`.
+AutoMobile favors small domain helpers over a general utility dependency, and
+it keeps time, randomness, I/O, concurrency, and process access behind an
+interface when a fake is needed for fast unit tests.
+
+## Decision order
+
+1. Use the standard library when it expresses the required behavior clearly.
+2. Reuse an existing AutoMobile helper or interface when it preserves an
+   established policy or test seam.
+3. Add a focused local helper only when neither option captures the required
+   domain behavior.
+4. Add a dependency only when the behavior is substantial, maintained, and
+   cannot be safely expressed by the preceding choices.
+
+Do not bypass existing `Timer`, `Random`, `IdGenerator`, retry, cache,
+filesystem, process, or download seams from production code. Inject the
+interface and use the corresponding fake in unit tests.
+
+`Map.groupBy()` is appropriate only when all records are already materialized.
+For streaming or incrementally assembled results, retain the project helper
+that appends to a `Map` bucket. Before adopting a newly available runtime API,
+verify it on the minimum Bun version declared in `package.json`, not merely the
+developer's local runtime.
+
+## Dependency decisions
+
+Every new direct dependency must have a short Markdown record in
+`docs/decisions/`. Include this exact field so `bun run check:stdlib-first` can
+verify it:
+
+```md
+# Why this dependency is needed
+
+- Dependency: `package-name`
+- Standard-library and existing-helper alternatives considered:
+- Why those alternatives do not meet the requirement:
+- Runtime, bundle, security, and maintenance impact:
+- Test strategy:
+```
+
+The check intentionally does not try to infer whether two implementations are
+semantically equivalent. Use review for that judgment; lint only bans the
+high-confidence cases (`Math.random()` in production and direct Lodash imports).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -518,6 +518,25 @@ export default [
 		rules: {
 			"auto-mobile/catch-convention": 2,
 			"auto-mobile/no-unknown-cast": 2,
+			"no-restricted-properties": [
+				"error",
+				{
+					object: "Math",
+					property: "random",
+					message: "Use an injected Random or IdGenerator. Math.random() makes production behavior non-deterministic and bypasses the project's test seams.",
+				},
+			],
+			"@typescript-eslint/no-restricted-imports": [
+				"error",
+				{
+					patterns: [
+						{
+							group: ["lodash", "lodash/*"],
+							message: "Prefer the JavaScript/Node standard library or an existing AutoMobile helper. Do not add a direct lodash dependency.",
+						},
+					],
+				},
+			],
 		},
 	},
 	{

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,7 +198,9 @@ nav:
               - 'Overview': design-docs/plat/ios/ide-plugin/overview.md
               - 'Test Recording': design-docs/plat/ios/ide-plugin/test-recording.md
               - 'Feature Flags': design-docs/plat/ios/ide-plugin/feature-flags.md
-  - 'Contributing': contributing.md
+  - 'Contributing':
+      - 'Overview': contributing.md
+      - 'Standard Library First': contributing/stdlib-first.md
   - 'GitHub Discussions': https://github.com/kaeawc/auto-mobile/discussions
   - 'FAQ': faq.md
   - 'Change Log': changelog.md

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "profile:memory": "bun --expose-gc --inspect scripts/detect-memory-leaks.ts --mode=profile",
     "profile:heap": "bun --expose-gc --heap-prof scripts/stress-test.ts",
     "validate:yaml": "bun scripts/validate-yaml.ts",
+    "check:stdlib-first": "bash scripts/check-stdlib-first.sh",
     "dead-code:ts": "bash scripts/detect-dead-code-ts.sh",
     "dead-code:ts:prune": "bash -o pipefail -c 'bunx ts-prune --project tsconfig.dead-code.json -i src/db/migrations | (grep -v \"(used in module)\" || true) | bash scripts/filter-ts-prune-allowlist.sh'",
     "dead-code:ts:knip": "bunx knip",

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -43,6 +43,7 @@ add_check "codex-skills" "\"$PROJECT_ROOT/scripts/validate_codex_skills.sh\"" "c
 add_check "lychee" "\"$PROJECT_ROOT/scripts/lychee/validate_lychee.sh\"" "docs,links" "Validate documentation links"
 add_check "dependabot" "\"$PROJECT_ROOT/scripts/validate_dependabot.sh\"" "config,yaml" "Validate Dependabot config"
 add_check "debug-tags" "\"$PROJECT_ROOT/scripts/validate-no-debug-log-tags.sh\"" "lint" "Reject stray [*-DEBUG] log tags in src/"
+add_check "dependency-decisions" "\"$PROJECT_ROOT/scripts/check-stdlib-first.sh\"" "lint,dependencies" "Require a decision record for new direct dependencies"
 add_check "datetime-now-literal" "\"$PROJECT_ROOT/scripts/validate-no-datetime-now-literal.sh\"" "lint" "Reject string-literal SQL time-expression defaults in migrations"
 add_check "desktop-core-unified" "\"$PROJECT_ROOT/scripts/android/validate-no-desktop-core-unified.sh\"" "lint,android" "Reject abandoned desktop-core unified socket-client package"
 add_check "workflow-assertion-triggers" "\"$PROJECT_ROOT/scripts/ci/validate_workflow_assertion_triggers.sh\"" "config,ci" "Ensure workflow-YAML assertion tests are triggered by the paths they assert"

--- a/scripts/check-stdlib-first.sh
+++ b/scripts/check-stdlib-first.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Require a short decision record when a PR adds a direct runtime or development
+# dependency. This keeps a generic package from becoming the first answer when
+# the standard library or an existing AutoMobile seam already fits.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_REF="${STDLIB_FIRST_BASE_REF:-origin/main}"
+
+cd "$ROOT_DIR"
+
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+  echo "error: stdlib-first check cannot resolve base ref '${BASE_REF}'" >&2
+  exit 2
+fi
+
+BASE_COMMIT="$(git merge-base "$BASE_REF" HEAD)"
+BASE_PACKAGE_JSON="$(git show "${BASE_COMMIT}:package.json")"
+CURRENT_PACKAGE_JSON="$(<package.json)"
+
+base_dependencies="$(jq -r '(.dependencies // {} | keys[]) , (.devDependencies // {} | keys[])' <<<"$BASE_PACKAGE_JSON" | sort -u)"
+current_dependencies="$(jq -r '(.dependencies // {} | keys[]) , (.devDependencies // {} | keys[])' <<<"$CURRENT_PACKAGE_JSON" | sort -u)"
+added_dependencies="$(comm -13 <(printf '%s\n' "$base_dependencies") <(printf '%s\n' "$current_dependencies"))"
+
+if [[ -z "$added_dependencies" ]]; then
+  echo "stdlib-first: no new direct dependencies."
+  exit 0
+fi
+
+missing=0
+while IFS= read -r dependency; do
+  [[ -z "$dependency" ]] && continue
+  if ! rg --glob '*.md' --fixed-strings "Dependency: \`${dependency}\`" docs/decisions >/dev/null 2>&1; then
+    echo "error: new direct dependency '${dependency}' needs a docs/decisions record containing: Dependency: \`${dependency}\`" >&2
+    missing=1
+  fi
+done <<<"$added_dependencies"
+
+if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "stdlib-first: every new direct dependency has a decision record."

--- a/src/features/utility/DefaultElementSelector.ts
+++ b/src/features/utility/DefaultElementSelector.ts
@@ -4,6 +4,7 @@ import type { ViewHierarchyResult } from "../../models/ViewHierarchyResult";
 import type { ElementSelectionStrategy } from "../../models/ElementSelectionStrategy";
 import type { ElementSelector } from "../../utils/interfaces/ElementSelector";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
+import { defaultRandom } from "../../utils/Random";
 import { DefaultElementFinder } from "./ElementFinder";
 
 export class DefaultElementSelector implements ElementSelector {
@@ -12,7 +13,7 @@ export class DefaultElementSelector implements ElementSelector {
 
   constructor(
     finder: ElementFinder = new DefaultElementFinder(),
-    random: () => number = Math.random
+    random: () => number = () => defaultRandom.next()
   ) {
     this.finder = finder;
     this.random = random;

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -22,6 +22,7 @@ import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import { DefaultElementParser } from "../features/utility/ElementParser";
 import { NoOpPerformanceTracker, type PerformanceTracker } from "../utils/PerformanceTracker";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { createTimestampedId } from "../utils/IdGenerator";
 import {
   elementContainerSchema,
   elementIdTextFieldsSchema,
@@ -31,9 +32,7 @@ import {
 import { boundsEqual } from "../utils/bounds";
 
 const generateHighlightId = (timer: Timer = defaultTimer): string => {
-  const timestamp = timer.now();
-  const random = Math.random().toString(36).substring(2, 10);
-  return `highlight_${timestamp}_${random}`;
+  return createTimestampedId("highlight", timer);
 };
 
 const highlightBaseSchema = z.object({

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -20,6 +20,7 @@ import {
 import { serverConfig } from "../utils/ServerConfig";
 import { logger } from "../utils/logger";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { createTimestampedId } from "../utils/IdGenerator";
 import { ResourceRegistry } from "./resourceRegistry";
 import {
   VideoRecordingRepository,
@@ -332,9 +333,7 @@ function highlightAnimationDurationMs(platform: BootedDevice["platform"]): numbe
 }
 
 function generateHighlightId(timer: Timer = defaultTimer): string {
-  const timestamp = timer.now();
-  const random = Math.random().toString(36).substring(2, 10);
-  return `highlight_${timestamp}_${random}`;
+  return createTimestampedId("highlight", timer);
 }
 
 function finalizeHighlightSession(

--- a/src/utils/ChecksumCalculator.ts
+++ b/src/utils/ChecksumCalculator.ts
@@ -1,10 +1,5 @@
-import { execFile } from "child_process";
-import { createReadStream } from "fs";
-import crypto from "crypto";
-import { promisify } from "util";
-import { logger } from "./logger";
-
-const execFileAsync = promisify(execFile);
+import { createReadStream } from "node:fs";
+import { createHash } from "node:crypto";
 
 export type Sha256Source = "sha256sum" | "shasum" | "node";
 
@@ -14,17 +9,7 @@ export interface ChecksumCalculator {
 
 export class DefaultChecksumCalculator implements ChecksumCalculator {
   public async computeFileSha256(filePath: string): Promise<{ checksum: string; source: Sha256Source }> {
-    const sha256sum = await this.tryChecksumCommand([filePath], "sha256sum");
-    if (sha256sum) {
-      return { checksum: sha256sum, source: "sha256sum" };
-    }
-
-    const shasum = await this.tryChecksumCommand(["-a", "256", filePath], "shasum");
-    if (shasum) {
-      return { checksum: shasum, source: "shasum" };
-    }
-
-    const hash = crypto.createHash("sha256");
+    const hash = createHash("sha256");
     await new Promise<void>((resolve, reject) => {
       const stream = createReadStream(filePath);
       stream.on("data", chunk => hash.update(chunk));
@@ -32,27 +17,5 @@ export class DefaultChecksumCalculator implements ChecksumCalculator {
       stream.on("end", () => resolve());
     });
     return { checksum: hash.digest("hex"), source: "node" };
-  }
-
-  private async tryChecksumCommand(args: string[], tool: string): Promise<string | null> {
-    try {
-      const { stdout } = await execFileAsync(tool, args, {
-        timeout: 120000,
-        maxBuffer: 10 * 1024 * 1024
-      });
-      // On Windows, sha256sum prefixes output with \ when the path contains backslashes
-      const checksum = stdout.trim().split(/\s+/)[0]?.replace(/^\\/, "");
-      if (!checksum) {
-        logger.warn("[ChecksumCalculator] checksum tool returned no output", { tool });
-        return null;
-      }
-      return checksum;
-    } catch (error) {
-      logger.info("[ChecksumCalculator] checksum tool unavailable, falling back", {
-        tool,
-        error: error instanceof Error ? error.message : String(error)
-      });
-      return null;
-    }
   }
 }

--- a/src/utils/IdGenerator.ts
+++ b/src/utils/IdGenerator.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { Timer } from "./SystemTimer";
 
 export interface IdGenerator {
   next(): string;
@@ -26,3 +27,17 @@ export class CountingIdGenerator implements IdGenerator {
 }
 
 export const defaultIdGenerator: IdGenerator = new NodeIdGenerator();
+
+/**
+ * Formats an identifier whose ordering should remain visible to operators while
+ * its uniqueness comes from an injected generator. Keep the generator at the
+ * boundary so unit tests can use CountingIdGenerator rather than time or
+ * randomness.
+ */
+export function createTimestampedId(
+  prefix: string,
+  timer: Pick<Timer, "now">,
+  idGenerator: IdGenerator = defaultIdGenerator
+): string {
+  return `${prefix}_${timer.now()}_${idGenerator.next()}`;
+}

--- a/src/utils/ScreenshotJobTracker.ts
+++ b/src/utils/ScreenshotJobTracker.ts
@@ -1,6 +1,7 @@
 import { logger } from "./logger";
 import { ScreenshotResult } from "../models/ScreenshotResult";
 import { Timer, defaultTimer } from "./SystemTimer";
+import { defaultIdGenerator, type IdGenerator, createTimestampedId } from "./IdGenerator";
 
 export interface ScreenshotJobHandle {
   jobId: string;
@@ -41,6 +42,7 @@ interface ScreenshotJobEntry {
 export class ScreenshotJobTracker {
   private static jobs: Map<string, ScreenshotJobEntry> = new Map();
   private static timer: Timer = defaultTimer;
+  private static idGenerator: IdGenerator = defaultIdGenerator;
 
   static setTimer(timer: Timer): void {
     ScreenshotJobTracker.timer = timer;
@@ -48,6 +50,14 @@ export class ScreenshotJobTracker {
 
   static resetTimer(): void {
     ScreenshotJobTracker.timer = defaultTimer;
+  }
+
+  static setIdGenerator(idGenerator: IdGenerator): void {
+    ScreenshotJobTracker.idGenerator = idGenerator;
+  }
+
+  static resetIdGenerator(): void {
+    ScreenshotJobTracker.idGenerator = defaultIdGenerator;
   }
 
   static startJob(
@@ -85,7 +95,11 @@ export class ScreenshotJobTracker {
       }
     }
 
-    const jobId = `screenshot_${ScreenshotJobTracker.timer.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const jobId = createTimestampedId(
+      "screenshot",
+      ScreenshotJobTracker.timer,
+      ScreenshotJobTracker.idGenerator
+    );
     const promise = Promise.resolve()
       .then(() => runner(abortController.signal))
       .catch(error => {

--- a/test/bats/check-stdlib-first.bats
+++ b/test/bats/check-stdlib-first.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+SCRIPT="scripts/check-stdlib-first.sh"
+
+@test "passes when the direct dependency lists have not changed" {
+  run env STDLIB_FIRST_BASE_REF=HEAD bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new direct dependencies"* ]]
+}
+
+@test "requires a decision record for a new direct dependency" {
+  local package_backup
+  local result_output
+  local result_status
+  package_backup="$(mktemp)"
+  cp package.json "$package_backup"
+
+  jq '.devDependencies["stdlib-first-bats-fixture"] = "1.0.0"' package.json > package.json.tmp
+  mv package.json.tmp package.json
+
+  run env STDLIB_FIRST_BASE_REF=HEAD bash "$SCRIPT"
+  result_status="$status"
+  result_output="$output"
+  cp "$package_backup" package.json
+  rm -f "$package_backup" docs/decisions/stdlib-first-bats-fixture.md
+
+  [ "$result_status" -eq 1 ]
+  [[ "$result_output" == *"stdlib-first-bats-fixture"* ]]
+}

--- a/test/utils/IdGenerator.test.ts
+++ b/test/utils/IdGenerator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { CountingIdGenerator, NodeIdGenerator } from "../../src/utils/IdGenerator";
+import { CountingIdGenerator, createTimestampedId, NodeIdGenerator } from "../../src/utils/IdGenerator";
 import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 
 describe("NodeIdGenerator", function() {
@@ -49,5 +49,15 @@ describe("FakeIdGenerator", function() {
 
     expect(generator.next()).toBe("x");
     expect(generator.next()).toBe("fake-1");
+  });
+});
+
+describe("createTimestampedId", function() {
+  test("keeps an observable timestamp while injecting deterministic uniqueness", function() {
+    const timer = { now: () => 1234 };
+    const ids = new CountingIdGenerator("test");
+
+    expect(createTimestampedId("highlight", timer, ids)).toBe("highlight_1234_test-1");
+    expect(createTimestampedId("highlight", timer, ids)).toBe("highlight_1234_test-2");
   });
 });

--- a/test/utils/ScreenshotJobTracker.test.ts
+++ b/test/utils/ScreenshotJobTracker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ScreenshotJobTracker } from "../../src/utils/ScreenshotJobTracker";
 import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 
 describe("ScreenshotJobTracker", () => {
   let fakeTimer: FakeTimer;
@@ -9,11 +10,13 @@ describe("ScreenshotJobTracker", () => {
   beforeEach(() => {
     fakeTimer = new FakeTimer();
     ScreenshotJobTracker.setTimer(fakeTimer);
+    ScreenshotJobTracker.setIdGenerator(new CountingIdGenerator("job"));
   });
 
   afterEach(() => {
     ScreenshotJobTracker.clear();
     ScreenshotJobTracker.resetTimer();
+    ScreenshotJobTracker.resetIdGenerator();
   });
 
   test("cancels the previous job for the same device", async () => {
@@ -45,6 +48,15 @@ describe("ScreenshotJobTracker", () => {
     expect(result1.error).toContain(OPERATION_CANCELLED_MESSAGE);
     expect(result2.success).toBe(true);
     expect(result2.path).toBe("job2");
+  });
+
+  test("uses the injected ID generator when jobs start in the same tick", async () => {
+    const first = ScreenshotJobTracker.startJob("device-id-1", async () => ({ success: true }));
+    const second = ScreenshotJobTracker.startJob("device-id-2", async () => ({ success: true }));
+
+    expect(first.jobId).toBe("screenshot_0_job-1");
+    expect(second.jobId).toBe("screenshot_0_job-2");
+    await Promise.all([first.promise, second.promise]);
   });
 
   test("waitForCompletion resolves with result when job completes", async () => {


### PR DESCRIPTION
## Summary

Establishes a standard-library-first convention for TypeScript: contributor and LLM guidance, lint guardrails, a direct-dependency decision check, and CI enforcement. It also replaces duplicated random ID generation with the existing injectable ID seam and makes SHA-256 calculation consistently use Node streaming crypto.

## Linked Issue

N/A

## Validation

- [x] `scripts/all_fast_validate_checks.sh --only stdlib-first --no-parallel` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` passes
- [x] Focused TypeScript tests pass (48 tests)
- [x] BATS coverage for the dependency-decision gate passes
- [x] MkDocs navigation and ShellCheck pass
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses the standard library or an existing project helper; any new direct dependency has a decision record under `docs/decisions/`

## Review

Three independent AutoMobile code-review passes covered runtime/test seams, enforcement/CI wiring, and repository compatibility. Their verified findings were addressed.

## Known unrelated validation result

`bun test --bail` reaches a pre-existing `DefaultProcessExecutor` contract failure in `test/contracts/runAll.test.ts`; no command-executor files are changed here.
