### PR TITLE
chore(image): remove stale Wasm OSR guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,12 +187,7 @@ jobs:
       - name: Run Bun MCP startup smoke
         run: bun run test:startup:bun
 
-      # Disable the JSC Wasm OSR tier: it intermittently miscompiles the
-      # @jimp/wasm-webp Emscripten module on Linux x64 (oven-sh/bun#26366),
-      # failing the smoke with an embind null-reference error. See issue #3189.
       - name: Run Bun image runtime smoke
-        env:
-          BUN_JSC_useWasmOSR: "0"
         run: bun run test:image:bun
 
       - name: Create release notes

--- a/src/utils/image/ImageTransformer.ts
+++ b/src/utils/image/ImageTransformer.ts
@@ -5,7 +5,7 @@ import { defaultTimer, type Timer } from "../SystemTimer";
 import type { ImageBackend, ImageMetadata, ImagePipeline } from "./backend/ImageBackend";
 import { resolveImageBackend } from "./backend/resolveImageBackend";
 
-const DEFAULT_JPEG_QUALITY = 75;
+const DEFAULT_WEBP_QUALITY = 75;
 
 // Re-exported from the backend seam so existing importers keep the same path.
 export type { ImageMetadata };
@@ -73,7 +73,7 @@ class JimpImageTransformer {
    * @param options.nearLossless Whether to use near-lossless compression
    */
   public webp(options?: { quality?: number; lossless?: boolean; nearLossless?: boolean }): JimpImageTransformer {
-    const quality = options?.quality || DEFAULT_JPEG_QUALITY;
+    const quality = options?.quality || DEFAULT_WEBP_QUALITY;
 
     if (quality < 1 || quality > 100) {
       throw new Error("WebP quality must be between 1 and 100");

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -92,6 +92,14 @@
   grep -q "verify-release-integrity.sh" ".github/workflows/release.yml"
 }
 
+@test "release.yml runs the Bun image smoke without the retired Wasm OSR override (#4009)" {
+  smoke_block="$(sed -n '/name: Run Bun image runtime smoke/,/run: bun run test:image:bun/p' ".github/workflows/release.yml")"
+
+  [[ "$smoke_block" == *"run: bun run test:image:bun"* ]]
+  [[ "$smoke_block" != *"BUN_JSC_useWasmOSR"* ]]
+  [[ "$smoke_block" != *"@jimp/wasm-webp"* ]]
+}
+
 @test "prepare-release.yml runs the release-integrity gate" {
   grep -q "verify-release-integrity.sh" ".github/workflows/prepare-release.yml"
 }

--- a/test/utils/image/ImageTransformer.test.ts
+++ b/test/utils/image/ImageTransformer.test.ts
@@ -137,7 +137,7 @@ describe("ImageTransformer (declarative pipeline + backend delegation)", () => {
     });
 
     test("webp quality 0 falls back to the default (preserved || quirk)", async () => {
-      // `quality || DEFAULT_JPEG_QUALITY` treats 0 as falsy, so it becomes 75
+      // `quality || DEFAULT_WEBP_QUALITY` treats 0 as falsy, so it becomes 75
       // rather than throwing. Preserving this pre-existing behavior verbatim.
       await imageOf().webp({ quality: 0 }).disableCache().toBuffer();
       expect(backend.lastPipeline!.encoding).toEqual({


### PR DESCRIPTION
## Summary

Removes the obsolete `BUN_JSC_useWasmOSR` override from the release image smoke now that `@jimp/wasm-webp` is no longer used. Renames the WebP quality default so it no longer implies unsupported JPEG encoding, while retaining the existing value and `quality: 0` fallback behavior.

## Linked Issue

Closes #4009

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes
- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run test:image:bun` passes without the retired override
- [x] Focused image and release-workflow tests pass
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not applicable; this changes CI wiring and an internal constant name only.
