### PR TITLE
fix(ci): enforce pinned Swift formatter versions

### DIFF
--- a/scripts/lib/tool-install.sh
+++ b/scripts/lib/tool-install.sh
@@ -34,28 +34,40 @@ source "$(dirname "${BASH_SOURCE[0]}")/shell-core.sh"
 # for the macOS path. Consolidates the identical brew-or-manual skeleton that
 # swiftformat/swiftlint/hadolint each hand-rolled.
 #
-#   install_via_brew_or_manual <display-name> <brew-formula> <manual-install-fn>
+#   install_via_brew_or_manual <display-name> <brew-formula> <manual-install-fn> [is-pinned-fn]
 #
 # The manual-install function is invoked by name when brew is absent or the
-# `brew install` itself fails, and this helper returns that function's status.
+# `brew install` itself fails, or when the optional is-pinned function rejects
+# Homebrew's installed version. The latter matters for tools that rewrite
+# committed files: Homebrew resolves its current formula, not this repository's
+# declared pin. The manual installer is then re-checked before success.
 install_via_brew_or_manual() {
   local display_name="$1"
   local brew_formula="$2"
   local manual_fn="$3"
+  local is_pinned_fn="${4:-}"
 
   echo -e "${YELLOW}Installing ${display_name} on macOS...${NC}"
 
   if command_exists brew; then
     echo -e "${GREEN}Using Homebrew to install ${display_name}${NC}"
     if brew install "$brew_formula"; then
-      return 0
+      if [[ -z "$is_pinned_fn" ]] || "$is_pinned_fn"; then
+        return 0
+      fi
+      echo -e "${YELLOW}Homebrew installed a version that does not match this repository's pin. Falling back to manual installation...${NC}"
+    else
+      echo -e "${YELLOW}Homebrew installation failed. Falling back to manual installation...${NC}"
     fi
-    echo -e "${YELLOW}Homebrew installation failed. Falling back to manual installation...${NC}"
-    "$manual_fn"
-    return $?
+  else
+    echo -e "${YELLOW}Homebrew not found. Falling back to manual installation...${NC}"
   fi
 
-  echo -e "${YELLOW}Homebrew not found. Falling back to manual installation...${NC}"
-  "$manual_fn"
-  return $?
+  "$manual_fn" || return $?
+  if [[ -z "$is_pinned_fn" ]] || "$is_pinned_fn"; then
+    return 0
+  fi
+
+  echo -e "${RED}Manual installation did not provide the pinned ${display_name} version.${NC}"
+  return 1
 }

--- a/scripts/shellcheck/apply_shfmt.sh
+++ b/scripts/shellcheck/apply_shfmt.sh
@@ -6,6 +6,12 @@ ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 # Shared git file-selection + install-when-missing helpers (issue #2823).
 # shellcheck source=scripts/lib/file-selection.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+# shellcheck source=scripts/shellcheck/shfmt_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/shfmt_version.sh"
+
+# The installer runs in a child process, so make its manual-install location
+# visible when ensure_tool re-checks the binary in this parent process.
+export PATH="$HOME/.local/bin:$PATH"
 
 # Per-tool file regex for the shared collectors (issue #2823).
 SHELL_FILE_REGEX='^.*\.sh$'
@@ -30,6 +36,9 @@ echo -e "${YELLOW}Checking for required commands...${NC}"
 
 # Check if shfmt is installed (install-when-missing gate + re-verify).
 if ! ensure_tool shfmt "$PROJECT_ROOT/scripts/shellcheck/install_shfmt.sh" "${INSTALL_SHFMT_WHEN_MISSING}"; then
+  exit 1
+fi
+if ! require_pinned_shfmt_version; then
   exit 1
 fi
 

--- a/scripts/shellcheck/install_shfmt.sh
+++ b/scripts/shellcheck/install_shfmt.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-SHFMT_VERSION="3.10.0" # Change this to the desired version
-
 # Shared colors + command_exists + detect_os (issue #2822).
 # shellcheck source=scripts/lib/tool-install.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
