### PR TITLE
test(ios): warm simulator before video recording

### DIFF
--- a/scripts/ios/video-recording-start-stop-integration.sh
+++ b/scripts/ios/video-recording-start-stop-integration.sh
@@ -49,6 +49,25 @@ fi
 export AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION=1
 export AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID="${DEVICE_ID}"
 
+# A simulator can report booted while its display service has not yet produced a
+# frame. Starting `simctl io recordVideo` in that state can leave the raw .mov at
+# zero bytes even after a graceful SIGINT. Capture one screenshot first: this
+# both exercises the same display service and gives the test a concrete readiness
+# signal before it begins recording.
+DISPLAY_WARMUP_DIR="$(mktemp -d)"
+DISPLAY_WARMUP_SCREENSHOT="${DISPLAY_WARMUP_DIR}/display-warmup.png"
+if ! xcrun simctl io "${DEVICE_ID}" screenshot "${DISPLAY_WARMUP_SCREENSHOT}"; then
+  rm -rf "${DISPLAY_WARMUP_DIR}"
+  echo "error: failed to warm simulator display for ${DEVICE_ID}" >&2
+  exit 1
+fi
+if [[ ! -s "${DISPLAY_WARMUP_SCREENSHOT}" ]]; then
+  rm -rf "${DISPLAY_WARMUP_DIR}"
+  echo "error: failed to warm simulator display for ${DEVICE_ID}: screenshot was empty" >&2
+  exit 1
+fi
+rm -rf "${DISPLAY_WARMUP_DIR}"
+
 # This integration test legitimately drives the real videoRecording start/stop
 # handler, which resolves the file-backed database (VideoRecordingRepository ->
 # getDatabase() -> resolveDbPath()). Under bun test, NODE_ENV=test arms a guard

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -51,10 +51,10 @@ const IOS_RECORDING_FILE_READY_INITIAL_BACKOFF_MS = 100;
 const IOS_RECORDING_FILE_READY_MAX_BACKOFF_MS = 1000;
 const FFMPEG_POST_PROCESS_TIMEOUT_MS = 60000;
 const IOS_RECORDING_START_TIMEOUT_MS = 30000;
-const IOS_RECORDING_START_MESSAGES = [
-  "Recording started",
-  "Defaulting to display:",
-];
+// `simctl` emits this only after processing its first video frame. The earlier
+// "Defaulting to display" diagnostic proves only display selection, which can
+// still produce a zero-byte capture on a cold simulator.
+const IOS_RECORDING_START_MESSAGES = ["Recording started"];
 
 interface HardwareAccelInfo {
   encoder: string;

--- a/test/bats/video-recording-start-stop-integration.bats
+++ b/test/bats/video-recording-start-stop-integration.bats
@@ -58,8 +58,8 @@ SCRIPT
   run env AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID="SIM-UDID" bash "$SCRIPT"
 
   [ "$status" -eq 0 ]
-  grep -q -- "simctl io SIM-UDID screenshot" "$INVOCATIONS_FILE"
-  grep -q -- "test test/integration/iosVideoRecordingStartStop.integration.test.ts" "$INVOCATIONS_FILE"
+  [[ "$(sed -n '1p' "$INVOCATIONS_FILE")" == "simctl io SIM-UDID screenshot "* ]]
+  [ "$(sed -n '2p' "$INVOCATIONS_FILE")" = "test test/integration/iosVideoRecordingStartStop.integration.test.ts" ]
 }
 
 @test "fails before the integration test when the simulator cannot produce a warm-up frame" {

--- a/test/bats/video-recording-start-stop-integration.bats
+++ b/test/bats/video-recording-start-stop-integration.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ios/video-recording-start-stop-integration.sh.
+# The simulator display warm-up is mocked so no Xcode installation is needed.
+
+SCRIPT="scripts/ios/video-recording-start-stop-integration.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  INVOCATIONS_FILE="${MOCK_BIN}/invocations"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+  export PATH="$ORIG_PATH"
+}
+
+make_mock_commands() {
+  cat > "${MOCK_BIN}/xcrun" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${INVOCATIONS_FILE}"
+if [[ "\$1" == "simctl" && "\$2" == "io" && "\$4" == "screenshot" ]]; then
+  printf 'warm display frame\n' > "\$5"
+  exit 0
+fi
+echo "unexpected xcrun invocation: \$*" >&2
+exit 1
+SCRIPT
+  cat > "${MOCK_BIN}/bun" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${INVOCATIONS_FILE}"
+exit 0
+SCRIPT
+  cat > "${MOCK_BIN}/ffmpeg" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+  cat > "${MOCK_BIN}/ffprobe" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+  cat > "${MOCK_BIN}/jq" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun" "${MOCK_BIN}/bun" "${MOCK_BIN}/ffmpeg" "${MOCK_BIN}/ffprobe" "${MOCK_BIN}/jq"
+  export PATH="${MOCK_BIN}:${PATH}"
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "warms the selected simulator display before starting the integration test" {
+  make_mock_commands
+
+  run env AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID="SIM-UDID" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  grep -q -- "simctl io SIM-UDID screenshot" "$INVOCATIONS_FILE"
+  grep -q -- "test test/integration/iosVideoRecordingStartStop.integration.test.ts" "$INVOCATIONS_FILE"
+}
+
+@test "fails before the integration test when the simulator cannot produce a warm-up frame" {
+  make_mock_commands
+  cat > "${MOCK_BIN}/xcrun" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${INVOCATIONS_FILE}"
+exit 1
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+
+  run env AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID="SIM-UDID" bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"failed to warm simulator display"* ]]
+  ! grep -q -- "test test/integration/iosVideoRecordingStartStop.integration.test.ts" "$INVOCATIONS_FILE"
+}

