### PR TITLE
fix(ci): stop gradle-task-run from silently dropping every gradle-flag

### DIFF
--- a/.github/actions/gradle-task-run/action.yml
+++ b/.github/actions/gradle-task-run/action.yml
@@ -2,6 +2,14 @@
 name: "gradle-task-run"
 description: ""
 inputs:
+  artifact-name-suffix:
+    description: >-
+      Disambiguator appended to this action's uploaded artifact names. Required
+      when a job invokes this action more than once with the same gradle-tasks:
+      the config-cache report name is derived from the task list and the runner
+      OS, so a second invocation would collide and fail with a 409.
+    required: "false"
+    default: ""
   gradle-flags:
     description: "Set of options we will pass to ./gradlew"
     example: '["--continue", "--stacktrace"]'
@@ -276,6 +284,6 @@ runs:
       uses: actions/upload-artifact@v7.0.1
       if: success()
       with:
-        name: config-cache-report-${{ steps.sanitize-name.outputs.sanitized_name }}-${{ runner.os }}
+        name: config-cache-report-${{ steps.sanitize-name.outputs.sanitized_name }}-${{ runner.os }}${{ inputs.artifact-name-suffix && format('-{0}', inputs.artifact-name-suffix) || '' }}
         path: |
           ${{ inputs.gradle-project-directory }}/build/reports/config-cache-report.html

--- a/.github/actions/gradle-task-run/action.yml
+++ b/.github/actions/gradle-task-run/action.yml
@@ -122,6 +122,11 @@ runs:
       id: eval_gradle
       shell: ${{ inputs.shell }}
       working-directory: ${{ inputs.gradle-project-directory }}
+      env:
+        # Read through the environment, never `${{ }}`-interpolated into the shell
+        # source: this input is a JSON array, so its double quotes would terminate
+        # the surrounding string and silently drop every flag (issue #3913).
+        GRADLE_FLAGS_JSON: ${{ inputs.gradle-flags }}
       run: |
         if [ "${{ inputs.gradle-version }}" == "" ]; then
           echo "Reading Gradle version from Gradle wrapper properties file."
@@ -132,13 +137,24 @@ runs:
           echo "version=${{ inputs.gradle-version }}" >> "$GITHUB_OUTPUT"
         fi
 
+        # Fail loudly on a malformed gradle-flags input. Without this the jq error
+        # goes to stderr, the command substitution yields an empty string, and the
+        # build runs with the caller's flags silently missing.
+        # `join(" ")`, not `.[]`: the newline stripping below deletes newlines without
+        # substituting a space, so newline-separated jq output would concatenate into
+        # one unparseable mega-flag. The literal flags survive only via their indent.
+        if ! caller_flags=$(printf '%s' "$GRADLE_FLAGS_JSON" | jq -M -r 'join(" ")'); then
+          echo "::error::gradle-flags is not a JSON array: $GRADLE_FLAGS_JSON"
+          exit 1
+        fi
+
         # Note that we do not attempt to visually align JVM args - spaces included in kotlin.daemon.jvmargs causes the Kotlin compiler daemon to not run and fallback to Gradle in-process
         export GRADLE_FLAGS="
           --continue
           --stacktrace
           $(if [ "${{ inputs.reuse-configuration-cache }}" == "true" ]; then echo ""; else echo "--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false"; fi;)
           $(if [ "${{ inputs.reuse-build-cache }}" == "true" ]; then echo ""; else echo "--no-build-cache --rerun-tasks"; fi;)
-          $(echo "${{ inputs.gradle-flags }}" | jq ".[]" -M -r)
+          $caller_flags
           -Dorg.gradle.configuration-cache.internal.report-link-as-warning=true
           "
 

--- a/.github/workflows/record-screenshot-baselines.yml
+++ b/.github/workflows/record-screenshot-baselines.yml
@@ -53,6 +53,9 @@ jobs:
           # --rerun-tasks forces the tests to actually execute (record mode) even
           # when Gradle would otherwise consider them up to date.
           gradle-flags: '["--tests", "${{ inputs.test_filter }}", "-Dscreenshot.record=true", "--rerun-tasks"]'
+          # Both invocations below run :desktop-core:test in this one job, so
+          # they need distinct artifact names or the second 409s.
+          artifact-name-suffix: "record"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true
@@ -76,6 +79,7 @@ jobs:
         with:
           gradle-tasks: ":desktop-core:test"
           gradle-flags: '["--tests", "${{ inputs.test_filter }}", "--rerun-tasks"]'
+          artifact-name-suffix: "verify"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true

--- a/test/bats/gradle-task-run-flags.bats
+++ b/test/bats/gradle-task-run-flags.bats
@@ -94,6 +94,23 @@ build_flags() {
   [ "$status" -ne 0 ]
 }
 