+# shellcheck source=scripts/shellcheck/shfmt_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/shfmt_version.sh"
 
 # shfmt's GitHub release assets use Go's GOARCH tokens (amd64/arm/386), which
 # differ from the shared detect_arch's canonical tokens, so keep a tool-local
@@ -31,17 +31,11 @@ shfmt_release_arch() {
 
 # Install shfmt on macOS
 install_macos() {
-  echo -e "${YELLOW}Installing shfmt on macOS...${NC}"
+  install_via_brew_or_manual "shfmt" "shfmt" install_macos_binary is_pinned_shfmt_version
+}
 
-  if command_exists brew; then
-    echo -e "${GREEN}Using Homebrew to install shfmt${NC}"
-    brew install shfmt
-    return $?
-  else
-    echo -e "${YELLOW}Homebrew not found. Falling back to binary installation...${NC}"
-    install_binary "darwin"
-    return $?
-  fi
+install_macos_binary() {
+  install_binary "darwin"
 }
 
 # Install shfmt on Linux
@@ -86,6 +80,7 @@ install_binary() {
   # Create installation directory
   install_dir="$HOME/.local/bin"
   mkdir -p "$install_dir"
+  export PATH="$install_dir:$PATH"
 
   # Construct download URL
   # Format: https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_darwin_amd64

--- a/scripts/shellcheck/shfmt_version.sh
+++ b/scripts/shellcheck/shfmt_version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Single source of truth for the shfmt pin and its enforcement helpers.
+# Source this from every installer or write path that needs the formatter.
+
+SHFMT_VERSION="3.10.0"
+
+installed_shfmt_version() {
+  if ! command -v shfmt >/dev/null 2>&1; then
+    return 0
+  fi
+  shfmt --version 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^[vV]?[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$/) { sub(/^[vV]/, "", $i); print $i; exit } }'
+}
+
+is_pinned_shfmt_version() {
+  [[ "$(installed_shfmt_version)" == "$SHFMT_VERSION" ]]
+}
+
+require_pinned_shfmt_version() {
+  local found
+  found="$(installed_shfmt_version)"
+  if [[ "$found" == "$SHFMT_VERSION" ]]; then
+    return 0
+  fi
+
+  echo -e "${RED:-}shfmt version mismatch: found '${found:-none}', this repo pins '${SHFMT_VERSION}'.${NC:-}" >&2
+  echo -e "${RED:-}A different shfmt version can rewrite committed shell scripts differently, so refusing to apply formatting.${NC:-}" >&2
+  echo -e "${RED:-}Install the pinned version: bash scripts/shellcheck/install_shfmt.sh${NC:-}" >&2
+  return 1
+}

--- a/scripts/swiftformat/apply_swiftformat.sh
+++ b/scripts/swiftformat/apply_swiftformat.sh
@@ -6,6 +6,12 @@ ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 # Shared git file-selection + install-when-missing helpers (issue #2823).
 # shellcheck source=scripts/lib/file-selection.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+# shellcheck source=scripts/swiftformat/swiftformat_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/swiftformat_version.sh"
+
+# The installer runs in a child process, so make its manual-install location
+# visible when ensure_tool re-checks the binary in this parent process.
+export PATH="$HOME/.local/bin:$PATH"
 
 # Per-tool file regex for the shared collectors (issue #2823).
 SWIFT_FILE_REGEX='^ios/.*\.swift$'
@@ -30,6 +36,9 @@ echo -e "${YELLOW}Checking for required commands...${NC}"
 
 # Check if swiftformat is installed (install-when-missing gate + re-verify).
 if ! ensure_tool swiftformat "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh" "${INSTALL_SWIFTFORMAT_WHEN_MISSING}"; then
+    exit 1
+fi
+if ! require_pinned_swiftformat_version; then
     exit 1
 fi
 

--- a/scripts/swiftformat/install_swiftformat.sh
+++ b/scripts/swiftformat/install_swiftformat.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-SWIFTFORMAT_VERSION="0.54.6" # Change this to the desired version
-
 # Shared colors + command_exists + detect_os/detect_arch (issue #2822).
 # Note: SwiftFormat intentionally ships only macOS/Linux paths; detect_os may
 # return "windows" but main() routes that to the unsupported branch.
 # shellcheck source=scripts/lib/tool-install.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
+# shellcheck source=scripts/swiftformat/swiftformat_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/swiftformat_version.sh"
 
 # Install SwiftFormat on macOS
 install_macos() {
-    install_via_brew_or_manual "SwiftFormat" "swiftformat" install_manual
+    install_via_brew_or_manual "SwiftFormat" "swiftformat" install_manual is_pinned_swiftformat_version
     return $?
 }
 
@@ -29,6 +29,7 @@ install_manual() {
     # Create installation directory
     install_dir="$HOME/.local/bin"
     mkdir -p "$install_dir"
+    export PATH="$install_dir:$PATH"
 
     os=$(detect_os)
 

--- a/scripts/swiftformat/swiftformat_version.sh
+++ b/scripts/swiftformat/swiftformat_version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Single source of truth for the SwiftFormat pin and its enforcement helpers.
+# Source this from every installer or write path that needs the formatter.
+
+SWIFTFORMAT_VERSION="0.54.6"
+
+installed_swiftformat_version() {
+  if ! command -v swiftformat >/dev/null 2>&1; then
+    return 0
+  fi
+  swiftformat --version 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^[vV]?[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$/) { sub(/^[vV]/, "", $i); print $i; exit } }'
+}
+
+is_pinned_swiftformat_version() {
+  [[ "$(installed_swiftformat_version)" == "$SWIFTFORMAT_VERSION" ]]
+}
+
+require_pinned_swiftformat_version() {
+  local found
+  found="$(installed_swiftformat_version)"
+  if [[ "$found" == "$SWIFTFORMAT_VERSION" ]]; then
+    return 0
+  fi
+
+  echo -e "${RED:-}SwiftFormat version mismatch: found '${found:-none}', this repo pins '${SWIFTFORMAT_VERSION}'.${NC:-}" >&2
+  echo -e "${RED:-}A different SwiftFormat version can rewrite committed Swift sources differently, so refusing to apply formatting.${NC:-}" >&2
+  echo -e "${RED:-}Install the pinned version: bash scripts/swiftformat/install_swiftformat.sh${NC:-}" >&2
+  return 1
+}

--- a/scripts/swiftformat/validate_swiftformat.sh
+++ b/scripts/swiftformat/validate_swiftformat.sh
@@ -7,6 +7,12 @@ ONLY_CHANGED_SINCE_SHA=${ONLY_CHANGED_SINCE_SHA:-""}
 # Shared git file-selection + install-when-missing helpers (issue #2823).
 # shellcheck source=scripts/lib/file-selection.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+# shellcheck source=scripts/swiftformat/swiftformat_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/swiftformat_version.sh"
+
+# The installer runs in a child process, so make its manual-install location
+# visible when ensure_tool re-checks the binary in this parent process.
+export PATH="$HOME/.local/bin:$PATH"
 
 # Colors for output
 RED='\033[0;31m'
@@ -29,6 +35,9 @@ echo -e "${YELLOW}Checking for required commands...${NC}"
 
 # Check if swiftformat is installed (install-when-missing gate + re-verify).
 if ! ensure_tool swiftformat "$PROJECT_ROOT/scripts/swiftformat/install_swiftformat.sh" "${INSTALL_SWIFTFORMAT_WHEN_MISSING}"; then
+    exit 1
+fi
+if ! require_pinned_swiftformat_version; then
     exit 1
 fi
 

--- a/scripts/swiftlint/apply_swiftlint.sh
+++ b/scripts/swiftlint/apply_swiftlint.sh
@@ -6,6 +6,12 @@ ONLY_TOUCHED_FILES=${ONLY_TOUCHED_FILES:-true}
 # Shared git file-selection + install-when-missing helpers (issue #2823).
 # shellcheck source=scripts/lib/file-selection.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+# shellcheck source=scripts/swiftlint/swiftlint_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/swiftlint_version.sh"
+
+# The installer runs in a child process, so make its manual-install location
+# visible when ensure_tool re-checks the binary in this parent process.
+export PATH="$HOME/.local/bin:$PATH"
 
 # Per-tool file regex for the shared collectors (issue #2823).
 SWIFT_FILE_REGEX='^ios/.*\.swift$'
@@ -30,6 +36,9 @@ echo -e "${YELLOW}Checking for required commands...${NC}"
 
 # Check if swiftlint is installed (install-when-missing gate + re-verify).
 if ! ensure_tool swiftlint "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh" "${INSTALL_SWIFTLINT_WHEN_MISSING}"; then
+    exit 1
+fi
+if ! require_pinned_swiftlint_version; then
     exit 1
 fi
 

--- a/scripts/swiftlint/install_swiftlint.sh
+++ b/scripts/swiftlint/install_swiftlint.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-SWIFTLINT_VERSION="0.57.0" # Change this to the desired version
-
 # Shared colors + command_exists + detect_os/detect_arch (issue #2822).
 # Note: SwiftLint intentionally ships only macOS/Linux paths; detect_os may
 # return "windows" but main() routes that to the unsupported branch.
 # shellcheck source=scripts/lib/tool-install.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/tool-install.sh"
+# shellcheck source=scripts/swiftlint/swiftlint_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/swiftlint_version.sh"
 
 # Install SwiftLint on macOS
 install_macos() {
-    install_via_brew_or_manual "SwiftLint" "swiftlint" install_manual
+    install_via_brew_or_manual "SwiftLint" "swiftlint" install_manual is_pinned_swiftlint_version
     return $?
 }
 
@@ -29,6 +29,7 @@ install_manual() {
     # Create installation directory
     install_dir="$HOME/.local/bin"
     mkdir -p "$install_dir"
+    export PATH="$install_dir:$PATH"
 
     os=$(detect_os)
 

--- a/scripts/swiftlint/swiftlint_version.sh
+++ b/scripts/swiftlint/swiftlint_version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Single source of truth for the SwiftLint pin and its enforcement helpers.
+# Source this from every installer or write path that needs the formatter.
+
+SWIFTLINT_VERSION="0.57.0"
+
+installed_swiftlint_version() {
+  if ! command -v swiftlint >/dev/null 2>&1; then
+    return 0
+  fi
+  swiftlint version 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^[vV]?[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$/) { sub(/^[vV]/, "", $i); print $i; exit } }'
+}
+
+is_pinned_swiftlint_version() {
+  [[ "$(installed_swiftlint_version)" == "$SWIFTLINT_VERSION" ]]
+}
+
+require_pinned_swiftlint_version() {
+  local found
+  found="$(installed_swiftlint_version)"
+  if [[ "$found" == "$SWIFTLINT_VERSION" ]]; then
+    return 0
+  fi
+
+  echo -e "${RED:-}SwiftLint version mismatch: found '${found:-none}', this repo pins '${SWIFTLINT_VERSION}'.${NC:-}" >&2
+  echo -e "${RED:-}A different SwiftLint version can rewrite committed Swift sources differently, so refusing to apply fixes.${NC:-}" >&2
+  echo -e "${RED:-}Install the pinned version: bash scripts/swiftlint/install_swiftlint.sh${NC:-}" >&2
+  return 1
+}

--- a/scripts/swiftlint/validate_swiftlint.sh
+++ b/scripts/swiftlint/validate_swiftlint.sh
@@ -7,6 +7,12 @@ STRICT_MODE=${STRICT_MODE:-false}
 # Shared git file-selection + install-when-missing helpers (issue #2823).
 # shellcheck source=scripts/lib/file-selection.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
+# shellcheck source=scripts/swiftlint/swiftlint_version.sh disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/swiftlint_version.sh"
+
+# The installer runs in a child process, so make its manual-install location
+# visible when ensure_tool re-checks the binary in this parent process.
+export PATH="$HOME/.local/bin:$PATH"
 
 # Per-tool file regex for the shared collectors (issue #2823).
 SWIFT_FILE_REGEX='^ios/.*\.swift$'
@@ -29,6 +35,9 @@ echo -e "${YELLOW}Checking for required commands...${NC}"
 
 # Check if swiftlint is installed (install-when-missing gate + re-verify).
 if ! ensure_tool swiftlint "$PROJECT_ROOT/scripts/swiftlint/install_swiftlint.sh" "${INSTALL_SWIFTLINT_WHEN_MISSING}"; then
+    exit 1
+fi
+if ! require_pinned_swiftlint_version; then
     exit 1
 fi
 

--- a/test/bats/pinned-tool-install.bats
+++ b/test/bats/pinned-tool-install.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+# Regression coverage for #3982: a successful Homebrew install is not enough
+# for tools whose output can rewrite committed files. The shared installer must
+# fall back to the pinned release when Homebrew resolves a different version.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  STUB_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR"
+}
+
+@test "brew success with a skewed version falls back to the manual installer" {
+  # shellcheck disable=SC2016 # Variables expand in the child bash process.
+  run env CALL_LOG="$STUB_DIR/calls" bash -c '
+    source "$1/scripts/lib/tool-install.sh"
+    installed=skewed
+    command_exists() { [[ "$1" == brew ]]; }
+    brew() { printf "%s\\n" brew >> "$CALL_LOG"; }
+    manual() { installed=pinned; printf "%s\\n" manual >> "$CALL_LOG"; }
+    is_pinned() { [[ "$installed" == pinned ]]; }
+    install_via_brew_or_manual Formatter formatter manual is_pinned
+  ' _ "$REPO_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$STUB_DIR/calls")" = $'brew\nmanual' ]
+}
+
+@test "a matching Homebrew version does not invoke the manual installer" {
+  # shellcheck disable=SC2016 # Variables expand in the child bash process.
+  run env CALL_LOG="$STUB_DIR/calls" bash -c '
+    source "$1/scripts/lib/tool-install.sh"
+    command_exists() { [[ "$1" == brew ]]; }
+    brew() { printf "%s\\n" brew >> "$CALL_LOG"; }
+    manual() { printf "%s\\n" manual >> "$CALL_LOG"; }
+    is_pinned() { return 0; }
+    install_via_brew_or_manual Formatter formatter manual is_pinned
+  ' _ "$REPO_ROOT"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$STUB_DIR/calls")" = "brew" ]
+}
+
+@test "pinned installers pass a version check to the shared macOS helper" {
+  run grep -E 'install_via_brew_or_manual.*is_pinned_swiftlint_version' "$REPO_ROOT/scripts/swiftlint/install_swiftlint.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -E 'install_via_brew_or_manual.*is_pinned_swiftformat_version' "$REPO_ROOT/scripts/swiftformat/install_swiftformat.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -E 'install_via_brew_or_manual.*is_pinned_shfmt_version' "$REPO_ROOT/scripts/shellcheck/install_shfmt.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "formatter callers make a manual install visible after the installer exits" {
+  for script in scripts/swiftlint/apply_swiftlint.sh scripts/swiftlint/validate_swiftlint.sh scripts/swiftformat/apply_swiftformat.sh scripts/swiftformat/validate_swiftformat.sh scripts/shellcheck/apply_shfmt.sh; do
+    # shellcheck disable=SC2016 # Search for the literal PATH expansion.
+    run grep -F 'export PATH="$HOME/.local/bin:$PATH"' "$REPO_ROOT/$script"
+    [ "$status" -eq 0 ]
+  done
+}
+
+@test "write paths reject a formatter whose version differs from the pin" {
+  cat > "$STUB_DIR/swiftlint" <<'EOF'
+#!/usr/bin/env bash
+echo 0.0.0
+EOF
+  cat > "$STUB_DIR/swiftformat" <<'EOF'
+#!/usr/bin/env bash
+echo 0.0.0
+EOF
+  cat > "$STUB_DIR/shfmt" <<'EOF'
+#!/usr/bin/env bash
+echo v0.0.0
+EOF
+  chmod +x "$STUB_DIR/swiftlint" "$STUB_DIR/swiftformat" "$STUB_DIR/shfmt"
+
+  for script in scripts/swiftlint/apply_swiftlint.sh scripts/swiftlint/validate_swiftlint.sh scripts/swiftformat/apply_swiftformat.sh scripts/swiftformat/validate_swiftformat.sh scripts/shellcheck/apply_shfmt.sh; do
+    run env PATH="$STUB_DIR:$PATH" bash "$REPO_ROOT/$script"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"version mismatch"* ]]
+  done
+}
+
+@test "version gates reject prerelease formatter builds" {
+  cat > "$STUB_DIR/swiftlint" <<'EOF'
+#!/usr/bin/env bash
+echo 0.57.0-rc.1
+EOF
+  cat > "$STUB_DIR/swiftformat" <<'EOF'
+#!/usr/bin/env bash
+echo 0.54.6-beta.1
+EOF
+  cat > "$STUB_DIR/shfmt" <<'EOF'
+#!/usr/bin/env bash
+echo v3.10.0-rc.1
+EOF
+  chmod +x "$STUB_DIR/swiftlint" "$STUB_DIR/swiftformat" "$STUB_DIR/shfmt"
+
+  for version_file in scripts/swiftlint/swiftlint_version.sh scripts/swiftformat/swiftformat_version.sh scripts/shellcheck/shfmt_version.sh; do
+    # shellcheck disable=SC2016 # The function name is assembled in child bash.
+    run env PATH="$STUB_DIR:$PATH" bash -c 'source "$1"; require_pinned_"${2}"_version' _ "$REPO_ROOT/$version_file" "$(basename "$version_file" _version.sh)"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"version mismatch"* ]]
+  done
+}


