### PR TITLE
feat(a11y): surface screen-reader navigation fidelity assertions

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7773,6 +7773,231 @@
           ],
           "additionalProperties": {}
         },
+        "screenReaderNavigation": {
+          "type": "object",
+          "properties": {
+            "reachable": {
+              "type": "boolean",
+              "description": "Whether swipe cursor navigation reached the target"
+            },
+            "traversalOrder": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "bounds": {
+                    "type": "object",
+                    "properties": {
+                      "left": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "right": {
+                        "type": "number"
+                      },
+                      "bottom": {
+                        "type": "number"
+                      },
+                      "centerX": {
+                        "type": "number"
+                      },
+                      "centerY": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "left",
+                      "top",
+                      "right",
+                      "bottom"
+                    ],
+                    "additionalProperties": false,
+                    "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "resource-id": {
+                    "type": "string"
+                  },
+                  "view-id": {
+                    "type": "string"
+                  },
+                  "content-desc": {
+                    "type": "string"
+                  },
+                  "occlusionState": {
+                    "type": "string"
+                  },
+                  "occludedBy": {
+                    "type": "string"
+                  },
+                  "occludedByViewId": {
+                    "type": "string"
+                  },
+                  "class": {
+                    "type": "string"
+                  },
+                  "package": {
+                    "type": "string"
+                  },
+                  "checkable": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "checked": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "clickable": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "enabled": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "focusable": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "focused": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "accessibility-focused": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "scrollable": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  },
+                  "selected": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string",
+                        "const": "true"
+                      },
+                      {
+                        "type": "string",
+                        "const": "false"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "bounds"
+                ],
+                "additionalProperties": {}
+              },
+              "description": "Focused nodes in cursor traversal order"
+            },
+            "focusTrapDetected": {
+              "type": "boolean",
+              "description": "Whether cursor navigation got stuck or failed to converge"
+            }
+          },
+          "required": [
+            "reachable",
+            "traversalOrder",
+            "focusTrapDetected"
+          ],
+          "additionalProperties": {}
+        },
         "debug": {}
       },
       "required": [

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -38,7 +38,7 @@ import { boundsEqual, boundsNearlyEqual } from "../../utils/bounds";
 import { androidPreTapConsecutiveStableMatchesRequired } from "./androidPreTapStablePolicy";
 import { androidViewHierarchyIndicatesLikelyBlockingLoading } from "../../utils/androidTransientLoading";
 import { hasAccessibilityAction, isTruthyFlag } from "../../utils/elementProperties";
-import { TalkBackTapStrategy } from "../talkback/TalkBackTapStrategy";
+import { TalkBackTapStrategy, type ScreenReaderNavigationResult } from "../talkback/TalkBackTapStrategy";
 import {
   DefaultTalkBackNavigationDriverFactory,
   type TalkBackNavigationDriverFactory
@@ -1159,12 +1159,13 @@ export class TapOnElement extends BaseVisualChange {
           const preTapHash = options.retryIfNoChange
             ? this.hashViewHierarchy(viewHierarchy)
             : null;
+          let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
 
           // Platform-specific tap execution
           await perf.track("executeTap", async () => {
             switch (this.device.platform) {
               case "android":
-                await this.executeAndroidTap(
+                screenReaderNavigation = await this.executeAndroidTap(
                   action,
                   tapPoint.x,
                   tapPoint.y,
@@ -1204,6 +1205,7 @@ export class TapOnElement extends BaseVisualChange {
             element: tapElement,
             selectedElement: selectedElementMetadata,
             searchUntil: searchOutcome.stats,
+            ...(screenReaderNavigation ? { screenReaderNavigation } : {}),
           };
         },
         {
@@ -1303,7 +1305,7 @@ export class TapOnElement extends BaseVisualChange {
     signal?: AbortSignal,
     options?: TapOnElementOptions,
     isTalkBackEnabled?: boolean
-  ): Promise<void> {
+  ): Promise<ScreenReaderNavigationResult | undefined> {
     // Check if TalkBack is enabled (not just any accessibility service)
     const talkBackEnabled = typeof isTalkBackEnabled === "boolean"
       ? isTalkBackEnabled
@@ -1311,10 +1313,11 @@ export class TapOnElement extends BaseVisualChange {
 
     if (talkBackEnabled) {
       // TalkBack mode: Use accessibility actions with coordinate fallback
-      await this.executeAndroidTapWithAccessibility(action, x, y, element, durationMs, options, signal);
+      return this.executeAndroidTapWithAccessibility(action, x, y, element, durationMs, options, signal);
     } else {
       // Standard mode: Use coordinate-based taps
       await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
+      return undefined;
     }
   }
 
@@ -1446,8 +1449,9 @@ export class TapOnElement extends BaseVisualChange {
     durationMs: number,
     options?: TapOnElementOptions,
     signal?: AbortSignal
-  ): Promise<void> {
+  ): Promise<ScreenReaderNavigationResult | undefined> {
     const driver = this.talkBackDriverFactory.createDriver(this.device);
+    let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
 
     if (action === "longPress") {
       // Long press: try ACTION_LONG_CLICK first, then coordinate gesture fallback
@@ -1466,7 +1470,7 @@ export class TapOnElement extends BaseVisualChange {
         );
         await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
       }
-      return;
+      return undefined;
     }
 
     if (action === "tap" || action === "doubleTap") {
@@ -1480,13 +1484,14 @@ export class TapOnElement extends BaseVisualChange {
         );
 
         if (result.success) {
-          return;
+          return result.screenReaderNavigation;
         }
 
         logger.warn(
           `[TapOnElement] Focus navigation failed (${result.error}), ` +
           `falling back to coordinate-based tap at (${x}, ${y})`
         );
+        screenReaderNavigation = result.screenReaderNavigation;
       } else if (action === "tap") {
         // Default (#3936): directly activate the target node via ACTION_CLICK,
         // without moving the cursor. doubleTap has no single accessibility action,
@@ -1494,7 +1499,7 @@ export class TapOnElement extends BaseVisualChange {
         const result = await this.talkBackStrategy.executeDirectActivation(element, driver);
 
         if (result.success) {
-          return;
+          return undefined;
         }
 
         logger.warn(
@@ -1521,6 +1526,7 @@ export class TapOnElement extends BaseVisualChange {
       );
       await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
     }
+    return screenReaderNavigation;
   }
 
   /**

--- a/src/features/talkback/FocusNavigationExecutor.ts
+++ b/src/features/talkback/FocusNavigationExecutor.ts
@@ -15,6 +15,7 @@ interface NavigationOptions {
   maxSwipes?: number;
   verificationInterval?: number;
   swipeDelay?: number;
+  onFocusObserved?: (element: Element | null) => void;
 }
 
 export interface FocusNavigationDriver {
@@ -164,8 +165,10 @@ export class FocusNavigationExecutor {
         targetSelector
       );
       if (initialVerification.reachedTarget) {
+        options.onFocusObserved?.(initialVerification.currentFocus);
         return true;
       }
+      options.onFocusObserved?.(initialVerification.currentFocus);
       if (initialVerification.targetIndex === null) {
         throw new ActionableError(
           `Target not found (${this.describeSelector(targetSelector)}). ` +
@@ -210,16 +213,25 @@ export class FocusNavigationExecutor {
         await this.timer.sleep(swipeDelay);
       }
 
-      const shouldVerify =
-        remainingSwipes === 0 || totalSwipes % verificationInterval === 0;
+      const shouldVerify = remainingSwipes === 0 || totalSwipes % verificationInterval === 0;
+      // Fidelity reporting observes each cursor step, but keeps path
+      // recalculation and the non-convergence guard at their configured cadence.
+      // A TalkBack focus event can lag several swipes; counting every sample as
+      // a failed verification would turn that normal delay into a false trap.
+      let verification: NavigationVerification | undefined;
+      if (options.onFocusObserved) {
+        verification = await this.verifyNavigationState(driver, targetSelector);
+        options.onFocusObserved(verification.currentFocus);
+        if (verification.reachedTarget) {
+          return true;
+        }
+      }
       if (!shouldVerify) {
         continue;
       }
 
-      const verification = await this.verifyNavigationState(
-        driver,
-        targetSelector
-      );
+      verification ??= await this.verifyNavigationState(driver, targetSelector);
+      options.onFocusObserved?.(verification.currentFocus);
 
       if (verification.reachedTarget) {
         return true;
@@ -296,6 +308,7 @@ export class FocusNavigationExecutor {
       driver,
       targetSelector
     );
+    options.onFocusObserved?.(finalVerification.currentFocus);
     return finalVerification.reachedTarget;
   }
 

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -15,6 +15,17 @@ export interface TalkBackTapResult {
    */
   method: "focus-navigation" | "accessibility-action" | "coordinate-fallback";
   error?: string;
+  screenReaderNavigation?: ScreenReaderNavigationResult;
+}
+
+/** Evidence captured while the opt-in screen-reader cursor journey runs. */
+export interface ScreenReaderNavigationResult {
+  /** Whether the cursor reached the target through swipe navigation. */
+  reachable: boolean;
+  /** Focused nodes in the order the cursor visited them. */
+  traversalOrder: Element[];
+  /** Whether navigation stopped because the cursor was stuck or diverging. */
+  focusTrapDetected: boolean;
 }
 
 export type TalkBackFallbackAction = "tap" | "doubleTap" | "longPress";
@@ -74,6 +85,7 @@ export class TalkBackTapStrategy {
     element: Element,
     driver: TalkBackNavigationDriver
   ): Promise<TalkBackTapResult> {
+    let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
     const resourceId = element?.["resource-id"] as string | undefined;
     const elementText = element.text as string | undefined;
     const elementContentDesc = element["content-desc"] as string | undefined;
@@ -82,7 +94,12 @@ export class TalkBackTapStrategy {
       return {
         success: false,
         method: "focus-navigation",
-        error: "Element has no resource-id, text, or content-desc for navigation"
+        error: "Element has no resource-id, text, or content-desc for navigation",
+        screenReaderNavigation: {
+          reachable: false,
+          traversalOrder: [],
+          focusTrapDetected: false
+        }
       };
     }
 
@@ -103,7 +120,12 @@ export class TalkBackTapStrategy {
         return {
           success: false,
           method: "focus-navigation",
-          error: `Failed to get traversal order: ${traversalResult.error}`
+          error: `Failed to get traversal order: ${traversalResult.error}`,
+          screenReaderNavigation: {
+            reachable: false,
+            traversalOrder: [],
+            focusTrapDetected: false
+          }
         };
       }
 
@@ -123,6 +145,13 @@ export class TalkBackTapStrategy {
         }
       }
 
+      const navigationResult: ScreenReaderNavigationResult = {
+        reachable: false,
+        traversalOrder: currentFocus ? [currentFocus] : [],
+        focusTrapDetected: false
+      };
+      screenReaderNavigation = navigationResult;
+
       // Calculate navigation path
       const navigationPath = this.pathCalculator.calculatePath(
         currentFocus,
@@ -134,7 +163,8 @@ export class TalkBackTapStrategy {
         return {
           success: false,
           method: "focus-navigation",
-          error: "Could not calculate navigation path to target element"
+          error: "Could not calculate navigation path to target element",
+          screenReaderNavigation: navigationResult
         };
       }
 
@@ -149,8 +179,10 @@ export class TalkBackTapStrategy {
         navigationPath,
         {
           maxSwipes: 100,
-          verificationInterval: 5,
-          swipeDelay: 100
+          // Fidelity assertions need every focused node, not periodic samples.
+          verificationInterval: 1,
+          swipeDelay: 100,
+          onFocusObserved: focus => this.appendTraversalFocus(navigationResult, focus)
         }
       );
 
@@ -158,15 +190,18 @@ export class TalkBackTapStrategy {
         return {
           success: false,
           method: "focus-navigation",
-          error: "Focus navigation did not reach target element"
+          error: "Focus navigation did not reach target element",
+          screenReaderNavigation: navigationResult
         };
       }
+
+      navigationResult.reachable = true;
 
       logger.info(`[TalkBackTapStrategy] Focus navigation successful, activating element`);
 
       // Activate the focused element with double-tap gesture
       const activationResult = await this.activateElement(element, driver);
-      return activationResult;
+      return { ...activationResult, screenReaderNavigation: navigationResult };
 
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -174,9 +209,41 @@ export class TalkBackTapStrategy {
       return {
         success: false,
         method: "focus-navigation",
-        error: errorMessage
+        error: errorMessage,
+        screenReaderNavigation: screenReaderNavigation
+          ? { ...screenReaderNavigation, focusTrapDetected: this.isFocusTrapError(errorMessage) }
+          : { reachable: false, traversalOrder: [], focusTrapDetected: this.isFocusTrapError(errorMessage) }
       };
     }
+  }
+
+  private appendTraversalFocus(
+    result: ScreenReaderNavigationResult,
+    focus: Element | null
+  ): void {
+    if (!focus) {
+      return;
+    }
+    const last = result.traversalOrder.at(-1);
+    if (!last || this.focusSignature(last) !== this.focusSignature(focus)) {
+      result.traversalOrder.push(focus);
+    }
+  }
+
+  private focusSignature(element: Element): string {
+    const bounds = element.bounds;
+    return [
+      element["resource-id"] ?? "",
+      element["content-desc"] ?? "",
+      element.text ?? "",
+      bounds ? `${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}` : ""
+    ].join("|");
+  }
+
+  private isFocusTrapError(error: string): boolean {
+    return error.includes("Focus did not move")
+      || error.includes("could not track the TalkBack cursor")
+      || error.includes("not converging on the target");
   }
 
   /**

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -3,6 +3,7 @@ import { ElementBounds } from "./ElementBounds";
 import { ElementSelectionStrategy } from "./ElementSelectionStrategy";
 import { BaseActionResult } from "./BaseActionResult";
 import { ToolDebugInfo } from "../utils/DebugContextBuilder";
+import type { ScreenReaderNavigationResult } from "../features/talkback/TalkBackTapStrategy";
 
 export interface TapOnSelectedElementBounds extends ElementBounds {
   centerX: number;
@@ -34,4 +35,5 @@ export interface TapOnElementResult extends BaseActionResult {
     requestCount: number;
     changeCount: number;
   };
+  screenReaderNavigation?: ScreenReaderNavigationResult;
 }

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -167,6 +167,12 @@ const tapOnSearchUntilSchema = z.object({
   changeCount: z.number().int()
 }).passthrough();
 
+const screenReaderNavigationSchema = z.object({
+  reachable: z.boolean().describe("Whether swipe cursor navigation reached the target"),
+  traversalOrder: z.array(elementSchema).describe("Focused nodes in cursor traversal order"),
+  focusTrapDetected: z.boolean().describe("Whether cursor navigation got stuck or failed to converge")
+}).passthrough();
+
 export const tapOnResultSchema = z.object({
   success: z.boolean(),
   action: z.string().optional(),
@@ -181,6 +187,7 @@ export const tapOnResultSchema = z.object({
   contextMenuOpened: z.boolean().optional(),
   selectionStarted: z.boolean().optional(),
   searchUntil: tapOnSearchUntilSchema.optional(),
+  screenReaderNavigation: screenReaderNavigationSchema.optional(),
   debug: z.any().optional()
 }).passthrough();
 

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -560,9 +560,18 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
     const navOptions = { screenReaderNavigation: true } as any;
 
     test("tap drives the cursor via executeTap", async () => {
+      fakeTalkBackStrategy.setTapResult({
+        success: true,
+        method: "focus-navigation",
+        screenReaderNavigation: {
+          reachable: true,
+          traversalOrder: [makeElement()],
+          focusTrapDetected: false
+        }
+      });
       const element = makeElement();
 
-      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+      const result = await (tapOnElement as any).executeAndroidTapWithAccessibility(
         "tap", 50, 50, element, 500, navOptions, undefined
       );
 
@@ -571,6 +580,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       expect(fakeTalkBackStrategy.tapCalls[0].element).toBe(element);
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
       expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
+      expect(result).toMatchObject({ reachable: true, focusTrapDetected: false });
     });
 
     test("doubleTap also drives the cursor via executeTap (activation is always double-tap)", async () => {
@@ -697,5 +707,78 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
       expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("longPress", 50, 50, 1000, element, undefined);
     });
+  });
+});
+
+describe("TapOnElement screen-reader navigation result", () => {
+  const element = {
+    "resource-id": "test:id/button",
+    "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+    "clickable": true
+  } as any;
+
+  const journey = {
+    reachable: true,
+    traversalOrder: [element],
+    focusTrapDetected: false
+  };
+
+  const createCommand = (tapResult: any) => {
+    const accessibilityDetector = new FakeAccessibilityDetector();
+    accessibilityDetector.setTalkBackEnabled(true);
+    const strategy = new FakeTalkBackTapStrategy();
+    strategy.setTapResult(tapResult);
+    const command = new TapOnElement(
+      { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
+      new FakeAdbClient() as any,
+      {
+        accessibilityDetector,
+        timer: new FakeTimer(),
+        talkBackStrategy: strategy,
+        featureFlags: { isEnabled: (key: string) => key === "screen-reader-navigation" } as FeatureFlagService
+      }
+    );
+    const observation = {
+      viewHierarchy: { hierarchy: {} },
+      screenSize: { width: 100, height: 100 }
+    } as any;
+    spyOn(command as any, "observedInteraction").mockImplementation(async (block: any) => ({
+      ...(await block(observation)),
+      observation
+    }));
+    spyOn(command as any, "searchForElement").mockResolvedValue({
+      selection: { element, indexInMatches: 0, totalMatches: 1, strategy: "first" },
+      viewHierarchy: observation.viewHierarchy,
+      containerFound: true,
+      stats: { durationMs: 0, requestCount: 0, changeCount: 0 }
+    });
+    spyOn(command as any, "resolveTapTargetElement").mockReturnValue({ element, usedParent: false });
+    spyOn((command as any).selectionStateTracker, "prepare").mockResolvedValue(null);
+    spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
+    return command;
+  };
+
+  test("returns the successful cursor journey from public execute", async () => {
+    const command = createCommand({ success: true, method: "focus-navigation", screenReaderNavigation: journey });
+
+    const result = await command.execute({ action: "tap", elementId: "test:id/button" });
+
+    expect(result.success).toBe(true);
+    expect(result.screenReaderNavigation).toEqual(journey);
+  });
+
+  test("keeps failed reachability evidence after coordinate fallback succeeds", async () => {
+    const failedJourney = { ...journey, reachable: false, focusTrapDetected: true };
+    const command = createCommand({
+      success: false,
+      method: "focus-navigation",
+      error: "Focus navigation is not converging on the target.",
+      screenReaderNavigation: failedJourney
+    });
+
+    const result = await command.execute({ action: "tap", elementId: "test:id/button" });
+
+    expect(result.success).toBe(true);
+    expect(result.screenReaderNavigation).toEqual(failedJourney);
   });
 });

--- a/test/features/talkback/FocusNavigationExecutor.test.ts
+++ b/test/features/talkback/FocusNavigationExecutor.test.ts
@@ -342,4 +342,47 @@ describe("FocusNavigationExecutor", () => {
     // Bailed after a couple of no-progress checks, nowhere near the 50 swipes.
     expect(driver.getSwipeCount()).toBeLessThan(10);
   });
+
+  test("reports every swipe without treating delayed focus updates as a trap", async () => {
+    const timer = new FakeTimer();
+    const driver = new FakeFocusNavigationDriver();
+    const elements = [
+      makeElement("a", 0),
+      makeElement("b", 1),
+      makeElement("c", 2),
+      makeElement("d", 3),
+      makeElement("e", 4)
+    ];
+    driver.setElements(elements, 0);
+    driver.autoAdvanceOnSwipe = false;
+    driver.onSwipe = () => {
+      if (driver.getSwipeCount() === 4) {
+        driver.focusedIndex = 4;
+      }
+    };
+    const observed: Element[] = [];
+    const executor = new FocusNavigationExecutor({
+      timer,
+      driverFactory: { createDriver: () => driver }
+    });
+
+    const result = await executor.navigateToElement(
+      "device-1",
+      { resourceId: "e" },
+      { currentFocusIndex: 0, targetFocusIndex: 4, swipeCount: 5, direction: "forward" },
+      {
+        verificationInterval: 5,
+        swipeDelay: 0,
+        onFocusObserved: element => {
+          if (element) {
+            observed.push(element);
+          }
+        }
+      }
+    );
+
+    expect(result).toBe(true);
+    expect(driver.getSwipeCount()).toBe(4);
+    expect(observed).toEqual([elements[0], elements[0], elements[0], elements[4]]);
+  });
 });

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -65,7 +65,18 @@ describe("TalkBackTapStrategy", () => {
 
       expect(result.success).toBe(true);
       expect(result.method).toBe("focus-navigation");
+      expect(result.screenReaderNavigation).toMatchObject({
+        reachable: true,
+        focusTrapDetected: false,
+        traversalOrder: [element]
+      });
       expect(navigateToElement).toHaveBeenCalledTimes(1);
+      expect(navigateToElement).toHaveBeenCalledWith(
+        "device-1",
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ verificationInterval: 1 })
+      );
       expect(driver.getTapCount()).toBe(2); // Double-tap to activate
     });
 
@@ -123,7 +134,31 @@ describe("TalkBackTapStrategy", () => {
       expect(result.success).toBe(false);
       expect(result.method).toBe("focus-navigation");
       expect(result.error).toContain("Navigation failed");
+      expect(result.screenReaderNavigation).toMatchObject({
+        reachable: false,
+        focusTrapDetected: false,
+        traversalOrder: [element]
+      });
       expect(navigateToElement).toHaveBeenCalledTimes(1);
+    });
+
+    test("reports a focus trap when the convergence guard stops navigation", async () => {
+      const element = {
+        "resource-id": "test:id/button",
+        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+      } as Element;
+      driver.setElements([element], 0);
+      spyOn(mockExecutor, "navigateToElement").mockRejectedValue(
+        new Error("Focus navigation is not converging on the target.")
+      );
+
+      const result = await strategy.executeTap("device-1", element, driver);
+
+      expect(result.screenReaderNavigation).toMatchObject({
+        reachable: false,
+        focusTrapDetected: true,
+        traversalOrder: [element]
+      });
     });
 
     test("uses ACTION_CLICK fallback if double-tap activation fails", async () => {

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -53,6 +53,15 @@ describe("elementBoundsSchema: object + compact tuple (#2990)", () => {
 });
 
 describe("tool output artifact metadata schema (#3480)", () => {
+  test("advertises screen-reader navigation fidelity assertions (#3963)", () => {
+    const json = JSON.stringify(toJSONSchema(tapOnResultSchema));
+
+    expect(json).toContain("screenReaderNavigation");
+    expect(json).toContain("reachable");
+    expect(json).toContain("traversalOrder");
+    expect(json).toContain("focusTrapDetected");
+  });
+
   const metadata = {
     artifact: {
       path: "/tmp/auto-mobile/123-tapOn-id.json",


### PR DESCRIPTION
## Summary

Expose Android screen-reader-navigation fidelity assertions on `tapOn`. The opt-in cursor journey now reports target reachability, the focused-node traversal order, and whether the existing non-convergence guard detected a focus trap. The generated tool definitions advertise the result to schema consumers.

Cursor observations occur after every swipe, while the existing recalculation and trap-guard cadence remains unchanged so delayed TalkBack focus updates do not become false traps.

## Linked Issue

Closes #3963

## Validation

- [x] `bun run turbo:validate` passes (lint, build, full test suite)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses fakes and FakeTimer in focused tests
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Not run: the change is covered by fast unit tests; no Android device session was used.

## Follow-ups

- [x] No follow-up issues needed.
