### PR TITLE
docs(streaming): correct the decoder choice from Klarity to bytedeco FFmpeg

### DIFF
--- a/docs/design-docs/mcp/observe/screen-streaming.md
+++ b/docs/design-docs/mcp/observe/screen-streaming.md
@@ -78,7 +78,7 @@ The capture mechanism differs significantly between platforms:
 
 | Platform | Capture Location | Frame Format | Decoder Needed |
 |----------|-----------------|--------------|----------------|
-| Android | On device | H.264 encoded | Yes (Klarity) |
+| Android | On device | H.264 encoded | Yes (bytedeco FFmpeg) |
 | iOS | On Mac | Raw BGRA | No |
 
 See platform-specific documentation for implementation details:
@@ -150,15 +150,15 @@ When video streaming is unavailable:
 | Touch input | Plan for it, implement later |
 | Quality auto-adjustment | Automatically lower quality on frame drops |
 | Multiple devices | Single device streaming at a time |
-| Android decoder | Klarity only, no FFmpeg subprocess fallback |
+| Android decoder | `org.bytedeco:ffmpeg` (in-process JNI), host-platform classifier only. Klarity was the original choice but cannot consume a live stream — its API takes file paths only. No FFmpeg *subprocess* fallback. |
 | iOS Swift integration | Swift-to-Node bridge |
 | macOS permissions | User handles permission prompts |
 | macOS entitlements | No special entitlements needed for iOS capture |
 
 ## Related: browser/CI streaming over WebRTC
 
-This document covers **IDE** live mirroring over a Unix socket with a Klarity
-decoder. For pushing a device stream to a **browser** or a **CI dashboard** over
+This document covers **desktop** live mirroring over a Unix socket
+(`video-stream.sock`) with an in-process FFmpeg decoder. For pushing a device stream to a **browser** or a **CI dashboard** over
 standard WebRTC (WHIP ingest → WHEP egress), see
 [WebRTC Screen Streaming (WHIP egress)](./webrtc-streaming.md). Both paths reuse
 the same on-device H.264 capture; only the transport and consumer differ.

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -19,7 +19,7 @@
 
 This is the **browser/CI-facing** streaming path. It is distinct from:
 - the `videoRecording` MCP tool (records a clip to a file), and
-- the IDE live-mirroring path over `video-stream.sock` + Klarity
+- the desktop live-mirroring path over `video-stream.sock` + an in-process FFmpeg decoder
   ([screen-streaming.md](./screen-streaming.md)).
 
 ## Motivation