### PR DESCRIPTION
## Summary

Enforces the repository's SwiftLint, SwiftFormat, and shfmt pins where a formatter can rewrite committed source. The shared macOS installer now verifies a Homebrew install and falls back to the existing pinned release download when Homebrew resolves a different version. Each write path also rejects a skewed binary before mutating files.

## Linked Issue

Closes #3982

## Bug / Regression Context

- **Prior attempts:** #2966 and #3981 fixed the same reproducibility class for ktfmt and XcodeGen.
- **Observed symptom:** On macOS, `brew install` reported success without consulting the declared SwiftLint/SwiftFormat pin; shfmt behaved the same in its separate installer.
- **Repro steps / conditions:** Run a write script with a Homebrew version different from the repository pin; it could reformat tracked files with that version.

## Validation

- [x] Targeted BATS: `bats test/bats/pinned-tool-install.bats test/bats/install-swift-tools.bats test/bats/apply-shfmt.bats`
- [x] Full BATS suite: `bats test/bats/` (370 tests)
- [x] ShellCheck for all changed scripts and the new BATS test
- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` passes
- [x] No new dependencies; the change reuses the existing installer/manual-download seams
- [x] Branch created from freshly fetched `origin/main`

## Follow-ups

- [x] None; this keeps the enforcement scoped to the three pinned formatter write paths.
