### PR TITLE
feat(playground): add custom VoiceOver rotor demo and initial-tab hook

### DIFF
--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C437D38FD2B064F815AE6F33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */; };
 		E46744897A309BECE20573D9 /* AutoMobileSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5B1F96DAE2D3DE50DD89C21C /* AutoMobileSDK */; };
 		EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF86B8E1368C9B39424F13C0 /* DiscoverTab.swift */; };
+		F99EE983EC6317D09E5A3247 /* AccessibilityRotorDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61225B3155981050B6A59A6 /* AccessibilityRotorDemo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Assets.xcassets; path = Sources/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		CBBA4475C2A7A68AE3987086 /* PlaygroundTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PlaygroundTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D01BCE22E951887741F32904 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D61225B3155981050B6A59A6 /* AccessibilityRotorDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityRotorDemo.swift; sourceTree = "<group>"; };
 		E40DD68F934F5F0D2981ACA1 /* Playground.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Playground.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF86B8E1368C9B39424F13C0 /* DiscoverTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverTab.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -138,6 +140,7 @@
 		EAF2D62F55B68E2361617BFC /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
+				D61225B3155981050B6A59A6 /* AccessibilityRotorDemo.swift */,
 				25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */,
 				FF86B8E1368C9B39424F13C0 /* DiscoverTab.swift */,
 				64FD18EC8D1B9A665615C374 /* SettingsTab.swift */,
@@ -244,6 +247,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F99EE983EC6317D09E5A3247 /* AccessibilityRotorDemo.swift in Sources */,
 				97CA6F2DE628A139094EF72D /* Colors.swift in Sources */,
 				5339DAC5909A688059ABBA80 /* ContentView.swift in Sources */,
 				15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */,

