### PR TITLE
feat(ios): capture WebRTC Simulator audio

### DIFF
--- a/docs/design-docs/mcp/observe/ios-webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/ios-webrtc-streaming.md
@@ -51,6 +51,13 @@ continuous BGRA frames for:
 - **Physical devices** via AVFoundation USB capture.
 - **Simulators** via ScreenCaptureKit simulator-window capture.
 
+When WebRTC audio is explicitly enabled, the Simulator helper also captures
+the selected window's audio through ScreenCaptureKit and multiplexes 8 kHz mono
+PCM16LE records over its existing stdout transport. `IosH264Source` forwards
+those chunks to the shared PCMU packetizer unchanged. Physical iOS playback
+audio remains unavailable through public APIs and fails with an actionable
+error rather than silently publishing video-only.
+
 `IosH264Source` wraps that helper, pipes frames into `ffmpeg` with
 `h264_videotoolbox`, and forwards raw H.264 Annex-B stdout chunks into the
 existing `WebRtcPublisher`. The helper binary is resolved from

--- a/docs/design-docs/plat/ios/screen-streaming.md
+++ b/docs/design-docs/plat/ios/screen-streaming.md
@@ -268,6 +268,11 @@ Since iOS provides raw frames (not H.264), use a simpler protocol:
 Followed by `height * bytesPerRow` bytes of BGRA pixel data.
 ```
 
+For explicitly enabled Simulator audio, the same transport reserves `width =
+0`; `height = 8000`, `bytesPerRow = 1`, and `timestamp = payload length`.
+The following payload is 8 kHz mono PCM16LE. Video-only capture never emits
+these records.
+
 ## Implementation Plan
 
 ### Milestone 1: Physical Device Capture

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -93,7 +93,7 @@ overridden per request on the `webrtc-stream.sock` control socket.
 | `AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER` | Path to the built `screen-capture-helper` binary for iOS WebRTC capture. Build with `swift build` in `ios/screen-capture` from a repo checkout, or in `dist/ios/screen-capture` from a package install. | repo/package-local debug/release build output when present |
 | `AUTOMOBILE_IOS_WEBRTC_FFMPEG` | Path to the `ffmpeg` binary used to encode iOS helper BGRA frames into H.264 Annex-B. | `ffmpeg` on `PATH` |
 | `AUTOMOBILE_WEBRTC_TRICKLE_ICE` | Enable trickle ICE: publish the WHIP offer immediately and PATCH candidates incrementally instead of blocking on ICE gathering. Requires an ingest server supporting the WHIP trickle extension. | `false` |
-| `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional audio alongside video. Android only; requires the persistent `video-server` jar and captures shell-privileged `REMOTE_SUBMIX` PCM16 audio, sent over WebRTC as PCMU. | `false` |
+| `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional audio alongside video. Android requires the persistent `video-server` jar and captures shell-privileged `REMOTE_SUBMIX`; iOS supports Simulator-window audio through ScreenCaptureKit. Both emit 8 kHz mono PCM16LE and publish as PCMU. Physical iOS playback capture is unavailable through public APIs. | `false` |
 
 ### `automobile-video.jar` resolution
 

--- a/ios/screen-capture/Sources/ScreenCaptureCore/AudioPcm16Encoder.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/AudioPcm16Encoder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Converts the Float32 little-endian PCM emitted by ScreenCaptureKit into
+/// signed little-endian PCM16 for the shared WebRTC PCMU packetizer.
+public enum AudioPcm16Encoder {
+    public static func encodeFloat32LE(_ input: Data) -> Data? {
+        guard input.count.isMultiple(of: MemoryLayout<Float>.size) else { return nil }
+
+        var output = Data(count: input.count / 2)
+        input.withUnsafeBytes { source in
+            output.withUnsafeMutableBytes { destination in
+                guard let sourceBase = source.baseAddress, let destinationBase = destination.baseAddress else { return }
+                for index in 0..<(input.count / MemoryLayout<Float>.size) {
+                    let float = sourceBase.advanced(by: index * 4).loadUnaligned(as: Float.self)
+                    let sample = Int16(max(-1, min(1, float)) * Float(Int16.max))
+                    destinationBase.advanced(by: index * 2).storeBytes(of: sample.littleEndian, as: Int16.self)
+                }
+            }
+        }
+        return output
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
@@ -6,7 +6,7 @@ public struct CommandLineOptions: Equatable {
         case listDevices
         case capture(deviceID: String?)
         case listSimulators
-        case captureSimulator(windowID: UInt32, fps: Int)
+        case captureSimulator(windowID: UInt32, fps: Int, audio: Bool)
         case help
     }
 
@@ -36,6 +36,7 @@ public struct CommandLineOptions: Equatable {
         var listSimulators = false
         var simulatorWindowID: UInt32?
         var simulatorFPS: Int?
+        var audio = false
         var help = false
 
         while let arg = iterator.next() {
@@ -69,6 +70,8 @@ public struct CommandLineOptions: Equatable {
                     throw ParseError.invalidValue(flag: arg, value: value)
                 }
                 simulatorFPS = parsed
+            case "--audio":
+                audio = true
             case "-h", "--help":
                 help = true
             default:
@@ -97,6 +100,9 @@ public struct CommandLineOptions: Equatable {
                 "--simulator-fps requires --simulator-window"
             )
         }
+        if audio && simulatorWindowID == nil {
+            throw ParseError.conflictingFlags("--audio requires --simulator-window")
+        }
 
         if listDevices {
             return CommandLineOptions(mode: .listDevices)
@@ -108,7 +114,8 @@ public struct CommandLineOptions: Equatable {
             return CommandLineOptions(
                 mode: .captureSimulator(
                     windowID: windowID,
-                    fps: simulatorFPS ?? defaultSimulatorFPS
+                    fps: simulatorFPS ?? defaultSimulatorFPS,
+                    audio: audio
                 )
             )
         }
@@ -121,7 +128,7 @@ public struct CommandLineOptions: Equatable {
     USAGE:
         screen-capture-helper [--device-id <id>]
         screen-capture-helper --list-devices
-        screen-capture-helper --simulator-window <windowID> [--simulator-fps <n>]
+        screen-capture-helper --simulator-window <windowID> [--simulator-fps <n>] [--audio]
         screen-capture-helper --list-simulators
 
     DEVICE OPTIONS (USB-connected iOS devices via AVFoundation):
@@ -134,6 +141,7 @@ public struct CommandLineOptions: Equatable {
         --simulator-window <n>  CGWindowID of the simulator window to capture.
         --simulator-fps <n>     Target frame rate (5-60, default 5). Higher
                                 values waste CPU for typical MCP workloads.
+        --audio                 Capture Simulator window audio as 8 kHz mono PCM16LE.
 
         -h, --help              Show this help.
 

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameProtocol.swift
@@ -11,6 +11,8 @@ import Foundation
 /// Followed by `height * bytesPerRow` bytes of BGRA pixel data.
 public enum FrameProtocol {
     public static let headerSize = 16
+    public static let audioSampleRate: UInt32 = 8_000
+    public static let audioChannelCount: UInt32 = 1
 
     public struct Header: Equatable {
         public let width: UInt32
@@ -38,6 +40,15 @@ public enum FrameProtocol {
             base.advanced(by: 12).storeBytes(of: header.timestampMs.littleEndian, as: UInt32.self)
         }
         return data
+    }
+
+    public static func encodeAudioHeader(payloadLength: Int) -> Data {
+        encodeHeader(Header(
+            width: 0,
+            height: audioSampleRate,
+            bytesPerRow: audioChannelCount,
+            timestampMs: UInt32(payloadLength)
+        ))
     }
 
     public static func decodeHeader(_ data: Data) -> Header? {

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
@@ -41,6 +41,11 @@ public final class FrameWriter {
         )
         sink.write(payload)
     }
+
+    public func writeAudio(pcm16le: Data) {
+        sink.write(FrameProtocol.encodeAudioHeader(payloadLength: pcm16le.count))
+        sink.write(pcm16le)
+    }
 }
 
 /// Sink that writes to a `FileHandle` (e.g. `FileHandle.standardOutput`).

--- a/ios/screen-capture/Sources/ScreenCaptureCore/SimulatorWindowInfo.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/SimulatorWindowInfo.swift
@@ -40,3 +40,12 @@ public struct SimulatorWindowListResponse: Codable, Equatable {
 
 /// Bundle identifier of the iOS Simulator host application on macOS.
 public let simulatorBundleIdentifier = "com.apple.iphonesimulator"
+
+/// ScreenCaptureKit cannot isolate a single Simulator window's audio from the
+/// Simulator host application, so audio capture is safe only with one window.
+public enum SimulatorAudioCaptureAvailability {
+    public static func errorMessage(for visibleSimulatorWindows: [SimulatorWindowInfo]) -> String? {
+        guard visibleSimulatorWindows.count > 1 else { return nil }
+        return "iOS Simulator audio capture requires exactly one visible Simulator window because ScreenCaptureKit cannot isolate audio to a selected Simulator window. Close other Simulator windows and try again."
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
@@ -1,6 +1,7 @@
 import AudioToolbox
 import CoreMedia
 import Foundation
+import ScreenCaptureCore
 
 /// ScreenCaptureKit is configured for 8 kHz mono output. Convert its common
 /// Float32 or signed-16-bit linear PCM representation to signed PCM16LE.
@@ -27,22 +28,14 @@ func pcm16leAudio(sampleBuffer: CMSampleBuffer) -> Data? {
     guard result == noErr, let input = audioBufferList.mBuffers.mData else { return nil }
 
     let sampleCount = CMSampleBufferGetNumSamples(sampleBuffer)
-    var output = Data(count: sampleCount * 2)
-    output.withUnsafeMutableBytes { bytes in
-        guard let destination = bytes.baseAddress else { return }
-        for index in 0..<sampleCount {
-            let sample: Int16
-            if asbd.mBitsPerChannel == 16 {
-                sample = input.advanced(by: index * 2).loadUnaligned(as: Int16.self)
-            } else if asbd.mBitsPerChannel == 32,
-                      (asbd.mFormatFlags & kAudioFormatFlagIsFloat) != 0 {
-                let float = input.advanced(by: index * 4).loadUnaligned(as: Float.self)
-                sample = Int16(max(-1, min(1, float)) * Float(Int16.max))
-            } else {
-                return
-            }
-            destination.advanced(by: index * 2).storeBytes(of: sample.littleEndian, as: Int16.self)
-        }
+    if asbd.mBitsPerChannel == 16 {
+        return Data(bytes: input, count: sampleCount * MemoryLayout<Int16>.size)
     }
-    return output
+    if asbd.mBitsPerChannel == 32,
+       (asbd.mFormatFlags & kAudioFormatFlagIsFloat) != 0 {
+        return AudioPcm16Encoder.encodeFloat32LE(
+            Data(bytes: input, count: sampleCount * MemoryLayout<Float>.size)
+        )
+    }
+    return nil
 }

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
@@ -1,0 +1,48 @@
+import AudioToolbox
+import CoreMedia
+import Foundation
+
+/// ScreenCaptureKit is configured for 8 kHz mono output. Convert its common
+/// Float32 or signed-16-bit linear PCM representation to signed PCM16LE.
+func pcm16leAudio(sampleBuffer: CMSampleBuffer) -> Data? {
+    guard let format = CMSampleBufferGetFormatDescription(sampleBuffer),
+          let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(format)?.pointee,
+          asbd.mSampleRate == 8_000,
+          asbd.mChannelsPerFrame == 1,
+          asbd.mFormatID == kAudioFormatLinearPCM
+    else { return nil }
+
+    var audioBufferList = AudioBufferList()
+    var blockBuffer: CMBlockBuffer?
+    let result = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+        sampleBuffer,
+        bufferListSizeNeededOut: nil,
+        bufferListOut: &audioBufferList,
+        bufferListSize: MemoryLayout<AudioBufferList>.size,
+        blockBufferAllocator: nil,
+        blockBufferMemoryAllocator: nil,
+        flags: 0,
+        blockBufferOut: &blockBuffer
+    )
+    guard result == noErr, let input = audioBufferList.mBuffers.mData else { return nil }
+
+    let sampleCount = CMSampleBufferGetNumSamples(sampleBuffer)
+    var output = Data(count: sampleCount * 2)
+    output.withUnsafeMutableBytes { bytes in
+        guard let destination = bytes.baseAddress else { return }
+        for index in 0..<sampleCount {
+            let sample: Int16
+            if asbd.mBitsPerChannel == 16 {
+                sample = input.advanced(by: index * 2).loadUnaligned(as: Int16.self)
+            } else if asbd.mBitsPerChannel == 32,
+                      (asbd.mFormatFlags & kAudioFormatFlagIsFloat) != 0 {
+                let float = input.advanced(by: index * 4).loadUnaligned(as: Float.self)
+                sample = Int16(max(-1, min(1, float)) * Float(Int16.max))
+            } else {
+                return
+            }
+            destination.advanced(by: index * 2).storeBytes(of: sample.littleEndian, as: Int16.self)
+        }
+    }
+    return output
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -16,6 +16,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     private var configuredPixelHeight: Int = 0
     private var hasReceivedFrame = false
     private var fps: Int = CommandLineOptions.defaultSimulatorFPS
+    private var audioEnabled = false
 
     init(writer: FrameWriter) {
         self.writer = writer
@@ -23,6 +24,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
 
     func start(window: SCWindow, fps: Int, audio: Bool) async throws {
         self.fps = fps
+        audioEnabled = audio
         let filter = SCContentFilter(desktopIndependentWindow: window)
         let config = SimulatorCaptureSession.makeConfiguration(window: window, fps: fps, audio: audio)
         configuredPixelWidth = config.width
@@ -107,6 +109,9 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         updated.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         updated.showsCursor = false
         updated.scalesToFit = false
+        updated.capturesAudio = audioEnabled
+        updated.sampleRate = 8_000
+        updated.channelCount = 1
 
         // Fire-and-forget: if the update fails we keep using the old config and
         // either resync on the next size change or stop with a delegate error.

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -21,15 +21,18 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         self.writer = writer
     }
 
-    func start(window: SCWindow, fps: Int) async throws {
+    func start(window: SCWindow, fps: Int, audio: Bool) async throws {
         self.fps = fps
         let filter = SCContentFilter(desktopIndependentWindow: window)
-        let config = SimulatorCaptureSession.makeConfiguration(window: window, fps: fps)
+        let config = SimulatorCaptureSession.makeConfiguration(window: window, fps: fps, audio: audio)
         configuredPixelWidth = config.width
         configuredPixelHeight = config.height
 
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
+        if audio {
+            try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: queue)
+        }
         try await stream.startCapture()
         self.stream = stream
     }
@@ -54,7 +57,14 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
         of type: SCStreamOutputType
     ) {
-        guard type == .screen, sampleBuffer.isValid else { return }
+        guard sampleBuffer.isValid else { return }
+        if type == .audio {
+            if let pcm16le = pcm16leAudio(sampleBuffer: sampleBuffer) {
+                writer.writeAudio(pcm16le: pcm16le)
+            }
+            return
+        }
+        guard type == .screen else { return }
 
         // Drop non-complete statuses (idle, blank, suspended, stopped) so we
         // don't re-emit identical pixels or partial buffers.
@@ -111,7 +121,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         }
     }
 
-    private static func makeConfiguration(window: SCWindow, fps: Int) -> SCStreamConfiguration {
+    private static func makeConfiguration(window: SCWindow, fps: Int, audio: Bool) -> SCStreamConfiguration {
         let config = SCStreamConfiguration()
         // Logical (points) size; the delivered CVPixelBuffer is in native
         // pixels (2x/3x for Retina), and downstream consumers must use
@@ -122,6 +132,9 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config.showsCursor = false
         config.scalesToFit = false
+        config.capturesAudio = audio
+        config.sampleRate = 8_000
+        config.channelCount = 1
         return config
     }
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -79,6 +79,19 @@ case .listSimulators:
     }
 
 case .captureSimulator(let windowID, let fps, let audio):
+    if audio {
+        switch runBlocking({ try await SimulatorWindowDiscovery.discover() }) {
+        case .success(let windows):
+            if let error = SimulatorAudioCaptureAvailability.errorMessage(for: windows) {
+                logError("error: \(error)")
+                exit(1)
+            }
+        case .failure(let error):
+            logError("error: failed to query simulator windows: \(error)")
+            exit(1)
+        }
+    }
+
     let window: SCWindow
     switch runBlocking({ try await SimulatorWindowDiscovery.find(windowID: windowID) }) {
     case .success(.some(let resolved)):

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -78,7 +78,7 @@ case .listSimulators:
         exit(1)
     }
 
-case .captureSimulator(let windowID, let fps):
+case .captureSimulator(let windowID, let fps, let audio):
     let window: SCWindow
     switch runBlocking({ try await SimulatorWindowDiscovery.find(windowID: windowID) }) {
     case .success(.some(let resolved)):
@@ -96,7 +96,7 @@ case .captureSimulator(let windowID, let fps):
     let simSession = SimulatorCaptureSession(writer: writer)
 
     if case .failure(let error) = runBlocking({
-        try await simSession.start(window: window, fps: fps)
+        try await simSession.start(window: window, fps: fps, audio: audio)
     }) {
         logError("error: failed to start simulator capture: \(error)")
         exit(1)

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/AudioPcm16EncoderTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/AudioPcm16EncoderTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class AudioPcm16EncoderTests: XCTestCase {
+    func testEncodesFloat32LittleEndianAsPCM16LE() {
+        let values: [Float] = [-1, 0, 1]
+        let input = values.withUnsafeBytes { Data($0) }
+
+        let output = AudioPcm16Encoder.encodeFloat32LE(input)
+
+        XCTAssertEqual(output, Data([0x01, 0x80, 0x00, 0x00, 0xFF, 0x7F]))
+    }
+
+    func testRejectsTruncatedFloat32Input() {
+        XCTAssertNil(AudioPcm16Encoder.encodeFloat32LE(Data([0, 0, 0])))
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import ScreenCaptureCore
 
 final class CommandLineOptionsTests: XCTestCase {
+    func testParsesAudioForSimulatorCapture() throws {
+        let options = try CommandLineOptions.parse([
+            "screen-capture-helper", "--simulator-window", "42", "--audio"
+        ])
+
+        XCTAssertEqual(options.mode, .captureSimulator(windowID: 42, fps: 5, audio: true))
+    }
+
     func testDefaultsToCaptureWithoutDeviceID() throws {
         let opts = try CommandLineOptions.parse(["screen-capture-helper"])
         XCTAssertEqual(opts.mode, .capture(deviceID: nil))
@@ -65,7 +73,8 @@ final class CommandLineOptionsTests: XCTestCase {
             opts.mode,
             .captureSimulator(
                 windowID: 98765,
-                fps: CommandLineOptions.defaultSimulatorFPS
+                fps: CommandLineOptions.defaultSimulatorFPS,
+                audio: false
             )
         )
     }
@@ -76,7 +85,7 @@ final class CommandLineOptionsTests: XCTestCase {
             "--simulator-window", "1",
             "--simulator-fps", "30",
         ])
-        XCTAssertEqual(opts.mode, .captureSimulator(windowID: 1, fps: 30))
+        XCTAssertEqual(opts.mode, .captureSimulator(windowID: 1, fps: 30, audio: false))
     }
 
     func testRejectsSimulatorFPSBelowRange() {

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameProtocolTests.swift
@@ -5,6 +5,18 @@ import XCTest
 @testable import ScreenCaptureCore
 
 final class FrameProtocolTests: XCTestCase {
+    func testEncodeAudioHeaderUsesReservedZeroWidthMarker() {
+        let data = FrameProtocol.encodeAudioHeader(payloadLength: 320)
+
+        XCTAssertEqual(data.count, FrameProtocol.headerSize)
+        XCTAssertEqual(Array(data), [
+            0, 0, 0, 0,
+            0x40, 0x1F, 0, 0,
+            1, 0, 0, 0,
+            0x40, 1, 0, 0,
+        ])
+    }
+
     func testEncodeHeaderProducesLittleEndianBytes() {
         let header = FrameProtocol.Header(
             width: 0x01020304,

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/SimulatorAudioCaptureAvailabilityTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/SimulatorAudioCaptureAvailabilityTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class SimulatorAudioCaptureAvailabilityTests: XCTestCase {
+    func testAllowsAudioWhenExactlyOneSimulatorWindowIsVisible() {
+        XCTAssertNil(SimulatorAudioCaptureAvailability.errorMessage(for: [window(id: 1)]))
+    }
+
+    func testRejectsAudioWhenMultipleSimulatorWindowsAreVisible() {
+        XCTAssertEqual(
+            SimulatorAudioCaptureAvailability.errorMessage(for: [window(id: 1), window(id: 2)]),
+            "iOS Simulator audio capture requires exactly one visible Simulator window because ScreenCaptureKit cannot isolate audio to a selected Simulator window. Close other Simulator windows and try again."
+        )
+    }
+
+    private func window(id: UInt32) -> SimulatorWindowInfo {
+        SimulatorWindowInfo(
+            windowID: id,
+            title: "iPhone",
+            applicationName: "Simulator",
+            bundleIdentifier: simulatorBundleIdentifier,
+            processID: 1,
+            width: 390,
+            height: 844
+        )
+    }
+}

--- a/src/features/screen-stream/IOSScreenCaptureHelper.ts
+++ b/src/features/screen-stream/IOSScreenCaptureHelper.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from "node:events";
 import { logger } from "../../utils/logger";
 import {
   type DecodedFrame,
+  type DecodedAudio,
   FrameDecoder,
   type MalformedFrameError,
 } from "./frameProtocol";
@@ -21,7 +22,7 @@ export type HelperSpawner = (
  */
 export type CaptureTarget =
   | { kind: "device"; deviceId?: string }
-  | { kind: "simulator"; windowID: number; fps?: number };
+  | { kind: "simulator"; windowID: number; fps?: number; audio?: boolean };
 
 /** Valid range for the simulator capture frame rate, mirrors the Swift CLI. */
 export const SIMULATOR_FPS_MIN = 5;
@@ -38,6 +39,7 @@ export interface IosScreenCaptureHelperOptions {
 
 export interface IosScreenCaptureHelperEvents {
   frame: (frame: DecodedFrame) => void;
+  audio: (audio: DecodedAudio) => void;
   malformed: (error: MalformedFrameError) => void;
   stderr: (line: string) => void;
   exit: (info: { code: number | null; signal: NodeJS.Signals | null }) => void;
@@ -103,7 +105,11 @@ export class IOSScreenCaptureHelper extends EventEmitter {
 
     proc.stdout.on("data", chunk => {
       const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      const frames = this.decoder.push(buf, err => this.emit("malformed", err));
+      const frames = this.decoder.push(
+        buf,
+        err => this.emit("malformed", err),
+        audio => this.emit("audio", audio)
+      );
       for (const frame of frames) {
         this.emit("frame", frame);
       }
@@ -185,6 +191,9 @@ function buildArgs(target: CaptureTarget): string[] {
           );
         }
         args.push("--simulator-fps", String(target.fps));
+      }
+      if (target.audio === true) {
+        args.push("--audio");
       }
       return args;
     }

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -4,7 +4,9 @@
  * Header (16 bytes, little-endian UInt32):
  *   width(4) | height(4) | bytesPerRow(4) | timestampMs(4)
  *
- * Followed by `height * bytesPerRow` bytes of BGRA pixel data.
+ * Followed by `height * bytesPerRow` bytes of BGRA pixel data. Audio records
+ * reserve width=0: height=8000, bytesPerRow=1, timestampMs=payload length,
+ * followed by 8 kHz mono PCM16LE bytes.
  *
  * The decoder buffers incoming chunks and emits complete frames as soon as
  * enough bytes have arrived. It tolerates arbitrary chunking from the helper's
@@ -25,6 +27,10 @@ export interface DecodedFrame {
   pixels: Buffer;
 }
 
+export interface DecodedAudio {
+  pcm16le: Buffer;
+}
+
 export interface MalformedFrameError {
   reason: "header_width_zero" | "header_height_zero" | "header_bytes_per_row_too_small";
   header: FrameHeader;
@@ -39,7 +45,11 @@ export class FrameDecoder {
    * have completed. Malformed headers are surfaced via `onMalformed`; the
    * decoder discards the offending bytes and continues parsing.
    */
-  push(chunk: Buffer, onMalformed?: (error: MalformedFrameError) => void): DecodedFrame[] {
+  push(
+    chunk: Buffer,
+    onMalformed?: (error: MalformedFrameError) => void,
+    onAudio?: (audio: DecodedAudio) => void
+  ): DecodedFrame[] {
     if (chunk.length > 0) {
       this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
     }
@@ -51,6 +61,10 @@ export class FrameDecoder {
         if (this.buffer.length < FRAME_HEADER_SIZE) {break;}
         const header = parseHeader(this.buffer);
         this.buffer = this.buffer.subarray(FRAME_HEADER_SIZE);
+        if (isAudioHeader(header)) {
+          this.pendingHeader = header;
+          continue;
+        }
         const malformed = validateHeader(header);
         if (malformed) {
           onMalformed?.({ reason: malformed, header });
@@ -59,19 +73,29 @@ export class FrameDecoder {
         this.pendingHeader = header;
       }
 
-      const expected = this.pendingHeader.height * this.pendingHeader.bytesPerRow;
+      const expected = isAudioHeader(this.pendingHeader)
+        ? this.pendingHeader.timestampMs
+        : this.pendingHeader.height * this.pendingHeader.bytesPerRow;
       if (this.buffer.length < expected) {break;}
 
       // Copy pixels to release the underlying chunk allocation; otherwise
       // every emitted frame pins the entire upstream buffer in memory.
-      const pixels = Buffer.from(this.buffer.subarray(0, expected));
+      const payload = Buffer.from(this.buffer.subarray(0, expected));
       this.buffer = this.buffer.subarray(expected);
-      frames.push({ header: this.pendingHeader, pixels });
+      if (isAudioHeader(this.pendingHeader)) {
+        onAudio?.({ pcm16le: payload });
+      } else {
+        frames.push({ header: this.pendingHeader, pixels: payload });
+      }
       this.pendingHeader = null;
     }
 
     return frames;
   }
+}
+
+function isAudioHeader(header: FrameHeader): boolean {
+  return header.width === 0 && header.height === 8_000 && header.bytesPerRow === 1;
 }
 
 function parseHeader(buffer: Buffer): FrameHeader {

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -73,9 +73,7 @@ export class FrameDecoder {
         this.pendingHeader = header;
       }
 
-      const expected = isAudioHeader(this.pendingHeader)
-        ? this.pendingHeader.timestampMs
-        : this.pendingHeader.height * this.pendingHeader.bytesPerRow;
+      const expected = payloadSize(this.pendingHeader);
       if (this.buffer.length < expected) {break;}
 
       // Copy pixels to release the underlying chunk allocation; otherwise
@@ -96,6 +94,12 @@ export class FrameDecoder {
 
 function isAudioHeader(header: FrameHeader): boolean {
   return header.width === 0 && header.height === 8_000 && header.bytesPerRow === 1;
+}
+
+function payloadSize(header: FrameHeader): number {
+  return isAudioHeader(header)
+    ? header.timestampMs
+    : header.height * header.bytesPerRow;
 }
 
 function parseHeader(buffer: Buffer): FrameHeader {

--- a/src/features/screen-stream/index.ts
+++ b/src/features/screen-stream/index.ts
@@ -2,6 +2,7 @@ export {
   FRAME_HEADER_SIZE,
   FrameDecoder,
   type DecodedFrame,
+  type DecodedAudio,
   type FrameHeader,
   type MalformedFrameError,
 } from "./frameProtocol";

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -53,7 +53,8 @@ export type IosFrameCaptureHelperFactory = (
 ) => IosFrameCaptureHelper;
 export type IosSimulatorWindowResolver = (
   helperPath: string,
-  device: BootedDevice
+  device: BootedDevice,
+  audioEnabled: boolean
 ) => Promise<number>;
 
 interface CommandResult {
@@ -150,8 +151,8 @@ export class IosH264Source implements H264CaptureSource {
     this.firstFrameTimeoutMs = options.firstFrameTimeoutMs ?? DEFAULT_FIRST_FRAME_TIMEOUT_MS;
     this.simulatorWindowResolver =
       options.simulatorWindowResolver ??
-      ((helperPath, device) =>
-        defaultResolveSimulatorWindowId(helperPath, device, this.commandRunner));
+      ((helperPath, device, audioEnabled) =>
+        defaultResolveSimulatorWindowId(helperPath, device, this.commandRunner, audioEnabled));
   }
 
   async start(): Promise<void> {
@@ -200,7 +201,11 @@ export class IosH264Source implements H264CaptureSource {
     if (isIosSimulatorUdid(this.options.device.deviceId)) {
       return {
         kind: "simulator",
-        windowID: await this.simulatorWindowResolver(helperPath, this.options.device),
+        windowID: await this.simulatorWindowResolver(
+          helperPath,
+          this.options.device,
+          this.options.audioEnabled === true
+        ),
         fps: this.fps,
         ...(this.options.audioEnabled === true ? { audio: true } : {}),
       };
@@ -608,7 +613,8 @@ async function validateFfmpegAvailability(
 async function defaultResolveSimulatorWindowId(
   helperPath: string,
   device: BootedDevice,
-  commandRunner: CommandRunner
+  commandRunner: CommandRunner,
+  audioEnabled: boolean
 ): Promise<number> {
   const result = await commandRunner(helperPath, ["--list-simulators"]);
   if (result.exitCode !== 0) {
@@ -622,6 +628,12 @@ async function defaultResolveSimulatorWindowId(
     windows = (JSON.parse(result.stdout) as { windows?: SimulatorWindowInfo[] }).windows ?? [];
   } catch (error) {
     throw new ActionableError(`Unable to parse iOS Simulator window list: ${error}`);
+  }
+
+  if (audioEnabled && windows.length > 1) {
+    throw new ActionableError(
+      "iOS Simulator audio capture requires exactly one visible Simulator window because ScreenCaptureKit cannot isolate audio to a selected Simulator window. Close other Simulator windows and try again."
+    );
   }
 
   const deviceName = device.name.toLowerCase();

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -173,8 +173,8 @@ export class IosH264Source implements H264CaptureSource {
       const helper = this.createHelper({ binaryPath: helperPath, target });
       this.helper = helper;
       this.wireHelperFrames(helper);
-      const firstFrame = this.waitForFirstFrame(helper, target);
       const firstAudio = this.options.audioEnabled ? this.waitForFirstAudio(helper) : null;
+      const firstFrame = this.waitForFirstFrame(helper, target);
       helper.start();
       await Promise.all([firstFrame, firstAudio]);
     } catch (error) {
@@ -292,6 +292,16 @@ export class IosH264Source implements H264CaptureSource {
       helper.on("audio", () => {
         if (this.helper === helper && this.isActive()) {
           finish(resolve);
+        }
+      });
+      helper.on("error", error => {
+        if (this.helper === helper && this.isActive()) {
+          finish(() => reject(error));
+        }
+      });
+      helper.on("exit", info => {
+        if (this.helper === helper && this.isActive()) {
+          finish(() => reject(new Error(`screen-capture-helper exited before audio (code=${info.code}, signal=${info.signal})`)));
         }
       });
     });

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -132,6 +132,7 @@ export class IosH264Source implements H264CaptureSource {
   private teardownPromise: Promise<void> | null = null;
   private cancelFirstFrameWait: (() => void) | null = null;
   private cancelFirstAudioWait: (() => void) | null = null;
+  private rejectFirstAudioWait: ((error: Error) => void) | null = null;
   private phase: IosH264SourcePhase = "idle";
 
   constructor(private readonly options: IosH264SourceOptions) {
@@ -282,13 +283,18 @@ export class IosH264Source implements H264CaptureSource {
         if (this.cancelFirstAudioWait === cancel) {
           this.cancelFirstAudioWait = null;
         }
+        if (this.rejectFirstAudioWait === rejectWait) {
+          this.rejectFirstAudioWait = null;
+        }
         callback();
       };
       const cancel = (): void => finish(resolve);
+      const rejectWait = (error: Error): void => finish(() => reject(error));
       const timeout = this.timer.setTimeout(() => {
         finish(() => reject(new ActionableError("iOS Simulator audio capture did not produce PCM audio before startup timed out.")));
       }, this.firstFrameTimeoutMs);
       this.cancelFirstAudioWait = cancel;
+      this.rejectFirstAudioWait = rejectWait;
       helper.on("audio", () => {
         if (this.helper === helper && this.isActive()) {
           finish(resolve);
@@ -431,6 +437,7 @@ export class IosH264Source implements H264CaptureSource {
     if (this.phase !== "running") {
       return;
     }
+    this.rejectFirstAudioWait?.(error);
     this.phase = "stopping";
     void this.beginTeardown();
     this.options.onError?.(error);

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -9,6 +9,7 @@ import {
 } from "../screen-stream/IOSScreenCaptureHelper";
 import type {
   CaptureTarget,
+  DecodedAudio,
   DecodedFrame,
   IosScreenCaptureHelperOptions,
   MalformedFrameError,
@@ -30,6 +31,7 @@ export interface IosFrameCaptureHelper {
   start(): void;
   stop(): Promise<unknown>;
   on(event: "frame", listener: (frame: DecodedFrame) => void): this;
+  on(event: "audio", listener: (audio: DecodedAudio) => void): this;
   on(event: "malformed", listener: (error: MalformedFrameError) => void): this;
   on(event: "stderr", listener: (line: string) => void): this;
   on(event: "exit", listener: (info: { code: number | null; signal: NodeJS.Signals | null }) => void): this;
@@ -129,6 +131,7 @@ export class IosH264Source implements H264CaptureSource {
   private encoderBackpressured = false;
   private teardownPromise: Promise<void> | null = null;
   private cancelFirstFrameWait: (() => void) | null = null;
+  private cancelFirstAudioWait: (() => void) | null = null;
   private phase: IosH264SourcePhase = "idle";
 
   constructor(private readonly options: IosH264SourceOptions) {
@@ -171,8 +174,9 @@ export class IosH264Source implements H264CaptureSource {
       this.helper = helper;
       this.wireHelperFrames(helper);
       const firstFrame = this.waitForFirstFrame(helper, target);
+      const firstAudio = this.options.audioEnabled ? this.waitForFirstAudio(helper) : null;
       helper.start();
-      await firstFrame;
+      await Promise.all([firstFrame, firstAudio]);
     } catch (error) {
       this.phase = "stopping";
       await this.beginTeardown();
@@ -187,6 +191,7 @@ export class IosH264Source implements H264CaptureSource {
     }
     this.phase = "stopping";
     this.cancelFirstFrameWait?.();
+    this.cancelFirstAudioWait?.();
     await this.beginTeardown();
   }
 
@@ -196,6 +201,7 @@ export class IosH264Source implements H264CaptureSource {
         kind: "simulator",
         windowID: await this.simulatorWindowResolver(helperPath, this.options.device),
         fps: this.fps,
+        ...(this.options.audioEnabled === true ? { audio: true } : {}),
       };
     }
     return { kind: "device", deviceId: this.options.device.deviceId };
@@ -264,8 +270,40 @@ export class IosH264Source implements H264CaptureSource {
     });
   }
 
+  private waitForFirstAudio(helper: IosFrameCaptureHelper): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (callback: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.timer.clearTimeout(timeout);
+        if (this.cancelFirstAudioWait === cancel) {
+          this.cancelFirstAudioWait = null;
+        }
+        callback();
+      };
+      const cancel = (): void => finish(resolve);
+      const timeout = this.timer.setTimeout(() => {
+        finish(() => reject(new ActionableError("iOS Simulator audio capture did not produce PCM audio before startup timed out.")));
+      }, this.firstFrameTimeoutMs);
+      this.cancelFirstAudioWait = cancel;
+      helper.on("audio", () => {
+        if (this.helper === helper && this.isActive()) {
+          finish(resolve);
+        }
+      });
+    });
+  }
+
   private wireHelperFrames(helper: IosFrameCaptureHelper): void {
     helper.on("frame", frame => this.handleFrame(frame));
+    helper.on("audio", audio => {
+      if (this.isActive() && this.options.audioEnabled) {
+        this.options.onAudioData?.(audio.pcm16le);
+      }
+    });
     helper.on("malformed", error => {
       logger.warn(`[IosH264Source] malformed frame from helper: ${error.reason}`);
     });
@@ -410,6 +448,8 @@ export class IosH264Source implements H264CaptureSource {
   }
 
   private async teardown(): Promise<void> {
+    this.cancelFirstAudioWait?.();
+    this.cancelFirstAudioWait = null;
     const encoder = this.encoder;
     this.encoder = null;
     this.encoderSize = null;

--- a/src/features/webrtc/h264CaptureSourceFactory.ts
+++ b/src/features/webrtc/h264CaptureSourceFactory.ts
@@ -2,6 +2,7 @@ import { ActionableError } from "../../models";
 import type { H264CaptureSource, H264CaptureSourceOptions } from "./H264CaptureSource";
 import { createAndroidH264CaptureSource } from "./androidH264CaptureSourceFactory";
 import { IosH264Source } from "./IosH264Source";
+import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 
 /**
  * Build a capture source for a device. `jarPath` is the pre-resolved Android
@@ -18,8 +19,10 @@ export const createH264CaptureSource: H264CaptureSourceFactory = (options, jarPa
     return createAndroidH264CaptureSource(options, jarPath);
   }
   if (options.device.platform === "ios") {
-    if (options.audioEnabled) {
-      throw new ActionableError("WebRTC audio capture is currently supported only on Android.");
+    if (options.audioEnabled && !isIosSimulatorUdid(options.device.deviceId)) {
+      throw new ActionableError(
+        "WebRTC playback audio capture is available only for iOS Simulator targets; public iOS APIs cannot capture playback audio from a physical device."
+      );
     }
     return new IosH264Source(options);
   }

--- a/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
@@ -24,6 +24,15 @@ function encodeFrame(
   return Buffer.concat([header, Buffer.alloc(height * bytesPerRow, fill)]);
 }
 
+function encodeAudio(pcm16le: Buffer): Buffer {
+  const header = Buffer.alloc(FRAME_HEADER_SIZE);
+  header.writeUInt32LE(0, 0);
+  header.writeUInt32LE(8_000, 4);
+  header.writeUInt32LE(1, 8);
+  header.writeUInt32LE(pcm16le.length, 12);
+  return Buffer.concat([header, pcm16le]);
+}
+
 function withFakeSpawner(
   target: CaptureTarget = { kind: "device", deviceId: "00008140-001A2B3C0AE2401E" }
 ): { fake: FakeChildProcess; spawnArgs: { command: string; args: string[] }; helper: IOSScreenCaptureHelper } {
@@ -132,6 +141,27 @@ describe("IOSScreenCaptureHelper", () => {
     await flush();
     expect(frames).toHaveLength(1);
     expect(frames[0].header.width).toBe(2);
+  });
+
+  test("passes --audio only for an explicitly audio-enabled simulator target", () => {
+    const { spawnArgs, helper } = withFakeSpawner({ kind: "simulator", windowID: 1, audio: true });
+    helper.start();
+
+    expect(spawnArgs.args).toEqual(["--simulator-window", "1", "--audio"]);
+  });
+
+  test("emits multiplexed PCM16LE audio without treating it as a malformed frame", async () => {
+    const { fake, helper } = withFakeSpawner({ kind: "simulator", windowID: 1, audio: true });
+    const audio: Buffer[] = [];
+    const malformed: MalformedFrameError[] = [];
+    helper.on("audio", chunk => audio.push(chunk.pcm16le));
+    helper.on("malformed", error => malformed.push(error));
+    helper.start();
+    fake.stdout.push(encodeAudio(Buffer.from([0x34, 0x12, 0xcc, 0xed])));
+    await flush();
+
+    expect(audio).toEqual([Buffer.from([0x34, 0x12, 0xcc, 0xed])]);
+    expect(malformed).toEqual([]);
   });
 
   test("emits malformed events for invalid headers", async () => {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -247,6 +247,16 @@ describe("IosH264Source", () => {
     await expect(started).rejects.toThrow(/did not produce PCM audio/);
   });
 
+  test("rejects audio startup when the helper exits after video but before PCM", async () => {
+    const { source, helper } = createHarness(IOS_SIMULATOR, { audioEnabled: true });
+    const started = source.start();
+    await flush();
+    helper.emitFrame(frame(1, 1, 0x11));
+    helper.emit("exit", { code: 1, signal: null });
+
+    await expect(started).rejects.toThrow(/exited before audio/);
+  });
+
   test("passes explicit simulator fps to helper target and ffmpeg input", async () => {
     const helper = new FakeFrameCaptureHelper();
     const encoder = new FakeChildProcess();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -257,6 +257,16 @@ describe("IosH264Source", () => {
     await expect(started).rejects.toThrow(/exited before audio/);
   });
 
+  test("rejects audio startup when the helper errors after video but before PCM", async () => {
+    const { source, helper } = createHarness(IOS_SIMULATOR, { audioEnabled: true });
+    const started = source.start();
+    await flush();
+    helper.emitFrame(frame(1, 1, 0x11));
+    helper.emit("error", new Error("helper crashed"));
+
+    await expect(started).rejects.toThrow("helper crashed");
+  });
+
   test("passes explicit simulator fps to helper target and ffmpeg input", async () => {
     const helper = new FakeFrameCaptureHelper();
     const encoder = new FakeChildProcess();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -120,7 +120,10 @@ async function startWithFrame(
   await started;
 }
 
-function createHarness(device: BootedDevice = IOS_DEVICE) {
+function createHarness(
+  device: BootedDevice = IOS_DEVICE,
+  overrides: Partial<ConstructorParameters<typeof IosH264Source>[0]> = {}
+) {
   const helper = new FakeFrameCaptureHelper();
   const encoder = new FakeChildProcess();
   const helperTargets: CaptureTarget[] = [];
@@ -144,6 +147,7 @@ function createHarness(device: BootedDevice = IOS_DEVICE) {
     },
     simulatorWindowResolver: async () => 42,
     commandRunner: successfulCommandRunner,
+    ...overrides,
   });
 
   return { source, helper, encoder, helperTargets, encoderSpawns, chunks, errors };
@@ -209,6 +213,38 @@ describe("IosH264Source", () => {
     await startWithFrame(source, helper, frame(1, 1, 0x11));
 
     expect(helperTargets).toEqual([{ kind: "simulator", windowID: 42, fps: 5 }]);
+  });
+
+  test("requests simulator audio and forwards its PCM16LE chunks unchanged", async () => {
+    const audio: Buffer[] = [];
+    const { source, helper, helperTargets } = createHarness(IOS_SIMULATOR, {
+      audioEnabled: true,
+      onAudioData: chunk => audio.push(chunk),
+    });
+
+    const started = source.start();
+    await flush();
+    helper.emitFrame(frame(1, 1, 0x11));
+    helper.emit("audio", { pcm16le: Buffer.from([0x34, 0x12]) });
+    await started;
+
+    expect(helperTargets).toEqual([{ kind: "simulator", windowID: 42, fps: 5, audio: true }]);
+    expect(audio).toEqual([Buffer.from([0x34, 0x12])]);
+  });
+
+  test("rejects audio startup when the Simulator never produces PCM", async () => {
+    const timer = new FakeTimer();
+    const { source, helper } = createHarness(IOS_SIMULATOR, {
+      audioEnabled: true,
+      timer,
+      firstFrameTimeoutMs: 1,
+    });
+    const started = source.start();
+    await flush();
+    helper.emitFrame(frame(1, 1, 0x11));
+    timer.advanceTime(1);
+
+    await expect(started).rejects.toThrow(/did not produce PCM audio/);
   });
 
   test("passes explicit simulator fps to helper target and ffmpeg input", async () => {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -559,6 +559,38 @@ describe("IosH264Source", () => {
     expect(helper.started).toBe(false);
   });
 
+  test("rejects audio startup before spawning the helper when multiple Simulator windows are visible", async () => {
+    const helper = new FakeFrameCaptureHelper();
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      audioEnabled: true,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      createHelper: () => helper,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      commandRunner: async (command, args) => {
+        if (command === FAKE_HELPER_PATH && args.includes("--list-simulators")) {
+          return {
+            stdout: JSON.stringify({
+              windows: [
+                { windowID: 42, title: "iPhone 16", applicationName: "Simulator" },
+                { windowID: 99, title: "iPad Pro", applicationName: "Simulator" },
+              ],
+            }),
+            stderr: "",
+            exitCode: 0,
+            signal: null,
+          };
+        }
+        return successfulCommandRunner(command, args);
+      },
+    });
+
+    await expect(source.start()).rejects.toThrow(/exactly one visible Simulator window/);
+    expect(helper.started).toBe(false);
+  });
+
   test("rejects startup when ffmpeg is missing", async () => {
     const { source, helper } = createHarnessWithOverrides({
       commandRunner: async () => {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -267,6 +267,26 @@ describe("IosH264Source", () => {
     await expect(started).rejects.toThrow("helper crashed");
   });
 
+  test("rejects audio startup when the encoder exits after video but before PCM", async () => {
+    const { source, helper, encoder } = createHarness(IOS_SIMULATOR, { audioEnabled: true });
+    const started = source.start();
+    await flush();
+    helper.emitFrame(frame(1, 1, 0x11));
+    encoder.emit("exit", 1, null);
+
+    await expect(started).rejects.toThrow(/ffmpeg exited/);
+  });
+
+  test("rejects audio startup when the encoder errors after video but before PCM", async () => {
+    const { source, helper, encoder } = createHarness(IOS_SIMULATOR, { audioEnabled: true });
+    const started = source.start();
+    await flush();
+    helper.emitFrame(frame(1, 1, 0x11));
+    encoder.emit("error", new Error("encoder crashed"));
+
+    await expect(started).rejects.toThrow("encoder crashed");
+  });
+
   test("passes explicit simulator fps to helper target and ffmpeg input", async () => {
     const helper = new FakeFrameCaptureHelper();
     const encoder = new FakeChildProcess();

--- a/test/features/webrtc/h264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/h264CaptureSourceFactory.test.ts
@@ -31,4 +31,24 @@ describe("createH264CaptureSource", () => {
 
     expect(source).toBeInstanceOf(IosH264Source);
   });
+
+  test("routes an audio-enabled iOS Simulator to the iOS source path", () => {
+    const simulator = { ...IOS, deviceId: "4DA8AF35-C59B-43D3-A8FE-5640A7B0B8C1" } as BootedDevice;
+    const source = createH264CaptureSource(
+      { device: simulator, onData: () => {}, onAudioData: () => {}, audioEnabled: true },
+      null
+    );
+
+    expect(source).toBeInstanceOf(IosH264Source);
+  });
+
+  test("explains that playback audio is unavailable on physical iOS devices", () => {
+    const physicalDevice = { ...IOS, deviceId: "00008140-001A2B3C0AE2401E" } as BootedDevice;
+    expect(() =>
+      createH264CaptureSource(
+        { device: physicalDevice, onData: () => {}, onAudioData: () => {}, audioEnabled: true },
+        null
+      )
+    ).toThrow(/playback audio.*iOS Simulator/i);
+  });
 });


### PR DESCRIPTION
## Summary

Adds opt-in WebRTC audio for iOS Simulator targets. The existing ScreenCaptureKit helper now captures and multiplexes 8 kHz mono PCM16LE audio over its current stdout transport; TypeScript routes it unchanged to the existing PCMU writer. Physical iOS playback capture remains an actionable unsupported case because public iOS APIs do not expose other-app playback audio.

Audio startup waits for both video and the first PCM chunk, so a silent capture cannot look like a successful audio-enabled stream.

## Linked Issue

Closes #3972

## Validation

- [x] `bun run turbo:validate` passes (`bun run lint` + build + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `cd ios/screen-capture && swift test`
- [x] New code uses interfaces + fakes + FakeTimer; focused unit tests run in <100ms
- [x] New generic code reuses existing transports and the shared PCMU writer; no dependencies added
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on an iOS Simulator via `observe`

Not manually verified against a Simulator window with audible playback yet; this requires host Screen Recording permission and a running Simulator.

## Follow-ups

- [x] Follow-up issues filed for gaps not addressed here: none
