### PR TITLE
fix(android): resolve detekt type resolution — replace .serializer() with reified serializer<T>()

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -99,6 +99,7 @@ import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 /**
  * Main AutoMobile Accessibility Service that provides view hierarchy extraction capabilities for
@@ -428,7 +429,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
         val payload = intent.getStringExtra(AutoMobileSDK.EXTRA_RECOMPOSITION_SNAPSHOT) ?: return
         try {
-          val snapshot = jsonLenient.decodeFromString(RecompositionSnapshot.serializer(), payload)
+          val snapshot = jsonLenient.decodeFromString(serializer<RecompositionSnapshot>(), payload)
           recompositionStore.updateSnapshot(snapshot)
         } catch (e: Exception) {
           Log.e(TAG, "Failed to parse recomposition snapshot", e)
@@ -5496,7 +5497,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           }
           append(""","totalTimeMs":$totalTimeMs""")
           if (focusedElement != null) {
-            val elementJson = jsonCompact.encodeToString(UIElementInfo.serializer(), focusedElement)
+            val elementJson =
+              jsonCompact.encodeToString(serializer<UIElementInfo>(), focusedElement)
             append(""","focusedElement":$elementJson""")
           } else {
             append(""","focusedElement":null""")
@@ -5565,7 +5567,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           append(""","totalTimeMs":$totalTimeMs""")
           val resultJson =
             jsonCompact.encodeToString(
-              dev.jasonpearson.automobile.ctrlproxy.models.TraversalOrderResult.serializer(),
+              serializer<dev.jasonpearson.automobile.ctrlproxy.models.TraversalOrderResult>(),
               traversalResult,
             )
           append(""","result":$resultJson""")

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.serializer
 
 /**
  * Component responsible for parsing AccessibilityNodeInfo trees and converting them into
@@ -285,7 +286,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
               val wrapped = wrapOptimizedElements(optimizedList)
               // Debug: Check if Tab elements have text children
               if (wrapped != null && window.isActive) {
-                val wrappedJson = json.encodeToString(UIElementInfo.serializer(), wrapped)
+                val wrappedJson = json.encodeToString(serializer<UIElementInfo>(), wrapped)
                 val hasTabText = wrappedJson.contains("\"text\":\"Tap\"")
                 Log.d(TAG, "[WRAP-ACTIVE] Has Tap text after wrap: $hasTabText")
               }
@@ -410,7 +411,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
       // Debug: Check if Tab text survives occlusion filtering
       mainHierarchy?.let {
-        val filteredJson = json.encodeToString(UIElementInfo.serializer(), it)
+        val filteredJson = json.encodeToString(serializer<UIElementInfo>(), it)
         val hasTabText = filteredJson.contains("\"text\":\"Tap\"")
         Log.d(TAG, "[OCCLUSION-FILTERED] Has Tap text after filtering: $hasTabText")
       }
@@ -925,8 +926,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val nodeElement =
         when {
           children.isEmpty() -> null
-          children.size == 1 -> json.encodeToJsonElement(UIElementInfo.serializer(), children[0])
-          else -> json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), children)
+          children.size == 1 -> json.encodeToJsonElement(serializer<UIElementInfo>(), children[0])
+          else -> json.encodeToJsonElement(ListSerializer(serializer<UIElementInfo>()), children)
         }
 
       val className =
@@ -1068,14 +1069,14 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       val children =
         when {
           nodeElement is JsonObject -> {
-            val child = json.decodeFromJsonElement(UIElementInfo.serializer(), nodeElement)
+            val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement)
             listOf(child)
           }
 
           nodeElement is JsonArray -> {
             nodeElement.jsonArray.mapNotNull { childJson ->
               try {
-                json.decodeFromJsonElement(UIElementInfo.serializer(), childJson)
+                json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
               } catch (e: Exception) {
                 null
               }
@@ -1219,7 +1220,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     return when {
       nodeElement is JsonObject -> {
         try {
-          listOf(json.decodeFromJsonElement(UIElementInfo.serializer(), nodeElement))
+          listOf(json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement))
         } catch (e: Exception) {
           null
         }
@@ -1229,7 +1230,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         for (childJson in nodeElement.jsonArray) {
           val child =
             try {
-              json.decodeFromJsonElement(UIElementInfo.serializer(), childJson)
+              json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
             } catch (e: Exception) {
               return null
             }
@@ -1322,7 +1323,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     return when (nodeElement) {
       is JsonObject -> {
         try {
-          val element = json.decodeFromJsonElement(UIElementInfo.serializer(), nodeElement)
+          val element = json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement)
           !element.text.isNullOrBlank() || hasTextInNode(element.node)
         } catch (e: Exception) {
           false
@@ -1343,7 +1344,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         when (node) {
           is JsonObject -> {
             try {
-              val child = json.decodeFromJsonElement(UIElementInfo.serializer(), node)
+              val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), node)
               countTextNodes(child)
             } catch (e: Exception) {
               0
@@ -1352,7 +1353,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           is JsonArray -> {
             node.jsonArray.sumOf { childJson ->
               try {
-                val child = json.decodeFromJsonElement(UIElementInfo.serializer(), childJson)
+                val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
                 countTextNodes(child)
               } catch (e: Exception) {
                 0
@@ -1369,9 +1370,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   private fun optimizeNode(nodeElement: JsonElement): JsonElement? {
     fun optimizeChild(childJson: JsonElement): List<JsonElement> {
       return try {
-        val child = json.decodeFromJsonElement(UIElementInfo.serializer(), childJson)
+        val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
         val optimizedChildren = optimizeHierarchy(child)
-        optimizedChildren.map { json.encodeToJsonElement(UIElementInfo.serializer(), it) }
+        optimizedChildren.map { json.encodeToJsonElement(serializer<UIElementInfo>(), it) }
       } catch (e: Exception) {
         listOf(childJson)
       }
@@ -1754,13 +1755,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     return try {
       when {
         nodeElement is JsonObject -> {
-          val child = json.decodeFromJsonElement(UIElementInfo.serializer(), nodeElement)
+          val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement)
           listOf(child)
         }
         nodeElement is JsonArray -> {
           nodeElement.jsonArray.mapNotNull { childJson ->
             try {
-              json.decodeFromJsonElement(UIElementInfo.serializer(), childJson)
+              json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
             } catch (e: Exception) {
               null
             }
@@ -1776,8 +1777,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   private fun encodeChildrenToNodeElement(children: List<UIElementInfo>): JsonElement? {
     return when {
       children.isEmpty() -> null
-      children.size == 1 -> json.encodeToJsonElement(UIElementInfo.serializer(), children[0])
-      else -> json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), children)
+      children.size == 1 -> json.encodeToJsonElement(serializer<UIElementInfo>(), children[0])
+      else -> json.encodeToJsonElement(ListSerializer(serializer<UIElementInfo>()), children)
     }
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AppearanceSocketClient.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 /** Socket file the daemon binds for appearance control. */
 internal const val APPEARANCE_SOCKET_FILE = "appearance.sock"
