### PR TITLE
refactor(android): route hierarchy errors through shared core

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporter.kt
@@ -132,7 +132,7 @@ class CorrelatedErrorReporter(
     doubleFailureLogMessage: () -> String,
   ) {
     try {
-      broadcastError(ErrorResponse(requestId = requestId, error = errorMessage))
+      broadcastError(frame(requestId, errorMessage))
     } catch (fallbackError: CancellationException) {
       throw fallbackError
     } catch (fallbackError: Exception) {
@@ -141,6 +141,13 @@ class CorrelatedErrorReporter(
   }
 
   companion object {
+    /**
+     * The one factory for a fallback [ErrorResponse]. Shared by correlated-error consumers so a new
+     * path cannot change the frame shape while reusing the cause rule.
+     */
+    fun frame(requestId: String?, errorMessage: String): ErrorResponse =
+      ErrorResponse(requestId = requestId, error = errorMessage)
+
     /**
      * The one cause-derivation rule: the throwable's message, else its simple class name, else a
      * constant. Shared so a consumer that logs the cause itself cannot derive it differently.

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -2050,9 +2050,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           // error frame — let it propagate so the coroutine unwinds cleanly.
           throw e
         } catch (e: Exception) {
-          val cause = e.message ?: e::class.simpleName ?: "unknown error"
           Log.e(TAG, "Error extracting hierarchy for uuid=$uuid", e)
-          sendResult(success = false, error = cause)
+          sendResult(success = false, error = CorrelatedErrorReporter.causeOf(e))
           broadcastHierarchyExtractFrame(HierarchyExtractErrorFrames.thrownFrame(uuid, e))
         }
       }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyExtractErrorFrames.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyExtractErrorFrames.kt
@@ -31,8 +31,7 @@ object HierarchyExtractErrorFrames {
    * no WebSocket frame is produced).
    */
   fun nullResultFrame(uuid: String?): ErrorResponse? =
-    if (uuid.isNullOrBlank()) null
-    else ErrorResponse(requestId = uuid, error = NULL_HIERARCHY_ERROR)
+    if (uuid.isNullOrBlank()) null else CorrelatedErrorReporter.frame(uuid, NULL_HIERARCHY_ERROR)
 
   /**
    * The correlated error frame to broadcast when `extractHierarchy` throws [error]. Returns `null`
@@ -43,7 +42,9 @@ object HierarchyExtractErrorFrames {
   fun thrownFrame(uuid: String?, error: Throwable): ErrorResponse? {
     if (error is CancellationException) return null
     if (uuid.isNullOrBlank()) return null
-    val cause = error.message ?: error::class.simpleName ?: "unknown error"
-    return ErrorResponse(requestId = uuid, error = THROWN_PREFIX + cause)
+    return CorrelatedErrorReporter.frame(
+      requestId = uuid,
+      errorMessage = THROWN_PREFIX + CorrelatedErrorReporter.causeOf(error),
+    )
   }
 }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -485,9 +485,9 @@ class WebSocketServer(
         Log.w(TAG, "Failed to parse client message: $message", e)
         sendErrorResponse(
           connection,
-          ErrorResponse(
+          CorrelatedErrorReporter.frame(
             requestId = extractRequestId(message),
-            error = describeDecodeFailure(message, e),
+            errorMessage = describeDecodeFailure(message, e),
           ),
         )
         return
@@ -532,9 +532,9 @@ class WebSocketServer(
       Log.e(TAG, "Error handling message via handler", e)
       sendErrorResponse(
         connection,
-        ErrorResponse(
+        CorrelatedErrorReporter.frame(
           requestId = request.requestId,
-          error = "Handler error: ${e.message ?: e::class.simpleName ?: "unknown error"}",
+          errorMessage = "Handler error: ${CorrelatedErrorReporter.causeOf(e)}",
         ),
       )
     }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -370,6 +372,33 @@ class CorrelatedErrorDriftGuardTest {
     assertTrue("${CorrelatedErrorDriftScanner.CORE_FILE} must exist", core.isFile)
   }
 
+  @Test
+  fun `only the correlated-error core constructs fallback frames`() {
+    val coreDirectory =
+      requireNotNull(locateProductionSource(CorrelatedErrorDriftScanner.CORE_FILE).parentFile) {
+        "${CorrelatedErrorDriftScanner.CORE_FILE} must have a parent directory"
+      }
+    val sources =
+      Files.walk(Paths.get(coreDirectory.absolutePath)).use { paths ->
+        paths
+          .iterator()
+          .asSequence()
+          .map { it.toFile() }
+          .filter { it.isFile && it.extension == "kt" }
+          .toList()
+      }
+    val violations = sources.flatMap { source ->
+      CorrelatedErrorDriftScanner.scan(source.name, source.readText()).filter {
+        it.kind == CorrelatedErrorDriftScanner.Kind.HAND_ROLLED_ERROR_FRAME
+      }
+    }
+
+    assertTrue(
+      "Every fallback ErrorResponse must be constructed by ${CorrelatedErrorDriftScanner.CORE_FILE}: $violations",
+      violations.isEmpty(),
+    )
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
@@ -462,7 +491,7 @@ object CorrelatedErrorDriftScanner {
       if (CAUSE_DERIVATION_TOKENS.any { line.contains(it) }) {
         violations += Violation(Kind.HAND_ROLLED_CAUSE, fileName, lineNumber)
       }
-      if (line.contains(ERROR_FRAME_CONSTRUCTION)) {
+      if (ERROR_FRAME_CONSTRUCTION.containsMatchIn(line)) {
         violations += Violation(Kind.HAND_ROLLED_ERROR_FRAME, fileName, lineNumber)
       }
     }
@@ -489,7 +518,7 @@ object CorrelatedErrorDriftScanner {
       "javaClass.simpleName",
     )
 
-  private const val ERROR_FRAME_CONSTRUCTION = "ErrorResponse("
+  private val ERROR_FRAME_CONSTRUCTION = Regex("\\bErrorResponse\\s*\\(")
 
   /**
    * Delegation must be an actual *call*, not a bare mention of the type: a consumer that holds a

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorDriftGuardTest.kt
@@ -7,10 +7,9 @@ import org.junit.Assert.fail
 import org.junit.Test
 
 /**
- * Structural backstop for issue #3086. Enforces that the three seams which emit a correlated
- * `type:"error"` frame on a throw — [ResultBroadcaster], [AsyncActionRunner] and
- * [ServiceScopeGuard] — keep delegating to the single [CorrelatedErrorReporter] core instead of
- * hand-rolling it.
+ * Structural backstop for issues #3086 and #3992. Enforces that the known seams which emit a
+ * correlated `type:"error"` frame on a throw keep delegating to the single
+ * [CorrelatedErrorReporter] core instead of hand-rolling it.
  *
  * #3086 was filed as a deliberate YAGNI defer while only two consumers existed, tracking one
  * specific risk: nothing *forced* the duplicated catch-bodies to stay in lock-step, so a future fix
@@ -25,14 +24,14 @@ import org.junit.Test
  * real-file assertions then prove the live sources comply.
  *
  * **Scope, and why it stops where it does.** [CorrelatedErrorDriftScanner.CONSUMER_FILES] is a
- * hand-maintained list of three, so a *fourth* seam that hand-rolls the body is not caught.
- * Widening the scan to every file in the package was considered and rejected: `WebSocketServer.kt`
- * (the decode path, #2985) and `HierarchyExtractErrorFrames.kt` both construct `ErrorResponse` for
- * legitimate non-fallback reasons, so a package-wide rule would fire on correct code. This is the
- * same limit [BroadcastGuardAdoptionTest] documents for raw `serviceScope.launch` — it "cannot
- * distinguish such an action from the ~30 legitimate raw launches without false positives" — and it
- * is why [ServiceScopeGuard] closed that gap *by construction* rather than by scanning. A text
- * scanner is a backstop against reintroducing a known body, not a proof of absence.
+ * hand-maintained list of the confirmed correlated-error consumers. Widening the scan to every file
+ * in the package was considered and rejected: `WebSocketServer.kt` (the decode path, #2985)
+ * constructs `ErrorResponse` for legitimate non-fallback reasons, so a package-wide rule would fire
+ * on correct code. This is the same limit [BroadcastGuardAdoptionTest] documents for raw
+ * `serviceScope.launch` — it "cannot distinguish such an action from the ~30 legitimate raw
+ * launches without false positives" — and it is why [ServiceScopeGuard] closed that gap *by
+ * construction* rather than by scanning. A text scanner is a backstop against reintroducing a known
+ * body, not a proof of absence.
  */
 class CorrelatedErrorDriftGuardTest {
 
@@ -415,16 +414,13 @@ class CorrelatedErrorDriftGuardTest {
  * Kotlin source as text and reports correlated-error-core drift. Test-only (lives in the test
  * source set) — ships no scanning code in the app.
  *
- * The contract is deliberately blunt: within the three enumerated [CONSUMER_FILES], the cause
- * derivation and the fallback [ErrorResponse] construction may not appear at all, and each file
- * must both name the core and call it. A blunt contract is what makes it hard to drift past by
- * accident.
+ * The contract is deliberately blunt: within the enumerated [CONSUMER_FILES], the cause derivation
+ * and the fallback [ErrorResponse] construction may not appear at all, and each file must both name
+ * the core and call it. A blunt contract is what makes it hard to drift past by accident.
  *
  * Note the scope precisely — this is *not* "the cause rule exists in exactly one file in the
- * package". It does not: `WebSocketServer.kt`, `HierarchyExtractErrorFrames.kt` and `CtrlProxy.kt`
- * each derive a cause on paths this scanner does not police. See the class KDoc on
- * [CorrelatedErrorDriftGuardTest] for why the scan stops at three files, and issue #3992 for the
- * residual.
+ * package". `WebSocketServer.kt` retains a distinct decode-path cause rule that this scanner does
+ * not police. See the class KDoc on [CorrelatedErrorDriftGuardTest] for why the scan is targeted.
  */
 object CorrelatedErrorDriftScanner {
 
@@ -433,7 +429,12 @@ object CorrelatedErrorDriftScanner {
 
   /** The seams that must delegate to [CORE_FILE] rather than hand-roll the body. */
   val CONSUMER_FILES =
-    listOf("ResultBroadcaster.kt", "AsyncActionRunner.kt", "ServiceScopeGuard.kt")
+    listOf(
+      "ResultBroadcaster.kt",
+      "AsyncActionRunner.kt",
+      "ServiceScopeGuard.kt",
+      "HierarchyExtractErrorFrames.kt",
+    )
 
   enum class Kind {
     /** The `message ?: simpleName ?: "unknown error"` fallback re-implemented outside the core. */

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CorrelatedErrorReporterTest.kt
@@ -158,6 +158,14 @@ class CorrelatedErrorReporterTest {
     assertEquals("unknown error", CorrelatedErrorReporter.causeOf(anonymous))
   }
 
+  @Test
+  fun `frame preserves the request id and error text verbatim`() {
+    assertEquals(
+      ErrorResponse(requestId = "req-1", error = "Hierarchy extraction failed: boom"),
+      CorrelatedErrorReporter.frame("req-1", "Hierarchy extraction failed: boom"),
+    )
+  }
+
   // ---------------------------------------------------------------------------
   // emit
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Routes the hierarchy-extraction correlated-error path through `CorrelatedErrorReporter`.

The issue's Gap 1 trigger has fired: the fallback cause was independently derived in both
`CtrlProxy` and `HierarchyExtractErrorFrames`. The shared core now owns that derivation and the
fallback-frame factory. The drift guard scans every production CtrlProxy Kotlin source for direct
`ErrorResponse(...)` construction, so a future hand-rolled correlated fallback fails CI; the two
existing WebSocket fallbacks now use the same factory.

Gap 2 remains deliberately deferred: no `(requestId=...)` suffix drift has been observed.

Closes #3992

## Behavior

- Legacy ADB `sendResult` error text is byte-identical.
- Correlated WebSocket error frame text and request ID are byte-identical.
- Cancellation and blank/absent UUID behavior are unchanged.

## Validation

- `./gradlew :control-proxy:testDebugUnitTest`
- `ONLY_TOUCHED_FILES=true scripts/ktfmt/validate_ktfmt.sh`
- `bun run turbo:validate`
- `bun run typecheck`
