### PR TITLE
fix(desktop): resolve detekt UnreachableCode in DaemonNotificationClient

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
@@ -219,16 +219,9 @@ class DaemonNotificationClient(
       val line = reader.readLine() ?: return
       if (line.isBlank()) continue
 
-      val frame =
-        try {
-          json.decodeFromString(DaemonFrame.serializer(), line)
-        } catch (e: Exception) {
-          // A frame this client does not model is not a reason to drop the subscription.
-          LOG.debug("Ignoring unparseable daemon frame: ${e.message}")
-          continue
-        }
-
+      val frame = decodeFrame(line) ?: continue
       if (frame.type != "daemon_notification") continue
+
       val kind = ListChangedKind.forMethod(frame.method)
       if (kind == null) {
         LOG.debug("Ignoring unknown daemon notification: ${frame.method}")
@@ -237,6 +230,22 @@ class DaemonNotificationClient(
       _notifications.tryEmit(kind)
     }
   }
+
+  /**
+   * Decodes one frame, or null when it is not something this client models.
+   *
+   * Kept as a function rather than an inline `try` expression: a `continue` inside a catch used in
+   * expression position makes the whole remainder of the loop body read as unreachable to
+   * control-flow analysis.
+   */
+  private fun decodeFrame(line: String): DaemonFrame? =
+    try {
+      json.decodeFromString(DaemonFrame.serializer(), line)
+    } catch (e: Exception) {
+      // An unmodelled frame is not a reason to drop the subscription.
+      LOG.debug("Ignoring unparseable daemon frame: ${e.message}")
+      null
+    }
 
   private fun closeChannel() {
     try {


### PR DESCRIPTION
**Main is currently red.** #4016 introduced 8 `UnreachableCode` violations that fail `:desktop-core:detektMain`, which fails Fast Validation on every subsequent PR — I found it because it blocked an unrelated docs-only PR (#4020).

## Cause

A `continue` inside a catch used in **expression position**:

```kotlin
val frame =
  try {
    json.decodeFromString(DaemonFrame.serializer(), line)
  } catch (e: Exception) {
    LOG.debug("…")
    continue          // ← makes the rest of the loop body read as unreachable
  }
```

Control-flow analysis treats everything after that assignment as unreachable, hence 8 findings across lines 222–237.

This is an **analysis artifact, not a runtime fault** — the notification tests pass and prove the code executes. But it fails the build, and honestly the loop reads better without the inline try.

## Fix

Extract the decode into a function returning null, and use `?: continue`:

```kotlin
val frame = decodeFrame(line) ?: continue
```

Behaviour is unchanged: an unparseable frame is still logged at debug and skipped without dropping the subscription. The new function carries a comment explaining why it isn't inlined, so it doesn't get "simplified" back.

## Verification

- `detektMain` + `detektTest` pass across **all** android modules, not just `desktop-core` — I ran the full CI command rather than only the failing task, since a partial fix would leave main red.
- 11 `DaemonNotificationClientTest` tests still pass; full desktop-core suite green.
- ktfmt verified via the `ONLY_CHANGED_SINCE_SHA` mode CI uses.

## Note

Detekt appears to be new to this repo (it wasn't running when this epic's earlier PRs landed). Worth knowing that it now gates Fast Validation, since a violation on main blocks unrelated work — which is exactly what happened here.