### PR TITLE
chore(desktop): share daemon JSON configuration

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClient.kt
@@ -82,12 +82,7 @@ interface AppearanceClient {
 /** Client for `~/.auto-mobile/appearance.sock`. One request per connection. */
 class AppearanceSocketClient(
   private val socketPathValue: String = AutoMobileSocketPaths.socketPath(APPEARANCE_SOCKET_FILE),
-  private val json: Json = Json {
-    ignoreUnknownKeys = true
-    explicitNulls = false
-    // `type` and `command` are defaults on the request class but required on the wire.
-    encodeDefaults = true
-  },
+  private val json: Json = DaemonJson,
 ) : AppearanceClient {
 
   override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -281,7 +282,7 @@ data class FeatureFlagState(
 
 @Serializable
 data class JsonRpcRequest(
-  val jsonrpc: String = "2.0",
+  @EncodeDefault(EncodeDefault.Mode.NEVER) val jsonrpc: String = "2.0",
   val id: JsonElement? = null,
   val method: String,
   val params: JsonElement? = null,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonJson.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonJson.kt
@@ -1,0 +1,10 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlinx.serialization.json.Json
+
+/** Canonical wire JSON configuration for clients that communicate with the AutoMobile daemon. */
+internal val DaemonJson = Json {
+  ignoreUnknownKeys = true
+  encodeDefaults = true
+  explicitNulls = false
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
@@ -93,12 +93,7 @@ interface DaemonNotificationSource {
  */
 class DaemonNotificationClient(
   private val socketPathValue: String = DaemonSocketPaths.socketPath(),
-  private val json: Json = Json {
-    ignoreUnknownKeys = true
-    // `type` is a default on the request class but the daemon routes on it; without this the
-    // subscribe goes out untyped.
-    encodeDefaults = true
-  },
+  private val json: Json = DaemonJson,
   private val initialBackoffMs: Long = 1_000,
   private val maxBackoffMs: Long = 30_000,
 ) : DaemonNotificationSource {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
@@ -1,7 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -10,7 +9,7 @@ import kotlinx.serialization.json.put
 /** MCP resource listing every captured snapshot. */
 internal const val DEVICE_SNAPSHOT_ARCHIVE_URI = "automobile:deviceSnapshots/archive"
 
-private val snapshotJson = Json { ignoreUnknownKeys = true }
+private val snapshotJson = DaemonJson
 
 /** Metadata for one captured snapshot, as listed by the archive resource. */
 @Serializable

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
@@ -85,13 +85,7 @@ interface DeviceSnapshotConfigClient {
 class DeviceSnapshotSocketClient(
   private val socketPathValue: String =
     AutoMobileSocketPaths.socketPath(DEVICE_SNAPSHOT_SOCKET_FILE),
-  private val json: Json = Json {
-    ignoreUnknownKeys = true
-    explicitNulls = false
-    // The daemon requires `type` and `method` on every request; kotlinx omits properties left at
-    // their default, so without this the envelope would go out incomplete.
-    encodeDefaults = true
-  },
+  private val json: Json = DaemonJson,
 ) : DeviceSnapshotConfigClient {
 
   override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
@@ -30,7 +30,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 
 /**
  * Client for the failures push Unix socket server. Subscribes to receive real-time failure
@@ -44,7 +43,7 @@ class FailuresPushSocketClient {
   }
 
   private val log = LoggerFactory.getLogger(FailuresPushSocketClient::class.java)
-  private val json = Json { ignoreUnknownKeys = true }
+  private val json = DaemonJson
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
   private var channel: SocketChannel? = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresStreamSocketClient.kt
@@ -352,11 +352,7 @@ data class FailureOccurrenceDto(
 /** Socket client for failures streaming */
 class FailuresStreamSocketClient(
   private val socketPathValue: String = FailuresStreamSocketPaths.socketPath(),
-  private val json: Json = Json {
-    ignoreUnknownKeys = true
-    explicitNulls = false
-    encodeDefaults = true // Required to include command field with default value
-  },
+  private val json: Json = DaemonJson,
 ) : FailuresStreamClient {
 
   override fun pollNotifications(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -25,7 +25,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 
 class McpDaemonClient(
   private val socketPathValue: String = DaemonSocketPaths.socketPath(),
-  private val json: Json = Json { ignoreUnknownKeys = true },
+  private val json: Json = DaemonJson,
 ) : AutoMobileClient {
   val socketPath: String
     get() = socketPathValue

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.json.put
 
 class McpHttpClient(
   private val endpoint: String,
-  private val json: Json = Json { ignoreUnknownKeys = true },
+  private val json: Json = DaemonJson,
   private val retryPolicy: RetryPolicy = RetryPolicy(),
 ) : AutoMobileClient {
   override val transportName: String = "MCP HTTP"

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.json.put
 
 class McpStdioClient(
   private val command: String,
-  private val json: Json = Json { ignoreUnknownKeys = true },
+  private val json: Json = DaemonJson,
 ) : AutoMobileClient {
   override val transportName: String = "MCP STDIO"
   override val connectionDescription: String = command

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -49,7 +48,7 @@ class ObservationStreamClient {
   }
 
   private val log = LoggerFactory.getLogger(ObservationStreamClient::class.java)
-  private val json = Json { ignoreUnknownKeys = true }
+  private val json = DaemonJson
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
   private var channel: SocketChannel? = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 
 /**
  * Client for the telemetry push Unix socket server. Subscribes to receive real-time telemetry
@@ -48,7 +47,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
   }
 
   private val log = LoggerFactory.getLogger(TelemetryPushSocketClient::class.java)
-  private val json = Json { ignoreUnknownKeys = true }
+  private val json = DaemonJson
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
   private var channel: SocketChannel? = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestRecordingSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TestRecordingSocketClient.kt
@@ -26,10 +26,7 @@ interface TestRecordingClient {
 
 class TestRecordingSocketClient(
   private val socketPathValue: String = TestRecordingSocketPaths.socketPath(),
-  private val json: Json = Json {
-    ignoreUnknownKeys = true
-    explicitNulls = false
-  },
+  private val json: Json = DaemonJson,
 ) : TestRecordingClient {
   override fun startTestRecording(platform: String?): TestRecordingStartResult {
     val response = sendRequest(TestRecordingSocketCommand(command = "start", platform = platform))

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingActions.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingActions.kt
@@ -1,13 +1,12 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
-private val recordingJson = Json { ignoreUnknownKeys = true }
+private val recordingJson = DaemonJson
 
 /**
  * One recorded artifact.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingSocketClient.kt
@@ -73,11 +73,7 @@ interface VideoRecordingConfigClient {
 class VideoRecordingSocketClient(
   private val socketPathValue: String =
     AutoMobileSocketPaths.socketPath(VIDEO_RECORDING_SOCKET_FILE),
-  private val json: Json = Json {
-    ignoreUnknownKeys = true
-    explicitNulls = false
-    encodeDefaults = true
-  },
+  private val json: Json = DaemonJson,
 ) : VideoRecordingConfigClient {
 
   override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
@@ -78,11 +78,7 @@ interface WebRtcStreamClient {
 /** Client for `~/.auto-mobile/webrtc-stream.sock`. One request per connection. */
 class WebRtcStreamSocketClient(
   private val socketPathValue: String = AutoMobileSocketPaths.socketPath(WEBRTC_STREAM_SOCKET_FILE),
-  private val json: Json = Json {
-    ignoreUnknownKeys = true
-    explicitNulls = false
-    encodeDefaults = true
-  },
+  private val json: Json = DaemonJson,
 ) : WebRtcStreamClient {
 
   override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonJsonTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonJsonTest.kt
@@ -1,0 +1,74 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+class DaemonJsonTest {
+  @Test
+  fun `encodes defaulted wire constants and omits optional nulls`() {
+    val encoded = DaemonJson.encodeToString(DefaultedWireRequest(id = "request-1"))
+
+    assertTrue(encoded.contains("\"type\":\"device_snapshot_request\""), encoded)
+    assertFalse(encoded.contains("optional"), encoded)
+  }
+
+  @Test
+  fun `preserves the existing JSON-RPC request payload`() {
+    val encoded = DaemonJson.encodeToString(JsonRpcRequest(method = "tools/list"))
+
+    assertFalse(encoded.contains("jsonrpc"), encoded)
+    assertFalse(encoded.contains("id"), encoded)
+    assertFalse(encoded.contains("params"), encoded)
+  }
+
+  @Test
+  fun `uses the shared daemon wire configuration`() {
+    assertTrue(DaemonJson.configuration.ignoreUnknownKeys)
+    assertTrue(DaemonJson.configuration.encodeDefaults)
+    assertFalse(DaemonJson.configuration.explicitNulls)
+  }
+
+  @Test
+  fun `production daemon sources do not create ad hoc Json instances`() {
+    val sourceDirectory = locateDaemonSourceDirectory()
+    val factories =
+      sourceDirectory
+        .walkTopDown()
+        .filter { it.isFile && it.extension == "kt" }
+        .flatMap { source ->
+          Regex("\\bJson\\s*(?:\\{|\\(|\\.Default\\b)").findAll(source.readText()).map {
+            source.name
+          }
+        }
+        .toList()
+
+    assertEquals(
+      listOf("DaemonJson.kt"),
+      factories,
+      "Daemon clients must use DaemonJson rather than construct Json directly (issue #4018).",
+    )
+  }
+
+  private fun locateDaemonSourceDirectory(): File {
+    val relative = "src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon"
+    return sequenceOf(
+        File(relative),
+        File("desktop-core/$relative"),
+        File("android/desktop-core/$relative"),
+      )
+      .firstOrNull { it.isDirectory }
+      ?: error("Could not locate daemon sources from user.dir=${System.getProperty("user.dir")}")
+  }
+}
+
+@Serializable
+private data class DefaultedWireRequest(
+  val id: String,
+  val type: String = "device_snapshot_request",
+  val optional: String? = null,
+)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -6,12 +6,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 
 class ObservationStreamClientTest {
-  // Mirrors the Json config used by ObservationStreamClient.sendRequest so the serialized subscribe
-  // payload asserted here matches what is written to the socket.
-  private val wireJson = Json { ignoreUnknownKeys = true }
+  // Uses the same configuration as ObservationStreamClient so these assertions match the socket.
+  private val wireJson = DaemonJson
 
   @Test
   fun `subscribe request carries requested cadence when provided`() {


### PR DESCRIPTION
## Summary

Centralizes daemon-client JSON serialization in `DaemonJson` so required defaulted wire fields are always emitted while optional nulls remain omitted. Migrates every daemon client and action helper to that shared configuration, preventing future ad-hoc configurations from reintroducing the omission.

## Linked Issue

Closes #4018

## Bug / Regression Context

- **Prior attempts:** Four separate clients previously needed one-off `encodeDefaults` fixes.
- **Observed symptom:** A required defaulted wire field could be omitted by kotlinx serialization, causing the daemon to reject or misroute a request.
- **Repro steps / conditions:** Serialize a request with a defaulted required constant using a plain `Json { ignoreUnknownKeys = true }`; the constant is absent from the payload.

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `./gradlew :desktop-core:test`
- [x] Added focused serialization and source-guard tests; no new interfaces, fakes, timers, or dependencies.
- [x] Rebased onto latest `main`, conflicts resolved.

## Kotlin Reuse Check

- [x] Reused kotlinx.serialization's existing `Json` configuration instead of adding a helper library or dependency.

## Device Verification

Not applicable: this changes desktop daemon wire serialization and is covered by unit tests.

## Follow-ups

None.