--- a/test/bats/video-recording-start-stop-integration.bats
+++ b/test/bats/video-recording-start-stop-integration.bats
@@ -77,3 +77,19 @@ SCRIPT
   [[ "$output" == *"failed to warm simulator display"* ]]
   ! grep -q -- "test test/integration/iosVideoRecordingStartStop.integration.test.ts" "$INVOCATIONS_FILE"
 }
+
+@test "fails before the integration test when the warm-up screenshot is empty" {
+  make_mock_commands
+  cat > "${MOCK_BIN}/xcrun" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${INVOCATIONS_FILE}"
+exit 0
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+
+  run env AUTOMOBILE_IOS_VIDEO_RECORDING_DEVICE_ID="SIM-UDID" bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"screenshot was empty"* ]]
+  ! grep -q -- "test test/integration/iosVideoRecordingStartStop.integration.test.ts" "$INVOCATIONS_FILE"
+}

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -379,10 +379,10 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function() {
   });
 
   describe("FFmpeg Diagnostics", function() {
-    test("should treat simctl display selection as iOS recording startup", function() {
+    test("should require simctl's first-frame signal before reporting iOS recording startup", function() {
       expect(containsIosRecordingStartMessage(
         "Note: No display specified. Defaulting to display: 4FCB34AC-FD7C-4A7E-9A19-CB10950490D8 (screenID: 1, name: LCD)\n"
-      )).toBe(true);
+      )).toBe(false);
       expect(containsIosRecordingStartMessage("Recording started\n")).toBe(true);
       expect(containsIosRecordingStartMessage("Unable to boot simulator\n")).toBe(false);
     });

--- a/test/integration/iosVideoRecordingStartStop.integration.test.ts
+++ b/test/integration/iosVideoRecordingStartStop.integration.test.ts
@@ -10,13 +10,11 @@ import { serverConfig } from "../../src/utils/ServerConfig";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 
 const execFileAsync = promisify(execFile);
-// Force-disabled: flaky in CI — the simulator's simctl recording intermittently
-// produces an empty (0-byte) .mov, so stop/finalize fails after the readiness
-// probe deadline. Tracked in #3910. Re-enable by restoring the env gate:
-//   const RUN_INTEGRATION = process.env.AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION === "1";
-//   const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
-const describeIntegration = describe.skip;
-const DEFAULT_WAIT_MS = 4000;
+const RUN_INTEGRATION = process.env.AUTOMOBILE_IOS_VIDEO_RECORDING_INTEGRATION === "1";
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+// Give a cold CI simulator enough time to render frames after the script's
+// screenshot readiness check, rather than stopping immediately after startup.
+const DEFAULT_WAIT_MS = 10000;
 const DEFAULT_TEST_TIMEOUT_MS = 420000;
 
 interface ToolTextResponse {


### PR DESCRIPTION
Closes #3910

## Summary

- warm the selected iOS simulator display with a verified screenshot before the video-recording integration test begins
- re-enable the environment-gated simulator start-stop recording test
- give cold simulators a 10-second recording window after display readiness
- add BATS coverage for successful and failed display warm-up

## Validation

- `scripts/ios/video-recording-start-stop-integration.sh`
- `bats test/bats/video-recording-start-stop-integration.bats`
- `shellcheck scripts/ios/video-recording-start-stop-integration.sh`
- `bun run turbo:validate`
- `bun run typecheck`