@@ -110,12 +111,12 @@ class AppearanceSocketClient(
           OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
         )
 
-      writer.write(json.encodeToString(AppearanceSocketRequest.serializer(), request))
+      writer.write(json.encodeToString(serializer<AppearanceSocketRequest>(), request))
       writer.newLine()
       writer.flush()
 
       val line = reader.readLine() ?: throw McpConnectionException("Appearance socket closed")
-      val response = json.decodeFromString(AppearanceSocketResponse.serializer(), line)
+      val response = json.decodeFromString(serializer<AppearanceSocketResponse>(), line)
 
       if (!response.success) {
         throw McpConnectionException(response.error ?: "Appearance request failed")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 interface AutoMobileClient {
   val transportName: String
@@ -366,7 +367,7 @@ internal fun <T> decodeToolResponse(
   element: JsonElement,
   serializer: KSerializer<T>,
 ): T {
-  val response = json.decodeFromJsonElement(McpToolResponse.serializer(), element)
+  val response = json.decodeFromJsonElement(serializer<McpToolResponse>(), element)
   val text =
     response.content.firstOrNull { it.type == "text" }?.text
       ?: throw McpConnectionException("Tool response missing text content")
@@ -381,7 +382,7 @@ internal fun <T> decodeResourceResponse(
   val text =
     contents.firstOrNull { !it.text.isNullOrBlank() }?.text
       ?: throw McpConnectionException("Resource response missing text content")
-  val element = json.decodeFromString(JsonElement.serializer(), text)
+  val element = json.decodeFromString(serializer<JsonElement>(), text)
   val error = (element as? JsonObject)?.get("error")?.jsonPrimitive?.content
   if (!error.isNullOrBlank()) {
     throw McpConnectionException(error)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DaemonNotificationClient.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 private val LOG = LoggerFactory.getLogger("DaemonNotificationClient")
 
@@ -193,12 +194,12 @@ class DaemonNotificationClient(
         id = UUID.randomUUID().toString(),
         method = SUBSCRIBE_NOTIFICATIONS_METHOD,
       )
-    writer.write(json.encodeToString(DaemonNotificationRequest.serializer(), request))
+    writer.write(json.encodeToString(serializer<DaemonNotificationRequest>(), request))
     writer.newLine()
     writer.flush()
 
     val line = reader.readLine() ?: throw IllegalStateException("Daemon closed during subscribe")
-    val response = json.decodeFromString(DaemonFrame.serializer(), line)
+    val response = json.decodeFromString(serializer<DaemonFrame>(), line)
 
     if (response.success != true) {
       val reason = response.error ?: "Daemon does not support pushed notifications"
@@ -235,7 +236,7 @@ class DaemonNotificationClient(
    */
   private fun decodeFrame(line: String): DaemonFrame? =
     try {
-      json.decodeFromString(DaemonFrame.serializer(), line)
+      json.decodeFromString(serializer<DaemonFrame>(), line)
     } catch (e: Exception) {
       // An unmodelled frame is not a reason to drop the subscription.
       LOG.debug("Ignoring unparseable daemon frame: ${e.message}")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotActions.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 /** MCP resource listing every captured snapshot. */
 internal const val DEVICE_SNAPSHOT_ARCHIVE_URI = "automobile:deviceSnapshots/archive"
@@ -66,7 +67,7 @@ class McpDeviceSnapshotActions(private val clientProvider: () -> AutoMobileClien
       decodeResourceResponse(
         snapshotJson,
         client.readResource(DEVICE_SNAPSHOT_ARCHIVE_URI),
-        DeviceSnapshotArchive.serializer(),
+        serializer<DeviceSnapshotArchive>(),
       )
     return archive.snapshots
   }
@@ -107,7 +108,7 @@ class McpDeviceSnapshotActions(private val clientProvider: () -> AutoMobileClien
     return decodeToolResponse(
       snapshotJson,
       client.callTool("deviceSnapshot", arguments),
-      DeviceSnapshotToolResponse.serializer(),
+      serializer<DeviceSnapshotToolResponse>(),
     )
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DeviceSnapshotSocketClient.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 /** Socket file the daemon binds for device-snapshot configuration. */
 internal const val DEVICE_SNAPSHOT_SOCKET_FILE = "device-snapshot.sock"
@@ -116,12 +117,12 @@ class DeviceSnapshotSocketClient(
           OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
         )
 
-      writer.write(json.encodeToString(DeviceSnapshotSocketRequest.serializer(), request))
+      writer.write(json.encodeToString(serializer<DeviceSnapshotSocketRequest>(), request))
       writer.newLine()
       writer.flush()
 
       val line = reader.readLine() ?: throw McpConnectionException("Device snapshot socket closed")
-      val response = json.decodeFromString(DeviceSnapshotSocketResponse.serializer(), line)
+      val response = json.decodeFromString(serializer<DeviceSnapshotSocketResponse>(), line)
 
       if (!response.success) {
         throw McpConnectionException(response.error ?: "Device snapshot request failed")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FailuresPushSocketClient.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
 
 /**
  * Client for the failures push Unix socket server. Subscribes to receive real-time failure
@@ -242,7 +243,7 @@ class FailuresPushSocketClient {
     val currentWriter = writer ?: return false
 
     return try {
-      val message = json.encodeToString(FailuresPushRequest.serializer(), request)
+      val message = json.encodeToString(serializer<FailuresPushRequest>(), request)
       currentWriter.write(message)
       currentWriter.newLine()
       currentWriter.flush()
@@ -288,7 +289,7 @@ class FailuresPushSocketClient {
   }
 
   private suspend fun handleMessage(message: String) {
-    val response = json.decodeFromString(FailuresPushResponse.serializer(), message)
+    val response = json.decodeFromString(serializer<FailuresPushResponse>(), message)
 
     when (response.type) {
       "subscription_response" -> {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.serializer
 
 class McpDaemonClient(
   private val socketPathValue: String = DaemonSocketPaths.socketPath(),
@@ -44,7 +45,7 @@ class McpDaemonClient(
   override fun listResources(): List<McpResource> {
     val response = sendRequest("resources/list")
     ensureSuccess(response)
-    val result = json.decodeFromJsonElement(ListResourcesResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ListResourcesResult>(), response.result!!)
     return result.resources
   }
 
@@ -52,14 +53,14 @@ class McpDaemonClient(
     val response = sendRequest("resources/list-templates")
     ensureSuccess(response)
     val result =
-      json.decodeFromJsonElement(ListResourceTemplatesResult.serializer(), response.result!!)
+      json.decodeFromJsonElement(serializer<ListResourceTemplatesResult>(), response.result!!)
     return result.resourceTemplates
   }
 
   override fun listTools(): List<McpTool> {
     val response = sendRequest("tools/list")
     ensureSuccess(response)
-    val result = json.decodeFromJsonElement(ListToolsResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ListToolsResult>(), response.result!!)
     return result.tools
   }
 
@@ -70,7 +71,7 @@ class McpDaemonClient(
         buildJsonObject { put("uri", JsonPrimitive(uri)) },
       )
     ensureSuccess(response)
-    val result = json.decodeFromJsonElement(ReadResourceResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ReadResourceResult>(), response.result!!)
     return result.contents
   }
 
@@ -87,7 +88,7 @@ class McpDaemonClient(
   override fun listFeatureFlags(): List<FeatureFlagState> {
     val response = sendRequest("ide/listFeatureFlags")
     ensureSuccess(response)
-    val result = json.decodeFromJsonElement(FeatureFlagListResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<FeatureFlagListResult>(), response.result!!)
     return result.flags
   }
 
@@ -108,7 +109,7 @@ class McpDaemonClient(
         },
       )
     ensureSuccess(response)
-    return json.decodeFromJsonElement(FeatureFlagState.serializer(), response.result!!)
+    return json.decodeFromJsonElement(serializer<FeatureFlagState>(), response.result!!)
   }
 
   override fun listPerformanceAuditResults(
@@ -124,12 +125,12 @@ class McpDaemonClient(
 
   override fun getTestTimings(query: TestTimingQuery): TestTimingSummary {
     val contents = readResource(query.toResourceUri())
-    return decodeResourceResponse(json, contents, TestTimingSummary.serializer())
+    return decodeResourceResponse(json, contents, serializer<TestTimingSummary>())
   }
 
   override fun getTestRuns(query: TestRunQuery): TestRunSummary {
     val contents = readResource(query.toResourceUri())
-    return decodeResourceResponse(json, contents, TestRunSummary.serializer())
+    return decodeResourceResponse(json, contents, serializer<TestRunSummary>())
   }
 
   override fun startTestRecording(platform: String): TestRecordingStartResult {
@@ -164,7 +165,7 @@ class McpDaemonClient(
           }
         },
       )
-    return decodeToolResponse(json, response, ExecutePlanResult.serializer())
+    return decodeToolResponse(json, response, serializer<ExecutePlanResult>())
   }
 
   override fun startDevice(name: String, platform: String, deviceId: String?): StartDeviceResult {
@@ -185,7 +186,7 @@ class McpDaemonClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, StartDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<StartDeviceResult>())
     } catch (e: Exception) {
       StartDeviceResult(success = false, message = e.message ?: "Failed to start device")
     }
@@ -201,7 +202,7 @@ class McpDaemonClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, SetActiveDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<SetActiveDeviceResult>())
     } catch (e: Exception) {
       SetActiveDeviceResult(success = false, message = e.message ?: "Failed to set active device")
     }
@@ -216,7 +217,7 @@ class McpDaemonClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, ObserveResult.serializer())
+      decodeToolResponse(json, response, serializer<ObserveResult>())
     } catch (e: Exception) {
       ObserveResult()
     }
@@ -238,7 +239,7 @@ class McpDaemonClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, KillDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<KillDeviceResult>())
     } catch (e: Exception) {
       KillDeviceResult(success = false, message = e.message ?: "Failed to kill device")
     }
@@ -249,7 +250,7 @@ class McpDaemonClient(
     val response = sendRequest("ide/status")
     ensureSuccess(response)
     return json.decodeFromJsonElement(
-      dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse.serializer(),
+      serializer<dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse>(),
       response.result!!,
     )
   }
@@ -264,7 +265,7 @@ class McpDaemonClient(
         },
       )
     ensureSuccess(response)
-    return json.decodeFromJsonElement(UpdateServiceResult.serializer(), response.result!!)
+    return json.decodeFromJsonElement(serializer<UpdateServiceResult>(), response.result!!)
   }
 
   override fun inputTap(
@@ -378,7 +379,7 @@ class McpDaemonClient(
       )
     ensureSuccess(response)
     return try {
-      json.decodeFromJsonElement(SetKeyValueResult.serializer(), response.result!!)
+      json.decodeFromJsonElement(serializer<SetKeyValueResult>(), response.result!!)
     } catch (e: Exception) {
       SetKeyValueResult(success = false, message = e.message ?: "Failed to set key value")
     }
@@ -402,7 +403,7 @@ class McpDaemonClient(
       )
     ensureSuccess(response)
     return try {
-      json.decodeFromJsonElement(RemoveKeyValueResult.serializer(), response.result!!)
+      json.decodeFromJsonElement(serializer<RemoveKeyValueResult>(), response.result!!)
     } catch (e: Exception) {
       RemoveKeyValueResult(success = false, message = e.message ?: "Failed to remove key value")
     }
@@ -424,7 +425,7 @@ class McpDaemonClient(
       )
     ensureSuccess(response)
     return try {
-      json.decodeFromJsonElement(ClearKeyValueResult.serializer(), response.result!!)
+      json.decodeFromJsonElement(serializer<ClearKeyValueResult>(), response.result!!)
     } catch (e: Exception) {
       ClearKeyValueResult(success = false, message = e.message ?: "Failed to clear key value file")
     }
@@ -455,7 +456,7 @@ class McpDaemonClient(
           success = false,
           error = "Daemon response missing result",
         )
-    val inputResult = json.decodeFromJsonElement(InputActionResult.serializer(), result)
+    val inputResult = json.decodeFromJsonElement(serializer<InputActionResult>(), result)
     if (inputResult.action != method) {
       return InputActionResult(
         action = method,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 class McpHttpClient(
   private val endpoint: String,
@@ -40,7 +41,7 @@ class McpHttpClient(
   override fun listResources(): List<McpResource> {
     ensureInitialized()
     val response = sendRequest("resources/list")
-    val result = json.decodeFromJsonElement(ListResourcesResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ListResourcesResult>(), response.result!!)
     return result.resources
   }
 
@@ -48,14 +49,14 @@ class McpHttpClient(
     ensureInitialized()
     val response = sendRequest("resources/list-templates")
     val result =
-      json.decodeFromJsonElement(ListResourceTemplatesResult.serializer(), response.result!!)
+      json.decodeFromJsonElement(serializer<ListResourceTemplatesResult>(), response.result!!)
     return result.resourceTemplates
   }
 
   override fun listTools(): List<McpTool> {
     ensureInitialized()
     val response = sendRequest("tools/list")
-    val result = json.decodeFromJsonElement(ListToolsResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ListToolsResult>(), response.result!!)
     return result.tools
   }
 
@@ -66,7 +67,7 @@ class McpHttpClient(
         "resources/read",
         buildJsonObject { put("uri", JsonPrimitive(uri)) },
       )
-    val result = json.decodeFromJsonElement(ReadResourceResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ReadResourceResult>(), response.result!!)
     return result.contents
   }
 
@@ -81,7 +82,7 @@ class McpHttpClient(
 
   override fun listFeatureFlags(): List<FeatureFlagState> {
     val response = callTool("listFeatureFlags", JsonObject(emptyMap()))
-    val result = decodeToolResponse(json, response, FeatureFlagListResult.serializer())
+    val result = decodeToolResponse(json, response, serializer<FeatureFlagListResult>())
     return result.flags
   }
 
@@ -101,7 +102,7 @@ class McpHttpClient(
           }
         },
       )
-    return decodeToolResponse(json, response, FeatureFlagState.serializer())
+    return decodeToolResponse(json, response, serializer<FeatureFlagState>())
   }
 
   override fun listPerformanceAuditResults(
@@ -117,12 +118,12 @@ class McpHttpClient(
 
   override fun getTestTimings(query: TestTimingQuery): TestTimingSummary {
     val contents = readResource(query.toResourceUri())
-    return decodeResourceResponse(json, contents, TestTimingSummary.serializer())
+    return decodeResourceResponse(json, contents, serializer<TestTimingSummary>())
   }
 
   override fun getTestRuns(query: TestRunQuery): TestRunSummary {
     val contents = readResource(query.toResourceUri())
-    return decodeResourceResponse(json, contents, TestRunSummary.serializer())
+    return decodeResourceResponse(json, contents, serializer<TestRunSummary>())
   }
 
   override fun startTestRecording(platform: String): TestRecordingStartResult {
@@ -157,7 +158,7 @@ class McpHttpClient(
           }
         },
       )
-    return decodeToolResponse(json, response, ExecutePlanResult.serializer())
+    return decodeToolResponse(json, response, serializer<ExecutePlanResult>())
   }
 
   override fun startDevice(name: String, platform: String, deviceId: String?): StartDeviceResult {
@@ -178,7 +179,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, StartDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<StartDeviceResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       StartDeviceResult(success = false, message = e.message ?: "Failed to start device")
@@ -195,7 +196,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, SetActiveDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<SetActiveDeviceResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       SetActiveDeviceResult(success = false, message = e.message ?: "Failed to set active device")
@@ -211,7 +212,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, ObserveResult.serializer())
+      decodeToolResponse(json, response, serializer<ObserveResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       ObserveResult()
@@ -234,7 +235,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, KillDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<KillDeviceResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       KillDeviceResult(success = false, message = e.message ?: "Failed to kill device")
@@ -253,7 +254,7 @@ class McpHttpClient(
       decodeToolResponse(
         json,
         response,
-        dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse.serializer(),
+        serializer<dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse>(),
       )
     } catch (e: Exception) {
       if (e is CancellationException) throw e
@@ -283,7 +284,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, SetKeyValueResult.serializer())
+      decodeToolResponse(json, response, serializer<SetKeyValueResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       SetKeyValueResult(success = false, message = e.message ?: "Failed to set key value")
@@ -308,7 +309,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, RemoveKeyValueResult.serializer())
+      decodeToolResponse(json, response, serializer<RemoveKeyValueResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       RemoveKeyValueResult(success = false, message = e.message ?: "Failed to remove key value")
@@ -331,7 +332,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, ClearKeyValueResult.serializer())
+      decodeToolResponse(json, response, serializer<ClearKeyValueResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       ClearKeyValueResult(success = false, message = e.message ?: "Failed to clear key value file")
@@ -348,7 +349,7 @@ class McpHttpClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, UpdateServiceResult.serializer())
+      decodeToolResponse(json, response, serializer<UpdateServiceResult>())
     } catch (e: Exception) {
       if (e is CancellationException) throw e
       UpdateServiceResult(success = false, message = e.message ?: "Failed to update service")
@@ -451,7 +452,7 @@ class McpHttpClient(
     includeSession: Boolean,
     expectResponse: Boolean,
   ): JsonRpcResponse {
-    val requestBody = json.encodeToString(JsonRpcRequest.serializer(), request)
+    val requestBody = json.encodeToString(serializer<JsonRpcRequest>(), request)
     val builder =
       HttpRequest.newBuilder(URI.create(endpoint)).header("Content-Type", "application/json")
 
@@ -486,7 +487,7 @@ class McpHttpClient(
         throw McpConnectionException("MCP HTTP response was empty")
       }
 
-      val rpcResponse = json.decodeFromString(JsonRpcResponse.serializer(), body)
+      val rpcResponse = json.decodeFromString(serializer<JsonRpcResponse>(), body)
       if (rpcResponse.error != null) {
         throw McpConnectionException(
           "MCP HTTP error ${rpcResponse.error.code}: ${rpcResponse.error.message}"

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 class McpStdioClient(
   private val command: String,
@@ -38,7 +39,7 @@ class McpStdioClient(
   override fun listResources(): List<McpResource> {
     ensureInitialized()
     val response = sendRequest("resources/list")
-    val result = json.decodeFromJsonElement(ListResourcesResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ListResourcesResult>(), response.result!!)
     return result.resources
   }
 
@@ -46,14 +47,14 @@ class McpStdioClient(
     ensureInitialized()
     val response = sendRequest("resources/list-templates")
     val result =
-      json.decodeFromJsonElement(ListResourceTemplatesResult.serializer(), response.result!!)
+      json.decodeFromJsonElement(serializer<ListResourceTemplatesResult>(), response.result!!)
     return result.resourceTemplates
   }
 
   override fun listTools(): List<McpTool> {
     ensureInitialized()
     val response = sendRequest("tools/list")
-    val result = json.decodeFromJsonElement(ListToolsResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ListToolsResult>(), response.result!!)
     return result.tools
   }
 
@@ -64,7 +65,7 @@ class McpStdioClient(
         "resources/read",
         buildJsonObject { put("uri", JsonPrimitive(uri)) },
       )
-    val result = json.decodeFromJsonElement(ReadResourceResult.serializer(), response.result!!)
+    val result = json.decodeFromJsonElement(serializer<ReadResourceResult>(), response.result!!)
     return result.contents
   }
 
@@ -79,7 +80,7 @@ class McpStdioClient(
 
   override fun listFeatureFlags(): List<FeatureFlagState> {
     val response = callTool("listFeatureFlags", JsonObject(emptyMap()))
-    val result = decodeToolResponse(json, response, FeatureFlagListResult.serializer())
+    val result = decodeToolResponse(json, response, serializer<FeatureFlagListResult>())
     return result.flags
   }
 
@@ -99,7 +100,7 @@ class McpStdioClient(
           }
         },
       )
-    return decodeToolResponse(json, response, FeatureFlagState.serializer())
+    return decodeToolResponse(json, response, serializer<FeatureFlagState>())
   }
 
   override fun listPerformanceAuditResults(
@@ -115,12 +116,12 @@ class McpStdioClient(
 
   override fun getTestTimings(query: TestTimingQuery): TestTimingSummary {
     val contents = readResource(query.toResourceUri())
-    return decodeResourceResponse(json, contents, TestTimingSummary.serializer())
+    return decodeResourceResponse(json, contents, serializer<TestTimingSummary>())
   }
 
   override fun getTestRuns(query: TestRunQuery): TestRunSummary {
     val contents = readResource(query.toResourceUri())
-    return decodeResourceResponse(json, contents, TestRunSummary.serializer())
+    return decodeResourceResponse(json, contents, serializer<TestRunSummary>())
   }
 
   override fun startTestRecording(platform: String): TestRecordingStartResult {
@@ -155,7 +156,7 @@ class McpStdioClient(
           }
         },
       )
-    return decodeToolResponse(json, response, ExecutePlanResult.serializer())
+    return decodeToolResponse(json, response, serializer<ExecutePlanResult>())
   }
 
   override fun startDevice(name: String, platform: String, deviceId: String?): StartDeviceResult {
@@ -176,7 +177,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, StartDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<StartDeviceResult>())
     } catch (e: Exception) {
       StartDeviceResult(success = false, message = e.message ?: "Failed to start device")
     }
@@ -192,7 +193,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, SetActiveDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<SetActiveDeviceResult>())
     } catch (e: Exception) {
       SetActiveDeviceResult(success = false, message = e.message ?: "Failed to set active device")
     }
@@ -207,7 +208,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, ObserveResult.serializer())
+      decodeToolResponse(json, response, serializer<ObserveResult>())
     } catch (e: Exception) {
       ObserveResult()
     }
@@ -229,7 +230,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, KillDeviceResult.serializer())
+      decodeToolResponse(json, response, serializer<KillDeviceResult>())
     } catch (e: Exception) {
       KillDeviceResult(success = false, message = e.message ?: "Failed to kill device")
     }
@@ -246,7 +247,7 @@ class McpStdioClient(
       decodeToolResponse(
         json,
         response,
-        dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse.serializer(),
+        serializer<dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse>(),
       )
     } catch (e: Exception) {
       dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse()
@@ -263,7 +264,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, UpdateServiceResult.serializer())
+      decodeToolResponse(json, response, serializer<UpdateServiceResult>())
     } catch (e: Exception) {
       UpdateServiceResult(success = false, message = e.message ?: "Failed to update service")
     }
@@ -294,7 +295,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, SetKeyValueResult.serializer())
+      decodeToolResponse(json, response, serializer<SetKeyValueResult>())
     } catch (e: Exception) {
       SetKeyValueResult(success = false, message = e.message ?: "Failed to set key value")
     }
@@ -318,7 +319,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, RemoveKeyValueResult.serializer())
+      decodeToolResponse(json, response, serializer<RemoveKeyValueResult>())
     } catch (e: Exception) {
       RemoveKeyValueResult(success = false, message = e.message ?: "Failed to remove key value")
     }
@@ -340,7 +341,7 @@ class McpStdioClient(
         },
       )
     return try {
-      decodeToolResponse(json, response, ClearKeyValueResult.serializer())
+      decodeToolResponse(json, response, serializer<ClearKeyValueResult>())
     } catch (e: Exception) {
       ClearKeyValueResult(success = false, message = e.message ?: "Failed to clear key value file")
     }
@@ -454,7 +455,7 @@ class McpStdioClient(
       val currentWriter = writer ?: throw McpConnectionException("MCP stdio writer unavailable")
       val currentReader = reader ?: throw McpConnectionException("MCP stdio reader unavailable")
 
-      val requestBody = json.encodeToString(JsonRpcRequest.serializer(), request)
+      val requestBody = json.encodeToString(serializer<JsonRpcRequest>(), request)
       currentWriter.write(requestBody)
       currentWriter.newLine()
       currentWriter.flush()
@@ -469,7 +470,7 @@ class McpStdioClient(
         if (line.isBlank()) {
           continue
         }
-        val response = json.decodeFromString(JsonRpcResponse.serializer(), line)
+        val response = json.decodeFromString(serializer<JsonRpcResponse>(), line)
         val responseId = response.id?.jsonPrimitive?.content
         if (expectedId != null && responseId != expectedId) {
           continue

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.serializer
 
 /**
  * Client for the observation stream Unix socket server. Subscribes to receive real-time hierarchy
@@ -252,7 +253,7 @@ class ObservationStreamClient {
     val currentWriter = writer ?: return false
 
     return try {
-      val message = json.encodeToString(StreamRequest.serializer(), request)
+      val message = json.encodeToString(serializer<StreamRequest>(), request)
       currentWriter.write(message)
       currentWriter.newLine()
       currentWriter.flush()
@@ -291,7 +292,7 @@ class ObservationStreamClient {
   }
 
   internal suspend fun handleMessage(message: String) {
-    val response = json.decodeFromString(StreamResponse.serializer(), message)
+    val response = json.decodeFromString(serializer<StreamResponse>(), message)
     log.info("Handling message type: ${response.type}")
 
     when (response.type) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditResults.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/PerformanceAuditResults.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.serializer
 
 @Serializable
 data class PerformanceAuditMetrics(
@@ -83,5 +84,5 @@ internal fun decodePerformanceAuditResource(
     }
   }
 
-  return json.decodeFromJsonElement(PerformanceAuditHistoryResult.serializer(), jsonElement)
+  return json.decodeFromJsonElement(serializer<PerformanceAuditHistoryResult>(), jsonElement)
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/TelemetryPushSocketClient.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.serializer
 
 /**
  * Client for the telemetry push Unix socket server. Subscribes to receive real-time telemetry
@@ -240,7 +241,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
     val currentWriter = writer ?: return false
 
     return try {
-      val message = json.encodeToString(TelemetryPushRequest.serializer(), request)
+      val message = json.encodeToString(serializer<TelemetryPushRequest>(), request)
       currentWriter.write(message)
       currentWriter.newLine()
       currentWriter.flush()
@@ -285,7 +286,7 @@ class TelemetryPushSocketClient : TelemetryPushClient {
   }
 
   private suspend fun handleMessage(message: String) {
-    val response = json.decodeFromString(TelemetryPushResponse.serializer(), message)
+    val response = json.decodeFromString(serializer<TelemetryPushResponse>(), message)
 
     when (response.type) {
       "subscription_response" -> {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingActions.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingActions.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 private val recordingJson = DaemonJson
 
@@ -84,7 +85,7 @@ class McpVideoRecordingActions(private val clientProvider: () -> AutoMobileClien
     decodeToolResponse(
       recordingJson,
       clientProvider().callTool("videoRecording", arguments),
-      VideoRecordingToolResponse.serializer(),
+      serializer<VideoRecordingToolResponse>(),
     )
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/VideoRecordingSocketClient.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 /** Socket file the daemon binds for video-recording configuration. */
 internal const val VIDEO_RECORDING_SOCKET_FILE = "video-recording.sock"
@@ -102,12 +103,12 @@ class VideoRecordingSocketClient(
           OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
         )
 
-      writer.write(json.encodeToString(VideoRecordingSocketRequest.serializer(), request))
+      writer.write(json.encodeToString(serializer<VideoRecordingSocketRequest>(), request))
       writer.newLine()
       writer.flush()
 
       val line = reader.readLine() ?: throw McpConnectionException("Video recording socket closed")
-      val response = json.decodeFromString(VideoRecordingSocketResponse.serializer(), line)
+      val response = json.decodeFromString(serializer<VideoRecordingSocketResponse>(), line)
 
       if (!response.success) {
         throw McpConnectionException(response.error ?: "Video recording request failed")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 /** Socket file the daemon binds for WebRTC stream control. */
 internal const val WEBRTC_STREAM_SOCKET_FILE = "webrtc-stream.sock"
@@ -118,12 +119,12 @@ class WebRtcStreamSocketClient(
           OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
         )
 
-      writer.write(json.encodeToString(WebRtcStreamSocketRequest.serializer(), request))
+      writer.write(json.encodeToString(serializer<WebRtcStreamSocketRequest>(), request))
       writer.newLine()
       writer.flush()
 
       val line = reader.readLine() ?: throw McpConnectionException("WebRTC stream socket closed")
-      val response = json.decodeFromString(WebRtcStreamSocketResponse.serializer(), line)
+      val response = json.decodeFromString(serializer<WebRtcStreamSocketResponse>(), line)
 
       if (!response.success) {
         throw McpConnectionException(response.error ?: "WebRTC stream request failed")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/AppListDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/AppListDataSource.kt
@@ -6,6 +6,7 @@ import dev.jasonpearson.automobile.desktop.core.daemon.encodeResourceUriComponen
 import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 typealias InstalledApp = dev.jasonpearson.automobile.desktop.domain.InstalledApp
 
@@ -54,7 +55,7 @@ class RealAppListDataSource(
       val responseText = contents.firstOrNull()?.text ?: return Result.Success(emptyList())
 
       // Parse the MCP apps query response
-      val response = json.decodeFromString(McpAppsQueryResponse.serializer(), responseText)
+      val response = json.decodeFromString(serializer<McpAppsQueryResponse>(), responseText)
 
       // Flatten apps from all devices (usually just one)
       val apps =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealLayoutDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealLayoutDataSource.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.serializer
 
 /**
  * Real layout data source that fetches from MCP. Calls the 'observe' tool to capture fresh screen
@@ -49,7 +50,7 @@ class RealLayoutDataSource(
           try {
             val viewHierarchyResult =
               json.decodeFromJsonElement(
-                ViewHierarchyResultDto.serializer(),
+                serializer<ViewHierarchyResultDto>(),
                 viewHierarchyJson,
               )
             viewHierarchyResult.hierarchy?.node?.let { nodes ->
@@ -235,7 +236,7 @@ private data class HierarchyNodeDto(
           nodeElement.mapNotNull { elem ->
             try {
               Json { ignoreUnknownKeys = true }
-                .decodeFromJsonElement(HierarchyNodeDto.serializer(), elem)
+                .decodeFromJsonElement(serializer<HierarchyNodeDto>(), elem)
             } catch (e: Exception) {
               null
             }
@@ -245,7 +246,7 @@ private data class HierarchyNodeDto(
           try {
             listOf(
               Json { ignoreUnknownKeys = true }
-                .decodeFromJsonElement(HierarchyNodeDto.serializer(), nodeElement)
+                .decodeFromJsonElement(serializer<HierarchyNodeDto>(), nodeElement)
             )
           } catch (e: Exception) {
             emptyList()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSource.kt
@@ -7,6 +7,7 @@ import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenTransition
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 /**
  * Real navigation data source that fetches from MCP resources. Adapts the MCP navigation/graph
@@ -46,7 +47,7 @@ class RealNavigationDataSource(
           )
 
       // Parse the MCP navigation graph response
-      val response = json.decodeFromString(McpNavigationGraphResponse.serializer(), graphText)
+      val response = json.decodeFromString(serializer<McpNavigationGraphResponse>(), graphText)
 
       // Count outgoing edges per screen for transitionCount
       val outgoingEdgeCounts = response.edges.groupBy { it.from }.mapValues { it.value.size }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSource.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 private val LOG = LoggerFactory.getLogger("RealStorageDataSource")
 
@@ -73,7 +74,7 @@ class RealStorageDataSource(
       LOG.info("getDatabases: Fetching from URI: $dbsUri")
       val dbsContents = client.readResource(dbsUri)
       val dbsText = dbsContents.firstOrNull()?.text ?: return Result.Success(emptyList())
-      val dbsResponse = json.decodeFromString(McpDatabasesResponse.serializer(), dbsText)
+      val dbsResponse = json.decodeFromString(serializer<McpDatabasesResponse>(), dbsText)
 
       if (dbsResponse.error != null) {
         LOG.warn("getDatabases: Response error: ${dbsResponse.error}")
@@ -90,7 +91,8 @@ class RealStorageDataSource(
           val tablesText = tablesContents.firstOrNull()?.text
           val tableNames =
             if (tablesText != null) {
-              val tablesResponse = json.decodeFromString(McpTablesResponse.serializer(), tablesText)
+              val tablesResponse =
+                json.decodeFromString(serializer<McpTablesResponse>(), tablesText)
               tablesResponse.tables
             } else {
               emptyList()
@@ -106,7 +108,7 @@ class RealStorageDataSource(
             val columns =
               if (structText != null) {
                 val structResponse =
-                  json.decodeFromString(McpTableStructureResponse.serializer(), structText)
+                  json.decodeFromString(serializer<McpTableStructureResponse>(), structText)
                 structResponse.columns.map { col ->
                   ColumnInfo(
                     name = col.name,
@@ -163,7 +165,7 @@ class RealStorageDataSource(
         contents.firstOrNull()?.text
           ?: return Result.Success(QueryResult(emptyList(), emptyList(), 0, 0))
 
-      val response = json.decodeFromString(McpTableDataResponse.serializer(), text)
+      val response = json.decodeFromString(serializer<McpTableDataResponse>(), text)
 
       if (response.error != null) {
         return Result.Error(RuntimeException(response.error))
@@ -204,7 +206,7 @@ class RealStorageDataSource(
         put("query", query)
       }
       val toolElement = client.callTool("sqlQuery", arguments)
-      val sqlResult = decodeToolResponse(json, toolElement, McpSqlResult.serializer())
+      val sqlResult = decodeToolResponse(json, toolElement, serializer<McpSqlResult>())
 
       if (sqlResult.error != null) {
         return Result.Success(QueryResult(emptyList(), emptyList(), 0, 0, error = sqlResult.error))
@@ -280,7 +282,7 @@ class RealStorageDataSource(
       }
       LOG.info("getKeyValueFiles: Response text (first 500 chars): ${filesText.take(500)}")
 
-      val filesResponse = json.decodeFromString(McpStorageFilesResponse.serializer(), filesText)
+      val filesResponse = json.decodeFromString(serializer<McpStorageFilesResponse>(), filesText)
       LOG.info(
         "getKeyValueFiles: Parsed response, files count=${filesResponse.files.size}, error=${filesResponse.error}"
       )
@@ -303,7 +305,7 @@ class RealStorageDataSource(
             if (entriesText != null) {
               val entriesResponse =
                 json.decodeFromString(
-                  McpStorageEntriesResponse.serializer(),
+                  serializer<McpStorageEntriesResponse>(),
                   entriesText,
                 )
               LOG.info(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/failures/FailuresDataSource.kt
@@ -8,6 +8,7 @@ import dev.jasonpearson.automobile.desktop.core.time.Clock
 import dev.jasonpearson.automobile.desktop.core.time.SystemClock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 typealias TimelineData = dev.jasonpearson.automobile.desktop.domain.TimelineData
 
@@ -78,7 +79,7 @@ class McpFailuresDataSource(private val clientProvider: () -> AutoMobileClient) 
     return try {
       val client = clientProvider()
       val contents = client.readResource("automobile:failures")
-      val response = decodeResourceResponse(json, contents, FailuresResponse.serializer())
+      val response = decodeResourceResponse(json, contents, serializer<FailuresResponse>())
       Result.Success(response.groups.map { it.toModel() })
     } catch (e: McpConnectionException) {
       Result.Error(e, "MCP server not available: ${e.message}")
@@ -96,7 +97,7 @@ class McpFailuresDataSource(private val clientProvider: () -> AutoMobileClient) 
       val uri =
         "automobile:failures/timeline?dateRange=${dateRange.toQueryParam()}&aggregation=${aggregation.toQueryParam()}"
       val contents = client.readResource(uri)
-      val response = decodeResourceResponse(json, contents, TimelineResponse.serializer())
+      val response = decodeResourceResponse(json, contents, serializer<TimelineResponse>())
       Result.Success(
         TimelineData(
           dataPoints =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.Image
@@ -159,7 +160,7 @@ class VideoStreamClient(
 
         writer.write(
           json.encodeToString(
-            VideoStreamRequest.serializer(),
+            serializer<VideoStreamRequest>(),
             VideoStreamRequest(id = UUID.randomUUID().toString(), deviceId = deviceId),
           )
         )
@@ -167,7 +168,7 @@ class VideoStreamClient(
         writer.flush()
 
         val ackLine = readAckLine(input)
-        val ack = json.decodeFromString(VideoStreamResponse.serializer(), ackLine)
+        val ack = json.decodeFromString(serializer<VideoStreamResponse>(), ackLine)
         if (!ack.success) {
           _state.value = VideoStreamState.Unavailable(ack.error ?: "Live mirroring was refused")
           return

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -30,6 +30,7 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.serializer
 
 internal object DaemonSocketClientManager {
   // Use ThreadLocal to give each thread its own socket connection
@@ -1103,7 +1104,7 @@ internal class DaemonSocketClient(
           continue
         }
         try {
-          val response = json.decodeFromString(DaemonResponse.serializer(), line)
+          val response = json.decodeFromString(serializer<DaemonResponse>(), line)
           handleResponse(response)
         } catch (e: Exception) {
           println("Failed to parse daemon response: ${e.message}")

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/TestTimingCache.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/TestTimingCache.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.serializer
 
 @Serializable
 internal data class TestTimingStatusCounts(
@@ -124,13 +125,13 @@ internal object TestTimingCache {
         return
       }
 
-      val element = json.decodeFromString(JsonElement.serializer(), payload)
+      val element = json.decodeFromString(serializer<JsonElement>(), payload)
       val error = (element as? JsonObject)?.get("error")?.jsonPrimitive?.content
       if (!error.isNullOrBlank()) {
         return
       }
 
-      val parsed = json.decodeFromJsonElement(TestTimingSummary.serializer(), element)
+      val parsed = json.decodeFromJsonElement(serializer<TestTimingSummary>(), element)
       summary = parsed
       timingMap = parsed.testTimings.associateBy { TestTimingKey(it.testClass, it.testMethod) }
     } catch (e: Exception) {}

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/SdkEventSerializer.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/SdkEventSerializer.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.protocol
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 /**
  * Serializer for converting SdkEvent sealed classes to/from JSON strings.
@@ -77,7 +78,7 @@ object SdkEventSerializer {
    * @return JSON string representation
    */
   fun toJson(event: SdkEvent): String {
-    return json.encodeToString(SdkEvent.serializer(), event)
+    return json.encodeToString(serializer<SdkEvent>(), event)
   }
 
   /**
@@ -88,7 +89,7 @@ object SdkEventSerializer {
    */
   fun fromJson(jsonString: String): SdkEvent? {
     return try {
-      json.decodeFromString(SdkEvent.serializer(), jsonString)
+      json.decodeFromString(serializer<SdkEvent>(), jsonString)
     } catch (e: Exception) {
       null
     }
@@ -102,7 +103,7 @@ object SdkEventSerializer {
    * @throws kotlinx.serialization.SerializationException if parsing fails
    */
   fun fromJsonOrThrow(jsonString: String): SdkEvent {
-    return json.decodeFromString(SdkEvent.serializer(), jsonString)
+    return json.decodeFromString(serializer<SdkEvent>(), jsonString)
   }
 
   /**

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/StorageProtocol.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/StorageProtocol.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.protocol
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 
 /**
  * Protocol types for SharedPreferences inspection via ContentProvider.
@@ -252,13 +253,13 @@ object StorageProtocolSerializer {
 
   /** Serialize a StorageRequest to JSON string. */
   fun requestToJson(request: StorageRequest): String {
-    return json.encodeToString(StorageRequest.serializer(), request)
+    return json.encodeToString(serializer<StorageRequest>(), request)
   }
 
   /** Deserialize a StorageRequest from JSON string. */
   fun requestFromJson(jsonString: String): StorageRequest? {
     return try {
-      json.decodeFromString(StorageRequest.serializer(), jsonString)
+      json.decodeFromString(serializer<StorageRequest>(), jsonString)
     } catch (e: Exception) {
       null
     }
@@ -266,13 +267,13 @@ object StorageProtocolSerializer {
 
   /** Serialize a StorageResponse to JSON string. */
   fun responseToJson(response: StorageResponse): String {
-    return json.encodeToString(StorageResponse.serializer(), response)
+    return json.encodeToString(serializer<StorageResponse>(), response)
   }
 
   /** Deserialize a StorageResponse from JSON string. */
   fun responseFromJson(jsonString: String): StorageResponse? {
     return try {
-      json.decodeFromString(StorageResponse.serializer(), jsonString)
+      json.decodeFromString(serializer<StorageResponse>(), jsonString)
     } catch (e: Exception) {
       null
     }

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ToolResultParser.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ToolResultParser.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.serializer
 
 object ToolResultParser {
   val json: Json = Json {
@@ -55,13 +56,13 @@ object ToolResultParser {
   }
 
   fun parseTapOnResponse(jsonString: String): TapOnResponse =
-    json.decodeFromString(TapOnResponse.serializer(), jsonString)
+    json.decodeFromString(serializer<TapOnResponse>(), jsonString)
 
   fun parseObserveResponse(jsonString: String): ObserveResponse =
-    json.decodeFromString(ObserveResponse.serializer(), jsonString)
+    json.decodeFromString(serializer<ObserveResponse>(), jsonString)
 
   fun parseExecutePlanResponse(jsonString: String): ExecutePlanResponse =
-    json.decodeFromString(ExecutePlanResponse.serializer(), jsonString)
+    json.decodeFromString(serializer<ExecutePlanResponse>(), jsonString)
 
   private fun inferSuccess(result: JsonObject): Boolean {
     val successValue = result["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull()


### PR DESCRIPTION
## Summary

Closes #4030. `./gradlew detektMain detektTest` used to print "There were N compiler errors found during analysis. This affects accuracy of reporting." six times (3, 7, 7, 30, 30, 377 — 424 total), silently because the build exits 0. Root cause: `.serializer()` is a companion-object member the kotlinx.serialization **compiler plugin** synthesizes onto every `@Serializable` class. Detekt's standalone type-resolution frontend never runs that plugin, so it cannot see the member — every call site fails to resolve, and the failure cascades into "cannot infer type parameter" and "unresolved reference" errors on everything downstream in the same expression.

This mattered beyond noise: `android/config/detekt/detekt.yml` disables `complexity`, `coroutines`, `empty-blocks`, `exceptions`, `naming`, `performance`, and `style`, leaving `potential-bugs` as the **only** active rule set — and its rules (`UnsafeCallOnNullableType`, `UnreachableCode`, `HasPlatformType`, `UnnecessarySafeCall`, `IgnoredReturnValue`) depend on type resolution. Incomplete resolution silently weakens the repo's entire active ruleset.

## The fix

`enableCompilerPlugin = true` was tested and does **not** fix it (confirmed while diagnosing #4030, still exactly 377 on `:desktop-core:detektMain`).

kotlinx.serialization ships a top-level reified function `kotlinx.serialization.serializer<T>(): KSerializer<T>` — a real source declaration, not compiler-plugin-synthesized — that detekt resolves without issue. It's a drop-in replacement for `SomeType.serializer()` in every context this codebase uses: direct `encodeToString`/`decodeFromString` calls, `ListSerializer(X.serializer())`, and custom function arguments, because it has the identical type.

```kotlin
// before
import kotlinx.serialization.json.Json
...
json.decodeFromString(StorageRequest.serializer(), jsonString)

// after
import kotlinx.serialization.json.Json
import kotlinx.serialization.serializer
...
json.decodeFromString(serializer<StorageRequest>(), jsonString)
```

Verified both directions: `./gradlew :protocol:detektMain` cleared its compiler-error line, and `./gradlew :protocol:compileKotlin` stayed green — this is real, correct Kotlin, not a detekt-only workaround.

## Scope

**~170 call sites across 28 files and 5 modules** (`test-plan-validation`, `protocol`, `junit-runner`, `control-proxy`, `desktop-core`). `desktop-core` alone accounted for 377 of the 424 errors across 20 files, so it was split into 5 file-disjoint groups. Work was parallelized across 9 isolated git worktrees (one per module/group), each independently verified via real compilation (`compileKotlin`/`compileDebugKotlin`) and a scoped detekt debug run grepped for that group's own filenames, then fan-in merged — all 9 merges were conflict-free, confirming the file assignments were genuinely disjoint.

One gap in the initial scoping surfaced during review: `control-proxy`'s error count was estimated from a rough grep rather than a precise per-file breakdown (unlike the other modules), and missed 3 call sites in `CtrlProxy.kt` (as opposed to `ViewHierarchyExtractor.kt`, which had the bulk of the module's count). Caught and fixed directly before merging.

One agent's self-reported verification ("zero matches" for its own files) was independently re-checked and found to be reporting against a stale/incomplete capture — the underlying fix was correct, but the check as described didn't prove it. Re-verified directly against a fresh detekt debug run before trusting it.

## Verification

- [x] `./gradlew detektMain detektTest --rerun-tasks` — **zero** occurrences of "compiler errors found during analysis" (down from 6 occurrences / 424 total)
- [x] Every module's detekt XML report checked directly for `<error>` elements — zero across the board, not just "below the fail threshold"
- [x] `./gradlew compileKotlin compileDebugKotlin compileTestKotlin` — BUILD SUCCESSFUL across all modules
- [x] Full-tree ktfmt (679 Kotlin files) — all properly formatted
- [x] `bats test/bats/` — full suite green except one pre-existing, unrelated, environment-specific failure (`verify-runtime-deps.bats`, dies inside `source ~/.bashrc` on this machine)
- [x] No TypeScript touched — typecheck baseline untouched
- [x] Rebased onto latest `main`

## What this does NOT do

No new detekt findings were surfaced by the now-complete type resolution (confirmed via the XML report check above) — but that's a fact about this codebase today, not a guarantee. Per #4030's acceptance criteria, this PR does not add a CI guard against the "compiler errors found" message reappearing. Without one the count can silently regrow the same way it silently grew to 424 in the first place. Filing that as a fast follow-up rather than scope-creeping this PR.
