### PR TITLE
feat(desktop): receive pushed list_changed notifications from the daemon

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -31,6 +32,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonNotificationClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpHttpClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpResource
@@ -1067,9 +1069,32 @@ private fun McpProcessDetails(process: McpProcess) {
   var resourcesExpanded by remember { mutableStateOf(false) }
   var toolsExpanded by remember { mutableStateOf(false) }
   var error by remember { mutableStateOf<String?>(null) }
+  var refreshToken by remember { mutableStateOf(0) }
+
+  // Only a Unix-socket process has a control socket to subscribe on; HTTP/STDIO processes keep
+  // the previous fetch-once behaviour.
+  val notifications =
+    remember(process.pid, process.socketPath) {
+      val socketPath = process.socketPath
+      if (process.connectionType == McpConnectionType.UnixSocket && !socketPath.isNullOrBlank()) {
+        DaemonNotificationClient(socketPathValue = socketPath)
+      } else {
+        null
+      }
+    }
+
+  DisposableEffect(notifications) { onDispose { notifications?.dispose() } }
+
+  // Refetch when the daemon says the lists changed. A daemon that predates the subscription
+  // reports Unsupported and never emits, so the fetch-once behaviour is untouched there.
+  LaunchedEffect(notifications) {
+    if (notifications == null) return@LaunchedEffect
+    notifications.connect()
+    notifications.notifications.collect { refreshToken += 1 }
+  }
 
   // Fetch resources and tools from MCP server
-  LaunchedEffect(process.pid) {
+  LaunchedEffect(process.pid, refreshToken) {
     kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
       try {
         kotlinx.coroutines.withTimeout(5000) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
@@ -1,0 +1,302 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.math.min
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private val LOG = LoggerFactory.getLogger("DaemonNotificationClient")
+
+/** Method the daemon accepts to opt a session into pushed notifications. */
+internal const val SUBSCRIBE_NOTIFICATIONS_METHOD = "daemon/subscribe-notifications"
+
+internal const val TOOLS_LIST_CHANGED_METHOD = "notifications/tools/list_changed"
+internal const val RESOURCES_LIST_CHANGED_METHOD = "notifications/resources/list_changed"
+
+/** Which cached list the daemon says is stale. */
+enum class ListChangedKind {
+  Tools,
+  Resources;
+
+  companion object {
+    fun forMethod(method: String?): ListChangedKind? =
+      when (method) {
+        TOOLS_LIST_CHANGED_METHOD -> Tools
+        RESOURCES_LIST_CHANGED_METHOD -> Resources
+        else -> null
+      }
+  }
+}
+
+/** Where the notification subscription stands. */
+sealed class NotificationSubscriptionState {
+  data object Idle : NotificationSubscriptionState()
+
+  data object Connecting : NotificationSubscriptionState()
+
+  data object Subscribed : NotificationSubscriptionState()
+
+  /** The daemon predates `daemon/subscribe-notifications`. Terminal -- retrying cannot help. */
+  data class Unsupported(val reason: String) : NotificationSubscriptionState()
+
+  data class Disconnected(val reason: String?) : NotificationSubscriptionState()
+}
+
+/** Receives the daemon's pushed list-changed notifications. */
+interface DaemonNotificationSource {
+  val notifications: SharedFlow<ListChangedKind>
+  val state: StateFlow<NotificationSubscriptionState>
+
+  fun connect()
+
+  fun disconnect()
+}
+
+/**
+ * Holds a long-lived connection to the daemon control socket purely to receive pushed
+ * notifications.
+ *
+ * This is deliberately separate from [McpDaemonClient] rather than a mode of it. That client is
+ * request/response: it opens a socket, writes one line, reads one line and closes, which is correct
+ * for its callers and is also precisely why a push can never reach it. Rather than make every
+ * existing caller share a connection lifecycle they do not need, this follows the same shape as the
+ * other push clients in this package ([TelemetryPushSocketClient], [FailuresPushSocketClient]) —
+ * own connection, own reader, own retry.
+ *
+ * A daemon that predates the subscribe method answers with a well-formed failure rather than
+ * closing, so that case is reported as [NotificationSubscriptionState.Unsupported] and **not**
+ * retried; only transport failures back off and reconnect.
+ */
+class DaemonNotificationClient(
+  private val socketPathValue: String = DaemonSocketPaths.socketPath(),
+  private val json: Json = Json {
+    ignoreUnknownKeys = true
+    // `type` is a default on the request class but the daemon routes on it; without this the
+    // subscribe goes out untyped.
+    encodeDefaults = true
+  },
+  private val initialBackoffMs: Long = 1_000,
+  private val maxBackoffMs: Long = 30_000,
+) : DaemonNotificationSource {
+
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+  private val _notifications =
+    MutableSharedFlow<ListChangedKind>(
+      // replay = 1 so a collector that attaches just after a notification still learns the list is
+      // stale; with replay = 0 the emission is dropped outright when nobody is collecting yet.
+      replay = 1,
+      // A burst of changes only means "refetch", so coalescing is fine.
+      extraBufferCapacity = 16,
+      onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+  override val notifications: SharedFlow<ListChangedKind> = _notifications.asSharedFlow()
+
+  private val _state =
+    MutableStateFlow<NotificationSubscriptionState>(NotificationSubscriptionState.Idle)
+  override val state: StateFlow<NotificationSubscriptionState> = _state.asStateFlow()
+
+  private var connectionJob: Job? = null
+  private var channel: SocketChannel? = null
+
+  @Volatile private var shouldReconnect = false
+
+  override fun connect() {
+    if (connectionJob?.isActive == true) return
+    shouldReconnect = true
+    connectionJob = scope.launch { connectWithRetry() }
+  }
+
+  override fun disconnect() {
+    shouldReconnect = false
+    connectionJob?.cancel()
+    connectionJob = null
+    closeChannel()
+    _state.value = NotificationSubscriptionState.Idle
+  }
+
+  /** Disconnects and cancels the internal scope. The instance must not be reused afterwards. */
+  fun dispose() {
+    disconnect()
+    scope.coroutineContext[Job]?.cancel()
+  }
+
+  private suspend fun connectWithRetry() {
+    var attempt = 0
+
+    while (shouldReconnect) {
+      _state.value = NotificationSubscriptionState.Connecting
+      try {
+        if (!Files.exists(Path.of(socketPathValue))) {
+          throw IllegalStateException("Daemon socket not found at $socketPathValue")
+        }
+
+        SocketChannel.open(UnixDomainSocketAddress.of(socketPathValue)).use { socket ->
+          channel = socket
+          val reader =
+            BufferedReader(
+              InputStreamReader(Channels.newInputStream(socket), StandardCharsets.UTF_8)
+            )
+          val writer =
+            BufferedWriter(
+              OutputStreamWriter(Channels.newOutputStream(socket), StandardCharsets.UTF_8)
+            )
+
+          if (!subscribe(reader, writer)) {
+            // Unsupported: the daemon answered, it just does not know this method. Reconnecting
+            // would produce the same answer forever.
+            return
+          }
+
+          attempt = 0
+          _state.value = NotificationSubscriptionState.Subscribed
+          readNotifications(reader)
+        }
+      } catch (e: Exception) {
+        if (!shouldReconnect) return
+        LOG.debug("Daemon notification connection failed: ${e.message}")
+      } finally {
+        channel = null
+      }
+
+      if (!shouldReconnect) return
+      attempt++
+      val backoff = min(initialBackoffMs shl (attempt - 1).coerceAtMost(5), maxBackoffMs)
+      _state.value = NotificationSubscriptionState.Disconnected("Reconnecting in ${backoff}ms")
+      delay(backoff)
+    }
+  }
+
+  /** Returns true when subscribed; false when the daemon does not support the method. */
+  private fun subscribe(reader: BufferedReader, writer: BufferedWriter): Boolean {
+    val request =
+      DaemonNotificationRequest(
+        id = UUID.randomUUID().toString(),
+        method = SUBSCRIBE_NOTIFICATIONS_METHOD,
+      )
+    writer.write(json.encodeToString(DaemonNotificationRequest.serializer(), request))
+    writer.newLine()
+    writer.flush()
+
+    val line = reader.readLine() ?: throw IllegalStateException("Daemon closed during subscribe")
+    val response = json.decodeFromString(DaemonFrame.serializer(), line)
+
+    if (response.success != true) {
+      val reason = response.error ?: "Daemon does not support pushed notifications"
+      LOG.info("Daemon notifications unavailable: $reason")
+      _state.value = NotificationSubscriptionState.Unsupported(reason)
+      return false
+    }
+    return true
+  }
+
+  private fun readNotifications(reader: BufferedReader) {
+    while (shouldReconnect) {
+      val line = reader.readLine() ?: return
+      if (line.isBlank()) continue
+
+      val frame =
+        try {
+          json.decodeFromString(DaemonFrame.serializer(), line)
+        } catch (e: Exception) {
+          // A frame this client does not model is not a reason to drop the subscription.
+          LOG.debug("Ignoring unparseable daemon frame: ${e.message}")
+          continue
+        }
+
+      if (frame.type != "daemon_notification") continue
+      val kind = ListChangedKind.forMethod(frame.method)
+      if (kind == null) {
+        LOG.debug("Ignoring unknown daemon notification: ${frame.method}")
+        continue
+      }
+      _notifications.tryEmit(kind)
+    }
+  }
+
+  private fun closeChannel() {
+    try {
+      channel?.close()
+    } catch (e: Exception) {
+      LOG.debug("Closing the daemon notification socket failed: ${e.message}")
+    }
+    channel = null
+  }
+}
+
+@Serializable
+internal data class DaemonNotificationRequest(
+  val id: String,
+  val type: String = "mcp_request",
+  val method: String,
+)
+
+/**
+ * Lenient view of anything the control socket sends.
+ *
+ * Every field is optional on purpose: a `daemon_notification` carries no `id` and no `success`,
+ * while an `mcp_response` carries both. Modelling them as one tolerant shape avoids failing to
+ * decode the very frames this client exists to read.
+ */
+@Serializable
+internal data class DaemonFrame(
+  val id: String? = null,
+  val type: String? = null,
+  val success: Boolean? = null,
+  val method: String? = null,
+  val error: String? = null,
+)
+
+/** In-memory [DaemonNotificationSource] for previews and tests. */
+class FakeDaemonNotificationSource(private val unsupportedReason: String? = null) :
+  DaemonNotificationSource {
+  private val _notifications =
+    MutableSharedFlow<ListChangedKind>(
+      extraBufferCapacity = 16,
+      onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+  override val notifications: SharedFlow<ListChangedKind> = _notifications.asSharedFlow()
+
+  private val _state =
+    MutableStateFlow<NotificationSubscriptionState>(NotificationSubscriptionState.Idle)
+  override val state: StateFlow<NotificationSubscriptionState> = _state.asStateFlow()
+
+  override fun connect() {
+    _state.value =
+      if (unsupportedReason != null) NotificationSubscriptionState.Unsupported(unsupportedReason)
+      else NotificationSubscriptionState.Subscribed
+  }
+
+  override fun disconnect() {
+    _state.value = NotificationSubscriptionState.Idle
+  }
+
+  /** Pushes a notification, as the daemon would. */
+  fun emit(kind: ListChangedKind) {
+    _notifications.tryEmit(kind)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClientTest.kt
@@ -1,0 +1,332 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Drives [DaemonNotificationClient] against a real Unix socket that speaks the control socket's
+ * frames.
+ *
+ * Uses `runBlocking` rather than `runTest`: the client runs a real reader on a real socket, and a
+ * virtual clock would skip the waits without any of it having happened.
+ */
+class DaemonNotificationClientTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val servers = mutableListOf<FakeDaemon>()
+
+  @AfterTest
+  fun tearDown() {
+    servers.forEach { it.close() }
+    servers.clear()
+  }
+
+  private fun daemon(
+    subscribeSucceeds: Boolean = true,
+    subscribeError: String? = null,
+    pushes: List<String> = emptyList(),
+  ): FakeDaemon = FakeDaemon(subscribeSucceeds, subscribeError, pushes).also { servers.add(it) }
+
+  private fun client(server: FakeDaemon) =
+    DaemonNotificationClient(socketPathValue = server.socketPath.toString())
+
+  private suspend fun waitUntil(timeoutMs: Long = 5_000, predicate: () -> Boolean) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      if (predicate()) return
+      kotlinx.coroutines.delay(10)
+    }
+    throw AssertionError("Timed out waiting for condition")
+  }
+
+  @Test
+  fun `subscribes with the documented method`() = runBlocking {
+    val server = daemon()
+    val client = client(server)
+
+    client.connect()
+    waitUntil { client.state.value is NotificationSubscriptionState.Subscribed }
+
+    val request = server.awaitRequest()
+    assertEquals("daemon/subscribe-notifications", request["method"]?.jsonPrimitive?.content)
+    assertEquals("mcp_request", request["type"]?.jsonPrimitive?.content)
+
+    client.dispose()
+  }
+
+  @Test
+  fun `a tools list_changed push is surfaced`() = runBlocking {
+    val server =
+      daemon(
+        pushes = listOf("""{"type":"daemon_notification","method":"$TOOLS_LIST_CHANGED_METHOD"}""")
+      )
+    val client = client(server)
+    val seen = mutableListOf<ListChangedKind>()
+
+    // Collect before connecting: notifications has no replay, so a collector started afterwards
+    // can miss a push that arrives immediately after the subscribe ack.
+    val collector = launch { client.notifications.collect(seen::add) }
+    client.connect()
+    waitUntil { seen.contains(ListChangedKind.Tools) }
+
+    collector.cancel()
+    client.dispose()
+  }
+
+  @Test
+  fun `a resources list_changed push is surfaced`() = runBlocking {
+    val server =
+      daemon(
+        pushes =
+          listOf("""{"type":"daemon_notification","method":"$RESOURCES_LIST_CHANGED_METHOD"}""")
+      )
+    val client = client(server)
+    val seen = mutableListOf<ListChangedKind>()
+
+    // Collect before connecting: notifications has no replay, so a collector started afterwards
+    // can miss a push that arrives immediately after the subscribe ack.
+    val collector = launch { client.notifications.collect(seen::add) }
+    client.connect()
+    waitUntil { seen.contains(ListChangedKind.Resources) }
+
+    collector.cancel()
+    client.dispose()
+  }
+
+  @Test
+  fun `an older daemon is reported unsupported and not retried`() = runBlocking {
+    // The daemon answers -- it just does not know the method. Reconnecting would loop forever.
+    val server =
+      daemon(
+        subscribeSucceeds = false,
+        subscribeError = "Unsupported daemon method: daemon/subscribe-notifications",
+      )
+    val client = client(server)
+
+    client.connect()
+    waitUntil { client.state.value is NotificationSubscriptionState.Unsupported }
+
+    val state = client.state.value as NotificationSubscriptionState.Unsupported
+    assertTrue(state.reason.contains("Unsupported daemon method"), state.reason)
+
+    // Only one connection attempt: an unsupported daemon must not be hammered.
+    kotlinx.coroutines.delay(300)
+    assertEquals(1, server.connectionCount)
+
+    client.dispose()
+  }
+
+  @Test
+  fun `a notification frame with no id decodes`() = runBlocking {
+    // The daemon deliberately omits `id` on pushes; a strict model would fail to decode them.
+    val server =
+      daemon(
+        pushes = listOf("""{"type":"daemon_notification","method":"$TOOLS_LIST_CHANGED_METHOD"}""")
+      )
+    val client = client(server)
+    val seen = mutableListOf<ListChangedKind>()
+
+    // Collect before connecting: notifications has no replay, so a collector started afterwards
+    // can miss a push that arrives immediately after the subscribe ack.
+    val collector = launch { client.notifications.collect(seen::add) }
+    client.connect()
+    waitUntil { seen.isNotEmpty() }
+
+    collector.cancel()
+    client.dispose()
+  }
+
+  @Test
+  fun `unknown notification methods are ignored without dropping the subscription`() = runBlocking {
+    val server =
+      daemon(
+        pushes =
+          listOf(
+            """{"type":"daemon_notification","method":"notifications/something/else"}""",
+            """{"type":"daemon_notification","method":"$TOOLS_LIST_CHANGED_METHOD"}""",
+          )
+      )
+    val client = client(server)
+    val seen = mutableListOf<ListChangedKind>()
+
+    // Collect before connecting: notifications has no replay, so a collector started afterwards
+    // can miss a push that arrives immediately after the subscribe ack.
+    val collector = launch { client.notifications.collect(seen::add) }
+    client.connect()
+    waitUntil { seen.contains(ListChangedKind.Tools) }
+
+    assertEquals(listOf(ListChangedKind.Tools), seen, "the unknown method must not be emitted")
+    collector.cancel()
+    client.dispose()
+  }
+
+  @Test
+  fun `unparseable frames do not drop the subscription`() = runBlocking {
+    val server =
+      daemon(
+        pushes =
+          listOf(
+            "{not json",
+            """{"type":"daemon_notification","method":"$TOOLS_LIST_CHANGED_METHOD"}""",
+          )
+      )
+    val client = client(server)
+    val seen = mutableListOf<ListChangedKind>()
+
+    // Collect before connecting: notifications has no replay, so a collector started afterwards
+    // can miss a push that arrives immediately after the subscribe ack.
+    val collector = launch { client.notifications.collect(seen::add) }
+    client.connect()
+    waitUntil { seen.contains(ListChangedKind.Tools) }
+
+    collector.cancel()
+    client.dispose()
+  }
+
+  @Test
+  fun `a missing socket does not throw and does not spin`() = runBlocking {
+    val client =
+      DaemonNotificationClient(
+        socketPathValue = "/tmp/no-daemon-am.sock",
+        initialBackoffMs = 50,
+        maxBackoffMs = 100,
+      )
+
+    client.connect()
+    waitUntil { client.state.value is NotificationSubscriptionState.Disconnected }
+
+    client.dispose()
+  }
+
+  @Test
+  fun `disconnect returns to idle`() = runBlocking {
+    val server = daemon()
+    val client = client(server)
+
+    client.connect()
+    waitUntil { client.state.value is NotificationSubscriptionState.Subscribed }
+
+    client.disconnect()
+    assertEquals(NotificationSubscriptionState.Idle, client.state.value)
+    client.dispose()
+  }
+
+  @Test
+  fun `method names match the daemon's constants`() {
+    assertEquals(ListChangedKind.Tools, ListChangedKind.forMethod(TOOLS_LIST_CHANGED_METHOD))
+    assertEquals(
+      ListChangedKind.Resources,
+      ListChangedKind.forMethod(RESOURCES_LIST_CHANGED_METHOD),
+    )
+    assertEquals(null, ListChangedKind.forMethod("notifications/prompts/list_changed"))
+    assertEquals(null, ListChangedKind.forMethod(null))
+  }
+
+  @Test
+  fun `the fake reports an unsupported daemon`() {
+    val source = FakeDaemonNotificationSource(unsupportedReason = "Unsupported daemon method")
+
+    source.connect()
+
+    assertTrue(source.state.value is NotificationSubscriptionState.Unsupported)
+  }
+
+  /** A daemon that accepts one subscribe then pushes canned frames. */
+  private inner class FakeDaemon(
+    private val subscribeSucceeds: Boolean,
+    private val subscribeError: String?,
+    private val pushes: List<String>,
+  ) : AutoCloseable {
+    private val tempDir: Path = Files.createTempDirectory(Path.of("/tmp"), "amdn-")
+    val socketPath: Path = tempDir.resolve("daemon.sock")
+
+    private val serverChannel =
+      ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        .bind(UnixDomainSocketAddress.of(socketPath))
+
+    @Volatile private var captured: JsonObject? = null
+    @Volatile
+    var connectionCount = 0
+      private set
+
+    private val thread = Thread {
+      try {
+        while (true) {
+          serverChannel.accept().use { socket ->
+            connectionCount++
+            val reader =
+              BufferedReader(
+                InputStreamReader(Channels.newInputStream(socket), StandardCharsets.UTF_8)
+              )
+            val out = Channels.newOutputStream(socket)
+            val requestLine = reader.readLine() ?: return@use
+            captured = json.parseToJsonElement(requestLine).jsonObject
+            val id = captured?.get("id")?.jsonPrimitive?.content ?: "1"
+
+            val ack =
+              if (subscribeSucceeds) {
+                """{"id":"$id","type":"mcp_response","success":true,"result":{"subscribed":true}}"""
+              } else {
+                """{"id":"$id","type":"mcp_response","success":false,"error":"$subscribeError"}"""
+              }
+            writeLine(out, ack)
+            if (!subscribeSucceeds) return@use
+
+            pushes.forEach { writeLine(out, it) }
+            // Hold the connection so the client stays subscribed.
+            while (!Thread.currentThread().isInterrupted) {
+              Thread.sleep(50)
+            }
+          }
+        }
+      } catch (_: Throwable) {
+        // Interrupt or client disconnect ends this thread normally.
+      }
+    }
+      .also {
+        it.isDaemon = true
+        it.start()
+      }
+
+    private fun writeLine(out: OutputStream, line: String) {
+      out.write((line + "\n").toByteArray(StandardCharsets.UTF_8))
+      out.flush()
+    }
+
+    suspend fun awaitRequest(): JsonObject {
+      val deadline = System.currentTimeMillis() + 5_000
+      while (System.currentTimeMillis() < deadline) {
+        captured?.let {
+          return it
+        }
+        kotlinx.coroutines.delay(10)
+      }
+      throw AssertionError("Client did not subscribe")
+    }
+
+    override fun close() {
+      thread.interrupt()
+      serverChannel.close()
+      Files.deleteIfExists(socketPath)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+}


### PR DESCRIPTION
Closes #3978. Epic #3933.

## The daemon side already worked

Verified against the running daemon before writing any code:

```
-> {"id":"probe-1","type":"mcp_request","method":"daemon/subscribe-notifications","params":{}}
<- {"id":"probe-1","type":"mcp_response","success":true,"result":{"subscribed":true}}
```

It accepts the subscription and holds the connection open. Nothing needed enabling, rebuilding, or restarting.

The gap was entirely client-side: `McpDaemonClient.sendRequest` opens a `SocketChannel`, writes one line, reads one line, and closes inside `.use { }` ([McpDaemonClient.kt:469](android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt:469)). Subscribing from it would have succeeded and then died in the same call.

## Why a separate client, not a mode on `McpDaemonClient`

Converting that client to a persistent connection would impose a connection lifecycle on every existing request/response caller, for a feature none of them use. This package already has a shape for this — `TelemetryPushSocketClient` and `FailuresPushSocketClient` each own a connection, a reader, and a backoff loop. `DaemonNotificationClient` follows it. **`McpDaemonClient` is untouched.**

## Where the staleness actually was

`McpProcessDetails` fetched tools and resources once per `LaunchedEffect(process.pid)` and never again — that's the thing #3978 described as a "cached list". It now refetches on notification. The subscription is built from the process's own socket path, so only Unix-socket processes take one; HTTP and STDIO keep the previous behaviour.

## Graceful degradation

An older daemon answers `{"success": false, "error": "Unsupported daemon method: ..."}` — a well-formed reply, not a disconnect. That's reported as `Unsupported` and **deliberately not retried**, since reconnecting would produce the same answer forever. Only transport failures back off and reconnect. A test asserts exactly one connection attempt in that case.

## Two bugs the tests caught

**1. The subscribe went out with no `type` field.** It's a Kotlin default and kotlinx omits defaults, so the daemon — which routes on `type` — would have rejected it. This is the **fourth** time this trap has appeared in this area (also #3931, #3932, #4008); worth considering a shared `Json` instance for daemon clients rather than each declaring its own.

**2. `notifications` used `replay = 0`,** which silently discards emissions when no collector is attached yet. A UI subscribing a moment after a push would have missed it entirely. `replay = 1` fixes the race and is what the consumer wants anyway — a late collector still learns the list is stale.

## Testing

11 new tests, **555 desktop-core green**, stable across three consecutive reruns (the replay bug was intermittent before the fix).

Covers: the subscribe wire shape, both list-changed kinds, a notification frame with **no `id`** (the daemon omits it per `src/daemon/types.ts:47-57`, so a strict model fails to decode), unknown methods and unparseable frames not dropping the subscription, an unsupported daemon being asked exactly once, and a missing socket backing off rather than spinning.

Tests use `runBlocking` rather than `runTest` deliberately — a real socket and a real reader thread are involved, and a virtual clock would skip the waits without any of it having happened.