### PR TITLE
feat(desktop): render live device stream

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -145,8 +145,14 @@ import dev.jasonpearson.automobile.desktop.core.timeline.TimelineCategory
 import dev.jasonpearson.automobile.desktop.core.timeline.activeLanes
 import dev.jasonpearson.automobile.desktop.core.timeline.buildTimelineSpans
 import dev.jasonpearson.automobile.desktop.core.timeline.rememberTimelineState
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
+import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -165,6 +171,54 @@ internal fun activeDeviceConnectionLostEvent(
 
 internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String?): Boolean {
   return activeDeviceId != null && deviceId == activeDeviceId
+}
+
+/**
+ * Connects a live-mirroring source for this composition and exposes only its newest decoded frame.
+ *
+ * The source already drops old decoded frames; conflation here also prevents Compose conversion
+ * from accumulating work when the relay runs faster than the UI can draw. A refused or unavailable
+ * relay clears the frame, allowing [DeviceScreenView] to continue rendering screenshot updates.
+ */
+@Composable
+internal fun rememberLiveVideoFrame(
+  source: VideoStreamSource?,
+  deviceId: String?,
+  frameConverter:
+    suspend (
+      dev.jasonpearson.automobile.desktop.core.video.DecodedFrame
+    ) -> androidx.compose.ui.graphics.ImageBitmap =
+    { frame ->
+      withContext(Dispatchers.Default) { frame.toImageBitmap() }
+    },
+): androidx.compose.ui.graphics.ImageBitmap? {
+  var liveFrame by
+    remember(source, deviceId) { mutableStateOf<androidx.compose.ui.graphics.ImageBitmap?>(null) }
+
+  DisposableEffect(source, deviceId) {
+    if (source != null && deviceId != null) source.connect(deviceId)
+    onDispose {
+      liveFrame = null
+      source?.dispose()
+    }
+  }
+
+  LaunchedEffect(source) {
+    source?.frames?.conflate()?.collect { frame ->
+      if (source.state.value is VideoStreamState.Streaming) {
+        val decodedFrame = frameConverter(frame)
+        if (source.state.value is VideoStreamState.Streaming) liveFrame = decodedFrame
+      }
+    }
+  }
+
+  LaunchedEffect(source) {
+    source?.state?.collect { state ->
+      if (state is VideoStreamState.Unavailable) liveFrame = null
+    }
+  }
+
+  return liveFrame
 }
 
 internal interface AutoMobileDeviceStreamEventSink {
@@ -281,6 +335,7 @@ fun AutoMobileContent(
   notificationHandler: NotificationHandler = NoOpNotificationHandler,
   onOpenSource: ((String, Int, String) -> Unit)? = null,
   menuBarActions: MenuBarActions? = null,
+  videoStreamSourceFactory: () -> VideoStreamSource = { VideoStreamClient() },
 ) {
   // When a MenuBarActions bridge is supplied (from Main.kt's MenuBar), delegate
   // pane-visibility and overlay state to it so the native menu items and the
@@ -395,6 +450,15 @@ fun AutoMobileContent(
 
   // Data source mode (Fake/Real) - global toggle for all dashboards
   var dataSourceMode by remember { mutableStateOf(DataSourceMode.Real) }
+  val liveVideoSource =
+    remember(activeDeviceId, dataSourceMode, isLiveLayoutMode) {
+      if (dataSourceMode == DataSourceMode.Real && isLiveLayoutMode && activeDeviceId != null) {
+        videoStreamSourceFactory()
+      } else {
+        null
+      }
+    }
+  val liveVideoFrame = rememberLiveVideoFrame(liveVideoSource, activeDeviceId)
 
   // Pending failure ID for deep linking from notifications
   var pendingFailureId by remember { mutableStateOf<String?>(null) }
@@ -1331,6 +1395,7 @@ fun AutoMobileContent(
           Box(mod.background(colors.text.normal.copy(alpha = 0.02f))) {
             DeviceScreenView(
               screenshotData = layoutInspectorState.screenshotData,
+              liveFrame = liveVideoFrame,
               screenWidth = layoutInspectorState.screenWidth,
               screenHeight = layoutInspectorState.screenHeight,
               rotation = layoutInspectorState.rotation,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -58,6 +58,9 @@ interface VideoStreamSource {
 
   fun disconnect()
 
+  /** Releases any resources owned by this source. It cannot be reused afterwards. */
+  fun dispose()
+
   /** True when the daemon exposes the relay socket; false on daemons that predate it. */
   fun isAvailable(): Boolean
 }
@@ -130,7 +133,7 @@ class VideoStreamClient(
   }
 
   /** Disconnects and cancels the internal scope. The instance must not be reused afterwards. */
-  fun dispose() {
+  override fun dispose() {
     disconnect()
     scope.coroutineContext[Job]?.cancel()
   }
@@ -171,6 +174,9 @@ class VideoStreamClient(
         }
 
         pumpFrames(input, decoder)
+        if (readerJob?.isActive == true) {
+          _state.value = VideoStreamState.Unavailable("Live mirroring stopped")
+        }
       }
     } catch (e: Exception) {
       // Cancellation arrives as an exception on the blocking read; that is a normal disconnect.
@@ -294,6 +300,15 @@ class FakeVideoStreamSource(
   override fun disconnect() {
     connectedDeviceId = null
     _state.value = VideoStreamState.Idle
+  }
+
+  override fun dispose() {
+    disconnect()
+  }
+
+  /** Simulates an unavailable relay after a stream has started. */
+  fun becomeUnavailable(reason: String = "Live mirroring is unavailable on this daemon") {
+    _state.value = VideoStreamState.Unavailable(reason)
   }
 
   /** Publishes a frame to collectors, as the real client would. */

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -1,0 +1,78 @@
+package dev.jasonpearson.automobile.desktop.core
+
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
+import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlinx.coroutines.CompletableDeferred
+
+@OptIn(ExperimentalTestApi::class)
+class LiveVideoStreamTest {
+  @Test
+  fun `connects for the active device and disposes when live layout closes`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    val showLiveLayout = mutableStateOf(true)
+
+    setContent {
+      if (showLiveLayout.value) {
+        rememberLiveVideoFrame(source, "emulator-5554")
+      }
+    }
+
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+    runOnUiThread { showLiveLayout.value = false }
+    waitUntil { source.connectedDeviceId == null }
+  }
+
+  @Test
+  fun `clears the live frame when the relay becomes unavailable`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    var observedFrame: androidx.compose.ui.graphics.ImageBitmap? = null
+
+    setContent {
+      val liveFrame = rememberLiveVideoFrame(source, "emulator-5554")
+      SideEffect { observedFrame = liveFrame }
+    }
+
+    source.emitFrame(width = 1, height = 1)
+    waitUntil { observedFrame != null }
+
+    source.becomeUnavailable()
+    waitUntil { observedFrame == null }
+
+    source.emitFrame(width = 1, height = 1)
+    waitForIdle()
+    assertNull(observedFrame)
+  }
+
+  @Test
+  fun `does not restore a frame decoded after the relay becomes unavailable`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    val decodingStarted = CompletableDeferred<Unit>()
+    val allowDecodingToFinish = CompletableDeferred<Unit>()
+    var observedFrame: androidx.compose.ui.graphics.ImageBitmap? = null
+
+    setContent {
+      val liveFrame =
+        rememberLiveVideoFrame(source, "emulator-5554") { frame ->
+          decodingStarted.complete(Unit)
+          allowDecodingToFinish.await()
+          frame.toImageBitmap()
+        }
+      SideEffect { observedFrame = liveFrame }
+    }
+
+    source.emitFrame(width = 1, height = 1)
+    decodingStarted.await()
+    source.becomeUnavailable()
+    waitUntil { observedFrame == null }
+
+    allowDecodingToFinish.complete(Unit)
+    waitForIdle()
+    assertNull(observedFrame)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
@@ -47,7 +47,8 @@ class VideoStreamClientTest {
     success: Boolean = true,
     error: String? = null,
     payload: ByteArray? = null,
-  ): FakeRelay = FakeRelay(success, error, payload).also { servers.add(it) }
+    keepOpen: Boolean = false,
+  ): FakeRelay = FakeRelay(success, error, payload, keepOpen).also { servers.add(it) }
 
   @Test
   fun `subscribes with the device id and decodes frames`() = runBlocking {
@@ -71,7 +72,7 @@ class VideoStreamClientTest {
   @Test
   fun `reports the decoded size, not the advertised header size`() = runBlocking {
     // The daemon advertises 0x0 unless a hint was sent; the truth is in the SPS.
-    val server = relay(payload = sampleH264())
+    val server = relay(payload = sampleH264(), keepOpen = true)
     val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
 
     client.connect(null)
@@ -152,6 +153,21 @@ class VideoStreamClientTest {
     client.dispose()
   }
 
+  @Test
+  fun `an orderly relay close reports the stream as unavailable`() = runBlocking {
+    val server = relay()
+    val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
+
+    client.connect("emulator-5554")
+
+    waitUntil { client.state.value is VideoStreamState.Unavailable }
+    assertEquals(
+      "Live mirroring stopped",
+      (client.state.value as VideoStreamState.Unavailable).reason,
+    )
+    client.dispose()
+  }
+
   private suspend fun waitUntil(timeoutMs: Long = 5_000, predicate: () -> Boolean) {
     val deadline = System.currentTimeMillis() + timeoutMs
     while (System.currentTimeMillis() < deadline) {
@@ -176,6 +192,7 @@ class VideoStreamClientTest {
     private val success: Boolean,
     private val error: String?,
     private val payload: ByteArray?,
+    private val keepOpen: Boolean,
   ) : AutoCloseable {
     private val tempDir: Path = Files.createTempDirectory(Path.of("/tmp"), "amvsc-")
     val socketPath: Path = tempDir.resolve("video-stream.sock")
@@ -207,6 +224,9 @@ class VideoStreamClientTest {
 
           if (success && payload != null) {
             writeStream(out, payload)
+          }
+          while (keepOpen && !Thread.currentThread().isInterrupted) {
+            Thread.sleep(1000)
           }
         }
       } catch (_: Throwable) {


### PR DESCRIPTION
Closes #3995.

## Summary

- wires the existing `VideoStreamClient` into the live Layout Inspector view for real active devices
- keeps only the newest decoded frame and falls back to pushed screenshots when the relay is unavailable
- disposes the client when live layout closes or the selected device changes

## Validation

- `./gradlew :desktop-core:test :desktop-core:detekt`
- `bun run turbo:validate`
- `bun run typecheck`

## Scope note

`LayoutInspectorDashboard` is currently unused; the visible Layout Inspector is rendered directly by `AutoMobileContent`, so the wiring belongs there.
