### PR TITLE
fix(ios): verify VoiceOver service liveness

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		714A3E41ACE47ACF314E0FC2 /* ClipboardResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D131E590A0CF8F9674B0E /* ClipboardResolutionTests.swift */; };
 		74B1E8F78E9FF807417ABC2D /* PinchGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */; };
 		74CA22BFA1779993CDCF59AE /* CtrlProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE277596991C059142C485B /* CtrlProxy.swift */; };
+		7EBA4E6991444E3154C6BC84 /* VoiceOverStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10362B68AB9153544B411CCA /* VoiceOverStateProvider.swift */; };
 		7F0A1FBC49EE6CFD37F53294 /* CtrlProxyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802717F6B1F37809C4806C23 /* CtrlProxyUITests.swift */; };
 		818C27D4C9349EE5D7B46AC4 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F9D3D13C3FE12BA2CD012082 /* ObjCExceptionCatcher.m */; };
 		81E23C054BAEC85A37171E29 /* CtrlProxy.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -79,6 +80,7 @@
 		D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A284B6FFBE969931BB03A2FF /* PerfProvider.swift */; };
 		D9EF3A486E53F97C1CCB7A3B /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
 		DFEE186C8B4CD32EF76D995A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */; };
+		E75D4EFAF582079165A67B66 /* VoiceOverStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10362B68AB9153544B411CCA /* VoiceOverStateProvider.swift */; };
 		E8327D679D58C8F804C064B1 /* PerformanceMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */; };
 		E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */; };
 		EA65C486C9E6DBB5BFE9CA41 /* HierarchyDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */; };
@@ -182,6 +184,7 @@
 		0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyMergerTests.swift; sourceTree = "<group>"; };
 		0F9D7B74C318EE243B225B95 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		0FEB521226F4C469CBFE7296 /* PinchFallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchFallback.swift; sourceTree = "<group>"; };
+		10362B68AB9153544B411CCA /* VoiceOverStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverStateProvider.swift; sourceTree = "<group>"; };
 		1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLinkFPSMonitor.swift; sourceTree = "<group>"; };
 		184CFC1280E0802EBF53965F /* ModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStorageInspecting.swift; sourceTree = "<group>"; };
@@ -380,6 +383,7 @@
 				043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */,
 				E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */,
 				83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */,
+				10362B68AB9153544B411CCA /* VoiceOverStateProvider.swift */,
 				B4CB9272A186932D89EB1072 /* WebSocketServer.swift */,
 			);
 			name = CtrlProxy;
@@ -601,6 +605,7 @@
 				0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */,
 				0A4F48C4211E43B829855704 /* SdkHierarchyClient.swift in Sources */,
 				2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */,
+				E75D4EFAF582079165A67B66 /* VoiceOverStateProvider.swift in Sources */,
 				C2DCB71857A14ED314300AAC /* WebSocketServer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -666,6 +671,7 @@
 				EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */,
 				261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */,
 				CB577FE46E063BB09F5D4010 /* SdkHierarchyModels.swift in Sources */,
