### PR TITLE
fix: require optional dependency decisions

### DIFF
--- a/docs/contributing/stdlib-first.md
+++ b/docs/contributing/stdlib-first.md
@@ -28,7 +28,8 @@ developer's local runtime.
 
 ## Dependency decisions
 
-Every new direct dependency must have a short Markdown record in
+Every new dependency declared in `dependencies`, `devDependencies`, or
+`optionalDependencies` must have a short Markdown record in
 `docs/decisions/`. Include this exact field so `bun run check:stdlib-first` can
 verify it:
 

--- a/scripts/check-stdlib-first.sh
+++ b/scripts/check-stdlib-first.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Require a short decision record when a PR adds a direct runtime or development
-# dependency. This keeps a generic package from becoming the first answer when
+# Require a short decision record when a PR adds a direct runtime, development,
+# or optional dependency. This keeps a generic package from becoming the first answer when
 # the standard library or an existing AutoMobile seam already fits.
 
 set -euo pipefail
@@ -20,8 +20,8 @@ BASE_COMMIT="$(git merge-base "$BASE_REF" HEAD)"
 BASE_PACKAGE_JSON="$(git show "${BASE_COMMIT}:package.json")"
 CURRENT_PACKAGE_JSON="$(<package.json)"
 
-base_dependencies="$(jq -r '(.dependencies // {} | keys[]) , (.devDependencies // {} | keys[])' <<<"$BASE_PACKAGE_JSON" | sort -u)"
-current_dependencies="$(jq -r '(.dependencies // {} | keys[]) , (.devDependencies // {} | keys[])' <<<"$CURRENT_PACKAGE_JSON" | sort -u)"
+base_dependencies="$(jq -r '(.dependencies // {} | keys[]) , (.devDependencies // {} | keys[]) , (.optionalDependencies // {} | keys[])' <<<"$BASE_PACKAGE_JSON" | sort -u)"
+current_dependencies="$(jq -r '(.dependencies // {} | keys[]) , (.devDependencies // {} | keys[]) , (.optionalDependencies // {} | keys[])' <<<"$CURRENT_PACKAGE_JSON" | sort -u)"
 added_dependencies="$(comm -13 <(printf '%s\n' "$base_dependencies") <(printf '%s\n' "$current_dependencies"))"
 
 if [[ -z "$added_dependencies" ]]; then

--- a/test/bats/check-stdlib-first.bats
+++ b/test/bats/check-stdlib-first.bats
@@ -27,3 +27,23 @@ SCRIPT="scripts/check-stdlib-first.sh"
   [ "$result_status" -eq 1 ]
   [[ "$result_output" == *"stdlib-first-bats-fixture"* ]]
 }
+
+@test "requires a decision record for a new optional dependency" {
+  local package_backup
+  local result_output
+  local result_status
+  package_backup="$(mktemp)"
+  cp package.json "$package_backup"
+
+  jq '.optionalDependencies["stdlib-first-optional-fixture"] = "1.0.0"' package.json > package.json.tmp
+  mv package.json.tmp package.json
+
+  run env STDLIB_FIRST_BASE_REF=HEAD bash "$SCRIPT"
+  result_status="$status"
+  result_output="$output"
+  cp "$package_backup" package.json
+  rm -f "$package_backup" docs/decisions/stdlib-first-optional-fixture.md
+
+  [ "$result_status" -eq 1 ]
+  [[ "$result_output" == *"stdlib-first-optional-fixture"* ]]
+}


### PR DESCRIPTION
## Summary

Closes the policy gap identified in the review of #4004: the stdlib-first dependency-decision gate now includes newly added `optionalDependencies`, along with runtime and development dependencies.

## Bug / Regression Context

- **Prior attempt:** #4004 established the dependency-decision gate.
- **Observed symptom:** an optional dependency could be added without a decision record.
- **Repro:** add a key to `optionalDependencies` and run `STDLIB_FIRST_BASE_REF=HEAD bun run check:stdlib-first`; previously the command passed.

## Validation

- [x] `bats test/bats/check-stdlib-first.bats`
- [x] `scripts/all_fast_validate_checks.sh --only dependency-decisions --no-parallel`
- [x] `shellcheck scripts/check-stdlib-first.sh`
- [x] Rebased onto latest `main`
