### PR TITLE
test(ios): guard GesturePerformer availability wiring

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		5DF6CF60A8796BBB8C80341C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0CDD96577EB9823B5FCF2585 /* Assets.xcassets */; };
 		5E092D55BDB7194E55190B26 /* MultiFingerSwipeDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB532F74A3F3A670BD526CC /* MultiFingerSwipeDiagnostics.swift */; };
 		5FDF9AE29841625DD7EFB7EC /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
+		671E243A2BD5CAF78FF48E1D /* GesturePerformerSymbolsUnavailableWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAAB1439B71724CA0BF2401 /* GesturePerformerSymbolsUnavailableWiringTests.swift */; };
 		6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */; };
 		6798190F766D01F963F6DFD0 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
 		714A3E41ACE47ACF314E0FC2 /* ClipboardResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D131E590A0CF8F9674B0E /* ClipboardResolutionTests.swift */; };
@@ -219,6 +220,7 @@
 		B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetrics.swift; sourceTree = "<group>"; };
 		B4CB9272A186932D89EB1072 /* WebSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServer.swift; sourceTree = "<group>"; };
 		B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocatorTests.swift; sourceTree = "<group>"; };
+		CCAAB1439B71724CA0BF2401 /* GesturePerformerSymbolsUnavailableWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturePerformerSymbolsUnavailableWiringTests.swift; sourceTree = "<group>"; };
 		D219492B8663B05AFF608428 /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
 		D81453AD074F2A392251CFC3 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		DBA97A6C3A1240A055D9876C /* OSLogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogReader.swift; sourceTree = "<group>"; };
@@ -288,6 +290,7 @@
 				8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */,
 				B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */,
 				76DC5538569B4FCF89EA7547 /* ErrorResponseTypeTests.swift */,
+				CCAAB1439B71724CA0BF2401 /* GesturePerformerSymbolsUnavailableWiringTests.swift */,
 				3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */,
 				0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */,
 				184CFC1280E0802EBF53965F /* ModelsTests.swift */,
@@ -628,6 +631,7 @@
 				9EFF1197D83979B0FC0E0BCE /* CommandPayloadTests.swift in Sources */,
 				E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */,
 				FBAA2ADC92863B6A10403BA1 /* ErrorResponseTypeTests.swift in Sources */,
+				671E243A2BD5CAF78FF48E1D /* GesturePerformerSymbolsUnavailableWiringTests.swift in Sources */,
 				4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */,
 				CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */,
 				F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */,

--- a/ios/control-proxy/Tests/CtrlProxyTests/GesturePerformerSymbolsUnavailableWiringTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/GesturePerformerSymbolsUnavailableWiringTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import XCTest
+
+@testable import CtrlProxy
+
+/// The bridge-driven gesture paths compile only for iOS, so a macOS test host
+/// cannot execute them. Keep this source guard close to the extracted pure
+/// tests so the availability signal cannot be silently disconnected. See #3985.
+final class GesturePerformerSymbolsUnavailableWiringTests: XCTestCase {
+    func testPinchRoutesBridgeAvailabilitySignalToFallback() throws {
+        let pinch = try gesturePerformerFunction(named: "pinch(")
+
+        let bridgeArgument = try XCTUnwrap(pinch.range(of: "&symbolsUnavailable"))
+        let availabilityGuard = try XCTUnwrap(pinch.range(of: "guard symbolsUnavailable.boolValue else"))
+        let fallback = try XCTUnwrap(pinch.range(of: "PinchFallback.parameters("))
+
+        XCTAssertLessThan(
+            bridgeArgument.lowerBound,
+            availabilityGuard.lowerBound,
+            "pinch must consume the bridge's symbolsUnavailable out-parameter"
+        )
+        XCTAssertLessThan(
+            availabilityGuard.lowerBound,
+            fallback.lowerBound,
+            "only unavailable private symbols may route pinch through PinchFallback"
+        )
+    }
+
+    func testMultiFingerSwipeRoutesBridgeAvailabilitySignalToDiagnostics() throws {
+        let multiFingerSwipe = try gesturePerformerFunction(named: "multiFingerSwipe(")
+
+        let bridgeArgument = try XCTUnwrap(multiFingerSwipe.range(of: "&symbolsUnavailable"))
+        let diagnosticsArgument = try XCTUnwrap(
+            multiFingerSwipe.range(of: "symbolsUnavailable: symbolsUnavailable.boolValue")
+        )
+        let diagnostics = try XCTUnwrap(
+            multiFingerSwipe.range(of: "MultiFingerSwipeDiagnostics.failureMessage(")
+        )
+
+        XCTAssertLessThan(
+            bridgeArgument.lowerBound,
+            diagnosticsArgument.lowerBound,
+            "multiFingerSwipe must pass the bridge's symbolsUnavailable out-parameter to diagnostics"
+        )
+        XCTAssertLessThan(
+            diagnostics.lowerBound,
+            diagnosticsArgument.lowerBound,
+            "symbolsUnavailable must be an argument to MultiFingerSwipeDiagnostics.failureMessage"
+        )
+    }
+
+    private func gesturePerformerFunction(named name: String) throws -> String {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = packageRoot.appendingPathComponent("Sources/CtrlProxy/GesturePerformer.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let functionStart = try XCTUnwrap(source.range(of: "public func " + name))
+        let remainingSource = source[functionStart.upperBound...]
+        let nextFunction = remainingSource.range(of: "\n        public func ")
+            ?? remainingSource.range(of: "\n        private ")
+        let functionEnd = nextFunction?.lowerBound ?? source.endIndex
+
+        return String(source[functionStart.lowerBound..<functionEnd])
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/GesturePerformerSymbolsUnavailableWiringTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/GesturePerformerSymbolsUnavailableWiringTests.swift
@@ -58,9 +58,11 @@ final class GesturePerformerSymbolsUnavailableWiringTests: XCTestCase {
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
         let functionStart = try XCTUnwrap(source.range(of: "public func " + name))
         let remainingSource = source[functionStart.upperBound...]
-        let nextFunction = remainingSource.range(of: "\n        public func ")
-            ?? remainingSource.range(of: "\n        private ")
-        let functionEnd = nextFunction?.lowerBound ?? source.endIndex
+        let nextDeclaration = [
+            remainingSource.range(of: "\n        public func ").map(\.lowerBound),
+            remainingSource.range(of: "\n        private ").map(\.lowerBound),
+        ].compactMap { $0 }.min()
+        let functionEnd = nextDeclaration ?? source.endIndex
 
         return String(source[functionStart.lowerBound..<functionEnd])
     }


### PR DESCRIPTION
## Summary

Adds an off-device source-scan guard that ensures both iOS `GesturePerformer` call sites consume the ObjC bridge's `symbolsUnavailable` out-parameter. It prevents pinch from silently bypassing `PinchFallback` and multi-finger swipe from silently bypassing `MultiFingerSwipeDiagnostics`.

## Linked Issue

Closes #3985

## Validation

- [x] `swift test` in `ios/control-proxy` (418 tests, 0 failures)
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Guard mutation check: replacing the multi-finger availability value with hardcoded `false` fails the new test
- [x] New test runs off-device and completes in under 100ms
- [x] Rebased onto latest `main`, conflicts resolved