+@test "repeated gradle-task-run invocations in one job get distinct artifact names" {
+  # The config-cache report name is derived from gradle-tasks + runner.os, so a
+  # job that invokes this action twice on the same task list uploads the same
+  # artifact name twice and the second 409s -- failing the step even when the
+  # Gradle build succeeded. That masked a *green* verify in run 29750419389.
+  workflow=".github/workflows/record-screenshot-baselines.yml"
+  suffixes="$(grep -oE 'artifact-name-suffix: "[^"]+"' "$workflow" | sort)"
+  [ "$(echo "$suffixes" | wc -l)" -eq 2 ]
+  [ "$(echo "$suffixes" | sort -u | wc -l)" -eq 2 ]
+}
+
+@test "the artifact name suffix is optional and appended only when set" {
+  # Every other caller omits the input; an unconditional "-" would rename all
+  # their artifacts and break anything downloading them by name.
+  grep -q "inputs.artifact-name-suffix && format('-{0}', inputs.artifact-name-suffix) || ''" "$ACTION"
+}
+
 @test "record and verify steps pass their flags as valid JSON arrays" {
   # A caller that hand-writes a malformed array would now hard-fail the step;
   # catch it here instead.

--- a/test/bats/gradle-task-run-flags.bats
+++ b/test/bats/gradle-task-run-flags.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+#
+# Guards the `gradle-flags` plumbing in .github/actions/gradle-task-run.
+#
+# The input is a JSON array ('["--tests", "*Foo"]'). It used to be spliced into
+# the step's shell source with `${{ inputs.gradle-flags }}` inside a
+# double-quoted string, so the array's own double quotes terminated that string
+# and jq received bare `[--tests, *Foo]`. jq failed, the command substitution
+# expanded to nothing, and the build ran with every caller flag silently
+# missing -- which is what actually broke #3752/#3913 for two debugging cycles:
+# `-Dscreenshot.record=true` never reached Gradle, so no baselines were ever
+# recorded and the verify step failed on MissingBaseline (not, as hypothesized,
+# on a pixel mismatch).
+#
+# Two invariants keep that from coming back:
+#   1. the input crosses into the shell via the environment, never `${{ }}`;
+#   2. flags are joined with spaces, because the newline-stripping below the
+#      splice deletes newlines without substituting anything -- so
+#      newline-separated jq output would concatenate into one mega-flag.
+#
+# The behavioral tests re-run the action's own flag-building logic rather than
+# grepping for it, so a refactor that keeps the invariants stays green.
+
+ACTION=".github/actions/gradle-task-run/action.yml"
+
+# Mirrors the flag assembly in the action's "Evaluate Gradle version & flags"
+# step. Kept in sync by the source-scan tests below, which pin the two lines
+# this depends on.
+build_flags() {
+  export GRADLE_FLAGS_JSON="$1"
+  local caller_flags
+  if ! caller_flags=$(printf '%s' "$GRADLE_FLAGS_JSON" | jq -M -r 'join(" ")' 2>/dev/null); then
+    return 1
+  fi
+  local flags="
+  --continue
+  --stacktrace
+  $caller_flags
+  -Dorg.gradle.configuration-cache.internal.report-link-as-warning=true
+  "
+  # shellcheck disable=SC1003
+  echo "${flags//[$'\t\r\n']}"
+}
+
+@test "gradle-flags reaches the shell through the environment, not \${{ }}" {
+  # The whole bug in one assertion: interpolating the JSON array into shell
+  # source breaks the surrounding quoting.
+  run grep -c 'inputs.gradle-flags' "$ACTION"
+  [ "$status" -eq 0 ]
+  grep -q 'GRADLE_FLAGS_JSON: ${{ inputs.gradle-flags }}' "$ACTION"
+}
+
+@test "the flag splice does not interpolate gradle-flags into the run body" {
+  # `${{ inputs.gradle-flags }}` may appear only in an `env:` mapping (above)
+  # and in the debug echo, never inside the flag-building expression.
+  ! grep -qE '\$\(echo "\$\{\{ inputs.gradle-flags \}\}"' "$ACTION"
+}
+
+@test "flags are joined with spaces, not newline-separated" {
+  # `.[]` here would survive this file's own tests but produce a mega-flag in
+  # CI, so pin the join explicitly.
+  grep -q "jq -M -r 'join(\" \")'" "$ACTION"
+}
+
+@test "a malformed gradle-flags input fails the step instead of dropping flags" {
+  grep -q '::error::gradle-flags is not a JSON array' "$ACTION"
+}
+
+@test "record-step flags survive assembly intact" {
+  run build_flags '["--tests", "*ComponentScreenshotTest", "-Dscreenshot.record=true", "--rerun-tasks"]'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--tests *ComponentScreenshotTest"* ]]
+  [[ "$output" == *"-Dscreenshot.record=true"* ]]
+  [[ "$output" == *"--rerun-tasks"* ]]
+}
+
+@test "adjacent flags stay separated" {
+  # The regression signature: "--tests*Foo-Dscreenshot.record=true--rerun-tasks".
+  run build_flags '["--tests", "*ComponentScreenshotTest", "-Dscreenshot.record=true", "--rerun-tasks"]'
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"--tests*"* ]]
+  [[ "$output" != *"true--rerun-tasks"* ]]
+}
+
+@test "the default empty input still yields a usable flag set" {
+  run build_flags '[]'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--continue"* ]]
+  [[ "$output" == *"--stacktrace"* ]]
+}
+
+@test "a non-JSON gradle-flags input is rejected" {
+  run build_flags '[--tests, *Foo]'
+  [ "$status" -ne 0 ]
+}
+
+@test "record and verify steps pass their flags as valid JSON arrays" {
+  # A caller that hand-writes a malformed array would now hard-fail the step;
+  # catch it here instead.
+  workflow=".github/workflows/record-screenshot-baselines.yml"
+  while IFS= read -r value; do
+    printf '%s' "$value" | jq -e 'type == "array"' >/dev/null
+  done < <(grep -oE "gradle-flags: '\[.*\]'" "$workflow" | sed "s/^gradle-flags: '//; s/'$//")
+}