--- a/ios/Playground/Sources/ContentView.swift
+++ b/ios/Playground/Sources/ContentView.swift
@@ -8,7 +8,20 @@ enum Tab: Hashable {
 }
 
 struct ContentView: View {
-    @State private var selectedTab: Tab = .discover
+    /// Lets automation launch straight into a tab, e.g.
+    /// `SIMCTL_CHILD_PLAYGROUND_INITIAL_TAB=demos xcrun simctl launch …`.
+    /// The tab bar is not reachable through the macOS accessibility bridge
+    /// (`UITabBar` bridges as an opaque group with no pressable children), so
+    /// without this a probe cannot get off the first tab.
+    private static var initialTab: Tab {
+        switch ProcessInfo.processInfo.environment["PLAYGROUND_INITIAL_TAB"] {
+        case "demos": return .demos
+        case "settings": return .settings
+        default: return .discover
+        }
+    }
+
+    @State private var selectedTab: Tab = ContentView.initialTab
     @Environment(\.autoMobileTheme) private var theme
 
     var body: some View {

--- a/ios/Playground/Sources/Tabs/AccessibilityRotorDemo.swift
+++ b/ios/Playground/Sources/Tabs/AccessibilityRotorDemo.swift
@@ -1,0 +1,130 @@
+import AutoMobileSDK
+import SwiftUI
+
+// MARK: - Accessibility Rotor Demo
+
+/// Exercises SwiftUI custom VoiceOver rotors (`accessibilityRotor`).
+///
+/// Two rotors are declared over the same list so a consumer can distinguish
+/// them by name: "Flagged Items" selects a sparse subset, "Landmarks" selects
+/// the section anchors. Deliberately distinctive names — this screen doubles as
+/// the fixture for probing whether custom rotors bridge out of the Simulator
+/// through the macOS accessibility API (`AXCustomRotors`), where the rotor name
+/// is the only way to tell a populated rotor from an empty one.
+///
+/// The view is split into small sub-expressions on purpose: inlining the list
+/// and both rotor modifiers into a single `body` exceeds the type checker's
+/// budget and fails to compile.
+struct AccessibilityRotorDemo: View {
+    struct Item: Identifiable {
+        let id: Int
+        let title: String
+        let isFlagged: Bool
+        let isLandmark: Bool
+    }
+
+    private static let instructions =
+        "Turn on VoiceOver and rotate two fingers to switch between the "
+            + "\"Flagged Items\" and \"Landmarks\" rotors, then flick up or down "
+            + "to move between entries."
+
+    private let items: [Item]
+    private let flagged: [Item]
+    private let landmarks: [Item]
+
+    @Namespace private var rotorNamespace
+    @Environment(\.autoMobileTheme) private var theme
+
+    init() {
+        let items: [Item] = (1 ... 24).map { index in
+            Item(
+                id: index,
+                title: "Row \(index)",
+                isFlagged: index.isMultiple(of: 5),
+                isLandmark: index % 8 == 1
+            )
+        }
+        self.items = items
+        flagged = items.filter(\.isFlagged)
+        landmarks = items.filter(\.isLandmark)
+    }
+
+    var body: some View {
+        list
+            .accessibilityRotor("Flagged Items") { rotorEntries(for: flagged) }
+            .accessibilityRotor("Landmarks") { rotorEntries(for: landmarks) }
+            .navigationTitle("Custom Rotors")
+            .navigationBarTitleDisplayMode(.inline)
+            .trackNavigation(destination: "AccessibilityRotorDemo")
+    }
+
+    private var list: some View {
+        List {
+            Section {
+                Text(Self.instructions)
+                    .font(.callout)
+                    .foregroundStyle(theme.textSecondary)
+            }
+
+            Section("Entries") {
+                ForEach(items) { item in
+                    row(for: item)
+                        .accessibilityRotorEntry(id: item.id, in: rotorNamespace)
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(theme.background)
+    }
+
+    @AccessibilityRotorContentBuilder
+    private func rotorEntries(for subset: [Item]) -> some AccessibilityRotorContent {
+        // The String-label overload takes an UNLABELED id; only the Text and
+        // LocalizedStringKey overloads spell it `id:`.
+        ForEach(subset) { item in
+            AccessibilityRotorEntry(item.title, item.id, in: rotorNamespace)
+        }
+    }
+
+    private func row(for item: Item) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: item.isFlagged ? "flag.fill" : "circle")
+                .foregroundStyle(item.isFlagged ? Color.autoMobileWarning : theme.textSecondary)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.headline)
+                    .foregroundStyle(theme.textPrimary)
+
+                if item.isLandmark {
+                    Text("Landmark")
+                        .font(.caption)
+                        .foregroundStyle(theme.textSecondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label(for: item))
+    }
+
+    private func label(for item: Item) -> String {
+        var parts = [item.title]
+        if item.isFlagged {
+            parts.append("Flagged")
+        }
+        if item.isLandmark {
+            parts.append("Landmark")
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AccessibilityRotorDemo()
+    }
+    .autoMobileTheme()
+}

--- a/ios/Playground/Sources/Tabs/DemosTab.swift
+++ b/ios/Playground/Sources/Tabs/DemosTab.swift
@@ -113,6 +113,16 @@ struct DemosTab: View {
                             icon: "accessibility.fill"
                         )
                     }
+
+                    NavigationLink {
+                        AccessibilityRotorDemo()
+                    } label: {
+                        DemoRow(
+                            title: "Custom Rotors",
+                            description: "VoiceOver rotor navigation",
+                            icon: "dial.medium.fill"
+                        )
+                    }
                 }
 
                 Section("View Hierarchy") {


### PR DESCRIPTION
## Summary

Adds a **Demos > Custom Rotors** screen to Playground declaring two SwiftUI custom rotors ("Flagged Items" and "Landmarks") over one list, plus a `PLAYGROUND_INITIAL_TAB` environment hook on `ContentView`.

Both came out of the #3934 / #3935 feasibility spike and are kept because they are needed for future work, not just for that investigation.

## Why the rotor screen

It is the fixture that answered the open question on #3934. With it, custom rotors were confirmed to bridge out of the Simulator through the macOS accessibility API with readable names:

```
ELEMENT AXStaticText 'Row 1, Landmark'
  rotor count = 2
   [0] {AXRotorLabel = Landmarks;       AXRotorType = 0;}
   [1] {AXRotorLabel = "Flagged Items"; AXRotorType = 0;}
```

No app in the tree previously declared a `UIAccessibilityCustomRotor`, so there was nothing to probe against and the question could not be settled. If rotor discovery is built, this screen is the only way to regression-test it.

## Why the initial-tab hook

`UITabBar` bridges to the macOS accessibility API as an **opaque group with no pressable children**, so an out-of-process accessibility client cannot move off the first tab. The hook lets automation launch directly into a tab:

```bash
SIMCTL_CHILD_PLAYGROUND_INITIAL_TAB=demos xcrun simctl launch <udid> dev.jasonpearson.automobile.Playground
```

Defaults to `.discover`, so behaviour is unchanged when the variable is absent. This is a limitation of the bridge rather than something that will be fixed upstream, so the hook has ongoing value.

## Two non-obvious constraints, commented inline

Both cost real time to diagnose and are easy to reintroduce:

- **Type-checker budget.** Inlining the list and both `accessibilityRotor` modifiers into a single `body` fails to compile with "the compiler is unable to type-check this expression in reasonable time". The view is split into `list` / `rotorEntries(for:)` with the subsets precomputed in `init`, which otherwise reads as gratuitous decomposition.
- **Asymmetric `AccessibilityRotorEntry` API.** The `String`-label overload takes an **unlabeled** id (`_ id: ID`); only the `Text` and `LocalizedStringKey` overloads spell it `id:`. Using `id:` with a `String` fails with the unhelpful "no exact matches in call to initializer".

## Testing

- `xcodebuild build -scheme Playground` against iPhone 17 Pro / iOS 26.2 (Xcode 26.3) — clean.
- `swiftlint` and `swiftformat --lint` — clean on both changed files. (`DemosTab.swift` retains pre-existing `identifier_name` / `legacy_multiple` warnings that this PR does not touch.)
- Installed and driven on the simulator: launched into the Demos tab via the env hook, navigated to Custom Rotors, and both rotors read back with the expected names.
- `project.pbxproj` regenerated with the pinned XcodeGen via `scripts/ios/xcodegen-generate.sh`.

## Notes

No production code paths change — this is Playground-only. `ContentView` reads one environment variable at init and otherwise behaves exactly as before.

Refs #3934, #2266