+				7EBA4E6991444E3154C6BC84 /* VoiceOverStateProvider.swift in Sources */,
 				53A41EE5F98E771345D6EA90 /* WebSocketServer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -23,6 +23,7 @@ public class CommandHandler: CommandHandling {
     private let sdkHierarchyCache: (any SdkHierarchyCaching)?
     private let sdkDatabaseClient: (any SdkDatabaseFetching)?
     private let hierarchyDebouncer: (any HierarchyDebouncing)?
+    private let voiceOverStateProvider: any VoiceOverStateProviding
 
     public init(
         elementLocator: ElementLocating,
@@ -32,7 +33,8 @@ public class CommandHandler: CommandHandling {
         sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
         sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
-        hierarchyDebouncer: (any HierarchyDebouncing)? = nil
+        hierarchyDebouncer: (any HierarchyDebouncing)? = nil,
+        voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider()
     ) {
         self.elementLocator = elementLocator
         self.gesturePerformer = gesturePerformer
@@ -42,6 +44,7 @@ public class CommandHandler: CommandHandling {
         self.sdkHierarchyCache = sdkHierarchyCache
         self.sdkDatabaseClient = sdkDatabaseClient
         self.hierarchyDebouncer = hierarchyDebouncer
+        self.voiceOverStateProvider = voiceOverStateProvider
     }
 
     /// Factory for testing - allows injecting fakes
@@ -53,7 +56,8 @@ public class CommandHandler: CommandHandling {
         sdkHierarchyClient: (any SdkHierarchyFetching)? = nil,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
         sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
-        hierarchyDebouncer: (any HierarchyDebouncing)? = nil
+        hierarchyDebouncer: (any HierarchyDebouncing)? = nil,
+        voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider()
     )
         -> CommandHandler
     {
@@ -65,7 +69,8 @@ public class CommandHandler: CommandHandling {
             sdkHierarchyClient: sdkHierarchyClient,
             sdkHierarchyCache: sdkHierarchyCache,
             sdkDatabaseClient: sdkDatabaseClient,
-            hierarchyDebouncer: hierarchyDebouncer
+            hierarchyDebouncer: hierarchyDebouncer,
+            voiceOverStateProvider: voiceOverStateProvider
         )
     }
 
@@ -1133,11 +1138,7 @@ public class CommandHandler: CommandHandling {
     )
         throws -> VoiceOverStateResponse
     {
-        #if os(iOS)
-            let enabled = UIAccessibility.isVoiceOverRunning
-        #else
-            let enabled = false
-        #endif
+        let enabled = voiceOverStateProvider.isVoiceOverRunning()
 
         return VoiceOverStateResponse(
             requestId: request.requestId,

--- a/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Reads the simulator's VoiceOver service liveness state.
+///
+/// `UIAccessibility.isVoiceOverRunning` can reflect `VoiceOverTouchEnabled`
+/// before `com.apple.VoiceOverTouch` has started, so it is not sufficient for
+/// confirming a simulator toggle.
+public protocol VoiceOverStateProviding {
+    func isVoiceOverRunning() -> Bool
+}
+
+public final class DefaultVoiceOverStateProvider: VoiceOverStateProviding {
+    private static let accessibilityDomain = "com.apple.Accessibility"
+    private static let runningKey = "VOTIsRunningKey"
+
+    public init() {}
+
+    public func isVoiceOverRunning() -> Bool {
+        #if os(iOS)
+            return UserDefaults(suiteName: Self.accessibilityDomain)?
+                .bool(forKey: Self.runningKey) ?? false
+        #else
+            return false
+        #endif
+    }
+}

--- a/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
@@ -9,18 +9,33 @@ public protocol VoiceOverStateProviding {
     func isVoiceOverRunning() -> Bool
 }
 
+public protocol VoiceOverDefaultsReading {
+    func bool(forKey key: String, inDomain domain: String) -> Bool
+}
+
+public final class SystemVoiceOverDefaultsReader: VoiceOverDefaultsReading {
+    public init() {}
+
+    public func bool(forKey key: String, inDomain domain: String) -> Bool {
+        #if os(iOS)
+            return UserDefaults(suiteName: domain)?.bool(forKey: key) ?? false
+        #else
+            return false
+        #endif
+    }
+}
+
 public final class DefaultVoiceOverStateProvider: VoiceOverStateProviding {
     private static let accessibilityDomain = "com.apple.Accessibility"
     private static let runningKey = "VOTIsRunningKey"
 
-    public init() {}
+    private let defaultsReader: any VoiceOverDefaultsReading
+
+    public init(defaultsReader: any VoiceOverDefaultsReading = SystemVoiceOverDefaultsReader()) {
+        self.defaultsReader = defaultsReader
+    }
 
     public func isVoiceOverRunning() -> Bool {
-        #if os(iOS)
-            return UserDefaults(suiteName: Self.accessibilityDomain)?
-                .bool(forKey: Self.runningKey) ?? false
-        #else
-            return false
-        #endif
+        return defaultsReader.bool(forKey: Self.runningKey, inDomain: Self.accessibilityDomain)
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -1,6 +1,14 @@
 @testable import CtrlProxy
 import XCTest
 
+private final class FakeVoiceOverStateProvider: VoiceOverStateProviding {
+    var isRunning = false
+
+    func isVoiceOverRunning() -> Bool {
+        return isRunning
+    }
+}
+
 final class CommandHandlerTests: XCTestCase {
     var fakeTimeProvider: FakeTimeProvider!
     var perfProvider: PerfProvider!
@@ -1570,6 +1578,40 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertNil(voResponse.requestId)
         XCTAssertEqual(voResponse.type, "voiceover_state_result")
         XCTAssertTrue(voResponse.success)
+    }
+
+    func testGetVoiceOverStateReportsLivenessProviderState() {
+        let voiceOverStateProvider = FakeVoiceOverStateProvider()
+        voiceOverStateProvider.isRunning = true
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            voiceOverStateProvider: voiceOverStateProvider
+        )
+
+        let request = WebSocketRequest.getVoiceOverState(RequestEnvelope(requestId: "voiceover-live"))
+
+        guard let response = handleRequest(request, as: VoiceOverStateResponse.self) else { return }
+
+        XCTAssertTrue(response.enabled)
+    }
+
+    func testGetVoiceOverStateDoesNotTreatPreferenceBackedUIKitStateAsLiveness() {
+        let voiceOverStateProvider = FakeVoiceOverStateProvider()
+        voiceOverStateProvider.isRunning = false
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            voiceOverStateProvider: voiceOverStateProvider
+        )
+
+        let request = WebSocketRequest.getVoiceOverState(RequestEnvelope(requestId: "voiceover-stopped"))
+
+        guard let response = handleRequest(request, as: VoiceOverStateResponse.self) else { return }
+
+        XCTAssertFalse(response.enabled)
     }
 
     func testGetVoiceOverStateIsEncodable() throws {

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -9,6 +9,18 @@ private final class FakeVoiceOverStateProvider: VoiceOverStateProviding {
     }
 }
 
+private final class FakeVoiceOverDefaultsReader: VoiceOverDefaultsReading {
+    private var values: [String: Bool] = [:]
+
+    func set(_ value: Bool, forKey key: String, inDomain domain: String) {
+        values["\(domain).\(key)"] = value
+    }
+
+    func bool(forKey key: String, inDomain domain: String) -> Bool {
+        return values["\(domain).\(key)"] ?? false
+    }
+}
+
 final class CommandHandlerTests: XCTestCase {
     var fakeTimeProvider: FakeTimeProvider!
     var perfProvider: PerfProvider!
@@ -1612,6 +1624,21 @@ final class CommandHandlerTests: XCTestCase {
         guard let response = handleRequest(request, as: VoiceOverStateResponse.self) else { return }
 
         XCTAssertFalse(response.enabled)
+    }
+
+    func testDefaultVoiceOverStateProviderReadsRunningKey() {
+        let defaultsReader = FakeVoiceOverDefaultsReader()
+        defaultsReader.set(true, forKey: "VOTIsRunningKey", inDomain: "com.apple.Accessibility")
+
+        let provider = DefaultVoiceOverStateProvider(defaultsReader: defaultsReader)
+
+        XCTAssertTrue(provider.isVoiceOverRunning())
+    }
+
+    func testDefaultVoiceOverStateProviderTreatsMissingRunningKeyAsStopped() {
+        let provider = DefaultVoiceOverStateProvider(defaultsReader: FakeVoiceOverDefaultsReader())
+
+        XCTAssertFalse(provider.isVoiceOverRunning())
     }
 
     func testGetVoiceOverStateIsEncodable() throws {

--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -39,6 +39,12 @@ export class VoiceOverToggle {
       await this.processExecutor.exec(
         `xcrun simctl spawn ${this.device.deviceId} notifyutil -p com.apple.accessibility.VoiceOverStatusDidChange`
       );
+      const serviceCommand = enabled
+        ? "launchctl kickstart -p system/com.apple.VoiceOverTouch"
+        : "launchctl kill SIGTERM system/com.apple.VoiceOverTouch";
+      await this.processExecutor.exec(
+        `xcrun simctl spawn ${this.device.deviceId} ${serviceCommand}`
+      );
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       logger.warn(`[VoiceOverToggle] Failed to ${enabled ? "enable" : "disable"} VoiceOver: ${reason}`);

--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -42,9 +42,16 @@ export class VoiceOverToggle {
       const serviceCommand = enabled
         ? "launchctl kickstart -p system/com.apple.VoiceOverTouch"
         : "launchctl kill SIGTERM system/com.apple.VoiceOverTouch";
-      await this.processExecutor.exec(
-        `xcrun simctl spawn ${this.device.deviceId} ${serviceCommand}`
-      );
+      try {
+        await this.processExecutor.exec(
+          `xcrun simctl spawn ${this.device.deviceId} ${serviceCommand}`
+        );
+      } catch (error) {
+        if (enabled || !this.isServiceAlreadyStopped(error)) {
+          throw error;
+        }
+        logger.debug("[VoiceOverToggle] VoiceOver service was already stopped");
+      }
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       logger.warn(`[VoiceOverToggle] Failed to ${enabled ? "enable" : "disable"} VoiceOver: ${reason}`);
@@ -74,5 +81,9 @@ export class VoiceOverToggle {
 
   private isSimulator(): boolean {
     return isIosSimulatorUdid(this.device.deviceId);
+  }
+
+  private isServiceAlreadyStopped(error: unknown): boolean {
+    return error instanceof Error && error.message.includes("No process to signal.");
   }
 }

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -90,6 +90,11 @@ describe("VoiceOverToggle", () => {
           `xcrun simctl spawn ${udid} notifyutil -p com.apple.accessibility.VoiceOverStatusDidChange`
         )
       ).toBe(true);
+      expect(
+        fakeExec.wasCommandExecuted(
+          `xcrun simctl spawn ${udid} launchctl kickstart -p system/com.apple.VoiceOverTouch`
+        )
+      ).toBe(true);
     });
 
     test("always applies even when detection would report already-enabled (CtrlProxy-safe)", async () => {
@@ -129,6 +134,11 @@ describe("VoiceOverToggle", () => {
       expect(
         fakeExec.wasCommandExecuted(
           `xcrun simctl spawn ${udid} notifyutil -p com.apple.accessibility.VoiceOverStatusDidChange`
+        )
+      ).toBe(true);
+      expect(
+        fakeExec.wasCommandExecuted(
+          `xcrun simctl spawn ${udid} launchctl kill SIGTERM system/com.apple.VoiceOverTouch`
         )
       ).toBe(true);
     });

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -142,6 +142,19 @@ describe("VoiceOverToggle", () => {
         )
       ).toBe(true);
     });
+
+    test("treats an already-stopped VoiceOver service as a successful disable", async () => {
+      fakeExec.setCommandHandler("launchctl kill SIGTERM", () => {
+        throw new Error("Command failed: launchctl kill SIGTERM\nexit code: 3\nstderr:\nNo process to signal.");
+      });
+
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const result = await toggle.toggle(false);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(true);
+      expect(result.currentState).toBe(false);
+    });
   });
 
   describe("simctl failure during apply phase", () => {


### PR DESCRIPTION
## Summary

Start and stop the iOS Simulator `com.apple.VoiceOverTouch` service explicitly when toggling VoiceOver. CtrlProxy now confirms service liveness from `VOTIsRunningKey` in `com.apple.Accessibility`, rather than the preference-backed UIKit state that can report a false positive.

## Linked Issue

Closes #4012

## Bug / Regression Context

- **Prior attempts:** #3959 added post-apply confirmation but its CtrlProxy source was `UIAccessibility.isVoiceOverRunning`.
- **Observed symptom:** `accessibility --voiceover true` reported success while no VoiceOver service was running.
- **Repro steps / conditions:** On iOS 26.2, write `VoiceOverTouchEnabled`, post the status notification, then inspect `launchctl list`; the preference was set but `com.apple.VoiceOverTouch` had no PID.

## Validation

- [x] `bun run turbo:validate` passes (8,115 tests; 11 hardware-dependent skips)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `swift test` in `ios/control-proxy` passes (414 tests) and the CtrlProxy iOS Simulator build succeeds
- [x] New code uses an interface plus a fake; focused unit tests complete in under 100ms
- [x] No new dependency or generic helper was added
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [x] Verified on an iOS 26.2 iPhone 17 Pro simulator: `kickstart` produced a VoiceOver PID and `VOTIsRunningKey = 1`; the disable sequence restored no PID and no running key.

## Follow-ups

- [x] No follow-up issue needed