### PR DESCRIPTION
Fixes the actual blocker behind #3752 — and corrects the root cause recorded in #3913.

## The bug

`.github/actions/gradle-task-run/action.yml` built its flag string with:

```bash
$(echo "${{ inputs.gradle-flags }}" | jq ".[]" -M -r)
```

`gradle-flags` is a JSON array. Its own double quotes terminate the surrounding double-quoted shell string, so jq received bare `[--tests, *Foo]`, errored to stderr, and the command substitution expanded to **nothing**. The build ran with every caller flag missing — and exited 0.

Both halves are visible in [run 29719391484](https://github.com/kaeawc/auto-mobile/actions/runs/29719391484):

```
jq: parse error: Invalid numeric literal at line 1, column 9
GRADLE_FLAGS:   --continue  --stacktrace  -Dorg.gradle.configuration-cache.internal.report-link-as-warning=true
```

### Second, independent bug

The `${GRADLE_FLAGS//[$'\t\r\n']}` line below the splice deletes newlines **without substituting a space**. The literal flags survive only via their source indentation; `jq '.[]'` output has none. So even with the quoting fixed, `.[]` produced a single unparseable mega-flag:

```
--tests*ComponentScreenshotTest-Dscreenshot.record=true--rerun-tasks
```

## The fix

1. Input crosses into the shell via `env: GRADLE_FLAGS_JSON`, never `${{ }}`-interpolated into shell source.
2. `jq -r 'join(" ")'` instead of `.[]`.
3. Malformed input hard-fails the step, so this can never again degrade to "silently ran with no flags".

## Why this went unnoticed

`record-screenshot-baselines.yml` is the **only** caller that passes `gradle-flags`. Every other caller takes the `[]` default — and `echo "[]" | jq` works fine.

## This corrects #3913

#3913 is closed diagnosing a **pixel / AA-tolerance mismatch**. The evidence says otherwise: `-Dscreenshot.record=true` never reached Gradle, so `recordEnabled` was false, `skipIfPending` skipped all 6 tests, the record step "succeeded" writing zero PNGs, un-pend made them active, and verify failed on `MissingBaseline`.

Three independent confirmations these were `MissingBaseline`, not `Mismatch`:

- `MissingBaseline` is the only `ScreenshotComparator` outcome that writes no files (`ScreenshotComparator.kt:78`); `Mismatch`/`SizeMismatch` both write `.actual.png`. The artifact step reported `No files were found` for **both** the report dir and the baseline dir.
- The dropped `--tests` filter meant verify ran **544 tests**, not 6.
- The `GRADLE_FLAGS` echo above.

The macOS local repro in that thread passed because it invoked Gradle directly, bypassing this composite action entirely.

## Testing

- New guard `test/bats/gradle-task-run-flags.bats` (9 tests) — pins both invariants, and exercises the real flag-assembly logic across record / verify / default `[]` / malformed inputs rather than only grepping source.
- Verified both bugs reproduce against the old logic and are caught by the guard.
- `scripts/all_fast_validate_checks.sh`: 17/17 pass.
- Full `bats test/bats/`: 372 pass; the one failure (`verify-runtime-deps.bats` "passes when all dependencies are present") reproduces on a clean `origin/main` checkout and is a local-environment issue, unrelated.

## Caveat

This unblocks the workflow but does **not** prove the baselines will verify green — no baseline has ever actually been recorded, so an AA-tolerance or Linux-rasterization problem could still be hiding behind this one. The next dispatch is the first run capable of producing real evidence, and the #3974 diff-upload tooling is in place to read it.

Refs #3752
Refs #3913