### PR TITLE
docs: start ship issue from fresh worktree

### DIFF
--- a/commands/ship-issue.md
+++ b/commands/ship-issue.md
@@ -8,7 +8,32 @@ Use this command when the user wants to implement a GitHub issue in the AutoMobi
 
 Parse the first user-provided argument as the GitHub issue number. If no issue number is provided, ask for one before doing any work.
 
-Keep all work in the current isolated worktree. Do not modify the central clone at `~/kaeawc/auto-mobile`.
+Before reading the issue or changing files, always create a fresh worktree from
+the latest `main`. Never reuse the caller's current worktree, even when it is
+clean. Do not commit, push, reset, or otherwise modify files in the central
+clone at `~/kaeawc/auto-mobile`.
+
+From the repository root, fetch the current remote main branch, then create a
+unique sibling worktree and branch based directly on `origin/main`. Use a
+timestamp or another collision-free suffix in both names, then change into the
+new worktree for every remaining phase. For example:
+
+```bash
+issue_number=<issue-number>
+stamp=$(date +%Y%m%d%H%M%S)
+repo_root=$(git rev-parse --show-toplevel)
+worktree_parent=$(dirname "$repo_root")
+worktree_path="$worktree_parent/auto-mobile-issue-${issue_number}-${stamp}"
+branch="work/issue-${issue_number}-${stamp}"
+git -C "$repo_root" fetch origin main
+git -C "$repo_root" worktree add -b "$branch" "$worktree_path" origin/main
+cd "$worktree_path"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+```
+
+If a generated path or branch already exists, choose a new unique suffix and
+repeat the creation step. Treat a failed freshness check as a blocker: do not
+continue in another worktree.
 
 ## Phase 1: Issue Intake
 

--- a/skills/ship-issue/SKILL.md
+++ b/skills/ship-issue/SKILL.md
@@ -5,41 +5,49 @@ description: "Drive one GitHub issue to a merged PR via TDD, with a plan-approva
 
 # Ship Issue
 
-Take a single GitHub issue from reading to a merged PR. All work stays in the
-current isolated git worktree — never commit, push, or reset the central clone.
+Take a single GitHub issue from reading to a merged PR. Every invocation starts
+by creating a new isolated worktree from the freshly fetched `origin/main`;
+never reuse the caller's worktree or commit, push, or reset the central clone.
 Two phases are hard STOP gates; do not cross them without the stated condition.
 
 ## Workflow
 
-0. **Understand** — `gh issue view <n> --comments`; read the body, all comments,
+0. **Fresh worktree** — after obtaining the issue number, locate the repository
+   root, run `git fetch origin main`, and create a uniquely named branch and
+   sibling worktree from `origin/main` (for example, `work/issue-<n>-<timestamp>`
+   and `../auto-mobile-issue-<n>-<timestamp>`). Change into that new worktree
+   before reading the issue or changing files. Confirm `HEAD` equals
+   `origin/main` at creation. Do not use an existing branch or worktree, even if
+   it appears clean.
+1. **Understand** — `gh issue view <n> --comments`; read the body, all comments,
    and linked issues/PRs. Extract acceptance criteria verbatim (mark inferred
    ones). Note prior work so you reuse repo helpers.
-1. **Plan — STOP GATE.** Map each acceptance criterion → change → the test that
+2. **Plan — STOP GATE.** Map each acceptance criterion → change → the test that
    pins it. State the risk class. Present the plan + criteria and wait for user
    approval before writing any code.
-2. **TDD (red).** Write tests encoding the approved criteria, run them, and
+3. **TDD (red).** Write tests encoding the approved criteria, run them, and
    confirm they fail for the right reason. Honor repo test rules (interface +
    fake + FakeTimer, <100ms units, never resolve the real file-backed
    `getDatabase()`).
-3. **Implement (green).** Minimum change to pass the tests and realize the plan;
+4. **Implement (green).** Minimum change to pass the tests and realize the plan;
    no scope creep — extras become follow-ups.
-4. **Pre-PR validation — STOP GATE.** Before any PR: `bun run turbo:validate`
+5. **Pre-PR validation — STOP GATE.** Before any PR: `bun run turbo:validate`
    (local Turbo lint/build/test whole suite, for regressions), `bun run typecheck` (new-error gate; run
    `typecheck:update` if you fixed errors), `validate` for touched
    shell/Swift/Docker/schema surfaces, and re-confirm every criterion test is
    green. Never open a PR on red.
-5. **PR.** Verify isolation with `git diff --name-only main...HEAD` (intended paths
+6. **PR.** Verify isolation with `git diff --name-only origin/main...HEAD` (intended paths
    only). Create the PR with the repo template if present, linking `Closes #<n>`.
    Do not enable auto-merge yet.
-6. **Review (triage).** Run `auto-mobile-code-review`; spawn three review lenses
+7. **Review (triage).** Run `auto-mobile-code-review`; spawn three review lenses
    (regression, test adequacy, API/interface contract) given the diff + criteria;
    read all PR/inline comments and failing CI (`check-ci`). Triage each finding —
    fix confirmed, reject artifacts with a reason, defer out-of-scope. Never blanket
    "address all"; never grow scope to satisfy a suggestion.
-7. **Merge (conditional).** Push all review edits first; only then, on green CI,
+8. **Merge (conditional).** Push all review edits first; only then, on green CI,
    touch auto-merge. Auto-merge only low-risk changes; for DB/migration/runner/
    schema surfaces, STOP and hand the merge decision to the user.
-8. **Follow-ups (conservative).** Search existing open issues before filing; one
+9. **Follow-ups (conservative).** Search existing open issues before filing; one
    issue per discrete unit, linked back to the PR and issue, enough context to act
    cold. Prefer grouping over near-duplicates. End with a status summary.
 


### PR DESCRIPTION
## Summary

- Require every `/ship-issue` invocation to fetch `origin/main` and create a new isolated worktree and branch before beginning issue work.
- Document the collision-safe worktree setup and freshness check in the command instructions.

## Why

Issue delivery should never inherit stale commits or local changes from a prior worktree.

## Validation

- `git diff --check`