@@ -262,4 +262,4 @@ both the H.264 and PCMU tracks to WHEP subscribers and exposes `audio` plus
 - [werift-webrtc](https://github.com/shinyoshiaki/werift-webrtc)
 - [CI worker setup guide](../../../webrtc-streaming-ci-worker.md)
 - [Reference coordination server](../../../../examples/webrtc-coordination-server/README.md)
-- [IDE live mirroring (Unix socket + Klarity)](./screen-streaming.md)
+- [Desktop live mirroring (Unix socket + FFmpeg decode)](./screen-streaming.md)

--- a/docs/design-docs/plat/android/screen-streaming.md
+++ b/docs/design-docs/plat/android/screen-streaming.md
@@ -4,7 +4,9 @@
 
 > **Current state:** The Android `video-server` module (`android/video-server/`) is fully implemented — `VideoServer.kt` captures via VirtualDisplay, encodes H.264 with MediaCodec, and streams over a LocalSocket. The `videoRecording` MCP tool (record-to-file) uses this server and is <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>.
 >
-> The **live IDE screen mirroring** pipeline (MCP video-stream relay → IDE DeviceScreenView with Klarity decoder) is in progress. Milestone 1 (video-server JAR) is complete; Milestones 2–5 are ongoing. See implementation plan below.
+> The **live screen mirroring** pipeline (daemon `video-stream.sock` relay → desktop `DeviceScreenView`) is in progress. Milestones 1–3 are complete: the video-server JAR, the daemon relay (#3994), and the desktop decoder and stream client (#4008). Milestone 4 is outstanding — nothing supplies a live frame to the device view yet, so behaviour is unchanged for users. Tracked in #3995.
+>
+> Note the decoder is **bytedeco FFmpeg**, not Klarity as originally designed; see [Video Decoder](#video-decoder-bytedeco-ffmpeg) for why.
 >
 > See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
@@ -71,10 +73,10 @@ The accessibility service can only do on-demand `takeScreenshot()` or request `M
    - Streams binary data to new Unix socket
    - Handles reconnection and device switching
 
-3. **Video Stream Client** (new IDE plugin component)
-   - Klarity library for H.264 decoding (FFmpeg via JNI)
-   - Decodes frames directly to Skia Pixmap
-   - Renders to Compose Canvas (no SwingPanel needed)
+3. **Video Stream Client** (desktop component, `core/video/`)
+   - `org.bytedeco:ffmpeg` for H.264 decoding (FFmpeg via JNI)
+   - Decodes frames to tightly packed BGRA
+   - Copied into a Skia raster image and drawn by Compose (no SwingPanel needed)
 
 ## Protocol Specification
 
@@ -151,11 +153,21 @@ val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, width
 
 USB 2.0: ~30 MB/s theoretical, ~20 MB/s practical - all quality levels supported.
 
-## Video Decoder: Klarity
+## Video Decoder: bytedeco FFmpeg
 
-We chose [Klarity](https://github.com/numq/Klarity) for H.264 decoding in the IDE plugin. It renders directly to Skiko Surface (Compose-native, no SwingPanel), supports composable overlays on video content, and bundles at ~20-30MB per platform.
+We use [`org.bytedeco:ffmpeg`](https://github.com/bytedeco/javacpp-presets/tree/master/ffmpeg) for H.264 decoding on the desktop (`H264Decoder`, issue #3995).
 
-Klarity decodes H.264 via FFmpeg/JNI, interprets frame data directly as Skia Pixmap via pointer (zero-copy), and renders to Compose Canvas.
+Depend on `org.bytedeco:ffmpeg` with the **host platform's classifier**, resolved at build time:
+
+- **not** `ffmpeg-platform`, which pulls every platform's natives (~150–200 MB)
+- **not** `javacv-platform`, which drags in OpenCV
+- **not** the `-gpl` artifact — only the x264/x265 *encoders* require it, and we decode, so the LGPL build is correct
+
+That keeps the installer growth to ~20–30 MB per platform. The decoder reads a raw Annex-B elementary stream from memory (an `AVCodecParserContext` reassembles access units, so callers may feed arbitrary chunk boundaries) and yields tightly packed BGRA that copies straight into a Skia raster image — no AWT/Swing surface involved.
+
+### Why not Klarity
+
+[Klarity](https://github.com/numq/Klarity) was the original choice on the strength of its zero-copy Skia rendering. It cannot be used here: **its API accepts file paths only**, with no way to feed a live stream, which is disqualifying regardless of anything else. Secondarily, it is not published to Maven Central — JitPack builds it, but that artifact is API classes with no native libraries, so the per-platform natives from GitHub releases would still need hand-managing.
 
 ## Implementation Plan
 
@@ -164,19 +176,22 @@ Klarity decodes H.264 via FFmpeg/JNI, interprets frame data directly as Skia Pix
 - [ ] Test manual execution via `adb shell`
 - [ ] Verify H.264 stream output with ffplay
 
-### Milestone 2: MCP Integration
-- [ ] Add video stream socket server to daemon
-- [ ] Implement ADB forward management
-- [ ] Add start/stop video streaming commands
+### Milestone 2: MCP Integration ✅ (#3994)
+- [x] Add video stream socket server to daemon (`video-stream.sock`)
+- [x] Implement ADB forward management (reuses the existing H.264 capture sources)
+- [x] Add start/stop video streaming commands (JSON subscribe handshake, then binary framing)
 
-### Milestone 3: IDE Plugin Decoder
-- [ ] Add Klarity dependency
-- [ ] Implement VideoStreamClient
-- [ ] Create frame-to-ImageBitmap pipeline
-- [ ] Benchmark decode performance
+### Milestone 3: Desktop Decoder ✅ (#4008)
+- [x] Add decoder dependency (`org.bytedeco:ffmpeg`, host-platform classifier)
+- [x] Implement VideoStreamClient
+- [x] Create frame-to-ImageBitmap pipeline (`DecodedFrame.toImageBitmap()`)
+- [ ] Benchmark decode performance — not yet measured against a real device
 
-### Milestone 4: Compose Integration
-- [ ] Update DeviceScreenView for live frames
+### Milestone 4: Compose Integration (#3995)
+- [x] `DeviceScreenView` accepts an optional `liveFrame` that renders instead of the polled screenshot
+- [ ] Supply that frame: `LayoutInspectorDashboard` must construct a client and collect its frames
+- [ ] Choose live vs screenshot at runtime and fall back on `VideoStreamState.Unavailable`
+- [ ] Frame-rate policy — the existing screenshot flow is `replay = 1` with no conflation and will not survive 60fps
 - [ ] Add FPS counter overlay
 - [ ] Implement latency measurement
 - [ ] Add quality/resolution controls
@@ -197,5 +212,6 @@ Klarity decodes H.264 via FFmpeg/JNI, interprets frame data directly as Skia Pix
 - [Android 14 MediaProjection requirements](https://developer.android.com/about/versions/14/changes/fgs-types-required)
 
 ### Video Decoding (Desktop)
-- [Klarity](https://github.com/numq/Klarity) - Compose Desktop video player (chosen solution)
+- [bytedeco javacpp-presets: ffmpeg](https://github.com/bytedeco/javacpp-presets/tree/master/ffmpeg) - chosen solution
+- [Klarity](https://github.com/numq/Klarity) - evaluated and rejected; file-path-only API cannot consume a live stream
 - [JetBrains Skiko](https://github.com/JetBrains/skiko) - Skia bindings for Kotlin

--- a/docs/design-docs/plat/ios/screen-streaming.md
+++ b/docs/design-docs/plat/ios/screen-streaming.md
@@ -24,7 +24,7 @@ Unlike Android (which requires a shell-user JAR running on device), iOS devices 
 | Requires app on device | Yes (video server) | No |
 | Transport | ADB socket → MCP server | Direct macOS API |
 | Encoding | MediaCodec H.264 on device | Already decoded frames from macOS |
-| Decoding | Klarity in IDE plugin | Not needed (raw frames) |
+| Decoding | bytedeco FFmpeg on desktop | Not needed (raw frames) |
 
 ## Physical iOS Devices (USB)
 
@@ -194,7 +194,7 @@ Poll `simctl io screenshot` at target frame rate. Simple but:
 xcrun simctl io booted recordVideo --codec=h264 -
 ```
 
-Pipe to ffmpeg or Klarity for decoding. However:
+Pipe to ffmpeg for decoding. However:
 - `recordVideo` doesn't support stdout piping well
 - Designed for file output, not streaming
 
@@ -250,9 +250,9 @@ Use **ScreenCaptureKit** to capture simulator window:
 3. Raw frames sent to Unix socket
 4. IDE plugin receives frames directly
 
-### Why Not Klarity for iOS?
+### Why No Decoder for iOS?
 
-Klarity is an H.264 decoder. iOS capture provides **raw frames** (CVPixelBuffer/BGRA), not encoded video. We can send these directly to the IDE plugin without encoding/decoding overhead.
+The Android path needs an H.264 decoder because the device encodes on-device. iOS capture provides **raw frames** (CVPixelBuffer/BGRA), not encoded video, so they go straight to the desktop with no encode/decode round trip.
 
 ## Protocol
 
@@ -288,7 +288,7 @@ Followed by `height * bytesPerRow` bytes of BGRA pixel data.
 - [ ] Unix-socket fan-out (shared with Milestone 1 follow-up)
 
 ### Milestone 3: IDE Plugin Integration
-- [ ] Add raw frame receiver (simpler than Klarity H.264 path)
+- [ ] Add raw frame receiver (simpler than the Android H.264 decode path)
 - [ ] Convert BGRA to ImageBitmap for Compose
 - [ ] Unify with Android video stream UI
 


### PR DESCRIPTION
The screen-streaming design docs specify **Klarity** for desktop H.264 decoding. It cannot work here, and leaving that in place is actively misleading — `- [ ] Add Klarity dependency` reads as work waiting to be picked up rather than a dead end.

## Why Klarity can't be used

**Its API accepts file paths only.** There is no way to feed a live stream, which is disqualifying regardless of anything else.

Secondarily (and this is what I chased first, before finding the real blocker): it is not published to Maven Central. JitPack does build it, but that artifact is 542 KB of API classes with **zero native libraries** — the per-platform natives live only in GitHub-release zips and would still need hand-managing.

## What actually shipped

`org.bytedeco:ffmpeg` with the host-platform classifier (#4008). The doc now records *why it is that artifact specifically*, since the naive choices are all wrong in different ways:

- **not** `ffmpeg-platform` — pulls every platform's natives, ~150–200 MB
- **not** `javacv-platform` — drags in OpenCV
- **not** the `-gpl` build — only the x264/x265 *encoders* need it, and we decode, so LGPL is correct

## Status and milestones brought in line

- Milestone 2 (daemon relay) — done, #3994
- Milestone 3 (desktop decoder + stream client) — done, #4008. **Its benchmark task stays unchecked**: decode performance has not been measured against a real device, only a 320×240 generated sample.
- Milestone 4 — `DeviceScreenView` accepts a `liveFrame`, but nothing supplies one yet, so behaviour is unchanged for users. Broken out into the specific remaining steps and pointed at #3995.

## Scope

Four docs, because the stale reference had spread:

| File | Change |
|---|---|
| `plat/android/screen-streaming.md` | Decoder section rewritten, status header, milestones, components list, references |
| `mcp/observe/screen-streaming.md` | Decisions table and the capability matrix row |
| `mcp/observe/webrtc-streaming.md` | Two cross-references to "the Klarity path" |
| `plat/ios/screen-streaming.md` | Comparisons only — its substance is unchanged, since iOS sends raw frames and needs no decoder either way |

The remaining mentions of Klarity are deliberate: a "Why not Klarity" section and an "evaluated and rejected" reference entry, so the next person doesn't re-litigate it.

`mkdocs-nav` validation passes; the new anchor `#video-decoder-bytedeco-ffmpeg` is verified to resolve.